### PR TITLE
fix: ActivityTrackerQuiesceTest waited a scheduler turn, not for the condition

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
@@ -101,6 +101,13 @@ public sealed class ActivityTracker : IDisposable
     /// Registers one run as in flight. Dispose the returned handle when the run reaches a TERMINAL
     /// state (succeeded or failed) — not when it was merely dispatched. A double dispose does not
     /// double-decrement.
+    ///
+    /// <para>🚨 <b>The effect is QUEUED, not immediate.</b> The delta goes through
+    /// <c>ObserveOn(scheduler)</c> before <see cref="InFlightChanges"/> or <see cref="WhenIdle"/>
+    /// reflect it — that queueing is how this type serialises without locking. So a caller that
+    /// registers a run and immediately reads either observable can still see the PREVIOUS count:
+    /// <see cref="WhenIdle"/> subscribed right after <c>Track()</c> may fire on the replayed value.
+    /// Wait for <see cref="InFlightChanges"/> to show the run before depending on it.</para>
     /// </summary>
     public IDisposable Track() => TrackRun("(unlabelled run)", cancel: null);
 

--- a/test/MeshWeaver.Hosting.Test/ActivityTrackerQuiesceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ActivityTrackerQuiesceTest.cs
@@ -124,6 +124,24 @@ public class ActivityTrackerQuiesceTest
     {
         using var tracker = new ActivityTracker();
         var registration = tracker.Track();
+
+        // 🚨 Track() QUEUES its delta; it does not apply it. The count pipeline is
+        // `deltas.ObserveOn(scheduler).Scan(...).StartWith(0).Replay(1)`, so the +1 lands on the
+        // tracker's scheduler AFTER Track() has returned. Subscribing to WhenIdle before it lands
+        // sees the replayed 0 and fires at once — "a tracked run holds idle open" then reads False
+        // through no fault of the tracker.
+        //
+        // This test used to bridge that gap with a single `await Task.Yield()`, i.e. it asserted on
+        // a race and passed only while the scheduler happened to win. It is not theoretical: adding
+        // FIFTY-FIVE LINES OF UNCALLED CODE to MeshWeaver.Mesh.Contract (the assembly ActivityTracker
+        // itself lives in) moved the timing enough to fail this 4 runs in 5, against 0 in 15 on the
+        // unmodified tree. Any change to that assembly can do it.
+        //
+        // So wait for the condition the assertion depends on — the count actually reaching 1 —
+        // instead of for a scheduler turn.
+        await tracker.InFlightChanges.Where(running => running == 1).FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(5)).Await(TestContext.Current.CancellationToken);
+
         var idle = tracker.WhenIdle.FirstAsync().Timeout(TimeSpan.FromSeconds(5)).Await(TestContext.Current.CancellationToken);
         await Task.Yield();
         idle.IsCompleted.Should().BeFalse("a tracked run holds idle open");


### PR DESCRIPTION
`ActivityTrackerQuiesceTest.Track_StillCounts_AndWhenIdleFiresOnRelease` asserted
`idle.IsCompleted == false` after a single `await Task.Yield()`. That is an assertion about a race,
and it passed only while the scheduler happened to win.

## Why the yield was never enough

`ActivityTracker` applies its deltas through a scheduler **by design** — that queueing is how it
serialises without locking:

```csharp
counts = deltas
    .ObserveOn(scheduler)
    .Scan(0, (running, delta) => running + delta)
    .StartWith(0)
    .Replay(1);
```

So `Track()` **queues** its `+1`; it does not apply it. Subscribing to `WhenIdle` before that lands
sees the replayed `0` and fires immediately, and the assertion reads `False` — through no fault of
the tracker. (`IsCompleted` is also true for a faulted or cancelled task, so the failure message
could not distinguish those either.)

## The measurement — this is the part that matters

| tree | ActivityTracker failures |
|---|---|
| unmodified | **0 in 15 runs** |
| + 55 lines of **uncalled** code in `MeshWeaver.Mesh.Contract` | **4 in 5 runs** |

`Mesh.Contract` is the assembly `ActivityTracker` itself lives in, so **any** change to it can move
the timing — code nobody calls is enough. That makes this suite's green partly a property of the
current bytes rather than of the code being correct.

I found it while attributing a red on an unrelated branch, and it took four experiments to stop
blaming my own change:

1. baseline vs branch — baseline 0/10, branch 4/5;
2. **load-controlled alternation** (base and branch back-to-back, same machine conditions) — baseline
   0/5, branch 2/5, so it was not ambient load;
3. removing my new tests so the suite composition matched exactly at 356 — still failed, so it was
   not test ordering;
4. bisecting to the **additive class alone** — 4/5, which is only possible if the cause is timing.

## The fix

Wait for the condition the assertion depends on — the count actually reaching 1 — rather than for a
scheduler turn:

```csharp
await tracker.InFlightChanges.Where(running => running == 1).FirstAsync()
    .Timeout(TimeSpan.FromSeconds(5)).Await(TestContext.Current.CancellationToken);
```

`Track()` also gains a doc note stating that its effect is **queued**, because the next test author
will otherwise assume the same synchrony this one did. That is the durable half: the contract was
real and undocumented, and the test encoded the wrong assumption about it.

## Verification

| | failures |
|---|---|
| fixed, unperturbed | **0 in 5** |
| fixed, same perturbation re-applied | **0 in 5** (was 4/5) |

Release `-warnaserror`: `0 Error(s)`.

`Pairs-with: none` — one test and one doc comment; no public surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
