### PR TITLE
feat(#3321): let a consumer ask whether a synchronization stream is alive

### DIFF
--- a/src/MeshWeaver.Data/ISynchronizationStream.cs
+++ b/src/MeshWeaver.Data/ISynchronizationStream.cs
@@ -84,7 +84,17 @@ public interface ISynchronizationStream : IDisposable
     /// reference cannot be reduced.</returns>
     ISynchronizationStream<TReduced>? ReduceShared<TReduced>(WorkspaceReference<TReduced> reference);
 
-    /// <summary>The message hub associated with this stream.</summary>
+    /// <summary>The message hub associated with this stream.
+    ///
+    /// <para>🚨 <b>Non-nullable in the contract, but not in life.</b> A stream whose owner has been
+    /// torn down keeps answering this property, and the hub it hands back may already be winding
+    /// down — dereferencing it is how a recycle window produced an NRE inside
+    /// <c>LayoutAreaHost</c>'s constructor that escaped to the subscriber as a TERMINAL
+    /// <c>DeliveryFailure</c> (Systemorph/MeshWeaver#3321). On any path that can run concurrently
+    /// with teardown, prefer <see cref="SynchronizationStreamLiveness.TryGetHub"/>, which answers
+    /// <c>null</c> instead, or gate on
+    /// <see cref="SynchronizationStreamLiveness.IsUsable(ISynchronizationStream?)"/>.</para>
+    /// </summary>
     IMessageHub Hub { get; }
     /// <summary>The hub that hosts the underlying data source backing this stream.</summary>
     IMessageHub Host { get; }

--- a/src/MeshWeaver.Data/SynchronizationStreamLiveness.cs
+++ b/src/MeshWeaver.Data/SynchronizationStreamLiveness.cs
@@ -1,0 +1,81 @@
+﻿using MeshWeaver.Data.Serialization;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Data;
+
+/// <summary>
+/// 🚨 The CONSUMER-facing half of stream liveness — the thing whose absence cost a production NRE
+/// (Systemorph/MeshWeaver#3321, step 1 of 3).
+///
+/// <para><b>The defect this closes.</b> <see cref="ISynchronizationStream.Hub"/> is declared
+/// NON-NULLABLE and 47 sites dereference it. A stream whose owner has been torn down is a corpse
+/// that still answers that property, and <see cref="ISynchronizationStream"/> exposed no member
+/// with which a consumer could ask. A predecessor of <c>SynchronizationStream</c> tried to make the
+/// corpse honest by building a DEAD stream with <c>Hub = null!</c> and documenting that "every code
+/// path that touches Hub goes through <c>TryGetActiveHub</c>". No consumer honoured that — it could
+/// not, the method was private to one file — and the result was an NRE inside
+/// <c>LayoutAreaHost</c>'s constructor (<c>Stream.Hub.ServiceProvider…</c>) during a recycle window,
+/// which escaped to the subscriber as a TERMINAL <c>DeliveryFailure</c>: a page that subscribed
+/// mid-recycle was told "this failed forever" instead of "ask again".</para>
+///
+/// <para><b>Why an extension and not a member on the interface.</b>
+/// <see cref="StreamLiveness"/> records both reasons and neither has expired. Adding a member to a
+/// public interface breaks every downstream implementer, and these assemblies ship as packages. And
+/// <c>IStreamLivenessSource.Source</c> is not a consumer-facing concept — it exists so the reduce
+/// chain is walked in exactly ONE place, and a consumer walking it by hand is the ad-hoc predicate
+/// that whole design removed. So the PREDICATE becomes reachable while the interface it reads stays
+/// internal: consumers gain the ability to ask, implementers are untouched.</para>
+///
+/// <para><b>One definition, not a second one.</b> Both methods delegate to
+/// <see cref="StreamLiveness.IsUsable"/> and add no logic of their own. That is deliberate:
+/// <see cref="StreamLiveness"/> exists because three hand-copied liveness predicates diverged
+/// (#1455), and a public wrapper that re-implemented the check would be the fourth. The name is
+/// kept as <c>IsUsable</c> for the same reason — a dozen comments across <c>Workspace</c>,
+/// <c>JsonSynchronizationStream</c> and <c>StreamNotConvergingException</c> already point readers at
+/// "StreamLiveness.IsUsable", and a consumer following one of them must find the thing it names.</para>
+///
+/// <para>🚨 <b>This is step 1 alone, and it changes no behaviour.</b> Steps 2 and 3 of #3321 —
+/// migrating the 47 dereference sites onto <see cref="TryGetHub"/>, and only THEN dropping the
+/// <c>Hub</c> reference on disposal so the leaked hub graph is released — are deliberately NOT done
+/// here. Dropping the reference before the call sites can answer "no" is precisely the production
+/// incident above, in the same order it happened.</para>
+/// </summary>
+public static class SynchronizationStreamLiveness
+{
+    /// <summary>
+    /// True when <paramref name="stream"/> is still safe to use: it and every ancestor in its
+    /// reduce chain are undisposed, unfaulted, and owned by a hub that has not begun winding down.
+    ///
+    /// <para>The ancestor walk is not optional pedantry. A reduced stream is its parent's SIBLING —
+    /// <c>WorkspaceStreams.CreateReducedStream</c> hosts its <c>sync/{id}</c> sub-hub under the
+    /// parent's <c>Host</c> and merely registers it for disposal ON the parent — so a child stays
+    /// alive for the whole teardown cascade and will happily mirror a source that is already
+    /// dead.</para>
+    ///
+    /// <para>Answers <c>false</c> for <c>null</c>, so a nullable stream can be tested directly.</para>
+    /// </summary>
+    /// <param name="stream">The stream to judge, or <c>null</c>.</param>
+    /// <returns><c>false</c> for <c>null</c>, for a disposed or terminally faulted stream, and for
+    /// a live stream whose source chain contains one.</returns>
+    public static bool IsUsable(this ISynchronizationStream? stream)
+        => StreamLiveness.IsUsable(stream);
+
+    /// <summary>
+    /// The stream's hub if the stream is still usable, otherwise <c>null</c> — the accessor that
+    /// can answer "no", and the migration target for a <c>stream.Hub.Something</c> dereference.
+    ///
+    /// <para>This is the public counterpart of <c>SynchronizationStream</c>'s private
+    /// <c>TryGetActiveHub</c>. That one guards the stream's OWN write paths and always did its job;
+    /// what was missing was the same question being answerable from outside the file, which is why
+    /// the in-file discipline did not save the predecessor.</para>
+    ///
+    /// <para>Never throws and never returns a hub belonging to a dead chain, so
+    /// <c>stream.TryGetHub() is { } hub</c> is a complete guard: <see cref="IsUsable"/> already
+    /// treats an absent hub as dead, so there is no path here that dereferences a null.</para>
+    /// </summary>
+    /// <param name="stream">The stream to read the hub from, or <c>null</c>.</param>
+    /// <returns>The hub, or <c>null</c> when the stream is <c>null</c>, disposed, faulted, or
+    /// mirrors something that is.</returns>
+    public static IMessageHub? TryGetHub(this ISynchronizationStream? stream)
+        => stream.IsUsable() ? stream!.Hub : null;
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/StreamLivenessAndTheHubReference.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StreamLivenessAndTheHubReference.md
@@ -1,0 +1,109 @@
+---
+Name: Stream Liveness and the Hub Reference
+Category: Architecture
+Description: A synchronization stream outlives the hub it holds, and ISynchronizationStream.Hub is declared non-nullable — so a corpse answers it and 47 call sites dereference it. Why the obvious fix (null the field) is the one that already caused a production NRE, and the three-step order that does not repeat it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+---
+
+# Stream Liveness and the Hub Reference
+
+**A `SynchronizationStream` holds `IMessageHub Hub`, the interface declares it NON-NULLABLE, and a
+stream whose owner has been torn down keeps answering it. So the corpse is indistinguishable from a
+live stream at every one of the 47 sites that dereference it — and the reference keeps the dead
+hub's whole resolved graph alive.**
+
+That is two defects wearing one shape: a **retention** leak, and a **contract** that lies. They have
+to be fixed in that order backwards — the contract first — and this page exists because the obvious
+order was already tried in production.
+
+## What the field costs while it is held
+
+Closing a DI scope does not null the fields on an object that outlives it. The retained graph is
+`stream → dead hub → its own resolved state` (`TypeRegistry`, and whatever else was resolved onto the
+hub at construction). `MessageHub` deliberately does not dispose its own `ServiceProvider` —
+`HostedHubsCollection.Add` closes the scope instead, being *"the only place that both knows the scope
+exists and can act strictly after this hub is terminally down"* — and it does its job: 1 495 of 1 496
+hubs were removed. The bytes stay reachable anyway, because reachability is about references, not
+scopes. The only way to reclaim them is to **drop the reference**.
+
+`Dispose()` sets `isDisposed`, completes the store, clears `sharedReduceCache` and disposes
+`streamDisposables` — but it never clears `Hub`. So even the streams that *are* properly disposed
+keep their hub reachable.
+
+## Why "just null the field" is not available
+
+It was already done, and it is recorded in `SynchronizationStream`'s own constructor refusal path.
+The predecessor built a DEAD stream — `isDisposed`, store completed, **`Hub = null!`** — and
+documented that *"every code path that touches Hub goes through `TryGetActiveHub`"*.
+
+**No consumer honoured that, and none could.** `TryGetActiveHub` was private to that one file, while
+~96 sites dereferenced `ISynchronizationStream.Hub`, which the interface declares non-nullable. A
+consumer could not even detect the corpse: the contract exposed no liveness member at all.
+
+The result was an NRE inside `LayoutAreaHost`'s constructor (`Stream.Hub.ServiceProvider…`) during
+the overlay self-heal recycle window, which escaped to the subscriber as a **terminal
+`DeliveryFailure`**. A page that subscribed mid-recycle was told *"this failed forever"* instead of
+*"ask again"*.
+
+So the in-file discipline is not what failed. The **contract** failed: it promised non-null to
+callers who had no way to ask.
+
+## Detection was never the missing piece
+
+`StreamLiveness.IsUsable` already computes the whole answer, and has since #1455 / #2387:
+
+- it treats `current.Hub is not { } hub` as dead;
+- it checks `RunLevel > Started` and `MessageHub { IsDisposing: true }`, because hub shutdown is
+  asynchronous and RunLevel still reads `Started` immediately after `Dispose()`;
+- it walks the **reduce chain** through `IStreamLivenessSource.Source`, because a reduced stream is
+  its parent's SIBLING — `WorkspaceStreams.CreateReducedStream` hosts its `sync/{id}` sub-hub under
+  the parent's `Host` and only registers it for disposal ON the parent — so a child happily mirrors
+  a source that is already dead;
+- it counts FAULTED exactly as much as DISPOSED, because a store is a `ReplaySubject` and a terminal
+  `OnError` is permanent under the Rx grammar.
+
+Every cache already refuses to *serve* a corpse. What was missing is letting it **go** — and, before
+that, letting a consumer **ask**.
+
+## The three steps, in the only order that works
+
+1. **Expose the predicate.** `SynchronizationStreamLiveness.IsUsable(stream)` and
+   `stream.TryGetHub()` make the existing answer reachable from other assemblies.
+2. **Migrate the dereference sites** onto `TryGetHub()`, which can answer `null`.
+3. **Only then** clear `Hub` on disposal — at which point a null hub is a state the contract admits
+   rather than a lie.
+
+Doing 3 before 2 is the production NRE, in the order it happened. Doing 2 before 1 is impossible.
+
+### Why step 1 is an extension, not an interface member
+
+`StreamLiveness` records both reasons and neither has expired:
+
+- **Adding a member to a public interface breaks every downstream implementer**, and these
+  assemblies ship as packages.
+- **`IStreamLivenessSource.Source` is not a consumer-facing concept.** It exists so the reduce chain
+  is walked in exactly ONE place; a consumer walking it by hand is the ad-hoc predicate that whole
+  design removed.
+
+An extension method satisfies both: the predicate becomes reachable, the interface it reads stays
+internal, and no implementer is touched. The public methods delegate and add no logic of their own —
+`StreamLiveness` exists *because* three hand-copied liveness predicates diverged, and a public
+wrapper that re-implemented the check would be the fourth. The name stays `IsUsable` for the same
+reason: a dozen comments across `Workspace`, `JsonSynchronizationStream` and
+`StreamNotConvergingException` already point readers at "StreamLiveness.IsUsable", and a consumer
+following one of them must find the thing it names.
+
+### The guard that keeps step 1 from silently reverting
+
+`MeshWeaver.Data` grants `InternalsVisibleTo("MeshWeaver.Data.Test")`, so a test that merely *called*
+`stream.IsUsable()` would compile and pass just as happily if the surface reverted to `internal` —
+which is the exact state this step exists to leave behind. So
+`StreamLivenessIsConsumerReachableTest.TheSurfaceIsGenuinelyPublic` reads accessibility by
+**reflection**, which `InternalsVisibleTo` does not alter. Measured: with the class flipped to
+`internal` the project still builds and the other three tests still pass — only that one goes red.
+
+## Related
+
+- `Doc/Architecture/RemovingHandWovenGates` — the sibling rule for gates the actor model cannot hold
+- `Doc/Architecture/AsynchronousCalls` — why every hub-reachable path is `IObservable<T>`
+- Systemorph/MeshWeaver#3321 (this program) · #1455, #2387 (why `StreamLiveness` is one predicate)

--- a/test/MeshWeaver.Data.Test/StreamLivenessIsConsumerReachableTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamLivenessIsConsumerReachableTest.cs
@@ -1,0 +1,153 @@
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// A CONSUMER MUST BE ABLE TO ASK WHETHER A STREAM IS STILL ALIVE — Systemorph/MeshWeaver#3321,
+/// step 1 of 3.
+///
+/// <para><b>What went wrong without this.</b> <see cref="ISynchronizationStream.Hub"/> is declared
+/// NON-NULLABLE and 47 sites dereference it, while a stream whose owner has been torn down keeps
+/// answering that property. A predecessor of <c>SynchronizationStream</c> tried to make the corpse
+/// honest by building a DEAD stream with <c>Hub = null!</c>, documenting that "every code path that
+/// touches Hub goes through <c>TryGetActiveHub</c>". No consumer honoured that — <c>TryGetActiveHub</c>
+/// was private to one file — and the result was an NRE in <c>LayoutAreaHost</c>'s constructor during
+/// a recycle window, which reached the subscriber as a TERMINAL <c>DeliveryFailure</c>.</para>
+///
+/// <para><b>Why this test is worth its keep.</b> The predicate itself
+/// (<c>StreamLiveness.IsUsable</c>) was never the missing piece — it already walks the reduce chain
+/// and already treats an absent hub as dead. What was missing is that it was <c>internal</c>. So the
+/// assertions here are deliberately about REACHABILITY and ACCESSIBILITY, not about the verdict:
+/// <see cref="TheSurfaceIsGenuinelyPublic"/> reads accessibility by REFLECTION rather than by
+/// compiling, because <c>MeshWeaver.Data</c> grants <c>InternalsVisibleTo</c> to this very assembly —
+/// a test that merely called the methods would compile just as happily if someone made them internal
+/// again, and would pass while the defect was fully restored.</para>
+///
+/// <para>🚨 <b>Behaviour is unchanged and that is the point.</b> Steps 2 and 3 of #3321 — migrating
+/// the dereference sites onto <c>TryGetHub</c>, and only then dropping the <c>Hub</c> reference on
+/// disposal — are not done. Dropping the reference before the call sites can answer "no" is exactly
+/// the incident above.</para>
+/// </summary>
+public class StreamLivenessIsConsumerReachableTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))));
+
+    /// <summary>
+    /// A live stream answers "usable", and hands back the very hub a caller would otherwise have
+    /// dereferenced. The positive half matters as much as the negative: a predicate that answered
+    /// "dead" for everything would satisfy every other assertion here while making the accessor
+    /// useless, and step 2 would then migrate 47 call sites onto something that always says no.
+    /// </summary>
+    [HubFact]
+    public async Task ALiveStream_IsUsable_AndYieldsItsHub()
+    {
+        var host = GetHost();
+        var workspace = host.GetWorkspace();
+        var accessService = host.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetContext(new AccessContext { ObjectId = "alice", Name = "Alice" });
+
+        var collectionName = workspace.DataContext.GetTypeSource(typeof(MyData))!.CollectionName;
+        var stream = workspace.GetStream(new CollectionsReference(collectionName))!;
+
+        // Wait for real data rather than asserting on a stream that has not yet produced anything:
+        // "alive" should be measured on a stream in the state a consumer actually holds one in.
+        host.Post(
+            new DataChangeRequest().WithUpdates(new MyData("live", "value-1")),
+            o => o.WithAccessContext(accessService.Context!));
+
+        await stream
+            .Where(ci => ci.Value is not null
+                         && ci.Value.Collections.GetValueOrDefault(collectionName)
+                             ?.Instances.ContainsKey("live") == true)
+            .FirstAsync()
+            .Timeout(10.Seconds());
+
+        stream.IsUsable().Should().BeTrue("a stream that is serving data is alive");
+        stream.TryGetHub().Should().BeSameAs(stream.Hub,
+            "the accessor must hand back the same hub the non-nullable property does, or step 2's "
+            + "migration would change behaviour rather than only its failure mode");
+    }
+
+    /// <summary>
+    /// The case the whole issue is about: after disposal the stream still answers
+    /// <see cref="ISynchronizationStream.Hub"/> — a non-null hub, exactly as the contract promises —
+    /// yet the accessor says no. That gap between the two is the corpse a consumer could not
+    /// previously detect.
+    /// </summary>
+    [HubFact]
+    public async Task ADisposedStream_IsNotUsable_EvenThoughHubStillAnswers()
+    {
+        var host = GetHost();
+        var workspace = host.GetWorkspace();
+        var collectionName = workspace.DataContext.GetTypeSource(typeof(MyData))!.CollectionName;
+        var stream = workspace.GetStream(new CollectionsReference(collectionName))!;
+
+        await stream.FirstAsync(ci => ci.Value is not null).Timeout(10.Seconds());
+        stream.IsUsable().Should().BeTrue("precondition: the stream is alive before we kill it");
+
+        stream.Dispose();
+
+        // 🚨 The assertion that names the defect. Hub is NOT null here — the contract's promise is
+        // kept to the letter — so nothing about `stream.Hub.Anything` looks wrong at a call site.
+        stream.Hub.Should().NotBeNull(
+            "the non-nullable contract still holds after disposal, which is precisely why a "
+            + "consumer needed a separate way to ask");
+        stream.IsUsable().Should().BeFalse("a disposed stream is a corpse");
+        stream.TryGetHub().Should().BeNull("the accessor is the way a consumer finds that out");
+    }
+
+    /// <summary>
+    /// A null stream is answerable rather than an exception, so a consumer holding an
+    /// <c>ISynchronizationStream?</c> can gate on one call instead of a null check plus a liveness
+    /// check — two steps being where a call site forgets one.
+    /// </summary>
+    [HubFact]
+    public Task ANullStream_IsAnswered_NotThrown()
+    {
+        ISynchronizationStream? stream = null;
+
+        stream.IsUsable().Should().BeFalse();
+        stream.TryGetHub().Should().BeNull();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// 🚨 The guard that cannot be satisfied by accident. <c>MeshWeaver.Data</c> grants
+    /// <c>InternalsVisibleTo("MeshWeaver.Data.Test")</c>, so every other test in this file would
+    /// compile and pass unchanged if the surface reverted to <c>internal</c> — which is the exact
+    /// state #3321 step 1 exists to leave behind. Reflection reports real CLR accessibility, which
+    /// <c>InternalsVisibleTo</c> does not alter, so this is the one assertion here that actually
+    /// fails when the surface is withdrawn.
+    /// </summary>
+    [HubFact]
+    public Task TheSurfaceIsGenuinelyPublic()
+    {
+        var type = typeof(SynchronizationStreamLiveness);
+        type.IsPublic.Should().BeTrue(
+            "consumers live in other assemblies; internal is the state that caused #3321");
+
+        foreach (var name in new[] { nameof(SynchronizationStreamLiveness.IsUsable), "TryGetHub" })
+        {
+            var method = type.GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+            method.Should().NotBeNull($"{name} must be public and static to be reachable");
+            method!.IsDefined(typeof(ExtensionAttribute), inherit: false).Should().BeTrue(
+                $"{name} must be an extension method so a call site reads stream.{name}() — the "
+                + "shape step 2 migrates 47 dereferences onto");
+            method.GetParameters()[0].ParameterType.Should().Be(typeof(ISynchronizationStream),
+                $"{name} must extend the CONTRACT, not an implementation type — a consumer holds "
+                + "the interface");
+        }
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Step 1 of the three-step shape agreed on #3321. **Behaviour is unchanged, deliberately.**

## The defect

`ISynchronizationStream.Hub` is declared NON-NULLABLE and **47 sites dereference it**, while a stream
whose owner has been torn down keeps answering it. The corpse is indistinguishable from a live stream
at every call site — and the reference keeps the dead hub's whole resolved graph (`TypeRegistry`, and
whatever else was resolved onto it) alive, which is the retention half of #3321.

## Detection was never the missing piece — reachability was

`StreamLiveness.IsUsable` already computes the entire answer, and has since #1455 / #2387:

- treats `current.Hub is not { } hub` as dead;
- checks `RunLevel > Started` **and** `MessageHub { IsDisposing: true }`, because hub shutdown is
  asynchronous and RunLevel still reads `Started` right after `Dispose()`;
- walks the **reduce chain** — a reduced stream is its parent's SIBLING
  (`CreateReducedStream` hosts its `sync/{id}` sub-hub under the parent's `Host` and only registers
  it for disposal ON the parent), so a child happily mirrors a source that is already dead;
- counts FAULTED exactly as much as DISPOSED, because a store is a `ReplaySubject` and a terminal
  `OnError` is permanent under the Rx grammar.

It was merely `internal`. Every cache already refuses to *serve* a corpse; what was missing is a
consumer being able to **ask**.

## Why that ordering is not negotiable

The obvious fix — null the field — was already tried, and `SynchronizationStream`'s own constructor
refusal path records it: the predecessor built a DEAD stream with `Hub = null!` and documented that
*"every code path that touches Hub goes through `TryGetActiveHub`"*. No consumer honoured that and
**none could** — that method was private to one file, while ~96 sites dereferenced a property the
interface declares non-null. The result was an NRE in `LayoutAreaHost`'s constructor
(`Stream.Hub.ServiceProvider…`) during the overlay self-heal recycle window, which escaped to the
subscriber as a **terminal `DeliveryFailure`**: a page that subscribed mid-recycle was told "this
failed forever" instead of "ask again".

So the in-file discipline is not what failed — the **contract** failed. Hence:

1. **Expose the predicate.** ← this PR
2. Migrate the 47 dereference sites onto `TryGetHub()`, which can answer `null`.
3. **Only then** clear `Hub` on disposal, reclaiming the leak.

Doing 3 before 2 is the production NRE, in the order it happened.

## Why an extension, not a member on `ISynchronizationStream`

`StreamLiveness` records both reasons and neither has expired:

- **Adding a member to a public interface breaks every downstream implementer**, and these assemblies
  ship as packages.
- **`IStreamLivenessSource.Source` is not a consumer-facing concept** — it exists so the reduce chain
  is walked in exactly ONE place; a consumer walking it by hand is the ad-hoc predicate that design
  removed.

An extension satisfies both: the predicate becomes reachable, the interface it reads stays internal,
no implementer is touched. Both methods **delegate and add no logic** — `StreamLiveness` exists
*because* three hand-copied liveness predicates diverged, and a public wrapper that re-implemented
the check would be the fourth. The name stays `IsUsable` because a dozen comments across `Workspace`,
`JsonSynchronizationStream` and `StreamNotConvergingException` already point readers at
"StreamLiveness.IsUsable".

## The guard is reflection-based on purpose

`MeshWeaver.Data` grants `InternalsVisibleTo("MeshWeaver.Data.Test")`, so a test that merely *called*
`stream.IsUsable()` would compile and pass just as happily if the surface reverted to `internal` —
the exact state this step exists to leave behind. `TheSurfaceIsGenuinelyPublic` reads accessibility by
reflection, which `InternalsVisibleTo` does not alter.

**Falsified, not assumed:** with the class flipped to `internal`, the project still builds and the
other three tests still pass — only that one goes red. That is the whole reason it is written that way.

## Verification

- `MeshWeaver.Data` and `MeshWeaver.Data.Test`: `-c Release -warnaserror`, **0 warnings, 0 errors**.
- 4/4 new tests pass.
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest`: 2/2 pass.
- Swept `MeshWeaver.Plugins` for an `IsUsable` that this extension could make ambiguous
  (break shape 3, `CS0419`): the only hits are `RegistrationKey.IsUsable(DateTimeOffset)` on an
  unrelated type and a test method name. No collision.

`Pairs-with: none` — this diff removes **zero** public types and zero public members; it only adds.

## Notes

- **No What's New entry.** This is a pure API addition with no user-observable behaviour; an entry
  reading "new extension method" would be noise in a user-facing feed. Step 3, which actually stops
  the leak, is the one users notice. Happy to add one if you'd rather.
- The design and the three-step order are committed as `Doc/Architecture/StreamLivenessAndTheHubReference`,
  so the next session does not re-derive the trap from issue comments.

Refs #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
