### PR TITLE
fix(gate): the bake-shortfall verdict names the seed-write timeout as a reason a type declines

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/BakeShortfallNamesTheTypeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeShortfallNamesTheTypeTest.cs
@@ -40,6 +40,27 @@ public class BakeShortfallNamesTheTypeTest
         Assert.DoesNotContain("DECLINED: Crm/Board", verdict);
     }
 
+    /// <summary>
+    /// A decline is not always a bake problem: on MeshWeaver.Reinsurance run 34027833694 the
+    /// verdict read "DECLINED: Hosting/Issue" and named three bake-identity reasons, while the
+    /// actual reason — logged right above it — was the seed's write to the type's owner timing out
+    /// ("seeding Hosting/Issue from Hosting.zip did not complete — the sweep compiles it instead").
+    /// The bytes were fine; the mesh was slow. A verdict that names only the bake-identity reasons
+    /// sends the reader to the wrong half of the log.
+    /// </summary>
+    [Fact]
+    public void Names_the_seed_write_timeout_as_a_reason_a_type_declines()
+    {
+        var declared = Set("Hosting/Issue", "Hosting/Admin");
+        var verdict = BakeSeedConsumer.DescribeShortfall(
+            declared, requested: declared, covered: Set("Hosting/Admin"), directory: "/seed");
+
+        Assert.NotNull(verdict);
+        Assert.Contains("did not complete", verdict);
+        Assert.Contains("not a bake problem", verdict);
+        Assert.Contains("framework identity", verdict);   // the bake-identity reasons stay named too
+    }
+
     [Fact]
     public void Silent_when_everything_declared_and_requested_was_backed()
     {

--- a/tools/MeshWeaver.PluginTester/BakeSeed.cs
+++ b/tools/MeshWeaver.PluginTester/BakeSeed.cs
@@ -287,9 +287,13 @@ public sealed class BakeSeedConsumer(
             + "not judge the bytes the bake shipped for them. DECLINED: "
             + $"{string.Join(", ", missing.Take(20))}"
             + (missing.Count > 20 ? ", …" : "")
-            + ". The per-assembly reason (framework identity, the per-type dependency record, or a "
-            + $"payload the bundle's manifest names but does not carry) is logged above under the "
-            + $"'{LogCategory}' category, which the gate raises to Information whenever it consumes "
-            + "a bake; outside the gate, enable that category to read it.";
+            + ". The per-assembly reason is logged above: a bake-identity decline (framework "
+            + "identity, the per-type dependency record, or a payload the bundle's manifest names "
+            + $"but does not carry) under the '{LogCategory}' category, which the gate raises to "
+            + "Information whenever it consumes a bake; or — not a bake problem at all — the seed's "
+            + "own write to the type's owner did not complete (a Warning reading 'seeding <type> "
+            + "from <bundle> did not complete — the sweep compiles it instead', preceded by that "
+            + "owner's write timing out), in which case the bytes were fine and the mesh was slow. "
+            + "Outside the gate, enable that category to read the first kind.";
     }
 }


### PR DESCRIPTION
## The bake-shortfall verdict names the seed-write timeout as a reason a type declines

On MeshWeaver.Reinsurance run 34027833694 the gate said `DECLINED: Hosting/Issue` and pointed the reader at *"framework identity, the per-type dependency record, or a payload the bundle's manifest names but does not carry"*. The actual reason was logged right above it and is none of those: `bake-seed: seeding Hosting/Issue from Hosting.zip did not complete — the sweep compiles it instead`, preceded by that owner's write timing out (`[UpdateQueue] FAILED path=Hosting/Issue … TimeoutException`). The bytes were fine; the mesh was slow. Read as written, the verdict sends whoever triages that red to a bake-identity diagnosis of a write-path problem (on that lane: a pin at `3.0.0-rc9.ci.7574`, before #3112 stopped a slow flush from NACKing).

The verdict now names both kinds — the bake-identity declines under the category the gate raises to Information, and the seed's own write not completing, with the Warning line to look for — so the reader lands in the right half of the log. `BakeShortfallNamesTheTypeTest` pins it (8/8, Release `-warnaserror`, 0 errors).

No What's New: a CI verdict's wording, nothing a portal user sees.

Pairs-with: none — a message and a test; no public surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
