### PR TITLE
docs(release): the OWASP ZAP scan is a release precondition; the notes page is a flat file (was served at _3_0_0)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -77,18 +77,23 @@ and the findings each release carried:
 [SecurityScanning.md](../../../src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md).
 
 ```bash
+ZAP=ghcr.io/zaproxy/zaproxy:2.17.0          # pinned by VERSION; the version goes on the notes page; bump deliberately
 OUT=~/.cache/zap-scan-$(date -u +%F); mkdir -p "$OUT/public" "$OUT/auth"   # a PLAIN dir: Docker mounts it
+# Each run's console output IS its log (the verdict is its last line), so it is captured; the
+# scripts exit 0 PASS / 2 WARN / 1 FAIL / 3 scanner error — echo it, never let it end the shell.
 # 1. PUBLIC, ACTIVE — anonymous, safe against production
-docker run --rm -v "$OUT/public":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
-  zap-full-scan.py -t https://memex.meshweaver.cloud -r public-full.html -J public-full.json -w public-full.md
+docker run --rm -v "$OUT/public":/zap/wrk/:rw -t "$ZAP" \
+  zap-full-scan.py -t https://memex.meshweaver.cloud -r public-full.html -J public-full.json -w public-full.md \
+  > "$OUT/public/public-full.log" 2>&1; echo "public exit=$?"
 # 2. AUTHENTICATED, PASSIVE — never zap-full-scan with a session on production (it fires payloads
 #    AS THE USER at every write endpoint). $COOKIE = the full Cookie header of a real browser
 #    session (.AspNetCore.Cookies; an API token does not authenticate the SPA). -j = AJAX spider,
 #    the only thing that reaches the bundles a signed-in page loads.
-docker run --rm -v "$OUT/auth":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+docker run --rm -v "$OUT/auth":/zap/wrk/:rw -t "$ZAP" \
   zap-baseline.py -t https://memex.meshweaver.cloud -j -r auth-report.html -J auth-report.json -w auth-report.md \
-  -z "-config replacer.full_list(0).description=sess -config replacer.full_list(0).enabled=true -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Cookie -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=$COOKIE"
-# 3. VERDICT — the last line of each log; FAIL-NEW must be 0 on both, and rule 10003 blocks:
+  -z "-config replacer.full_list(0).description=sess -config replacer.full_list(0).enabled=true -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Cookie -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=$COOKIE" \
+  > "$OUT/auth/auth-baseline.log" 2>&1; echo "authenticated exit=$?"
+# 3. VERDICT — the last line of each captured log; FAIL-NEW must be 0 on both, and rule 10003 blocks:
 tail -1 "$OUT/public/public-full.log" "$OUT/auth/auth-baseline.log"
 grep -h "Vulnerable JS Library" "$OUT"/*/*.log        # PASS = clean; WARN-NEW = a shipped library with advisories → blocker
 ```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -60,12 +60,46 @@ continuous builds ARE the pre-releases, and `PlatformVersion` always names the n
    ```
 2. **`PlatformVersion` at that commit equals the tag** (`3.0.0` ↔ `v3.0.0`). The lane refuses a
    mismatch; so does it refuse a `-rc`/`-beta` suffix and a lightweight tag.
-3. **The notes page exists at that commit**: `src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0/index.md`
+3. **The notes page exists at that commit**: `src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0.md` (a
+   FLAT file — a `3_0_0/index.md` is embedded as `_3_0_0` and served at the wrong path)
    (`Category: Release Notes`). The GitHub Release is published FROM it.
 4. **Secrets present** (can't be read; confirm with the operator): `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/
    `AZURE_SUBSCRIPTION_ID` (OIDC → ACR + the artifact stores, via the `release` environment),
    `MESHWEAVER_APP_ID`/`MESHWEAVER_APP_PRIVATE_KEY` (the next-line PR), repo var
    `BAKE_PUBLISH_TARGETS`. The lane's `preflight` job fails RED naming any that is missing.
+5. **The OWASP ZAP scans ran against the candidate and every finding has a disposition on the
+   notes page** — the lane cannot check this one; it is the operator's gate (next section).
+
+## Security scan — every release, before the tag
+
+Both runs, against the deployment that serves the candidate build. Full reference, verdict rules
+and the findings each release carried:
+[SecurityScanning.md](../../../src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md).
+
+```bash
+OUT=~/.cache/zap-scan-$(date -u +%F); mkdir -p "$OUT/public" "$OUT/auth"   # a PLAIN dir: Docker mounts it
+# 1. PUBLIC, ACTIVE — anonymous, safe against production
+docker run --rm -v "$OUT/public":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+  zap-full-scan.py -t https://memex.meshweaver.cloud -r public-full.html -J public-full.json -w public-full.md
+# 2. AUTHENTICATED, PASSIVE — never zap-full-scan with a session on production (it fires payloads
+#    AS THE USER at every write endpoint). $COOKIE = the full Cookie header of a real browser
+#    session (.AspNetCore.Cookies; an API token does not authenticate the SPA). -j = AJAX spider,
+#    the only thing that reaches the bundles a signed-in page loads.
+docker run --rm -v "$OUT/auth":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py -t https://memex.meshweaver.cloud -j -r auth-report.html -J auth-report.json -w auth-report.md \
+  -z "-config replacer.full_list(0).description=sess -config replacer.full_list(0).enabled=true -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Cookie -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=$COOKIE"
+# 3. VERDICT — the last line of each log; FAIL-NEW must be 0 on both, and rule 10003 blocks:
+tail -1 "$OUT/public/public-full.log" "$OUT/auth/auth-baseline.log"
+grep -h "Vulnerable JS Library" "$OUT"/*/*.log        # PASS = clean; WARN-NEW = a shipped library with advisories → blocker
+```
+
+Then write the two verdict lines and a disposition for EVERY `WARN-NEW` — fixed, or carried with
+the rule id, the reason and the tracking issue — on the notes page (the 3.0.0 page's *Security*
+section is the shape). A WARN without a disposition is an untriaged finding, not a pass. The raw
+reports stay under `$OUT` (they are a site map with bodies); the cookie is a live session — keep it
+out of every repo and sign out when done. 🚨 The version string on a package manifest is not the
+verdict: the DOMPurify finding on 3.0.0 (MeshWeaver#3378) lived inside a NuGet package's static
+bundle, invisible to Dependabot and to any source build — only the served bytes tell.
 
 ## Continuous release (the common case — just merge)
 
@@ -144,8 +178,9 @@ az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command \
 ```bash
 # 0. Pick the commit: on main, its CD run SEALED (preconditions above), PlatformVersion == the tag.
 grep -m1 '<PlatformVersion Condition' Directory.Build.props          # e.g. 3.0.0
-# 1. Make sure the notes page is committed at that commit:
-#    src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0/index.md
+# 1. Make sure the notes page is committed at that commit — WITH the Security section: both OWASP
+#    ZAP verdict lines and a disposition per WARN (section above):
+#    src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0.md   (flat — never <version>/index.md)
 # 2. Tag it ANNOTATED and push — this is the whole release (maintainer: only once every open
 #    issue is closed):
 git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,10 @@ jobs:
             echo "::error::PlatformVersion at $SHA is '$PROPS' but the tag says '$VERSION'. The tag must name the line the commit was built under — either the wrong commit was tagged, or Directory.Build.props was bumped ahead of the release. Retag the right commit."
             exit 1
           fi
-          NOTES="src/MeshWeaver.Documentation/Data/ReleaseNotes/${VERSION//./_}/index.md"
+          # A flat file, not <version>/index.md: MSBuild embeds a digit-leading FOLDER as an identifier
+          # (3_0_0 → _3_0_0), so a page inside one is served at Doc/ReleaseNotes/_3_0_0 and no link to
+          # the documented path resolves. File names are embedded verbatim.
+          NOTES="src/MeshWeaver.Documentation/Data/ReleaseNotes/${VERSION//./_}.md"
           if [ ! -f "$NOTES" ]; then
             echo "::error::no release-notes page at $NOTES. The GitHub Release is published FROM that page (Doc/ReleaseNotes/${VERSION//./_}); commit it (Category: Release Notes) and tag a commit that carries it."
             exit 1

--- a/src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md
@@ -16,7 +16,16 @@ Documentation lives as markdown files under `src/MeshWeaver.Documentation/Data/`
 | `Data/Architecture.md` | `Doc/Architecture` |
 | `Data/Architecture/AsynchronousCalls.md` | `Doc/Architecture/AsynchronousCalls` |
 | `Data/GUI/ContainerControl/Stack.md` | `Doc/GUI/ContainerControl/Stack` |
-| `Data/ReleaseNotes/3_0_0/index.md` | `Doc/ReleaseNotes/3_0_0` (an `index.md` *is* its folder's node) |
+| `Data/GUI/ContainerControl/index.md` | `Doc/GUI/ContainerControl` (an `index.md` *is* its folder's node) |
+| `Data/ReleaseNotes/3_0_0.md` | `Doc/ReleaseNotes/3_0_0` — a flat file on purpose, see below |
+
+🚨 **A folder name must be a C# identifier; a file name need not.** The embedded-resource name MSBuild
+gives a file makes every *folder* segment an identifier — a folder starting with a digit is prefixed
+(`3_0_0/` → `_3_0_0`), a hyphen becomes an underscore — while the *file* name is kept verbatim. So
+`Data/ReleaseNotes/3_0_0/index.md` is served at `/Doc/ReleaseNotes/_3_0_0`, and every link to the
+documented path is broken with nothing in the build to say so (`DocumentationLinkIntegrityTest` is
+what caught it). Version pages are therefore flat files, `Data/ReleaseNotes/3_0_0.md`, and no doc
+folder starts with a digit or carries a hyphen.
 
 Note the pairing: `Architecture.md` is the **index node** and the folder `Architecture/` holds its children. Agent definitions follow the same scheme under the **`Agent`** partition (`content/ai/Agent/Researcher.md` → `Agent/Researcher`), and skills under the **`Skill`** partition (`content/ai/Skill/code.md` → `Skill/code`).
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -163,9 +163,14 @@ Everything the lane needs is asserted RED by a `preflight` job — no `continue-
    shipped` **and** `Plugins: bake + seal` green — read the seal JOB, never the run's conclusion
    ([ContinuousDeliveryContract](/Doc/Architecture/ContinuousDeliveryContract)). Commit its notes
    page, `Doc/ReleaseNotes/3_0_0`, first: the lane will not release without it.
-3. **Tag it, annotated.** `git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0`.
+3. **Scan it.** Run the two OWASP ZAP scans — public active, authenticated passive — against the
+   deployment serving that build, and write the verdict and every finding's disposition on the
+   notes page ([OWASP ZAP Scan — Every Release](/Doc/Architecture/SecurityScanning)). `FAIL-NEW`
+   must read 0 on both runs; a `Vulnerable JS Library` WARN blocks the tag; every other WARN is
+   fixed or carried with a written reason. The lane cannot check this — it is the operator's gate.
+4. **Tag it, annotated.** `git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0`.
    The lane promotes the set (§3); Stable installs pick it up on their next check.
-4. **Merge the bump.** The lane's pull request moves the line to `3.1.0`; auto-arm enqueues it.
+5. **Merge the bump.** The lane's pull request moves the line to `3.1.0`; auto-arm enqueues it.
    Until it merges, no continuous build may be relied on to roll a Continuous install forward.
 
 > **Tagging discipline.** A version tag must be **immutable** (annotated, never force-moved): the
@@ -201,3 +206,5 @@ and no packages.
 - [DataSyncSetup.md](/Doc/Architecture/DataSyncSetup) — the platform version doubles as the
   content-version for static-repo / GitHub data-sync.
 - [Deployment.md](/Doc/Architecture/Deployment) — where the built images go (AKS vs Container Apps).
+- [SecurityScanning.md](/Doc/Architecture/SecurityScanning) — the OWASP ZAP scans every release
+  runs before its tag, and the findings each release carried.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -1,0 +1,112 @@
+---
+Name: OWASP ZAP Scan — Every Release
+Category: Architecture
+Description: Every release is scanned with OWASP ZAP against the deployment serving the candidate build — a public active scan and an authenticated passive baseline — before its tag is pushed. What is run, how, what the verdict is, what the scanner cannot see, and the findings each release carried.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><circle cx="12" cy="11" r="3"/><path d="M14.2 13.2 17 16"/></svg>
+---
+
+# OWASP ZAP Scan — Every Release
+
+**A release is tagged only after the deployment serving the candidate build has been scanned with
+OWASP ZAP (Zed Attack Proxy), and the release notes page says what the scan found.** The scan is a
+precondition in [Release Process & Versioning](/Doc/Architecture/ReleaseProcess), beside the sealed
+image set and the notes page; the `release` skill carries the same commands for the operator. Raw
+reports never enter a repository — they are a site map with response bodies — so the record that
+ships is the verdict line and the finding table below.
+
+## The two runs
+
+The portal has two surfaces, and one run cannot cover both: everything a signed-in user loads —
+the code editor, the settings tabs, the layout areas — is invisible to an anonymous spider, and an
+**active** scan must never run with a real session, because it fires its payloads as that user at
+every write endpoint it finds.
+
+| run | who | mode | what it reaches |
+|---|---|---|---|
+| **Public** | anonymous | **active** (`zap-full-scan.py`) — spiders, then attacks every input it found | the public pages, sign-in, the assets they load |
+| **Authenticated** | a real browser session | **passive** (`zap-baseline.py -j`) — spiders with the AJAX spider, inspects every response, sends no payload | the signed-in portal and the bundles only its pages load |
+
+```bash
+# Both runs use the pinned scanner image; $OUT is a PLAIN directory (a Docker bind mount —
+# an agent scratchpad is not mountable), one sub-folder per run.
+OUT=~/.cache/zap-scan-$(date -u +%F); mkdir -p "$OUT/public" "$OUT/auth"
+
+# 1. Public, ACTIVE — anonymous, so safe against production.
+docker run --rm -v "$OUT/public":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+  zap-full-scan.py -t https://memex.meshweaver.cloud \
+  -r public-full.html -J public-full.json -w public-full.md
+
+# 2. Authenticated, PASSIVE — $COOKIE is the full `Cookie` header of a real browser session
+#    (the OIDC `.AspNetCore.Cookies` session; an API token does not authenticate the SPA).
+#    -j turns on the AJAX spider, which is what reaches the assets a signed-in page loads.
+docker run --rm -v "$OUT/auth":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py -t https://memex.meshweaver.cloud -j \
+  -r auth-report.html -J auth-report.json -w auth-report.md \
+  -z "-config replacer.full_list(0).description=sess -config replacer.full_list(0).enabled=true \
+      -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Cookie \
+      -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=$COOKIE"
+```
+
+The cookie is a live session: it stays in the shell that runs the scan, never in a file under a
+repository, and the session is signed out when the run ends.
+
+## The verdict
+
+The last line of each run's log is the verdict:
+
+```
+FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
+```
+
+- **`FAIL-NEW` must be 0** on both runs. A FAIL is a release blocker, full stop.
+- **Every `WARN-NEW` is triaged before the tag**: fixed on the candidate, or carried with a
+  disposition — the rule id, why it is accepted or deferred, and the issue that tracks it — written
+  on the release notes page. A WARN without a disposition is an untriaged finding, not a pass.
+- **`Vulnerable JS Library [10003]` is a blocker whatever its level.** It names a shipped library
+  version with published advisories, and its evidence is exact: in `auth-report.json`,
+  `site[].alerts[]` where `name` starts with *Vulnerable JS Library* carries the library and version
+  retire.js matched in `otherinfo` and the bundle in `instances[].uri`. Trust that, never a version
+  string read off a package manifest — the shipped bundle is what the browser runs.
+
+## What the scanner cannot see
+
+- **The public run does not reach the signed-in surface.** The 3.0.0 DOMPurify finding below is
+  visible only to the authenticated run; a public scan alone reports `PASS` on rule 10003.
+- **Retire.js reads banners and signatures.** A bundle that strips its `@license` banner passes the
+  rule while still shipping the vulnerable code. That is why the fix for MeshWeaver#3378 keeps the
+  banner and a guard test (`MonacoBundleGuard`, MeshWeaver.Plugins) asserts the version behind it.
+- **The authenticated run is passive.** Nothing is fired at the signed-in write surface; a
+  vulnerability that needs a payload to show is out of its reach by design.
+- **Nothing here scans dependencies at rest.** Dependabot covers declared packages; a library
+  inlined into a NuGet package's static assets (the Monaco bundle) is visible to neither Dependabot
+  nor a source build — only to a scan of what is served.
+
+## Findings by release
+
+### 3.0.0 — scanned 2026-09-06 against memex.meshweaver.cloud
+
+| run | verdict | endpoints |
+|---|---|---|
+| public, active | `FAIL-NEW: 0 · WARN-NEW: 5 · PASS: 136` | 296 |
+| authenticated, passive | `FAIL-NEW: 0 · WARN-NEW: 9 · PASS: 58` | 179 |
+
+| rule | level | run | instances | disposition |
+|---|---|---|---|---|
+| Vulnerable JS Library [10003] — DOMPurify 3.2.7 inside BlazorMonaco's Monaco bundle | Medium | authenticated | 1 | **Fixed**: MeshWeaver#3378 — the portal builds its own Monaco with DOMPurify 3.4.14 (MeshWeaver.Plugins, `tools/monaco-editor`), guarded by `MonacoBundleGuard` |
+| Backup File Disclosure [10095] | Medium | public | 21 | open — triage before the tag |
+| Proxy Disclosure [40025] | Medium | public | systemic | open — triage before the tag |
+| CSP: Failure to Define Directive with No Fallback [10055] | Medium | both | 15 / 10 | open — triage before the tag |
+| CSP: Wildcard Directive · script-src unsafe-eval · script-src unsafe-inline · style-src unsafe-inline | Medium | both | 3 each / 2 each | open — triage before the tag |
+| Cross-Origin-Resource-Policy header missing [90004] · Cross-Origin-Embedder-Policy header missing | Low | both | systemic / 7 | open — triage before the tag |
+| Dangerous JS Functions [10110] | Low | both | 1 | open — triage before the tag |
+| Timestamp Disclosure — Unix [10096] | Low | authenticated | 3 | open — triage before the tag |
+| Re-examine Cache-control Directives [10015] · Non-Storable Content [10049] · Suspicious Comments [10027] · Modern Web Application [10109] | Informational | authenticated | 5 / 11 / 15 / 5 | informational — no action |
+
+An earlier scan of the same portal on 2026-08-23 had already reported rule 10003 on the Monaco
+bundle; the advisory list had grown by 2026-09-06, which is what turned it into MeshWeaver#3378.
+
+## See also
+
+- [Release Process & Versioning](/Doc/Architecture/ReleaseProcess) — where the scan sits among the release preconditions.
+- [Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy) — the end-to-end release model.
+- [MeshWeaver 3.0.0](/Doc/ReleaseNotes/3_0_0) — the first notes page carrying a scan record.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -27,24 +27,30 @@ every write endpoint it finds.
 | **Authenticated** | a real browser session | **passive** (`zap-baseline.py -j`) — spiders with the AJAX spider, inspects every response, sends no payload | the signed-in portal and the bundles only its pages load |
 
 ```bash
-# Both runs use the pinned scanner image; $OUT is a PLAIN directory (a Docker bind mount —
-# an agent scratchpad is not mountable), one sub-folder per run.
+# The scanner is pinned by VERSION, and that version goes on the notes page beside the verdict;
+# bumping it is a deliberate change (a new release of the scanner brings new rules). $OUT is a
+# PLAIN directory (a Docker bind mount — an agent scratchpad is not mountable), one sub-folder
+# per run, and each run's console output IS its log: the verdict is that log's last line, so it
+# is captured — the scripts exit 0 on PASS, 2 on WARN, 1 on FAIL, 3 on a scanner error.
+ZAP=ghcr.io/zaproxy/zaproxy:2.17.0
 OUT=~/.cache/zap-scan-$(date -u +%F); mkdir -p "$OUT/public" "$OUT/auth"
 
 # 1. Public, ACTIVE — anonymous, so safe against production.
-docker run --rm -v "$OUT/public":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+docker run --rm -v "$OUT/public":/zap/wrk/:rw -t "$ZAP" \
   zap-full-scan.py -t https://memex.meshweaver.cloud \
-  -r public-full.html -J public-full.json -w public-full.md
+  -r public-full.html -J public-full.json -w public-full.md \
+  > "$OUT/public/public-full.log" 2>&1; echo "public scan exit=$?"
 
 # 2. Authenticated, PASSIVE — $COOKIE is the full `Cookie` header of a real browser session
 #    (the OIDC `.AspNetCore.Cookies` session; an API token does not authenticate the SPA).
 #    -j turns on the AJAX spider, which is what reaches the assets a signed-in page loads.
-docker run --rm -v "$OUT/auth":/zap/wrk/:rw -t ghcr.io/zaproxy/zaproxy:stable \
+docker run --rm -v "$OUT/auth":/zap/wrk/:rw -t "$ZAP" \
   zap-baseline.py -t https://memex.meshweaver.cloud -j \
   -r auth-report.html -J auth-report.json -w auth-report.md \
   -z "-config replacer.full_list(0).description=sess -config replacer.full_list(0).enabled=true \
       -config replacer.full_list(0).matchtype=REQ_HEADER -config replacer.full_list(0).matchstr=Cookie \
-      -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=$COOKIE"
+      -config replacer.full_list(0).regex=false -config replacer.full_list(0).replacement=$COOKIE" \
+  > "$OUT/auth/auth-baseline.log" 2>&1; echo "authenticated scan exit=$?"
 ```
 
 The cookie is a live session: it stays in the shell that runs the scan, never in a file under a
@@ -52,7 +58,7 @@ repository, and the session is signed out when the run ends.
 
 ## The verdict
 
-The last line of each run's log is the verdict:
+The last line of each run's log (the console output captured above) is the verdict:
 
 ```
 FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
@@ -83,7 +89,7 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
 
 ## Findings by release
 
-### 3.0.0 — scanned 2026-09-06 against memex.meshweaver.cloud
+### 3.0.0 — scanned 2026-09-06 against memex.meshweaver.cloud, ZAP 2.17.0
 
 | run | verdict | endpoints |
 |---|---|---|

--- a/src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0.md
+++ b/src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0.md
@@ -161,6 +161,21 @@ or outside; admins enroll a user in one step; and there is a playbook for host c
 - [Admins can enroll a user in one step](/Doc/WhatsNew/2026-08-08-admin-enroll-action) · [Coupons administration tab](/Doc/WhatsNew/2026-08-02-coupons-administration-tab) · [Invite a whole list of emails to a group](/Doc/WhatsNew/2026-07-11-group-bulk-invite) · [See at a glance what is public](/Doc/WhatsNew/2026-08-10-see-what-is-public)
 - [A playbook for host crashes](/Doc/WhatsNew/2026-08-28-crash-triage-playbook) · [A guide for standing up a new repository](/Doc/WhatsNew/2026-08-28-new-repo-skill) · [What's New now covers every repository](/Doc/WhatsNew/2026-08-28-whats-new-from-every-repo)
 
+## Security
+
+Every release is scanned with OWASP ZAP against the deployment serving the candidate build, in
+two runs — a public active scan and an authenticated passive baseline — and the tag is pushed
+only after every finding has a disposition ([OWASP ZAP Scan — Every Release](/Doc/Architecture/SecurityScanning)).
+For 3.0.0, scanned on 2026-09-06: the public run reads `FAIL-NEW: 0 · WARN-NEW: 5 · PASS: 136`
+and the authenticated run `FAIL-NEW: 0 · WARN-NEW: 9 · PASS: 58`. The one Medium finding unique
+to the signed-in portal — a DOMPurify with published cross-site-scripting advisories inside the
+code editor's bundle — is fixed on this line: the portal builds its own Monaco editor with a
+current sanitiser and a guard test keeps it there. The remaining warnings and their dispositions
+are on that page.
+
+- [Every release is scanned with OWASP ZAP](/Doc/WhatsNew/2026-09-06-every-release-is-scanned-with-owasp-zap) · the editor fix itself ships from MeshWeaver.Plugins and appears in the What's New feed from there
+- [Unanchored security reads](/Doc/Architecture/UnanchoredSecurityReads) · [Access control](/Doc/Architecture/AccessControl)
+
 ## How the platform itself is built
 
 Core `main` merges through a merge queue with a steward; a platform change runs the plugin suites

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-every-release-is-scanned-with-owasp-zap.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-every-release-is-scanned-with-owasp-zap.md
@@ -1,0 +1,22 @@
+---
+Name: Every release is scanned with OWASP ZAP before it is tagged
+Category: Feature
+Description: A release now carries a security scan record — an OWASP ZAP public active scan and an authenticated passive baseline against the deployment serving the candidate — with the verdict and every finding's disposition on the release notes page.
+Icon: ShieldCheckmark
+Order: -20260906
+---
+
+# Every release is scanned with OWASP ZAP before it is tagged
+
+A release is a promotion of a tested continuous build, and one more thing is now tested before
+the tag goes on: the deployment serving that build is scanned with OWASP ZAP (the Zed Attack
+Proxy), twice. A public active scan attacks everything an anonymous visitor can reach; an
+authenticated passive baseline walks the signed-in portal with a real session and inspects every
+response without firing a payload, which is what reaches the bundles only a signed-in page loads.
+
+The verdict is written on the release notes page: both runs must report zero failures, a shipped
+library with published advisories blocks the tag outright, and every other warning is either
+fixed on the candidate or carried with its reason and tracking issue. The 3.0.0 notes are the first
+page with that record — including the one finding it fixed, a sanitiser with cross-site-scripting
+advisories inside the code editor's bundle. The procedure, the commands and what the scanner
+cannot see are on [OWASP ZAP Scan — Every Release](/Doc/Architecture/SecurityScanning).


### PR DESCRIPTION
## The OWASP ZAP scan is a release precondition — in the material, the skill and the process

Maintainer: *"in the release material, you reference the official owasp scan, which we say we do for every release. put this also in the release skill."*

- **New page** `Doc/Architecture/SecurityScanning` — the two runs (public **active** `zap-full-scan.py`; authenticated **passive** `zap-baseline.py -j` with a real session cookie, never active with a session on production), the exact commands, the verdict rules (`FAIL-NEW: 0` on both; `Vulnerable JS Library [10003]` blocks; every WARN fixed or carried with a written disposition), what the scanner cannot see, and a findings table per release.
- **3.0.0 notes** gain a *Security* section with the 2026-09-06 verdicts (public `FAIL 0 / WARN 5 / PASS 136`, authenticated `FAIL 0 / WARN 9 / PASS 58`) and the one Medium unique to the signed-in surface — DOMPurify 3.2.7 inside the Monaco bundle — fixed by #3378 (Plugins PR to follow).
- **Release skill**: precondition 5 + a *Security scan — every release, before the tag* section with the commands; **ReleaseProcess.md** §4 gets the step; a **What's New** entry announces the practice.

### Found on the way: the notes page was served at the wrong path

`Data/ReleaseNotes/3_0_0/index.md` is embedded as `…ReleaseNotes._3_0_0.index.md` — MSBuild makes every *folder* segment of a manifest resource name a C# identifier, so a digit-leading folder gets an underscore — and the page's node was `Doc/ReleaseNotes/_3_0_0`. Nothing linked it until this PR, and `DocumentationLinkIntegrityTest` went red the moment something did. File names are embedded verbatim, so the notes page is now the flat `Data/ReleaseNotes/3_0_0.md`; `release.yml` reads that path, the skill and `AuthoringDocumentation` say why.

### Open before the tag
The WARNs other than 10003 (CSP family, Backup File Disclosure, Proxy Disclosure, CORP/COEP headers, Dangerous JS Functions, timestamp disclosure) are listed on the page as **open — triage before the tag**; their dispositions are the maintainer's, not invented here.

### Verified
- `MeshWeaver.Documentation.Test`: `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest` and the skill guards — 4/4 (Release, `-warnaserror` build 0 errors).
- `actionlint` and `check-workflow-shell.py` clean on `release.yml`.
- Manifest resource names read back from the built DLL: `…ReleaseNotes.3_0_0.md` (was `…ReleaseNotes._3_0_0.index.md`).

Pairs-with: none — docs, a skill and one path in release.yml; no public type or member leaves `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
