### PR TITLE
fix(#890): the emit-dead attribution reaches the sink CI keeps, and leg 3 reads both polarities

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -2938,6 +2938,71 @@ internal static class NodeTypeCompilationHelpers
             && EmitPipeline.IsProcessEmitFailure(error.Data[EmitPipeline.EmitCanaryDataKey]));
 
     /// <summary>
+    /// Reports a terminal compile outcome that reached NO VERDICT — the two shapes
+    /// <see cref="IsAvailabilityNonVerdict"/> admits, told apart because only one of them is a
+    /// statement about the whole PROCESS.
+    ///
+    /// <para>Extracted from <see cref="RunCompile"/>'s terminal handler so the record this writes
+    /// is assertable. The thing worth asserting is not the wording: it is that the #890 line
+    /// carries the EXCEPTION OBJECT, because that is what decides which CI sink can ever see
+    /// it.</para>
+    ///
+    /// <para>🚨 <b>An attribution line that reaches no durable sink is not attribution.</b> A CI
+    /// shard has two sinks and they are not equivalent. The job log is written post-hoc and
+    /// carries only the output of tests that FAILED — and #890's first canary record is routinely
+    /// printed under a test that PASSED (measured: <c>CreateLayoutAreaIntegrationTest…</c> in the
+    /// calibrated core occurrence, which was not one of that shard's five failures). The complete
+    /// sink is the phase trace <c>_meshweaver-test-trace.log</c>, and it takes a record if and only if
+    /// <c>exception is not null &amp;&amp; logLevel &gt;= Warning</c>
+    /// (<c>XUnitFileLogger.Log</c> → <c>TestTraceLog.AppendFault</c>). This line was logged with
+    /// no exception, so it could not reach the trace <b>by construction</b> — while its quieter
+    /// sibling, <c>"Compile failure for {HubPath}"</c>, passes <c>outcome.Error</c> and always
+    /// does. The loudest statement this defect produces was the least durable one, and the
+    /// documented detector pattern <c>PROCESS CANNOT EMIT</c> was a guaranteed zero on the sink
+    /// the triage docs call authoritative. Passing the exception is the whole fix, and it is the
+    /// same one #612 already applied to the sibling call three lines away.</para>
+    ///
+    /// <para>The <see cref="LogLevel.Information"/> branch is deliberately left as it is: an
+    /// availability fact about one node is not an error, its level is a production cost contract,
+    /// and it is not a statement about the process that anyone needs to find later.</para>
+    /// </summary>
+    /// <param name="logger">The pipeline's logger; <c>null</c> in the unit-test shape.</param>
+    /// <param name="hubPath">The node whose compile aborted.</param>
+    /// <param name="error">The terminal exception — never <c>null</c> on this path.</param>
+    internal static void LogTerminalNonVerdict(ILogger? logger, string hubPath, Exception error)
+    {
+        // 🚨 ATTRIBUTION for the emit-dead case (#890). One poisoned process reports as up to ten
+        // unrelated test names — 23 % of all distinct failing test names in the 08-22→08-29 sweep —
+        // and each occurrence has cost a fresh, always-identical misdiagnosis. The canary already
+        // KNOWS the process is the broken thing at the first throw; nothing said so in a form the
+        // next reader could act on. This line is that statement, and it is deliberately louder than
+        // its sibling: an Information line about one node does not describe a process that can no
+        // longer compile anything, and every compile after it in this process will fail the same
+        // way for the same reason.
+        if (EmitPipeline.IsProcessEmitFailure(error.Data[EmitPipeline.EmitCanaryDataKey]))
+            logger?.LogError(
+                // The exception OBJECT, not just its message: it is the sole reason this record
+                // reaches `_meshweaver-test-trace.log`, the one sink that does not depend on
+                // whichever test happened to be running having FAILED. See the class remark above.
+                error,
+                "PROCESS CANNOT EMIT (#890) — the compile of {HubPath} aborted inside "
+                + "Roslyn's emit, and the canary's control compilation (trivial, freshly "
+                + "parsed, known-good) could not emit either. This says NOTHING about that "
+                + "type's code: it is left at Unavailable, no verdict is recorded and the "
+                + "park budget is untouched. 🚨 EVERY LATER COMPILE IN THIS PROCESS WILL "
+                + "FAIL THE SAME WAY — attribute the failures that follow to this line, not "
+                + "to the change under test, and do not re-diagnose them one by one. "
+                + "Verdict: {Verdict}",
+                hubPath, error.Data[EmitPipeline.EmitCanaryDataKey]);
+        else
+            logger?.LogInformation(
+                "Compile for {HubPath} reached NO VERDICT ({Type}) — an availability fact, "
+                + "not a compile failure: it does not count towards the park budget and the "
+                + "type is left at Unavailable for the automatic re-drive to retry. {Error}",
+                hubPath, error.GetType().Name, error.Message);
+    }
+
+    /// <summary>
     /// THE terminal stamp of a FAILED compile — the exact field set <see cref="RunCompile"/>'s
     /// write-back has always applied on failure, extracted for the same one-stamp-shape reason
     /// as <see cref="ApplyCompileSuccess"/>.
@@ -3329,34 +3394,10 @@ internal static class NodeTypeCompilationHelpers
                             parkRegistry.OnCompileSucceeded(hubPath);
                         else if (IsAvailabilityNonVerdict(outcome.Error))
                         {
-                            // 🚨 ATTRIBUTION for the emit-dead case (#890). One poisoned process
-                            // reports as up to ten unrelated test names — 23 % of all distinct
-                            // failing test names in the 08-22→08-29 sweep — and each occurrence has
-                            // cost a fresh, always-identical misdiagnosis. The canary already KNOWS
-                            // the process is the broken thing at the first throw; nothing said so in
-                            // a form the next reader could act on. This line is that statement, and
-                            // it is deliberately louder than its sibling: an Information line about
-                            // one node does not describe a process that can no longer compile
-                            // anything, and every compile after it in this process will fail the
-                            // same way for the same reason.
-                            if (EmitPipeline.IsProcessEmitFailure(
-                                    outcome.Error!.Data[EmitPipeline.EmitCanaryDataKey]))
-                                logger?.LogError(
-                                    "PROCESS CANNOT EMIT (#890) — the compile of {HubPath} aborted inside "
-                                    + "Roslyn's emit, and the canary's control compilation (trivial, freshly "
-                                    + "parsed, known-good) could not emit either. This says NOTHING about that "
-                                    + "type's code: it is left at Unavailable, no verdict is recorded and the "
-                                    + "park budget is untouched. 🚨 EVERY LATER COMPILE IN THIS PROCESS WILL "
-                                    + "FAIL THE SAME WAY — attribute the failures that follow to this line, not "
-                                    + "to the change under test, and do not re-diagnose them one by one. "
-                                    + "Verdict: {Verdict}",
-                                    hubPath, outcome.Error.Data[EmitPipeline.EmitCanaryDataKey]);
-                            else
-                                logger?.LogInformation(
-                                    "Compile for {HubPath} reached NO VERDICT ({Type}) — an availability fact, "
-                                    + "not a compile failure: it does not count towards the park budget and the "
-                                    + "type is left at Unavailable for the automatic re-drive to retry. {Error}",
-                                    hubPath, outcome.Error!.GetType().Name, outcome.Error.Message);
+                            // Both no-verdict shapes report through ONE extracted, assertable
+                            // funnel — the #890 attribution line has to carry the exception object
+                            // or it reaches no durable CI sink at all. See LogTerminalNonVerdict.
+                            LogTerminalNonVerdict(logger, hubPath, outcome.Error!);
                         }
                         else
                         {

--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -458,15 +458,47 @@ public static class EmitPipeline
     ///     Cci explicit interface implementation does not, called DIRECTLY. #890 then reproduces in
     ///     one property call with no emit, no metadata writer and no PE stream: the smallest repro
     ///     this defect has ever had, and the one a <c>dotnet/runtime</c> report needs.</item>
-    ///   <item><c>dissect=READS-HEALTHY</c> — BOTH reads return the right answer, on freshly bound
-    ///     symbols, microseconds after <c>Emit</c> threw on exactly this shape. A corrupted object
-    ///     graph does not predict that; code that is only wrong when reached from
-    ///     <c>MetadataWriter</c>'s own call site does — which is what the split-arm
-    ///     <c>DOTNET_TieredPGO=0</c> re-run tests.</item>
+    ///   <item><c>dissect=GUARD-READ-BROKEN</c> — the TOP-LEVEL type's <c>ContainingType</c> reads
+    ///     NON-null when it is null by construction. That is the read
+    ///     <c>AsNestedTypeDefinitionImpl</c>'s guard makes, and a wrong TRUE there is on its own
+    ///     sufficient to produce #890 — see the polarity note below.</item>
+    ///   <item><c>dissect=READS-HEALTHY</c> — ALL THREE reads return the right answer, on freshly
+    ///     bound symbols, microseconds after <c>Emit</c> threw on exactly this shape. Neither a
+    ///     corrupted object graph nor a broken guard read predicts that; code that is only wrong
+    ///     when reached from <c>MetadataWriter</c>'s own call site does — which is what the
+    ///     split-arm <c>DOTNET_TieredPGO=0</c> re-run tests.</item>
     ///   <item><c>dissect=UNAVAILABLE(…)</c> — the probe could not run (a Roslyn shape change, an
     ///     unbindable canary). Its OWN verdict, never folded into the others: the
     ///     <c>INCONCLUSIVE</c> lesson one layer further in.</item>
     /// </list>
+    ///
+    /// <para>🚨 <b>BOTH POLARITIES, because the read that fails is a NULL that must stay null.</b>
+    /// This leg shipped reading only <c>Leaf.ContainingType</c> and <c>Inner.ContainingType</c> —
+    /// two reads that must come back NON-null — and the first two readings it ever produced
+    /// (2026-09-05 and 2026-09-06, both <c>READS-HEALTHY</c>) were earned on that half alone. But
+    /// look at what the metadata writer actually does:
+    /// <code>
+    /// // AsNestedTypeDefinitionImpl — the GUARD
+    /// if ((object)ContainingType != null &amp;&amp; IsDefinition &amp;&amp; ContainingModule == …) return this;
+    /// // ITypeDefinitionMember.ContainingTypeDefinition — reached ONLY when the guard said TRUE
+    /// return ContainingType.GetCciAdapter();          // NRE iff ContainingType is null
+    /// </code>
+    /// <c>getConsolidatedTypeParameters</c> recurses up the containing chain and calls these two
+    /// back to back on the same object, so it walks Leaf → Inner → <c>MwEmitCanary</c> — and at the
+    /// TOP-LEVEL type the guard is supposed to answer FALSE and stop the recursion. If that read
+    /// answers TRUE, the property is then called on a type whose <c>ContainingType</c> is null
+    /// <i>correctly</i>, and it throws the #890 NRE at the #890 frame. <b>No corrupted symbol and
+    /// no pair of disagreeing reads is required for that</b> — which is the framing this issue has
+    /// carried since 2026-08-13. A probe that only ever asks "does a non-null read come back
+    /// non-null" cannot see it, and would report a process broken in exactly that way as
+    /// <c>symbol:OK</c>. So the top-level read is made too, and it must come back NULL.</para>
+    ///
+    /// <para>🚨 The Cci leg stays on the NESTED type on purpose. On a perfectly healthy process,
+    /// <c>get_ContainingTypeDefinition</c> called on a TOP-LEVEL type throws a
+    /// <see cref="NullReferenceException"/> at the exact frame every #890 stack names — correctly,
+    /// because the containing type really is null. Probing it there would manufacture this
+    /// defect's signature on every healthy run. The frame is not the finding; the metadata writer
+    /// having REACHED it is.</para>
     ///
     /// <para>🚨 A local control (our own nested generic + explicit interface implementation) was
     /// considered and deliberately left out. Its failing branch would be informative, but its
@@ -499,9 +531,24 @@ public static class EmitPipeline
             // The ordinary, public route to the very property the NRE is thrown from.
             var inner = leaf.ContainingType;
             var outer = inner?.ContainingType;
-            symbolLeg = inner is null ? "symbol:NULL@Leaf.ContainingType"
-                : outer is null ? "symbol:NULL@Inner.ContainingType"
-                : "symbol:OK";
+
+            // 🚨 THE THIRD READ, AND IT IS THE OPPOSITE POLARITY. The two reads above assert that a
+            // non-null containing type reads non-null. The read `MetadataWriter` actually dies
+            // behind is the other one: `AsNestedTypeDefinitionImpl`'s guard asks
+            // `(object)ContainingType != null` on a type whose ContainingType is legitimately NULL
+            // — the TOP-LEVEL one — and only calls `get_ContainingTypeDefinition` when that answers
+            // TRUE. A guard that wrongly answers TRUE for a top-level type sends the writer
+            // straight into `return this.ContainingType.GetCciAdapter()` on a genuine null, which
+            // IS the #890 NRE, at the #890 frame, with no "two reads disagree" needed at all.
+            // Omitting this read made `READS-HEALTHY` unearned: a process whose null-reads-non-null
+            // is broken would still answer `symbol:OK` on the two reads above and be reported
+            // healthy. Same defect as a control that only ever exercises the populated case.
+            var topLevel = outer?.ContainingType;
+
+            symbolLeg = ClassifySymbolReads(
+                leafContainer: inner is not null,
+                innerContainer: outer is not null,
+                topLevelContainer: topLevel is not null);
         }
         catch (Exception bindError)
         {
@@ -509,7 +556,23 @@ public static class EmitPipeline
                 + "binding the canary source, so no read was attempted)";
         }
 
+        // 🚨 The Cci leg is probed on LEAF — a genuinely NESTED type — and never on the top-level
+        // one. On a HEALTHY process `get_ContainingTypeDefinition` throws exactly the #890
+        // NullReferenceException at exactly the #890 frame when called on a top-level type, because
+        // its ContainingType is correctly null. The frame is therefore NOT diagnostic on its own;
+        // what is diagnostic is that the METADATA WRITER reached it. Probing the top-level type
+        // here would manufacture that stack on every healthy process.
         var cciLeg = ProbeCciContainingTypeDefinition(leaf);
+
+        if (symbolLeg.StartsWith("symbol:NON-NULL", StringComparison.Ordinal))
+            return $"dissect=GUARD-READ-BROKEN {symbolLeg} {cciLeg} — the TOP-LEVEL source type's "
+                + "ContainingType reads NON-NULL when it is null by construction, on a compilation "
+                + "created AFTER the fault, with no emit involved. That is precisely the read "
+                + "AsNestedTypeDefinitionImpl's guard makes, and a wrong TRUE there hands "
+                + "MetadataWriter a top-level type to call ITypeDefinitionMember."
+                + "ContainingTypeDefinition on — whose NRE on a genuine null IS #890, needing no "
+                + "corrupted symbol and no divergent pair of reads. #890 reproduces here in ONE "
+                + "property read: take this to dotnet/runtime";
 
         if (symbolLeg != "symbol:OK")
             return $"dissect=SYMBOL-GRAPH-BROKEN {symbolLeg} {cciLeg} — ContainingType reads NULL "
@@ -523,18 +586,45 @@ public static class EmitPipeline
                 + "Cci leg could not be reached, so the discriminator did not run";
 
         if (cciLeg.StartsWith("cci:OK", StringComparison.Ordinal))
-            return $"dissect=READS-HEALTHY {symbolLeg} {cciLeg} — BOTH reads, including the exact "
-                + "ITypeDefinitionMember.ContainingTypeDefinition frame every #890 stack dies in, "
-                + "return the right answer when called DIRECTLY on symbols bound after the fault. "
-                + "A corrupted object graph does not predict that; code that is wrong only when "
-                + "reached from MetadataWriter's call site does — run the split-arm "
-                + "DOTNET_TieredPGO=0 re-run";
+            return $"dissect=READS-HEALTHY {symbolLeg} {cciLeg} — ALL of it reads correctly on "
+                + "symbols bound after the fault: nested ContainingType reads non-null, TOP-LEVEL "
+                + "ContainingType reads NULL (the read AsNestedTypeDefinitionImpl's guard makes), "
+                + "and the exact ITypeDefinitionMember.ContainingTypeDefinition frame every #890 "
+                + "stack dies in answers correctly when called DIRECTLY. Neither a corrupted object "
+                + "graph nor a wrong guard read predicts that; code that is wrong only when reached "
+                + "from MetadataWriter's own call site — where both of those are INLINED into "
+                + "getConsolidatedTypeParameters — does. That is what the split-arm "
+                + "DOTNET_TieredPGO=0 re-run tests";
 
         return $"dissect=REPRODUCED-OUTSIDE-EMIT {symbolLeg} {cciLeg} — the public ContainingType "
             + "reads correctly while the Cci explicit interface implementation on the SAME symbol "
             + "does not, called directly. #890 reproduces here in ONE property call, with no emit, "
             + "no metadata writer and no PE stream: take these two readings to dotnet/runtime";
     }
+
+    /// <summary>
+    /// Reduces leg 3's three <c>ContainingType</c> reads on <c>MwEmitCanary&lt;T&gt;.Inner&lt;U&gt;.Leaf&lt;V&gt;</c>
+    /// to one token. Pure, so every branch — including the two polarities — is unit-testable
+    /// without a poisoned process, which is the only way the <c>NON-NULL</c> branch can be covered
+    /// at all: a healthy Roslyn cannot be made to produce it.
+    ///
+    /// <para>🚨 <b>The third parameter is the whole point.</b> Two of the reads must come back
+    /// PRESENT and the third must come back ABSENT, because a top-level type has no containing
+    /// type — and that absent read is the one <c>AsNestedTypeDefinitionImpl</c>'s guard makes
+    /// before the metadata writer calls the property that #890 dies in. A classification that took
+    /// only the first two would answer <c>symbol:OK</c> for a process broken in exactly the
+    /// direction that produces this defect.</para>
+    /// </summary>
+    /// <param name="leafContainer"><c>Leaf&lt;V&gt;.ContainingType</c> resolved — expected TRUE.</param>
+    /// <param name="innerContainer"><c>Inner&lt;U&gt;.ContainingType</c> resolved — expected TRUE.</param>
+    /// <param name="topLevelContainer"><c>MwEmitCanary&lt;T&gt;.ContainingType</c> resolved —
+    /// expected FALSE: its container is the global namespace, which is not a type.</param>
+    internal static string ClassifySymbolReads(
+        bool leafContainer, bool innerContainer, bool topLevelContainer)
+        => !leafContainer ? "symbol:NULL@Leaf.ContainingType"
+            : !innerContainer ? "symbol:NULL@Inner.ContainingType"
+            : topLevelContainer ? "symbol:NON-NULL@MwEmitCanary.ContainingType"
+            : "symbol:OK";
 
     /// <summary>
     /// Calls <c>NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition()</c>

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -977,9 +977,40 @@ directly, on symbols bound **after** the fault, with no emit, no metadata writer
 | verdict | what it means | where it sends triage |
 |---|---|---|
 | `dissect=SYMBOL-GRAPH-BROKEN` | the ordinary `ContainingType` property reads **null** for a nested source type | the broken read is the property, not emit — every consumer of a nested symbol in the process is affected |
+| `dissect=GUARD-READ-BROKEN` | the **top-level** type's `ContainingType` reads **non-null**, when it is null by construction | that is the read `AsNestedTypeDefinitionImpl`'s guard makes — #890 in ONE property read, needing no corrupted symbol at all (see the polarity note below) |
 | `dissect=REPRODUCED-OUTSIDE-EMIT` | the public property reads correctly, the Cci explicit interface implementation on the **same symbol** does not | #890 in ONE property call — the smallest repro it has ever had, and what a `dotnet/runtime` report needs |
-| `dissect=READS-HEALTHY` | **both** reads answer correctly, microseconds after `Emit` threw on this exact shape | a corrupted object graph does not predict that; code that is wrong only when reached from `MetadataWriter`'s call site does — run the split-arm `DOTNET_TieredPGO=0` re-run |
+| `dissect=READS-HEALTHY` | **all three** reads answer correctly, microseconds after `Emit` threw on this exact shape | neither a corrupted object graph nor a wrong guard read predicts that; code that is wrong only when reached from `MetadataWriter`'s call site — where both reads are INLINED into `getConsolidatedTypeParameters` — does. Run the split-arm `DOTNET_TieredPGO=0` re-run |
 | `dissect=UNAVAILABLE(…)` | the probe could not run | its **own** verdict, never folded into the others |
+
+##### 🚨 Both polarities — the read that fails is a NULL that must stay null
+
+Leg 3 shipped reading only `Leaf<V>.ContainingType` and `Inner<U>.ContainingType`, **two reads that
+must come back NON-null**, and the first two readings it ever produced were earned on that half
+alone. Look at what the metadata writer actually does, though:
+
+```csharp
+// AsNestedTypeDefinitionImpl — the GUARD
+if ((object)ContainingType != null && IsDefinition && ContainingModule == …) return this;
+// ITypeDefinitionMember.ContainingTypeDefinition — reached ONLY when the guard answered TRUE
+return ContainingType.GetCciAdapter();          // NRE iff ContainingType is null
+```
+
+`getConsolidatedTypeParameters` recurses **up the containing chain**, calling those two back to back
+on the same object, so it walks `Leaf` → `Inner` → `MwEmitCanary` — and at the **top-level** type the
+guard is supposed to answer FALSE and stop. **If that read answers TRUE, the property is then called
+on a type whose `ContainingType` is null *correctly*, and it throws the #890 NRE at the #890 frame.**
+No corrupted symbol, and no pair of disagreeing reads, is required — which is the framing this issue
+had carried since 2026-08-13 (*"two reads of a readonly reference field, no writer in between,
+different answers"*). A probe that only asks *"does a non-null read come back non-null"* cannot see
+that shape and reports it as `symbol:OK`. The top-level read is now made too, and it must come back
+NULL; the classification is a pure function so the branch a healthy Roslyn can never produce is still
+covered by a test.
+
+🚨 **The Cci leg deliberately stays on the NESTED type.** On a perfectly healthy process,
+`get_ContainingTypeDefinition` called on a top-level type throws a `NullReferenceException` at the
+exact frame every #890 stack names — correctly, because the containing type really is null. Probing
+it there would manufacture this defect's signature on every healthy run. **The frame is not the
+finding; the metadata writer having REACHED it is.**
 
 🚨 **`UNAVAILABLE` is the branch that has to stay impossible on a healthy process.** Leg 3 reaches
 Roslyn's internal symbol model by reflection (`PublicModel.Symbol.UnderlyingSymbol`, then the
@@ -999,6 +1030,48 @@ green means nothing is the shape this canary keeps having to remove.
 `DOTNET_TieredPGO=0` (sharper) or `DOTNET_TieredCompilation=0`, and read it together with the
 `dissect=` line. At ~1 % per run a single clean arm proves nothing — that caveat is part of the
 instruction, because an experiment stated without it gets read as a fix.
+
+#### The first `dissect=` readings, 2026-09-06 — and what they do and do not settle
+
+Leg 3 landed 2026-09-04 and its first readings arrived immediately. Two occurrences, both in
+MeshWeaver.Plugins `Plugin Catalog CI`, both on platform commits that carry leg 3:
+
+| occurrence | run / job | shard | first poisoned type | ending |
+|---|---|---|---|---|
+| 2026-09-05 19:34Z | [`33986905290`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33986905290) / `101362087452` | 3 | `type/CleanType12835552…` | `exit=124` |
+| 2026-09-06 05:50Z | [`34014658302`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34014658302) attempt 1 / `101436270797` | 2 | `TestData/SelfHeal4b9026c1…` | `17 failing tests` |
+
+**Every reading, in both sinks of both occurrences, is `dissect=READS-HEALTHY symbol:OK cci:OK`** —
+78/78 and 53/53 for the first, 62/62 and 28/28 for the second; **zero** `SYMBOL-GRAPH-BROKEN`,
+`REPRODUCED-OUTSIDE-EMIT`, `UNAVAILABLE` or `NOT-RUN`. All faults in each occurrence carry one pid
+(`3033`, `2800`).
+
+🚨 **Read that verdict against what leg 3 measured at the time, not against what it names.** Those
+readings were produced by the two NON-null reads only — the top-level, null-polarity read is added by
+this change, and a process broken in that direction would have answered `symbol:OK` too. So the two
+`READS-HEALTHY` readings **exclude a symbol graph whose nested containers read null**, and they do
+**not yet** exclude a guard read that answers TRUE for a top-level type. The next occurrence, on a
+platform commit carrying the third read, is the first one whose `READS-HEALTHY` means what the word
+says.
+
+**Two things the readings do settle**, and they are worth having:
+
+- `get_ContainingTypeDefinition` **called directly** — the exact frame every #890 stack dies in —
+  answers correctly on symbols bound microseconds after `Emit` threw on that very shape. The
+  method's own compiled body is not the broken thing.
+- Combined with `BELOW-ROSLYN` (references, mappings and source already excluded), what is left is
+  code that is wrong only where `MetadataWriter` reaches it — i.e. the **inlined** copies of the
+  guard and the property inside `getConsolidatedTypeParameters`. **That is the split-arm
+  `DOTNET_TieredPGO=0` hypothesis, and it remains UNTESTED.**
+
+🚨 **Two sweep traps this measurement walked into, both worth inheriting.** `GET
+/actions/runs/{id}/jobs` defaults to `filter=latest`, so attempt-1 shard jobs of a re-run run are
+invisible — the 2026-09-06 occurrence is on attempt 1 of a run whose **overall conclusion is
+`success`**, because attempt 2 re-ran that shard and passed. A sweep over non-success jobs of the
+latest attempt finds only the first occurrence. And the trace artifact is written only when a suite
+FAILED (measured: 29 of 609 `teardown-stragglers-*` artifacts carry
+`_meshweaver-test-trace.log`), so **both** known sinks are failure-gated: an occurrence that reddened
+no test would be invisible to either.
 
 #### The rate has not moved — a null here is worth ~half a coin toss
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -483,6 +483,29 @@ Plugins shard"* — with a real occurrence rather than an argument.
 occurrence's own report published. A detector that cannot reproduce those numbers is not entitled to
 report a zero.
 
+🚨 **One of those four patterns was a guaranteed ZERO on the authoritative sink, and the loudest line
+was the least durable one.** The trace log takes a record if and only if
+`exception is not null && logLevel >= Warning` (`XUnitFileLogger.Log` → `TestTraceLog.AppendFault`).
+`PROCESS CANNOT EMIT (#890)` — the `LogError` whose entire job is *"attribute the failures that
+follow to this line, not to the change under test"* — was logged with **no exception object**, so it
+could never reach the trace **by construction**, while its quieter `LogWarning` sibling
+(`Compile failure for {HubPath}`, which passes the error and carries the whole `canary=`/`dissect=`
+verdict in brackets) always did. Measured on both 2026-09-05/06 occurrences:
+
+| pattern | job log | `_meshweaver-test-trace.log` |
+|---|---|---|
+| `PROCESS CANNOT EMIT` | 25 · 25 | **0 · 0** |
+| `canary=` | 78 · 62 | 55 · 28 |
+| `Compile failure for` | — | 54 · 31 |
+
+Since the job log carries only FAILED tests' output and this defect's first canary record is
+routinely logged under a test that PASSED, an occurrence could reach **neither** sink with its
+attribution intact. Fixed by passing the exception (the same thing #612 already did to the sibling
+call three lines away), so the record now satisfies the trace sink's gate — the general lesson being
+that **for a fault the trace log is the sink, and reaching it is a property of the CALL, not of the
+level or the wording**. An `ILogger.LogError` about an exception that does not pass the exception is
+invisible there.
+
 🚨 **And know which questions the sinks cannot answer.** *Neither* Plugins sink carries a compile
 **success**: `Compile success for …` is `LogInformation`, so the trace log (faults only) never sees
 it and the post-hoc job log never sees it either unless the test that logged it failed. Core's live

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-poisoned-compile-process-names-itself-in-the-log-ci-keeps.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-poisoned-compile-process-names-itself-in-the-log-ci-keeps.md
@@ -1,0 +1,28 @@
+---
+Name: A poisoned compile process now names itself in the log CI keeps
+Category: Fix
+Description: When one Roslyn emit leaves a process unable to compile anything else, the line that says so — and tells you not to blame the change under test — reached only a log that records failed tests. It now reaches the complete one.
+Icon: DocumentError
+Order: -20260906
+---
+
+Sometimes a single Roslyn `Emit` throws and, from that moment, **every** later compile in the same
+process fails identically. Parsing and binding keep working perfectly; only the emit is dead. One
+such event surfaces as up to a dozen unrelated test failures, and each time it has cost a fresh —
+and always identical — misdiagnosis of whatever change happened to be under test.
+
+The compile pipeline already detects this and logs one loud line saying so: *"every later compile in
+this process will fail the same way — attribute the failures that follow to this line, not to the
+change under test"*. But it logged that line **without the exception object**, and the complete log
+a CI run retains only records entries that carry one. So the loudest statement the pipeline produces
+was also its least durable: absent from that log by construction, and absent from the per-test output
+whenever the test that happened to be running had passed. Measured on two real occurrences: 25 copies
+of the line in the per-test output, **zero** in the retained log, both times.
+
+Passing the exception is the whole fix — the same thing the neighbouring call already did.
+
+The self-diagnosis that runs at the first failed emit also grew a read it was missing. It checked
+that a nested type's container reads back correctly, but never that a **top-level** type's container
+reads back as *absent* — which is precisely the check the metadata writer makes before the call that
+crashes. A process broken in that direction would have been reported healthy. It now reads both
+directions, and says which one it read.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitCanaryDissectionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitCanaryDissectionTest.cs
@@ -58,8 +58,56 @@ public class EmitCanaryDissectionTest
             + "answers UNAVAILABLE for ever and #890's discriminator is gone with nothing red");
 
         dissection.Should().StartWith("dissect=READS-HEALTHY",
-            "both legs resolved and answered, so the verdict must be the one that says the reads "
+            "every leg resolved and answered, so the verdict must be the one that says the reads "
             + "work — never UNAVAILABLE, which would mean the probe never ran");
+
+        dissection.Should().Contain("TOP-LEVEL",
+            "READS-HEALTHY must state that the null-polarity read was made. Leg 3 shipped reading "
+            + "only the two containers that must be NON-null, and the first two readings it ever "
+            + "produced (2026-09-05, 2026-09-06) were earned on that half alone — while the read "
+            + "the metadata writer's guard actually makes is the TOP-LEVEL one, which must come "
+            + "back NULL. A verdict that claims health without naming that read is claiming more "
+            + "than it measured");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The branch a healthy process can never produce, and therefore the one only a pure
+    /// function can cover.</b>
+    ///
+    /// <para><c>getConsolidatedTypeParameters</c> recurses up the containing chain calling
+    /// <c>AsNestedTypeDefinition</c> (whose guard reads <c>ContainingType != null</c>) and then
+    /// <c>ITypeDefinitionMember.ContainingTypeDefinition</c> (which dereferences the same
+    /// <c>ContainingType</c>) back to back. At the TOP-LEVEL type the guard must answer FALSE and
+    /// stop the walk. If that read answers TRUE, the property is called on a type whose
+    /// <c>ContainingType</c> is null <i>correctly</i> — and throws the #890 NRE at the #890 frame,
+    /// with no corrupted symbol and no pair of disagreeing reads. That path is invisible to a probe
+    /// that only asks whether non-null reads come back non-null.</para>
+    /// </summary>
+    [Theory]
+    // leaf   inner  topLevel      expected token
+    [InlineData(true, true, false, "symbol:OK")]
+    [InlineData(true, true, true, "symbol:NON-NULL@MwEmitCanary.ContainingType")]
+    [InlineData(false, true, false, "symbol:NULL@Leaf.ContainingType")]
+    [InlineData(true, false, false, "symbol:NULL@Inner.ContainingType")]
+    public void TheClassification_ReadsBOTHPolarities(
+        bool leaf, bool inner, bool topLevel, string expected)
+        => EmitPipeline.ClassifySymbolReads(leaf, inner, topLevel).Should().Be(expected,
+            "a top-level type has no containing type, so a NON-null read there is a fault of the "
+            + "opposite polarity to the two above — and it is the polarity #890's own stack sits "
+            + "on. Collapsing it into symbol:OK would report a broken process as healthy");
+
+    /// <summary>
+    /// The verdict the new polarity produces has to send triage somewhere different from
+    /// SYMBOL-GRAPH-BROKEN: nothing about the symbol graph is wrong in that case — the graph is
+    /// right and the READ of it is wrong, which is a one-property-call reproduction.
+    /// </summary>
+    [Fact]
+    public void AGuardReadThatAnswersTrueForATopLevelType_IsItsOwnVerdict()
+    {
+        EmitPipeline.ClassifySymbolReads(true, true, topLevelContainer: true)
+            .Should().NotBe("symbol:OK")
+            .And.NotStartWith("symbol:NULL",
+                "it is not a NULL read — it is a read that should have been null and was not");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitDeadAttributionReachesTheTraceSinkTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitDeadAttributionReachesTheTraceSinkTest.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 The #890 attribution line must carry the EXCEPTION OBJECT, because that — and nothing about
+/// its wording or its level — is what decides whether any CI artifact can ever show it.
+///
+/// <para><b>The defect.</b> A poisoned process reports as up to ten unrelated test failures; across
+/// 2026-08-22→08-29 that was 9 events wearing 37 distinct test names, 23 % of all failing test names
+/// in the week, and every occurrence cost a fresh and always-identical misdiagnosis.
+/// <c>PROCESS CANNOT EMIT (#890)</c> is the one line that exists to stop that — *"attribute the
+/// failures that follow to this line, not to the change under test"*. It was logged with **no
+/// exception**, and a CI shard's two sinks are not equivalent:</para>
+///
+/// <list type="bullet">
+///   <item>the <b>job log</b> is written post-hoc and carries only the output of tests that
+///     <b>FAILED</b> — and #890's first canary record is routinely printed under a test that
+///     PASSED (measured: <c>CreateLayoutAreaIntegrationTest.CreateArea_WithoutTypeParam_ShowsTypeSelection</c>
+///     in the calibrated core occurrence, which was not one of that shard's five failures);</item>
+///   <item>the complete sink is the phase trace <c>_meshweaver-test-trace.log</c>, which takes a
+///     record <b>if and only if</b> <c>exception is not null &amp;&amp; logLevel &gt;= Warning</c>
+///     — <c>XUnitFileLogger.Log</c> → <c>TestTraceLog.AppendFault</c>.</item>
+/// </list>
+///
+/// <para>So the loudest statement this defect produces was the <b>least durable</b> one: absent from
+/// the trace by construction, and absent from the job log whenever the test that logged it passed.
+/// Meanwhile its quieter sibling — <c>"Compile failure for {HubPath}"</c>, which passes
+/// <c>outcome.Error</c> — always survives. The documented triage pattern <c>PROCESS CANNOT EMIT</c>
+/// was therefore a guaranteed <b>zero</b> on the sink the triage docs call authoritative.</para>
+///
+/// <para>🚨 <b>What this file pins is the sink predicate, not the prose.</b> Asserting "we passed an
+/// exception" would be tautological. The assertions below evaluate the trace sink's own condition
+/// against the captured record, so the test fails for the reason that actually matters — the record
+/// would not be written to the file CI keeps. Reverting the fix (dropping the exception argument in
+/// <see cref="NodeTypeCompilationHelpers.LogTerminalNonVerdict"/>) turns
+/// <c>ProcessCannotEmit_IsRecordedByTheTraceSinkPredicate</c> red naming the sink.</para>
+///
+/// <para>The <see cref="LogLevel.Information"/> branch is deliberately NOT changed and is pinned
+/// here too: an availability fact about one node is not an error, its level is a production cost
+/// contract, and nobody needs to find it later. Only the process-wide claim is durable.</para>
+/// </summary>
+public class EmitDeadAttributionReachesTheTraceSinkTest
+{
+    private const string Site =
+        "NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition";
+
+    private static string Threw(string site = Site)
+        => $"THREW NullReferenceException at {site}: Object reference not set to an instance of an object.";
+
+    /// <summary>The real thing, built the way <c>EmitPipeline</c> builds it: the ORIGINAL exception
+    /// with the canary verdict on <see cref="Exception.Data"/>, never a wrapper.</summary>
+    private static Exception EmitThrewWith(string verdict)
+    {
+        var error = new NullReferenceException("Object reference not set to an instance of an object.");
+        error.Data[EmitPipeline.EmitCanaryDataKey] = verdict;
+        return error;
+    }
+
+    // Derived from EmitPipeline.Verdict, never hand-typed, so a wording change cannot leave this
+    // file asserting against strings that no longer exist. The two CLAIMING verdicts are the two
+    // EmitPipeline.IsProcessEmitFailure admits; DIVERGENT withholds because the legs died in
+    // different frames.
+    public static TheoryData<string, string> ClaimingVerdicts() => new()
+    {
+        { EmitPipeline.Verdict(Threw(), Threw()), "canary=BELOW-ROSLYN" },
+        { EmitPipeline.Verdict(Threw(), "OK"), "canary=REFERENCES" },
+    };
+
+    public static TheoryData<string> WithholdingVerdicts() =>
+    [
+        EmitPipeline.Verdict(Threw(), Threw("SomethingElse.Unrelated")),  // DIVERGENT
+        "canary=OK (a trivial nested-generic emit against the SAME reference set still succeeds)",
+        "canary=INCONCLUSIVE shared:THREW … pristine:UNAVAILABLE(no CoreLib on disk)",
+    ];
+
+    /// <summary>
+    /// The trace sink's gate, restated exactly as <c>XUnitFileLogger.Log</c> applies it before
+    /// <c>TestTraceLog.AppendFault</c>. A record that does not satisfy this NEVER appears in
+    /// <c>collected-logs/_meshweaver-test-trace.log</c>, whatever it says.
+    /// </summary>
+    private static bool ReachesTheTraceSink(Record record)
+        => record.Exception is not null && record.Level >= LogLevel.Warning;
+
+    /// <summary>
+    /// The fix, asserted at the sink rather than at the call. A confirmed process-wide emit failure
+    /// must produce a record the trace sink will actually write.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ClaimingVerdicts))]
+    public void ProcessCannotEmit_IsRecordedByTheTraceSinkPredicate(string verdict, string expected)
+    {
+        var logger = new RecordingLogger();
+        var error = EmitThrewWith(verdict);
+
+        NodeTypeCompilationHelpers.LogTerminalNonVerdict(logger, "TestData/BrokenType", error);
+
+        var record = Assert.Single(logger.Records);
+
+        Assert.True(ReachesTheTraceSink(record),
+            "the #890 attribution line must satisfy the trace sink's gate "
+            + "(exception is not null && level >= Warning — XUnitFileLogger.Log → "
+            + "TestTraceLog.AppendFault). Without it the line reaches ONLY the post-hoc job log, "
+            + "which carries the output of FAILED tests only — and this defect's first canary "
+            + "record is routinely logged under a test that passed, so the occurrence would be "
+            + $"attributable from no CI artifact at all. Captured: level={record.Level}, "
+            + $"exception={record.Exception?.GetType().Name ?? "<none>"}.");
+
+        // It must be THE terminal exception, not a fresh one: the stack is what a recurrence is
+        // triaged from, and #612's whole finding was that message-only logging left this
+        // undiagnosable.
+        Assert.Same(error, record.Exception);
+
+        // And it must still be the line triage greps for, carrying the verdict it is about.
+        Assert.Contains("PROCESS CANNOT EMIT (#890)", record.Message);
+        Assert.Contains(expected, record.Message);
+    }
+
+    /// <summary>
+    /// 🚨 Non-vacuity. Only two of the canary's five verdicts prove the PROCESS is at fault. A
+    /// change that made every emit-phase abort shout would hand the bake gate the blind spot
+    /// <c>SourceSnapshotEstablishmentTest.EveryOtherCompileFailure_StillStampsError</c> exists to
+    /// refuse — so the withholding verdicts must stay quiet, and stay OUT of the trace.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(WithholdingVerdicts))]
+    public void AWithholdingVerdict_StaysInformation_AndDoesNotReachTheTraceSink(string verdict)
+    {
+        var logger = new RecordingLogger();
+
+        NodeTypeCompilationHelpers.LogTerminalNonVerdict(
+            logger, "TestData/BrokenType", EmitThrewWith(verdict));
+
+        var record = Assert.Single(logger.Records);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.DoesNotContain("PROCESS CANNOT EMIT", record.Message);
+        Assert.False(ReachesTheTraceSink(record),
+            "an availability fact about ONE node is not a process-wide claim and must not be "
+            + "promoted into the fault sink — that widening is the blind spot the verdict-reading "
+            + "predicate exists to refuse.");
+    }
+
+    /// <summary>
+    /// The other availability non-verdict shape — the compile never reached Roslyn at all, so there
+    /// is no canary and nothing process-wide to claim. Pinned so the extraction cannot start
+    /// shouting about an unestablished source set.
+    /// </summary>
+    [Fact]
+    public void AnUnestablishedSourceSet_IsNotAProcessWideClaim()
+    {
+        var logger = new RecordingLogger();
+
+        NodeTypeCompilationHelpers.LogTerminalNonVerdict(
+            logger, "TestData/BrokenType", new InvalidOperationException("source set not established"));
+
+        var record = Assert.Single(logger.Records);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.False(ReachesTheTraceSink(record));
+    }
+
+    private sealed record Record(LogLevel Level, string Message, Exception? Exception);
+
+    /// <summary>Captures level, formatted message AND the exception — the third is the whole
+    /// point: the two existing recording loggers in this project drop it, which is exactly how a
+    /// missing exception argument stayed invisible.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly List<Record> records = [];
+
+        public IReadOnlyList<Record> Records => records;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => records.Add(new Record(logLevel, formatter(state, exception), exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
Relates to #890. **Deliberately not `Closes`** — the NRE is below Roslyn and neither change touches it. What these two changes fix is that #890's own instruments could not report what they were built to report.

## It still reproduces

Measured 2026-09-04T22:47Z → 2026-09-06 on MeshWeaver.Plugins `Plugin Catalog CI` (where the exposure lives; `MeshWeaver.Hosting.Monolith.Test` no longer exists in core): **168 runs → 452 `Portal hosts (shard N)` jobs → 451 logs fetched (1 unfetchable, still running), 609 `teardown-stragglers-*` artifacts all scanned. Sensitivity denominator: 226 jobs actually executed the exposure suite, in 109/109 runs. Detector calibrated on both positives (159 / 220 / 122 / 94 signature lines) and silent on a passing shard (0).**

**2 occurrences**, both `canary=BELOW-ROSLYN`:

| | run / job | shard | first poisoned type | ending |
|---|---|---|---|---|
| 2026-09-05 19:34Z | `33986905290` / `101362087452` | 3 | `type/CleanType12835552…` | `exit=124` |
| 2026-09-06 05:50Z | `34014658302` **attempt 1** / `101436270797` | 2 | `TestData/SelfHeal4b9026c1…` | `17 failing tests` |

🚨 Two sweep traps, both recorded in the docs: `GET /actions/runs/{id}/jobs` defaults to `filter=latest`, so the second occurrence — on **attempt 1 of a run whose overall conclusion is `success`** — is invisible to a sweep of latest-attempt non-success jobs. And the trace artifact is written only when a suite FAILED (29 of 609 artifacts carry one), so *both* sinks are failure-gated.

## 1. The attribution line could not reach the sink CI keeps

The trace log takes a record **iff `exception is not null && level >= Warning`** (`XUnitFileLogger.Log` → `TestTraceLog.AppendFault`). `PROCESS CANNOT EMIT (#890)` — the line whose whole job is *"attribute the failures that follow to this line, not to the change under test"* — was logged with **no exception object**.

| pattern | job log | `_meshweaver-test-trace.log` |
|---|---|---|
| `PROCESS CANNOT EMIT` | 25 · 25 | **0 · 0** |
| `canary=` | 78 · 62 | 55 · 28 |
| `Compile failure for` | — | 54 · 31 |

The job log carries only FAILED tests' output, and this defect's first canary record is routinely logged under a test that **passes** — so an occurrence could reach neither sink with its attribution intact, while its quieter `LogWarning` sibling always survived. Passing the exception is the fix, and it is the same one #612 already applied to that sibling three lines away. Extracted as `LogTerminalNonVerdict` so the record is assertable **against the sink's own predicate**, not against its wording.

## 2. Leg 3 read only one polarity — so `READS-HEALTHY` was unearned

Leg 3 landed 2026-09-04 and these are its **first readings ever**: `dissect=READS-HEALTHY symbol:OK cci:OK`, unanimously — 78/78, 53/53, 62/62, 28/28, zero of any other value.

But it read `Leaf.ContainingType` and `Inner.ContainingType`, **two reads that must come back NON-null**. The read `MetadataWriter` actually dies behind is the other one:

```csharp
// AsNestedTypeDefinitionImpl — the GUARD
if ((object)ContainingType != null && IsDefinition && ContainingModule == …) return this;
// ITypeDefinitionMember.ContainingTypeDefinition — reached ONLY when the guard said TRUE
return ContainingType.GetCciAdapter();          // NRE iff ContainingType is null
```

`getConsolidatedTypeParameters` recurses **up the containing chain**, calling those two back to back on the same object — so it reaches the **top-level** type, where the guard must answer FALSE and stop. **If that read answers TRUE, the property is then called on a type whose `ContainingType` is null *correctly*, and throws the #890 NRE at the #890 frame.** No corrupted symbol, and no pair of disagreeing reads — which is the framing this issue has carried since 2026-08-13. Leg 3 would have reported such a process as `symbol:OK`.

So the top-level read is made too and must come back NULL; a wrong TRUE gets its own verdict, `dissect=GUARD-READ-BROKEN` (a one-property-read reproduction, the smallest this defect could have). The classification is a pure function so the branch a healthy Roslyn can never produce is still covered by a test.

🚨 The Cci leg **stays on the nested type on purpose**: on a healthy process, `get_ContainingTypeDefinition` on a top-level type throws exactly this defect's NRE at exactly its frame, correctly. Probing there would manufacture the signature on every healthy run. **The frame is not the finding; the metadata writer having reached it is.**

## Falsification — counts both ways

| | passed | failed |
|---|---|---|
| both fixes in | **39** | 0 |
| revert (1) alone — exception argument dropped | 4 | **2** |
| revert (2) alone — third read dropped | 17 | **1** |

Whole project 635/635; `MeshWeaver.Documentation.Test` 279/279. Every touched project built `-c Release -warnaserror`, one per invocation, `0 Warning(s) 0 Error(s)`.

**Stated residual:** a healthy process cannot produce the `NON-NULL` branch, so the end-to-end test couples the claim to the read by asserting `READS-HEALTHY` names the top-level read; the branch itself is covered by the pure function. Someone who dropped the read *and* kept the wording would pass — that is deliberate sabotage, not a refactor slip.

## What this does not do

The mechanism is unchanged and unfixed: below Roslyn, in the CLR. The next occurrence on a platform commit carrying the third read is the first whose `READS-HEALTHY` means what the word says — and the split-arm `DOTNET_TieredPGO=0` re-run remains the untested follow-up.

Pairs-with: none — the diff removes no public type and no public member; both new members are `internal`.
