### PR TITLE
feat(#3353): read-through OCI mirror in front of ACR (v1, pull only)

### DIFF
--- a/src/MeshWeaver.ContainerImages/ContainerImageCatalog.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageCatalog.cs
@@ -1,0 +1,213 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// Turns manifests the mirror served into mesh nodes: one <see cref="ContainerImageRecord"/> per
+/// (repository, reference) observed, under the configured
+/// <see cref="ContainerImageOptions.ImageRoot"/>.
+///
+/// <para><b>The mirror records what it SEES</b> — it never fetches anything speculatively. A real
+/// pull fetches the index for a tag and then the manifest for its own architecture, so both
+/// records appear from that one pull, and the index's <see cref="ContainerImageRecord.Platforms"/>
+/// entries are digests whose own records carry the layers. That keeps recording free: no extra
+/// upstream request, no added pull latency, and no upstream load a cache would later have to
+/// justify.</para>
+///
+/// <para>🚨 <b>Recording is OFF unless <see cref="ContainerImageOptions.ImageRoot"/> is set</b>,
+/// and it is OBSERVATIONAL: a failed write is logged by the caller and never fails the pull. The
+/// mirror's job is to serve bytes correctly; the record is a by-product, and a by-product that can
+/// break the primary function is a liability. Switching recording off — like switching the whole
+/// mirror off — is a configuration change, never a migration.</para>
+/// </summary>
+public static class ContainerImageCatalog
+{
+    /// <summary>The node-type identifier for observed container images.</summary>
+    public const string NodeType = "ContainerImage";
+
+    /// <summary>Separator between the repository and reference halves of a node id.</summary>
+    private const string IdSeparator = "--";
+
+    /// <summary>Registers the ContainerImage node type on the mesh builder. Call alongside the
+    /// portal's <c>MapContainerImages</c>; the two halves are independent — the mirror serves
+    /// without this, and this is inert without the mirror.</summary>
+    /// <typeparam name="TBuilder">The mesh builder type.</typeparam>
+    /// <param name="builder">The mesh builder.</param>
+    /// <returns>The builder, for chaining.</returns>
+    public static TBuilder AddContainerImages<TBuilder>(this TBuilder builder)
+        where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.WithMeshType<ContainerImageRecord>();
+        return builder;
+    }
+
+    /// <summary>Builds the MeshNode definition for the ContainerImage node type.</summary>
+    /// <returns>The node-type node.</returns>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Container Image",
+        NodeType = MeshNode.NodeTypePath,
+        Icon = "/static/NodeTypeIcons/box.svg",
+        HubConfiguration = config => config
+            .AddDefaultLayoutAreas()
+            .AddMeshDataSource(source => source.WithContentType<ContainerImageRecord>())
+    };
+
+    /// <summary>
+    /// The node id for one observed (repository, reference) pair — deterministic, so a consumer
+    /// that knows the tag knows the path, which is the whole of "a pin bump moves ONE reference".
+    ///
+    /// <para>Both halves are reduced to <c>[A-Za-z0-9._-]</c>, so <c>sha256:ab…</c> becomes
+    /// <c>sha256-ab…</c> and a slashed repository becomes one segment. 🚨 That reduction is LOSSY
+    /// — <c>a/b</c> and <c>a-b</c> would collide — so when it actually changed anything, an
+    /// 8-hex fingerprint of the EXACT pair is appended. The common case (a single-segment
+    /// repository and a plain tag) stays verbatim and predictable; the ambiguous case stays
+    /// distinct. Silently letting two images share a node would make the closure answer for one
+    /// of them wrong, which is the one failure this data must not have.</para>
+    /// </summary>
+    /// <param name="repository">The repository name, slashes intact.</param>
+    /// <param name="reference">The tag or digest as requested.</param>
+    /// <returns>The node id.</returns>
+    public static string NodeId(string repository, string reference)
+    {
+        var repositorySegment = Sanitize(repository, out var repositoryChanged);
+        var referenceSegment = Sanitize(reference, out var referenceChanged);
+        var id = $"{repositorySegment}{IdSeparator}{referenceSegment}";
+        if (!repositoryChanged && !referenceChanged)
+            return id;
+        var fingerprint = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes($"{repository}\n{reference}")))
+            .ToLowerInvariant()[..8];
+        return $"{id}-{fingerprint}";
+    }
+
+    private static string Sanitize(string value, out bool changed)
+    {
+        var builder = new StringBuilder(value.Length);
+        changed = false;
+        foreach (var c in value)
+        {
+            if (char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or '-')
+            {
+                builder.Append(c);
+                continue;
+            }
+            builder.Append('-');
+            changed = true;
+        }
+        // An empty result would collapse every such value onto one id, so it counts as CHANGED
+        // even when nothing was replaced (an empty input) — that is what makes the fingerprint
+        // below disambiguate it.
+        if (builder.Length != 0)
+            return builder.ToString();
+        changed = true;
+        return "-";
+    }
+
+    /// <summary>
+    /// The record for one manifest the mirror served, or null when the bytes are not an OCI/Docker
+    /// v2 manifest (see <see cref="OciManifestDocument.TryParse"/> — the mirror still SERVES those
+    /// bytes; it records nothing about them).
+    ///
+    /// <para>🚨 The digest is COMPUTED over the served bytes, not taken from the upstream's
+    /// <c>Docker-Content-Digest</c> header. A manifest is defined by its content hash, so
+    /// computing it is both cheaper to trust and correct when the header is absent — and a
+    /// recorded digest that disagreed with the bytes would silently break every pin derived from
+    /// it.</para>
+    /// </summary>
+    /// <param name="registry">The upstream host these bytes came from.</param>
+    /// <param name="repository">The repository name.</param>
+    /// <param name="reference">The reference as requested (tag or digest).</param>
+    /// <param name="manifest">The manifest body exactly as served.</param>
+    /// <param name="observedBy">The caller the mirror authenticated, when it named one.</param>
+    /// <param name="observedAt">The observation timestamp (UTC).</param>
+    /// <returns>The record, or null when the bytes are not a manifest this mirror models.</returns>
+    public static ContainerImageRecord? Describe(
+        string registry,
+        string repository,
+        string reference,
+        byte[] manifest,
+        string? observedBy,
+        DateTimeOffset observedAt)
+    {
+        if (!OciManifestDocument.TryParse(manifest, out var document))
+            return null;
+
+        var digest = "sha256:" + Convert.ToHexString(SHA256.HashData(manifest)).ToLowerInvariant();
+        return new ContainerImageRecord
+        {
+            Registry = registry,
+            Repository = repository,
+            Reference = reference,
+            Digest = digest,
+            MediaType = document.MediaType,
+            IsIndex = document.IsIndex,
+            ObservedAt = observedAt,
+            ObservedBy = observedBy,
+            ConfigDigest = document.Config?.Digest,
+            ClosureSize = document.ClosureSize,
+            Layers = document.Layers.IsDefaultOrEmpty
+                ? []
+                : [.. document.Layers.Select(l => new ContainerImageBlob(l.Digest, l.MediaType, l.Size))],
+            Platforms = document.Manifests.IsDefaultOrEmpty
+                ? []
+                : [.. document.Manifests.Select(m => new ContainerImagePlatform(
+                    m.Digest, m.MediaType, m.Os, m.Architecture, m.Variant))],
+        };
+    }
+
+    /// <summary>
+    /// The node one record lands as: id from <see cref="NodeId"/>, namespace
+    /// <paramref name="imageRoot"/>.
+    /// </summary>
+    /// <param name="imageRoot">The configured mesh path image records live under.</param>
+    /// <param name="record">The record to store.</param>
+    /// <returns>The node.</returns>
+    public static MeshNode BuildNode(string imageRoot, ContainerImageRecord record) =>
+        new(NodeId(record.Repository, record.Reference), imageRoot)
+        {
+            Name = $"{record.Repository}:{record.Reference}",
+            NodeType = NodeType,
+            Content = record,
+        };
+
+    /// <summary>
+    /// Writes <paramref name="record"/> under <paramref name="imageRoot"/>, upserting so a
+    /// re-pull of the same reference refreshes it rather than racing a create against an update.
+    ///
+    /// <para>Stored under the SYSTEM identity, for the same reason the webhook inbox is: the
+    /// caller is an instance key, not a mesh user with write access anywhere — the repository
+    /// allowlist plus <c>IContainerImageAuthenticator</c> IS the authorization, and the caller is
+    /// recorded in <see cref="ContainerImageRecord.ObservedBy"/> rather than impersonated.</para>
+    ///
+    /// <para>Cold — nothing is written until subscribed.</para>
+    /// </summary>
+    /// <param name="hub">The hub whose services resolve the mesh.</param>
+    /// <param name="imageRoot">The mesh path image records live under.</param>
+    /// <param name="record">The record to store.</param>
+    /// <returns>The stored node.</returns>
+    public static IObservable<MeshNode> Record(
+        IMessageHub hub, string imageRoot, ContainerImageRecord record)
+    {
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Throw<MeshNode>(
+                new InvalidOperationException("The mesh service is not available."));
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var node = BuildNode(imageRoot, record);
+        // 🚨 RunAsSystem, never `Observable.Using(() => access.ImpersonateAsSystem(), …)`. That
+        // shape opens an AsyncLocal scope on the SUBSCRIBING thread and disposes it on whichever
+        // thread the work terminates on — leaving the subscriber running as System afterwards
+        // (#1790). RunAsSystem seals the scope to the subscribe.
+        return accessService.RunAsSystem(() => mesh.CreateOrUpdateNode(node).Take(1));
+    }
+}

--- a/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
@@ -274,7 +274,24 @@ public static class ContainerImageEndpoints
 
         if (TryReadManifestForRecording(route, upstream, options, ct, out var manifest))
         {
-            var body = await manifest;
+            byte[] body;
+            try
+            {
+                body = await manifest;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or IOException)
+            {
+                // 🚨 The upstream connection died mid-manifest. Nothing has been written to the
+                // caller yet, so this is a clean 502 — and the response MUST be disposed here:
+                // ownership normally passes to UpstreamPassthroughResult, which is never
+                // constructed on this path, so returning without disposing leaks the connection.
+                upstream.Dispose();
+                logger?.LogWarning(ex,
+                    "Container registry mirror: reading the manifest for {Path} failed mid-body",
+                    http.Request.Path);
+                return Results.StatusCode(StatusCodes.Status502BadGateway);
+            }
+
             Record(http, client.Upstream, route, body, options.ImageRoot!, logger);
             // Serving the bytes we already hold, rather than re-reading a consumed stream.
             return new UpstreamPassthroughResult(upstream, pool, body);

--- a/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
@@ -1,18 +1,20 @@
 using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace MeshWeaver.ContainerImages;
 
 /// <summary>
-/// The OCI Distribution pull surface, served from the mesh: <c>GET /v2/</c>,
-/// <c>…/manifests/{reference}</c>, <c>…/blobs/{digest}</c> and <c>…/tags/list</c>, proxied to the
-/// upstream registry with the mirror's own credential while the CALLER authenticates against
-/// memex.
+/// The OCI Distribution pull surface, served from the mesh: <c>GET /v2/</c>, the bearer token
+/// exchange at <c>GET /v2/token</c>, <c>…/manifests/{reference}</c>, <c>…/blobs/{digest}</c> and
+/// <c>…/tags/list</c>, proxied to the upstream registry with the mirror's own credential while the
+/// CALLER authenticates against memex.
 ///
 /// <para><b>Why this exists</b> (see <c>Doc/Architecture/ContainerRegistryInMemex</c>): the fleet
 /// carried an <c>ACR_USERNAME</c>/<c>ACR_PASSWORD</c> pair in every satellite repository purely so
@@ -33,24 +35,57 @@ public static class ContainerImageEndpoints
     /// <summary>Route prefix mandated by the OCI Distribution Specification.</summary>
     public const string RoutePrefix = "/v2";
 
-    /// <summary>Set by the auth gate so handlers can name the caller in logs.</summary>
+    /// <summary>
+    /// The token endpoint, relative to <see cref="RoutePrefix"/>. This is the <c>realm</c> the
+    /// bearer challenge NAMES, so the two must never drift: a challenge pointing at a route
+    /// nothing serves turns every <c>docker pull</c> into "401, fetch the realm, 404, give up".
+    /// </summary>
+    public const string TokenRoute = "/token";
+
+    /// <summary>The API version every OCI client expects the version probe to declare.</summary>
+    public const string ApiVersionHeader = "Docker-Distribution-Api-Version";
+
+    /// <summary>Value of <see cref="ApiVersionHeader"/>.</summary>
+    public const string ApiVersion = "registry/2.0";
+
+    /// <summary>
+    /// Lifetime advertised on an issued token, in seconds. Short on purpose: the token IS the
+    /// caller's own instance key (see <see cref="IssueToken"/>), so a client re-presenting it
+    /// re-runs <see cref="IContainerImageAuthenticator"/> — which is what makes revoking a key
+    /// take effect in minutes rather than whenever a minted credential happened to expire.
+    /// </summary>
+    public const int TokenLifetimeSeconds = 300;
+
+    /// <summary>Set by the auth gate so handlers can name the caller in logs and records.</summary>
     private const string CallerItemKey = "ContainerImages.Caller";
+
+    private const string ManifestsKind = "manifests";
 
     /// <summary>
     /// Maps the pull surface. <c>AllowAnonymous</c> at the ASP.NET layer for the same reason the
     /// plugin registry does it — callers are INSTANCES and CI jobs, not signed-in users — with the
     /// bearer gate below doing the real work.
     /// </summary>
+    /// <param name="endpoints">The route builder to map onto.</param>
+    /// <returns>The route builder, for chaining.</returns>
     public static IEndpointRouteBuilder MapContainerImages(this IEndpointRouteBuilder endpoints)
     {
+        // 🚨 The token endpoint sits OUTSIDE the challenge filter, in its own group over the same
+        // prefix. The filter answers "not authenticated" with a challenge that NAMES this route —
+        // so putting this route behind it makes an unauthenticated client loop: challenge → token
+        // → challenge → token. A token endpoint authenticates ITSELF and refuses with a bare 401.
+        // Route precedence puts the literal `/v2/token` ahead of the `/v2/{**rest}` catch-all, so
+        // this wins without depending on registration order.
+        var tokenGroup = endpoints.MapGroup(RoutePrefix).AllowAnonymous();
+        tokenGroup.MapGet(TokenRoute, (HttpContext http, CancellationToken ct) => IssueToken(http, ct));
+
         var group = endpoints.MapGroup(RoutePrefix).AllowAnonymous();
 
         group.AddEndpointFilter(async (ctx, next) =>
         {
             var http = ctx.HttpContext;
             var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
-            var logger = http.RequestServices.GetService<ILoggerFactory>()
-                ?.CreateLogger(typeof(ContainerImageEndpoints));
+            var logger = Logger(http);
 
             // Unconfigured is 404 on everything, not 401 and not a partial service. A mirror
             // without a credential cannot serve a single byte, and saying "unauthorised" would
@@ -64,20 +99,7 @@ public static class ContainerImageEndpoints
                 return Results.NotFound();
             }
 
-            var authenticator = http.RequestServices
-                .GetRequiredService<IContainerImageAuthenticator>();
-            // 🚨 ObserveCompletion, never .ToTask() — a Task completed inside an Rx pipeline
-            // resumes its awaiter INLINE on the signalling thread, still inside Rx's trampoline,
-            // and everything the continuation then does inherits that scheduler.
-            var caller = await authenticator
-                .Authenticate(http.Request.Headers.Authorization.ToString(), http.RequestAborted)
-                .FirstAsync()
-                .ObserveCompletion(
-                    ex => logger?.LogWarning(ex,
-                        "Container registry mirror: authentication for {Path} faulted after the "
-                        + "request had already been answered", http.Request.Path),
-                    http.RequestAborted);
-
+            var caller = await Authenticate(http, ct: http.RequestAborted);
             if (caller is null)
                 return Challenge(http);
 
@@ -87,21 +109,120 @@ public static class ContainerImageEndpoints
 
         // The spec's version probe. A client hits this first and reads the challenge from it, so
         // it must answer 200 (authenticated) or 401-with-challenge — never 404.
-        group.MapGet("/", () => Results.Ok(new { }));
+        group.MapGet("/", (HttpContext http) =>
+        {
+            http.Response.Headers[ApiVersionHeader] = ApiVersion;
+            return Results.Ok(new { });
+        });
 
         group.MapGet("/{**rest}", (HttpContext http, CancellationToken ct) => Serve(http, ct));
         return endpoints;
     }
 
     /// <summary>
+    /// Resolves the caller through <see cref="IContainerImageAuthenticator"/>, normalising the
+    /// <c>Authorization</c> header to the single bearer shape the seam has to speak.
+    /// </summary>
+    private static async Task<string?> Authenticate(HttpContext http, CancellationToken ct)
+    {
+        var authenticator = http.RequestServices.GetRequiredService<IContainerImageAuthenticator>();
+        var header = http.Request.Headers.Authorization.ToString();
+        // Both shapes a registry client uses reduce to one secret; an unreadable header is passed
+        // through verbatim so the seam — not this file — stays the authority on what counts.
+        var normalized = RegistryCredential.TryReadSecret(header) is { } secret
+            ? RegistryCredential.AsBearerHeader(secret)
+            : header;
+        var logger = Logger(http);
+        // 🚨 ObserveCompletion, never .ToTask() — a Task completed inside an Rx pipeline
+        // resumes its awaiter INLINE on the signalling thread, still inside Rx's trampoline,
+        // and everything the continuation then does inherits that scheduler.
+        return await authenticator
+            .Authenticate(normalized, ct)
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Container registry mirror: authentication for {Path} faulted after the "
+                    + "request had already been answered", http.Request.Path),
+                ct);
+    }
+
+    /// <summary>
+    /// The token exchange the bearer challenge sends a client to:
+    /// <c>GET /v2/token?service=…&amp;scope=repository:&lt;name&gt;:pull</c> carrying
+    /// <c>Basic base64(user:key)</c>, answered with a bearer the client then presents on every
+    /// pull.
+    ///
+    /// <para>🚨 <b>The mirror does not MINT a credential in v1 — the bearer it hands back IS the
+    /// caller's own instance key.</b> That is a deliberate choice, not a shortcut: a minted token
+    /// would stay valid for its full lifetime after the key behind it was revoked, and it would
+    /// make the mirror a second issuer of credentials for an identity it does not own. Echoing the
+    /// key means every subsequent request re-runs
+    /// <see cref="IContainerImageAuthenticator"/> — revocation takes effect at the next token
+    /// exchange, which <see cref="TokenLifetimeSeconds"/> keeps minutes away. It also means the
+    /// mirror stores no token state at all, so there is nothing to leak, expire or replicate.</para>
+    ///
+    /// <para>The <c>scope</c> query parameter is deliberately NOT enforced here. The pull path
+    /// checks the repository allowlist on every request against the repository it actually
+    /// forwards, so a token scoped by this endpoint would be a SECOND opinion about what may be
+    /// served — and two opinions is how one of them ends up wrong.</para>
+    /// </summary>
+    private static async Task<IResult> IssueToken(HttpContext http, CancellationToken ct)
+    {
+        var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
+        if (!client.IsConfigured)
+            return Results.NotFound();
+
+        var secret = RegistryCredential.TryReadSecret(http.Request.Headers.Authorization.ToString());
+        if (secret is null)
+            return RefuseToken(http);
+
+        var caller = await Authenticate(http, ct);
+        if (caller is null)
+            return RefuseToken(http);
+
+        Logger(http)?.LogDebug(
+            "Container registry mirror: issued a pull token to {Caller} for scope {Scope}",
+            caller, http.Request.Query["scope"].ToString());
+
+        // `token` is the OCI Distribution field; `access_token` is the OAuth2 spelling ACR and
+        // Docker Hub both also return. Clients read one or the other, so emit both.
+        return Results.Json(new
+        {
+            token = secret,
+            access_token = secret,
+            expires_in = TokenLifetimeSeconds,
+            issued_at = DateTimeOffset.UtcNow.ToString("O"),
+        });
+    }
+
+    /// <summary>
+    /// A refused token exchange: 401 WITHOUT a bearer challenge. Challenging here would name this
+    /// very route and loop the client.
+    /// </summary>
+    private static IResult RefuseToken(HttpContext http)
+    {
+        http.Response.Headers[ApiVersionHeader] = ApiVersion;
+        return Results.Json(
+            new { errors = new[] { new { code = "UNAUTHORIZED", message = "instance key required" } } },
+            statusCode: StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
     /// The bearer challenge every OCI client expects before it will present a credential. Naming
-    /// the realm is what makes `docker pull` fetch a token rather than simply failing.
+    /// the realm is what makes `docker pull` fetch a token rather than simply failing — and the
+    /// realm names <see cref="TokenRoute"/>, which <see cref="MapContainerImages"/> serves.
     /// </summary>
     private static IResult Challenge(HttpContext http)
     {
-        var realm = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}/token";
-        http.Response.Headers["WWW-Authenticate"] =
-            $"Bearer realm=\"{realm}\",service=\"{http.Request.Host}\"";
+        var realm = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}{TokenRoute}";
+        var challenge = $"Bearer realm=\"{realm}\",service=\"{http.Request.Host}\"";
+        // The scope, when the request names a repository: a client uses it verbatim to ask for a
+        // token, and the shape matches the one ACR emits (the live reference for this handshake).
+        if (http.Request.RouteValues["rest"] is string rest
+            && RegistryRoute.TryParse(rest, out var route))
+            challenge += $",scope=\"repository:{route.Repository}:pull\"";
+        http.Response.Headers["WWW-Authenticate"] = challenge;
+        http.Response.Headers[ApiVersionHeader] = ApiVersion;
         return Results.Json(
             new { errors = new[] { new { code = "UNAUTHORIZED", message = "instance key required" } } },
             statusCode: StatusCodes.Status401Unauthorized);
@@ -110,8 +231,7 @@ public static class ContainerImageEndpoints
     private static async Task<IResult> Serve(HttpContext http, CancellationToken ct)
     {
         var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
-        var logger = http.RequestServices.GetService<ILoggerFactory>()
-            ?.CreateLogger(typeof(ContainerImageEndpoints));
+        var logger = Logger(http);
 
         var rest = (string?)http.Request.RouteValues["rest"] ?? string.Empty;
         if (!RegistryRoute.TryParse(rest, out var route))
@@ -119,9 +239,7 @@ public static class ContainerImageEndpoints
 
         // 🚨 The allowlist is the difference between a mirror and an open read proxy for the whole
         // upstream. Empty means NONE.
-        var options = http.RequestServices
-            .GetRequiredService<Microsoft.Extensions.Options.IOptions<ContainerImageOptions>>()
-            .Value;
+        var options = http.RequestServices.GetRequiredService<IOptions<ContainerImageOptions>>().Value;
         if (!options.Repositories.Contains(route.Repository, StringComparer.Ordinal))
         {
             logger?.LogDebug(
@@ -146,6 +264,103 @@ public static class ContainerImageEndpoints
             return Results.StatusCode(StatusCodes.Status502BadGateway);
         }
 
-        return new UpstreamPassthroughResult(upstream);
+        // 🚨 The bound on the layer transfer. IoPoolNames.Blob, not Http: `Http` is capped at 16
+        // for short API round-trips, and one 300 MB layer parked in that pool for a minute would
+        // starve every plugin-catalog and registration call the portal makes. `Blob` IS the
+        // large-async-binary resource class (cap 128), which is exactly what a layer transfer is.
+        var pool = http.RequestServices.GetService<IMessageHub>()?.ServiceProvider
+                       .GetService<IoPoolRegistry>()?.Get(IoPoolNames.Blob)
+                   ?? IoPool.Unbounded;
+
+        if (TryReadManifestForRecording(route, upstream, options, ct, out var manifest))
+        {
+            var body = await manifest;
+            Record(http, client.Upstream, route, body, options.ImageRoot!, logger);
+            // Serving the bytes we already hold, rather than re-reading a consumed stream.
+            return new UpstreamPassthroughResult(upstream, pool, body);
+        }
+
+        return new UpstreamPassthroughResult(upstream, pool);
     }
+
+    /// <summary>
+    /// Whether this response is a MANIFEST small enough to hold in memory in order to record it.
+    ///
+    /// <para>🚨 The size test is on the upstream's declared <c>Content-Length</c>, BEFORE
+    /// anything is read — so a body that would not fit is never partially consumed, and streams
+    /// untouched. And it applies to manifests only: a blob is never buffered under any
+    /// configuration, which is the difference between recording an image and OOMing the portal.</para>
+    /// </summary>
+    private static bool TryReadManifestForRecording(
+        RegistryRoute route,
+        HttpResponseMessage upstream,
+        ContainerImageOptions options,
+        CancellationToken ct,
+        out Task<byte[]> body)
+    {
+        body = Task.FromResult<byte[]>([]);
+        if (route.Kind != ManifestsKind
+            || !upstream.IsSuccessStatusCode
+            || options.ImageRoot is not { Length: > 0 }
+            || upstream.Content.Headers.ContentLength is not { } length
+            || length <= 0
+            || length > options.MaxRecordedManifestBytes)
+            return false;
+        body = upstream.Content.ReadAsByteArrayAsync(ct);
+        return true;
+    }
+
+    /// <summary>
+    /// Records what the mirror just served as a <see cref="ContainerImageRecord"/> node.
+    ///
+    /// <para>🚨 OFF the response path, and never able to fail it. The write is a cold observable
+    /// subscribed here with an explicit error arm — it runs on <c>Subscribe</c>, not on call, and
+    /// a failure is a warning naming the root, never an error handed to a <c>docker pull</c>.
+    /// Recording is observational: the mirror's contract is to serve the right bytes.</para>
+    /// </summary>
+    private static void Record(
+        HttpContext http, string registry, RegistryRoute route, byte[] body, string imageRoot,
+        ILogger? logger)
+    {
+        var hub = http.RequestServices.GetService<IMessageHub>();
+        if (hub is null)
+        {
+            logger?.LogDebug(
+                "Container registry mirror: no message hub in scope, so {Repository}:{Reference} "
+                + "was served but not recorded.", route.Repository, route.Reference);
+            return;
+        }
+
+        var record = ContainerImageCatalog.Describe(
+            registry, route.Repository, route.Reference, body,
+            http.Items.TryGetValue(CallerItemKey, out var caller) ? caller as string : null,
+            DateTimeOffset.UtcNow);
+        if (record is null)
+        {
+            // Not an OCI/Docker v2 manifest — an attestation, a signature artifact, a v1 manifest.
+            // Served, not modelled. Recording a half-parsed closure would be worse than none.
+            logger?.LogDebug(
+                "Container registry mirror: {Repository}:{Reference} is not a manifest shape this "
+                + "mirror models, so it was served but not recorded.",
+                route.Repository, route.Reference);
+            return;
+        }
+
+        ContainerImageCatalog.Record(hub, imageRoot, record)
+            .Subscribe(
+                node => logger?.LogDebug(
+                    "Container registry mirror: recorded {Repository}:{Reference} at {Path} "
+                    + "({Digest}, {Layers} layer(s), {Platforms} platform(s))",
+                    route.Repository, route.Reference, node.Path, record.Digest,
+                    record.Layers.Length, record.Platforms.Length),
+                ex => logger?.LogWarning(ex,
+                    "Container registry mirror: serving {Repository}:{Reference} succeeded but "
+                    + "recording it under {ImageRoot} failed. The pull is unaffected; the closure "
+                    + "for this image is simply not in the mesh. Check that {ImageRoot} exists.",
+                    route.Repository, route.Reference, imageRoot, imageRoot));
+    }
+
+    private static ILogger? Logger(HttpContext http) =>
+        http.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ContainerImageEndpoints));
 }

--- a/src/MeshWeaver.ContainerImages/ContainerImageOptions.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageOptions.cs
@@ -28,4 +28,27 @@ public sealed class ContainerImageOptions
     /// open read proxy for the whole registry.
     /// </summary>
     public string[] Repositories { get; set; } = [];
+
+    /// <summary>
+    /// The mesh path observed images are recorded under, e.g. <c>Platform/Images</c>. That node
+    /// must already exist — a record is a CHILD of it, and creating a parent chain from a pull
+    /// path is how a write lane NotFound-storms itself (#2229).
+    ///
+    /// <para>🚨 EMPTY MEANS RECORDING IS OFF, and the mirror still proxies normally. Recording is
+    /// observational: it answers "what is in this image, and where did it come from" without a
+    /// <c>docker run</c>, and it must never be able to fail a pull. Turning it off — like turning
+    /// the whole mirror off — is a configuration change, never a migration.</para>
+    /// </summary>
+    public string? ImageRoot { get; set; }
+
+    /// <summary>
+    /// Largest manifest the mirror will hold in memory in order to record it. Manifests are
+    /// small — the OCI spec caps them at 4 MiB and ACR's are single-digit KB — so this is a
+    /// sanity bound, not a tuning knob.
+    ///
+    /// <para>🚨 It applies to MANIFESTS ONLY. A blob (a layer, hundreds of megabytes) is NEVER
+    /// buffered under any setting: it streams upstream → socket → client. A manifest larger than
+    /// this is still served, streamed, and simply not recorded.</para>
+    /// </summary>
+    public int MaxRecordedManifestBytes { get; set; } = 4 * 1024 * 1024;
 }

--- a/src/MeshWeaver.ContainerImages/ContainerImageRecord.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageRecord.cs
@@ -1,0 +1,98 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// One blob of an image's closure, by digest. Content-addressed, so the same entry in two
+/// repositories names the same bytes.
+/// </summary>
+/// <param name="Digest">The content digest, <c>algorithm:hex</c>.</param>
+/// <param name="MediaType">The blob's media type.</param>
+/// <param name="Size">Size in bytes, as the manifest declares it.</param>
+public record ContainerImageBlob(string Digest, string MediaType, long Size);
+
+/// <summary>
+/// One platform an index resolves to. The DIGEST is the reference: the record holding that
+/// platform's actual closure is <see cref="ContainerImageRecord"/> for the same repository at this
+/// digest, recorded when anything pulls it (which every real pull does — a client fetches the
+/// index and then the manifest for its own architecture).
+/// </summary>
+/// <param name="Digest">The per-platform manifest's digest.</param>
+/// <param name="MediaType">That manifest's media type.</param>
+/// <param name="Os">Operating system, e.g. <c>linux</c>.</param>
+/// <param name="Architecture">Architecture, e.g. <c>amd64</c>.</param>
+/// <param name="Variant">Architecture variant, e.g. <c>v8</c>. Usually null.</param>
+public record ContainerImagePlatform(
+    string Digest, string MediaType, string? Os, string? Architecture, string? Variant);
+
+/// <summary>
+/// What the mirror saw when an image was pulled through it: the image's CLOSURE and its
+/// PROVENANCE, as mesh data rather than something recoverable only by pulling a tarball.
+///
+/// <para><b>Why this record exists</b> (<c>Doc/Architecture/ContainerRegistryInMemex</c>, issue
+/// #3353): an image's contents were opaque until something failed to compile against them —
+/// #3328 was, at bottom, "nobody can see what is in <c>/app</c>", and it was diagnosed with
+/// <c>docker run … ls /app</c>. Every pull that flows through the mirror now leaves the manifest's
+/// answer behind as a node.</para>
+///
+/// <para>🚨 <b>Scope, stated so nothing over-reads it.</b> This is the OCI-level closure: the
+/// config blob and the layer blobs, by digest and size. It is NOT yet the /app ASSEMBLY closure
+/// that <c>check-platform-reference-set.sh</c> asserts over — that lives INSIDE a layer tarball
+/// and needs a layer scan, which is a separate increment (see the doc page). A consumer that
+/// needs "which assemblies" must still extract; a consumer that needs "which bytes, from where,
+/// resolved from which tag" is answered here.</para>
+/// </summary>
+public record ContainerImageRecord
+{
+    /// <summary>
+    /// The upstream registry these bytes came from, e.g. <c>meshweaver.azurecr.io</c>. The root of
+    /// the provenance chain, and the reason a record can never be mistaken for something the mesh
+    /// itself produced.
+    /// </summary>
+    public string Registry { get; init; } = "";
+
+    /// <summary>The repository, slashes intact, e.g. <c>memex-portal-ai</c>.</summary>
+    public string Repository { get; init; } = "";
+
+    /// <summary>
+    /// The reference AS REQUESTED — a tag (<c>ci.7794</c>) or a digest. Keeping the requested form
+    /// is what makes the tag → digest resolution below a recorded FACT rather than an inference.
+    /// </summary>
+    public string Reference { get; init; } = "";
+
+    /// <summary>
+    /// The manifest's content digest, computed over the bytes the upstream served rather than
+    /// taken on trust from a header. This is the value a pin should carry, and recording it
+    /// against <see cref="Reference"/> is what lets a pin bump move ONE reference: the tag is
+    /// resolved here, once, instead of being copied as a digest literal into every consumer.
+    /// </summary>
+    public string Digest { get; init; } = "";
+
+    /// <summary>The manifest's media type — an index type or a single-platform manifest type.</summary>
+    public string? MediaType { get; init; }
+
+    /// <summary>True when this is a multi-architecture index; then <see cref="Platforms"/> is
+    /// populated and <see cref="Layers"/> is empty.</summary>
+    public bool IsIndex { get; init; }
+
+    /// <summary>When the mirror served this manifest (UTC). Point-in-time, not a first-seen
+    /// watermark: the store already versions the node, so the history is the node's history.</summary>
+    public DateTimeOffset ObservedAt { get; init; }
+
+    /// <summary>Who pulled it — the caller the mirror authenticated. Null when the authenticator
+    /// named no caller.</summary>
+    public string? ObservedBy { get; init; }
+
+    /// <summary>The image config blob's digest, on a single-platform manifest. Null on an index.</summary>
+    public string? ConfigDigest { get; init; }
+
+    /// <summary>Total bytes of this manifest's own closure (config + layers). Zero on an index,
+    /// whose closure is reached through <see cref="Platforms"/>.</summary>
+    public long ClosureSize { get; init; }
+
+    /// <summary>The layer blobs, in order. Empty on an index.</summary>
+    public ImmutableArray<ContainerImageBlob> Layers { get; init; } = [];
+
+    /// <summary>The platforms an index names. Empty on a single-platform manifest.</summary>
+    public ImmutableArray<ContainerImagePlatform> Platforms { get; init; } = [];
+}

--- a/src/MeshWeaver.ContainerImages/IContainerImageAuthenticator.cs
+++ b/src/MeshWeaver.ContainerImages/IContainerImageAuthenticator.cs
@@ -5,6 +5,14 @@ namespace MeshWeaver.ContainerImages;
 /// does not depend on the plugin catalogue, so the portal binds it to
 /// <c>InstanceRegistryAuthenticator</c> — the same instance key satellites already present to the
 /// plugin registry, which is the credential this mirror exists to reuse.
+///
+/// <para>🚨 <b>The contract is ONE shape: <c>Bearer &lt;instance key&gt;</c>.</b> A registry client
+/// speaks two — <c>Basic base64(user:key)</c> to the token endpoint, <c>Bearer &lt;token&gt;</c>
+/// everywhere after — and the mirror reduces both to a bearer (<see cref="RegistryCredential"/>)
+/// BEFORE calling this. An implementation therefore never has to know about Basic, and must not
+/// grow a second code path for it: two places deciding what a credential means is how one of them
+/// ends up disagreeing. A header the mirror could not read is passed through verbatim, so this
+/// seam stays the authority on what counts as authenticated.</para>
 /// </summary>
 public interface IContainerImageAuthenticator
 {
@@ -12,5 +20,8 @@ public interface IContainerImageAuthenticator
     /// Resolves the caller from an <c>Authorization</c> header. Emits <c>null</c> for "not
     /// authenticated" — which the endpoint turns into the bearer challenge, never into a pull.
     /// </summary>
+    /// <param name="authorizationHeader">The header, normalised to <c>Bearer &lt;key&gt;</c>.</param>
+    /// <param name="ct">Cancels the resolution.</param>
+    /// <returns>The caller's identity, or null when the credential does not authenticate.</returns>
     IObservable<string?> Authenticate(string? authorizationHeader, CancellationToken ct);
 }

--- a/src/MeshWeaver.ContainerImages/MeshWeaver.ContainerImages.csproj
+++ b/src/MeshWeaver.ContainerImages/MeshWeaver.ContainerImages.csproj
@@ -10,5 +10,15 @@
          deliberately takes NO dependency on the plugin catalogue: the caller-authentication seam
          is IContainerImageAuthenticator, bound by the portal. -->
     <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
+    <!-- IIoPool / IoPoolRegistry (the bound on layer transfers) and MeshNode / IMeshService (the
+         closure + provenance records). -->
+    <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
+    <!-- 🚨 The NodeType registration only. AddDefaultLayoutAreas / AddMeshDataSource /
+         WithContentType live in MeshWeaver.Graph, and a ContainerImage node WITHOUT them would
+         keep its content as an untyped JsonElement — the silent-null trap AGENTS.md names, where
+         the view renders empty and nothing logs. The alternative (a second seam interface, bound
+         by the portal like the authenticator) was rejected: nothing in THIS repo would implement
+         it, so the recording half would ship dead and untestable end to end. -->
+    <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MeshWeaver.ContainerImages/OciManifest.cs
+++ b/src/MeshWeaver.ContainerImages/OciManifest.cs
@@ -1,0 +1,182 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// One entry of an image's closure: a content-addressed blob, named by digest and sized. This is
+/// the OCI Distribution spec's <c>descriptor</c>, reduced to the fields the mirror records.
+/// </summary>
+/// <param name="MediaType">The blob's media type, e.g.
+/// <c>application/vnd.oci.image.layer.v1.tar+gzip</c>.</param>
+/// <param name="Digest">The content digest, <c>algorithm:hex</c>. An IMMUTABLE id: two images
+/// naming the same digest name the same bytes, which is why layer dedup across repositories is
+/// free and why a closure recorded once stays true.</param>
+/// <param name="Size">The blob's size in bytes as the manifest declares it.</param>
+public sealed record OciDescriptor(string MediaType, string Digest, long Size)
+{
+    /// <summary>Operating system, for an index entry (<c>linux</c>). Null on a layer or config.</summary>
+    public string? Os { get; init; }
+
+    /// <summary>Architecture, for an index entry (<c>amd64</c>, <c>arm64</c>). Null otherwise.</summary>
+    public string? Architecture { get; init; }
+
+    /// <summary>Architecture variant, for an index entry (<c>v8</c>). Null otherwise.</summary>
+    public string? Variant { get; init; }
+}
+
+/// <summary>
+/// A parsed OCI manifest or image index — the ONE place the mirror interprets registry bytes.
+///
+/// <para>Two shapes share one route. An <b>index</b> (<c>manifests</c>) is the multi-architecture
+/// entry point a tag usually resolves to: it names one manifest per platform and carries no layers
+/// of its own. A <b>manifest</b> (<c>config</c> + <c>layers</c>) is one platform's image and IS
+/// the closure — the config blob plus every layer blob, each by digest.</para>
+///
+/// <para>🚨 Parsing is <b>total and refusing</b>: anything that is not one of those two shapes —
+/// a Docker v1 <c>fsLayers</c> manifest, a signature artifact, a truncated body — returns
+/// <c>false</c> rather than a half-populated document. A half-populated closure is worse than no
+/// closure: it would answer "what is in this image?" with a confident, wrong, shorter list.</para>
+/// </summary>
+public sealed record OciManifestDocument
+{
+    /// <summary>The manifest's own declared media type, when it carries one.</summary>
+    public string? MediaType { get; init; }
+
+    /// <summary>The image config blob — present on a single-platform manifest, null on an index.</summary>
+    public OciDescriptor? Config { get; init; }
+
+    /// <summary>The layer blobs, in order. Empty on an index.</summary>
+    public ImmutableArray<OciDescriptor> Layers { get; init; } = [];
+
+    /// <summary>The per-platform manifests this index names. Empty on a single-platform manifest.</summary>
+    public ImmutableArray<OciDescriptor> Manifests { get; init; } = [];
+
+    /// <summary>True when this is a multi-architecture index rather than one platform's image.</summary>
+    public bool IsIndex => !Manifests.IsDefaultOrEmpty;
+
+    /// <summary>
+    /// Total bytes of this manifest's own closure — the config blob plus every layer. Zero on an
+    /// index, whose closure is reached through <see cref="Manifests"/> rather than held directly.
+    /// </summary>
+    public long ClosureSize =>
+        (Config?.Size ?? 0)
+        + (Layers.IsDefaultOrEmpty ? 0 : Layers.Sum(l => l.Size));
+
+    /// <summary>
+    /// Parses manifest bytes. Returns false for anything that is not an OCI/Docker v2 manifest or
+    /// index — see the refusal note on the type.
+    /// </summary>
+    /// <param name="json">The manifest body exactly as the upstream served it.</param>
+    /// <param name="document">The parsed document; undefined when this returns false.</param>
+    public static bool TryParse(byte[] json, out OciManifestDocument document)
+    {
+        document = new OciManifestDocument();
+        if (json.Length == 0)
+            return false;
+
+        JsonDocument parsed;
+        try
+        {
+            parsed = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            // Not JSON at all. The mirror still SERVES the bytes — recording is observational and
+            // never gates a pull — it simply records nothing about them.
+            return false;
+        }
+
+        using (parsed)
+        {
+            var root = parsed.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return false;
+
+            var mediaType = root.TryGetProperty("mediaType", out var mt)
+                            && mt.ValueKind == JsonValueKind.String
+                ? mt.GetString()
+                : null;
+
+            if (root.TryGetProperty("manifests", out var manifests)
+                && manifests.ValueKind == JsonValueKind.Array)
+            {
+                var entries = ReadDescriptors(manifests, withPlatform: true);
+                if (entries.IsEmpty)
+                    return false;
+                document = new OciManifestDocument { MediaType = mediaType, Manifests = entries };
+                return true;
+            }
+
+            if (root.TryGetProperty("layers", out var layers)
+                && layers.ValueKind == JsonValueKind.Array
+                && root.TryGetProperty("config", out var config)
+                && TryReadDescriptor(config, withPlatform: false, out var configDescriptor))
+            {
+                document = new OciManifestDocument
+                {
+                    MediaType = mediaType,
+                    Config = configDescriptor,
+                    // A layerless manifest is legal (an attestation, an empty scratch image), so
+                    // an empty array is NOT a refusal here — unlike an index naming no platforms,
+                    // which cannot be resolved by any client.
+                    Layers = ReadDescriptors(layers, withPlatform: false),
+                };
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    private static ImmutableArray<OciDescriptor> ReadDescriptors(JsonElement array, bool withPlatform)
+    {
+        var builder = ImmutableArray.CreateBuilder<OciDescriptor>();
+        foreach (var element in array.EnumerateArray())
+            if (TryReadDescriptor(element, withPlatform, out var descriptor))
+                builder.Add(descriptor);
+        return builder.ToImmutable();
+    }
+
+    private static bool TryReadDescriptor(
+        JsonElement element, bool withPlatform, out OciDescriptor descriptor)
+    {
+        descriptor = null!;
+        if (element.ValueKind != JsonValueKind.Object)
+            return false;
+        // 🚨 The DIGEST is the only field that must be present and well-shaped: it is the id the
+        // closure is expressed in. A descriptor without one names nothing and is dropped rather
+        // than recorded as a blank entry.
+        if (!element.TryGetProperty("digest", out var digest)
+            || digest.ValueKind != JsonValueKind.String
+            || digest.GetString() is not { Length: > 0 } digestValue)
+            return false;
+
+        var mediaType = element.TryGetProperty("mediaType", out var mt)
+                        && mt.ValueKind == JsonValueKind.String
+            ? mt.GetString() ?? string.Empty
+            : string.Empty;
+        var size = element.TryGetProperty("size", out var sz) && sz.TryGetInt64(out var sizeValue)
+            ? sizeValue
+            : 0;
+
+        descriptor = new OciDescriptor(mediaType, digestValue, size);
+        if (withPlatform
+            && element.TryGetProperty("platform", out var platform)
+            && platform.ValueKind == JsonValueKind.Object)
+        {
+            descriptor = descriptor with
+            {
+                Os = ReadString(platform, "os"),
+                Architecture = ReadString(platform, "architecture"),
+                Variant = ReadString(platform, "variant"),
+            };
+        }
+        return true;
+    }
+
+    private static string? ReadString(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/src/MeshWeaver.ContainerImages/README.md
+++ b/src/MeshWeaver.ContainerImages/README.md
@@ -18,12 +18,39 @@ registry, and consumers present a registry token.
 | route | |
 |---|---|
 | `GET /v2/` | version probe; answers the bearer challenge when unauthenticated |
+| `GET /v2/token` | the bearer exchange the challenge's `realm` names |
 | `GET /v2/{name}/manifests/{reference}` | tag or digest; multi-arch indexes included |
-| `GET /v2/{name}/blobs/{digest}` | streamed, range-capable |
+| `GET /v2/{name}/blobs/{digest}` | streamed, range-capable, bounded by `IIoPool` |
 | `GET /v2/{name}/tags/list` | |
 
 **Pull only.** No push, no upload, no delete — those keep going to the upstream, so this can be
-switched off without a migration.
+switched off without a migration. There is **no cache**: every pull reaches the upstream.
+
+### The token exchange
+
+A client probes `/v2/`, is answered `401` with
+`WWW-Authenticate: Bearer realm="…/v2/token",service="…"`, fetches that realm with
+`Basic base64(user:key)`, and presents the result as a bearer on every later request.
+
+🚨 The mirror **mints nothing**: the bearer it returns IS the caller's own key. A minted token would
+outlive the key's revocation; echoing it means every request re-runs the authenticator, and the
+mirror holds no token state. `/v2/token` therefore refuses with a BARE 401 — a challenge there would
+name itself and loop the client.
+
+## What it records
+
+With `ImageRoot` set, every manifest served is written as a `ContainerImage` node: the resolved
+digest (computed over the served bytes, never taken from a header), media type, config digest, every
+layer by digest and size, an index's platforms, and the provenance — which upstream, which
+repository, which reference, observed when and by whom. Register the node type with
+`builder.AddContainerImages()`.
+
+The mirror records what it **sees** and never fetches speculatively, so recording costs no extra
+upstream request and adds no pull latency. It is observational: a failed write is a warning, never a
+failed pull.
+
+🚨 This is the **OCI-level** closure — which blobs, from where. It is *not* the `/app` assembly list;
+those names live inside a layer tarball and reaching them is a separate increment.
 
 ## Configuration
 
@@ -35,7 +62,10 @@ switched off without a migration.
     "Password": "<pull credential>",
     // EMPTY MEANS NONE. Without this, one upstream credential becomes an
     // open read proxy for the entire registry.
-    "Repositories": [ "memex-portal-ai", "mw-plugin-test" ]
+    "Repositories": [ "memex-portal-ai", "mw-plugin-test" ],
+    // Where observed images are recorded. The node must already exist.
+    // EMPTY MEANS RECORDING IS OFF — the mirror still proxies normally.
+    "ImageRoot": "Platform/Images"
   }
 }
 ```
@@ -47,14 +77,19 @@ answers 404 rather than serving partially.
 
 ```csharp
 services.AddSingleton<IContainerImageAuthenticator, MyAuthenticator>();
-services.AddHttpClient<UpstreamRegistryClient>();
+// 🚨 A SINGLETON: the upstream token cache is an INSTANCE field on this client, so a transient
+// registration silently re-fetches a token on every request.
+services.AddSingleton<UpstreamRegistryClient>();
 services.Configure<ContainerImageOptions>(config.GetSection(ContainerImageOptions.SectionName));
 
-app.MapContainerImages();
+meshBuilder.AddContainerImages();   // the ContainerImage node type (recording half)
+app.MapContainerImages();           // the pull surface
 ```
 
 `IContainerImageAuthenticator` is a seam: this package takes no dependency on any particular
-identity system, so a host binds it to whatever already issues its tokens.
+identity system, so a host binds it to whatever already issues its tokens. It speaks ONE shape —
+`Bearer <key>` — because the mirror normalises `Basic` to it first; an implementation must not grow
+a second code path for `Basic`.
 
 ## The one hard limit
 

--- a/src/MeshWeaver.ContainerImages/RegistryCredential.cs
+++ b/src/MeshWeaver.ContainerImages/RegistryCredential.cs
@@ -1,0 +1,79 @@
+using System.Text;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// Reads the SECRET out of an <c>Authorization</c> header, in the two shapes an OCI client
+/// presents it.
+///
+/// <para>A registry client speaks BOTH: it sends <c>Basic base64(user:secret)</c> to the token
+/// endpoint named by the <c>WWW-Authenticate</c> challenge (that is what <c>docker login</c>
+/// stores and replays), and <c>Bearer &lt;token&gt;</c> to every route afterwards. This is the one
+/// place the mirror reduces the two to the single value it authenticates.</para>
+///
+/// <para>🚨 The username half is DELIBERATELY discarded. The credential the fleet already carries
+/// is an instance key — a bearer token — and <c>docker login -u &lt;anything&gt;</c> is how a
+/// client is made to send it. Authenticating on the username too would mean inventing a second
+/// identity concept that nothing issues.</para>
+/// </summary>
+public static class RegistryCredential
+{
+    /// <summary>The scheme a client uses against the token endpoint.</summary>
+    public const string BasicScheme = "Basic";
+
+    /// <summary>The scheme a client uses against every route after the token exchange.</summary>
+    public const string BearerScheme = "Bearer";
+
+    /// <summary>
+    /// The secret carried by <paramref name="authorizationHeader"/>, or null when the header is
+    /// absent, malformed, or names a scheme the mirror does not speak. Null is always "not
+    /// authenticated" — never "allow".
+    /// </summary>
+    public static string? TryReadSecret(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+            return null;
+
+        var header = authorizationHeader.Trim();
+        var space = header.IndexOf(' ');
+        if (space <= 0)
+            return null;
+        var scheme = header[..space];
+        var value = header[(space + 1)..].Trim();
+        if (value.Length == 0)
+            return null;
+
+        if (scheme.Equals(BearerScheme, StringComparison.OrdinalIgnoreCase))
+            return value;
+
+        if (!scheme.Equals(BasicScheme, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        byte[] decoded;
+        try
+        {
+            decoded = Convert.FromBase64String(value);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        var pair = Encoding.UTF8.GetString(decoded);
+        var colon = pair.IndexOf(':');
+        if (colon < 0)
+            return null;
+        // 🚨 Split on the FIRST colon only: a token may itself contain colons (an ACR refresh
+        // token does), and splitting on the last — or on all — would hand back a truncated secret
+        // that fails to authenticate for a reason no log would explain.
+        var secret = pair[(colon + 1)..];
+        return secret.Length == 0 ? null : secret;
+    }
+
+    /// <summary>
+    /// The <c>Authorization</c> header value that presents <paramref name="secret"/> as a bearer —
+    /// the shape the mirror's own routes are authenticated with, and what the token endpoint's
+    /// answer makes a client send next.
+    /// </summary>
+    public static string AsBearerHeader(string secret) => $"{BearerScheme} {secret}";
+}

--- a/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
+++ b/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
@@ -1,4 +1,9 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.ContainerImages;
 
@@ -9,9 +14,36 @@ namespace MeshWeaver.ContainerImages;
 /// <para>🚨 The body is NEVER buffered. <c>CopyToAsync</c> against the raw response stream is what
 /// keeps a 300 MB layer off the heap; materialising it would OOM the portal under a rolling
 /// restart, when many pods pull at once.</para>
+///
+/// <para>🚨 And the copy runs THROUGH <see cref="IIoPool"/>, holding one slot for the whole
+/// transfer. Not buffering keeps one layer off the heap; the pool is what keeps a HUNDRED
+/// concurrent layer pulls — a rolling restart of a large deployment — from each holding a socket,
+/// a buffer and a thread's worth of scheduling at once. The bound is backpressure, deliberately:
+/// a pull that waits for a slot is correct, a portal that falls over is not. The pool slot is
+/// held across the copy rather than only across the connect, because the transfer is the part
+/// that costs.</para>
 /// </summary>
 public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IResult
 {
+    private readonly IIoPool? pool;
+    private readonly byte[]? body;
+
+    /// <summary>
+    /// A passthrough whose body copy is bounded by <paramref name="ioPool"/>, optionally serving
+    /// <paramref name="preRead"/> bytes the caller already read (a manifest it recorded) instead
+    /// of the upstream stream.
+    /// </summary>
+    /// <param name="upstream">The upstream response; this result owns its disposal.</param>
+    /// <param name="ioPool">The pool bounding the transfer, or null for an unbounded copy.</param>
+    /// <param name="preRead">Body bytes already read, or null to stream the upstream body.</param>
+    public UpstreamPassthroughResult(
+        HttpResponseMessage upstream, IIoPool? ioPool, byte[]? preRead = null)
+        : this(upstream)
+    {
+        pool = ioPool;
+        body = preRead;
+    }
+
     /// <summary>Headers an OCI client depends on. <c>Docker-Content-Digest</c> is how a client
     /// verifies it got the bytes it asked for, and dropping it silently breaks digest pinning.</summary>
     private static readonly string[] ForwardedHeaders =
@@ -34,11 +66,50 @@ public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IR
                     httpContext.Response.Headers[name] = cv.ToArray();
             }
 
+            if (body is not null)
+            {
+                // A manifest the caller already read in order to record it. Bounded by
+                // ContainerImageOptions.MaxRecordedManifestBytes at the point it was read, so
+                // this is kilobytes — never a layer.
+                await httpContext.Response.Body.WriteAsync(body, httpContext.RequestAborted);
+                return;
+            }
+
             // Content-Length is set from the upstream header above; Kestrel refuses a body longer
             // than it, so a truncated upstream surfaces as a failed request rather than a short
             // layer the client would cache as complete.
-            await using var body = await upstream.Content.ReadAsStreamAsync(httpContext.RequestAborted);
-            await body.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted);
+            if (pool is null)
+            {
+                await Copy(httpContext, httpContext.RequestAborted);
+                return;
+            }
+
+            var logger = httpContext.RequestServices.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(UpstreamPassthroughResult));
+            // 🚨 ObserveCompletion, never .ToTask() — a Task completed inside an Rx pipeline
+            // resumes its awaiter INLINE on the signalling thread, still inside Rx's trampoline,
+            // and in a pool that is the worst place for it: the continuation that runs there is
+            // the one RELEASING THE SLOT.
+            //
+            // 🚨 cancelSource: true, because this wait OWNS a bounded resource. A client that
+            // gives up mid-layer (a `docker pull` interrupted, a pod rescheduled) must release the
+            // pool permit with it — under the non-disposing default the permit would be held for
+            // the full remaining transfer that nobody is reading, invisibly, until the pool
+            // starved (#2772).
+            await pool.Invoke(ct => Copy(httpContext, ct))
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "Container registry mirror: the upstream body copy for {Path} faulted "
+                        + "after the request had already been answered", httpContext.Request.Path),
+                    cancelSource: true,
+                    httpContext.RequestAborted);
         }
+    }
+
+    private async Task Copy(HttpContext httpContext, CancellationToken ct)
+    {
+        await using var source = await upstream.Content.ReadAsStreamAsync(ct);
+        await source.CopyToAsync(httpContext.Response.Body, ct);
     }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
@@ -1,7 +1,7 @@
 ---
 Name: A Container Registry in Memex
 Category: Architecture
-Description: A design for serving OCI images from the mesh — what it would buy us that ACR cannot, the bootstrap circularity that decides the shape, and why the first increment is a read-through mirror rather than a replacement. Proposal, not built.
+Description: Serving OCI images from the mesh — what it buys us that ACR cannot, the bootstrap circularity that decides the shape, and why the first increment is a read-through mirror rather than a replacement. The pull surface, the bearer handshake and closure-as-data are built; the cache, GC and the /app assembly closure are not.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="9" width="20" height="11" rx="2"/><path d="M6 9V6a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v3"/><line x1="7" y1="14" x2="7" y2="14"/><line x1="11" y1="14" x2="11" y2="14"/><line x1="15" y1="14" x2="15" y2="14"/></svg>
 ---
 
@@ -16,10 +16,21 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 > one-producer FATAL by name; two identical fully-qualified types is `CS0433`; two identical
 > extension signatures is `CS0121`. The config section moved to `ContainerImages:` for the same
 > reason. Renamed in #3361 while nothing referenced it yet — which is the only cheap moment.
-> `GET /v2/`, `…/manifests/{reference}`, `…/blobs/{digest}` and `…/tags/list`, proxied to the
-> upstream with the mirror's own credential while the caller authenticates against memex. No push,
-> no cache yet, and the boot image still comes from the upstream. The rest of this page — caching,
-> closure-as-data, GC — remains DESIGN. Nothing else described here is built. Container images live in Azure Container
+> **Built:** `GET /v2/`, the bearer token exchange at `GET /v2/token`, `…/manifests/{reference}`,
+> `…/blobs/{digest}` (Range included) and `…/tags/list`, proxied to the upstream with the mirror's
+> own credential while the caller authenticates against memex — plus the OCI-level **closure and
+> provenance of every manifest served, recorded as `ContainerImage` nodes**.
+>
+> 🚨 The token exchange arrived one increment LATE, and the gap is worth recording: the first cut
+> emitted a correct-looking `WWW-Authenticate` challenge naming a realm at `/v2/token`, and **nothing
+> served that route**. Every endpoint read correctly in isolation; a real `docker pull` went
+> 401 → fetch the realm → 404 → give up. Only a test that walks the WHOLE handshake — probe,
+> challenge, token, pull — could see it, which is why `PullSurfaceTest` is written as one
+> conversation rather than per-endpoint assertions.
+>
+> **Not built:** no push, **no cache** (every pull still goes to the upstream), no GC, and no
+> **/app assembly** closure — see "What v1 records" below for exactly where that line falls. The
+> boot image comes from the upstream, permanently. Container images live in Azure Container
 > Registry (`meshweaver.azurecr.io`), named by `ACR:` in `main-cd.yml` and referenced by eight
 > workflows. This page exists so the decision is a decision rather than a recurring conversation.
 
@@ -175,6 +186,64 @@ alone, because they all derive from *reading* manifests and layers.
   on the heap.
 * **The mirror's own credential failing is a 502, not a 401** — a 401 would send the caller to fix
   a token that is not the broken thing.
+* **The handshake COMPLETES.** `GET /v2/token` is the realm the challenge names, and it sits
+  OUTSIDE the challenge filter: a token endpoint that answered 401-with-a-challenge would name
+  itself and loop a client between the two forever. It refuses with a bare 401 instead.
+* **The mirror mints nothing.** The bearer the token exchange hands back IS the caller's own
+  instance key. A minted token would stay valid for its full lifetime after the key behind it was
+  revoked, and would make the mirror a second issuer of credentials for an identity it does not
+  own. Echoing the key means every later request re-runs the authenticator, so revocation takes
+  effect at the next exchange — and the mirror stores no token state at all.
+* **Layer transfers are BOUNDED, not merely unbuffered.** The body copy runs through `IIoPool`'s
+  `Blob` pool (cap 128), holding a slot for the whole transfer. Not buffering keeps one layer off
+  the heap; the pool is what stops a hundred concurrent pulls — a rolling restart of a large
+  deployment — from each holding a socket and a buffer at once. `Http` (cap 16) would have been
+  wrong: one layer parked there for a minute starves every plugin-catalog call the portal makes.
+
+### What v1 records, and the line it does not cross
+
+Every manifest the mirror serves is recorded as a `ContainerImage` node under
+`ContainerImages:ImageRoot` — **empty means recording is off, and the mirror still proxies**. The
+record carries the resolved digest (computed over the served bytes, never taken from a header), the
+media type, the config digest, every layer by digest and size, an index's platforms, and the
+provenance: which upstream, which repository, which reference, observed when and by whom.
+
+**It records what it SEES, and fetches nothing speculatively.** A real pull fetches the index for a
+tag and then the manifest for its own architecture, so one pull leaves both records behind, and the
+index's platform entries are digests whose own records carry the layers. That keeps recording free:
+no extra upstream request, no added pull latency, nothing a cache would later have to justify. The
+cost is stated plainly — an index nobody ever resolves (`crane manifest` and stop) leaves its
+platforms unrecorded.
+
+Recording is **observational and cannot fail a pull**: the write is subscribed off the response
+path with an explicit error arm, and a failure is a warning naming the root, never something handed
+to a `docker pull`.
+
+🚨 **The line.** This is the **OCI-level** closure — which blobs, how big, from where. It is NOT
+the **/app assembly** closure that [The Platform Image's Closure](../PlatformImageClosure)
+is about, and that #3328 was: those file names live INSIDE a layer tarball and no manifest names
+them. Reaching them means streaming the app layer through gzip + tar and recording entry names plus
+the (few-KB) `meshweaver-surface.manifest`. That is a bounded, streamable piece of work, and
+deliberately a separate increment: it cannot ride the pull path — decompressing hundreds of
+megabytes per pull is exactly the cost this design refuses — so it needs a trigger and a bandwidth
+budget of its own.
+
+#### How #3334's gate maps onto this data
+
+`check-platform-reference-set.sh` has two halves, and they land on opposite sides of that line.
+
+* **One producer** — no composed module's name may appear as `<name>.dll` in `/app` nor as an entry
+  in the surface manifest. This becomes a data assertion *once the layer scan exists*: read the
+  composed set from `main-cd.yml` (unchanged — it must stay the producer's own list, never a second
+  copy) and assert no name appears in the image record's app-assembly list or surface manifest.
+  Today the data cannot answer it.
+* **The set must resolve** — this half can **never** become an assertion over data, by construction.
+  It does not model MSBuild's binding rules, it RUNS them: a throwaway project whose references ARE
+  the directory, built with the module lane's own flags. Data can make the probe cheaper (its inputs
+  become known without pulling), but the verdict still requires a build. Saying otherwise would be
+  the second-opinion mistake the script's own comments warn about.
+
+So acceptance (2) is *"half of it, after one more increment"* — not "done", and not "impossible".
 
 **v1 is the proxy WITHOUT the cache, deliberately.** The credential goal is met by authenticating
 the caller against memex and using the mirror's credential upstream; caching is an optimisation on
@@ -211,12 +280,21 @@ verb list.
 
 ## What would say this is working
 
-Not "images pull". The measurable claims are:
+Not "images pull". The measurable claims, with where each one actually stands:
 
-* the closure of a promoted image can be answered from mesh data, with no `docker run`;
-* #3334's gate can be re-expressed as an assertion over that data;
-* a pin bump moves **one** reference instead of six literals;
-* an ACR outage still costs us nothing at boot, because the boot image never moved.
+| claim | status |
+|---|---|
+| the closure of a promoted image can be answered from mesh data, with no `docker run` | **OCI closure: yes** — config and every layer, by digest and size, read off the node. **/app assembly closure: not yet** — it needs the layer scan described above |
+| #3334's gate can be re-expressed as an assertion over that data | **half, and the other half never** — see the mapping above: one-producer becomes data once the layer scan lands; the resolve half RUNS MSBuild and cannot be modelled |
+| a pin bump moves **one** reference instead of six literals | **the data supports it** — a tag is resolved to a digest at a deterministic node path, so a consumer carries the tag. Nothing has been converted to use it yet; `ci.yml` still carries its six literals |
+| an ACR outage still costs us nothing at boot | **yes, structurally** — the boot image never moved, and switching the mirror off is a configuration change |
+
+🚨 **And one that is NOT yet measured: pull latency.** The mirror adds a hop, and no number for it
+against a real upstream exists. The streaming and pool behaviour are tested (a client receives the
+first bytes while the upstream is still producing the rest), but that is a correctness property, not
+a latency measurement. Nothing should DEPEND on the mirror until pull latency through it is measured
+against ACR directly — which is also what would settle whether the mirror *improves* pull
+availability, the open question the single-zone measurement above raised.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-you-can-see-what-is-inside-an-image.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-you-can-see-what-is-inside-an-image.md
@@ -1,0 +1,54 @@
+---
+Name: You can see what is inside a container image, without pulling it
+Category: Feature
+Description: Images pulled through your portal now leave a record behind — where they came from, which tag resolved to which digest, and every layer by digest and size. Answering "what is in this image?" no longer means downloading and unpacking it.
+Icon: Checkmark
+Order: -20260906
+---
+
+# You can see what is inside a container image, without pulling it
+
+Until now, a container image was opaque. The only way to find out what it contained was to download
+it, unpack it, and look — which meant that questions like *"which version of this did the build
+actually use?"* or *"did these two builds ship the same thing?"* were answered by hand, slowly, by
+whoever happened to have the tooling installed.
+
+## What changes
+
+Every image pulled through your portal now leaves a record behind, visible like any other content:
+
+- **where it came from** — the registry, the repository, the reference that was asked for;
+- **what a tag resolved to** — the exact content digest, computed from the bytes that were served
+  rather than taken on trust;
+- **what it is made of** — every layer by digest and size, the total, and for a
+  multi-architecture image, which platforms it offers;
+- **when it was pulled, and by whom.**
+
+That makes a tag a *reference* instead of something to copy around. A build pipeline that needs to
+pin an exact image can name the tag and read the digest, rather than pasting the digest into every
+place that needs it and then keeping those copies in step.
+
+Recording is off until an administrator names a location for it, and it can be turned off again the
+same way. It never affects a pull: if recording fails, the image is still served.
+
+## Also fixed: pulling actually works now
+
+The pull surface announced yesterday could not complete a real `docker pull`. A client asks the
+portal for a token before it will send its credentials, and the address the portal gave for that
+had nothing behind it — so every client got as far as being told where to go, went there, and found
+nothing. That exchange now exists, and pulling works end to end.
+
+The token the portal hands back is your own key rather than a new credential it invents. That is
+deliberate: if your key is withdrawn, pulling stops within minutes, instead of a separately issued
+token staying usable until it happened to expire.
+
+## What it does not do yet
+
+**This is what the image's manifest says, not what is inside its layers.** It answers "which blobs,
+how big, from where" — it does not yet list the *files* an image contains, which is what would
+answer questions about which libraries a build compiled against. That needs reading inside the
+layers themselves and is a separate piece of work.
+
+**Your portal does not keep a copy.** Every pull still goes to the upstream registry; the portal
+proxies it rather than storing it. So this makes images *visible*, not *faster*, and nothing should
+depend on it as its only source.

--- a/test/MeshWeaver.ContainerImages.Test/ContainerImageCatalogTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/ContainerImageCatalogTest.cs
@@ -1,0 +1,236 @@
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// What the mirror records, as data. These are the acceptance criteria of issue #3353 expressed
+/// as assertions over a manifest the mirror served — no <c>docker run</c>, no tarball, no ACR.
+/// </summary>
+public class ContainerImageCatalogTest
+{
+    private const string Registry = "meshweaver.azurecr.io";
+    private const string Repository = "memex-portal-ai";
+
+    private const string PortalManifest = """
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "config": {
+        "mediaType": "application/vnd.oci.image.config.v1+json",
+        "digest": "sha256:c000000000000000000000000000000000000000000000000000000000000000",
+        "size": 4096
+      },
+      "layers": [
+        {
+          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "digest": "sha256:a000000000000000000000000000000000000000000000000000000000000000",
+          "size": 84000000
+        },
+        {
+          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "digest": "sha256:b000000000000000000000000000000000000000000000000000000000000000",
+          "size": 216000000
+        }
+      ]
+    }
+    """;
+
+    private const string PortalIndex = """
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "size": 1234,
+          "platform": { "architecture": "amd64", "os": "linux" }
+        },
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "size": 1234,
+          "platform": { "architecture": "arm64", "os": "linux" }
+        }
+      ]
+    }
+    """;
+
+    private static ContainerImageRecord Describe(string reference, string json) =>
+        ContainerImageCatalog.Describe(
+            Registry, Repository, reference, Encoding.UTF8.GetBytes(json),
+            observedBy: "instance/ci", observedAt: DateTimeOffset.UnixEpoch)!;
+
+    /// <summary>
+    /// ACCEPTANCE (1): the closure of a promoted image is answerable from the record — every blob
+    /// by digest and size, with no <c>docker run</c> and nothing extracted.
+    /// </summary>
+    [Fact]
+    public void TheClosureOfAPromotedImage_IsAnsweredFromTheRecordAlone()
+    {
+        var record = Describe("ci.7794", PortalManifest);
+
+        Assert.False(record.IsIndex);
+        Assert.Equal(
+            "sha256:c000000000000000000000000000000000000000000000000000000000000000",
+            record.ConfigDigest);
+        Assert.Equal(2, record.Layers.Length);
+        Assert.Equal(300_004_096, record.ClosureSize);
+        Assert.All(record.Layers, l => Assert.StartsWith("sha256:", l.Digest));
+    }
+
+    /// <summary>
+    /// ACCEPTANCE (3): a pin bump moves ONE reference. A consumer holds the TAG; the record
+    /// resolves it to a digest, so nothing downstream has to carry a digest literal.
+    /// </summary>
+    [Fact]
+    public void ATagIsResolvedToADigest_SoAConsumerCarriesTheTagAndNotTheDigest()
+    {
+        var record = Describe("ci.7794", PortalManifest);
+
+        Assert.Equal("ci.7794", record.Reference);
+        Assert.StartsWith("sha256:", record.Digest);
+        // The node id is derived from the tag alone, so "the current sealed set" is one path a
+        // workflow can name — not six literals it has to keep in step.
+        Assert.Equal(
+            ContainerImageCatalog.NodeId(Repository, "ci.7794"),
+            ContainerImageCatalog.NodeId(record.Repository, record.Reference));
+    }
+
+    /// <summary>
+    /// 🚨 The digest is COMPUTED over the bytes, never taken from a header. A manifest IS its
+    /// content hash, so a recorded digest that disagreed with the bytes would silently break
+    /// every pin derived from it.
+    /// </summary>
+    [Fact]
+    public void TheDigestIsComputedOverTheServedBytes()
+    {
+        var bytes = Encoding.UTF8.GetBytes(PortalManifest);
+        var expected = "sha256:" + Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+        Assert.Equal(expected, Describe("ci.7794", PortalManifest).Digest);
+    }
+
+    /// <summary>
+    /// PROVENANCE (2 of the design's gains): where the bytes came from and who pulled them are
+    /// typed fields, not a tag-naming convention to string-split.
+    /// </summary>
+    [Fact]
+    public void ProvenanceIsRecordedAsFields_NotEncodedInAName()
+    {
+        var record = Describe("ci.7794", PortalManifest);
+
+        Assert.Equal(Registry, record.Registry);
+        Assert.Equal(Repository, record.Repository);
+        Assert.Equal("instance/ci", record.ObservedBy);
+        Assert.Equal(DateTimeOffset.UnixEpoch, record.ObservedAt);
+    }
+
+    /// <summary>
+    /// An index records its PLATFORMS. Each platform digest is the reference to the record
+    /// carrying that platform's own layers — written when anything pulls it, which every real
+    /// pull does. The mirror never fetches speculatively, so recording costs no extra upstream
+    /// request and adds no pull latency.
+    /// </summary>
+    [Fact]
+    public void AnIndexRecordsItsPlatformsAsReferencesToTheirOwnRecords()
+    {
+        var record = Describe("ci.7794", PortalIndex);
+
+        Assert.True(record.IsIndex);
+        Assert.Empty(record.Layers);
+        Assert.Equal(2, record.Platforms.Length);
+        Assert.Contains(record.Platforms, p => p.Architecture == "amd64" && p.Os == "linux");
+        Assert.Contains(record.Platforms, p => p.Architecture == "arm64");
+
+        // The reference resolves: the platform's digest IS the reference of its own record.
+        var platform = record.Platforms[0];
+        Assert.Equal(
+            ContainerImageCatalog.NodeId(Repository, platform.Digest),
+            ContainerImageCatalog.NodeId(record.Repository, platform.Digest));
+    }
+
+    /// <summary>Bytes the mirror does not model produce NO record — it still serves them.</summary>
+    [Fact]
+    public void BytesThatAreNotAManifest_ProduceNoRecord() =>
+        Assert.Null(ContainerImageCatalog.Describe(
+            Registry, Repository, "latest", Encoding.UTF8.GetBytes("<html>502</html>"),
+            null, DateTimeOffset.UnixEpoch));
+
+    // ── node ids ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The common case stays verbatim, so a consumer that knows the tag knows the path.</summary>
+    [Fact]
+    public void ANodeIdIsPredictableForAPlainRepositoryAndTag() =>
+        Assert.Equal("memex-portal-ai--ci.7794",
+            ContainerImageCatalog.NodeId("memex-portal-ai", "ci.7794"));
+
+    /// <summary>A digest reference is a legal id: the colon becomes a dash.</summary>
+    [Fact]
+    public void ADigestReferenceBecomesALegalSegment()
+    {
+        var id = ContainerImageCatalog.NodeId("memex-portal-ai", "sha256:abc123");
+        Assert.DoesNotContain(':', id);
+        Assert.DoesNotContain('/', id);
+        Assert.StartsWith("memex-portal-ai--sha256-abc123", id);
+    }
+
+    /// <summary>
+    /// 🚨 The reduction to one path segment is LOSSY, and two images sharing a node would make
+    /// the closure answer for one of them WRONG — the single failure this data may not have. Pairs
+    /// that collide after sanitisation must stay distinct.
+    /// </summary>
+    [Theory]
+    [InlineData("team/service", "a-b")]
+    [InlineData("team-service", "a/b")]
+    [InlineData("team/service", "a/b")]
+    [InlineData("team-service", "a-b")]
+    public void LossilySanitisedPairsNeverCollide(string repository, string reference)
+    {
+        var ids = new[]
+        {
+            ContainerImageCatalog.NodeId("team/service", "a-b"),
+            ContainerImageCatalog.NodeId("team-service", "a/b"),
+            ContainerImageCatalog.NodeId("team/service", "a/b"),
+            ContainerImageCatalog.NodeId("team-service", "a-b"),
+        };
+        Assert.Equal(4, ids.Distinct().Count());
+        // …and the id for this pair is one of them, deterministically.
+        Assert.Contains(ContainerImageCatalog.NodeId(repository, reference), ids);
+    }
+
+    [Fact]
+    public void ANodeIdIsDeterministic() =>
+        Assert.Equal(
+            ContainerImageCatalog.NodeId("a/b", "sha256:ff"),
+            ContainerImageCatalog.NodeId("a/b", "sha256:ff"));
+
+    /// <summary>
+    /// Whatever the input, the id is ONE path segment carrying only legal characters, and is never
+    /// a relative-path token — otherwise a repository name could steer where the record is written.
+    ///
+    /// <para>Note what is NOT asserted: that the id contains no <c>..</c> substring. A dot is legal
+    /// inside a segment (every tag has one), and traversal needs a segment that IS <c>..</c> — which
+    /// the mandatory <c>--</c> separator makes impossible. Asserting the substring would be
+    /// asserting a property that is neither true nor needed.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("a/b/c", "latest")]
+    [InlineData("../escape", "latest")]
+    [InlineData("repo", "../../secret")]
+    [InlineData("repo", "sha256:0123456789abcdef")]
+    [InlineData("", "")]
+    public void ANodeIdIsAlwaysOneLegalSegment(string repository, string reference)
+    {
+        var id = ContainerImageCatalog.NodeId(repository, reference);
+        Assert.NotEmpty(id);
+        Assert.DoesNotContain('/', id);
+        Assert.All(id, c => Assert.True(
+            char.IsAsciiLetterOrDigit(c) || c is '.' or '_' or '-',
+            $"'{c}' is not legal in a node id"));
+        Assert.NotEqual(".", id);
+        Assert.NotEqual("..", id);
+    }
+}

--- a/test/MeshWeaver.ContainerImages.Test/ContainerImageRecordingTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/ContainerImageRecordingTest.cs
@@ -1,0 +1,204 @@
+using System.Reactive.Linq;
+using System.Text;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// The recording half, against a REAL mesh: a manifest the mirror served becomes a node whose
+/// content is a typed <see cref="ContainerImageRecord"/>, and the image's closure is then
+/// answerable from mesh data with no <c>docker run</c> and nothing extracted.
+///
+/// <para>🚨 The typed read is the point of the last assertion, not a formality. Without the
+/// NodeType's <c>WithContentType</c> registration the content survives as an untyped
+/// <c>JsonElement</c> — the silent-null trap: the node exists, <c>get</c> returns it, and every
+/// consumer reads the closure as absent while nothing errors and nothing logs.</para>
+/// </summary>
+public class ContainerImageRecordingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Registry = "meshweaver.azurecr.io";
+    private const string Repository = "memex-portal-ai";
+    private static string ImageRoot => $"{TestPartition}/Images";
+
+    private const string Manifest = """
+    {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:c000000000000000000000000000000000000000000000000000000000000000","size":4096},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:a000000000000000000000000000000000000000000000000000000000000000","size":84000000},{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:b000000000000000000000000000000000000000000000000000000000000000","size":216000000}]}
+    """;
+
+    private const string Index = """
+    {"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","size":1234,"platform":{"architecture":"amd64","os":"linux"}}]}
+    """;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        ConfigureMeshBase(builder).AddContainerImages();
+
+    private async Task CreateImageRoot() =>
+        await NodeFactory.CreateNode(MeshNode.FromPath(ImageRoot) with
+        {
+            Name = "Images",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+    private static ContainerImageRecord Describe(string reference, string json) =>
+        ContainerImageCatalog.Describe(
+            Registry, Repository, reference, Encoding.UTF8.GetBytes(json),
+            "instance/ci", DateTimeOffset.UtcNow)!;
+
+    /// <summary>
+    /// ACCEPTANCE (1): the closure of a promoted image is answered from mesh data — read back off
+    /// the node's own stream, typed, with no <c>docker run</c> and no tarball.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AServedManifestBecomesANodeWhoseContentAnswersTheClosure()
+    {
+        await CreateImageRoot();
+        var record = Describe("ci.7794", Manifest);
+
+        var node = await ContainerImageCatalog.Record(Mesh, ImageRoot, record)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Assert.Equal($"{ImageRoot}/{ContainerImageCatalog.NodeId(Repository, "ci.7794")}", node!.Path);
+        Assert.Equal(ContainerImageCatalog.NodeType, node.NodeType);
+
+        // Read it BACK, the way a consumer would: the node's own stream is authoritative and live.
+        var stored = await Mesh.GetMeshNodeStream(node.Path)
+            .Where(n => n?.Content is not null)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        // 🚨 ContentAs, never a cast: content that crossed a hub boundary can arrive as an
+        // untyped JsonElement, and `is ContainerImageRecord` would read that as a silent null.
+        var closure = stored!.ContentAs<ContainerImageRecord>(Mesh.JsonSerializerOptions);
+        Assert.NotNull(closure);
+        Assert.Equal(Registry, closure!.Registry);
+        Assert.Equal(Repository, closure.Repository);
+        Assert.Equal("ci.7794", closure.Reference);
+        Assert.Equal(record.Digest, closure.Digest);
+        Assert.Equal(
+            "sha256:c000000000000000000000000000000000000000000000000000000000000000",
+            closure.ConfigDigest);
+        Assert.Equal(2, closure.Layers.Length);
+        Assert.Equal(300_004_096, closure.ClosureSize);
+        Assert.Equal("instance/ci", closure.ObservedBy);
+
+        Output.WriteLine(
+            $"closure answered from mesh data: {closure.Layers.Length} layer(s), "
+            + $"{closure.ClosureSize:N0} bytes, digest {closure.Digest}");
+    }
+
+    /// <summary>
+    /// ACCEPTANCE (3): a consumer holds the TAG. The node id is derived from it, so "what digest
+    /// is ci.7794 today" is one path — not a digest literal copied into six places that then have
+    /// to be kept in step.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ATagResolvesToADigestAtOneKnownPath()
+    {
+        await CreateImageRoot();
+
+        await ContainerImageCatalog.Record(Mesh, ImageRoot, Describe("ci.7794", Manifest))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        // A consumer that knows only the repository and the tag can name the path.
+        var path = $"{ImageRoot}/{ContainerImageCatalog.NodeId(Repository, "ci.7794")}";
+        var stored = await Mesh.GetMeshNodeStream(path)
+            .Where(n => n?.Content is not null)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        var closure = stored!.ContentAs<ContainerImageRecord>(Mesh.JsonSerializerOptions);
+        Assert.StartsWith("sha256:", closure!.Digest);
+    }
+
+    /// <summary>
+    /// A re-pull of the same reference REFRESHES the record rather than racing a create against an
+    /// update — the upsert is serialised by the owning hub, which is why this is
+    /// <c>CreateOrUpdateNode</c> and not a hand-rolled create-then-catch.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task RePullingTheSameReferenceUpdatesTheSameNode()
+    {
+        await CreateImageRoot();
+        var first = Describe("latest", Index);
+        var second = Describe("latest", Manifest);
+
+        var a = await ContainerImageCatalog.Record(Mesh, ImageRoot, first)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var b = await ContainerImageCatalog.Record(Mesh, ImageRoot, second)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Assert.Equal(a!.Path, b!.Path);
+
+        var stored = await Mesh.GetMeshNodeStream(b.Path)
+            .Select(n => n?.ContentAs<ContainerImageRecord>(Mesh.JsonSerializerOptions))
+            .Where(c => c is { IsIndex: false })
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Assert.Equal(2, stored!.Layers.Length);
+    }
+
+    /// <summary>
+    /// An index and each platform it names get their OWN records, and the index's platform entry
+    /// is the reference that reaches the platform's closure. The mirror never fetches
+    /// speculatively — a real pull fetches both, so both are recorded from the one pull.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task AnIndexAndItsPlatformAreSeparateRecordsLinkedByDigest()
+    {
+        await CreateImageRoot();
+        const string platformDigest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+
+        var index = Describe("ci.7794", Index);
+        await ContainerImageCatalog.Record(Mesh, ImageRoot, index)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        await ContainerImageCatalog.Record(Mesh, ImageRoot, Describe(platformDigest, Manifest))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Assert.True(index.IsIndex);
+        var platform = Assert.Single(index.Platforms);
+        Assert.Equal(platformDigest, platform.Digest);
+
+        // Following the reference: the platform digest names a path that holds the layers.
+        var path = $"{ImageRoot}/{ContainerImageCatalog.NodeId(Repository, platform.Digest)}";
+        var stored = await Mesh.GetMeshNodeStream(path)
+            .Select(n => n?.ContentAs<ContainerImageRecord>(Mesh.JsonSerializerOptions))
+            .Where(c => c is not null)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Assert.Equal(2, stored!.Layers.Length);
+    }
+
+    /// <summary>
+    /// The node type is REGISTERED by <c>AddContainerImages</c> — without it the content stays an
+    /// untyped JsonElement and every closure reads as absent.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task TheNodeTypeIsRegistered()
+    {
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var nodeType = await mesh
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{ContainerImageCatalog.NodeType}"))
+            .Select(c => c.Items.FirstOrDefault(n => n.Id == ContainerImageCatalog.NodeType))
+            .Where(n => n is not null)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Assert.Equal(MeshNode.NodeTypePath, nodeType!.NodeType);
+    }
+}

--- a/test/MeshWeaver.ContainerImages.Test/FakeUpstreamRegistry.cs
+++ b/test/MeshWeaver.ContainerImages.Test/FakeUpstreamRegistry.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// A real, in-process OCI registry standing in for ACR: it speaks the same token handshake
+/// (<c>Basic</c> to <c>/oauth2/token</c>, then <c>Bearer</c> on every route), serves manifests,
+/// blobs and tag lists, and honours <c>Range</c>.
+///
+/// <para>This substitutes the NETWORK, not a MeshWeaver interface — the alternative is a live ACR,
+/// which a test cannot have. It is deliberately a hand-written <see cref="HttpMessageHandler"/>
+/// rather than a mocking framework: the behaviour under test IS the protocol conversation, so the
+/// stand-in has to actually hold the protocol's invariants (a 401 without a token, a 401 on a
+/// stale one) rather than replay recorded answers.</para>
+/// </summary>
+internal sealed class FakeUpstreamRegistry : HttpMessageHandler
+{
+    /// <summary>The upstream host the mirror is configured with.</summary>
+    public const string Host = "fake.azurecr.io";
+
+    /// <summary>The mirror's own upstream credential — the ONE copy the fleet keeps.</summary>
+    public const string Username = "mirror";
+
+    /// <summary>The mirror's own upstream credential.</summary>
+    public const string Password = "mirror-secret";
+
+    /// <summary>The repository the mirror is allowed to serve.</summary>
+    public const string Repository = "memex-portal-ai";
+
+    /// <summary>A repository that exists upstream but is NOT on the mirror's allowlist.</summary>
+    public const string UnlistedRepository = "memex-secret";
+
+    private const string UpstreamToken = "upstream-bearer";
+
+    /// <summary>A single-platform manifest whose closure is a config plus two layers.</summary>
+    public const string ManifestJson = """
+    {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:c000000000000000000000000000000000000000000000000000000000000000","size":4096},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:a000000000000000000000000000000000000000000000000000000000000000","size":84000000},{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"sha256:b000000000000000000000000000000000000000000000000000000000000000","size":216000000}]}
+    """;
+
+    /// <summary>The blob the mirror streams in the layer tests.</summary>
+    public static readonly byte[] LayerBytes = CreateLayer(1024 * 1024);
+
+    /// <summary>How many times the mirror asked for an upstream token — the token cache's
+    /// observable effect.</summary>
+    public int TokenRequests;
+
+    /// <summary>Total requests the upstream received, token exchanges included.</summary>
+    public int Requests;
+
+    /// <summary>When set, the token endpoint refuses the mirror's credential — the "our own
+    /// credential is broken" case, which must surface as 502 and never as 401.</summary>
+    public bool RefuseMirrorCredential;
+
+    /// <summary>When set, a blob body parks after its first chunk until
+    /// <see cref="ReleaseLayer"/> flips — the streaming proof.</summary>
+    public bool ParkLayerAfterFirstChunk;
+
+    /// <summary>Released by the test once it has seen the first bytes arrive. Volatile int polled
+    /// under a bounded SpinWait: the park IS the subject of the test, and a hand-woven async gate
+    /// is forbidden here.</summary>
+    public int ReleaseLayer;
+
+    private static byte[] CreateLayer(int size)
+    {
+        var bytes = new byte[size];
+        for (var i = 0; i < size; i++)
+            bytes[i] = (byte)(i % 251);
+        return bytes;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref Requests);
+        var uri = request.RequestUri!;
+        if (!string.Equals(uri.Host, Host, StringComparison.Ordinal))
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        if (uri.AbsolutePath == "/oauth2/token")
+            return Task.FromResult(Token(request));
+
+        // Every /v2 route needs the bearer the token endpoint issued. This is not decoration: it
+        // is what makes the mirror's own token handling — cache, expiry, one retry on 401 — real
+        // rather than assumed.
+        if (request.Headers.Authorization is not { Scheme: "Bearer" } auth
+            || auth.Parameter != UpstreamToken)
+            return Task.FromResult(Unauthorized());
+
+        var path = uri.AbsolutePath;
+        foreach (var repository in new[] { Repository, UnlistedRepository })
+        {
+            if (path == $"/v2/{repository}/manifests/ci.7794"
+                || path == $"/v2/{repository}/manifests/latest")
+                return Task.FromResult(Manifest());
+            if (path == $"/v2/{repository}/tags/list")
+                return Task.FromResult(Json($$"""{"name":"{{repository}}","tags":["ci.7794","latest"]}"""));
+            if (path.StartsWith($"/v2/{repository}/blobs/sha256:", StringComparison.Ordinal))
+                return Task.FromResult(Blob(request));
+        }
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+
+    private HttpResponseMessage Token(HttpRequestMessage request)
+    {
+        Interlocked.Increment(ref TokenRequests);
+        var presented = RegistryCredential.TryReadSecret(
+            request.Headers.Authorization?.ToString());
+        if (RefuseMirrorCredential || presented != Password)
+            return Unauthorized();
+        return Json($$"""{"access_token":"{{UpstreamToken}}","expires_in":300}""");
+    }
+
+    private static HttpResponseMessage Unauthorized()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        response.Headers.TryAddWithoutValidation(
+            "Www-Authenticate",
+            $"Bearer realm=\"https://{Host}/oauth2/token\",service=\"{Host}\"");
+        return response;
+    }
+
+    private static HttpResponseMessage Manifest()
+    {
+        var bytes = Encoding.UTF8.GetBytes(ManifestJson);
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes),
+        };
+        response.Content.Headers.ContentType =
+            new MediaTypeHeaderValue("application/vnd.oci.image.manifest.v1+json");
+        response.Headers.TryAddWithoutValidation(
+            "Docker-Content-Digest",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        return response;
+    }
+
+    private HttpResponseMessage Blob(HttpRequestMessage request)
+    {
+        var range = request.Headers.Range?.Ranges.FirstOrDefault();
+        if (range is { From: { } from, To: { } to })
+        {
+            var length = (int)(to - from + 1);
+            var slice = LayerBytes.AsSpan((int)from, length).ToArray();
+            var partial = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new ByteArrayContent(slice),
+            };
+            partial.Content.Headers.ContentRange =
+                new ContentRangeHeaderValue(from, to, LayerBytes.Length);
+            partial.Headers.AcceptRanges.Add("bytes");
+            return partial;
+        }
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = ParkLayerAfterFirstChunk
+                ? new StreamContent(new ParkingStream(this))
+                : new ByteArrayContent(LayerBytes),
+        };
+        response.Content.Headers.ContentLength = LayerBytes.Length;
+        response.Headers.AcceptRanges.Add("bytes");
+        return response;
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+
+    /// <summary>
+    /// A body that hands over its first chunk and then PARKS until the test releases it. That
+    /// park is the whole experiment: if the mirror buffered, the client could not possibly have
+    /// the first bytes while the upstream is still holding the rest.
+    /// </summary>
+    private sealed class ParkingStream(FakeUpstreamRegistry owner) : Stream
+    {
+        private const int FirstChunk = 4096;
+        private int position;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => LayerBytes.Length;
+        public override long Position { get => position; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (position >= LayerBytes.Length)
+                return 0;
+            if (position >= FirstChunk)
+                // Bounded, never indefinite: if the release never comes the stream simply ends and
+                // the test fails on its assertion rather than hanging the run.
+                SpinWait.SpinUntil(
+                    () => Volatile.Read(ref owner.ReleaseLayer) != 0, TimeSpan.FromSeconds(10));
+
+            var available = position < FirstChunk
+                ? Math.Min(FirstChunk - position, buffer.Length)
+                : Math.Min(LayerBytes.Length - position, buffer.Length);
+            LayerBytes.AsSpan(position, available).CopyTo(buffer);
+            position += available;
+            return available;
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(Read(buffer.Span));
+    }
+}

--- a/test/MeshWeaver.ContainerImages.Test/MeshWeaver.ContainerImages.Test.csproj
+++ b/test/MeshWeaver.ContainerImages.Test/MeshWeaver.ContainerImages.Test.csproj
@@ -3,6 +3,20 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.ContainerImages\MeshWeaver.ContainerImages.csproj" />
+    <!-- ContainerImageRecordingTest drives the recording half against a REAL monolith mesh: the
+         thing under test is that a served manifest lands as a node whose content reads back TYPED,
+         and only a real mesh can be wrong about that. -->
+    <ProjectReference Include="..\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <ProjectReference Include="..\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- PullSurfaceTest walks the whole bearer handshake over a real HTTP pipeline. The realm the
+         challenge names has to be a route that ANSWERS, and nothing short of a real pipeline
+         (routing precedence included) can show that. -->
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
   </ItemGroup>
 </Project>

--- a/test/MeshWeaver.ContainerImages.Test/OciManifestTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/OciManifestTest.cs
@@ -1,0 +1,154 @@
+using System.Text;
+using Xunit;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// The manifest parser is what turns registry bytes into a CLOSURE. Everything the mirror can
+/// later answer about an image — which blobs, how big, which platforms — comes from here, so the
+/// property that matters is not "it parses the happy case" but that it REFUSES anything it does
+/// not model. A half-parsed closure is worse than none: it answers "what is in this image?"
+/// confidently, and short.
+/// </summary>
+public class OciManifestTest
+{
+    private const string Index = """
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "manifests": [
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "size": 1234,
+          "platform": { "architecture": "amd64", "os": "linux" }
+        },
+        {
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "size": 1235,
+          "platform": { "architecture": "arm64", "os": "linux", "variant": "v8" }
+        }
+      ]
+    }
+    """;
+
+    private const string Manifest = """
+    {
+      "schemaVersion": 2,
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "config": {
+        "mediaType": "application/vnd.oci.image.config.v1+json",
+        "digest": "sha256:c0c0000000000000000000000000000000000000000000000000000000000000",
+        "size": 700
+      },
+      "layers": [
+        {
+          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "digest": "sha256:aaaa000000000000000000000000000000000000000000000000000000000000",
+          "size": 30000000
+        },
+        {
+          "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+          "digest": "sha256:bbbb000000000000000000000000000000000000000000000000000000000000",
+          "size": 270000000
+        }
+      ]
+    }
+    """;
+
+    private static byte[] Bytes(string json) => Encoding.UTF8.GetBytes(json);
+
+    [Fact]
+    public void AnIndex_NamesItsPlatforms_AndCarriesNoLayersOfItsOwn()
+    {
+        Assert.True(OciManifestDocument.TryParse(Bytes(Index), out var document));
+
+        Assert.True(document.IsIndex);
+        Assert.Equal("application/vnd.oci.image.index.v1+json", document.MediaType);
+        Assert.Null(document.Config);
+        Assert.Empty(document.Layers);
+        Assert.Equal(2, document.Manifests.Length);
+
+        Assert.Equal("linux", document.Manifests[0].Os);
+        Assert.Equal("amd64", document.Manifests[0].Architecture);
+        Assert.Null(document.Manifests[0].Variant);
+        Assert.Equal("v8", document.Manifests[1].Variant);
+        // An index's closure is REACHED through these digests, not held — so it declares none.
+        Assert.Equal(0, document.ClosureSize);
+    }
+
+    [Fact]
+    public void AManifest_IsTheClosure_ConfigPlusEveryLayerByDigestAndSize()
+    {
+        Assert.True(OciManifestDocument.TryParse(Bytes(Manifest), out var document));
+
+        Assert.False(document.IsIndex);
+        Assert.NotNull(document.Config);
+        Assert.Equal(
+            "sha256:c0c0000000000000000000000000000000000000000000000000000000000000",
+            document.Config!.Digest);
+        Assert.Equal(2, document.Layers.Length);
+        Assert.Equal(300_000_700, document.ClosureSize);
+    }
+
+    /// <summary>
+    /// Every shape the mirror does NOT model. Each is still SERVED — the refusal is about
+    /// recording, never about the pull — but none may produce a partially-populated document.
+    /// </summary>
+    [Theory]
+    // A Docker schema-1 manifest: fsLayers, no `layers`, no `config`.
+    [InlineData("""{"schemaVersion":1,"fsLayers":[{"blobSum":"sha256:ab"}]}""")]
+    // An index naming no platforms — no client can resolve it, and recording it as an image with
+    // an empty closure would be a lie about a thing that does not work.
+    [InlineData("""{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}""")]
+    // Layers without a config: not a manifest shape.
+    [InlineData("""{"layers":[{"digest":"sha256:ab","size":1}]}""")]
+    // A config that names no digest cannot anchor a closure.
+    [InlineData("""{"config":{"size":1},"layers":[]}""")]
+    // Not an object.
+    [InlineData("[]")]
+    [InlineData("\"a string\"")]
+    // Not JSON at all — a truncated body, or an error page an intermediary substituted.
+    [InlineData("<html>502</html>")]
+    [InlineData("")]
+    public void RefusesEveryShapeItDoesNotModel(string json) =>
+        Assert.False(OciManifestDocument.TryParse(Bytes(json), out _));
+
+    /// <summary>
+    /// A layerless manifest IS legal — an attestation, a scratch image — so an empty
+    /// <c>layers</c> array beside a real config is accepted rather than refused. The refusal list
+    /// above is about shapes that cannot be modelled, not about images that happen to be small.
+    /// </summary>
+    [Fact]
+    public void AcceptsALayerlessManifest_WhichIsLegal()
+    {
+        Assert.True(OciManifestDocument.TryParse(
+            Bytes("""{"config":{"digest":"sha256:ab","size":7},"layers":[]}"""),
+            out var document));
+        Assert.Empty(document.Layers);
+        Assert.Equal(7, document.ClosureSize);
+    }
+
+    /// <summary>
+    /// A descriptor without a digest names nothing, so it is DROPPED rather than recorded as a
+    /// blank entry — a closure listing an unnamed blob would be unusable and look complete.
+    /// </summary>
+    [Fact]
+    public void DropsADescriptorThatNamesNoDigest()
+    {
+        Assert.True(OciManifestDocument.TryParse(
+            Bytes("""
+            {
+              "config": { "digest": "sha256:ab", "size": 1 },
+              "layers": [
+                { "digest": "sha256:cd", "size": 2 },
+                { "size": 3 }
+              ]
+            }
+            """),
+            out var document));
+        Assert.Single(document.Layers);
+        Assert.Equal("sha256:cd", document.Layers[0].Digest);
+    }
+}

--- a/test/MeshWeaver.ContainerImages.Test/PullSurfaceTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/PullSurfaceTest.cs
@@ -1,0 +1,405 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// The pull surface driven over a REAL HTTP pipeline, against a real in-process upstream registry.
+///
+/// <para>The subject is the CONVERSATION, not the individual handlers: an OCI client probes
+/// <c>/v2/</c>, reads a challenge, fetches the realm the challenge names, and only then pulls. Every
+/// step of that has to line up, and the step that did not was the realm — the challenge named
+/// <c>/v2/token</c> and nothing served it, so a client's dance went 401 → 404 → give up. Nothing
+/// short of walking the whole handshake catches that: each endpoint in isolation looked right.</para>
+/// </summary>
+public class PullSurfaceTest
+{
+    private const string InstanceKey = "mw_instance_key";
+    private const string CallerName = "instance/ci";
+
+    /// <summary>
+    /// The reference implementation of the seam: ONE shape (<c>Bearer &lt;instance key&gt;</c>),
+    /// because the mirror normalises before it asks. Real, not a mock — the contract is small
+    /// enough that a stand-in with different behaviour would be testing the stand-in.
+    /// </summary>
+    private sealed class InstanceKeyAuthenticator : IContainerImageAuthenticator
+    {
+        public IObservable<string?> Authenticate(string? authorizationHeader, CancellationToken ct) =>
+            Observable.Return(
+                RegistryCredential.TryReadSecret(authorizationHeader) == InstanceKey
+                    ? CallerName
+                    : null);
+    }
+
+    private static async Task<WebApplication> BuildMirror(
+        FakeUpstreamRegistry upstream,
+        bool configured = true,
+        string? imageRoot = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        var options = new ContainerImageOptions
+        {
+            Upstream = configured ? FakeUpstreamRegistry.Host : null,
+            Username = configured ? FakeUpstreamRegistry.Username : null,
+            Password = configured ? FakeUpstreamRegistry.Password : null,
+            Repositories = [FakeUpstreamRegistry.Repository],
+            ImageRoot = imageRoot,
+        };
+        builder.Services.AddSingleton(Options.Create(options));
+        // 🚨 A SINGLETON, as the portal must register it: the upstream token cache is an INSTANCE
+        // field on this object, so a transient registration would silently re-fetch a token per
+        // request — which `OneTokenExchangeServesManyPulls` below is the guard for.
+        builder.Services.AddSingleton(_ => new HttpClient(upstream));
+        builder.Services.AddSingleton<UpstreamRegistryClient>();
+        builder.Services.AddSingleton<IContainerImageAuthenticator, InstanceKeyAuthenticator>();
+
+        var app = builder.Build();
+        app.MapContainerImages();
+        // The negative control: without a route that DOES answer, "everything 404s" and "nothing
+        // is mapped" would be the same observation.
+        app.MapGet("/ordinary", () => "the portal");
+        // StartAsync, not Start(): the sync overload blocks the calling thread on host startup.
+        await app.StartAsync();
+        return app;
+    }
+
+    private static HttpClient Anonymous(WebApplication app) => app.GetTestClient();
+
+    private static HttpClient Authenticated(WebApplication app)
+    {
+        var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", InstanceKey);
+        return client;
+    }
+
+    // ── the handshake ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE WHOLE DANCE, as a real client walks it: probe → challenge → token → pull. The realm
+    /// the challenge names must be a route that answers, or every <c>docker pull</c> ends at a 404
+    /// it cannot interpret. This is the test that proves the handshake COMPLETES; asserting the
+    /// challenge header alone proved only that a client would be sent somewhere.
+    /// </summary>
+    [Fact]
+    public async Task TheBearerDanceCompletes_ProbeThenChallengeThenTokenThenPull()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+        var client = Anonymous(app);
+
+        // 1. The probe, unauthenticated: 401 carrying a challenge that names a realm.
+        var probe = await client.GetAsync("/v2/");
+        Assert.Equal(HttpStatusCode.Unauthorized, probe.StatusCode);
+        var challenge = Assert.Single(probe.Headers.WwwAuthenticate).ToString();
+        Assert.StartsWith("Bearer ", challenge);
+        Assert.Equal("registry/2.0", probe.Headers.GetValues("Docker-Distribution-Api-Version").Single());
+
+        var realm = Realm(challenge);
+        Assert.Contains("/v2/token", realm);
+
+        // 2. The realm, with the credential a `docker login` stores — Basic, not Bearer.
+        var tokenRequest = new HttpRequestMessage(
+            HttpMethod.Get, $"{realm}?service=localhost&scope=repository:{FakeUpstreamRegistry.Repository}:pull");
+        tokenRequest.Headers.Authorization = new AuthenticationHeaderValue(
+            "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"ci:{InstanceKey}")));
+        var tokenResponse = await client.SendAsync(tokenRequest);
+        Assert.Equal(HttpStatusCode.OK, tokenResponse.StatusCode);
+
+        using var token = JsonDocument.Parse(await tokenResponse.Content.ReadAsStringAsync());
+        var bearer = token.RootElement.GetProperty("token").GetString();
+        Assert.False(string.IsNullOrEmpty(bearer));
+        // Both spellings, because clients read one or the other.
+        Assert.Equal(bearer, token.RootElement.GetProperty("access_token").GetString());
+        Assert.True(token.RootElement.GetProperty("expires_in").GetInt32() > 0);
+
+        // 3. The token the exchange handed back opens the probe…
+        var authorized = new HttpRequestMessage(HttpMethod.Get, "/v2/");
+        authorized.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(authorized)).StatusCode);
+
+        // 4. …and a manifest pull.
+        var pull = new HttpRequestMessage(
+            HttpMethod.Get, $"/v2/{FakeUpstreamRegistry.Repository}/manifests/ci.7794");
+        pull.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        var manifest = await client.SendAsync(pull);
+        Assert.Equal(HttpStatusCode.OK, manifest.StatusCode);
+        Assert.Equal(
+            FakeUpstreamRegistry.ManifestJson.Trim(),
+            (await manifest.Content.ReadAsStringAsync()).Trim());
+    }
+
+    /// <summary>
+    /// The challenge names the SCOPE for the repository actually requested — the shape ACR emits,
+    /// and what a client copies verbatim into its token request.
+    /// </summary>
+    [Fact]
+    public async Task TheChallengeOnARepositoryRouteNamesThatRepositorysPullScope()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var response = await Anonymous(app)
+            .GetAsync($"/v2/{FakeUpstreamRegistry.Repository}/manifests/ci.7794");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(
+            $"scope=\"repository:{FakeUpstreamRegistry.Repository}:pull\"",
+            Assert.Single(response.Headers.WwwAuthenticate).ToString());
+    }
+
+    /// <summary>
+    /// 🚨 The token endpoint refuses with a BARE 401 — no challenge. Challenging here would name
+    /// this very route, and a client that follows challenges would loop between the two forever.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedTokenExchangeCarriesNoChallenge_SoAClientCannotLoop()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var anonymous = await Anonymous(app).GetAsync("/v2/token");
+        Assert.Equal(HttpStatusCode.Unauthorized, anonymous.StatusCode);
+        Assert.Empty(anonymous.Headers.WwwAuthenticate);
+
+        var wrongKey = app.GetTestClient();
+        wrongKey.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", "not-the-key");
+        var refused = await wrongKey.GetAsync("/v2/token");
+        Assert.Equal(HttpStatusCode.Unauthorized, refused.StatusCode);
+        Assert.Empty(refused.Headers.WwwAuthenticate);
+    }
+
+    /// <summary>
+    /// Route precedence, asserted rather than assumed: the literal <c>/v2/token</c> must win over
+    /// the <c>/v2/{**rest}</c> catch-all, or the token endpoint would be swallowed by the pull
+    /// handler (which would parse it as a route, fail, and 404).
+    /// </summary>
+    [Fact]
+    public async Task TheTokenRouteWinsOverThePullCatchAll()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var response = await Authenticated(app).GetAsync("/v2/token");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("access_token", await response.Content.ReadAsStringAsync());
+    }
+
+    /// <summary>
+    /// The token IS the caller's instance key, deliberately — the mirror mints nothing. So
+    /// revoking the key revokes the pull at the next exchange, instead of leaving a minted
+    /// credential valid for its full lifetime.
+    /// </summary>
+    [Fact]
+    public async Task TheIssuedTokenIsTheCallersOwnKey_SoRevocationTakesEffect()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var response = await Authenticated(app).GetAsync("/v2/token");
+        using var token = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        Assert.Equal(InstanceKey, token.RootElement.GetProperty("token").GetString());
+    }
+
+    // ── the pull routes ───────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TagsListIsServed()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var response = await Authenticated(app)
+            .GetAsync($"/v2/{FakeUpstreamRegistry.Repository}/tags/list");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("ci.7794", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ABlobIsServedWhole_AndByteForByte()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var response = await Authenticated(app).GetAsync(
+            $"/v2/{FakeUpstreamRegistry.Repository}/blobs/sha256:a000000000000000000000000000000000000000000000000000000000000000");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, await response.Content.ReadAsByteArrayAsync());
+    }
+
+    /// <summary>
+    /// Range requests are not optional: a client resuming an interrupted layer pull asks for one,
+    /// and a mirror that answered 200-with-everything would restart the transfer it was asked to
+    /// continue.
+    /// </summary>
+    [Fact]
+    public async Task ARangeRequestIsForwarded_AndPartialContentComesBack()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+        var client = Authenticated(app);
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v2/{FakeUpstreamRegistry.Repository}/blobs/sha256:a000000000000000000000000000000000000000000000000000000000000000");
+        request.Headers.Range = new RangeHeaderValue(100, 199);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+        var body = await response.Content.ReadAsByteArrayAsync();
+        Assert.Equal(100, body.Length);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes[100..200], body);
+        // Content-Range is a CONTENT header on the client side, whatever the wire looks like.
+        Assert.Equal("bytes 100-199/1048576",
+            response.Content.Headers.GetValues("Content-Range").Single());
+    }
+
+    /// <summary>
+    /// 🚨 THE STREAMING PROOF. The upstream hands over its first chunk and then PARKS. If the
+    /// mirror buffered the layer, the client could not possibly hold those bytes while the
+    /// upstream still holds the rest — so receiving them IS the evidence that nothing is
+    /// materialised. A portal that buffers a 300 MB layer OOMs under a rolling restart.
+    /// </summary>
+    [Fact]
+    public async Task ALayerStreams_TheClientGetsBytesWhileTheUpstreamIsStillProducing()
+    {
+        var upstream = new FakeUpstreamRegistry { ParkLayerAfterFirstChunk = true };
+        using var app = await BuildMirror(upstream);
+        try
+        {
+            var response = await Authenticated(app).GetAsync(
+                $"/v2/{FakeUpstreamRegistry.Repository}/blobs/sha256:a000000000000000000000000000000000000000000000000000000000000000",
+                HttpCompletionOption.ResponseHeadersRead);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            await using var body = await response.Content.ReadAsStreamAsync();
+            var head = new byte[1024];
+            var read = await body.ReadAtLeastAsync(head, 1024, throwOnEndOfStream: false);
+
+            Assert.Equal(1024, read);
+            Assert.Equal(FakeUpstreamRegistry.LayerBytes[..1024], head);
+        }
+        finally
+        {
+            // In a finally: a failing assertion above must not strand the parked producer into
+            // the next test.
+            Volatile.Write(ref upstream.ReleaseLayer, 1);
+        }
+    }
+
+    // ── the refusals ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Unconfigured is 404 on EVERY route, never a partial service — a half-configured registry
+    /// that served something would be indistinguishable from a working one until a pull returned
+    /// the wrong bytes.
+    /// </summary>
+    [Theory]
+    [InlineData("/v2/")]
+    [InlineData("/v2/memex-portal-ai/manifests/ci.7794")]
+    [InlineData("/v2/memex-portal-ai/tags/list")]
+    [InlineData("/v2/token")]
+    public async Task AnUnconfiguredMirrorIs404Everywhere(string path)
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, configured: false);
+
+        Assert.Equal(HttpStatusCode.NotFound, (await Authenticated(app).GetAsync(path)).StatusCode);
+        // The negative control: the host itself is serving.
+        Assert.Equal(HttpStatusCode.OK, (await Anonymous(app).GetAsync("/ordinary")).StatusCode);
+        // …and nothing reached the upstream.
+        Assert.Equal(0, upstream.Requests);
+    }
+
+    /// <summary>
+    /// A repository the upstream WOULD serve but the allowlist does not name is 404 — and the
+    /// request never leaves the portal. Empty means none; one upstream credential must not become
+    /// an open read proxy for the whole registry.
+    /// </summary>
+    [Fact]
+    public async Task ARepositoryOutsideTheAllowlistNeverReachesTheUpstream()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        var response = await Authenticated(app)
+            .GetAsync($"/v2/{FakeUpstreamRegistry.UnlistedRepository}/manifests/ci.7794");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(0, upstream.Requests);
+    }
+
+    /// <summary>The push family, refused by shape at the edge — nothing forwarded.</summary>
+    [Theory]
+    [InlineData("/v2/memex-portal-ai/blobs/uploads/")]
+    [InlineData("/v2/memex-portal-ai/blobs/uploads/abc")]
+    [InlineData("/v2/memex-portal-ai/blobs/latest")]
+    public async Task UploadRoutesAreRefusedWithoutReachingTheUpstream(string path)
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+
+        Assert.Equal(HttpStatusCode.NotFound, (await Authenticated(app).GetAsync(path)).StatusCode);
+        Assert.Equal(0, upstream.Requests);
+    }
+
+    /// <summary>
+    /// 🚨 The MIRROR's own credential failing is a 502, never a 401. A 401 would send the caller
+    /// to fix a token that is not the broken thing — and the caller cannot fix ours.
+    /// </summary>
+    [Fact]
+    public async Task TheMirrorsOwnCredentialFailingIsA502()
+    {
+        var upstream = new FakeUpstreamRegistry { RefuseMirrorCredential = true };
+        using var app = await BuildMirror(upstream);
+
+        var response = await Authenticated(app)
+            .GetAsync($"/v2/{FakeUpstreamRegistry.Repository}/manifests/ci.7794");
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The upstream token is cached on the client INSTANCE, so many pulls cost one exchange. The
+    /// cache being an instance field on a singleton — never static — is what keeps a credential
+    /// from outliving the mesh; this is its observable effect.
+    /// </summary>
+    [Fact]
+    public async Task OneTokenExchangeServesManyPulls()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+        var client = Authenticated(app);
+
+        for (var i = 0; i < 4; i++)
+            Assert.Equal(HttpStatusCode.OK,
+                (await client.GetAsync($"/v2/{FakeUpstreamRegistry.Repository}/manifests/ci.7794"))
+                .StatusCode);
+
+        Assert.Equal(1, upstream.TokenRequests);
+    }
+
+    private static string Realm(string challenge)
+    {
+        const string marker = "realm=\"";
+        var start = challenge.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        return challenge[start..challenge.IndexOf('"', start)];
+    }
+}

--- a/test/MeshWeaver.ContainerImages.Test/RegistryCredentialTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/RegistryCredentialTest.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using Xunit;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// A registry client presents its credential in TWO shapes — <c>Basic</c> to the token endpoint,
+/// <c>Bearer</c> everywhere after — and this is the one place the mirror reduces them to the
+/// single value it authenticates. Getting it wrong is silent in the worst direction: a truncated
+/// secret fails to authenticate for a reason no log explains, and a too-permissive read lets a
+/// malformed header through as if it carried something.
+/// </summary>
+public class RegistryCredentialTest
+{
+    private static string Basic(string user, string secret) =>
+        "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{secret}"));
+
+    [Fact]
+    public void ReadsABearerVerbatim() =>
+        Assert.Equal("mw_key_abc", RegistryCredential.TryReadSecret("Bearer mw_key_abc"));
+
+    [Fact]
+    public void ReadsThePasswordHalfOfABasicCredential() =>
+        Assert.Equal("mw_key_abc", RegistryCredential.TryReadSecret(Basic("ci", "mw_key_abc")));
+
+    /// <summary>
+    /// 🚨 The FIRST colon separates user from secret. An ACR refresh token contains colons, and a
+    /// last-colon (or split-on-all) reading would hand back a truncated secret — which
+    /// authenticates as "wrong credential", the one failure mode with no diagnostic.
+    /// </summary>
+    [Fact]
+    public void SplitsOnTheFirstColonOnly_SoASecretMayContainColons() =>
+        Assert.Equal("a:b:c", RegistryCredential.TryReadSecret(Basic("ci", "a:b:c")));
+
+    /// <summary>
+    /// <c>docker login -u &lt;anything&gt;</c> is how a client is made to send an instance key, so
+    /// the username half carries no meaning and must not be able to change the outcome.
+    /// </summary>
+    [Theory]
+    [InlineData("ci")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    [InlineData("")]
+    public void TheUsernameHalfIsDiscarded(string user) =>
+        Assert.Equal("mw_key_abc", RegistryCredential.TryReadSecret(Basic(user, "mw_key_abc")));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Bearer")]                 // scheme with no value
+    [InlineData("Bearer ")]
+    [InlineData("Basic ")]
+    [InlineData("Basic not-base64!!")]     // undecodable
+    [InlineData("Negotiate abc")]          // a scheme the mirror does not speak
+    [InlineData("mw_key_abc")]             // a bare secret with no scheme
+    public void RefusesEverythingElse_NullIsNeverAllow(string? header) =>
+        Assert.Null(RegistryCredential.TryReadSecret(header));
+
+    /// <summary>A Basic credential with no colon at all carries no secret half.</summary>
+    [Fact]
+    public void RefusesABasicPayloadWithNoColon() =>
+        Assert.Null(RegistryCredential.TryReadSecret(
+            "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes("nocolonhere"))));
+
+    /// <summary>An empty secret half is not a credential.</summary>
+    [Fact]
+    public void RefusesAnEmptySecretHalf() =>
+        Assert.Null(RegistryCredential.TryReadSecret(Basic("ci", "")));
+
+    [Theory]
+    [InlineData("bearer mw_key_abc")]
+    [InlineData("BEARER mw_key_abc")]
+    public void TheSchemeIsCaseInsensitive_AsHttpRequires(string header) =>
+        Assert.Equal("mw_key_abc", RegistryCredential.TryReadSecret(header));
+
+    /// <summary>The round trip the token exchange relies on: what the endpoint hands back, read
+    /// as a bearer on the next request, is the same secret.</summary>
+    [Fact]
+    public void ABasicCredentialRoundTripsThroughTheBearerHeaderTheTokenEndpointIssues()
+    {
+        var secret = RegistryCredential.TryReadSecret(Basic("ci", "mw_key_abc"));
+        Assert.NotNull(secret);
+        Assert.Equal(secret, RegistryCredential.TryReadSecret(
+            RegistryCredential.AsBearerHeader(secret!)));
+    }
+}


### PR DESCRIPTION
The **second** increment of the read-through OCI mirror. #3357 landed the proxy surface;
this makes the protocol actually complete and turns an image's contents into mesh data.

`Refs #3353` — v1 does not finish the issue, and the table below says exactly where each
acceptance criterion stands.

## 🚨 The defect this found: the bearer handshake did not complete

The merged surface emitted a correct-looking challenge —
`WWW-Authenticate: Bearer realm="…/v2/token",service="…"` — and **nothing served `/v2/token`**.
A real `docker pull` went **401 → fetch the realm → 404 → give up**. Every endpoint read
correctly in isolation; only walking the whole conversation could see it, which is why
`PullSurfaceTest` is written as one handshake rather than per-endpoint assertions.

Nothing shipped: `MapContainerImages` is called nowhere in this repo, so no deployment could
reach it. That is why there is no `Category: Fix` What's New entry — no user could have hit it.

## What is implemented

**The token exchange** — `GET /v2/token`, the realm the challenge names.
* It sits **outside** the challenge filter, in its own group over the same prefix. A token
  endpoint that answered 401-with-a-challenge would name *itself* and loop the client; it
  refuses with a bare 401 instead.
* 🚨 **The mirror mints nothing.** The bearer it returns IS the caller's own instance key. A
  minted token would stay valid for its full lifetime after the key behind it was revoked, and
  would make the mirror a second issuer of credentials for an identity it does not own. Echoing
  the key means every later request re-runs `IContainerImageAuthenticator` — revocation takes
  effect at the next exchange (`expires_in: 300`) — and the mirror stores **no token state at
  all**.
* `RegistryCredential` is the one place `Basic base64(user:key)` (what `docker login` stores)
  and `Bearer <key>` reduce to one secret, so the authenticator seam speaks ONE shape. Splitting
  on the **first** colon only: an ACR refresh token contains colons, and a truncated secret
  fails to authenticate for a reason no log explains.
* `Docker-Distribution-Api-Version: registry/2.0` on the probe and both refusals, and the
  challenge now carries `scope="repository:<name>:pull"` when the route names a repository —
  the shape ACR itself emits.

**Closure + provenance as mesh nodes.** Every manifest served is recorded as a `ContainerImage`
node under `ContainerImages:ImageRoot`: the resolved digest, media type, config digest, every
layer by digest and size, an index's platforms, and where it came from / when / pulled by whom.
* The digest is **computed over the served bytes**, never taken from `Docker-Content-Digest`. A
  manifest IS its content hash, so computing it is both cheaper to trust and correct when the
  header is absent — and a recorded digest disagreeing with the bytes would silently break every
  pin derived from it.
* **It records what it SEES and fetches nothing speculatively.** A real pull fetches the index
  and then the manifest for its own architecture, so one pull leaves both records behind and the
  index's platform entries are digests whose own records carry the layers. Recording therefore
  costs **zero** extra upstream requests and adds **zero** pull latency. Stated cost: an index
  nobody resolves (`crane manifest` and stop) leaves its platforms unrecorded.
* **Observational, and cannot fail a pull** — the write is subscribed off the response path with
  an explicit error arm; a failure is a warning naming the root.
* Recording is **off** unless `ImageRoot` is set; the mirror still proxies normally.

**Layer transfers are now bounded, not merely unbuffered.** The body copy runs through
`IIoPool`'s `Blob` pool (cap 128), holding a slot for the whole transfer, with
`cancelSource: true` so a client that gives up mid-layer releases the permit. `Http` (cap 16)
would have been wrong: one 300 MB layer parked there for a minute starves every plugin-catalog
call the portal makes. Manifests — and only manifests — are read into memory, bounded by
`Content-Length` **before** anything is consumed, so a body that would not fit streams untouched
and unrecorded.

## What is deliberately NOT in this PR

**No cache.** Every pull still reaches the upstream. Reasons, in order:
1. None of the four acceptance criteria requires one — three are about *data*, one about the
   boot path.
2. It is the largest remaining piece (blob storage, content-addressed keys, partial-write
   correctness, eviction, and its interaction with GC) and it changes **no surface**, so it
   lands cleanly afterwards.
3. The issue says pull latency must be measured before anything depends on the mirror. Adding a
   cache first would be optimising without a number.

**No `/app` assembly closure** — the file list *inside* the layers. Those names live in a layer
tarball and no manifest names them; reaching them means streaming the app layer through
gzip + tar. Bounded and streamable, but it **cannot ride the pull path** (decompressing hundreds
of megabytes per pull is exactly the cost this design refuses), so it needs a trigger and a
bandwidth budget of its own.

**No push, no GC, and the boot image stays on ACR permanently.** Nothing here makes a portal's
own boot depend on the mirror: `MapContainerImages` is a portal-side route, and Kubernetes pulls
before any MeshWeaver process exists. Switching the mirror — or just the recording — off remains
a configuration change, not a migration.

## Acceptance criteria, honestly

| # | criterion | status |
|---|---|---|
| 1 | closure answerable from mesh data, no `docker run` | **OCI closure: yes** — asserted end to end in `ContainerImageRecordingTest` against a real monolith mesh: record → node → read back typed → config digest, both layers, 300 004 096 bytes. **/app assembly closure: no** — needs the layer scan |
| 2 | #3334's gate re-expressible over that data | **half, and the other half never.** `check-platform-reference-set.sh` has two halves. *One-producer* (no composed module name in `/app` or the surface manifest) becomes a data assertion once the layer scan lands: read the composed set from `main-cd.yml` (unchanged — it must stay the producer's own list) and assert no name appears in the record's app-assembly list. *The set must resolve* can **never** be data: it does not model MSBuild's binding rules, it RUNS them. Data makes the probe's inputs known; the verdict still needs a build. Writing it out is in the doc page |
| 3 | a pin bump moves ONE reference | **the data supports it, nothing is converted yet.** A tag resolves to a digest at a deterministic node path (`{ImageRoot}/{repo}--{tag}`), so a consumer carries the tag. `ci.yml` still carries its six literals — converting them is a separate change |
| 4 | an ACR outage costs nothing at boot | **yes, structurally** — the boot image never moved |

🚨 **Pull latency is NOT measured, and I did not measure it.** Doing it properly needs a real
ACR credential and a real network; an in-process number would be the mirror's own overhead
dressed up as a latency measurement. What IS proven is the correctness property underneath:
`ALayerStreams_TheClientGetsBytesWhileTheUpstreamIsStillProducing` parks the upstream after its
first chunk and asserts the client already holds those bytes — if the mirror buffered, it could
not. **Nothing should depend on the mirror until latency through it is measured against ACR
directly**, which is also what would settle whether a mirror *improves* pull availability
(ACR is single-zone) or merely adds a hop.

## Design decisions worth flagging for review

* **`MeshWeaver.ContainerImages` now references `MeshWeaver.Graph`.** The NodeType registration
  needs `AddDefaultLayoutAreas`/`AddMeshDataSource`/`WithContentType`, which live there — and
  without them the content stays an untyped `JsonElement`, the silent-null trap. The alternative
  (a second seam interface, bound by the portal like the authenticator) was rejected: nothing in
  *this* repo would implement it, so the recording half would ship dead and untestable end to end.
* **Node ids are lossy-but-collision-free.** `memex-portal-ai--ci.7794` stays verbatim and
  predictable; a pair whose sanitisation actually changed something gets an 8-hex fingerprint of
  the exact pair appended. Two images sharing a node would make the closure answer for one of
  them *wrong* — the one failure this data may not have.
* **`RunAsSystem`, not `Observable.Using(() => access.ImpersonateAsSystem(), …)`.** I wrote the
  latter first, copying `WebhookInbox.Deliver`; `ImpersonationScopeSiteRatchetGuard` failed the
  build and named #1790 — that shape opens an AsyncLocal scope on the subscribing thread and
  disposes it wherever the work terminates. Fixed at the source; **no allow-file line added.**

## Verification

Built `-c Release -warnaserror`, one project per invocation, all `0 Error(s) 0 Warning(s)`:
`MeshWeaver.ContainerImages`, `MeshWeaver.ContainerImages.Test`, `MeshWeaver.Documentation`,
`MeshWeaver.Documentation.Test`.

| suite | result |
|---|---|
| `MeshWeaver.ContainerImages.Test` | **95 / 95 passed**, 2 s — per class from the TRX: `PullSurfaceTest` 19, `RegistryCredentialTest` 20, `ContainerImageCatalogTest` 18, `RegistryRouteTest` 13, `OciManifestTest` 12, `BlobsAreDigestAddressedTest` 8, `ContainerImageRecordingTest` 5 (real monolith mesh) |
| `MeshWeaver.Documentation.Test` (full suite — a `--filter`ed run is a false pass for ratchet guards) | **269 / 269** after the impersonation fix; it was the guard that caught it |

`DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest` and `NoConflictMarkersGuard` all
green over the edited doc page and the new What's New entry.

## Docs

`Doc/Architecture/ContainerRegistryInMemex` updated: the status block no longer overclaims, a new
**"What v1 records, and the line it does not cross"** section states the OCI-vs-`/app` boundary
and maps #3334's gate onto it half by half, and the closing "what would say this is working"
section is now a per-criterion status table with the unmeasured-latency caveat. Assembly README
updated. What's New entry added (`Category: Feature`).

`Pairs-with: none` — this diff removes no public type and no public member (verified: zero
removed lines declaring `public` under `src/`). Every surface change is an addition:
`ContainerImageOptions.ImageRoot`/`MaxRecordedManifestBytes`, four consts on
`ContainerImageEndpoints`, one extra `UpstreamPassthroughResult` constructor beside the existing
one, and four new public types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
