### PR TITLE
feat(Memex#132): a secret channel for operator Jobs, in the namespace they run in

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -297,6 +297,23 @@ data:
 {{- range $key, $value := (.Values.hostingOperator).environment }}
   Hosting__Operator__Environment__{{ $key }}: "{{ $value }}"
 {{- end }}
+{{- /* The SECRET half of the Job environment (Memex#132). `environment` above renders into this
+       ConfigMap, one plaintext key each — fine for AZ_RESOURCE_GROUP or INGRESS_IP, and NOT fine for
+       PGPASSWORD, which is the shared admin credential for every instance database on the flexible
+       server. hosting-operator-secrets.yaml renders a SecretProviderClass and a synced Secret in the
+       OPERATOR's namespace for those; these three keys are how HostingOperator.Resolve finds them.
+
+       🚨 All THREE, not just the Secret name. The CSI driver creates the synced Secret only as a
+       side effect of a pod mounting the volume, so on a Job's first run it does not exist yet. A Job
+       that mounts the class at SecretMountPath can read the value from a file immediately; an
+       `envFrom` on SecretName is correct only once something has already mounted it. */}}
+{{- if (.Values.hostingOperator).secretEnvironment }}
+{{- $kv := ((.Values.hostingOperator).keyVault) | default dict }}
+{{- $spcName := $kv.name | default "hosting-operator-keyvault" }}
+  Hosting__Operator__SecretProviderClass: "{{ $spcName }}"
+  Hosting__Operator__SecretName: "{{ $kv.syncedSecret | default $spcName }}"
+  Hosting__Operator__SecretMountPath: "{{ $kv.mountPath | default "/mnt/operator-secrets" }}"
+{{- end }}
 {{- end }}
 {{- if (.Values.portalNext).enabled }}
   # ---- Next.js React frontend (FEATURE-FLAGGED — see .Values.portalNext) -----

--- a/deploy/helm/templates/memex-portal/hosting-operator-secrets.yaml
+++ b/deploy/helm/templates/memex-portal/hosting-operator-secrets.yaml
@@ -1,0 +1,84 @@
+{{- /*
+The hosting operator's Key Vault secrets — the SECRET half of the Job environment, which until now
+did not exist.
+
+🚨 WHY THIS TEMPLATE EXISTS. `HostingOperator.Resolve` builds a Job's environment from the config
+keys `Hosting:Operator:Environment:*`, and config.yaml renders those into the portal's ConfigMap,
+one key each. That is the ONLY env channel a Job has, and a ConfigMap is plaintext by construction.
+So the documented way to give `Backup`/`Restore`/`Suspend`/`Teardown` the `PGPASSWORD` they need was
+to put the shared `memexadmin` password for `memexaks-pg` — the one credential that reaches EVERY
+instance database on the server — into a ConfigMap readable by anything with configmap read in the
+namespace, and into git if committed. Every database action failed at step 1 rather than do that
+(Memex#132). `hosting-backup` already describes the value as "(mounted from Key Vault)"; this is the
+mechanism that makes the description true.
+
+🚨 THE OPERATOR'S NAMESPACE IS NOT THE PORTAL'S. Jobs run in `hostingOperator.namespace`
+(`memex-ops`), and a Secret in the portal's namespace is invisible there — measured 2026-09-06:
+`memex-ops` carried no SecretProviderClass and no secret but a service-account token. So this
+renders its own class and its own synced Secret INTO that namespace rather than extending
+.Values.keyVaultSecrets, which is portal-scoped. It is also deliberately a SEPARATE object from the
+portal's: an operator Job has no business carrying the portal's AI provider keys and OAuth secrets,
+and `envFrom` on the portal's synced Secret would hand it all of them.
+
+🚨 A SECRETPROVIDERCLASS WITH NO MOUNTING POD SYNCS NOTHING, silently. The CSI driver creates the
+synced Secret as a SIDE EFFECT of a pod mounting the volume — so the Job must mount it, and on the
+first run the synced Secret does not exist yet. That is why all three coordinates are published to
+config below, not just the Secret name: a Job that mounts the volume can read the value from
+`Hosting:Operator:SecretMountPath/<vault object>` on the very first run, with no dependency on the
+sync having happened. Reading the FILE is the ordering-safe form; `envFrom` on the synced Secret is
+correct only from the second run onward.
+
+NAMES ONLY: `secretEnvironment` maps the env key the operator script reads to the vault object's
+name. No value is ever in values, and no value is ever in this render.
+
+Rendered only when `hostingOperator.secretEnvironment` is non-empty, so every environment that has
+not opted in renders byte-identically.
+*/ -}}
+{{- if (.Values.hostingOperator).enabled }}
+{{- with (.Values.hostingOperator).secretEnvironment }}
+{{- $op := $.Values.hostingOperator }}
+{{- $portal := $.Values.keyVaultSecrets | default dict }}
+{{- $ns := $op.namespace | default "memex-ops" }}
+{{- $vault := required "hostingOperator.secretEnvironment needs a vault: set hostingOperator.keyVault.vaultName (or keyVaultSecrets.vaultName)" (($op.keyVault).vaultName | default $portal.vaultName) }}
+{{- $tenant := required "hostingOperator.secretEnvironment needs hostingOperator.keyVault.tenantId (or keyVaultSecrets.tenantId)" (($op.keyVault).tenantId | default $portal.tenantId) }}
+{{- $identity := required "hostingOperator.secretEnvironment needs hostingOperator.keyVault.identityClientId (or keyVaultSecrets.identityClientId) — the Key Vault Secrets Provider add-on's user-assigned identity" (($op.keyVault).identityClientId | default $portal.identityClientId) }}
+{{- $name := ($op.keyVault).name | default "hosting-operator-keyvault" }}
+{{- $synced := ($op.keyVault).syncedSecret | default $name }}
+---
+apiVersion: "secrets-store.csi.x-k8s.io/v1"
+kind: "SecretProviderClass"
+metadata:
+  name: "{{ $name }}"
+  namespace: "{{ $ns }}"
+  labels:
+    app.kubernetes.io/name: "{{ $.Chart.Name }}"
+    app.kubernetes.io/component: "hosting-operator"
+    app.kubernetes.io/instance: "{{ $.Release.Name }}"
+spec:
+  provider: "azure"
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "true"
+    userAssignedIdentityID: "{{ $identity }}"
+    keyvaultName: "{{ $vault }}"
+    tenantId: "{{ $tenant }}"
+    objects: |
+      array:
+{{- range $key, $vaultSecret := . }}
+        - |
+          objectName: {{ $vaultSecret | required (printf "hostingOperator.secretEnvironment.%s must name a Key Vault object" $key) }}
+          objectType: secret
+{{- end }}
+  # One key per declared entry, named as the env key the operator script reads. A Job that mounts
+  # the volume gets the files immediately; this synced Secret is what an `envFrom` would consume
+  # once it exists.
+  secretObjects:
+    - secretName: "{{ $synced }}"
+      type: "Opaque"
+      data:
+{{- range $key, $vaultSecret := . }}
+        - objectName: {{ $vaultSecret }}
+          key: {{ $key }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -187,6 +187,34 @@ hostingOperator:
   #   PAYWALL_URL:           https://<control instance>/suspended
   #   CATALOG_CONFIG:        /tmp/hosting-catalog-config
   #   HOSTING_VALUES_FILE:   /tmp/hosting-values.yaml   (where run.sh materialises the RECORD-rendered values)
+  # ── The SECRET half of that environment (Memex#132) ────────────────────────────────────────
+  # `environment` above renders into the portal's ConfigMap, one plaintext key each. That is right
+  # for AZ_RESOURCE_GROUP or INGRESS_IP and WRONG for a credential: PGPASSWORD is the shared
+  # `memexadmin` password for the flexible server, i.e. the one credential that reaches EVERY
+  # instance database on it. Putting it in `environment` means a ConfigMap readable by anything with
+  # configmap read in the namespace, and git if committed. Declaring it here instead renders a
+  # SecretProviderClass and a CSI-synced Secret in the OPERATOR's namespace (memex-ops), which is
+  # where the Jobs run and where a portal-namespace Secret is not visible.
+  #
+  # NAMES ONLY — `<ENV KEY>: <Key Vault object name>`. No value ever enters values or the render.
+  secretEnvironment: {}
+  #   PGPASSWORD: memex-postgres-password
+  #
+  # Vault coordinates. Each falls back to the portal's .Values.keyVaultSecrets, so an environment
+  # that already declares those needs only `secretEnvironment` above.
+  keyVault: {}
+  #   vaultName:        Systemorph
+  #   tenantId:         <tenant guid>
+  #   identityClientId: <the Key Vault Secrets Provider add-on's user-assigned identity>
+  #   name:             hosting-operator-keyvault   (the SecretProviderClass; also the synced Secret)
+  #   syncedSecret:     hosting-operator-keyvault
+  #   mountPath:        /mnt/operator-secrets
+  #
+  # 🚨 The Job must MOUNT the class — a SecretProviderClass with no mounting pod syncs nothing, with
+  # no error anywhere. The three coordinates are published as Hosting__Operator__SecretProviderClass
+  # / __SecretName / __SecretMountPath so HostingOperator.Resolve can attach volume, mount and env.
+  # Reading the file under the mount path is the ordering-safe form; an envFrom on the synced Secret
+  # only works once something has already mounted the class at least once.
 # ---- Fixed replica count (portal) ------------------------------------------
 # Read ONLY when keda.enabled is false — with KEDA on, the HPA owns spec.replicas and the chart
 # deliberately renders no such field (see templates/memex-portal/deployment.yaml).


### PR DESCRIPTION
Every hosting-operator action that touches Postgres — `Backup`, `Restore`, `Suspend`, `Teardown`
and `Provision`'s database step — fails at its first real step:

```
hosting-backup: ERROR: environment variable PGPASSWORD is empty or unset — the admin password
for the flexible server (mounted from Key Vault). It is supplied by Hosting:Operator:Environment
on the control instance.
```

The message names a channel that cannot carry it. `Hosting:Operator:Environment:*` is the only env
a Job gets, and `config.yaml` renders those into the portal's **ConfigMap**, one plaintext key each.
That is right for `AZ_RESOURCE_GROUP` or `INGRESS_IP` and wrong for this one: `PGPASSWORD` is the
shared `memexadmin` password for `memexaks-pg` — the single credential that reaches *every*
instance database on the server. `hosting-backup` already describes it as *"(mounted from Key
Vault)"*; nothing ever wired that.

Adds `hostingOperator.secretEnvironment` — **names only**, env key → Key Vault object — rendering a
`SecretProviderClass` and its CSI-synced Secret from one declaration, exactly as
`.Values.keyVaultSecrets` already does for the portal.

## 🚨 Two constraints that came from measuring, not from the issue

**1 · The Jobs run in a different namespace, and it is empty.** `hostingOperator.namespace` is
`memex-ops`; a Secret in the portal's namespace is not visible there. Measured on the live cluster:

```
=== secretproviderclasses in memex-ops ===
No resources found in memex-ops namespace.
=== secrets in memex-ops ===
NAME                      TYPE                                  DATA   AGE
hosting-jobrunner-token   kubernetes.io/service-account-token   3      14d
```

So this renders its own objects **into that namespace** rather than extending the portal-scoped
block. Separate deliberately, too: an operator Job has no business carrying the portal's AI provider
keys and OAuth secrets, which an `envFrom` on the portal's synced Secret would hand it wholesale.

**2 · A SecretProviderClass with no mounting pod syncs nothing, silently.** The CSI driver creates
the synced Secret only as a *side effect* of a pod mounting the volume — so on a Job's **first** run
it does not exist. That is why all three coordinates are published, not just the Secret name:

```
Hosting__Operator__SecretProviderClass: "hosting-operator-keyvault"
Hosting__Operator__SecretName:          "hosting-operator-keyvault"
Hosting__Operator__SecretMountPath:     "/mnt/operator-secrets"
```

Mounting the class and reading the file is ordering-safe on the first run; an `envFrom` on the
synced Secret is correct only from the second onward.

## Verified — `helm template`, four renders

| Case | Result |
|---|---|
| Opted out | **0** occurrences; byte-identical to today |
| Opted in | `SecretProviderClass` in ns `memex-ops`, `objectName: memex-postgres-password`, `key: PGPASSWORD`, plus the three config keys |
| Declared with no vault anywhere | Render **FAILS**: `hostingOperator.secretEnvironment needs a vault: set hostingOperator.keyVault.vaultName (or keyVaultSecrets.vaultName)` |
| Vault coords omitted, portal's present | Falls back to `.Values.keyVaultSecrets` |

The third is the one that matters: a half-declared block fails the render **naming the key**, rather
than producing a class that syncs nothing — which the CSI driver surfaces as a pod stuck in
`ContainerCreating`, never as an error naming this file.

## Scope — this is the chart half only

What attaches the volume, mount and env to the Job is `HostingOperator.Resolve`, an **in-mesh node**
(`Hosting/InstanceAction/Source/HostingOperator.cs`): it compiles at runtime in the portal, so **no
CI in this repo covers it**. The values half lands in `Systemorph/Memex`. Neither is here.
Systemorph/Memex#132 carries the three-surface split and the remaining design call between
mount-and-read and `envFrom`.

No What's New entry: nothing a user can observe changes until the in-mesh half lands — the mechanism
renders inert for every environment that has not opted in.

`Pairs-with: none` — additive chart values and one new template; no public surface removed.

Refs Systemorph/Memex#132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
