### PR TITLE
ci(allow): drop the stale Rail record-signature allow entry (#3414 has merged) — unblocks the queue

### DIFF
--- a/scripts/record-signatures.allow
+++ b/scripts/record-signatures.allow
@@ -10,4 +10,3 @@
 #
 # Example:
 #   BurstAggregation  #2234 — bundles republished in the same wave, image rolled after
-Rail  #3406 — SuppliedNavigationRail.Rail: the two order-losing buckets (Pages, Groups) become one ordered Items sequence. Nothing outside core binds it: `SuppliedNavigationRail` has 3 org-wide code-search hits, all in this repo, and 0 in MeshWeaver.Plugins' whole origin/main tree (node sources included), so there is no module to rebuild and the atomic move is already complete. Pages/Groups survive as [Obsolete] computed properties for in-mesh callers no grep can see; only the PRIMARY constructor, which nothing can be shown to call, changes. DELETE THIS LINE in the change right after #3414 merges.


### PR DESCRIPTION
## The queue is red on a stale allow entry

`scripts/record-signatures.allow` carries the `Rail` line from #3406, whose own text says *DELETE THIS LINE in the change right after #3414 merges*. #3414 merged at 13:38Z and the line stayed, so `Public surface (binary compatibility)` now reds on every PR and merge-queue build that touches C# — #3415 (queue run 34037425197), #3418 (34037343949), #3420 — with:

```
✗ scripts/record-signatures.allow lists `Rail`, but its primary constructor no longer differs.
🚨 0 binary-breaking record change(s), 1 stale allow entr(ies).
```

while main itself reads green because its gate was reuse-skipped on 7812631a5. Same shape as the recorded `type-forwards.allow` trap: an allow entry goes stale the moment its PR merges.

One line removed; the file is empty of entries again. `check-record-signatures.py --self-test` unchanged.

Pairs-with: none — a CI allow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)