### PR TITLE
i18n(Plugins#1336): a key for "history is not retained on this deployment"

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1097,6 +1097,7 @@
   "versions.title": "Versionsverlauf",
   "versions.none": "Kein Versionsverlauf vorhanden.",
   "versions.unavailable": "Der Versionsverlauf ist nicht verfügbar.",
+  "versions.notRetained": "Auf dieser Installation wird kein Versionsverlauf aufbewahrt. Das ist eine Konfigurationseigenschaft, keine Eigenschaft dieses Knotens.",
   "versions.current": "Aktuell",
   "versions.from": "Von",
   "versions.to": "Bis",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1097,6 +1097,7 @@
   "versions.title": "Version History",
   "versions.none": "No version history available.",
   "versions.unavailable": "Version history is not available.",
+  "versions.notRetained": "Version history is not retained on this deployment. This is a configuration fact, not a property of this node.",
   "versions.current": "Current",
   "versions.from": "From",
   "versions.to": "To",


### PR DESCRIPTION
The **core half** of Plugins#1336, landing first because core owns the catalog.

## Why a new key rather than reusing one

`VersionViews` in MeshWeaver.Plugins still guards on `versionQuery == null`, which #3264 established **can never be true** — `NoOpVersionQuery` is registered unconditionally (`TryAddSingleton`), so the service is never null on any deployment. Where the no-op is what wins, the Versions page reports `versions.none` — *"No version history available."* — a **data-shaped miss about the node**, when the truth is a **configuration fact about the deployment**.

That is exactly the confusion #3278 was opened to end. Core's own `VersionLayoutArea` was migrated to `versionQuery is null or { RetainsHistory: false }`; the **view** half was not, and it lives in Plugins.

Reusing `versions.unavailable` or `versions.none` would keep telling the data-shaped lie, so the view needs its own message.

## The wording is not new

`versions.notRetained` carries the sentence `VersionLayoutArea.RollbackNode` already uses verbatim, so a portal says the same thing whichever door the user came through:

> Version history is not retained on this deployment. This is a configuration fact, not a property of this node.

German states it as a property of the **installation** rather than of the software — *"Auf dieser Installation wird kein Versionsverlauf aufbewahrt"* — which is the distinction the English is drawing too.

## Verified

`LocalizationTest` **58/58**; both catalogs carry the key and both parse.

## 🚦 Follow-ups this creates

1. The **Plugins half** — the two null checks, plus dropping a `Controls.Html("<p style=…>")` paragraph for `Controls.Body`, which is the banned hand-built-HTML shape for a line of prose.
2. The **React mirror** (`MeshWeaver.Plugins/clients/react/src/i18n/`) compares VALUES against a *pinned* core commit, so adding a key here reddens nothing and leaves the mirror silently stale. It needs `npm run sync:i18n -- --ref <this merge sha>`.

Refs Plugins#1336, #3264, #3278 · `Pairs-with: none` — additive catalog entries only.