### PR TITLE
fix(#3390): stamp the dispatched inputs at every Pending door and clear them on completion

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -640,20 +640,13 @@ internal static class NodeTypeCompilationHelpers
                     // path (explicit user button, second kickoff for a Take(1)
                     // ordering race) already set status, leave as-is.
                     if (def.CompilationStatus is not null) return curr;
-                    return curr with
-                    {
-                        Content = def with
-                        {
-                            CompilationStatus = CompilationStatus.Pending, 
-                            // 🚨 CLEAR the watcher's stamp (#2544). This flip does not come from
-                            // the release watcher and records no inputs, so leaving a previous
-                            // dispatch's token behind would let a later request be absorbed
-                            // against a compile nobody can vouch for — and if that compile fails,
-                            // the absorbed release request is simply lost. Null means "unstamped",
-                            // and the absorber parks on it exactly as it did before this change.
-                            DispatchedBuildInputs = null,
-                        }
-                    };
+                    // 🚨 STAMPED, not unstamped (#3390). This flip used to write an explicit null
+                    // — honest about recording nothing, but it meant every release request
+                    // arriving during a first build PARKED and re-fired on the compile's own
+                    // terminal write-back, the very "one logical event → N sequential compiles"
+                    // shape #2544 removed for the release door only. The inputs ARE known here:
+                    // the watcher's own `guards` and the definition being committed.
+                    return curr with { Content = DispatchPending(def, guards.ModulesHash) };
                 }).Subscribe(_ => { },
                     ex => logger?.LogWarning(ex,
                         "First-build kickoff: Update failed for {HubPath}", hubPath));
@@ -710,10 +703,9 @@ internal static class NodeTypeCompilationHelpers
                     // Only recover if STILL Compiling — the genuine compile may
                     // have settled between the init emission and this lambda.
                     if (def.CompilationStatus != CompilationStatus.Compiling) return curr;
-                    return curr with
-                    {
-                        Content = def with { CompilationStatus = CompilationStatus.Pending, DispatchedBuildInputs = null }
-                    };
+                    // Stamped for the same reason as the first-build kickoff above (#3390) — the
+                    // recovery re-drive is dispatched against the live inputs, so say so.
+                    return curr with { Content = DispatchPending(def, guards.ModulesHash) };
                 }).Subscribe(_ => { },
                     ex => logger?.LogWarning(ex,
                         "Compile recovery: re-trigger Update failed for {HubPath}", hubPath));
@@ -831,10 +823,10 @@ internal static class NodeTypeCompilationHelpers
                     // Re-check staleness inside the lambda — a genuine rebuild may have refreshed
                     // CompiledFrameworkVersion between the outer Where and this write.
                     if (!HasStaleFrameworkBuild(def, guards)) return curr;
-                    return curr with
-                    {
-                        Content = def with { CompilationStatus = CompilationStatus.Pending, DispatchedBuildInputs = null }
-                    };
+                    // Stamped (#3390): the stale-framework re-drive dispatches against the LIVE
+                    // framework and module set — which is precisely what makes it different from
+                    // the build it is replacing, so the token is the honest record of it.
+                    return curr with { Content = DispatchPending(def, guards.ModulesHash) };
                 }).Subscribe(_ => { },
                     ex => logger?.LogWarning(ex,
                         "Framework-stale kickoff: Update failed for {HubPath}", hubPath));
@@ -1037,10 +1029,16 @@ internal static class NodeTypeCompilationHelpers
     /// <param name="snapshot">The owner's live source snapshot
     /// (<see cref="NodeTypeDefinition.CurrentSourceVersions"/>, or the value about to be written
     /// into it in this same update).</param>
+    /// <param name="modulesHash">The installed-module fingerprint the REFUSAL branch's Pending
+    /// dispatch is stamped with (#3390). Defaulted because the two verifying branches never
+    /// dispatch anything, and because omitting it degrades in the SAFE direction: the token then
+    /// reads <c>mod=(none)</c>, which cannot match a request's token built from a real hash, so the
+    /// request PARKS exactly as an unstamped flip made it park.</param>
     internal static NodeTypeDefinition ApplyAdoptedSourceStamp(
         NodeTypeDefinition def,
         IReadOnlyDictionary<string, long> snapshot,
-        bool canCompileLocally)
+        bool canCompileLocally,
+        string? modulesHash = null)
     {
         var stamped = def with
         {
@@ -1088,10 +1086,13 @@ internal static class NodeTypeCompilationHelpers
         //
         // The refusal is recorded on the node rather than only logged: a reader must be able to see
         // that the assembly currently serving was rejected, not merely that a compile is pending.
-        var refused = def with
+        // 🚨 The Pending flip goes through the ONE door (#3390) so the dispatch records what it is
+        // for. The source half is `snapshot` — the LIVE set this refusal is driving a compile of —
+        // never def.CurrentSourceVersions, which on the sources-watcher path is still the value
+        // this same write is replacing.
+        var refused = DispatchPending(def, modulesHash, snapshot) with
         {
             RequestedSourceStampAt = null,
-            CompilationStatus = CompilationStatus.Pending,
             BuildProvenance = BuildProvenance.AdoptionRefused,
             // 🚨 CLEARED, not merely "not stamped". Seed does NOT clear CompiledSources, so a type
             // that had previously COMPILED here carries a snapshot matching CurrentSourceVersions
@@ -1179,7 +1180,10 @@ internal static class NodeTypeCompilationHelpers
         }
 
         var canCompileLocally = !PrebuiltAssemblySeeder.RequirePrebuilt(hub.ServiceProvider);
-        var result = ApplyAdoptedSourceStamp(def, snapshot, canCompileLocally);
+        // The hub is in hand here, so the refusal branch's Pending dispatch is stamped with the
+        // REAL module fingerprint rather than the safe-but-blind default (#3390).
+        var result = ApplyAdoptedSourceStamp(
+            def, snapshot, canCompileLocally, ModulesHashOf(hub));
 
         if (result.BuildProvenance is not BuildProvenance.AdoptionRefused)
             return result;
@@ -1528,18 +1532,24 @@ internal static class NodeTypeCompilationHelpers
                                 if (curr.Content is not NodeTypeDefinition def) return curr;
                                 // Never clobber an in-flight compile (Pending/Compiling) — only
                                 // refresh the snapshot; a settled state re-drives to Pending.
-                                var status =
-                                    def.CompilationStatus is CompilationStatus.Pending
-                                        or CompilationStatus.Compiling
-                                        ? def.CompilationStatus
-                                        : CompilationStatus.Pending;
+                                //
+                                // 🚨 …and the in-flight branch also leaves DispatchedBuildInputs
+                                // ALONE, which is the whole point of the stamp (#3390): that
+                                // compile was dispatched for the OLD source set, so a request
+                                // arriving now — whose token is built from this NEW snapshot —
+                                // must still PARK. Re-stamping here would claim the running
+                                // compile produces the new sources, which it will not.
+                                var refreshed = def with { CurrentSourceVersions = snapshot };
                                 return curr with
                                 {
-                                    Content = def with
-                                    {
-                                        CurrentSourceVersions = snapshot,
-                                        CompilationStatus = status
-                                    }
+                                    Content =
+                                        def.CompilationStatus is CompilationStatus.Pending
+                                            or CompilationStatus.Compiling
+                                            ? refreshed
+                                            // The snapshot is applied FIRST so the dispatch is
+                                            // stamped for the sources it is actually re-driving.
+                                            : DispatchPending(
+                                                refreshed, ModulesHashOf(hub), snapshot)
                                 };
                             }).Subscribe(
                                 _ => { },
@@ -1925,16 +1935,15 @@ internal static class NodeTypeCompilationHelpers
                         // LastReleaseRequestHandledAt — advance the in-memory
                         // high-water in the same breath so the two marks never diverge.
                         dispatchHighWater.Advance(triggerAt);
+                        // Stamp WHAT this dispatch is for, on the same commit that flips to
+                        // Pending, so a later trigger for the same inputs can be recognised as
+                        // already satisfied instead of queued behind it. Since #3390 that is the
+                        // ONE Pending door every flipper goes through, not a courtesy this one
+                        // site pays.
                         return curr with
                         {
-                            Content = def with
+                            Content = DispatchPending(def, GuardsOf(hub).ModulesHash) with
                             {
-                                CompilationStatus = CompilationStatus.Pending,
-                                // Stamp WHAT this dispatch is for, on the same commit that flips to
-                                // Pending, so a later trigger for the same inputs can be recognised
-                                // as already satisfied instead of queued behind it.
-                                DispatchedBuildInputs = BuildInputsToken(
-                                    GuardsOf(hub).ModulesHash, def.CurrentSourceVersions),
                                 // Stamp the CARRIED trigger value, never the
                                 // (possibly flapped-back) live value, and never
                                 // below the existing stamp — the on-node stamp is
@@ -2491,6 +2500,64 @@ internal static class NodeTypeCompilationHelpers
         string? modulesHash, IReadOnlyDictionary<string, long>? sources) =>
         $"fw={FrameworkVersion};mod={modulesHash ?? "(none)"};src={SourceToken(sources)}";
 
+    /// <summary>
+    /// 🚨 <b>THE Pending door (#3390)</b> — the ONE place a <see cref="NodeTypeDefinition"/> may be
+    /// flipped to <see cref="CompilationStatus.Pending"/>, so a dispatch can never happen without
+    /// recording WHAT it dispatched for.
+    ///
+    /// <para><b>Why one door and not a rule to remember.</b> Twelve production sites flip to
+    /// Pending; before this, exactly ONE stamped
+    /// <see cref="NodeTypeDefinition.DispatchedBuildInputs"/>. The other eleven either wrote an
+    /// explicit <c>null</c> (four) or did not mention the field at all (seven) — and a write site
+    /// that simply does not mention a field is invisible on review, which is how the hole got
+    /// there. A stamp added at eleven call sites is a rule the twelfth must remember; routing
+    /// every flip through this function makes forgetting a compile error's worth of visible
+    /// instead: <c>DispatchedBuildInputsInvariantGuard</c> asserts that the initializer below is
+    /// the only <c>CompilationStatus = …Pending</c> write in <c>src/</c>.</para>
+    ///
+    /// <para><b>Why stamping is safe where absorbing eagerly would not be.</b> The token is a
+    /// statement about the INPUTS THIS DISPATCH WAS MADE AGAINST, computed from the very
+    /// definition being committed — the identical derivation the release watcher has used since
+    /// #2544. It is not a promise about the future: if the sources, framework or module set move
+    /// after the dispatch, a later request's token differs and
+    /// <see cref="IsSatisfiedByInFlightCompile"/> PARKS it, which is the safe failure and stays
+    /// the behaviour. That is also the answer to a module set that can legitimately differ between
+    /// two compiles seconds apart (#3395): an accurate <c>mod=</c> at dispatch makes the mismatch
+    /// visible to the absorb read, where an absent stamp merely hides it behind a park.</para>
+    ///
+    /// <para>Every terminal write clears the stamp again, so non-null means <i>in flight</i> and
+    /// nothing else — see <see cref="ApplyCompileSuccess"/>, <see cref="ApplyCompileFailure"/> and
+    /// <see cref="ApplyGateSettle"/>.</para>
+    /// </summary>
+    /// <param name="def">The definition being committed — its
+    /// <see cref="NodeTypeDefinition.CurrentSourceVersions"/> is the source half of the token, so a
+    /// caller that also refreshes the snapshot must apply that FIRST (or use the overload that
+    /// takes the snapshot explicitly).</param>
+    /// <param name="modulesHash">The installed-module fingerprint half of the compile inputs
+    /// (<see cref="ModulesHashOf"/> / <see cref="BuildGuards.ModulesHash"/>).</param>
+    internal static NodeTypeDefinition DispatchPending(
+        NodeTypeDefinition def, string? modulesHash)
+        => DispatchPending(def, modulesHash, def.CurrentSourceVersions);
+
+    /// <summary>The Pending door for a caller that publishes a NEWER source snapshot in the SAME
+    /// write — the sources watcher's parked auto-retry does exactly that. Stamping
+    /// <c>def.CurrentSourceVersions</c> there would record the set the dispatch is REPLACING.</summary>
+    internal static NodeTypeDefinition DispatchPending(
+        NodeTypeDefinition def, string? modulesHash,
+        IReadOnlyDictionary<string, long>? sources)
+        => def with
+        {
+            CompilationStatus = CompilationStatus.Pending,
+            DispatchedBuildInputs = BuildInputsToken(modulesHash, sources),
+        };
+
+    /// <summary>The Pending door for a caller that holds a hub rather than a resolved
+    /// <see cref="BuildGuards"/> — the module fingerprint is a mesh-scoped singleton, so the
+    /// per-NodeType hub and the mesh hub answer the same value.</summary>
+    internal static NodeTypeDefinition DispatchPending(
+        NodeTypeDefinition def, IMessageHub hub)
+        => DispatchPending(def, ModulesHashOf(hub));
+
     /// <summary>The source snapshot folded to a short, order-insensitive token. A <c>null</c>
     /// snapshot (the sources watcher has not seeded yet) is deliberately DISTINCT from an empty
     /// one (the mesh answered "this type has no sources"): those are different facts, and
@@ -2646,16 +2713,19 @@ internal static class NodeTypeCompilationHelpers
             parkRegistry.AdmitOneRetry(hubPath);
         return curr with
         {
-            Content = d with
+            // 🚨 The bookkeeping and the flip land TOGETHER. Stamping the live
+            // inputs here — not only in ApplyCompileFailure — is what makes the
+            // re-drive unable to schedule another pass even if the compile
+            // never writes back at all (process death mid-compile, the parked
+            // re-settle, a poisoned content read).
+            //
+            // The two stamps are DIFFERENT facts over the same token: FailedBuildInputs is what
+            // the standing FAILURE was formed under, DispatchedBuildInputs is what THIS dispatch
+            // is for (#3390). They coincide here — the re-drive fires precisely because the live
+            // inputs moved past the failure — and diverge again the moment either side moves.
+            Content = DispatchPending(d, modulesHash) with
             {
-                // 🚨 The bookkeeping and the flip land TOGETHER. Stamping the live
-                // inputs here — not only in ApplyCompileFailure — is what makes the
-                // re-drive unable to schedule another pass even if the compile
-                // never writes back at all (process death mid-compile, the parked
-                // re-settle, a poisoned content read).
                 FailedBuildInputs = BuildInputsToken(modulesHash, d.CurrentSourceVersions),
-                CompilationStatus = CompilationStatus.Pending,
-                DispatchedBuildInputs = null
             }
         };
     }
@@ -2962,6 +3032,10 @@ internal static class NodeTypeCompilationHelpers
         string? modulesHash = null)
         => def with
         {
+            // 🚨 Terminal ⇒ no compile in flight (#3390). Missed by the first half of #3390
+            // because the status here is a TERNARY, not the literal the guard matched on — the
+            // guard now classifies the assigned expression instead of the spelling.
+            DispatchedBuildInputs = null,
             CompilationStatus = IsAvailabilityNonVerdict(error)
                 ? CompilationStatus.Unavailable
                 : CompilationStatus.Error,

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
@@ -255,6 +255,11 @@ internal static class NodeTypeContractHandler
                                 {
                                     Content = def with
                                     {
+                                        // Terminal ⇒ no compile in flight (#3390). Unavailable is
+                                        // as settled as Error here: EnsureCompileDispatched treats
+                                        // it as "never determined" and dispatches a FRESH compile,
+                                        // so the stamp of the one that gave up must not survive.
+                                        DispatchedBuildInputs = null,
                                         CompilationStatus = CompilationStatus.Unavailable,
                                         CompilationError = response.Error
                                     }
@@ -380,9 +385,12 @@ internal static class NodeTypeContractHandler
                     if (NodeTypeCompilationHelpers.HasUsableBuild(
                             curr, def, NodeTypeCompilationHelpers.GuardsOf(hub))) return curr;
                     if (NodeTypeCompilationHelpers.IsStaticOnlyNodeType(curr, def)) return curr;
+                    // THE Pending door (#3390) — stamped with the inputs this dispatch is for,
+                    // so a release request arriving while this first build is in flight can be
+                    // absorbed instead of parked and re-fired on its terminal write-back.
                     return curr with
                     {
-                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                        Content = NodeTypeCompilationHelpers.DispatchPending(def, hub)
                     };
                 }))
             .Take(1);

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -151,6 +151,45 @@ status-guarded flip to `Pending`, which the watcher turns into the one activity 
 **waits** for that compile to settle before hydrating the answer. The status field is the
 single-flight lock.
 
+### 🚨 There is exactly ONE door to `Pending`, and it records what the dispatch is for
+
+A trigger arriving while a compile is in flight is **absorbed** when that compile will produce
+byte-for-byte what the trigger asks for, and **parked** otherwise. The discriminator is
+`NodeTypeDefinition.DispatchedBuildInputs` — a `fw=…;mod=…;src=…` token
+(`NodeTypeCompilationHelpers.BuildInputsToken`) written **in the same update that flips `Pending`**,
+recording the framework identity, the installed-module fingerprint and the source snapshot that
+dispatch was made against. `IsSatisfiedByInFlightCompile` absorbs only on an exact match.
+
+Two rules keep the field meaningful, and both are mechanical rather than conventions to remember:
+
+1. **Non-null means *in flight*, and nothing else.** Every terminal write — `Ok`, `Error` and
+   `Unavailable` alike — clears it. A stamp that outlives its compile makes non-null mean "in
+   flight **or** finished at some point", and the absorb read branches on exactly that field.
+2. **Every flip to `Pending` goes through `NodeTypeCompilationHelpers.DispatchPending`.** Twelve
+   production sites dispatch a compile — the first-build kickoff, the persisted-`Compiling`
+   recovery, the framework-stale re-drive, the adoption refusal, the sources watcher's parked
+   auto-retry, the release watcher, the failed-verdict re-drive, `EnsureCompileDispatched`, two
+   enrichment self-heals, `CreateReleaseRequest`, and the pre-warmer's missing-bytes rebuild — and
+   `DispatchPending` is the only place any of them may write the status.
+
+Rule 2 is what makes rule 1 hold. Before #3390 the stamp was a call each door had to remember:
+eleven of the twelve did not, so a compile started by any of them was **unstamped**, every request
+arriving during it parked, and the parked trigger re-fired on that compile's own terminal
+write-back — one logical event, two compiles, each invalidating the type's instance hubs and raising
+a *newer build available* adornment (#2544 measured pairs 65 ms apart and seven compiles for one
+merge). A write site that simply does not mention a field is invisible on review, which is why
+`DispatchedBuildInputsInvariantGuard` now asserts both halves over `src/` — one Pending write, all
+terminal writes clearing — classifying the assigned expression rather than matching a spelling, so a
+status written as a ternary cannot slip past it.
+
+🚨 **Stamping accurately is not the same as absorbing eagerly, and the difference is the safety
+property.** The token describes the inputs the dispatch was made *against*; it promises nothing
+about the future. If the sources, the framework or the module set move afterwards, the next
+request's token differs and it **parks** — which is also the right answer when one boot resolves two
+different module sets seconds apart (#3395): an accurate `mod=` makes that mismatch visible to the
+absorb read, where an absent stamp merely hid it behind a park that happened to be correct. Force
+(`RequestedReleaseForce`) is never absorbed.
+
 ### The store address is a TRIPLE, and it moves together or not at all
 
 `LatestAssemblyCollection`, `LatestAssemblyPath` and `LastCompiledVersion` are not three independent

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-one-compile-button-press-is-one-compile.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-one-compile-button-press-is-one-compile.md
@@ -1,0 +1,40 @@
+---
+Name: Pressing Compile while a build is already running no longer queues a second one
+Category: Fix
+Description: A NodeType that was already compiling for exactly the inputs you asked for used to queue your request behind it and compile again the moment the first finished — so one edit could cost several rebuilds, each one invalidating the page you were looking at.
+Icon: ArrowSync
+Order: -20260906
+---
+
+# Pressing Compile while a build is already running no longer queues a second one
+
+When you press **Compile** on a NodeType — or when anything else asks for a build — the portal
+checks whether a compile is already running for the *same* inputs. If it is, your request is
+answered by that build rather than queued behind it, because the two would produce byte-for-byte the
+same assembly.
+
+That check has existed for a while, but it could only ever say *yes* for one kind of build: the one
+started by the Compile button itself. Every other way a build starts — a NodeType compiling for the
+first time, recovering after a restart, rebuilding after a platform update, retrying after you fixed
+a compile error, healing a record whose assembly had gone missing — started without recording what
+it was building. With nothing recorded, the portal could not tell whether the running build matched
+your request, so it did the safe thing and queued yours: a second full compile, kicked off the
+instant the first one finished.
+
+The visible cost was a page that kept refreshing itself. Each rebuild invalidates the views backed
+by that NodeType and raises a *newer build available* prompt, so a single edit could show up as
+several rounds of both. It was measured in production as compiles arriving in pairs 65 ms apart, and
+seven builds for one merge.
+
+Now every kind of build records what it is building, so the check works for all of them.
+
+## What has deliberately not changed
+
+**If the inputs differ at all, your request still gets its own compile.** Sources edited since the
+running build started, a different platform version, a different set of installed modules — any of
+these and your request is queued rather than absorbed, because the build in flight would *not*
+produce what you asked for. Answering your request with the wrong bytes would be far worse than
+compiling twice.
+
+**Compile (force) always compiles.** The explicit force option remains an escape hatch and is never
+absorbed into a running build.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -529,9 +529,12 @@ internal static class NodeTypeEnrichmentHelpers
                     && d.CompilationStatus == CompilationStatus.Ok
                     && (string.IsNullOrEmpty(d.LatestAssemblyCollection)
                         || string.IsNullOrEmpty(d.LatestAssemblyPath))
+                        // THE Pending door (#3390): the self-heal dispatches against the live
+                        // inputs, so it records them — an unstamped flip made every release
+                        // request arriving during the heal park and re-fire, compiling twice.
                         ? curr with
                         {
-                            Content = d with { CompilationStatus = CompilationStatus.Pending }
+                            Content = NodeTypeCompilationHelpers.DispatchPending(d, meshHub)
                         }
                         : curr)))
             .Subscribe(
@@ -1504,7 +1507,8 @@ internal static class NodeTypeEnrichmentHelpers
                             is { CompilationStatus: CompilationStatus.Ok } cdef)
                         return curr with
                         {
-                            Content = cdef with { CompilationStatus = CompilationStatus.Pending }
+                            // THE Pending door (#3390) — same reason as the sibling stale-Ok heal.
+                            Content = NodeTypeCompilationHelpers.DispatchPending(cdef, meshHub)
                         };
                     return curr;
                 }))

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1710,9 +1710,12 @@ public static class MeshDataSourceExtensions
                 if (def.CompilationStatus == CompilationStatus.Pending
                     || def.CompilationStatus == CompilationStatus.Compiling)
                     return curr;
+                // THE Pending door (#3390) — the CreateReleaseRequest dispatch records what it is
+                // for, so a second request for the same inputs arriving while this compile runs is
+                // absorbed rather than parked behind it.
                 return curr with
                 {
-                    Content = def with { CompilationStatus = CompilationStatus.Pending }
+                    Content = NodeTypeCompilationHelpers.DispatchPending(def, hub)
                 };
             })
             .Subscribe(

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -908,9 +908,15 @@ public static class DynamicTypePreWarmer
                                     // and only ever reinterprets a claim that has provably expired.
                                     if (IsLiveCompileClaim(def, budget))
                                         return node;
+                                    // THE Pending door (#3390): the rebuild is dispatched against
+                                    // the live inputs, so it says so instead of leaving the field
+                                    // untouched — an untouched field meant a release request
+                                    // arriving during the rebuild parked and compiled a second
+                                    // time on the first one's terminal write-back.
                                     return node with
                                     {
-                                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                                        Content = NodeTypeCompilationHelpers.DispatchPending(
+                                            def, workspace.Hub)
                                     };
                                 })
                                 .IgnoreElements()

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsInvariantGuard.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsInvariantGuard.cs
@@ -22,10 +22,18 @@ namespace MeshWeaver.Graph.Test;
 /// <para>So this guard is written as a <b>classifier over the assigned expression</b>, not a
 /// substring search for a spelling, and it pins BOTH halves:</para>
 /// <list type="number">
+///   <item><b>Readable, or refused.</b> The two rules below decide what a write commits from the
+///     enum members its expression NAMES, so an expression that names none —
+///     <c>CompilationStatus = status</c>, where <c>status</c> was computed above — would slip past
+///     both while committing <c>Pending</c>. That is the shape door 5 (the sources watcher's
+///     parked auto-retry) actually had before #3390, and it is why that door was one of the seven
+///     that never stamped. An unclassifiable expression is therefore a FAILURE naming the site,
+///     not a pass.</item>
 ///   <item><b>One door.</b> A <c>CompilationStatus = …Pending</c> write may appear in exactly one
-///     place in <c>src/</c> — <c>NodeTypeCompilationHelpers.DispatchPending</c>. That is what makes
-///     stamping structural rather than a rule every future door has to remember: a thirteenth door
-///     cannot be opened without either going through that function or reddening this test.</item>
+///     place in <c>src/</c> — <c>NodeTypeCompilationHelpers.DispatchPending</c>. Together with the
+///     rule above, that makes stamping structural rather than a rule every future door has to
+///     remember: a thirteenth door cannot be opened without going through that function or
+///     reddening this test.</item>
 ///   <item><b>Every terminal write clears.</b> An initializer that assigns a terminal status
 ///     (<c>Ok</c> / <c>Error</c> / <c>Unavailable</c>, however spelled) must mention the field.</item>
 /// </list>
@@ -41,9 +49,50 @@ public class DispatchedBuildInputsInvariantGuard
     private const string TheDoor = "src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs";
 
     // Floors, because a matcher that stops matching reports a clean tree — the failure this file
-    // exists to prevent. Measured on the branch that closed #3390's stamping half.
-    private const int KnownTerminalWrites = 6;
-    private const int KnownStatusWrites = 12;
+    // exists to prevent. Measured on the branch that closed #3390's stamping half, over REAL code
+    // only: 11 `CompilationStatus = …` initializer writes, 7 of them terminal.
+    //
+    // 🚨 These numbers were 12 and 6 for about ten minutes, padded by log templates the scanner
+    // had not yet learned to blank ("flipping CompilationStatus=Pending to rebuild" and friends).
+    // A floor met by prose is a floor that cannot fail — the exact defect a floor exists to catch,
+    // one level up. Re-measure them from a blanked scan, never from the raw grep count.
+    private const int KnownTerminalWrites = 7;
+    private const int KnownStatusWrites = 11;
+
+    /// <summary>
+    /// 🚨 <b>FAIL CLOSED on an expression the classifier cannot read.</b>
+    ///
+    /// <para>The other two assertions decide what a write is from the enum members its expression
+    /// NAMES. That is only sound if every expression names them — a write through an opaque local
+    /// (<c>CompilationStatus = status</c>, where <c>status</c> was computed above) commits
+    /// <c>Pending</c> while naming nothing, so it would slip past the one-door assertion and past
+    /// the terminal one, silently. This is not hypothetical: it is exactly the shape door 5 (the
+    /// sources watcher's parked auto-retry) had before #3390, and it is why that door was one of
+    /// the seven that never touched the stamp.</para>
+    ///
+    /// <para>So an unclassifiable expression is a FAILURE naming the site, not a pass. Two shapes
+    /// are readable and everything else is refused: an expression whose <c>CompilationStatus</c>
+    /// values are all written as <c>CompilationStatus.&lt;Member&gt;</c> literals (a ternary
+    /// between two of them included), and a plain copy of another object's status
+    /// (<c>x.CompilationStatus</c>), which transfers a status some door already produced rather
+    /// than creating a dispatch.</para>
+    /// </summary>
+    [Fact]
+    public void NoCompilationStatusIsWrittenThroughAnExpressionThisGuardCannotRead()
+    {
+        var root = FindRepoRoot();
+        var opaque = ScanSrc(root).Where(w => !IsReadable(w.Value)).ToList();
+
+        Assert.True(opaque.Count == 0,
+            "A CompilationStatus write assigns an expression this guard cannot classify, so it "
+            + "cannot tell whether that write commits Pending — and a Pending flip that does not "
+            + "stamp DispatchedBuildInputs is #3390. Write the enum members literally "
+            + "(`CompilationStatus.Ok`, a ternary between two of them), or — if this is a dispatch "
+            + "— call `NodeTypeCompilationHelpers.DispatchPending(def, modulesHash | hub)`, which "
+            + "flips the status and stamps the token in one place."
+            + System.Environment.NewLine
+            + string.Join(System.Environment.NewLine, opaque.Select(o => "  · " + o.Where)));
+    }
 
     [Fact]
     public void ExactlyOnePlaceInSrcMayFlipAStatusToPending()
@@ -149,16 +198,53 @@ public class DispatchedBuildInputsInvariantGuard
         Mentions(compiling.Value, "Ok").Should().BeFalse();
         Mentions(compiling.Value, "Error").Should().BeFalse();
 
-        // A projection copying an arbitrary value is neither a dispatch nor a terminal write.
+        // A projection copying an arbitrary value is neither a dispatch nor a terminal write —
+        // and it IS readable, so it must not trip the fail-closed assertion.
         var copy = Single("new Snapshot\n{\n    CompilationStatus = definition.CompilationStatus,\n};");
         Mentions(copy.Value, "Pending").Should().BeFalse();
         Mentions(copy.Value, "Ok").Should().BeFalse();
+        IsReadable(copy.Value).Should().BeTrue("a plain status copy is not a dispatch");
+
+        // 🚨 The shape the member-naming rule is BLIND to, and therefore the shape that must fail
+        // closed: a status computed above and assigned through a local. It commits Pending while
+        // naming nothing — exactly how door 5 (the sources watcher's parked auto-retry) looked
+        // before #3390, which is why it was one of the seven that never stamped.
+        var opaque = Single(
+            "var status = live ? def.CompilationStatus : CompilationStatus.Pending;\n"
+            + "return curr with\n{\n    CompilationStatus = status\n};");
+        Mentions(opaque.Value, "Pending").Should().BeFalse(
+            "this is the blind spot — the assignment names no member at all");
+        IsReadable(opaque.Value).Should().BeFalse(
+            "so it must be REFUSED rather than read as benign, or a new door opens silently");
+
+        // …and a method call is the same case.
+        IsReadable(" StatusFor(def) ").Should().BeFalse();
+        // Readable shapes stay readable.
+        IsReadable(" CompilationStatus.Compiling ").Should().BeTrue();
+        IsReadable("\n    a ? CompilationStatus.Unavailable\n      : CompilationStatus.Error")
+            .Should().BeTrue();
 
         // A comparison is not a write, and neither is prose in a comment.
         Classify("if (def.CompilationStatus == CompilationStatus.Pending) return curr;")
             .Should().BeEmpty();
         Classify("{\n    // flips CompilationStatus = Pending so the watcher fires\n}")
             .Should().BeEmpty();
+
+        // 🚨 …and neither is prose in a LOG TEMPLATE. This file's messages say things like
+        // "flipping CompilationStatus=Pending to rebuild", and eight of them were reported as
+        // unreadable writes before the scanner learned to blank strings. Left unblanked they do
+        // worse than produce noise: a brace inside one derails the initializer walk, and they pad
+        // the floors below so a scan that stopped seeing real code still looks busy.
+        Classify("logger.LogInformation(\n    \"flipping CompilationStatus = Pending to rebuild\");")
+            .Should().BeEmpty();
+        Classify("var s = @\"CompilationStatus = Pending {and a brace}\";").Should().BeEmpty();
+        Classify("var s = $\"\"\"\nCompilationStatus = CompilationStatus.Pending\n\"\"\";")
+            .Should().BeEmpty();
+
+        // Blanking preserves offsets, so reported line numbers still point at the real line.
+        Single("var s = \"CompilationStatus = Pending\";\nreturn def with\n{\n"
+               + "    CompilationStatus = CompilationStatus.Ok,\n    DispatchedBuildInputs = null,\n};")
+            .Line.Should().Be(4);
     }
 
     private static StatusWrite Single(string code)
@@ -205,9 +291,14 @@ public class DispatchedBuildInputsInvariantGuard
 
     /// <summary>Every <c>CompilationStatus = &lt;expr&gt;</c> assignment that sits inside an object
     /// initializer, with the assigned expression and the enclosing initializer.</summary>
-    private static List<StatusWrite> Classify(string code)
+    private static List<StatusWrite> Classify(string source)
     {
         const string Property = "CompilationStatus";
+        // 🚨 Comments and string literals FIRST, and blanked in place rather than skipped: this
+        // file's log templates are full of prose like "flipping CompilationStatus=Pending to
+        // rebuild", and a brace inside one would also derail the initializer walk. Blanking
+        // preserves every index and line number, so the reports still point at real lines.
+        var code = Blank(source);
         var writes = new List<StatusWrite>();
 
         for (var i = code.IndexOf(Property, System.StringComparison.Ordinal); i >= 0;
@@ -227,8 +318,6 @@ public class DispatchedBuildInputsInvariantGuard
             if (j >= code.Length || code[j] != '=') continue;
             if (j + 1 < code.Length && (code[j + 1] == '=' || code[j + 1] == '>')) continue;
             if (j > 0 && (code[j - 1] == '!' || code[j - 1] == '<' || code[j - 1] == '>')) continue;
-
-            if (IsInsideComment(code, i)) continue;
 
             var value = ReadValue(code, j + 1);
             if (value is null) continue;
@@ -267,13 +356,125 @@ public class DispatchedBuildInputsInvariantGuard
     private static bool Mentions(string value, string member) =>
         value.Contains("CompilationStatus." + member, System.StringComparison.Ordinal);
 
-    private static bool IsInsideComment(string code, int index)
+    private static readonly string[] Members =
+        ["Pending", "Compiling", "Ok", "Error", "Unavailable"];
+
+    /// <summary>
+    /// Whether this guard can say what the expression commits. Two readable shapes:
+    /// it names <see cref="CompilationStatus"/> members literally, or it is a plain copy of
+    /// another object's status. Everything else — an opaque local, a method call, a ternary over
+    /// locals — is refused rather than assumed benign; see
+    /// <see cref="NoCompilationStatusIsWrittenThroughAnExpressionThisGuardCannotRead"/>.
+    /// </summary>
+    private static bool IsReadable(string value)
     {
-        var lineStart = code.LastIndexOf('\n', System.Math.Max(0, index - 1)) + 1;
-        var line = code[lineStart..index];
-        return line.Contains("//", System.StringComparison.Ordinal)
-            || line.Contains("///", System.StringComparison.Ordinal)
-            || line.TrimStart().StartsWith('*');
+        if (Members.Any(m => Mentions(value, m))) return true;
+
+        // A copy: `x.CompilationStatus`, `x.Y.CompilationStatus`, `((T)x).CompilationStatus` — a
+        // dotted path and nothing else. It transfers a status a door already produced; it is not
+        // itself a dispatch.
+        var v = value.Trim().TrimEnd(',');
+        if (!v.EndsWith(".CompilationStatus", System.StringComparison.Ordinal)) return false;
+        return v.All(c => char.IsLetterOrDigit(c) || c is '.' or '_' or '?' or '!' or '(' or ')');
+    }
+
+    /// <summary>
+    /// Every comment, string and char literal replaced by spaces (newlines kept), so indices and
+    /// line numbers are unchanged and only real code is classified. Handles line and block
+    /// comments, ordinary, verbatim (<c>@"…"</c>, doubled quotes) and raw (<c>"""…"""</c>) strings.
+    /// </summary>
+    private static string Blank(string code)
+    {
+        var sb = new System.Text.StringBuilder(code.Length);
+        var i = 0;
+        void Skip(char c) => sb.Append(c == '\n' ? '\n' : ' ');
+
+        while (i < code.Length)
+        {
+            var c = code[i];
+
+            if (c == '/' && i + 1 < code.Length && code[i + 1] == '/')
+            {
+                while (i < code.Length && code[i] != '\n') { sb.Append(' '); i++; }
+                continue;
+            }
+            if (c == '/' && i + 1 < code.Length && code[i + 1] == '*')
+            {
+                sb.Append("  "); i += 2;
+                while (i < code.Length
+                       && !(code[i] == '*' && i + 1 < code.Length && code[i + 1] == '/'))
+                { Skip(code[i]); i++; }
+                if (i < code.Length) { sb.Append("  "); i += 2; }
+                continue;
+            }
+            if (c == '\'')
+            {
+                sb.Append(' '); i++;
+                while (i < code.Length && code[i] != '\'')
+                {
+                    if (code[i] == '\\') { sb.Append(' '); i++; if (i < code.Length) { sb.Append(' '); i++; } continue; }
+                    Skip(code[i]); i++;
+                }
+                if (i < code.Length) { sb.Append(' '); i++; }
+                continue;
+            }
+            if (c == '"')
+            {
+                var open = 0;
+                while (i + open < code.Length && code[i + open] == '"') open++;
+
+                if (open >= 3)   // raw string
+                {
+                    for (var k = 0; k < open; k++) sb.Append(' ');
+                    i += open;
+                    while (i < code.Length)
+                    {
+                        if (code[i] == '"')
+                        {
+                            var run = 0;
+                            while (i + run < code.Length && code[i + run] == '"') run++;
+                            for (var k = 0; k < run; k++) sb.Append(' ');
+                            i += run;
+                            if (run >= open) break;
+                            continue;
+                        }
+                        Skip(code[i]); i++;
+                    }
+                    continue;
+                }
+
+                var verbatim = false;
+                for (var k = i - 1; k >= 0 && (code[k] == '$' || code[k] == '@'); k--)
+                    if (code[k] == '@') verbatim = true;
+
+                sb.Append(' '); i++;
+                if (verbatim)
+                {
+                    while (i < code.Length)
+                    {
+                        if (code[i] == '"')
+                        {
+                            if (i + 1 < code.Length && code[i + 1] == '"') { sb.Append("  "); i += 2; continue; }
+                            sb.Append(' '); i++; break;
+                        }
+                        Skip(code[i]); i++;
+                    }
+                }
+                else
+                {
+                    while (i < code.Length && code[i] != '"' && code[i] != '\n')
+                    {
+                        if (code[i] == '\\') { sb.Append(' '); i++; if (i < code.Length) { sb.Append(' '); i++; } continue; }
+                        sb.Append(' '); i++;
+                    }
+                    if (i < code.Length && code[i] == '"') { sb.Append(' '); i++; }
+                }
+                continue;
+            }
+
+            sb.Append(c); i++;
+        }
+        return sb.ToString();
     }
 
     // The braces enclosing an object initializer: walk back to the nearest UNMATCHED '{', then

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsInvariantGuard.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsInvariantGuard.cs
@@ -13,93 +13,267 @@ namespace MeshWeaver.Graph.Test;
 /// the request asks for (#2544, <c>IsSatisfiedByInFlightCompile</c>). Its whole value is that it
 /// describes something currently running.</para>
 ///
-/// <para>No terminal write cleared it (#3390): a definition that reached <c>Ok</c> or <c>Error</c>
-/// kept the token of the compile that had already finished, so a non-null value meant "in flight OR
-/// finished at some point". Today the <c>Pending</c>/<c>Compiling</c> gate ahead of the absorb read
-/// hides that, which makes it a latent trap rather than a live bug — the kind that surfaces the day
-/// somebody reads the field without checking status first, and absorbs a release request against a
-/// compile that ended minutes ago.</para>
+/// <para>The failure mode is a write site that simply <b>does not mention the field</b> — invisible
+/// on review, and it has now bitten this one invariant twice. #3390 measured SEVEN
+/// <c>Pending</c> doors that never touched it (plus four that wrote an honest <c>null</c>) against
+/// ONE that stamped; and the terminal half, closed first, still left two sites uncleared because
+/// they spell the status as a ternary rather than as the literal the first matcher looked for.</para>
 ///
-/// <para>This guard pins the writing half mechanically, because the failure is a write site that
-/// simply does not mention the field — invisible on review, and exactly how the six unstamped
-/// <c>Pending</c> doors in #3390 came about.</para>
+/// <para>So this guard is written as a <b>classifier over the assigned expression</b>, not a
+/// substring search for a spelling, and it pins BOTH halves:</para>
+/// <list type="number">
+///   <item><b>One door.</b> A <c>CompilationStatus = …Pending</c> write may appear in exactly one
+///     place in <c>src/</c> — <c>NodeTypeCompilationHelpers.DispatchPending</c>. That is what makes
+///     stamping structural rather than a rule every future door has to remember: a thirteenth door
+///     cannot be opened without either going through that function or reddening this test.</item>
+///   <item><b>Every terminal write clears.</b> An initializer that assigns a terminal status
+///     (<c>Ok</c> / <c>Error</c> / <c>Unavailable</c>, however spelled) must mention the field.</item>
+/// </list>
+///
+/// <para><c>Compiling</c> is deliberately in NEITHER list: the Pending → Compiling transition is the
+/// SAME compile continuing, so it must PRESERVE the stamp — which it does by not mentioning it.</para>
 /// </summary>
 public class DispatchedBuildInputsInvariantGuard
 {
-    private const string Subject = "src/MeshWeaver.Compiler.Pipeline";
+    private const string Subject = "src";
 
-    // Terminal write sites found on origin/main a60b1e6db. A floor, because a matcher that stops
-    // matching reports a clean tree — the failure this file exists to prevent.
-    private const int KnownTerminalWrites = 5;
+    /// <summary>The ONE sanctioned Pending door. Everything else must route through it.</summary>
+    private const string TheDoor = "src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs";
 
-    private static readonly string[] TerminalWrites =
-    [
-        "CompilationStatus = CompilationStatus.Ok",
-        "CompilationStatus = CompilationStatus.Error",
-    ];
+    // Floors, because a matcher that stops matching reports a clean tree — the failure this file
+    // exists to prevent. Measured on the branch that closed #3390's stamping half.
+    private const int KnownTerminalWrites = 6;
+    private const int KnownStatusWrites = 12;
+
+    [Fact]
+    public void ExactlyOnePlaceInSrcMayFlipAStatusToPending()
+    {
+        var root = FindRepoRoot();
+        var doors = ScanSrc(root)
+            .Where(w => Mentions(w.Value, "Pending"))
+            .ToList();
+
+        Assert.True(
+            doors.Count == 1 && doors[0].File == TheDoor,
+            "A CompilationStatus = …Pending write exists outside the one sanctioned door. Every "
+            + "dispatch must record WHAT it is for, or a release request arriving during it parks "
+            + "and compiles a second time on the first compile's terminal write-back (#2544, "
+            + "#3390). Do not add `DispatchedBuildInputs = …` here — call "
+            + "`NodeTypeCompilationHelpers.DispatchPending(def, modulesHash | hub)` instead, which "
+            + "flips the status and stamps the token in one place."
+            + System.Environment.NewLine
+            + $"  Expected exactly one, in {TheDoor}. Found {doors.Count}:"
+            + System.Environment.NewLine
+            + string.Join(System.Environment.NewLine, doors.Select(d => "  · " + d.Where)));
+    }
 
     [Fact]
     public void EveryTerminalCompilationStatusWrite_ClearsTheInFlightStamp()
     {
         var root = FindRepoRoot();
-        var dir = Path.Combine(root, Subject.Replace('/', Path.DirectorySeparatorChar));
-        Assert.True(Directory.Exists(dir),
-            $"{Subject} is gone — this guard now checks nothing. Point it at the code's new home.");
+        var all = ScanSrc(root);
 
-        var offenders = new List<string>();
-        var found = 0;
+        var terminal = all
+            .Where(w => Mentions(w.Value, "Ok")
+                     || Mentions(w.Value, "Error")
+                     || Mentions(w.Value, "Unavailable"))
+            .ToList();
 
-        foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
-        {
-            var code = File.ReadAllText(path);
-            var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
-
-            foreach (var write in TerminalWrites)
-            {
-                for (var i = code.IndexOf(write, System.StringComparison.Ordinal); i >= 0;
-                     i = code.IndexOf(write, i + 1, System.StringComparison.Ordinal))
-                {
-                    var block = EnclosingInitializer(code, i);
-                    if (block is null)
-                        continue;   // not inside an object initializer — e.g. a comparison
-
-                    found++;
-                    if (!block.Contains("DispatchedBuildInputs", System.StringComparison.Ordinal))
-                        offenders.Add($"{relative}:{LineOf(code, i)} — {write}");
-                }
-            }
-        }
+        var offenders = terminal
+            .Where(w => !w.Initializer.Contains("DispatchedBuildInputs", System.StringComparison.Ordinal))
+            .Select(w => w.Where)
+            .ToList();
 
         Assert.True(offenders.Count == 0,
             "A terminal CompilationStatus write does not clear DispatchedBuildInputs. The stamp "
-            + "describes the compile currently IN FLIGHT; once the status is Ok or Error there is "
-            + "none, so a stale token makes `non-null` mean \"in flight OR finished long ago\" and "
-            + "IsSatisfiedByInFlightCompile can absorb a release request against a compile that has "
-            + "already ended. Add `DispatchedBuildInputs = null` to the initializer (#3390)."
+            + "describes the compile currently IN FLIGHT; once the status is Ok, Error or "
+            + "Unavailable there is none, so a stale token makes `non-null` mean \"in flight OR "
+            + "finished long ago\" and IsSatisfiedByInFlightCompile can absorb a release request "
+            + "against a compile that has already ended. Add `DispatchedBuildInputs = null` to the "
+            + "initializer (#3390)."
             + System.Environment.NewLine
             + string.Join(System.Environment.NewLine, offenders.Select(o => "  · " + o)));
 
-        Assert.True(found >= KnownTerminalWrites,
+        Assert.True(terminal.Count >= KnownTerminalWrites,
             $"Expected at least {KnownTerminalWrites} terminal CompilationStatus writes under "
-            + $"{Subject}, saw {found}. The matcher has gone blind, so this guard is reporting a "
-            + "clean tree having checked nothing. Re-point it before trusting it.");
+            + $"{Subject}/, saw {terminal.Count}. The matcher has gone blind, so this guard is "
+            + "reporting a clean tree having checked nothing. Re-point it before trusting it.");
+
+        Assert.True(all.Count >= KnownStatusWrites,
+            $"Expected at least {KnownStatusWrites} CompilationStatus initializer writes under "
+            + $"{Subject}/, saw {all.Count}. Same reason: a scan that matches nothing passes.");
     }
 
-    /// <summary>The matcher sees both shapes it claims to — without this, every assertion above
-    /// passes on a scan that silently matched nothing.</summary>
+    /// <summary>
+    /// 🚨 The matcher sees every shape it claims to — without this, both assertions above pass on a
+    /// scan that silently matched nothing, or on one that cannot tell a ternary terminal write from
+    /// a Pending flip. Each row below is a shape that EXISTS in <c>src/</c>.
+    /// </summary>
     [Fact]
-    public void TheMatcher_SeesACleared_AndAnUnclearedInitializer()
+    public void TheClassifier_SeesEveryShapeItClaimsTo()
     {
-        const string cleared =
-            "return def with\n{\n    DispatchedBuildInputs = null,\n    CompilationStatus = CompilationStatus.Ok,\n};";
-        const string uncleared =
-            "return def with\n{\n    CompilationStatus = CompilationStatus.Ok,\n    CompilationError = null,\n};";
+        // The Pending door, and a cleared / uncleared terminal pair.
+        var door = Single("return def with\n{\n    CompilationStatus = CompilationStatus.Pending,\n"
+                          + "    DispatchedBuildInputs = t,\n};");
+        Mentions(door.Value, "Pending").Should().BeTrue();
+        door.Initializer.Should().Contain("DispatchedBuildInputs");
 
-        var i1 = cleared.IndexOf("CompilationStatus = CompilationStatus.Ok", System.StringComparison.Ordinal);
-        var i2 = uncleared.IndexOf("CompilationStatus = CompilationStatus.Ok", System.StringComparison.Ordinal);
+        var cleared = Single("return def with\n{\n    DispatchedBuildInputs = null,\n"
+                             + "    CompilationStatus = CompilationStatus.Ok,\n};");
+        Mentions(cleared.Value, "Ok").Should().BeTrue();
+        cleared.Initializer.Should().Contain("DispatchedBuildInputs");
 
-        Assert.Contains("DispatchedBuildInputs", EnclosingInitializer(cleared, i1)!);
-        Assert.DoesNotContain("DispatchedBuildInputs", EnclosingInitializer(uncleared, i2)!);
+        var uncleared = Single("return def with\n{\n    CompilationStatus = CompilationStatus.Ok,\n"
+                               + "    CompilationError = null,\n};");
+        Mentions(uncleared.Value, "Ok").Should().BeTrue();
+        uncleared.Initializer.Should().NotContain("DispatchedBuildInputs",
+            "the guard's whole job is telling these two apart");
+
+        // 🚨 The shape the FIRST matcher was blind to: a terminal status written as a ternary, so
+        // the literal "CompilationStatus = CompilationStatus.Error" never appears. Both branches
+        // must be seen, or ApplyCompileFailure goes unchecked again.
+        var ternary = Single(
+            "return def with\n{\n    CompilationStatus = IsAvailabilityNonVerdict(e)\n"
+            + "        ? CompilationStatus.Unavailable\n        : CompilationStatus.Error,\n"
+            + "    CompilationError = null,\n};");
+        Mentions(ternary.Value, "Unavailable").Should().BeTrue();
+        Mentions(ternary.Value, "Error").Should().BeTrue();
+        Mentions(ternary.Value, "Pending").Should().BeFalse(
+            "a ternary between two terminal states is not a dispatch");
+
+        // Compiling is in neither list — the transition continues the SAME compile, so preserving
+        // the stamp (by not mentioning it) is correct and must not be reported.
+        var compiling = Single(
+            "return def with\n{\n    CompilationStatus = CompilationStatus.Compiling,\n};");
+        Mentions(compiling.Value, "Pending").Should().BeFalse();
+        Mentions(compiling.Value, "Ok").Should().BeFalse();
+        Mentions(compiling.Value, "Error").Should().BeFalse();
+
+        // A projection copying an arbitrary value is neither a dispatch nor a terminal write.
+        var copy = Single("new Snapshot\n{\n    CompilationStatus = definition.CompilationStatus,\n};");
+        Mentions(copy.Value, "Pending").Should().BeFalse();
+        Mentions(copy.Value, "Ok").Should().BeFalse();
+
+        // A comparison is not a write, and neither is prose in a comment.
+        Classify("if (def.CompilationStatus == CompilationStatus.Pending) return curr;")
+            .Should().BeEmpty();
+        Classify("{\n    // flips CompilationStatus = Pending so the watcher fires\n}")
+            .Should().BeEmpty();
+    }
+
+    private static StatusWrite Single(string code)
+    {
+        var writes = Classify(code);
+        Assert.True(writes.Count == 1,
+            $"the classifier should see exactly one write in this fixture, saw {writes.Count} — "
+            + "it has gone blind (or double-counts), which makes every assertion above vacuous");
+        return writes[0];
+    }
+
+    // ── The scanner ─────────────────────────────────────────────────────────────────────────────
+
+    private sealed record StatusWrite(string File, int Line, string Value, string Initializer)
+    {
+        public string Where => $"{File}:{Line} — CompilationStatus = {Collapse(Value)}";
+        private static string Collapse(string v) =>
+            string.Join(' ', v.Split((char[]?)null, System.StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static List<StatusWrite> ScanSrc(string root)
+    {
+        var dir = Path.Combine(root, Subject);
+        Assert.True(Directory.Exists(dir),
+            $"{Subject}/ is gone — this guard now checks nothing. Point it at the code's new home.");
+
+        var found = new List<StatusWrite>();
+        foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+            if (relative.Contains("/obj/", System.StringComparison.Ordinal)
+                || relative.Contains("/bin/", System.StringComparison.Ordinal))
+                continue;
+
+            var code = File.ReadAllText(path);
+            if (!code.Contains("CompilationStatus", System.StringComparison.Ordinal))
+                continue;
+
+            foreach (var write in Classify(code))
+                found.Add(write with { File = relative });
+        }
+        return found;
+    }
+
+    /// <summary>Every <c>CompilationStatus = &lt;expr&gt;</c> assignment that sits inside an object
+    /// initializer, with the assigned expression and the enclosing initializer.</summary>
+    private static List<StatusWrite> Classify(string code)
+    {
+        const string Property = "CompilationStatus";
+        var writes = new List<StatusWrite>();
+
+        for (var i = code.IndexOf(Property, System.StringComparison.Ordinal); i >= 0;
+             i = code.IndexOf(Property, i + 1, System.StringComparison.Ordinal))
+        {
+            // A qualified read (`def.CompilationStatus`, `CompilationStatus.Ok`) is not the
+            // property being assigned in an initializer.
+            if (i > 0 && (code[i - 1] == '.' || char.IsLetterOrDigit(code[i - 1]) || code[i - 1] == '_'))
+                continue;
+            var after = i + Property.Length;
+            if (after < code.Length && (char.IsLetterOrDigit(code[after]) || code[after] == '_' || code[after] == '.'))
+                continue;
+
+            // …followed by a single '=' (never '==', '=>' or '>=').
+            var j = after;
+            while (j < code.Length && (code[j] == ' ' || code[j] == '\t' || code[j] == '\r' || code[j] == '\n')) j++;
+            if (j >= code.Length || code[j] != '=') continue;
+            if (j + 1 < code.Length && (code[j + 1] == '=' || code[j + 1] == '>')) continue;
+            if (j > 0 && (code[j - 1] == '!' || code[j - 1] == '<' || code[j - 1] == '>')) continue;
+
+            if (IsInsideComment(code, i)) continue;
+
+            var value = ReadValue(code, j + 1);
+            if (value is null) continue;
+
+            var initializer = EnclosingInitializer(code, i);
+            if (initializer is null) continue;   // not inside an object initializer
+
+            writes.Add(new StatusWrite("(inline)", LineOf(code, i), value, initializer));
+        }
+        return writes;
+    }
+
+    /// <summary>The assigned expression: everything up to the ',' or '}' that closes this member,
+    /// at the nesting depth the value started at — so a ternary spanning lines is read whole.</summary>
+    private static string? ReadValue(string code, int start)
+    {
+        var depth = 0;
+        for (var i = start; i < code.Length; i++)
+        {
+            var c = code[i];
+            if (c is '(' or '[' or '{') depth++;
+            else if (c is ')' or ']') depth--;
+            else if (c == '}')
+            {
+                if (depth == 0) return code[start..i];
+                depth--;
+            }
+            else if (c == ',' && depth == 0) return code[start..i];
+            else if (c == ';' && depth == 0) return code[start..i];
+        }
+        return null;
+    }
+
+    /// <summary>Whether the assigned expression names a given <see cref="CompilationStatus"/>
+    /// member — both branches of a ternary count, since either may be committed.</summary>
+    private static bool Mentions(string value, string member) =>
+        value.Contains("CompilationStatus." + member, System.StringComparison.Ordinal);
+
+    private static bool IsInsideComment(string code, int index)
+    {
+        var lineStart = code.LastIndexOf('\n', System.Math.Max(0, index - 1)) + 1;
+        var line = code[lineStart..index];
+        return line.Contains("//", System.StringComparison.Ordinal)
+            || line.Contains("///", System.StringComparison.Ordinal)
+            || line.TrimStart().StartsWith('*');
     }
 
     // The braces enclosing an object initializer: walk back to the nearest UNMATCHED '{', then

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsStampedAtEveryDoorTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsStampedAtEveryDoorTest.cs
@@ -1,0 +1,297 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#3390 — a compile dispatch RECORDS what it was dispatched for, whichever door opened it.</b>
+///
+/// <para>Twelve production sites flip <see cref="CompilationStatus.Pending"/>. Exactly ONE stamped
+/// <see cref="NodeTypeDefinition.DispatchedBuildInputs"/>; four wrote an explicit <c>null</c> and
+/// seven did not mention the field at all. An unstamped in-flight compile PARKS every release
+/// request that arrives during it — by design, because "absorbing against an unknown input set is
+/// a guess" — and the parked trigger re-fires on that compile's own terminal write-back and
+/// compiles a second time. That is exactly the "one logical event → N sequential compiles" shape
+/// #2544 removed, and it was still the outcome for every compile the other eleven doors started.</para>
+///
+/// <para><b>What this file pins is the OUTCOME, not the spelling.</b> Each assertion runs a door's
+/// state transition and then asks
+/// <see cref="NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile"/> the question the release
+/// watcher asks — so it fails if a door stops stamping, and it fails if the stamp is
+/// <i>wrong</i>. Which doors exist at all is pinned mechanically by
+/// <see cref="DispatchedBuildInputsInvariantGuard"/>: there is exactly one
+/// <c>CompilationStatus = …Pending</c> write in <c>src/</c>, inside
+/// <see cref="NodeTypeCompilationHelpers.DispatchPending(NodeTypeDefinition, string?)"/>, so a
+/// thirteenth door cannot be added without going through the function these tests exercise.</para>
+///
+/// <para>🚨 <b>The safe direction is preserved and asserted.</b> Absorbing a request whose inputs
+/// do NOT match would serve bytes that are not what was asked for, so a request against moved
+/// sources, a moved framework or a moved module set still PARKS — see
+/// <see cref="A_request_against_MOVED_sources_still_parks"/> and
+/// <see cref="A_request_against_a_MOVED_module_set_still_parks"/>, the second being the shape
+/// #3395 makes reachable (one boot resolving two different module sets seconds apart).</para>
+/// </summary>
+public class DispatchedBuildInputsStampedAtEveryDoorTest
+{
+    private const string ModulesHash = "mod-1";
+    private const string TypePath = "P/T";
+
+    private static ImmutableDictionary<string, long> Sources(params (string Path, long Ticks)[] entries)
+        => ImmutableDictionary.CreateRange(
+            new Dictionary<string, long>(
+                System.Linq.Enumerable.ToDictionary(entries, e => e.Path, e => e.Ticks)));
+
+    private static readonly ImmutableDictionary<string, long> LiveSources =
+        Sources(("P/T/Source/code", 638_000_000_000_000_000));
+
+    /// <summary>The token a release request arriving right now would be built from — the exact
+    /// expression <c>InstallReleaseRequestWatcher</c> uses before it calls the absorb predicate.</summary>
+    private static string RequestedToken(
+        NodeTypeDefinition def, string? modulesHash = ModulesHash)
+        => NodeTypeCompilationHelpers.BuildInputsToken(modulesHash, def.CurrentSourceVersions);
+
+    private static NodeTypeDefinition NeverCompiled() => new()
+    {
+        Configuration = "config => config",
+        Sources = ["namespace:Source scope:subtree"],
+        CurrentSourceVersions = LiveSources,
+    };
+
+    // ── The door itself ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🔴 THE discriminating assertion. A release request arriving while a compile dispatched for
+    /// these exact inputs is in flight is ABSORBED. Before #3390 every door but one left the stamp
+    /// null or untouched, so this composition answered FALSE and the request was parked.
+    /// </summary>
+    [Fact]
+    public void A_request_for_the_inputs_the_door_dispatched_for_is_ABSORBED()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+
+        dispatched.CompilationStatus.Should().Be(CompilationStatus.Pending);
+        NodeTypeCompilationHelpers
+            .IsSatisfiedByInFlightCompile(dispatched, RequestedToken(dispatched))
+            .Should().BeTrue(
+                "the compile this door dispatched will produce byte-for-byte what the request "
+                + "asks for, so parking it buys nothing and costs a second compile plus an "
+                + "instance-hub invalidation on the first one's terminal write-back");
+    }
+
+    /// <summary>
+    /// 🚨 The safe failure, unchanged. The sources moved after the dispatch, so the in-flight
+    /// compile will NOT produce what this request asks for. Absorbing here would silently drop the
+    /// user's latest edits — the one outcome worse than the storm #2544 removed.
+    /// </summary>
+    [Fact]
+    public void A_request_against_MOVED_sources_still_parks()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+        var afterAnEdit = dispatched with
+        {
+            CurrentSourceVersions = Sources(("P/T/Source/code", 638_000_000_000_000_001)),
+        };
+
+        NodeTypeCompilationHelpers
+            .IsSatisfiedByInFlightCompile(afterAnEdit, RequestedToken(afterAnEdit))
+            .Should().BeFalse(
+                "the source snapshot changed after the dispatch, so the running compile is not "
+                + "the one this request is asking for");
+    }
+
+    /// <summary>
+    /// 🚨 The #3395 shape, and the reason ACCURATE stamping is the fix rather than eager
+    /// absorbing: one boot can resolve two different module sets seconds apart, and a dispatch
+    /// stamped under the first must not absorb a request formed under the second.
+    /// </summary>
+    [Fact]
+    public void A_request_against_a_MOVED_module_set_still_parks()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+
+        NodeTypeCompilationHelpers
+            .IsSatisfiedByInFlightCompile(dispatched, RequestedToken(dispatched, "mod-2"))
+            .Should().BeFalse(
+                "the installed-module fingerprint moved between the dispatch and the request, so "
+                + "the running compile does not produce what this request asks for — parking is "
+                + "the answer, and it is only reachable because the dispatch recorded mod-1 "
+                + "instead of recording nothing");
+    }
+
+    /// <summary>A door publishing a NEWER source snapshot in the same write stamps the set it is
+    /// re-driving, never the one it is replacing — the sources watcher's parked auto-retry.</summary>
+    [Fact]
+    public void A_door_that_refreshes_the_snapshot_stamps_the_NEW_one()
+    {
+        var newSnapshot = Sources(("P/T/Source/code", 638_000_000_000_000_009));
+        var stale = NeverCompiled();
+
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(
+            stale with { CurrentSourceVersions = newSnapshot }, ModulesHash, newSnapshot);
+
+        dispatched.DispatchedBuildInputs.Should().Be(
+            NodeTypeCompilationHelpers.BuildInputsToken(ModulesHash, newSnapshot),
+            "the dispatch is FOR the fixed sources; stamping the broken set it is replacing would "
+            + "park the very retry the user is waiting for and absorb one asking for the old code");
+    }
+
+    // ── The terminal write: the stamp must stop describing anything ─────────────────────────────
+
+    /// <summary>
+    /// 🔴 After completion the record must no longer report in-flight inputs. A stamp that
+    /// survives a terminal write makes non-null mean "in flight OR finished at some point", and
+    /// the absorb read branches on exactly that field.
+    /// </summary>
+    [Fact]
+    public void After_a_SUCCESSFUL_compile_the_stamp_reports_nothing_in_flight()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+        var token = RequestedToken(dispatched);
+
+        var settled = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            dispatched,
+            new NodeCompilationResult(
+                AssemblyLocation: "/cache/T_1/T.dll",
+                NodeTypeConfigurations: [],
+                CompiledSources: LiveSources,
+                Collection: "assemblies",
+                ContentPath: "P_T/v7.dll",
+                Version: 7),
+            currentNodeVersion: 3,
+            activityPath: null,
+            releasePath: null,
+            modulesHash: ModulesHash);
+
+        settled.CompilationStatus.Should().Be(CompilationStatus.Ok);
+        settled.DispatchedBuildInputs.Should().BeNull(
+            "the invariant is `non-null ⇔ Pending/Compiling` — a finished compile is not one");
+        NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile(settled, token)
+            .Should().BeFalse("there is no compile in flight to absorb against");
+    }
+
+    /// <summary>
+    /// The failure twin — and the one the first half of #3390 MISSED, because
+    /// <c>ApplyCompileFailure</c> writes its status as a ternary
+    /// (<c>Unavailable</c> / <c>Error</c>) rather than the literal the static guard matched on.
+    /// </summary>
+    [Fact]
+    public void After_a_FAILED_compile_the_stamp_reports_nothing_in_flight()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+        var token = RequestedToken(dispatched);
+
+        var settled = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            dispatched, result: null, error: new System.InvalidOperationException("CS0103"),
+            activityPath: null, modulesHash: ModulesHash);
+
+        settled.CompilationStatus.Should().Be(CompilationStatus.Error);
+        settled.DispatchedBuildInputs.Should().BeNull(
+            "a failure is as terminal as a success — the compile it described has ended");
+        NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile(settled, token)
+            .Should().BeFalse("there is no compile in flight to absorb against");
+    }
+
+    /// <summary>The parked short-circuit's re-settle: a Pending flip the watcher REFUSES to
+    /// dispatch never became a compile, so its stamp must not outlive the refusal either.</summary>
+    [Fact]
+    public void A_REFUSED_dispatch_clears_the_stamp_when_it_settles()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+
+        var settled = NodeTypeCompilationHelpers.ApplyGateSettle(
+            dispatched, reason: "parked", formedUnderLiveInputs: true, modulesHash: ModulesHash);
+
+        settled.DispatchedBuildInputs.Should().BeNull(
+            "no Roslyn ran, so nothing is in flight — and this is the path a stamped flip takes "
+            + "when the type is parked, which is why it may not leave the token standing");
+    }
+
+    // ── Two doors whose transition is a pure function, checked end-to-end ───────────────────────
+
+    /// <summary>
+    /// The adoption REFUSAL door (#2813). It dispatches a compile of the LIVE source, so it stamps
+    /// the live snapshot — the one it was handed, never <c>def.CurrentSourceVersions</c>, which on
+    /// the sources-watcher path is the value the same write is replacing.
+    /// </summary>
+    [Fact]
+    public void The_adoption_refusal_door_stamps_the_live_snapshot()
+    {
+        var refused = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            new NodeTypeDefinition
+            {
+                CompilationStatus = CompilationStatus.Ok,
+                RequestedSourceStampAt = System.DateTimeOffset.UtcNow,
+                AdoptedSourceFingerprint = "aaaaaaaaaaaaaaaa",
+                CurrentSourceFingerprint = "bbbbbbbbbbbbbbbb",
+                CurrentSourceVersions = LiveSources,
+                LatestAssemblyCollection = "assemblies",
+                LatestAssemblyPath = "adopted/T.dll",
+            },
+            LiveSources,
+            canCompileLocally: true,
+            modulesHash: ModulesHash);
+
+        refused.BuildProvenance.Should().Be(BuildProvenance.AdoptionRefused);
+        refused.CompilationStatus.Should().Be(CompilationStatus.Pending);
+        refused.DispatchedBuildInputs.Should().Be(
+            NodeTypeCompilationHelpers.BuildInputsToken(ModulesHash, LiveSources),
+            "a refusal drives a real compile of the live source — a release request arriving "
+            + "during it asks for exactly that, so it is absorbable rather than a second compile");
+    }
+
+    /// <summary>
+    /// The failed-verdict re-drive door (#1793). Two stamps, two different facts over the same
+    /// token shape: <c>FailedBuildInputs</c> is what the standing failure was formed under,
+    /// <c>DispatchedBuildInputs</c> is what THIS dispatch is for. Both are written together.
+    /// </summary>
+    [Fact]
+    public void The_failed_verdict_redrive_door_stamps_the_dispatch_AND_keeps_the_verdict_stamp()
+    {
+        var node = new MeshNode("P", "T")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Content = NeverCompiled() with
+            {
+                CompilationStatus = CompilationStatus.Error,
+                CompilationError = "CS0103",
+                // Formed under an OLDER module set, which is what makes the verdict stale and the
+                // re-drive fire in the first place.
+                FailedBuildInputs = NodeTypeCompilationHelpers.BuildInputsToken(
+                    "mod-OLD", LiveSources),
+            },
+        };
+
+        var redriven = NodeTypeCompilationHelpers.ApplyFailedVerdictRedrive(
+            node, TypePath, ModulesHash, parkRegistry: null);
+
+        var def = (NodeTypeDefinition)redriven.Content!;
+        def.CompilationStatus.Should().Be(CompilationStatus.Pending);
+        def.DispatchedBuildInputs.Should().Be(
+            NodeTypeCompilationHelpers.BuildInputsToken(ModulesHash, LiveSources),
+            "the re-drive dispatches against the LIVE inputs — recording nothing made every "
+            + "release request arriving during the recovery compile park and compile again");
+        def.FailedBuildInputs.Should().Be(
+            NodeTypeCompilationHelpers.BuildInputsToken(ModulesHash, LiveSources),
+            "the verdict stamp still moves to the live inputs in the same write — that is what "
+            + "stops the re-drive scheduling another pass if the compile never writes back");
+    }
+
+    /// <summary>
+    /// Force is still the escape hatch. Stamping more doors must not make an explicit user
+    /// Compile absorbable — it always compiles.
+    /// </summary>
+    [Fact]
+    public void A_FORCED_request_is_never_absorbed_by_a_stamped_door()
+    {
+        var dispatched = NodeTypeCompilationHelpers.DispatchPending(
+            NeverCompiled() with { RequestedReleaseForce = true }, ModulesHash);
+
+        NodeTypeCompilationHelpers
+            .IsSatisfiedByInFlightCompile(dispatched, RequestedToken(dispatched))
+            .Should().BeFalse("RequestedReleaseForce is the escape hatch every UI and MCP path sets");
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsStampedAtEveryDoorTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DispatchedBuildInputsStampedAtEveryDoorTest.cs
@@ -61,6 +61,20 @@ public class DispatchedBuildInputsStampedAtEveryDoorTest
         CurrentSourceVersions = LiveSources,
     };
 
+    /// <summary>
+    /// A definition with a compile genuinely in flight, written OUT — never taken from
+    /// <see cref="NodeTypeCompilationHelpers.DispatchPending(NodeTypeDefinition, string?)"/>.
+    /// The three terminal-write tests below assert that a stamp is CLEARED, so seeding them from
+    /// the door would make them pass for free the moment the door stopped stamping: they would be
+    /// asserting <c>null == null</c> about a state the defect never produces.
+    /// </summary>
+    private static NodeTypeDefinition InFlight() => NeverCompiled() with
+    {
+        CompilationStatus = CompilationStatus.Pending,
+        DispatchedBuildInputs =
+            NodeTypeCompilationHelpers.BuildInputsToken(ModulesHash, LiveSources),
+    };
+
     // ── The door itself ─────────────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -149,7 +163,7 @@ public class DispatchedBuildInputsStampedAtEveryDoorTest
     [Fact]
     public void After_a_SUCCESSFUL_compile_the_stamp_reports_nothing_in_flight()
     {
-        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+        var dispatched = InFlight();
         var token = RequestedToken(dispatched);
 
         var settled = NodeTypeCompilationHelpers.ApplyCompileSuccess(
@@ -181,7 +195,7 @@ public class DispatchedBuildInputsStampedAtEveryDoorTest
     [Fact]
     public void After_a_FAILED_compile_the_stamp_reports_nothing_in_flight()
     {
-        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+        var dispatched = InFlight();
         var token = RequestedToken(dispatched);
 
         var settled = NodeTypeCompilationHelpers.ApplyCompileFailure(
@@ -200,7 +214,7 @@ public class DispatchedBuildInputsStampedAtEveryDoorTest
     [Fact]
     public void A_REFUSED_dispatch_clears_the_stamp_when_it_settles()
     {
-        var dispatched = NodeTypeCompilationHelpers.DispatchPending(NeverCompiled(), ModulesHash);
+        var dispatched = InFlight();
 
         var settled = NodeTypeCompilationHelpers.ApplyGateSettle(
             dispatched, reason: "parked", formedUnderLiveInputs: true, modulesHash: ModulesHash);


### PR DESCRIPTION
`DispatchedBuildInputs` records which inputs the compile **in flight** was dispatched for, so a
release request arriving mid-compile can be *absorbed* instead of parked and re-fired on that
compile's own terminal write-back (#2544, `IsSatisfiedByInFlightCompile`). #3405 closed the half
that makes the field honest after the fact — every terminal write clears it. This closes the other
half: making sure something is written in the first place.

## The measurement, re-taken on `origin/main` `4248aba7b`

The issue counted **11 doors, 1 stamping**. I measure **12 doors, 1 stamping** — the issue's table
misses `NodeTypeCompilationHelpers.cs:1532-1541`, the sources watcher's parked auto-retry, which
flips `Pending` *and* publishes a new source snapshot in the same write.

| door | site on `4248aba7b` | before |
|---|---|---|
| first-build kickoff | `NodeTypeCompilationHelpers.cs:647` | explicit `null` |
| persisted-`Compiling` recovery | `NodeTypeCompilationHelpers.cs:715` | explicit `null` |
| framework-stale re-drive | `NodeTypeCompilationHelpers.cs:836` | explicit `null` |
| adoption refusal (`ApplyAdoptedSourceStamp`) | `NodeTypeCompilationHelpers.cs:1094` | **untouched** |
| sources-watcher parked auto-retry | `NodeTypeCompilationHelpers.cs:1541` | **untouched** ← not in the issue |
| release watcher | `NodeTypeCompilationHelpers.cs:1932` | **stamps** |
| failed-verdict re-drive | `NodeTypeCompilationHelpers.cs:2657` | explicit `null` |
| `EnsureCompileDispatched` | `NodeTypeContractHandler.cs:385` | **untouched** |
| stale-`Ok` self-heal | `NodeTypeEnrichmentHelpers.cs:534` | **untouched** |
| `TriggerRecompileAndRetry` | `NodeTypeEnrichmentHelpers.cs:1507` | **untouched** |
| `CreateReleaseRequest` dispatch | `MeshDataSource.cs:1715` | **untouched** |
| pre-warmer missing-bytes rebuild | `DynamicTypePreWarmer.cs:913` | **untouched** |

So: **12 flip, 1 stamped, 4 wrote an honest explicit `null`, 7 did not mention the field at all.**
`MeshOperations.cs:4368` is in the issue's neighbourhood but is a *read* (a display fallback), not a
door.

**I also found two terminal-clear sites #3405 could not see**, both because they spell the status as
a ternary or a non-`Error` terminal rather than the literal its matcher searched for:
`ApplyCompileFailure` (`Unavailable` / `Error`) and `NodeTypeContractHandler`'s `Unavailable` marker
write. Both now clear, and the guard was rewritten so the spelling stops mattering.

## Structural — yes

`NodeTypeCompilationHelpers.DispatchPending(def, modulesHash | hub)` flips the status **and** writes
the token, and it is now the **only** `CompilationStatus = …Pending` write anywhere in `src/`. Three
overloads cover the three shapes the doors actually need: the definition's own snapshot; an explicit
newer snapshot published in the same write (the sources watcher — stamping
`def.CurrentSourceVersions` there would record the broken set it is *replacing*); and a hub instead
of an already-resolved `BuildGuards`.

C# cannot make an `init` property unassignable, so "structural" here means enforced by a guard
rather than by the type system — but it is enforced over the whole tree and it names the offender:
`DispatchedBuildInputsInvariantGuard.ExactlyOnePlaceInSrcMayFlipAStatusToPending`. That is the
difference between this and a rule the thirteenth door has to remember, which is the shape that has
now failed on this one field twice.

The guard is rewritten as a **classifier over the assigned expression**, not a substring search:
it reads `CompilationStatus = <expr>` out of its enclosing object initializer and asks what `<expr>`
can commit. `Compiling` is deliberately in neither list — that transition continues the *same*
compile, so it must **preserve** the stamp, which it does by not mentioning it.

## What I deliberately did NOT change

- **The absorb predicate.** Untouched. A request against moved sources, a moved framework or a moved
  module set still **parks**, and force still always compiles — both asserted.
- **#3395.** Not fixed here. But it is the reason accurate stamping is the right fix rather than
  eager absorbing: if a boot can resolve two different module sets 15 s apart, an accurate `mod=`
  makes the mismatch *visible* to the absorb read, where an absent stamp merely hid it behind a park
  that happened to be correct. `A_request_against_a_MOVED_module_set_still_parks` pins that.
- **The parked-refusal window.** A `Pending` flip the compile watcher refuses to dispatch is briefly
  stamped before `ApplyGateSettle` clears it, so a request landing inside that window can be
  absorbed against a compile that never runs. That window is pre-existing on the release-watcher
  door (#2544 shipped it) and unchanged in shape here; narrowing it means teaching the absorb read
  about the park registry, which is #2544's business, not #3390's. Flagged rather than quietly
  widened.
- **`ApplyAdoptedSourceStamp`'s new `modulesHash` is defaulted**, so its 12 existing test call sites
  are untouched. Omitting it degrades in the safe direction only: the token then reads `mod=(none)`,
  which cannot match a request's token built from a real hash, so the request parks exactly as an
  unstamped flip made it park.

## Falsification — the guard can fail, and so can the tests

**Control (unchanged `src/`):** `Passed! - Failed: 0, Passed: 635` — the whole project, not a
`--filter`ed subset.

**A. Behaviour reverted** — `DispatchPending` writes `null`, and both new terminal clears removed:

```
Failed  DispatchedBuildInputsInvariantGuard.EveryTerminalCompilationStatusWrite_ClearsTheInFlightStamp
  · src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs:3036 — CompilationStatus = IsAvailabilityNonVerdict(error) ? CompilationStatus.Unavailable : CompilationStatus.Error
  · src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs:258 — CompilationStatus = CompilationStatus.Unavailable
Failed  …StampedAtEveryDoorTest.A_request_for_the_inputs_the_door_dispatched_for_is_ABSORBED
Failed  …StampedAtEveryDoorTest.The_adoption_refusal_door_stamps_the_live_snapshot
Failed  …StampedAtEveryDoorTest.The_failed_verdict_redrive_door_stamps_the_dispatch_AND_keeps_the_verdict_stamp
Failed  …StampedAtEveryDoorTest.A_door_that_refreshes_the_snapshot_stamps_the_NEW_one
Failed  …StampedAtEveryDoorTest.After_a_FAILED_compile_the_stamp_reports_nothing_in_flight
Failed!  - Failed: 6, Passed: 629, Total: 635
```

The two `Ok`/gate-settle terminal pins stay green there, correctly: those clears are #3405's and I
did not revert them.

🚨 The first run of this experiment reddened only **5**, and the sixth is the interesting one. Three
terminal-clear tests took their in-flight definition *from the door*, so the moment the door stopped
stamping they asserted `null == null` and passed for free — vacuous about exactly the state the
defect produces. They now write the in-flight stamp out explicitly (commit 2). A test that cannot
fail is not a test.

**B. One door reopened** — `MeshDataSource`'s `CreateReleaseRequest` dispatch put back to a bare
`def with { CompilationStatus = CompilationStatus.Pending }`:

```
Failed  DispatchedBuildInputsInvariantGuard.ExactlyOnePlaceInSrcMayFlipAStatusToPending
  Expected exactly one, in src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs. Found 2:
  · src/MeshWeaver.Graph/MeshDataSource.cs:1718 — CompilationStatus = CompilationStatus.Pending
  · src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs:2550 — CompilationStatus = CompilationStatus.Pending
Failed!  - Failed: 1, Passed: 12
```

**C. One door reopened through an OPAQUE LOCAL** — the shape Copilot's review named, and the shape
door 5 actually had before this PR (`var status = CompilationStatus.Pending; … def with {
CompilationStatus = status }`):

```
Failed  DispatchedBuildInputsInvariantGuard.NoCompilationStatusIsWrittenThroughAnExpressionThisGuardCannotRead
  · src/MeshWeaver.Graph/MeshDataSource.cs:1719 — CompilationStatus = status
Failed!  - Failed: 1, Passed: 3
```

The classifier self-test stays green in all three experiments, which is the point: the guard failed
for the reason claimed, not because it broke.

## 🚨 The review found the guard claiming more than it enforced — and that found a second hole

Copilot's review was right: the original rules decided what a write commits from the enum members
its expression NAMES, so a door written through a local named nothing and slipped past both. The
guard now **fails closed** on any expression it cannot classify (readable = names
`CompilationStatus.<Member>` literally, a ternary between two of them included, or is a plain
`x.CompilationStatus` copy). Experiment C is that rule failing on the example from the review.

Chasing it surfaced a worse blindness in the same scanner: **it was not skipping string literals.**
Eight log templates (`"flipping CompilationStatus=Pending to rebuild"` and friends) were being read
as status writes. They caused no false offence — none names a member — but they were **padding the
floors**: `at least 12 writes / 6 terminal` was partly met by prose, so a scan that stopped seeing
real code would still have looked busy. A floor met by prose cannot fail, which is the exact defect
a floor exists to catch, one level up. The scanner now blanks comments and string literals (line,
block, ordinary, verbatim, raw) in place — offsets preserved, so reported line numbers still point
at the real line — and the floors are re-measured over real code only: **11 writes, 7 terminal**.

## Verification

| project | Release `-warnaserror` | tests |
|---|---|---|
| `MeshWeaver.Compiler.Pipeline` | `0 Warning(s)`, `0 Error(s)` | — |
| `MeshWeaver.Graph` | `0 Warning(s)`, `0 Error(s)` | — |
| `MeshWeaver.Hosting` | `0 Warning(s)`, `0 Error(s)` | — |
| `MeshWeaver.Documentation` | `0 Warning(s)`, `0 Error(s)` | — |
| `MeshWeaver.Hosting.Monolith` (dependent) | `0 Warning(s)`, `0 Error(s)` | — |
| `MeshWeaver.Compiler.Pipeline.Test` | `0 Warning(s)`, `0 Error(s)` | `Failed: 0, Passed: 635` |
| `MeshWeaver.Graph.Test` | `0 Warning(s)`, `0 Error(s)` | `Failed: 0, Passed: 1362` |
| `MeshWeaver.Hosting.Test` | `0 Warning(s)`, `0 Error(s)` | `Failed: 0, Passed: 356` |
| `MeshWeaver.Documentation.Test` | `0 Warning(s)`, `0 Error(s)` | `Failed: 0, Passed: 279` |

Work products conserved: the one-door invariant, both rules and the safety argument are written up
in `Doc/Architecture/NodeTypeCompilation` (a new section under "Triggering a compile" — the absorb
mechanism was previously undocumented), plus a What's New entry, since the user-visible symptom
#2544 was reported as is exactly what this widens the fix for: a page that keeps recompiling itself
while you look at it.

## The first CI run was red on a known teardown race, not on this diff

Run [34036079623](https://github.com/Systemorph/MeshWeaver/actions/runs/34036079623) failed one test,
`PluginTester.Test.BakeEquivalenceTest.MeshDrivenAndCompilerDrivenBakes_ProduceTheSameArtifacts`.
Attributed rather than re-run:

- The job log shows `portal/nodeops` replying in 24 ms and the reply never reaching the requester,
  then `[QUIESCE-TIMEOUT] … 2 callback(s) still pending after 2s — forcibly cancelling`, then
  `mesh/… is shutting down (RunLevel=DisposeHostedHubs)`. That is **#2543** ("Bake wedge:
  portal/nodeops stops draining mid-bake") by hub, by phase, and by the trace's own verdict.
- The test's own comment records three prior sightings (#3333), one from a PR with **zero**
  `src/**.cs` changes.
- Locally on this branch that suite is green (`Failed: 0, Passed: 2`).
- This diff touches none of response routing, quiesce, `portal/nodeops` or the store upload leg, and
  its only behavioural change — a mid-compile release request absorbed rather than parked — can only
  reduce in-flight work at teardown.

Evidence posted to [#2543](https://github.com/Systemorph/MeshWeaver/issues/2543#issuecomment-5559590220).
It is the **first sighting with the message un-truncated**, which is the fact #3333 said was cut off
every time: `claims a usable build at v7 but the run's assembly store has NO bytes for it` — so the
stamp is ahead of the store, an absent version rather than a wrong one.

`Pairs-with: none` — no public surface changes. `DispatchPending` is `internal`, reached from
`MeshWeaver.Graph` and `MeshWeaver.Hosting` through the existing `InternalsVisibleTo`;
`ApplyAdoptedSourceStamp` gained a defaulted parameter, which is source- and binary-compatible.

Closes #3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

