### PR TITLE
fix(#3390): a terminal compilation status clears the in-flight build-inputs stamp

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -2699,6 +2699,13 @@ internal static class NodeTypeCompilationHelpers
         NodeTypeDefinition parkedDef, string? reason, bool formedUnderLiveInputs, string? modulesHash) =>
         parkedDef with
         {
+            // 🚨 The stamp describes a compile IN FLIGHT (#3390). A terminal status means there is
+            // no longer one, so leaving the token set makes a non-null value mean "in flight OR
+            // finished some time ago" — and IsSatisfiedByInFlightCompile absorbs a release request
+            // against it. Today the Pending/Compiling gate ahead of that read hides the lie; the
+            // invariant is `non-null ⇔ Pending/Compiling`, and it is cheaper to keep than to rely on
+            // a caller checking status first forever.
+            DispatchedBuildInputs = null,
             CompilationStatus = CompilationStatus.Error,
             CompilationError = reason
                 ?? parkedDef.CompilationError
@@ -2766,6 +2773,7 @@ internal static class NodeTypeCompilationHelpers
         string? modulesHash = null)
         => def with
         {
+            DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
             CompilationStatus = CompilationStatus.Ok,
             CompilationError = null,
             CompilationDiagnostics = null,

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
@@ -263,6 +263,7 @@ internal static class NodeTypeContractHandler
                         {
                             Content = def with
                             {
+                                DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
                                 CompilationStatus = CompilationStatus.Error,
                                 CompilationError = response.Error ?? "Compilation failed"
                             }
@@ -613,6 +614,7 @@ internal static class NodeTypeContractHandler
         MeshNode curr)
         => def with
         {
+            DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
             CompilationStatus = CompilationStatus.Ok,
             CompilationError = null,
             // 🚨 A HYDRATE IS NOT A COMPILE (#2895). Handle's published-release

--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -480,6 +480,7 @@ public static class PrebuiltAssemblySeeder
                     {
                         Content = def with
                         {
+                            DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
                             CompilationStatus = CompilationStatus.Ok,
                             CompilationError = null,
                             CompilationDiagnostics = null,

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsInvariantGuard.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsInvariantGuard.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b><c>DispatchedBuildInputs</c> non-null means a compile is IN FLIGHT — and nothing else.</b>
+///
+/// <para>The stamp records which inputs the in-flight compile was dispatched for, so a release
+/// request arriving mid-compile can be ABSORBED when that compile will produce byte-for-byte what
+/// the request asks for (#2544, <c>IsSatisfiedByInFlightCompile</c>). Its whole value is that it
+/// describes something currently running.</para>
+///
+/// <para>No terminal write cleared it (#3390): a definition that reached <c>Ok</c> or <c>Error</c>
+/// kept the token of the compile that had already finished, so a non-null value meant "in flight OR
+/// finished at some point". Today the <c>Pending</c>/<c>Compiling</c> gate ahead of the absorb read
+/// hides that, which makes it a latent trap rather than a live bug — the kind that surfaces the day
+/// somebody reads the field without checking status first, and absorbs a release request against a
+/// compile that ended minutes ago.</para>
+///
+/// <para>This guard pins the writing half mechanically, because the failure is a write site that
+/// simply does not mention the field — invisible on review, and exactly how the six unstamped
+/// <c>Pending</c> doors in #3390 came about.</para>
+/// </summary>
+public class DispatchedBuildInputsInvariantGuard
+{
+    private const string Subject = "src/MeshWeaver.Compiler.Pipeline";
+
+    // Terminal write sites found on origin/main a60b1e6db. A floor, because a matcher that stops
+    // matching reports a clean tree — the failure this file exists to prevent.
+    private const int KnownTerminalWrites = 5;
+
+    private static readonly string[] TerminalWrites =
+    [
+        "CompilationStatus = CompilationStatus.Ok",
+        "CompilationStatus = CompilationStatus.Error",
+    ];
+
+    [Fact]
+    public void EveryTerminalCompilationStatusWrite_ClearsTheInFlightStamp()
+    {
+        var root = FindRepoRoot();
+        var dir = Path.Combine(root, Subject.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(Directory.Exists(dir),
+            $"{Subject} is gone — this guard now checks nothing. Point it at the code's new home.");
+
+        var offenders = new List<string>();
+        var found = 0;
+
+        foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+        {
+            var code = File.ReadAllText(path);
+            var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+
+            foreach (var write in TerminalWrites)
+            {
+                for (var i = code.IndexOf(write, System.StringComparison.Ordinal); i >= 0;
+                     i = code.IndexOf(write, i + 1, System.StringComparison.Ordinal))
+                {
+                    var block = EnclosingInitializer(code, i);
+                    if (block is null)
+                        continue;   // not inside an object initializer — e.g. a comparison
+
+                    found++;
+                    if (!block.Contains("DispatchedBuildInputs", System.StringComparison.Ordinal))
+                        offenders.Add($"{relative}:{LineOf(code, i)} — {write}");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A terminal CompilationStatus write does not clear DispatchedBuildInputs. The stamp "
+            + "describes the compile currently IN FLIGHT; once the status is Ok or Error there is "
+            + "none, so a stale token makes `non-null` mean \"in flight OR finished long ago\" and "
+            + "IsSatisfiedByInFlightCompile can absorb a release request against a compile that has "
+            + "already ended. Add `DispatchedBuildInputs = null` to the initializer (#3390)."
+            + System.Environment.NewLine
+            + string.Join(System.Environment.NewLine, offenders.Select(o => "  · " + o)));
+
+        Assert.True(found >= KnownTerminalWrites,
+            $"Expected at least {KnownTerminalWrites} terminal CompilationStatus writes under "
+            + $"{Subject}, saw {found}. The matcher has gone blind, so this guard is reporting a "
+            + "clean tree having checked nothing. Re-point it before trusting it.");
+    }
+
+    /// <summary>The matcher sees both shapes it claims to — without this, every assertion above
+    /// passes on a scan that silently matched nothing.</summary>
+    [Fact]
+    public void TheMatcher_SeesACleared_AndAnUnclearedInitializer()
+    {
+        const string cleared =
+            "return def with\n{\n    DispatchedBuildInputs = null,\n    CompilationStatus = CompilationStatus.Ok,\n};";
+        const string uncleared =
+            "return def with\n{\n    CompilationStatus = CompilationStatus.Ok,\n    CompilationError = null,\n};";
+
+        var i1 = cleared.IndexOf("CompilationStatus = CompilationStatus.Ok", System.StringComparison.Ordinal);
+        var i2 = uncleared.IndexOf("CompilationStatus = CompilationStatus.Ok", System.StringComparison.Ordinal);
+
+        Assert.Contains("DispatchedBuildInputs", EnclosingInitializer(cleared, i1)!);
+        Assert.DoesNotContain("DispatchedBuildInputs", EnclosingInitializer(uncleared, i2)!);
+    }
+
+    // The braces enclosing an object initializer: walk back to the nearest UNMATCHED '{', then
+    // forward to its partner. A write split across lines is the normal shape here, so a line-wise
+    // read would miss precisely the sites that matter.
+    private static string? EnclosingInitializer(string code, int index)
+    {
+        var depth = 0;
+        var open = -1;
+        for (var i = index; i >= 0; i--)
+        {
+            if (code[i] == '}') depth++;
+            else if (code[i] == '{')
+            {
+                if (depth == 0) { open = i; break; }
+                depth--;
+            }
+        }
+        if (open < 0) return null;
+
+        depth = 0;
+        for (var i = open; i < code.Length; i++)
+        {
+            if (code[i] == '{') depth++;
+            else if (code[i] == '}' && --depth == 0)
+                return code[open..(i + 1)];
+        }
+        return null;
+    }
+
+    private static int LineOf(string text, int index) => text.AsSpan(0, index).Count('\n') + 1;
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "Could not locate the repository root (MeshWeaver.slnx).");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
`DispatchedBuildInputs` records which inputs the compile **in flight** was dispatched for, so a
release request arriving mid-compile can be *absorbed* when that compile will produce byte-for-byte
what the request asks for (#2544, `IsSatisfiedByInFlightCompile`). Its entire value is that it
describes something currently running.

**No terminal write cleared it.** A definition reaching `Ok` or `Error` kept the token of the compile
that had already finished, so a non-null value meant *"in flight **or** finished at some point"* —
and the absorb read branches on exactly that field:

```csharp
&& def.DispatchedBuildInputs is { } dispatched
```

## Latent, not live — and worth fixing anyway

The `Pending`/`Compiling` gate ahead of that read hides it today. That makes this a trap rather than
an outage: it surfaces the day something reads the stamp without checking status first, and absorbs
a release request against a compile that ended minutes ago. Keeping the invariant
*`non-null ⇔ Pending/Compiling`* is cheaper than relying on every future caller to check status in
the right order.

All five terminal writes now clear it:

| site | status |
|---|---|
| `NodeTypeCompilationHelpers.ApplyGateSettle` | `Error` |
| `NodeTypeCompilationHelpers` | `Ok` |
| `NodeTypeContractHandler` | `Error` |
| `NodeTypeContractHandler` (the hydrate path) | `Ok` |
| `PrebuiltAssemblySeeder` | `Ok` |

## The guard, and why this defect needs one

The failure mode is a write site that simply **does not mention the field**. That is invisible on
review — and it is precisely how #3390's six unstamped `Pending` doors came about in the first place.
So `DispatchedBuildInputsInvariantGuard` pins the writing half mechanically: every terminal
`CompilationStatus` write must clear the stamp, with

- a **floor** on the number of terminal writes found, so a renamed status enum fails loudly instead
  of reporting a clean tree having matched nothing, and
- a **self-test** that the brace-balanced matcher really distinguishes a cleared initializer from an
  uncleared one (the writes span lines, so a line-wise read would miss exactly the sites that matter).

**Verified it can fail.** Removing the clear from `PrebuiltAssemblySeeder` alone reddens it and names
the site:

```
· src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs:483 — CompilationStatus = CompilationStatus.Ok
Failed!  - Failed: 1, Passed: 1
```

The matcher self-test stays green there, which is the point: the guard failed for the reason claimed,
not because it broke.

## 🚨 Deliberately NOT the other half of #3390

Six kickoff doors flip to `Pending` without stamping. I have not touched them, and the issue stays
open for that.

The reason is a safety asymmetry rather than effort: **a wrong stamp is worse than none.** An absent
stamp merely parks the release request, which is the documented safe behaviour — *"absorbing against
an unknown input set is a guess"*. An **incorrect** one absorbs the request against a compile that
will not produce what was asked, silently. Giving each door the right token is a per-door judgement
about what its inputs actually are at that point, and it wants someone with the dispatch-path
context — plus the guard this PR adds, which is what will keep the result honest.

## Verification

| | Release `-warnaserror` |
|---|---|
| `MeshWeaver.Compiler.Pipeline` | `0 Warning(s)`, `0 Error(s)` |
| `MeshWeaver.Graph` (its one dependent) | `0 Error(s)` |
| `MeshWeaver.Compiler.Pipeline.Test` | `0 Error(s)` |

Full test project: `Passed! - Failed: 0, Passed: 614` — the whole project, not a `--filter`ed subset.

No What's New entry: nothing a user can observe changes, because the gate ahead of the read means the
stale value is not currently reachable. This closes the hole before it is.

`Pairs-with: none` — no public surface changes; the guard is a new test.

Refs #3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
