### PR TITLE
fix(#3338): an inbox that never checked our signature ends the publish

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2191,12 +2191,11 @@ jobs:
               echo "### 📣 Release event for $SHA ($DIGEST) accepted by the inbox (HTTP $code)" >> "$GITHUB_STEP_SUMMARY"
               echo "The mesh STORED the delivery. Whether the wave actually ran is verified on the satellites (a repository_dispatch run + the MW_IMAGE_DIGEST bump PR), never here — see #2235." >> "$GITHUB_STEP_SUMMARY"
               # 🚨 #3312: a 2xx says bytes landed; only the BODY says whether this instance
-              # actually checked the HMAC we just computed. Recorded here, judged in the next step.
-              if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
-                echo "- signature: **verified** — the instance checked this POST's HMAC." >> "$GITHUB_STEP_SUMMARY"
-              else
-                echo "- signature: **NOT checked** — the instance declares no SecretConfigKey for this target (#3312)." >> "$GITHUB_STEP_SUMMARY"
-              fi
+              # actually checked the HMAC we just computed. RECORDED here verbatim and JUDGED in
+              # the next step — ONE judge, so the summary can never disagree with the verdict, and
+              # an answer carrying no verdict cannot be paraphrased into one (#3338).
+              verdict=$(tr -d '\n' < /tmp/resp | sed -n 's/.*"signature"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+              echo "- signature: **${verdict:-(the answer carried no verdict)}** — judged in the next step." >> "$GITHUB_STEP_SUMMARY"
               ;;
             000)
               echo "::error::could not reach the platform-update inbox at all (DNS/TLS/connection refused). No release event was delivered, so no satellite will re-bake against $SHA until its next schedule poll."
@@ -2224,25 +2223,61 @@ jobs:
       # (PlatformReleaseNotifyGuard forbids `::warning` in it outright), because a release event
       # that never arrived must never be decorated into a pass. THIS is the opposite case: the
       # event DID arrive and was stored — the open question is whether the instance verified the
-      # signature while doing so, which is a provisioning gap on the receiving end, not a failed
-      # delivery. Mixing the two into one step would either soften that guard or overstate this.
+      # signature while doing so, which is a gap on the RECEIVING end (a missing declaration, or a
+      # portal that has not rolled), never a failed delivery. Mixing the two into one step would
+      # either soften that guard or overstate this.
       #
-      # A warning and not a failure only while the declaration rolls out: it reaches an instance
-      # through its Hosting/Deployment record + `helm upgrade`, never through self-update (a `set
-      # image`), so failing here would red every publish until that lands. Escalate to an error
-      # once the control instance answers "verified" — that is the last step of #3312.
+      # 🚨 THREE ANSWERS, NOT TWO (#3338). The first form of this step tested for the single string
+      # "verified" and reported everything else as "it declares no SecretConfigKey" — so the
+      # ABSENCE of a verdict read as a verdict, and named the wrong fix. Measured 2026-09-06 on CD
+      # run 34039122957: this step's own POST answered `200` with an EMPTY BODY (14:44:39Z), as did
+      # the satellite lane's (15:16:47Z), because the control instance still runs the pre-#3312
+      # endpoint (`Results.Ok()`), and the step told the reader to provision a chart key on a pod
+      # that could not have read one. The three states are distinct and only ONE is a
+      # misconfiguration:
+      #
+      #   verified      the instance checked THIS POST's HMAC                  → pass, silently
+      #   not-required  the instance RAN the verdict code and says it declares → ::error:: + exit 1
+      #                 no SecretConfigKey for this target, so the signature
+      #                 we did send was never looked at
+      #   (no verdict)  the instance cannot answer — it predates #3312         → ::warning::
+      #
+      # Why `not-required` is the fatal one and an absent verdict is not: this lane ALWAYS signs
+      # (`preflight` asserts PLATFORM_WEBHOOK_SECRET, and the POST step always sends
+      # X-Hub-Signature-256), so "we never looked at it" is a broken PAIR whose fix is one key on
+      # the receiving record. An absent verdict is a receiver that has not rolled the code yet —
+      # nothing in this repository can fix that, and failing on it would red every promoted build
+      # until a roll this repo does not control happens, which is the outage #3338 was split out of
+      # #3312 to avoid. So the escalation ARMS ITSELF: the moment the receiver answers a verdict at
+      # all, the `not-required` branch becomes reachable and fatal, with nothing for anyone to
+      # remember to switch on.
       - name: "Did the inbox VERIFY the build fact?"
         run: |
           set -euo pipefail
-          if [ ! -f /tmp/resp ]; then
+          # Overridable ONLY so a guard can execute this exact script against synthetic answers
+          # (InboxSignatureVerdictGuard); CI never sets it, and the default is the POST step's file.
+          RESP="${RESP:-/tmp/resp}"
+          if [ ! -f "$RESP" ]; then
             echo "::error::no inbox response was captured — the POST step did not run to completion."
             exit 1
           fi
-          if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
-            echo "the control instance verified this POST's HMAC — a drifted PLATFORM_WEBHOOK_SECRET would now fail loudly (401)."
-          else
-            echo "::warning::the inbox ACCEPTED this release event WITHOUT checking its signature: it declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so secrets.PLATFORM_WEBHOOK_SECRET was never exercised and a drifted secret would still be invisible (#3312). Provision it on the receiving instance's Hosting/Deployment record."
-          fi
+          verdict=$(tr -d '\n' < "$RESP" | sed -n 's/.*"signature"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+          case "$verdict" in
+            verified)
+              echo "signature VERIFIED — the control instance checked this POST's HMAC, so a drifted PLATFORM_WEBHOOK_SECRET would now fail loudly (401)."
+              ;;
+            not-required)
+              echo "::error::the inbox ACCEPTED this release event WITHOUT checking its signature. It answered \"not-required\", i.e. it declares no WebhookInbox__Targets__N__SecretConfigKey for Hosting/PlatformBuilds, so secrets.PLATFORM_WEBHOOK_SECRET was never exercised and a drifted secret would still be invisible (#3312). Fix it on the RECEIVING instance's Hosting/Deployment record — extraPortalConfig[\"WebhookInbox__Targets__1__SecretConfigKey\"] = \"Hosting:PlatformWebhookSecret\", slot __1 because its __0 is Store/Payments — then deploy. Nothing in this repository can fix it and nothing here may go green on it (#3338)."
+              exit 1
+              ;;
+            "")
+              echo "::warning::the inbox answered NO signature verdict at all (a bare 200 with no \"signature\" field), so it cannot say whether it checked our HMAC: the receiving instance still runs a pre-#3312 endpoint. That is a ROLLOUT gap on the receiver, NOT a missing chart key — provisioning one would change nothing until it rolls. Deploy the control instance; from its first publish afterwards this step judges for real, and a target that then answers \"not-required\" fails the job (#3338)."
+              ;;
+            *)
+              echo "::error::the inbox answered an unrecognised signature verdict \"$verdict\". This step judges the receiver's own word, so a word it does not know is not a pass: either the answer's contract changed (memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs) or something is rewriting the body in transit."
+              exit 1
+              ;;
+          esac
 
   # ─────────────────────────── DID IT ACTUALLY SHIP? ──────────────────────────
   # Belt and braces: `promote` PREVENTS a partial set, this CONFIRMS one landed. Assert the

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1267,11 +1267,8 @@ jobs:
                 echo "### 📣 Publication registered with memex (HTTP $code)"
                 echo "- source: \`$SOURCE\`  identity: \`${IDENTITY:-?}\`  image: \`$IMAGE\`  platform: \`$PLATFORM_IMAGE\`"
                 echo "memex STORED the record. Whether it dispatched meshweaver-upstream-published is read on memex and on the dependents, never here."
-                if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
-                  echo "- signature: **verified** — the instance checked this POST's HMAC."
-                else
-                  echo "- signature: **NOT checked** — the instance declares no SecretConfigKey for this target, so a drifted webhook-secret would still be invisible (MeshWeaver#3312)."
-                fi
+                verdict=$(tr -d '\n' < /tmp/resp | sed -n 's/.*"signature"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+                echo "- signature: **${verdict:-(the answer carried no verdict)}** — judged in the next step."
               } >> "$GITHUB_STEP_SUMMARY"
               ;;
             000) echo "::error::could not reach the inbox at all (DNS/TLS/connection refused) — the publication is sealed but unregistered; no dependent is told until its schedule poll."; exit 1 ;;
@@ -1286,23 +1283,55 @@ jobs:
       # anywhere in `register-publication`, because the lane's whole contract is that a record memex
       # never received goes RED and is never decorated into a pass. This step reports a DIFFERENT
       # thing — the record arrived, but did the instance check the signature while storing it? — and
-      # a guard cannot tell the two apart from a substring, so the plain-echo form is the honest
-      # answer rather than weakening a guard that exists because a delivery failure was once
-      # downgraded to a warning.
+      # a guard cannot tell the two apart from a substring. So this step never WARNS: the state it
+      # can act on is an `::error::` that ends the job (which the guard positively wants — it
+      # already asserts `exit 1` here), and the state it cannot act on is a plain echo. Neither
+      # weakens a guard that exists because a delivery failure was once downgraded to a warning.
       #
-      # The verdict is still recorded, twice: on the step summary above and in this log. When the
-      # receiving instance declares its SecretConfigKey and this becomes an `::error::` + `exit 1`
-      # (MeshWeaver#3338), the guard positively WANTS that shape — it already asserts the job
-      # carries `exit 1`. So the end state is guard-compatible; only this interim is quiet.
+      # 🚨 THREE ANSWERS, NOT TWO (MeshWeaver#3338), and the ESCALATION is now armed on the middle
+      # one. The first form tested for the single string "verified" and reported everything else as
+      # "declares no SecretConfigKey" — so the ABSENCE of a verdict read as a verdict and named the
+      # wrong fix. Measured 2026-09-06 (core CD run 34039122957, this job at 15:16:47Z): the
+      # receiving instance answered `200` with an EMPTY BODY, because it still runs the pre-#3312
+      # endpoint. The three states are distinct and only ONE is a misconfiguration:
+      #
+      #   verified      the instance checked THIS POST's HMAC                  → pass, silently
+      #   not-required  the instance RAN the verdict code and says it declares → ::error:: + exit 1
+      #                 no SecretConfigKey for this target, so the signature
+      #                 this lane did send was never looked at
+      #   (no verdict)  the instance cannot answer — it predates #3312         → plain echo
+      #
+      # `not-required` is fatal because this lane ALWAYS signs (the POST step fails RED without
+      # `webhook-secret`, and always sends X-Hub-Signature-256), so a receiver telling us it never
+      # looked is a broken PAIR with a one-key fix on the receiving record. An absent verdict is a
+      # receiver that has not rolled yet — nothing this lane or its callers can fix, and failing on
+      # it would red every satellite publish for a roll none of them controls. The escalation
+      # therefore ARMS ITSELF: the moment the receiver answers a verdict at all, the fatal branch
+      # becomes reachable, with nothing for anyone to remember to switch on.
       - name: "Did the inbox VERIFY the publication record?"
         run: |
           set -euo pipefail
-          if [ ! -f /tmp/resp ]; then
+          # Overridable ONLY so a guard can execute this exact script against synthetic answers
+          # (MeshWeaver's InboxSignatureVerdictGuard); CI never sets it.
+          RESP="${RESP:-/tmp/resp}"
+          if [ ! -f "$RESP" ]; then
             echo "::error::no inbox response was captured — the POST step did not run to completion."
             exit 1
           fi
-          if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
-            echo "signature VERIFIED — the instance checked this POST's HMAC, so a drifted webhook-secret would now fail loudly (401)."
-          else
-            echo "signature NOT CHECKED — the inbox accepted this publication record without verifying it: the receiving instance declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so webhook-secret was never exercised and a drifted secret would still be invisible (MeshWeaver#3312). Provision it on that instance's Hosting/Deployment record."
-          fi
+          verdict=$(tr -d '\n' < "$RESP" | sed -n 's/.*"signature"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+          case "$verdict" in
+            verified)
+              echo "signature VERIFIED — the instance checked this POST's HMAC, so a drifted webhook-secret would now fail loudly (401)."
+              ;;
+            not-required)
+              echo "::error::the inbox ACCEPTED this publication record WITHOUT checking its signature. It answered \"not-required\", i.e. the receiving instance declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so this repo's webhook-secret was never exercised and a drifted secret would still be invisible (MeshWeaver#3312). Fix it on that instance's Hosting/Deployment record: extraPortalConfig[\"WebhookInbox__Targets__N__SecretConfigKey\"] on whichever slot carries this target, then deploy. The publication is sealed and registered; what is NOT established is that the record came from us (MeshWeaver#3338)."
+              exit 1
+              ;;
+            "")
+              echo "signature verdict ABSENT — the inbox answered a bare 200 with no \"signature\" field, so it cannot say whether it checked our HMAC: the receiving instance still runs a pre-MeshWeaver#3312 endpoint. That is a ROLLOUT gap on the receiver, not a missing chart key; provisioning one changes nothing until it rolls. From its first publish after that roll this step judges for real, and a \"not-required\" answer then fails the job."
+              ;;
+            *)
+              echo "::error::the inbox answered an unrecognised signature verdict \"$verdict\". This step judges the receiver's own word, so a word it does not know is not a pass: either the answer's contract changed or something is rewriting the body in transit."
+              exit 1
+              ;;
+          esac

--- a/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
@@ -135,15 +135,77 @@ body, so no integration-specific code lands in the portal.
 `"verified"` and `"not-required"` are both 200, and they mean very different things to a sender that
 signed. The second says this instance declares no `SecretConfigKey` for the target, so the signature
 was never looked at. Without that distinction, "we verify now" would degrade silently back to "we
-used to verify" the day a chart value goes missing — the same shape as the bug, one level up. Both
-lanes therefore read the **body**, print the verdict into the step summary, and `::warning::` on
-`not-required`.
+used to verify" the day a chart value goes missing — the same shape as the bug, one level up.
 
-That is a warning and not a failure **only while the declaration rolls out**: the instance half
-arrives by `helm upgrade` from the private `Systemorph/Memex` env folders, never through
-self-update (which is a `set image`), so failing on it would red every publish until that lands.
-Escalating it to an error once the control instance answers `verified` is the remaining step, and
-it is a one-line change in both lanes.
+### How a publishing lane judges that answer
+
+Both lanes — `main-cd.yml`'s *Did the inbox VERIFY the build fact?* and
+`node-repo-publish-bake.yml`'s *Did the inbox VERIFY the publication record?* — read the **body**,
+not the status, in a step of their own. There are **three** answers, and only one is a
+misconfiguration:
+
+| the answer carries | what it means | the lane |
+|---|---|---|
+| `"signature":"verified"` | this instance checked the HMAC we just sent | passes, silently |
+| `"signature":"not-required"` | it ran the verdict code and declares no `SecretConfigKey` for this target — our signature was never looked at | **`::error::` + `exit 1`** |
+| no `signature` field at all | it cannot answer: the instance predates the verdict body and returns a bare `200` | warns (core lane) / echoes (satellite lane) |
+
+🚨 **The third row is the one that is easy to get wrong, and getting it wrong is worse than having
+no check.** The first form of these steps tested for the single string `verified` and reported
+*everything else* as `not-required`, so the **absence** of a verdict was printed as a verdict — and
+named the wrong fix. Measured on 2026-09-06 (core CD run `34039122957`, the notify job at 14:44:39Z
+and the satellite bake leg at 15:16:47Z): the control instance answered `200` with an **empty body**
+on both lanes, because it still runs the pre-verdict endpoint, and both lanes told the reader to
+provision a chart key on a pod that could not have read one.
+
+### What makes `not-required` a misconfiguration and an absent verdict not
+
+**The expectation is the act of signing** — there is no flag, no input and no opt-out, because a
+"verification expected" knob is a skip-trapdoor by another name. Both lanes ALWAYS sign:
+`main-cd.yml`'s `preflight` asserts `PLATFORM_WEBHOOK_SECRET`, the satellite lane's POST step fails
+RED without `webhook-secret`, and both always send `X-Hub-Signature-256`. So inside these lanes a
+`not-required` answer is a **broken pair**: the sender's secret is doing nothing, and a drifted one
+would be as invisible as it was before the verdict existed. The fix is one key on the receiving
+instance's record, and the error message names it.
+
+The legitimate `not-required` case is a target with an **unsigned sender** — Stripe on
+`Store/Payments`, which signs `Stripe-Signature`; GitHub on its own target — and neither of these
+steps ever runs against one. A target cannot be moved into that category silently: doing so means
+removing the lane's secret, at which point the POST step fails first, naming what to provision.
+
+An absent verdict is not a receiver declining to verify; it is a receiver that **cannot answer**
+because it has not rolled the endpoint yet. That half arrives by `helm upgrade` from the private
+`Systemorph/Memex` env folders, never through self-update (which is a `set image`), so failing on it
+would red every promoted build until a roll no repository here controls happens.
+
+**The escalation therefore arms itself.** The moment a receiver answers a verdict at all, the
+`not-required` branch becomes reachable and fatal — nothing has to be remembered, switched on, or
+re-decided. An unrecognised verdict word is fatal too: this step judges the receiver's own word, so
+a word it does not know is not a pass.
+
+`InboxSignatureVerdictGuard` lifts each step's script verbatim out of its workflow and RUNS it
+against synthetic answers, because a substring assertion cannot tell "classifies three states" from
+"classifies two and guesses" — which is precisely the defect that shipped. That is also why both
+steps read their response file through `RESP="${RESP:-/tmp/resp}"`.
+
+### The declaration has no typed home, and it has already been lost once
+
+`SecretConfigKey` is not a field on the `Hosting/Deployment` record — it rides in the free-form
+`extraPortalConfig` bag, which every writer of that record replaces **wholesale**. Measured on the
+control instance's own record:
+
+| version | when | by | `WebhookInbox__Targets__1__SecretConfigKey` |
+|---|---|---|---|
+| 25 | 2026-09-05 07:42Z | a person | `Hosting:PlatformWebhookSecret` |
+| 26 | 2026-09-05 09:24Z | `system-security` | **gone** — every other key in the bag survived |
+| 32 | 2026-09-06 17:03Z | `system-security` | still gone |
+
+So the declaration was provisioned by hand and removed by the next automated write, 1 h 42 min
+later, with nothing red anywhere — the shape this whole page exists to end, arriving one level
+further up than the last time. Until it is set again the receiver has nothing to verify with, and
+the escalation above is what will say so: it fires the first time that portal answers a verdict at
+all. When re-provisioning it, set it on slot **`__1`** (its `__0` is `Store/Payments`), and expect
+the next unrelated record rewrite to drop it again until the key has a typed home.
 
 ### The two shapes that were rejected, so they are not re-derived
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
@@ -188,24 +188,29 @@ against synthetic answers, because a substring assertion cannot tell "classifies
 "classifies two and guesses" — which is precisely the defect that shipped. That is also why both
 steps read their response file through `RESP="${RESP:-/tmp/resp}"`.
 
-### The declaration has no typed home, and it has already been lost once
+### Register is not persist: the declaration has already been lost once
 
-`SecretConfigKey` is not a field on the `Hosting/Deployment` record — it rides in the free-form
-`extraPortalConfig` bag, which every writer of that record replaces **wholesale**. Measured on the
-control instance's own record:
+`SecretConfigKey` is not a field on `DeploymentContent` — it can only ride in the free-form
+`extraPortalConfig` bag. And a `Hosting/Deployment` record is **git-synced**: the control instance's
+lives in the private `Systemorph/Memex` repo as `mesh/Deployments/memex-cloud.json`, so an edit made
+on the *live node* that is not committed there is reverted by the next sync. Measured on that
+record's own version history:
 
-| version | when | by | `WebhookInbox__Targets__1__SecretConfigKey` |
+| version | when (UTC) | by | `WebhookInbox__Targets__1__SecretConfigKey` |
 |---|---|---|---|
-| 25 | 2026-09-05 07:42Z | a person | `Hosting:PlatformWebhookSecret` |
-| 26 | 2026-09-05 09:24Z | `system-security` | **gone** — every other key in the bag survived |
-| 32 | 2026-09-06 17:03Z | `system-security` | still gone |
+| 25 | 2026-09-05 07:42 | a person, on the live node | `Hosting:PlatformWebhookSecret` |
+| 26 | 2026-09-05 09:24 | `system-security` | **gone** — every other key in the bag survived |
+| 32 | 2026-09-06 17:03 | `system-security` | still gone |
 
-So the declaration was provisioned by hand and removed by the next automated write, 1 h 42 min
-later, with nothing red anywhere — the shape this whole page exists to end, arriving one level
-further up than the last time. Until it is set again the receiver has nothing to verify with, and
-the escalation above is what will say so: it fires the first time that portal answers a verdict at
-all. When re-provisioning it, set it on slot **`__1`** (its `__0` is `Store/Payments`), and expect
-the next unrelated record rewrite to drop it again until the key has a typed home.
+The key appears **nowhere in `Systemorph/Memex`** — not in a record, not in an overlay — so it was
+never persisted at all. It was set by hand 2026-09-05, round-tripped away 1 h 42 min later, and
+nothing anywhere went red: the shape this page exists to end, arriving one level further up than
+last time.
+
+Until it is committed the receiver has nothing to verify with, and the escalation above is what will
+say so — it fires the first time that portal answers a verdict at all. So: set it in the **repo**
+(never only on the node), on slot **`__1`**, because this instance's `__0` is `Store/Payments` and
+demanding `X-Hub-Signature-256` from Stripe would 401 every payment delivery.
 
 ### The two shapes that were rejected, so they are not re-derived
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-an-unchecked-release-event-now-fails-the-publish.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-an-unchecked-release-event-now-fails-the-publish.md
@@ -1,0 +1,60 @@
+---
+Name: An unchecked release event now fails the publish
+Category: Fix
+Description: A publishing lane that signs its delivery and is told the receiver never looked at the signature now fails, instead of printing a warning nobody reads. And the answer that carries no verdict at all — a receiver that has not rolled yet — is no longer reported as a missing configuration key, which sent operators to fix something that was not broken.
+Icon: ShieldKeyhole
+Order: -20260906
+---
+
+# An unchecked release event now fails the publish
+
+When a build is promoted, the pipeline signs a small record — *this platform build exists, here are
+its images* — and posts it to the receiving portal's webhook inbox. The portal answers whether it
+actually **checked** that signature, because a `200` on its own only says the bytes arrived.
+
+Two things were wrong with how the pipeline read that answer.
+
+## It could not tell "did not check" from "cannot say"
+
+The step tested for the single word `verified` and reported **everything else** as *"the instance
+declares no `SecretConfigKey` for this target"*. That is one specific diagnosis with one specific
+fix — and it was printed even when the portal had said nothing of the kind.
+
+Measured on 2026-09-06, on two independent lanes of the same delivery run: the receiving portal
+answered `200` with an **empty body**, because it is still running a build from before the verdict
+existed. Both lanes told the reader to provision a configuration key on a portal that could not have
+read one. The absence of an answer was being printed as an answer.
+
+There are three states, and they now read as three:
+
+- **`verified`** — the portal checked the signature. The step passes, quietly.
+- **`not-required`** — the portal ran the check and declares no secret for this target, so the
+  signature it was sent was never looked at. **The step now fails**, and names the one key that
+  fixes it.
+- **no verdict at all** — the portal cannot answer, because it predates the verdict. The step says
+  so, and says that this is a rollout gap rather than a missing key.
+
+## The failure is scoped so it cannot cry wolf
+
+Accepting a delivery without checking its signature is perfectly legitimate — that is how
+integrations whose signing scheme the portal does not speak have always worked, and nothing about
+them changes.
+
+What makes it a fault here is that **the sender signed**. Both publishing lanes require a shared
+secret and always send a signature, so being told "we never looked" means the secret is doing
+nothing and a drifted one would be as invisible as it was before any of this existed. There is no
+switch and no "expect verification" setting to get wrong: the expectation is the act of signing, and
+a lane cannot stop expecting without dropping its secret — at which point it fails earlier, saying
+so.
+
+The same scoping is why an absent verdict does not fail. It is not a portal declining to check; it
+is a portal that has not been deployed yet, which no amount of configuration would fix and which
+would otherwise turn every promoted build red until an unrelated deployment happened. The escalation
+arms itself instead: the first time a receiver answers a verdict at all, the failing branch becomes
+live, with nothing for anyone to remember.
+
+## What you may notice
+
+If you operate an instance that receives signed platform records, its publishing lanes will now go
+red — with the key to set, on the record to set it on — rather than printing a warning that scrolls
+past. Nothing changes for webhook targets you never signed for.

--- a/test/MeshWeaver.Documentation.Test/InboxSignatureVerdictGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/InboxSignatureVerdictGuard.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// The escalation of #3338, held to the one thing that makes an escalation worth having: it must
+/// FIRE on the misconfiguration and STAY SILENT on the legitimate case. Both publishing lanes read
+/// the webhook inbox's answer and decide whether the release event / publication record was stored
+/// HAVING BEEN VERIFIED — <c>main-cd.yml</c> ("Did the inbox VERIFY the build fact?") and the
+/// reusable <c>node-repo-publish-bake.yml</c> ("Did the inbox VERIFY the publication record?").
+///
+/// <para>🚨 <b>Why this guard EXECUTES the step instead of reading it.</b> Every earlier control on
+/// this leg was a substring assertion, and the defect it missed was invisible to one: the step
+/// tested <c>grep -q '"signature"…"verified"'</c> and reported EVERYTHING ELSE as
+/// "the instance declares no SecretConfigKey", so the ABSENCE of a verdict was reported as a
+/// verdict. Measured on 2026-09-06 (core CD run 34039122957): the control instance answered
+/// <c>200</c> with an EMPTY body on both lanes — it still runs the pre-#3312 endpoint
+/// (<c>Results.Ok()</c>) — and both lanes named a chart key the pod could not have read. A
+/// substring test cannot tell "classifies three states" from "classifies two and guesses"; running
+/// the script can. So the script itself is lifted out of the YAML verbatim and run under
+/// <c>bash</c> against synthetic answers, which is why both steps read their response file through
+/// <c>RESP="${RESP:-/tmp/resp}"</c>.</para>
+///
+/// <para>🚨 <b>The discrimination, stated once.</b> A sender that signs expects to be verified;
+/// a sender that does not sign has no expectation. BOTH lanes always sign — <c>main-cd</c>'s
+/// <c>preflight</c> asserts <c>PLATFORM_WEBHOOK_SECRET</c> and the satellite lane's POST step fails
+/// RED without <c>webhook-secret</c>, and both always send <c>X-Hub-Signature-256</c> — so within
+/// these lanes <c>not-required</c> is never legitimate: it is the receiver saying, in as many
+/// words, that the signature we did send was never looked at. The legitimate <c>not-required</c>
+/// case is a target with an UNSIGNED sender (Stripe on <c>Store/Payments</c>, GitHub on its own
+/// target), which neither of these steps ever runs against. There is no flag, no opt-out and no
+/// "verification expected" input: the expectation IS the act of signing, so a target cannot be
+/// moved into the unsigned category without removing the lane's secret — at which point the POST
+/// step fails first, naming what to provision.</para>
+///
+/// <para>🚨 <b>Why the absent verdict is NOT fatal.</b> It is not the receiver declining to verify;
+/// it is a receiver that cannot answer the question because it has not rolled #3312's endpoint.
+/// Nothing in this repository can fix that, and failing on it would red every promoted build until
+/// a roll this repo does not control happens — the outage #3338 was split out of #3312 to avoid.
+/// The escalation therefore arms ITSELF: the moment a receiver answers a verdict at all, the
+/// <c>not-required</c> branch becomes reachable and fatal, with nothing for anyone to remember.
+/// </para>
+/// </summary>
+public class InboxSignatureVerdictGuard
+{
+    private const string CoreLane = ".github/workflows/main-cd.yml";
+    private const string CoreStep = "Did the inbox VERIFY the build fact?";
+    private const string SatelliteLane = ".github/workflows/node-repo-publish-bake.yml";
+    private const string SatelliteStep = "Did the inbox VERIFY the publication record?";
+
+    /// <summary>The exact answer a #3312 receiver gives when it checked our HMAC.</summary>
+    private const string Verified = """{"status":"accepted","signature":"verified"}""";
+
+    /// <summary>The exact answer a #3312 receiver gives when the target declares no key.</summary>
+    private const string NotRequired = """{"status":"accepted","signature":"not-required"}""";
+
+    /// <summary>What the control instance actually answered on 2026-09-06 — a bare 200, no body.
+    /// The state the old two-way test reported as a declaration.</summary>
+    private const string NoBody = "";
+
+    /// <summary>A well-formed answer that simply carries no verdict — the same state as
+    /// <see cref="NoBody"/>, reached a different way.</summary>
+    private const string NoVerdictField = """{"status":"accepted"}""";
+
+    /// <summary>A verdict word neither end knows. Fail-closed: an unknown word is not a pass.</summary>
+    private const string UnknownVerdict = """{"status":"accepted","signature":"maybe"}""";
+
+    // ── the escalation FIRES ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE CASE THE ESCALATION IS FOR. The receiver ran the verdict code and told us it never
+    /// looked at the signature we sent. Both lanes must END, and the message must name the ONE key
+    /// that fixes it — a red whose message does not say what to provision teaches people to ignore
+    /// the red.
+    /// </summary>
+    [Theory]
+    [InlineData(CoreLane, CoreStep)]
+    [InlineData(SatelliteLane, SatelliteStep)]
+    public void AnAcceptedButUNVERIFIEDDelivery_FailsTheLane(string lane, string step)
+    {
+        var (exit, output) = RunVerdictStep(lane, step, NotRequired);
+
+        Assert.True(exit == 1,
+            $"{lane}: an inbox answering \"not-required\" to a SIGNED delivery must fail the job "
+            + $"(#3338) — it says our secret was never exercised, so a drifted one is invisible. "
+            + $"Exit was {exit}. Output:\n{output}");
+        Assert.Contains("::error", output, StringComparison.Ordinal);
+        Assert.Contains("SecretConfigKey", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A verdict word neither end knows is not a pass. The whole step judges the RECEIVER's own
+    /// word, so the day that word changes shape the lane must say so rather than fall through to
+    /// the quiet branch — which is how "we verify now" would degrade to "we used to" a third time.
+    /// </summary>
+    [Theory]
+    [InlineData(CoreLane, CoreStep)]
+    [InlineData(SatelliteLane, SatelliteStep)]
+    public void AnUnrecognisedVerdict_FailsTheLane(string lane, string step)
+    {
+        var (exit, output) = RunVerdictStep(lane, step, UnknownVerdict);
+
+        Assert.True(exit == 1, $"{lane}: an unknown verdict must not read as a pass. Output:\n{output}");
+        Assert.Contains("::error", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// No response file at all means the POST step did not run to completion — the one state in
+    /// which this step has nothing to judge and must not decorate the job green.
+    /// </summary>
+    [Theory]
+    [InlineData(CoreLane, CoreStep)]
+    [InlineData(SatelliteLane, SatelliteStep)]
+    public void NoCapturedResponse_FailsTheLane(string lane, string step)
+    {
+        var (exit, output) = RunVerdictStep(lane, step, responseBody: null);
+
+        Assert.True(exit == 1, $"{lane}: a missing response file must fail. Output:\n{output}");
+        Assert.Contains("::error", output, StringComparison.Ordinal);
+    }
+
+    // ── the escalation STAYS SILENT ──────────────────────────────────────────
+
+    /// <summary>
+    /// The verified path is the point of the whole leg: it must pass, silently. A step that also
+    /// warned here would train the reader to ignore its warnings.
+    /// </summary>
+    [Theory]
+    [InlineData(CoreLane, CoreStep)]
+    [InlineData(SatelliteLane, SatelliteStep)]
+    public void AVerifiedDelivery_PassesQuietly(string lane, string step)
+    {
+        var (exit, output) = RunVerdictStep(lane, step, Verified);
+
+        Assert.True(exit == 0, $"{lane}: a verified delivery must pass. Output:\n{output}");
+        Assert.DoesNotContain("::error", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("::warning", output, StringComparison.Ordinal);
+        Assert.Contains("VERIFIED", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 THE ARM THAT MATTERS MOST, because getting it wrong is worse than having no escalation:
+    /// a receiver that answers NO verdict has not declined to verify — it cannot answer at all. It
+    /// must NOT fail the lane, and it must NOT be described as a missing declaration. That exact
+    /// conflation is what both lanes printed on every publish until #3338: the reader was sent to
+    /// provision a chart key on a pod running an endpoint that predates the key.
+    /// </summary>
+    [Theory]
+    [InlineData(CoreLane, CoreStep, NoBody)]
+    [InlineData(CoreLane, CoreStep, NoVerdictField)]
+    [InlineData(SatelliteLane, SatelliteStep, NoBody)]
+    [InlineData(SatelliteLane, SatelliteStep, NoVerdictField)]
+    public void AnAnswerCarryingNoVerdict_DoesNotFail_AndIsNotCalledAMissingDeclaration(
+        string lane, string step, string responseBody)
+    {
+        var (exit, output) = RunVerdictStep(lane, step, responseBody);
+
+        Assert.True(exit == 0,
+            $"{lane}: an answer with no signature verdict is a receiver that has not rolled #3312, "
+            + $"not a target that declines to verify. Failing it reds every publish for a roll no "
+            + $"repository here controls — the outage #3338 exists to avoid. Exit was {exit}. "
+            + $"Output:\n{output}");
+        Assert.DoesNotContain("::error", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("SecretConfigKey", output, StringComparison.Ordinal);
+        Assert.Contains("ROLLOUT", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The two lanes POST the same shape to the same endpoint and must never disagree about what
+    /// its answer means — a satellite going red where core goes green (or the reverse) is a state
+    /// nobody could act on. They are two inline scripts rather than one shared file because the
+    /// satellite job runs in the CALLING repository's checkout, where core's <c>.github/scripts</c>
+    /// is not present; this is what stops the copies drifting.
+    /// </summary>
+    [Fact]
+    public void BothLanesClassifyEveryAnswerIdentically()
+    {
+        var answers = new (string Name, string? Body)[]
+        {
+            ("verified", Verified),
+            ("not-required", NotRequired),
+            ("no body", NoBody),
+            ("no verdict field", NoVerdictField),
+            ("unknown verdict", UnknownVerdict),
+            ("no response captured", null),
+        };
+
+        var disagreements = answers
+            .Select(a => (
+                a.Name,
+                Core: RunVerdictStep(CoreLane, CoreStep, a.Body).Exit,
+                Satellite: RunVerdictStep(SatelliteLane, SatelliteStep, a.Body).Exit))
+            .Where(r => r.Core != r.Satellite)
+            .Select(r => $"  {r.Name}: main-cd exits {r.Core}, node-repo-publish-bake exits {r.Satellite}")
+            .ToArray();
+
+        Assert.True(disagreements.Length == 0,
+            "the two publishing lanes read the same inbox answer differently:\n"
+            + string.Join("\n", disagreements));
+    }
+
+    // ── the shape, so the classification cannot regress to a substring test ──
+
+    /// <summary>
+    /// The step must SWITCH on the receiver's word, not test for one string. The regressed form is
+    /// specifically <c>grep …"verified"</c> plus an <c>else</c>: it cannot represent the third
+    /// state, so it necessarily mislabels it. Asserted textually as well as behaviourally because
+    /// a future rewrite could reproduce the three exit codes with two branches and a comment.
+    /// </summary>
+    [Theory]
+    [InlineData(CoreLane, CoreStep)]
+    [InlineData(SatelliteLane, SatelliteStep)]
+    public void TheStepSwitchesOnTheVerdict_RatherThanTestingForOneString(string lane, string step)
+    {
+        var script = VerdictScript(lane, step);
+
+        Assert.Contains("case \"$verdict\" in", script, StringComparison.Ordinal);
+        Assert.Contains("not-required)", script, StringComparison.Ordinal);
+        Assert.Contains("exit 1", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("continue-on-error", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("grep -Eq '\"signature\"", script, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The satellite lane's job forbids <c>::warning</c> anywhere in it
+    /// (<c>UpstreamBuildGateGuard.TheLaneEndsByRegisteringWithMemex_AndDispatchesToNobody</c>,
+    /// because a delivery failure was once downgraded to one). So its quiet branch is a plain echo
+    /// and its loud branch is an <c>::error::</c> — never a warning in between. Pinned here so the
+    /// three-way classification cannot be "harmonised" with core's by adding one.
+    /// </summary>
+    [Fact]
+    public void TheSatelliteLaneNeverWarns()
+    {
+        Assert.DoesNotContain("::warning", VerdictScript(SatelliteLane, SatelliteStep),
+            StringComparison.Ordinal);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The named step's <c>run: |</c> body, lifted verbatim out of the workflow and dedented — the
+    /// bytes CI executes, not a restatement of them.
+    /// </summary>
+    private static string VerdictScript(string workflow, string stepName)
+    {
+        var path = Path.Combine(SourceScan.FindRepoRoot(),
+            workflow.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"{workflow} is gone — the publishing lane it holds has moved.");
+        var lines = File.ReadAllLines(path);
+
+        var stepAt = Array.FindIndex(lines, l => l.Contains($"- name: \"{stepName}\"", StringComparison.Ordinal));
+        Assert.True(stepAt >= 0,
+            $"step '{stepName}' is gone from {workflow} — the signature verdict is no longer judged, "
+            + "which no other check would catch.");
+
+        var runAt = Array.FindIndex(lines, stepAt, l => l.TrimEnd().EndsWith("run: |", StringComparison.Ordinal));
+        Assert.True(runAt > stepAt, $"step '{stepName}' in {workflow} no longer carries a `run: |` script.");
+        var runIndent = Indent(lines[runAt]);
+
+        var body = new List<string>();
+        for (var i = runAt + 1; i < lines.Length; i++)
+        {
+            if (lines[i].Trim().Length == 0)
+            {
+                body.Add("");
+                continue;
+            }
+            if (Indent(lines[i]) <= runIndent)
+                break;
+            body.Add(lines[i]);
+        }
+        Assert.True(body.Count > 0, $"step '{stepName}' in {workflow} has an empty script.");
+
+        var dedent = body.Where(l => l.Length > 0).Min(Indent);
+        return string.Join("\n", body.Select(l => l.Length == 0 ? l : l[dedent..])) + "\n";
+    }
+
+    private static int Indent(string line) => line.Length - line.TrimStart().Length;
+
+    /// <summary>
+    /// Runs the extracted step against one synthetic inbox answer. <paramref name="responseBody"/>
+    /// null means the POST step captured nothing at all.
+    /// </summary>
+    private static (int Exit, string Output) RunVerdictStep(
+        string workflow, string stepName, string? responseBody)
+    {
+        var script = VerdictScript(workflow, stepName);
+        var dir = Path.Combine(Path.GetTempPath(), "mw-3338-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var scriptPath = Path.Combine(dir, "step.sh");
+            File.WriteAllText(scriptPath, script);
+            var responsePath = Path.Combine(dir, "resp");
+            if (responseBody is not null)
+                File.WriteAllText(responsePath, responseBody);
+
+            var psi = new ProcessStartInfo("bash")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = dir,
+            };
+            psi.ArgumentList.Add(scriptPath);
+            psi.Environment["RESP"] = responsePath;
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException(
+                    "bash could not be started. It is the shell CI runs these steps in, so this is a "
+                    + "real missing prerequisite, not a reason to skip the control.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return (process.ExitCode, stdout + stderr);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/PlatformReleaseNotifyGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformReleaseNotifyGuard.cs
@@ -119,6 +119,41 @@ public class PlatformReleaseNotifyGuard
     }
 
     /// <summary>
+    /// 🚨 The signature verdict is judged in its OWN step, and its misconfiguration branch ENDS the
+    /// job (#3338). Two things are pinned here and neither is redundant.
+    ///
+    /// <para>Separation, because the POST step is held to "every message ends the job" — a release
+    /// event that never arrived must never be decorated. Folding the verdict back into it would
+    /// force one of the two to give: either the POST step gains a non-fatal message, or a receiver
+    /// that has not rolled #3312 yet starts failing deliveries that DID arrive.</para>
+    ///
+    /// <para>Fatality, because the escalation is the whole of #3338: an inbox that answers
+    /// <c>not-required</c> to a delivery this lane SIGNED is saying our secret was never exercised,
+    /// so a drifted one would still be invisible — the state #3312 exists to end. That the branch
+    /// actually fires (and that the third state, an answer carrying no verdict at all, does NOT)
+    /// is proven by running the script in <see cref="InboxSignatureVerdictGuard"/>; this asserts
+    /// the shape survives, which a behavioural test alone would not notice if the step were
+    /// deleted outright.</para>
+    /// </summary>
+    [Fact]
+    public void TheSignatureVerdictIsItsOwnStep_AndItsMisconfigurationBranchEndsTheJob()
+    {
+        var notify = JobBlock(Body(), "notify-platform-update:");
+
+        var post = StepBlock(notify, "Sign and POST the build fact");
+        Assert.DoesNotContain("::warning", post, StringComparison.Ordinal);
+        // The POST step RECORDS the receiver's word and never judges it. Two judges can disagree,
+        // and the step summary is the line a reader believes.
+        Assert.DoesNotContain("not-required", post, StringComparison.Ordinal);
+
+        var verify = StepBlock(notify, "Did the inbox VERIFY the build fact?");
+        Assert.Contains("case \"$verdict\" in", verify, StringComparison.Ordinal);
+        Assert.Contains("not-required)", verify, StringComparison.Ordinal);
+        Assert.Contains("::error", verify, StringComparison.Ordinal);
+        Assert.Contains("exit 1", verify, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// 🚨 The half this repository CANNOT see, written down where the next reader will look. The
     /// inbox is deliberately dumb, so a 2xx means "stored", not "the wave ran": if the control
     /// instance's <c>Hosting:PlatformWebhookSecret</c> is unset or differs from CD's, the watcher

--- a/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
@@ -133,6 +133,30 @@ public class UpstreamBuildGateGuard
         Assert.DoesNotContain("secrets.", condition, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// 🚨 A publication record the instance stored WITHOUT checking its signature now ends the lane
+    /// (MeshWeaver#3338). This lane always signs — the POST step fails RED without
+    /// <c>webhook-secret</c> and always sends <c>X-Hub-Signature-256</c> — so an inbox answering
+    /// <c>not-required</c> is telling every satellite that its secret was never exercised, and a
+    /// drifted one would be invisible exactly as it was before #3312.
+    ///
+    /// <para>The job still carries NO <c>::warning</c>: the state this lane can act on is fatal,
+    /// and the state it cannot (a receiver that predates #3312 and answers no verdict at all) is a
+    /// plain echo. That the fatal branch fires on <c>not-required</c> and stays silent on an absent
+    /// verdict is proven by running the script in <see cref="InboxSignatureVerdictGuard"/>.</para>
+    /// </summary>
+    [Fact]
+    public void AnAcceptedButUnverifiedPublicationRecord_EndsTheLane()
+    {
+        var job = JobBlock(Body(), "register-publication:");
+
+        Assert.Contains("case \"$verdict\" in", job, StringComparison.Ordinal);
+        Assert.Contains("not-required)", job, StringComparison.Ordinal);
+        Assert.Contains("::error", job, StringComparison.Ordinal);
+        Assert.Contains("exit 1", job, StringComparison.Ordinal);
+        Assert.DoesNotContain("::warning", job, StringComparison.Ordinal);
+    }
+
     /// <summary>Everything from a job's key to the next job key at the same indent.</summary>
     private static string JobBlock(string body, string jobKey)
     {

--- a/test/MeshWeaver.Graph.Test/WebhookInboxTest.cs
+++ b/test/MeshWeaver.Graph.Test/WebhookInboxTest.cs
@@ -198,6 +198,9 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             [Sign(BuildFact, InstanceSecret)], BuildFact);
 
         result.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
+        result.SignatureVerified.Should().BeTrue(
+            "the ANSWER, not the status, is what a signing publisher reads — this is the flag the "
+            + "endpoint renders as `\"signature\":\"verified\"` and both CD lanes judge (#3338)");
         (await InboxCount("Signed")).Should().Be(1);
     }
 
@@ -281,6 +284,13 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             [new(WebhookInbox.SignatureHeader, "sha256=deadbeef")], "{}");
 
         result.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
+        result.SignatureVerified.Should().BeFalse(
+            "an undeclared target is accepted having verified NOTHING — it renders as "
+            + "`\"signature\":\"not-required\"`, and a publisher that signed must be able to tell "
+            + "that apart from a delivery that WAS checked. This assertion and the one in "
+            + "SignedTarget_WithTheRightSecret_IsAccepted are the pair: if a change makes them "
+            + "agree, the two states are indistinguishable again and the #3338 escalation is "
+            + "judging a constant");
         (await InboxCount("Dumb")).Should().Be(1);
     }
 


### PR DESCRIPTION
Closes #3338

## Which side, and why

**The sending side — both publishing lanes' existing verify step.** It is the only side outside the
receiver's failure domain: an assertion living on the portal (a `RequireSignature` flag on the
target declaration, say) would sit in the very configuration that #3312 exists to notice going
missing, which is recovery in the failure domain that failed. Not a log-level change, and not a new
gate: the two steps already exist and already read the answer — what changes is what they do with
it.

## What the measurement changed about the plan

The issue proposed one line per lane: `::warning::` → `::error::` + `exit 1`. Taken literally that
would have been wrong, because the step it edits **cannot tell the two cases apart**. It tested for
the single string `verified` and reported *everything else* as
*"it declares no `SecretConfigKey` for this target"* — so an answer carrying **no verdict at all**
was printed as a verdict, naming a fix that could not have applied.

Measured, core CD run [`34039122957`](https://github.com/Systemorph/MeshWeaver/actions/runs/34039122957):

| lane | when | HTTP | body |
|---|---|---|---|
| `notify-platform-update` | 2026-09-06 14:44:39Z | 200 | **empty** |
| `register-publication` (Plugins bake leg) | 2026-09-06 15:16:47Z | 200 | **empty** |

An empty body is `Results.Ok()` — the endpoint as it was before e59cfc657. So the control instance
still runs a pre-#3312 portal and *cannot* answer the question; making that state fatal would have
reddened every promoted build until an unrelated deployment happened, which is exactly the outage
#3338 was split out of #3312 to avoid.

## The change

Both steps now switch on the receiver's own word, with three arms:

| the answer carries | verdict |
|---|---|
| `"signature":"verified"` | pass, silently |
| `"signature":"not-required"` | **`::error::` + `exit 1`** — the escalation #3338 asks for |
| no `signature` field | `::warning::` (core) / plain echo (satellite lane, whose job forbids `::warning`), naming the **rollout** gap and explicitly not a missing key |
| any other word | `::error::` + `exit 1` — this step judges the receiver's word, so a word it does not know is not a pass |

Each POST step now records the verdict verbatim into the step summary and judges nothing, so the
summary and the verdict cannot disagree.

### How it tells a misconfiguration from a legitimate `not-required`

**The expectation is the act of signing.** No flag, no input, no opt-out — a "verification expected"
knob is a skip-trapdoor by another name. Both lanes always sign: `main-cd`'s `preflight` asserts
`PLATFORM_WEBHOOK_SECRET`, the satellite lane's POST step fails RED without `webhook-secret`, and
both always send `X-Hub-Signature-256`. So inside these lanes `not-required` is the receiver saying
the signature we *did* send was never looked at — a broken pair whose fix is one key on the
receiving record, which the error message names.

The legitimate `not-required` case is a target with an **unsigned** sender (Stripe on
`Store/Payments`, GitHub on its own target). Neither step ever runs against one, and the endpoint's
`not-required` branch is untouched. A target cannot change category silently: doing so means
dropping the lane's secret, at which point the POST step fails first, saying what to provision.

An absent verdict is not a receiver declining — it is a receiver that cannot answer. So **the
escalation arms itself**: the first time any receiver answers a verdict at all, the fatal branch
becomes reachable, with nothing for anyone to remember to switch on.

## Falsification — both arms, run rather than read

`InboxSignatureVerdictGuard` lifts each step's `run:` script **verbatim** out of the YAML and
executes it under `bash` against synthetic answers (which is why both steps now read their response
file through `RESP="${RESP:-/tmp/resp}"`). A substring assertion cannot tell "classifies three
states" from "classifies two and guesses" — which is precisely the defect that shipped.

12 evaluations (6 answers × 2 lanes), both lanes identical:

| answer | exit | shape |
|---|---|---|
| `{"signature":"verified"}` | 0 | no error, no warning |
| `{"signature":"not-required"}` | **1** | `::error::`, names the key |
| empty body *(the live answer today)* | 0 | warn/echo, **does not** name a key |
| `{"status":"accepted"}` | 0 | warn/echo, **does not** name a key |
| `{"signature":"maybe"}` | **1** | `::error::` |
| no response file | **1** | `::error::` |

Three mutations, to prove each arm can fail:

| mutation | guard result |
|---|---|
| drop `exit 1` from the `not-required` arm (the escalation removed) | **2 failed** / 22 passed |
| make the absent-verdict arm fatal (the false alarm) | **3 failed** / 21 passed |
| describe the absent verdict as "declares no `SecretConfigKey`" (the original wrong diagnosis) | **2 failed** / 14 passed |

Unmutated: `InboxSignatureVerdictGuard` 16/16; `MeshWeaver.Documentation.Test` 297/297;
`WebhookInboxTest` 10/10 (two new assertions pin `SignatureVerified` on **both** arms — the field
the whole escalation reads had no test at all).

## 🚨 Also measured: the receiving record has LOST the declaration — register is not persist

`Deployments/memex-cloud` on the control instance:

| version | when (UTC) | by | `WebhookInbox__Targets__1__SecretConfigKey` |
|---|---|---|---|
| 25 | 2026-09-05 07:42 | a person, on the live node | `Hosting:PlatformWebhookSecret` |
| 26 | 2026-09-05 09:24 | `system-security` | **gone** — every other `extraPortalConfig` key survived |
| 32 | 2026-09-06 17:03 | `system-security` | still gone |

The key appears **nowhere in `Systemorph/Memex`** — a fleet-wide code search returns exactly two
hits, both in this repo's chart where the slot is deliberately empty, and
`mesh/Deployments/memex-cloud.json` at `main` carries 16 `extraPortalConfig` keys, none of them the
declaration. So v25 was an edit to the LIVE NODE and v26 is the sync writing the repo's state back
over it, 1 h 42 min later, with nothing red anywhere. Every other key in the bag survived because
every other key IS committed there.

The fix is to COMMIT it, not to re-set it on the node — filed as Systemorph/Memex#205, and committed
to the doc page here so it is not only in a thread.

## Docs

- `Doc/Architecture/WebhookInbox` — the three-arm contract, the discrimination rule, why the absent
  verdict is not fatal, and the record-loss measurement.
- What's New: *An unchecked release event now fails the publish* (`Category: Fix`).

`DocumentationLinkIntegrityTest` and `check-workflow-timeouts.py` both clean.

Pairs-with: none — no `public` type or member is removed from `src/` (the only `src/` change is a
Markdown doc page); `git diff -U0 | grep '^-' | grep 'public '` is empty.
