### PR TITLE
fix(#3321): step 2 — migrate stream.Hub dereferences onto TryGetHub

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -1675,7 +1675,13 @@ public static class JsonSynchronizationStream
             .Where(predicate)
             .Select(x =>
             {
-                var logger = GetLogger(stream.Hub.ServiceProvider);
+                // `null` is this projection's declared "nothing to forward" (IObservable<TChange?>;
+                // the value-equal skip below returns it too). A stream whose reduce chain is dead
+                // has no container left to resolve a logger from and nothing legitimate to
+                // announce, so it forwards nothing instead of dereferencing a corpse.
+                if (stream.TryGetHub() is not { } streamHub)
+                    return null;
+                var logger = GetLogger(streamHub.ServiceProvider);
                 logger.LogDebug("ToDataChanged processing change item: StreamId={StreamId}, ChangeType={ChangeType}, ChangedBy={ChangedBy}, UpdatesCount={UpdatesCount}",
                     stream.ClientId, x.ChangeType, x.ChangedBy, x.Updates.Count);
 

--- a/src/MeshWeaver.Data/WorkspaceOperations.cs
+++ b/src/MeshWeaver.Data/WorkspaceOperations.cs
@@ -150,7 +150,14 @@ public static class WorkspaceOperations
         var stream = group.Key.DataSource!.GetStreamForPartition(group.Key.Partition);
         if (stream is null)
             throw new DataException($"Data source {group.Key.DataSource.Reference} does not have a stream for partition {group.Key.Partition}");
-        if (!stream.Hub.Started.IsCompleted)
+        // Two distinct refusals, both through this method's existing error channel (DataException,
+        // which the caller already surfaces as an activity log entry). "Torn down" is checked
+        // FIRST because a dead stream cannot answer the readiness question at all — its Hub is a
+        // corpse — and because the two states need different words: "not initialized" says wait,
+        // "torn down" says this stream will never be ready.
+        if (stream.TryGetHub() is not { } streamHub)
+            throw new DataException($"Data source {group.Key.DataSource.Reference} for partition {group.Key.Partition} has been torn down.");
+        if (!streamHub.Started.IsCompleted)
             throw new DataException($"Data source {group.Key.DataSource.Reference} for partition {group.Key.Partition} is not initialized.");
 
         var applied = new AsyncSubject<ImmutableList<LogMessage>>();

--- a/src/MeshWeaver.Documentation/Data/Architecture/StreamLivenessAndTheHubReference.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StreamLivenessAndTheHubReference.md
@@ -67,13 +67,65 @@ that, letting a consumer **ask**.
 
 ## The three steps, in the only order that works
 
-1. **Expose the predicate.** `SynchronizationStreamLiveness.IsUsable(stream)` and
+1. ✅ **Expose the predicate.** `SynchronizationStreamLiveness.IsUsable(stream)` and
    `stream.TryGetHub()` make the existing answer reachable from other assemblies.
-2. **Migrate the dereference sites** onto `TryGetHub()`, which can answer `null`.
+2. ✅ **Migrate the dereference sites** onto `TryGetHub()`, which can answer `null`.
 3. **Only then** clear `Hub` on disposal — at which point a null hub is a state the contract admits
-   rather than a lie.
+   rather than a lie. **Not done.**
 
 Doing 3 before 2 is the production NRE, in the order it happened. Doing 2 before 1 is impossible.
+
+### What step 2 actually migrated, and what it deliberately did not
+
+Measured on the branch that did it: **54** occurrences in `src/` where the receiver of `.Hub` is an
+`ISynchronizationStream` (excluding comments, and excluding `SynchronizationStream`'s own bare
+`Hub` field reads). The header's "47" is the earlier count and is superseded. Of those 54, **28**
+were migrated and **26** were deliberately left.
+
+**Every migrated site answers with the "no" its own signature already modelled** — that is the rule,
+not a style preference. `GetPatch` returns `null` (its callers already test for it); `GetStream<T>`
+returns `Observable.Empty<T>()` (a dead stream's completed store would produce exactly that);
+`GetDataBoundValue<T>` returns `default` (the answer it already gives twice for an absent value);
+`SubmitModel` returns an `ActivityLog` carrying `activity.dataUpdate.streamClosed`, the same shape
+as its existing no-route branch; `ToDataChanged` returns `null`, its declared "nothing to forward".
+Where a surface has no absent value, the refusal goes out the channel it does have:
+`WorkspaceOperations.UpdateStream` throws its existing `DataException`, and `LayoutAreaHost`'s
+constructor and `MarkdownExecutionExtensions.Execute` throw `HubDisposingException` — an
+`ObjectDisposedException`, so it classifies as `ErrorType.ShuttingDown`, the transient
+"retry, the address may reactivate" answer instead of the terminal `DeliveryFailure` the NRE
+produced. **No site swallows.**
+
+The 26 left fall in three groups, and the reason differs per group:
+
+- **Already answerable, or already a liveness check (3).** `LayoutClientExtensions`'
+  conversion-failure logger is already written `stream?.Hub?.…`. `Workspace`'s cache probe reads
+  `existing.Stream.Hub is { RunLevel: <= Started }` — a null-safe pattern that IS a liveness check;
+  replacing it with `IsUsable` would TIGHTEN it (chain walk, fault check) and so change behaviour
+  for a live stream, which step 2 may not do. `Workspace`'s eviction path calls
+  `kv.Value.Stream.Hub.Dispose()` inside a try/catch that already logs the failure — and guarding it
+  would SKIP a disposal, leaking the hub of a reduced stream whose parent died first.
+  (`SynchronizationStream`'s own write paths funnel through the private `TryGetActiveHub`, and
+  `DeliverMessage` / `OnNext` / `RegisterForDisposal` carry `isDisposed || Hub is null`. Those are
+  bare `Hub` field reads with no stream receiver, so they are outside the 54 by construction.)
+- **Hub-turn confined (3).** The three `Stream.Hub.Version` reads inside `LayoutAreaHost`'s
+  `Stream.Update(…)` lambdas. `Update` already refuses on a dead stream via
+  `SignalDisposedToProducer`, and the lambda itself runs inside the sync hub's
+  `UpdateStreamRequest` handler — a hub that is executing a turn is by construction alive.
+- **Owner-side, no way to say "no" (20).** `StandardReducers` (10), `MeshDataSource`'s patch
+  reducer (2), and the stream-creation paths in `WorkspaceStreams` (2),
+  `PartitionedHubDataSource` (2), `VirtualDataSource` (1), `GenericUnpartitionedDataSource` (1) and
+  `JsonSynchronizationStream`'s `reduced.Hub.Register` (2). A reducer's signature is
+  `… → ChangeItem<T>`: it MUST return a change, so
+  there is no absent value to hand back and no error channel to use. Forcing one would mean
+  inventing a failure mode rather than migrating onto an existing one — so they are named here
+  instead. **They are step 3's remaining work**: before `Hub` can be cleared on disposal, each of
+  these needs a decision about what a reducer does when its stream has died, and that is a design
+  question, not a mechanical substitution.
+
+One more constraint the migration follows: **a guarded read inside a per-emission lambda re-reads
+`TryGetHub()` rather than capturing the hub resolved at pipeline-construction time.** Capturing
+would pin the hub's whole resolved graph for the lifetime of every subscription — the exact
+retention this issue exists to release.
 
 ### Why step 1 is an extension, not an interface member
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-recycled-page-asks-again-instead-of-giving-up.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-recycled-page-asks-again-instead-of-giving-up.md
@@ -1,0 +1,27 @@
+---
+Name: A recycled page asks again instead of giving up
+Category: Fix
+Description: A view that loaded while its page was being recycled used to report a permanent failure. It now reports a transient one, so the page comes back on its own instead of needing a reload.
+Icon: ArrowSync
+Order: -20260906
+---
+
+# A recycled page asks again instead of giving up
+
+When a page is recycled — a node is republished, a hub restarts, an app updates — the connection
+behind an open view is torn down and rebuilt. A view that happened to load during that short window
+could hit the connection just as it was going away, and what came back was an error that said *this
+failed permanently*. It had not: the page was seconds away from being available again. The view
+stayed blank until you reloaded it by hand.
+
+Those moments are now reported for what they are — **temporary**. A view that lands in a recycle
+window is told to ask again, and comes back on its own.
+
+The same correction reaches the surfaces around it. A form submitted while its page was closing used
+to fail with nothing to show for it; it now tells you the connection was closed and that nothing was
+submitted, so you know to send it again rather than wondering whether it went through. A data
+binding whose page has gone simply stops delivering values instead of taking the rest of the view
+down with it.
+
+Nothing changes for a page that is working normally: every one of these paths behaves exactly as it
+did before while the connection is live.

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -68,7 +68,11 @@ public static class MeshNodeExtensions
                 dsStream.StreamId));
         }, ex =>
         {
-            var logger = stream.Hub.ServiceProvider.GetService<ILoggerFactory>()
+            // Best effort BY CONSTRUCTION: this is a stream Update's exception callback, and the
+            // commonest reason it fires is that the stream is dead — in which case the hub that
+            // died is the one holding the log sink, and this static extension has no other. The
+            // refusal itself is still reported to the producer by SignalDisposedToProducer.
+            var logger = stream.TryGetHub()?.ServiceProvider.GetService<ILoggerFactory>()
                 ?.CreateLogger("MeshWeaver.Graph.UpdateMeshNode");
             logger?.LogError(ex, "UpdateMeshNode failed for {NodePath}", nodePath);
         });

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -56,8 +56,15 @@ public static class LayoutClientExtensions
                 },
                     ex =>
                     {
-                        stream.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
-                            .CreateLogger(typeof(LayoutClientExtensions)).LogWarning(ex, "Cannot update layout");
+                        // Best effort BY CONSTRUCTION: this callback fires when the write was
+                        // refused, and the commonest reason is that the stream is dead — in which
+                        // case the thing that died is the very hub holding the log sink. There is
+                        // no other channel here (a static extension, no injected logger), so a
+                        // hub-less stream leaves the report nowhere to go. It must not NRE on the
+                        // way, which is what the guard buys; the write's refusal is still reported
+                        // to the producer by SynchronizationStream.SignalDisposedToProducer.
+                        stream.TryGetHub()?.ServiceProvider.GetService<ILoggerFactory>()
+                            ?.CreateLogger(typeof(LayoutClientExtensions)).LogWarning(ex, "Cannot update layout");
                     });
 
         }
@@ -77,7 +84,14 @@ public static class LayoutClientExtensions
                 ? null
                 : new JsonPatch(PatchOperation.Remove(pointer));
 
-        var valueSerialized = JsonSerializer.SerializeToNode(value, stream.Hub.JsonSerializerOptions);
+        // "No patch" is already this method's modelled absent answer — every caller tests the
+        // result for null before applying it — so a stream whose hub is gone (no serializer
+        // options to serialize WITH, and no live store to patch) answers with it rather than
+        // dereferencing a corpse.
+        if (stream.TryGetHub() is not { } hub)
+            return null;
+
+        var valueSerialized = JsonSerializer.SerializeToNode(value, hub.JsonSerializerOptions);
 
         return existing == null
                 ? new JsonPatch(PatchOperation.Add(pointer, valueSerialized))
@@ -104,9 +118,18 @@ public static class LayoutClientExtensions
         T? defaultValue = default(T)) =>
         stream.GetStream<object>(JsonPointer.Parse(GetPointer(reference.Pointer, dataContext ?? "")))
             .Select(x =>
-                conversion is not null
-                    ? conversion.Invoke(x, defaultValue)
-                    : stream.Hub.ConvertSingle(x, null, defaultValue!))
+            {
+                if (conversion is not null)
+                    return conversion.Invoke(x, defaultValue);
+                // A dead stream can still hand a LATE subscriber its replayed last frame (its
+                // store is a ReplaySubject), so this lambda can run after teardown. There is no
+                // hub left to convert with; `default` is the pipeline's existing absent value and
+                // the .Where below drops it, so the binding gets no emission — the truth — rather
+                // than an NRE inside the circuit.
+                return stream.TryGetHub() is { } hub
+                    ? hub.ConvertSingle(x, null, defaultValue!)
+                    : default;
+            })
             .Where(x => x is not null)
             .Select(x => (T)x!)
             .DistinctUntilChanged();
@@ -199,7 +222,12 @@ public static class LayoutClientExtensions
         var ret = jsonPointer.Evaluate(stream.Current.Value);
         if (ret == null)
             return default;
-        return ret.Value.Deserialize<T>(stream.Hub.JsonSerializerOptions);
+        // `default` is this method's existing "the value is not there" answer (two lines above
+        // say so twice). A stream whose hub is gone has no serializer options to read WITH, and
+        // its Current is a frozen last frame; answering absent is the truth.
+        if (stream.TryGetHub() is not { } hub)
+            return default;
+        return ret.Value.Deserialize<T>(hub.JsonSerializerOptions);
     }
 
     /// <summary>
@@ -219,7 +247,11 @@ public static class LayoutClientExtensions
         return stream.Select(s =>
         {
             var ret = jsonPointer.Evaluate(s.Value);
-            return ret is null ? default : ret.Value.Deserialize<T>(stream.Hub.JsonSerializerOptions);
+            if (ret is null)
+                return default;
+            // Replayed frames can reach a late subscriber after teardown — see DataBind. No hub,
+            // no deserializer: emit the pipeline's existing absent value, which the .Where drops.
+            return stream.TryGetHub() is { } hub ? ret.Value.Deserialize<T>(hub.JsonSerializerOptions) : default;
         })
         .Where(x => x is not null)
         .Select(x => x!);
@@ -655,7 +687,24 @@ public static class LayoutClientExtensions
     /// </summary>
     public static IObservable<ActivityLog> SubmitModel(this ISynchronizationStream stream, ModelParameter<JsonElement> data)
     {
-        var delivery = stream.Hub.Post(
+        // A failed submit is ALREADY modelled here as an ActivityLog carrying an error message —
+        // see the no-route branch below. A torn-down stream is the same class of answer and gets
+        // the same shape, so the form's existing error surface reports "the page went away, submit
+        // again" instead of the circuit taking an NRE on a non-nullable Hub.
+        if (stream.TryGetHub() is not { } hub)
+        {
+            return Observable.Return(new ActivityLog(ActivityCategory.DataUpdate)
+            {
+                End = DateTime.UtcNow,
+                Messages =
+                [
+                    new LogMessage("The connection to this page was closed; nothing was submitted.", LogLevel.Error)
+                        .WithKey("activity.dataUpdate.streamClosed")
+                ]
+            });
+        }
+
+        var delivery = hub.Post(
             new DataChangeRequest { Updates = [data.Submit()] },
             o => o.WithTarget(stream.Owner));
 
@@ -672,7 +721,7 @@ public static class LayoutClientExtensions
             });
         }
 
-        return stream.Hub.Observe(delivery)
+        return hub.Observe(delivery)
             .FirstAsync()
             .Select(callbackResponse =>
             {

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -149,26 +149,46 @@ public record LayoutAreaHost : IDisposable
                     context, isDefaultArea, resolvedArea, accessService, capturedAccessContext, ctorLogger))
                 .WithExceptionCallback(FailRendering));
         Reference = reference;
-        logger = Stream.Hub.ServiceProvider.GetRequiredService<ILogger<LayoutAreaHost>>();
+
+        // 🚨 THIS IS THE LINE THAT NRE'd IN PRODUCTION (Systemorph/MeshWeaver#3321) — the whole
+        // reason `TryGetHub()` exists. `Stream.Hub` is declared non-nullable, so `Stream.Hub
+        // .ServiceProvider…` read as safe; on the overlay self-heal recycle window it was not, and
+        // the NullReferenceException escaped this constructor as a TERMINAL DeliveryFailure. A page
+        // that subscribed mid-recycle was told "this failed forever" instead of "ask again".
+        //
+        // The stream's own constructor already refuses (HubDisposingException) when it cannot host
+        // its sub-hub, so a LIVE workspace reaches the next line exactly as before — nothing here
+        // changes for a healthy stream. What this closes is the window BETWEEN that refusal check
+        // and these reads: the host hub can begin winding down in between, and a stream whose
+        // reduce chain is already dead answers `Hub` with a corpse.
+        //
+        // Answering with the SAME HubDisposingException the stream constructor throws is what makes
+        // the difference: it is an ObjectDisposedException, so the Blazor circuit's existing
+        // catch around BindStream() keeps working, and escaping a handler it classifies as
+        // ErrorType.ShuttingDown — the transient "the address may reactivate, retry" answer.
+        if (Stream.TryGetHub() is not { } streamHub)
+            throw new HubDisposingException(workspace.Hub.Address, reference);
+
+        logger = streamHub.ServiceProvider.GetRequiredService<ILogger<LayoutAreaHost>>();
 
         // Manually trigger initialization now that Stream property is assigned
         // This resolves the circular dependency where initialization lambda uses 'this'
-        Stream.Hub.Post(new InitializeHubRequest());
+        streamHub.Post(new InitializeHubRequest());
         Stream.RegisterForDisposal(this);
         Stream.RegisterForDisposal(
-            Stream.Hub.Register<ClickedEvent>(
+            streamHub.Register<ClickedEvent>(
                 OnClick,
                 delivery => Stream.ClientId.Equals(delivery.Message.StreamId)
             )
         );
         Stream.RegisterForDisposal(
-            Stream.Hub.Register<CloseDialogEvent>(
+            streamHub.Register<CloseDialogEvent>(
                 OnCloseDialog,
                 delivery => Stream.ClientId.Equals(delivery.Message.StreamId)
             )
         );
         Stream.RegisterForDisposal(
-            Stream.Hub.Register<BlurEvent>(
+            streamHub.Register<BlurEvent>(
                 OnBlur,
                 delivery => Stream.ClientId.Equals(delivery.Message.StreamId)
             )
@@ -658,7 +678,10 @@ public record LayoutAreaHost : IDisposable
                 "[LAH-RENDER] Render depth {Depth} exceeded limit {Max} at area={Area} on hub {Hub} — " +
                 "aborting to avoid a stack-overflow crash. The layout is almost certainly recursive " +
                 "(a control or area that embeds its own area).",
-                context.Depth, MaxRenderDepth, context.Area, Stream.Hub.Address);
+                // A diagnostic field only — a torn-down stream has no address left to name, and
+                // saying so beats printing "(null)" next to a recursion report.
+                context.Depth, MaxRenderDepth, context.Area,
+                (object?)Stream.TryGetHub()?.Address ?? "(stream torn down)");
             var recursionError = new MarkdownControl(
                 $"**Layout recursion detected**\n\nRendering of `{context.Area}` was stopped at depth " +
                 $"{context.Depth} to protect the server from a stack-overflow crash. This layout appears " +
@@ -1220,7 +1243,22 @@ public record LayoutAreaHost : IDisposable
     /// <param name="exceptionCallback">Called with any exception thrown by <paramref name="action"/>.</param>
     public void InvokeAsync(Func<CancellationToken, Task> action, Func<Exception, Task> exceptionCallback)
     {
-        Stream.Hub.InvokeAsync(action, exceptionCallback);
+        // A torn-down stream has no action block left to schedule on. Say so — the work is
+        // DROPPED and the log names it. Deliberately NOT routed to exceptionCallback: that
+        // callback is `Func<Exception, Task>`, and invoking it here would leave a fire-and-forget
+        // Task on a Blazor-reachable path, which is the very shape AsynchronousCalls.md forbids.
+        // Its contract is also narrower than this case — it reports what `action` threw, and
+        // `action` never ran.
+        if (Stream.TryGetHub() is not { } hub)
+        {
+            logger.LogWarning(
+                "Dropping scheduled work for area {Area}: stream {StreamId} is torn down, so its "
+                + "hub has no action block left to run it on.",
+                resolvedArea, Stream.StreamId);
+            return;
+        }
+
+        hub.InvokeAsync(action, exceptionCallback);
     }
 
     /// <summary>
@@ -1614,14 +1652,24 @@ public record LayoutAreaHost : IDisposable
     private void PostNavigation(NavigationRequest request)
     {
         var subscriber = Viewer;
-        if (subscriber != null)
-        {
-            Stream.Hub.Post(request, o => o.WithTarget(subscriber));
-        }
-        else
+        if (subscriber == null)
         {
             logger.LogWarning("Cannot navigate: no subscriber address found for stream {StreamId}", Stream.StreamId);
+            return;
         }
+
+        // Same "no" as the branch above, for the other way this can fail: the stream that would
+        // carry the navigation is gone. Naming it separately matters — "no subscriber" and "the
+        // stream died" look identical from the page (nothing happens) and have opposite causes.
+        if (Stream.TryGetHub() is not { } hub)
+        {
+            logger.LogWarning(
+                "Cannot navigate to {Request}: stream {StreamId} is torn down.",
+                request, Stream.StreamId);
+            return;
+        }
+
+        hub.Post(request, o => o.WithTarget(subscriber));
     }
 
     internal IEnumerable<LayoutAreaDefinition> GetLayoutAreaDefinitions()

--- a/src/MeshWeaver.Layout/LayoutExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutExtensions.cs
@@ -271,6 +271,12 @@ public static class LayoutExtensions
         JsonPointer referencePointer
     )
     {
+        // A stream whose hub is gone can neither parse this pointer's id (no serializer options)
+        // nor ever emit again — its store is completed or terminally faulted. So an empty sequence
+        // is EXACTLY what subscribing to it would produce, minus the NRE on the way in.
+        if (stream.TryGetHub() is not { } hub)
+            return Observable.Empty<T>();
+
         var first = true;
         var collection = referencePointer.GetSegment(0).ToString();
         var idString = referencePointer.SegmentCount == 1 ? null : referencePointer.GetSegment(1).ToString();
@@ -280,7 +286,7 @@ public static class LayoutExtensions
         var id =
             unescapedIdString == null ? null :
                 unescapedIdString == string.Empty ? string.Empty
-                : JsonSerializer.Deserialize<string>(unescapedIdString, stream.Hub.JsonSerializerOptions);
+                : JsonSerializer.Deserialize<string>(unescapedIdString, hub.JsonSerializerOptions);
 
         return stream
             .Synchronize() // Ensure thread-safety for the 'first' closure variable
@@ -307,9 +313,16 @@ public static class LayoutExtensions
                     var evaluated = referencePointer
                         .Evaluate(i.Value);
                     if (evaluated is null) return default!;
+                    // Re-read the hub per emission rather than capturing the one resolved above:
+                    // capturing would pin the hub's whole resolved graph for the lifetime of every
+                    // subscription, which is the retention #3321 exists to release. A replayed
+                    // frame can reach a late subscriber after teardown, and `default!` is this
+                    // lambda's existing absent answer (the line above and the catch below both
+                    // use it), so the pipeline keeps flowing instead of NRE'ing in the circuit.
+                    if (stream.TryGetHub() is not { } liveHub) return default!;
                     try
                     {
-                        return evaluated.Value.Deserialize<T>(stream.Hub.JsonSerializerOptions)!;
+                        return evaluated.Value.Deserialize<T>(liveHub.JsonSerializerOptions)!;
                     }
                     catch (Exception ex) when (ex is NotSupportedException || ex is JsonException)
                     {
@@ -317,7 +330,7 @@ public static class LayoutExtensions
                         // discriminator the local hub's TypeRegistry doesn't know about. Surface
                         // the failure via the hub logger and yield default(T) so the observable
                         // pipeline keeps flowing instead of crashing the circuit on decode.
-                        var logger = stream.Hub.ServiceProvider.GetService<ILoggerFactory>()
+                        var logger = liveHub.ServiceProvider.GetService<ILoggerFactory>()
                             ?.CreateLogger("LayoutExtensions.GetStream");
                         var rawPreview = evaluated.Value.ValueKind == JsonValueKind.Undefined
                             ? "<undefined>"
@@ -411,7 +424,13 @@ public static class LayoutExtensions
                 if (!enumerator.MoveNext())
                     return null;
 
-                return enumerator.Current.Value.Deserialize<UiControl>(synchronizationItems.Hub.JsonSerializerOptions);
+                // `null` is this lambda's absent answer on all four branches above and the .Where
+                // below drops it — so a stream torn down under a late subscriber yields no
+                // control, which is the truth, instead of an NRE on a non-nullable Hub.
+                if (synchronizationItems.TryGetHub() is not { } hub)
+                    return null;
+
+                return enumerator.Current.Value.Deserialize<UiControl>(hub.JsonSerializerOptions);
             })
             .Where(x => x is not null);
 
@@ -446,7 +465,11 @@ public static class LayoutExtensions
         stream
             .Reduce(reference)!
             .Where(x => x.Value.ValueKind != JsonValueKind.Null && x.Value.ValueKind != JsonValueKind.Undefined)
-            .Select(x => x.Value.Deserialize<object?>(stream.Hub.JsonSerializerOptions));
+            // 🚨 A REDUCED stream is its parent's SIBLING, not its child — so this pipeline can
+            // still emit while `stream` itself is already dead (the #1455 shape). Without a hub
+            // there is nothing to deserialize with; `null` is the declared element type's absent
+            // value, so the binding sees "no value" rather than the circuit taking an NRE.
+            .Select(x => stream.TryGetHub() is { } hub ? x.Value.Deserialize<object?>(hub.JsonSerializerOptions) : null);
 
     /// <summary>
     /// Returns an observable of the data value stored under <paramref name="id"/> in the Data
@@ -483,7 +506,10 @@ public static class LayoutExtensions
         string id
     ) => stream.Reduce(new EntityReference(LayoutAreaReference.Data, id))!
         .Where(x => x.Value != null)
-        .Select(x => ConvertDataValue<T>(x.Value!, stream.Hub.JsonSerializerOptions))
+        // The reduced stream outlives its parent (see the JsonPointerReference overload above),
+        // so guard the hub read per emission. `default` is what an unconvertible value already
+        // yields here; the DistinctUntilChanged below is unaffected for a live stream.
+        .Select(x => stream.TryGetHub() is { } hub ? ConvertDataValue<T>(x.Value!, hub.JsonSerializerOptions) : default!)
         .DistinctUntilChangedWithJsonSupport()
     ;
 
@@ -554,7 +580,13 @@ public static class LayoutExtensions
 
     private static void FailRendering(this ISynchronizationStream stream, Exception exception)
     {
-        stream.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(LayoutExtensions)).LogWarning(exception, "Rendering failed");
+        // Best effort BY CONSTRUCTION — see the identical note in LayoutClientExtensions. This is
+        // the exception callback of a stream Update; when the stream is dead, the hub that died is
+        // the one holding the log sink, and this static extension has no other. The refusal is
+        // still reported to the producer by SynchronizationStream.SignalDisposedToProducer, which
+        // is what invoked this in the first place.
+        stream.TryGetHub()?.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(LayoutExtensions)).LogWarning(exception, "Rendering failed");
     }
 
     /// <summary>
@@ -583,7 +615,13 @@ public static class LayoutExtensions
         stream
             .Reduce(reference)!
             .Where(x => x.Value.ValueKind != JsonValueKind.Null && x.Value.ValueKind != JsonValueKind.Undefined)
-            .Select(x => x.Value.Deserialize<object>(stream.Hub.JsonSerializerOptions)!);
+            // The element type is non-nullable, so a hub-less stream cannot answer with `null`
+            // here — it answers by not emitting. The added .Where is inert for a live stream: the
+            // .Where above already excludes Null/Undefined, the only kinds Deserialize<object>
+            // maps to null.
+            .Select(x => stream.TryGetHub() is { } hub ? x.Value.Deserialize<object>(hub.JsonSerializerOptions) : null)
+            .Where(x => x is not null)
+            .Select(x => x!);
 
     /// <summary>
     /// Returns a strongly-typed observable of the value at <paramref name="reference"/> in the
@@ -599,9 +637,11 @@ public static class LayoutExtensions
         stream
             .Reduce(reference)!
             .Select(x =>
-                x.Value.ValueKind == JsonValueKind.Undefined
+                // This overload documents `default` as its answer for an undefined position, so a
+                // torn-down stream — which likewise has no value to give — reuses it.
+                x.Value.ValueKind == JsonValueKind.Undefined || stream.TryGetHub() is not { } hub
                     ? default!
-                    : x.Value.Deserialize<T>(stream.Hub.JsonSerializerOptions)!
+                    : x.Value.Deserialize<T>(hub.JsonSerializerOptions)!
             );
 
     /// <summary>

--- a/src/MeshWeaver.Markdown/ExecutionManager.cs
+++ b/src/MeshWeaver.Markdown/ExecutionManager.cs
@@ -41,8 +41,20 @@ public static class MarkdownExecutionExtensions
     public static void Execute(this ISynchronizationStream stream, Address address, IReadOnlyList<(string Id, string Code)> codeBlock)
     {
         var manager = stream.Get<ExecutionManager>();
-        if(manager == null)
-            stream.Set(manager = new(stream.Hub, address));
+        if (manager == null)
+        {
+            // The manager IS a hub — it exists to post SubmitCodeRequest — so a stream whose hub
+            // is gone cannot build one and the code cannot run. This surface is `void` and has no
+            // logger, so the refusal goes out the only channel it has: the same
+            // HubDisposingException the stream's own constructor throws. That is an
+            // ObjectDisposedException, so it classifies as ErrorType.ShuttingDown — the transient
+            // "retry, the address may reactivate" answer — instead of the NRE this line used to
+            // take, which reaches a subscriber as a TERMINAL failure.
+            if (stream.TryGetHub() is not { } hub)
+                throw new HubDisposingException(stream.Owner, $"execution manager for {address}");
+
+            stream.Set(manager = new(hub, address));
+        }
 
         manager.Update(codeBlock);
     }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1221,6 +1221,7 @@
   "activity.compile.aborted": "Kompilierung abgebrochen durch {exceptionType}:\n{detail}",
   "activity.compile.releaseCreated": "Release erstellt: {path}",
   "activity.dataUpdate.noRoute": "DataChangeRequest konnte nicht gesendet werden (keine Route).",
+  "activity.dataUpdate.streamClosed": "Die Verbindung zu dieser Seite wurde geschlossen; es wurde nichts übermittelt.",
   "activity.dataUpdate.unexpectedResponse": "Unerwartete Antwortform '{shape}'.",
   "activity.dataUpdate.typesUnmapped": "Die Typen {types} konnten keiner Datenquelle zugeordnet werden",
   "activity.dataUpdate.streamUpdateFailed": "Aktualisierung von {stream} fehlgeschlagen: {error}",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1221,6 +1221,7 @@
   "activity.compile.aborted": "Compile aborted by {exceptionType}:\n{detail}",
   "activity.compile.releaseCreated": "Release created: {path}",
   "activity.dataUpdate.noRoute": "Failed to post DataChangeRequest (no route).",
+  "activity.dataUpdate.streamClosed": "The connection to this page was closed; nothing was submitted.",
   "activity.dataUpdate.unexpectedResponse": "Unexpected response shape '{shape}'.",
   "activity.dataUpdate.typesUnmapped": "Types {types} could not be mapped to data source",
   "activity.dataUpdate.streamUpdateFailed": "Update of {stream} failed: {error}",

--- a/test/MeshWeaver.Layout.Test/TornDownStreamCallSitesTest.cs
+++ b/test/MeshWeaver.Layout.Test/TornDownStreamCallSitesTest.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// THE CALL SITES SURVIVE A DEAD STREAM — Systemorph/MeshWeaver#3321, step 2 of 3.
+///
+/// <para><b>What these tests are about.</b> <see cref="ISynchronizationStream.Hub"/> is declared
+/// NON-NULLABLE, so a stream whose owner has been torn down keeps answering it with a corpse and
+/// every <c>stream.Hub.Something</c> reads as safe. It is not: the production incident behind this
+/// issue was an NRE inside <c>LayoutAreaHost</c>'s constructor during a recycle window, which
+/// reached the subscriber as a TERMINAL <c>DeliveryFailure</c> — "this failed forever" for what was
+/// a transient recycle. Step 1 made the question askable (<c>stream.TryGetHub()</c>); this step
+/// moves the consumer sites onto it, each answering with the "no" its own signature already
+/// models.</para>
+///
+/// <para>🚨 <b>Every test here has to be able to FAIL, and it was MEASURED that they do.</b> Run
+/// against the pre-change sources with the tests unchanged: <b>4 failed, 1 passed</b> — the four
+/// negatives red, the live control green. Post-change: 5 passed. That measurement is the point,
+/// because the obvious version of these tests would NOT discriminate today. Step 3 has not landed,
+/// so a disposed stream still answers <see cref="ISynchronizationStream.Hub"/> with a non-null
+/// corpse and nothing NREs YET — an assertion of "did not throw" would have passed on the defect.
+/// What the pre-change code did instead is USE the corpse, and each failure names a different way
+/// that is wrong: a subscriber got the dead stream's replayed last frame as though it were live
+/// (<c>found 1 item(s)</c>), a synchronous read handed back a value off a frozen frame
+/// (<c>found "rendered"</c>), and a submit into a disposed hub reported no refusal at all
+/// (<c>found &lt;null&gt;</c> where the log key belongs). So the assertions pin the SHAPE of the
+/// answer, never merely its absence.</para>
+///
+/// <para>The live control is not decoration either: a guard that answered "dead" unconditionally
+/// would satisfy all four negatives at once. It is the half that pins step 2's acceptance bar —
+/// for a LIVE stream every migrated site does exactly what it did before.</para>
+/// </summary>
+public class TornDownStreamCallSitesTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string TestArea = nameof(TestArea);
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
+            .AddLayout(layout => layout
+                .WithView(TestArea, (_, _) => Controls.Html("rendered")));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private ISynchronizationStream<JsonElement> OpenStream()
+        => GetClient().GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(TestArea));
+
+    /// <summary>
+    /// Opens a stream, waits until it has actually served the area, then disposes it — so what the
+    /// assertions below face is a stream that WAS alive and is now a corpse, not one that never
+    /// started. That distinction is the whole point: an unstarted stream would fail these paths for
+    /// reasons that have nothing to do with #3321.
+    /// </summary>
+    private async Task<ISynchronizationStream<JsonElement>> OpenThenTearDownStream()
+    {
+        var stream = OpenStream();
+        await stream.GetControlStream(TestArea)
+            .Should().Within(10.Seconds()).Match(x => x is HtmlControl);
+
+        stream.IsUsable().Should().BeTrue("precondition: the stream served the area before we kill it");
+        stream.Dispose();
+        stream.TryGetHub().Should().BeNull("precondition: the stream is a corpse now");
+        stream.Hub.Should().NotBeNull(
+            "and the non-nullable contract still holds — which is exactly why every site below "
+            + "looked safe while it was not");
+
+        return stream;
+    }
+
+    /// <summary>
+    /// The flagship. <c>SubmitModel</c> already models failure as an <see cref="ActivityLog"/>
+    /// carrying an error message (the no-route branch), so a torn-down stream gets the SAME shape
+    /// rather than an NRE on the way into <c>Hub.Post</c>. A form whose page was recycled mid-edit
+    /// tells the user "submit again"; before this it took the circuit down.
+    /// </summary>
+    [HubFact]
+    public async Task SubmitModel_OnATornDownStream_AnswersInTheActivityLog()
+    {
+        var stream = await OpenThenTearDownStream();
+        var model = new ModelParameter<JsonElement>(
+            JsonSerializer.SerializeToElement(new { Value = 1 }),
+            (_, _) => null);
+
+        var log = await stream.SubmitModel(model).FirstAsync().Timeout(10.Seconds());
+
+        log.Category.Should().Be(ActivityCategory.DataUpdate);
+        log.Messages.Should().ContainSingle()
+            .Which.MessageKey.Should().Be("activity.dataUpdate.streamClosed",
+                "the refusal is REPORTED through the surface's own error channel and is localizable "
+                + "— a submit that silently did nothing would be the swallow this issue forbids");
+    }
+
+    /// <summary>
+    /// <c>GetStream&lt;T&gt;</c> read <c>Hub.JsonSerializerOptions</c> twice: once eagerly, to parse
+    /// the pointer's id, and once per emission. A dead stream can neither parse nor ever emit
+    /// again — its store is completed — so the honest answer is the empty sequence, which is
+    /// exactly what subscribing to the dead stream would have produced anyway.
+    ///
+    /// <para>The two-segment pointer is deliberate: the eager read only happens for a pointer that
+    /// HAS an id segment, so a one-segment pointer would leave the pre-change NRE unreached and the
+    /// test would pass against the defect.</para>
+    /// </summary>
+    [HubFact]
+    public async Task GetControlStream_OnATornDownStream_CompletesWithoutEmitting()
+    {
+        var stream = await OpenThenTearDownStream();
+
+        var emissions = await stream.GetControlStream(TestArea)
+            .ToList()
+            .Timeout(10.Seconds());
+
+        emissions.Should().BeEmpty(
+            "a stream that can never emit again must hand back a sequence that says so by "
+            + "COMPLETING, not one that throws when a subscriber arrives");
+    }
+
+    /// <summary>
+    /// The synchronous read path. <c>default</c> is already this method's answer for "the value is
+    /// not there" — it says so twice before the hub is ever touched — so a corpse reuses it rather
+    /// than inventing a new failure mode.
+    /// </summary>
+    [HubFact]
+    public async Task GetDataBoundValue_OnATornDownStream_IsAbsentRatherThanThrowing()
+    {
+        var stream = await OpenThenTearDownStream();
+
+        var value = stream.GetDataBoundValue<string>(
+            new JsonPointerReference($"{LayoutAreaReference.GetControlPointer(TestArea)}/data"), null);
+
+        value.Should().BeNull("absent is the modelled answer; an NRE is not an answer");
+    }
+
+    /// <summary>
+    /// The reactive binding path — the one a Blazor view actually holds. A dead stream yields no
+    /// emission (the existing null filter drops the absent value), so the binding stalls honestly
+    /// instead of faulting the circuit.
+    /// </summary>
+    [HubFact]
+    public async Task DataBind_OnATornDownStream_EmitsNothing()
+    {
+        var stream = await OpenThenTearDownStream();
+
+        var emissions = await stream
+            .DataBind<string>(new JsonPointerReference(LayoutAreaReference.GetControlPointer(TestArea)))
+            .ToList()
+            .Timeout(10.Seconds());
+
+        emissions.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL, and it is not decoration. Every assertion above is satisfied by a guard that
+    /// says "dead" unconditionally — which would migrate the call sites onto something that never
+    /// works. This pins the acceptance bar of step 2 instead: for a LIVE stream every migrated site
+    /// does exactly what it did before.
+    /// </summary>
+    [HubFact]
+    public async Task OnALiveStream_TheMigratedSitesBehaveExactlyAsBefore()
+    {
+        var stream = OpenStream();
+
+        var control = await stream.GetControlStream(TestArea)
+            .Should().Within(10.Seconds()).Match(x => x is HtmlControl);
+        control.Should().BeOfType<HtmlControl>()
+            .Which.Data!.ToString().Should().Be("rendered",
+                "GetStream<T> still deserializes through the hub's serializer options");
+
+        stream.TryGetHub().Should().BeSameAs(stream.Hub,
+            "the guarded read resolves the very hub the non-nullable property does");
+
+        var bound = await stream
+            .DataBind<string>(new JsonPointerReference($"{LayoutAreaReference.GetControlPointer(TestArea)}/data"))
+            .FirstAsync()
+            .Timeout(10.Seconds());
+        bound.Should().Be("rendered", "the data binding still delivers the live value");
+    }
+}


### PR DESCRIPTION
Step 2 of 3 for #3321. Step 1 (#3380) made stream liveness askable from outside `MeshWeaver.Data`; this moves the consumer sites onto it. **Step 3 — clearing `Hub` on disposal — is deliberately NOT here**: doing it before the call sites can answer "no" is the production incident this issue is about, in the order it happened.

`Refs #3321` — the issue stays open until step 3.

## Measured site count

`grep -rn "\.Hub\b" src/ --include='*.cs'` returns **726** lines, almost all of them `host.Hub` / `workspace.Hub` (`LayoutAreaHost.Hub` is `Workspace.Hub`, not a stream's). Filtering to receivers whose declared type is an `ISynchronizationStream` — by resolving each distinct receiver expression against its declaration, then counting **occurrences** rather than lines (`StandardReducers.cs:112` carries two) — gives:

**54 dereferences of `ISynchronizationStream.Hub` in `src/`**, excluding comments and excluding `SynchronizationStream.cs`'s own bare `Hub` field reads (those have no stream receiver and are already guarded by `TryGetActiveHub` / `isDisposed || Hub is null`).

The "~47" in the brief and in the step-1 doc header is the earlier count; 54 is what I measured on this tree, and the doc page is updated to say so. The receivers that turned out to be streams and are easy to miss by a name heuristic: `reduced.Hub`, `ret.Hub`, `s.Hub`, `synchronizationItems.Hub`, `existing.Stream.Hub`, `kv.Value.Stream.Hub`.

## Classification

| | Count |
|---|---|
| **(b) migrated** — reachable concurrently with teardown | **28** |
| (a) already guarded / already a liveness check | 3 |
| (a) hub-turn confined | 3 |
| (c) owner-side, no way to express "no" | 20 |
| **total** | **54** |

### Migrated (28)

Every one answers with the **"no" its own signature already modelled** — that is the rule, not a style choice:

- `LayoutClientExtensions.GetPatch` → `null` (every caller already tests for it)
- `LayoutExtensions.GetStream<T>` → `Observable.Empty<T>()` (a dead stream's completed store produces exactly that)
- `GetDataBoundValue<T>` / `GetDataBoundObservable<T>` / `DataBind<T>` / `GetDataStream` ×4 / `GetFirstControlStream` → the `default` / `null` those pipelines already filter out
- `SubmitModel` → an `ActivityLog` carrying `activity.dataUpdate.streamClosed`, the same shape as its existing no-route branch (new key in `strings.{en,de}.json`)
- `JsonSynchronizationStream.ToDataChanged` → `null`, its declared "nothing to forward" (`IObservable<TChange?>`)

Where a surface has no absent value, the refusal goes out the channel it **does** have:

- `WorkspaceOperations.UpdateStream` → its existing `DataException`, with wording that distinguishes "not initialized" (wait) from "torn down" (never)
- `LayoutAreaHost`'s constructor (the line that NRE'd in production) and `MarkdownExecutionExtensions.Execute` → `HubDisposingException`. It is an `ObjectDisposedException`, so the Blazor circuit's existing catch around `BindStream()` keeps working, and escaping a handler it classifies as `ErrorType.ShuttingDown` — the transient *"the address may reactivate, retry"* answer instead of the terminal `DeliveryFailure` the NRE produced.
- `LayoutAreaHost.PostNavigation` / `InvokeAsync` / the render-depth diagnostic → a warning that names what did not happen. `InvokeAsync` deliberately does **not** route to its `exceptionCallback`: that is `Func<Exception, Task>`, and invoking it there would leave a fire-and-forget `Task` on a Blazor-reachable path.

**No site swallows.** Two logger-resolution sites (`LayoutClientExtensions`' update-failure callback, `LayoutExtensions.FailRendering`, `MeshNodeExtensions`) degrade to no sink — but that is best-effort *by construction*, not a swallow: they are the exception callbacks of a stream `Update`, so when they fire because the stream is dead, the hub that died is the one holding the log sink and these static extensions have no other. The refusal itself is still reported to the producer by `SignalDisposedToProducer`.

### Left, and why (26)

- **Already answerable, or already a liveness check (3).** `LayoutClientExtensions:187` is already `stream?.Hub?.…`. `Workspace:1277` reads `existing.Stream.Hub is { RunLevel: <= Started }` — a null-safe pattern that IS a liveness check; swapping in `IsUsable` would *tighten* it (chain walk, fault check) and so change behaviour for a live stream, which step 2 may not do. `Workspace:1342` calls `kv.Value.Stream.Hub.Dispose()` inside a try/catch that already logs — and guarding it would **skip a disposal**, leaking the hub of a reduced stream whose parent died first.
- **Hub-turn confined (3).** The three `Stream.Hub.Version` reads inside `LayoutAreaHost`'s `Stream.Update(…)` lambdas. `Update` already refuses on a dead stream via `SignalDisposedToProducer`, and the lambda runs inside the sync hub's `UpdateStreamRequest` handler — a hub executing a turn is by construction alive.
- **🚨 Owner-side, no way to say "no" (20) — needs a design decision, listed rather than forced.** `StandardReducers` (10), `MeshDataSource`'s patch reducer (2), and the stream-creation paths in `WorkspaceStreams` (2), `PartitionedHubDataSource` (2), `VirtualDataSource` (1), `GenericUnpartitionedDataSource` (1), `JsonSynchronizationStream`'s `reduced.Hub.Register` (2). A reducer's signature is `… → ChangeItem<T>`: it MUST return a change, so there is no absent value to hand back and no error channel to use. Forcing one would mean *inventing* a failure mode rather than migrating onto an existing one. **These are step 3's remaining work** — before `Hub` can be cleared on disposal, each needs a decision about what a reducer does when its stream has died.

One further constraint the migration follows: a guarded read inside a **per-emission** lambda re-reads `TryGetHub()` rather than capturing the hub resolved at pipeline-construction time. Capturing would pin the hub's whole resolved graph for the lifetime of every subscription — the exact retention #3321 exists to release.

## Tests — and the measurement that they discriminate

`test/MeshWeaver.Layout.Test/TornDownStreamCallSitesTest.cs`, 5 cases: 4 negatives on a stream that was opened, served its area, and was then disposed; 1 live control.

🚨 **The obvious version of these tests would NOT discriminate today.** Step 3 has not landed, so a disposed stream still answers `Hub` with a non-null corpse and *nothing NREs yet* — an assertion of "did not throw" would have passed on the defect. So each assertion pins the **shape** of the answer. Measured by reverting the `src/` half (`git diff > patch` + `git apply -R`) and re-running the tests unchanged:

| | pre-change | post-change |
|---|---|---|
| `TornDownStreamCallSitesTest` | **4 failed, 1 passed** | **5 passed** |

The four pre-change failures name four different ways the corpse was *used*: a subscriber got the dead stream's replayed last frame as if live (`found 1 item(s)`), a synchronous read handed back a value off a frozen frame (`found "rendered"`), a submit into a disposed hub reported no refusal at all (`found <null>` where the log key belongs), and a binding converted against a dead hub (`Object must implement IConvertible`). The live control passed in **both** runs — a guard that answered "dead" unconditionally would satisfy all four negatives, and that control is what rules it out.

## Verification

All local, `-c Release -warnaserror`, one project per invocation:

| Project | Result |
|---|---|
| `src/MeshWeaver.Data` | 0 Warning(s), 0 Error(s) |
| `src/MeshWeaver.Layout` | 0 Warning(s), 0 Error(s) |
| `src/MeshWeaver.Graph` | 0 Warning(s), 0 Error(s) |
| `src/MeshWeaver.Markdown` | 0 Warning(s), 0 Error(s) |
| `src/MeshWeaver.Messaging.Hub` | 0 Warning(s), 0 Error(s) |
| `src/MeshWeaver.Documentation` | 0 Warning(s), 0 Error(s) |
| **whole solution** (`dotnet build -c Release -warnaserror`) | **0 Warning(s), 0 Error(s) — 64/64 projects** |

| Suite | Result |
|---|---|
| `MeshWeaver.Layout.Test` (full) | **450 passed, 0 failed** |
| `MeshWeaver.Data.Test` (full) | **479 passed, 0 failed** |
| `LocalizationTest` (`MeshWeaver.Messaging.Hub.Test`) | **58 passed, 0 failed** |
| `DocumentationLinkIntegrityTest` | **1 passed, 0 failed** |

## Work products conserved

`Doc/Architecture/StreamLivenessAndTheHubReference` gains a "What step 2 actually migrated, and what it deliberately did not" section carrying the 54/28/26 breakdown, the per-group reasons, the named 20 that step 3 still has to decide about, and the no-capture rule. Plus a What's New entry (`Category: Fix`).

## i18n

One new key in **both** `strings.en.json` and `strings.de.json` (`activity.dataUpdate.streamClosed`). Per AGENTS.md the mirror in `MeshWeaver.Plugins/clients/react/src/i18n/` compares against a **pinned** core commit, so this reddens nothing there and leaves the mirror stale — the sync (`npm run sync:i18n -- --ref <merged sha>`) is handed over once this merges.

Pairs-with: none — the diff removes no public type and no public member (`git diff --cached -U0 | grep '^-' | grep 'public '` is empty; every change is a method body).
