### PR TITLE
The dropped build fact names what it cost (#3374)

### DIFF
--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -605,7 +605,22 @@ public sealed class GitHubWebhookProcessor
                 {
                     // Never throw: GitHub retries a non-2xx delivery, so a write failure would turn
                     // into a delivery storm. Surface it and report "nothing recorded".
-                    logger?.LogWarning("Recording build completion at {Path} failed: {Error}", path, d.Message.Error);
+                    //
+                    // 🚨 The line NAMES WHAT THE DROP COST, because nothing else will (#3374). The
+                    // comment below states the invariant this path breaks — the record and the sync
+                    // "hang off this one green-build event so they cannot disagree about what
+                    // shipped" — and here they disagree: neither happened, GitHub is answered 200 so
+                    // it will not redeliver, and no other lane retries this. A reader who finds only
+                    // "recording … failed" has to derive all of that from the source; 154 of these
+                    // were logged on memex-cloud in one week and every one of them cost that
+                    // derivation. The sibling failure path below already states its outcome
+                    // ("recorded, but triggering the sync failed"); this one now meets the same bar.
+                    logger?.LogWarning(
+                        "Recording build completion at {Path} failed: {Error}. The green build of "
+                        + "{Repo} at {Sha} is NOT recorded AND the sync it authorises did NOT run. "
+                        + "GitHub is answered 200, so there is no redelivery, and nothing retries "
+                        + "this elsewhere — the build fact is lost unless someone replays it.",
+                        path, d.Message.Error, repoUrl, headSha);
                     return Observable.Return(0);
                 }
                 // The build record is the CI gate's verdict; the import is what the verdict authorises.


### PR DESCRIPTION
## 🚨 Diagnostic only — this does NOT fix #3374

The remedy is a scope call the issue explicitly declines to make: record the missed fact where the CD
heal ledger can see it (#3176 is the consumer that would care), or make the write survive a transient
owner outage. Both change behaviour on a live webhook path, and neither should be picked off the back
of an issue comment. **Nothing here changes the 200, the return value, or the control flow.**

## What it does change

When the `Admin/_Build/<owner>.<repo>` write fails, the line said only that the write failed.
Everything that matters about the drop had to be derived from the source:

- the build fact is **not recorded**, so `Admin/_Build/…` silently keeps its previous value;
- `TriggerSyncForGreenBuild` sits on the **success** branch, so the import that green build authorises
  **never runs** — breaking the invariant the very next comment states, that both *"hang off this one
  green-build event so they cannot disagree about what shipped"*;
- GitHub is answered **200**, so there is no redelivery, and nothing retries this elsewhere.

memex-cloud logged **154** of these in one week. Every one cost a reader that derivation, from a line
that named none of it.

```
before  Recording build completion at {Path} failed: {Error}

after   Recording build completion at {Path} failed: {Error}. The green build of {Repo} at {Sha}
        is NOT recorded AND the sync it authorises did NOT run. GitHub is answered 200, so there
        is no redelivery, and nothing retries this elsewhere — the build fact is lost unless
        someone replays it.
```

## Why this shape

The **sibling failure path immediately below already meets this bar** — *"Green build of {Repo}
recorded, but triggering the sync failed"* says what happened *and* what did not. One of the two
failure paths on this method told you the outcome and the other didn't; now both do.

**Verified:** `MeshWeaver.GitSync` builds clean under `-c Release -warnaserror`.

Pairs-with: none — a log message; removes no public surface.

Refs #3374