### PR TITLE
fix(#3396): the diagnostics workspace cache keys on the reference set, not just source versions

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
@@ -320,8 +320,9 @@ internal sealed class MeshNodeLanguageService : IMeshLanguageService
 
     private CachedWorkspace BuildOrReuseWorkspace(string nodeTypePath, CompilationInputs inputs)
     {
+        var shapeKey = ShapeKeyOf(inputs);
         if (_cache.TryGetValue(nodeTypePath, out var existing)
-            && VersionsEqual(existing.SourceVersions, inputs.SourceVersions))
+            && CanReuseWorkspace(existing.SourceVersions, existing.ShapeKey, inputs))
         {
             return existing;
         }
@@ -389,12 +390,64 @@ internal sealed class MeshNodeLanguageService : IMeshLanguageService
             ProjectId: projectId,
             SourceVersions: inputs.SourceVersions,
             DocumentsByPath: pathToDocId.ToImmutable(),
-            SkeletonDocumentId: skeletonDocId);
+            SkeletonDocumentId: skeletonDocId,
+            ShapeKey: shapeKey);
 
         _cache[nodeTypePath] = cached;
         logger.LogDebug("Built AdhocWorkspace for {NodeTypePath} with {DocCount} user documents",
             nodeTypePath, inputs.Sources.Length);
         return cached;
+    }
+
+    /// <summary>
+    /// Whether a cached workspace still describes <paramref name="inputs"/> — the WHOLE reuse
+    /// decision, extracted so it can be driven directly by a test.
+    ///
+    /// <para>🚨 Both halves are load-bearing and they cover different things: source VERSIONS carry
+    /// the identity of the source texts, and the shape key carries everything else the workspace was
+    /// built from — above all the reference set. Testing <see cref="ShapeKeyOf"/> alone would leave
+    /// this call site free to drop the shape check and stay green, which is the failure mode #3396
+    /// is an instance of.</para>
+    /// </summary>
+    internal static bool CanReuseWorkspace(
+        ImmutableDictionary<string, long> cachedSourceVersions,
+        int cachedShapeKey,
+        CompilationInputs inputs)
+        => VersionsEqual(cachedSourceVersions, inputs.SourceVersions)
+           && cachedShapeKey == ShapeKeyOf(inputs);
+
+    /// <summary>
+    /// Everything a workspace is built from EXCEPT the source texts, whose identity
+    /// <see cref="CompilationInputs.SourceVersions"/> already carries.
+    ///
+    /// <para>🚨 <b>Source versions alone are NOT the cache key.</b> They were, and the result was a
+    /// workspace pinned to a stale REFERENCE set: a NodeType whose sources had not changed but whose
+    /// module/reference set had kept answering the diagnostics it produced against the old
+    /// references. On memex-cloud that surfaced as a byte-identical 403,625-byte <c>Error</c> payload
+    /// nine minutes apart for <c>Store/Plugin</c>, whose own <c>compilationStatus</c> was <c>Ok</c> —
+    /// a false positive from the tool AGENTS.md points at for the pre-deploy sweep (#3396). The
+    /// reference set genuinely does move underneath unchanged sources: #3395 measured two compiles in
+    /// ONE boot resolving different module sets 15 s apart.</para>
+    ///
+    /// <para>A hash rather than a stored copy because this is compared on the interactive paths too
+    /// (hover, completions), and because retaining every reference list per NodeType would keep the
+    /// old <see cref="MetadataReference"/> graph alive — the very thing the disposal below exists to
+    /// release. A collision would reuse a stale workspace, i.e. degrade to exactly today's behaviour
+    /// for that one entry, so the failure direction is no worse than the bug being fixed.</para>
+    /// </summary>
+    internal static int ShapeKeyOf(CompilationInputs inputs)
+    {
+        var hash = new HashCode();
+        hash.Add(inputs.AssemblyName, StringComparer.Ordinal);
+        hash.Add(inputs.SkeletonSource, StringComparer.Ordinal);
+        hash.Add(inputs.GlobalUsingsSource, StringComparer.Ordinal);
+        hash.Add(inputs.ParseOptions);
+        hash.Add(inputs.CompilationOptions);
+        // Order matters: the reference list IS ordered, and a reorder can change resolution.
+        hash.Add(inputs.References.Length);
+        foreach (var reference in inputs.References)
+            hash.Add(reference.Display, StringComparer.Ordinal);
+        return hash.ToHashCode();
     }
 
     private static bool VersionsEqual(
@@ -871,5 +924,6 @@ internal sealed class MeshNodeLanguageService : IMeshLanguageService
         ProjectId ProjectId,
         ImmutableDictionary<string, long> SourceVersions,
         ImmutableDictionary<string, DocumentId> DocumentsByPath,
-        DocumentId SkeletonDocumentId);
+        DocumentId SkeletonDocumentId,
+        int ShapeKey);
 }

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-diagnostics-stop-answering-from-a-stale-cache.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-diagnostics-stop-answering-from-a-stale-cache.md
@@ -1,0 +1,24 @@
+---
+Name: Diagnostics stop answering from a stale cache
+Category: Fix
+Description: The language service reused a NodeType's compiled workspace whenever its sources were unchanged — even when its reference set had moved — so diagnostics could report errors that no longer existed, or miss ones that did.
+Icon: DocumentError
+Order: -20260906
+---
+
+`get_diagnostics` could report an `Error` for a NodeType whose own compilation status was `Ok`, and
+keep reporting it: on one portal the same 403,625-byte payload came back byte-identical nine minutes
+apart.
+
+The workspace cache treated a NodeType's **source versions** as the whole identity of its
+compilation. But the reference set moves independently of the sources — a module arriving or
+changing alters what the code compiles against without touching a single source file. When that
+happened, the cached workspace stayed pinned to the old references and answered from them
+indefinitely, because nothing else could evict it.
+
+The cache now keys on everything a workspace is built from: the reference set and its order, the
+skeleton, the global usings and the assembly name, alongside the source versions it already tracked.
+Unchanged inputs still reuse the workspace, so editing stays as fast as before.
+
+The direction that mattered most is the quiet one: the same staleness could answer *clean* for a type
+that had since broken, and this tool is the one the pre-deploy sweep relies on.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DiagnosticsWorkspaceCacheKeyTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DiagnosticsWorkspaceCacheKeyTest.cs
@@ -1,0 +1,141 @@
+using System.Collections.Immutable;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins what invalidates the language service's per-NodeType workspace cache.
+///
+/// <para>🚨 <b>Source versions alone are not the identity of a compilation.</b> The cache reused a
+/// workspace whenever <c>SourceVersions</c> matched, so a NodeType whose sources had not changed but
+/// whose REFERENCE set had went on answering diagnostics computed against the old references —
+/// permanently, since nothing else could evict it. On memex-cloud that surfaced as a byte-identical
+/// 403,625-byte <c>Error</c> payload nine minutes apart for a node whose own
+/// <c>compilationStatus</c> was <c>Ok</c> (#3396): a false positive from the tool AGENTS.md points
+/// at for the mandated pre-deploy sweep. The dangerous direction is the other one — the same
+/// staleness can answer clean for a type that has since broken.</para>
+///
+/// <para>The reference set really does move under unchanged sources: #3395 measured two NodeType
+/// compiles in ONE boot resolving different module sets 15 seconds apart.</para>
+/// </summary>
+public class DiagnosticsWorkspaceCacheKeyTest
+{
+    private static readonly MetadataReference CoreLib =
+        MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+
+    private static readonly MetadataReference Linq =
+        MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+
+    private static CompilationInputs Inputs(
+        ImmutableArray<MetadataReference>? references = null,
+        string skeleton = "// skeleton",
+        string usings = "global using System;",
+        string assemblyName = "Widget.Thing",
+        ImmutableArray<(string Path, string Code)>? sources = null,
+        ImmutableDictionary<string, long>? versions = null)
+        => new(
+            AssemblyName: assemblyName,
+            Sources: sources ?? [("Thing.cs", "public class Thing { }")],
+            SkeletonSource: skeleton,
+            GlobalUsingsSource: usings,
+            References: references ?? [CoreLib],
+            ParseOptions: new CSharpParseOptions(LanguageVersion.Latest),
+            CompilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            SourceVersions: versions ?? ImmutableDictionary<string, long>.Empty.Add("Thing.cs", 1));
+
+    // ───────────────────────────── the reuse DECISION, not just the key ─────────────────────────
+
+    /// <summary>
+    /// 🚨 The assertion that actually fails if the fix is undone. A cache entry built from one
+    /// reference set must NOT be reused for inputs carrying another, even though every source and
+    /// every source version is identical — which is #3396 exactly.
+    /// </summary>
+    [Fact]
+    public void ACachedWorkspace_IsNotReused_WhenOnlyTheReferenceSetChanged()
+    {
+        var built = Inputs(references: [CoreLib]);
+        var now = Inputs(references: [CoreLib, Linq]);
+
+        Assert.Equal(built.SourceVersions, now.SourceVersions);   // the sources did not move…
+        Assert.False(MeshNodeLanguageService.CanReuseWorkspace(
+            built.SourceVersions, MeshNodeLanguageService.ShapeKeyOf(built), now));  // …the workspace still must not be reused
+    }
+
+    /// <summary>The other half: unchanged inputs DO reuse, or every keystroke rebuilds Roslyn.</summary>
+    [Fact]
+    public void ACachedWorkspace_IsReused_WhenNothingMoved()
+    {
+        var built = Inputs();
+        Assert.True(MeshNodeLanguageService.CanReuseWorkspace(
+            built.SourceVersions, MeshNodeLanguageService.ShapeKeyOf(built), Inputs()));
+    }
+
+    /// <summary>And the original half still holds: a source EDIT invalidates via SourceVersions.</summary>
+    [Fact]
+    public void ACachedWorkspace_IsNotReused_WhenASourceVersionMoved()
+    {
+        var built = Inputs();
+        var now = Inputs(versions: ImmutableDictionary<string, long>.Empty.Add("Thing.cs", 2));
+
+        Assert.Equal(MeshNodeLanguageService.ShapeKeyOf(built), MeshNodeLanguageService.ShapeKeyOf(now));
+        Assert.False(MeshNodeLanguageService.CanReuseWorkspace(
+            built.SourceVersions, MeshNodeLanguageService.ShapeKeyOf(built), now));
+    }
+
+    /// <summary>Identical inputs reuse the workspace — without this the fix would rebuild Roslyn
+    /// state on every hover and completion keystroke.</summary>
+    [Fact]
+    public void IdenticalInputs_ShareAShapeKey()
+        => Assert.Equal(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs()),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs()));
+
+    /// <summary>🚨 The defect: same sources, different references, and the cache could not tell.</summary>
+    [Fact]
+    public void AChangedReferenceSet_ChangesTheShapeKey()
+        => Assert.NotEqual(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(references: [CoreLib])),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(references: [CoreLib, Linq])));
+
+    /// <summary>Order is part of the identity — a reorder can change how a name resolves.</summary>
+    [Fact]
+    public void AReorderedReferenceSet_ChangesTheShapeKey()
+        => Assert.NotEqual(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(references: [CoreLib, Linq])),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(references: [Linq, CoreLib])));
+
+    [Fact]
+    public void AChangedSkeleton_ChangesTheShapeKey()
+        => Assert.NotEqual(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(skeleton: "// skeleton")),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(skeleton: "// skeleton v2")));
+
+    [Fact]
+    public void ChangedGlobalUsings_ChangeTheShapeKey()
+        => Assert.NotEqual(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(usings: "global using System;")),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(usings: "global using System;\nglobal using System.Linq;")));
+
+    [Fact]
+    public void AChangedAssemblyName_ChangesTheShapeKey()
+        => Assert.NotEqual(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(assemblyName: "Widget.Thing")),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(assemblyName: "Widget.Other")));
+
+    /// <summary>
+    /// 🚨 The non-vacuity half. The shape key must deliberately IGNORE the source texts, because
+    /// <c>SourceVersions</c> is what carries their identity and the two are checked together. A key
+    /// that hashed everything would pass every assertion above while telling us nothing about which
+    /// half covers what — and would rebuild the workspace on each keystroke, since the edited buffer
+    /// changes before its version does.
+    /// </summary>
+    [Fact]
+    public void ChangedSourceTEXT_DoesNotChangeTheShapeKey_ThatIsSourceVersionsJob()
+        => Assert.Equal(
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(sources: [("Thing.cs", "public class Thing { }")])),
+            MeshNodeLanguageService.ShapeKeyOf(Inputs(sources: [("Thing.cs", "public class Thing { int x; }")])));
+}


### PR DESCRIPTION
`get_diagnostics` reported **`Error`** for a NodeType whose own `compilationStatus` was **`Ok`**, and
kept reporting it — on memex-cloud the same **403,625-byte payload came back byte-identical nine
minutes apart** for `Store/Plugin`, while on memex the same type answered the opposite way (#3396).

## Root cause

`MeshNodeLanguageService` caches one `AdhocWorkspace` per NodeType and reused it whenever
`SourceVersions` matched:

```csharp
if (_cache.TryGetValue(nodeTypePath, out var existing)
    && VersionsEqual(existing.SourceVersions, inputs.SourceVersions))
    return existing;
```

But `CompilationInputs` carries more than sources:

```csharp
internal sealed record CompilationInputs(
    string AssemblyName,
    ImmutableArray<(string Path, string Code)> Sources,
    string SkeletonSource,
    string GlobalUsingsSource,
    ImmutableArray<MetadataReference> References,   // ← never consulted
    CSharpParseOptions ParseOptions,
    CSharpCompilationOptions CompilationOptions,
    ImmutableDictionary<string, long> SourceVersions);
```

So a NodeType whose sources had not changed but whose **reference set had** kept answering
diagnostics computed against the *old* references — indefinitely, because nothing else evicts the
entry. That is precisely a byte-identical payload nine minutes apart.

**The reference set really does move under unchanged sources.** #3395 measured two NodeType compiles
in *one boot* resolving different module sets 15 seconds apart. #3396 and #3395 are the same
underlying churn seen from two ends.

## The fix

- `ShapeKeyOf(inputs)` hashes everything a workspace is built from **except** the source texts, whose
  identity `SourceVersions` already carries — references *and their order*, skeleton, global usings,
  assembly name, both option sets.
- `CanReuseWorkspace(cachedVersions, cachedShapeKey, inputs)` is the **whole** reuse decision,
  extracted as one internal function.

### 🚨 Why the decision is extracted, not just the key tested

Pinning `ShapeKeyOf` alone would leave the call site free to drop the shape check and stay green —
the same *control that cannot fail* shape this issue is an instance of. So the test drives the real
predicate.

**Verified it can fail.** Reverting the predicate to source-versions-only reddens **exactly one**
test, and the other nine correctly still pass:

```
DiagnosticsWorkspaceCacheKeyTest.ACachedWorkspace_IsNotReused_WhenOnlyTheReferenceSetChanged [FAIL]
Failed!  - Failed: 1, Passed: 9
```

With the fix: `Passed! - Failed: 0, Passed: 622` across the whole project (not a `--filter`ed
subset).

The suite also pins the two directions that keep the fix honest: unchanged inputs **do** reuse (or
every keystroke rebuilds Roslyn), and a changed source **text** deliberately does *not* move the
shape key — that is `SourceVersions`' job, and a key that hashed everything would pass every other
assertion while telling us nothing about which half covers what.

## Design note

A hash rather than a retained copy, because this is compared on the interactive paths too (hover,
completions), and retaining every reference list per NodeType would hold the old `MetadataReference`
graph alive — the very thing the existing `existing?.Workspace.Dispose()` exists to release. A
collision would reuse one stale workspace, i.e. degrade that single entry to today's behaviour, so
the failure direction is no worse than the bug being fixed.

## Why it matters beyond a wrong answer

This is the tool AGENTS.md points at for the mandated pre-deploy NodeType sweep. A false `Error`
blocks a good deploy, which is annoying. The same staleness in the other direction answers **clean
for a type that has since broken** — and that is the direction the sweep exists to catch.

Verified: `MeshWeaver.Compiler.Pipeline` Release `-warnaserror` → `0 Warning(s)`, `0 Error(s)`;
`MeshWeaver.Documentation` and the test project likewise. What's New entry included
(`Category: Fix` — a user sees the diagnostics panel stop lying).

`Pairs-with: none` — the changed members are `internal`, and both additions are new.

Closes #3396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
