### PR TITLE
fix(catalog): a mounted checkout's packages reconcile on every boot instead of seeding once (#3359)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -92,7 +92,13 @@ and they are independent:
   installation with **no install records yet** installs every catalog entry matching its
   `Source/Package` patterns, through the same path the Install button uses. Our deployments set
   `["Plugins/*"]`, so a new portal comes up with the platform plugins — the Store included — already
-  present and (per `AutoUpdateByDefault`) tracking their repo.
+  present and (per `AutoUpdateByDefault`) tracking their repo. 🚨 Over a **local checkout** — a
+  `PluginCatalog:Sources:N:RepoPath` that is a directory on the host, which is what a self-registry
+  `memex-local` mounts — the same patterns do NOT seed once: they are reconciled on every boot,
+  because a mounted working tree is standing operator intent and nothing else refreshes it (the
+  update watcher needs webhooks a local install never receives; the registry reconciler needs a
+  registry). Seeded once, a local portal silently served a week-old course (#3359). It costs
+  nothing when nothing changed, and a disabled feature flag still excludes.
 - **`Features:Flags:{name}:Packages`** *asserts* a per-environment policy, reconciled on **every**
   boot: what THIS deployment always has, with a declared-but-disabled flag EXCLUDING what it names.
   🚨 Use this, not `InstallByDefault`, whenever the portal already has install records — the seed is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-local-install-keeps-mirroring-its-checkouts.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-local-install-keeps-mirroring-its-checkouts.md
@@ -1,0 +1,22 @@
+---
+Name: A local install keeps mirroring its mounted checkouts
+Category: Fix
+Description: A self-registry memex-local installed its mounted repositories once and then stopped tracking them; the packages an operator's install patterns select out of a local checkout now re-assert on every boot, at no cost when nothing changed.
+Icon: ArrowSync
+Order: -20260906
+---
+
+# A local install keeps mirroring its mounted checkouts
+
+A self-registry `memex-local` mounts your checkouts and serves packages from them — but it
+installed them once and then never looked again. The mounted repositories sat on the install
+lane that seeds a fresh deployment, which by design never re-asserts what it delivered, and
+neither mechanism that refreshes an installed package applies to a local install: one needs
+GitHub webhooks it never receives, the other a registry it does not have. So the portal quietly
+served a week-old course while every boot reported that nothing had changed.
+
+A mounted working tree is standing intent, not a one-time seed. Packages selected out of a
+local checkout are now reconciled on every boot: a changed file lands, a new node appears, and
+an unchanged tree costs one listing and no writes. Fetched sources keep seeding once, exactly as
+before, so a deployed portal whose admin removed a package is still not fought by the next
+restart.

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -741,6 +741,16 @@ public sealed class InstanceAutoRegistrationService(
     ///     not fought by the next restart. 🚨 Deliberately UNCHANGED by the flag lane — the two
     ///     coexist, and an already-populated installation is exactly the case the seed cannot
     ///     express and the flags can.</item>
+    ///   <item><b>The operator's patterns over a LOCAL CHECKOUT</b>
+    ///     (<see cref="ConfiguredPackageSource.LocalCheckout"/>) — the same patterns, but the
+    ///     source is a working tree mounted into this host, which is what a self-registry
+    ///     <c>memex-local</c> serves. Reconciled on EVERY boot: a mounted tree is standing operator
+    ///     intent, the portal exists to MIRROR it, and nothing else refreshes it — the update
+    ///     watcher needs GitHub webhooks a local install never receives and the registry
+    ///     reconciler does nothing without a registry. Seeded once, the portal silently served a
+    ///     week-old course while every boot logged "0 written, 0 unchanged" (MeshWeaver#3359).
+    ///     Costs nothing when nothing changed (the content-hash gate), and a disabled feature flag
+    ///     still excludes — the exclusion outranks this lane like every other.</item>
     /// </list>
     ///
     /// <para>Installs run SEQUENTIALLY (<c>Concat</c>) — each one writes a partition's worth of
@@ -1215,10 +1225,10 @@ public sealed class InstanceAutoRegistrationService(
                     .ToList();
                 bool IsIncluded(InstallCandidate c) =>
                     included.Any(i => i.Entry.Matches(c.Package.Source ?? "", c.Package.Id));
+                bool IsWanted(InstallCandidate c) =>
+                    wanted.Any(w => w.Matches(c.Package.Source ?? "", c.Package.Id));
                 var selected = catalog
-                    .Where(c => (baseline && c.Package.PreInstalled)
-                                || IsIncluded(c)
-                                || wanted.Any(w => w.Matches(c.Package.Source ?? "", c.Package.Id)))
+                    .Where(c => (baseline && c.Package.PreInstalled) || IsIncluded(c) || IsWanted(c))
                     .ToList();
                 // Judge the FLAG lane on its own too, for the same reason the operator's patterns
                 // are judged on their own below: with a baseline selected, "matched something" is
@@ -1234,8 +1244,7 @@ public sealed class InstanceAutoRegistrationService(
                 // baseline: with 8 baseline packages selected, "matched something" is true while
                 // every InstallByDefault pattern matched nothing — which is exactly how a local
                 // registry came up with no plugins and no warning.
-                if (wanted.Count > 0
-                    && !selected.Any(c => wanted.Any(w => w.Matches(c.Package.Source ?? "", c.Package.Id))))
+                if (wanted.Count > 0 && !selected.Any(IsWanted))
                     logger.LogWarning(
                         "The default install matched no packages for the operator's patterns "
                         + "(wanted [{Wanted}]; {Baseline} pre-installed package(s) were still "
@@ -1291,13 +1300,15 @@ public sealed class InstanceAutoRegistrationService(
                                 + "stop selecting the dependent.", c.Package.Id, flag);
                         return false;
                     })
-                    // Whether this candidate belongs to a RECONCILED lane (the platform baseline or
-                    // this environment's flags) rather than the seed-once one. Read by the ledger
-                    // filter: a reconciled package re-asserts on every boot, a seeded one never
-                    // does.
+                    // Whether this candidate belongs to a RECONCILED lane (the platform baseline,
+                    // this environment's flags, or the operator's patterns over a LOCAL CHECKOUT)
+                    // rather than the seed-once one. Read by the ledger filter: a reconciled
+                    // package re-asserts on every boot, a seeded one never does.
                     .Select(c => c with
                     {
-                        Reconciled = (baseline && c.Package.PreInstalled) || IsIncluded(c),
+                        Reconciled = (baseline && c.Package.PreInstalled)
+                                     || IsIncluded(c)
+                                     || (c.Source.LocalCheckout && IsWanted(c)),
                     })
                     .ToList();
             }));
@@ -1597,11 +1608,13 @@ public sealed class InstanceAutoRegistrationService(
     private sealed record InstallCandidate(ConfiguredPackageSource Source, PackageManifest Package)
     {
         /// <summary>
-        /// Whether a RECONCILED lane selected it — the platform's own <c>preInstalled</c> baseline or
-        /// this environment's feature flags — as opposed to the seed-once
-        /// <see cref="PluginCatalogOptions.InstallByDefault"/>. A reconciled candidate is exempt from
-        /// the seed ledger: it re-asserts on every boot, which is the entire difference between a
-        /// per-environment policy and a seed.
+        /// Whether a RECONCILED lane selected it — the platform's own <c>preInstalled</c> baseline,
+        /// this environment's feature flags, or the operator's
+        /// <see cref="PluginCatalogOptions.InstallByDefault"/> patterns over a
+        /// <see cref="ConfiguredPackageSource.LocalCheckout"/> — as opposed to those same patterns
+        /// over a fetched source, which seed once. A reconciled candidate is exempt from the seed
+        /// ledger: it re-asserts on every boot, which is the entire difference between a policy
+        /// (or a mirrored working tree) and a seed.
         /// </summary>
         public bool Reconciled { get; init; }
     }

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -61,8 +61,9 @@ public sealed record ConfiguredPackageSource(IPackageSource Source, string GitRe
     public bool AutoSync { get; init; }
 
     /// <summary>
-    /// Whether <see cref="RepoPath"/> is a directory on this host — a MOUNTED WORKING TREE, which is
-    /// what a self-registry <c>memex-local</c> serves — rather than a URL. Read by the default
+    /// Whether <see cref="RepoPath"/> is NOT a URL — a path read off this host's disk (whether it
+    /// exists is the fetch's business, reported at listing time), i.e. a MOUNTED WORKING TREE,
+    /// which is what a self-registry <c>memex-local</c> serves. Read by the default
     /// install: a package an operator's <c>InstallByDefault</c> pattern selects out of a local
     /// checkout is RECONCILED on every boot, not seeded once, because a mounted tree is standing
     /// operator intent — the portal exists to mirror it — and no other mechanism refreshes it

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -59,6 +59,18 @@ public sealed record ConfiguredPackageSource(IPackageSource Source, string GitRe
     /// <see cref="AutoDiscover"/> is on: there is nothing to sync that was never discovered.
     /// </summary>
     public bool AutoSync { get; init; }
+
+    /// <summary>
+    /// Whether <see cref="RepoPath"/> is a directory on this host — a MOUNTED WORKING TREE, which is
+    /// what a self-registry <c>memex-local</c> serves — rather than a URL. Read by the default
+    /// install: a package an operator's <c>InstallByDefault</c> pattern selects out of a local
+    /// checkout is RECONCILED on every boot, not seeded once, because a mounted tree is standing
+    /// operator intent — the portal exists to mirror it — and no other mechanism refreshes it
+    /// (<c>PluginUpdateWatcher</c> needs GitHub webhooks a local install never receives,
+    /// <c>RegistryUpdateReconciler</c> does nothing without a registry; MeshWeaver#3359).
+    /// Cost when nothing changed: none — the install short-circuits on the content hash.
+    /// </summary>
+    public bool LocalCheckout { get; init; }
 }
 
 /// <summary>
@@ -147,6 +159,9 @@ public static class PackageSources
                 {
                     RepoPath = repo ?? "",
                     Subdir = subdir ?? "",
+                    // The same split FromRepo makes: a URL is fetched, anything else is read off
+                    // this host's disk — and is therefore a working tree this portal mirrors.
+                    LocalCheckout = repo is { Length: > 0 } && !IsUrl(repo),
                     // Both default to FALSE: an instance that configures nothing keeps today's
                     // behaviour exactly (no enumeration, no unattended Space creation). Opting in is
                     // a deliberate deployment decision, made in the same place the source itself is

--- a/test/Memex.Portal.Shared.Test/MountedCheckoutReassertsOnEveryBootTest.cs
+++ b/test/Memex.Portal.Shared.Test/MountedCheckoutReassertsOnEveryBootTest.cs
@@ -68,8 +68,8 @@ public class MountedCheckoutReassertsOnEveryBootTest(ITestOutputHelper output) :
 
     public override async ValueTask DisposeAsync()
     {
-        await base.DisposeAsync();
-        MountedRepo.Delete(checkout);
+        try { await base.DisposeAsync(); }
+        finally { MountedRepo.Delete(checkout); }
     }
 
     private InstanceAutoRegistrationService Installer =>
@@ -144,8 +144,8 @@ public class FetchedSourceStillSeedsOnceTest(ITestOutputHelper output) : Monolit
 
     public override async ValueTask DisposeAsync()
     {
-        await base.DisposeAsync();
-        MountedRepo.Delete(checkout);
+        try { await base.DisposeAsync(); }
+        finally { MountedRepo.Delete(checkout); }
     }
 
     private InstanceAutoRegistrationService Installer =>
@@ -219,7 +219,10 @@ internal static class MountedRepo
             .Select(p => new MeshWeaver.GitSync.RepoFile(
                 Path.GetRelativePath(root, p).Replace('\\', '/'), File.ReadAllText(p)))
             .ToList();
-        var sha = string.Join(";", files.Select(f => $"{f.Path}:{f.Content.Length}"));
+        // The snapshot id is a hash of paths AND contents, so any change — even one that keeps a
+        // file's length — is a new snapshot.
+        var sha = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(string.Join("\n", files.Select(f => f.Path + "\0" + f.Content)))));
         return Observable.Return(new MeshWeaver.GitSync.RepoSnapshot(sha, files));
     }
 

--- a/test/Memex.Portal.Shared.Test/MountedCheckoutReassertsOnEveryBootTest.cs
+++ b/test/Memex.Portal.Shared.Test/MountedCheckoutReassertsOnEveryBootTest.cs
@@ -1,0 +1,230 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// MeshWeaver#3359 — a self-registry <c>memex-local</c> mounts the developer's checkouts and
+/// serves packages from them, and the mounted repos are selected by the operator's
+/// <c>PluginCatalog:InstallByDefault</c> patterns. That lane SEEDS: it installs once, records the
+/// package on <c>Plugins/_DefaultInstallLedger</c>, and never re-asserts it — right for a
+/// deployment seeding itself, wrong for a portal whose purpose is to MIRROR a working tree. Measured
+/// on 2026-09-05: a portal served a course as of 2026-08-31 while the mount had moved on for a week,
+/// every boot logging "0 written, 0 unchanged". Neither auto-update mechanism covers the shape
+/// (webhooks a local install never receives; a registry reconciler with no registry).
+///
+/// <para>The fix is a lane, not a script: a package the operator's patterns select out of a
+/// <see cref="ConfiguredPackageSource.LocalCheckout"/> is RECONCILED — exempt from the seed
+/// ledger, re-asserted on every boot, at no cost when nothing changed. This fixture is the
+/// production decision end to end: a real directory in node-repo format, configured the way
+/// <c>memex-local</c> configures a mount (<c>PluginCatalog:Sources:N</c> with a local
+/// <c>RepoPath</c>), selected by <c>InstallByDefault</c>, through the very
+/// <see cref="InstanceAutoRegistrationService.RunDefaultInstall"/> the boot pass runs.</para>
+/// </summary>
+public class MountedCheckoutReassertsOnEveryBootTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // Written BEFORE the mesh is built: a derived class's field initializers run ahead of the base
+    // constructor, which is what calls ConfigureMesh.
+    private readonly string checkout = MountedRepo.Write("mw-mount-", "A course, as of its first install.");
+
+    private IConfiguration Environment() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            // Exactly what memex-local writes for a mounted repo: a local RepoPath, node-repo format,
+            // the repo's name as the source name.
+            ["PluginCatalog:Sources:0:Name"] = "Education",
+            ["PluginCatalog:Sources:0:RepoPath"] = checkout,
+            ["PluginCatalog:Sources:0:Format"] = "node-repo",
+        }).Build();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                .AddSingleton(Environment())
+                // The baseline is off and no flag is declared: only the operator's pattern over the
+                // mount can select anything here, so what re-asserts proves the local-checkout lane
+                // and nothing else.
+                .AddSingleton(new PluginCatalogOptions
+                {
+                    InstallPreInstalledPackages = false,
+                    InstallByDefault = ["Education/*"],
+                }));
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        MountedRepo.Delete(checkout);
+    }
+
+    private InstanceAutoRegistrationService Installer =>
+        Mesh.ServiceProvider.GetRequiredService<InstanceAutoRegistrationService>();
+
+    [Fact(Timeout = 240_000)]
+    public async Task ThePortalKeepsMirroringTheMount_AfterItWasSeededOnce()
+    {
+        // Boot 1: the seed installs the course and ledgers it — the state every populated
+        // self-registry portal sits in.
+        var first = await Installer.Completed.FirstAsync().Timeout(TimeSpan.FromSeconds(180)).Await();
+        first.Packages.Should().Equal(new[] { "Course" });
+        first.Failed.Should().Be(0);
+        (await Read("Course/Lesson"))!.ContentAs<string>(Mesh.JsonSerializerOptions).Should().Be("# Lesson, as of its first install.");
+
+        // The developer keeps working: the lesson changes and a new node appears in the checkout.
+        MountedRepo.Write(checkout, "A course, as of its first install.", lesson: "# Lesson, rewritten since.");
+        MountedRepo.WriteNode(checkout, "Quiz", "# A quiz that did not exist at the first install.");
+
+        // Boot 2: the same production decision, unchanged configuration. Seeded once, this pass
+        // skipped the package on the ledger and the portal kept serving the first install forever —
+        // the defect. A mounted checkout is standing operator intent, so it re-asserts.
+        var second = await Installer.RunDefaultInstall().Timeout(TimeSpan.FromSeconds(120)).Await();
+        second.Packages.Should().Equal(new[] { "Course" },
+            "a package selected out of a LOCAL checkout is reconciled on every boot, never seeded once (MeshWeaver#3359)");
+        second.Failed.Should().Be(0);
+        second.Installed.Should().Be(1, "the checkout changed, so the pass wrote it");
+
+        (await Read("Course/Lesson"))!.ContentAs<string>(Mesh.JsonSerializerOptions).Should().Be("# Lesson, rewritten since.");
+        (await Read("Course/Quiz")).Should().NotBeNull("a node added to the checkout after the first install reaches the portal");
+
+        // Boot 3: nothing changed in the checkout — the reconcile is one listing and no writes.
+        var third = await Installer.RunDefaultInstall().Timeout(TimeSpan.FromSeconds(120)).Await();
+        third.Packages.Should().Equal(new[] { "Course" });
+        third.Installed.Should().Be(0, "the content-hash gate turns an unchanged mount into a no-op");
+        third.UpToDate.Should().Be(1);
+    }
+
+    /// <summary>Authoritative single-node read straight off storage (never the lagging index).</summary>
+    private Task<MeshNode?> Read(string path) =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read(path, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).Await();
+}
+
+/// <summary>
+/// The control for <see cref="MountedCheckoutReassertsOnEveryBootTest"/>: the SAME patterns over a
+/// source that is NOT a local checkout keep seeding once. A registered <see cref="IPackageSource"/>
+/// (the shape a remote registry or a DI-provided source takes — no <c>RepoPath</c>, so never a
+/// checkout) is installed on boot 1, ledgered, and left alone on boot 2 even though its content
+/// moved. That is the seed contract every deployed portal relies on ("the seed must not fight an
+/// operator"), and the local-checkout lane must not widen it.
+/// </summary>
+public class FetchedSourceStillSeedsOnceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly string checkout = MountedRepo.Write("mw-fetched-", "A course, fetched.");
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                // A DI-registered source is named `registered-0` by the service and carries no
+                // RepoPath: the fetched-source shape, whatever it reads from — here the same files,
+                // so the only difference between the two fixtures is the source's kind.
+                .AddSingleton<IPackageSource>(_ => new NodeRepoPackageSource(
+                    (_, _, _, _) => MountedRepo.Snapshot(checkout), "https://example.invalid/education"))
+                .AddSingleton(new PluginCatalogOptions
+                {
+                    InstallPreInstalledPackages = false,
+                    InstallByDefault = ["registered-0/*"],
+                }));
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        MountedRepo.Delete(checkout);
+    }
+
+    private InstanceAutoRegistrationService Installer =>
+        Mesh.ServiceProvider.GetRequiredService<InstanceAutoRegistrationService>();
+
+    [Fact(Timeout = 240_000)]
+    public async Task ASeededPackageFromAFetchedSource_IsNotReasserted()
+    {
+        var first = await Installer.Completed.FirstAsync().Timeout(TimeSpan.FromSeconds(180)).Await();
+        first.Packages.Should().Equal(new[] { "Course" });
+
+        MountedRepo.Write(checkout, "A course, fetched.", lesson: "# Lesson, rewritten since.");
+
+        var second = await Installer.RunDefaultInstall().Timeout(TimeSpan.FromSeconds(120)).Await();
+        second.Packages.Should().BeEmpty(
+            "a fetched source's package is a SEED: ledgered on the first boot and never re-asserted, "
+            + "so an operator who removes it is not fought by the next restart");
+
+        (await Read("Course/Lesson"))!.ContentAs<string>(Mesh.JsonSerializerOptions).Should().Be("# Lesson, fetched.",
+            "the seed did not touch it again");
+    }
+
+    private Task<MeshNode?> Read(string path) =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read(path, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).Await();
+}
+
+/// <summary>One package, <c>Course</c>, in node-repo format on disk — the shape memex-local mounts.</summary>
+internal static class MountedRepo
+{
+    private const string Root =
+        """
+        {"$type":"MeshNode","id":"Course","namespace":"","path":"Course","mainNode":"Course",
+         "name":"Course","nodeType":"Space","state":"Active",
+         "content":{"$type":"PluginManifest","description":"DESCRIPTION","minMeshVersion":"1.0.0"}}
+        """;
+
+    private const string Node =
+        """
+        {"$type":"MeshNode","id":"ID","namespace":"Course","path":"Course/ID","mainNode":"Course/ID",
+         "name":"ID","nodeType":"Markdown","state":"Active","content":"CONTENT"}
+        """;
+
+    public static string Write(string prefix, string description)
+    {
+        var root = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N")[..8]);
+        Write(root, description, lesson: "# Lesson, " + description.Split(", ")[1]);
+        return root;
+    }
+
+    /// <summary>(Re)writes the package root and its lesson; a longer lesson changes the
+    /// directory's content hash, which is what the mirror has to notice.</summary>
+    public static void Write(string root, string description, string lesson)
+    {
+        Directory.CreateDirectory(Path.Combine(root, "Course"));
+        File.WriteAllText(Path.Combine(root, "Course", "index.json"),
+            Root.Replace("DESCRIPTION", description, StringComparison.Ordinal));
+        WriteNode(root, "Lesson", lesson);
+    }
+
+    public static void WriteNode(string root, string id, string content) =>
+        File.WriteAllText(Path.Combine(root, "Course", id + ".json"),
+            Node.Replace("ID", id, StringComparison.Ordinal).Replace("CONTENT", content, StringComparison.Ordinal));
+
+    /// <summary>The directory as a fetched snapshot — what a remote source would answer.</summary>
+    public static IObservable<MeshWeaver.GitSync.RepoSnapshot> Snapshot(string root)
+    {
+        var files = Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .Select(p => new MeshWeaver.GitSync.RepoFile(
+                Path.GetRelativePath(root, p).Replace('\\', '/'), File.ReadAllText(p)))
+            .ToList();
+        var sha = string.Join(";", files.Select(f => $"{f.Path}:{f.Content.Length}"));
+        return Observable.Return(new MeshWeaver.GitSync.RepoSnapshot(sha, files));
+    }
+
+    public static void Delete(string root)
+    {
+        try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
## A mounted checkout's packages reconcile on every boot instead of seeding once — fixes #3359

A self-registry `memex-local` mounts the developer's checkouts and selects them through `PluginCatalog:InstallByDefault` — the **seed** lane, which installs once, ledgers the package on `Plugins/_DefaultInstallLedger` and never re-asserts it. Right for a deployment seeding itself; wrong for a portal whose purpose is to *mirror* a working tree, and nothing else refreshes it (`PluginUpdateWatcher` needs GitHub webhooks a local install never receives; `RegistryUpdateReconciler` does nothing without a registry). Measured on 2026-09-05: a portal served a course as of 2026-08-31 while the mount had moved on for a week, every boot logging `0 written, 0 unchanged`.

### The fix is a lane, not a script (the issue's option 2)
- `ConfiguredPackageSource.LocalCheckout` — set by `PackageSources.FromConfiguration` for a `RepoPath` that is not a URL, the same split `FromRepo` already makes between fetching and reading off disk.
- In the default install, a candidate the operator's patterns select **out of a local checkout is `Reconciled`**: exempt from the seed ledger, re-asserted on every boot, at no cost when nothing changed (the content-hash gate). The lane doc in `InstanceAutoRegistrationService` gains its fourth bullet; `PluginRegistry.md` states it beside `InstallByDefault`.
- Untouched: fetched sources keep seeding once ("the seed must not fight an operator"); a disabled feature flag still excludes; `memex-local` needs no change (the peer's option-1 patch — the same repos on a feature-flag lane from the script — is not needed).

### Tests — `Memex.Portal.Shared.Test`, the production decision end to end
`MountedCheckoutReassertsOnEveryBootTest`: a real directory in node-repo format, configured the way `memex-local` configures a mount, selected by `InstallByDefault`, through the very `RunDefaultInstall` the boot pass runs. Boot 1 seeds; the lesson is rewritten and a node added on disk; boot 2 re-asserts (the rewritten lesson lands, the new node appears, `Installed == 1`); boot 3 on an unchanged mount is one listing and no writes (`UpToDate == 1`).
`FetchedSourceStillSeedsOnceTest` (the control): the same files behind a DI-registered source — no `RepoPath`, the fetched shape — seed once and are left alone when the content moves.

**Falsified**: with the lane disabled, the mirror test fails (`Expected collection {} to equal {"Course"}`) and the control passes; restored, 2/2.

### Verified
- `Memex.Portal.Shared.Test` and `MeshWeaver.Documentation.Test`: Release `-warnaserror`, 0 errors; the two tests 2/2; `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` 2/2.
- What's New (Fix): *A local install keeps mirroring its mounted checkouts*.

### Split out
#3384 — a `PluginCatalog` node over a local node-repo checkout lists nothing (`BuildSource` never selects the node-repo source; the content has no format field) — the issue's option 3, found by the same investigation, its own defect.

Pairs-with: none — one public init-only property added, nothing removed; Plugins' `EnvironmentCompositionTest` selects through feature flags, not `InstallByDefault`, so its second-boot expectation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
