### PR TITLE
docs: branch protection lives in RULESETS on core and Memex — the prescribed command reads them as unprotected

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,15 @@ it, not before.
 
 ### 🚨 Before you push: make CI green LOCALLY first
 
-CI builds **Release with warnings-as-errors**; a plain local Debug build passes while CI fails. **Build every touched project and its dependents with `dotnet build -c Release -warnaserror`, one project per invocation, and only push when that is clean.** The bar is MERGEABLE, not merged: a branch merely *behind* main merges fine here (`strict: false`, one required check — `Consolidate test results`), so do NOT re-sync just to catch up; merge main only when the PR is `DIRTY` or CI fails on something your diff cannot reach. 🚨 `strict` is **PER-REPO** and it FLIPS — `MeshWeaver.Plugins` was `strict: true` until 2026-08-29 and measured `false` on 2026-09-02; never trust a written value, run `gh api repos/Systemorph/<repo>/branches/main/protection --jq '.required_status_checks.strict'`.
+CI builds **Release with warnings-as-errors**; a plain local Debug build passes while CI fails. **Build every touched project and its dependents with `dotnet build -c Release -warnaserror`, one project per invocation, and only push when that is clean.** The bar is MERGEABLE, not merged: a branch merely *behind* main merges fine here (`strict: false`, one required check — `Consolidate test results`), so do NOT re-sync just to catch up; merge main only when the PR is `DIRTY` or CI fails on something your diff cannot reach. 🚨 `strict` is **PER-REPO** and it FLIPS — `MeshWeaver.Plugins` was `strict: true` until 2026-08-29 and measured `false` on 2026-09-02; never trust a written value, measure it. 🚨 **But `branches/main/protection` ALONE gives a FALSE NEGATIVE, including on THIS repo.** Protection lives in one of two places and the fleet is split between them: `MeshWeaver` and `Memex` are protected by **RULESETS**, for which the classic endpoint answers `Branch not protected (HTTP 404)` — read as "unprotected" it is simply wrong — while `MeshWeaver.Plugins` uses classic protection (5 contexts). So check BOTH, and treat a 404 from the first as "look in the second", never as an answer:
+
+```bash
+gh api repos/Systemorph/<repo>/branches/main/protection --jq '.required_status_checks'   # classic; 404 ⇒ not the answer
+gh api repos/Systemorph/<repo>/rulesets --jq '.[]|"\(.id) \(.name) \(.enforcement)"'      # rulesets
+gh api repos/Systemorph/<repo>/rulesets/<id> --jq '.rules[]|select(.type=="required_status_checks")'
+```
+
+Measured 2026-09-06: core is ruleset `2128472` (`main pr protection`, active, required context `Consolidate test results`); Memex is ruleset `21038115` with the single required context `config-key-coverage`, `required_approving_review_count: 0` — so its `Build (Release)` is ADVISORY and auto-merge lands PRs seconds after arming, with the build still running.
 
 ### 🚨 A verification step that cannot fail is not a verification step
 


### PR DESCRIPTION
`AGENTS.md` tells every agent to measure branch protection with:

```
gh api repos/Systemorph/<repo>/branches/main/protection --jq '.required_status_checks.strict'
```

**On this repo, that command answers `Branch not protected (HTTP 404)`.**

## It is a false negative

Core `main` IS protected — by **ruleset `2128472`** ("main pr protection", active, required context `Consolidate test results`). The classic endpoint only ever describes *classic* protection and returns 404 when a **ruleset** is what protects the branch.

The fleet is split between the two mechanisms, so neither endpoint alone is sufficient anywhere:

| repo | mechanism | classic endpoint |
|---|---|---|
| `MeshWeaver` | ruleset `2128472` | **404s** |
| `Memex` | ruleset `21038115` | **404s** |
| `MeshWeaver.Plugins` | classic, 5 required contexts | works |

Measured 2026-09-06, independently on both endpoints.

## This produced a real error today, not a hypothetical one

I ran the prescribed command against `Memex`, got `Branch not protected`, and reported to the maintainer that the repo had **no required checks and no branch protection**. Both wrong.

`Memex` in fact requires `config-key-coverage` — and, far more importantly, does **not** require `Build (Release)`. That is why auto-merge lands its PRs seconds after arming with the build still running (measured: PR #184 armed 11:13:57Z, **merged 11:14:03Z**, its build finished 11:15:26Z — *after* the merge; ten PRs merged 18–45 s after opening against a ~100 s build).

So the guidance did not merely fail to answer. It produced a **confident wrong answer about a gate** — and the wrong answer was the reassuring direction.

## Why this is the repo's own rule, violated in measurement form

AGENTS.md: *"a gate NEVER tests its own inputs — GitHub paints a skipped job the same colour as a passed one, so 'the gate never ran' and 'the gate passed' become indistinguishable"*, and *"an ABSENT required context reads as SATISFIED"*.

A 404 that reads as "unprotected" is exactly that failure, one level up: absence of an answer presented as an answer.

## The change

One paragraph. Check **both** endpoints, and treat a 404 from the classic one as *"look in the other place"* — never as a result. Commands spelled out inline, with the measured per-repo mechanisms so the next reader does not have to rediscover the split.

No code, no behaviour, no test surface. `Pairs-with: none` — removes zero public types and zero public members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
