### PR TITLE
fix(#3424): the plugin tester's gate serves — and verifies — a package's content assets

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -67,6 +67,11 @@ shipped image ever contains those (see "The identity rule" below), so `doc-gate`
 What the portals adopt is baked **inside the shipped image** for the platform's content, and
 **published by each plugin repo's own `publish-bake`** for plugins — see "The delivery" below.
 
+🚨 **The gate's verdict is not assemblies alone.** A package's committed `content/**` binaries —
+course videos, posters, og cards, fonts — are installed and read back on the same run; see
+[Gate Content Assets](/Doc/Architecture/GateContentAssets) for the host shape that made them
+invisible to the gate for months, and the `content` check that now covers them.
+
 ## BAKE is a build step; GATE is a mesh run that CONSUMES one
 
 This is how the bake worked until issue #1763: `mw-plugin-test` stood up an in-process mesh

--- a/src/MeshWeaver.Documentation/Data/Architecture/GateContentAssets.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GateContentAssets.md
@@ -1,0 +1,129 @@
+---
+nodeType: Markdown
+name: Gate Content Assets
+category: Architecture
+description: Why a package's committed content/** binaries are part of the node-repo gate's verdict, and the host shape that made them invisible to it for months.
+icon: /static/NodeTypeIcons/box.svg
+---
+
+# Gate Content Assets
+
+A package ships more than nodes. Its **binaries** — course videos and their posters, og cards,
+fonts — are ordinary files committed under `{package}/content/**`, and installing the package is
+only half-done until they are being *served*. The other half is
+[`PackageInstaller.SyncPackageContent`](/Doc/Architecture/CqrsAndContentAccess): it classifies those
+files with `ContentAssetMapper`, and posts **one `SyncContentFilesRequest` to the package's
+partition ROOT**, where a portal mounts the `content` collection that children inherit.
+
+This page is about the host shape that request needs, and about what the `mw-plugin-test` gate now
+asserts because of it (issue #3424).
+
+---
+
+## The handler comes from exactly one place
+
+`SyncContentFilesRequest` is handled by `ContentImportExtensions.AddContentImportHandler`, which is
+reached **only** through `AddContentCollections()` / `AddContentCollectionsInfrastructure()`. So a
+per-node hub either called one of those or it answers *"No handler found for message type
+`SyncContentFilesRequest`"* — a `DeliveryFailure`, not a content verdict.
+
+Three hosts, three different answers, and it is worth being precise about which is which:
+
+| Host | Where the handler comes from | Where the `content` collection comes from |
+|---|---|---|
+| Portal (`memex`, `memex-cloud`) | `MemexConfiguration`'s `ConfigureDefaultNodeHub` maps `attachments` on **every** per-node hub, which calls `AddContentCollections()` | the same lambda mounts a writable `content` collection on the partition ROOT only (`!nodePath.Contains('/')`), `ExposeInChildren = true` |
+| A `Space`-typed root anywhere | `SpaceNodeType`'s own `HubConfiguration` calls `AddContentCollections()` | nothing — the handler answers, then fails *"Target content collection 'content' not found"* |
+| The gate mesh, before #3424 | nothing: `AddGraph()`'s default node chain does not call it, and neither does the `Store/Plugin` NodeType most package roots declare | nothing |
+
+The distinction between the last two matters when reading a log. **"No handler found"** means the
+publish was refused before the collection question was ever asked; **"collection not found"** means
+the host heard the request and has nowhere to put the bytes. Both end as the same installer warning
+— *"the package's nodes are installed but its binaries are not being served"* — because the publish
+**logs and continues** rather than throwing (a package whose nodes landed and whose binaries lag is
+strictly better than a half-written package).
+
+## What that cost
+
+Measured on two `MeshWeaver.Education` bakes on 2026-09-06, and independently on
+`MeshWeaver.Reinsurance`'s `test-repos` job the same day: **15 packages, 30 refusals per run,
+exit 0**. Every package that ships `content/**` — AppleMusic, BusinessRules, Chess, Collaboration,
+DataModelling, DoublePendulum, Edu, Essentials, Feedback, FractalStars, Google, Publish, RolePlay,
+ThreeBody, Training — installed its nodes and then had its binaries refused, twice (the installer
+re-asks once after the root recycles). Four of them additionally surfaced as
+`ContentDeliveryRefusedException`, because their largest asset exceeds the inline per-delivery
+budget and the [out-of-band transfer](/Doc/Architecture/OutOfBandContentTransfer) has to ask the
+owning node for its collection config first.
+
+Two separate problems, and only one of them is about noise:
+
+1. **The gate never exercised the path that serves a package's binaries.** A package whose
+   `content/**` is broken — a wrong path, a video its course's `<video src>` points at that never
+   lands — passed. The bake verified 101/101 assemblies and zero bytes of content.
+2. **Thirty warnings a run that read as a production incident**, on every satellite, unchanged from
+   run to run, saying nothing about the change under test.
+
+The fix is (1). (2) follows from it, and *only* from it: the condition stops occurring because the
+publish now succeeds. Lowering the log level would have been the forbidden move — the levels reflect
+the production cost model, and on a real portal that warning is exactly right.
+
+## The gate now hosts content the way a portal does
+
+`PluginGateRunner`'s mesh gained one `ConfigureDefaultNodeHub` lambda that mirrors the portal shape,
+both halves:
+
+- **every** per-node hub calls `AddContentCollections()` — a child reads its Space's collection
+  through its own hub, so the infrastructure cannot be root-only;
+- a **partition root** (a single-segment node path) additionally mounts a writable, `IsStatic`,
+  `ExposeInChildren` FileSystem `content` collection under the run's own temp root
+  (`{runRoot}/content/{node}`), so two concurrent gate runs cannot see each other's bytes and the
+  whole thing dies with the container.
+
+Nothing here is gate-specific behaviour: it is the production mount, pointed at a throwaway
+directory.
+
+## …and holds a verdict on it
+
+Exercising the path is not enough on its own. The publish logs-and-continues, so a gate that merely
+*ran* it would go green on a host where nothing landed — which is precisely how #3424 survived. The
+accounting is therefore structural, not a log line:
+
+- `PackageInstaller.ContentPublication` carries the target **root**, how many assets the install
+  **carried**, and the collection-relative **path of every one published**. It rides out on
+  `InstallResult.ContentRoot` / `ContentAssets` / `ContentAssetsPublished`.
+- The gate compares carried against published, and then **reads every published asset back through
+  [`ContentFileResolver.Resolve`](/Doc/Architecture/ContentRoute503)** — the one server-side reading
+  of a content reference, i.e. what a course's `<video src>` actually resolves through: the owning
+  node's own hub answers with its collection config (gated by an ordinary node `Read`), and the
+  collection then either has bytes at that path or does not. The probe reads the file's **size**,
+  never its bytes — a course video is tens of megabytes and existence is the whole question.
+- The result is a `content` check beside `install` and `idempotence`: `PackageResult.ContentError`
+  plus the two counts, printed in the summary as `[N/M content asset(s) served]`, carried across the
+  process boundary on `GateRunPackage.ContentError` for the combo verifier, and ratchetable in an
+  allow file as `<package> content`.
+
+🚨 **The counts are the point, not the absent error.** A run in which the content check looked at
+nothing reports the same "no error" as a run that verified two files; only `0` versus `2` tells them
+apart. This is the same rule `PackageResult.CountsMeasured` encodes one column over — a green check
+has to say what it verified.
+
+## What it does not cover
+
+- **A package that ships no `content/**` at all** reports `0` carried and never fails. The check
+  cannot red a package for not having binaries.
+- **The incremental install path** syncs only the *changed* files, so its accounting is over that
+  delta. An unchanged asset is neither carried nor re-published, and reporting it as missing would
+  red a package that changed nothing.
+- **`ROUTER_TRAFFIC: RawJson has the mesh hub as sender`** is a *different* defect and was not
+  involved: the content sync posts through `NodeOperationIssuingHub()` precisely so the router is
+  neither end of the pair, and a sweep of eleven job logs (~15,000 lines) across both repos on
+  2026-09-06 found **zero** ROUTER_TRAFFIC lines beside these refusals. The historical sighting of
+  that line came from the root-recycle `DisposeRequest` on a different repo's run, and was fixed the
+  same way.
+
+## Related
+
+- [CI Content Bake](/Doc/Architecture/CiContentBake) — what the gate's other half verifies.
+- [Out-of-Band Content Transfer](/Doc/Architecture/OutOfBandContentTransfer) — how an over-budget
+  asset travels, and why it needs the destination collection resolved on the producer.
+- [Content Sync Visibility](/Doc/Architecture/ContentSyncVisibility) — what a refusal reports.
+- [Content Route 503](/Doc/Architecture/ContentRoute503) — the read path the gate verifies against.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-plugins-videos-and-images-are-checked-before-it-ships.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-plugins-videos-and-images-are-checked-before-it-ships.md
@@ -1,0 +1,34 @@
+---
+Name: A plugin's videos and images are checked before it ships
+Category: Fix
+Description: The pre-publication check now installs a plugin's videos, posters and images the way a portal does and reads every one of them back, so a broken or missing file is caught before release instead of turning up as a blank player on your page.
+Icon: Video
+Order: -20260906
+---
+
+# A plugin's videos and images are checked before it ships
+
+A plugin, a course or an app brings more than text with it. Its **videos, posters, images and
+fonts** ship alongside its pages, and installing it is only half-done until those files are actually
+being served. The check that runs before any of it is published verified the pages thoroughly — and
+never once looked at the files.
+
+It could not: the check ran on a stripped-down environment that had nowhere to put them, so every
+plugin's files were quietly turned away, every run, and the check still came back green. A course
+whose intro video pointed at a file that never arrived would pass, and the first sign of trouble was
+a blank player on the page after it had been installed.
+
+The check now sets up the same file storage a real portal has. Every file a plugin carries is
+installed exactly as it would be on your own portal, and then **read back through the very route
+your browser uses** — a course's `<video>` tag, an image on a page, a font on a card. If a file did
+not arrive, or arrived somewhere your page would never look for it, the plugin is held back and the
+report names the file.
+
+The report also says what it verified, not merely that nothing complained: each plugin now shows
+`2/2 files served`, so "everything is fine" and "nothing was looked at" can no longer read the same
+way.
+
+If you maintain plugins, one thing follows from this: a run that used to end with a wall of warnings
+about files that were *"installed but not being served"* now ends without them. Those warnings were
+about the check's own environment and never about your plugin — they are gone because the condition
+they reported is gone, not because they were turned off.

--- a/src/MeshWeaver.PluginCatalog/ComboVerification.cs
+++ b/src/MeshWeaver.PluginCatalog/ComboVerification.cs
@@ -265,6 +265,14 @@ public sealed record GateRunPackage
     /// <summary>Re-install idempotence failure detail; null when the re-install wrote nothing.</summary>
     public string? IdempotenceError { get; init; }
 
+    /// <summary>
+    /// Content-asset failure detail: the package's committed <c>content/**</c> binaries were not
+    /// published into its root's content collection, or were published and cannot be read back
+    /// through the content route. Null when every asset it carries is being served (and when it
+    /// carries none). See <c>PackageInstaller.ContentPublication</c> — issue #3424.
+    /// </summary>
+    public string? ContentError { get; init; }
+
     /// <summary>Per-NodeType gate results.</summary>
     public ImmutableList<GateRunNodeType> NodeTypes { get; init; } = [];
 
@@ -273,6 +281,7 @@ public sealed record GateRunPackage
     public bool Success =>
         InstallError is null
         && IdempotenceError is null
+        && ContentError is null
         && NodeTypes.All(t => t.Success);
 }
 

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1842,9 +1842,19 @@ public static class PackageInstaller
         IObservable<ContentPublication> Publish() => syncs
             // Impersonated per post, like every other installer write: the pipeline hops schedulers
             // and an ambient impersonation does not survive those hops (see Upsert).
-            .Select(sync => Observable.Using(
-                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                    _ => hub.SyncContentFiles(sync.NodePath)
+            //
+            // 🚨 RunAsSystem, never `Observable.Using(access.ImpersonateAsSystem, …)` (#1790). Rx
+            // runs a Using's resource factory on the SUBSCRIBING thread and disposes it when the
+            // inner observable TERMINATES — for this cross-hub post, the owning root's response
+            // thread — so the subscriber was left latched as System, and everything composed
+            // downstream inherited it. RunAsSystem seals both ends: entered at Subscribe, left on
+            // the way out of that same Subscribe, and every notification reaches the subscriber
+            // under its OWN identity. The post is the only leaf that needs the identity (the
+            // projections below are pure), and a RetryWhen re-ask re-subscribes this same operator,
+            // so it re-enters the scope exactly as the Using did. Null-safe by construction: a host
+            // with no AccessService defers the work unimpersonated.
+            .Select(sync => accessService.RunAsSystem(
+                    () => hub.SyncContentFiles(sync.NodePath)
                         .To(sync.TargetCollection, sync.TargetPath)
                         .Add(sync.Files)
                         .Mirror(false)

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -187,8 +187,14 @@ public static class PackageInstaller
                     // …then the package's committed binaries, into the warmed root's content
                     // collection — the half of "publish" that merging used to leave undone (#848).
                     .SelectMany(_ => SyncPackageContent(hub, partition, sourceFolder, files, nodes, logger))
-                    .SelectMany(_ => RunInstallHooks(hub, partition!, logger))
-                    .Select(_ => result);
+                    .SelectMany(publication => RunInstallHooks(hub, partition!, logger)
+                        .Select(_ => publication))
+                    .Select(publication => result with
+                    {
+                        ContentRoot = publication.Root,
+                        ContentAssets = publication.Assets,
+                        ContentAssetsPublished = publication.Published,
+                    });
             });
     }
 
@@ -1790,12 +1796,12 @@ public static class PackageInstaller
     /// condition the warm consults. Gating INSIDE this method rather than at its three call sites
     /// is deliberate: a call site that forgot would silently reopen the door.</para>
     /// </summary>
-    private static IObservable<int> SyncPackageContent(
+    private static IObservable<ContentPublication> SyncPackageContent(
         IMessageHub hub, string? rootPath, string? sourceFolder,
         IReadOnlyList<PackageFile> files, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(rootPath))
-            return Observable.Return(0);
+            return Observable.Return(ContentPublication.None);
 
         // TryClassify is itself the path-only precheck: it invokes the bytes factory ONLY once it
         // has classified the path as content, so node files never materialize bytes. A separate
@@ -1806,7 +1812,17 @@ public static class PackageInstaller
             .Where(asset => asset is not null).Select(asset => asset!)
             .ToArray();
         if (assets.Length == 0)
-            return Observable.Return(0);
+            return Observable.Return(ContentPublication.None);
+
+        // 🚨 The syncs are built ONCE, and the CARRIED count is theirs — not `assets.Length`. The
+        // mapper de-duplicates by collection-relative path (case-insensitively), so two repo files
+        // that map onto one collection path are ONE publishable file; counting the pre-dedup assets
+        // would make a package with such a pair permanently report a shortfall it can never close.
+        // The comparison a caller holds a verdict on has to be over the SAME set both sides.
+        var syncs = ContentAssetMapper.ToContentSyncs(rootPath!, assets);
+        var carried = syncs.Sum(sync => sync.Files.Count);
+        if (carried == 0)
+            return Observable.Return(ContentPublication.None);
 
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         return MayPublishIntoRoot(hub, rootPath!, nodes, logger)
@@ -1818,9 +1834,12 @@ public static class PackageInstaller
                 // SettleRetypedRoot has normally already done this; the probe costs one ping when
                 // the root is up, and covers the call sites that do not run it.
                 ? WaitForRootReady(hub, rootPath!, logger).SelectMany(_ => Publish())
-                : Observable.Return(0));
+                // The skip is REPORTED, never rendered as "this package carries no assets": the
+                // assets exist and are not being served, which is the whole distinction
+                // ContentPublication exists to keep.
+                : Observable.Return(new ContentPublication(rootPath, carried, [])));
 
-        IObservable<int> Publish() => ContentAssetMapper.ToContentSyncs(rootPath!, assets)
+        IObservable<ContentPublication> Publish() => syncs
             // Impersonated per post, like every other installer write: the pipeline hops schedulers
             // and an ambient impersonation does not survive those hops (see Upsert).
             .Select(sync => Observable.Using(
@@ -1830,10 +1849,24 @@ public static class PackageInstaller
                         .Add(sync.Files)
                         .Mirror(false)
                         .Post())
-                .Select(response => response.Success
-                    ? response.FilesImported
-                    : throw new InvalidOperationException(
-                        response.Error ?? "content sync failed without an error message"))
+                // The PATHS, not merely the count. A caller that has to decide whether the package's
+                // binaries are actually being served needs to name them — a bare number cannot be
+                // read back, and the gate that now holds this verdict reads every one of them back
+                // through the content route (#3424).
+                .Select(response => !response.Success
+                    ? throw new InvalidOperationException(
+                        response.Error ?? "content sync failed without an error message")
+                    // 🚨 A SUCCESS that landed fewer files than it was handed is not a success —
+                    // it is a partial write nobody can name, and reporting every path as published
+                    // would hand the gate a green over assets that are not there. The handler
+                    // throws on every failure it can see (a missing staged blob, a truncated one),
+                    // so the two counts agree by construction; asserting it is what keeps a future
+                    // silent-skip from riding out as a full publish.
+                    : response.FilesImported < sync.Files.Count
+                        ? throw new InvalidOperationException(
+                            $"the content sync reported success for only {response.FilesImported} of "
+                            + $"{sync.Files.Count} file(s) — a partial write with no per-file reason")
+                        : sync.Files.Select(f => f.Path).ToImmutableList())
                 // 🚨 "The address may reactivate (recycle / restart); retry to get the
                 // authoritative answer" is not advice — it is the framework's TRANSIENT verdict,
                 // and this is the one consumer that used to throw it away and declare the
@@ -1855,20 +1888,46 @@ public static class PackageInstaller
                     .SelectMany(f => IsRootRecycling(f.fault) && f.attempt < RootRecycleReAsks
                         ? RootTeardownSettled(hub, sync.NodePath, logger)
                         : Observable.Throw<Unit>(f.fault)))
-                .Catch<int, Exception>(exception =>
+                .Catch<ImmutableList<string>, Exception>(exception =>
                 {
                     logger?.LogWarning(exception,
                         "[PackageInstaller] publishing {Count} content asset(s) to {Node} failed — the "
                         + "package's nodes are installed but its binaries are not being served",
                         sync.Files.Count, sync.NodePath);
-                    return Observable.Return(0);
+                    return Observable.Return(ImmutableList<string>.Empty);
                 }))
             .ToObservable()
             .Concat()
-            .Sum()
-            .Do(written => logger?.LogInformation(
+            .ToList()
+            .Select(batches => new ContentPublication(
+                rootPath, carried, batches.SelectMany(batch => batch).ToImmutableList()))
+            .Do(publication => logger?.LogInformation(
                 "[PackageInstaller] published {Written}/{Total} content asset(s) into {Root}'s "
-                + "content collection", written, assets.Length, rootPath));
+                + "content collection", publication.Published.Count, publication.Assets, rootPath));
+    }
+
+    /// <summary>
+    /// What an install's CONTENT half actually did: how many <c>content/**</c> assets the package
+    /// carries, and the collection-relative path of every one that was published.
+    ///
+    /// <para>🚨 The publish LOGS its failures and carries on (a half-written package is worse than
+    /// a package whose binaries lag), so before #3424 the ONLY report of a content shortfall was a
+    /// warning line — which is exactly how the plugin tester's gate came to install fifteen
+    /// packages' content assets into a host with no <c>SyncContentFilesRequest</c> handler on every
+    /// run, green, for months. A caller that wants to HOLD a verdict on the served binaries needs
+    /// the two numbers and the names; the gate reads each published path back through
+    /// <c>ContentFileResolver</c>, which is the one server-side reading of a content reference.</para>
+    /// </summary>
+    /// <param name="Root">The partition root whose <c>content</c> collection the assets belong in,
+    /// or null when the package carries none — so a caller never has to re-derive the installer's
+    /// own target rule to read an asset back.</param>
+    /// <param name="Assets">The <c>content/**</c> assets the package carries.</param>
+    /// <param name="Published">The collection-relative paths actually published.</param>
+    public readonly record struct ContentPublication(
+        string? Root, int Assets, ImmutableList<string> Published)
+    {
+        /// <summary>A package that carries no content assets at all.</summary>
+        public static ContentPublication None => new(null, 0, ImmutableList<string>.Empty);
     }
 
     /// <summary>
@@ -2923,7 +2982,12 @@ public static class PackageInstaller
                     .SelectMany(_ => SyncPackageContent(
                         hub, manifest.TargetPartition ?? manifest.Id,
                         manifest.SourceFolder ?? manifest.Id, files, nodes, logger))
-                    .Select(_ => result);
+                    .Select(publication => result with
+                    {
+                        ContentRoot = publication.Root,
+                        ContentAssets = publication.Assets,
+                        ContentAssetsPublished = publication.Published,
+                    });
             }));
             });
     }
@@ -3248,7 +3312,15 @@ public static class PackageInstaller
                     .SelectMany(_ => SyncPackageContent(
                         hub, manifest.TargetPartition ?? manifest.Id,
                         manifest.SourceFolder ?? manifest.Id, changedFiles, nodes, logger))
-                    .Select(_ => result);
+                    // 🚨 The INCREMENTAL path syncs only the CHANGED files, so its accounting is
+                    // over that delta — an unchanged asset is neither carried nor re-published, and
+                    // reporting it as missing would red a gate for a package that changed nothing.
+                    .Select(publication => result with
+                    {
+                        ContentRoot = publication.Root,
+                        ContentAssets = publication.Assets,
+                        ContentAssetsPublished = publication.Published,
+                    });
             });
     }
 
@@ -3846,5 +3918,27 @@ public readonly record struct InstallResult(int Total, int Written)
     public System.Collections.Immutable.ImmutableList<string> WrittenPaths { get; init; } =
         System.Collections.Immutable.ImmutableList<string>.Empty;
 
+    /// <summary>
+    /// The partition root whose <c>content</c> collection this install's assets belong in, or null
+    /// when it carried none. Handed over rather than re-derivable so a caller reading an asset back
+    /// cannot get the installer's own target rule subtly wrong.
+    /// </summary>
+    public string? ContentRoot { get; init; }
 
+    /// <summary>
+    /// How many <c>content/**</c> assets this install carried — the package's committed binaries
+    /// (course videos and their posters, og images, fonts), which are NOT nodes and are therefore
+    /// counted by neither <see cref="Total"/> nor <see cref="Written"/>.
+    /// </summary>
+    public int ContentAssets { get; init; }
+
+    /// <summary>
+    /// The collection-relative paths of the content assets actually PUBLISHED into the target
+    /// root's <c>content</c> collection. Fewer than <see cref="ContentAssets"/> means the package's
+    /// nodes landed and its binaries are not being served — a state the publish deliberately
+    /// LOGS-and-continues rather than throwing (a half-written package is worse), so this is the
+    /// only structural report of it. See <see cref="PackageInstaller.ContentPublication"/>.
+    /// </summary>
+    public System.Collections.Immutable.ImmutableList<string> ContentAssetsPublished { get; init; } =
+        System.Collections.Immutable.ImmutableList<string>.Empty;
 }

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -67,7 +67,7 @@ src/MeshWeaver.Hosting/NodeUpdatePipeline.cs	1
 src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs	6
 src/MeshWeaver.PluginCatalog/InstanceComboReader.cs	1
 src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs	4
-src/MeshWeaver.PluginCatalog/PackageInstaller.cs	10
+src/MeshWeaver.PluginCatalog/PackageInstaller.cs	9
 src/MeshWeaver.PluginCatalog/PackageUpdateReconciler.cs	1
 src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs	1
 src/MeshWeaver.PluginCatalog/RegistrationKeyService.cs	1

--- a/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
@@ -64,7 +64,7 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
     /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
     /// new file's line. Lower it whenever you delete or lower an entry.
     /// </summary>
-    private const int TotalBudget = 68;
+    private const int TotalBudget = 67;
 
     /// <summary>Production roots. <c>test/</c> and <c>samples/</c> are deliberately out of scope —
     /// the leak there costs test isolation, not a user's permissions, and listing 21 more entries

--- a/test/MeshWeaver.PluginTester.Test/GateRunReportContractTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateRunReportContractTest.cs
@@ -52,6 +52,12 @@ public class GateRunReportContractTest
                 NodeCount = 1,
                 InstallError = "import faulted",
                 IdempotenceError = "second install wrote 2 node(s)",
+                // #3424: the content-asset verdict is verdict-bearing, so it crosses the process
+                // boundary with the other two. A package whose ONLY red is its unserved binaries
+                // must not read as green to the combo verifier.
+                ContentAssets = 3,
+                ContentAssetsServed = 0,
+                ContentError = "only 0 of 3 content asset(s) reached 'Store's content collection",
             },
         ]);
 
@@ -77,7 +83,23 @@ public class GateRunReportContractTest
         var store = read.Packages.Single(p => p.Id == "Store");
         store.InstallError.Should().Be("import faulted");
         store.IdempotenceError.Should().Be("second install wrote 2 node(s)");
+        store.ContentError.Should().Be(
+            "only 0 of 3 content asset(s) reached 'Store's content collection");
         store.Success.Should().BeFalse();
+
+        // …and the content verdict ALONE is enough to fail a package on the far side.
+        var contentOnly = Roundtrip(new GateReport(
+        [
+            new PackageResult("Assets")
+            {
+                NodeCount = 1,
+                ContentAssets = 2,
+                ContentAssetsServed = 1,
+                ContentError = "1 of 2 published content asset(s) do not read back",
+            },
+        ]));
+        contentOnly.Packages.Single().Success.Should().BeFalse(
+            "an unserved binary is a red package, with nothing else wrong");
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginTester.Test/GateServesPackageContentTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateServesPackageContentTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// <b>The gate SERVES a package's content assets — the coverage hole of #3424, closed.</b>
+///
+/// <para>A package ships its binaries as ordinary files under <c>{package}/content/**</c> — the
+/// course videos and posters, the og cards, the fonts — and the installer publishes them by posting
+/// ONE <c>SyncContentFilesRequest</c> to the package's partition ROOT. The handler for that message
+/// is registered by <c>AddContentCollections()</c> and by nothing else. A PORTAL has it on every
+/// per-node hub; the tester's mesh did not, and neither does the <c>Store/Plugin</c> NodeType most
+/// package roots declare — so every root answered <i>"No handler found for message type
+/// SyncContentFilesRequest"</i>, the publish was refused before the collection question was even
+/// asked, and the gate NEVER ONCE exercised the path that serves a package's binaries. Measured on
+/// two Education bakes on 2026-09-06: the same 15 packages, 30 warnings, exit 0.</para>
+///
+/// <para><b>What this test asserts, and why it is a read-back and not a count.</b> The publish
+/// logs-and-continues by design, so "the installer did not complain" proves nothing. This runs the
+/// REAL gate over a repo whose package carries two <c>content/**</c> assets and requires the gate's
+/// own verdict to say <c>2/2 served</c> — where <i>served</i> means each asset resolved through
+/// <c>ContentFileResolver</c> (the one server-side reading of a content reference, i.e. what a
+/// course's <c>&lt;video src&gt;</c> actually goes through) and the collection had bytes at that
+/// path. A package whose content lands in the wrong place publishes "successfully" and fails
+/// here.</para>
+///
+/// <para>The negative control is in the same class: a repo carrying NO content assets must report
+/// <c>0</c> carried and no error — so the check cannot pass by being inert, and cannot fail a
+/// package that ships no binaries.</para>
+/// </summary>
+public class GateServesPackageContentTest(ITestOutputHelper output)
+{
+    private const string CourseIndexJson =
+        """{"$type":"MeshNode","id":"Course","namespace":"","path":"Course","mainNode":"Course","name":"Course Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A package that ships binaries."}}""";
+
+    private const string LessonJson =
+        """{"$type":"MeshNode","id":"Lesson1","namespace":"Course","path":"Course/Lesson1","mainNode":"Course/Lesson1","name":"Lesson 1","nodeType":"Markdown","state":"Active","content":{"$type":"MarkdownContent","content":"# Lesson"}}""";
+
+    // The two assets, in the two shapes ContentAssetMapper distinguishes: one owned by the Space
+    // ROOT (`content/…` → collection-relative `videos/intro.mp4`) and one owned by a CHILD node
+    // (`Lesson1/content/…` → collection-relative `Lesson1/poster.png`). A mount that only ever
+    // resolved the root's own files would pass on the first and fail on the second.
+    private const string RootAssetPath = "Course/content/videos/intro.mp4";
+    private const string ChildAssetPath = "Course/Lesson1/content/poster.png";
+
+    /// <summary>The collection-relative paths the two files above must be served at.</summary>
+    private static readonly string[] ServedPaths = ["videos/intro.mp4", "Lesson1/poster.png"];
+
+    [Fact(Timeout = 900_000)]
+    public async Task ThePackagesCommittedBinaries_AreServedAfterTheGateInstallsIt()
+    {
+        var repo = TempDirectory("mw-3424-content");
+        var bakeOut = TempDirectory("mw-3424-bake");
+        try
+        {
+            Write(repo, "Course/index.json", CourseIndexJson);
+            Write(repo, "Course/Lesson1.json", LessonJson);
+            // Deliberately NOT valid UTF-8 — these ride as binary, exactly as a real .mp4/.png does.
+            WriteBytes(repo, RootAssetPath, [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0xFF]);
+            WriteBytes(repo, ChildAssetPath, [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0xFF]);
+
+            var log = new StringWriter();
+            var report = await PluginGateRunner.Run(new GateOptions
+            {
+                RepoRoot = repo,
+                Output = log,
+                BakeOutputDirectory = bakeOut,
+                SourceSha = "cafebabe",
+                CompileTimeout = TimeSpan.FromMinutes(4),
+                RenderTimeout = TimeSpan.FromMinutes(2),
+            }).FirstAsync().Await();
+            output.WriteLine(log.ToString());
+            report.WriteSummary(new StringWriterAdapter(output));
+
+            report.FatalError.Should().BeNull("the gate must boot and run to a verdict");
+            var package = report.Packages.Single(p => p.Id == "Course");
+            package.InstallError.Should().BeNull("the package's nodes must install");
+
+            // 🚨 A MEASUREMENT, not merely an absent error. Before the fix these are 2 carried and
+            // 0 served, with ContentError naming the refusal; a check that could only ever say
+            // "nothing complained" would have stayed green through the whole of #3424.
+            package.ContentAssets.Should().Be(2,
+                "the package ships two content/** binaries — one owned by the Space root and one "
+                + "by a child node");
+            package.ContentError.Should().BeNull(
+                "every committed binary must be published into the root's content collection AND "
+                + "read back through the content route — the gate serves what a portal serves");
+            package.ContentAssetsServed.Should().Be(2,
+                "both assets must READ BACK, at the collection-relative paths the content route "
+                + $"resolves them at ({string.Join(", ", ServedPaths)})");
+            report.ExitCode.Should().Be(0, "nothing else about this package is broken");
+        }
+        finally
+        {
+            Cleanup(repo);
+            Cleanup(bakeOut);
+        }
+    }
+
+    /// <summary>
+    /// The negative control: a package shipping NO binaries reports zero carried and no error. This
+    /// is what keeps the check from being satisfiable by inertia — a run in which the content check
+    /// never looked at anything would report the same "no error" as a run in which it verified two
+    /// files, and only the COUNT tells the two apart.
+    /// </summary>
+    [Fact(Timeout = 900_000)]
+    public async Task APackageWithNoBinaries_ReportsZeroCarried_AndNoContentFailure()
+    {
+        var repo = TempDirectory("mw-3424-nocontent");
+        var bakeOut = TempDirectory("mw-3424-nocontent-bake");
+        try
+        {
+            Write(repo, "Course/index.json", CourseIndexJson);
+            Write(repo, "Course/Lesson1.json", LessonJson);
+
+            var log = new StringWriter();
+            var report = await PluginGateRunner.Run(new GateOptions
+            {
+                RepoRoot = repo,
+                Output = log,
+                BakeOutputDirectory = bakeOut,
+                SourceSha = "cafebabe",
+                CompileTimeout = TimeSpan.FromMinutes(4),
+                RenderTimeout = TimeSpan.FromMinutes(2),
+            }).FirstAsync().Await();
+            output.WriteLine(log.ToString());
+
+            report.FatalError.Should().BeNull();
+            var package = report.Packages.Single(p => p.Id == "Course");
+            package.InstallError.Should().BeNull();
+            package.ContentAssets.Should().Be(0, "this package ships no content/** files at all");
+            package.ContentAssetsServed.Should().Be(0);
+            package.ContentError.Should().BeNull(
+                "a package that ships no binaries must never fail the content check");
+            report.ExitCode.Should().Be(0);
+        }
+        finally
+        {
+            Cleanup(repo);
+            Cleanup(bakeOut);
+        }
+    }
+
+    private sealed class StringWriterAdapter(ITestOutputHelper output) : StringWriter
+    {
+        public override void WriteLine(string? value) => output.WriteLine(value ?? string.Empty);
+    }
+
+    private static string TempDirectory(string prefix) =>
+        Path.Combine(Path.GetTempPath(), prefix + "-" + Guid.NewGuid().ToString("N"));
+
+    private static void Write(string root, string relative, string content)
+    {
+        var full = FullPath(root, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static void WriteBytes(string root, string relative, byte[] bytes)
+    {
+        var full = FullPath(root, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllBytes(full, bytes);
+    }
+
+    private static string FullPath(string root, string relative) =>
+        Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+
+    private static void Cleanup(string directory)
+    {
+        try { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+        catch { /* best effort */ }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -11,7 +11,7 @@ namespace MeshWeaver.PluginTester;
 /// <para>File format: one entry per line, <c>#</c> comments, blank lines ignored:</para>
 /// <code>
 /// &lt;scope&gt; &lt;check&gt;
-/// Claims idempotence          # package-level checks: install, idempotence
+/// Claims idempotence          # package-level checks: install, idempotence, content
 /// Edu/Exercise tests          # type-level checks: compile, render, tests
 /// </code>
 /// </summary>
@@ -42,7 +42,7 @@ public sealed record GateAllowlist(IReadOnlyList<AllowEntry> Entries)
     /// <summary>The valid check names, package-level and type-level.</summary>
     public static readonly IReadOnlySet<string> Checks =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            { "install", "idempotence", "compile", "render", "tests" };
+            { "install", "idempotence", "content", "compile", "render", "tests" };
 
     /// <summary>Parses the allow file, throwing on a malformed line — a typo that silently
     /// allowed nothing (or everything) would defeat the ratchet.</summary>
@@ -289,7 +289,7 @@ public sealed record GateVerdict(
 
     /// <summary>The checks in pipeline order — the order <see cref="Headline"/> lists them in.</summary>
     private static readonly string[] CheckOrder =
-        ["install", "idempotence", "compile", "render", "tests"];
+        ["install", "idempotence", "content", "compile", "render", "tests"];
 
     /// <summary>
     /// The not-passing kinds, most-conclusive first — so a run carrying a REAL compile error and a
@@ -309,6 +309,8 @@ public sealed record GateVerdict(
                 yield return new GateFailure(package.Id, "install", package.InstallError);
             if (package.IdempotenceError is not null)
                 yield return new GateFailure(package.Id, "idempotence", package.IdempotenceError);
+            if (package.ContentError is not null)
+                yield return new GateFailure(package.Id, "content", package.ContentError);
             foreach (var type in package.NodeTypes)
             {
                 // 🚨 .Fails(), never `== Failed`. An equality test here would have DROPPED every
@@ -341,6 +343,9 @@ public sealed record GateVerdict(
                 {
                     "install" => package.InstallError is null,
                     "idempotence" => package.InstallError is null && package.IdempotenceError is null,
+                    // An install that never reported cannot have exercised the content publish, so
+                    // its silence is not a pass — the same rule the idempotence entry follows.
+                    "content" => package.InstallError is null && package.ContentError is null,
                     _ => false,
                 };
             foreach (var type in package.NodeTypes)

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -220,11 +220,48 @@ public sealed record PackageResult(string Id)
     /// </summary>
     public string? IdempotenceError { get; init; }
 
+    /// <summary>
+    /// Content-asset failure detail: the package's committed <c>content/**</c> binaries — course
+    /// videos and their posters, og images, fonts — are not being served after the install. Null
+    /// when every asset it carries was published AND reads back through the content route, and
+    /// null for a package that carries none.
+    ///
+    /// <para>🚨 Why this is a CHECK and not a log line (#3424). The publish deliberately
+    /// logs-and-continues, so a host on which it cannot land at all — the tester's own mesh, whose
+    /// package roots had no <c>SyncContentFilesRequest</c> handler and no <c>content</c> collection
+    /// — produced 30 warnings a run and a GREEN verdict, for every satellite, for months. A package
+    /// whose <c>content/**</c> is broken (a wrong path, a video its course's <c>&lt;video src&gt;</c>
+    /// points at that never lands) passed the gate. The gate now MOUNTS the collection the way a
+    /// portal does and reads every published asset back, so the assets are exercised and the
+    /// verdict says so.</para>
+    /// </summary>
+    public string? ContentError { get; init; }
+
+    /// <summary>
+    /// How many <c>content/**</c> assets the package carried — a MEASUREMENT, so a green content
+    /// check says <i>what it verified</i> rather than merely "nothing complained". Zero is the
+    /// honest reading for a package that ships no binaries, which is why the check is also
+    /// reported as a count and not only as an absent error.
+    /// </summary>
+    public int ContentAssets { get; init; }
+
+    /// <summary>
+    /// How many of those assets were published AND read back through the content route. Equal to
+    /// <see cref="ContentAssets"/> on a clean run; anything less has a <see cref="ContentError"/>
+    /// naming the paths.
+    /// </summary>
+    public int ContentAssetsServed { get; init; }
+
     /// <summary>Per-NodeType gate results.</summary>
     public IReadOnlyList<NodeTypeResult> NodeTypes { get; init; } = [];
 
-    /// <summary>True when the install, the re-install idempotence pin and every NodeType gate passed.</summary>
-    public bool Success => InstallError is null && IdempotenceError is null && NodeTypes.All(t => t.Success);
+    /// <summary>
+    /// True when the install, the re-install idempotence pin, the content-asset check and every
+    /// NodeType gate passed.
+    /// </summary>
+    public bool Success =>
+        InstallError is null && IdempotenceError is null && ContentError is null
+        && NodeTypes.All(t => t.Success);
 }
 
 /// <summary>The whole run's outcome: per-package results and the process exit code.</summary>
@@ -257,6 +294,7 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
                 NodeCount = package.NodeCount,
                 InstallError = package.InstallError,
                 IdempotenceError = package.IdempotenceError,
+                ContentError = package.ContentError,
                 NodeTypes = package.NodeTypes
                     .Select(type => new GateRunNodeType
                     {
@@ -308,12 +346,17 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
                              (package.CountsMeasured
                                  ? $"({package.NodeCount} node(s), {package.NodeTypes.Count} type(s))"
                                  : "(counts unavailable — the pipeline threw before the install reported)") +
+                             (package.ContentAssets == 0
+                                 ? string.Empty
+                                 : $" [{package.ContentAssetsServed}/{package.ContentAssets} content asset(s) served]") +
                              (package.Upstream ? " [upstream: installed, not gated here]" : "") +
                              (package.Support ? " [support: installed, gated on another shard]" : ""));
             if (package.InstallError is not null)
                 output.WriteLine($"    install{Debt(verdict, package.Id, "install")}: {package.InstallError}");
             if (package.IdempotenceError is not null)
                 output.WriteLine($"    idempotence{Debt(verdict, package.Id, "idempotence")}: {package.IdempotenceError}");
+            if (package.ContentError is not null)
+                output.WriteLine($"    content{Debt(verdict, package.Id, "content")}: {package.ContentError}");
             foreach (var type in package.NodeTypes)
             {
                 output.WriteLine(
@@ -368,6 +411,7 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
         var allKnown =
             (package.InstallError is null || verdict.IsKnownDebt(package.Id, "install"))
             && (package.IdempotenceError is null || verdict.IsKnownDebt(package.Id, "idempotence"))
+            && (package.ContentError is null || verdict.IsKnownDebt(package.Id, "content"))
             && package.NodeTypes.All(t =>
                 (!t.Compile.Fails() || verdict.IsKnownDebt(t.Path, "compile"))
                 && (!t.Render.Fails() || verdict.IsKnownDebt(t.Path, "render"))

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.ContentCollections;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
@@ -289,7 +290,8 @@ public static class PluginGateRunner
                         options.Output.WriteLine(
                             $"── {package.Id}: installed ({install.Written} written, " +
                             $"{install.Unchanged} unchanged); checking {types.Count} NodeType(s)…");
-                        return types
+                        return VerifyContentAssets(harness, options, install)
+                            .SelectMany(content => types
                             .Select(type => TestNodeType(harness, options, type))
                             .ToObservable().Concat().ToList()
                             // The idempotence pin: a SECOND install of the same snapshot must write
@@ -308,6 +310,9 @@ public static class PluginGateRunner
                                     Upstream = upstream,
                                     Support = support,
                                     NodeCount = install.Total,
+                                    ContentAssets = content.Assets,
+                                    ContentAssetsServed = content.Served,
+                                    ContentError = content.Error,
                                     IdempotenceError = second.Written == 0
                                         ? null
                                         : $"re-install of the unchanged snapshot wrote {second.Written} node(s) " +
@@ -323,9 +328,12 @@ public static class PluginGateRunner
                                     Upstream = upstream,
                                     Support = support,
                                     NodeCount = install.Total,
+                                    ContentAssets = content.Assets,
+                                    ContentAssetsServed = content.Served,
+                                    ContentError = content.Error,
                                     IdempotenceError = $"re-install failed: {ex.GetType().Name}: {ex.Message}",
                                     NodeTypes = typeResults.ToImmutableList(),
-                                })));
+                                }))));
                     });
             })
             .Catch((Exception ex) => Observable.Return(new PackageResult(package.Id)
@@ -338,6 +346,125 @@ public static class PluginGateRunner
                 InstallError = $"[{stage}] {ex.GetType().Name}: {ex.Message}",
             }));
     }
+
+    /// <summary>
+    /// 🚨 <b>THE CONTENT-ASSET CHECK (#3424) — the gate's verdict on a package's committed
+    /// binaries.</b> Every <c>content/**</c> asset the install carried must have been PUBLISHED
+    /// into its root's <c>content</c> collection, and every published one must READ BACK through
+    /// the content route. Returns the failure detail, or null when the package is clean (and null
+    /// outright for a package that carries no assets).
+    ///
+    /// <para><b>Why the read-back, and not just the count.</b> The publish deliberately
+    /// logs-and-continues — a package whose nodes landed and whose binaries did not is better than
+    /// a half-written package — so a count alone tells the gate only what the installer believed.
+    /// The route is what a course's <c>&lt;video src&gt;</c> actually resolves through:
+    /// <see cref="ContentFileResolver.Resolve"/> is the ONE server-side reading of a content
+    /// reference (the owning node's own hub answers with its collection config, gated by an
+    /// ordinary node Read), and the collection then either has the bytes at that path or does not.
+    /// A wrong path publishes "successfully" into the wrong place and fails here.</para>
+    ///
+    /// <para>Reads the SIZE, never the bytes: a course video is tens of megabytes and existence is
+    /// the whole question. Errors are reported per asset with the path named — an unnamed content
+    /// failure is undiagnosable, exactly as the idempotence pin's unnamed count was.</para>
+    /// </summary>
+    private static IObservable<ContentCheck> VerifyContentAssets(
+        GateMesh harness, GateOptions options, InstallResult install)
+    {
+        var carried = install.ContentAssets;
+        if (carried == 0)
+            return Observable.Return(ContentCheck.NoAssets);
+        if (install.ContentRoot is not { Length: > 0 } root)
+            return Observable.Return(new ContentCheck(carried, 0,
+                $"the install carried {carried} content asset(s) but named no target root, so none "
+                + "of them could be published"));
+
+        var published = install.ContentAssetsPublished ?? [];
+        if (published.Count < carried)
+            return Observable.Return(new ContentCheck(carried, 0,
+                $"only {published.Count} of {carried} content asset(s) reached '{root}'s content "
+                + "collection — the package's nodes are installed and its binaries are not being "
+                + "served. The installer logs the refusal at Warning; the usual cause is a host "
+                + "whose partition roots carry no content collection at all (\"No handler found "
+                + "for message type SyncContentFilesRequest\")."));
+
+        // 🚨 The MESH HUB's provider, not the mesh's root DI container: AddContentCollections()
+        // registers IContentService through the hub configuration's WithServices, so the root
+        // container never sees it (measured — "The requested service … has not been registered").
+        var contentService = harness.Mesh.ServiceProvider.GetRequiredService<IContentService>();
+        options.Output.WriteLine(
+            $"── {root}: verifying {published.Count} published content asset(s) read back…");
+        return published
+            .Select(path => ReadContentAssetBack(harness, contentService, root, path))
+            .ToObservable()
+            .Concat()
+            .ToList()
+            // The whole check shares the install budget — it is a handful of resolves and stat
+            // calls, so exceeding it means something is wedged, not slow.
+            .Timeout(options.InstallTimeout)
+            .Select(reads =>
+            {
+                var unserved = reads.Where(r => r.Reason is not null).ToArray();
+                return new ContentCheck(carried, reads.Count - unserved.Length,
+                    unserved.Length == 0
+                        ? null
+                        : $"{unserved.Length} of {published.Count} published content asset(s) do "
+                          + $"not read back from '{root}'s content collection: "
+                          + string.Join("; ", unserved.Select(r => $"'{r.Path}' — {r.Reason}")));
+            })
+            .Catch((Exception ex) => Observable.Return(new ContentCheck(carried, 0,
+                $"the content read-back did not complete: {ex.GetType().Name}: {ex.Message}")));
+    }
+
+    /// <summary>
+    /// The content-asset verdict for one package: how many binaries it carried, how many are
+    /// actually SERVED, and the detail when those differ. A count, not just an absent error — a
+    /// green check has to say what it verified (see <c>PackageResult.CountsMeasured</c> for the
+    /// same rule one column over).
+    /// </summary>
+    /// <param name="Assets">The <c>content/**</c> assets the package carried.</param>
+    /// <param name="Served">Assets published AND read back through the content route.</param>
+    /// <param name="Error">Why they differ, or null.</param>
+    private sealed record ContentCheck(int Assets, int Served, string? Error)
+    {
+        /// <summary>A package shipping no binaries — nothing to publish, nothing to verify.</summary>
+        public static ContentCheck NoAssets { get; } = new(0, 0, null);
+    }
+
+    /// <summary>
+    /// One published asset, read back exactly as the content route reads it: resolve the reference
+    /// on the owning node, register the resolved config under its qualified name (two nodes
+    /// inheriting one ancestor collection must not share a cache entry), then probe the file.
+    /// </summary>
+    private static IObservable<ContentReadBack> ReadContentAssetBack(
+        GateMesh harness, IContentService contentService, string root, string path)
+    {
+        var reference =
+            $"{root}/{ContentCollectionsExtensions.DefaultCollectionName}/{path}";
+        return ContentFileResolver.Resolve(harness.Mesh, reference)
+            .SelectMany(result =>
+            {
+                if (result.Resolution is not { } resolution)
+                    return Observable.Return(new ContentReadBack(
+                        path, result.Reason ?? "the reference could not be resolved"));
+                contentService.AddConfiguration(resolution.QualifiedConfig);
+                return contentService.GetCollection(resolution.QualifiedName)
+                    .SelectMany(collection => collection is null
+                        ? Observable.Return(new ContentReadBack(path,
+                            $"content collection '{resolution.Collection.Name}' could not be opened"))
+                        : collection.GetContentSize(resolution.FilePath)
+                            .Select(size => new ContentReadBack(path, size is null
+                                ? $"nothing is served at '{resolution.FilePath}' in collection "
+                                  + $"'{resolution.Collection.Name}'"
+                                : null)));
+            })
+            .Catch((Exception ex) => Observable.Return(
+                new ContentReadBack(path, $"{ex.GetType().Name}: {ex.Message}")));
+    }
+
+    /// <summary>One published content asset's read-back: the path, and why it is not served.</summary>
+    /// <param name="Path">The collection-relative path of the asset.</param>
+    /// <param name="Reason">Why it does not read back, or null when it does.</param>
+    private sealed record ContentReadBack(string Path, string? Reason);
 
     /// <summary>One NodeType of one package, as parsed from its file (pre-install).</summary>
     internal sealed record NodeTypeUnderTest(
@@ -806,6 +933,47 @@ public static class PluginGateRunner
                 .InstallConfiguredModules(gateModules,
                     msg => output.WriteLine($"[gate modules] {msg}"))
                 .AddPluginCatalog()
+                // 🚨 THE CONTENT-COLLECTION MOUNT — the PORTAL's shape, on the gate's own per-node
+                // hubs (#3424). A package publishes its committed `content/**` binaries by posting
+                // one SyncContentFilesRequest to its partition ROOT's hub, and the handler for that
+                // message is registered by AddContentCollections() and by nothing else. A portal
+                // has it on EVERY per-node hub because MemexConfiguration's own
+                // ConfigureDefaultNodeHub maps a collection there; AddGraph()'s default node chain
+                // does not, and neither does the `Store/Plugin` NodeType most package roots
+                // declare. So the tester's roots answered "No handler found for message type
+                // SyncContentFilesRequest" — the publish was refused BEFORE the collection question
+                // was even asked, ~30 DeliveryFailures per run (measured: the same 15 packages on
+                // every Education bake, and on Reinsurance's test-repos job), and the gate never
+                // once exercised the path that serves a package's binaries. A course whose video
+                // never lands passed.
+                //
+                // Same rule as production, both halves: the handler + service go on EVERY node hub
+                // (a child reads its Space's collection through its own hub), and the WRITABLE
+                // `content` collection is mounted ONCE per Space — on the partition root, gated on
+                // a single-segment path — with ExposeInChildren so children inherit it. Backed by
+                // this run's own temp root, so two concurrent gate runs cannot see each other's
+                // bytes and the whole thing dies with the container.
+                .ConfigureDefaultNodeHub(config =>
+                {
+                    var nodePath = config.Address.ToString();
+                    if (nodePath.Contains('/'))
+                        return config.AddContentCollections();
+                    var basePath = Path.Combine(runRoot, "content", nodePath);
+                    return config.AddContentCollection(_ => new ContentCollectionConfig
+                    {
+                        Name = ContentCollectionsExtensions.DefaultCollectionName,
+                        SourceType = "FileSystem",
+                        BasePath = basePath,
+                        Address = config.Address,
+                        IsEditable = true,
+                        ExposeInChildren = true,
+                        // Published on the access-controlled content route, exactly as a portal
+                        // mounts it: the gate's read-back resolves through ContentFileResolver,
+                        // which reports the collection's real IsStatic.
+                        IsStatic = true,
+                        Settings = new Dictionary<string, string> { ["BasePath"] = basePath },
+                    });
+                })
                 .AddMeshNodes(RootAdminAccess())
                 // Per-run isolated assembly store + compilation cache (AddInMemoryPersistence
                 // TryAdds a process-pid-scoped store — REPLACE it, mirroring the test base).


### PR DESCRIPTION
## The mechanism

A package ships more than nodes. Its **binaries** — course videos and their posters, og cards, fonts — are committed under `{package}/content/**`, and `PackageInstaller.SyncPackageContent` publishes them by posting **one `SyncContentFilesRequest` to the package's partition ROOT**.

That handler comes from exactly one place: `ContentImportExtensions.AddContentImportHandler`, reachable only through `AddContentCollections()`. Three hosts, three different answers:

| Host | Handler | `content` collection |
|---|---|---|
| Portal (`memex`, `memex-cloud`) | `MemexConfiguration`'s `ConfigureDefaultNodeHub` maps `attachments` on **every** per-node hub, which calls `AddContentCollections()` | the same lambda mounts a writable one on the partition ROOT (`!nodePath.Contains('/')`), `ExposeInChildren` |
| A `Space`-typed root | `SpaceNodeType`'s own `HubConfiguration` | none — answers, then fails *"Target content collection 'content' not found"* |
| **The gate mesh** | **none** — `AddGraph()`'s default node chain does not call it, and neither does the `Store/Plugin` NodeType most package roots declare | **none** |

So the publish was refused **before the collection question was even asked**, and the gate never once exercised the path that serves a package's binaries.

### Measured, not inferred

Eleven CI job logs read in full on 2026-09-06 (~15,000 lines), across both repos:

| | Education bake `34036343718` | Education bake `34037514537` | Reinsurance `gate shard` | Reinsurance `publish-bake` |
|---|---|---|---|---|
| `content asset(s) … failed` | 30 | 30 | 40 | 14 |
| `No handler found …` | 60 | 60 | 80 | 28 |
| `published N/N content asset(s)` | **0** | **0** | **0** | **0** |

The same 15 packages every run (AppleMusic, BusinessRules, Chess, Collaboration, DataModelling, DoublePendulum, Edu, Essentials, Feedback, FractalStars, Google, Publish, RolePlay, ThreeBody, Training), twice each — the installer re-asks once after the root recycles. Four surface as `ContentDeliveryRefusedException` because their largest asset exceeds the inline per-delivery budget, so the out-of-band transfer has to ask the owning node for its collection config first. `SyncContentFilesRequest` is the **only** message type that ever appears with "No handler found" in any of those logs.

### `ROUTER_TRAFFIC` — established, and unrelated

**Zero occurrences in all eleven job logs.** The content sync posts through `NodeOperationIssuingHub()` precisely so the router is neither end of the pair, so it cannot produce that line by construction. The historical `RawJson has the mesh hub as sender` sighting is documented in `PackageInstaller.cs:1516` against the **Manufacturing** gate run 33623113056, and came from the root-recycle `DisposeRequest` — a different message on a different path, fixed the same way. Nothing to do here.

## What I changed

**`tools/MeshWeaver.PluginTester/PluginGateRunner.cs`** — one `ConfigureDefaultNodeHub` lambda that is the **production mount pointed at a throwaway directory**, both halves:
- every per-node hub calls `AddContentCollections()` (a child reads its Space's collection through its own hub, so the infrastructure cannot be root-only);
- a partition root additionally mounts a writable, `IsStatic`, `ExposeInChildren` FileSystem `content` collection at `{runRoot}/content/{node}` — so two concurrent gate runs cannot see each other's bytes and it dies with the container.

**`src/MeshWeaver.PluginCatalog/PackageInstaller.cs`** — the publish logs-and-continues by design (a package whose nodes landed and whose binaries lag beats a half-written package), so a warning line was the *only* report of a shortfall. Now `ContentPublication(Root, Assets, Published)` rides out on `InstallResult.ContentRoot` / `ContentAssets` / `ContentAssetsPublished`. Two details worth naming:
- the carried count is taken **after** `ContentAssetMapper`'s case-insensitive dedup, so a package with two repo files mapping onto one collection path cannot report a shortfall it could never close;
- a success reporting **fewer** files imported than it was handed now fails instead of claiming every path published.

**The gate holds a verdict.** A new `content` check beside `install` and `idempotence` reads every published asset back through **`ContentFileResolver.Resolve`** — the one server-side reading of a content reference, i.e. what a course's `<video src>` actually resolves through: the owning node's own hub answers with its collection config (gated by an ordinary node `Read`), and the collection then either has bytes at that path or does not. It probes the **size**, never the bytes. The report prints `[N/M content asset(s) served]`, the verdict crosses to the combo verifier on `GateRunPackage.ContentError`, and a satellite can ratchet it as `<package> content`.

🚨 **The counts are the point, not the absent error.** A run in which the check looked at nothing reports the same "no error" as one that verified two files; only `0` versus `2` tells them apart — the same rule `PackageResult.CountsMeasured` encodes one column over.

### Review follow-up (1ac35064d) — the impersonation boundary in that same pipeline

The publish's post ran under `Observable.Using(() => accessService?.ImpersonateAsSystem(), …)`. That is pre-existing code, but it is **ratcheted debt**, not a style preference: `test/ImpersonationScopeSites.allow` carried `PackageInstaller.cs 10` under #1790, because Rx runs a `Using`'s resource factory on the **subscribing** thread and disposes it when the inner observable **terminates** — for a cross-hub post, the owning root's response thread — leaving the subscriber latched as System.

Since this PR makes that exact pipeline verdict-bearing, leaving it would have hardened a leak. Swapped to `accessService.RunAsSystem(() => hub.SyncContentFiles(…).Post())` — the documented replacement, null-safe on `AccessService?`. The post is the only leaf needing the identity (the projections after it are pure), and a `RetryWhen` re-ask re-subscribes the same operator, so it re-enters the scope exactly as the `Using` did. Ratchet moved the way it exists for: `PackageInstaller.cs` **10 → 9**, `TotalBudget` **68 → 67**.

One honest correction, deliberately NOT acted on: reading the guard's detailed output rather than its green shows `PackageInstaller.cs — 8 found, 9 allowed`, i.e. the entry was **already stale by one before this PR** (10 allowed against 9 real). Lowering it to 8 would need another push, which ejects a PR that is already in the merge queue and burns a full CI cycle — for a number the guard reports as a courtesy and never fails on (`total 66 ≤ budget 67`). The inherited slack of 1 is unchanged; three other entries in that file are stale the same way and predate this change. Left for whoever next fixes a site there, where the guard prints it on every run.

Re-verified after the swap: `MeshWeaver.PluginTester.Test` **360/360** (`GateServesPackageContentTest` still reports 2/2 served — the publish still authorizes *and* still reads back), `MeshWeaver.Documentation.Test` **279/279** including `ImpersonationScopeSiteRatchetGuard` at the lowered budget.

## What I did NOT change

- **No log level moved.** The noise stops because the condition stops occurring. On a real portal that warning is exactly right, and dialling it down would have been the forbidden move.
- **No installer message rewording.** With the collection mounted the tester no longer produces the line, and for a genuinely minimal host it is accurate as written.
- **The platform's own gates are unaffected**: neither `src/MeshWeaver.Documentation/Data` nor the seven trees `stage-samples-gate.sh` stages contains a `content/` directory (`samples/Graph/content` sits outside `Data`), so both report `0` carried.
- **The incremental install path** accounts over the changed-file delta only — an unchanged asset is neither carried nor re-published, and calling it missing would red a package that changed nothing.

## Falsification

`GateServesPackageContentTest` runs the **real gate** over a repo whose package ships two `content/**` binaries in the two shapes `ContentAssetMapper` distinguishes — one owned by the Space root (`content/videos/intro.mp4`), one by a child node (`Lesson1/content/poster.png`) — both written as non-UTF-8 bytes, the shape a real `.mp4`/`.png` takes.

| Run | Result |
|---|---|
| **With the fix** | `Passed! Failed: 0, Passed: 2` |
| **`src`/tools change reverted** (mount removed, everything else identical) | `Failed! Failed: 1, Passed: 1` — `content: only 0 of 2 content asset(s) reached 'Course's content collection …` → `GATE FAILED — content: Course` |
| Whole `MeshWeaver.PluginTester.Test` suite, with the fix | `Passed! Failed: 0, Passed: 360` |
| `MeshWeaver.Documentation.Test` (the doc page + What's New entry) | `Passed! Failed: 0, Passed: 279` |

The negative control is in the same class: a package shipping no binaries reports `0` carried and no error, so the check can neither pass by inertia nor red a package for having nothing to serve.

Every touched project builds `-c Release -warnaserror`, one per invocation: `MeshWeaver.PluginCatalog`, `MeshWeaver.PluginTester`, `MeshWeaver.PluginTester.Test`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation`, `MeshWeaver.Documentation.Test` — all `0 Warning(s), 0 Error(s)`.

## Work product conserved

`Doc/Architecture/GateContentAssets` — the host shape, the three-host table, what the check covers and what it deliberately does not (including the ROUTER_TRAFFIC finding), linked from `CiContentBake`. Plus a What's New entry (`Category: Fix`).

Pairs-with: none — every change is additive (`InstallResult` gains three init properties, `GateRunPackage` one, a new nested `PackageInstaller.ContentPublication`); no public type or member is removed, and no overload is added.

Closes #3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
