### PR TITLE
docs: Loki `since=` is silently IGNORED here, not capped — a false zero over 1 h

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeasuringALivePortalReadOnly.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeasuringALivePortalReadOnly.md
@@ -127,6 +127,47 @@ silent-default failure this section is about.
 A zero without that control beside it is not a measurement, and per the rule at the top of this page
 it cannot license a "not happening" verdict.
 
+#### 🚨 `count_over_time(…[R])` counts a window that starts R *before* your `start`
+
+A range vector is evaluated at each step over `[t-R, t]`, so the **first** bucket of a
+`start`/`end` query reaches `R` before `start`. With `[24h]` at `step=86400` over a 72 h window,
+two of the four buckets lie almost entirely outside the window you asked for.
+
+This is not academic: it over-counted one signal here **by 17×** — 124 summed across the buckets
+against 7 lines actually inside the window, because the burst being counted sat just before
+`start`. The two readings disagreeing is what exposed it; either alone looks authoritative.
+
+**For "how many in window W", use an instant query with W as the range**, so there is exactly one
+bucket and it is the window:
+
+```bash
+curl -sG ".../loki/api/v1/query" \
+  --data-urlencode 'query=sum(count_over_time({namespace="memex-cloud"} |= "<phrase>" [72h]))' \
+  --data-urlencode "time=$(date -u +%s)000000000"
+```
+
+Keep `query_range` with a range vector for the **shape** of a signal over time — a burst that ended
+looks completely different from a steady drip, and that difference usually decides the severity. Just
+do not read the sum of its buckets as a total.
+
+#### 🚨 A rate needs a denominator, and `Information` is not emitted here
+
+Before reporting *N failures*, check that the **success** line is observable at all. A success
+logged at `LogInformation` against a category the deployment filters is simply absent, and the
+failure count then has no denominator: N could be 5 % of traffic or 100 % of it, and the logs cannot
+distinguish those.
+
+The test is one query, and its answer is binary:
+
+```
+sum(count_over_time({namespace="…"} |= "<the success phrase>" [30d]))   -> empty
+sum(count_over_time({namespace="…"} |= "<the failure phrase>" [30d]))   -> 154
+```
+
+Empty-against-nonzero **over the same chunks** means the success path is not being logged, not that
+it never ran. Report the absolute count and say the rate is unavailable — do not silently upgrade
+"154 failures" into "failing".
+
 ### Prometheus — the metric seam, and its rules
 
 Three endpoints, and the last two are the ones people forget:
@@ -262,6 +303,8 @@ example 1. Three issues filed as unrelated were one degradation.
 | Attributing to a stale topology | "restarted the app" | a remediation on something serving no traffic |
 | `python3` inside `--command` | `not found` | a silently empty result |
 | Loki `since=` on 2.6.1 | "nothing in 168 h" | a false zero over the last **1 h** |
+| `count_over_time(…[24h])` summed across buckets | "124 in the window" | 17× over-count; the burst was before `start` |
+| Counting failures with no success line | "154 failures" | a count read as a rate, with no denominator |
 
 ## What a verdict must contain
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeasuringALivePortalReadOnly.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeasuringALivePortalReadOnly.md
@@ -79,6 +79,54 @@ az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
 random, and an aggregate hides that completely — one replica at a steady 40/h next to five at zero
 is a different bug from six replicas at 7/h.
 
+#### 🚨 `since=` is SILENTLY IGNORED — always write `start`/`end`
+
+The Loki running here is **2.6.1** (built 2022-07-18), which predates `since` on `query_range`. It
+does not reject the parameter; it **ignores** it and falls back to the endpoint's default window of
+**one hour**. So `since=168h` does not ask for a week and get trimmed — it asks for nothing, and
+gets the last hour:
+
+| Query over `{namespace="memex-cloud"}` | Oldest line it can see |
+|---|---|
+| `since=168h`, `direction=forward&limit=1` | **1.0 h** ago |
+| *no time parameters at all*, same otherwise | **1.0 h** ago — within 36 s of the line above |
+| `start`/`end` as explicit ns, same otherwise | **167 h** ago — the whole window |
+
+Rows one and two landing on the same window is the proof: the parameter is inert, not clipped.
+
+**This is not a limit you can raise.** The cluster's limits are `max_query_lookback: 0s` (no
+lookback cap at all) and `max_query_length: 30d1h`, against `retention_period: 31d` — nothing was
+capping anything. A reading that blames a cap will send the next person to raise a bound that is
+already unlimited.
+
+The consequence is a **false zero that looks exactly like a real one**: you write `since=72h`, get
+`0` lines, and report three days of silence that you never queried. This has already happened here
+and nearly parked an issue on it.
+
+**The control — run it every time, alongside the query, never instead of it:** ask the same
+selector for its *oldest* visible line and check the age against the window you meant to search.
+
+```bash
+END=$(date -u +%s); START=$((END - 168*3600))          # the window you actually mean
+
+az aks command invoke -g memex-aks-rg -n memexaks-cluster --command \
+ "curl -sG 'http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/query_range' \
+    --data-urlencode 'query={namespace=\"memex-cloud\"}' \
+    --data-urlencode 'start=${START}000000000' \
+    --data-urlencode 'end=${END}000000000' \
+    --data-urlencode 'direction=forward' \
+    --data-urlencode 'limit=1'" -o tsv --query "logs"
+```
+
+`direction=forward` is what makes this a control: the default is `backward`, which returns the
+*newest* entries, so it reports the freshness of the stream no matter how small the window really
+was. Forward returns the oldest, which is the only end that can expose a truncated window. Bounds are
+nanoseconds, hence the `000000000` suffix; RFC3339 works too, but mixing the two invites the same
+silent-default failure this section is about.
+
+A zero without that control beside it is not a measurement, and per the rule at the top of this page
+it cannot license a "not happening" verdict.
+
 ### Prometheus — the metric seam, and its rules
 
 Three endpoints, and the last two are the ones people forget:
@@ -213,6 +261,7 @@ example 1. Three issues filed as unrelated were one degradation.
 | Probing a load-balanced host once | "it is fixed" | a per-replica fault, still live |
 | Attributing to a stale topology | "restarted the app" | a remediation on something serving no traffic |
 | `python3` inside `--command` | `not found` | a silently empty result |
+| Loki `since=` on 2.6.1 | "nothing in 168 h" | a false zero over the last **1 h** |
 
 ## What a verdict must contain
 


### PR DESCRIPTION
`MeasuringALivePortalReadOnly.md` exists for one purpose: to keep *"I could not find it"* and
*"it is not happening"* apart. It was missing the trap that collapses those two on this cluster most
cheaply, and that trap has already produced a wrong mechanism in a live issue thread.

## Measured, with a control

Same selector (`{namespace="memex-cloud"}`), same `direction=forward&limit=1`, against the live
cluster:

| Query | Oldest line it can see |
|---|---|
| `since=168h` | **1.0 h** ago |
| *no time parameters at all* | **1.0 h** ago — within 36 s of the row above |
| explicit `start`/`end` in ns | **167 h** ago — the whole window |

Rows one and two landing on the same window is the proof. `since=168h` is not a week that gets
trimmed; it is **the same query as passing no window at all**.

The reason: Loki here is **2.6.1**, built 2022-07-18, which predates `since` on `query_range`. It
does not reject the parameter — it ignores it, and the endpoint falls back to its one-hour default.

## Why the distinction is load-bearing

#3338 records this as *"the query had silently been capped"*. **Nothing capped it.** The cluster
reports `max_query_lookback: 0s` — no lookback cap at all — and `max_query_length: 30d1h` against
`retention_period: 31d`.

"Capped" and "ignored" fail identically and are fixed differently: capped sends the next reader
looking for a bound to raise, and there is no such bound. The parameter does not exist on this
deployment and never will until Loki is upgraded.

## What the page gains

- The mechanism, with the three-row measurement above.
- **The control**, which is the part that generalises: ask the same selector for its *oldest*
  visible line and check that age against the window you meant to search. `direction=forward` is
  what makes it a control — the default `backward` returns the *newest* entries, so it reports the
  freshness of the stream no matter how small the window really was, and can never expose a
  truncated one.
- A fifth row in the traps table: *Loki `since=` on 2.6.1 → "nothing in 168 h" → a false zero over
  the last 1 h.*

## Scope

**This does not un-park #3338.** That issue waits on observing a publish report `signature: verified`,
and its zero was taken with the corrected explicit-bounds query, so it stands as a real zero — only
the stated reason for the first, false zero was wrong. The escalation stays parked on its own terms.

No code, no live code path: there is no `query_range` call site anywhere in this repo, so the
exposure is human queries and this page's guidance.

Verified: `MeshWeaver.Documentation` Release `-warnaserror` → `0 Error(s)`. The documented command
block was executed verbatim, as a reader would copy it, before committing.

`Pairs-with: none` — one markdown file, no public surface.

Refs #3338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
