### PR TITLE
fix(#3374): keep the green-build fact the webhook could not record

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -324,6 +324,7 @@ install-time seed.
 | Nothing happens on a green build | The webhook does not send **Workflow runs**; or no catalog's `SourceRepoPath` matches the repo; or the run's conclusion was not `success` — only completed+successful runs are recorded; or the run's **trigger is not on the allow-list** (`push`, `repository_dispatch`, `schedule`, `workflow_dispatch` record; `pull_request`, `dynamic` and anything unknown do not — see *Which green runs count as a publish signal* above); or the run was **not on the repository's default branch** — a green PR-branch build is unmerged code and is deliberately never recorded (fail-closed: a payload with no readable branch records nothing either). |
 | A module never updates, and the log says it "has no module content identity" | The module's `manifest.lock` is missing or unparseable, so there is no `ModuleVersion` to compare and "has it changed" is unanswerable. A missing hash is the **absence of evidence**, not evidence of a change: treating it as changed would re-install the module on every green build of the repo *and* on every pod start, which is acting on the event rather than the content. It is refused, loudly, and the catalog card's manual **Update** stays available. Fix the module's CI to emit the sidecar. |
 | Nothing happens on a green build, **and the log says the delivery "matched NONE of the N sync config(s)"** | No `_GitSync` targets that repository — usually because the repository was **renamed** and the configs still store its old name. The matcher falls back to GitHub's canonical `full_name` (which follows the rename redirect) and repoints the config when it finds one, so this line surviving means the lookup could not be made either: the repository is unreachable with the config creator's credential, or the hook really is installed on a repository this mesh does not sync. The Warning names both sides — the incoming repository and everything it was compared against. |
+| A green build produced nothing, and the log says the fact is **NOT recorded AND the sync did not run** | The `Admin/_Build/{owner}.{repo}` write failed. GitHub was answered 200, so there is no redelivery. The payload is kept at `Admin/_MissedBuild/{owner}.{repo}` (#3374) — read it with `MissedBuildFact.WatchQuery`, and compare it against the current build record to see whether a later green run of the SAME workflow has already superseded it. If a second Warning says the miss could not be recorded either, the log line is the only witness and the fact must be replayed from GitHub. |
 | Build node updates but no installation reacts | The package is not installed on that instance. A catalog lists far more packages than any instance installs; only packages with an install record are considered. |
 | The same "Update available" reminder keeps reappearing, or the bell re-lights on one you dismissed | Before #3213 this was the norm — a new row per reconcile, forever. The reminder is now told once per candidate version: the install record carries `NotifiedModuleVersion`, and the notification's id is derived from *(record, kind, candidate)*. Seeing it again means the candidate genuinely moved (`ModuleVersion` differs from the one on the record's marker) — read the record and compare the two, rather than assuming a duplicate. |
 | The boot log says the feed of a registry could not be read after N attempts and was **recorded as PENDING**, and admins got a bell notification pointing at `Plugins/_RegistryReconcileLedger` | The registry stayed unavailable for longer than the boot's retry budget (#2888). Nothing is lost: the ledger entry for that registry reads `Pending: true`, and the reconcile runs on the next successful feed read — open the catalog page (or install anything from that registry) once the registry is back, then check the entry reads `LastReconciledVia: feed-read`. If the registry answers a *definite* refusal (401/403) instead, the entry is pending too, but no catalog open will drain it until the key or grant is fixed — the `LastFault` names which. |
@@ -331,6 +332,46 @@ install-time seed.
 The webhook **never throws** on a write failure: GitHub retries a non-2xx delivery, so an unhandled
 fault would turn one bad write into a delivery storm. Failures are logged and reported as "nothing
 recorded" instead.
+
+### 🚨 What a failed build-record write costs, and where the fact goes now (#3374)
+
+Answering 200 on a failed write is right — a non-2xx is the storm above — but on its own it made the
+event **gone for good**: the build record kept its previous value, the sync the green build
+authorises never ran (it hangs off the success branch), GitHub did not redeliver, and nothing else
+retried. A transient infrastructure fault became permanent data loss. Measured on `memex-cloud`:
+**154 of these in one week**, from two distinct inner causes — an owner that returned no verdict,
+and initial state that never arrived within 30 s.
+
+It was also **un-monitorable**, not merely broken. The *attempt* is logged at `Information`, and
+`Information` is not emitted on that deployment, so the failure line has no denominator: 154
+failures could be 5 % of deliveries or 100 % and nothing could tell them apart.
+
+So the fact is now KEPT. On a failed write the webhook records a `MissedBuildFact` node at
+`Admin/_MissedBuild/{owner}.{repo}` carrying the build payload **verbatim**, so the lost build can
+be replayed rather than reconstructed from a log line. The delivery still answers 200 and still
+reports "nothing recorded" — recording the miss must not change the delivery's outcome.
+
+Two properties are deliberate:
+
+- **There is no drain, no `Pending` flag and no timer.** A later green build of the same workflow
+  writes the build record and runs the sync, superseding the lost one outright — so "does this
+  record still matter?" is a **read** (`MissedBuildFact.IsSupersededBy`), comparing it against the
+  build record that exists now. The happy path therefore writes no extra node, opens no query, and
+  cannot fail in a new way. Same *end on a fact you can read* shape `RegistryUpdateReconciler`
+  settled on.
+- **Superseding is per WORKFLOW.** Run numbers are per-workflow counters, so a busy second workflow
+  on the same repository sits far ahead; comparing across workflows would retire every real gap
+  almost immediately and hand back the silent loss this record replaced.
+
+The record shares a failure domain with the write that just failed. It is a **different node with a
+different owning hub**, so it survives the per-node faults actually observed — but a cluster-wide
+fault takes both, and when it does the log says so explicitly ("recorded NOWHERE — this log line is
+the only remaining witness") rather than counting the miss as handled.
+
+🚨 Read these with `MissedBuildFact.WatchQuery`, never a bare `nodeType:MissedBuildFact`. Like build
+records, they live in the **Admin partition**, which an unscoped query does not reach — it answers
+empty however many exist, so "nothing has been missed" would be indistinguishable from "the query
+cannot see them".
 
 ## Related
 

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -191,6 +191,18 @@ public static class GitHubSyncConfiguration
                 ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
                 HubConfiguration = config => config
                     .AddMeshDataSource(source => source.WithContentType<BuildCompletion>()),
+            },
+            // MissedBuildFact satellite (Admin/_MissedBuild/{owner}.{repo}) — the record of a green
+            // build the webhook could NOT write (#3374). Registering the NODE type is not optional
+            // bookkeeping: without it the write dies with "NodeType is not registered", and the
+            // record that exists precisely to stop a silent loss would itself be silently lost.
+            new MeshNode(MissedBuildFact.NodeType)
+            {
+                Name = "Missed Build Fact",
+                IsSatelliteType = true,
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
+                HubConfiguration = config => config
+                    .AddMeshDataSource(source => source.WithContentType<MissedBuildFact>()),
             });
 
         // Also register the content types on the mesh hub + every per-node hub so reads via
@@ -200,13 +212,15 @@ public static class GitHubSyncConfiguration
             .WithType<GitHubSyncConfig>(nameof(GitHubSyncConfig))
             .WithType<GitHubPullRequest>(nameof(GitHubPullRequest))
             .WithType<GitHubIssue>(nameof(GitHubIssue))
-            .WithType<BuildCompletion>(nameof(BuildCompletion)));
+            .WithType<BuildCompletion>(nameof(BuildCompletion))
+            .WithType<MissedBuildFact>(nameof(MissedBuildFact)));
         builder.ConfigureDefaultNodeHub(c => c
             .WithType<GitHubCredential>(nameof(GitHubCredential))
             .WithType<GitHubSyncConfig>(nameof(GitHubSyncConfig))
             .WithType<GitHubPullRequest>(nameof(GitHubPullRequest))
             .WithType<GitHubIssue>(nameof(GitHubIssue))
             .WithType<BuildCompletion>(nameof(BuildCompletion))
+            .WithType<MissedBuildFact>(nameof(MissedBuildFact))
             // The "GitHub" node-menu dropdown (its own context) + the action area its items navigate
             // to. Per-node-hub scoped provider (self-gates to Spaces with a configured repo).
             .WithServices(s =>

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -621,7 +621,17 @@ public sealed class GitHubWebhookProcessor
                         + "GitHub is answered 200, so there is no redelivery, and nothing retries "
                         + "this elsewhere — the build fact is lost unless someone replays it.",
                         path, d.Message.Error, repoUrl, headSha);
-                    return Observable.Return(0);
+                    // 🚨 …and now the fact is KEPT rather than only mourned (#3374). The warning
+                    // above is the floor, not the record: on memex-cloud the ATTEMPT is logged at
+                    // Information and Information is not emitted, so 154 of these in one week had
+                    // no denominator at all. The node is queryable, survives the pod, and carries
+                    // the payload verbatim, so the lost build can be REPLAYED.
+                    //
+                    // Still returns 0 and still answers GitHub 200 — recording the miss must not
+                    // change the delivery's outcome, and a non-2xx is the redelivery storm the
+                    // comment above exists to avoid.
+                    return RecordMissedBuildFact(target, completion, d.Message.Error)
+                        .Select(_ => 0);
                 }
                 // The build record is the CI gate's verdict; the import is what the verdict authorises.
                 // Both hang off this one green-build event so they cannot disagree about what shipped.
@@ -635,6 +645,67 @@ public sealed class GitHubWebhookProcessor
                             "Green build of {Repo} recorded, but triggering the sync failed.", repoUrl);
                         return Observable.Return(1);
                     });
+            });
+    }
+
+    /// <summary>
+    /// Keeps a green build the mesh refused to record, at
+    /// <c>Admin/_MissedBuild/{owner}.{repo}</c> (Systemorph/MeshWeaver#3374).
+    ///
+    /// <para><b>Never fails the delivery.</b> Every outcome — a refusal, a throw — is logged and
+    /// swallowed. This runs on a path that has ALREADY lost the build fact; turning that into a
+    /// non-2xx would trade a silent loss for the redelivery storm the caller's comment exists to
+    /// avoid, and turning it into a throw would lose the caller's own warning too.</para>
+    ///
+    /// <para>🚨 <b>It shares a failure domain with the write that just failed, and says so.</b>
+    /// This is a different node with a different owning hub, so it survives the per-node faults
+    /// actually observed (an owner returning no verdict; initial state not arriving) — but a
+    /// cluster-wide fault takes both. When it does, the log line is all that is left, which is why
+    /// the refusal below is logged at Warning naming what is now unrecorded, rather than counted as
+    /// a success.</para>
+    /// </summary>
+    private IObservable<System.Reactive.Unit> RecordMissedBuildFact(
+        RepoIdentity target, BuildCompletion completion, string? error)
+    {
+        var path = MissedBuildFact.PathFor(target.Owner, target.Repo);
+        var slash = path.LastIndexOf('/');
+        var node = new MeshNode(path[(slash + 1)..], path[..slash])
+        {
+            NodeType = MissedBuildFact.NodeType,
+            Name = $"{target.Owner}/{target.Repo} missed build",
+            State = MeshNodeState.Active,
+            Content = MissedBuildFact.For(completion, error, DateTimeOffset.UtcNow),
+        };
+
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        return Observable.Using(
+                () => accessService.ImpersonateAsSystem(),
+                _ => hub.NodeOperationIssuingHub()
+                    .Observe<CreateOrUpdateNodeResponse>(new CreateOrUpdateNodeRequest(node))
+                    .FirstAsync())
+            .Select(r =>
+            {
+                if (r.Message.Success)
+                    logger?.LogInformation(
+                        "Missed build fact for {Repo} at {Sha} recorded at {Path} — replay it from "
+                        + "there, or let the next green build of the same workflow supersede it.",
+                        completion.RepositoryUrl, completion.HeadSha, path);
+                else
+                    logger?.LogWarning(
+                        "Could not record the missed build fact at {Path} either: {Error}. The "
+                        + "green build of {Repo} at {Sha} is now recorded NOWHERE — this log line "
+                        + "is the only remaining witness.",
+                        path, r.Message.Error, completion.RepositoryUrl, completion.HeadSha);
+                return System.Reactive.Unit.Default;
+            })
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "Could not record the missed build fact at {Path} either. The green build of "
+                    + "{Repo} at {Sha} is now recorded NOWHERE — this log line is the only "
+                    + "remaining witness.",
+                    path, completion.RepositoryUrl, completion.HeadSha);
+                return Observable.Return(System.Reactive.Unit.Default);
             });
     }
 

--- a/src/MeshWeaver.Graph/MissedBuildFact.cs
+++ b/src/MeshWeaver.Graph/MissedBuildFact.cs
@@ -1,0 +1,124 @@
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// The durable record that a green build was reported and NOT recorded — the fact
+/// <see cref="BuildCompletion"/> should have carried, kept where someone can find it
+/// (Systemorph/MeshWeaver#3374).
+///
+/// <para><b>What was losing it.</b> The <c>workflow_run</c> webhook writes
+/// <c>Admin/_Build/{owner}.{repo}</c>. When that write fails, the handler logs a warning, returns 0
+/// and answers GitHub <b>200 OK</b>. The 200 is deliberate and right — a non-2xx makes GitHub
+/// redeliver, and the comment guarding it anticipates that storm — but the consequence is that the
+/// event is gone for good: the build record keeps its previous value, the sync the green build
+/// authorises never runs (it hangs off the success branch), GitHub will not redeliver, and nothing
+/// else retries. A transient infrastructure fault becomes permanent data loss. Measured on
+/// memex-cloud: <b>154 of these in one week</b>, and two distinct inner causes — an owner that
+/// returned no verdict, and initial state that never arrived within 30 s.</para>
+///
+/// <para><b>Why a node and not just a louder log.</b> The log line is the floor, not the record.
+/// On that deployment the ATTEMPT is logged at <c>Information</c> and <c>Information</c> is not
+/// emitted, so the failure line has no denominator — 154 failures could be 5 % of deliveries or
+/// 100 % and nothing can tell them apart. A node is queryable, survives the pod, and carries the
+/// payload verbatim, so the lost build can be replayed rather than merely mourned.</para>
+///
+/// <para>🚨 <b>Being "still missing" is a READ, not a second write.</b> There is deliberately no
+/// drain, no <c>Pending</c> flag to clear and no timer. A later green build for the same repository
+/// writes <c>Admin/_Build/{owner}.{repo}</c> and runs the sync, which supersedes the lost one
+/// outright — so whether this record still matters is answered by comparing it against the build
+/// record that exists now (<see cref="IsSupersededBy"/>). That is the same "end on a fact you can
+/// read" shape <c>RegistryUpdateReconciler</c> settled on, and it costs the happy path nothing: a
+/// green delivery that works writes no extra node, opens no query, and cannot fail in a new
+/// way.</para>
+///
+/// <para><b>One node per repository, updated in place</b> — the same choice
+/// <see cref="BuildCompletion"/> makes and for the same reason. A node per missed run would grow
+/// without bound; the per-run history is already in the node's own version history, and the
+/// question anyone actually asks is "is this repo currently missing a build fact?".</para>
+/// </summary>
+public record MissedBuildFact
+{
+    /// <summary>The node type registered for these records.</summary>
+    public const string NodeType = "MissedBuildFact";
+
+    /// <summary>The path segment missed-build records are anchored under, inside the Admin partition.</summary>
+    public const string SatelliteSegment = "_MissedBuild";
+
+    /// <summary>The namespace every missed-build record lives in: <c>Admin/_MissedBuild</c>.</summary>
+    public const string Namespace = "Admin/" + SatelliteSegment;
+
+    /// <summary>
+    /// The query to WATCH or LIST every repository's missed-build record.
+    ///
+    /// <para>🚨 PATH-SCOPED for the same non-obvious reason <see cref="BuildCompletion.WatchQuery"/>
+    /// is: these records live in the <b>Admin partition</b>, which an UNSCOPED query does not reach.
+    /// A bare <c>nodeType:MissedBuildFact</c> answers EMPTY however many records exist — and it
+    /// fails that way silently, so "no build facts have been missed" would be indistinguishable
+    /// from "the query cannot see them". A record whose whole purpose is to make a silent loss
+    /// visible must not be readable only through a query that is silently blind.</para>
+    /// </summary>
+    public const string WatchQuery = $"path:{Namespace} scope:children nodeType:{NodeType}";
+
+    /// <summary>
+    /// The canonical node path for one repository's missed-build record:
+    /// <c>Admin/_MissedBuild/{owner}.{repo}</c> — deliberately the same
+    /// <c>{owner}.{repo}</c> id as <see cref="BuildCompletion.PathFor"/>, so the two are trivially
+    /// paired by a reader.
+    /// </summary>
+    /// <param name="owner">The repository owner (GitHub org or user).</param>
+    /// <param name="repo">The repository name.</param>
+    public static string PathFor(string owner, string repo)
+        => $"{Namespace}/{Sanitize(owner)}.{Sanitize(repo)}";
+
+    /// <summary>Path separators would fabricate node hierarchy, so they never survive into a path
+    /// segment. Identical to <see cref="BuildCompletion"/>'s rule, and for the same reason: the
+    /// value arrives from a webhook payload and is treated as untrusted.</summary>
+    private static string Sanitize(string s) => s.Replace('/', '-').Replace('\\', '-');
+
+    /// <summary>
+    /// The build fact that was NOT recorded, verbatim — everything the write would have stored, so
+    /// the record can be replayed rather than reconstructed from a log line.
+    /// </summary>
+    public BuildCompletion Build { get; init; } = new();
+
+    /// <summary>When the write was attempted and failed (UTC).</summary>
+    public DateTimeOffset MissedAt { get; init; }
+
+    /// <summary>
+    /// The write's own error text — the mesh's answer, not a summary of it. The two shapes seen in
+    /// production are an owner that returned no verdict and initial state that never arrived, and
+    /// they have different causes, so the distinction has to survive into the record.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Builds the record for a build fact that could not be written.
+    /// </summary>
+    /// <param name="build">The completion that was being recorded.</param>
+    /// <param name="error">The failing write's error text, if it gave one.</param>
+    /// <param name="missedAt">When the attempt failed (UTC).</param>
+    public static MissedBuildFact For(BuildCompletion build, string? error, DateTimeOffset missedAt)
+        => new() { Build = build, Error = error, MissedAt = missedAt };
+
+    /// <summary>
+    /// Whether <paramref name="current"/> — the build record that exists NOW for this repository —
+    /// already covers what this record says was lost.
+    ///
+    /// <para>A later green build both writes the record and runs the sync the verdict authorises,
+    /// so it supersedes the lost one outright and this record is history rather than a to-do.
+    /// Compared on <see cref="BuildCompletion.RunNumber"/>, GitHub's monotonically incrementing
+    /// per-workflow counter, because it is the only field here that ORDERS: a sha does not, and
+    /// <see cref="BuildCompletion.CompletedAtUtc"/> is a remote clock that may be absent. A run
+    /// number that is equal counts as superseding — the same run recorded on a retry is exactly the
+    /// fact this record was holding.</para>
+    ///
+    /// <para>🚨 Different WORKFLOWS have independent run numbers, so a record is only superseded by
+    /// a build of the same workflow. Comparing across workflows would let an unrelated workflow's
+    /// higher counter silently retire a real gap.</para>
+    /// </summary>
+    /// <param name="current">The repository's current build record, or <c>null</c> when it has none.</param>
+    /// <returns><c>true</c> when the lost fact no longer matters.</returns>
+    public bool IsSupersededBy(BuildCompletion? current)
+        => current is not null
+           && string.Equals(current.WorkflowName, Build.WorkflowName, StringComparison.Ordinal)
+           && current.RunNumber >= Build.RunNumber;
+}

--- a/test/MeshWeaver.Graph.Test/MissedBuildFactTest.cs
+++ b/test/MeshWeaver.Graph.Test/MissedBuildFactTest.cs
@@ -1,0 +1,96 @@
+using MeshWeaver.Graph;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The record that exists to make a SILENT loss visible must not itself be readable only through a
+/// query that is silently blind — Systemorph/MeshWeaver#3374.
+///
+/// <para><c>MissedBuildFact</c> lands in the <b>Admin partition</b>, exactly like
+/// <see cref="BuildCompletion"/>, and an UNSCOPED query does not reach that partition: a bare
+/// <c>nodeType:MissedBuildFact</c> answers EMPTY however many records exist. That failure mode is
+/// the reason this test is worth writing rather than obvious — "no build facts have been missed"
+/// and "the query cannot see them" would be the same answer, on the one record whose entire job is
+/// to stop a loss from looking like a success. <see cref="BuildCompletionWatchQueryTest"/> records
+/// what that cost when the self-updater hit it: the unscoped form answered 0 while
+/// <c>Admin/_Build/Systemorph.MeshWeaver</c> sat at version 1746.</para>
+/// </summary>
+public class MissedBuildFactTest
+{
+    [Fact]
+    public void TheWatchQuery_IsPathScoped_BecauseTheAdminPartitionIsInvisibleUnscoped()
+    {
+        Assert.Contains($"path:{MissedBuildFact.Namespace}", MissedBuildFact.WatchQuery);
+        Assert.Contains("scope:children", MissedBuildFact.WatchQuery);
+        Assert.Contains($"nodeType:{MissedBuildFact.NodeType}", MissedBuildFact.WatchQuery);
+
+        Assert.Equal(
+            "path:Admin/_MissedBuild scope:children nodeType:MissedBuildFact",
+            MissedBuildFact.WatchQuery);
+    }
+
+    [Fact]
+    public void TheRecordPairsWithTheBuildRecordItStandsIn_For()
+    {
+        // Same {owner}.{repo} id under a sibling namespace, so a reader holding one path can derive
+        // the other without a lookup table — which is what IsSupersededBy's caller has to do.
+        var missed = MissedBuildFact.PathFor("Systemorph", "MeshWeaver");
+        var build = BuildCompletion.PathFor("Systemorph", "MeshWeaver");
+
+        Assert.Equal("Admin/_MissedBuild/Systemorph.MeshWeaver", missed);
+        Assert.StartsWith(MissedBuildFact.Namespace + "/", missed);
+        Assert.Equal(
+            build[(build.LastIndexOf('/') + 1)..],
+            missed[(missed.LastIndexOf('/') + 1)..]);
+    }
+
+    [Fact]
+    public void APayloadOwnerCannotFabricateNodeHierarchy()
+    {
+        // owner/repo arrive from a webhook body. GitHub names cannot contain a separator, but the
+        // value is untrusted, and a surviving '/' would write the record somewhere else entirely —
+        // out of the namespace the watch query scopes to, i.e. invisible again.
+        var path = MissedBuildFact.PathFor("evil/owner", @"re\po");
+
+        Assert.Equal("Admin/_MissedBuild/evil-owner.re-po", path);
+        Assert.StartsWith(MissedBuildFact.Namespace + "/", path);
+    }
+
+    /// <summary>
+    /// A repository with no build record at all cannot have superseded anything — the case that
+    /// matters, because it is the state right after the very failure this record documents.
+    /// </summary>
+    [Fact]
+    public void NoCurrentBuildRecord_SupersedesNothing()
+        => Assert.False(Missed(runNumber: 10).IsSupersededBy(null));
+
+    [Theory]
+    [InlineData(11, true)]   // a later run recorded the fact and ran the sync — this is history now
+    [InlineData(10, true)]   // the SAME run, recorded on a retry: exactly what was being held
+    [InlineData(9, false)]   // an older run says nothing about the gap
+    public void ASameWorkflowRun_SupersedesOnlyFromTheMissedRunOnward(long current, bool expected)
+        => Assert.Equal(expected, Missed(runNumber: 10).IsSupersededBy(Build("CI", current)));
+
+    /// <summary>
+    /// 🚨 The guard that stops a real gap being retired by an unrelated workflow. Run numbers are
+    /// per-workflow counters, so a busy second workflow on the same repository will routinely sit
+    /// far ahead — and comparing across workflows would mark every miss superseded almost
+    /// immediately, turning this record back into the silent loss it replaced.
+    /// </summary>
+    [Fact]
+    public void ADifferentWorkflowsHigherRunNumber_DoesNotSupersede()
+        => Assert.False(Missed(runNumber: 10).IsSupersededBy(Build("Some Other Workflow", 9999)));
+
+    private static MissedBuildFact Missed(long runNumber) =>
+        MissedBuildFact.For(Build("CI", runNumber), "owner returned no verdict", DateTimeOffset.UtcNow);
+
+    private static BuildCompletion Build(string workflow, long runNumber) => new()
+    {
+        RepositoryUrl = "https://github.com/Systemorph/MeshWeaver",
+        Branch = "main",
+        HeadSha = "deadbeef",
+        WorkflowName = workflow,
+        RunNumber = runNumber,
+    };
+}


### PR DESCRIPTION
Closes #3374.

## What was being lost

The `workflow_run` webhook writes `Admin/_Build/{owner}.{repo}`. When that write fails it logs a
warning, returns `0`, and answers GitHub **200 OK**.

The 200 is right — a non-2xx makes GitHub redeliver, which is the storm the comment there
anticipates. But the consequence was that **the event was gone for good**: the build record kept its
previous value, the sync the green build authorises never ran (it hangs off the success branch),
GitHub did not redeliver, and nothing else retried. A transient infrastructure fault became
permanent data loss.

Measured on `memex-cloud`: **154 in one week**, from two distinct inner causes — an owner that
returned no verdict, and initial state that never arrived within 30 s.

And it was **un-monitorable**, not merely broken: the *attempt* is logged at `Information`, and
`Information` is not emitted on that deployment, so the failure line has no denominator. 154
failures could be 5 % of deliveries or 100 % and nothing could tell them apart. #3375 already made
the warning name what the drop cost — but a log line is the floor, not the record.

## What this does

On a failed write the webhook now records a **`MissedBuildFact`** node at
`Admin/_MissedBuild/{owner}.{repo}`, carrying the build payload **verbatim** so the lost build can be
**replayed** rather than reconstructed from a log line. The delivery still returns `0` and still
answers GitHub 200 — recording the miss must not change the delivery's outcome.

### Two deliberate properties

**No drain, no `Pending` flag, no timer.** A later green build of the same workflow writes the record
and runs the sync, superseding the lost one outright — so *"does this still matter?"* is a **read**
(`IsSupersededBy`) against the build record that exists now. The happy path therefore writes no extra
node, opens no query, and cannot fail in a new way. Same *end on a fact you can read* shape
`RegistryUpdateReconciler` settled on for #2888.

**Superseding is per WORKFLOW.** Run numbers are per-workflow counters, so a busy second workflow on
the same repository sits far ahead. Comparing across workflows would retire every real gap almost
immediately and hand back exactly the silent loss this replaces. There is a test for that case
specifically.

### Honest about the failure domain

The record shares a failure domain with the write that just failed. It is a **different node with a
different owning hub**, so it survives the per-node faults actually observed — but a cluster-wide
fault takes both. When it does, the log says so explicitly (*"recorded NOWHERE — this log line is the
only remaining witness"*) rather than counting the miss as handled. I'd rather ship that than imply a
guarantee this cannot make.

### The blind-query trap

`WatchQuery` is path-scoped because these land in the **Admin partition**, which an unscoped query
does not reach — a bare `nodeType:MissedBuildFact` answers empty however many exist. On the one
record whose whole job is to stop a loss from looking like a success, *"nothing was missed"* must not
be indistinguishable from *"the query is blind"*. That is the trap `BuildCompletionWatchQueryTest`
already documents, costing the self-updater 0-vs-version-1746; the new type would have fallen into it
identically.

## Verification

- `MeshWeaver.Graph`, `MeshWeaver.GitSync`, `MeshWeaver.Graph.Test`: `-c Release -warnaserror`,
  **0 warnings, 0 errors**.
- **8/8** new tests pass, `DocumentationLinkIntegrityTest` passes.
- Node type AND content type registered in all three places `BuildCompletion` is — without the node
  type the write dies with *"NodeType is not registered"*, i.e. the record that exists to stop a
  silent loss would itself be silently lost.

`Pairs-with: none` — this diff removes **zero** public types and zero public members; it only adds.

## Scope note

The **behavioural** end-to-end test (webhook write refused → missed node written) belongs in
`MeshWeaver.GitSync.Test`, which lives in `MeshWeaver.Plugins` and compiles against core at
`MW_PLATFORM_REF` — so it can only be written after this merges and the pin moves. `MeshWeaver.Graph.Test`
does not reference GitSync. I put the state logic on the record itself precisely so the part that can
be got wrong (supersession, path shape, the sanitiser, the query scope) is covered here rather than
deferred; the mesh plumbing is thin by design. I'll open the follow-up for the Plugins-side test.

Also deliberately **not** done: no bell notification to platform admins (the `RegistryUpdateReconciler`
half of that pattern). The decided scope was recording the fact; a notification on a path that fires
154 times in a bad week needs its own throttling decision, and I'd rather that be made explicitly.

Refs #3375 (the diagnostic half, already merged) · #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
