### PR TITLE
fix(bake): the bake ships from a SETTLED record, not from the first one it sees (#3370)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -205,6 +205,26 @@ last word; with two, the first `Ok` opens a window in which a concurrent writer'
 overwritten by the tail. Readers are safe either way (both writes describe a real build); writers
 must not treat the first `Ok` as "the pipeline is finished".
 
+### The bake ships from a SETTLED record, never from the first one it sees
+
+The record and the store are two states, and a reader that takes them at different moments can
+name bytes that are gone. The package installer requests a **release** for every type it installs
+(the idempotence re-install too), and `ObserveNodeTypeRelease` completes when the
+`RequestedReleaseAt` trigger has been **written**, not when the compile it starts has finished — so a
+gate's report, and the bake behind it, can run while that compile is still in flight. The compile's
+upload then lands under a newer store version, the file-system store evicts superseded versions at
+write (it keeps the newest three), and the record the bake already read names a version the store
+no longer holds: *"claims a usable build at v7 but the run's assembly store has NO bytes for it"*
+(#3370, #3333 — measured on a tree that already carried the triple fix above).
+
+`BakeOutput.CollectOne` therefore waits for the record to **settle** before it names the bytes —
+`CompilationStatus == Ok`, `DispatchedBuildInputs` cleared (a terminal status clears it, #3390),
+and no release request the watcher has not handled (the watcher's own pending test:
+`RequestedReleaseAt` newer than `LastReleaseRequestHandledAt`) — and, if it never settles inside
+the read budget, fails naming what was still in flight. The claim and the payload are read as one
+state; no bound was raised. `BakeOutput.NotYetSettled` is the predicate, pinned by
+`BakeReadsASettledRecordTest`.
+
 ### Explicit — Create Release
 
 **The one entry point is `hub.RequestNodeTypeRelease(nodeTypePath, …)`** (`MeshWeaver.Graph/NodeTypeReleaseExtensions.cs`) — GUI, agents, and tests all call it. It writes the trigger onto the NodeType node via `stream.Update`: `RequestedReleaseAt` (a timestamp, so repeated requests are distinct), plus `RequestedReleaseForce` to bypass the "sources match the last compile" short-circuit and `RequestedReleaseBy` to attribute the release to the caller. The per-NodeType release watcher dispatches only while `RequestedReleaseAt > LastReleaseRequestHandledAt` — an idempotent CAS — and lands on the same `RunCompile`.

--- a/test/MeshWeaver.PluginTester.Test/BakeReadsASettledRecordTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeReadsASettledRecordTest.cs
@@ -1,0 +1,80 @@
+using System;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// MeshWeaver#3370 / #3333 — the bake must ship from a SETTLED record. It used to take the first
+/// record it saw as "a replay — the compile gate already saw it settle", and the gate had not: the
+/// installer's release request completes when the trigger is written, not when the compile it
+/// starts has finished, so the bake read a record whose compile was still in flight — and the
+/// store, which evicts superseded versions at write, no longer held the version that record named
+/// ("claims a usable build at v7 but the run's assembly store has NO bytes for it", run
+/// 34036079623, on a tree that already carried the #3341 stamp fix).
+///
+/// <para>These pin the predicate the bake now waits on: the three ways a record is not yet
+/// settled, and the one shape that is.</para>
+/// </summary>
+public class BakeReadsASettledRecordTest
+{
+    private static NodeTypeDefinition Settled() => new()
+    {
+        CompilationStatus = CompilationStatus.Ok,
+        DispatchedBuildInputs = null,
+        RequestedReleaseAt = new DateTimeOffset(2026, 9, 6, 13, 30, 1, TimeSpan.Zero),
+        LastReleaseRequestHandledAt = new DateTimeOffset(2026, 9, 6, 13, 30, 1, TimeSpan.Zero),
+        LastCompiledVersion = 7,
+    };
+
+    [Fact]
+    public void A_record_whose_compile_reached_Ok_with_nothing_in_flight_is_settled()
+    {
+        Assert.Null(BakeOutput.NotYetSettled(Settled()));
+    }
+
+    [Fact]
+    public void A_handled_release_older_than_the_request_is_still_pending()
+    {
+        // The installer's release trigger landed (the observable completed) but the watcher has
+        // not handled it yet — the compile it will start has not even been dispatched.
+        var def = Settled() with
+        {
+            RequestedReleaseAt = new DateTimeOffset(2026, 9, 6, 13, 30, 2, TimeSpan.Zero),
+        };
+        var reason = BakeOutput.NotYetSettled(def);
+        Assert.NotNull(reason);
+        Assert.Contains("release request is pending", reason);
+    }
+
+    [Fact]
+    public void A_compile_in_flight_is_not_settled_even_at_Ok()
+    {
+        // DispatchedBuildInputs is stamped at every Pending door and cleared on every terminal
+        // status (#3390); while it is present the record will be re-stamped.
+        var def = Settled() with { DispatchedBuildInputs = "fw=abc;mod=def;src=ghi" };
+        var reason = BakeOutput.NotYetSettled(def);
+        Assert.NotNull(reason);
+        Assert.Contains("in flight", reason);
+    }
+
+    [Theory]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    [InlineData(CompilationStatus.Error)]
+    public void A_non_Ok_status_is_not_settled(CompilationStatus status)
+    {
+        var reason = BakeOutput.NotYetSettled(Settled() with { CompilationStatus = status });
+        Assert.NotNull(reason);
+        Assert.Contains(status.ToString(), reason);
+    }
+
+    [Fact]
+    public void A_record_that_never_requested_a_release_is_settled_at_Ok()
+    {
+        var def = Settled() with { RequestedReleaseAt = null, LastReleaseRequestHandledAt = null };
+        Assert.Null(BakeOutput.NotYetSettled(def));
+    }
+}

--- a/tools/MeshWeaver.PluginTester/BakeOutput.cs
+++ b/tools/MeshWeaver.PluginTester/BakeOutput.cs
@@ -155,22 +155,70 @@ public static class BakeOutput
     }
 
     /// <summary>
-    /// One compiled type's bundle entry: read the stamped record back (a replay — the compile gate
-    /// already saw it settle), resolve the bytes the compile put in the run's assembly store, and
-    /// bind them to the node path plus the source snapshot the compile consumed.
+    /// Why this record is NOT yet the settled one the bake may ship from, or <c>null</c> when it is.
+    ///
+    /// <para>🚨 The bake used to read the FIRST record it saw and treat it as settled — "a replay,
+    /// the compile gate already saw it settle". It had not (MeshWeaver#3370, #3333): the package
+    /// installer requests a RELEASE for every type it installs, and
+    /// <c>ObserveNodeTypeRelease</c> completes when the trigger has been WRITTEN, not when the
+    /// compile it starts has finished — so the gate's report, and the bake behind it, run while
+    /// that compile is in flight. Its upload lands under a NEWER store version, the file-system
+    /// store evicts superseded versions at write, and the still-old record then names bytes the
+    /// store no longer holds: <i>"claims a usable build at v7 but the run's assembly store has NO
+    /// bytes for it"</i>. Reading a settled record closes that window at its source; the claim and
+    /// the payload are read as one state.</para>
+    ///
+    /// <para>Settled means: the compile reached <see cref="CompilationStatus.Ok"/>, no compile is
+    /// in flight (<see cref="NodeTypeDefinition.DispatchedBuildInputs"/> is cleared on every
+    /// terminal status, #3390), and no release request is waiting for the watcher — the same
+    /// pending test the release watcher itself applies.</para>
+    /// </summary>
+    internal static string? NotYetSettled(NodeTypeDefinition def)
+    {
+        if (def.CompilationStatus is not CompilationStatus.Ok)
+            return $"CompilationStatus={def.CompilationStatus?.ToString() ?? "(null)"}";
+        if (def.DispatchedBuildInputs is not null)
+            return $"a compile is in flight (DispatchedBuildInputs={def.DispatchedBuildInputs})";
+        if (def.RequestedReleaseAt is { } req
+            && (def.LastReleaseRequestHandledAt is null || req > def.LastReleaseRequestHandledAt.Value))
+            return $"a release request is pending (RequestedReleaseAt={req:O}, "
+                   + $"LastReleaseRequestHandledAt={def.LastReleaseRequestHandledAt?.ToString("O") ?? "(null)"})";
+        return null;
+    }
+
+    /// <summary>
+    /// One compiled type's bundle entry: wait for the SETTLED record (see
+    /// <see cref="NotYetSettled"/>), resolve the bytes the compile put in the run's assembly
+    /// store, and bind them to the node path plus the source snapshot the compile consumed.
     /// </summary>
     private static IObservable<BundleWriter.AssemblyEntry> CollectOne(
         IWorkspace workspace,
         IAssemblyStore store,
         IIoPool pool,
         string typePath)
-        => workspace.GetMeshNodeStream(typePath)
+    {
+        string? lastReason = null;
+        return workspace.GetMeshNodeStream(typePath)
             .Where(node => node is not null)
-            .Take(1)
-            .Timeout(ReadBudget)
-            .SelectMany(node =>
+            .Select(node => (Node: node!, Def: node!.ContentAs<NodeTypeDefinition>(workspace.Hub.JsonSerializerOptions)))
+            // The record must be SETTLED before it names the bytes: a compile still in flight
+            // will re-stamp it, and the store may already have moved past what it names.
+            .Where(x =>
             {
-                var def = node!.ContentAs<NodeTypeDefinition>(workspace.Hub.JsonSerializerOptions);
+                if (x.Def is null) { lastReason = "content is not a NodeTypeDefinition"; return false; }
+                lastReason = NotYetSettled(x.Def);
+                return lastReason is null;
+            })
+            .Take(1)
+            .Timeout(ReadBudget, Observable.Defer(() => Observable.Throw<(MeshNode Node, NodeTypeDefinition? Def)>(
+                new InvalidOperationException(
+                    $"bake: '{typePath}' did not settle within {ReadBudget.TotalSeconds:0}s — last seen: "
+                    + $"{lastReason ?? "no record"}. The bake ships only a record whose compile has reached "
+                    + "its terminal state and whose release requests are handled (MeshWeaver#3370)."))))
+            .SelectMany(x =>
+            {
+                var node = x.Node;
+                var def = x.Def;
                 if (def?.LastCompiledVersion is not { } version)
                     throw new InvalidOperationException(
                         $"bake: '{typePath}' settled at CompilationStatus.Ok but records no "
@@ -216,6 +264,7 @@ public static class BakeOutput
                             }));
                     });
             });
+    }
 
     /// <summary>
     /// The live source set's fingerprint for one NodeType (#2813) — the mesh-driven producer's half

--- a/tools/MeshWeaver.PluginTester/BakeOutput.cs
+++ b/tools/MeshWeaver.PluginTester/BakeOutput.cs
@@ -213,8 +213,8 @@ public static class BakeOutput
             .Timeout(ReadBudget, Observable.Defer(() => Observable.Throw<(MeshNode Node, NodeTypeDefinition? Def)>(
                 new InvalidOperationException(
                     $"bake: '{typePath}' did not settle within {ReadBudget.TotalSeconds:0}s — last seen: "
-                    + $"{lastReason ?? "no record"}. The bake ships only a record whose compile has reached "
-                    + "its terminal state and whose release requests are handled (MeshWeaver#3370)."))))
+                    + $"{lastReason ?? "no record"}. The bake ships only a record at CompilationStatus.Ok "
+                    + "with no compile in flight and every release request handled (MeshWeaver#3370)."))))
             .SelectMany(x =>
             {
                 var node = x.Node;


### PR DESCRIPTION
## The bake ships from a SETTLED record, not from the first one it sees — fixes #3370, closes the #3333 shape

`BakeEquivalenceTest` went red on #3415's first run ([34036079623](https://github.com/Systemorph/MeshWeaver/actions/runs/34036079623)) with #3333's message, finally un-truncated thanks to #3372:

```
bake: 'Widget/Thing' claims a usable build at v7 but the run's assembly store has NO bytes for it
```

That tree already carried #3341 (the store-address triple) **and** the init-gate FIFO fix, so neither is the cure, and #3409's green after merging `main` was one passing run of a flake.

### Mechanism (shard log + code)
- The package installer requests a **release** for every type it installs — the idempotence re-install too (`Widget` installed at 13:30:01.873 and 13:30:02.108).
- `ObserveNodeTypeRelease` completes when the `RequestedReleaseAt` trigger has been **written**, not when the compile it starts has finished (its own doc says so). So `RunPackages` reports, and the bake behind it reads `Widget/Thing`'s record, while that compile is in flight: release request consumed 13:30:01.924, bake verdict ~13:30:02.2, the compile's own stamp writes dying at teardown 13:30:04 (`ReleasePostCondition`, `HubDisposedBeforeResponse`).
- `CollectOne` took the **first** record it saw — its comment said *"a replay — the compile gate already saw it settle"*; it had not — and `FileSystemAssemblyStore` evicts superseded versions at write (keeps 3), so a record still naming an older version points at bytes the store no longer holds.

### Fix
`BakeOutput.CollectOne` waits for a **settled** record before naming bytes: `CompilationStatus == Ok`, `DispatchedBuildInputs` cleared (a terminal status clears it — #3390/#3405), and no release request the watcher has not handled (the watcher's own pending test, `RequestedReleaseAt` vs `LastReleaseRequestHandledAt`). If it never settles inside the read budget it fails naming what was still in flight. The claim and the payload are read as one state; no bound was raised, nothing retried. `BakeOutput.NotYetSettled` is the predicate; `NodeTypeCompilation.md` carries the rule beside the store-address triple.

**Sequencing:** the predicate leans on `DispatchedBuildInputs` being cleared on every terminal status. #3405 (merged today) clears it on the paths that reach `Ok`; #3415 (in the queue) closes two further clear-holes on failure/`Unavailable` paths — those are already refused by the `CompilationStatus` check first, so this is correct before #3415 lands, and complete after it.

### Verified
- `BakeReadsASettledRecordTest`: 7 cases (settled; pending release; in-flight compile; Pending/Compiling/Error; never-requested).
- `PluginTester.Test` bake suites — `BakeEquivalenceTest`, `BakeOutputTest`, `BakeGateSplitTest` + the new test: 13/13 on a Release `-warnaserror` build, 0 errors.
- The race is not deterministically reproducible locally (it needs the release compile to land its upload inside the bake's read window); the predicate is what is pinned, the mechanism is what the log shows.

No What's New: the CI bake's read, nothing a portal user sees.

Pairs-with: none — one `internal` helper added in the tester; no public surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
