### PR TITLE
fix(#3384): a catalog node declares its source format, and both readers honour it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -150,6 +150,14 @@ contribution (logged), never a broken catalog. The legacy single-source keys
 is advisory. The wire shapes are produced by `PluginRegistryPayloads` and parsed by
 `RegistryPackageSource`, one place each, so producer and consumer cannot drift.
 
+🚨 **A `PluginCatalog` node carries the same `Format` knob, with the same default** — a browse page
+over a repository is the same question as a configured source over one, and it must answer it the
+same way. It did not until #3384: the node's content had no format field, so the browse view always
+built a `package.json` source while `PluginUpdateWatcher` read the identical record as a node repo.
+A catalog node over a local node-repo checkout therefore rendered *"No installable packages found."*
+while its own watcher listed those packages happily. One record with two readers must have one rule;
+that rule is `PackageSources.IsNodeRepoFormat`, and both readers call it.
+
 ## The sync licence — what a grant now carries
 
 A `PluginGrant` IS the **sync licence**: the right of a registered instance to REPLICATE a package

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-catalog-over-a-local-checkout-lists-its-plugins.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-catalog-over-a-local-checkout-lists-its-plugins.md
@@ -1,7 +1,9 @@
 ---
 Name: A catalog over a local checkout lists its plugins
 Category: Fix
-Date: 2026-09-06
+Description: A plugin catalog pointed at a local checkout showed "No installable packages found." while its own update watcher listed those same packages — the node can now declare its repository format, and both readers honour it.
+Icon: PackageImport
+Order: -20260906
 ---
 
 A `PluginCatalog` node pointed at a local node-repo checkout showed **"No installable packages

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-catalog-over-a-local-checkout-lists-its-plugins.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-catalog-over-a-local-checkout-lists-its-plugins.md
@@ -1,0 +1,17 @@
+---
+Name: A catalog over a local checkout lists its plugins
+Category: Fix
+Date: 2026-09-06
+---
+
+A `PluginCatalog` node pointed at a local node-repo checkout showed **"No installable packages
+found."** even though the repository was full of them.
+
+The catalog node could not say which format its repository used, so the browse page always read it
+as a `package.json` manifest repo — while the update watcher, reading the very same node, treated it
+as a node repo. One record, two readers, opposite answers.
+
+The node now carries a `Format` field — the same values and the same `node-repo` default as the
+`PluginCatalog:Sources:N:Format` configuration knob — and both readers resolve it through one shared
+rule. A catalog over a local checkout lists its plugins; a `package.json` repo opts in with
+`Format: package-json`.

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -119,7 +119,7 @@ public static class CatalogLayoutAreas
         return host.Workspace.GetMeshNodeStream()
             .Select(node => node.ContentAs<PluginCatalogContent>(host.Hub.JsonSerializerOptions))
             .Select(cfg => RenderFromSource(
-                host, BuildSource(host, cfg?.SourceRepoPath, cfg?.SourceSubdir),
+                host, BuildSource(host, cfg?.SourceRepoPath, cfg?.SourceSubdir, cfg?.Format),
                 cfg?.SourceRef ?? "HEAD", cfg?.Description,
                 cfg?.SourceRepoPath is { Length: > 0 } p ? $"{p} @ {cfg.SourceRef}" : null))
             .Switch()
@@ -405,8 +405,10 @@ public static class CatalogLayoutAreas
 
     // Selects the git-based package source for a repo path/subdir (delegates to the shared factory so
     // the node view and the registry endpoints build sources identically). Null when unconfigured.
-    internal static IPackageSource? BuildSource(LayoutAreaHost host, string? sourceRepoPath, string? sourceSubdir) =>
-        PackageSources.FromRepo(host.Hub, sourceRepoPath, sourceSubdir, Logger(host));
+    internal static IPackageSource? BuildSource(
+        LayoutAreaHost host, string? sourceRepoPath, string? sourceSubdir, string? format = null) =>
+        PackageSources.FromRepo(
+            host.Hub, sourceRepoPath, sourceSubdir, Logger(host), PackageSources.IsNodeRepoFormat(format));
 
     /// <summary>
     /// The live installed-plugin inventory: every <c>Package</c> record in the install registry,

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -70,12 +70,30 @@ public sealed record ConfiguredPackageSource(IPackageSource Source, string GitRe
 public static class PackageSources
 {
     /// <summary>
+    /// Reads a configured/declared <c>Format</c>. Defaults to the node-native repo format (what
+    /// MeshWeaver.Plugins ships); a <c>package.json</c> manifest repo opts in with
+    /// <c>package-json</c>.
+    ///
+    /// <para>This is deliberately the ONE place the default lives. It used to be an inline literal
+    /// on the configuration path only, so the two readers of a <c>PluginCatalog</c> node disagreed
+    /// about the same repository — see <see cref="PluginCatalogContent.Format"/>.</para>
+    /// </summary>
+    public static bool IsNodeRepoFormat(string? format) =>
+        !string.Equals(format ?? "node-repo", "package-json", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Builds a package source for <paramref name="sourceRepoPath"/> (a URL or local path), or
     /// <c>null</c> when the path is empty / a URL source has no <see cref="IGitHubRepoClient"/>.
-    /// <paramref name="nodeRepo"/> selects the format for a URL source: <c>true</c> (the default the
-    /// registry uses) reads a node-native repo — <c>&lt;Plugin&gt;/index.json</c> Space roots, node-per-file
+    /// <paramref name="nodeRepo"/> selects the format for BOTH a URL and a local path: <c>true</c>
+    /// (what the registry, the catalog node and its watcher all use by default) reads a node-native
+    /// repo — <c>&lt;Plugin&gt;/index.json</c> Space roots, node-per-file
     /// (<see cref="NodeRepoPackageSource"/>); <c>false</c> reads a <c>package.json</c>-manifest repo
-    /// (<see cref="GitHubPackageSource"/>). A local path always uses the git-CLI package.json source.
+    /// (<see cref="GitHubPackageSource"/> for a URL, <see cref="GitPackageSource"/> via the git CLI
+    /// for a local path).
+    ///
+    /// <para>Resolve it with <see cref="IsNodeRepoFormat"/> rather than defaulting the
+    /// <c>bool</c> — the parameter defaults to <c>false</c>, which is the WRONG default for a
+    /// declared source and is exactly how #3384 happened.</para>
     /// </summary>
     public static IPackageSource? FromRepo(
         IMessageHub hub, string? sourceRepoPath, string? sourceSubdir, ILogger? logger = null, bool nodeRepo = false)
@@ -137,10 +155,7 @@ public static class PackageSources
             string? repo, string? subdir, string? gitRef, string? format, string? name,
             string? autoDiscover, string? autoSync)
         {
-            // Default to the node-native repo format (what MeshWeaver.Plugins ships); a package.json
-            // repo can opt in with Format=package-json.
-            var nodeRepo = !string.Equals(format ?? "node-repo", "package-json", StringComparison.OrdinalIgnoreCase);
-            var source = FromRepo(hub, repo, subdir, logger, nodeRepo);
+            var source = FromRepo(hub, repo, subdir, logger, IsNodeRepoFormat(format));
             return source is null
                 ? null
                 : new ConfiguredPackageSource(source, gitRef ?? "HEAD", name ?? repo ?? "")

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogContent.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogContent.cs
@@ -2,8 +2,9 @@ namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
 /// The content of a <c>PluginCatalog</c> node — points the catalog browse view at a source git
-/// repository and ref. The catalog lists that repo's installable folders (folders carrying a
-/// <c>package.json</c>) at <see cref="SourceRef"/> and offers Install / Update per package.
+/// repository and ref. The catalog lists that repo's installable folders at
+/// <see cref="SourceRef"/> and offers Install / Update per package. Which shape those folders have
+/// is <see cref="Format"/>.
 /// </summary>
 public record PluginCatalogContent
 {
@@ -17,6 +18,20 @@ public record PluginCatalogContent
     /// <summary>Optional subdirectory within the repo that holds the package folders (e.g.
     /// <c>"catalog"</c>). When empty, package folders are read from the repo root.</summary>
     public string? SourceSubdir { get; init; }
+
+    /// <summary>
+    /// The repository's package format — the SAME knob, with the same values and the same default,
+    /// as <c>PluginCatalog:Sources:N:Format</c> in configuration: <c>node-repo</c> (the default;
+    /// <c>&lt;Plugin&gt;/index.json</c> Space roots, what MeshWeaver.Plugins ships) or
+    /// <c>package-json</c> for a manifest repo.
+    ///
+    /// <para>🚨 It exists because a catalog node previously could not say: the browse view built its
+    /// source without a format and so always read <c>package.json</c>, while
+    /// <c>PluginUpdateWatcher</c> read the very same content as a node repo. One record, two
+    /// readers, opposite answers — a node-repo checkout rendered "No installable packages found."
+    /// while its watcher happily listed the same packages (#3384).</para>
+    /// </summary>
+    public string? Format { get; init; }
 
     /// <summary>Optional markdown intro shown above the package list.</summary>
     public string? Description { get; init; }

--- a/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
@@ -164,7 +164,11 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
             "Plugin update watcher: {Repo} built green at {Sha} ({Workflow} #{Run}) — checking installed modules.",
             build.RepositoryUrl, build.HeadSha, build.WorkflowName, build.RunNumber);
 
-        var source = PackageSources.FromRepo(hub, content.SourceRepoPath, content.SourceSubdir, logger, nodeRepo: true);
+        // The catalog node declares its own format; before #3384 this read `nodeRepo: true`
+        // unconditionally while the browse view read the same record as package.json.
+        var source = PackageSources.FromRepo(
+            hub, content.SourceRepoPath, content.SourceSubdir, logger,
+            nodeRepo: PackageSources.IsNodeRepoFormat(content.Format));
         if (source is null)
         {
             logger?.LogWarning(

--- a/test/MeshWeaver.Documentation.Test/CatalogSourceFormatGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CatalogSourceFormatGuard.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>Every reader of a declared source resolves its format through ONE rule.</b>
+///
+/// <para>A <c>PluginCatalog</c> node is read by two different pieces of code — the browse view
+/// (<c>CatalogLayoutAreas</c>) and <c>PluginUpdateWatcher</c> — and before #3384 they disagreed
+/// about the same record. The view called <c>FromRepo</c> without a format, taking the parameter's
+/// <c>false</c> default and reading the repository as a <c>package.json</c> manifest repo; the
+/// watcher passed <c>nodeRepo: true</c> unconditionally. A catalog over a local node-repo checkout
+/// therefore rendered <i>"No installable packages found."</i> while its own watcher listed those
+/// same packages without complaint.</para>
+///
+/// <para><b>Why a guard and not just the fix.</b> The defect is not that one call site was wrong —
+/// it is that the format was decided independently at each call site, so the two could drift apart
+/// again the moment a third reader appears. The invariant that makes that impossible is mechanical:
+/// <c>PackageSources.FromRepo</c>'s <c>nodeRepo</c> argument always comes from
+/// <see cref="PackageSources.IsNodeRepoFormat"/>, never from a literal. That is what this pins.</para>
+///
+/// <para>🚨 The <c>bool</c> parameter defaults to <c>false</c>, which is the WRONG default for a
+/// declared source — the shipped format is <c>node-repo</c>. So "forgot to pass it" and "asked for
+/// package.json" are the same text at a call site, and only this guard tells them apart.</para>
+/// </summary>
+public class CatalogSourceFormatGuard
+{
+    private const string Subject = "src/MeshWeaver.PluginCatalog";
+
+    // Every call site found by the scan below. A floor, because a matcher that stops matching
+    // reports a clean tree — the failure mode this whole file exists to prevent.
+    private const int KnownCallSites = 3;
+
+    [Theory]
+    // Nothing declared: the shipped format wins. This is the case #3384 got wrong.
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("node-repo", true)]
+    [InlineData("NODE-REPO", true)]
+    // The manifest repo opts IN, explicitly, and case does not matter.
+    [InlineData("package-json", false)]
+    [InlineData("Package-Json", false)]
+    // An unrecognised value is not silently package.json — it falls back to the shipped format.
+    [InlineData("something-else", true)]
+    public void TheFormatRule_DefaultsToTheShippedNodeRepoFormat(string? format, bool expected) =>
+        Assert.Equal(expected, PackageSources.IsNodeRepoFormat(format));
+
+    /// <summary>
+    /// A catalog node can SAY what it is. Before #3384 the record had no format field at all, so
+    /// "the view picked wrong" was not even fixable at the node — the information did not exist.
+    /// </summary>
+    [Fact]
+    public void ACatalogNode_CanDeclareItsFormat()
+    {
+        Assert.True(PackageSources.IsNodeRepoFormat(new PluginCatalogContent().Format));
+        Assert.False(PackageSources.IsNodeRepoFormat(
+            new PluginCatalogContent { Format = "package-json" }.Format));
+    }
+
+    /// <summary>
+    /// No call site decides the format for itself: each passes the shared rule's answer.
+    /// </summary>
+    [Fact]
+    public void EveryFromRepoCallSite_ResolvesTheFormatThroughTheSharedRule()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var dir = Path.Combine(root, Subject.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(Directory.Exists(dir),
+            $"{Subject} is gone — this guard now checks nothing. Point it at the code's new home.");
+
+        var offenders = new List<string>();
+        var found = 0;
+
+        foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+        {
+            var code = SourceScan.MaskCommentsAndStrings(File.ReadAllText(path));
+            var relative = SourceScan.Relative(root, path);
+            foreach (var (args, index) in CallsTo(code, "FromRepo"))
+            {
+                // The declaration itself, not a call.
+                if (args.Contains("this IMessageHub", StringComparison.Ordinal)
+                    || args.Contains("ILogger? logger", StringComparison.Ordinal))
+                    continue;
+
+                found++;
+                if (!args.Contains("IsNodeRepoFormat", StringComparison.Ordinal))
+                    offenders.Add($"{relative}:{LineOf(code, index)} — FromRepo({Squash(args)})");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A PackageSources.FromRepo call site decides the repository's format for itself instead "
+            + "of resolving it through PackageSources.IsNodeRepoFormat. The nodeRepo parameter "
+            + "defaults to FALSE — the package.json format — while the shipped format is node-repo, "
+            + "so omitting it (or passing a literal) makes this reader disagree with every other "
+            + "reader of the same declared source. That is #3384: a catalog node rendered \"No "
+            + "installable packages found.\" while its own update watcher listed those packages. "
+            + "Pass PackageSources.IsNodeRepoFormat(<the declared Format>)."
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders.Select(o => "  · " + o)));
+
+        Assert.True(found >= KnownCallSites,
+            $"Expected at least {KnownCallSites} FromRepo call sites under {Subject}, saw {found}. "
+            + "The matcher has gone blind — most likely the factory was renamed — so this guard is "
+            + "reporting a clean tree having checked nothing. Re-point it before trusting it.");
+    }
+
+    /// <summary>
+    /// The matcher sees the shape it claims to. Without this, every assertion above passes on a
+    /// scan that silently matched nothing.
+    /// </summary>
+    [Fact]
+    public void TheMatcher_SeesAHardcodedFormatAndAResolvedOne()
+    {
+        const string hardcoded = "var s = PackageSources.FromRepo(hub, p, sub, logger, nodeRepo: true);";
+        const string resolved =
+            "var s = PackageSources.FromRepo(hub, p, sub, logger, PackageSources.IsNodeRepoFormat(c.Format));";
+        const string wrapped = "var s = PackageSources.FromRepo(\n    hub, p, sub, logger,\n    nodeRepo: true);";
+
+        Assert.Single(CallsTo(hardcoded, "FromRepo"));
+        Assert.DoesNotContain("IsNodeRepoFormat", CallsTo(hardcoded, "FromRepo").Single().Args);
+        Assert.Contains("IsNodeRepoFormat", CallsTo(resolved, "FromRepo").Single().Args);
+        // A call split across lines is the shape the real code uses — the scan must not stop at \n.
+        Assert.DoesNotContain("IsNodeRepoFormat", CallsTo(wrapped, "FromRepo").Single().Args);
+    }
+
+    // Every call to `name(` with its full, paren-balanced argument list — calls span lines here, so
+    // a line-wise regex would miss exactly the ones that matter.
+    private static List<(string Args, int Index)> CallsTo(string code, string name)
+    {
+        var results = new List<(string, int)>();
+        var needle = name + "(";
+        for (var i = code.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = code.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            // `XFromRepo(` is a different method.
+            if (i > 0 && (char.IsLetterOrDigit(code[i - 1]) || code[i - 1] == '_'))
+                continue;
+
+            var open = i + needle.Length - 1;
+            var depth = 0;
+            for (var j = open; j < code.Length; j++)
+            {
+                if (code[j] == '(') depth++;
+                else if (code[j] == ')' && --depth == 0)
+                {
+                    results.Add((code[(open + 1)..j], i));
+                    break;
+                }
+            }
+        }
+        return results;
+    }
+
+    private static int LineOf(string text, int index) =>
+        text.AsSpan(0, index).Count('\n') + 1;
+
+    private static string Squash(string args) =>
+        string.Join(' ', args.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+}


### PR DESCRIPTION
A `PluginCatalog` node pointed at a local node-repo checkout rendered **"No installable packages
found."** while the repository was full of them.

## One record, two readers, opposite answers

`PluginCatalogContent` had no format field. So the browse view called the factory without one —

```csharp
PackageSources.FromRepo(host.Hub, sourceRepoPath, sourceSubdir, Logger(host));
```

— taking `nodeRepo`'s `false` default, the `package.json` manifest format. Meanwhile
`PluginUpdateWatcher`, reading **the same record**, did this:

```csharp
PackageSources.FromRepo(hub, content.SourceRepoPath, content.SourceSubdir, logger, nodeRepo: true);
```

So the catalog page listed nothing while its own update watcher listed those very packages. The node
could not settle the disagreement even deliberately, because the information did not exist on it.

## The fix

- **`PluginCatalogContent.Format`** — the same values and the same `node-repo` default as the
  `PluginCatalog:Sources:N:Format` configuration knob. A browse page over a repository is the same
  question as a configured source over one; it now answers it the same way.
- **`PackageSources.IsNodeRepoFormat`** is the ONE place that default lives. It had been an inline
  literal on the configuration path *only* — which is exactly how the node path came to disagree
  with it.
- Both readers resolve through it. The watcher stops hardcoding its answer.

## Why there is also a guard

The `nodeRepo` parameter defaults to `false` while the shipped format is `node-repo`. That means
**"forgot to pass it" and "deliberately asked for package.json" are the same text at a call site** —
the defect is invisible on review, and it is the same shape whenever a third reader appears.

`CatalogSourceFormatGuard` makes it mechanical: every `FromRepo` call site must pass
`IsNodeRepoFormat(...)`. It carries a floor on the number of call sites found, so a renamed factory
fails loudly instead of reporting a clean tree having matched nothing, and a self-test that the
paren-balanced matcher really sees both a hardcoded and a resolved call (including one split across
lines, which is the shape the real code uses).

**Verified it can fail.** Restoring both pre-#3384 call sites reddens it and names them exactly:

```
· src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs:410 — FromRepo(host.Hub, sourceRepoPath, sourceSubdir, Logger(host))
· src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs:169 — FromRepo(hub, content.SourceRepoPath, content.SourceSubdir, logger, nodeRepo: true)
Failed!  - Failed: 1, Passed: 0
```

With the fix in place: `Passed! - Failed: 0, Passed: 10`.

## Also

`FromRepo`'s own summary claimed *"A local path always uses the git-CLI package.json source"*. That
stopped being true when the local node-repo source landed, and it is the sentence that made this
defect easy to miss — corrected.

## Verification

| Project | Release `-warnaserror` |
|---|---|
| `MeshWeaver.PluginCatalog` | `0 Error(s)`, `0 Warning(s)` |
| `MeshWeaver.Documentation` | `0 Error(s)` |
| `Memex.Portal.Shared` | `0 Error(s)` |
| `MeshWeaver.Documentation.Test` | `0 Error(s)` |

Guard: 10/10. What's New entry included (`Category: Fix` — a user sees an empty catalog become a
populated one). `PluginRegistry.md` gains the node-side knob beside the configuration one it already
documented.

`Pairs-with: none` — additive only: one new property, one new static method, nothing removed.

Closes #3384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
