### PR TITLE
diag(#2543): the trail names which arm owes the verdict after the echo; [STALE-CALLBACK] carries the pool's numbers

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1261,7 +1261,8 @@ public static class DataExtensions
         string hubPath,
         Func<bool> ownerIsShuttingDown,
         ILogger? logger = null,
-        System.Reactive.Concurrency.IScheduler? flushBoundScheduler = null)
+        System.Reactive.Concurrency.IScheduler? flushBoundScheduler = null,
+        Action<string>? noteStage = null)
         => commitEcho
             .WhenCompletesEmpty(() =>
             {
@@ -1344,10 +1345,18 @@ public static class DataExtensions
                                 }
                                 ackOnce(false, ClassifyPatchException(ex, hubPath));
                             });
+                    // The Subscribe above returned: the storage write chain did not block the thread the
+                    // echo arrived on. A trail that ends at PATCH_ECHO_SEEN without this stage names a
+                    // flush whose Subscribe never returned (MeshWeaver#2543, arm 1). A synchronous flush
+                    // has already acked by now, so PATCH_ACK may legitimately precede this stage.
+                    noteStage?.Invoke("PATCH_FLUSH_SUBSCRIBED");
                     bound.Disposable = Observable
                         .Timer(flushTimeout, flushBoundScheduler ?? System.Reactive.Concurrency.Scheduler.Default)
                         .Subscribe(_ =>
                         {
+                            // The bound's scheduler ran the callback; a trail ending at BOUND_ARMED without
+                            // this stage names a scheduler that never ran it (arm 2: a starved pool).
+                            noteStage?.Invoke("PATCH_FLUSH_BOUND_FIRED");
                             if (!ClaimVerdict()) return;
                             logger?.LogWarning(
                                 "[PatchAck] FLUSH_OUTLIVED_BOUND path={Path} bound={BoundMs}ms — the merge "
@@ -1358,6 +1367,9 @@ public static class DataExtensions
                         });
                     // ONE registration for the leg, as before: the flush subscription and the bound
                     // timer live and die together with the owner hub.
+                    // The bound timer exists from here on; if the flush is still in flight, the verdict
+                    // is now owed by the flush OR by the bound's scheduler — never by nothing.
+                    noteStage?.Invoke("PATCH_FLUSH_BOUND_ARMED");
                     registerForDisposal(new CompositeDisposable(flushSub, bound));
                 },
                 ex => ackOnce(false, ClassifyPatchException(ex, hubPath)));
@@ -1952,7 +1964,8 @@ public static class DataExtensions
                         // caller's watch already gone, standing aside converts an answerable write into
                         // silence — so answer now, on whatever transport is still open.
                         () => hub.IsShuttingDown && lateVerdicts is not null && lateVerdicts.IsAdmissible(request.Id),
-                        hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
+                        hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"),
+                        noteStage: stage => hub.NoteRequestStage(request.Id, stage));
                     hub.RegisterForDisposal(postSub);
 
                     // Route via the hub's DataChangeRequest pipeline — the workspace
@@ -2097,7 +2110,8 @@ public static class DataExtensions
             // caller's watch already gone, standing aside converts an answerable write into
             // silence — so answer now, on whatever transport is still open.
             () => hub.IsShuttingDown && lateVerdicts is not null && lateVerdicts.IsAdmissible(request.Id),
-            hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
+            hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"),
+            noteStage: stage => hub.NoteRequestStage(request.Id, stage));
         hub.RegisterForDisposal(postSub);
         // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK
         // claims the gate — an unacked in-flight patch always gets a terminal, never silence.

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
@@ -245,7 +245,10 @@ after it, on both hops, and could not say which wait it was in):
 | `PATCH_MERGE_DEFERRED cold-store` | the owner was activating cold; the retry re-arms once the store loads (`deferred-retry`) |
 | `PATCH_MERGE_STAMPED v=… refused=…` and nothing after | the merge committed on the executor but the echo CONTAINING it never reached the ack watcher — the reduced stream is not emitting |
 | `PATCH_MERGE_NOCHANGE refused=…` | the merge changed nothing (a no-op or a fully refused write); the verdict follows immediately |
-| `PATCH_ECHO_SEEN` and nothing after | the commit echo arrived; the wait is the durable flush (storage behind) — `[PatchAck] FLUSH_OUTLIVED_BOUND` names the same wait from the log side |
+| `PATCH_ECHO_SEEN` and nothing after | the commit echo arrived and the flush's `Subscribe` **never returned** — the storage write chain blocked the thread the echo arrived on, so the 10 s bound timer (armed only after that call) never existed. 🚨 Measured 2026-09-06 (#2543, Reinsurance gate 34044287799): twelve stalls ended here with **no** `PATCH_ACK`, **no** `FLUSH_OUTLIVED_BOUND` — the earlier reading of this row ("the wait is the durable flush, the bound names it") was FALSE, the bound never fired |
+| `PATCH_FLUSH_SUBSCRIBED` | the flush's `Subscribe` returned; a synchronous flush has acked before this, so `PATCH_ACK` may precede it |
+| `PATCH_FLUSH_BOUND_ARMED` and nothing after | the flush is in flight AND the bound timer exists, yet neither produced a verdict — the bound's scheduler (`Scheduler.Default`, the thread pool) never ran the callback: read the `[STALE-CALLBACK]` line's `[pool threads=… pendingWork=…]` — a pinned thread count with a large pending count is a starved pool |
+| `PATCH_FLUSH_BOUND_FIRED` | the bound expired before the flush answered; `[PatchAck] FLUSH_OUTLIVED_BOUND` is the same event from the log side and `PATCH_ACK ok` follows — the commit is acked, the flush keeps running |
 | `PATCH_ACK ok` / `PATCH_ACK nack=<code>` | the owner posted its verdict |
 
 `NoteRequestStage` is a no-op unless something is awaiting that id, so it is free to call

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -364,10 +364,17 @@ public sealed class MessageHub : IMessageHub
             // serving, which is where the #981 callbacks actually go unanswered (measured ~3.1 s
             // before Dispose() was even invoked). Dial MESHWEAVER_STALE_CALLBACK_MS down on a
             // repro run and this line, not the teardown one, names the handler side first.
+            // The pool's numbers ride on the line the host already writes (MeshWeaver#2543): a wall of
+            // stale callbacks with a large pending-work count and a thread count pinned at the minimum
+            // is a STARVED pool — timers (a flush bound, an activation budget) do not fire on it — and
+            // that reading is impossible from the callbacks alone.
             TryLog(LogLevel.Warning,
-                "[STALE-CALLBACK] {Address}: {Count} callback(s) pending > {ThresholdMs}ms: {Detail}{Fates}",
+                "[STALE-CALLBACK] {Address}: {Count} callback(s) pending > {ThresholdMs}ms: {Detail}{Fates} "
+                + "[pool threads={PoolThreads} pendingWork={PoolPending} completed={PoolCompleted}]",
                 Address, stale.Length, thresholdMs, FormatPendingCallbacks(stale),
-                FormatPendingCallbackFates(stale));
+                FormatPendingCallbackFates(stale),
+                System.Threading.ThreadPool.ThreadCount, System.Threading.ThreadPool.PendingWorkItemCount,
+                System.Threading.ThreadPool.CompletedWorkItemCount);
         }
         catch (Exception ex)
         {

--- a/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
@@ -217,6 +217,54 @@ public class PatchAckTotalityTest
         flush.HasObservers.Should().BeFalse("Take(1) completes on the flush's own emission");
     }
 
+    /// <summary>
+    /// MeshWeaver#2543: a trail that ended at <c>PATCH_ECHO_SEEN</c> with no <c>PATCH_ACK</c> and no
+    /// <c>FLUSH_OUTLIVED_BOUND</c> could not say whether the flush's Subscribe never returned or the
+    /// bound's scheduler never ran. The watcher now names each step: SUBSCRIBED once the storage
+    /// chain's Subscribe returns, BOUND_ARMED once the timer exists, BOUND_FIRED when the scheduler
+    /// runs it. Driven on a virtual clock. A slow flush therefore reads SUBSCRIBED → BOUND_ARMED →
+    /// (bound) → BOUND_FIRED, and the ack follows the firing.
+    /// </summary>
+    [Fact]
+    public void ASlowFlush_NamesSubscribedThenBoundArmed_ThenBoundFiredBeforeTheAck()
+    {
+        using var h = new Harness();
+        var flush = new Subject<bool>();
+        var clock = new TestScheduler();
+        var stages = new List<string>();
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => flush, FlushTimeout, (ok, err) => { stages.Add(ok ? "ACK" : "NACK"); h.AckOnce(ok, err); },
+            h.Register, HubPath, () => false, logger: null, flushBoundScheduler: clock, noteStage: stages.Add);
+        stages.Should().Equal(new[] { "PATCH_FLUSH_SUBSCRIBED", "PATCH_FLUSH_BOUND_ARMED" },
+            "the Subscribe returned and the timer exists — a trail stopping before either names its own arm");
+        clock.AdvanceBy(FlushTimeout.Ticks);
+        stages.Should().Equal(new[] { "PATCH_FLUSH_SUBSCRIBED", "PATCH_FLUSH_BOUND_ARMED", "PATCH_FLUSH_BOUND_FIRED", "ACK" },
+            "the scheduler ran the bound, and the commit was acked on it");
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null));
+    }
+
+    /// <summary>
+    /// A flush that answers synchronously on Subscribe acks BEFORE the SUBSCRIBED stage is recorded —
+    /// the order the doc row states, so a reader never mistakes <c>PATCH_ACK</c> preceding
+    /// <c>PATCH_FLUSH_SUBSCRIBED</c> for a defect. No bound stage follows: the timer was disposed by
+    /// the flush's own completion before it could fire.
+    /// </summary>
+    [Fact]
+    public void AFlushThatAnswersOnSubscribe_AcksFirst_ThenRecordsSubscribedAndArmed()
+    {
+        using var h = new Harness();
+        var clock = new TestScheduler();
+        var stages = new List<string>();
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => Observable.Return(true), FlushTimeout,
+            (ok, err) => { stages.Add(ok ? "ACK" : "NACK"); h.AckOnce(ok, err); },
+            h.Register, HubPath, () => false, logger: null, flushBoundScheduler: clock, noteStage: stages.Add);
+        stages.Should().Equal(new[] { "ACK", "PATCH_FLUSH_SUBSCRIBED", "PATCH_FLUSH_BOUND_ARMED" });
+        clock.AdvanceBy(FlushTimeout.Ticks * 2);
+        stages.Should().NotContain("PATCH_FLUSH_BOUND_FIRED", "the flush's completion disposed the bound before it fired");
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null));
+    }
+
     /// <summary>A flush that faults AFTER the bound acked the commit must not re-verdict it: the gate
     /// is latched on the owner, so the fault is logged and the sampler stays the writer of record.</summary>
     [Fact]


### PR DESCRIPTION
## #2543: the trail names which arm owes the verdict after the echo, and the stale-callback line carries the pool's numbers

Diagnostic, root-cause-directed — the same shape as #3393, one leg further along the write path. Measured today on Reinsurance#169's gate (run 34044287799): twelve `OwnerUnreachable … no verdict within 31s` stalls whose trails all ended at `PATCH_MERGE_STAMPED v=3 → PATCH_ECHO_SEEN (+2ms)`, with **zero** `PATCH_ACK`, **zero** `FLUSH_OUTLIVED_BOUND` in the log. The code fixes what that means: after the echo the ack watcher subscribes the durable flush and *only then* arms the 10 s bound; every terminal arm records `PATCH_ACK` before posting. So the verdict was never produced and the bound never fired — leaving exactly two arms the trail could not tell apart: the flush's `Subscribe` never returned (the storage chain blocked the thread the echo arrived on), or the bound was armed and its scheduler — the thread pool — never ran the callback. Full reading on the issue: https://github.com/Systemorph/MeshWeaver/issues/2543#issuecomment-5561422132

### What changes
- `ArmPatchAckWatcher` takes an optional `noteStage` and records **`PATCH_FLUSH_SUBSCRIBED`** (the storage chain's Subscribe returned), **`PATCH_FLUSH_BOUND_ARMED`** (the timer exists) and **`PATCH_FLUSH_BOUND_FIRED`** (the scheduler ran it). Both patch paths (`ApplyMeshNodePatchInTurn`, `ApplyJsonMergePatchAndUpdate`) wire it to `hub.NoteRequestStage`. A trail ending at `PATCH_ECHO_SEEN` now means "the Subscribe hung"; one ending at `BOUND_ARMED` means "the pool never ran the timer".
- `[STALE-CALLBACK]` gains `[pool threads=… pendingWork=… completed=…]` — the host already writes that line during exactly these stalls (107 lines on 15 hubs in the failing run), and a pinned thread count with a large pending count is a starved pool, which no callback list can show.
- `DebuggingMessageFlow.md`: the `PATCH_ECHO_SEEN and nothing after` row claimed the bound would name the wait; measured, it never fired. Row corrected, three rows added.

### Verified
- `PatchAckTotalityTest`: `ASlowFlush_NamesSubscribedThenBoundArmed_ThenBoundFiredBeforeTheAck` (virtual clock: SUBSCRIBED → BOUND_ARMED → BOUND_FIRED → ack) and `AFlushThatAnswersOnSubscribe_AcksFirst_ThenRecordsSubscribedAndArmed` (the synchronous order the doc states). Data ack suites 21/21, documentation + guards 304/304, `-c Release -warnaserror` clean on Data.Test, Documentation.Test and Messaging.Hub.Test.

No What's New: nothing a portal user sees changes. Refs #3355.
