### PR TITLE
docs(#3453 follow-up): the incident's timestamps as the API answers them, and the lane joins the table

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -721,6 +721,7 @@ deliberately deferred.
 | `.github/workflows/node-repo-gate.yml` | the tester gate — `mw-plugin-test` over the (optionally affected-narrowed) mount, cross-repo `requires` staged in; since #3022 executed by the tester **as the portal** (`platform-image`, composed gate host, `--app /app`) |
 | `.github/workflows/node-repo-publish-bake.yml` | the main-only bake + publication — `compile --output` then `--seed` over the full repo or (opt-in) the affected closure, staged-module exclusion, OIDC publish via the canonical `publish-bake-bundles.sh`; since #3022 the bake compiles against and is keyed to the **portal** (`platform-image` + `platform-image-digest`, both required-or-explicit exactly like the tester's) |
 | `.github/workflows/node-repo-tag-modules.yml` | the `<Module>/vX.Y.Z` tag publisher (`scripts/tag-modules.py`) |
+| `.github/workflows/node-repo-platform-ref-bump.yml` | the scheduled `MW_PLATFORM_REF` bump — polls the upstream's default branch and opens a PR (never a push) so the source pin cannot silently lag; mints a GitHub App token, because a pull request opened with `GITHUB_TOKEN` starts no CI at all. Called by MeshWeaver.Plugins and MeshWeaver.SocialMedia — the two node repos that carry such a pin. See [Keeping the Platform Source Pin Current](../PlatformRefBumpLane) |
 
 The design rules the extraction preserves:
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md
@@ -21,18 +21,22 @@ one — the one that, until 2026-09-06, had no automated mover at all.
 
 ## The incident (2026-09-06)
 
-Core [#3408](https://github.com/Systemorph/MeshWeaver/pull/3408) (`c8c7dd327`) fixed a FIFO
-ordering defect in `MessageService.OpenGate`. It was written *for* a MeshWeaver.Plugins `main` red —
-`ActivationBacklogFifoTest` observing `B, C, A` — and it merged at **13:06:47Z**.
+Core [#3408](https://github.com/Systemorph/MeshWeaver/pull/3408) fixed a FIFO ordering defect
+in `MessageService.OpenGate`. It was written *for* a MeshWeaver.Plugins `main` red —
+`ActivationBacklogFifoTest` observing `B, C, A` — and it merged at **13:10:47Z** as `7278d3d22`
+(`c8c7dd327` is the pull request's head, which is what the queue built).
 
-MeshWeaver.Plugins was still failing on that same test at **13:31Z**, because its `MW_PLATFORM_REF`
-— the core commit its `portal-hosts` job compiles `src/` against — was `bbcb22f25` (05:43:18Z),
-**49 commits before the fix**. The fix existed; the repo that needed it could not reach it.
+MeshWeaver.Plugins was still failing on that same test afterwards, because its `MW_PLATFORM_REF` —
+the core commit its `portal-hosts` job compiles `src/` against — was `bbcb22f25` (05:43:18Z). The
+fix's merge commit was the **49th commit after that pin** (`compare/bbcb22f25...7278d3d22` →
+`ahead_by: 49`). The fix existed; the repo that needed it could not reach it.
 
-🚨 **The staleness comment passed the whole time.** `bbcb22f25` was 10.3 hours and 102 commits
-behind, comfortably inside the 24 h / 120-commit bounds the pin's own comment describes as healthy.
-That is the lesson worth keeping: *"roughly current"* is not *"carries the fix we merged for this
-repo's red."* Age bounds catch neglect. They cannot catch a specific commit being needed.
+🚨 **The staleness gate passed throughout, and kept passing for hours.** At the moment the fix
+merged the pin was **7 h 27 m and 48 commits** behind — nowhere near the 24 h / 120-commit bounds it
+calls healthy. It first went RED at **17:11Z**, at 121 commits, seven hours after the fix landed;
+by 17:25Z it read 132. So the bound is real and it does fire — it simply cannot fire in time to
+protect a same-day fix, because it measures *drift*, not *reachability*. That is the lesson worth
+keeping: *"roughly current"* is not *"carries the fix we merged for this repo's red."*
 
 ### Why the gap existed
 


### PR DESCRIPTION
Follow-up to #3453 (merged). Three corrections, all measured rather than inherited.

## 1. The merge instant and the commit the "49" is true of

`#3408` merged at **13:10:47Z**, not 13:06:47Z — and its merge commit is **`7278d3d22`**.
`c8c7dd327` is the pull request's **head**, which is what the merge queue built. That distinction
changes the number beside it:

```
compare/bbcb22f25...c8c7dd327  → ahead_by: 1    (the PR branched off an older main)
compare/bbcb22f25...7278d3d22  → ahead_by: 49
```

The "49 commits before the fix" claim is true of the merge commit and false of the head, so the page
now names which one it is measuring to.

## 2. The staleness figures, with their instants

The page carried *"10.3 hours and 102 commits behind"* as if that were the reading **at the merge**.
It was a reading taken hours later. At the moment the fix merged the pin was **7 h 27 m and 48
commits** behind.

And the gate deserves a sharper description than "permissive": **it went RED today at 17:11Z, at 121
commits — seven hours after the fix landed** (MeshWeaver.Plugins#1410's own run, job 101525773838;
by 17:25Z it read 132). The bound is real and it fires. It simply measures **drift**, not
**reachability**, so it cannot fire in time to protect a same-day fix. That is the honest lesson and
it is stronger than the one the page shipped with.

## 3. The lane joins the table

`node-repo-platform-ref-bump.yml` is now listed in `CiContentBake`'s reusable-lane table. Its
absence there is part of why it had no callers for three weeks: AGENTS.md sends a satellite author to
that table for *"Node repos run the same lane"*, and the bump lane was not in it.

## Verification

`MeshWeaver.Documentation.Test`: **7 passed, 0 failed** (`DocumentationLinkIntegrityTest` +
`ArmedMergeMustTriggerMainsPushLanesGuard`), Release, `-warnaserror`, `0 Error(s)`. The new table
entry links to a **sibling** (`../PlatformRefBumpLane`) — the link test is what proves that, and it
caught exactly this mistake in the page's first draft.

Pairs-with: none — documentation only.
