### PR TITLE
fix(#3201): a Deployment record can hold every Key Vault class its portal reads

### DIFF
--- a/deploy/helm/templates/memex-portal/_keyvault.tpl
+++ b/deploy/helm/templates/memex-portal/_keyvault.tpl
@@ -1,0 +1,65 @@
+{{- /*
+The portal's Key Vault secret CLASSES, resolved: one entry per SecretProviderClass the chart owns,
+with every name already defaulted, so the four templates that need them (secretproviderclass.yaml
+and deployment.yaml's envFrom / volumeMounts / volumes) can never disagree about a name.
+
+🚨 WHY A LIST AND NOT ONE BLOCK. `keyVaultSecrets` held exactly ONE class, and a namespace that
+runs two could therefore not be described by any file. `memex` runs two — the hand-made `memex-kv`
+(13 keys: the connection string, the GitHub App key, the AI keys) and the chart-owned
+`memex-portal-keyvault` (the plugin-registry token) — so with one slot the record had to choose,
+and whichever it named, a re-render DROPPED the other. That is not hypothetical: on 2026-09-06 the
+`memex` record described `memex-kv` while the deployed overlay described `memex-portal-keyvault`,
+so a re-render from the record would have removed the registry-token class that had just fixed the
+poll (MeshWeaver#3201 / Memex#164) AND rendered a class for `memex-kv` whose derived vault object
+does not exist — a mount failure, i.e. a portal that cannot start.
+
+ORDER IS PRECEDENCE. Kubernetes keeps the LAST `envFrom` entry on a key clash, so the classes are
+emitted in list order, after the chart's own ConfigMap and Secret. `keyVaultSecrets` (the singular,
+legacy block) comes first so an existing environment renders byte-identically; entries in
+`keyVaultSecretClasses` follow, in order.
+
+NAMES ARE REQUIRED ON THE PLURAL FORM. The singular block may lean on the chart's defaults
+(`memex-portal-keyvault` / `kv-secrets` / `/mnt/secrets-store`); a SECOND class that did the same
+would collide with the first on all three — two volumes of one name is an invalid pod spec and two
+SecretProviderClasses syncing into one Secret race each other — so `name`, `volumeName` and
+`mountPath` must be stated. `syncedSecret` still defaults to the class's own name.
+
+The vault coordinates fall back to the singular block's, because a namespace's classes normally
+read the SAME vault with the SAME add-on identity; stating them per class stays possible.
+
+NAMES ONLY. No value of any secret is in values, in this helper, or in any render.
+*/ -}}
+{{- define "memex.keyVaultClasses" -}}
+{{- $root := . -}}
+{{- $fallback := (.Values.keyVaultSecrets | default dict) -}}
+{{- $classes := list -}}
+{{- with .Values.keyVaultSecrets -}}
+{{- if .secrets -}}
+{{- $name := .name | default "memex-portal-keyvault" -}}
+{{- $classes = append $classes (dict
+      "name" $name
+      "syncedSecret" (.syncedSecret | default $name)
+      "volumeName" (.volumeName | default "kv-secrets")
+      "mountPath" (.mountPath | default "/mnt/secrets-store")
+      "vaultName" (required "keyVaultSecrets.vaultName is required when keyVaultSecrets.secrets is non-empty" .vaultName)
+      "tenantId" (required "keyVaultSecrets.tenantId is required when keyVaultSecrets.secrets is non-empty" .tenantId)
+      "identityClientId" (required "keyVaultSecrets.identityClientId is required when keyVaultSecrets.secrets is non-empty (the Key Vault Secrets Provider add-on's user-assigned identity client id)" .identityClientId)
+      "secrets" .secrets) -}}
+{{- end -}}
+{{- end -}}
+{{- range $i, $class := ($root.Values.keyVaultSecretClasses | default list) -}}
+{{- if $class.secrets -}}
+{{- $name := required (printf "keyVaultSecretClasses[%d].name is required — a second SecretProviderClass may not default to the first's name" $i) $class.name -}}
+{{- $classes = append $classes (dict
+      "name" $name
+      "syncedSecret" ($class.syncedSecret | default $name)
+      "volumeName" (required (printf "keyVaultSecretClasses[%d].volumeName is required — two pod volumes of one name is an invalid spec" $i) $class.volumeName)
+      "mountPath" (required (printf "keyVaultSecretClasses[%d].mountPath is required — the mount is what makes the CSI driver sync and rotate the Secret" $i) $class.mountPath)
+      "vaultName" (required (printf "keyVaultSecretClasses[%d].vaultName is required (or keyVaultSecrets.vaultName)" $i) ($class.vaultName | default $fallback.vaultName))
+      "tenantId" (required (printf "keyVaultSecretClasses[%d].tenantId is required (or keyVaultSecrets.tenantId)" $i) ($class.tenantId | default $fallback.tenantId))
+      "identityClientId" (required (printf "keyVaultSecretClasses[%d].identityClientId is required (or keyVaultSecrets.identityClientId)" $i) ($class.identityClientId | default $fallback.identityClientId))
+      "secrets" $class.secrets) -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $classes -}}
+{{- end -}}

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -157,11 +157,11 @@ spec:
                    wins over a chart-rendered blank for the same key — k8s keeps the LAST envFrom
                    on a clash. Rendered only when secrets are declared; the values file says why
                    the declaration lives here and not on the cluster. */}}
-            {{- with .Values.keyVaultSecrets }}
-            {{- if .secrets }}
+            {{- /* One entry per declared class, in list order — and that order IS precedence:
+                   Kubernetes keeps the LAST envFrom on a key clash. */}}
+            {{- range $class := (include "memex.keyVaultClasses" . | fromYamlArray) }}
             - secretRef:
-                name: "{{ .syncedSecret | default (.name | default "memex-portal-keyvault") }}"
-            {{- end }}
+                name: "{{ $class.syncedSecret }}"
             {{- end }}
             {{- /* ⚠️ LEGACY: the block below is the escape hatch for an environment whose
                    SecretProviderClass is still HAND-MADE. Declare the secrets under
@@ -236,12 +236,10 @@ spec:
 {{- /* The mount of the DECLARED Key Vault CSI volume (.Values.keyVaultSecrets). The mount is what
        makes the driver fetch the vault objects, create the synced Secret and keep rotating it — a
        SecretProviderClass with no mounting pod syncs nothing, with no error anywhere. */}}
-{{- with .Values.keyVaultSecrets }}
-{{- if .secrets }}
-            - name: "{{ .volumeName | default "kv-secrets" }}"
-              mountPath: "{{ .mountPath | default "/mnt/secrets-store" }}"
+{{- range $class := (include "memex.keyVaultClasses" . | fromYamlArray) }}
+            - name: "{{ $class.volumeName }}"
+              mountPath: "{{ $class.mountPath }}"
               readOnly: true
-{{- end }}
 {{- end }}
 {{- /* ⚠️ LEGACY: extra mounts the chart does not own — the mount half of .Values.extraVolumes
        (typically a HAND-MADE secrets-store CSI volume, whose mount is what makes the driver sync
@@ -468,15 +466,13 @@ spec:
 {{- /* The DECLARED Key Vault CSI volume (.Values.keyVaultSecrets) — the volume half of the
        SecretProviderClass the chart renders in secretproviderclass.yaml. Same block, so the
        SecretProviderClass, the volume, its mount and the envFrom can never disagree on a name. */}}
-{{- with .Values.keyVaultSecrets }}
-{{- if .secrets }}
-        - name: "{{ .volumeName | default "kv-secrets" }}"
+{{- range $class := (include "memex.keyVaultClasses" . | fromYamlArray) }}
+        - name: "{{ $class.volumeName }}"
           csi:
             driver: "secrets-store.csi.k8s.io"
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "{{ .name | default "memex-portal-keyvault" }}"
-{{- end }}
+              secretProviderClass: "{{ $class.name }}"
 {{- end }}
 {{- /* ⚠️ LEGACY: extra volumes the chart does not own — typically the secrets-store CSI volume
        behind a HAND-MADE SecretProviderClass. Prefer .Values.keyVaultSecrets, which renders the

--- a/deploy/helm/templates/memex-portal/secretproviderclass.yaml
+++ b/deploy/helm/templates/memex-portal/secretproviderclass.yaml
@@ -25,18 +25,18 @@ are derived from the SAME block in deployment.yaml, so a declared secret cannot 
 NAMES ONLY: `vaultSecret` is the vault object's name, `key` the env key it lands as. No value is
 ever in values, and no value is ever in this render — the driver fetches them at pod start.
 */ -}}
-{{- with .Values.keyVaultSecrets }}
-{{- if .secrets }}
-{{- $vault := required "keyVaultSecrets.vaultName is required when keyVaultSecrets.secrets is non-empty" .vaultName }}
-{{- $tenant := required "keyVaultSecrets.tenantId is required when keyVaultSecrets.secrets is non-empty" .tenantId }}
-{{- $identity := required "keyVaultSecrets.identityClientId is required when keyVaultSecrets.secrets is non-empty (the Key Vault Secrets Provider add-on's user-assigned identity client id)" .identityClientId }}
-{{- $name := .name | default "memex-portal-keyvault" }}
-{{- $synced := .syncedSecret | default $name }}
+{{- /* One SecretProviderClass per declared CLASS — `keyVaultSecrets` (the singular, legacy block)
+       first, then every entry of `keyVaultSecretClasses`, resolved by the `memex.keyVaultClasses`
+       helper so all four render sites agree on every name. A namespace that reads two vault-secret
+       sets (memex: the hand-made `memex-kv` plus the chart-owned `memex-portal-keyvault`) is now
+       describable in ONE file; with a single slot, whichever the record named, a re-render DROPPED
+       the other. */ -}}
+{{- range $class := (include "memex.keyVaultClasses" . | fromYamlArray) }}
 ---
 apiVersion: "secrets-store.csi.x-k8s.io/v1"
 kind: "SecretProviderClass"
 metadata:
-  name: "{{ $name }}"
+  name: "{{ $class.name }}"
   labels:
     app.kubernetes.io/name: "{{ $.Chart.Name }}"
     app.kubernetes.io/component: "memex-portal"
@@ -46,12 +46,12 @@ spec:
   parameters:
     usePodIdentity: "false"
     useVMManagedIdentity: "true"
-    userAssignedIdentityID: "{{ $identity }}"
-    keyvaultName: "{{ $vault }}"
-    tenantId: "{{ $tenant }}"
+    userAssignedIdentityID: "{{ $class.identityClientId }}"
+    keyvaultName: "{{ $class.vaultName }}"
+    tenantId: "{{ $class.tenantId }}"
     objects: |
       array:
-{{- range .secrets }}
+{{- range $class.secrets }}
         - |
           objectName: {{ required "every keyVaultSecrets.secrets entry needs a vaultSecret (the vault object's name)" .vaultSecret }}
           objectType: secret
@@ -59,13 +59,19 @@ spec:
   # The synced Kubernetes Secret: one key per declared secret, named as the env key the portal
   # reads. deployment.yaml loads it via envFrom, AFTER the chart's own ConfigMap and Secret, so a
   # vault-supplied value wins over a chart-rendered blank for the same key.
+{{- /* 🚨 ONE VAULT OBJECT MAY SERVE SEVERAL KEYS, and that is not a mistake to guard against — it
+       is the fix for MeshWeaver#3201. `memex` reads its plugin-registry credential under TWO names
+       that different code paths look for (`PluginCatalog__RegistryToken`, the legacy
+       single-registry key, and `PluginCatalog__Registries__0__Token`, the per-registry key of the
+       named registry), and both come from the single vault object `PluginCatalog-RegistryToken`.
+       A KEY may have only one home; a vault OBJECT may have as many keys as the portal reads it
+       under. This is a template comment on purpose: it must not reach the rendered manifest. */}}
   secretObjects:
-    - secretName: "{{ $synced }}"
+    - secretName: "{{ $class.syncedSecret }}"
       type: "Opaque"
       data:
-{{- range .secrets }}
+{{- range $class.secrets }}
         - objectName: {{ .vaultSecret }}
           key: {{ required "every keyVaultSecrets.secrets entry needs a key (the Section__Key it lands as)" .key }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -298,7 +298,49 @@ keyVaultSecrets:
   #       key: Email__ClientSecret
   #     - vaultSecret: memexcloud-Authentication-Microsoft-ClientSecret
   #       key: Authentication__Microsoft__ClientSecret
+  #
+  # 🚨 ONE VAULT OBJECT MAY SERVE SEVERAL KEYS. A key has exactly one home; an
+  # object may be read under as many names as the portal looks for. `memex`
+  # reads its registry credential as BOTH `PluginCatalog__RegistryToken` (the
+  # legacy single-registry key) and `PluginCatalog__Registries__0__Token` (the
+  # per-registry key of the named registry) from the one object
+  # `PluginCatalog-RegistryToken` — that second mapping IS the fix for
+  # MeshWeaver#3201 / Memex#164, and it must stay expressible.
   secrets: []
+# ---- ADDITIONAL Key Vault secret classes (a namespace that reads more than one)
+# The block above holds ONE SecretProviderClass. A namespace whose pod reads two
+# vault-secret sets — `memex` runs the hand-made `memex-kv` (13 keys: the
+# connection string, the GitHub App key, the AI provider keys) alongside the
+# chart-owned `memex-portal-keyvault` (the plugin-registry token) — declares the
+# rest here. Same shape as `keyVaultSecrets`, one entry per class.
+#
+# 🚨 WHY IT EXISTS. With one slot, a record or overlay describing this namespace
+# had to CHOOSE which class to state, and whichever it chose, a re-render dropped
+# the other. On 2026-09-06 the `memex` record described `memex-kv` while the
+# deployed overlay described `memex-portal-keyvault`: a re-render would have
+# removed the class that had just fixed the registry poll AND rendered one for
+# `memex-kv` naming a vault object that does not exist — a failed mount, i.e. a
+# portal that cannot start.
+#
+# ORDER IS PRECEDENCE. The classes are appended to `envFrom` after the chart's
+# ConfigMap and Secret, in this order; Kubernetes keeps the LAST entry on a key
+# clash, so a later class wins over an earlier one for a shared key.
+#
+# `name`, `volumeName` and `mountPath` are REQUIRED on every entry — a second
+# class falling back to the first's defaults would collide on all three (two pod
+# volumes of one name is an invalid spec; two classes syncing into one Secret
+# race each other). `syncedSecret` still defaults to the class's own name, and
+# the vault coordinates fall back to `keyVaultSecrets` above.
+#
+#   keyVaultSecretClasses:
+#     - name: "memex-kv"
+#       syncedSecret: "memex-kv-secrets"
+#       volumeName: "kv-secrets"
+#       mountPath: "/mnt/kv-secrets"
+#       secrets:
+#         - vaultSecret: memex-connectionstring
+#           key: ConnectionStrings__memex
+keyVaultSecretClasses: []
 # ---- Extra env sources for the portal (verbatim EnvFromSource objects) ----
 # ⚠️ LEGACY ESCAPE HATCH — kept for environments whose SecretProviderClass is
 # still hand-made. Declare the secrets under `keyVaultSecrets` above instead;

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -424,6 +424,14 @@ Empty `secrets` renders nothing, so an environment that has not opted in is byte
 before. With any entry the vault, tenant and identity are **required** and a half-declared block
 fails `helm template` naming the key. Names only: no value is ever in values or in the render.
 
+An instance that reads **more than one** vault-secret set — `memex` runs the hand-made `memex-kv`
+alongside the chart-owned `memex-portal-keyvault` — declares the rest under `keyVaultSecretClasses`,
+a list of the same shape. Order is precedence, and **one vault object may serve several keys**: that
+is how one credential lands under both `PluginCatalog__RegistryToken` and
+`PluginCatalog__Registries__0__Token`. Why a single slot was a data-loss bug, and the other two
+layers a record could not previously see, are in
+[Deployment env layers](/Doc/Architecture/DeploymentEnvLayers).
+
 🚨 **Why it moved into the chart.** Until then every `SecretProviderClass` in the fleet was a
 hand-made object — `kubectl apply`-ed once from a laptop, present in no repository, rendered by
 nothing — and the values file could only point at it by name (`extraEnvFrom` / `extraVolumes`,

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -1,0 +1,162 @@
+---
+Name: Deployment env layers — what a record must be able to hold
+Category: Architecture
+Description: The five layers that decide a portal's configuration, why a Deployment record that can hold only one Key Vault class silently destroys the other on a re-render, and the shape that fixes it
+Icon: Layer
+---
+
+# Deployment env layers: what a record must be able to hold
+
+A `Hosting/Deployment` record is supposed to be the ONE source of an instance's deployment: change
+the record, re-render, deploy. That claim is only as good as the record's ability to describe what
+the instance actually runs — and on 2026-09-06 it could not. Re-rendering `memex` from its own
+record and diffing the result structurally against the deployed overlay gave **41 differences**, and
+every one of them was a silent loss. This page records the five layers, what each one is, and the
+record shape that can hold all of them.
+
+## The five layers, lowest precedence first
+
+A portal pod's configuration is assembled from five sources. Kubernetes keeps the **last** `envFrom`
+entry when two supply the same key, and an inline `env:` entry outranks every `envFrom`. So the
+list is a precedence order, and the last source that carries a key is the value the portal reads.
+
+| # | Layer | Rendered by | Recorded as |
+|---|---|---|---|
+| 1 | ConfigMap `memex-portal-config` | the chart, from `config.memex_portal` | the typed fields + `extraPortalConfig` |
+| 2 | Secret `memex-portal-secrets` | the chart, from the Key Vault **values half** | `vaultValuesKeys` (names only) |
+| 3… | Secret per **SecretProviderClass** | the chart, from `keyVaultSecrets` / `keyVaultSecretClasses` | `keyVaultSecrets` + `keyVaultSecretClasses` |
+| last | inline `env:` on the Deployment | **nothing** — `kubectl` put it there | `inlineEnv` (declarative) |
+
+Layers 2 and 5 are the ones a record could not previously see at all. Layer 2 comes from a values
+file captured into Key Vault (`helm-values-memex`), which no repository holds; layer 5 comes from
+somebody's `kubectl set env`, which no file renders. `HelmValues.EnvPrecedence` folds all five into
+one answer per key: every layer that supplies it, and therefore which one wins.
+
+## Why one Key Vault class was not enough
+
+Until this change the record had exactly one slot for a `SecretProviderClass`
+(`keyVaultSecrets`), plus a legacy escape hatch that could only *point at* a hand-made one by name.
+`memex` runs **two** classes:
+
+- `memex-kv` → Secret `memex-kv-secrets`, hand-made, 13 keys — the mesh connection string, the
+  GitHub App private key, the AI provider keys, the webhook secrets;
+- `memex-portal-keyvault` → Secret `memex-portal-keyvault`, chart-owned, the plugin-registry token.
+
+With one slot the record had to CHOOSE, and whichever it named, a re-render destroyed the other. It
+named `memex-kv` while the deployed overlay named `memex-portal-keyvault`, so a re-render would
+have:
+
+1. **deleted both `PluginCatalog` mappings** — the fix that had made the registry poll work that
+   same morning after 740 consecutive 401s;
+2. **dropped `extraEnvFrom: memex-kv-secrets`**, detaching all 13 keys of the hand-made class from
+   the pod;
+3. **added a mapping for a vault object that does not exist**
+   (`memexsystemorph-PluginCatalog-RegistryToken`, derived from the record's prefix) — and a
+   declared object the vault does not hold fails the *whole* CSI mount, so every new pod stays in
+   `ContainerCreating` and the rollout stalls.
+
+None of that is visible from the record; it is a data-loss bug wearing the shape of a formatting
+change.
+
+## One vault object may serve several keys
+
+The projection used to refuse `maps vault object X onto more than one key — state distinct vault
+objects`. That rule was wrong, and it refused the shape that fixes the registry poll: `memex` reads
+one credential under **two** names because two code paths look for two names —
+`PluginCatalog__RegistryToken` (the legacy single-registry key) and
+`PluginCatalog__Registries__0__Token` (the per-registry key of the named registry) — both from the
+one vault object `PluginCatalog-RegistryToken`. Nothing about that is ambiguous: both land, both are
+read, and rotating the object rotates both.
+
+The same rule was silently losing a key on `memex-cloud`, where one object
+(`memexcloud-AzureAIS-ApiKey`) has served both `AzureAIS__ApiKey` and `AzureFoundry__ApiKey` since
+before the record existed: the record could hold only one of the two.
+
+**The correct rule is the other way round.** A KEY has exactly one home — two sources for one key
+means `envFrom` order alone decides what the portal reads, which is the 2026-08-30
+`EmailConfigurationGuard` crash re-created. An OBJECT may have as many keys as the portal reads it
+under. `HelmValues.Problems` now checks the first, across classes as well as within one, and permits
+the second.
+
+## Recording an inline `env:` entry does not create one
+
+`inlineEnv` and `vaultValuesKeys` render **nothing**, and that is the point.
+
+An inline entry is out-of-band by construction: the chart never emits one, and `helm upgrade` does
+not remove one either — three-way merge removes only what helm previously *owned*. That was measured
+on helm v3.21.1 and v4.2.4 with a positive control; see
+[Chart Drift — what a deploy actually does](/Doc/Architecture/ChartDriftSemantics). So an inline
+entry survives every deploy and keeps outranking the ConfigMap and every synced Secret.
+
+Recording one therefore neither creates nor deletes it. What recording buys is that the record stops
+silently **disagreeing** with the pod — and once the known, deliberate entries are declared, anything
+left over is a surprise rather than noise. Each entry says what it stands over (`shadows`), whether
+that source is known to agree (`agreesWithShadowed`), why it is still there, and what retires it.
+
+Three things the fleet's own entries show, none of which was written down anywhere before:
+
+- **A "shadow" is often the SOLE source.** `PluginCatalog__RegistryUrl` is inline on both portals
+  while the ConfigMap renders it *empty*. Deleting the inline entry would blank the key, not fall
+  back to anything.
+- **Some entries disagree with the ConfigMap, and the pod wins.**
+  `Features__Ai__Providers__AzureOpenAI` runs `true` on `memex` while every committed file says
+  `false`; `PreWarm__GateReadiness` runs `false` on `memex-cloud` while the ConfigMap says `true`,
+  which renders the NodeType bake gate inert there. Removing that one entry is what *arms* the gate
+  on `memex-cloud` — the opposite act to `memex`, where the inline entry already agrees.
+- **Some have no other home at all.** `Features__Ai__Clis__ClaudeCode` / `__Copilot` on `memex`, and
+  `Speech__{Endpoint,Enabled,Language}` on `memex-cloud`, correspond to no chart key whatsoever.
+
+### Never a credential's value
+
+These records sync to a git repository. An inline entry that carries a credential — both portals
+hold a plugin-registry instance key inline, in plaintext, readable by anything that can
+`get deploy` — sets `isSecret` and leaves `value` unset. Stating both is **refused** by
+`HelmValues.Problems`, so the one shape that would put a live token into a git-synced node fails the
+render instead of shipping.
+
+## What else the record gained
+
+- **`gates`** — the language gate sidecars (`python`, `node`, `pandas`). The chart has been able to
+  render them from `grpc.gates` all along, but nothing declared them: `memex` has run two of them
+  since a `kubectl patch` on 2026-08-24, so the record described a one-container pod while three
+  containers ran.
+- **`vaultValuesKeys`** — the keys the chart's own Secret supplies. Six of `memex`'s eleven are also
+  supplied by a declared class, which sits later in `envFrom` and therefore wins; without the list,
+  nothing said the chart's Secret carried them at all.
+
+## The chart half
+
+`keyVaultSecrets` in values still holds one class, unchanged, so every existing environment renders
+byte-identically. Additional classes go in `keyVaultSecretClasses`, a list of the same shape;
+`templates/memex-portal/_keyvault.tpl` resolves both into one ordered list that the
+`SecretProviderClass` template, the `envFrom`, the volumes and the mounts all read, so the four can
+never disagree about a name.
+
+On an entry in the plural list `name`, `volumeName` and `mountPath` are **required**: a second class
+falling back to the chart's defaults would collide with the first on all three at once, and two pod
+volumes of one name is an invalid spec while two classes syncing into one Secret race each other.
+`syncedSecret` still defaults to the class's own name, and the vault coordinates fall back to the
+singular block's — a namespace's classes normally read one vault with one add-on identity.
+
+## The falsification test
+
+The shape is only worth having if rendering the record reproduces what is actually running. Rendering
+`memex`'s extended record through `HelmValues` and then through `helm template`, and comparing the
+result against the live cluster objects, reproduces: the same two `SecretProviderClass` objects with
+the same vault, tenant and identity; all 2 + 13 object→key mappings in the same order, duplicates
+included; the same four `envFrom` sources in the same order; the same CSI volumes and mount paths;
+and the same three containers. `memex-cloud` reproduces the same way, including its
+one-object-two-keys `AzureAIS` mapping.
+
+One entry does **not** reproduce, and it is a real defect rather than a modelling gap: both committed
+overlays declare an `Embedding-ApiKey` secret whose vault object does not exist. It is not on either
+live `SecretProviderClass` because it has not been deployed yet — and when it is, the missing object
+will fail the whole mount. The record states it because it states the overlay's intent; provisioning
+the vault secret is what unblocks the next deploy.
+
+## Related
+
+- [Chart Drift — what a deploy actually does](/Doc/Architecture/ChartDriftSemantics) — what a
+  `helm upgrade` does and does not remove, measured.
+- [Deployment on AKS](/Doc/Architecture/DeploymentAKS) — the `keyVaultSecrets` block, and why a
+  declared object the vault lacks stalls a rollout.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deployment-record-can-describe-two-secret-stores.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deployment-record-can-describe-two-secret-stores.md
@@ -1,0 +1,61 @@
+---
+Name: A deployment record can finally describe everything its portal runs with
+Category: Fix
+Description: A portal that read two Key Vault secret stores could only be half described, so regenerating its configuration deleted the other half. It can now hold both — plus the settings someone had only ever typed into the cluster.
+Icon: ShieldCheckmark
+Order: -20260906
+---
+
+# A deployment record can finally describe everything its portal runs with
+
+Every portal we operate has a **record** that says what it is: its host, its database, how much
+memory it gets, which secrets it reads. The idea is simple — change the record, regenerate the
+configuration, deploy. The record is the source of truth and nothing is kept in step by hand.
+
+That only works if the record can describe the portal. Ours could not, and the gap was the dangerous
+kind: regenerating a portal's configuration from its own record **deleted settings that were keeping
+it running**, silently, because the record had nowhere to put them.
+
+## What was wrong
+
+A portal reads its passwords and API keys out of a secure vault. The record had room for **one**
+such connection. Our own portal uses **two** — one holding its database connection, its GitHub key
+and its AI provider keys, and a second, newly added, holding the credential it uses to fetch plugin
+updates.
+
+With room for only one, the record described one and the second existed only in a separate file.
+Regenerating from the record would have deleted the plugin credential added that same morning to fix
+a broken update feed, detached thirteen other keys from the running portal, and pointed it at a
+vault entry that does not exist — which stops new instances from starting at all. Measured against
+the deployed configuration, forty-one settings would have been lost.
+
+There was a second, quieter problem. The record refused to let one vault entry be read under two
+names — and that is exactly what the plugin-update fix needed, because two parts of the portal look
+for the same credential under different names. The same refusal had already been quietly losing one
+of the AI provider keys on the public portal.
+
+## What changes
+
+A record can now describe **as many secret stores as the portal actually reads**, and one vault
+entry may be read under as many names as the portal looks for. The reverse is now checked instead,
+which is the rule that matters: a single setting may only come from one place. Two sources for one
+setting means whichever the system happens to read last wins, and that is how a portal once crashed
+on startup with half its email configuration.
+
+A record can also now write down two things that only ever existed on the running machine:
+
+- **Settings typed straight into the cluster.** These outrank everything a file can say, and a
+  deploy does not remove them. Writing them down does not create or delete them; it stops the record
+  from disagreeing with reality at every read, so that anything left unexplained is a genuine
+  surprise. Each one now says what it overrides, whether the two agree, why it is still there, and
+  what will retire it.
+- **Extra programs running alongside the portal.** Our own portal has been running two
+  language sandboxes for weeks that no file mentioned.
+
+Along the way, this made a few things visible that nobody had written down: a setting the public
+portal reads as *off* while every file says *on*; three settings that would simply vanish if someone
+"tidied up" the cluster, because nothing else supplies them; and a vault entry two portals are
+configured to read that has never been created — which will stall their next deploy until it is.
+
+Credentials themselves are still never recorded. A setting that carries one says so and leaves the
+value out, and a record that tries to keep both is refused rather than quietly trimmed.


### PR DESCRIPTION
## The problem, measured

A `Hosting/Deployment` record is meant to be the ONE source of an instance's deployment. On
2026-09-06 it could not describe `memex`: **rendering `memex` from its own record and diffing the
result structurally against the deployed overlay gave 41 differences, and every one was a silent
loss.**

`keyVaultSecrets` in values held exactly **one** `SecretProviderClass`. `memex` reads **two**:

| class | synced Secret | keys |
|---|---|---|
| `memex-kv` (hand-made) | `memex-kv-secrets` | 13 — the mesh connection string, the GitHub App private key, the AI provider keys, the webhook secrets |
| `memex-portal-keyvault` (chart-owned) | `memex-portal-keyvault` | the plugin-registry token, under **two** key names |

With one slot the record had to CHOOSE. It named `memex-kv` while the deployed overlay named
`memex-portal-keyvault`, so a re-render would have:

1. **deleted both `PluginCatalog` mappings** — the fix that had made the registry poll work that
   morning after **740 consecutive 401s** (#3201 / Memex#164);
2. **dropped `extraEnvFrom: memex-kv-secrets`**, detaching all 13 keys of the hand-made class from
   the pod;
3. **added a mapping for a vault object that does not exist**
   (`memexsystemorph-PluginCatalog-RegistryToken`, derived from the record's prefix) — a declared
   object the vault does not hold fails the *whole* CSI mount, so every new pod stays in
   `ContainerCreating` and the rollout stalls.

## What this changes

`keyVaultSecretClasses` — a list of the same shape as `keyVaultSecrets`, for every further class
the instance reads. `templates/memex-portal/_keyvault.tpl` resolves the singular block and the list
into **one ordered list** that the `SecretProviderClass` template, the `envFrom`, the volumes and
the mounts all read, so those four can never disagree about a name.

- **Order is precedence** — Kubernetes keeps the last `envFrom` on a key clash.
- **`name`, `volumeName` and `mountPath` are required** on a plural entry: falling back to the chart
  defaults would collide with the singular block on all three at once (two pod volumes of one name
  is an invalid spec; two classes syncing into one Secret race each other). `syncedSecret` still
  defaults to the class's own name, and the vault coordinates fall back to the singular block's.

## Verification

**1. No-op for every existing environment.** Rendering the chart with an unchanged (singular-only)
values file is **byte-identical** to the chart before this change:

```
diff base-render.yaml new-render.yaml   →   DIFF-EXIT=0
```

**2. Reproduces the live cluster.** With `memex`'s two classes declared, `helm template` produces —
compared against the cluster, measured read-only, names only:

```
OK  classes rendered ['memex-kv', 'memex-portal-keyvault'] == live
OK  memex-portal-keyvault  vault/tenant/identity == live
OK  memex-portal-keyvault  2 object→key mappings identical (order included)
OK  memex-portal-keyvault  objects[] lists one entry per mapping (2), duplicates included
OK  memex-kv               vault/tenant/identity == live
OK  memex-kv               13 object→key mappings identical (order included)
OK  envFrom order ['memex-portal-config','memex-portal-secrets','memex-portal-keyvault','memex-kv-secrets'] == live
OK  CSI volumes  {'kv-portal-keyvault': 'memex-portal-keyvault', 'kv-secrets': 'memex-kv'} == live
OK  CSI mounts   {'kv-portal-keyvault': '/mnt/kv-portal-keyvault', 'kv-secrets': '/mnt/kv-secrets'} == live
```

**3. The three chart gates, run locally:** `check-chart-invariants.sh` (3/3 combinations),
`check-values-are-read.sh` (116 keys across 3 values files, all read), `test-chart-drift-compare.sh`
(all classification assertions). `DocumentationLinkIntegrityTest` passes;
`MeshWeaver.Documentation` builds `-c Release -warnaserror` with `0 Warning(s) 0 Error(s)`.

Nothing was applied to any cluster. This PR renders; it does not deploy.

## Doc

`Doc/Architecture/DeploymentEnvLayers` — the five layers that decide a portal's configuration, why
one Key Vault slot was a data-loss bug, why **one vault object may serve several keys** while a KEY
must have one home, and why recording an inline `env:` entry neither creates nor deletes one.

Pairs-with: none — this PR removes no public type or member from `src/`; the change is the helm
chart plus documentation. The projection half is Systemorph/MeshWeaver.Plugins (in-mesh
`Hosting/Deployment`), the record half is Systemorph/Memex; both are separate PRs that land after
this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
