### PR TITLE
Every instance reports what it runs — the fleet inventory files itself hourly

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -415,6 +415,26 @@ data:
   # #2494's safety net. Same typed-key rule as the line above: a real default, never "" — this
   # binds to a TimeSpan and an empty string aborts the host in the configuration binder.
   SelfUpdate__SafetyNetCheckInterval: "{{ .Values.config.memex_portal.SelfUpdate__SafetyNetCheckInterval | default "01:00:00" }}"
+  # ---- Deployment inventory (Doc/Architecture/DeploymentInventory) ---------------------------
+  # Every instance reports what it runs — platform build, commit, framework identity, update policy
+  # and every module's pinned coordinate — to the control instance's Hosting/Modules inbox, once
+  # the default install settles and hourly after. Hosting__Deployment MUST equal this instance's
+  # Hosting/Deployment record id on the control instance; empty = the reporter is INERT (a report
+  # under a guessed id overwrites another instance's inventory, and the fleet page renders that as
+  # fact). The control instance leaves ReportTo empty and files its own record locally. The signing
+  # key is Hosting__ModuleReportSecret — a SECRET (Key Vault via the SecretProviderClass, or
+  # secrets.memex_portal), never a config key. OperationalSpace must resolve the same on both ends.
+  {{- if .Values.config.memex_portal.Hosting__Deployment }}
+  Hosting__Deployment: "{{ .Values.config.memex_portal.Hosting__Deployment }}"
+  {{- end }}
+  {{- if .Values.config.memex_portal.Hosting__ReportTo }}
+  Hosting__ReportTo: "{{ .Values.config.memex_portal.Hosting__ReportTo }}"
+  {{- end }}
+  {{- if .Values.config.memex_portal.Hosting__OperationalSpace }}
+  Hosting__OperationalSpace: "{{ .Values.config.memex_portal.Hosting__OperationalSpace }}"
+  {{- end }}
+  # A TimeSpan: a real default, never "" (the same typed-key rule as SelfUpdate__MinRollInterval).
+  Hosting__ReportInterval: "{{ .Values.config.memex_portal.Hosting__ReportInterval | default "01:00:00" }}"
   WebhookInbox__Targets__0: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0 | default "" }}"
   # 🚨 #3312 — how a target says it is AUTHENTICATED, paired with the slot it authenticates.
   # Names the CONFIGURATION KEY holding that target's shared HMAC (never the secret itself), and

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -86,6 +86,18 @@ stringData:
   {{- if .Values.secrets.memex_portal.Authentication__Microsoft__ClientSecret }}
   Authentication__Microsoft__ClientSecret: "{{ .Values.secrets.memex_portal.Authentication__Microsoft__ClientSecret }}"
   {{- end }}
+  # ---- Deployment inventory signing key (Doc/Architecture/DeploymentInventory) ----------------
+  # The HMAC key a reporting instance signs its module inventory with, and the control instance
+  # verifies against. Fleet-wide under Hosting__ModuleReportSecret; the control instance may bind a
+  # report to its SENDER with a per-deployment key instead — Hosting__ModuleReportSecrets is a map
+  # {<deployment id>: <key>} rendered as Hosting__ModuleReportSecret__<id>. On AKS both arrive from
+  # Key Vault through the SecretProviderClass under the same key names; this is the values route.
+  {{- if .Values.secrets.memex_portal.Hosting__ModuleReportSecret }}
+  Hosting__ModuleReportSecret: "{{ .Values.secrets.memex_portal.Hosting__ModuleReportSecret }}"
+  {{- end }}
+  {{- range $id, $key := .Values.secrets.memex_portal.Hosting__ModuleReportSecrets }}
+  Hosting__ModuleReportSecret__{{ $id }}: "{{ $key }}"
+  {{- end }}
   # Sign in with Apple: the .p8 key content (PEM; literal \n or base64 both accepted —
   # the portal normalizes). With it the portal mints the ES256 client-secret JWT itself;
   # Apple issues no static client secret.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -572,6 +572,11 @@ secrets:
     # credential — it refuses rather than persisting one in plaintext. Every real
     # deployment must set it in an overlay / --set / Key Vault CSI.
     Ai__KeyProtection__MasterKey: ""
+    # Deployment inventory signing key (Doc/Architecture/DeploymentInventory): the reporter signs
+    # with it, the control instance verifies with it. Per-deployment keys on the control instance
+    # go in the map: {memex-cloud: "<key>"} → Hosting__ModuleReportSecret__memex-cloud.
+    Hosting__ModuleReportSecret: ""
+    Hosting__ModuleReportSecrets: {}
     # ---- Plugin catalog credentials -------------------------------------------
     # CONSUMER ONLY. There is no registry-side token allowlist here any more: the
     # `PluginCatalog__RegistryTokens` list this block used to advertise bound to nothing (no such
@@ -635,6 +640,14 @@ config:
     ASPNETCORE_HTTP_PORTS: "8080"
     Deployment__Backend: "Filesystem"
     Deployment__DataRoot: "/data"
+    # ---- Deployment inventory (Doc/Architecture/DeploymentInventory) -------------------------
+    # This instance's id in the fleet — MUST equal its Hosting/Deployment record id on the control
+    # instance. Empty = the instance reports nothing. The control instance sets its id and leaves
+    # Hosting__ReportTo empty (it files its own record); every other instance points ReportTo at
+    # the control instance's base URL and carries the signing key as a SECRET (below).
+    Hosting__Deployment: ""
+    Hosting__ReportTo: ""
+    Hosting__ReportInterval: "01:00:00"
     # The writable root for store-installed modules (ModuleRoot.ConfigKey). Empty here means
     # "follow Deployment__DataRoot", which the template applies — a deployment only sets this
     # when its module tree must live somewhere other than the data root.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
@@ -19,6 +19,7 @@ MeshWeaver has **two distinct deploy routes**. They target different infrastruct
 | Scenario | Read |
 |---|---|
 | See every **running instance** — who it's for, its infra, database, and version — and how to create or delete one | [Instances.md](/Doc/Architecture/Instances) |
+| Know **what each instance actually runs** — platform build, commit, framework identity, update policy and every module's pinned coordinate, reported by the instance itself, hourly | [DeploymentInventory.md](/Doc/Architecture/DeploymentInventory) |
 | **Database backups** & disaster recovery — managed PITR, geo-redundancy, restore | [DatabaseBackups.md](/Doc/Architecture/DatabaseBackups) |
 | Understand the release model, merge gates, version channels, and **policy-driven self-update** | [ReleaseStrategy.md](/Doc/Architecture/ReleaseStrategy) |
 | Know what CD **guarantees** about a published image set — all-or-nothing publication, the promote ordering, the self-healing reconciler — and why you verify the IMAGE and never the green tick | [ContinuousDeliveryContract.md](/Doc/Architecture/ContinuousDeliveryContract) |

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentInventory.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentInventory.md
@@ -1,0 +1,114 @@
+---
+Name: DeploymentInventory
+Category: Architecture
+Description: Every instance reports what it runs — platform build, commit, framework identity, update policy and every module's pinned coordinate — to the control instance's fleet inbox, automatically and hourly
+Icon: ClipboardTaskListLtr
+---
+
+# Deployment Inventory — every instance reports what it runs
+
+**The question "which instance runs what?" is answered by the instances, not by whoever remembers.**
+Each portal carries a hosted reporter (`DeploymentReportService`, in `MeshWeaver.PluginCatalog`) that
+composes one report — the platform build it serves, the framework identity its bundles are keyed on,
+the self-update policy it follows, and one row per module it carries with that module's pinned
+coordinate — and files it with the control instance once the default install has settled and then on a
+fixed cadence. The control instance folds every report into the **Fleet** view and the Deployments
+board (`Hosting/ModuleInventory` in MeshWeaver.Plugins), where drift between instances is a table row,
+not an investigation.
+
+## Why the instance reports itself
+
+An instance is the only party that can answer this about itself: the control instance cannot read
+another installation's nodes, and giving it a way to would be a far larger permission decision than a
+fleet inventory deserves. The previous design had the same shape but a human in the loop — a Code node
+on the control instance (`Hosting/Script/report-modules`) an operator ran by hand. Measured on
+2026-08-19, it had never run on any instance: zero inventory records, nine days after the type shipped.
+A report nobody sends is an inventory nobody has. This service is that report on a clock.
+
+## Configuration
+
+| Key | Meaning | Default |
+|---|---|---|
+| `Hosting:Deployment` | This instance's id — **must equal the id of its `Hosting/Deployment` record** on the control instance. Unset ⇒ the reporter is **inert** (a report under a guessed id would overwrite another instance's inventory, and the fleet page renders that as fact). | — |
+| `Hosting:ReportTo` | Base URL of the control instance. Unset ⇒ this instance **is** the control instance and writes the record locally. | — |
+| `Hosting:ModuleReportSecret:{deployment}` / `Hosting:ModuleReportSecret` | The HMAC key the report is signed with — per-deployment first, fleet-wide fallback, exactly as the receiver resolves it. `ReportTo` set with no secret ⇒ a **warning** and nothing sent: the receiver drops unsigned reports, so sending one would only look like reporting. | — |
+| `Hosting:OperationalSpace` | The partition a local write lands in. Must resolve the same way on both ends or the control instance files its own record beside, not among, the reported ones. | `Ops` |
+| `Hosting:ReportInterval` | Cadence, as a `TimeSpan`. | `01:00:00` |
+
+Deployment configuration lives with the deployment — for the installations Systemorph runs, in the
+private `Systemorph/Memex` repo's per-environment values, never in this repo.
+
+## Cadence
+
+1. **Boot:** the first report waits for `InstanceAutoRegistrationService.Completed` — the default
+   install has settled. Reporting mid-install would file "this instance carries nothing" for an instance
+   about to carry the baseline.
+2. **Then every interval.** Reports run one at a time. A failed tick is a **warning carrying the
+   fault** (a rejected POST names the status and the receiver's answer), never a silent skip and never
+   the end of the schedule — the next tick reports again.
+3. **On demand:** `DeploymentReportService.Report()` composes and delivers one report now and emits
+   where it went (`Skipped` with the reason, `Written` with the path, `Sent` with the URL and status).
+
+## What a report carries
+
+The module list is `InstanceComboReader`'s combo — the **one** reader of "what does this instance
+carry", the same read the candidate-release deploy gate verifies an image against
+([CandidateReleaseProtocol](/Doc/Architecture/CandidateReleaseProtocol)). The fleet page and the deploy
+gate therefore cannot disagree about an instance's modules. Both recorded shapes are read, always: the
+`{Space}/_GitSync` config and the `Plugins/{id}` install record. An inventory read off one of them looks
+healthy and reports almost nothing (memex, 2026-08-10: 42 sync configs, zero install records).
+
+| Field | Source |
+|---|---|
+| `event` | `module-inventory` — the inbox's discriminator |
+| `deployment`, `instanceId`, `host` | `Hosting:Deployment`, `PluginCatalog:InstanceId`, `PluginCatalog:HomeUrl` |
+| `platformVersion` | `PlatformBuildInfo.PlatformVersion` — the string Settings ▸ About shows and `Admin/PlatformVersion` records; never a third opinion |
+| `commitSha` | `PlatformBuildInfo.CommitHash` — the core commit the image was built from |
+| `frameworkIdentity` | the live framework identity (`PrebuiltAssemblySeeder.LiveFrameworkMvid`) — the key every prebuilt bundle is filed under ([ModuleVersioning](/Doc/Architecture/ModuleVersioning)) |
+| `updatePolicy` | the `Admin/UpdatePolicy` node's policy, read as a children listing of the partition (a point read of an absent node trips the routing NotFound and its storm-breaker; a test mesh has no such node) |
+| `sampledAt` | UTC, second precision |
+| `modules[]` | per module: `id`, `origin` (`GitSync` or `Package`), `repository`, `ref`, `subdirectory`, `commitSha`, `lastSyncedAt`, `moduleVersion`. A module recorded under both shapes reports as `GitSync` carrying the install record's version — the receiver's fold keeps exactly that |
+| `warnings[]` | an incomplete read (a source that could not be queried), an empty module list, a missing platform version or home url |
+| `reporter` | `hosted` — distinguishes the service from the manual script in the record |
+
+Fields the control instance's inbox does not read yet (`commitSha`, `frameworkIdentity`,
+`updatePolicy`, `reporter`) ride along: an older control instance ignores them, a newer one shows them.
+
+## Delivery
+
+- **`Hosting:ReportTo` set:** `POST {ReportTo}/api/hooks/Hosting/Modules`, body as above, header
+  `X-Hub-Signature-256: sha256=<lowercase hex HMAC-SHA256 of the raw body>` — GitHub's webhook
+  signature shape, which the inbox verifies before it parses anything. The POST runs through the
+  `Http` IO pool, never on a hub thread.
+- **`Hosting:ReportTo` unset:** the same body is written to `{OperationalSpace}/Modules/{deployment}`
+  as a `Hosting/ModuleInventory` node **with `$type: ModuleInventoryContent` stamped** — content
+  written without the discriminator is stored perfectly and then materialises as nothing: the node
+  keeps the whole document while every reader of the record type sees an empty record. The write runs
+  as system: there is no principal on a clock tick, and the record is the platform's observation of
+  itself.
+
+## Reading the fleet
+
+On the control instance, **Deployments** (the board) and **Fleet** (`Hosting/ModuleInventory`'s area)
+show one column per instance and one row per module; a row whose builds differ across instances, or
+that is missing on one, is drift. The `Hosting/Deployment` record is the **intent** (what an instance
+should run, GitSynced from the deployments repo), `Hosting/DeploymentStatus` is what the cluster
+**observes** (image, replicas), and this report is what the instance **says about itself** — three
+sources, and a disagreement between any two is the finding.
+
+## Failure modes, by design
+
+| You see | It means |
+|---|---|
+| `[DeploymentReport] inert: Hosting:Deployment is not set` at boot | This instance is not in the fleet. Name it, or accept that it reports nothing. |
+| `Hosting:ReportTo is set but no signing secret is configured` | Misconfiguration; nothing was sent. Provision the secret on both ends. |
+| `the report for X was REJECTED by …: 401` | The secret differs from the receiver's `Hosting:ModuleReportSecret:X` (or the claimed deployment id does not match the key it was signed with). |
+| `the report for X failed; the next one runs in 01:00:00` | A transient fault (network, a slow query). It is logged with the exception and retried on the next tick — never silently. |
+| A `Modules/{deployment}` record whose `warnings` name an INCOMPLETE read | A module source could not be queried on that tick. The record is marked, not shortened. |
+
+## Related
+
+- [Instances](/Doc/Architecture/Instances) — what an instance is and how its version is read
+- [ModuleVersioning](/Doc/Architecture/ModuleVersioning) — the framework identity a report carries
+- [CandidateReleaseProtocol](/Doc/Architecture/CandidateReleaseProtocol) — the deploy gate that reads the same combo
+- [ReleaseStrategy](/Doc/Architecture/ReleaseStrategy) — the update policy a report carries

--- a/src/MeshWeaver.Documentation/Data/Architecture/Instances.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Instances.md
@@ -24,6 +24,10 @@ uses is operational detail about live services — it belongs with whoever runs 
   [Systemorph/Memex](https://github.com/Systemorph/Memex) repo — `docs/deployments.md` for what runs
   where, `deployments/aks/` for each one's configuration.
 
+- **What each instance actually runs** — platform build, commit, framework identity, update policy and
+  every module's coordinate — is not written down anywhere: every instance **reports it** to the control
+  instance, hourly. See [DeploymentInventory](/Doc/Architecture/DeploymentInventory).
+
 The rest of this page is the mechanism, and applies to any installation.
 
 ## Shared platform (all cloud instances)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-every-instance-reports-what-it-runs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-every-instance-reports-what-it-runs.md
@@ -1,0 +1,26 @@
+---
+Name: Every instance reports what it runs
+Category: Feature
+Description: A portal now files its own inventory with the control instance — platform build, commit, framework identity, update policy and every module's pinned coordinate — once it has booted and hourly after, so the fleet view shows what each instance runs without anyone running a script.
+Icon: ClipboardTaskListLtr
+Order: -20260906
+---
+
+# Every instance reports what it runs
+
+Which instance runs which build, and which modules at which commit, used to depend on an operator
+running a script on each portal — and nobody ever had. Every portal that is named as a deployment now
+reports itself: once its default install has settled and then every hour, it sends the control
+instance the platform version and commit it serves, the framework identity its module bundles are
+keyed on, the self-update policy it follows, and one row per module with the repository, branch and
+commit or package version it is pinned to.
+
+On the control instance the Fleet view and the Deployments board fold those reports into one table:
+a module whose build differs between two instances, or that one instance is missing, is a row you
+can see rather than a question you have to ask. A report that could not read one of its sources says
+so in the record instead of arriving short, and a rejected or failed report is logged with the reason
+and retried on the next tick.
+
+Operators name an instance with `Hosting:Deployment` and point it at the control instance with
+`Hosting:ReportTo` and a signing secret; the manual reporting script remains as a fallback. Details in
+[DeploymentInventory](/Doc/Architecture/DeploymentInventory).

--- a/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
+++ b/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
@@ -5,6 +5,7 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -55,9 +56,35 @@ namespace MeshWeaver.PluginCatalog;
 /// Full reference: <c>Doc/Architecture/DeploymentInventory</c>.
 /// </para>
 /// </remarks>
-public sealed class DeploymentReportService(IMessageHub hub, ILogger<DeploymentReportService> logger)
-    : IHostedService, IDisposable
+public sealed class DeploymentReportService : IHostedService, IDisposable
 {
+    private readonly IMessageHub hub;
+    private readonly ILogger<DeploymentReportService> logger;
+
+    /// <summary>
+    /// ONE channel for every report — the boot report, the hourly tick and an on-demand
+    /// <see cref="Report"/> all enqueue here and run one at a time, in request order. Two reports in
+    /// flight at once are a defect, not a race to tolerate: the older read can land LAST and the
+    /// record then says what the instance carried a moment ago, not now (measured on this test's
+    /// first CI run — the boot report read one seeded module, an explicit report read two, and the
+    /// boot report's write arrived second).
+    /// </summary>
+    private readonly ISubject<Guid> requests = Subject.Synchronize(new Subject<Guid>());
+    private readonly Subject<(Guid Id, Notification<DeploymentReportOutcome> Result)> results = new();
+
+    public DeploymentReportService(IMessageHub hub, ILogger<DeploymentReportService> logger)
+    {
+        this.hub = hub;
+        this.logger = logger;
+        httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        http = hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName) ?? SharedHttp;
+        subscriptions.Add(requests
+            .ObserveOn(TaskPoolScheduler.Default)
+            .Select(id => Observable.Defer(RunOnce).Materialize().Select(result => (id, result)))
+            .Concat()
+            .Subscribe(results.OnNext, results.OnError));
+    }
+
     public const string DeploymentKey = "Hosting:Deployment";
     public const string ReportToKey = "Hosting:ReportTo";
     public const string SecretKey = "Hosting:ModuleReportSecret";
@@ -93,10 +120,8 @@ public sealed class DeploymentReportService(IMessageHub hub, ILogger<DeploymentR
     };
 
     private readonly CompositeDisposable subscriptions = new();
-    private readonly IIoPool httpPool =
-        hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
-    private readonly HttpClient http =
-        hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName) ?? SharedHttp;
+    private readonly IIoPool httpPool;
+    private readonly HttpClient http;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -110,7 +135,11 @@ public sealed class DeploymentReportService(IMessageHub hub, ILogger<DeploymentR
         return Task.CompletedTask;
     }
 
-    public void Dispose() => subscriptions.Dispose();
+    public void Dispose()
+    {
+        subscriptions.Dispose();
+        results.OnCompleted();
+    }
 
     private void Start()
     {
@@ -133,8 +162,8 @@ public sealed class DeploymentReportService(IMessageHub hub, ILogger<DeploymentR
 
         subscriptions.Add(defaultsDone
             .SelectMany(_ => Observable.Timer(TimeSpan.Zero, settings.Interval, TaskPoolScheduler.Default))
-            // One report at a time, and a failed tick is a WARNING with the fault — never a silent
-            // skip and never the end of the schedule: the next tick reports again.
+            // Through the one channel like every report. A failed tick is a WARNING with the fault —
+            // never a silent skip and never the end of the schedule: the next tick reports again.
             .Select(_ => Report().Catch((Exception exception) =>
             {
                 logger.LogWarning(exception,
@@ -154,10 +183,25 @@ public sealed class DeploymentReportService(IMessageHub hub, ILogger<DeploymentR
     }
 
     /// <summary>
-    /// Compose and deliver ONE report now. Cold: the read, the write and the POST run on subscribe.
+    /// Compose and deliver ONE report now. Cold: subscribing enqueues the request on the service's
+    /// single channel, so it runs after every report requested before it and never beside one.
     /// Emits the outcome — where the report went and the report itself — or errors with the fault.
     /// </summary>
-    public IObservable<DeploymentReportOutcome> Report()
+    public IObservable<DeploymentReportOutcome> Report() =>
+        Observable.Create<DeploymentReportOutcome>(observer =>
+        {
+            var id = Guid.NewGuid();
+            var subscription = results
+                .Where(r => r.Id == id)
+                .Select(r => r.Result)
+                .Dematerialize()
+                .Take(1)
+                .Subscribe(observer);
+            requests.OnNext(id);
+            return subscription;
+        });
+
+    private IObservable<DeploymentReportOutcome> RunOnce()
     {
         var settings = ReadSettings();
         if (settings.Deployment.Length == 0)

--- a/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
+++ b/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
@@ -1,0 +1,440 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Net.Http;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Every instance reports what it runs — the platform build it serves, the framework identity its
+/// bundles are keyed on, the update policy it follows and every module it carries with that
+/// module's pinned coordinate — to the control instance's fleet inbox, once the default install has
+/// settled and then on a fixed cadence (<c>Hosting:ReportInterval</c>, one hour by default).
+/// </summary>
+/// <remarks>
+/// <para>
+/// An instance is the only party that can answer this about itself: the control instance cannot
+/// read another installation's nodes, and giving it a way to would be a far larger permission
+/// decision than a fleet inventory deserves. Before this service the answer was a Code node an
+/// operator ran by hand (<c>Hosting/Script/report-modules</c> on the control instance) — which,
+/// measured 2026-08-19, had never run on any instance. A report nobody sends is an inventory
+/// nobody has; this service is the same report on a clock.
+/// </para>
+/// <para>
+/// The module list is <see cref="InstanceComboReader"/>'s combo, the ONE reader of "what does this
+/// instance carry" — the candidate-release gate verifies an image against the same read, so the
+/// fleet page and the deploy gate can never disagree about an instance's modules. The wire shape is
+/// the control instance's inbox contract (<c>Hosting/Modules</c> in MeshWeaver.Plugins): a JSON body
+/// keyed on <c>event: module-inventory</c>, signed GitHub-style with HMAC-SHA256 over the RAW body
+/// in <c>X-Hub-Signature-256</c>. Fields the inbox does not read yet (<c>commitSha</c>,
+/// <c>frameworkIdentity</c>, <c>updatePolicy</c>, <c>reporter</c>) ride along; an older control
+/// instance ignores them, a newer one shows them.
+/// </para>
+/// <para>
+/// Inert without <c>Hosting:Deployment</c>: a report filed under the wrong deployment id overwrites
+/// ANOTHER instance's inventory and the fleet page renders that as fact, so the service refuses to
+/// guess. Without <c>Hosting:ReportTo</c> it IS the control instance and writes the record locally
+/// under <c>{Hosting:OperationalSpace}/Modules/{deployment}</c>, exactly where a reported one lands.
+/// Full reference: <c>Doc/Architecture/DeploymentInventory</c>.
+/// </para>
+/// </remarks>
+public sealed class DeploymentReportService(IMessageHub hub, ILogger<DeploymentReportService> logger)
+    : IHostedService, IDisposable
+{
+    public const string DeploymentKey = "Hosting:Deployment";
+    public const string ReportToKey = "Hosting:ReportTo";
+    public const string SecretKey = "Hosting:ModuleReportSecret";
+    public const string OperationalSpaceKey = "Hosting:OperationalSpace";
+    public const string IntervalKey = "Hosting:ReportInterval";
+    public const string DefaultOperationalSpace = "Ops";
+    public const string EventName = "module-inventory";
+    public const string InboxRoute = "/api/hooks/Hosting/Modules";
+    public const string SignatureHeader = "X-Hub-Signature-256";
+    public const string InventoryNodeType = "Hosting/ModuleInventory";
+    /// <summary>
+    /// The discriminator a LOCAL write stamps. Content written without a <c>$type</c> is stored
+    /// perfectly and then materialises as NOTHING — the node keeps the whole document while every
+    /// reader of the control instance's record type sees an empty record.
+    /// </summary>
+    public const string InventoryContentType = "ModuleInventoryContent";
+    /// <summary>
+    /// The self-update policy node this reporter reads the policy off. The declaring type lives in
+    /// Memex.Portal.Shared, which this assembly cannot reference; a parity test there keeps the two
+    /// constants equal.
+    /// </summary>
+    public const string UpdatePolicyNodeType = "UpdatePolicy";
+    public const string UpdatePolicyPartition = "Admin";
+    public const string HttpClientName = "deployment-report";
+    public static readonly TimeSpan DefaultInterval = TimeSpan.FromHours(1);
+    private static readonly TimeSpan ReadBudget = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DeliveryBudget = TimeSpan.FromSeconds(60);
+    private static readonly HttpClient SharedHttp = new() { Timeout = DeliveryBudget };
+
+    internal static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly CompositeDisposable subscriptions = new();
+    private readonly IIoPool httpPool =
+        hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+    private readonly HttpClient http =
+        hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName) ?? SharedHttp;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        Start();
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() => subscriptions.Dispose();
+
+    private void Start()
+    {
+        var settings = ReadSettings();
+        if (settings.Deployment.Length == 0)
+        {
+            logger.LogInformation(
+                "[DeploymentReport] inert: {Key} is not set, so this instance reports nothing. Set it to "
+                + "the id of this instance's Hosting/Deployment record on the control instance to join "
+                + "the fleet inventory.", DeploymentKey);
+            return;
+        }
+
+        // The first report waits for the default install to settle — reporting mid-install would file
+        // "this instance carries nothing" for an instance that is about to carry the baseline, and
+        // the fleet page would render it as fact until the next tick.
+        var autoRegistration = hub.ServiceProvider.GetService<InstanceAutoRegistrationService>();
+        var defaultsDone = autoRegistration?.Completed.Take(1).Select(_ => Unit.Default)
+            ?? Observable.Return(Unit.Default);
+
+        subscriptions.Add(defaultsDone
+            .SelectMany(_ => Observable.Timer(TimeSpan.Zero, settings.Interval, TaskPoolScheduler.Default))
+            // One report at a time, and a failed tick is a WARNING with the fault — never a silent
+            // skip and never the end of the schedule: the next tick reports again.
+            .Select(_ => Report().Catch((Exception exception) =>
+            {
+                logger.LogWarning(exception,
+                    "[DeploymentReport] the report for {Deployment} failed; the next one runs in "
+                    + "{Interval}.", settings.Deployment, settings.Interval);
+                return Observable.Empty<DeploymentReportOutcome>();
+            }))
+            .Concat()
+            .SubscribeOn(TaskPoolScheduler.Default)
+            .Subscribe(
+                outcome => logger.LogInformation(
+                    "[DeploymentReport] {Deployment}: {Delivery} — {Detail}",
+                    settings.Deployment, outcome.Delivery, outcome.Detail),
+                exception => logger.LogError(exception,
+                    "[DeploymentReport] the schedule for {Deployment} ended; nothing reports until the "
+                    + "next boot.", settings.Deployment)));
+    }
+
+    /// <summary>
+    /// Compose and deliver ONE report now. Cold: the read, the write and the POST run on subscribe.
+    /// Emits the outcome — where the report went and the report itself — or errors with the fault.
+    /// </summary>
+    public IObservable<DeploymentReportOutcome> Report()
+    {
+        var settings = ReadSettings();
+        if (settings.Deployment.Length == 0)
+            return Observable.Return(DeploymentReportOutcome.Skipped(
+                $"no deployment id — set {DeploymentKey} to this instance's Hosting/Deployment record id; "
+                + "nothing was reported."));
+
+        var comboReader = hub.ServiceProvider.GetRequiredService<InstanceComboReader>();
+        return comboReader.Read()
+            .Take(1)
+            .Zip(ReadUpdatePolicy(), (combo, policy) => Compose(settings, combo, policy))
+            .SelectMany(report => Deliver(settings, report));
+    }
+
+    private DeploymentReport Compose(Settings settings, InstanceCombo combo, string? updatePolicy)
+    {
+        var warnings = ImmutableList.CreateBuilder<string>();
+        if (!combo.IsComplete)
+            warnings.Add("a module source could not be read — this inventory is INCOMPLETE");
+        // The reader's gate-oriented caveats (provenance shape, missing discovery records, moving
+        // refs) are about reproducing a combo, not about what runs; the read FAILURES are what a
+        // fleet operator must see, and they arrive as the caveats that are not one of the two
+        // constant ones.
+        foreach (var caveat in combo.Caveats)
+            if (caveat != InstanceComboReader.ProvenanceCaveat
+                && caveat != InstanceComboReader.NoDiscoveryCaveat
+                && caveat.StartsWith("Could not read", StringComparison.Ordinal))
+                warnings.Add(caveat);
+        if (combo.Modules.Count == 0)
+            warnings.Add("no modules were found — unusual for a running portal");
+
+        var platformVersion = PlatformBuildInfo.PlatformVersion;
+        if (string.IsNullOrWhiteSpace(platformVersion))
+            warnings.Add("could not read the platform version");
+        if (string.IsNullOrWhiteSpace(settings.Host))
+            warnings.Add("could not read this instance's home url (PluginCatalog:HomeUrl)");
+
+        return new DeploymentReport
+        {
+            Deployment = settings.Deployment,
+            InstanceId = Blank(settings.InstanceId),
+            Host = Blank(settings.Host),
+            PlatformVersion = Blank(platformVersion),
+            CommitSha = Blank(PlatformBuildInfo.CommitHash),
+            FrameworkIdentity = Blank(PrebuiltAssemblySeeder.LiveFrameworkMvid),
+            UpdatePolicy = Blank(updatePolicy),
+            SampledAt = Stamp(DateTimeOffset.UtcNow),
+            Modules = combo.Modules.Select(ModuleOf).ToImmutableList(),
+            Warnings = warnings.ToImmutable(),
+        };
+    }
+
+    /// <summary>
+    /// One row per module. A module recorded under BOTH shapes reports as GitSync (the sync is what
+    /// moves it) carrying the install record's version; the control instance's fold keeps exactly
+    /// that.
+    /// </summary>
+    private static ModuleReport ModuleOf(ModuleCoordinate module) => new()
+    {
+        Id = module.ModuleId,
+        Repository = Blank(module.GitSync?.RepositoryUrl),
+        Ref = Blank(module.GitSync?.Branch),
+        Subdirectory = Blank(module.GitSync?.Subdirectory),
+        CommitSha = Blank(module.GitSync?.LastSyncCommitSha),
+        LastSyncedAt = module.GitSync?.LastSyncedAt is { } at ? Stamp(at) : null,
+        ModuleVersion = Blank(module.Package?.ModuleVersion) ?? Blank(module.Package?.Version),
+        Origin = module.GitSync is not null ? "GitSync" : "Package",
+    };
+
+    /// <summary>
+    /// The self-update policy, read as a children listing of the Admin partition rather than a
+    /// point read: an instance without the node (every non-portal host, every test mesh) must not
+    /// trip the routing NotFound and its storm-breaker once an hour. Null when absent or unreadable.
+    /// </summary>
+    private IObservable<string?> ReadUpdatePolicy()
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        var query = $"path:{UpdatePolicyPartition} scope:children nodeType:{UpdatePolicyNodeType}";
+        return accessService
+            .RunAsSystem(() => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query)))
+            .Take(1)
+            .Timeout(ReadBudget)
+            .Select(change => change.Items
+                .Select(node => PolicyOf(node.Content))
+                .FirstOrDefault(policy => policy is not null))
+            .Catch((Exception exception) =>
+            {
+                logger.LogDebug(exception,
+                    "[DeploymentReport] the update policy could not be read; the report carries none.");
+                return Observable.Return<string?>(null);
+            });
+    }
+
+    private string? PolicyOf(object? content)
+    {
+        if (content is null)
+            return null;
+        // Content arrives TYPED as often as raw. Serialize the CONCRETE runtime type with the mesh's
+        // own options (never the object overload, which adopts a foreign type into this hub's
+        // registry as a side effect of a read) and read the one property generically.
+        var element = content is JsonElement je
+            ? je
+            : JsonSerializer.SerializeToElement(content, content.GetType(), hub.JsonSerializerOptions);
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty("policy", out var policy))
+            return null;
+        return policy.ValueKind switch
+        {
+            JsonValueKind.String => Blank(policy.GetString()),
+            JsonValueKind.Number => policy.GetRawText(),
+            _ => null,
+        };
+    }
+
+    private IObservable<DeploymentReportOutcome> Deliver(Settings settings, DeploymentReport report)
+    {
+        var body = JsonSerializer.Serialize(report, Json);
+
+        if (settings.ReportTo.Length == 0)
+            return WriteLocally(settings, report, body);
+
+        if (settings.Secret.Length == 0)
+        {
+            // Loud: a control url without a signing secret is a misconfiguration, and the receiver
+            // drops unsigned reports — sending one would only look like reporting.
+            logger.LogWarning(
+                "[DeploymentReport] {ReportToKey} is set but no signing secret is configured "
+                + "({SecretKey}:{Deployment} or {SecretKey}); the receiver drops unsigned reports, so "
+                + "nothing was sent.", ReportToKey, SecretKey, settings.Deployment, SecretKey);
+            return Observable.Return(DeploymentReportOutcome.Skipped(
+                $"{ReportToKey} is set but no signing secret is configured — nothing was sent.", report));
+        }
+
+        var url = settings.ReportTo.TrimEnd('/') + InboxRoute;
+        var signature = Sign(body, settings.Secret);
+        return httpPool.Invoke(async ct =>
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Add(SignatureHeader, signature);
+            using var response = await http.SendAsync(request, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var text = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                throw new DeploymentReportRejectedException(
+                    $"the report for {settings.Deployment} was REJECTED by {url}: "
+                    + $"{(int)response.StatusCode} {response.ReasonPhrase} {text}".TrimEnd());
+            }
+            return DeploymentReportOutcome.Sent(
+                $"{report.Modules.Count} module(s) to {url} ({(int)response.StatusCode})", report);
+        });
+    }
+
+    private IObservable<DeploymentReportOutcome> WriteLocally(
+        Settings settings, DeploymentReport report, string body)
+    {
+        var payload = JsonNode.Parse(body)!.AsObject();
+        payload["$type"] = InventoryContentType;
+        var node = new MeshNode(settings.Deployment, $"{settings.OperationalSpace}/Modules")
+        {
+            Name = $"{settings.Deployment} — {report.Modules.Count} module(s)",
+            NodeType = InventoryNodeType,
+            State = MeshNodeState.Active,
+            Content = payload,
+        };
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // Infrastructure, not a user action: there is no principal on a clock tick, and the record is
+        // the platform's own observation of itself.
+        return accessService
+            .RunAsSystem(() => meshService.CreateOrUpdateNode(node))
+            .Take(1)
+            .Timeout(DeliveryBudget)
+            .Select(written => DeploymentReportOutcome.Written(
+                $"{report.Modules.Count} module(s) at {written.Path}", report));
+    }
+
+    /// <summary>GitHub's webhook signature shape: <c>sha256=</c> + lowercase hex HMAC-SHA256 of the raw body.</summary>
+    public static string Sign(string body, string secret)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        return "sha256=" + Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(body))).ToLowerInvariant();
+    }
+
+    public static string Stamp(DateTimeOffset instant) =>
+        instant.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static string? Blank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private Settings ReadSettings()
+    {
+        var config = hub.ServiceProvider.GetService<IConfiguration>();
+        var options = hub.ServiceProvider.GetService<PluginCatalogOptions>() ?? new PluginCatalogOptions();
+        string Setting(string key) => config?[key]?.Trim() ?? "";
+
+        var deployment = Setting(DeploymentKey);
+        // Per-deployment secret first, fleet-wide fallback — mirrors the receiver's resolution.
+        var secret = deployment.Length > 0 ? Setting($"{SecretKey}:{deployment}") : "";
+        if (secret.Length == 0)
+            secret = Setting(SecretKey);
+        var interval = TimeSpan.TryParse(Setting(IntervalKey), CultureInfo.InvariantCulture, out var parsed)
+            && parsed > TimeSpan.Zero
+                ? parsed
+                : DefaultInterval;
+        var ops = Setting(OperationalSpaceKey);
+        return new Settings(
+            deployment,
+            Setting(ReportToKey),
+            secret,
+            ops.Length > 0 ? ops : DefaultOperationalSpace,
+            interval,
+            Blank(options.InstanceId) ?? Setting("PluginCatalog:InstanceId"),
+            Blank(options.HomeUrl) ?? Setting("PluginCatalog:HomeUrl"));
+    }
+
+    private sealed record Settings(
+        string Deployment,
+        string ReportTo,
+        string Secret,
+        string OperationalSpace,
+        TimeSpan Interval,
+        string InstanceId,
+        string Host);
+}
+
+/// <summary>The wire body of one report — the control instance's <c>Hosting/Modules</c> inbox contract.</summary>
+public sealed record DeploymentReport
+{
+    public string Event { get; init; } = DeploymentReportService.EventName;
+    public string Deployment { get; init; } = "";
+    public string? InstanceId { get; init; }
+    public string? Host { get; init; }
+    public string? PlatformVersion { get; init; }
+    public string? CommitSha { get; init; }
+    public string? FrameworkIdentity { get; init; }
+    public string? UpdatePolicy { get; init; }
+    public string Reporter { get; init; } = "hosted";
+    public string SampledAt { get; init; } = "";
+    public ImmutableList<ModuleReport> Modules { get; init; } = [];
+    public ImmutableList<string> Warnings { get; init; } = [];
+}
+
+public sealed record ModuleReport
+{
+    public string Id { get; init; } = "";
+    public string? Repository { get; init; }
+    public string? Ref { get; init; }
+    public string? Subdirectory { get; init; }
+    public string? CommitSha { get; init; }
+    public string? LastSyncedAt { get; init; }
+    public string? ModuleVersion { get; init; }
+    public string Origin { get; init; } = "GitSync";
+}
+
+public enum DeploymentReportDelivery
+{
+    /// <summary>Nothing left this instance; <see cref="DeploymentReportOutcome.Detail"/> says why.</summary>
+    Skipped,
+    /// <summary>Written to this instance's own operational space — it IS the control instance.</summary>
+    Written,
+    /// <summary>Accepted by the control instance's inbox.</summary>
+    Sent,
+}
+
+public sealed record DeploymentReportOutcome(
+    DeploymentReportDelivery Delivery,
+    string Detail,
+    DeploymentReport? Report)
+{
+    public static DeploymentReportOutcome Skipped(string detail, DeploymentReport? report = null) =>
+        new(DeploymentReportDelivery.Skipped, detail, report);
+    public static DeploymentReportOutcome Written(string detail, DeploymentReport report) =>
+        new(DeploymentReportDelivery.Written, detail, report);
+    public static DeploymentReportOutcome Sent(string detail, DeploymentReport report) =>
+        new(DeploymentReportDelivery.Sent, detail, report);
+}
+
+public sealed class DeploymentReportRejectedException(string message) : InvalidOperationException(message);

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -137,6 +137,15 @@ public static class PluginCatalogConfigurationExtensions
                 // service: it is a pull-on-demand READER — it starts nothing, subscribes to nothing,
                 // and writes nothing, so it costs an instance that never calls it exactly nothing.
                 .AddSingleton<InstanceComboReader>()
+                // Every instance reports what it runs (Doc/Architecture/DeploymentInventory): the
+                // platform build, framework identity, update policy and the combo above, to the
+                // control instance's fleet inbox once the default install settles and hourly after.
+                // Inert without Hosting:Deployment — a report under a guessed id would overwrite
+                // another instance's inventory. Same two-registration idiom: the IHostedService
+                // forward is what STARTS it.
+                .AddSingleton<DeploymentReportService>()
+                .AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
+                    sp => sp.GetRequiredService<DeploymentReportService>())
                 // The runtime modules/ writer (#1664 step 7) — lands a compiled module's
                 // assemblies + activation record; restart-as-activation. Inert until called:
                 // Slice C's PackageInstaller binary branch is its caller. Mesh-scoped so its

--- a/test/Memex.Portal.Shared.Test/AnInstanceReportsWhatItRunsTest.cs
+++ b/test/Memex.Portal.Shared.Test/AnInstanceReportsWhatItRunsTest.cs
@@ -1,0 +1,200 @@
+#pragma warning disable CS1591
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Memex.Portal.Shared.SelfUpdate;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The fleet inventory is fed by the instances themselves: a named instance composes the report the
+/// control instance's inbox understands — platform build, commit, framework identity, update policy
+/// and one row per module in BOTH recorded shapes — and, being its own control instance here (no
+/// Hosting:ReportTo), lands it where a reported one would land, with the discriminator stamped.
+/// </summary>
+public class AnInstanceReportsWhatItRunsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Deployment = "unit-dep";
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(60);
+    private const string Sha = "0123456789abcdef0123456789abcdef01234567";
+
+    private static IConfiguration Environment() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [DeploymentReportService.DeploymentKey] = Deployment,
+        }).Build();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddPluginCatalog()
+            .AddGitHubSyncTypes()
+            .AddUpdatePolicyType()
+            // The control instance carries the Hosting package, whose ModuleInventory type owns the
+            // record a local write lands in; this mesh stands in for that one declaration.
+            .AddMeshNodes(new MeshNode(DeploymentReportService.InventoryNodeType)
+            {
+                Name = "Module Inventory",
+                IsSatelliteType = false,
+                ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
+            })
+            .ConfigureServices(services => services
+                .AddSingleton(Environment())
+                .AddSingleton(new PluginCatalogOptions
+                {
+                    InstallPreInstalledPackages = false,
+                    InstanceId = "instance-1",
+                    HomeUrl = "https://unit.example",
+                }));
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private DeploymentReportService Reporter => Mesh.ServiceProvider.GetRequiredService<DeploymentReportService>();
+
+    [Fact(Timeout = 180_000)]
+    public async Task TheReport_CarriesBothModuleShapesAndThePlatform_AndLandsWhereAReportedOneWould()
+    {
+        await Seed(new MeshNode(GitHubSyncService.ConfigId, "Course")
+        {
+            NodeType = GitHubSyncService.ConfigNodeType,
+            Name = "Course sync",
+            State = MeshNodeState.Active,
+            Content = new GitHubSyncConfig
+            {
+                RepositoryUrl = "https://github.com/Systemorph/MeshWeaver.Education",
+                Branch = "main",
+                Subdirectory = "Course",
+                LastSyncCommitSha = Sha,
+                LastSyncedAt = new DateTimeOffset(2026, 9, 6, 8, 0, 0, TimeSpan.Zero),
+            },
+        });
+        await Seed(new MeshNode("Sample", PackageInstaller.InstalledPartition)
+        {
+            NodeType = PackageInstaller.PackageNodeType,
+            Name = "Sample",
+            State = MeshNodeState.Active,
+            Content = new PackageManifest { Id = "Sample", Name = "Sample", ModuleVersion = "1.2.3" },
+        });
+        await Seed(new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+        {
+            NodeType = UpdatePolicyNodeType.NodeType,
+            Name = "Update Policy",
+            State = MeshNodeState.Active,
+            Content = new UpdatePolicyContent { Policy = UpdatePolicyKind.Stable },
+        });
+
+        var outcome = await Reporter.Report().Timeout(Budget).Await(TestContext.Current.CancellationToken);
+
+        outcome.Delivery.Should().Be(DeploymentReportDelivery.Written,
+            "without Hosting:ReportTo this instance IS the control instance and files the record itself");
+        var report = outcome.Report!;
+        report.Event.Should().Be(DeploymentReportService.EventName);
+        report.Deployment.Should().Be(Deployment);
+        report.InstanceId.Should().Be("instance-1");
+        report.Host.Should().Be("https://unit.example");
+        report.PlatformVersion.Should().NotBeNullOrWhiteSpace("the standard platform version, never a bespoke key");
+        report.FrameworkIdentity.Should().NotBeNullOrWhiteSpace("bundles are keyed on it, so the fleet must see it");
+        report.UpdatePolicy.Should().Be(nameof(UpdatePolicyKind.Stable));
+        report.SampledAt.Should().EndWith("Z");
+
+        report.Modules.Select(m => m.Id).Should().Equal(new[] { "Course", "Sample" },
+            "BOTH shapes, always — an inventory read off one of them looks healthy and reports almost nothing");
+        var course = report.Modules.Single(m => m.Id == "Course");
+        course.Origin.Should().Be("GitSync");
+        course.Repository.Should().Be("https://github.com/Systemorph/MeshWeaver.Education");
+        course.Ref.Should().Be("main");
+        course.Subdirectory.Should().Be("Course");
+        course.CommitSha.Should().Be(Sha);
+        course.LastSyncedAt.Should().Be("2026-09-06T08:00:00Z");
+        var sample = report.Modules.Single(m => m.Id == "Sample");
+        sample.Origin.Should().Be("Package");
+        sample.ModuleVersion.Should().Be("1.2.3", "a package-only module reports the installer's version, never an unknown build");
+
+        // The landed node: the same partition a reported one is filed under, the discriminator stamped.
+        var node = await Read($"{DeploymentReportService.DefaultOperationalSpace}/Modules/{Deployment}");
+        node.Should().NotBeNull();
+        node!.NodeType.Should().Be(DeploymentReportService.InventoryNodeType);
+        var content = Element(node.Content!);
+        content.GetProperty("$type").GetString().Should().Be(DeploymentReportService.InventoryContentType,
+            "content without the discriminator is stored perfectly and materialises as NOTHING");
+        content.GetProperty("deployment").GetString().Should().Be(Deployment);
+        content.GetProperty("modules").GetArrayLength().Should().Be(2);
+        content.GetProperty("commitSha").ValueKind.Should().BeOneOf(JsonValueKind.String, JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void TheSignature_IsGitHubsWebhookShape()
+    {
+        // RFC 4231-style vector for HMAC-SHA256("key", "The quick brown fox jumps over the lazy dog").
+        DeploymentReportService.Sign("The quick brown fox jumps over the lazy dog", "key")
+            .Should().Be("sha256=f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8");
+    }
+
+    [Fact]
+    public void TheReporter_ReadsThePolicyOffTheNodeMemexDeclares()
+    {
+        // MeshWeaver.PluginCatalog cannot reference Memex.Portal.Shared, so it carries the node's
+        // type and partition as constants; this is what keeps them from drifting apart.
+        DeploymentReportService.UpdatePolicyNodeType.Should().Be(UpdatePolicyNodeType.NodeType);
+        DeploymentReportService.UpdatePolicyPartition.Should().Be(UpdatePolicyNodeType.AdminPartition);
+    }
+
+    private Task Seed(MeshNode node) =>
+        Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return MeshService.CreateOrUpdateNode(node).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+
+    private Task<MeshNode?> Read(string path) =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read(path, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(Budget).Await(TestContext.Current.CancellationToken);
+
+    private JsonElement Element(object content) =>
+        content is JsonElement je
+            ? je
+            : JsonSerializer.SerializeToElement(content, content.GetType(), Mesh.JsonSerializerOptions);
+}
+
+/// <summary>
+/// An instance nobody named reports nothing: a report filed under a guessed deployment id would
+/// overwrite another instance's inventory, and the fleet page would render that as fact.
+/// </summary>
+public class AnUnnamedInstanceReportsNothingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                .AddSingleton(new ConfigurationBuilder().Build())
+                .AddSingleton(new PluginCatalogOptions { InstallPreInstalledPackages = false }));
+
+    [Fact(Timeout = 60_000)]
+    public async Task WithoutADeploymentId_TheReportIsSkipped_AndSaysWhichKeyNamesTheInstance()
+    {
+        var outcome = await Mesh.ServiceProvider.GetRequiredService<DeploymentReportService>()
+            .Report().Timeout(TimeSpan.FromSeconds(30)).Await(TestContext.Current.CancellationToken);
+
+        outcome.Delivery.Should().Be(DeploymentReportDelivery.Skipped);
+        outcome.Detail.Should().Contain(DeploymentReportService.DeploymentKey);
+        outcome.Report.Should().BeNull("nothing was composed, so nothing could have been written or sent");
+    }
+}

--- a/test/Memex.Portal.Shared.Test/AnInstanceReportsWhatItRunsTest.cs
+++ b/test/Memex.Portal.Shared.Test/AnInstanceReportsWhatItRunsTest.cs
@@ -136,6 +136,45 @@ public class AnInstanceReportsWhatItRunsTest(ITestOutputHelper output) : Monolit
         content.GetProperty("commitSha").ValueKind.Should().BeOneOf(JsonValueKind.String, JsonValueKind.Null);
     }
 
+    /// <summary>
+    /// The shape this test's first CI run failed on: the service's own boot report read one seeded
+    /// module, an explicit report read two, and the boot report's write landed LAST. Every report
+    /// now goes through one channel in request order, so the later request — which read the later
+    /// state — is what the record says. Under overlapping reports this assertion can fail; under
+    /// the channel it cannot.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task TwoOverlappingRequests_LandInRequestOrder_SoTheRecordSaysWhatTheInstanceCarriesNow()
+    {
+        await Seed(new MeshNode(GitHubSyncService.ConfigId, "Course")
+        {
+            NodeType = GitHubSyncService.ConfigNodeType,
+            Name = "Course sync",
+            State = MeshNodeState.Active,
+            Content = new GitHubSyncConfig { RepositoryUrl = "https://github.com/Systemorph/MeshWeaver.Education", Branch = "main" },
+        });
+        // Request A is enqueued NOW, before the second seed; it may read one module or two.
+        var first = Reporter.Report().Timeout(Budget).Await(TestContext.Current.CancellationToken);
+        await Seed(new MeshNode("Sample", PackageInstaller.InstalledPartition)
+        {
+            NodeType = PackageInstaller.PackageNodeType,
+            Name = "Sample",
+            State = MeshNodeState.Active,
+            Content = new PackageManifest { Id = "Sample", Name = "Sample", ModuleVersion = "1.2.3" },
+        });
+        // Request B is enqueued after both seeds, so it must read both and its write must land last.
+        var second = await Reporter.Report().Timeout(Budget).Await(TestContext.Current.CancellationToken);
+        var earlier = await first;
+
+        earlier.Delivery.Should().Be(DeploymentReportDelivery.Written);
+        second.Delivery.Should().Be(DeploymentReportDelivery.Written);
+        second.Report!.Modules.Select(m => m.Id).Should().Equal(new[] { "Course", "Sample" });
+
+        var node = await Read($"{DeploymentReportService.DefaultOperationalSpace}/Modules/{Deployment}");
+        Element(node!.Content!).GetProperty("modules").GetArrayLength().Should().Be(2,
+            "the record is the LATER request's write — an earlier read landing last would say what the instance carried a moment ago");
+    }
+
     [Fact]
     public void TheSignature_IsGitHubsWebhookShape()
     {


### PR DESCRIPTION
## Every instance reports what it runs

**Which instance runs which build, and which modules at which commit, is now answered by the instances themselves.** `DeploymentReportService` (hosted, in `MeshWeaver.PluginCatalog`) composes one report — platform version, core commit, the framework identity its bundles are keyed on, the self-update policy, and one row per module with its pinned coordinate — and files it with the control instance's `Hosting/Modules` inbox once the default install has settled and then every `Hosting:ReportInterval` (1 h).

Before this, the same report was a Code node an operator ran by hand on the control instance, and measured on 2026-08-19 it had never run on any instance. A report nobody sends is an inventory nobody has.

### Shape
- **One reader.** The module list is `InstanceComboReader.Read()` — the same read the candidate-release deploy gate verifies an image against — so the fleet page and the gate cannot disagree. Both recorded shapes (`{Space}/_GitSync`, `Plugins/{id}`) are always read.
- **Wire contract unchanged.** The body is what the Plugins inbox already parses (`event: module-inventory`, `X-Hub-Signature-256` HMAC over the raw body). New fields `commitSha`, `frameworkIdentity`, `updatePolicy`, `reporter` ride along; an older control instance ignores them (Plugins half: shows them).
- **Inert without `Hosting:Deployment`** — a report under a guessed id overwrites another instance's inventory. Without `Hosting:ReportTo` the instance is the control instance and writes `{Ops}/Modules/{deployment}` locally with `$type` stamped. `ReportTo` without a secret is a warning and nothing sent.
- **A failed tick is a warning carrying the fault**, never a silent skip and never the end of the schedule.
- Update policy read as a `scope:children` listing of `Admin` (a point read of an absent node would trip the storm-breaker hourly on every non-portal host). Both system reads use `RunAsSystem` (the `Observable.Using(Impersonate…)` shape is refused by `ImpersonationScopeSiteRatchetGuard`, rightly).

### Chart
`deploy/helm`: renders `Hosting__Deployment`, `Hosting__ReportTo`, `Hosting__OperationalSpace` (guarded) and `Hosting__ReportInterval` (typed default `01:00:00`) in the ConfigMap; `Hosting__ModuleReportSecret` and a `Hosting__ModuleReportSecrets` map (`→ Hosting__ModuleReportSecret__<id>`) in the Secret. Verified: `helm template` with and without values; `scripts/check-config-key-coverage.py` against every overlay in the deployments repo → PASS (231 keys, 0 new rendered-nowhere), and a probe overlay with the four keys plus a bogus one → fails naming only the bogus key.

### Verified
- `Memex.Portal.Shared.Test`: `AnInstanceReportsWhatItRunsTest` (both shapes, platform/commit/identity/policy, the landed node with `$type`), GitHub-shaped signature vector, the node-type parity guard against `Memex.Portal.Shared`, and `AnUnnamedInstanceReportsNothingTest` — 4/4, fresh `.trx`.
- `MeshWeaver.Documentation.Test` 279/279 (link integrity, What's New integrity, every ratchet guard).
- `dotnet build -c Release -warnaserror` on the test project closure: 0 errors.

### Docs
`Doc/Architecture/DeploymentInventory` (new), linked from `Deployment` and `Instances`; What's New (Feature).

### Follow-ups (same change set)
- MeshWeaver.Plugins: the Hosting package shows the new fields — an **Instances** table on the Fleet area (platform / commit / identity / policy / reported / via) and the freshness line; `Modules.md` says the reporter is automatic. Additive; no `Pairs-with` needed (no public surface leaves core).
- Systemorph/Memex overlays: `Hosting__Deployment` per env (`memex`, `memex-cloud`, `pearl`, `atioz`), `Hosting__ReportTo: https://memex.systemorph.com` on the three tenants, the signing key in Key Vault. Its config-key gate reads this chart from core `main`, so this merges first.

Refs #3355.

### CI round 1 → fixed (7331aa9e1)
Shard 5 failed the landed-record assertion: the record carried one module while the report carried two. Root cause, not a flake: the service's own **boot report** (armed at mesh start after auto-registration settles) read the index while one seed was in place, and its write landed after the explicit report's. Two reports in flight is a defect in production too — an on-demand `Report()` beside the hourly tick. Every report now enqueues on **one channel** (`Subject` + `Concat`, the sanctioned serialization shape) and runs in request order, so the record is always the latest request's read. `TwoOverlappingRequests_LandInRequestOrder…` reproduces the CI shape deliberately (request A, seed, request B → B's write lands). 5/5 local runs on a fresh binary; documentation and ratchet suite 279/279.
