### PR TITLE
fix(#3404): the pre-warmer reads the durable GO when the subscription door is unreachable

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -372,9 +372,25 @@ Four properties are load-bearing, and each is pinned by a case in
 - **The transport fault stays fully visible.** Nothing here widens a timeout, retries, polls or
   swallows. `RetryUnreachableCoordination` logs the unreachability at its own severity with its own
   diagnostic detail either way, and the grant logs a second `Warning` naming what could not be
-  reached. That fault is the only signal the pod↔`Admin/Build`-hub path is broken (routing loss, a
-  wedged per-node hub of the #2896 class, or a lost reply); the durable door changes the readiness
-  VERDICT, never the visibility of the fault, and does not diagnose or repair it.
+  reached. That fault is the only signal the pod↔`Admin/Build`-hub path is broken; the durable door
+  changes the readiness VERDICT, never the visibility of the fault, and does not diagnose or repair
+  it.
+
+🚨 **The durable door is a FAIL-SAFE, not a cure — and the cause is still open.** The pod's own
+diagnostic names three candidates for the silence: the request never reached the target (routing),
+the target received it and is wedged (a per-node hub that stops answering — the #2896 class), or the
+target answered and the reply was lost. There is a **fourth**, root-caused separately in #3408:
+`MessageService.OpenGate` drained the deferred queue by **appending** it to the main queue, so a
+message that arrived before the gate opened but had not yet been turned sat *ahead* of the deferred
+turns appended behind it — and the parked message ran last. Appending is always the wrong end:
+deferral happens at TURN time, not arrival, and the loop is strictly FIFO, so everything deferred is
+by construction older than everything still waiting. A `SubscribeRequest` is exactly the message
+that triggers a per-node hub's activation, so it is the one that loses its place — load-sensitive by
+construction, green in isolation, and capable of being processed after the requester's 60 s budget
+has already expired. That fits a requester measured healthy and idle against a target never observed
+dead better than a wedge does. **#3408 may reduce or remove these timeouts independently; the two
+fixes are separate and must not be read as one.** The durable door is correct whichever of the four
+it is, and is the only one of them that does not depend on diagnosing the transport first.
 - **No stand-down on this path.** The follower withdraws its claim before probing because it really
   registered one. This path did not: the registration is written by `RequestBuildClaim` through
   `GetMeshNodeStream(path).Update(current => …)`, and an `Update` whose stream never delivered

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -336,6 +336,52 @@ on durable state, exactly like the arbiter (and see #1366 for why the poll clock
 clusters instead of at the arbiter's next pass, but it changes behaviour for every partitioned-PG
 deployment and wants its own justification and measurement. The follower is correct without it.
 
+### The PRE-WARMER has the same two doors — and it did not, until #3404
+
+The follower's two doors only ever opened once a process had already got *inside*. Everything the
+pre-warmer knew about the build arrived through ONE door: `BuildProtocolDriver.Run` opens with a
+claim handshake, and a claim handshake is a `SubscribeRequest` to `Admin/Build`. Exhaust its
+attempts and the driver threw `BuildCoordinationUnreachableException`, the sweep faulted, readiness
+was refused, and the rollout held the previous image.
+
+🚨 **A pod can therefore refuse a build that was already approved.** Measured on `memex-cloud`,
+2026-09-06: two pods of one deployment refused at 11:44:32Z and 11:49:37Z for a fingerprint whose GO
+had been written on an already-`Ready` build root at **11:28:56Z** — sixteen minutes earlier. Their
+own hubs were healthy and idle throughout (`RunLevel=Started`, empty queue); the silence was between
+them and the hub that owns `Admin/Build`. They could not open a subscription to read a verdict that
+was already durable — and the verdict was the only thing they needed.
+
+So `Run`'s subscription-borne composition is now treated as ONE DOOR, and when it cannot be opened
+at all the **durable witness is asked** (`WhenTheSubscriptionDoorIsShut`). Same read as door 1 of
+the follower — `ReadBuildGo` on the durable row, the record the claim arbiter itself decides on —
+at the one point in the protocol that never had it.
+
+Four properties are load-bearing, and each is pinned by a case in
+`PreWarmerReadsTheDurableGoTest`:
+
+- **Per-fingerprint, never "a GO exists".** The `Ready` map is keyed by framework version precisely
+  so an old-image pod stays ready while a new image is unproven. `ReadBuildGo` looks the pod's own
+  fingerprint up by exact key; a GO for any other image reads as no GO and the door stays shut.
+  Granting on a foreign GO would certify a build the process is not running — strictly worse than
+  the refusal it replaces.
+- **Fail-closed is unchanged.** Neither door answering — including the two cases `ReadBuildGo`
+  deliberately folds into `null`, no durable store and a failed read — re-throws the ORIGINAL
+  `BuildCoordinationUnreachableException`, so the sweep still faults, readiness is still refused,
+  and `DescribesUnreachableCoordination` still separates "no verdict" from "a bad verdict" in the
+  health payload.
+- **The transport fault stays fully visible.** Nothing here widens a timeout, retries, polls or
+  swallows. `RetryUnreachableCoordination` logs the unreachability at its own severity with its own
+  diagnostic detail either way, and the grant logs a second `Warning` naming what could not be
+  reached. That fault is the only signal the pod↔`Admin/Build`-hub path is broken (routing loss, a
+  wedged per-node hub of the #2896 class, or a lost reply); the durable door changes the readiness
+  VERDICT, never the visibility of the fault, and does not diagnose or repair it.
+- **No stand-down on this path.** The follower withdraws its claim before probing because it really
+  registered one. This path did not: the registration is written by `RequestBuildClaim` through
+  `GetMeshNodeStream(path).Update(current => …)`, and an `Update` whose stream never delivered
+  current state never computed a patch, so there is no candidate entry to hand back — and calling
+  `WithdrawBuildClaim` would post a second write into the same unreachable hub. The two paths share
+  the post-GO share probe; they deliberately do not share the stand-down.
+
 The probe semantics of `NodeTypeBakeGateState` are preserved unchanged — fail **closed**
 on a measured regression (the rollout stalls, the old image keeps serving), fail **open**
 when nothing is measuring (a configuration mistake must never black-hole a pod), gate

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -376,27 +376,53 @@ Four properties are load-bearing, and each is pinned by a case in
   changes the readiness VERDICT, never the visibility of the fault, and does not diagnose or repair
   it.
 
-🚨 **The durable door is a FAIL-SAFE, not a cure — and the cause is still open.** The pod's own
-diagnostic names three candidates for the silence: the request never reached the target (routing),
-the target received it and is wedged (a per-node hub that stops answering — the #2896 class), or the
-target answered and the reply was lost. There is a **fourth**, root-caused separately in #3408:
-`MessageService.OpenGate` drained the deferred queue by **appending** it to the main queue, so a
-message that arrived before the gate opened but had not yet been turned sat *ahead* of the deferred
-turns appended behind it — and the parked message ran last. Appending is always the wrong end:
-deferral happens at TURN time, not arrival, and the loop is strictly FIFO, so everything deferred is
-by construction older than everything still waiting. A `SubscribeRequest` is exactly the message
-that triggers a per-node hub's activation, so it is the one that loses its place — load-sensitive by
-construction, green in isolation, and capable of being processed after the requester's 60 s budget
-has already expired. That fits a requester measured healthy and idle against a target never observed
-dead better than a wedge does. **#3408 may reduce or remove these timeouts independently; the two
-fixes are separate and must not be read as one.** The durable door is correct whichever of the four
-it is, and is the only one of them that does not depend on diagnosing the transport first.
 - **No stand-down on this path.** The follower withdraws its claim before probing because it really
   registered one. This path did not: the registration is written by `RequestBuildClaim` through
   `GetMeshNodeStream(path).Update(current => …)`, and an `Update` whose stream never delivered
   current state never computed a patch, so there is no candidate entry to hand back — and calling
   `WithdrawBuildClaim` would post a second write into the same unreachable hub. The two paths share
   the post-GO share probe; they deliberately do not share the stand-down.
+
+🚨 **The durable door is a FAIL-SAFE, not a cure — and the cause is still open.** The pod's own
+diagnostic names three candidates for the silence: the request never reached the target (routing),
+the target received it and is wedged (a per-node hub that stops answering — the #2896 class), or the
+target answered and the reply was lost. Two more have since been measured, and **neither subsumes
+the other**:
+
+**Fourth — deferred-queue ordering (#3408).** `MessageService.OpenGate` drained the deferred queue by
+**appending** it to the main queue, so a message that arrived before the gate opened but had not yet
+been turned sat *ahead* of the deferred turns appended behind it — and the parked message ran last.
+Appending is always the wrong end, not merely unlucky: deferral happens at TURN time, not arrival,
+and the loop is strictly FIFO, so everything deferred is by construction older than everything still
+waiting. A `SubscribeRequest` is exactly the message that triggers a per-node hub's activation, so it
+is the one that loses its place — load-sensitive by construction, green in isolation, and capable of
+being processed after the requester's 60 s budget has expired. That fits a requester measured healthy
+and idle against a target never observed dead better than a wedge does.
+
+**Fifth — a granted-but-never-acted-on claim that emits nothing further (`MeshWeaver.Plugins#1193`).**
+A controlled load experiment on `BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStart` —
+18 cores, two arms of ten runs, same binary and same sha, only background load differing — passed
+10/10 under 12 burners (load ~31–39) and failed 1 of 10 under 64 burners (load 49–91+), at 32.9 s,
+with the CI signature. Instrumenting the wait recorded **exactly one** root state in 15 seconds and
+then nothing at all:
+
+```
+ClaimedBy=<machine-scoped id>  Status=Planning  RequestedClaims=[]  Ready=[fp]
+```
+
+Read it field by field: the build **completed** — `Ready` carries the fingerprint, the GO was
+published. `RequestedClaims` is **empty**, so this is *not* a pending registration outliving its
+candidate; it was consumed. And the holder sits at `Status=Planning` — **granted, never started,
+never released.** One emission in fifteen seconds is terminal, not slow. **A reader waiting on that
+state waits forever.** 🚨 It reproduced **with #3408 already in the core**, so #3408 does not remove
+it and #3131 did not close it: this is a second, independent hole.
+
+The fifth cause is the one this door most clearly answers. In that state the target is neither dead
+nor slow, so nothing about the transport is going to recover it — while the durable GO is already
+published and already readable. **The durable door is correct whichever of the five it is, it is the
+only one that does not depend on diagnosing the transport first, and for the fifth it is the only one
+of the fixes in flight that helps at all.** None of that makes it a cure: each cause is a separate
+change, owned separately, and this one must not be read as having addressed any of them.
 
 The probe semantics of `NodeTypeBakeGateState` are preserved unchanged — fail **closed**
 on a measured regression (the rollout stalls, the old image keeps serving), fail **open**

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -399,30 +399,43 @@ is the one that loses its place — load-sensitive by construction, green in iso
 being processed after the requester's 60 s budget has expired. That fits a requester measured healthy
 and idle against a target never observed dead better than a wedge does.
 
-**Fifth — a granted-but-never-acted-on claim that emits nothing further (`MeshWeaver.Plugins#1193`).**
-A controlled load experiment on `BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStart` —
+**Fifth — a root that STOPS EMITTING with a holder still set (`MeshWeaver.Plugins#1193`).** A
+controlled load experiment on `BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStart` —
 18 cores, two arms of ten runs, same binary and same sha, only background load differing — passed
 10/10 under 12 burners (load ~31–39) and failed 1 of 10 under 64 burners (load 49–91+), at 32.9 s,
-with the CI signature. Instrumenting the wait recorded **exactly one** root state in 15 seconds and
-then nothing at all:
+with the CI signature. Instrumenting the wait recorded **exactly one** root emission in 15 seconds
+and nothing after it.
+
+🚨 **The control is what makes the reading honest.** The PASSING state was captured at the same
+point in the same test (by temporarily making the predicate unsatisfiable — a diagnostic never seen
+to run reads exactly like one that works). The two states differ in **one field**:
 
 ```
-ClaimedBy=<machine-scoped id>  Status=Planning  RequestedClaims=[]  Ready=[fp]
+FAIL:  ClaimedBy=<machine-scoped id>   Status=Planning  RequestedClaims=[]  Ready=[fp]
+PASS:  ClaimedBy=<null>                Status=Planning  RequestedClaims=[]  Ready=[fp]
 ```
 
-Read it field by field: the build **completed** — `Ready` carries the fingerprint, the GO was
-published. `RequestedClaims` is **empty**, so this is *not* a pending registration outliving its
-candidate; it was consumed. And the holder sits at `Status=Planning` — **granted, never started,
-never released.** One emission in fifteen seconds is terminal, not slow. **A reader waiting on that
-state waits forever.** 🚨 It reproduced **with #3408 already in the core**, so #3408 does not remove
-it and #3131 did not close it: this is a second, independent hole.
+So `Status=Planning` and the empty `RequestedClaims` are **not symptoms** — the healthy run carries
+both, and the build completed in both (`Ready` holds the fingerprint either way). Any account
+resting on those two fields rests equally on the passing run. What is measured is exactly this:
+**`ClaimedBy` stays set, one root emission in 15 s, nothing after.** A reader waiting on such a root
+waits forever.
 
-The fifth cause is the one this door most clearly answers. In that state the target is neither dead
-nor slow, so nothing about the transport is going to recover it — while the durable GO is already
-published and already readable. **The durable door is correct whichever of the five it is, it is the
-only one that does not depend on diagnosing the transport first, and for the fifth it is the only one
-of the fixes in flight that helps at all.** None of that makes it a cure: each cause is a separate
-change, owned separately, and this one must not be read as having addressed any of them.
+**The mechanism is open.** Whether the holder cannot act or was never told to is precisely the
+question still live on `MeshWeaver.Plugins#1193` — so this page names the SHAPE, not a cause. The
+permanent diagnostic landed as `MeshWeaver.Plugins#1401` (diagnostic only, no production code) and
+the repro recipe is on #1193; reproduce from those rather than re-deriving.
+
+🚨 It reproduced **with #3408 already in the core**, so #3408 does not remove it and #3131 did not
+close it: fourth and fifth are independent, and neither subsumes the other.
+
+This shape is the one the durable door most clearly answers — and note the claim is about the shape,
+not about any mechanism. A root that has stopped emitting is neither dead nor slow, so nothing about
+the transport is going to recover it, while the durable GO is already published and already readable.
+**The durable door is correct whichever of the five it is, it is the only one that does not depend on
+diagnosing the transport first, and in this shape it is the only fix in flight that helps at all.**
+None of that makes it a cure: each cause is a separate change, owned separately, and this one must
+not be read as having addressed any of them.
 
 The probe semantics of `NodeTypeBakeGateState` are preserved unchanged — fail **closed**
 on a measured regression (the rollout stalls, the old image keeps serving), fail **open**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-rollout-no-longer-stalls-on-a-build-it-already-approved.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-rollout-no-longer-stalls-on-a-build-it-already-approved.md
@@ -1,0 +1,29 @@
+---
+Name: A rollout no longer stalls on a build it already approved
+Category: Fix
+Description: A portal pod that could not reach the build coordination node refused readiness and held the rollout on the previous image — even when the go-ahead for exactly that image was already recorded and readable.
+Icon: CloudArrowUp
+Order: -20260906
+---
+
+On 2026-09-06 two pods of one deployment refused to come up and held the rollout on the previous
+image. The build they were waiting for had already been approved: the go-ahead for their exact
+image was written on the build coordination node at 11:28:56Z, and they refused at 11:44:32Z and
+11:49:37Z — about sixteen minutes later.
+
+Nothing was wrong with the verdict. The pods simply had only one way of learning it. At boot each
+pod *subscribes* to the coordination node, and those subscription requests went unanswered; when
+that runs out of attempts the pod concludes it has verified nothing about this image and refuses
+readiness. That refusal is correct in itself — a pod that verified nothing must never claim it
+did — but it was being reached while a durable "yes" for that very image sat unread.
+
+A pod now has the second door the rest of the protocol already had: when the subscription cannot be
+established, it **reads** the coordination record directly and lets readiness follow what is
+recorded there. The go-ahead is per-image, so only this pod's own build counts — one written for a
+different image reads as no answer at all, which is what keeps an old pod serving safely while a
+new image is still unproven.
+
+Everything protective stays exactly as it was. No timeout was lengthened and no retry was added. If
+neither door answers, the pod still refuses readiness and the rollout still holds — the underlying
+connectivity fault is a real, separate problem, and it is still reported in full so it can be found
+and fixed rather than quietly papered over.

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -116,25 +116,126 @@ public static class BuildProtocolDriver
         // is the sweep itself, whose failures are verdicts about this image and must reach the
         // gate untouched. Only reaching the coordination node at all is retried — see
         // CoordinationAttempts for why, and for why exhausting them is still a refusal.
-        return RetryUnreachableCoordination(
-                () => mesh.RequestBuildClaim(holder, fingerprint, priority: priority).Take(1),
-                CoordinationAttempts,
-                CoordinationBackoff,
-                Scheduler.Default,
-                logger)
-            .SelectMany(_ => mesh.ObserveBuildClaim(holder)
-                .Take(1)
-                .Timeout(GrantWindow)
-                .Select(__ => true)
-                // The Catch bounds the GRANT WAIT and nothing else. It used to wrap the bake as
-                // well, so a TimeoutException raised anywhere inside the sweep demoted the winner
-                // to a follower — still holding its claim, now waiting for a GO only it could ever
-                // publish.
-                .Catch((TimeoutException _) => Observable.Return(false))
-                .SelectMany(granted => granted
-                    ? BakeAsMaster(mesh, holder, fingerprint, definitions, bake, logger)
-                    : FollowGo(mesh, holder, fingerprint, definitions, store, bake, logger)));
+        //
+        // The whole subscription-borne composition is ONE DOOR. When it cannot be opened at all,
+        // the durable witness is asked — see WhenTheSubscriptionDoorIsShut (#3404).
+        return WhenTheSubscriptionDoorIsShut(
+            RetryUnreachableCoordination(
+                    () => mesh.RequestBuildClaim(holder, fingerprint, priority: priority).Take(1),
+                    CoordinationAttempts,
+                    CoordinationBackoff,
+                    Scheduler.Default,
+                    logger)
+                .SelectMany(_ => mesh.ObserveBuildClaim(holder)
+                    .Take(1)
+                    .Timeout(GrantWindow)
+                    .Select(__ => true)
+                    // The Catch bounds the GRANT WAIT and nothing else. It used to wrap the bake as
+                    // well, so a TimeoutException raised anywhere inside the sweep demoted the winner
+                    // to a follower — still holding its claim, now waiting for a GO only it could ever
+                    // publish.
+                    .Catch((TimeoutException _) => Observable.Return(false))
+                    .SelectMany(granted => granted
+                        ? BakeAsMaster(mesh, holder, fingerprint, definitions, bake, logger)
+                        : FollowGo(mesh, holder, fingerprint, definitions, store, bake, logger))),
+            mesh, fingerprint, definitions, store, logger);
     }
+
+    // ── the pre-warmer's second door ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The pre-warmer's SECOND DOOR: when the coordination node cannot be REACHED at all, ask the
+    /// DURABLE witness whether this image's GO is already recorded, and let readiness follow that
+    /// answer (#3404).
+    ///
+    /// <para><b>The defect this closes.</b> Everything the pre-warmer knew about the build arrived
+    /// through ONE door — a <c>SubscribeRequest</c> to <c>Admin/Build</c>. When that request went
+    /// unanswered the driver exhausted <see cref="CoordinationAttempts"/> and refused readiness, so
+    /// the rollout held the previous image. Measured on <c>memex-cloud</c> 2026-09-06: two pods
+    /// refused at 11:44:32Z and 11:49:37Z for a fingerprint whose GO had been written on an already
+    /// <c>Ready</c> build root at <b>11:28:56Z</b> — sixteen minutes earlier. They refused a build
+    /// that had already been approved, because they could not open a subscription to read a verdict
+    /// that was already durable.</para>
+    ///
+    /// <para><b>The shape is the follower's, not a new one.</b> <see cref="FollowGo"/> has had two
+    /// doors since #1440: <c>ReadBuildGo</c> — the durable row, the same witness the claim arbiter
+    /// decides on — merged with <c>ObserveBuildGo</c>, this cluster's mirror. Only the pre-warmer's
+    /// ENTRY was single-doored. This is the same durable read, at the one point that never had it.
+    /// </para>
+    ///
+    /// <para>🚨 <b>The GO must be THIS process's, and nothing else counts.</b> A GO is
+    /// per-fingerprint: the root's <c>Ready</c> map is keyed by framework version precisely so an
+    /// old-image pod stays ready through a rollout while the new image is still unproven.
+    /// <c>ReadBuildGo</c> looks the fingerprint up by exact key, so a GO written for ANY other
+    /// framework version reads as no GO here and this door stays shut. Accepting a foreign GO would
+    /// grant readiness for a build this process is not running — which is the one wrong answer this
+    /// door could give, and strictly worse than the refusal it replaces.</para>
+    ///
+    /// <para>🚨 <b>Fail-closed survives untouched.</b> No GO for this fingerprint — including the
+    /// "no durable store at all" and "the read failed" cases <c>ReadBuildGo</c> deliberately folds
+    /// into <c>null</c> — and the original
+    /// <see cref="BuildCoordinationUnreachableException"/> propagates UNCHANGED, so the sweep still
+    /// faults, readiness is still refused, and the health payload still classifies it through
+    /// <see cref="DescribesUnreachableCoordination"/>. Nothing here widens a timeout, retries,
+    /// polls, or swallows: the transport fault is still logged by
+    /// <see cref="RetryUnreachableCoordination"/> at its own severity with its own diagnostic
+    /// detail, because it remains the only signal that the pod↔<c>Admin/Build</c>-hub path is
+    /// broken. This changes the readiness VERDICT, never the visibility of the fault.</para>
+    ///
+    /// <para><b>No stand-down, deliberately.</b> The follower's post-GO path withdraws its claim
+    /// first, because it really did register one. This path did not: the registration is written by
+    /// <c>RequestBuildClaim</c> through <c>GetMeshNodeStream(path).Update(current =&gt; …)</c>, and
+    /// an <c>Update</c> whose stream never delivered current state never computed a patch, so no
+    /// candidate entry can exist to hand back. Calling <c>WithdrawBuildClaim</c> here would post a
+    /// second write into the same unreachable hub and re-fault the stream on the way out.</para>
+    /// </summary>
+    /// <param name="subscriptionDoor">The subscription-borne composition — claim, grant, bake or follow.</param>
+    /// <param name="mesh">The mesh hub.</param>
+    /// <param name="fingerprint">This process's framework fingerprint.</param>
+    /// <param name="definitions">Discovered NodeType definitions by path.</param>
+    /// <param name="store">The shared assembly store, for the post-GO probe.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <returns>The subscription door's outcomes, or — when it is shut and the GO is durable — the probe's.</returns>
+    internal static IObservable<PreWarmOutcome> WhenTheSubscriptionDoorIsShut(
+        IObservable<PreWarmOutcome> subscriptionDoor,
+        IMessageHub mesh,
+        string fingerprint,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        ILogger? logger)
+        => subscriptionDoor.Catch((BuildCoordinationUnreachableException unreachable) =>
+            mesh.ReadBuildGo(fingerprint, logger)
+                .SelectMany(go =>
+                {
+                    if (go is null)
+                    {
+                        // BOTH doors shut. Fail closed, with the original exception — the health
+                        // payload reads it through DescribesUnreachableCoordination, and the
+                        // hosted service logs the refusal.
+                        logger?.LogError(
+                            "BuildProtocol: '{Path}' is unreachable AND the durable witness carries "
+                            + "no GO for framework {Fingerprint} — BOTH doors are shut, so this "
+                            + "process has verified NOTHING and readiness stays REFUSED. The rollout "
+                            + "holds the previous image; a restart re-attempts.",
+                            BuildNodeType.RootPath, fingerprint);
+                        return Observable.Throw<PreWarmOutcome>(unreachable);
+                    }
+
+                    // Warning, not Information: readiness is granted on durable evidence, but the
+                    // transport fault that forced this door open is REAL and unfixed. It is already
+                    // logged in full by RetryUnreachableCoordination; this line says what the
+                    // process did about it, so the two are not confused for one another.
+                    logger?.LogWarning(
+                        "BuildProtocol: '{Path}' is UNREACHABLE from this process, but the DURABLE "
+                        + "witness already carries the GO for framework {Fingerprint} (ready at "
+                        + "{ReadyAt:O}) — the build this image needs was approved before this "
+                        + "process asked for it. Readiness follows the durable verdict instead of "
+                        + "refusing a build that is already approved. The unreachability above is "
+                        + "NOT cleared by this and remains the signal that the path from this pod "
+                        + "to the '{Path}' hub is broken.",
+                        BuildNodeType.RootPath, fingerprint, go.ReadyAt, BuildNodeType.RootPath);
+                    return ProbeTheShare(mesh, definitions, store, logger);
+                }));
 
     // ── the winner ──────────────────────────────────────────────────────────────────────────────
 
@@ -503,9 +604,28 @@ public static class BuildProtocolDriver
             fingerprint, go.ReadyAt, holder);
 
         return mesh.WithdrawBuildClaim(holder)
-            .SelectMany(_ => NodeTypeBakeStatus.Probe(definitions, store, logger: logger,
+            .SelectMany(_ => ProbeTheShare(mesh, definitions, store, logger));
+    }
+
+    /// <summary>
+    /// What a GO actually buys: the share is PROBED rather than trusted, so the verdict stays
+    /// level-triggered on reality — the same property the sweep itself has. A type still pending
+    /// after GO is reported as not-evaluated (<see cref="PreWarmStatus.TimedOut"/>, non-gating):
+    /// this process has no verdict about it, which is different from a verdict against it.
+    ///
+    /// <para>Deliberately contains NO claim bookkeeping. <see cref="ProbeAfterGo"/> stands down
+    /// first because it registered as a candidate; <see cref="WhenTheSubscriptionDoorIsShut"/> has
+    /// nothing to stand down from and must not post into an unreachable hub to find that out. Split
+    /// out so the two share the probe without sharing the stand-down.</para>
+    /// </summary>
+    private static IObservable<PreWarmOutcome> ProbeTheShare(
+        IMessageHub mesh,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IAssemblyStore store,
+        ILogger? logger)
+        => NodeTypeBakeStatus.Probe(definitions, store, logger: logger,
                 liveDependencyIdOf: NodeTypeCompilationHelpers.DependencyIdResolverOf(mesh),
-                liveToolchainId: NodeTypeCompilationHelpers.ProcessToolchainId))
+                liveToolchainId: NodeTypeCompilationHelpers.ProcessToolchainId)
             .SelectMany(fresh => fresh.Entries
                 .Select(e => new PreWarmOutcome(
                     e.TypePath,
@@ -516,7 +636,6 @@ public static class BuildProtocolDriver
                 {
                     WasHealthyBeforeBake = e.WasHealthy,
                 }));
-    }
 
     // ── shared ──────────────────────────────────────────────────────────────────────────────────
 

--- a/test/MeshWeaver.Hosting.Test/PreWarmerReadsTheDurableGoTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PreWarmerReadsTheDurableGoTest.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>The pre-warmer's SECOND DOOR: a durable GO already recorded for THIS image's fingerprint
+/// must grant readiness even when the coordination node cannot be subscribed to.</b> Issue #3404.
+///
+/// <para><b>The defect.</b> Everything the pre-warmer knew about the build arrived through ONE
+/// door — a <c>SubscribeRequest</c> to <c>Admin/Build</c>. On <c>memex-cloud</c>, 2026-09-06, two
+/// pods exhausted that door's attempt budget and refused readiness at 11:44:32Z and 11:49:37Z,
+/// holding the rollout on the previous image. The GO for the fingerprint those pods were running
+/// had been written on an already-<c>Ready</c> build root at <b>11:28:56Z</b> — sixteen minutes
+/// earlier. They refused a build that had already been approved, because they could not open a
+/// subscription to read a verdict that was already durable. <c>BuildProtocolDriver.FollowGo</c> has
+/// had two doors since #1440 (<c>ReadBuildGo</c> on the durable row, merged with
+/// <c>ObserveBuildGo</c> on this cluster's mirror); only the pre-warmer's ENTRY was single-doored.
+/// </para>
+///
+/// <para><b>What these cases discriminate.</b> The subscription door is shut in EVERY case — the
+/// arms differ only in what the durable witness holds — so a pass can only come from the durable
+/// read, never from the subscription. The refusal arms are what make the grant arm non-vacuous: an
+/// implementation that simply stopped failing closed passes the first case and fails the other
+/// three.</para>
+///
+/// <list type="bullet">
+/// <item><see cref="ADurableGoForThisFingerprint_GrantsReadiness"/> — GO present ⇒ granted.</item>
+/// <item><see cref="NoDurableGo_StillRefusesReadiness"/> — fail-closed survives.</item>
+/// <item><see cref="AGoForAnotherFingerprint_StillRefusesReadiness"/> — a GO is PER-FINGERPRINT;
+/// accepting a foreign one would certify a build this process is not running.</item>
+/// <item><see cref="AnUnreachableNodeIsStillReportedLoudly_EvenWhenTheDurableGoGrants"/> — the
+/// transport fault stays visible. The durable door changes the readiness VERDICT, never the
+/// visibility of the fault, because that fault is the only signal the pod↔hub path is broken.</item>
+/// </list>
+///
+/// <para>🚨 <b>Nothing here touches the follower's stand-down.</b> That protocol has a live
+/// load-sensitive defect under separate investigation, and the durable door deliberately does not
+/// route through it: this path never registered a claim (the registration is a
+/// <c>GetMeshNodeStream(path).Update(…)</c> whose stream never delivered state, so no patch was
+/// ever computed) and therefore has nothing to hand back. The probe is shared with the follower;
+/// the stand-down is not.</para>
+///
+/// <para>The mesh is REAL (<see cref="MonolithMeshTestBase"/>): the witness is read back through
+/// the mesh's own <c>IStorageAdapter</c> and its own <c>JsonSerializerOptions</c>, so a
+/// <c>BuildState</c> that failed to round-trip would read as "no GO" and fail the grant arm rather
+/// than passing silently. Only the fault is injected, exactly as
+/// <c>BuildCoordinationRetryTest</c> injects one into <c>RetryUnreachableCoordination</c>.</para>
+/// </summary>
+public class PreWarmerReadsTheDurableGoTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>This pod's own framework fingerprint — the shape the incident carried.</summary>
+    private const string MyFingerprint = "s2f227642b1c4419aa1b1a7d5d21a2f11";
+
+    /// <summary>Some OTHER image's fingerprint. Its GO must never satisfy this pod.</summary>
+    private const string AnotherFingerprint = "s9911ccddee0844a1bb2c3d4e5f607182";
+
+    /// <summary>When the GO was written on the live root, per the incident.</summary>
+    private static readonly DateTime GoWrittenAt = new(2026, 9, 6, 11, 28, 56, DateTimeKind.Utc);
+
+    /// <summary>
+    /// One dynamic NodeType for the post-GO share probe, so the grant arm proves the door actually
+    /// opened onto the probe rather than merely declining to throw.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, NodeTypeDefinition?> Definitions =
+        ImmutableDictionary<string, NodeTypeDefinition?>.Empty
+            .Add("TestData/Widget", new NodeTypeDefinition());
+
+    /// <summary>
+    /// The verbatim production refusal: a <see cref="BuildCoordinationUnreachableException"/> whose
+    /// inner is the hub's own request-budget <see cref="TimeoutException"/> naming
+    /// <c>Admin/Build</c> — what <c>RetryUnreachableCoordination</c> throws after its attempts are
+    /// exhausted, copied from the incident's log lines.
+    /// </summary>
+    private static BuildCoordinationUnreachableException TheSubscriptionDoorIsShut() =>
+        new(
+            "BuildProtocol: could not reach the build coordination node 'Admin/Build' in 3 "
+            + "attempt(s) — the pre-warm sweep never started, so this process has verified NOTHING "
+            + "about its NodeTypes on this image. This is a refusal, not a pass: readiness stays "
+            + "refused and the rollout holds the previous image. A restart re-attempts.",
+            new TimeoutException(
+                "No response received in hub cache/UE4Wtq7CgkiAqGLfYRiJPQ within 00:01:00 for "
+                + "request SubscribeRequest (id=ASCknHcTgkSMVRR-dy6F3Q) → target Admin/Build."));
+
+    /// <summary>
+    /// Writes the DURABLE build root exactly as a builder in another process leaves it — the row
+    /// <c>ReadBuildGo</c> reads, which is the one record a peer cluster shares with the builder.
+    /// </summary>
+    /// <param name="ready">The per-fingerprint GO history to record, or null for a root with none.</param>
+    private Task WriteTheDurableBuildRoot(ImmutableDictionary<string, BuildGo>? ready)
+    {
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var root = new MeshNode("Build", "Admin")
+        {
+            NodeType = BuildNodeType.NodeType,
+            Content = new BuildState
+            {
+                Status = BuildStatus.Ready,
+                FrameworkVersion = ready is null ? null : ready.Keys.FirstOrDefault(),
+                Ready = ready,
+            },
+        };
+        return storage.Write(root, Mesh.JsonSerializerOptions).Await();
+    }
+
+    private static ImmutableDictionary<string, BuildGo> Go(params string[] fingerprints) =>
+        fingerprints.Aggregate(
+            ImmutableDictionary<string, BuildGo>.Empty,
+            (map, fp) => map.Add(fp, new BuildGo(fp, GoWrittenAt, Detail: "baked by a peer process")));
+
+    private Task<IList<PreWarmOutcome>> DriveTheDoor(ILogger? logger = null) =>
+        BuildProtocolDriver.WhenTheSubscriptionDoorIsShut(
+                Observable.Throw<PreWarmOutcome>(TheSubscriptionDoorIsShut()),
+                Mesh,
+                MyFingerprint,
+                Definitions,
+                Mesh.ServiceProvider.GetRequiredService<IAssemblyStore>(),
+                logger)
+            .ToList()
+            .Await();
+
+    // ── the grant ───────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE FIX. The subscription door is shut and the durable root already carries the GO for
+    /// THIS pod's fingerprint — written, as in the incident, before this process ever asked. The
+    /// sweep therefore COMPLETES (readiness granted) instead of faulting (readiness refused), and
+    /// it completes having probed the share: every emitted outcome is non-gating, which is exactly
+    /// what lets <c>NodeTypeBakeGateState</c> reach <c>Complete</c> rather than <c>Regressed</c>.
+    ///
+    /// <para>The root also carries a GO for another image — the <c>Ready</c> map is history, never
+    /// a boolean — so this pins that the right entry is selected rather than that the map is
+    /// merely non-empty.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ADurableGoForThisFingerprint_GrantsReadiness()
+    {
+        await WriteTheDurableBuildRoot(Go(AnotherFingerprint, MyFingerprint));
+
+        var outcomes = await DriveTheDoor();
+
+        outcomes.Should().NotBeEmpty(
+            "the durable GO opens the door ONTO the share probe — a door that grants without "
+            + "probing would certify a share it never looked at");
+        outcomes.Should().OnlyContain(o => !BuildProtocolDriver.IsGatingFailure(o),
+            "a post-GO probe reports a still-pending type as not-evaluated, never as a regression: "
+            + "this process has no verdict about it, which is not a verdict against it");
+    }
+
+    // ── the refusals: fail-closed must survive the fix ───────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 FAIL CLOSED, UNCHANGED. Both doors shut ⇒ the ORIGINAL
+    /// <see cref="BuildCoordinationUnreachableException"/> propagates, so the sweep still faults,
+    /// readiness is still refused, the rollout still holds the previous image — and the health
+    /// payload still tells "no verdict" from "a bad verdict" through
+    /// <see cref="BuildProtocolDriver.DescribesUnreachableCoordination"/>. This is the case that
+    /// fails against an implementation which bought readiness by weakening the refusal.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task NoDurableGo_StillRefusesReadiness()
+    {
+        await WriteTheDurableBuildRoot(ready: null);
+
+        var refuse = () => DriveTheDoor();
+
+        var thrown = await refuse.Should().ThrowAsync<BuildCoordinationUnreachableException>(
+            "a process that reached NEITHER door has verified nothing and must never claim it did");
+        thrown.Which.Message.Should().Contain("verified NOTHING",
+            "the refusal keeps the message an operator reads, unrewritten by the second door");
+        BuildProtocolDriver.DescribesUnreachableCoordination(thrown.Which).Should().BeTrue(
+            "the readiness payload must still classify this as an unreachable node — the one "
+            + "failure worth restarting on — rather than as a bad verdict about this image");
+    }
+
+    /// <summary>
+    /// 🚨 A GO IS PER-FINGERPRINT. The root is <c>Ready</c> and carries a GO — for a DIFFERENT
+    /// image. Granting on it would certify a build this process is not running, which is strictly
+    /// worse than the refusal it replaces: the whole reason the <c>Ready</c> map is keyed by
+    /// framework version is that an old-image pod stays ready while a new image is still unproven.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task AGoForAnotherFingerprint_StillRefusesReadiness()
+    {
+        await WriteTheDurableBuildRoot(Go(AnotherFingerprint));
+
+        var refuse = () => DriveTheDoor();
+
+        await refuse.Should().ThrowAsync<BuildCoordinationUnreachableException>(
+            "someone else's GO says nothing about whether THIS image's NodeTypes build");
+    }
+
+    // ── the fault stays visible ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The durable door changes the READINESS VERDICT, never the visibility of the fault. The
+    /// pod↔<c>Admin/Build</c>-hub silence is a real, unfixed transport defect and remains the only
+    /// signal that it is broken, so granting readiness on durable evidence must NOT read as
+    /// "everything was fine". A door that granted quietly would delete the only evidence anyone
+    /// has that the mesh has a routing or wedged-hub problem.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task AnUnreachableNodeIsStillReportedLoudly_EvenWhenTheDurableGoGrants()
+    {
+        await WriteTheDurableBuildRoot(Go(MyFingerprint));
+        var recorder = new RecordingLogger();
+
+        await DriveTheDoor(recorder);
+
+        recorder.Entries.Should().Contain(
+            e => e.Level >= LogLevel.Warning && e.Message.Contains("UNREACHABLE"),
+            "the grant must SAY that the coordination node could not be reached — the readiness "
+            + "verdict came from the durable witness, and the transport fault is still live");
+        recorder.Entries.Should().Contain(
+            e => e.Message.Contains("Admin/Build"),
+            "naming what could not be reached is what makes the line actionable");
+    }
+
+    /// <summary>
+    /// Captures what the driver logged. An <see cref="ILogger"/> is diagnostics, not mesh
+    /// machinery — every other case here passes <c>null</c> for it, exactly as the driver's
+    /// existing tests do.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        // Lock-free and immutable: the driver logs from whatever thread the Rx pipeline is on, and
+        // the assertion reads from the test's. ImmutableInterlocked is the house shape for that.
+        private ImmutableList<(LogLevel Level, string Message)> entries =
+            ImmutableList<(LogLevel, string)>.Empty;
+
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries => Volatile.Read(ref entries);
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => Disposable.Empty;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            ImmutableInterlocked.Update(
+                ref entries,
+                (list, entry) => list.Add(entry),
+                (logLevel, formatter(state, exception)));
+    }
+}


### PR DESCRIPTION
## The decisive fact

`Admin/Build` was **already `Ready`**, and a GO for the pods' own framework fingerprint
(`s2f227642…`) had been written on it at **2026-09-06T11:28:56Z**. The two refusals followed at
**11:44:32Z** and **11:49:37Z** — about **sixteen minutes later**.

The pods refused a build that had already been approved, because they could not establish a
subscription to read a verdict that was already durable. Their own hubs were healthy and idle
throughout the wait (`RunLevel=Started`, empty queue, `deliveryActionCompleted=True`).

## The two-door pattern, and where it was matched from

`Doc/Architecture/BuildCoordination` → *"The follower has two doors, and it closes them behind
it"*. Since #1440 `BuildProtocolDriver.FollowGo` ends on either of two **real, level-triggered**
events:

1. **The GO becomes visible** — `ReadBuildGo` reads it off the **durable** build root (the same
   witness `BuildNodeType.ArbitrateDurably` decides on) merged with `ObserveBuildGo` on this
   cluster's mirror, whichever answers first. The durable read is what lets a peer cluster's GO
   mean anything at all here, because a PG `NOTIFY` reaches only a live `LISTEN` session and is
   never replayed.
2. **The arbiter hands us the claim** — and on that grant the follower **re-reads the durable
   witness** to decide whether to stand down or bake.

The follower's doors only ever opened once a process was already *inside*. `BuildProtocolDriver.Run`
opens with the claim handshake, and a claim handshake is a `SubscribeRequest` to `Admin/Build` — so
the pre-warmer's **entry** had exactly one door, and exhausting `CoordinationAttempts` on it was a
terminal refusal.

**The fix:** `Run`'s whole subscription-borne composition is now treated as ONE door, and
`WhenTheSubscriptionDoorIsShut` asks the **same `ReadBuildGo`** when it cannot be opened at all.
Same read, same witness, same fault taxonomy — at the one point in the protocol that never had it.
`ProbeAfterGo`'s share probe is split out as `ProbeTheShare` so both paths share the probe.

🚨 **The GO is matched on THIS process's fingerprint by exact key.** The root's `Ready` map is keyed
by framework version precisely so an old-image pod stays ready while a new image is unproven; a GO
written for any other image reads as *no GO* and the door stays shut. Granting on a foreign GO would
certify a build this process is not running — the one wrong answer this door could give, and
strictly worse than the refusal it replaces.

## What I deliberately did NOT change

- **The transport fault.** Not diagnosed, not repaired, not papered over. `RetryUnreachableCoordination`
  still logs the unreachability at **its current severity with its current diagnostic detail** on
  both branches, and the grant adds a `Warning` naming what could not be reached and saying the
  fault is *not* cleared. It remains the only signal that the pod↔`Admin/Build`-hub path is broken.
  **The durable door changes the readiness VERDICT, never the visibility of the fault.**
- **Fail-closed.** Neither door answering re-throws the **original**
  `BuildCoordinationUnreachableException` — including the two cases `ReadBuildGo` deliberately folds
  into `null` (no durable store; the read itself failed). The sweep still faults, readiness is still
  refused, the rollout still holds the previous image, and `DescribesUnreachableCoordination` still
  separates *no verdict* from *a bad verdict* in the health payload.
- **The bounds.** `CoordinationAttempts` (3) and the hub's 60 s request budget are untouched. No
  retry loop, no watchdog, no poller, no resubscribe timer, no `catch {}`.
- **The follower's stand-down.** See below.

## This is the FAIL-SAFE; the CAUSES are elsewhere — and there are now five

🚨 **This PR does not fix the silence.** It changes the readiness verdict when the silence happens.

The issue lists three candidates for the unanswered `SubscribeRequest`: it never reached the target
(routing), the target received it and is wedged (the #2896 class), or the reply was lost. There is a
**fourth** and a **fifth**, both measured since the issue was filed.

### Fourth — deferred-queue ordering (#3408)

`MessageService.OpenGate` drained the deferred queue by **appending** it to the main queue, so a message that arrived before the gate opened but had not
yet been turned sat *ahead* of the deferred turns appended behind it — and the parked message ran
last. Appending is always the wrong end, not merely unlucky: deferral happens at TURN time, not
arrival, and the loop is strictly FIFO, so everything deferred is by construction older than
everything still waiting.

A `SubscribeRequest` to `Admin/Build` is very plausibly exactly that message — the one that triggers
the target hub's activation, and therefore the one that loses its place. Load-sensitive by
construction, green in isolation, and capable of being processed *after* the requester's 60 s budget
has expired. That fits this incident's evidence better than a wedge does: the requesting hubs were
measured healthy and idle, and the target was never observed dead. The concurrent Orleans
`ConnectionFailedException` incident (`Admin/_LogIncident/522013736000428b`, same cluster and
overlapping window) remains a candidate for the routing branch.

### Fifth — a root that STOPS EMITTING with a holder still set (`MeshWeaver.Plugins#1193`)

A controlled load experiment on `BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStart` —
18 cores, two arms of ten runs, **same binary and same sha**, only background load differing:

| Arm | Load | Result |
|---|---|---|
| 12 burners | ~31–39 | **10 / 10 passed** |
| 64 burners | 49–91+ | **9 passed, 1 FAILED** at 32.9 s, with the CI signature |

Instrumenting the `settled` wait recorded **exactly one** root emission in 15 seconds, then nothing.

🚨 **The control is what makes the reading honest.** The PASSING state was captured at the same point
in the same test — by temporarily making the predicate unsatisfiable, to prove the diagnostic
actually prints, since a diagnostic never seen to run reads exactly like one that works. The two
states differ in **one field**:

```
FAIL:  ClaimedBy=<machine-scoped id>   Status=Planning  RequestedClaims=[]  Ready=[fp-stand-down]
PASS:  ClaimedBy=<null>                Status=Planning  RequestedClaims=[]  Ready=[fp-stand-down]
```

So `Status=Planning` and the empty `RequestedClaims` are **not symptoms** — the healthy run carries
both, and the build completed in both. Any account resting on those two fields rests equally on the
passing run. What is measured is exactly: **`ClaimedBy` stays set, one root emission in 15 s, nothing
after.** A reader waiting on such a root waits forever.

**The mechanism is open**, and this PR does not assert one. Whether the holder cannot act or was
never told to is the question still live on `MeshWeaver.Plugins#1193`. The permanent diagnostic
landed as `MeshWeaver.Plugins#1401` (diagnostic only, no production code); the repro recipe is on
#1193 — reproduce from those rather than re-deriving.

🚨 It reproduced **with #3408 already in the core**, so #3408 does not remove it and #3131 did not
close it. Fourth and fifth are **independent holes; neither subsumes the other.**

### Why this matters for this PR

This **shape** is the one the durable door most clearly answers — and the claim is about the shape,
not about any mechanism. A root that has stopped emitting is neither dead nor slow, so nothing about
the transport is going to recover it, while the durable GO is already published and already readable.
**This change is correct whichever of the five it is, it is the only one that does not depend on
diagnosing the transport first, and in this shape it is the only fix in flight that helps at all.**

None of which makes it a cure. Each cause is a separate change, owned separately, and this PR must
not be read as having addressed any of them.

## Interaction with the live follower defect (Plugins#1193)

The subscription door's underlying protocol has a **live, load-sensitive defect** under separate
investigation — `BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStart`, whose controlled
measurement is the fifth cause above. **This PR does not touch it and must not be read as having
addressed it.** Two other sessions are on it from the opposite end; changing this protocol from both
ends at once is how one fix hides the other.

The durable door is deliberately **independent of the stand-down path**: it never calls
`WithdrawBuildClaim`. That is not an omission but a consequence — `RequestBuildClaim` writes its
registration through `GetMeshNodeStream(path).Update(current => …)`, and an `Update` whose stream
never delivered current state never computed a patch, so **no candidate entry can exist to hand
back**. Calling `WithdrawBuildClaim` here would also post a second write into the same unreachable
hub and re-fault the stream on the way out. The two paths share the post-GO share probe; they
deliberately do not share the stand-down.

## Falsification — real numbers

The test is `test/MeshWeaver.Hosting.Test/PreWarmerReadsTheDurableGoTest.cs`, on a **real**
`MonolithMeshTestBase` mesh: the witness is written to and read back through the mesh's own
`IStorageAdapter` and its own `JsonSerializerOptions`, and the share is probed through the mesh's
own `IAssemblyStore`. Only the fault is injected — the verbatim production
`BuildCoordinationUnreachableException` over the incident's own inner `TimeoutException` — exactly
as `BuildCoordinationRetryTest` injects one into `RetryUnreachableCoordination`. No mocks, no
`Task.Delay`, no `.ToTask()`, no `SemaphoreSlim`; the recording logger is lock-free
`ImmutableInterlocked`.

The subscription door is shut in **every** case, so a pass can only come from the durable read.

| | With the fix | Second door removed, tests unchanged |
|---|---|---|
| `ADurableGoForThisFingerprint_GrantsReadiness` | **pass** | **FAIL** — threw `BuildCoordinationUnreachableException` (the production defect, reproduced) |
| `AnUnreachableNodeIsStillReportedLoudly_EvenWhenTheDurableGoGrants` | **pass** | **FAIL** — same throw, nothing logged |
| `NoDurableGo_StillRefusesReadiness` | pass | pass *(fail-closed control — passing both ways is its job)* |
| `AGoForAnotherFingerprint_StillRefusesReadiness` | pass | pass *(fingerprint control — same)* |
| **Totals** | **Failed: 0, Passed: 4** | **Failed: 2, Passed: 2** |

The falsification reverted the behaviour under test (`WhenTheSubscriptionDoorIsShut` → pass the
subscription door straight through, which *is* the pre-fix composition) rather than the file, so the
tests compiled unchanged and produced counts. The two controls pass in both arms **by design**: they
are what proves the fix bought readiness without weakening the refusal — an implementation that
simply stopped failing closed passes the first case and fails those two.

Restored and re-run: **Failed: 0, Passed: 11** (the 4 new cases plus the 7 existing
`BuildCoordinationRetryTest` cases, which pin the retry and fail-closed contract).

`DocumentationLinkIntegrityTest` and the ratchet guards: **Failed: 0, Passed: 15**.

Builds, `-c Release -warnaserror`, one project per invocation: `MeshWeaver.Hosting`,
`MeshWeaver.Hosting.Monolith`, `MeshWeaver.Documentation`, `MeshWeaver.Hosting.Test`,
`MeshWeaver.Documentation.Test` — all `0 Warning(s), 0 Error(s)`.

## Docs

`Doc/Architecture/BuildCoordination` gains *"The PRE-WARMER has the same two doors — and it did not,
until #3404"*, recording the incident, the four load-bearing properties (per-fingerprint,
fail-closed, the fault stays visible, no stand-down) and which test pins each. Plus a What's New
entry (`Category: Fix`).

## Scope — and what remains

Fixed here: a pod no longer refuses a build that is **already approved and durably readable**. That
is the decisive complaint in the issue, and the case both 2026-09-06 refusals were.

Deliberately NOT fixed, and why this is `Refs`, not `Closes`:

1. **The silence itself is still open.** See the section above — there are now five candidate
   causes, #3408 and `MeshWeaver.Plugins#1193` are separate changes owned elsewhere, and neither
   subsumes the other. Until one of the five is closed, the fingerprint can still fire.
2. **A pod that is the FIRST to need a GO that does not exist yet** still refuses readiness under
   the same silence, and still holds the rollout. That is the correct fail-closed behaviour and this
   PR must not change it — but it means incident `4b3ea19559962a76` can recur, with a different
   consequence.
3. **The second protocol question the issue asks is untouched**: whether this subscription should
   follow the `SubscribeWithReEstablish` fault taxonomy instead of exhausting a fixed attempt budget.
   That is a separate decision about the subscription door and is not attempted here.

Refs #3404

Pairs-with: none — the diff removes no public type and no public member (`git diff --cached -U0 |
grep '^-' | grep 'public '` returns nothing); the one new member is `internal`.
