### PR TITLE
diag(#2543): the patch commit path and nodeops' upsert record their arms on the request trail

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -2019,6 +2019,9 @@ public static class DataExtensions
         void AckOnce(bool success, MeshNodeError? error = null)
         {
             if (System.Threading.Interlocked.Exchange(ref ackPosted, 1) != 0) return;
+            // The verdict leg of the trail (MeshWeaver#2543): which arm produced the terminal.
+            hub.NoteRequestStage(request.Id,
+                success ? "PATCH_ACK ok" : $"PATCH_ACK nack={error?.Code}");
             var resp = new PatchDataResponse(success, hub.Version);
             if (error is not null)
                 resp = resp with { Error = error.Message, NodeError = error };
@@ -2074,7 +2077,13 @@ public static class DataExtensions
             // stream that ENDS before the echo arrives, or a flush that ends without emitting,
             // still posts exactly one terminal (#3033) — ArmPatchAckWatcher names each path's
             // verdict and why a bare completion arm would NACK successful writes.
-            committed => hub.ServiceProvider.GetService<IPostCommitFlush>()?.Flush(committed.Value!),
+            committed =>
+            {
+                // The echo CONTAINING this write reached the watcher: the merge committed. What
+                // follows is durability; a trail ending here names a slow or lost flush.
+                hub.NoteRequestStage(request.Id, "PATCH_ECHO_SEEN");
+                return hub.ServiceProvider.GetService<IPostCommitFlush>()?.Flush(committed.Value!);
+            },
             TimeSpan.FromSeconds(10),
             AckOnce,
             d => hub.RegisterForDisposal(d),
@@ -2130,6 +2139,11 @@ public static class DataExtensions
             {
                 try
                 {
+                    // 🚨 The stage that splits #2543's two readings of "HANDLER_EXIT … then nothing":
+                    // recorded ON the primary's executor, so its absence after PATCH_MERGE_DISPATCHED
+                    // means the turn never ran (the executor is behind other work), and its offset
+                    // says how long it queued.
+                    hub.NoteRequestStage(request.Id, deferred ? "PATCH_MERGE_TURN deferred-retry" : "PATCH_MERGE_TURN entered");
                     var s = store ?? new EntityStore();
                     var collection = s.GetCollection(collectionName);
                     var entityId = preReadId;
@@ -2226,6 +2240,7 @@ public static class DataExtensions
                                         + "the patch was NOT applied; safe to retry once the "
                                         + "activation has loaded")));
                             hub.RegisterForDisposal(deferSub);
+                            hub.NoteRequestStage(request.Id, "PATCH_MERGE_DEFERRED cold-store");
                             return null; // no write this turn — the deferred attempt commits
                         }
                         AckOnce(false, new MeshNodeError(
@@ -2259,6 +2274,7 @@ public static class DataExtensions
                     // so the caller re-reads and re-applies instead of believing the lie.
                     if (System.Text.Json.Nodes.JsonNode.DeepEquals(preMergeNode, currentNode))
                     {
+                        hub.NoteRequestStage(request.Id, $"PATCH_MERGE_NOCHANGE refused={refusedKeys}");
                         if (refusedKeys > 0)
                             AckOnce(false, new MeshNodeError(
                                 MeshNodeErrorCode.Conflict, hubPath,
@@ -2312,6 +2328,7 @@ public static class DataExtensions
                     // write, so a load echo / sibling emission can never ack it.
                     System.Threading.Volatile.Write(ref stampedId, entityId);
                     System.Threading.Interlocked.Exchange(ref stampedVersion, minted);
+                    hub.NoteRequestStage(request.Id, $"PATCH_MERGE_STAMPED v={minted} refused={refusedKeys}");
 
                     var newStore = s.Update(collectionName, c => c.Update(entityId, merged));
                     return primary.ApplyChanges(new EntityStoreAndUpdates(
@@ -2327,6 +2344,8 @@ public static class DataExtensions
             },
             ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
 
+        // Dispatched to the primary's executor; the next stage is recorded on that executor.
+        hub.NoteRequestStage(request.Id, "PATCH_MERGE_DISPATCHED");
         RunMergeTurn(deferred: false);
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
@@ -231,6 +231,23 @@ hub.NoteRequestStage(request.Id, "CREATE_CHAIN_COMPLETED_EMPTY …");      // �
 hub.NoteRequestStage(request.Id, $"CREATE_SAVE_DECLINED adapter={…} path={…}");
 ```
 
+The two handlers behind every cross-hub mesh-node write record their arms the same way
+(MeshWeaver#2543 — the bake wedge's trail ended at `HANDLER_EXIT state=Processed` with nothing
+after it, on both hops, and could not say which wait it was in):
+
+| trail ends at | what it means |
+|---|---|
+| `UPSERT_READ …` (nodeops, `CreateOrUpdateNodeRequest`) | the existing-node read answered; the arrow names the branch taken (`create`, `no-op probe`, `update`) |
+| `UPSERT_WRITE_THROUGH_STREAM path=…` | nodeops handed the write to the per-node OWNER; the wait is now on that owner's `PatchDataRequest` — read ITS trail |
+| `UPSERT_REPLY ok …` / `UPSERT_REPLY fail reason=…` | nodeops posted its verdict; a caller still waiting lost the reply in transit |
+| `PATCH_MERGE_DISPATCHED` and nothing after | the owner queued its merge turn on the primary stream's executor and the turn NEVER RAN — the executor is behind other work (a compile, a burst of sibling writes); the offset of the next stage, when it comes, is the queueing time |
+| `PATCH_MERGE_TURN entered` | the turn ran; a trail ending here faulted inside the merge without a verdict |
+| `PATCH_MERGE_DEFERRED cold-store` | the owner was activating cold; the retry re-arms once the store loads (`deferred-retry`) |
+| `PATCH_MERGE_STAMPED v=… refused=…` and nothing after | the merge committed on the executor but the echo CONTAINING it never reached the ack watcher — the reduced stream is not emitting |
+| `PATCH_MERGE_NOCHANGE refused=…` | the merge changed nothing (a no-op or a fully refused write); the verdict follows immediately |
+| `PATCH_ECHO_SEEN` and nothing after | the commit echo arrived; the wait is the durable flush (storage behind) — `[PatchAck] FLUSH_OUTLIVED_BOUND` names the same wait from the log side |
+| `PATCH_ACK ok` / `PATCH_ACK nack=<code>` | the owner posted its verdict |
+
 `NoteRequestStage` is a no-op unless something is awaiting that id, so it is free to call
 unconditionally. **Add the `onCompleted` arm**: a chain that completes empty posts nothing, and
 without a stage there it is indistinguishable from one that is still running. `HandleCreateNodeRequest`

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4390,21 +4390,27 @@ public static class MeshExtensions
             existing =>
             {
                 answered = true;
+                // Trail stages (MeshWeaver#2543): after HANDLER_EXIT this handler owes its reply from
+                // detached work, and the pending-callback report could only say "no reply yet".
                 if (existing is null)
                 {
+                    hub.NoteRequestStage(request.Id, "UPSERT_READ absent → create");
                     DispatchInnerCreate();
                     return;
                 }
                 if (IsNoOpUpsert(existing, node, hub.JsonSerializerOptions, upsertMeshConfig))
                 {
+                    hub.NoteRequestStage(request.Id, "UPSERT_READ existing → no-op probe");
                     SkipNoOpIfAuthorized(existing);
                     return;
                 }
+                hub.NoteRequestStage(request.Id, "UPSERT_READ existing → update");
                 ApplyUpdateViaStream(existing, existing.NodeType);
             },
             ex =>
             {
                 answered = true;
+                hub.NoteRequestStage(request.Id, "UPSERT_READ faulted");
                 logger.LogWarning(ex,
                     "[CreateOrUpdate] persistence read failed for {Path}", node.Path);
                 PostFail($"Persistence read failed: {ex.Message}",
@@ -4631,6 +4637,9 @@ public static class MeshExtensions
 
         void WriteThroughStream(MeshNode existing)
         {
+            // From here the reply rides the per-node owner's PatchDataResponse (its own trail
+            // carries the PATCH_* stages); a trail ending at this stage is waiting on that owner.
+            hub.NoteRequestStage(request.Id, $"UPSERT_WRITE_THROUGH_STREAM path={existing.Path}");
             // Apply the update through the canonical mesh-node stream write API
             // (UpdateNodeRequest retired). hub.GetMeshNodeStream(path).Update routes
             // to the owning per-node hub via the IMeshNodeStreamCache (RFC 7396 merge
@@ -4708,6 +4717,7 @@ public static class MeshExtensions
         // viewer's language at render time while `logLine` stays the fallback (#3236).
         void PostOk(MeshNode result, bool isCreate, string logLine, string logKey)
         {
+            hub.NoteRequestStage(request.Id, isCreate ? "UPSERT_REPLY ok created" : "UPSERT_REPLY ok updated");
             var okLog = baseActivity.Append(
                 new LogMessage(logLine, Microsoft.Extensions.Logging.LogLevel.Information)
                     .WithKey(logKey, ("path", node.Path))) with
@@ -4724,6 +4734,7 @@ public static class MeshExtensions
 
         void PostFail(string error, NodeUpsertRejectionReason reason)
         {
+            hub.NoteRequestStage(request.Id, $"UPSERT_REPLY fail reason={reason}");
             var failLog = baseActivity.Append(
                 new LogMessage(error, Microsoft.Extensions.Logging.LogLevel.Error)) with
             {


### PR DESCRIPTION
## #2543: the patch commit path and nodeops' upsert record their arms on the request trail

Today's recurrence (CD run 34025558310, 10:43Z, seal failed on cc7e31db3) ended every trail at `HANDLER_EXIT state=Processed` with nothing after — on **both** hops: the callers waiting on `portal/nodeops` for `CreateOrUpdateNodeRequest`, and nodeops waiting on the `Chess/*` owners for `PatchDataRequest`. The ledger says why that is not a verdict: these handlers return `Processed` at once and owe their reply from detached work, and the pipeline cannot see which wait that work is in. The issue has called the nodeops-saturation half "untouched and unmeasured" since it was filed; this makes it measurable at the next occurrence.

What the log did rule out today: no compile was running (every Chess type adopted a prebuilt assembly, `no compile needed`, 10:42:55–10:43:04, and the same bundle was adopted three times in nine seconds); the writes went unanswered while the same owners were also receiving the adoption's stamp request, the installer's release trigger, `CompileStateMirror` satellite writes and a `PluginGating` reconcile rewriting Chess `_Access` nodes. Which of those the owner was stuck behind is exactly what the trail could not say.

### Stages (diagnostic only — `NoteRequestStage` is a no-op unless the request is awaited; no behaviour changes)
| hop | stage | a trail ending there means |
|---|---|---|
| owner | `PATCH_MERGE_DISPATCHED` | the merge turn is queued on the primary's executor and **never ran** — executor behind other work; the next stage's offset is the queueing time |
| owner | `PATCH_MERGE_TURN entered` / `deferred-retry` | recorded ON the executor: the turn ran |
| owner | `PATCH_MERGE_DEFERRED cold-store` | activating cold; re-armed on the store's first load |
| owner | `PATCH_MERGE_STAMPED v= refused=` / `PATCH_MERGE_NOCHANGE` | the merge committed / changed nothing — an ending here means the commit echo never reached the ack watcher |
| owner | `PATCH_ECHO_SEEN` | the commit is in; the wait is the durable flush (`FLUSH_OUTLIVED_BOUND` names it from the log side) |
| owner | `PATCH_ACK ok` / `nack=<code>` | the verdict was posted |
| nodeops | `UPSERT_READ <outcome → branch>` · `UPSERT_WRITE_THROUGH_STREAM path=` · `UPSERT_REPLY ok/fail` | which branch, and when the wait moved to the owner |

`DebuggingMessageFlow.md` carries the table.

### Verified
Release `-warnaserror` (`--no-incremental` on the two touched projects), 0 errors. Patch and upsert suites: `MeshWeaver.Data.Test` 16/16, `MeshWeaver.Graph.Test` (WriteBaseStateTotality, DanglingNodeTypeUpdate, ContentReadIsNotQueuedBehindNodeCrud, StaticRepoImportBulkWrite) 17/17, `Memex.Portal.Shared.Test` (UpdatePolicyMcpPatch + the #3359 upsert fixtures) 5/5.

No What's New: nothing a user can notice.

Pairs-with: none — no public surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
