### PR TITLE
review(#3391): bound every await in GitHubAppTokenRefreshTest with a 10 s budget

### DIFF
--- a/test/Memex.Portal.Shared.Test/GitHubAppTokenRefreshTest.cs
+++ b/test/Memex.Portal.Shared.Test/GitHubAppTokenRefreshTest.cs
@@ -115,6 +115,7 @@ public class GitHubAppTokenRefreshTest
             .SelectMany(_ => held.Take(1))
             .ToList()
             .FirstAsync()
+            .Timeout(Budget)
             .Await();
         Assert.All(tokens, t => Assert.Equal("ghs_2", t));
         Assert.Equal(2, handler.Mints);

--- a/test/Memex.Portal.Shared.Test/GitHubAppTokenRefreshTest.cs
+++ b/test/Memex.Portal.Shared.Test/GitHubAppTokenRefreshTest.cs
@@ -34,6 +34,9 @@ public class GitHubAppTokenRefreshTest
 {
     private static readonly DateTimeOffset T0 = new(2026, 9, 6, 0, 0, 0, TimeSpan.Zero);
 
+    // Every await is bounded: a wedged token stream must surface as a timeout, never a stuck run.
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(10);
+
     [Fact]
     public async Task OneHeldObservable_RefreshesOnEveryExpiry_NotOnlyTheFirst()
     {
@@ -54,34 +57,34 @@ public class GitHubAppTokenRefreshTest
         // ONE observable, held — the Store feed's shape — subscribed per pass below.
         var held = service.GetInstallationToken();
 
-        Assert.Equal("ghs_1", await held.FirstAsync().Await());
+        Assert.Equal("ghs_1", await held.FirstAsync().Timeout(Budget).Await());
         Assert.Equal(1, handler.Mints);
 
         // Well inside the lifetime: replayed, no mint.
         clock = T0.AddMinutes(30);
-        Assert.Equal("ghs_1", await held.FirstAsync().Await());
+        Assert.Equal("ghs_1", await held.FirstAsync().Timeout(Budget).Await());
         Assert.Equal(1, handler.Mints);
 
         // Inside the five-minute refresh window: the FIRST refresh — this one always worked.
         clock = T0.AddMinutes(56);
-        Assert.Equal("ghs_2", await held.FirstAsync().Await());
+        Assert.Equal("ghs_2", await held.FirstAsync().Timeout(Budget).Await());
         Assert.Equal(2, handler.Mints);
 
         // Token 2 expires at T0+116 min. The SECOND refresh is the one the defect skipped: before
         // the fix this pass answered ghs_2, four minutes from expiry, and every later pass answered
         // it too — long after GitHub had stopped accepting it.
         clock = T0.AddMinutes(112);
-        Assert.Equal("ghs_3", await held.FirstAsync().Await());
+        Assert.Equal("ghs_3", await held.FirstAsync().Timeout(Budget).Await());
         Assert.Equal(3, handler.Mints);
 
         // And the third, to show it is every expiry rather than the first two.
         clock = T0.AddMinutes(168);
-        Assert.Equal("ghs_4", await held.FirstAsync().Await());
+        Assert.Equal("ghs_4", await held.FirstAsync().Timeout(Budget).Await());
         Assert.Equal(4, handler.Mints);
 
         // A pass while the token is fresh still replays: the fix did not turn the cache into a mint-per-pass.
         clock = T0.AddMinutes(170);
-        Assert.Equal("ghs_4", await held.FirstAsync().Await());
+        Assert.Equal("ghs_4", await held.FirstAsync().Timeout(Budget).Await());
         Assert.Equal(4, handler.Mints);
     }
 
@@ -103,7 +106,7 @@ public class GitHubAppTokenRefreshTest
             clock: () => clock);
 
         var held = service.GetInstallationToken();
-        Assert.Equal("ghs_1", await held.FirstAsync().Await());
+        Assert.Equal("ghs_1", await held.FirstAsync().Timeout(Budget).Await());
 
         // Five sources poll on the same timer; when the token is stale they all refresh at once
         // and must share the single new promise rather than mint five tokens.


### PR DESCRIPTION
Follow-up to #3391, carrying the change Copilot asked for on that PR. The branch was already in the merge queue when the fix was ready, and a queued branch cannot be updated, so it lands here rather than by dequeuing and re-running the queue for a test-hygiene change.

`ObservableAwait.Await` needs the source to terminate, so a wedged token stream would have hung the run instead of failing it. Every `.FirstAsync()` in `GitHubAppTokenRefreshTest` now carries `.Timeout(Budget)` with `Budget = 10 s`, the shape the sibling tests in `Memex.Portal.Shared.Test` use.

Built Release `-warnaserror` on top of the merged main: 0 errors; both cases pass (153 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK4B83GneTFF7cvwHJUCVf
