### PR TITLE
docs: state precisely why the sole-source inline entries have no ConfigMap home

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -103,8 +103,15 @@ Three things the fleet's own entries show, none of which was written down anywhe
   `false`; `PreWarm__GateReadiness` runs `false` on `memex-cloud` while the ConfigMap says `true`,
   which renders the NodeType bake gate inert there. Removing that one entry is what *arms* the gate
   on `memex-cloud` — the opposite act to `memex`, where the inline entry already agrees.
-- **Some have no other home at all.** `Features__Ai__Clis__ClaudeCode` / `__Copilot` on `memex`, and
-  `Speech__{Endpoint,Enabled,Language}` on `memex-cloud`, correspond to no chart key whatsoever.
+- **Some have no other home today.** `Features__Ai__Clis__ClaudeCode` / `__Copilot` on `memex`, and
+  `Speech__{Endpoint,Enabled,Language}` and `Commerce__BaseUrl` on `memex-cloud`, are supplied by
+  the inline entry alone. Be precise about why: the chart *can* render each of them, but only when
+  the values file declares the key (`{{- if hasKey .Values.config.memex_portal "…" }}`), and no
+  committed file declares any of them — so the ConfigMap carries no such key at all and the inline
+  entry is the only source on the pod. Putting them in the record's `extraPortalConfig` is what
+  would give them a ConfigMap home. `PluginCatalog__RegistryUrl` is the other shape: the chart
+  renders it *unconditionally* from `pluginCatalog.registryUrl | default ""`, so the ConfigMap
+  carries it **empty** and the inline entry stands over a blank.
 
 ### Never a credential's value
 


### PR DESCRIPTION
Follow-up to #3439, doc-only. The page shipped with a **wrong reason** on one bullet.

`Doc/Architecture/DeploymentEnvLayers` said `Features__Ai__Clis__ClaudeCode` / `__Copilot` and
`Speech__{Endpoint,Enabled,Language}` "correspond to no chart key whatsoever". Measured against
`deploy/helm/templates/memex-portal/config.yaml`, that is **false** — the chart renders every one of
them:

```
592:  {{- if hasKey .Values.config.memex_portal "Features__Ai__Clis__ClaudeCode" }}
639:  {{- if hasKey .Values.config.memex_portal "Speech__Endpoint" }}
645:  {{- if hasKey .Values.config.memex_portal "Commerce__BaseUrl" }}
```

What is true, and what actually makes them sole-source on the pod: **no committed values file
declares any of them**, so the `hasKey` guard is never satisfied, the ConfigMap carries no such key,
and the inline `env:` entry is the only source.

**The distinction is the actionable half.** These keys are already reachable from a record's
`extraPortalConfig`, so giving them a ConfigMap home is a *record edit*, not a chart change. A reason
that says "no chart key exists" sends the next reader to the wrong repository.

`PluginCatalog__RegistryUrl` is the *other* shape and was right as written: it is rendered
**unconditionally** from `pluginCatalog.registryUrl | default ""`, so the ConfigMap really does carry
it empty and the inline entry stands over a blank. The bullet now states both shapes and which key
is which.

Verified: `MeshWeaver.Documentation` builds `-c Release -warnaserror` with `0 Warning(s) 0 Error(s)`;
`DocumentationLinkIntegrityTest` passes (1 passed, 0 failed).

The same correction landed on the records in Systemorph/Memex#201.

Pairs-with: none — doc-only; removes no public type or member from `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
