### PR TITLE
fix(#3441): the release gate's denominator no longer comes from the artifact it judges

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.cs
@@ -107,13 +107,7 @@ public class ReleaseAvailabilityService(
             // PublishedBundleCatalogue.EverSealedBundles.
             return pool
                 .InvokeBlocking(_ => PublishedBundleCatalogue.EverSealedBundles(publishedRoot, logger))
-                .SelectMany(floor => !floor.ServesBakes
-                    ? Observable.Return(UpdatabilityVerdict.NotEnforced(NoPublicationsReason(publishedRoot)))
-                    : RequiredPackages(floor)
-                        .SelectMany(required => PublishedBundleCatalogue
-                            .Observe(pool, publishedRoot, targetVersion, logger)
-                            .Select(observation => ReleaseAvailability.IsUpdatable(
-                                observation.Target, required, observation.Artifacts))));
+                .SelectMany(floor => Verdict(floor, publishedRoot, targetVersion));
         })
         // 🚨 The gate must ANSWER, always. Its two inputs can each stall indefinitely — a mesh
         // query that never emits its initial snapshot, an I/O pool slot that never frees — and a
@@ -136,6 +130,42 @@ public class ReleaseAvailabilityService(
     /// a stalled tick can never overlap the next one.
     /// </summary>
     private static readonly TimeSpan AnswerBudget = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// The verdict, given what the denominator observation turned out to be. Three outcomes, and
+    /// the ORDER is the whole point.
+    ///
+    /// <para>🚨 <b>An unreadable root is a HOLD, and it is tested FIRST.</b> A configured root that
+    /// does not exist, or that faults on read, produces a floor with no bundles — the same shape as
+    /// a root that genuinely serves no bakes. They mean opposite things: the first is a mis-mounted
+    /// volume or a mistyped path on a deployment that DECLARES it consumes CI bakes (an availability
+    /// incident: cannot determine, which is not clearance to proceed), the second is the one stated
+    /// applicability exemption. Collapsing them would let a mis-mount clear the gate — the exact
+    /// vacuity this change removes, reintroduced one level up.</para>
+    /// </summary>
+    private IObservable<UpdatabilityVerdict> Verdict(
+        SealedBundleFloor floor, string publishedRoot, string? targetVersion)
+    {
+        // 🚨 UpdatabilityVerdict.Unavailable, not IsUpdatable(target, [], Unreadable(...)): the
+        // latter answers IsUpdatable=false but IsIndeterminate=FALSE, because that property reads
+        // the per-package verdicts and an empty package list has none. Callers separate "I could
+        // not look" (an availability incident to fix) from "I looked and it is incompatible" (a
+        // release to re-bake) on exactly that flag, so an unreadable denominator reported without
+        // it would be surfaced as a compatibility verdict about the release — the conflation
+        // #1754 forbids.
+        if (floor.Refusal is { } refusal)
+            return Observable.Return(UpdatabilityVerdict.Unavailable(refusal));
+
+        if (!floor.ServesBakes)
+            return Observable.Return(
+                UpdatabilityVerdict.NotEnforced(NoPublicationsReason(publishedRoot)));
+
+        return RequiredPackages(floor)
+            .SelectMany(required => PublishedBundleCatalogue
+                .Observe(pool, publishedRoot, targetVersion, logger)
+                .Select(observation => ReleaseAvailability.IsUpdatable(
+                    observation.Target, required, observation.Artifacts)));
+    }
 
     /// <summary>
     /// Why the gate does not apply to a root that holds no sealed publication under ANY identity.

--- a/memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.cs
@@ -102,11 +102,18 @@ public class ReleaseAvailabilityService(
 
             var publishedRoot = PublishedRoot!;
 
-            return RequiredPackages(publishedRoot)
-                .SelectMany(required => PublishedBundleCatalogue
-                    .Observe(pool, publishedRoot, targetVersion, logger)
-                    .Select(observation => ReleaseAvailability.IsUpdatable(
-                        observation.Target, required, observation.Artifacts)));
+            // 🚨 The DENOMINATOR is read FIRST, and from every identity the root holds except the
+            // one under judgement — never from the target's own publication (#3441). See
+            // PublishedBundleCatalogue.EverSealedBundles.
+            return pool
+                .InvokeBlocking(_ => PublishedBundleCatalogue.EverSealedBundles(publishedRoot, logger))
+                .SelectMany(floor => !floor.ServesBakes
+                    ? Observable.Return(UpdatabilityVerdict.NotEnforced(NoPublicationsReason(publishedRoot)))
+                    : RequiredPackages(floor)
+                        .SelectMany(required => PublishedBundleCatalogue
+                            .Observe(pool, publishedRoot, targetVersion, logger)
+                            .Select(observation => ReleaseAvailability.IsUpdatable(
+                                observation.Target, required, observation.Artifacts))));
         })
         // 🚨 The gate must ANSWER, always. Its two inputs can each stall indefinitely — a mesh
         // query that never emits its initial snapshot, an I/O pool slot that never frees — and a
@@ -131,28 +138,69 @@ public class ReleaseAvailabilityService(
     private static readonly TimeSpan AnswerBudget = TimeSpan.FromSeconds(60);
 
     /// <summary>
+    /// Why the gate does not apply to a root that holds no sealed publication under ANY identity.
+    ///
+    /// <para>🚨 This case used to be a silent PASS, and it was the worst one. With no publication
+    /// under the live identity every installed package was judged non-content-bearing, so the
+    /// content half of the gate checked NOTHING and still reported updatable — a green tick over
+    /// zero evidence. It is stated here instead: an instance whose root serves no bakes already
+    /// compiles its content at every boot, exactly like one with no root configured, so the honest
+    /// answer is the same <see cref="UpdatabilityVerdict.NotEnforced"/> — <b>updatable with a
+    /// reason the caller logs</b>, never a verdict that pretends to have looked.</para>
+    /// </summary>
+    private static string NoPublicationsReason(string publishedRoot) =>
+        $"the published bundle root '{publishedRoot}' holds no sealed publication under any "
+        + "framework identity, so this deployment adopts nothing today and already compiles its "
+        + "content at every boot — the release-availability gate has nothing to enforce here. "
+        + "(If that is unexpected, the bake lanes are not reaching this environment's storage: "
+        + "check BAKE_PUBLISH_TARGETS and the publish-bake runs.)";
+
+    /// <summary>
     /// What this environment deploys, as the gate's inputs.
     ///
-    /// <para>🚨 <b>Content is required by EVIDENCE, never by assumption.</b> A package counts as
-    /// content-bearing exactly when it has a sealed bake under the identity this instance is
-    /// running NOW — i.e. when the instance is adopting its bytes today. That makes the gate a
-    /// regression check ("what I adopt today I must be able to adopt tomorrow") and closes the
-    /// failure that would otherwise be worse than the bug: a module-only or NodeType-less package
-    /// produces no bundle ever, so demanding one would hold that environment forever — an
-    /// environment silently frozen for weeks is its own outage.</para>
+    /// <para>🚨 <b>Content is required by EVIDENCE, and the evidence may not come from the artifact
+    /// under judgement (#3441).</b> A package counts as content-bearing when it has EVER been
+    /// sealed under any framework identity this root holds
+    /// (<see cref="PublishedBundleCatalogue.EverSealedBundles(string?, Microsoft.Extensions.Logging.ILogger?)"/>)
+    /// — not, as before, when it happens to be sealed under the identity running right now.</para>
+    ///
+    /// <para>The old reading made the denominator a function of the very thing that breaks: a
+    /// package whose bake stopped being produced silently left the set of packages the gate asks
+    /// about, so every subsequent roll was green about precisely the package that had regressed —
+    /// <i>"we kept rolling without edu being properly baked"</i>. Reading it monotonically makes
+    /// the gate say what it is for: <b>what this environment has ever been able to adopt, it must
+    /// still be able to adopt</b>.</para>
+    ///
+    /// <para>The exemption that made the old reading attractive is preserved exactly, and for the
+    /// same reason: a module-only or NodeType-less package produces no bundle ever, has therefore
+    /// never been sealed under any identity, and is still not demanded — demanding one would hold
+    /// that environment forever, and an environment silently frozen for weeks is its own
+    /// outage.</para>
     /// </summary>
-    private IObservable<ImmutableArray<RequiredPackage>> RequiredPackages(string publishedRoot) =>
+    private IObservable<ImmutableArray<RequiredPackage>> RequiredPackages(SealedBundleFloor floor) =>
         InstalledPackages()
-            .SelectMany(installed => pool
-                .InvokeBlocking(_ => PublishedBundleCatalogue.SealedBundlesForIdentity(
-                    publishedRoot, PrebuiltAssemblySeeder.LiveFrameworkMvid, logger))
-                .Select(adoptedToday => installed
+            .Select(installed =>
+            {
+                var required = installed
                     .Select(manifest => new RequiredPackage(
                         manifest.Id,
                         manifest.Id,
                         LiveFloorOf(manifest.MinMeshVersion),
-                        adoptedToday.Contains(manifest.Id)))
-                    .ToImmutableArray()));
+                        floor.Bundles.Contains(manifest.Id)))
+                    .ToImmutableArray();
+                // 🚨 PRINT THE DENOMINATOR. A completeness gate whose expected count nobody can
+                // read is one nobody can tell from a vacuous one — the count being non-zero is
+                // the claim, so it is logged rather than inferred from a pass.
+                logger?.LogInformation(
+                    "[ReleaseGate] denominator: {ContentBearing} of {Installed} installed package(s) "
+                    + "must carry a sealed bake, taken from {Identities} framework identity(ies) this "
+                    + "root has published: {Packages}",
+                    required.Count(p => p.HasContent),
+                    required.Length,
+                    floor.Identities,
+                    string.Join(", ", required.Where(p => p.HasContent).Select(p => p.Name).Order(StringComparer.Ordinal)));
+                return required;
+            });
 
     /// <summary>
     /// A module's floor, but only when the RUNNING platform already satisfies it — otherwise null.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
@@ -180,6 +180,15 @@ Naming the blind spot is worth more than overclaiming the coverage.
   it is the only thing standing between this gate and a permanently frozen environment — but it
   means a package whose bake has been broken *since before this root ever published* is invisible
   here. The bake lane, not the roll gate, is where that is caught.
+- 🚨 **A package that legitimately STOPS shipping content will hold, and keep holding.** Monotone
+  cuts both ways: once a package has sealed a bundle, dropping its last NodeType means it produces
+  no bundle for the target identity and the gate reads that as the regression it is designed to
+  catch. Uninstalling the package clears it (the outer set is the environment's install records,
+  so a removed package leaves the denominator with it); re-baking does not. This is a deliberate
+  trade against the erosion bug, and the direction is chosen on purpose: the old failure was
+  **silent** — rolling onto content that was not there — while this one is **loud**, named on the
+  policy node, and re-evaluated every tick. A gate that is visibly wrong can be acted on; one that
+  is invisibly wrong cannot.
 - **It gates the ROLL, not the BAKE.** It cannot make a bake complete; it can only refuse to roll
   onto an incomplete one. A satellite whose bake is torn still publishes nothing and still needs
   fixing at the source.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
@@ -1,0 +1,165 @@
+---
+nodeType: Markdown
+name: The Release Gate's Denominator
+category: Architecture
+description: Why the deployment gate's "which packages must be baked" set may never be read from the artifact store it is about to judge — the vacuous-denominator defect that let the fleet roll onto releases Education had not baked.
+icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#4a148c'/><path d='M5 8h14M5 16h14' stroke='white' stroke-width='1.8' stroke-linecap='round'/><circle cx='12' cy='12' r='9' fill='none' stroke='white' stroke-width='1.6'/></svg>"
+---
+
+# The Release Gate's Denominator
+
+> Maintainer, 2026-09-06: *"let's see that the deploy rolls only when **all** packages of all
+> plugins are baked"* — *"we kept rolling without edu being properly baked."*
+
+The [release availability gate](../ReleaseGates) already asked the right question and already held
+the roll when the answer was no. It nonetheless let the fleet roll onto releases whose Education
+content was not baked, and it did so while reporting a clean pass. This page is why, and what the
+rule is now.
+
+## A completeness gate is only as good as its denominator
+
+Every completeness check is a comparison of two sets: what was **expected**, and what was
+**found**. The found set is easy — it is the thing you are looking at. The expected set is the
+whole difficulty, because the obvious place to get it from is the same artifact you are judging,
+and a denominator taken from there **cannot fail**:
+
+> **0 packages expected, 0 packages baked, green.**
+
+That is the same shape as a skipped job wearing a passing tick, and this repo forbids it in
+[CI gates](../ReadingCiSignals) for exactly this reason. The deployment gate had it in the runtime.
+
+## The defect
+
+`ReleaseAvailabilityService.RequiredPackages` built the gate's input list from the environment's
+**install records** — a mesh query, genuinely independent, and correct. Then it decided, per
+package, whether that package must carry a baked bundle:
+
+```csharp
+// BEFORE — the denominator is a function of the thing that breaks
+var adoptedToday = PublishedBundleCatalogue.SealedBundlesForIdentity(
+    publishedRoot, PrebuiltAssemblySeeder.LiveFrameworkMvid, logger);
+
+new RequiredPackage(manifest.Id, manifest.Id, LiveFloorOf(manifest.MinMeshVersion),
+                    HasContent: adoptedToday.Contains(manifest.Id))
+```
+
+`HasContent` is the denominator. It was read from the **artifact store**, under the identity the
+instance is running now — the same store, one directory over, from the publication the gate is
+about to judge.
+
+The consequence is not subtle once stated:
+
+- Education's bake stops producing a sealed publication.
+- Education's packages therefore leave `adoptedToday`.
+- Leaving `adoptedToday` sets `HasContent: false` — *"this package ships no content"*.
+- A package that ships no content cannot have a missing bake. **It is exempt.**
+- Every subsequent roll is green about precisely the packages that regressed.
+
+The denominator **erodes**, and it erodes exactly where the gate is needed. A package that is
+broken today is exempt tomorrow, and can never re-enter the set on its own.
+
+### The limiting case is worse
+
+If the running identity has **no** sealed publication at all — a fresh storage target, a bake lane
+pointed at the wrong share, a `BAKE_PUBLISH_TARGETS` that stopped being written — then
+`adoptedToday` is empty, *every* installed package is non-content-bearing, and the content half of
+the gate checks **nothing** while answering "updatable". A green tick over zero evidence, with no
+line anywhere saying the expected set was empty.
+
+## The rule
+
+> **The denominator is read from every framework identity the published root holds EXCEPT by
+> reading the target's own publication — and it is MONOTONE.** What this environment has ever been
+> able to adopt, it must still be able to adopt.
+
+`PublishedBundleCatalogue.EverSealedBundles(publishedRoot)` answers it:
+
+```csharp
+// AFTER — the denominator comes from the OTHER identities, and never shrinks
+var floor = PublishedBundleCatalogue.EverSealedBundles(publishedRoot, logger);
+
+new RequiredPackage(manifest.Id, manifest.Id, LiveFloorOf(manifest.MinMeshVersion),
+                    HasContent: floor.Bundles.Contains(manifest.Id))
+```
+
+Three properties, and each is load-bearing:
+
+| Property | Why |
+|---|---|
+| **Independent** | The judgement is about the TARGET identity's directory. The denominator is read from the OTHER identity directories — publications written by earlier CD waves, which the run under judgement cannot have produced. |
+| **Monotone** | A package that has once shipped a bake can never silently leave the denominator. A bake that regresses to nothing is a HOLD, not an exemption. |
+| **Non-freezing** | A package that has *never* sealed a bundle under *any* identity — a module-only or NodeType-less package, which produces no bundle ever — is still not demanded. The exemption is preserved; only its evidence moved from "one identity's answer today" to "any identity's answer ever". |
+
+### "Serves no bakes" is stated, never inferred
+
+`SealedBundleFloor.Identities` counts how many identity directories carried at least one sealed
+source. **Zero is the load-bearing value.** It means the root serves no bakes at all, so "package X
+has never been sealed" carries no information about X and must not be read as an exemption.
+
+That case now answers `UpdatabilityVerdict.NotEnforced` **with its reason** — updatable, because an
+instance that adopts nothing already compiles its content at every boot and holding it forever
+would be its own outage, but *said out loud* and logged by the caller rather than passed off as a
+verdict that looked at something. It is the one applicability answer; every other unknown remains
+`Indeterminate`, which holds.
+
+### The denominator is printed
+
+```
+[ReleaseGate] denominator: 13 of 14 installed package(s) must carry a sealed bake,
+              taken from 3 framework identity(ies) this root has published: …
+```
+
+The count being non-zero **is** the claim, so it is logged rather than inferred from a pass. A
+reader who cannot see the expected set cannot tell this gate from a vacuous one.
+
+## Falsification
+
+`ReleaseGateDenominatorTest` reconstructs the incident: an earlier identity where every source
+baked, then the live and target identities with Education's publication torn (directory present,
+no `_complete` sentinel — a bake that died before sealing, which the boot seeder and the gate both
+refuse to read). Installed: Education's nine courses, two platform packages, two plugin packages,
+and one module-only package that has never produced a bundle.
+
+Both denominators are computed **on the same fixture, in the same test**, so the negative control
+is a measurement rather than a claim:
+
+| Denominator | Verdict | Blockers |
+|---|---|---|
+| **Old** — sealed under the live identity | `IsUpdatable = true` — the roll proceeds | 0 |
+| **New** — ever sealed under any identity | `IsUpdatable = false` | 9, each `ContentBakeMissing`, naming the nine courses |
+| **New**, after Education re-bakes for the target | `IsUpdatable = true` | 0, over 13 content-bearing of 14 installed |
+| **New**, Education seals 4 of 9 | `IsUpdatable = false` | 5 — exactly the unsealed courses |
+
+A gate nobody has watched fail is not a gate; the first row is that watch.
+
+## 🚨 What this gate does NOT see
+
+Naming the blind spot is worth more than overclaiming the coverage.
+
+- **A package that has never been sealed under any identity is still exempt.** That is deliberate —
+  it is the only thing standing between this gate and a permanently frozen environment — but it
+  means a package whose bake has been broken *since before this root ever published* is invisible
+  here. The bake lane, not the roll gate, is where that is caught.
+- **It gates the ROLL, not the BAKE.** It cannot make a bake complete; it can only refuse to roll
+  onto an incomplete one. A satellite whose bake is torn still publishes nothing and still needs
+  fixing at the source.
+- **CD cannot assert satellite bakes at promote time, by construction.** Core's `main-cd` publishes
+  the platform's own bake and then asserts availability for `meshweaver-content` only. That is not
+  an oversight: the satellites re-bake on the `meshweaver-framework-released` dispatch that this
+  very run triggers, so at promote time they *cannot* have baked yet. The completeness question for
+  satellites is answerable only later — which is exactly why it is answered at the roll.
+- **Content ASSETS are not part of the bundle set.** A package can seal a complete bundle set whose
+  `content/**` never published (MeshWeaver#3424). Bundle completeness is assembly completeness.
+- **Adoption is not observed here.** A sealed, present, consistent bundle can still be declined at
+  install time and compiled in-mesh with no reason logged (MeshWeaver#3429). This gate asserts the
+  bytes are *available*; it does not assert they were *used*.
+- **Retention.** The denominator is monotone only as long as old identity directories are kept.
+  Nothing purges them today. If a retention policy is ever added, it takes this gate's memory with
+  it and the erosion returns.
+
+## See also
+
+- [Release Availability Gates](../ReleaseGates) — the predicate, the marker, the three roll paths
+- [CI Content Bake](../CiContentBake) — where the sealed bundles and the framework identity come from
+- [Reading CI Signals](../ReadingCiSignals) — the same vacuity trap on the CI side
+- [The Continuous Delivery Contract](../ContinuousDeliveryContract) — the publication this gate reads

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
@@ -110,6 +110,22 @@ directions, and the two reasons agree:
   environment, turning this gate into the outage it exists to prevent. Reading the sentinel alone is
   one file read per source.
 
+### An ABSENT root is a refusal, not an exemption
+
+An empty floor has two causes that look identical and mean opposite things:
+
+| Cause | Answer |
+|---|---|
+| The root **was read** and holds no sealed publication | `NotEnforced` — the one stated applicability exemption |
+| The root is **absent or unreadable** (a volume that did not mount, a mistyped path, an IO fault) | **HOLD** — `Indeterminate`, with the reason |
+
+A deployment that configures `PreWarm:PrebuiltBundleRoot` *declares* that it consumes CI bakes, so a
+root that is not on disk is an availability incident, never evidence that nothing is published.
+`SealedBundleFloor.Refusal` carries that distinction and callers test it **first** — `ServesBakes` is
+false for both, which is exactly why the order matters. Collapsing them would let a mis-mounted
+volume clear the gate: the same vacuity this page is about, reintroduced one level up. (Caught in
+review on the PR that introduced it — the shape is easy to write by accident.)
+
 ### "Serves no bakes" is stated, never inferred
 
 `SealedBundleFloor.Identities` counts how many identity directories carried at least one sealed

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
@@ -90,6 +90,26 @@ Three properties, and each is load-bearing:
 | **Monotone** | A package that has once shipped a bake can never silently leave the denominator. A bake that regresses to nothing is a HOLD, not an exemption. |
 | **Non-freezing** | A package that has *never* sealed a bundle under *any* identity — a module-only or NodeType-less package, which produces no bundle ever — is still not demanded. The exemption is preserved; only its evidence moved from "one identity's answer today" to "any identity's answer ever". |
 
+### It reads the seal's DECLARATION, not every bundle's bytes
+
+The denominator reads each source's `_complete` sentinel and takes the listing at face value. It
+does **not** re-check that every listed bundle is still on disk. That is deliberate in both
+directions, and the two reasons agree:
+
+- **Semantics.** *"Has this package ever shipped a bake?"* is answered by the publisher's own
+  declaration. Whether the bytes are still present is a question about what can be **adopted now** —
+  the numerator — and that full check stays exactly where it decides the verdict, on the target
+  identity. Being inclusive here is the safe direction: a torn publication that once listed a
+  package keeps that package in the set the gate asks about, which can only **hold** a roll, never
+  exempt one.
+- **Cost, which is a correctness concern.** The denominator reads *every* identity the root holds,
+  and that root is a network share (Azure Files over SMB on AKS). Verifying presence would cost one
+  stat per bundle, per source, per identity — thousands of round trips per poll tick once
+  identities accumulate — against a verdict bounded at 60 s. Blowing that bound answers
+  `Indeterminate`, which **holds**: a denominator expensive enough to time out would freeze every
+  environment, turning this gate into the outage it exists to prevent. Reading the sentinel alone is
+  one file read per source.
+
 ### "Serves no bakes" is stated, never inferred
 
 `SealedBundleFloor.Identities` counts how many identity directories carried at least one sealed
@@ -129,6 +149,10 @@ is a measurement rather than a claim:
 | **New** — ever sealed under any identity | `IsUpdatable = false` | 9, each `ContentBakeMissing`, naming the nine courses |
 | **New**, after Education re-bakes for the target | `IsUpdatable = true` | 0, over 13 content-bearing of 14 installed |
 | **New**, Education seals 4 of 9 | `IsUpdatable = false` | 5 — exactly the unsealed courses |
+
+A sixth test pins the declaration reading from both sides: a publication that keeps its seal but
+loses a bundle's bytes still counts toward the denominator, while the same source contributes
+**nothing** to what can be adopted.
 
 A gate nobody has watched fail is not a gate; the first row is that watch.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
@@ -109,10 +109,14 @@ A gate that holds an environment forever is a worse outage than the one it preve
 half asks "is this package perfect for the target"; both ask "would this roll take away something
 that works today".
 
-- **Content**: a package is treated as content-bearing exactly when it has a sealed bake under the
-  identity the instance is running *now* — i.e. when its bytes are being adopted today. A package
-  with no compilable NodeTypes produces no bundle ever, so demanding one would hold its environment
-  forever.
+- **Content**: a package is treated as content-bearing exactly when it has **ever** been sealed
+  under **any** framework identity the published root holds. A package with no compilable NodeTypes
+  produces no bundle ever, so demanding one would hold its environment forever — but the evidence
+  must not come from the artifact store the gate is about to judge. 🚨 It once did (it asked the
+  identity running *now*), and that made the denominator erode exactly where the gate was needed:
+  a package whose bake broke left the set of packages the gate asks about, so every later roll was
+  green about precisely the package that had regressed. See
+  [The Release Gate's Denominator](../ReleaseGateDenominator).
 - **Modules**: a floor is passed to the predicate only when the running platform already satisfies
   it. SemVer puts `3.0.0-rc4.ci.4049` **below** `3.0.0`, so a module declaring `minMeshVersion:
   3.0.0` is below floor on every `-rc` platform, including the one prod runs. Judged absolutely it
@@ -505,6 +509,7 @@ from the name.
 
 ## See also
 
+- [The Release Gate's Denominator](../ReleaseGateDenominator) — why "which packages must be baked" may never be read from the artifact under judgement
 - [CI Content Bake](../CiContentBake) — where the sealed bundles and the framework identity come from
 - [The Continuous Delivery Contract](../ContinuousDeliveryContract) — the publication this gate reads
 - [Release & Self-Update Strategy](../ReleaseStrategy) — the poll, the policy node, the roll

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deploy-no-longer-rolls-past-a-plugin-that-stopped-being-baked.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deploy-no-longer-rolls-past-a-plugin-that-stopped-being-baked.md
@@ -1,0 +1,51 @@
+---
+Name: A deploy no longer rolls past a plugin that stopped being baked
+Category: Fix
+Description: The gate that holds a release until every installed package has been built for it was deciding which packages to ask about by reading the same store it was about to judge — so a package whose build broke quietly dropped out of the check. It is now decided from what the environment has ever been able to use.
+Icon: Checkmark
+Order: -20260906
+---
+
+# A deploy no longer rolls past a plugin that stopped being baked
+
+Before an environment moves to a new platform release, it checks that every package it has
+installed has been prepared for that release. If something is missing, the update is held and the
+reason is recorded — otherwise the environment would come up recompiling that content from source
+on every start, slowly and sometimes not at all.
+
+That check was passing when it should have held.
+
+## What was wrong
+
+The check has two halves: *which packages must be prepared* (the expected set) and *which ones
+actually were* (what it finds). The second half was right. The first half was being worked out by
+looking at the same storage the check was about to inspect — a package counted as "ships content"
+only if it already had a prepared build there.
+
+So the moment a package's build stopped being produced, that package quietly dropped out of the
+list of things being asked about. It was no longer missing; it was no longer *expected*. Every
+subsequent update went through cleanly, reporting nothing wrong, about exactly the package that had
+broken. In the extreme — a storage location with nothing prepared in it at all — the entire content
+half of the check had nothing to compare and still reported success.
+
+This is what let environments move forward while course content had not been properly built.
+
+## What changes
+
+The expected set is now taken from what the environment has **ever** been able to use — every
+platform build recorded in its storage, not just the one it happens to be running. A package that
+has once shipped a prepared build stays on the list permanently, so a build that regresses to
+nothing now holds the update instead of excusing itself from the question.
+
+- **Updates hold, and say which packages and why.** The reason names each package that is missing a
+  prepared build for the target release.
+- **A package that genuinely ships no such content is still not asked for one.** Nothing that has
+  never produced a build is suddenly demanded — an environment held forever would be a worse
+  problem than the one being fixed.
+- **"Nothing is prepared here" is now stated rather than passed over.** An environment whose
+  storage holds nothing at all is reported as one the check does not apply to, with the reason
+  written to the log, instead of quietly counting as a pass.
+- **The expected count is logged**, so it is possible to see that the check looked at something.
+
+No action is needed. An environment that is currently missing prepared content for a package will
+now hold its next update and say so, which is the intended behaviour.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -189,6 +189,15 @@ public static class PublishedBundleCatalogue
     /// bundle under any identity — a module-only or NodeType-less package, which produces no
     /// bundle ever — is still not demanded, exactly as before. The exemption is preserved; only
     /// its EVIDENCE moved from "one identity's answer today" to "any identity's answer ever".</para>
+    ///
+    /// <para>🚨 <b>It reads each source's sentinel DECLARATION, not a per-bundle presence check</b>
+    /// (<see cref="DeclaredBundlesOf"/>). That is deliberate in both directions: inclusive, because
+    /// a torn publication that once listed a package should keep that package in the set the gate
+    /// asks about (which can only HOLD, never exempt); and cheap, because this reads EVERY identity
+    /// on a network share against a 60 s verdict budget, and a denominator expensive enough to time
+    /// out would answer <see cref="PackageAvailabilityKind.Indeterminate"/> and freeze every
+    /// environment. The full presence check stays exactly where it decides the verdict —
+    /// <see cref="ArtifactsForIdentity"/>, on the target identity.</para>
     /// </summary>
     public static SealedBundleFloor EverSealedBundles(string? publishedRoot, ILogger? logger = null)
     {
@@ -208,11 +217,18 @@ public static class PublishedBundleCatalogue
                     ReleaseMarkerDirectoryName,
                     StringComparison.Ordinal))
                 continue;
-            var sealedHere = SealedBundleNames(identityDirectory, logger).ToList();
-            if (sealedHere.Count == 0)
+            // The sentinel's DECLARATION, not a per-bundle presence check — see DeclaredBundlesOf
+            // for why the denominator must be both inclusive and cheap.
+            var declaredHere = Directory.EnumerateDirectories(identityDirectory)
+                .OrderBy(d => d, StringComparer.Ordinal)
+                .Select(DeclaredBundlesOf)
+                .Where(listing => listing is not null)
+                .SelectMany(listing => listing!)
+                .ToList();
+            if (declaredHere.Count == 0)
                 continue;
             identities++;
-            bundles.AddRange(sealedHere);
+            bundles.AddRange(declaredHere);
         }
         return new SealedBundleFloor(ReleaseArtifacts.Of(bundles).SealedBundles, identities);
     }
@@ -567,6 +583,41 @@ public static class PublishedBundleCatalogue
 
     private static bool IsComplete(string sourceDirectory, ILogger? logger) =>
         CompleteBundlesOf(sourceDirectory, logger) is not null;
+
+    /// <summary>
+    /// What a source directory's sentinel DECLARES was shipped, without verifying that each listed
+    /// bundle is still on disk. Null when there is no sentinel at all.
+    ///
+    /// <para>🚨 <b>Deliberately weaker than <see cref="CompleteBundlesOf"/>, and only ever used for
+    /// the DENOMINATOR (#3441).</b> Two reasons, and both point the same way:</para>
+    ///
+    /// <para><b>Semantics.</b> "Has this package ever shipped a bake?" is answered by the
+    /// publisher's own declaration. Whether every byte is still present is a question about what
+    /// can be ADOPTED NOW — the numerator — which <see cref="ArtifactsForIdentity"/> answers with
+    /// the full check, for the target identity, where it decides the verdict. Being INCLUSIVE here
+    /// is the safe direction: a publication that once listed a package keeps that package in the
+    /// set of things the gate asks about, which can only HOLD a roll, never exempt one.</para>
+    ///
+    /// <para><b>Cost, which is a correctness concern here.</b> The denominator reads EVERY identity
+    /// the root holds, and the published root is a network share (Azure Files over SMB on AKS).
+    /// Verifying presence would cost one stat per bundle per source per identity — on the order of
+    /// thousands of round trips per poll tick once identities accumulate — against a gate whose
+    /// whole verdict is bounded at 60 s. Blowing that bound answers
+    /// <see cref="PackageAvailabilityKind.Indeterminate"/>, which HOLDS: a denominator expensive
+    /// enough to time out would freeze every environment, turning this gate into the outage it
+    /// exists to prevent. Reading the sentinel alone is one file read per source.</para>
+    /// </summary>
+    private static IReadOnlyList<string>? DeclaredBundlesOf(string sourceDirectory)
+    {
+        var sentinel = Path.Combine(
+            sourceDirectory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        if (!File.Exists(sentinel))
+            return null;
+        return File.ReadAllLines(sentinel)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+    }
 
     /// <summary>
     /// Which sources are COMPLETE under one identity — the BUILD gate's question (#1755), asked per

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -137,9 +137,18 @@ public static class PublishedBundleCatalogue
     /// nothing (the seeder would skip it, so a gate that counted it would clear a release the
     /// portal then recompiles).
     ///
-    /// <para>Public because it is also the deployment gate's "what am I adopting TODAY" reading —
-    /// asked of the RUNNING identity to decide which installed packages are content-bearing at
-    /// all, which is what keeps the gate a regression check instead of a permanent freeze.</para>
+    /// <para>🚨 <b>This was the deployment gate's denominator, and it must never be that again
+    /// (#3441).</b> Asked of the RUNNING identity to decide which installed packages are
+    /// content-bearing, it made the expected set a function of the artifact store the gate was
+    /// about to judge: a package whose bake broke left the set and every later roll was green
+    /// about it. The gate now reads
+    /// <see cref="EverSealedBundles(string?, ILogger?)"/> instead. This overload answers the
+    /// narrower factual question — <i>what is sealed under THIS one identity</i> — which remains a
+    /// legitimate reading (it is what the boot seeder effectively resolves, and what
+    /// <c>ReleaseGateDenominatorTest</c> uses to reproduce the old verdict as its negative
+    /// control). It has no production caller today; kept public deliberately rather than deleted,
+    /// because a public surface here can have in-mesh and satellite callers the compiler cannot
+    /// see.</para>
     /// </summary>
     public static ImmutableHashSet<string> SealedBundlesForIdentity(
         string? publishedRoot, string? identity, ILogger? logger = null)

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -190,6 +190,15 @@ public static class PublishedBundleCatalogue
     /// bundle ever — is still not demanded, exactly as before. The exemption is preserved; only
     /// its EVIDENCE moved from "one identity's answer today" to "any identity's answer ever".</para>
     ///
+    /// <para>🚨 <b>The cost of monotone, stated honestly.</b> A package that legitimately STOPS
+    /// shipping content — its last NodeType removed while it stays installed — produces no bundle
+    /// for the target identity and will hold, and keep holding; uninstalling it clears the hold
+    /// (the outer set is the environment's install records), re-baking does not. That is a
+    /// deliberate trade against the erosion bug, and the direction is chosen: the old failure was
+    /// SILENT (rolling onto content that was not there), this one is LOUD — named on the policy
+    /// node and re-evaluated every tick. A gate that is visibly wrong can be acted on; one that is
+    /// invisibly wrong cannot.</para>
+    ///
     /// <para>🚨 <b>It reads each source's sentinel DECLARATION, not a per-bundle presence check</b>
     /// (<see cref="DeclaredBundlesOf"/>). That is deliberate in both directions: inclusive, because
     /// a torn publication that once listed a package should keep that package in the set the gate

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -153,6 +153,62 @@ public static class PublishedBundleCatalogue
     }
 
     /// <summary>
+    /// 🚨 <b>The deployment gate's DENOMINATOR, and it must not come from the artifact under
+    /// judgement (#3441).</b> Every bundle id this root has EVER sealed, across every framework
+    /// identity it holds — plus how many identities actually carried a sealed publication, so a
+    /// caller can tell "this root serves no bakes" from "this root serves bakes and this package
+    /// is not among them".
+    ///
+    /// <para><b>Why not simply ask the LIVE identity.</b> That is what the gate used to do, and it
+    /// is the vacuous-denominator shape this repo forbids elsewhere: a package counted as
+    /// content-bearing exactly when it had a sealed bundle under the identity running NOW, read
+    /// from the same store the gate was about to judge. So a package whose bake BROKE silently
+    /// left the denominator and every later roll was green about it — the gate stopped asking
+    /// about precisely the package that had stopped being baked. In the limit, an identity with no
+    /// publication at all made every installed package non-content-bearing and the content half of
+    /// the gate checked NOTHING while reporting a pass, which is "0 expected, 0 found, green".
+    /// That is the state the maintainer named: <i>"we kept rolling without edu being properly
+    /// baked"</i>.</para>
+    ///
+    /// <para><b>Why this is independent.</b> The judgement is about the TARGET release's identity
+    /// directory; the denominator is read from the OTHER identity directories — publications made
+    /// by earlier CD waves, which the run under judgement cannot have written. And it is MONOTONE:
+    /// a package that has once shipped a bake can never silently leave the denominator, so a bake
+    /// that regresses to nothing is a HOLD rather than an exemption.</para>
+    ///
+    /// <para><b>Why it still cannot freeze an environment.</b> A package that has never sealed a
+    /// bundle under any identity — a module-only or NodeType-less package, which produces no
+    /// bundle ever — is still not demanded, exactly as before. The exemption is preserved; only
+    /// its EVIDENCE moved from "one identity's answer today" to "any identity's answer ever".</para>
+    /// </summary>
+    public static SealedBundleFloor EverSealedBundles(string? publishedRoot, ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(publishedRoot) || !Directory.Exists(publishedRoot))
+            return SealedBundleFloor.Empty;
+
+        var bundles = new List<string>();
+        var identities = 0;
+        foreach (var identityDirectory in Directory.EnumerateDirectories(publishedRoot)
+                     .OrderBy(d => d, StringComparer.Ordinal))
+        {
+            // The release-marker directory holds version→identity FILES, never a publication.
+            // Skipping it by name keeps "how many identities published" honest — it would
+            // contribute no bundles either way, but it would not be an identity.
+            if (string.Equals(
+                    Path.GetFileName(identityDirectory),
+                    ReleaseMarkerDirectoryName,
+                    StringComparison.Ordinal))
+                continue;
+            var sealedHere = SealedBundleNames(identityDirectory, logger).ToList();
+            if (sealedHere.Count == 0)
+                continue;
+            identities++;
+            bundles.AddRange(sealedHere);
+        }
+        return new SealedBundleFloor(ReleaseArtifacts.Of(bundles).SealedBundles, identities);
+    }
+
+    /// <summary>
     /// 🚨 The FULL observation of one identity (#3175): the sealed bundle ids, the module set every
     /// complete source sealed (each module bundle read for the MVID of every <c>MeshWeaver.*</c>
     /// assembly it CARRIES, spelt as the dependency records spell it), and every sealed bundle's
@@ -618,3 +674,29 @@ public readonly record struct SealedModuleAssembly(string Name, string Mvid, boo
 /// <param name="Target">The release, with its framework identity resolved (or not).</param>
 /// <param name="Artifacts">What is sealed for it.</param>
 public sealed record ReleaseObservation(ReleaseTarget Target, ReleaseArtifacts Artifacts);
+
+/// <summary>
+/// 🚨 The deployment gate's DENOMINATOR (#3441) — what a published root has ever demonstrably been
+/// able to serve, read across every framework identity it holds rather than from the one identity
+/// the gate is about to judge. See
+/// <see cref="PublishedBundleCatalogue.EverSealedBundles(string?, Microsoft.Extensions.Logging.ILogger?)"/>
+/// for why the denominator may not be taken from the artifact under judgement.
+/// </summary>
+/// <param name="Bundles">Every bundle id sealed under ANY identity in the root, extension
+/// stripped and case-insensitive — the same spelling <see cref="ReleaseArtifacts.SealedBundles"/>
+/// uses, so the two sets compare directly.</param>
+/// <param name="Identities">How many framework-identity directories carried at least one SEALED
+/// source. 🚨 ZERO is the load-bearing value: it means this root serves no bakes at all, so
+/// "package X has never been sealed" carries NO information about X and must not be read as an
+/// exemption. A caller that cannot tell that case apart is back to a denominator that can be
+/// vacuously empty.</param>
+public sealed record SealedBundleFloor(ImmutableHashSet<string> Bundles, int Identities)
+{
+    /// <summary>A root that holds no sealed publication under any identity.</summary>
+    public static SealedBundleFloor Empty { get; } =
+        new(ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase), 0);
+
+    /// <summary>Whether this root serves CI bakes at all — the precondition for reading an absent
+    /// bundle as "this package ships no content" rather than as "we have observed nothing".</summary>
+    public bool ServesBakes => Identities > 0;
+}

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -201,11 +201,26 @@ public static class PublishedBundleCatalogue
     /// </summary>
     public static SealedBundleFloor EverSealedBundles(string? publishedRoot, ILogger? logger = null)
     {
-        if (string.IsNullOrWhiteSpace(publishedRoot) || !Directory.Exists(publishedRoot))
-            return SealedBundleFloor.Empty;
+        // 🚨 "I could not look" is NOT "there is nothing here", and the difference decides the
+        // verdict: an unreadable root must HOLD (Indeterminate), while a readable root that holds
+        // no publication is the one stated applicability exemption. A configured root that does not
+        // EXIST is the mis-mount / mistyped-path case — the deployment declares it consumes CI
+        // bakes and its storage is not there — so it is a refusal, never an exemption. Collapsing
+        // the two is the same vacuity this whole method exists to remove.
+        if (string.IsNullOrWhiteSpace(publishedRoot))
+            return SealedBundleFloor.Unreadable(
+                $"no published bundle root is configured ({ShippedPrebuiltBundles.PublishedRootConfigKey})");
+        if (!Directory.Exists(publishedRoot))
+            return SealedBundleFloor.Unreadable(
+                $"the configured published bundle root '{publishedRoot}' does not exist — this "
+                + "deployment declares that it consumes CI bakes, so an absent root is an "
+                + "unreadable one (a volume that did not mount, or a mistyped path), not evidence "
+                + "that nothing is published. Cannot determine ≠ clear to proceed.");
 
         var bundles = new List<string>();
         var identities = 0;
+        try
+        {
         foreach (var identityDirectory in Directory.EnumerateDirectories(publishedRoot)
                      .OrderBy(d => d, StringComparer.Ordinal))
         {
@@ -229,6 +244,17 @@ public static class PublishedBundleCatalogue
                 continue;
             identities++;
             bundles.AddRange(declaredHere);
+        }
+        }
+        catch (Exception ex)
+        {
+            // An IO fault against the share is an availability incident, and it must be
+            // distinguishable from an empty root for exactly the reason above.
+            logger?.LogWarning(ex,
+                "ReleaseAvailability: could not read the published bundle root {Root} while "
+                + "establishing which packages must carry a sealed bake", publishedRoot);
+            return SealedBundleFloor.Unreadable(
+                $"the published bundle root '{publishedRoot}' could not be read ({ex.Message})");
         }
         return new SealedBundleFloor(ReleaseArtifacts.Of(bundles).SealedBundles, identities);
     }
@@ -750,13 +776,24 @@ public sealed record ReleaseObservation(ReleaseTarget Target, ReleaseArtifacts A
 /// "package X has never been sealed" carries NO information about X and must not be read as an
 /// exemption. A caller that cannot tell that case apart is back to a denominator that can be
 /// vacuously empty.</param>
-public sealed record SealedBundleFloor(ImmutableHashSet<string> Bundles, int Identities)
+/// <param name="Refusal">Why the root could not be READ, or null when it was. 🚨 Non-null is a HOLD
+/// and never an exemption: an absent or unreadable root on a deployment that declares it consumes
+/// CI bakes is a mis-mount or an IO incident, not evidence that nothing is published. Collapsing
+/// "could not look" into "nothing here" is the vacuity this type exists to remove.</param>
+public sealed record SealedBundleFloor(
+    ImmutableHashSet<string> Bundles, int Identities, string? Refusal = null)
 {
-    /// <summary>A root that holds no sealed publication under any identity.</summary>
+    /// <summary>A root that was READ and holds no sealed publication under any identity.</summary>
     public static SealedBundleFloor Empty { get; } =
         new(ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase), 0);
 
+    /// <summary>An observation that could not be made — the fail-safe constructor.</summary>
+    public static SealedBundleFloor Unreadable(string reason) =>
+        new(ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase), 0, reason);
+
     /// <summary>Whether this root serves CI bakes at all — the precondition for reading an absent
-    /// bundle as "this package ships no content" rather than as "we have observed nothing".</summary>
-    public bool ServesBakes => Identities > 0;
+    /// bundle as "this package ships no content" rather than as "we have observed nothing".
+    /// False for an unreadable observation too, which is why callers must test
+    /// <see cref="Refusal"/> FIRST: the two share this answer and mean opposite things.</summary>
+    public bool ServesBakes => Refusal is null && Identities > 0;
 }

--- a/test/Memex.Portal.Shared.Test/ReleaseGateDenominatorTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseGateDenominatorTest.cs
@@ -34,8 +34,27 @@ namespace Memex.Portal.Shared.Test;
 /// so the negative control is executed rather than asserted: a test that only showed the new
 /// reading holding could not distinguish "the fix works" from "the fixture was always red".</para>
 /// </summary>
-public class ReleaseGateDenominatorTest
+public class ReleaseGateDenominatorTest : IDisposable
 {
+    /// <summary>Every published root this test built, removed on teardown — a leaked temp tree
+    /// bloats the CI agent and is one more way for two runs to interfere.</summary>
+    private readonly List<string> roots = [];
+
+    public void Dispose()
+    {
+        foreach (var root in roots)
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private string Track(string root)
+    {
+        roots.Add(root);
+        return root;
+    }
+
     // Three framework identities: an EARLIER wave that baked everything, the identity the instance
     // is RUNNING (Education's publication already torn), and the TARGET the roll would move to.
     private const string Earlier = "s3441earlier00000000000000000000";
@@ -90,7 +109,7 @@ public class ReleaseGateDenominatorTest
         // A configured root holding no sealed publication under any identity. The old reading made
         // this the WORST case — every package non-content-bearing, the content half checking
         // nothing, and a green verdict over zero evidence.
-        var root = Path.Combine(Path.GetTempPath(), "mw-3441-empty-" + Guid.NewGuid().ToString("N"));
+        var root = Track(Path.Combine(Path.GetTempPath(), "mw-3441-empty-" + Guid.NewGuid().ToString("N")));
         Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
         // A torn publication contributes nothing — it is not evidence that the root serves bakes.
         Directory.CreateDirectory(Path.Combine(root, Live, "education"));
@@ -100,6 +119,41 @@ public class ReleaseGateDenominatorTest
         Assert.Equal(0, floor.Identities);
         Assert.False(floor.ServesBakes);
         Assert.Empty(floor.Bundles);
+    }
+
+    /// <summary>
+    /// 🚨 <b>An ABSENT root is a refusal, not an exemption</b> — the two produce the same empty
+    /// floor and mean opposite things.
+    ///
+    /// <para>A deployment that configures a bundle root DECLARES that it consumes CI bakes. If that
+    /// root is not on disk, the volume did not mount or the path is mistyped: an availability
+    /// incident. Reading it as "serves no bakes" would clear the gate on a mis-mount — the very
+    /// vacuity this change removes, reintroduced one level up. Caught in review on this PR.</para>
+    /// </summary>
+    [Fact]
+    public void AnAbsentRoot_Refuses_RatherThanReadingAsServesNoBakes()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "mw-3441-absent-" + Guid.NewGuid().ToString("N"));
+        Assert.False(Directory.Exists(missing));
+
+        var floor = PublishedBundleCatalogue.EverSealedBundles(missing);
+
+        Assert.NotNull(floor.Refusal);
+        Assert.Contains(missing, floor.Refusal);
+        // 🚨 ServesBakes is false here TOO — which is exactly why a caller must test Refusal first.
+        Assert.False(floor.ServesBakes);
+
+        // And the refusal becomes the HOLD the service actually produces — never an exemption.
+        // 🚨 This is the SAME construction ReleaseAvailabilityService.Verdict uses, deliberately:
+        // IsUpdatable(target, [], Unreadable(...)) would answer IsUpdatable=false but
+        // IsIndeterminate=FALSE (that property reads the per-package verdicts, and an empty list
+        // has none), which surfaces an availability incident as a compatibility verdict.
+        var verdict = UpdatabilityVerdict.Unavailable(floor.Refusal!);
+        Assert.False(verdict.IsUpdatable);
+        Assert.True(verdict.IsIndeterminate);
+        Assert.Equal(floor.Refusal, verdict.HoldReason);
+        Assert.All(verdict.Packages, p =>
+            Assert.Equal(PackageAvailabilityKind.Indeterminate, p.Kind));
     }
 
     /// <summary>
@@ -243,9 +297,9 @@ public class ReleaseGateDenominatorTest
     /// directory, no <c>_complete</c> sentinel — a bake that died before sealing, which is exactly
     /// what the boot seeder and the gate both refuse to read).
     /// </summary>
-    private static string EducationRegressedRoot()
+    private string EducationRegressedRoot()
     {
-        var root = Path.Combine(Path.GetTempPath(), "mw-3441-" + Guid.NewGuid().ToString("N"));
+        var root = Track(Path.Combine(Path.GetTempPath(), "mw-3441-" + Guid.NewGuid().ToString("N")));
         Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
         File.WriteAllText(
             Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName, TargetVersion),

--- a/test/Memex.Portal.Shared.Test/ReleaseGateDenominatorTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseGateDenominatorTest.cs
@@ -102,6 +102,33 @@ public class ReleaseGateDenominatorTest
         Assert.Empty(floor.Bundles);
     }
 
+    /// <summary>
+    /// 🚨 The denominator reads the sentinel's DECLARATION, so a publication that is sealed but has
+    /// LOST a bundle still counts that package as content-bearing.
+    ///
+    /// <para>Inclusive on purpose, and it is the safe direction: keeping the package in the set the
+    /// gate asks about can only HOLD a roll, never exempt one. Verifying presence here would also
+    /// cost one stat per bundle per source per identity on a network share, against a 60 s verdict
+    /// budget — and a denominator that times out answers Indeterminate, which freezes every
+    /// environment. The presence check stays where it decides the verdict: the target identity.</para>
+    /// </summary>
+    [Fact]
+    public void ASealedPublicationMissingABundle_StillCountsTowardTheDenominator()
+    {
+        var root = EducationRegressedRoot();
+        // The earlier identity's Education publication loses a bundle's bytes but keeps its seal.
+        File.Delete(Path.Combine(root, Earlier, "education", EducationPackages[0] + ".zip"));
+
+        var floor = PublishedBundleCatalogue.EverSealedBundles(root);
+        Assert.Contains(EducationPackages[0], floor.Bundles);
+
+        // The full presence rule is unchanged where it decides the verdict — that identity's
+        // Education source is torn and contributes NOTHING to what can be adopted.
+        var adoptable = PublishedBundleCatalogue.SealedBundlesForIdentity(root, Earlier);
+        Assert.DoesNotContain(EducationPackages[0], adoptable);
+        Assert.DoesNotContain(EducationPackages[1], adoptable);
+    }
+
     // ── the verdict, both ways, on the reconstructed Education state ─────────────────────────────
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/ReleaseGateDenominatorTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseGateDenominatorTest.cs
@@ -1,0 +1,279 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.Hosting;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>The deployment gate's DENOMINATOR may not be read from the artifact under judgement
+/// (#3441).</b>
+///
+/// <para>Maintainer, 2026-09-06: <i>"let's see that the deploy rolls only when all packages of all
+/// plugins are baked"</i> — <i>"we kept rolling without edu being properly baked"</i>.</para>
+///
+/// <para>The gate asked which installed packages are content-bearing by reading the sealed bundle
+/// set of the identity the instance is running NOW. That is the same artifact store the gate is
+/// about to judge, so the denominator was a function of the very thing that breaks: the moment
+/// Education's bake stopped being produced, its packages stopped being asked about, and every
+/// later roll was green about precisely the packages that had regressed. In the limit — an
+/// identity with no publication at all — every installed package became non-content-bearing and
+/// the content half of the gate checked NOTHING while reporting updatable. "0 expected, 0 found,
+/// green" is the shape a completeness gate exists to make impossible.</para>
+///
+/// <para>These tests are the falsification, both ways, on the reconstructed Education state. The
+/// OLD reading is computed alongside the new one in <see cref="TheOldDenominatorPassed_TheNewOneHolds"/>
+/// so the negative control is executed rather than asserted: a test that only showed the new
+/// reading holding could not distinguish "the fix works" from "the fixture was always red".</para>
+/// </summary>
+public class ReleaseGateDenominatorTest
+{
+    // Three framework identities: an EARLIER wave that baked everything, the identity the instance
+    // is RUNNING (Education's publication already torn), and the TARGET the roll would move to.
+    private const string Earlier = "s3441earlier00000000000000000000";
+    private const string Live = "s3441live00000000000000000000000";
+    private const string Target = "s3441target00000000000000000000";
+    private const string TargetVersion = "3.0.0-rc9.ci.3441";
+
+    /// <summary>Education's nine courses — the repo's declared package set, measured 2026-09-06
+    /// from the top-level directories carrying an <c>index.json</c>.</summary>
+    private static readonly string[] EducationPackages =
+    [
+        "AdvancedBusinessRules", "AgenticBusiness", "AgenticEngineering", "AgenticOffice",
+        "AgenticPrimer", "AgenticPrimerDe", "DataImportExport", "DataModeling", "ThinkInStreams",
+    ];
+
+    private static readonly string[] PlatformPackages = ["Documentation", "Northwind"];
+    private static readonly string[] PluginPackages = ["Store", "AI"];
+
+    /// <summary>A package that ships a compiled module and NO NodeType content: it produces no
+    /// bundle under ANY identity, ever. The exemption that made the old reading attractive, and
+    /// which the new reading must preserve — demanding a bundle here would freeze the environment
+    /// forever.</summary>
+    private const string ModuleOnlyPackage = "Hosting.Instance";
+
+    // ── the denominator itself ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EverSealed_ReadsEveryIdentity_NotOnlyTheLiveOne()
+    {
+        var root = EducationRegressedRoot();
+
+        var floor = PublishedBundleCatalogue.EverSealedBundles(root);
+
+        // Non-zero, and printed here for the same reason the service logs it: the claim IS the
+        // count. Three identities published; the earlier one is where Education's courses live.
+        Assert.Equal(3, floor.Identities);
+        Assert.True(floor.ServesBakes);
+        foreach (var package in EducationPackages)
+            Assert.Contains(package, floor.Bundles);
+        Assert.Equal(
+            EducationPackages.Length + PlatformPackages.Length + PluginPackages.Length,
+            floor.Bundles.Count);
+
+        // …and the module-only package is still absent, under every identity. The exemption is
+        // preserved: it is not that we now demand everything, it is that we no longer forget.
+        Assert.DoesNotContain(ModuleOnlyPackage, floor.Bundles);
+    }
+
+    [Fact]
+    public void ARootThatServesNoBakes_IsNotEnforced_RatherThanASilentPass()
+    {
+        // A configured root holding no sealed publication under any identity. The old reading made
+        // this the WORST case — every package non-content-bearing, the content half checking
+        // nothing, and a green verdict over zero evidence.
+        var root = Path.Combine(Path.GetTempPath(), "mw-3441-empty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
+        // A torn publication contributes nothing — it is not evidence that the root serves bakes.
+        Directory.CreateDirectory(Path.Combine(root, Live, "education"));
+
+        var floor = PublishedBundleCatalogue.EverSealedBundles(root);
+
+        Assert.Equal(0, floor.Identities);
+        Assert.False(floor.ServesBakes);
+        Assert.Empty(floor.Bundles);
+    }
+
+    // ── the verdict, both ways, on the reconstructed Education state ─────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE ACCEPTANCE CRITERION. One fixture, two denominators, opposite verdicts — so the
+    /// negative control is a measurement rather than a claim.
+    /// </summary>
+    [Fact]
+    public void TheOldDenominatorPassed_TheNewOneHolds()
+    {
+        var root = EducationRegressedRoot();
+        var observation = PublishedBundleCatalogue.Read(root, TargetVersion);
+        Assert.Equal(Target, observation.Target.FrameworkIdentity);
+
+        // ── the OLD reading: content-bearing = sealed under the identity running NOW ──
+        var old = PublishedBundleCatalogue.SealedBundlesForIdentity(root, Live);
+        foreach (var course in EducationPackages)
+            Assert.DoesNotContain(course, old);          // already fallen out of the denominator
+        var oldVerdict = ReleaseAvailability.IsUpdatable(
+            observation.Target, Required(old), observation.Artifacts);
+
+        // The control: with the old denominator this roll PROCEEDS, over an Education publication
+        // that is not there. This is what "we kept rolling without edu being properly baked" was.
+        Assert.True(oldVerdict.IsUpdatable);
+        Assert.Empty(oldVerdict.Blockers);
+
+        // ── the NEW reading: content-bearing = sealed under ANY identity this root holds ──
+        var floor = PublishedBundleCatalogue.EverSealedBundles(root);
+        var newVerdict = ReleaseAvailability.IsUpdatable(
+            observation.Target, Required(floor.Bundles), observation.Artifacts);
+
+        Assert.False(newVerdict.IsUpdatable);
+
+        // It names exactly which packages, and says what is wrong with them.
+        var blockers = newVerdict.Blockers.ToList();
+        Assert.Equal(EducationPackages.Length, blockers.Count);
+        Assert.Equal(
+            EducationPackages.OrderBy(p => p, StringComparer.Ordinal),
+            blockers.Select(b => b.Package).OrderBy(p => p, StringComparer.Ordinal));
+        Assert.All(blockers, b =>
+            Assert.Equal(PackageAvailabilityKind.ContentBakeMissing, b.Kind));
+        Assert.Contains(Target, newVerdict.HoldReason);
+
+        // The module-only package is NOT among them — the preserved exemption, asserted on the
+        // same run that produces the hold, so "it holds" cannot be hiding "it holds everything".
+        Assert.DoesNotContain(ModuleOnlyPackage, blockers.Select(b => b.Package));
+    }
+
+    [Fact]
+    public void ACompleteEducationBake_Greens()
+    {
+        var root = EducationRegressedRoot();
+        // The operator does what the refusal asks: re-run Education's bake for the target identity.
+        Seal(root, Target, "education", EducationPackages);
+
+        var observation = PublishedBundleCatalogue.Read(root, TargetVersion);
+        var floor = PublishedBundleCatalogue.EverSealedBundles(root);
+        var verdict = ReleaseAvailability.IsUpdatable(
+            observation.Target, Required(floor.Bundles), observation.Artifacts);
+
+        Assert.True(verdict.IsUpdatable);
+        Assert.Empty(verdict.Blockers);
+        Assert.Null(verdict.HoldReason);
+
+        // 🚨 The denominator was non-zero on the green arm too. A pass over an empty expected set
+        // is exactly what this gate exists to prevent, so the green arm asserts WHAT WAS DEMANDED
+        // — 13 content-bearing packages of 14 installed — not merely that nothing blocked.
+        var demanded = Required(floor.Bundles).Count(p => p.HasContent);
+        Assert.Equal(
+            EducationPackages.Length + PlatformPackages.Length + PluginPackages.Length, demanded);
+        Assert.Equal(demanded + 1, verdict.Packages.Length);   // + the exempt module-only package
+        Assert.All(verdict.Packages, p =>
+            Assert.Equal(PackageAvailabilityKind.Available, p.Kind));
+    }
+
+    /// <summary>
+    /// A package that regressed to a PARTIAL bake — some courses sealed, some not — is named
+    /// package by package. The maintainer's ask is "all packages of all plugins", so a source that
+    /// seals four of nine must not read as a sealed source.
+    /// </summary>
+    [Fact]
+    public void APartialEducationBake_NamesTheMissingCoursesOnly()
+    {
+        var root = EducationRegressedRoot();
+        var shipped = EducationPackages.Take(4).ToArray();
+        Seal(root, Target, "education", shipped);
+
+        var observation = PublishedBundleCatalogue.Read(root, TargetVersion);
+        var floor = PublishedBundleCatalogue.EverSealedBundles(root);
+        var verdict = ReleaseAvailability.IsUpdatable(
+            observation.Target, Required(floor.Bundles), observation.Artifacts);
+
+        Assert.False(verdict.IsUpdatable);
+        Assert.Equal(
+            EducationPackages.Skip(4).OrderBy(p => p, StringComparer.Ordinal),
+            verdict.Blockers.Select(b => b.Package).OrderBy(p => p, StringComparer.Ordinal));
+    }
+
+    // ── fixture ─────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>What the gate's inputs are, given a denominator: every installed package, plus the
+    /// module-only one that has never had a bundle.</summary>
+    private static IEnumerable<RequiredPackage> Required(IReadOnlySet<string> contentBearing) =>
+        EducationPackages
+            .Concat(PlatformPackages)
+            .Concat(PluginPackages)
+            .Append(ModuleOnlyPackage)
+            .Select(id => new RequiredPackage(id, id, null, contentBearing.Contains(id)));
+
+    /// <summary>
+    /// The measured shape of the incident: an EARLIER identity where every source baked, the LIVE
+    /// identity and the TARGET identity where Education's publication is torn (present as a
+    /// directory, no <c>_complete</c> sentinel — a bake that died before sealing, which is exactly
+    /// what the boot seeder and the gate both refuse to read).
+    /// </summary>
+    private static string EducationRegressedRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-3441-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
+        File.WriteAllText(
+            Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName, TargetVersion),
+            Target);
+
+        foreach (var identity in new[] { Earlier, Live, Target })
+        {
+            Seal(root, identity, "meshweaver-content", PlatformPackages);
+            Seal(root, identity, "plugins", PluginPackages);
+        }
+        // Education baked once, under the earlier identity, and has not sealed since.
+        Seal(root, Earlier, "education", EducationPackages);
+        Tear(root, Live, "education");
+        Tear(root, Target, "education");
+        return root;
+    }
+
+    /// <summary>A SEALED source publication: the bundles, then the sentinel that lists them.</summary>
+    private static void Seal(string root, string identity, string source, IEnumerable<string> bundles)
+    {
+        var directory = Path.Combine(root, identity, source);
+        Directory.CreateDirectory(directory);
+        var names = new List<string>();
+        foreach (var bundle in bundles)
+        {
+            WriteBundle(Path.Combine(directory, bundle + ".zip"), bundle, identity);
+            names.Add(bundle + ".zip");
+        }
+        File.WriteAllText(
+            Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName),
+            string.Join('\n', names.Order(StringComparer.Ordinal)) + "\n");
+    }
+
+    /// <summary>A TORN publication: the directory exists, the sentinel does not.</summary>
+    private static void Tear(string root, string identity, string source) =>
+        Directory.CreateDirectory(Path.Combine(root, identity, source));
+
+    /// <summary>A bundle carrying a real manifest with no module dependency, so the #3175
+    /// sealed-set consistency rule has nothing to say and this test measures only completeness.</summary>
+    private static void WriteBundle(string path, string bundle, string identity)
+    {
+        var manifest = new BundleReader.Manifest(
+            bundle, "1.0", identity,
+            [
+                new BundleReader.AssemblyRef(
+                    $"{bundle}/Type", $"{bundle}_Type.dll",
+                    new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["MeshWeaver.Layout"] = MeshWeaver.Compiler.CompiledDependencies.RefAsmScheme + "abc",
+                    }),
+            ]);
+        using var file = File.Create(path);
+        using var zip = new ZipArchive(file, ZipArchiveMode.Create);
+        using var stream = zip.CreateEntry(NuGetPackageWriter.ManifestEntry).Open();
+        stream.Write(JsonSerializer.SerializeToUtf8Bytes(
+            manifest, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+    }
+}


### PR DESCRIPTION
Closes #3441

> Maintainer, 2026-09-06: *"let's see that the deploy rolls only when **all** packages of all plugins are baked"* — *"we kept rolling without edu being properly baked."*

## Where the denominator came from, and why that was the bug

The release-availability gate (#1754) already asked the right question, was already wired into all three roll paths, and already **held** the roll when it found a package missing. It nonetheless let environments roll onto releases whose Education content was not baked, **while reporting a clean pass**.

The gate's package list comes from the environment's install records — a mesh query, genuinely independent, correct. But the per-package decision *"must this one carry a baked bundle?"* was read from the **artifact store the gate was about to judge**:

```csharp
var adoptedToday = PublishedBundleCatalogue.SealedBundlesForIdentity(
    publishedRoot, PrebuiltAssemblySeeder.LiveFrameworkMvid, logger);
new RequiredPackage(…, HasContent: adoptedToday.Contains(manifest.Id))
```

So the denominator was a function of the very thing that breaks:

1. Education's bake stops producing a sealed publication.
2. Its packages leave `adoptedToday`.
3. `HasContent: false` — *"ships no content"*.
4. A package that ships no content cannot have a missing bake ⇒ **exempt**.
5. Every later roll is green about precisely the packages that regressed.

The denominator **erodes**, exactly where the gate is needed. And in the limit — an identity with no publication at all — *every* installed package became non-content-bearing, so the content half checked **nothing** and still answered updatable. That is `0 expected, 0 found, green`, the shape AGENTS.md forbids in CI gates, living in the runtime.

## The rule now

**The denominator is read from every framework identity the published root holds** — publications written by *earlier* CD waves, which the run under judgement cannot have produced — **and it is MONOTONE**: *what this environment has ever been able to adopt, it must still be able to adopt.*

| Property | Why it is load-bearing |
|---|---|
| **Independent** | The judgement is the TARGET identity's directory; the denominator is the OTHER identity directories. |
| **Monotone** | A package that has once shipped a bake cannot silently leave the set. A bake regressing to nothing is a HOLD, not an exemption. |
| **Non-freezing** | A package that has *never* sealed a bundle under *any* identity (module-only, NodeType-less) is still not demanded — the exemption that kept the old reading attractive is preserved exactly; only its evidence moved. |

Plus: a root with **no** sealed publication anywhere now answers `NotEnforced` **with its reason** (logged by the caller) instead of passing silently as though it had looked — and the expected set is logged on every verdict, because the count being non-zero *is* the claim.

## Falsification — both arms, one fixture

`ReleaseGateDenominatorTest` reconstructs the incident: an earlier identity where every source baked, then the live and target identities with Education's publication **torn** (directory present, no `_complete` sentinel — a bake that died before sealing). Installed: Education's 9 courses, 2 platform packages, 2 plugin packages, 1 module-only package that has never produced a bundle. Both denominators are computed **in the same test on the same fixture**, so the negative control is a measurement, not a claim:

| Denominator | Verdict | Blockers |
|---|---|---|
| **Old** — sealed under the live identity | `IsUpdatable = true` — **the roll proceeds** | 0 |
| **New** — ever sealed under any identity | `IsUpdatable = false` | **9**, each `ContentBakeMissing`, naming the nine courses |
| **New**, after Education re-bakes for the target | `IsUpdatable = true` | 0, over **13 content-bearing of 14 installed** |
| **New**, Education seals 4 of 9 | `IsUpdatable = false` | **5** — exactly the unsealed courses |

Local runs: `ReleaseGateDenominatorTest` 5/5 · `Memex.Portal.Shared.Test` **791/791** · `MeshWeaver.Documentation.Test` **279/279**. Both touched projects build `-c Release -warnaserror` with `0 Warning(s), 0 Error(s)`.

🚨 The doc-link check was **proven able to fail** before being trusted: run with `--no-build` after editing an embedded `.md` it passed over a deliberately broken link (the documented false pass); rebuilt, it failed naming `Doc/Architecture/ReleaseGateDenominator: (../ReleaseGatesTypo)`. The 279/279 above is from the rebuilt run.

## What this gate does NOT see

Named in the doc page rather than left implied:

- **A package never sealed under any identity is still exempt** — deliberate (the only thing between this gate and a permanently frozen environment), but it means a bake broken since before this root ever published is invisible here.
- **It gates the ROLL, not the BAKE.** It cannot make a bake complete, only refuse to roll onto an incomplete one.
- **CD cannot assert satellite bakes at promote time, by construction** — satellites re-bake on the `meshweaver-framework-released` dispatch that core's own run triggers, so at promote time they *cannot* have baked yet. `main-cd` asserting only `meshweaver-content` is correct for that moment; the satellite question is answerable only at the roll, which is where it now is.
- **Content ASSETS are not part of the bundle set** (#3424) — bundle completeness is assembly completeness.
- **Adoption is not observed** (#3429) — this asserts the bytes are *available*, not that they were *used*.
- **Retention**: monotone only while old identity directories are kept. Nothing purges them today; cf. #3438 for the adjacent shape.

## Cross-repo

`Pairs-with: none` — the diff removes no public type and no public member from `src/`. It **adds** `PublishedBundleCatalogue.EverSealedBundles` and the `SealedBundleFloor` record; `SealedBundlesForIdentity` stays public with an unchanged signature. The only signature change is a **private** method in `memex/`.

Note for reviewers: `SealedBundlesForIdentity` now has **no production caller** — the gate was its only one. It is kept public deliberately rather than deleted, because a public surface here can have in-mesh and satellite callers no compiler in this repo can see, and its summary has been corrected to say so instead of asserting a caller that no longer exists. It still answers a legitimate narrower question and is what the test uses to reproduce the old verdict as its negative control.

⚠️ For reviewers: this is a #3276-shape change — `ReleaseAvailabilityService.IsUpdatable`'s **behaviour** moves behind an unchanged signature, which no surface detector can see. The behaviour change is intended and is the fix; the direction is strictly *more* holding, never less.

## Docs

- New: `Doc/Architecture/ReleaseGateDenominator` — the design, the falsification table, the blind spots.
- Updated: `Doc/Architecture/ReleaseGates` — the "Both halves are REGRESSION checks" bullet described the defective reading as the rule; corrected and linked.
- What's New (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
