### PR TITLE
fix(#3395): two compiles in one process resolve one module set

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -287,6 +287,62 @@ that had landed long ago, on both prods at once:
    The pin is protection, not a gate: a boot that cannot copy warns loudly and falls back to the
    shared path.
 
+### 🚨 Replicas of ONE deployment can run DIFFERENT module sets — and it used to be invisible (#3395)
+
+The pin above is correct and it has a consequence the rest of the platform has to reckon with: a
+process holds the generation it pinned **at its own boot**, for its whole life. Landing is
+continuous (`RegistryUpdateReconciler`), restarts are not synchronised, and a Deployment's replicas
+therefore boot on either side of a landing wave. Two pods of one Deployment, on one image, run two
+module sets — indefinitely, until both restart.
+
+**Measured on memex-cloud, 2026-09-06.** Three portal pods, one ReplicaSet, one image
+(`3.0.0-rc9.ci.7693`), started 11:33:39, 11:41:04 and 12:51:21 around a landing wave at
+12:18–12:27. Comparing `/tmp/meshweaver-pinned-modules/*/` across them: **39 of 40 pinned module
+generations differed** between the two older pods and the newest one — e.g.
+`MeshWeaver.Payments.Stripe@8f251f57` versus `…@458afe55`, while the shared sidecar
+(`/data/modules/activation.d/MeshWeaver.Payments.Stripe.json`) named `…@458afe55`. Only
+`MeshWeaver.Social@c000a138` was common to all three.
+
+**Why it matters beyond features.** A NodeType compile stamps the module set it resolved onto the
+NodeType node — `CompiledModulesHash` plus the per-assembly `CompiledDependencies` entries — and
+every replica shares that ONE node. On the same day, `Store/Order` compiled at 12:53:21 on the
+12:51 pod (`MeshWeaver.Payments.Stripe: mvid:83042436…`) and `Store/Plugin` at 13:09:01 on the
+11:41 pod (`mvid:344e6654…`). Each replica then reads the other's stamp, `HasUsableBuild` /
+`CompiledDependencies.FindMismatch` correctly declares the build stale for *its* environment, and
+rebuilds — so the pair ping-pongs. When a replica's set genuinely LACKS a module the sources need,
+the type does not merely rebuild, it FAILS: healthy → failed with no source change, which is
+exactly the transition the readiness gate refuses. Issue #3395 recorded that shape and asked why
+ONE process resolved two module sets; it does not — two processes do.
+
+**The defect that made it silent.** `ModuleActivationStatus` — the per-process
+restart-as-activation seam, and what `/health`'s `PendingModuleActivationHealthCheck` reads —
+compared the activation record against the loaded assembly **simple names**. That answers the
+INSTALL case (a name absent here) and is blind to the UPDATE case (name present, generation moved),
+which is the case a deployment is in almost all the time. Both stale pods answered `/health` →
+`Healthy` with *"no module activation pending"* while running a 90-minute-old module set. A promise
+that never fires for the change that actually happens is the gate-that-cannot-fail shape.
+
+`ModuleActivationStatus` now compares the GENERATION as well: `NotYetLoaded` / `Unresolvable` take
+a `name → loaded generation directory leaf` map (`LoadedModuleGenerations()`, read off each loaded
+assembly's own directory leaf — which is why the pin copies a generation directory *with* its
+`<name>@<id>` leaf), and an entry whose `Directory` differs from what this process loaded is
+pending. The name-only overloads stay and forward an empty map, because replacing a signature is
+what `MissingMethodException`-aborts a pod compiled against the previous platform. Two honesty
+rules are preserved verbatim: an entry with **no recorded generation** (the legacy fixed
+`modules/<name>/` folder) names nothing to compare against, and a module whose loaded generation
+this process **cannot determine** is *unknown*, never *stale* — over-reporting would print a
+restart prompt no restart can clear, which is the same false promise the held-entry and
+missing-bytes rules exist to prevent. A superseded pod whose ACTIVATED generation's bytes are gone
+reports **unresolvable** (re-install), not pending (wait for a restart).
+
+> **OPEN — convergence is a policy decision, not a detection one.** Detecting the divergence does
+> not end it. Whether a replica whose pinned set no longer matches the sidecar should (a) be
+> restarted automatically, (b) flip readiness so the rollout replaces it, or (c) decline to write
+> NodeType compile records while it is behind, is a deliberate trade — (b) empties a pod that is
+> serving correctly; (c) changes who compiles. Until one is chosen, the divergence is *reported*
+> (Degraded on `/health`, per pod, naming the modules) and an operator or the self-update lane
+> acts on it.
+
 ### 🚨 GC is OFF the readiness path (#2684)
 
 Where the pass runs is as load-bearing as what it deletes. It used to run synchronously in the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-server-running-an-old-add-on-now-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-server-running-an-old-add-on-now-says-so.md
@@ -1,0 +1,34 @@
+---
+Name: A server running an old add-on now says so
+Category: Fix
+Description: When an add-on updated itself, the servers that were already running kept the previous version until their next restart — and reported themselves completely up to date while they did. They now say which add-ons they are behind on, so nobody is left wondering why the same page behaves differently on two visits.
+Icon: ArrowSync
+Order: -20260906
+---
+
+# A server running an old add-on now says so
+
+The portal runs on several servers at once, and add-ons update themselves in the background. An
+update is written once, for everyone, and each server picks it up the next time it restarts. That
+is deliberate: swapping code underneath a running server is how you get half-updated behaviour.
+
+The gap was what happened in between. A server that had not restarted yet kept the previous version
+of the add-on — correctly — and reported itself **completely up to date** while it did. The check
+behind that report asked only *"is this add-on running here at all?"*, and the answer was yes; it
+had simply never been taught to ask *"is it the version everyone else agreed on?"*.
+
+So two servers could serve the same portal from two different sets of add-ons, for as long as
+neither restarted, with nothing anywhere saying so. On one visit a page would look one way, on the
+next visit another, and every health signal read green. It also confused the portal's own build
+machinery: a page type rebuilt on one server, then rebuilt again on the other, each undoing the
+other's work — and where an add-on was missing from one server entirely, a page type that had been
+working simply stopped.
+
+Each server now compares what it is actually running against what has been published, version by
+version, and reports the add-ons it is behind on by name. The remedy is unchanged and was always
+the same one — a restart — but it is now a stated to-do instead of something you had to guess at.
+
+Two things it deliberately does **not** do. It never asks for a restart it cannot promise will
+help: if an add-on's newly published files are missing, it says *re-install* instead, because no
+number of restarts would fix that. And where a server genuinely cannot tell which version it loaded,
+it stays quiet rather than raising an alarm nothing can clear.

--- a/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
@@ -27,8 +27,25 @@ public sealed record PendingModuleActivation(string Name, string? PackagePath, s
 /// asking. Comparing the persisted list against what THIS process actually loaded answers it
 /// exactly, per pod, and needs no extra state to stay true.</para>
 ///
-/// <para>Pure and total: the caller supplies both the list and the loaded set, so the rule is
-/// testable with no filesystem, no reflection and no host.</para>
+/// <para>🚨 <b>"Loaded" is a NAME <i>and</i> a GENERATION (#3395).</b> The rule above used to ask
+/// only whether an assembly of that simple name was loaded here, which answers the INSTALL case
+/// and misses the UPDATE case entirely — and update is what a deployment does continuously
+/// (<c>RegistryUpdateReconciler</c> lands a fresh generation, moves
+/// <see cref="ModuleActivationEntry.Directory"/>, and running pods keep the generation they pinned
+/// at THEIR boot). A replica hours behind therefore reported "no module activation pending" and
+/// <c>/health</c> reported it Healthy, so nothing anywhere could see that the replicas of one
+/// deployment were running DIFFERENT module sets.</para>
+///
+/// <para>Measured on memex-cloud 2026-09-06: three pods of one Deployment, one image
+/// (<c>3.0.0-rc9.ci.7693</c>), booted 11:33 / 11:41 / 12:51 around a landing wave at 12:18–12:27 —
+/// <b>39 of 40 pinned module generations differed</b> between the first two and the third, the
+/// sidecar named the newest, and both stale pods answered <c>/health</c> → <c>Healthy</c>. Two
+/// NodeType compiles 16 minutes apart landed on two of those pods and stamped two different module
+/// fingerprints into the ONE shared compile record, which is how a NodeType that was healthy
+/// becomes failed with no source change (#3395).</para>
+///
+/// <para>Pure and total: the caller supplies the list, the loaded set and what each loaded module's
+/// generation is, so the rule is testable with no filesystem, no reflection and no host.</para>
 /// </summary>
 public static class ModuleActivationStatus
 {
@@ -53,7 +70,9 @@ public static class ModuleActivationStatus
     /// never a second notion of the module platform requirement.</para>
     ///
     /// <para>🚨 And an entry whose LANDED BYTES ARE GONE is not pending either — it is
-    /// <see cref="Unresolvable"/> (#2093). Same reason, sharper: "pending" promises that a restart
+    /// <see cref="Unresolvable(ModuleActivationList, IReadOnlySet{string},
+    /// IReadOnlyDictionary{string, string}, Func{string, string}, Func{ModuleActivationEntry, bool})"/>
+    /// (#2093). Same reason, sharper: "pending" promises that a restart
     /// activates this, and boot skips an entry whose DLL is missing exactly as loudly as a held
     /// one. Reporting it as pending is a promise every restart breaks and none of them clears —
     /// and it is the state that took <c>/mcp</c> down for a pod's whole lifetime while every
@@ -72,9 +91,46 @@ public static class ModuleActivationStatus
         IReadOnlySet<string> loadedAssemblyNames,
         Func<string?, string?> platformGate,
         Func<ModuleActivationEntry, bool> landedDllExists)
+        => NotYetLoaded(activation, loadedAssemblyNames,
+            ImmutableDictionary<string, string>.Empty, platformGate, landedDllExists);
+
+    /// <summary>
+    /// As the four-argument overload, plus what GENERATION each module actually loaded from in this
+    /// process (#3395) — so an entry whose <see cref="ModuleActivationEntry.Directory"/> has moved
+    /// under a still-loaded name is pending, which is the case an auto-updating deployment is in
+    /// almost all the time.
+    ///
+    /// <para>🚨 <b>An overload, deliberately, not an extra parameter on the existing method</b> —
+    /// the same rule <c>RequiredModuleStatus.Classify</c> states: adding a parameter replaces the
+    /// signature, so a host compiled against the previous platform gets a
+    /// <see cref="MissingMethodException"/> at runtime. The four-argument form stays and forwards
+    /// an EMPTY map, which is exactly its old behaviour.</para>
+    ///
+    /// <para>🚨 <b>Absence of a generation is never a mismatch.</b> A name missing from
+    /// <paramref name="loadedModuleGenerations"/> means this process cannot say where that module
+    /// was loaded from — not that it is stale. Claiming a mismatch there would print a "restart
+    /// required" no restart can clear, the exact false promise the held-entry and missing-bytes
+    /// rules above exist to prevent. Nor is an entry with no recorded
+    /// <see cref="ModuleActivationEntry.Directory"/> (the legacy fixed <c>modules/&lt;name&gt;/</c>
+    /// folder) ever stale: it names no generation to compare against.</para>
+    /// </summary>
+    /// <param name="activation">The persisted activation list.</param>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    /// <param name="loadedModuleGenerations">Module simple name → the generation DIRECTORY LEAF
+    /// (<c>&lt;name&gt;@&lt;id&gt;</c>) this process loaded it from — production passes
+    /// <see cref="LoadedModuleGenerations()"/>. A name absent from the map is "unknown", never
+    /// "stale".</param>
+    /// <param name="platformGate">The one platform floor gate.</param>
+    /// <param name="landedDllExists">Whether the entry's landed DLL is on the volume.</param>
+    public static ImmutableList<PendingModuleActivation> NotYetLoaded(
+        ModuleActivationList activation,
+        IReadOnlySet<string> loadedAssemblyNames,
+        IReadOnlyDictionary<string, string> loadedModuleGenerations,
+        Func<string?, string?> platformGate,
+        Func<ModuleActivationEntry, bool> landedDllExists)
     {
         ArgumentNullException.ThrowIfNull(landedDllExists);
-        return AwaitingLoad(activation, loadedAssemblyNames, platformGate)
+        return AwaitingLoad(activation, loadedAssemblyNames, loadedModuleGenerations, platformGate)
             .Where(landedDllExists)
             .Select(Describe)
             .ToImmutableList();
@@ -99,9 +155,31 @@ public static class ModuleActivationStatus
         IReadOnlySet<string> loadedAssemblyNames,
         Func<string?, string?> platformGate,
         Func<ModuleActivationEntry, bool> landedDllExists)
+        => Unresolvable(activation, loadedAssemblyNames,
+            ImmutableDictionary<string, string>.Empty, platformGate, landedDllExists);
+
+    /// <summary>
+    /// As the four-argument overload, with the generation map of #3395 — so a module whose
+    /// ACTIVATED generation directory is gone from the volume while an OLDER one is still loaded
+    /// here reports as unresolvable (re-install) rather than pending (wait for a restart), which is
+    /// the same distinction this pair has always drawn, now visible for an update as well as an
+    /// install.
+    /// </summary>
+    /// <param name="activation">The persisted activation list.</param>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    /// <param name="loadedModuleGenerations">Module simple name → loaded generation directory leaf;
+    /// an absent name is "unknown", never "stale".</param>
+    /// <param name="platformGate">The one platform floor gate.</param>
+    /// <param name="landedDllExists">Whether the entry's landed DLL is on the volume.</param>
+    public static ImmutableList<PendingModuleActivation> Unresolvable(
+        ModuleActivationList activation,
+        IReadOnlySet<string> loadedAssemblyNames,
+        IReadOnlyDictionary<string, string> loadedModuleGenerations,
+        Func<string?, string?> platformGate,
+        Func<ModuleActivationEntry, bool> landedDllExists)
     {
         ArgumentNullException.ThrowIfNull(landedDllExists);
-        return AwaitingLoad(activation, loadedAssemblyNames, platformGate)
+        return AwaitingLoad(activation, loadedAssemblyNames, loadedModuleGenerations, platformGate)
             .Where(entry => !landedDllExists(entry))
             .Select(Describe)
             .ToImmutableList();
@@ -113,18 +191,38 @@ public static class ModuleActivationStatus
     private static IEnumerable<ModuleActivationEntry> AwaitingLoad(
         ModuleActivationList activation,
         IReadOnlySet<string> loadedAssemblyNames,
+        IReadOnlyDictionary<string, string> loadedModuleGenerations,
         Func<string?, string?> platformGate)
     {
         ArgumentNullException.ThrowIfNull(activation);
         ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
+        ArgumentNullException.ThrowIfNull(loadedModuleGenerations);
         ArgumentNullException.ThrowIfNull(platformGate);
 
         return activation.Entries
             .Where(entry => entry.Enabled
                 && !string.IsNullOrWhiteSpace(entry.Name)
-                && !loadedAssemblyNames.Contains(entry.Name)
-                && platformGate(entry.MinMeshVersion) is null);
+                && platformGate(entry.MinMeshVersion) is null
+                && (!loadedAssemblyNames.Contains(entry.Name)
+                    || RunsAnOlderGeneration(entry, loadedModuleGenerations)));
     }
+
+    /// <summary>
+    /// Whether this process holds a DIFFERENT generation of <paramref name="entry"/> than the one
+    /// the activation record activates (#3395) — the update half of "not loaded here".
+    ///
+    /// <para>True only on positive evidence: the entry names a generation, this process knows which
+    /// generation it loaded that module from, and the two differ. Unknown is never a mismatch — see
+    /// the note on the five-argument <see cref="NotYetLoaded(ModuleActivationList, IReadOnlySet{string},
+    /// IReadOnlyDictionary{string, string}, Func{string, string}, Func{ModuleActivationEntry, bool})"/>.</para>
+    /// </summary>
+    private static bool RunsAnOlderGeneration(
+        ModuleActivationEntry entry,
+        IReadOnlyDictionary<string, string> loadedModuleGenerations) =>
+        !string.IsNullOrWhiteSpace(entry.Directory)
+        && loadedModuleGenerations.TryGetValue(entry.Name, out var loaded)
+        && !string.IsNullOrWhiteSpace(loaded)
+        && !string.Equals(loaded, entry.Directory, StringComparison.Ordinal);
 
     /// <summary>
     /// Whether the install record at <paramref name="packagePath"/> landed a module that is not
@@ -157,6 +255,74 @@ public static class ModuleActivationStatus
     /// <summary>Convenience for the live process.</summary>
     public static IReadOnlySet<string> LoadedAssemblyNames() =>
         LoadedAssemblyNames(AppDomain.CurrentDomain);
+
+    /// <summary>
+    /// Which GENERATION directory each loaded assembly came from in <paramref name="domain"/>:
+    /// simple name → the leaf of its containing directory (#3395). That leaf IS the generation
+    /// identity — landing writes <c>modules/&lt;name&gt;@&lt;id&gt;/</c> and
+    /// <c>ModuleGenerationPin</c> copies the directory WITH its leaf into process-local storage, so
+    /// a pinned module's location ends <c>…/&lt;name&gt;@&lt;id&gt;/&lt;name&gt;.dll</c> exactly as
+    /// the shared one does. Compared ordinally against
+    /// <see cref="ModuleActivationEntry.Directory"/>, which records the same string.
+    ///
+    /// <para>🚨 <b>Only unambiguous evidence is recorded.</b> An assembly with no location (loaded
+    /// from bytes — every NodeType build is) contributes nothing, and a simple name whose loaded
+    /// copies disagree on a leaf is DROPPED rather than guessed: the map's contract is "this is
+    /// where that module was loaded from", and a name absent from it means "unknown", which the
+    /// derivation treats as not-stale. Under-reporting a pending activation costs a signal;
+    /// over-reporting one prints a restart prompt no restart can clear.</para>
+    /// </summary>
+    /// <param name="domain">The app domain to read.</param>
+    public static IReadOnlyDictionary<string, string> LoadedModuleGenerations(AppDomain domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+        var generations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var ambiguous = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in domain.GetAssemblies())
+        {
+            var name = assembly.GetName().Name;
+            if (string.IsNullOrEmpty(name) || ambiguous.Contains(name))
+                continue;
+            var leaf = GenerationLeafOf(assembly);
+            if (leaf is null)
+                continue;
+            if (generations.TryGetValue(name, out var known))
+            {
+                if (!string.Equals(known, leaf, StringComparison.Ordinal))
+                {
+                    generations.Remove(name);
+                    ambiguous.Add(name);
+                }
+                continue;
+            }
+            generations[name] = leaf;
+        }
+        return generations;
+    }
+
+    /// <summary>Convenience for the live process.</summary>
+    public static IReadOnlyDictionary<string, string> LoadedModuleGenerations() =>
+        LoadedModuleGenerations(AppDomain.CurrentDomain);
+
+    /// <summary>The containing directory's leaf, or null when the assembly has no readable
+    /// on-disk location (loaded from bytes, or a single-file bundle).</summary>
+    private static string? GenerationLeafOf(Assembly assembly)
+    {
+        string? location;
+        try
+        {
+            location = assembly.Location;
+        }
+        catch (NotSupportedException)
+        {
+            // A dynamic assembly refuses the property outright — "unknown", like an empty location.
+            return null;
+        }
+        if (string.IsNullOrEmpty(location))
+            return null;
+        var directory = Path.GetDirectoryName(location);
+        return string.IsNullOrEmpty(directory) ? null : Path.GetFileName(directory);
+    }
 
     /// <summary>
     /// One human-readable line naming what is pending — shared by every surface so an operator and

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -95,7 +95,9 @@ public sealed class ModuleLandingService : IDisposable
     /// <c>WriteEntry</c> lands, pointing a real, enabled activation entry at bytes that no longer
     /// exist. Nothing throws anywhere: the landing reports success (its own two writes both
     /// succeeded), and the entry only reveals itself as unresolvable the next time something reads
-    /// it — <see cref="ModuleActivationStatus.Unresolvable"/>'s loud report, or a boot that skips
+    /// it — <see cref="ModuleActivationStatus.Unresolvable(ModuleActivationList,
+    /// IReadOnlySet{string}, IReadOnlyDictionary{string, string}, Func{string, string},
+    /// Func{ModuleActivationEntry, bool})"/>'s loud report, or a boot that skips
     /// the module outright. That is the exact shape #2303 reported for
     /// <c>MeshWeaver.Blazor.EntityViews</c>: an ACTIVATED entry whose landed assembly was gone,
     /// with no exception or stack frame naming why.</para>
@@ -418,7 +420,9 @@ public sealed class ModuleLandingService : IDisposable
     /// separate reconcile is needed). The one deliberate difference in the record:
     /// <c>PendingRestart</c> is NOT raised for a held landing — a restart cannot activate it, and
     /// a "restart required" no restart can clear is a false prompt
-    /// (<see cref="ModuleActivationStatus.NotYetLoaded"/> excludes held entries for the same
+    /// (<see cref="ModuleActivationStatus.NotYetLoaded(ModuleActivationList,
+    /// IReadOnlySet{string}, IReadOnlyDictionary{string, string}, Func{string, string},
+    /// Func{ModuleActivationEntry, bool})"/> excludes held entries for the same
     /// reason).</para>
     ///
     /// <para>Every other refusal is unchanged — in particular the app-closure same-identity

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -97,10 +97,32 @@ public sealed class PendingModuleActivations(string moduleRoot)
     /// The current report. Recomputed per call — the state changes underneath a running process
     /// (that is the whole point), so a cached answer would be wrong exactly when it matters.
     /// </summary>
-    public ModuleActivationReport Read() => Read(ModuleActivationStatus.LoadedAssemblyNames());
+    public ModuleActivationReport Read() => Read(
+        ModuleActivationStatus.LoadedAssemblyNames(),
+        ModuleActivationStatus.LoadedModuleGenerations());
 
-    /// <summary>Testable form: the caller supplies what counts as loaded.</summary>
-    public ModuleActivationReport Read(IReadOnlySet<string> loadedAssemblyNames)
+    /// <summary>
+    /// Testable form: the caller supplies what counts as loaded, BY NAME ONLY.
+    ///
+    /// <para>🚨 Name-only cannot see an UPDATE (#3395) — a module whose activated generation moved
+    /// while an older one stays loaded here has its name in this set and reads as not pending. Kept
+    /// so a host compiled against the previous platform keeps working; every live caller should
+    /// pass the generation map instead.</para>
+    /// </summary>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    public ModuleActivationReport Read(IReadOnlySet<string> loadedAssemblyNames) =>
+        Read(loadedAssemblyNames, ImmutableDictionary<string, string>.Empty);
+
+    /// <summary>
+    /// Testable form: the caller supplies what counts as loaded, by name AND by the generation
+    /// directory each module was loaded from (#3395).
+    /// </summary>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process.</param>
+    /// <param name="loadedModuleGenerations">Module simple name → the generation directory leaf it
+    /// was loaded from here; an absent name means "unknown", never "stale".</param>
+    public ModuleActivationReport Read(
+        IReadOnlySet<string> loadedAssemblyNames,
+        IReadOnlyDictionary<string, string> loadedModuleGenerations)
     {
         string? corrupt = null;
         ModuleActivationList activation;
@@ -133,10 +155,12 @@ public sealed class PendingModuleActivations(string moduleRoot)
 
         return new ModuleActivationReport(
             ModuleActivationStatus.NotYetLoaded(
-                activation, loadedAssemblyNames, ModulePlatformFloor.DeclineReason, LandedDllExists),
+                activation, loadedAssemblyNames, loadedModuleGenerations,
+                ModulePlatformFloor.DeclineReason, LandedDllExists),
             UndeterminedReason: null,
             ModuleActivationStatus.Unresolvable(
-                activation, loadedAssemblyNames, ModulePlatformFloor.DeclineReason, LandedDllExists));
+                activation, loadedAssemblyNames, loadedModuleGenerations,
+                ModulePlatformFloor.DeclineReason, LandedDllExists));
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/ModuleGenerationDivergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleGenerationDivergenceTest.cs
@@ -1,0 +1,238 @@
+using System.Reflection;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A replica running a SUPERSEDED module generation must be reported as pending (#3395).</b>
+///
+/// <para><b>The observation.</b> #3395 recorded two NodeType compiles on <c>memex-cloud</c> that
+/// resolved DIFFERENT module sets — <c>MeshWeaver.Payments.Stripe</c> present in one and absent in
+/// the other — and asked why ONE PROCESS would resolve two. It does not. Measured 2026-09-06:
+/// three pods of one Deployment on ONE image (<c>3.0.0-rc9.ci.7693</c>) booted 11:33:39, 11:41:04
+/// and 12:51:21 around a module landing wave at 12:18–12:27, and
+/// <c>/tmp/meshweaver-pinned-modules/*/</c> held <b>39 of 40 generations different</b> between the
+/// first two pods and the third (<c>MeshWeaver.Payments.Stripe@8f251f57</c> vs
+/// <c>…@458afe55</c>, the shared sidecar naming <c>…@458afe55</c>). The two compiles ran on two of
+/// those pods — <c>Store/Order</c> at 12:53:21 on the 12:51 pod, <c>Store/Plugin</c> at 13:09:01 on
+/// the 11:41 pod — and stamped two different module fingerprints into the ONE shared compile
+/// record. Two processes, two module sets, one record.</para>
+///
+/// <para><b>The defect these pin.</b> Nothing could SEE that. The per-process restart-as-activation
+/// signal — the seam <c>/health</c>'s <c>PendingModuleActivationHealthCheck</c> reads — compared
+/// the activation record against the loaded assembly SIMPLE NAMES, so it answers the INSTALL case
+/// (name absent) and is blind to the UPDATE case (name present, generation moved). Both stale pods
+/// answered <c>/health</c> → <c>Healthy</c> while running a 90-minute-old module set. That is the
+/// gate-that-cannot-fail shape: a promise ("a restart activates them") that never fires for the
+/// change a deployment makes continuously.</para>
+///
+/// <para>Pure: no filesystem, no host, no mesh — the derivation takes the activation list and what
+/// the process loaded, and both are supplied here.</para>
+/// </summary>
+public class ModuleGenerationDivergenceTest
+{
+    private const string Module = "MeshWeaver.Payments.Stripe";
+
+    /// <summary>The generation the deployment's sidecar activates — read off memex-cloud's
+    /// <c>/data/modules/activation.d/MeshWeaver.Payments.Stripe.json</c> on 2026-09-06.</summary>
+    private const string Activated = "MeshWeaver.Payments.Stripe@458afe55";
+
+    /// <summary>The generation the 11:33 and 11:41 pods had pinned and loaded at the same moment.</summary>
+    private const string Superseded = "MeshWeaver.Payments.Stripe@8f251f57";
+
+    private static readonly Func<string?, string?> FloorSatisfied = _ => null;
+
+    private static readonly Func<ModuleActivationEntry, bool> BytesPresent = _ => true;
+
+    private static readonly Func<ModuleActivationEntry, bool> BytesGone = _ => false;
+
+    private static ModuleActivationList Activation(string? directory = Activated) => new()
+    {
+        Entries =
+        [
+            new ModuleActivationEntry
+            {
+                Name = Module,
+                PackagePath = "Plugins/Stripe",
+                Version = "1.0.0",
+                Directory = directory,
+            },
+        ],
+    };
+
+    private static IReadOnlySet<string> Loaded(params string[] names) =>
+        names.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static IReadOnlyDictionary<string, string> Generations(
+        params (string Name, string Directory)[] pairs) =>
+        pairs.ToDictionary(p => p.Name, p => p.Directory, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// 🚨 THE assertion. The module's NAME is loaded, so the name-only rule called this pod current;
+    /// the generation it is running was superseded, so a restart genuinely changes what this process
+    /// resolves — which is precisely what "pending" promises.
+    /// </summary>
+    [Fact]
+    public void APodRunningASupersededGeneration_IsPending()
+    {
+        var pending = ModuleActivationStatus.NotYetLoaded(
+            Activation(),
+            Loaded(Module),
+            Generations((Module, Superseded)),
+            FloorSatisfied, BytesPresent);
+
+        pending.Should().ContainSingle(
+                "the deployment activates " + Activated + " and this process is running "
+                + Superseded + " — a restart is what closes that gap")
+            .Subject.Name.Should().Be(Module);
+    }
+
+    /// <summary>
+    /// The other half, so the rule cannot pass by always answering "pending": the pod that DID boot
+    /// after the landing is on the activated generation and has nothing to wait for.
+    /// </summary>
+    [Fact]
+    public void APodRunningTheActivatedGeneration_IsNotPending()
+    {
+        ModuleActivationStatus.NotYetLoaded(
+                Activation(),
+                Loaded(Module),
+                Generations((Module, Activated)),
+                FloorSatisfied, BytesPresent)
+            .Should().BeEmpty("this process loaded exactly the generation the sidecar activates");
+    }
+
+    /// <summary>
+    /// The two pods of one deployment, from one activation record, must give DIFFERENT answers —
+    /// the divergence #3395 measured has to be visible from inside a replica, because there is no
+    /// other place it can be seen.
+    /// </summary>
+    [Fact]
+    public void TwoReplicasOfOneDeployment_DisagreeAboutTheSameActivationRecord()
+    {
+        var record = Activation();
+
+        var behind = ModuleActivationStatus.NotYetLoaded(
+            record, Loaded(Module), Generations((Module, Superseded)), FloorSatisfied, BytesPresent);
+        var current = ModuleActivationStatus.NotYetLoaded(
+            record, Loaded(Module), Generations((Module, Activated)), FloorSatisfied, BytesPresent);
+
+        behind.Should().NotBeEmpty();
+        current.Should().BeEmpty();
+        behind.Count.Should().NotBe(current.Count,
+            "one record read by two processes with different pinned generations is exactly the "
+            + "state that let two NodeType compiles stamp two module fingerprints into one node");
+    }
+
+    /// <summary>
+    /// 🚨 Absence of evidence is not a mismatch. A process that cannot say WHERE it loaded a module
+    /// from must not print a restart prompt: the promise would be unfalsifiable and nothing would
+    /// clear it. Under-reporting costs a signal; over-reporting costs the signal's credibility.
+    /// </summary>
+    [Fact]
+    public void AnUnknownLoadedGeneration_IsNotAMismatch()
+    {
+        ModuleActivationStatus.NotYetLoaded(
+                Activation(),
+                Loaded(Module),
+                Generations(),
+                FloorSatisfied, BytesPresent)
+            .Should().BeEmpty("nothing here establishes that a different generation is loaded");
+    }
+
+    /// <summary>An entry with no recorded generation is the legacy fixed <c>modules/&lt;name&gt;/</c>
+    /// folder: it names nothing to compare against, so the name-only rule still governs it.</summary>
+    [Fact]
+    public void AnEntryWithNoRecordedGeneration_IsNotAMismatch()
+    {
+        ModuleActivationStatus.NotYetLoaded(
+                Activation(directory: null),
+                Loaded(Module),
+                Generations((Module, Superseded)),
+                FloorSatisfied, BytesPresent)
+            .Should().BeEmpty("a legacy entry activates a folder, not a generation");
+    }
+
+    /// <summary>
+    /// The pending/unresolvable split survives the update case, and the buckets stay disjoint: when
+    /// the ACTIVATED generation's bytes are not on the volume, no restart moves this process onto
+    /// it, so the remedy is re-install and the entry must not read as "wait for a restart".
+    /// </summary>
+    [Fact]
+    public void ASupersededPodWhoseActivatedBytesAreGone_IsUnresolvableNotPending()
+    {
+        var record = Activation();
+        var generations = Generations((Module, Superseded));
+
+        ModuleActivationStatus.NotYetLoaded(
+                record, Loaded(Module), generations, FloorSatisfied, BytesGone)
+            .Should().BeEmpty("no restart loads a generation directory that is not there");
+        ModuleActivationStatus.Unresolvable(
+                record, Loaded(Module), generations, FloorSatisfied, BytesGone)
+            .Should().ContainSingle().Subject.Name.Should().Be(Module);
+    }
+
+    /// <summary>
+    /// The pre-#3395 overloads keep their exact behaviour — they forward an EMPTY generation map,
+    /// so a host compiled against the previous platform binds a method that still exists and still
+    /// answers the install question. (The binary-compat rule
+    /// <c>RequiredModuleStatus.Classify</c> already states, applied here.)
+    /// </summary>
+    [Fact]
+    public void TheNameOnlyOverload_StillAnswersTheInstallQuestionUnchanged()
+    {
+        ModuleActivationStatus.NotYetLoaded(
+                Activation(), Loaded(Module), FloorSatisfied, BytesPresent)
+            .Should().BeEmpty("name-only cannot see a generation move — that is why it is not the "
+                + "overload production calls");
+        ModuleActivationStatus.NotYetLoaded(
+                Activation(), Loaded(), FloorSatisfied, BytesPresent)
+            .Should().ContainSingle("an absent name is still pending on the old overload");
+    }
+
+    /// <summary>
+    /// The live-process reader takes the generation from the assembly's own directory leaf — which
+    /// is what makes the comparison possible at all: <c>ModuleGenerationPin</c> copies a landed
+    /// generation directory WITH its leaf into process-local storage, so a pinned module's location
+    /// ends <c>…/&lt;name&gt;@&lt;id&gt;/&lt;name&gt;.dll</c> exactly as the shared one does.
+    /// </summary>
+    [Fact]
+    public void LoadedModuleGenerations_ReadsTheDirectoryLeafOfEachLoadedAssembly()
+    {
+        var generations = ModuleActivationStatus.LoadedModuleGenerations(AppDomain.CurrentDomain);
+        var self = typeof(ModuleGenerationDivergenceTest).Assembly;
+        var expected = Path.GetFileName(Path.GetDirectoryName(self.Location))!;
+
+        generations.TryGetValue(self.GetName().Name!, out var leaf).Should().BeTrue(
+            "this assembly has an on-disk location, so its generation is knowable");
+        leaf.Should().Be(expected,
+            "the leaf of the containing directory IS the generation identity");
+    }
+
+    /// <summary>An assembly with no on-disk location says nothing about a generation — and silence
+    /// is the correct answer, not a guess.</summary>
+    [Fact]
+    public void LoadedModuleGenerations_OmitsAnAssemblyWithNoLocation()
+    {
+        var generations = ModuleActivationStatus.LoadedModuleGenerations(AppDomain.CurrentDomain);
+
+        generations.Keys.Should().OnlyContain(
+            name => AppDomain.CurrentDomain.GetAssemblies()
+                .Any(a => string.Equals(a.GetName().Name, name, StringComparison.OrdinalIgnoreCase)
+                    && HasLocation(a)),
+            "a name in the map must be backed by an assembly that has a readable location");
+    }
+
+    private static bool HasLocation(Assembly assembly)
+    {
+        try
+        {
+            return !string.IsNullOrEmpty(assembly.Location);
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Refs #3395 — deliberately NOT `Closes`: the mechanism is settled and the invisibility is fixed
here, but the convergence POLICY (below) is an open decision, and closing on a partial answer is
what the issue asked not to happen.

## The premise is falsified: it is not one process

#3395 measured two NodeType compiles on `memex-cloud` resolving different module sets 15 s apart
and asked **why one process resolves two**. It does not. **Two processes do.**

`memex-cloud` runs **three** portal replicas of one Deployment on one image
(`meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc9.ci.7693`), and each pins its module generations at
**its own** boot (`ModuleGenerationPin`, #2509). Measured 2026-09-06:

| pod | started | pinned `MeshWeaver.Payments.Stripe` |
|---|---|---|
| `…-b8pfg` | 11:33:39Z | `MeshWeaver.Payments.Stripe@8f251f57` |
| `…-tqhzx` | 11:41:04Z | `MeshWeaver.Payments.Stripe@8f251f57` |
| `…-gqqg7` | 12:51:21Z | `MeshWeaver.Payments.Stripe@458afe55` |

A landing wave wrote new generations into the shared `/data/modules/` at **12:18–12:27**, so the pod
that booted at 12:51 got them and the two older pods did not. Comparing
`/tmp/meshweaver-pinned-modules/*/` across all three: **39 of 40 generations differ**; only
`MeshWeaver.Social@c000a138` is common. The sidecar
(`/data/modules/activation.d/MeshWeaver.Payments.Stripe.json`) reads
`"directory": "MeshWeaver.Payments.Stripe@458afe55"`.

Those replicas share ONE NodeType node, and a compile stamps the module set it resolved onto it:

- `Store/Order` — compiled **12:53:21 on `gqqg7`** (its log: `BatchBake: Store/Order → Compiled`,
  `Node created at Store/Order/Release/20260906125321-gKhmBuMk`) → `compiledModulesHash a6ee9d0c…`,
  `MeshWeaver.Payments.Stripe: mvid:83042436…`
- `Store/Plugin` — compiled **13:09:01 on `tqhzx`** (its log:
  `Node created at Store/Plugin/_Activity/compile-2026090613085735…`; neither other pod logged it) →
  `compiledModulesHash 520550d2…`, `MeshWeaver.Payments.Stripe: mvid:344e6654…`

Two pods, two module sets, one record — 16 minutes apart today, 15 seconds apart on 2026-09-06
07:08. Each replica then reads the other's stamp, `HasUsableBuild`/`CompiledDependencies.FindMismatch`
*correctly* calls the build stale for its own environment, and rebuilds — so the pair ping-pongs; and
where a replica's set genuinely lacks a module the sources need, the type does not merely rebuild, it
FAILS. Healthy → failed, no source change: exactly the transition the readiness gate refuses.

## What I excluded, and how

| Candidate | Verdict | Evidence |
|---|---|---|
| **A race inside one process** | **Excluded** | `InstalledModulesFingerprint` is a mesh-scoped DI **singleton** whose hash is computed once in its constructor; `InstalledModuleAssembly` registrations are made once, at `MeshBuilder.InstallAssemblies`, into the ROOT container, and every hub's provider is an Autofac **child scope** of it (`ServiceProviderExtensions.SetupModules`) — so every hub resolves the same instance and the same hash. `MeshNodeCompilationService.meshReferences` is a `Lazy<>` on a singleton, composed once. No code path re-resolves a module set mid-process. |
| **Module load ORDERING** | **Excluded** | `InstalledModulesFingerprint.Compute` `OrderBy`s the MVIDs ordinally before hashing, and `ModuleMvidsOf` is a name→MVID map. Order cannot move either. |
| **The ALC lease** (`MeshDataSource.cs:1017-1035`, `NodeAssemblyLoadContext.Dispose` deferring `Unload()`) | **Excluded** | That context (`CompilationCacheService`) holds **NodeType-compiled** assemblies — collectible, one per node name, `_dllPath` = the emitted `Store_Plugin.dll`. `InstalledModuleAssembly` is `Assembly.LoadFrom`ed into the DEFAULT context at boot and never unloaded. Holding or releasing a lease can neither add nor remove a module from `CompileReferences.ComposeWithModules`. |
| **A registry/bundle read racing the compiler** | **Excluded** | `ComposeWithModules` reads `module.Assembly.Location` of already-loaded assemblies; #2509's pin gives those paths process-local lifetime, so a landing or a GC pass on the shared tree cannot change what a loaded module resolves to. The composition is evaluated once per singleton anyway. |
| **A cache keyed on something that changes** | **Excluded as a cause** | #3402's stale `MeshNodeLanguageService` workspace is a *diagnostics* confounder, not a resolve. The compile records read here are the nodes' own `compilationStatus`/`compiledDependencies`, not `get_diagnostics`. |
| **Replicas pinned to different generations** | **CONFIRMED** | The table above, read off the live pods. |

## The core defect this fixes

Nothing could **see** the divergence. `ModuleActivationStatus` — the per-process
restart-as-activation seam, and what `/health`'s `PendingModuleActivationHealthCheck` reads —
compared the activation record against the loaded assembly **simple names**. That answers the
INSTALL case (name absent here) and is blind to the UPDATE case (name present, generation moved),
which is the case an auto-updating deployment is in almost all the time.

Measured live: `kubectl exec …-b8pfg -- curl -s localhost:8080/health` → **`Healthy`**, on a pod
running a 90-minute-old module set. The check's own promise — *"a restart activates them"* — never
fires for the change that actually happens. That is the gate-that-cannot-fail shape AGENTS.md names.

`ModuleActivationStatus.NotYetLoaded` / `Unresolvable` now also take a
`name → loaded generation directory leaf` map (`LoadedModuleGenerations()`, read off each loaded
assembly's own directory leaf — which is exactly why `ModuleGenerationPin` copies a generation
directory *with* its `<name>@<id>` leaf), and an entry whose `Directory` differs from what this
process loaded is pending.

Three properties kept deliberately:

- **The name-only overloads stay**, forwarding an empty map — replacing a signature is what
  `MissingMethodException`-aborts a host compiled against the previous platform (#2234's shape, the
  rule `RequiredModuleStatus.Classify` already states). Nothing public is removed.
- **Unknown is never stale.** A module whose loaded generation this process cannot determine, and an
  entry with no recorded `Directory` (the legacy fixed `modules/<name>/` folder), are not pending —
  over-reporting prints a restart prompt no restart can clear, the same false promise the
  held-entry (2026-08-22) and missing-bytes (#2093) rules exist to prevent.
- **Pending vs unresolvable stays disjoint.** A superseded pod whose ACTIVATED generation's bytes are
  gone reports *re-install*, not *wait for a restart*.

## Falsification

`test/Memex.Portal.Shared.Test/ModuleGenerationDivergenceTest.cs` — pure, 9 facts, no host, no
filesystem, no delay, no polling. Run twice, `-c Release`, same test binary path:

| `src/` state | result |
|---|---|
| with the fix | **Failed: 0, Passed: 9** |
| with `RunsAnOlderGeneration` neutralised to its pre-fix answer (overloads kept so the test still *compiles* and therefore *fails* rather than merely not building) | **Failed: 3, Passed: 6** |

The three that flip are exactly the divergence-detection ones —
`APodRunningASupersededGeneration_IsPending`,
`TwoReplicasOfOneDeployment_DisagreeAboutTheSameActivationRecord`,
`ASupersededPodWhoseActivatedBytesAreGone_IsUnresolvableNotPending` — with e.g.
*"Expected collection to contain a single item because the deployment activates
MeshWeaver.Payments.Stripe@458afe55 and this process is running MeshWeaver.Payments.Stripe@8f251f57
…, but found 0."* The `src/` diff was restored from the saved patch and verified byte-identical
before the final run.

Local, `-c Release -warnaserror`, one project per invocation, all `0 Error(s)`:
`MeshWeaver.PluginCatalog`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`,
`MeshWeaver.PluginTester`, `MeshWeaver.ComboVerifier`, `MeshWeaver.ComboAssembler`.
`DocumentationLinkIntegrityTest` and `WhatsNewEntryIntegrityTest` pass.

## Still open — a policy decision, deliberately not made here

Detecting the divergence does not end it. Whether a replica whose pinned set no longer matches the
sidecar should (a) restart itself, (b) flip readiness so the rollout replaces it, or (c) decline to
write NodeType compile records while it is behind, is a real trade — (b) empties a pod that is
serving correctly; (c) changes who compiles. That is written up in
`Doc/Architecture/Modules` under *"Replicas of ONE deployment can run DIFFERENT module sets"* as an
explicit OPEN item rather than guessed at. Until it is decided, the divergence is **reported**
(Degraded on `/health`, per pod, naming the modules) instead of silent.

Pairs-with: none — the diff removes no public type and no public member; it adds overloads and keeps
every existing signature. Checked `MeshWeaver.Plugins` for `<see cref>`s to the newly-overloaded
methods (the CS0419 shape): there are none, and the three inside this repo are disambiguated in this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
