### PR TITLE
docs(Payments): the review finding on #3434, and what landing an abstraction costs across the fleet

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PaymentProviderContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PaymentProviderContract.md
@@ -125,6 +125,39 @@ implementation bridges its HTTP leaf through the mesh's bounded `IIoPool`
 ([Controlled IO Pooling](../ControlledIoPooling)) and never `Observable.FromAsync`, which would run
 the prologue on the subscribing thread and bound nothing.
 
+## Landing an abstraction like this across the fleet
+
+🚨 **The contract has to be IN THE IMAGE before any consumer can bind it, and a dependent repo's
+compile gate proves that against the image rather than against core's source.** MeshWeaver.Plugins'
+`Compile every NodeType (vs core)` takes its whole reference set from the pinned platform image —
+
+```yaml
+- name: Take the framework assemblies from the platform image
+  run: docker cp "$id:/app/." refs/          # MW_IMAGE_DIGEST
+```
+
+— so `MW_PLATFORM_REF` (which core commit is *built and tested*) does not move it. A pinned digest is
+immutable and no CD run changes it. The consequence is a strict order, and skipping a step reads as a
+defect in the content rather than as a missing pin:
+
+1. the contract merges to core `main`;
+2. core's Continuous Delivery seals a platform set that contains it;
+3. the dependent repo moves its pins as **one gate** — `MW_PLATFORM_SET`, `MW_IMAGE_DIGEST`,
+   `MW_PORTAL_IMAGE_DIGEST`, `MW_PLATFORM_REF`, every `uses:` ref and every
+   `platform-image-digest:` / `tester-image-digest:` literal
+   (`check-platform-pins.py --check-tags` is what refuses a half-move);
+4. only then does the content that binds the contract compile there.
+
+Between (1) and (3) the dependent's PR is **structurally red**, which is the mechanism working. Hold
+it as a draft — draft is the opt-out from auto-arm, so it cannot enqueue while a required gate cannot
+pass — and say in the body which of the four steps it is waiting on.
+
+The verdict that *can* be had immediately is the one that matters most, and it needs no image at all:
+compile the dependent's node types against a **core-only** reference set
+(`compile-check.py --refs <core>/src`). That set is precisely "a mesh with no optional modules", so
+it answers the acceptance question — does this content compile where the module is absent? — before
+any pin moves.
+
 ## Adding a second provider
 
 Implement `IPaymentProvider` in a new module assembly, register it as a singleton from the module's

--- a/src/MeshWeaver.Mesh.Contract/Payments/PaymentCheckout.cs
+++ b/src/MeshWeaver.Mesh.Contract/Payments/PaymentCheckout.cs
@@ -16,7 +16,16 @@ namespace MeshWeaver.Payments;
 /// </summary>
 public sealed record PaymentCheckoutRequest
 {
-    /// <summary>The caller's own handle for this purchase (an order path). Travels back verbatim.</summary>
+    /// <summary>
+    /// The caller's own handle for this purchase (an order path), for the PROVIDER's records — it is
+    /// what makes a session traceable to an order in the processor's own dashboard.
+    ///
+    /// <para>🚨 It is NOT how the facts come back. A delivery hands back
+    /// <see cref="PaymentCheckoutEvent.Metadata"/>, and nothing else; a caller that needs its
+    /// reference on fulfilment stamps it there too — which is exactly what
+    /// <see cref="PaymentMetadata.OrderPath"/> is. Deliberate: one map, read one way, rather than
+    /// two channels that can disagree about which purchase a payment was for.</para>
+    /// </summary>
     public required string Reference { get; init; }
 
     /// <summary>What the buyer sees on the provider's page.</summary>


### PR DESCRIPTION
Two documentation follow-ups to #3434, which was already **in the merge queue** when the first of
them was found — pushing to a queued branch ejects it, so they were held rather than disturbing a
shared queue for a doc comment.

## 1. `Reference` is for the provider's records, not a return channel

The Copilot review on #3434 was right: `PaymentCheckoutRequest.Reference` said it *"travels back
verbatim"*, but the contract's parsed delivery shape exposes no `Reference` — a caller reading the
doc would expect to get it back and cannot.

The doc was the wrong half, not the contract. A delivery hands back
`PaymentCheckoutEvent.Metadata` and nothing else, deliberately: **one map, read one way, rather than
two channels that can disagree about which purchase a payment was for.** A caller that needs its
reference at fulfilment stamps it into the metadata too — which is exactly what
`PaymentMetadata.OrderPath` is. The summary now says that, and points at the return channel that
actually exists.

## 2. What landing an abstraction like this costs across the fleet

Non-obvious from either repo alone, and it cost a full diagnosis to establish: **a dependent repo's
compile gate takes its whole reference set from the PINNED PLATFORM IMAGE, not from
`MW_PLATFORM_REF`.**

```yaml
- name: Take the framework assemblies from the platform image
  run: docker cp "$id:/app/." refs/          # MW_IMAGE_DIGEST
```

So a contract merged to core `main` is **not yet bindable anywhere**, and the dependent's PR is
structurally red until a sealed set carries it and the pins move as one gate. Skipping a step in
that order reads as a defect in the *content* — which is exactly the misreading
`Doc/Architecture/PaymentProviderContract` exists to prevent, since it is the same misreading the
whole page is about, one level up.

The section also names the verdict that **can** be had immediately and needs no image at all:
compiling the dependent's node types against a **core-only** reference set
(`compile-check.py --refs <core>/src`). That set *is* a mesh with no optional modules, so it answers
the acceptance question — does this content compile where the module is absent? — before any pin
moves. It is what measured MeshWeaver.Plugins#1413 (69 → 73 clean, 19 → 15 breaks, all 17 `Store/*`
NodeTypes OK).

## Verification

- `dotnet build src/MeshWeaver.Mesh.Contract -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → 0/0, then
  `DocumentationLinkIntegrityTest` → **Passed! Failed: 0, Passed: 1**

Doc comments and one doc page only — no behaviour, no public surface.

`Pairs-with: none — documentation only; the diff removes no public type and no public member.`

Refs #3434, Systemorph/MeshWeaver.Plugins#1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
