### PR TITLE
fix(#3395): one module set per mesh — a landing wave proposes it, boot adopts it

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -600,6 +600,32 @@ public static class PluginBundleEndpoints
                         accepted.Module, plugin, accepted.Files.Count,
                         accepted.Version ?? "(unversioned)", accepted.MinMeshVersion ?? "(none)");
 
+                // 🚨 #3395 — a publish is a landing wave of one module, and a wave that does not
+                // propose its module set never activates ANYWHERE: boot loads the mesh's set, not
+                // the activation record it was derived from. Held or not, the set has to name it:
+                // a held entry is skipped by the platform-floor gate at boot exactly as before,
+                // and it must still be in the set for the boot AFTER a platform update to be able
+                // to load it (which is the whole shelf contract). Never fails the publish — an
+                // unproposable set leaves this instance on the set it is already on, the bytes
+                // still serve to consumers, and the next wave proposes again.
+                try
+                {
+                    await landing.ProposeModuleSet()
+                        .ObserveCompletion(
+                            ex => logger?.LogWarning(ex,
+                                "Module publish for {Plugin}: proposing the module set after "
+                                + "'{Module}' faulted late", plugin, accepted.Module),
+                            ct);
+                }
+                catch (Exception exception)
+                {
+                    logger?.LogWarning(exception,
+                        "Module publish for {Plugin}: '{Module}' landed but its module set could "
+                        + "not be proposed — this instance stays on its current set and the next "
+                        + "landing wave proposes again; the bytes still serve to consumers",
+                        plugin, accepted.Module);
+                }
+
                 // held/holdReason let the publisher tell "shelved, will serve" apart from
                 // "activated here"; pendingRestart is honest for the held case — a restart of
                 // THIS instance would not load a held module, so nothing is pending on one.

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -221,9 +221,27 @@ public static class MemexConfiguration
             builder.ConfigureServices(services => services.AddModuleGenerationsGc(moduleRoot));
             var persistedActivation = ModuleActivationSidecar.Read(moduleRoot,
                 msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
+
+            // 🚨 #3395 — CONVERGE ON THE MESH'S MODULE SET, never on this process's own snapshot of
+            // the activation record. The record moves per module, the instant each landing finishes,
+            // so reading it directly makes the module set a function of WHEN this pod happened to
+            // boot: three pods of one ReplicaSet differed in 39 of 40 generations on memex-cloud
+            // (2026-09-06), and a pod booting mid-wave pinned a TORN mix no wave ever intended.
+            // The set is proposed ONCE per completed landing wave (ModuleSetStore.Propose), so
+            // every boot between two waves loads identical bytes. A deployment that has never
+            // completed a wave has no set, and the projection is then the identity — pre-#3395
+            // behaviour, which is what makes this inert until the first wave.
+            var meshModuleSets = ModuleSetStore.Read(moduleRoot,
+                msg => Console.Error.WriteLine($"[ModuleSet] {msg}"));
+            Console.WriteLine($"[ModuleSet] {ModuleSetStore.Describe(meshModuleSets)}");
+            var activationOnMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(
+                persistedActivation,
+                meshModuleSets.Proposed,
+                (module, reason) => Console.Error.WriteLine(
+                    $"[ModuleSet] DEFERRED store-installed module '{module}': {reason}"));
             var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(
                 moduleAssemblies,
-                persistedActivation,
+                activationOnMeshSet,
                 // The ONE module platform gate (ModulePlatformFloor) — never a second notion of
                 // the module platform requirement.
                 ModulePlatformFloor.DeclineReason,
@@ -313,6 +331,17 @@ public static class MemexConfiguration
             builder.WithConfiguration(configuration);
             if (resolvedModules.Length > 0)
                 builder.InstallAssemblies(resolvedModules);
+
+            // 🚨 #3395 — say, once and durably, that a replica came up on the mesh's set. Written
+            // AFTER the assemblies are installed, because the claim is "this set is running", not
+            // "this set was read": a boot that dies before InstallAssemblies must not close the
+            // convergence window it never entered. Create-if-absent, so the second and every later
+            // replica writes nothing, and best-effort — a read-only volume costs the mesh-level
+            // signal and nothing else.
+            if (meshModuleSets.Proposed is { } adoptedSet)
+                ModuleSetStore.RecordAdoption(moduleRoot, adoptedSet,
+                    adoptedBy: Environment.MachineName,
+                    onWarn: msg => Console.Error.WriteLine($"[ModuleSet] {msg}"));
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
             // consume the pending flag so the step-10 signal reads current. Best-effort: on a
             // read-only app filesystem the flag simply stays set (cosmetic), and boot proceeds.

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -238,7 +238,13 @@ public static class MemexConfiguration
                 persistedActivation,
                 meshModuleSets.Proposed,
                 (module, reason) => Console.Error.WriteLine(
-                    $"[ModuleSet] DEFERRED store-installed module '{module}': {reason}"));
+                    $"[ModuleSet] DEFERRED store-installed module '{module}': {reason}"),
+                // The SAME existence check boot's own gate applies below — so the projection can
+                // never hand the gate a generation the gate would then skip, leaving the module
+                // absent when an older one is sitting right there.
+                entry => ModuleActivationBoot.LandedModuleDllExists(moduleRoot, entry),
+                (module, reason) => Console.Error.WriteLine(
+                    $"[ModuleSet] DEGRADED module '{module}': {reason}"));
             var effectiveModules = ModuleActivationBoot.ComputeEffectiveModuleEntries(
                 moduleAssemblies,
                 activationOnMeshSet,

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -1,0 +1,242 @@
+---
+Name: Module Set Convergence
+Category: Architecture
+Description: One module set per mesh at a time — how a landing wave proposes the set, how boot adopts it, why the mid-wave window is bounded and observable, and what makes a half-landed wave a failure rather than drift.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/><path d="M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M19.1 4.9l-2.8 2.8M7.7 16.3l-2.8 2.8"/></svg>
+---
+
+Replicas of one deployment used to run **different module sets**, indefinitely, and nothing made
+them converge. This page is the design that ends it: a mesh runs **one module set at a time**, a
+landing wave is what moves it, and boot adopts what the mesh declares instead of reading a record
+that is still moving underneath it.
+
+Read [Modules](/Doc/Architecture/Modules) first for the landing lane itself — generations, the
+per-module activation record, the process-local pin.
+
+## The mechanism, corrected
+
+Issue #3395 was filed as *"two NodeType compiles in ONE boot resolved different module sets, 15
+seconds apart"*. That premise is **false**, and the correction matters because it moves the fix from
+"find the race inside the process" to "there is no race inside the process".
+
+**It is three processes, sixteen minutes apart.** Measured on `memex-cloud`, 2026-09-06: one
+Deployment, three portal replicas, one image (`3.0.0-rc9.ci.7693`), started 11:33:39, 11:41:04 and
+12:51:21 around a landing wave at 12:18–12:27.
+
+| pod | started | pinned `MeshWeaver.Payments.Stripe` |
+|---|---|---|
+| `…-b8pfg` | 11:33:39Z | `MeshWeaver.Payments.Stripe@8f251f57` |
+| `…-tqhzx` | 11:41:04Z | `MeshWeaver.Payments.Stripe@8f251f57` |
+| `…-gqqg7` | 12:51:21Z | `MeshWeaver.Payments.Stripe@458afe55` |
+
+Diffing `/tmp/meshweaver-pinned-modules/*/` across the three: **39 of 40 generations differed**
+between the two older pods and the newest. The sidecar named the newest. Only
+`MeshWeaver.Social@c000a138` was common to all three.
+
+Inside one process nothing moves: `InstalledModulesFingerprint` is a mesh-scoped singleton whose
+hash is computed once in its constructor, `InstalledModuleAssembly` registrations are made once at
+`MeshBuilder.InstallAssemblies`, and `MeshNodeCompilationService.meshReferences` is a `Lazy<>`
+composed once. What moves is **which process answers**. Those replicas share ONE NodeType node, and
+a compile stamps the module set *it* resolved (`CompiledModulesHash` plus the per-assembly
+`CompiledDependencies`). `Store/Order` compiled at 12:53:21 on the 12:51 pod; `Store/Plugin` at
+13:09:01 on the 11:41 pod. Each replica then reads the other's stamp, `HasUsableBuild` /
+`CompiledDependencies.FindMismatch` correctly calls the build stale *for its own environment*, and
+rebuilds — so the pair ping-pongs. Where a replica's set genuinely LACKS a module the sources need,
+the type does not merely rebuild: it FAILS. Healthy → failed, with no source change, which is
+exactly the transition the readiness gate refuses for the whole startup budget.
+
+**And there is a second, sharper shape the incident table cannot show.** A landing wave lands its
+modules one at a time and moves each module's activation entry the instant that module's bytes are
+down. A replica booting *in the middle* of a wave therefore pins a **torn** set — some modules of
+the new wave, the rest of the old — a combination no wave ever produced and nothing was ever tested
+against. That is the shape behind "a module that resolved fine fifteen seconds earlier".
+
+## The rule
+
+> **A landing wave does not move what the mesh RUNS. It stages bytes, and when the WHOLE wave is
+> done it proposes ONE set. Boot loads the mesh's newest proposal — never its own read of the
+> per-module activation record.**
+
+Everything below follows from that one sentence. In particular: **every replica that boots between
+two wave completions loads identical bytes**, and no boot can observe a half-landed mix at all.
+
+The stamp stays **one per NodeType**. Fanning `CompiledModulesHash` out per environment was
+considered and rejected: it makes the divergence permanent and moves the cost into every read of
+every build record, when the divergence itself is what has to go.
+
+## The authority
+
+`ModuleSetStore` (`src/MeshWeaver.PluginCatalog/ModuleSet.cs`) — records under
+`modules/sets/` on the deployment's shared volume, beside the module folders they name.
+
+| Record | File | Written by | Says |
+|---|---|---|---|
+| `ModuleSet` | `<sequence:D9>-<id16>.proposed.json` | the landing wave that completed | "the mesh's module set is N: {module → generation}" |
+| `ModuleSetAdoption` | `<sequence:D9>-<id16>.adopted.json` | the first process that BOOTS onto it | "a replica is serving set N" |
+
+- **`Proposed`** = the highest-sequence proposal. This is what a boot loads.
+- **`Current`** = the highest proposal that also carries an adoption record — *the mesh is on
+  generation N*, as opposed to merely having declared it.
+- **`Id`** is the content id: lowercase hex SHA-256 over the ordinal-sorted `name@generation` pairs.
+  Two sets with the same id activate the same bytes.
+
+**Why a file and not a mesh node.** Boot is the first reader, and boot runs before the DI container,
+before any storage provider is registered and (on PG) before a connection string has been validated
+— the same reason the activation record is a file. The set also cannot drift from the DLLs it names:
+the landing service writes both onto the same volume.
+
+**Why immutable and monotone.** Each record is written ONCE and never modified, never renamed over.
+That removes both defects the activation record was split to remove (#2090/#2189): there is no
+read-modify-write to lose an update, and no replace-in-place for a concurrent reader to open into.
+`ModuleSetStore.WriteOnce` renames with `overwrite: false`, and a loser whose bytes are identical
+treats the refusal as success.
+
+**Conflicts are resolved, not absorbed.** Two replicas can complete a wave at the same instant and
+each write sequence N+1. Both files survive, so every reader must resolve the tie the same way
+without coordinating: **the ordinally smallest `Id` wins**, and the conflict is REPORTED. Nothing is
+lost — a proposal is derived from the activation record, never from the previous proposal, so the
+next wave's sequence N+2 carries everything both replicas landed.
+
+## Boot — converge, don't serve your own
+
+`MemexConfiguration.ConfigureMemexMesh`, in order:
+
+```
+ModuleActivationSidecar.Read(moduleRoot)          // what has LANDED — a moving target
+ModuleSetStore.Read(moduleRoot)                   // what the MESH runs — stable between waves
+ModuleActivationBoot.ProjectOntoMeshSet(...)      // the convergence
+ModuleActivationBoot.ComputeEffectiveModuleEntries(...)
+ModuleGenerationPin.PinnedLoadPath(...)           // unchanged (#2509)
+MeshBuilder.InstallAssemblies(...)
+ModuleSetStore.RecordAdoption(...)                // AFTER the install — see below
+```
+
+`ProjectOntoMeshSet` has three rules, and each is a deliberate refusal to guess:
+
+- An enabled entry whose module the set names loads **the SET's generation**, even when the entry
+  has since moved past it. That is the convergence.
+- An enabled entry the set does **not** name is **landed but unproposed** — a wave that has not
+  completed. It is deferred, loudly, and activates at the first restart after the wave proposes.
+  Adopting it is exactly the independent per-replica pin this design removes; adopting *half* a wave
+  is the torn set.
+- A **disabled** entry passes through untouched. An uninstall deletes the folder, so honouring it is
+  not optional and never waits for a set.
+
+A deployment with **no** set records — every deployment until its first wave after this change —
+gets the list back unchanged. Pre-#3395 behaviour, byte for byte, is the migration path; the first
+completed wave proposes sequence 1 and the mechanism starts.
+
+**Adoption is recorded after `InstallAssemblies`, not after the read.** The claim is *"this set is
+running"*, not *"this set was read"* — a boot that dies earlier must not close a convergence window
+it never entered.
+
+## The window, and why it is bounded
+
+A running process cannot adopt new module bytes; restart-as-activation is the model and this design
+does not change it. So there IS a window in which replicas genuinely differ, and the design's job is
+to make it **short, singular and visible** rather than open-ended and silent.
+
+| | before | after |
+|---|---|---|
+| replicas booting between two waves | each pins its own snapshot | **identical set** |
+| a replica booting mid-wave | a torn mix | the previous complete set |
+| distinct sets across a 3-pod rollout | up to 3 (measured: 39/40 generations apart) | at most 2, differing by exactly one wave |
+| the window's end | unobservable | `ModuleSetIndex.ConvergencePending` flips false |
+
+`ConvergencePending` is the window stated positively: **the mesh has proposed a set no replica has
+booted onto yet.** It opens at the wave's proposal and closes at the first restart. A user hitting an
+old replica during it is hitting a replica running the mesh's *previous* set — one coherent set, not
+a torn one — and every pod says which set it is on:
+`ModuleSetStore.Describe` on the boot line and on `PendingModuleActivations.Read().MeshModuleSet`,
+with the per-pod half unchanged from #3417 (`Degraded` on `/health`, naming the modules).
+
+## A half-landed wave is a failure, not drift
+
+A wave that dies before it proposes **proposes nothing**. Three consequences, and they are the
+answer to "what breaks it":
+
+1. **The mesh stays on the set it was on.** Nothing half-landed is ever adopted, by anybody. There
+   is no drift to detect, because the state that used to drift is no longer reachable.
+2. **The modules whose bytes DID land are named.** `ModuleActivationReport.Deferred` carries them,
+   and `Describe()` says *"N module(s) have landed but are in NO proposed module set — the landing
+   wave that brought them has not completed, so they are running on no replica and a restart will
+   not change that"*. Compare with the old behaviour: those modules ran on whichever pods happened
+   to boot after their own landing and not on the others, and every surface reported `Healthy`.
+3. **It is a THIRD state, never folded into "pending".** "Pending" promises that a restart activates
+   this. For a deferred module that promise is false — boot loads the mesh's set and the module is
+   not in it — and a restart prompt no restart can clear is the same lie as a green tick over a gate
+   that never ran. The same rule already separates HELD entries and missing bytes.
+
+The next completed wave supersedes it: the proposal is derived from the activation record, so
+whatever the dead wave landed rides the next one.
+
+## GC must see the set
+
+🚨 The convergence deliberately pins an **older** generation than the activation entry while a
+wave's landings wait to be proposed — and that older generation is what every running replica
+LOADED. `ModuleLandingService.CollectGarbage` therefore unions
+`ModuleSetStore.ReferencedGenerations` (both retained sets) into its reference set. Without it the
+sweep would reclaim the very bytes the whole mesh is executing: the 2026-08-27 outage, from the
+other side. A set directory that cannot be read counts as a read fault for the same fail-closed
+reason the entries do.
+
+The same pass prunes set records below the CURRENT set — never below the proposal, which would take
+the mesh's own generations out of the reference set.
+
+## Where a wave ends
+
+Exactly two lanes land modules, and each proposes at its own completion:
+
+- `RegistryUpdateReconciler.ReconcileModules` — the auto-update wave, after its per-package
+  `Concat` completes. Deliberately outside the `Concat`: proposing per module would publish every
+  intermediate combination as a set the next boot could adopt.
+- `CatalogLayoutAreas.InstallOrUpdateCore` → `WithModule` — an interactive or default install. A
+  one-package install IS a wave, and a wave that does not propose never activates.
+
+…plus the registry's publish endpoint (`PluginBundleEndpoints`), because a `ShelveModule` landing
+also writes an activation entry: a HELD module is skipped at boot by the platform-floor gate exactly
+as before, but it must still be IN the set for the boot after a platform update to be able to load
+it, which is the whole shelf contract.
+
+All three are `ModuleLandingService.ProposeModuleSet()`, on the landing service's cap-1 IO pool, so
+a proposal never observes a landing halfway through. Idempotent: a wave that landed nothing derives
+the set that is already proposed and writes nothing — which matters because the reconcile runs at
+EVERY boot and normally lands nothing.
+
+None of them can fail its lane. A proposal that cannot be written leaves the mesh on its previous
+set — every replica still agrees with every other one — and the next wave proposes again.
+
+**How an existing deployment starts.** The reconcile's wave-end proposal IS the bootstrap: the first
+pass after this change derives sequence 1 from the activation record as it already stands and the
+mechanism is live from the next boot. Deliberately not done at boot, and deliberately not by every
+replica: several replicas bootstrapping at once, mid-wave, would each derive a different sequence 1.
+Until it happens, a deployment with no set records gets the activation list back unchanged.
+
+## Rejected alternatives
+
+**Fan the stamp out per environment.** Rejected by the maintainer and by the shape of the problem:
+it makes the divergence permanent and pays for it on every read of every build record. The stamp
+stays one per NodeType and the sets converge instead.
+
+**Seal the set at LANDING time rather than at wave completion + boot adoption.** A set sealed by the
+wave has, by construction, no live holder: the replica that landed the bytes has not loaded them.
+Any rule keyed on "is this replica on the mesh's set" would then answer *no* for every replica the
+moment a wave finishes. Proposal (by the wave) and adoption (by a boot) are two records for exactly
+this reason.
+
+**Have a behind replica restart itself, or flip readiness so the rollout replaces it.** Both are
+live options on top of this design and neither is taken here: (b) empties a pod that is serving
+correctly, and both change deployment behaviour on evidence this change is the first to produce.
+They become *decidable* now that "behind" is a named state with a bounded window rather than an
+invisible one.
+
+**Decline to write NodeType compile records while behind.** This is option (c) from #3395's open
+item and it is now SAFE to build — the adoption record guarantees the mesh's `Current` set always
+has a live holder, so the rule can never reach zero eligible writers — but it changes who compiles
+and belongs in its own change with its own falsification. It is not in this one.
+
+## Related
+
+[Modules](/Doc/Architecture/Modules) · [Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) ·
+[Module Versioning](/Doc/Architecture/ModuleVersioning) · [Plugins](/Doc/Architecture/Plugins) ·
+[Build Coordination](/Doc/Architecture/BuildCoordination) · [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -122,6 +122,16 @@ ModuleSetStore.RecordAdoption(...)                // AFTER the install — see b
 - A **disabled** entry passes through untouched. An uninstall deletes the folder, so honouring it is
   not optional and never waits for a set.
 
+🚨 **One degradation, and it is reported.** The set can only pin what is on the volume. If the pinned
+generation's bytes are gone — a replica on the PREVIOUS platform build sweeping by the entries alone
+during this change's own rollout, a manual deletion, a partial restore — the two candidates are "run
+the generation the entry names" and "run nothing", and running nothing is the *worse* half of #3395:
+a missing module is what turns a healthy NodeType into a failed one. So the projection falls back to
+the entry and says so on its own channel (`onSetGenerationMissing`, separate from the deferred one,
+because that one means "running on no replica" and this module IS running). The next completed wave
+re-proposes a set whose bytes exist, and the state is unreachable once every replica sweeps with the
+GC change below.
+
 A deployment with **no** set records — every deployment until its first wave after this change —
 gets the list back unchanged. Pre-#3395 behaviour, byte for byte, is the migration path; the first
 completed wave proposes sequence 1 and the mechanism starts.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -335,13 +335,17 @@ restart prompt no restart can clear, which is the same false promise the held-en
 missing-bytes rules exist to prevent. A superseded pod whose ACTIVATED generation's bytes are gone
 reports **unresolvable** (re-install), not pending (wait for a restart).
 
-> **OPEN — convergence is a policy decision, not a detection one.** Detecting the divergence does
-> not end it. Whether a replica whose pinned set no longer matches the sidecar should (a) be
-> restarted automatically, (b) flip readiness so the rollout replaces it, or (c) decline to write
-> NodeType compile records while it is behind, is a deliberate trade — (b) empties a pod that is
-> serving correctly; (c) changes who compiles. Until one is chosen, the divergence is *reported*
-> (Degraded on `/health`, per pod, naming the modules) and an operator or the self-update lane
-> acts on it.
+> **DECIDED — force convergence on a landing wave: one module set per mesh at a time.** Detection
+> does not end the divergence, and the policy call is the maintainer's: the stamp stays ONE per
+> NodeType (never fanned out per environment) and the SETS converge instead. A landing wave no
+> longer moves what the mesh runs — it stages bytes and, when the whole wave is done, PROPOSES one
+> immutable sequenced set; **boot loads the mesh's newest proposal, never its own read of the
+> per-module entries**. So every replica booting between two wave completions loads identical bytes,
+> and a boot mid-wave cannot see a half-landed mix at all. The residual window (a replica that has
+> not restarted since the last wave) is now singular, bounded and named — `ConvergencePending` is
+> open exactly while the mesh has proposed a set no replica has booted onto. The full design, the
+> record layout, the GC consequence and the rejected alternatives are in
+> [Module Set Convergence](/Doc/Architecture/ModuleSetConvergence).
 
 ### 🚨 GC is OFF the readiness path (#2684)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-every-server-now-runs-the-same-set-of-add-ons.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-every-server-now-runs-the-same-set-of-add-ons.md
@@ -1,0 +1,47 @@
+---
+Name: Every server now runs the same set of add-ons
+Category: Fix
+Description: Servers used to pick up add-on updates one file at a time, so two servers started minutes apart could end up running two different combinations — and a server started mid-update could end up running a combination nobody ever shipped. Updates now arrive as one complete set, and every server takes the same one.
+Icon: ArrowSync
+Order: -20260906
+---
+
+# Every server now runs the same set of add-ons
+
+The portal runs on several servers at once, and add-ons update themselves in the background. Each
+server picks up whatever has been published the next time it restarts — swapping code underneath a
+running server is how you get half-updated behaviour, so waiting for a restart is deliberate.
+
+What was not deliberate was **what** each server picked up.
+
+An update run publishes add-ons one at a time, and each one became live the instant its own files
+were written. So the answer to "what should I run?" changed continuously while an update was in
+progress, and every server simply took whatever the answer happened to be at the moment it started.
+Two servers restarted a few minutes apart got two different answers and then kept them, side by
+side, until they both restarted again. On one production portal three servers of the same
+deployment, running the same portal build, disagreed about **39 of 40** add-ons.
+
+Worse was a server that started in the *middle* of an update: it got the new version of the add-ons
+published so far and the old version of the rest — a combination no update run ever produced and
+nothing was ever tested against. That is what made a page type that had been working for months
+suddenly fail to build, with nothing about it having changed: it was built against a mixture that
+existed for a few minutes on one server.
+
+Now an update run publishes its add-ons as one **complete set**, once, when the whole run has
+finished, and a starting server takes the set rather than reading the individual files. Two servers
+starting at any two moments between two update runs therefore run exactly the same add-ons, and the
+half-and-half combination cannot occur at all — a server that starts mid-run takes the previous
+complete set, which is the one the other servers are already on.
+
+Three things follow from that, and each is visible rather than assumed:
+
+- **A server that has not restarted since the last update is still behind**, because that has not
+  changed and cannot: code is swapped at restart. But it is now behind by exactly one update run
+  rather than by some private mixture, and the portal says which set it is on and whether any server
+  has taken the new one yet.
+- **An update run that fails part-way changes nothing.** It never publishes a set, so no server ever
+  takes a partial one. The add-ons whose files did arrive are listed by name as waiting for a
+  complete run — instead of quietly running on some servers and not others.
+- **Housekeeping knows about it.** The routine that reclaims disk space from superseded add-on
+  versions now treats the set every server is running as in use, so it can never delete something
+  underneath a running server.

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -917,6 +917,28 @@ public static class CatalogLayoutAreas
             .SelectMany(_ => InstallOrUpdateCore(hub, source, sourceRef, pkg, logger, authorizingUserId));
     }
 
+    /// <summary>
+    /// Closes an install's landing wave by proposing the module set the activation record now
+    /// describes (#3395) — the same step <c>RegistryUpdateReconciler</c> takes at the end of its
+    /// auto-update wave, so both lanes move the mesh's set the one way. A deployment with no
+    /// landing service (a consumer with no module store) proposes nothing, silently.
+    /// </summary>
+    private static IObservable<ModuleSet?> ProposeMeshModuleSet(IMessageHub hub, ILogger? logger)
+    {
+        var landing = hub.ServiceProvider.GetService<ModuleLandingService>();
+        if (landing is null)
+            return Observable.Return<ModuleSet?>(null);
+        return landing.ProposeModuleSet()
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "The module landed but its module set could not be proposed — the mesh stays "
+                    + "on its current set and the next landing wave proposes again. Cause: {Cause}",
+                    ex.Message);
+                return Observable.Return<ModuleSet?>(null);
+            });
+    }
+
     private static IObservable<InstallResult> InstallOrUpdateCore(
         IMessageHub hub, IPackageSource source, string sourceRef, PackageManifest pkg, ILogger? logger,
         string? authorizingUserId)
@@ -936,6 +958,12 @@ public static class CatalogLayoutAreas
                 : install.SelectMany(result => bundles
                     .AdoptModule(pkg.Id, pkg.Module!,
                         $"{PackageInstaller.InstalledPartition}/{pkg.Id}")
+                    // 🚨 #3395 — a one-package install IS a landing wave, and a wave that does not
+                    // propose its module set never activates: boot loads the mesh's set, not the
+                    // activation record it was derived from. Never fails the install: an
+                    // unproposable set leaves the mesh on the one every replica already runs, and
+                    // the next wave proposes again.
+                    .SelectMany(_ => ProposeMeshModuleSet(hub, logger))
                     .Select(_ => result));
 
         IObservable<InstallResult> Full() =>

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -469,22 +469,47 @@ public static class ModuleActivationBoot
     ///     wave proposes. Adopting it would be exactly the independent per-replica pin this
     ///     exists to remove, and adopting HALF a wave is the torn set.</item>
     ///   <item>A DISABLED entry passes through untouched. An uninstall deletes the folder, so
-    ///     honouring it is not optional and never waits for a set.</item>
+    ///     honouring it is not optional and never waits for a set. So does an entry with NO
+    ///     GENERATION — the legacy fixed <c>modules/&lt;name&gt;/</c> folder, which
+    ///     <see cref="ModuleSetStore.GenerationsOf"/> excludes by design because there is nothing
+    ///     to pin; deferring it would silently disable it.</item>
     /// </list>
     ///
     /// <para>A null <paramref name="meshSet"/> — a deployment on which no landing wave has ever
     /// completed, which is every deployment until the first wave after this change — returns the
     /// list UNCHANGED. Pre-#3395 behaviour, byte for byte, is the migration path.</para>
+    ///
+    /// <para>🚨 <b>One degradation, loud and deliberate: a set generation whose BYTES ARE GONE.</b>
+    /// The set can only pin what is on the volume, and the GC that could take it away is fixed in
+    /// the same change (the modules GC now counts the set's
+    /// generations as referenced). What remains is what no rule here controls — a pod still running
+    /// the PREVIOUS platform build sweeping by the entries alone during this change's own rollout, a
+    /// manual deletion, a partial volume restore. In that state the two candidates are "run the
+    /// generation the entry names" and "run nothing", and running nothing is the WORSE half of the
+    /// very defect this exists to fix: a missing module is what turns a healthy NodeType into a
+    /// failed one. So it falls back to the entry, reports it through
+    /// <paramref name="onDeferred"/>, and the next completed wave re-proposes a set whose bytes
+    /// exist. It is a REPORTED degradation, never a silent one, and it is unreachable once every
+    /// replica sweeps with this build.</para>
     /// </summary>
     /// <param name="landed">The activation record as <see cref="ModuleActivationSidecar.Read"/>
     /// answered it.</param>
     /// <param name="meshSet">The mesh's module set — <see cref="ModuleSetIndex.Proposed"/>.</param>
-    /// <param name="onDeferred">The loud channel for a landed-but-unproposed entry: (module name,
-    /// reason).</param>
+    /// <param name="onDeferred">The loud channel for a landed-but-UNPROPOSED entry: (module name,
+    /// reason). Exactly one meaning, so a surface can render it as one state.</param>
+    /// <param name="landedDllExists">Whether an entry's landed DLL is on the volume — production
+    /// passes <see cref="LandedModuleDllExists"/>, the SAME check boot's own gate applies. Null
+    /// skips the check entirely, which is the pure form this stays testable in.</param>
+    /// <param name="onSetGenerationMissing">The loud channel for the degradation above — the set's
+    /// generation is not on the volume and the entry's is used instead: (module name, reason).
+    /// SEPARATE from <paramref name="onDeferred"/> deliberately: that one means "running on no
+    /// replica", and this module IS running, just possibly not what the set says.</param>
     public static ModuleActivationList ProjectOntoMeshSet(
         ModuleActivationList landed,
         ModuleSet? meshSet,
-        Action<string, string>? onDeferred = null)
+        Action<string, string>? onDeferred = null,
+        Func<ModuleActivationEntry, bool>? landedDllExists = null,
+        Action<string, string>? onSetGenerationMissing = null)
     {
         ArgumentNullException.ThrowIfNull(landed);
         if (meshSet is null)
@@ -493,7 +518,15 @@ public static class ModuleActivationBoot
         var projected = ImmutableList.CreateBuilder<ModuleActivationEntry>();
         foreach (var entry in landed.Entries)
         {
-            if (!entry.Enabled || string.IsNullOrWhiteSpace(entry.Name))
+            // 🚨 An entry with NO GENERATION is the legacy fixed folder `modules/<name>/`, and a set
+            // has nothing to say about it: `ModuleSetStore.GenerationsOf` excludes it BY DESIGN
+            // (there is no `<name>@<id>` to pin), so asking whether the set names it would defer —
+            // i.e. silently DISABLE — every such module on every deployment that still has one.
+            // It passes through for the same reason a disabled entry does: this projection chooses
+            // between generations, and where there are none to choose between it must not choose.
+            if (!entry.Enabled
+                || string.IsNullOrWhiteSpace(entry.Name)
+                || string.IsNullOrWhiteSpace(entry.Directory))
             {
                 projected.Add(entry);
                 continue;
@@ -501,9 +534,26 @@ public static class ModuleActivationBoot
 
             if (meshSet.Generations.TryGetValue(entry.Name, out var generation))
             {
-                projected.Add(string.Equals(entry.Directory, generation, StringComparison.Ordinal)
-                    ? entry
-                    : entry with { Directory = generation });
+                if (string.Equals(entry.Directory, generation, StringComparison.Ordinal))
+                {
+                    projected.Add(entry);
+                    continue;
+                }
+
+                var onSet = entry with { Directory = generation };
+                if (landedDllExists is null || landedDllExists(onSet))
+                {
+                    projected.Add(onSet);
+                    continue;
+                }
+
+                onSetGenerationMissing?.Invoke(entry.Name,
+                    $"the mesh's module set {meshSet.Sequence} ('{meshSet.Id}') pins generation "
+                    + $"'{generation}', whose bytes are NOT on the volume — running '{entry.Directory}' "
+                    + "instead, which may differ from what other replicas run until the next landing "
+                    + "wave proposes a set whose bytes exist. A module that is simply ABSENT is the "
+                    + "worse half of #3395: it is what turns a healthy NodeType into a failed one.");
+                projected.Add(entry);
                 continue;
             }
 

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -446,6 +446,81 @@ public sealed record EffectiveModule(string Entry, ModuleActivationEntry? Landed
 public static class ModuleActivationBoot
 {
     /// <summary>
+    /// Rewrites the activation list onto THE module set the mesh runs (#3395) — the convergence
+    /// step, applied before <see cref="ComputeEffectiveModuleEntries"/> so the union it computes is
+    /// the mesh's set rather than this process's own snapshot of a moving record.
+    ///
+    /// <para>🚨 <b>Why the raw record is not what a boot should load.</b> Landing moves each
+    /// module's entry the instant that module's bytes are on disk, so the record is a MOVING
+    /// TARGET: two replicas booting seconds apart read two different answers, and a replica
+    /// booting mid-wave reads a TORN one — some modules of the new wave, the rest of the old — a
+    /// combination no wave ever intended and nothing ever tested. Every replica pinning its own
+    /// answer is how three pods of one ReplicaSet came to differ in 39 of 40 module generations
+    /// (memex-cloud, 2026-09-06). The set is proposed ONCE per completed wave
+    /// (<see cref="ModuleSetStore.Propose"/>), so every boot between two waves converges on the
+    /// same bytes.</para>
+    ///
+    /// <para>Three rules, and each one is a deliberate refusal to guess:</para>
+    /// <list type="bullet">
+    ///   <item>An enabled entry whose module the set names loads the SET's generation, even when
+    ///     the entry has since moved past it. That is the convergence.</item>
+    ///   <item>An enabled entry the set does NOT name is LANDED BUT UNPROPOSED — a wave that has
+    ///     not completed (or died half-landed). It is deferred, loudly, and activates when the
+    ///     wave proposes. Adopting it would be exactly the independent per-replica pin this
+    ///     exists to remove, and adopting HALF a wave is the torn set.</item>
+    ///   <item>A DISABLED entry passes through untouched. An uninstall deletes the folder, so
+    ///     honouring it is not optional and never waits for a set.</item>
+    /// </list>
+    ///
+    /// <para>A null <paramref name="meshSet"/> — a deployment on which no landing wave has ever
+    /// completed, which is every deployment until the first wave after this change — returns the
+    /// list UNCHANGED. Pre-#3395 behaviour, byte for byte, is the migration path.</para>
+    /// </summary>
+    /// <param name="landed">The activation record as <see cref="ModuleActivationSidecar.Read"/>
+    /// answered it.</param>
+    /// <param name="meshSet">The mesh's module set — <see cref="ModuleSetIndex.Proposed"/>.</param>
+    /// <param name="onDeferred">The loud channel for a landed-but-unproposed entry: (module name,
+    /// reason).</param>
+    public static ModuleActivationList ProjectOntoMeshSet(
+        ModuleActivationList landed,
+        ModuleSet? meshSet,
+        Action<string, string>? onDeferred = null)
+    {
+        ArgumentNullException.ThrowIfNull(landed);
+        if (meshSet is null)
+            return landed;
+
+        var projected = ImmutableList.CreateBuilder<ModuleActivationEntry>();
+        foreach (var entry in landed.Entries)
+        {
+            if (!entry.Enabled || string.IsNullOrWhiteSpace(entry.Name))
+            {
+                projected.Add(entry);
+                continue;
+            }
+
+            if (meshSet.Generations.TryGetValue(entry.Name, out var generation))
+            {
+                projected.Add(string.Equals(entry.Directory, generation, StringComparison.Ordinal)
+                    ? entry
+                    : entry with { Directory = generation });
+                continue;
+            }
+
+            // 🚨 Not a skip we can be quiet about: the module IS installed and its bytes ARE on
+            // disk. What is missing is the wave's completion, and until that lands, activating it
+            // here would put this replica on a set no other replica has.
+            onDeferred?.Invoke(entry.Name,
+                $"it landed after module set {meshSet.Sequence} ('{meshSet.Id}') was proposed, so "
+                + "the landing wave that brought it has not completed — it activates on the first "
+                + "restart after the wave proposes its set. Running it here would put this replica "
+                + "on a module set no other replica has (#3395).");
+        }
+
+        return landed with { Entries = projected.ToImmutable() };
+    }
+
+    /// <summary>
     /// Computes the effective module list the boot loader feeds to
     /// <c>MeshBuilder.InstallAssemblies</c> (after per-module <see cref="ResolveLoadPath"/>).
     ///

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -197,6 +197,34 @@ public sealed class ModuleLandingService : IDisposable
             .Where(e => !string.IsNullOrWhiteSpace(e.Directory))
             .Select(e => e.Directory!)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // 🚨 #3395: the activation entries are NOT the whole reference set any more. The mesh's
+        // module set deliberately pins an OLDER generation than the entry while a wave's landings
+        // wait to be proposed — and that older generation is what every running replica LOADED. A
+        // sweep that trusted the entries alone would reclaim the bytes the whole mesh is executing:
+        // the 2026-08-27 outage from the other side. Both retained sets count (the one the mesh is
+        // on and the one it has proposed), and a set directory that cannot be read counts as a read
+        // fault for the same fail-closed reason the entries do.
+        var setIndex = ModuleSetStore.Read(baseDirectory,
+            msg =>
+            {
+                readFaults++;
+                logger?.LogError("{Message}", msg);
+            });
+        foreach (var generation in ModuleSetStore.ReferencedGenerations(setIndex))
+            referenced.Add(generation);
+        // Superseded set records are housekeeping like the rest of this pass — and only ever below
+        // the CURRENT set, so a record whose generations are still in the reference set above is
+        // never the one removed. Skipped entirely when anything was unreadable, for the same
+        // fail-closed reason the generation deletes are.
+        if (readFaults == 0 && setIndex.Current is { } onSet)
+        {
+            var prunedSets = ModuleSetStore.Prune(baseDirectory, onSet.Sequence,
+                msg => logger?.LogDebug("{Message}", msg));
+            if (prunedSets > 0)
+                logger?.LogInformation(
+                    "Modules GC: removed {Count} superseded module set record(s) below sequence "
+                    + "{Sequence}", prunedSets, onSet.Sequence);
+        }
         // 🚨 #2509: with any entry file unreadable, `referenced` is INCOMPLETE — an ACTIVE
         // generation would read as an orphan. Generation deletes are skipped wholesale this pass.
         var referencesReliable = readFaults == 0;
@@ -470,6 +498,41 @@ public sealed class ModuleLandingService : IDisposable
     public IObservable<ModuleActivationList> GetActivation()
         => pool.InvokeBlocking(_ => ModuleActivationSidecar.Read(baseDirectory,
             msg => logger?.LogError("{Message}", msg)));
+
+    /// <summary>
+    /// Proposes the module set the deployment's activation record now describes — the coordination
+    /// step that ENDS a landing wave (#3395), and the only thing that moves what the mesh runs.
+    ///
+    /// <para>🚨 <b>Call it when the WAVE is done, never after each module.</b> A wave lands its
+    /// modules one at a time; proposing per module would publish every intermediate combination as
+    /// a set the next boot could adopt, which is the torn half-landed mix this whole mechanism
+    /// exists to make unreachable. A wave that dies half-landed simply never proposes: the mesh
+    /// keeps running the set it was on, nothing half-landed is ever adopted, and the modules it did
+    /// land report as landed-but-unproposed
+    /// (<see cref="ModuleActivationBoot.ProjectOntoMeshSet"/>) — a named, visible failure rather
+    /// than drift.</para>
+    ///
+    /// <para>Idempotent: a wave that landed nothing new derives the set that is already proposed
+    /// and writes nothing, so sequences count waves that changed something rather than boots.
+    /// Runs on this service's cap-1 pool, so it never observes a landing halfway through.
+    /// Cold — nothing happens until Subscribe.</para>
+    /// </summary>
+    /// <returns>The set that was proposed, or null when the wave changed nothing.</returns>
+    public IObservable<ModuleSet?> ProposeModuleSet()
+        => pool.InvokeBlocking(_ =>
+        {
+            var landed = ModuleActivationSidecar.Read(baseDirectory,
+                msg => logger?.LogError("{Message}", msg));
+            var proposed = ModuleSetStore.Propose(baseDirectory, landed,
+                proposedBy: Environment.MachineName,
+                onCorrupt: msg => logger?.LogWarning("{Message}", msg));
+            if (proposed is not null)
+                logger?.LogInformation(
+                    "[ModuleSet] landing wave complete — the mesh's module set is now {Sequence} "
+                    + "('{Id}', {Count} module(s)). Replicas adopt it as they restart.",
+                    proposed.Sequence, proposed.Id, proposed.Generations.Count);
+            return proposed;
+        });
 
     /// <summary>
     /// Uninstalls a module landed by <see cref="LandModule"/>: disables its activation entry

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -1,0 +1,476 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// THE module set a mesh runs — one, mesh-wide, at a time (#3395).
+///
+/// <para>🚨 <b>What it fixes.</b> Landing moves each module's activation entry INDEPENDENTLY, the
+/// moment that module's bytes are on disk (<see cref="ModuleActivationSidecar.WriteEntry"/>), and a
+/// process pins whatever the entries said at ITS boot instant
+/// (<see cref="ModuleGenerationPin"/>). Two consequences, both measured on memex-cloud
+/// 2026-09-06: a replica booting DURING a landing wave pins a TORN mix (some modules of the new
+/// wave, the rest of the old one — a combination no wave ever intended), and replicas booting on
+/// either side of a wave pin two whole sets and hold them for their whole lives — <b>39 of 40
+/// generations differed</b> across three pods of one ReplicaSet on one image. They share ONE
+/// NodeType node, so each stamps the module set IT resolved and each then reads the other's stamp
+/// as stale: the pair ping-pongs recompiles, and where one replica's set lacks a module the
+/// sources need, a healthy NodeType FAILS with no source change.</para>
+///
+/// <para><b>The rule.</b> A landing wave does not move what the mesh RUNS. It stages bytes, and
+/// when the WHOLE wave is done it PROPOSES one set — an immutable, sequenced record naming every
+/// module's generation. Boot loads the mesh's newest proposal, never its own read of the moving
+/// per-module entries. So every replica that boots between two wave completions loads the
+/// IDENTICAL set, and no boot can ever observe a half-landed mix.</para>
+///
+/// <para><b>Immutable and monotone, never a mutable cell.</b> Each proposal is one write-once file
+/// named for its sequence AND its content id, and adoption is a second write-once file beside it.
+/// Nothing here is ever read-modify-written or renamed over a live file — the two defects that
+/// #2090/#2189 removed from the activation record, which is why that record is one file per module
+/// in the first place. Two replicas that propose the same sequence therefore CONFLICT visibly
+/// instead of losing one another's work: both files exist, every reader resolves the conflict the
+/// same way (see <see cref="ModuleSetIndex.Proposed"/>), and the next wave folds everything the
+/// loser landed into sequence + 1, because the proposal is derived from the activation record and
+/// never from the previous proposal.</para>
+/// </summary>
+/// <param name="Sequence">Monotonically increasing; the mesh's newest proposal is the highest one.
+/// The first proposal a deployment ever writes is 1.</param>
+/// <param name="Id">Content id — lowercase hex SHA-256 over the set's <c>name@generation</c> pairs,
+/// ordinal-sorted and joined with <c>;</c>. Two sets with the same id activate the same bytes.</param>
+/// <param name="Generations">Module simple name → the GENERATION directory leaf
+/// (<c>&lt;name&gt;@&lt;id&gt;</c>) this set activates for it — the same string
+/// <see cref="ModuleActivationEntry.Directory"/> records and
+/// <see cref="ModuleActivationStatus.LoadedModuleGenerations()"/> reads back off a loaded
+/// assembly.</param>
+/// <param name="ProposedAtUtc">When the wave that produced this set finished.</param>
+/// <param name="ProposedBy">Which process proposed it — diagnostics only, never a gate.</param>
+public sealed record ModuleSet(
+    long Sequence,
+    string Id,
+    ImmutableSortedDictionary<string, string> Generations,
+    DateTime ProposedAtUtc,
+    string? ProposedBy = null);
+
+/// <summary>
+/// What one process recorded when it BOOTED onto a <see cref="ModuleSet"/> — the evidence that the
+/// mesh's proposal is not merely declared but actually running somewhere (#3395).
+///
+/// <para>Written create-if-absent, once per set: the question it answers is "has ANY replica come
+/// up on this set yet", which is exactly what bounds the convergence window. A proposal no replica
+/// has adopted means the window is OPEN — the mesh has declared a set that nothing serves yet, and
+/// the next restart closes it.</para>
+/// </summary>
+/// <param name="Sequence">The set's sequence.</param>
+/// <param name="Id">The set's content id.</param>
+/// <param name="AdoptedAtUtc">When the first process booted onto it.</param>
+/// <param name="AdoptedBy">Which process — diagnostics only.</param>
+public sealed record ModuleSetAdoption(
+    long Sequence,
+    string Id,
+    DateTime AdoptedAtUtc,
+    string? AdoptedBy = null);
+
+/// <summary>
+/// Everything the <c>modules/sets/</c> directory says, read in one pass: which set the mesh has
+/// PROPOSED (what the next boot loads) and which set it is ON (the newest proposal some replica has
+/// actually booted onto).
+/// </summary>
+/// <param name="Proposed">The mesh's newest proposal, or null on a deployment that has never
+/// completed a landing wave. 🚨 When two replicas proposed the same sequence, the ordinally
+/// SMALLEST <see cref="ModuleSet.Id"/> wins — deterministic, so every reader picks the same one
+/// without coordinating, and the loser's landings return in the next proposal.</param>
+/// <param name="Current">The newest PROPOSED set that also carries an adoption record — "the mesh
+/// is on generation N". Null when no proposal has been adopted yet.</param>
+/// <param name="ConflictingSequences">Sequences that more than one replica proposed. Reported, not
+/// repaired: the conflict is resolved deterministically and the next wave supersedes it.</param>
+public sealed record ModuleSetIndex(
+    ModuleSet? Proposed,
+    ModuleSet? Current,
+    ImmutableList<long> ConflictingSequences)
+{
+    /// <summary>An empty deployment's index — no proposal, no adoption, no conflict.</summary>
+    public static readonly ModuleSetIndex Empty = new(null, null, []);
+
+    /// <summary>
+    /// True while the mesh has declared a set that NO replica has booted onto yet — the
+    /// convergence window, stated positively. It opens when a landing wave proposes and closes at
+    /// the first restart; a window that stays open is a wave whose bytes nothing is serving.
+    /// </summary>
+    public bool ConvergencePending =>
+        Proposed is not null && (Current is null || Current.Sequence < Proposed.Sequence);
+}
+
+/// <summary>
+/// The <c>modules/sets/</c> record store — plain, synchronous file IO, because BOOT is its first
+/// caller and boot runs before the DI container, any storage provider or any hub exists (the same
+/// reason <see cref="ModuleActivationSidecar"/> is a file). Runtime callers go through
+/// <see cref="ModuleLandingService"/>, which runs these on its bounded IO pool.
+///
+/// <para>Layout, beside the module folders the sets name:</para>
+/// <list type="bullet">
+///   <item><c>modules/sets/&lt;sequence:D9&gt;-&lt;id8&gt;.proposed.json</c> — a
+///     <see cref="ModuleSet"/>, written ONCE by the landing wave that completed it.</item>
+///   <item><c>modules/sets/&lt;sequence:D9&gt;-&lt;id8&gt;.adopted.json</c> — a
+///     <see cref="ModuleSetAdoption"/>, written create-if-absent by the first process that boots
+///     onto that set.</item>
+/// </list>
+/// </summary>
+public static class ModuleSetStore
+{
+    /// <summary>The directory inside <c>modules/</c> the set records live in.</summary>
+    public const string DirectoryName = "sets";
+
+    private const string ProposedSuffix = ".proposed.json";
+    private const string AdoptedSuffix = ".adopted.json";
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>The set-record directory for a deployment rooted at
+    /// <paramref name="baseDirectory"/> — <c>{baseDirectory}/modules/sets</c>.</summary>
+    public static string SetsDirectory(string baseDirectory) =>
+        Path.Combine(baseDirectory, "modules", DirectoryName);
+
+    /// <summary>
+    /// The set an activation list activates: every ENABLED entry that names a generation, as
+    /// name → generation. Pure — the one derivation, so a proposal and the comparison a running
+    /// process makes against it can never be computed two different ways.
+    ///
+    /// <para>An entry with no <see cref="ModuleActivationEntry.Directory"/> (the legacy fixed
+    /// <c>modules/&lt;name&gt;/</c> folder) contributes nothing: it names no generation, so there
+    /// is nothing for a set to pin, and it keeps resolving exactly as it does today.</para>
+    /// </summary>
+    public static ImmutableSortedDictionary<string, string> GenerationsOf(ModuleActivationList? landed) =>
+        (landed?.Entries ?? [])
+        .Where(e => e.Enabled
+            && !string.IsNullOrWhiteSpace(e.Name)
+            && !string.IsNullOrWhiteSpace(e.Directory))
+        .GroupBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+        // First ENABLED entry of a name wins — the same tie-break the boot union applies.
+        .ToImmutableSortedDictionary(g => g.Key, g => g.First().Directory!, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The content id of a set: lowercase hex SHA-256 over the ordinal-sorted
+    /// <c>name@generation</c> pairs joined with <c>;</c>. The empty set hashes to the empty string
+    /// — stable, and distinguishable from "no set at all", which is <c>null</c>.
+    /// </summary>
+    public static string IdOf(ImmutableSortedDictionary<string, string> generations)
+    {
+        ArgumentNullException.ThrowIfNull(generations);
+        if (generations.Count == 0)
+            return string.Empty;
+        var payload = string.Join(";", generations
+            .Select(kv => kv.Key + "@" + kv.Value)
+            .OrderBy(x => x, StringComparer.Ordinal));
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
+
+    /// <summary>
+    /// Reads the whole set directory. An ABSENT directory is the normal state of a deployment that
+    /// has never completed a landing wave and answers <see cref="ModuleSetIndex.Empty"/> silently
+    /// — which is what keeps this change inert until the first wave proposes.
+    ///
+    /// <para>🚨 A record file that cannot be READ costs exactly that one record, loudly, and never
+    /// the whole answer — the #2189 rule, for the same reason: boot calls this un-wrapped, and a
+    /// transient SMB fault must not take a portal down or silently collapse the mesh's module set
+    /// to "none". A proposal that is skipped simply leaves an older one current, which is a set
+    /// that was correct a moment ago.</para>
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
+    /// <param name="onCorrupt">The loud channel — one call per record that could not be read.</param>
+    public static ModuleSetIndex Read(string baseDirectory, Action<string>? onCorrupt = null)
+    {
+        var directory = SetsDirectory(baseDirectory);
+        string[] files;
+        try
+        {
+            files = Directory.Exists(directory)
+                ? [.. Directory.EnumerateFiles(directory, "*.json").OrderBy(f => f, StringComparer.Ordinal)]
+                : [];
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            onCorrupt?.Invoke(
+                $"Module set records under '{directory}' could not be listed ({ex.GetType().Name}: "
+                + $"{ex.Message}) — this process cannot tell which module set the mesh is on and "
+                + "falls back to the activation record, which is what every replica did before "
+                + "#3395. Restart once the volume is readable to rejoin the mesh's set.");
+            return ModuleSetIndex.Empty;
+        }
+
+        var proposals = new List<ModuleSet>();
+        var adopted = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var file in files)
+        {
+            if (file.EndsWith(ProposedSuffix, StringComparison.Ordinal))
+            {
+                if (TryRead<ModuleSet>(file, onCorrupt) is { } set && set.Generations is not null)
+                    // 🚨 The comparer does NOT survive the JSON round-trip — a deserialized
+                    // ImmutableSortedDictionary carries the DEFAULT ordinal one. Module identity is
+                    // case-insensitive everywhere else (the activation record, the loaded-assembly
+                    // set, MeshBuilder's probe), and a set that alone compared case-sensitively
+                    // would silently defer a module whose entry differs only in case — the same
+                    // name reading as two.
+                    proposals.Add(set with
+                    {
+                        Generations = set.Generations
+                            .WithComparers(StringComparer.OrdinalIgnoreCase),
+                    });
+            }
+            else if (file.EndsWith(AdoptedSuffix, StringComparison.Ordinal)
+                     && TryRead<ModuleSetAdoption>(file, onCorrupt) is { } adoption)
+            {
+                adopted.Add(Key(adoption.Sequence, adoption.Id));
+            }
+        }
+
+        if (proposals.Count == 0)
+            return ModuleSetIndex.Empty;
+
+        // 🚨 Deterministic conflict resolution. Two replicas can complete a wave at the same
+        // moment and each write sequence N+1; both files survive (nothing is ever renamed over).
+        // Every reader must then pick the SAME one without talking to anyone, so the tie-break is
+        // the ordinally smallest content id. The loser is not lost: the proposal is derived from
+        // the activation record, so the next wave's sequence N+2 carries everything both landed.
+        var bySequence = proposals
+            .GroupBy(p => p.Sequence)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(p => p.Id, StringComparer.Ordinal).First());
+        var conflicts = proposals
+            .GroupBy(p => p.Sequence)
+            .Where(g => g.Select(p => p.Id).Distinct(StringComparer.Ordinal).Count() > 1)
+            .Select(g => g.Key)
+            .OrderBy(x => x)
+            .ToImmutableList();
+        foreach (var sequence in conflicts)
+            onCorrupt?.Invoke(
+                $"Module set sequence {sequence} was proposed by more than one replica — the "
+                + $"ordinally smallest id wins ('{bySequence[sequence].Id}'), and the next landing "
+                + "wave folds every landing back in. No module is lost; the mesh runs one set.");
+
+        var newest = bySequence.Values.OrderByDescending(p => p.Sequence).First();
+        var current = bySequence.Values
+            .Where(p => adopted.Contains(Key(p.Sequence, p.Id)))
+            .OrderByDescending(p => p.Sequence)
+            .FirstOrDefault();
+        return new ModuleSetIndex(newest, current, conflicts);
+    }
+
+    /// <summary>
+    /// Proposes the set the deployment's activation record currently describes — the coordination
+    /// step at the END of a landing wave (#3395), and the ONLY thing that moves what the mesh runs.
+    ///
+    /// <para>A NO-OP when the derived set is byte-identical to the newest proposal, which is the
+    /// steady state: a reconcile pass that lands nothing proposes nothing, so sequences count
+    /// waves that actually changed something rather than boots.</para>
+    ///
+    /// <para>🚨 Called only when the wave COMPLETED. A wave that dies half-landed must not propose
+    /// — the mesh then keeps running the set it was on, no replica ever adopts a half-landed mix,
+    /// and the modules it did land show up as landed-but-unproposed
+    /// (<see cref="ModuleActivationBoot.ProjectOntoMeshSet"/>) rather than as silent drift.</para>
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
+    /// <param name="landed">The activation record as the wave left it.</param>
+    /// <param name="proposedBy">Diagnostics — which process completed the wave.</param>
+    /// <param name="onCorrupt">The loud channel for unreadable existing records.</param>
+    /// <returns>The set that was written, or null when nothing changed.</returns>
+    public static ModuleSet? Propose(
+        string baseDirectory,
+        ModuleActivationList landed,
+        string? proposedBy = null,
+        Action<string>? onCorrupt = null)
+    {
+        ArgumentNullException.ThrowIfNull(landed);
+        var generations = GenerationsOf(landed);
+        var id = IdOf(generations);
+        var index = Read(baseDirectory, onCorrupt);
+        if (index.Proposed is { } newest && string.Equals(newest.Id, id, StringComparison.Ordinal))
+            return null;
+
+        var set = new ModuleSet(
+            (index.Proposed?.Sequence ?? 0) + 1,
+            id,
+            generations,
+            DateTime.UtcNow,
+            proposedBy);
+        WriteOnce(PathOf(baseDirectory, set.Sequence, set.Id, ProposedSuffix),
+            JsonSerializer.Serialize(set, Json));
+        return set;
+    }
+
+    /// <summary>
+    /// Records that THIS process booted onto <paramref name="set"/> — create-if-absent, so the
+    /// second and every later replica to come up on it write nothing. Best effort: a read-only or
+    /// full volume costs the mesh-level "somebody is serving this set" signal and nothing else,
+    /// which is why it is never allowed to fail a boot.
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root.</param>
+    /// <param name="set">The set this process loaded.</param>
+    /// <param name="adoptedBy">Diagnostics — which process.</param>
+    /// <param name="onWarn">The loud channel for a failed record.</param>
+    public static void RecordAdoption(
+        string baseDirectory,
+        ModuleSet set,
+        string? adoptedBy = null,
+        Action<string>? onWarn = null)
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        var path = PathOf(baseDirectory, set.Sequence, set.Id, AdoptedSuffix);
+        try
+        {
+            if (File.Exists(path))
+                return;
+            WriteOnce(path, JsonSerializer.Serialize(
+                new ModuleSetAdoption(set.Sequence, set.Id, DateTime.UtcNow, adoptedBy), Json));
+        }
+        catch (Exception ex)
+        {
+            onWarn?.Invoke(
+                $"could not record adoption of module set {set.Sequence} ('{set.Id}') "
+                + $"({ex.GetType().Name}: {ex.Message}) — this process still runs that set; only "
+                + "the mesh-level 'a replica is serving it' signal is missing.");
+        }
+    }
+
+    /// <summary>
+    /// Every generation directory leaf the retained set records reference — what the modules GC
+    /// must treat as REFERENCED on top of the activation entries.
+    ///
+    /// <para>🚨 Without this the convergence rule would re-open the 2026-08-27 outage from the
+    /// other side: the mesh's set deliberately pins an OLDER generation than the activation entry
+    /// while a wave's landings wait to be proposed, so that generation is unreferenced by the
+    /// entries alone — and GC would reclaim the very bytes every replica is running.</para>
+    /// </summary>
+    /// <param name="index">The set index, as <see cref="Read"/> answered it.</param>
+    public static IReadOnlySet<string> ReferencedGenerations(ModuleSetIndex? index)
+    {
+        var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var set in new[] { index?.Proposed, index?.Current })
+            foreach (var generation in set?.Generations.Values ?? Enumerable.Empty<string>())
+                if (!string.IsNullOrWhiteSpace(generation))
+                    referenced.Add(generation);
+        return referenced;
+    }
+
+    /// <summary>
+    /// Removes set records the mesh has moved past — everything below <paramref name="keepFrom"/>.
+    /// One tiny file per record, but a deployment that lands weekly for a year accumulates
+    /// hundreds, and <see cref="Read"/> is on the BOOT path.
+    ///
+    /// <para>🚨 A record below the CURRENT set references generations nothing the mesh runs
+    /// resolves against — and a process still on one of them loaded from its own pinned copy
+    /// (<see cref="ModuleGenerationPin"/>), which is exactly why that pin exists. The caller must
+    /// pass the current set's sequence, never the proposed one: pruning the record of the set
+    /// replicas are still on would take its generations out of the GC reference set.</para>
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root.</param>
+    /// <param name="keepFrom">The lowest sequence to keep — the mesh's CURRENT set.</param>
+    /// <param name="onWarn">The loud channel for a record that could not be removed.</param>
+    /// <returns>How many records were removed.</returns>
+    public static int Prune(string baseDirectory, long keepFrom, Action<string>? onWarn = null)
+    {
+        var directory = SetsDirectory(baseDirectory);
+        if (!Directory.Exists(directory))
+            return 0;
+        var removed = 0;
+        foreach (var file in Directory.EnumerateFiles(directory, "*.json").ToArray())
+        {
+            var leaf = Path.GetFileName(file);
+            var dash = leaf.IndexOf('-');
+            if (dash <= 0 || !long.TryParse(leaf[..dash], out var sequence) || sequence >= keepFrom)
+                continue;
+            try
+            {
+                File.Delete(file);
+                removed++;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                onWarn?.Invoke(
+                    $"Module set record '{leaf}' could not be removed ({ex.GetType().Name}: "
+                    + $"{ex.Message}) — a later pass collects it; nothing resolves against it.");
+            }
+        }
+        return removed;
+    }
+
+    /// <summary>One human-readable line naming which set the mesh is on and whether a replica is
+    /// serving it yet — shared by every surface so two of them can never report different sets.</summary>
+    /// <param name="index">The set index.</param>
+    public static string Describe(ModuleSetIndex? index) =>
+        index?.Proposed is not { } proposed
+            ? "the mesh has no proposed module set (no landing wave has completed here)"
+            : index.ConvergencePending
+                ? $"the mesh's module set is {proposed.Sequence} ('{proposed.Id}', "
+                  + $"{proposed.Generations.Count} module(s)) and NO replica has booted onto it yet "
+                  + $"— it was proposed at {proposed.ProposedAtUtc:O}"
+                : $"the mesh is on module set {proposed.Sequence} ('{proposed.Id}', "
+                  + $"{proposed.Generations.Count} module(s))";
+
+    private static string Key(long sequence, string? id) => $"{sequence}:{id}";
+
+    private static string PathOf(string baseDirectory, long sequence, string id, string suffix) =>
+        Path.Combine(
+            SetsDirectory(baseDirectory),
+            sequence.ToString("D9") + "-" + ShortId(id) + suffix);
+
+    /// <summary>The id fragment that goes into the file NAME — enough to keep two different sets at
+    /// one sequence in two different files, while the file's own content carries the full id. The
+    /// empty set (a deployment with no generation-landed modules) needs a stand-in that is still a
+    /// legal file name.</summary>
+    private static string ShortId(string id) =>
+        string.IsNullOrEmpty(id) ? "empty" : id[..Math.Min(16, id.Length)];
+
+    private static T? TryRead<T>(string file, Action<string>? onCorrupt) where T : class
+    {
+        try
+        {
+            var text = File.ReadAllText(file);
+            return JsonSerializer.Deserialize<T>(text, Json);
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // Vanished between the listing and the read — a concurrent GC pass pruning superseded
+            // records. Nothing to report: the record it removed is one nothing resolves against.
+            return null;
+        }
+        catch (Exception ex)
+        {
+            onCorrupt?.Invoke(
+                $"Module set record '{file}' could not be read ({ex.GetType().Name}: {ex.Message}) "
+                + "— that ONE record is skipped; every other set record is unaffected.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a record that is never rewritten: a temp file in the same directory, then a rename
+    /// that does NOT overwrite. Two replicas racing the same path both produce the same bytes, so
+    /// the loser's failed rename is success — never a replace over a file a reader holds open,
+    /// which is the SMB sharing violation of #2090.
+    /// </summary>
+    private static void WriteOnce(string path, string content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var temp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        File.WriteAllText(temp, content);
+        try
+        {
+            File.Move(temp, path, overwrite: false);
+        }
+        catch (IOException) when (File.Exists(path))
+        {
+            // Another replica wrote the identical record first. That IS the outcome we wanted.
+            File.Delete(temp);
+        }
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -212,9 +212,17 @@ public sealed class PendingModuleActivations(string moduleRoot)
         // has not completed (a restart would not load it — a promise no restart can keep, the exact
         // false prompt the held-entry and missing-bytes rules exist to prevent), and it is what let
         // a pod 90 minutes behind answer Healthy in the first place.
-        var sets = ModuleSetStore.Read(ModuleRootPath, reason => corrupt ??= reason);
-        if (corrupt is not null)
-            return new ModuleActivationReport([], corrupt);
+        // 🚨 The set store's reports are NOT verdicts, and folding them into UndeterminedReason
+        // would make them into one. `ModuleSetStore.Read` reports a deterministically-RESOLVED
+        // conflict (two replicas proposed one sequence; every reader picks the same set) and a
+        // single unreadable record (skipped, the rest stand) through the same channel — both are
+        // handled conditions with a valid index behind them. Even the one genuinely blind case, a
+        // directory that cannot be listed, answers `Empty`, which projects as the IDENTITY: this
+        // pod then reports exactly what it reported before #3395, which is an answer, not an
+        // absence of one. So the notes go on the mesh-set LINE, where an operator sees them, and
+        // the verdict stays what the activation record supports.
+        var setNotes = new List<string>();
+        var sets = ModuleSetStore.Read(ModuleRootPath, setNotes.Add);
 
         var deferred = ImmutableList.CreateBuilder<PendingModuleActivation>();
         var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(
@@ -225,7 +233,10 @@ public sealed class PendingModuleActivations(string moduleRoot)
                 activation.Entries.FirstOrDefault(e =>
                     string.Equals(e.Name, module, StringComparison.OrdinalIgnoreCase))?.PackagePath,
                 activation.Entries.FirstOrDefault(e =>
-                    string.Equals(e.Name, module, StringComparison.OrdinalIgnoreCase))?.Version)));
+                    string.Equals(e.Name, module, StringComparison.OrdinalIgnoreCase))?.Version)),
+            // The same existence check boot passes, so this report describes the set boot would
+            // actually load rather than the one on paper.
+            LandedDllExists);
 
         return new ModuleActivationReport(
             ModuleActivationStatus.NotYetLoaded(
@@ -237,7 +248,8 @@ public sealed class PendingModuleActivations(string moduleRoot)
                 ModulePlatformFloor.DeclineReason, LandedDllExists))
         {
             Deferred = deferred.ToImmutable(),
-            MeshModuleSet = ModuleSetStore.Describe(sets),
+            MeshModuleSet = ModuleSetStore.Describe(sets)
+                + (setNotes.Count > 0 ? " — " + string.Join("; ", setNotes) : string.Empty),
         };
     }
 

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -29,6 +29,33 @@ public sealed record ModuleActivationReport(
     /// <summary>The activated modules whose bytes are gone. Never null.</summary>
     public ImmutableList<PendingModuleActivation> Unresolvable { get; init; } = Unresolvable ?? [];
 
+    /// <summary>
+    /// 🚨 The modules that have LANDED on the volume but are in no proposed module set (#3395) —
+    /// a landing wave that has not completed. A restart does NOT activate them, because boot loads
+    /// the mesh's set and they are not in it, so they are a THIRD state and never folded into
+    /// <see cref="Pending"/>.
+    ///
+    /// <para>Two causes, one report. While a wave is running this is the wave's own progress and
+    /// clears when it proposes, in seconds. A wave that DIED leaves it standing — and that is the
+    /// honest failure: the module's bytes are on the volume and it is running on NO replica, said
+    /// out loud, instead of the old behaviour where it silently ran on whichever pods happened to
+    /// boot after its own landing and not on the others.</para>
+    ///
+    /// <para>An init-only property rather than a fourth positional parameter: replacing
+    /// the constructor signature is what <see cref="MissingMethodException"/>-aborts a host
+    /// compiled against the previous platform — the same rule the
+    /// <see cref="ModuleActivationStatus"/> overloads follow.</para>
+    /// </summary>
+    public ImmutableList<PendingModuleActivation> Deferred { get; init; } = [];
+
+    /// <summary>One line naming which module set the mesh is on and whether a replica has booted
+    /// onto it yet (<see cref="ModuleSetStore.Describe"/>), or null on a deployment with no set
+    /// records. The mesh-level half of the report; <see cref="Pending"/> is the per-pod half.</summary>
+    public string? MeshModuleSet { get; init; }
+
+    /// <summary>True when the state is KNOWN and a landing wave has not proposed its set.</summary>
+    public bool HasDeferred => !IsUndetermined && !Deferred.IsEmpty;
+
     /// <summary>True when this process could not establish the activation state at all.</summary>
     public bool IsUndetermined => UndeterminedReason is not null;
 
@@ -65,10 +92,35 @@ public sealed record ModuleActivationReport(
     public string Describe() =>
         UndeterminedReason is { } reason
             ? "module activation state could not be determined — " + reason
-            : HasUnresolvable
+            : (HasUnresolvable
                 ? ModuleActivationStatus.DescribeUnresolvable(Unresolvable)
                     + (HasPending ? "; " + ModuleActivationStatus.Describe(Pending) : string.Empty)
-                : ModuleActivationStatus.Describe(Pending);
+                : ModuleActivationStatus.Describe(Pending))
+              + (HasDeferred ? "; " + DescribeDeferred(Deferred) : string.Empty);
+
+    /// <summary>
+    /// One human-readable line naming the modules a landing wave landed but never proposed
+    /// (#3395) — kept separate from both other lines because the remedy differs again: nothing an
+    /// operator does to THIS pod helps, the wave has to complete.
+    /// </summary>
+    /// <param name="deferred">The landed-but-unproposed modules.</param>
+    /// <param name="maxNamed">How many are named before the line truncates.</param>
+    public static string DescribeDeferred(
+        IReadOnlyCollection<PendingModuleActivation> deferred, int maxNamed = 10)
+    {
+        ArgumentNullException.ThrowIfNull(deferred);
+        if (deferred.Count == 0)
+            return "no module is waiting on a landing wave";
+        var names = deferred
+            .Select(p => p.Name)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return $"{names.Length} module(s) have landed but are in NO proposed module set — the "
+            + "landing wave that brought them has not completed, so they are running on no replica "
+            + "and a restart will not change that; the next completed wave activates them: "
+            + string.Join(", ", names.Take(Math.Max(1, maxNamed)))
+            + (names.Length > maxNamed ? $", …(+{names.Length - maxNamed})" : string.Empty);
+    }
 }
 
 /// <summary>
@@ -153,14 +205,40 @@ public sealed class PendingModuleActivations(string moduleRoot)
         bool LandedDllExists(ModuleActivationEntry entry) =>
             ModuleActivationBoot.LandedModuleDllExists(ModuleRootPath, entry);
 
+        // 🚨 #3395 — compare against THE MESH'S MODULE SET, which is what a restart of this process
+        // would actually load, not against the raw activation record, which is a moving target no
+        // boot resolves any more. Getting this wrong in either direction breaks the report's one
+        // promise: comparing against the record would call a pod "pending" for a landing whose wave
+        // has not completed (a restart would not load it — a promise no restart can keep, the exact
+        // false prompt the held-entry and missing-bytes rules exist to prevent), and it is what let
+        // a pod 90 minutes behind answer Healthy in the first place.
+        var sets = ModuleSetStore.Read(ModuleRootPath, reason => corrupt ??= reason);
+        if (corrupt is not null)
+            return new ModuleActivationReport([], corrupt);
+
+        var deferred = ImmutableList.CreateBuilder<PendingModuleActivation>();
+        var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(
+            activation,
+            sets.Proposed,
+            (module, _) => deferred.Add(new PendingModuleActivation(
+                module,
+                activation.Entries.FirstOrDefault(e =>
+                    string.Equals(e.Name, module, StringComparison.OrdinalIgnoreCase))?.PackagePath,
+                activation.Entries.FirstOrDefault(e =>
+                    string.Equals(e.Name, module, StringComparison.OrdinalIgnoreCase))?.Version)));
+
         return new ModuleActivationReport(
             ModuleActivationStatus.NotYetLoaded(
-                activation, loadedAssemblyNames, loadedModuleGenerations,
+                onMeshSet, loadedAssemblyNames, loadedModuleGenerations,
                 ModulePlatformFloor.DeclineReason, LandedDllExists),
             UndeterminedReason: null,
             ModuleActivationStatus.Unresolvable(
-                activation, loadedAssemblyNames, loadedModuleGenerations,
-                ModulePlatformFloor.DeclineReason, LandedDllExists));
+                onMeshSet, loadedAssemblyNames, loadedModuleGenerations,
+                ModulePlatformFloor.DeclineReason, LandedDllExists))
+        {
+            Deferred = deferred.ToImmutable(),
+            MeshModuleSet = ModuleSetStore.Describe(sets),
+        };
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -617,6 +617,35 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
             .ToObservable()
             .Concat()
             .DefaultIfEmpty(Unit.Default)
-            .LastAsync();
+            .LastAsync()
+            // 🚨 #3395 — the wave ENDS here, and ending it is what moves the mesh's module set.
+            // Deliberately outside the per-package Concat: proposing after each module would
+            // publish every intermediate combination as a set the next boot could adopt, which is
+            // the torn half-landed mix the set exists to make unreachable. A wave that dies before
+            // this point proposes nothing, so the mesh keeps running the set it was on.
+            .SelectMany(_ => ProposeMeshModuleSet());
+    }
+
+    /// <summary>
+    /// Closes the landing wave by proposing the module set the activation record now describes
+    /// (#3395). Never fails the reconcile: a proposal that cannot be written leaves the mesh on its
+    /// previous set — every replica still agrees with every other one, and the next wave proposes
+    /// again — so the loud log is the whole remedy.
+    /// </summary>
+    private IObservable<Unit> ProposeMeshModuleSet()
+    {
+        var landing = hub.ServiceProvider.GetService<ModuleLandingService>();
+        if (landing is null)
+            return Observable.Return(Unit.Default);
+        return landing.ProposeModuleSet()
+            .Select(_ => Unit.Default)
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "[RegistryUpdate] the landing wave completed but its module set could not be "
+                    + "proposed — the mesh stays on its current set and the next wave proposes "
+                    + "again. Cause: {Cause}", ex.Message);
+                return Observable.Return(Unit.Default);
+            });
     }
 }

--- a/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>Every replica of one mesh runs ONE module set (#3395).</b>
+///
+/// <para><b>The mechanism these pin.</b> Landing moves each module's activation entry
+/// INDEPENDENTLY, the moment that module's bytes are on disk, and a process pins whatever the
+/// entries said at ITS boot instant. Measured on memex-cloud 2026-09-06: three pods of one
+/// ReplicaSet, one image (<c>3.0.0-rc9.ci.7693</c>), booted 11:33:39 / 11:41:04 / 12:51:21 around a
+/// landing wave at 12:18–12:27, and <b>39 of 40 pinned generations differed</b> between the two
+/// older pods and the newest. They share ONE NodeType node, so each stamped the module set IT
+/// resolved and each read the other's stamp as stale: the pair ping-pongs recompiles, and where one
+/// replica's set lacks a module the sources need, a healthy NodeType FAILS with no source change.
+/// The issue was filed as "one boot, two module sets 15 s apart"; it is three replicas, 16 minutes
+/// apart — a rolling replacement across a landing wave, not a process racing itself.</para>
+///
+/// <para><b>The fix these prove.</b> A landing wave no longer moves what the mesh RUNS. It stages
+/// bytes, and when the whole wave is done it PROPOSES one immutable, sequenced set
+/// (<see cref="ModuleSetStore.Propose"/>); boot loads the mesh's newest proposal
+/// (<see cref="ModuleActivationBoot.ProjectOntoMeshSet"/>), never its own read of the moving
+/// per-module entries. Two replicas booting at any two instants between two wave completions
+/// therefore load identical bytes, and a boot mid-wave cannot observe a half-landed mix at all.</para>
+///
+/// <para><b>What makes each of these able to FAIL.</b> Every one drives the REAL
+/// <see cref="ModuleLandingService"/> against a real temp volume and composes the boot exactly as
+/// <c>MemexConfiguration.ConfigureMemexMesh</c> does — nothing is mocked and nothing re-derives the
+/// rule locally. Neutralising the convergence (making
+/// <see cref="ModuleActivationBoot.ProjectOntoMeshSet"/> return its input) flips
+/// <see cref="ReplicasBootingAroundOneWave_LoadTheIdenticalModuleSet"/>,
+/// <see cref="AReplicaBootingMidWave_NeverLoadsAHalfLandedMix"/> and
+/// <see cref="AWaveThatNeverCompletes_LeavesTheMeshOnTheSetItWasOn"/> — the three that ARE the
+/// divergence.</para>
+/// </summary>
+public class ModuleSetConvergenceTest : IDisposable
+{
+    private const string ModuleA = "MeshWeaver.Payments.Stripe";
+    private const string ModuleB = "MeshWeaver.Social";
+    private const string ModuleC = "MeshWeaver.Speech";
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-moduleset-" + Guid.NewGuid().ToString("N"));
+
+    private readonly ModuleLandingService landing;
+
+    /// <summary>Creates the per-test deployment root and the REAL landing service over it.</summary>
+    public ModuleSetConvergenceTest()
+    {
+        Directory.CreateDirectory(root);
+        landing = new ModuleLandingService(baseDirectory: root);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        landing.Dispose();
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // ───────────────────────────────────────────────────────────── the mechanism
+
+    /// <summary>
+    /// 🚨 <b>THE repro.</b> Three replicas boot across one landing wave — before it, in the middle
+    /// of it, and after it — exactly the memex-cloud shape. All three must run the SAME generation
+    /// of every module: the two that boot before the wave PROPOSES load the previous set, and the
+    /// one that boots after loads the proposed one, so the mesh is on at most ONE set at a time
+    /// and the replicas that share a set share it exactly.
+    ///
+    /// <para>Without the convergence the middle replica takes whatever half of the wave had landed
+    /// by its boot instant — a THIRD set, distinct from both — which is the 39-of-40 divergence.</para>
+    /// </summary>
+    [Fact]
+    public async Task ReplicasBootingAroundOneWave_LoadTheIdenticalModuleSet()
+    {
+        await LandWave(ModuleA, ModuleB, ModuleC);
+        var first = BootReplica();
+
+        // The second wave starts: ModuleA's bytes are down and its ENTRY has already moved, which
+        // is the state the middle replica of the incident booted into.
+        await Land(ModuleA);
+        var second = BootReplica();
+
+        // …and only now does the wave finish and propose.
+        await Land(ModuleB);
+        await Land(ModuleC);
+        await ProposeWave();
+        var third = BootReplica();
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(first, third);
+        // The whole set moved together — a wave is all-or-nothing, never per module.
+        Assert.All(first.Keys, name => Assert.NotEqual(first[name], third[name]));
+    }
+
+    /// <summary>
+    /// A replica booting while a wave is landing must never see the TORN combination — some
+    /// modules from the new wave, the rest from the old. That combination is one no wave ever
+    /// produced and nothing was ever tested against; it is what makes a NodeType compile fail
+    /// against a module set that "resolved fine fifteen seconds earlier".
+    /// </summary>
+    [Fact]
+    public async Task AReplicaBootingMidWave_NeverLoadsAHalfLandedMix()
+    {
+        await LandWave(ModuleA, ModuleB, ModuleC);
+        var before = BootReplica();
+
+        await Land(ModuleA);
+        var midWave = BootReplica();
+
+        Assert.Equal(before[ModuleA], midWave[ModuleA]);
+        Assert.Equal(before, midWave);
+    }
+
+    /// <summary>
+    /// 🚨 <b>A wave that dies half-landed is a FAILURE, not drift.</b> The mesh stays on the set it
+    /// was on — nothing half-landed is ever adopted by anybody — and the modules whose bytes DID
+    /// land are named as stranded on every surface that reads the report. The old behaviour had no
+    /// such state: those modules simply ran on whichever pods happened to boot after their own
+    /// landing and not on the others, with every surface reporting Healthy.
+    /// </summary>
+    [Fact]
+    public async Task AWaveThatNeverCompletes_LeavesTheMeshOnTheSetItWasOn()
+    {
+        await LandWave(ModuleA, ModuleB);
+        var settled = BootReplica();
+
+        // A wave lands a module the mesh has never carried, and dies — no ProposeWave().
+        await Land(ModuleC);
+
+        Assert.Equal(settled, BootReplica());
+
+        var report = new PendingModuleActivations(root).Read(
+            loadedAssemblyNames: settled.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase),
+            loadedModuleGenerations: settled);
+        Assert.True(report.HasDeferred);
+        Assert.Equal(ModuleC, Assert.Single(report.Deferred).Name);
+        Assert.Contains("landed but are in NO proposed module set", report.Describe());
+        // 🚨 And NOT reported as pending: "a restart activates this" would be a promise no restart
+        // can keep, because boot loads the mesh's set and the stranded module is not in it.
+        Assert.False(report.HasPending);
+    }
+
+    /// <summary>
+    /// The convergence window, stated positively: it OPENS when a wave proposes a set nothing is
+    /// serving yet and CLOSES at the first replica that boots onto it. That is what makes "the old
+    /// replica is still serving the previous set" a known, bounded, visible state rather than
+    /// silence — and a window that stays open names a wave whose bytes no replica runs.
+    /// </summary>
+    [Fact]
+    public async Task TheConvergenceWindow_OpensOnTheProposalAndClosesOnTheFirstBoot()
+    {
+        await LandWave(ModuleA);
+        BootReplica();
+        Assert.False(ModuleSetStore.Read(root).ConvergencePending);
+
+        await LandWave(ModuleA);
+        var afterProposal = ModuleSetStore.Read(root);
+        Assert.True(afterProposal.ConvergencePending);
+        Assert.Contains("NO replica has booted onto it yet", ModuleSetStore.Describe(afterProposal));
+
+        BootReplica();
+        var afterRestart = ModuleSetStore.Read(root);
+        Assert.False(afterRestart.ConvergencePending);
+        Assert.Equal(afterProposal.Proposed!.Id, afterRestart.Current!.Id);
+    }
+
+    // ───────────────────────────────────────────────────────────── the store's own rules
+
+    /// <summary>
+    /// A wave that changed nothing proposes nothing, so sequences count waves that moved bytes
+    /// rather than boots. Without this the auto-update reconcile — which runs at EVERY boot and
+    /// normally lands nothing — would mint a fresh set on every restart and re-open the
+    /// convergence window forever.
+    /// </summary>
+    [Fact]
+    public async Task AWaveThatLandedNothing_ProposesNothing()
+    {
+        await LandWave(ModuleA, ModuleB);
+        var first = ModuleSetStore.Read(root).Proposed!;
+
+        Assert.Null(await ProposeWave());
+        Assert.Equal(first.Sequence, ModuleSetStore.Read(root).Proposed!.Sequence);
+    }
+
+    /// <summary>
+    /// 🚨 Two replicas can finish a wave at the same moment and each write sequence N+1. Both
+    /// records survive — nothing here is ever renamed over a live file — so every reader must
+    /// resolve the tie the SAME way without coordinating, and the conflict must be reported rather
+    /// than absorbed. Nothing is lost either: the proposal is derived from the activation record,
+    /// so the next wave carries everything both replicas landed.
+    /// </summary>
+    [Fact]
+    public async Task TwoReplicasProposingOneSequence_ResolveToTheSameSetAndSaySo()
+    {
+        await LandWave(ModuleA);
+        var landed = ModuleActivationSidecar.Read(root);
+
+        // The second replica's wave also landed ModuleB, so its set for the SAME sequence differs.
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2");
+        Assert.NotNull(rival);
+        WriteRivalProposalAtSameSequence(rival!.Sequence, landed);
+
+        var reported = new List<string>();
+        var index = ModuleSetStore.Read(root, reported.Add);
+
+        Assert.Equal([rival.Sequence], index.ConflictingSequences);
+        Assert.Contains(reported, m => m.Contains("proposed by more than one replica"));
+        // Deterministic: the ordinally smallest id, so two replicas reading this pick one set.
+        Assert.Equal(
+            ProposalIds(rival.Sequence).OrderBy(id => id, StringComparer.Ordinal).First(),
+            index.Proposed!.Id);
+        Assert.Equal(index.Proposed.Id, ModuleSetStore.Read(root).Proposed!.Id);
+    }
+
+    /// <summary>
+    /// 🚨 The generations the mesh's set PINS are referenced even when the activation entries have
+    /// moved past them — otherwise the convergence would re-open the 2026-08-27 outage from the
+    /// other side, with GC reclaiming the very bytes every replica is executing.
+    /// </summary>
+    [Fact]
+    public async Task GarbageCollection_KeepsTheGenerationsTheMeshSetPins()
+    {
+        await LandWave(ModuleA);
+        var pinned = ModuleSetStore.Read(root).Proposed!.Generations[ModuleA];
+
+        // A wave lands a newer generation and has not proposed: the entry has moved off `pinned`,
+        // so the activation record alone no longer references it — but every replica runs it.
+        await Land(ModuleA);
+        Assert.NotEqual(pinned, ModuleActivationSidecar.Read(root).Entries.Single(e => e.Name == ModuleA).Directory);
+
+        ModuleLandingService.CollectGarbage(root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+
+        Assert.True(Directory.Exists(Path.Combine(root, "modules", pinned)),
+            "the generation the mesh's module set pins was reclaimed — every replica is running it");
+    }
+
+    // ───────────────────────────────────────────────────────────── harness
+
+    /// <summary>Lands one module through the REAL landing service — a fresh generation plus the
+    /// activation entry, exactly as an auto-update or an install does.</summary>
+    private async Task Land(string name) =>
+        await landing.LandModule(name, [(name + ".dll", [0x4D, 0x5A, 0x90])])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+    /// <summary>Closes a landing wave — the coordination step that moves the mesh's set.</summary>
+    private async Task<ModuleSet?> ProposeWave() =>
+        await landing.ProposeModuleSet().Timeout(TestTimeouts.Convergence).Await();
+
+    /// <summary>A COMPLETE wave: land every module, then propose once.</summary>
+    private async Task LandWave(params string[] names)
+    {
+        foreach (var name in names)
+            await Land(name);
+        await ProposeWave();
+    }
+
+    /// <summary>
+    /// One replica's boot, composed EXACTLY as <c>MemexConfiguration.ConfigureMemexMesh</c> does —
+    /// read the record, read the mesh's sets, project, compute the union, record the adoption.
+    /// Re-deriving any of it here would let this test agree with itself while the portal diverges.
+    /// </summary>
+    /// <returns>Module name → the generation directory this replica loaded it from.</returns>
+    private ImmutableSortedDictionary<string, string> BootReplica()
+    {
+        var persisted = ModuleActivationSidecar.Read(root);
+        var sets = ModuleSetStore.Read(root);
+        var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(persisted, sets.Proposed);
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            baselineEntries: null,
+            onMeshSet,
+            ModulePlatformFloor.DeclineReason,
+            entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
+        if (sets.Proposed is { } adopted)
+            ModuleSetStore.RecordAdoption(root, adopted, adoptedBy: "replica");
+        return effective
+            .Where(m => m.Landed is { Directory.Length: > 0 })
+            .ToImmutableSortedDictionary(
+                m => m.Landed!.Name, m => m.Landed!.Directory!, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static readonly JsonSerializerOptions SetJson = new(JsonSerializerDefaults.Web);
+
+    /// <summary>The ids of every proposal file recorded at one sequence — read off the volume, so
+    /// the conflict test asserts on what is actually there rather than what it expected.</summary>
+    private ImmutableList<string> ProposalIds(long sequence)
+    {
+        var prefix = sequence.ToString("D9") + "-";
+        return [.. Directory
+            .EnumerateFiles(ModuleSetStore.SetsDirectory(root), "*.proposed.json")
+            .Where(f => Path.GetFileName(f).StartsWith(prefix, StringComparison.Ordinal))
+            .Select(f => JsonSerializer.Deserialize<ModuleSet>(File.ReadAllText(f), SetJson)!.Id)];
+    }
+
+    /// <summary>
+    /// Writes a SECOND proposal at <paramref name="sequence"/> from a different activation record —
+    /// the two-replicas-one-sequence race, arranged rather than waited for.
+    /// </summary>
+    private void WriteRivalProposalAtSameSequence(long sequence, ModuleActivationList other)
+    {
+        var generations = ModuleSetStore.GenerationsOf(other);
+        var set = new ModuleSet(sequence, ModuleSetStore.IdOf(generations), generations, DateTime.UtcNow, "replica-1");
+        File.WriteAllText(
+            Path.Combine(
+                ModuleSetStore.SetsDirectory(root),
+                $"{sequence:D9}-{set.Id[..Math.Min(16, set.Id.Length)]}.proposed.json"),
+            JsonSerializer.Serialize(set, SetJson));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
@@ -249,6 +249,97 @@ public class ModuleSetConvergenceTest : IDisposable
             "the generation the mesh's module set pins was reclaimed — every replica is running it");
     }
 
+    /// <summary>
+    /// 🚨 The one degradation, and it is REPORTED. If the generation the mesh's set pins is not on
+    /// the volume — a pod on the PREVIOUS platform build sweeping by the entries alone during this
+    /// change's own rollout, a manual deletion, a partial restore — the two candidates are "run the
+    /// generation the entry names" and "run nothing", and running nothing is the WORSE half of
+    /// #3395: a missing module is what turns a healthy NodeType into a failed one. So it falls back
+    /// and says so, rather than handing boot's own existence gate a generation it would then skip.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheSetsGenerationIsGone_ItFallsBackToTheEntryAndSaysSo()
+    {
+        await LandWave(ModuleA);
+        var pinned = ModuleSetStore.Read(root).Proposed!.Generations[ModuleA];
+
+        // A newer generation lands and is not proposed; then the pinned one is reclaimed.
+        await Land(ModuleA);
+        Directory.Delete(Path.Combine(root, "modules", pinned), recursive: true);
+
+        var degraded = new List<(string Module, string Reason)>();
+        var projected = ModuleActivationBoot.ProjectOntoMeshSet(
+            ModuleActivationSidecar.Read(root),
+            ModuleSetStore.Read(root).Proposed,
+            onDeferred: null,
+            landedDllExists: entry => ModuleActivationBoot.LandedModuleDllExists(root, entry),
+            onSetGenerationMissing: (module, reason) => degraded.Add((module, reason)));
+
+        var entry = Assert.Single(projected.Entries);
+        Assert.NotEqual(pinned, entry.Directory);
+        Assert.True(ModuleActivationBoot.LandedModuleDllExists(root, entry));
+        Assert.Equal(ModuleA, Assert.Single(degraded).Module);
+        Assert.Contains("whose bytes are NOT on the volume", degraded[0].Reason);
+    }
+
+    /// <summary>
+    /// 🚨 A LEGACY fixed-folder entry — one with no <c>Directory</c>, resolving to
+    /// <c>modules/&lt;name&gt;/</c> — names no generation, so <c>GenerationsOf</c> excludes it by
+    /// design and the set can say nothing about it. Asking "does the set name it?" would therefore
+    /// DEFER it, i.e. silently disable every such module on every deployment that still has one.
+    /// It must pass through, exactly as a disabled entry does. (Copilot review, #3444.)
+    /// </summary>
+    [Fact]
+    public async Task ALegacyFixedFolderEntry_IsNeverDeferredByTheMeshSet()
+    {
+        await LandWave(ModuleA);
+
+        // The pre-generation shape: an entry with no Directory, bytes in modules/<name>/.
+        Directory.CreateDirectory(Path.Combine(root, "modules", ModuleB));
+        File.WriteAllBytes(Path.Combine(root, "modules", ModuleB, ModuleB + ".dll"), [0x4D, 0x5A]);
+        ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry { Name = ModuleB });
+
+        var deferred = new List<string>();
+        var projected = ModuleActivationBoot.ProjectOntoMeshSet(
+            ModuleActivationSidecar.Read(root),
+            ModuleSetStore.Read(root).Proposed,
+            (module, _) => deferred.Add(module),
+            entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
+
+        Assert.Empty(deferred);
+        var legacy = Assert.Single(projected.Entries, e => e.Name == ModuleB);
+        Assert.Null(legacy.Directory);
+        Assert.Contains(
+            ModuleActivationBoot.ComputeEffectiveModuleEntries(
+                baselineEntries: null, projected, ModulePlatformFloor.DeclineReason,
+                entry => ModuleActivationBoot.LandedModuleDllExists(root, entry)),
+            m => m.Landed?.Name == ModuleB);
+    }
+
+    /// <summary>
+    /// 🚨 A deterministically-RESOLVED set conflict is a handled condition with a valid index
+    /// behind it, not an absence of evidence. Folding the store's notes into
+    /// <c>UndeterminedReason</c> would make the whole activation report — and the health check
+    /// reading it — go unknown for a state every replica resolves identically. The notes belong on
+    /// the mesh-set line. (Copilot review, #3444.)
+    /// </summary>
+    [Fact]
+    public async Task AResolvedSetConflict_IsReportedWithoutMakingTheStateUndetermined()
+    {
+        await LandWave(ModuleA);
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+
+        var report = new PendingModuleActivations(root).Read(
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            loadedModuleGenerations: ImmutableDictionary<string, string>.Empty);
+
+        Assert.False(report.IsUndetermined);
+        Assert.Contains("proposed by more than one replica", report.MeshModuleSet);
+    }
+
     // ───────────────────────────────────────────────────────────── harness
 
     /// <summary>Lands one module through the REAL landing service — a fresh generation plus the
@@ -279,7 +370,11 @@ public class ModuleSetConvergenceTest : IDisposable
     {
         var persisted = ModuleActivationSidecar.Read(root);
         var sets = ModuleSetStore.Read(root);
-        var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(persisted, sets.Proposed);
+        var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(
+            persisted,
+            sets.Proposed,
+            onDeferred: null,
+            landedDllExists: entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
         var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
             baselineEntries: null,
             onMeshSet,


### PR DESCRIPTION
## The mechanism, corrected

#3395 was filed as *"two NodeType compiles in ONE boot resolved different module sets, 15 seconds
apart"*. **That premise is false**, and the correction is what moves the fix.

**It is three processes, sixteen minutes apart.** `memex-cloud`, 2026-09-06: one Deployment, three
replicas, one image (`3.0.0-rc9.ci.7693`), started 11:33:39 / 11:41:04 / 12:51:21 around a landing
wave at 12:18–12:27 — **39 of 40 pinned module generations differed** between the two older pods and
the newest. They share ONE NodeType node, so each stamps the module set *it* resolved and reads the
other's as stale: the pair ping-pongs recompiles, and where a replica's set lacks a module the
sources need, a healthy type FAILS with no source change.

Inside one process nothing moves — `InstalledModulesFingerprint` is a mesh-scoped singleton hashed
once in its constructor, the `InstalledModuleAssembly` registrations are made once at
`MeshBuilder.InstallAssemblies`, and `MeshNodeCompilationService.meshReferences` is a `Lazy<>`
composed once. What moves is **which process answers**.

And there is a second, sharper shape the incident table cannot show: landing moves each module's
activation entry the instant that module's bytes are down, so a replica booting **in the middle** of
a wave pins a **torn** set — some modules of the new wave, the rest of the old — a combination no
wave ever produced and nothing was ever tested against. That is the real form of "a module that
resolved fine fifteen seconds earlier".

## The rule

> **A landing wave does not move what the mesh RUNS. It stages bytes, and when the WHOLE wave is
> done it proposes ONE set. Boot loads the mesh's newest proposal — never its own read of the
> per-module activation record.**

Every replica that boots between two wave completions therefore loads identical bytes, and no boot
can observe a half-landed mix at all. The stamp stays **one per NodeType** — fanning
`CompiledModulesHash` out per environment was rejected: it makes the divergence permanent.

## Answers to the four design questions

**Who is the authority?** `ModuleSetStore` — immutable, monotonically-sequenced records under
`modules/sets/` on the deployment's shared volume, beside the module folders they name.
`<seq>-<id>.proposed.json` is written ONCE by the landing wave that completed; `<seq>-<id>.adopted.json`
create-if-absent by the first process that BOOTS onto it. `Proposed` is what a boot loads; `Current`
is the newest proposal a replica is actually serving. A file rather than a mesh node because BOOT is
the first reader and boot runs before the DI container, any storage provider or a validated
connection string — the same reason the activation record is a file. Immutable and monotone, so
neither #2090's lost update nor #2189's replace-in-place race can recur; two replicas proposing one
sequence CONFLICT visibly and resolve deterministically (ordinally smallest id), losing nothing,
because a proposal is derived from the activation record and never from the previous proposal.

**What does a booting replica do when the mesh is on a different generation?** It loads the mesh's,
not its own (`ModuleActivationBoot.ProjectOntoMeshSet`). An entry the set names loads the SET's
generation even when the entry has moved past it. An entry the set does NOT name is
landed-but-unproposed and is deferred, loudly. A disabled entry passes through — an uninstall
deletes the folder and never waits for a set. A deployment with no set records gets the list back
unchanged: pre-#3395 behaviour, byte for byte, is the migration path.

**Is the mid-wave window bounded and observable?** Yes, and it is now singular:

| | before | after |
|---|---|---|
| replicas booting between two waves | each pins its own snapshot | **identical set** |
| a replica booting mid-wave | a torn mix | the previous complete set |
| distinct sets across a 3-pod rollout | up to 3 (39/40 generations apart, measured) | at most 2, differing by exactly one wave |
| the window's end | unobservable | `ConvergencePending` flips false |

`ModuleSetIndex.ConvergencePending` states it positively — *the mesh has proposed a set no replica
has booted onto yet*. It opens at the proposal and closes at the first restart. A user hitting an old
replica during it hits one running the mesh's *previous* set — one coherent set, never a torn one —
and every pod reports which set it is on (`ModuleSetStore.Describe` on the boot line and on
`PendingModuleActivations.Read().MeshModuleSet`), with the per-pod half unchanged from #3417.

**What breaks a wave that gets stuck half-landed?** It proposes nothing, so (1) the mesh stays on the
set it was on and **nothing half-landed is ever adopted by anybody** — the state that used to drift
is no longer reachable; (2) the modules whose bytes DID land are NAMED —
`ModuleActivationReport.Deferred`, *"N module(s) have landed but are in NO proposed module set … they
are running on no replica and a restart will not change that"* — where the old behaviour ran them on
whichever pods happened to boot after their own landing and reported `Healthy`; (3) it is a THIRD
state, never folded into `Pending`, because "a restart activates this" is a promise no restart can
keep for it. The next completed wave supersedes it.

## Also in the change

- **GC must see the set.** The convergence deliberately pins an OLDER generation than the entry while
  a wave waits to be proposed, and that is what every replica LOADED. `CollectGarbage` now unions
  `ModuleSetStore.ReferencedGenerations` into its reference set — without it the sweep reclaims the
  bytes the mesh is executing (the 2026-08-27 outage, from the other side). The same pass prunes set
  records below the CURRENT set, never below the proposal.
- **Three lanes end a wave and propose**: the auto-update reconcile's module lane (outside its
  per-package `Concat`, so no intermediate combination is ever published), the install funnel's
  `WithModule`, and the registry publish endpoint (a `ShelveModule` landing writes an activation
  entry too, and a HELD module must be IN the set for the boot after a platform update to load it).
  None can fail its lane.

## Falsification — both arms, with numbers

| run | result |
|---|---|
| with the fix | **10 / 10 pass** |
| `ProjectOntoMeshSet` neutralised to return its input | **4 / 7** at the time — the 3 failures are exactly `ReplicasBootingAroundOneWave_LoadTheIdenticalModuleSet`, `AReplicaBootingMidWave_NeverLoadsAHalfLandedMix`, `AWaveThatNeverCompletes_LeavesTheMeshOnTheSetItWasOn` |
| GC reference-set union neutralised | **6 / 7** at the time — the failure is `GarbageCollection_KeepsTheGenerationsTheMeshSetPins` |
| legacy-entry clause removed (Copilot finding 1) | **9 / 10** — `ALegacyFixedFolderEntry_IsNeverDeferredByTheMeshSet` |
| `onCorrupt` fold into `UndeterminedReason` restored (Copilot finding 2) | **9 / 10** — `AResolvedSetConflict_IsReportedWithoutMakingTheStateUndetermined` |

Every test drives the REAL `ModuleLandingService` against a real temp volume and composes the boot
exactly as `MemexConfiguration.ConfigureMemexMesh` does — nothing mocked, no rule re-derived locally.

Full suites, Release: `Memex.Portal.Shared.Test` **796 / 796**, `MeshWeaver.Documentation.Test`
**279 / 279**. `-c Release -warnaserror`, one project per invocation, clean on
`MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, `MeshWeaver.Documentation`, both test projects and
every dependent (`MeshWeaver.PluginTester`, `MeshWeaver.ComboVerifier`, `MeshWeaver.ComboAssembler`).

## Deliberately NOT in this change

- **A replica that restarts itself, or flips readiness so the rollout replaces it.** Both are live
  options on top of this design; (b) empties a pod that is serving correctly, and both change
  deployment behaviour on evidence this change is the first to produce. They become *decidable* now
  that "behind" is a named state with a bounded window.
- **Declining to write NodeType compile records while behind** (#3395's option (c)). It is now SAFE
  to build — the adoption record guarantees the mesh's `Current` set always has a live holder, so the
  rule can never reach zero eligible writers — but it changes who compiles and deserves its own
  change with its own falsification.

Both are recorded with their reasons in `Doc/Architecture/ModuleSetConvergence` → *Rejected
alternatives*.

Design doc: `Doc/Architecture/ModuleSetConvergence` (new). `Doc/Architecture/Modules`' OPEN item is
now DECIDED and points at it. What's New: *Every server now runs the same set of add-ons*
(`Category: Fix`).

Pairs-with: none — the change removes no public type or member (`git diff --cached -U0 | grep '^-' | grep 'public '` is empty); everything added is additive, and the two `ModuleActivationReport` additions are init-only properties rather than constructor parameters precisely so a host compiled against the previous platform keeps working.

Closes #3395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
