### PR TITLE
fix(gitsync): a held installation-token observable refreshes on every expiry, not only the first

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -419,6 +419,20 @@ Server configuration for GitHub Sync — the first two are required, the rest op
    large-repo sync exhausted the App installation's hourly rate budget. Refs, PRs and issues
    stay on the Octokit REST client.
 
+   **Installation tokens live one hour, and the cache refreshes at subscription time.**
+   `GitHubAppTokenService.GetInstallationToken()` returns a *deferred* observable: every
+   subscription reads the current cached token, replays it while it is more than five minutes
+   from expiry, and otherwise mints a replacement that concurrent subscribers share. That is
+   the contract a long-lived consumer relies on — the Store's git poll loop holds ONE such
+   observable for the life of its feed and subscribes once per pass. Before 2026-09-06 the
+   promise was captured when the observable was *built*, so the refresh guard matched exactly
+   once: the first expiry minted a new token, every later expiry compared against the stale
+   capture and handed the expired token back. Two token lifetimes after boot every private
+   source read as `401 Bad credentials` until the process restarted (Systemorph/Memex#165 —
+   measured on memex-cloud as the first failure 2 h 01 min after the container started).
+   `GitHubAppTokenRefreshTest` in `Memex.Portal.Shared.Test` holds the invariant with an
+   injected clock: the second and third refresh mint, a fresh token replays.
+
 All GitHub HTTP and serialization run through the controlled I/O pool — see
 [ControlledIoPooling.md](/Doc/Architecture/ControlledIoPooling).
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-held-installation-token-refreshes-on-every-expiry.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-held-installation-token-refreshes-on-every-expiry.md
@@ -1,0 +1,24 @@
+---
+Name: A held installation token refreshes on every expiry
+Category: Fix
+Description: The Store's package feed on a portal that reads GitHub as a GitHub App no longer freezes two hours after boot. The installation-token cache refreshed exactly once per held observable and then served the expired token forever, which GitHub reported as "Bad credentials" on every private source; it now refreshes at every subscription that finds the token within five minutes of expiry.
+Icon: Checkmark
+Order: -20260906
+---
+
+# A held installation token refreshes on every expiry
+
+A portal that polls its package sources as a **GitHub App installation** mints a token that lives
+one hour. The Store's git poll loop holds one token observable for the life of its feed and
+subscribes to it once per pass, every five minutes. The cache behind that observable refreshed the
+token the first time it neared expiry — and never again: the refresh guard compared against the
+promise captured when the observable was built, found it already replaced, and handed the expired
+token back on every later pass. Two token lifetimes after boot, every private source read as
+`401 Bad credentials`, the catalog froze on its last good snapshot, and the log said the credential
+had been rejected — which sent the investigation to GitHub and to the deployment's configuration
+rather than to the cache (Systemorph/Memex#165).
+
+The observable is now deferred: each subscription reads the current cached token, replays it while
+it is fresh, and mints a replacement — shared by concurrent subscribers — when it is within five
+minutes of expiry. A regression test drives the held observable through three expiries with an
+injected clock and asserts a new token at each, and a fresh one replayed in between.

--- a/src/MeshWeaver.GitSync/GitHubAppTokenService.cs
+++ b/src/MeshWeaver.GitSync/GitHubAppTokenService.cs
@@ -36,6 +36,7 @@ public sealed class GitHubAppTokenService
     // Refreshed when the delivered token nears expiry; nulled on error so failures don't stick.
     private readonly object gate = new();
     private IObservable<InstallationToken>? cached;
+    private readonly Func<DateTimeOffset> now;
 
     /// <summary>Initializes the service.</summary>
     /// <param name="ioPools">Registry the HTTP I/O pool is resolved from so every HTTP leaf runs off the hub.</param>
@@ -46,11 +47,13 @@ public sealed class GitHubAppTokenService
         IoPoolRegistry ioPools,
         IOptions<GitHubAppOptions> options,
         ILogger<GitHubAppTokenService>? logger = null,
-        HttpClient? httpClient = null)
+        HttpClient? httpClient = null,
+        Func<DateTimeOffset>? clock = null)
     {
         this.ioPools = ioPools;
         this.options = options.Value;
         this.logger = logger;
+        now = clock ?? (() => DateTimeOffset.UtcNow);
         http = httpClient ?? new HttpClient();
         if (!http.DefaultRequestHeaders.UserAgent.Any())
             http.DefaultRequestHeaders.UserAgent.ParseAdd("MeshWeaver-GitSync");
@@ -71,14 +74,24 @@ public sealed class GitHubAppTokenService
             return Observable.Throw<string>(new InvalidOperationException(
                 "The GitHub App is not configured (set GitHub:App:ClientId + GitHub:App:PrivateKey)."));
 
-        IObservable<InstallationToken> source;
-        lock (gate)
-            source = cached ??= CreateFetch();
+        // Deferred: the promise is read at SUBSCRIPTION time, not when this observable was built.
+        // A long-lived consumer holds ONE of these for the life of its feed and subscribes per pass
+        // (the Store's git poll loop). Before, the promise of the moment was captured here, so
+        // after the first refresh <see cref="Refresh"/> compared every later expiry against that
+        // stale capture, never matched the current promise again, and handed the expired token
+        // back on every pass — two token lifetimes after boot, every private source read as
+        // "Bad credentials" until the process restarted (Systemorph/Memex#165).
+        return Observable.Defer(() =>
+        {
+            IObservable<InstallationToken> source;
+            lock (gate)
+                source = cached ??= CreateFetch();
 
-        return source.SelectMany(tok =>
-            tok.ExpiresAt > DateTimeOffset.UtcNow.AddMinutes(5)
-                ? Observable.Return(tok.Token)
-                : Refresh(source).Select(t => t.Token));
+            return source.SelectMany(tok =>
+                tok.ExpiresAt > now().AddMinutes(5)
+                    ? Observable.Return(tok.Token)
+                    : Refresh(source).Select(t => t.Token));
+        });
     }
 
     /// <summary>Swap the stale promise for a fresh fetch (only once — concurrent refreshers share it).</summary>
@@ -105,7 +118,7 @@ public sealed class GitHubAppTokenService
 
     private async Task<InstallationToken> FetchInstallationTokenAsync(CancellationToken ct)
     {
-        var jwt = BuildAppJwt(DateTimeOffset.UtcNow);
+        var jwt = BuildAppJwt(now());
         var installationId = options.InstallationId
             ?? await DiscoverInstallationIdAsync(jwt, ct).ConfigureAwait(false);
 
@@ -128,7 +141,7 @@ public sealed class GitHubAppTokenService
                         && e.ValueKind == JsonValueKind.String
                         && DateTimeOffset.TryParse(e.GetString(), out var dto)
             ? dto
-            : DateTimeOffset.UtcNow.AddMinutes(50);   // GitHub's documented lifetime is 1h
+            : now().AddMinutes(50);   // GitHub's documented lifetime is 1h
         logger?.LogInformation("Minted GitHub App installation token (installation {Id}, expires {Exp})",
             installationId, expiresAt);
         return new InstallationToken(token, expiresAt);

--- a/test/Memex.Portal.Shared.Test/GitHubAppTokenRefreshTest.cs
+++ b/test/Memex.Portal.Shared.Test/GitHubAppTokenRefreshTest.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The installation-token cache of <see cref="GitHubAppTokenService"/> as a LONG-LIVED consumer
+/// sees it: one <see cref="GitHubAppTokenService.GetInstallationToken"/> observable held for the
+/// life of a feed and subscribed once per poll pass — the shape of the Store's git poll loop.
+///
+/// <para>🚨 <b>The failure this file makes impossible (Systemorph/Memex#165):</b> the promise was
+/// captured when the observable was BUILT, so the refresh guard matched it exactly once. The first
+/// expiry minted a new token; every later expiry compared against the stale capture, found the
+/// cache already replaced, and handed the expired token back. Two token lifetimes after boot the
+/// portal presented an expired installation token on every pass, and GitHub reported that as
+/// <c>401 Bad credentials</c> on every private source until the process restarted — measured on
+/// memex-cloud as the first failure landing 2 h 01 min after the container started.</para>
+///
+/// <para>Time is injected, so each assertion names the minute at which the held observable is
+/// subscribed and the token it must answer with; the third refresh is the one the defect skipped.</para>
+/// </summary>
+public class GitHubAppTokenRefreshTest
+{
+    private static readonly DateTimeOffset T0 = new(2026, 9, 6, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task OneHeldObservable_RefreshesOnEveryExpiry_NotOnlyTheFirst()
+    {
+        using var rsa = RSA.Create(2048);
+        var clock = T0;
+        var handler = new MintingHandler(() => clock);
+        var service = new GitHubAppTokenService(
+            new IoPoolRegistry(),
+            Options.Create(new GitHubAppOptions
+            {
+                ClientId = "Iv23liTestApp",
+                PrivateKey = rsa.ExportRSAPrivateKeyPem(),
+                InstallationId = 77,
+            }),
+            httpClient: new HttpClient(handler),
+            clock: () => clock);
+
+        // ONE observable, held — the Store feed's shape — subscribed per pass below.
+        var held = service.GetInstallationToken();
+
+        Assert.Equal("ghs_1", await held.FirstAsync().Await());
+        Assert.Equal(1, handler.Mints);
+
+        // Well inside the lifetime: replayed, no mint.
+        clock = T0.AddMinutes(30);
+        Assert.Equal("ghs_1", await held.FirstAsync().Await());
+        Assert.Equal(1, handler.Mints);
+
+        // Inside the five-minute refresh window: the FIRST refresh — this one always worked.
+        clock = T0.AddMinutes(56);
+        Assert.Equal("ghs_2", await held.FirstAsync().Await());
+        Assert.Equal(2, handler.Mints);
+
+        // Token 2 expires at T0+116 min. The SECOND refresh is the one the defect skipped: before
+        // the fix this pass answered ghs_2, four minutes from expiry, and every later pass answered
+        // it too — long after GitHub had stopped accepting it.
+        clock = T0.AddMinutes(112);
+        Assert.Equal("ghs_3", await held.FirstAsync().Await());
+        Assert.Equal(3, handler.Mints);
+
+        // And the third, to show it is every expiry rather than the first two.
+        clock = T0.AddMinutes(168);
+        Assert.Equal("ghs_4", await held.FirstAsync().Await());
+        Assert.Equal(4, handler.Mints);
+
+        // A pass while the token is fresh still replays: the fix did not turn the cache into a mint-per-pass.
+        clock = T0.AddMinutes(170);
+        Assert.Equal("ghs_4", await held.FirstAsync().Await());
+        Assert.Equal(4, handler.Mints);
+    }
+
+    [Fact]
+    public async Task ConcurrentPassesOnAnExpiredToken_ShareOneRefresh()
+    {
+        using var rsa = RSA.Create(2048);
+        var clock = T0;
+        var handler = new MintingHandler(() => clock);
+        var service = new GitHubAppTokenService(
+            new IoPoolRegistry(),
+            Options.Create(new GitHubAppOptions
+            {
+                ClientId = "Iv23liTestApp",
+                PrivateKey = rsa.ExportRSAPrivateKeyPem(),
+                InstallationId = 77,
+            }),
+            httpClient: new HttpClient(handler),
+            clock: () => clock);
+
+        var held = service.GetInstallationToken();
+        Assert.Equal("ghs_1", await held.FirstAsync().Await());
+
+        // Five sources poll on the same timer; when the token is stale they all refresh at once
+        // and must share the single new promise rather than mint five tokens.
+        clock = T0.AddMinutes(58);
+        var tokens = await Observable.Range(0, 5)
+            .SelectMany(_ => held.Take(1))
+            .ToList()
+            .FirstAsync()
+            .Await();
+        Assert.All(tokens, t => Assert.Equal("ghs_2", t));
+        Assert.Equal(2, handler.Mints);
+    }
+
+    /// <summary>GitHub App token endpoint fake: every mint answers the next token, valid one hour from the injected clock.</summary>
+    private sealed class MintingHandler(Func<DateTimeOffset> clock) : HttpMessageHandler
+    {
+        private int mints;
+        public int Mints => Volatile.Read(ref mints);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (request.Method == HttpMethod.Post && path == "/app/installations/77/access_tokens")
+            {
+                var n = Interlocked.Increment(ref mints);
+                var expires = clock().AddHours(1).ToString("o");
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent(
+                        $$"""{"token": "ghs_{{n}}", "expires_at": "{{expires}}"}""",
+                        Encoding.UTF8, "application/json"),
+                });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"unexpected {request.Method} {path}"),
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes the cause behind Systemorph/Memex#165 — the Store's git package feed on memex-cloud reads every private source as `401 Bad credentials` from two hours after boot until the process restarts.

## What was wrong

`GitHubAppTokenService.GetInstallationToken()` captured the cached promise when the observable was **built**:

```csharp
IObservable<InstallationToken> source;
lock (gate) source = cached ??= CreateFetch();
return source.SelectMany(tok => tok.ExpiresAt > now + 5min ? Return(tok.Token) : Refresh(source)…);
```

`Refresh(stale)` re-mints only when `ReferenceEquals(cached, stale)`. A long-lived consumer — the Store's git poll loop (`StoreManifestSource.Feeds`) holds ONE token observable for the life of its feed and subscribes per pass — therefore refreshed exactly once: the first expiry minted token 2 and replaced `cached`; every later expiry compared against the captured promise 1, found `cached` already different, and returned promise 2's expired token. GitHub reports an expired installation token as `401 Bad credentials`, uniformly, on every source.

## Measured on memex-cloud (read-only, 2026-09-06)

| | |
|---|---|
| pod | `memex-portal-deployment-5b9cbf46dd-5nqbz` — the ONE replica of eight running the poll loop |
| container started | `2026-09-05T00:40:41Z` |
| first `Bad credentials` | `2026-09-05T02:41:59Z` — **2 h 01 min**, two token lifetimes |
| `Minted GitHub App installation token` lines | 0 in 48 h |
| `[StoreManifestSource] … token could not be obtained` lines | 0 in 48 h |
| `Bad credentials` lines | 465 in 12 h |

Zero mint-side diagnostics is the discriminator Memex#165's 09-04 comment asked for: the mint never failed, so #1227's diagnostic had nothing to say — the token was simply stale. The later episodes in that pod's log (failure counters resetting after hours of silence) line up with each re-evaluation of `Token(hub)` inside `Feeds`' `Select`, which calls `GetInstallationToken()` afresh and buys one more lifetime.

## The fix

The observable is `Observable.Defer`'d, so every subscription reads the **current** promise and the refresh guard matches on every expiry; concurrent stale subscribers still share one mint. Time is injectable through an optional `clock` constructor parameter (default `UtcNow`) so the regression test can name the minute of each pass; the DI factory is unchanged.

## Verification

- `GitHubAppTokenRefreshTest` (in `Memex.Portal.Shared.Test`, next to the other GitHub token tests) drives ONE held observable through three expiries with the injected clock and asserts a new token at each (`ghs_2`, `ghs_3`, `ghs_4`), a fresh one replayed in between (no extra mint), and one shared mint for five concurrent stale subscribers.
- **Control run** on the pre-fix shape (Defer removed, clock kept): fails at the second refresh — `Expected: "ghs_3"  Actual: "ghs_2"`. Restored, both tests pass (143 ms).
- `dotnet build -c Release -warnaserror` on `MeshWeaver.GitSync` and `Memex.Portal.Shared.Test`: `0 Warning(s) 0 Error(s)`.

## Conserved

- `Doc/Architecture/GitHubSync` — the App identity section now states the token-cache contract and this failure.
- What's New `2026-09-06-a-held-installation-token-refreshes-on-every-expiry`.

Not in this PR: getting it onto memex-cloud. That install has `Admin/UpdatePolicy = None` (SelfUpdate disabled), so it waits on the deploy the maintainer has parked (Memex#116 / #3201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK4B83GneTFF7cvwHJUCVf
