### PR TITLE
feat(Payments): the platform carries a provider-neutral payment contract

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PaymentProviderContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PaymentProviderContract.md
@@ -1,0 +1,138 @@
+---
+Name: The Payment Provider Contract
+Category: Architecture
+Description: Taking money is an optional module, so the commerce content binds IPaymentProvider — a platform abstraction — and answers "no provider installed" as a modelled state. Why a module namespace in mesh-compiled source breaks every consumer that does not mount it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><path d="M2 10h20"/><path d="M6 15h4"/></svg>
+---
+
+# The Payment Provider Contract
+
+🚨 **Card payments are an optional module. The commerce content binds an abstraction the platform
+always ships — [`IPaymentProvider`](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Mesh.Contract/Payments/IPaymentProvider.cs) —
+and a portal with no payments module mounted must compile, install and run, with the payment
+features absent or inert rather than broken.**
+
+The same shape as `IEmailSender`, and for the same reason: a provider-neutral contract in
+`MeshWeaver.Mesh.Contract`, the concrete implementation in a module that a deployment may or may not
+mount.
+
+## Why this is not a style preference
+
+A `NodeType`'s C# is stored **as data** and compiled by the mesh at runtime
+([NodeType Compilation](../NodeTypeCompilation)) against the portal image's reference set **plus the
+module assemblies that deployment actually mounts**. A `using` of a module namespace in that source
+is therefore not a compile-time dependency the build can check — it is a **runtime requirement on
+every consumer's module set**, and `dotnet build` is blind to it.
+
+When the Store's `Store/Catalog`, `Store/Order`, `Store/Plugin` and `Store/Maintenance` sources took
+`using MeshWeaver.Payments.Stripe;`, every deployment that did not mount that module got both halves
+of the failure at once:
+
+```
+Prebuilt assembly for Store/Catalog DECLINED: dependency record mismatch —
+  'MeshWeaver.Payments.Stripe' built against mvid:ac387a93…, live is absent — compiling instead
+Compilation failed for 'Store/Catalog': CS0234 — the type or namespace name 'Payments'
+  does not exist in the namespace 'MeshWeaver'
+```
+
+The prebuilt assembly is declined *and* the local fallback compile fails, because the namespace
+genuinely is not there. The fallback exists to survive a version skew; it cannot conjure an absent
+assembly. Every instance of those node types then reads back with an empty `content`, so pages that
+have nothing to do with money render blank.
+
+**Nothing in a deployment's own configuration can fix that.** Its only escape is to mount the
+payment module — which is the opposite of optional, and makes an outbound-call surface to a card
+processor mandatory on portals that sell nothing.
+
+## The contract
+
+`MeshWeaver.Mesh.Contract/Payments/` carries the whole seam, and nothing in it names a processor:
+
+| Member | What it answers |
+|---|---|
+| `Sells` | does this portal take money at all? |
+| `Unavailable` | the reason a payment cannot be taken right now, in the viewer's language — `null` when one can |
+| `CreateCheckout(PaymentCheckoutRequest)` | open a hosted checkout; `Recurrence` non-null makes it recurring |
+| `CancelAtPeriodEnd(subscriptionId)` | stop renewing at the end of the paid period, never immediately |
+| `ReadDelivery(signature, body, now)` | verify a webhook delivery **and** parse it, in one answer |
+| `DescribeDeliveryPath(hookUrl)` | can the processor actually reach this portal? |
+| `SecretSettingName` / `WebhookSecretSettingName` / `DeliverySignatureHeader` | the names an operator finding has to quote |
+
+`PaymentMetadata` holds the keys a checkout stamps and the delivery reader looks for
+(`orderPath`, `pluginPath`, `buyer`, `couponCode`, `planTier`, `cadence`). They are **on the wire**
+at the processor: a session created before a rename hands the old key back weeks later, so they are
+durable contract exactly like a configuration key — and they live in the platform because the
+mesh-compiled content that stamps them must bind something present in every image.
+
+`PaymentSettings.BaseUrlConfig` (`Commerce:BaseUrl`) is the portal's own public URL. It is
+provider-neutral on purpose: a deployment states it once, and swapping providers does not restate
+it.
+
+### Verify and parse come back together
+
+`ReadDelivery` returns a `PaymentDelivery` carrying **both** `Authentic` and what the delivery is
+about. That is not a convenience — it is the only shape in which a caller can say *"this did not
+authenticate AND it names a paid order"*, which is the distinction that keeps **someone paid and was
+not served** from looking exactly like **the processor never called**
+([Plugins#1069](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1069)). An unauthenticated
+delivery that names consequential work is retained as evidence and replayed once the secret is
+fixed; junk is discarded so nobody can fill the container and drown the signal.
+
+### A read that failed is not an empty account
+
+`DescribeDeliveryPath` never faults. An unreachable processor, a refused credential, a truncated
+listing and an unparseable body all produce "nothing found", and collapsing them into "there is no
+endpoint" is what left a portal taking money and fulfilling nothing for days
+([Plugins#1109](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1109)). So `ReadProblem` and
+`Truncated` are carried separately from `Endpoints`, and a caller that cannot tell must say so
+rather than report health.
+
+## Absence is a modelled state
+
+`hub.PaymentProvider()` returns `IPaymentProvider?`. The null **is the design**: it makes "no
+payments module mounted" a state a caller answers in code, instead of a missing type a caller cannot
+compile against.
+
+🚨 **These three are forbidden**, and each was ruled out explicitly:
+
+- a `try`/`catch` around a payment type — the failure is at compile time, not at call time, so
+  there is nothing to catch;
+- a reflection probe for the module assembly — it re-creates the runtime coupling the abstraction
+  removes, and answers differently on a deployment that mounts the module *later*;
+- a `null` provider held and dereferenced at first use — that is not degradation, it is a
+  `NullReferenceException` on the payment path, which is worse than the compile error it replaced.
+
+The correct shape is the same everywhere: resolve, ask, and have a sentence ready for "no provider".
+
+```csharp
+// The reason this portal cannot take a payment, or null when it can.
+public static string? PaymentsUnavailable(IMessageHub hub) =>
+    hub.PaymentProvider() is { } provider
+        ? provider.Unavailable
+        : Texts(hub).NoPaymentProvider;
+```
+
+A portal with no provider therefore *refuses* a checkout with a sentence, reports its payment path
+as **out of scope** rather than healthy or broken, and leaves an unverifiable delivery in place
+instead of discarding it — all states the commerce surfaces already had for an unconfigured
+provider.
+
+## Everything reactive, everything cold
+
+Nothing on the contract returns a `Task`. Every method returns `IObservable<T>` and the side effect
+runs on `Subscribe`, never on the call ([Asynchronous Calls](../AsynchronousCalls)). An
+implementation bridges its HTTP leaf through the mesh's bounded `IIoPool`
+([Controlled IO Pooling](../ControlledIoPooling)) and never `Observable.FromAsync`, which would run
+the prologue on the subscribing thread and bound nothing.
+
+## Adding a second provider
+
+Implement `IPaymentProvider` in a new module assembly, register it as a singleton from the module's
+`MeshNodeProviderAttribute`, and ship it as its own package. Nothing in the commerce content
+changes, and no deployment that does not mount it is affected — which is the property this contract
+exists to buy.
+
+The one thing a new provider owns beyond the calls is its **vocabulary**: the events its delivery
+endpoint must be subscribed to, the word it uses for an enabled endpoint, and the remedy an operator
+follows. Those ride on `PaymentDeliveryPath` rather than being hard-coded by the caller, so an
+operator health board written once reads correctly for any provider.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-payments-are-something-a-portal-can-leave-out.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-payments-are-something-a-portal-can-leave-out.md
@@ -1,0 +1,25 @@
+---
+Name: Payments are something a portal can leave out
+Category: Feature
+Description: The platform now carries a provider-neutral payment contract, so commerce content binds an abstraction instead of a card processor and a deployment that mounts no payments module still works.
+Icon: PlugConnected
+Order: -20260906
+---
+
+Taking card payments is an optional module, but the Store's node types named one directly. A
+deployment that did not mount it could not compile them at all — `CS0234: the type or namespace name
+'Payments' does not exist in the namespace 'MeshWeaver'` — and pages with nothing to do with money
+rendered blank.
+
+The platform now ships `IPaymentProvider` in `MeshWeaver.Mesh.Contract`: a provider-neutral contract
+for opening a hosted checkout, cancelling a subscription at the end of its paid period, verifying and
+reading a webhook delivery, and asking whether the processor can actually reach this portal. A
+payment module supplies an implementation; a portal that mounts none simply resolves nothing.
+
+**The absence is a state, not a null to guard.** `hub.PaymentProvider()` returns `null` on a portal
+that does not sell, and every commerce surface answers that case explicitly — a refusal with a
+sentence in the viewer's language, a payment-path report that says *out of scope* rather than healthy
+or broken. No reflection probe for an assembly, no `try`/`catch` around a payment type.
+
+The reasoning, and the shape a second provider implements, is in
+[The Payment Provider Contract](/Doc/Architecture/PaymentProviderContract).

--- a/src/MeshWeaver.Mesh.Contract/Payments/HubPaymentExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/HubPaymentExtensions.cs
@@ -1,0 +1,42 @@
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Payments;
+
+/// <summary>
+/// How a caller reaches the payment provider — the ONE resolve, so no surface names an
+/// implementation and every one of them answers the no-provider case the same way.
+/// </summary>
+public static class HubPaymentExtensions
+{
+    /// <summary>
+    /// The payment provider this mesh has, or <c>null</c> when it has none — which is an ordinary,
+    /// supported configuration meaning "this portal does not sell", never an error.
+    ///
+    /// <para>🚨 The null is the point. It is what makes "no payments module mounted" a state a
+    /// caller must answer in code, instead of a missing type a caller cannot compile against.
+    /// Nothing anywhere probes for an assembly, reflects for a provider or catches a
+    /// <c>TypeLoadException</c>: the provider is either registered in this mesh's services or it is
+    /// not.</para>
+    /// </summary>
+    public static IPaymentProvider? PaymentProvider(this IMessageHub hub) =>
+        hub.ServiceProvider.GetService<IPaymentProvider>();
+
+    /// <summary>
+    /// Whether this portal takes money at all: a provider is registered AND holds the credential it
+    /// would need. False both when no module is mounted and when one is mounted unconfigured — two
+    /// routes to the same, correct behaviour of a portal that does not sell.
+    /// </summary>
+    public static bool Sells(this IMessageHub hub) => hub.PaymentProvider() is { Sells: true };
+
+    /// <summary>
+    /// This portal's public base URL, trimmed of its trailing slash; empty when it declares none.
+    /// Read from <see cref="PaymentSettings.BaseUrlConfig"/>, independent of which provider (if
+    /// any) is mounted — a portal states its own URL once.
+    /// </summary>
+    public static string CommerceBaseUrl(this IMessageHub hub) =>
+        (hub.ServiceProvider.GetService<IConfiguration>()?[PaymentSettings.BaseUrlConfig] ?? string.Empty)
+        .Trim()
+        .TrimEnd('/');
+}

--- a/src/MeshWeaver.Mesh.Contract/Payments/IPaymentProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/IPaymentProvider.cs
@@ -126,7 +126,10 @@ public interface IPaymentProvider
     /// This is what sees that. Cold; it never faults — a read that failed comes back as
     /// <see cref="PaymentDeliveryPath.ReadProblem"/>, because "I could not look" must stay
     /// distinguishable from "there is nothing there".</para>
+    ///
+    /// <para>It reports what the provider HAS, and never what the caller expected: comparing the
+    /// account's endpoints against this portal's own hook URL is the caller's decision, so a
+    /// provider cannot quietly answer the question it finds easier.</para>
     /// </summary>
-    /// <param name="hookUrl">The URL this portal expects deliveries on, or null when it declares none.</param>
-    IObservable<PaymentDeliveryPath> DescribeDeliveryPath(string? hookUrl);
+    IObservable<PaymentDeliveryPath> DescribeDeliveryPath();
 }

--- a/src/MeshWeaver.Mesh.Contract/Payments/IPaymentProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/IPaymentProvider.cs
@@ -1,0 +1,132 @@
+using System.Reactive;
+
+namespace MeshWeaver.Payments;
+
+/// <summary>
+/// The platform's provider-neutral PAYMENT contract: everything a commerce surface must be able to
+/// ask of "whatever takes the money on this deployment", and nothing about any particular card
+/// processor.
+///
+/// <para>🚨 <b>The absence of a provider is a MODELLED STATE, not a null to guard.</b> Taking card
+/// payments is an outbound-call surface to a named third party, so it ships as an optional module
+/// (<c>MeshWeaver.Payments.Stripe</c> is the first implementation) and a great many deployments
+/// mount none at all. A portal with no provider registered is a portal that <b>does not sell</b> —
+/// a perfectly good configuration that must compile, install and run, with the payment features
+/// absent or inert rather than broken. Callers therefore resolve
+/// <see cref="HubPaymentExtensions.PaymentProvider"/> (nullable by construction) and answer the
+/// no-provider case explicitly; they never reflect for an assembly, never <c>try/catch</c> around a
+/// payment type, and never hold a provider they have not checked (MeshWeaver.Plugins#1328).</para>
+///
+/// <para>The contract lives here — beside <see cref="MeshWeaver.Mesh.IEmailSender"/>, and for the
+/// identical reason. Content compiled INSIDE the mesh (the Store's NodeTypes) has to bind
+/// something that is present in every portal image; binding a module assembly instead is what made
+/// every consumer that did not mount that module fail to compile its Store types at all
+/// (<c>CS0234: the type or namespace name 'Payments' does not exist in the namespace
+/// 'MeshWeaver'</c>). An abstraction in the platform plus an implementation in a module is the one
+/// shape where "not installed" degrades instead of breaking.</para>
+///
+/// <para>🚨 <b>Reactive end to end, and every returned observable is COLD.</b> Nothing here returns
+/// a <c>Task</c>; the request is made on <c>Subscribe</c>, never on the call. An implementation
+/// bridges its HTTP leaf through the mesh's bounded <c>IIoPool</c> and never
+/// <c>Observable.FromAsync</c>.</para>
+/// </summary>
+public interface IPaymentProvider
+{
+    /// <summary>
+    /// What this provider is called, for operator-facing prose ("Stripe"). A product name, not a
+    /// translated one — the surrounding sentence is localized, the processor's name is not.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// The reason a payment cannot be taken on this portal right now — <c>null</c> when one can.
+    /// Resolved in the VIEWER's language by the implementation, because it is shown to a buyer at
+    /// the till.
+    ///
+    /// <para>Distinct from <see cref="Sells"/>: a provider can be installed and hold a credential
+    /// (so the portal <i>does</i> sell) and still refuse a specific checkout for a reason of its
+    /// own — no public base URL to return the buyer to, for instance.</para>
+    /// </summary>
+    string? Unavailable { get; }
+
+    /// <summary>
+    /// Whether this portal takes money at all — i.e. the provider holds the credential it would
+    /// need to create a checkout.
+    ///
+    /// <para>This is the out-of-scope answer an operator health board needs: a portal that creates
+    /// no checkout sessions has no payment path that can be broken, which is a different statement
+    /// from "the payment path was measured and is fine".</para>
+    /// </summary>
+    bool Sells { get; }
+
+    /// <summary>
+    /// The configuration key holding this provider's server-side credential — named in operator
+    /// findings so a diagnosis carries its own remedy. The VALUE is never read into a log, a
+    /// message or a rendered page.
+    /// </summary>
+    string SecretSettingName { get; }
+
+    /// <summary>
+    /// The configuration key holding the signing secret this provider verifies deliveries against.
+    /// Named in operator findings for the same reason as <see cref="SecretSettingName"/>.
+    /// </summary>
+    string WebhookSecretSettingName { get; }
+
+    /// <summary>
+    /// The HTTP header a delivery from this provider carries its signature in
+    /// (<c>Stripe-Signature</c> for Stripe). The generic webhook inbox stores every header
+    /// verbatim; this names the one that authorizes the delivery.
+    /// </summary>
+    string DeliverySignatureHeader { get; }
+
+    /// <summary>
+    /// Creates a hosted checkout — one-off when <see cref="PaymentCheckoutRequest.Recurrence"/> is
+    /// null, recurring when it is not. Cold; errors carry a viewer-language message.
+    ///
+    /// <para>The provider is told everything and decides nothing about the domain: it receives a
+    /// reference, a product name, an amount, two return URLs and a metadata map, and it knows
+    /// nothing of plugins, plans or covers. Where the buyer returns to is the CALLER's policy, so a
+    /// moved checkout surface can never leave a payment provider redirecting at a dead URL.</para>
+    /// </summary>
+    IObservable<PaymentCheckout> CreateCheckout(PaymentCheckoutRequest request);
+
+    /// <summary>
+    /// Asks the provider to stop renewing a subscription AT THE END of the period already paid
+    /// for, never immediately: the buyer paid for this period, so this period is theirs. The
+    /// provider then reports the actual ending as a delivery
+    /// (<see cref="PaymentSubscriptionChange.Ended"/>), and THAT is what files the cancellation —
+    /// the portal never revokes access on its own guess about what the processor did.
+    ///
+    /// <para>Cold; emits once on success.</para>
+    /// </summary>
+    IObservable<Unit> CancelAtPeriodEnd(string subscriptionId);
+
+    /// <summary>
+    /// Reads one stored webhook delivery: VERIFIES its signature and PARSES what it is about, in
+    /// one answer.
+    ///
+    /// <para>🚨 The two halves are returned together on purpose. A caller has to be able to say
+    /// "this delivery did not authenticate AND it names a paid order", because an unauthenticated
+    /// delivery that names consequential work is retained as evidence while junk is discarded — the
+    /// distinction that keeps "someone paid and was not served" from looking exactly like "the
+    /// processor never called" (MeshWeaver.Plugins#1069). Pure: the secret comes from the
+    /// implementation's configuration, the payload and the clock from the caller.</para>
+    /// </summary>
+    /// <param name="signatureHeader">The delivery's <see cref="DeliverySignatureHeader"/> value.</param>
+    /// <param name="body">The raw body, exactly as stored.</param>
+    /// <param name="now">The instant to bound the delivery's timestamp against.</param>
+    PaymentDelivery ReadDelivery(string? signatureHeader, string body, DateTimeOffset now);
+
+    /// <summary>
+    /// The provider's own account of whether it can DELIVER events back to this portal — the half
+    /// of the payment path that lives at the processor and is invisible from the mesh.
+    ///
+    /// <para>A checkout can complete at the processor and nothing ever call the mesh: the order
+    /// stays unpaid-looking, both delivery containers stay empty, and every surface reports health.
+    /// This is what sees that. Cold; it never faults — a read that failed comes back as
+    /// <see cref="PaymentDeliveryPath.ReadProblem"/>, because "I could not look" must stay
+    /// distinguishable from "there is nothing there".</para>
+    /// </summary>
+    /// <param name="hookUrl">The URL this portal expects deliveries on, or null when it declares none.</param>
+    IObservable<PaymentDeliveryPath> DescribeDeliveryPath(string? hookUrl);
+}

--- a/src/MeshWeaver.Mesh.Contract/Payments/PaymentCheckout.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/PaymentCheckout.cs
@@ -1,0 +1,62 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Payments;
+
+/// <summary>
+/// Everything a payment provider must be TOLD to open a hosted checkout — provider-neutral by
+/// construction: a reference, what the buyer is buying, what it costs, where to send them back to,
+/// and the facts that must survive the round trip.
+///
+/// <para>🚨 <see cref="Metadata"/> is the load-bearing part. It is stamped at submit and handed
+/// back on the verified delivery — months later for a subscription renewal — and fulfilment trusts
+/// THAT snapshot rather than a node the buyer can edit. Its keys are
+/// <see cref="PaymentMetadata"/>'s constants, never literals: producer and consumer are hours or
+/// weeks apart, so a typo is not a compile error and not a test failure, it is a subscriber who
+/// lapses with nothing anywhere to say why.</para>
+/// </summary>
+public sealed record PaymentCheckoutRequest
+{
+    /// <summary>The caller's own handle for this purchase (an order path). Travels back verbatim.</summary>
+    public required string Reference { get; init; }
+
+    /// <summary>What the buyer sees on the provider's page.</summary>
+    public required string ProductName { get; init; }
+
+    /// <summary>The price in the currency's MAJOR unit; the provider converts if it bills in minor units.</summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>ISO-4217, any case.</summary>
+    public required string Currency { get; init; }
+
+    /// <summary>Where the provider returns a buyer who paid.</summary>
+    public required string SuccessUrl { get; init; }
+
+    /// <summary>Where the provider returns a buyer who walked away.</summary>
+    public required string CancelUrl { get; init; }
+
+    /// <summary>Facts the verified delivery must hand back, verbatim. Keyed by <see cref="PaymentMetadata"/>.</summary>
+    public ImmutableDictionary<string, string> Metadata { get; init; } =
+        ImmutableDictionary<string, string>.Empty;
+
+    /// <summary>
+    /// Null for a ONE-OFF purchase; set for a recurring one. The single discriminator between the
+    /// two checkout shapes, so a caller cannot ask for a subscription and forget to say on what
+    /// cadence.
+    /// </summary>
+    public PaymentRecurrence? Recurrence { get; init; }
+}
+
+/// <summary>
+/// What makes a checkout RECURRING: the cadence it bills on, and optionally the buyer's email to
+/// prefill the provider's page with.
+/// </summary>
+/// <param name="Cadence">The caller's cadence word (e.g. <c>monthly</c>, <c>annual</c>); the
+/// provider maps it onto its own billing interval.</param>
+/// <param name="CustomerEmail">Prefills the provider's page; omitted when blank. The billing
+/// profile already asked for it, and asking twice is how a receipt ends up at a second address.</param>
+public sealed record PaymentRecurrence(string Cadence, string? CustomerEmail = null);
+
+/// <summary>One created hosted-checkout session.</summary>
+/// <param name="SessionId">The provider's session id — stamped on the order so a delivery can be paired.</param>
+/// <param name="Url">Where to send the buyer.</param>
+public sealed record PaymentCheckout(string SessionId, string Url);

--- a/src/MeshWeaver.Mesh.Contract/Payments/PaymentDelivery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/PaymentDelivery.cs
@@ -1,0 +1,162 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Payments;
+
+/// <summary>
+/// One webhook delivery as the provider read it: whether it AUTHENTICATED, and what it is ABOUT.
+///
+/// <para>🚨 Both halves in one answer, deliberately. The caller has to distinguish an
+/// unauthenticated delivery that names consequential work — someone may have PAID and not been
+/// served, so it is retained as evidence and replayed once the secret is fixed — from junk, which
+/// is discarded so nobody can fill the container and drown the signal
+/// (MeshWeaver.Plugins#1069).</para>
+/// </summary>
+public sealed record PaymentDelivery
+{
+    /// <summary>Nothing readable: neither a checkout nor a subscription event, and unauthenticated.</summary>
+    public static PaymentDelivery None { get; } = new();
+
+    /// <summary>
+    /// Whether the provider holds the signing secret it would need to authenticate ANY delivery.
+    ///
+    /// <para>🚨 Distinct from <see cref="Authentic"/>, and the two must never be collapsed. "This
+    /// deployment cannot check signatures at all" is a configuration state whose right answer is to
+    /// LEAVE the delivery where it is — it processes once the secret lands. "This delivery failed a
+    /// check that could have passed" is a security event whose right answer is to retain it as
+    /// evidence and shout. Treating the first as the second discards deliveries a portal was simply
+    /// not yet configured to read.</para>
+    /// </summary>
+    public bool CanAuthenticate { get; init; }
+
+    /// <summary>Whether the signature verified — i.e. the delivery genuinely came from the provider.</summary>
+    public bool Authentic { get; init; }
+
+    /// <summary>The checkout this delivery is about, or null when it is not a checkout event.</summary>
+    public PaymentCheckoutEvent? Checkout { get; init; }
+
+    /// <summary>The subscription lifecycle this delivery is about, or null when it is not one.</summary>
+    public PaymentSubscriptionEvent? Subscription { get; init; }
+
+    /// <summary>
+    /// Whether this delivery names work the portal would actually DO — a checkout naming an order,
+    /// or a subscription event that renews or ends a plan. The predicate the retention decision
+    /// turns on: a renewal discarded as noise is a subscriber whose plan silently lapses next month
+    /// with nothing anywhere to say why. Pure.
+    /// </summary>
+    public bool NamesWork =>
+        Checkout is { OrderPath: { Length: > 0 } } || Subscription is { IsActionable: true };
+}
+
+/// <summary>What a checkout delivery says happened to the session.</summary>
+public enum PaymentCheckoutOutcome
+{
+    /// <summary>Something else about a checkout session — nothing the portal acts on.</summary>
+    Other = 0,
+
+    /// <summary>The buyer PAID. This is what fulfils an order.</summary>
+    Completed = 1,
+
+    /// <summary>The session expired unpaid. This is what cancels an abandoned order.</summary>
+    Expired = 2,
+}
+
+/// <summary>
+/// One parsed CHECKOUT delivery — the facts fulfilment runs on, taken from the session's metadata
+/// as stamped at submit, never from a buyer-editable node.
+/// </summary>
+/// <param name="Outcome">What happened to the session.</param>
+/// <param name="SessionId">The checkout session; paired against the order's stamped session id.</param>
+/// <param name="Metadata">The metadata the session carries, verbatim.</param>
+public sealed record PaymentCheckoutEvent(
+    PaymentCheckoutOutcome Outcome,
+    string SessionId,
+    ImmutableDictionary<string, string> Metadata)
+{
+    /// <summary>The subscription the completed session created, when it created one.</summary>
+    public string? SubscriptionId { get; init; }
+
+    /// <summary>The order this purchase is for.</summary>
+    public string? OrderPath => Meta(PaymentMetadata.OrderPath);
+
+    /// <summary>The package bought, on a one-off purchase.</summary>
+    public string? PluginPath => Meta(PaymentMetadata.PluginPath);
+
+    /// <summary>The viewer who bought.</summary>
+    public string? Buyer => Meta(PaymentMetadata.Buyer);
+
+    /// <summary>The coupon applied, when one was.</summary>
+    public string? CouponCode => Meta(PaymentMetadata.CouponCode);
+
+    /// <summary>
+    /// The plan bought, when this session was a subscription checkout. This is what makes a PLAN
+    /// checkout distinguishable from a package one: the same delivery shape carries both, and only
+    /// the metadata says which was bought.
+    /// </summary>
+    public string? PlanTier => Meta(PaymentMetadata.PlanTier);
+
+    /// <summary>The billing cadence the plan was bought on.</summary>
+    public string? Cadence => Meta(PaymentMetadata.Cadence);
+
+    /// <summary>Whether this session bought a PLAN rather than a package. Pure.</summary>
+    public bool IsPlan => !string.IsNullOrWhiteSpace(PlanTier);
+
+    /// <summary>One metadata value, or null when absent or blank. Pure.</summary>
+    public string? Meta(string key) =>
+        Metadata.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value) ? value : null;
+}
+
+/// <summary>What a subscription-lifecycle delivery does to the plan it names.</summary>
+public enum PaymentSubscriptionChange
+{
+    /// <summary>Nothing the portal acts on — including an event that names no viewer and no plan.</summary>
+    None = 0,
+
+    /// <summary>
+    /// A new billing period was PAID. The plan is topped up.
+    ///
+    /// <para>🚨 The FIRST charge of a subscription is deliberately not a renewal — it is already
+    /// granted by the completed checkout, and counting it twice grants two periods for one payment.
+    /// Which invoice is which is the provider's own discriminator, so the provider decides this,
+    /// never the caller.</para>
+    /// </summary>
+    Renewed = 1,
+
+    /// <summary>The provider has stopped billing the subscription. This is what ends the plan.</summary>
+    Ended = 2,
+}
+
+/// <summary>
+/// One parsed SUBSCRIPTION-LIFECYCLE delivery — the renewals and the ending, which arrive long
+/// after the checkout that started them and carry their facts on the SUBSCRIPTION's own metadata.
+/// </summary>
+/// <param name="Change">What this delivery does to the plan; <see cref="PaymentSubscriptionChange.None"/>
+/// when it names no viewer and no plan, or is not one of the two the portal acts on.</param>
+/// <param name="SubscriptionId">The subscription this is about.</param>
+/// <param name="Metadata">The subscription's metadata as this payload carries it.</param>
+public sealed record PaymentSubscriptionEvent(
+    PaymentSubscriptionChange Change,
+    string? SubscriptionId,
+    ImmutableDictionary<string, string> Metadata)
+{
+    /// <summary>The viewer whose plan it is.</summary>
+    public string? Buyer => Meta(PaymentMetadata.Buyer);
+
+    /// <summary>The plan.</summary>
+    public string? PlanTier => Meta(PaymentMetadata.PlanTier);
+
+    /// <summary>The billing cadence.</summary>
+    public string? Cadence => Meta(PaymentMetadata.Cadence);
+
+    /// <summary>Whether this event RENEWS the plan. Pure.</summary>
+    public bool Renews => Change is PaymentSubscriptionChange.Renewed;
+
+    /// <summary>Whether this event ENDS the plan. Pure.</summary>
+    public bool Ends => Change is PaymentSubscriptionChange.Ended;
+
+    /// <summary>Whether this event is one the portal acts on at all. Pure.</summary>
+    public bool IsActionable => Renews || Ends;
+
+    /// <summary>One metadata value, or null when absent or blank. Pure.</summary>
+    public string? Meta(string key) =>
+        Metadata.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value) ? value : null;
+}

--- a/src/MeshWeaver.Mesh.Contract/Payments/PaymentDeliveryPath.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/PaymentDeliveryPath.cs
@@ -1,0 +1,78 @@
+namespace MeshWeaver.Payments;
+
+/// <summary>
+/// The provider's account of the DELIVERY half of the payment path — the half that lives at the
+/// processor, where a portal cannot see it.
+///
+/// <para>🚨 <b>A read that FAILED is not an account with no endpoints.</b> An unreachable provider,
+/// a refused credential, a truncated listing and an unparseable body all produce "nothing found",
+/// and collapsing them into "there is no endpoint" is exactly the conflation that left a portal
+/// silently taking money and never fulfilling anything (MeshWeaver.Plugins#1109). So
+/// <see cref="ReadProblem"/> and <see cref="Truncated"/> are carried separately, and a caller that
+/// cannot tell must say so rather than report health.</para>
+/// </summary>
+public sealed record PaymentDeliveryPath
+{
+    /// <summary>
+    /// The account MODE this portal's credential operates in, as operator-facing display text
+    /// ("TEST", "LIVE", or the provider's word for "not one I recognise").
+    ///
+    /// <para>Named in every line because it is the fact the whole question turns on: a provider
+    /// that keeps separate test and live configurations lists only the endpoints of the mode its
+    /// credential belongs to, so "no endpoint for my URL" means "no endpoint IN THIS MODE" — which
+    /// is what tells "never registered" from "registered in the other one".</para>
+    /// </summary>
+    public required string Mode { get; init; }
+
+    /// <summary>The endpoints the provider reports for this account, in this mode.</summary>
+    public IReadOnlyList<PaymentDeliveryEndpoint> Endpoints { get; init; } = [];
+
+    /// <summary>
+    /// Whether the listing was TRUNCATED. A partial listing cannot prove an endpoint absent — "I
+    /// did not see it on the first page" is not "it does not exist".
+    /// </summary>
+    public bool Truncated { get; init; }
+
+    /// <summary>
+    /// Why the listing could not be read, or null when it was read. Carries the failure KIND and
+    /// nothing that could restate a credential.
+    /// </summary>
+    public string? ReadProblem { get; init; }
+
+    /// <summary>
+    /// The delivery events this provider's fulfilment path needs an endpoint to be subscribed to.
+    /// The provider names them because they are its own event vocabulary.
+    /// </summary>
+    public IReadOnlyList<string> RequiredEvents { get; init; } = [];
+
+    /// <summary>
+    /// What an operator DOES about a broken delivery path, in the provider's own terms — carried in
+    /// the report because a diagnosis without its remedy is what left the defect open for days.
+    /// </summary>
+    public required string Remedy { get; init; }
+}
+
+/// <summary>One delivery endpoint as the provider reports it.</summary>
+/// <param name="Url">The URL the provider posts deliveries to, verbatim.</param>
+/// <param name="Enabled">Whether the provider would actually deliver to it. A disabled endpoint
+/// delivers nothing, which is indistinguishable from an absent one on the receiving side.</param>
+/// <param name="Status">The provider's own status word, for display; null when it named none.</param>
+/// <param name="Events">The events it is subscribed to. <see cref="AllEvents"/> means every event.</param>
+public sealed record PaymentDeliveryEndpoint(
+    string Url,
+    bool Enabled,
+    string? Status,
+    IReadOnlyList<string> Events)
+{
+    /// <summary>The wildcard subscription — an endpoint carrying it receives every event.</summary>
+    public const string AllEvents = "*";
+
+    /// <summary>
+    /// Whether this endpoint's subscription covers <paramref name="wanted"/> — directly or through
+    /// <see cref="AllEvents"/>. Pure.
+    /// </summary>
+    public bool Covers(string wanted) =>
+        Events.Any(subscribed =>
+            string.Equals(subscribed?.Trim(), AllEvents, StringComparison.Ordinal)
+            || string.Equals(subscribed?.Trim(), wanted, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/MeshWeaver.Mesh.Contract/Payments/PaymentMetadata.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/PaymentMetadata.cs
@@ -1,0 +1,56 @@
+namespace MeshWeaver.Payments;
+
+/// <summary>
+/// The metadata keys a MeshWeaver checkout stamps onto a provider's session and subscription, and
+/// the keys its delivery reader looks for.
+///
+/// <para>🚨 <b>Producer and consumer must agree, and they are hours apart.</b> A subscription's
+/// metadata is written once at submit and read back months later on a renewal; a typo on either
+/// side is not a compile error and not a test failure — it is a renewal that arrives naming nobody,
+/// and a subscriber who lapses with nothing anywhere to say why. One constant per key, so the two
+/// sides cannot drift.</para>
+///
+/// <para>The keys are also ON THE WIRE at the provider: sessions created before a rename would hand
+/// back the old key. Treat them as durable contract, exactly like configuration keys. They live in
+/// the platform rather than in a payment module because the mesh-compiled commerce content that
+/// STAMPS them must bind something present in every portal image, whether or not a payment module
+/// is mounted.</para>
+/// </summary>
+public static class PaymentMetadata
+{
+    /// <summary>The mesh path of the order this purchase is for.</summary>
+    public const string OrderPath = "orderPath";
+
+    /// <summary>The mesh path of the package being bought (a one-off purchase).</summary>
+    public const string PluginPath = "pluginPath";
+
+    /// <summary>The viewer buying.</summary>
+    public const string Buyer = "buyer";
+
+    /// <summary>The coupon applied, when one was.</summary>
+    public const string CouponCode = "couponCode";
+
+    /// <summary>The plan tier being subscribed to (a recurring purchase).</summary>
+    public const string PlanTier = "planTier";
+
+    /// <summary>The billing cadence the plan was bought on.</summary>
+    public const string Cadence = "cadence";
+}
+
+/// <summary>
+/// Deployment settings the COMMERCE surfaces read directly, independent of which payment provider
+/// (if any) is mounted.
+/// </summary>
+public static class PaymentSettings
+{
+    /// <summary>
+    /// The configuration key of the portal's public base URL — what a checkout's success and cancel
+    /// redirects are built from, and what a delivery endpoint has to be registered against.
+    ///
+    /// <para>Provider-neutral on purpose: a portal declares its own public URL once, and a
+    /// deployment that swaps payment providers does not restate it. The key STRING is contract —
+    /// it is read out of an environment variable, a Key Vault secret name and a helm values file,
+    /// so renaming it is a silent deletion on every running deployment.</para>
+    /// </summary>
+    public const string BaseUrlConfig = "Commerce:BaseUrl";
+}


### PR DESCRIPTION
## Why

Card payments ship as an **optional module** (`MeshWeaver.Payments.Stripe`), but the mesh-compiled
commerce content had no abstraction to bind, so `Store/Catalog`, `Store/Order`, `Store/Plugin` and
`Store/Maintenance` took `using MeshWeaver.Payments.Stripe;` directly (Plugins `589a17a1`).

A NodeType's C# compiles **at runtime**, against the portal image's reference set plus the modules
that deployment actually mounts. A `using` of a module namespace there is therefore not a
compile-time dependency any build can check — it is a runtime requirement on **every consumer's
module set**. Every deployment that did not mount the module got both halves of the failure at once:

```
Prebuilt assembly for Store/Catalog DECLINED: dependency record mismatch —
  'MeshWeaver.Payments.Stripe' built against mvid:ac387a93…, live is absent — compiling instead
Compilation failed for 'Store/Catalog': CS0234 — the type or namespace name 'Payments'
  does not exist in the namespace 'MeshWeaver'   (+ CS0246, and 1703 more)
```

The fallback cannot save it — the namespace genuinely is not there — so instances of those node
types read back with an empty `content` and pages unrelated to money render blank. Measured on
MeshWeaver.Reinsurance's gate (`adopted 210 of 214`) and on both production portals.

This is the **adding half** of Systemorph/MeshWeaver.Plugins#1328, a 3.0.0 release blocker
(Systemorph/MeshWeaver#3355): 3.0.0 will not ship a Store that hard-requires the payments module.

## What

`src/MeshWeaver.Mesh.Contract/Payments/` — beside `IEmailSender`, and for the identical reason: a
provider-neutral contract in the platform, the implementation in a module a deployment may or may
not mount.

- **`IPaymentProvider`** — `Sells`, `Unavailable` (the viewer-language reason a payment cannot be
  taken, or null), `CreateCheckout`, `CancelAtPeriodEnd`, `ReadDelivery`, `DescribeDeliveryPath`,
  plus the setting names an operator finding has to quote.
- **`PaymentCheckoutRequest` / `PaymentRecurrence` / `PaymentCheckout`** — one request type for both
  checkout shapes; `Recurrence` non-null is the single discriminator, so a caller cannot ask for a
  subscription and forget to say on what cadence.
- **`PaymentDelivery` / `PaymentCheckoutEvent` / `PaymentSubscriptionEvent`** — verify **and** parse
  in one answer. `CanAuthenticate` (no signing secret at all) is deliberately separate from
  `Authentic` (a check that could have passed and did not): the first leaves the delivery in place,
  the second retains it as evidence and shouts.
- **`PaymentDeliveryPath` / `PaymentDeliveryEndpoint`** — the provider's account of whether the
  processor can reach this portal. `ReadProblem` and `Truncated` are carried separately from
  `Endpoints`, because a read that failed is not an account with no endpoints.
- **`PaymentMetadata`** — the keys a checkout stamps and the delivery reader looks for. They are on
  the wire at the processor (a session created before a rename hands the old key back weeks later),
  so they are durable contract, and they live in the platform because the mesh-compiled content that
  stamps them must bind something present in every image.
- **`PaymentSettings.BaseUrlConfig`** (`Commerce:BaseUrl`) — the portal's own public URL,
  provider-neutral so swapping providers does not restate it.
- **`HubPaymentExtensions`** — the one resolve, `IPaymentProvider?`.

**Absence is a modelled state.** `hub.PaymentProvider()` returning `null` *is* the design: it makes
"no payments module mounted" a case a caller answers in code instead of a type it cannot compile
against. No reflection probe for the assembly, no `try`/`catch` around a payment type, no null
provider dereferenced at first use.

Everything reactive and cold — no `Task`, no `Observable.FromAsync`; an implementation bridges its
HTTP leaf through the mesh's bounded `IIoPool`.

## Docs

- `Doc/Architecture/PaymentProviderContract` — the design, the failure it removes, what a second
  provider implements, and the three shapes that are forbidden.
- What's New: *Payments are something a portal can leave out*.

## Verification

- `dotnet build src/MeshWeaver.Mesh.Contract -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**.
- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → 0/0; then
  `DocumentationLinkIntegrityTest` → **Passed! Failed: 0, Passed: 1**.

Nothing implements the contract yet, by design — this is the adding half and it ships unimplemented.
The implementation (`StripePaymentProvider`) and the content that binds it are the Plugins half:
Systemorph/MeshWeaver.Plugins#1328, which follows on a pin bump to this commit.

`Pairs-with: none — purely additive; the diff removes no public type and no public member
(`git diff --cached -U0 -- src/ | grep '^-' | grep 'public '` is empty).`

Refs Systemorph/MeshWeaver.Plugins#1328, Systemorph/MeshWeaver.Plugins#1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
