### PR TITLE
main-cd: one commit yields one image set — a newer run defers to an older run still publishing it (#3376)

### DIFF
--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -113,6 +113,13 @@ def fixture(tagged: bool) -> list[dict]:
 # will still be there after someone edits the other.
 GH_STUB = """#!/usr/bin/env bash
 echo "gh $*" >> "$GH_CALLS"
+# The ONE read the decide step makes through gh: "is an older run of this workflow on this sha
+# still running?" (MeshWeaver#3376). A case supplies the answer the real `--jq` would have
+# produced (the older run's URL, or nothing) in GH_RUNS_RESULT; every other invocation stays
+# silent, exactly as before.
+case "$*" in
+  *actions/runs*) printf '%s' "${GH_RUNS_RESULT:-}" ;;
+esac
 exit 0
 """
 
@@ -175,6 +182,12 @@ def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: b
         e["GITHUB_OUTPUT"] = str(out)
         e["GITHUB_STEP_SUMMARY"] = str(summary)
         e.setdefault("GITHUB_REPOSITORY", "Systemorph/MeshWeaver")
+        # The decide step reads these from `env:` on the runner (MeshWeaver#3376); a case may
+        # override them, and GH_RUNS_RESULT is what the stub `gh` answers for the in-flight probe.
+        e.setdefault("SHA", "abc1234000000000000000000000000000000000")
+        e.setdefault("RUN_ID", "1000")
+        e.setdefault("WORKFLOW_NAME", "Continuous Delivery (main)")
+        e.pop("GH_RUNS_RESULT", None)
         e["GH_CALLS"] = str(calls)
         # Belt AND braces: the stub above shadows `gh` on PATH, and these leave a real `gh` — if one
         # is ever reached another way — with no credential to write with.
@@ -263,6 +276,22 @@ def run_decide_cases(root, case) -> None:
     rc, log, outputs = run_step(body, {**reconcile, "FORCE_REBUILD": "false"}, None)
     case("rebuild=false leaves the bake-only branch exactly as it was",
          rc == 0 and "bake_only=true" in outputs, f"rc={rc} out={outputs!r} log={log}")
+    # 🚨 ONE COMMIT, ONE IMAGE SET (MeshWeaver#3376). The reconcile tick that fires while the
+    # push-triggered run is still building must defer to it, on BOTH event paths, before any
+    # other verdict — and it must say which run it deferred to.
+    older = "https://example.invalid/actions/runs/999"
+    for reason, extra in (("reconcile", {"COMPLETE": "false"}),
+                          ("push", {"COMPLETE": "false", "FRESH_AGE_MIN": "999999"})):
+        rc, log, outputs = run_step(body, {**reconcile, "REASON": reason, **extra, "GH_RUNS_RESULT": older}, None)
+        case(f"an OLDER run still publishing this sha defers the {reason} path (#3376)",
+             rc == 0 and "publish=false" in outputs and older in log and "bake_only=true" not in outputs,
+             f"rc={rc} out={outputs!r} log={log}")
+    # And the probe must be inert when nothing is in flight: the same inputs with an empty answer
+    # publish exactly as they did before the probe existed. Without this, "defers" would also
+    # pass if the step deferred unconditionally.
+    rc, log, outputs = run_step(body, {**reconcile, "REASON": "reconcile", "COMPLETE": "false", "GH_RUNS_RESULT": ""}, None)
+    case("...and with nothing in flight the same reconcile still builds",
+         rc == 0 and "publish=true" in outputs, f"rc={rc} out={outputs!r} log={log}")
 
 
 def main() -> int:

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -704,6 +704,9 @@ jobs:
           AGE_MIN: ${{ steps.required.outputs.age_min }}
           COMPLETE: ${{ steps.acr.outputs.complete }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ steps.target.outputs.sha }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
           MAX_ATTEMPTS: "3"
           BATCH_WINDOW: ${{ vars.CD_BATCH_WINDOW_MINUTES }}
           FRESH_AGE_MIN: ${{ steps.freshness.outputs.age_min }}
@@ -718,6 +721,36 @@ jobs:
             gh issue view "$1" --repo "$GITHUB_REPOSITORY" --json comments \
               --jq "[.comments[] | select(.body | contains(\"$2\"))] | length"
           }
+
+          # ── ONE COMMIT, ONE IMAGE SET (MeshWeaver#3376) ────────────────────────────────────
+          # On 2026-09-05 core 34c3eecec got two publishing runs: the push-triggered run (#7845)
+          # and the hourly reconcile (#7846) both passed this step, because "is the set complete?"
+          # was asked while the first build was still in flight — not complete YET, so the second
+          # built too. Two `dotnet publish`es of one commit are two different digests: each got
+          # its own `<version>-ci.<n>` tag, phase A's `<short-sha>` tag moved to the later one, the
+          # earlier one's tag was orphaned, and the 25-minute build plus a bake were paid twice.
+          # The batching window cannot see this either — it compares against the newest PUBLISHED
+          # set, and neither had published.
+          #
+          # So before any other verdict: is an OLDER run of this workflow on THIS sha still running?
+          # Older by run id, deliberately — two runs deciding at the same instant would otherwise
+          # each see the other and BOTH defer, and one commit would yield no set at all. The older
+          # proceeds, the newer defers, and if the older one dies the next reconcile tick heals
+          # HEAD exactly as it does for any other incomplete set. `actions: read` is on this job.
+          # The probe FAILS OPEN, and says so: an API error here must not stop a publication that
+          # was correct before the probe existed — the worst case is the duplicate set this guards
+          # against, and the log names the reason instead of an empty answer.
+          if INFLIGHT=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$SHA&per_page=30" \
+                          --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\" and .id < $RUN_ID and (.status == \"in_progress\" or .status == \"queued\"))] | first // empty | .html_url"); then
+            :
+          else
+            echo "::warning::the in-flight probe failed (exit $?) — cannot tell whether an older run is publishing $SHORT; proceeding as before MeshWeaver#3376 (a duplicate image set is the worst case)"
+            INFLIGHT=""
+          fi
+          if [ -n "$INFLIGHT" ]; then
+            decision false "⏳ An older run of this workflow is still publishing \`$SHORT\`: $INFLIGHT — deferring, so one commit yields ONE image set (MeshWeaver#3376). If that run fails, the next reconcile tick heals HEAD."
+            exit 0
+          fi
 
           if [ "$REASON" = "push" ]; then
             if [ "$GREEN" != "true" ]; then

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -741,7 +741,7 @@ jobs:
           # was correct before the probe existed — the worst case is the duplicate set this guards
           # against, and the log names the reason instead of an empty answer.
           if INFLIGHT=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$SHA&per_page=30" \
-                          --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\" and .id < $RUN_ID and (.status == \"in_progress\" or .status == \"queued\"))] | first // empty | .html_url"); then
+                          --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\" and .id < $RUN_ID and (.status == \"in_progress\" or .status == \"queued\"))] | .[0] // empty | .html_url"); then
             :
           else
             echo "::warning::the in-flight probe failed (exit $?) — cannot tell whether an older run is publishing $SHORT; proceeding as before MeshWeaver#3376 (a duplicate image set is the worst case)"


### PR DESCRIPTION
## Summary

Closes #3376. Core `34c3eecec` got two publishing CD runs last night: the push-triggered run (#7845) and the hourly reconcile (#7846) both passed `decide`, because "is the set complete?" was asked while the first build was still in flight. Two `dotnet publish`es of one commit are two digests; the earlier one's `3.0.0-ci.7845` tag was orphaned when phase A's `<short-sha>` tag moved on, and the 25-minute build plus a bake were paid twice (the duplicate's seal then failed on the #2543 class). The batching window cannot see this either — it compares against the newest *published* set.

**`decide` now asks first, on both event paths: is an OLDER run of this workflow on this sha still in progress or queued?** Older by run id, deliberately: two runs deciding at the same instant would otherwise each see the other and both defer, and one commit would yield no set at all. The older proceeds; the newer defers and names the run it deferred to; if the older one dies, the next reconcile tick heals HEAD exactly as it does for any incomplete set.

The probe **fails open and says so** (`::warning::` naming the exit code): an API error must not stop a publication that was correct before the probe existed — the worst case is the duplicate set this guards against. The first draft swallowed that failure (`2>/dev/null || true`) and `check-workflow-shell.py` refused it, correctly.

## Verification

- `test-cd-steps.py` (executes the extracted `decide` body): the stub `gh` now answers the one read the step makes from `GH_RUNS_RESULT`; three new cases — an older in-flight run defers the **reconcile** path, defers the **push** path, and with nothing in flight the same reconcile still builds. **10/10.**
- `check-workflow-shell.py --root .`: 0 live findings. `actionlint`: the same 5 pre-existing infos on `main-cd.yml` as main.
- Inputs added to the step's `env:`: `SHA`, `RUN_ID`, `WORKFLOW_NAME` (the harness supplies defaults for them, as it does for `GITHUB_REPOSITORY`). `gate` already carries `actions: read`.

No What's New entry: CI plumbing, nothing a user can notice.

Pairs-with: none — a workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
