### PR TITLE
fix(#3451): a repair cannot create a partition, and an install record cannot outlive one

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCatalogs.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCatalogs.md
@@ -78,8 +78,9 @@ The seams that do:
 **The one that did not — and the deepest cause of #902.** `EnsurePartitionBootstrap`'s root-existence
 probe (`ReadNodeAuthoritative`) fell back to `FindStaticNode(path)` with no guard. For a catalog
 whose discriminator equals its partition name, the definition at `@Agent` therefore answered *"the
-root exists"*, so `ProvisionAndCreateRoot` never ran: **no schema was provisioned and no durable root
-was written**, while every other seam correctly saw nothing. That is the ghost precisely — present to
+root exists"*, so `HealPartitionRoot` never ran: **no durable root was written** (and, until #3451
+took provisioning off the repair path, no schema either), while every other seam correctly saw
+nothing. That is the ghost precisely — present to
 the existence check, absent to reads, un-creatable ("already exists"), no version history, and no
 route back. The probe now skips definition-only entries, so the bare partition path is free to be an
 ordinary root.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PartitionTeardown.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PartitionTeardown.md
@@ -139,10 +139,10 @@ the gate.
 ## No resurrection: the bootstrap may repair a root, never re-create a partition
 
 `MeshExtensions.EnsurePartitionBootstrap` heals a partition whose root row is missing when a child is
-created under it. Left unbounded that heal is a **second** trigger for partition creation:
-`ProvisionAndCreateRoot` calls `EnsurePartitionProvisioned` and then writes a `Space` root, behind
-`OwnsPartitionProvisioningValidator`'s back and past `PartitionWriteGuardValidator`'s
-"no partition, no write" rule (System passes both).
+created under it. That heal used to be a **second** trigger for partition creation:
+`HealPartitionRoot` (then named `ProvisionAndCreateRoot`) called `EnsurePartitionProvisioned` and
+then wrote a `Space` root, behind `OwnsPartitionProvisioningValidator`'s back and past
+`PartitionWriteGuardValidator`'s "no partition, no write" rule (System passes both).
 
 That is where the visible half of the incident came from. The four deleted roots reappeared as bare
 `Space` nodes named after their path segment, each with a `PartitionAccessPolicy` child 67 ms later:
@@ -151,22 +151,108 @@ bootstrap conjured the root to hold it. The new policy granted Delete to nobody 
 deleted the original — so the resurrected partition was **undeletable through the ordinary API**
 (`Delete permission denied for 'AgenticPrimerDe'`) and invisible as damage in a Space listing.
 
-So the ABSENT-root branch is now gated: when **every** provider definitively reports the backing
-store gone, no root is created and a warning names the partition. The fold is the global OR the write
-guard already uses — any `true` means it exists somewhere, every provider `false` means confirmed
-absent, and anything else (a `null`, a probe fault, no providers) is indeterminate and allows the
-heal. Fail OPEN, so a probe hiccup can never block a legitimate repair. The GHOST-root branch is
-exempt by construction: a durable row means the store it was read from exists.
+### 🚨 The seam the existing guards could never see: provisioning is not a write
 
-🚨 **This does not make resurrection unreachable, only much narrower.** The remaining window is a
-child write that lands while the delete is still draining, before the drop: the partition's store is
-genuinely still there, the probe says so, and the bootstrap correctly heals a root. Closing that
-needs the delete to hold a partition-scoped exclusion that outlives its own drop — the
-`RecentlyDeletedRegistry` subtree scope covers the drain but is released with the operation. It is
-also worth noting what re-arms the write in the first place: `InstalledPackageRepairService` re-asserts
-`EnsureDeclaredAccess` for **every recorded install** on every boot, and a package's install record
-lives in the `Plugins` partition, so deleting the installed partition does not remove it. Both gaps
-are tracked as MeshWeaver#3451.
+#3436's first answer was a probe: skip the heal when **every** provider definitively reports the
+store gone. That closed the steady state and nothing else, and the reason is worth stating exactly,
+because it is what MeshWeaver#3451 turned out to be.
+
+Two exclusions already existed and neither applies:
+
+| Mechanism | Lifetime | What it guards |
+|---|---|---|
+| `RecentlyDeletedRegistry.BeginSubtreeDeletion` | opened before the deletion plan, released after step 5 — so it **does** cover the drop | `IStorageAdapter` writes, via `SubtreeDeletionGuardStorageAdapter` |
+| `RecentlyDeletedRegistry.MarkDeleted` ("delete wins") | 30 s TTL from the delete, superseded by a real re-create | per-node-hub resurrecting SAVES |
+
+Both guard **writes**. The resurrection did not happen through a write. `EnsurePartitionProvisioned`
+— the API whose own contract calls it *"the ONLY trigger for partition creation"* — is DDL. It
+crosses no storage adapter, so no scope, no tombstone and no guard was ever consulted for it, and the
+bootstrap called it on every heal.
+
+And a probe cannot substitute for an exclusion, because it is **read at one instant and acted on at
+another**. The drop is step 5, *after* the drain, so a probe taken while the delete was draining
+answers a truthful `true` — and authorises a `CREATE SCHEMA` that runs after the `DROP`. Measured on
+the in-memory harness, the provider's ledger for one deleted partition read:
+
+```
+provision:P, drop:P, provision:P, provision:P
+```
+
+— the store came back **twice**, from a repair, after its own teardown had removed it.
+
+### What replaced it
+
+Two changes, and the first is the structural one:
+
+1. **A repair cannot provision.** `HealPartitionRoot` no longer calls `EnsurePartitionProvisioned` at
+   all. In every state where the heal is legitimate that call was a **no-op by construction** — a
+   ghost row means the store it was read from exists, and an absent root over a live store means the
+   store is already provisioned — so removing it costs nothing and removes the capability. What
+   remains is a plain row write into whatever store already routes the partition: refused by the
+   subtree guard while the delete is in flight, and failing loudly (Postgres `42P01`) afterwards
+   instead of silently minting a shell over a schema it re-created itself.
+2. **The heal consults the delete record, at the point of effect.**
+   `MeshExtensions.PartitionRemovalOnRecord` asks the registry two questions — *is a deletion of this
+   partition in flight?* (`IsUnderActiveDeletion`, the hard invariant) and *was it just deleted and
+   not re-created since?* (`IsRecentlyDeleted`, the tombstone). The second is the half that
+   **outlives the drop**, which is what #3436 asked for: a probe-based decision taken before the drop
+   is still refused when it lands after it, because the tombstone was already on record when the
+   probe ran. It gates the creator GRANT as well as the root — `{P}/_Access/{creator}_Access` written
+   into a partition that is going away is the "fresh policy 67 ms later" half of the incident.
+
+No new state, no new timer, no widened bound: both records already existed and are already written
+synchronously at the delete source. `RecentlyDeletedRegistry` is registered unconditionally by
+`MeshBuilder` at the mesh ROOT, so the check resolves with `GetRequiredService` and **always
+decides** — it has no arming condition, which is the failure mode #3436's first coverage-gate draft
+had (it armed only when a writable provider existed, and went silent on the read-only Monolith host).
+
+The store probe stays where it was, as the second half of the refusal, and still fails OPEN on an
+indeterminate answer so a probe hiccup cannot block a legitimate repair. The GHOST-root branch is
+exempt from it by construction: a durable row means the store it was read from exists.
+
+A legitimate delete-then-recreate is unaffected: re-creating the partition goes through
+`OwnsPartitionProvisioningValidator` or the installer, whose root write crosses the storage seam and
+supersedes the tombstone.
+
+`PartitionResurrectionTest` (MeshWeaver.Graph.Test) pins all of it, including the positive control —
+a missing root over a live store is still healed.
+
+## The install record must not outlive its partition
+
+A package's install record lives at `Plugins/{packageId}` — in the RECORDS partition, never in the
+package's own — so deleting the installed partition left the record behind, aimed at nothing.
+`InstalledPackageRepairService` then re-drove `PackageInstaller.EnsureDeclaredAccess` at that dead
+partition on **every boot**: a permanent per-boot error for every partition anyone had ever deleted
+— and the #3436 census counted **21 partition definitions with no live root** on the systemorph
+staff portal, which is the upper bound on how many such records a single portal can be carrying —
+and, before the change above, the writer that re-armed the resurrection race on every restart.
+
+Core deliberately knows nothing about `Plugins/Package`; teaching the delete pipeline about it would
+re-introduce exactly the coupling the structural teardown removed. So **the discriminator comes from
+the record side**, through the same seam:
+
+- **On delete — the state becomes unreachable.** `AddPluginCatalog` registers
+  `InstallRecordPartitionTeardownHandler`, an `INodePostDeletionHandler` matching the same structural
+  `PartitionDefinition.IsPartitionRoot` predicate (minus the mirrors and minus `Plugins` itself). It
+  removes every install record targeting the deleted partition via
+  `PackageInstaller.RemoveInstalledRecord`, the one sanctioned removal route. It resolves the records
+  from two sources unioned: an authoritative point read of `Plugins/{partition}` (the shape of nearly
+  every install, and a STORE read, so CQRS lag cannot hide a record written seconds ago) plus a
+  listing for records whose `TargetPartition` differs from their id.
+- **On boot — the records that already dangle are reported, not written to.**
+  `InstalledPackageRepairService` asks `TargetPartitionIsGone` before re-asserting: a CONJUNCTION of
+  three signals that each always answer — no provider reports the store present, the root node does
+  not read back, and the partition has no child paths. A false "gone" would need a partition with no
+  store, no root and no content, which is not a partition; any fault reads as the safe answer
+  (present). A record that fails all three is **skipped and named at Warning**, with the remedy (the
+  admin orphan list). It reports rather than deletes deliberately: the delete path knows exactly
+  which partition went, in-process, right now, so removing the record there is deterministic; a boot
+  pass that silently deleted install records on a three-probe heuristic would be a worse failure than
+  the one it fixes.
+
+`InstallRecordFollowsItsPartitionTest` (Memex.Portal.Shared.Test) pins the delete-side half, with
+both controls: a nested node's deletion leaves the record alone, and deleting one partition does not
+touch another's record.
 
 ## Auditing a portal for orphans
 
@@ -183,6 +269,10 @@ orphaned schema is there either way. Reconcile three lists instead:
 3. **The schemas themselves** — `SELECT nspname FROM pg_namespace ORDER BY 1` on the portal's
    database. This is the only authoritative list: a definition can be missing while the schema is
    there, and vice versa.
+4. **The install records** — `search 'namespace:Plugins nodeType:Package scope:children select:id,content'`.
+   A record whose target partition is not in list 2 is a dangling reference from before the teardown
+   handler existed; the boot pass names each one at Warning and an admin clears it from the
+   catalog's orphaned-records list. New deletions cannot add to this list.
 
 🚨 **Confirm every candidate with an exact-path read** (`get @{partition}`), never with the query
 alone. `scope:children` listings are partition-scoped and RLS-filtered — the `Admin` partition, for

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deleted-space-stays-deleted.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deleted-space-stays-deleted.md
@@ -1,0 +1,44 @@
+---
+Name: A deleted space stays deleted
+Category: Fix
+Description: A space you deleted could quietly come back as an empty shell nobody could delete again, and an installed package whose space you removed kept trying to write into it on every restart. Both are closed.
+Icon: Delete
+Order: -20260906
+---
+
+# A deleted space stays deleted
+
+Deleting a space is meant to be final. On production portals it sometimes was not: a space would
+reappear a little later as an empty shell — carrying its old name, none of its content, and a fresh
+access policy that granted delete rights to nobody, including the person who had just deleted it. It
+did not show up as damage in any listing, and it could not be removed again through the ordinary
+interface.
+
+What brought it back was the platform's own self-repair. When something is written into a space whose
+top-level entry has gone missing, the platform recreates that entry so the space stays reachable —
+a repair that exists because a half-finished creation used to leave spaces unusable. The repair also
+made sure the space's underlying storage existed, and *that* is what made it a resurrection rather
+than a repair: a write arriving while a deletion was still running found storage that was genuinely
+still there for another moment, and the repair put it back after the deletion had removed it.
+
+Repair and creation are now separate things. The self-repair can still restore a missing top-level
+entry over a space that exists, which is what it is for — but it can no longer create a space's
+storage, so it has nothing to bring back. On top of that, the platform now remembers, for as long as
+a deletion is running and for a short window after it, that a given space was deleted; a repair for a
+space in that state is refused outright, and so is the access grant that used to come with it.
+
+## Installed packages let go of spaces that are gone
+
+The second half was quieter. Installing a package records the installation centrally, not inside the
+space it installs into — so deleting that space left the record behind, pointing at nothing. On every
+restart the platform re-applied the package's access settings to a space that no longer existed:
+a failed write and an error in the log, every boot, for every space anyone had ever deleted.
+
+Now the record goes with the space: deleting a space removes the installation records that name it,
+so the package correctly reads as not installed. Records that were already orphaned before this
+change are no longer written to — the platform names each one in the log once per restart, with the
+remedy, and administrators can clear them from the catalog's orphaned-records list.
+
+Nothing changes for ordinary use. Deleting a space and creating a new one with the same name works
+exactly as before, and a space whose top-level entry really did go missing is still repaired on the
+next write into it.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1811,7 +1811,7 @@ public static class MeshExtensions
             : ReadNodeAuthoritative(hub, persistence, grantPath);
         // A GitSynced partition is SYSTEM-OWNED by definition — its content is rewritten from the
         // repo and only system-security writes it. That is the ownership signal the root itself
-        // does not carry (ProvisionAndCreateRoot writes the root as System, so root.CreatedBy is
+        // does not carry (HealPartitionRoot writes the root as System, so root.CreatedBy is
         // never the owner), and it is what distinguishes "I am creating my own partition" from
         // "I am a deploy touching somebody else's".
         var syncObs = ReadNodeAuthoritative(hub, persistence, $"{partition}/_GitSync");
@@ -1933,9 +1933,25 @@ public static class MeshExtensions
                                     t.sync, hub.JsonSerializerOptions),
                                 persistence, meshService, accessService, logger);
 
+                        // 🚨 A partition whose REMOVAL is in flight or on record is not healed —
+                        // neither its root nor its creator grant (#3451). The grant matters as much
+                        // as the root: `{P}/_Access/{creator}_Access` written into a partition that
+                        // is going away is the "fresh policy 67 ms later" half of the incident, and
+                        // it is what made the resurrected shells undeletable. Checked here, AFTER
+                        // the permission fold, so the decision is as close to the writes as it can
+                        // be; HealPartitionRoot re-asks at its own point of effect.
+                        if (PartitionRemovalOnRecord(hub, partition) is { } removal)
+                        {
+                            logger.LogWarning(
+                                "[PartitionBootstrap] NOT healing partition '{Partition}': {Reason}. "
+                                + "Neither a root nor a creator grant is written — a repair must never "
+                                + "bring a deleted partition back (#3451).", partition, removal);
+                            return Observable.Return(System.Reactive.Unit.Default);
+                        }
+
                         var healRoot = rootUsable
                             ? Observable.Return(System.Reactive.Unit.Default)
-                            : ProvisionAndCreateRoot(hub, partition, meshService, accessService, logger,
+                            : HealPartitionRoot(hub, partition, meshService, accessService, logger,
                                 // A DURABLE but unusable row is repaired in place; an absent root
                                 // (or a static/config one) takes the ordinary create path.
                                 ghost: t.root.Durable ? t.root.Node : null);
@@ -1977,8 +1993,8 @@ public static class MeshExtensions
     /// a served node, and it is the platform's only name-keyed home for the non-serialisable
     /// <c>HubConfiguration</c> delegate. Letting it answer here made
     /// <c>EnsurePartitionBootstrap</c> believe the partition root already existed, so
-    /// <c>ProvisionAndCreateRoot</c> never ran: no schema was provisioned and no durable root was
-    /// written, while every other seam correctly saw nothing. That is exactly the ghost partition
+    /// <c>HealPartitionRoot</c> never ran: no durable root was written, while every other seam
+    /// correctly saw nothing. That is exactly the ghost partition
     /// root of #902 — present to the existence check, absent to reads, un-creatable ("already
     /// exists"), with no version history — and it is why the platform's agent catalog could not be
     /// repaired by any route. See Doc/Architecture/NodeTypeCatalogs.md.</para>
@@ -2030,8 +2046,8 @@ public static class MeshExtensions
         && (!string.IsNullOrWhiteSpace(root.NodeType) || root.Content is not null);
 
     /// <summary>
-    /// Provisions every provider's backing store (PG schema + tables) then writes the partition's
-    /// <c>Space</c> root under System. Idempotent — a concurrent-create "already exists" is success.
+    /// Writes the partition's missing <c>Space</c> root under System. Idempotent — a
+    /// concurrent-create "already exists" is success.
     ///
     /// <para>When <paramref name="ghost"/> is supplied — a DURABLE row that exists but is not a
     /// usable root — the root is repaired IN PLACE instead (see <see cref="RepairGhostRoot"/>).
@@ -2039,35 +2055,42 @@ public static class MeshExtensions
     /// "already exists", which this method treats as success, so the ghost survived every
     /// bootstrap that ran over it.</para>
     ///
+    /// <para>🚨 <b>A REPAIR MUST NOT BE ABLE TO CREATE A PARTITION (#3451).</b> This method used
+    /// to open with <c>EnsurePartitionProvisioned</c> on every provider — the API whose own
+    /// contract calls it "the ONLY trigger for partition creation" — and #3436 tried to make that
+    /// safe by probing first and skipping the heal when every provider reported the backing store
+    /// gone. A probe is not an exclusion: it is read at one instant and acted on at another, and
+    /// the delete drops the store at step 5 (AFTER the drain), so a probe taken while the delete
+    /// was draining answered a truthful <c>true</c> and authorised a <c>CREATE SCHEMA</c> that ran
+    /// after the <c>DROP</c>. Neither the <see cref="RecentlyDeletedRegistry"/> subtree scope nor
+    /// <c>SubtreeDeletionGuardStorageAdapter</c> could see it: both guard <see cref="IStorageAdapter"/>
+    /// WRITES, and provisioning is a DDL side-channel that never crosses a storage adapter.</para>
+    ///
+    /// <para>So the call is gone. In every state where a heal is legitimate the provisioning was a
+    /// NO-OP by construction — a ghost row means the store it was read from exists, and an absent
+    /// root over a live store is exactly a store that is already provisioned — so removing it costs
+    /// nothing and removes the capability that made resurrection reachable. What is left is a plain
+    /// row write into whatever store already routes the partition: refused by the subtree guard
+    /// while the delete is in flight, and failing loudly (Postgres <c>42P01</c>) afterwards instead
+    /// of silently minting a shell over a schema it re-created itself.</para>
+    ///
     /// <para>🚨 <b>REPAIR, never RESURRECTION (#3436).</b> With NO root at all, this method is
-    /// only allowed to heal a partition whose backing store is still there. When every provider
-    /// definitively answers that the store is GONE, the partition was deleted — and creating a
-    /// <c>Space</c> root here would <c>EnsurePartitionProvisioned</c> the schema straight back,
-    /// making this a SECOND trigger for partition creation behind
-    /// <c>OwnsPartitionProvisioningValidator</c>'s back and laundering an implicit space creation
-    /// past <c>PartitionWriteGuardValidator</c>'s "no partition, no write" rule. That is exactly
-    /// how four deleted partitions came back on the systemorph staff portal as bare, differently
-    /// typed <c>Space</c> shells with a fresh <c>_Policy</c> 67 ms later — a policy that granted
-    /// Delete to nobody who could have deleted the original, so the shell was then undeletable
-    /// through the ordinary API. A ghost repair is exempt by construction: a durable row means the
-    /// store it was read from exists.</para>
+    /// additionally refused whenever the partition's removal is in flight or on record
+    /// (<see cref="PartitionRemovalOnRecord"/>) or every provider definitively answers that the
+    /// store is GONE. That is what four deleted partitions came back through on the systemorph
+    /// staff portal — bare, differently typed <c>Space</c> shells with a fresh <c>_Policy</c> 67 ms
+    /// later, whose policy granted Delete to nobody who could have deleted the original, so the
+    /// shell was then undeletable through the ordinary API. A ghost repair is exempt from the
+    /// store probe by construction: a durable row means the store it was read from exists.</para>
     /// </summary>
-    private static IObservable<System.Reactive.Unit> ProvisionAndCreateRoot(
+    private static IObservable<System.Reactive.Unit> HealPartitionRoot(
         IMessageHub hub, string partition, IMeshService meshService,
         AccessService? accessService, ILogger logger, MeshNode? ghost = null)
     {
-        // Reactive + pooled + promise-cached; the InMemory / FileSystem providers no-op. Merge +
-        // ToList so the chain always emits exactly once (even with no providers) before the write.
-        var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>().ToArray();
-        var provision = providers.Length == 0
-            ? Observable.Return(System.Reactive.Unit.Default)
-            : Observable.Merge(providers.Select(p => p.EnsurePartitionProvisioned(partition)))
-                .ToList()
-                .Select(_ => System.Reactive.Unit.Default);
-
         if (ghost is not null)
-            return provision.SelectMany(_ => RepairGhostRoot(hub, partition, ghost, accessService, logger));
+            return RepairGhostRoot(hub, partition, ghost, accessService, logger);
 
+        var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>().ToArray();
         var root = new MeshNode(partition)
         {
             NodeType = PartitionRootNodeTypeName,
@@ -2075,23 +2098,74 @@ public static class MeshExtensions
             Name = partition,
         };
 
-        return PartitionStoreConfirmedAbsent(providers, partition, logger).SelectMany(absent =>
-            absent
+        // 🚨 Evaluated at the POINT OF EFFECT (Observable.Defer + a probe subscribed here), not
+        // earlier in the chain: the whole defect class is a decision taken at one instant and acted
+        // on at another. The removal record is read first because it is synchronous, free, and
+        // always decides — the store probe can only ever REINFORCE it.
+        return Observable
+            .Defer(() => Observable.Return(PartitionRemovalOnRecord(hub, partition)))
+            .SelectMany(removal => removal is not null
+                ? Observable.Return<string?>(removal)
+                : PartitionStoreConfirmedAbsent(providers, partition, logger)
+                    .Select(absent => absent
+                        ? "every storage provider reports its backing store is gone"
+                        : null))
+            .SelectMany(refusal => refusal is not null
                 ? Observable.Return(System.Reactive.Unit.Default)
                     .Do(_ => logger.LogWarning(
-                        "[PartitionBootstrap] NOT creating a Space root for '{Partition}': every "
-                        + "storage provider reports its backing store is gone, so the partition was "
-                        + "deleted. Healing a root here would re-provision the schema and resurrect "
-                        + "the partition as an empty shell (#3436); the child write that triggered "
-                        + "this is refused by the partition write guard instead.", partition))
-                : provision.SelectMany(_ =>
-                    AsSystem(accessService, () => meshService.CreateNode(root).Take(1))
-                        .Select(_ => System.Reactive.Unit.Default)
-                        .Catch<System.Reactive.Unit, Exception>(ex => IsAlreadyExists(ex)
-                            ? Observable.Return(System.Reactive.Unit.Default)
-                            : Observable.Throw<System.Reactive.Unit>(ex))
-                        .Do(_ => logger.LogInformation(
-                            "[PartitionBootstrap] created missing Space root for partition '{Partition}'", partition))));
+                        "[PartitionBootstrap] NOT creating a Space root for '{Partition}': {Reason}, "
+                        + "so the partition was deleted. Healing a root here would resurrect it as an "
+                        + "empty shell (#3436/#3451); the child write that triggered this is refused "
+                        + "by the partition write guard instead.", partition, refusal))
+                : AsSystem(accessService, () => meshService.CreateNode(root).Take(1))
+                    .Select(_ => System.Reactive.Unit.Default)
+                    .Catch<System.Reactive.Unit, Exception>(ex => IsAlreadyExists(ex)
+                        ? Observable.Return(System.Reactive.Unit.Default)
+                        : Observable.Throw<System.Reactive.Unit>(ex))
+                    .Do(_ => logger.LogInformation(
+                        "[PartitionBootstrap] created missing Space root for partition '{Partition}'", partition)));
+    }
+
+    /// <summary>
+    /// Is this partition's REMOVAL in flight, or on record? The exclusion that
+    /// <c>SubtreeDeletionGuardStorageAdapter</c> enforces for node-row writes, asked here for the
+    /// one decision that is not a node-row write: whether the self-healing bootstrap may bring a
+    /// partition back (#3451). Returns the reason, or <c>null</c> when nothing about this partition
+    /// has been deleted.
+    ///
+    /// <para><b>Two records, two lifetimes, and both already exist</b> — this adds no new state and
+    /// no new timer:</para>
+    /// <list type="bullet">
+    ///   <item><see cref="RecentlyDeletedRegistry.IsUnderActiveDeletion"/> — the hard invariant with
+    ///     an exact lifetime: opened before the deletion plan is enumerated and released when the
+    ///     operation completes, which is AFTER the partition drop (step 5 runs inside the scope).</item>
+    ///   <item><see cref="RecentlyDeletedRegistry.IsRecentlyDeleted"/> — the "delete wins" tombstone,
+    ///     marked SYNCHRONOUSLY at the delete source for every path including the root, and cleared
+    ///     by a real re-create (<see cref="RecentlyDeletedRegistry.Supersede"/>, run by the storage
+    ///     write seam). This is the half that <b>outlives the drop</b>, which is what #3436 asked
+    ///     for: a probe-based decision taken before the drop is still refused when it lands after
+    ///     it, because the tombstone was already on record when the probe ran.</item>
+    /// </list>
+    ///
+    /// <para>🚨 <b>It always decides.</b> The registry is registered unconditionally by
+    /// <c>MeshBuilder</c> at the mesh ROOT (deliberately — the delete handler and the persistence
+    /// container must share one instance), so this resolves with <c>GetRequiredService</c> and has
+    /// no arming condition. A guard that goes silent when its input is missing is the shape that
+    /// let #3436's first draft boot clean on a host whose providers were all read-only.</para>
+    ///
+    /// <para>A legitimate delete-then-recreate is unaffected: creating the partition again goes
+    /// through <c>OwnsPartitionProvisioningValidator</c> / the installer, whose root write crosses
+    /// the storage seam and supersedes the tombstone — after which this answers <c>null</c> and the
+    /// bootstrap heals that partition's children exactly as before.</para>
+    /// </summary>
+    private static string? PartitionRemovalOnRecord(IMessageHub hub, string partition)
+    {
+        var registry = hub.ServiceProvider.GetRequiredService<RecentlyDeletedRegistry>();
+        if (registry.IsUnderActiveDeletion(partition, out var deletionRoot))
+            return $"its deletion is in flight (subtree '{deletionRoot}')";
+        return registry.IsRecentlyDeleted(partition)
+            ? "it was just deleted and nothing has re-created it since"
+            : null;
     }
 
     /// <summary>
@@ -2121,12 +2195,20 @@ public static class MeshExtensions
                         "[PartitionBootstrap] existence probe failed for '{Partition}' via {Provider}; "
                         + "treating as indeterminate", partition, p.Name);
                     return Observable.Return<bool?>(null);
-                }))
+                })
+                // 🚨 A probe that COMPLETES WITHOUT EMITTING is not caught by the Timeout above —
+                // Timeout faults on silence, not on a clean finish (#2901). Without this the
+                // CombineLatest below would never emit and the whole create would hang unanswered;
+                // "no answer" is indeterminate, which is what null means.
+                .DefaultIfEmpty(null))
             .ToList();
 
         return Observable.CombineLatest(probes)
             .Take(1)
-            .Select(results => results.Count > 0 && results.All(r => r == false));
+            .Select(results => results.Count > 0 && results.All(r => r == false))
+            // Same rule one level up, and the same verdict: nothing observed ⇒ NOT confirmed absent
+            // ⇒ the heal is allowed. Fail OPEN, exactly as an indeterminate probe does.
+            .DefaultIfEmpty(false);
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/InstallRecordPartitionTeardownHandler.cs
+++ b/src/MeshWeaver.PluginCatalog/InstallRecordPartitionTeardownHandler.cs
@@ -1,0 +1,170 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Removes a package's INSTALL RECORD when the partition it was installed into is deleted
+/// (Systemorph/MeshWeaver#3451).
+///
+/// <para><b>The dangling reference this closes.</b> An install record lives at
+/// <c>{InstalledPartition}/{packageId}</c> — in the <c>Plugins</c> partition, never in the package's
+/// own — so deleting the installed partition left the record behind, pointing at nothing. Nothing
+/// reconciled it, and <see cref="InstalledPackageRepairService"/> re-drove
+/// <see cref="PackageInstaller.EnsureDeclaredAccess"/> at that dead partition on EVERY boot, forever:
+/// a permanent per-boot error for every partition anyone had ever deleted, and — before #3451's other
+/// half — the writer that re-armed the resurrection race on every restart.</para>
+///
+/// <para>🚨 <b>Why the discriminator comes from the record side.</b> Core deliberately knows nothing
+/// about <c>Plugins/Package</c>, and teaching the delete pipeline about it would be exactly the
+/// coupling #3436 spent its fix removing. <see cref="INodePostDeletionHandler"/> is the seam that
+/// makes that unnecessary: the plugin catalog registers its OWN post-deletion handler, matching the
+/// same STRUCTURAL predicate the partition teardown uses
+/// (<see cref="PartitionDefinition.IsPartitionRoot"/>), and answers the one question only it can —
+/// "is this partition a recorded install target?". Referential integrity is maintained by the side
+/// that owns the reference.</para>
+///
+/// <para><b>Ordering and blast radius.</b> Post-deletion handlers run at step 5, after the subtree is
+/// drained, so "the partition root was deleted" and "the partition is empty" are the same statement
+/// by then. Only the RECORD is removed — via <see cref="PackageInstaller.RemoveInstalledRecord"/>,
+/// the one sanctioned removal route (<c>Plugins/_Policy</c> caps delete for every ordinary caller,
+/// so it runs as System). The record's own delete cannot recurse here: it is namespaced under
+/// <c>Plugins</c> and is therefore not a partition root. Deleting the <c>Plugins</c> partition itself
+/// is excluded — its records go with it, and cascading each one first would be a no-op race against
+/// the drain that just removed them.</para>
+///
+/// <para>Failures are logged and surfaced as a Warning on the deletion activity; they never
+/// un-delete the partition. 100% reactive — no <c>async</c>/<c>await</c>.</para>
+/// </summary>
+/// <param name="hub">Hub supplying the workspace, mesh service and access service.</param>
+/// <param name="logger">Diagnostics.</param>
+public sealed class InstallRecordPartitionTeardownHandler(
+    IMessageHub hub,
+    ILogger<InstallRecordPartitionTeardownHandler>? logger = null) : INodePostDeletionHandler
+{
+    /// <summary>
+    /// Diagnostic label only — <see cref="Matches"/> never reads it, exactly as
+    /// <c>PartitionDropPostDeletionHandler</c> does for the same structural reason.
+    /// </summary>
+    public string NodeType => "*";
+
+    /// <summary>
+    /// Structural match: every partition ROOT except the install-RECORDS partition itself and the
+    /// system-managed mirrors. No NodeType is consulted, so a partition rooted at an in-mesh type
+    /// that arrived after boot (<c>Store/Plugin</c>, <c>Crm/Client</c>) is covered by construction —
+    /// which matters here more than anywhere, because those ARE the installed partitions.
+    /// </summary>
+    /// <param name="deletedNode">The node as it was loaded before deletion.</param>
+    /// <returns><c>true</c> when the deleted node is a partition root whose install record may exist.</returns>
+    public bool Matches(MeshNode deletedNode) =>
+        PartitionDefinition.IsPartitionRoot(deletedNode)
+        && !WellKnownPartitions.IsMirror(deletedNode.Id)
+        && !string.Equals(deletedNode.Id, PackageInstaller.InstalledPartition,
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IObservable<Unit> Handle(MeshNode deletedNode, string? deletedBy)
+    {
+        // Defence in depth: Handle is public, and a caller invoking it directly must never remove a
+        // record because a NESTED node was deleted.
+        if (!Matches(deletedNode))
+            return Observable.Return(Unit.Default);
+
+        var partition = deletedNode.Id;
+        return RecordedInstallsTargeting(hub, partition)
+            .SelectMany(packageIds => packageIds.Count == 0
+                ? Observable.Return(Unit.Default)
+                : packageIds
+                    .Select(packageId => PackageInstaller
+                        .RemoveInstalledRecord(hub, packageId, logger)
+                        .Do(_ => logger?.LogInformation(
+                            "[PluginCatalog] removed the install record for '{PackageId}': its target "
+                            + "partition '{Partition}' was deleted by {User}",
+                            packageId, partition, deletedBy ?? "system"))
+                        .Catch<bool, Exception>(ex =>
+                        {
+                            logger?.LogWarning(ex,
+                                "[PluginCatalog] could not remove the install record for '{PackageId}' "
+                                + "after its partition '{Partition}' was deleted — it will keep "
+                                + "re-asserting access into a partition that is gone until it is "
+                                + "removed from the admin orphan list",
+                                packageId, partition);
+                            return Observable.Return(false);
+                        }))
+                    .ToObservable()
+                    .Concat()
+                    .TakeLast(1)
+                    .Select(_ => Unit.Default));
+    }
+
+    /// <summary>
+    /// The package ids whose recorded install targets <paramref name="partition"/>, from TWO sources
+    /// unioned — deliberately, because neither alone is both authoritative and complete:
+    /// <list type="number">
+    ///   <item>an authoritative point read of <c>{InstalledPartition}/{partition}</c> through the
+    ///     storage adapter. The installer names a record after the package id and targets a partition
+    ///     of that name, so this is the shape of nearly every install — and it is a STORE read, not a
+    ///     query, so a record written seconds ago is already visible (CQRS lag cannot hide it);</item>
+    ///   <item>a listing of the records partition — the same query
+    ///     <see cref="InstalledPackageRepairService"/> issues — which is the only way to see a record
+    ///     whose <see cref="PackageManifest.TargetPartition"/> differs from its id. A listing is the
+    ///     sanctioned CQRS use, and a stale answer here can only MISS a record (which the boot
+    ///     reconciliation then reports), never remove one it should not.</item>
+    /// </list>
+    ///
+    /// <para>🚨 No <c>.Catch</c> on the listing, on purpose: a listing that could not be read is not
+    /// evidence that there is no record. The fault propagates, lands as a Warning on the deletion
+    /// activity, and the record stays visible to the boot reconciliation — swallowing it would report
+    /// a clean sweep having checked nothing.</para>
+    /// </summary>
+    internal static IObservable<IReadOnlyList<string>> RecordedInstallsTargeting(
+        IMessageHub hub, string partition)
+    {
+        var options = hub.JsonSerializerOptions;
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        var byName = storage is null
+            ? Observable.Return<string?>(null)
+            : storage.Read($"{PackageInstaller.InstalledPartition}/{partition}", options)
+                .Take(1)
+                .DefaultIfEmpty(null!)
+                .Select(node => node?.ContentAs<PackageManifest>(options) is { } manifest
+                                && string.Equals(
+                                    PackageInstaller.TargetPartitionOf(node!.Id, manifest), partition,
+                                    StringComparison.OrdinalIgnoreCase)
+                    ? node!.Id
+                    : null)
+                .Catch<string?, Exception>(_ => Observable.Return<string?>(null));
+
+        var byListing = hub.GetWorkspace()
+            .GetQuery("installed-packages-partition-teardown",
+                $"namespace:{PackageInstaller.InstalledPartition} "
+                + $"nodeType:{PackageInstaller.PackageNodeType} select:path,id,name,nodeType,content")
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Select(nodes => nodes
+                .Select(node => (node.Id, Manifest: node.ContentAs<PackageManifest>(options)))
+                .Where(x => x.Manifest is not null
+                            && string.Equals(
+                                PackageInstaller.TargetPartitionOf(x.Id, x.Manifest!), partition,
+                                StringComparison.OrdinalIgnoreCase))
+                .Select(x => x.Id))
+            // 🚨 A listing that COMPLETES WITHOUT EMITTING is not caught by the Timeout above —
+            // Timeout faults on silence, not on a clean finish (#2901) — and a Zip leg that never
+            // emits would park the whole deletion's step 5. Empty means "no records seen", which is
+            // the same conclusion as an empty listing.
+            .DefaultIfEmpty(Enumerable.Empty<string>());
+
+        return Observable.Zip(byName, byListing, (direct, listed) => (IReadOnlyList<string>)listed
+            .Concat(direct is null ? [] : new[] { direct })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList());
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -67,16 +68,7 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
             .SelectMany(records => records.Count == 0
                 ? Observable.Return(Unit.Default)
                 : records
-                    .Select(record => PackageInstaller
-                        .EnsureDeclaredAccess(hub, record.Manifest, record.Partition, logger)
-                        .Catch<Unit, Exception>(ex =>
-                        {
-                            logger?.LogWarning(ex,
-                                "[PackageRepair] re-asserting declared access for {Partition} failed",
-                                record.Partition);
-                            return Observable.Return(Unit.Default);
-                        })
-                        .SelectMany(_ => PackageInstaller.RunInstallHooks(hub, record.Partition, logger)))
+                    .Select(record => Reconcile(record, logger))
                     .ToObservable()
                     .Concat()
                     .DefaultIfEmpty(Unit.Default)
@@ -91,8 +83,126 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
         return Task.CompletedTask;
     }
 
-    /// <summary>One recorded install: its target partition and the manifest recorded for it.</summary>
-    private sealed record InstalledRecord(string Partition, PackageManifest Manifest);
+    /// <summary>
+    /// Reconciles ONE recorded install: re-assert its declared access and re-run its hooks — unless
+    /// the partition it names is GONE, in which case the record is a dangling reference and the
+    /// write is skipped and reported (#3451).
+    ///
+    /// <para>🚨 <b>Why a stale record must not be written to.</b> The record lives in the
+    /// <c>Plugins</c> partition and outlives the partition it points at, so deleting an installed
+    /// space used to leave this pass aiming <c>{partition}/_Policy</c> at nothing on every boot,
+    /// forever — a permanent per-boot error, and the writer that re-armed the resurrection race on
+    /// every restart. Going FORWARD there is nothing to skip:
+    /// <see cref="InstallRecordPartitionTeardownHandler"/> removes the record with the partition. This
+    /// arm is for the records that already dangle (the #3436 census counted 21 partition definitions
+    /// with no live root on one portal) and for a partition deleted by another replica or an older
+    /// build.</para>
+    ///
+    /// <para>🚨 <b>It reports; it does not delete.</b> The delete path knows exactly which partition
+    /// went, in-process, right now — so removing the record there is deterministic. Here the same
+    /// conclusion rests on three probes, and a boot pass that silently deletes install records on a
+    /// heuristic is a worse failure than the one it fixes. The remedy is the admin orphan list
+    /// (<c>CatalogLayoutAreas</c> → <see cref="PackageInstaller.RemoveInstalledRecord"/>), named in
+    /// the log line.</para>
+    /// </summary>
+    private IObservable<Unit> Reconcile(InstalledRecord record, ILogger? logger) =>
+        TargetPartitionIsGone(record.Partition, logger).SelectMany(gone =>
+        {
+            if (gone)
+            {
+                logger?.LogWarning(
+                    "[PackageRepair] SKIPPING install record '{Record}': its target partition "
+                    + "'{Partition}' no longer exists — no root node, no children, and no storage "
+                    + "provider reports a backing store. The record is a dangling reference; remove "
+                    + "it from the admin orphan list (Catalog → orphaned install records). Nothing "
+                    + "is written into a partition that is gone (#3451).",
+                    $"{PackageInstaller.InstalledPartition}/{record.PackageId}", record.Partition);
+                return Observable.Return(Unit.Default);
+            }
+
+            return PackageInstaller
+                .EnsureDeclaredAccess(hub, record.Manifest, record.Partition, logger)
+                .Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[PackageRepair] re-asserting declared access for {Partition} failed",
+                        record.Partition);
+                    return Observable.Return(Unit.Default);
+                })
+                .SelectMany(_ => PackageInstaller.RunInstallHooks(hub, record.Partition, logger));
+        });
+
+    /// <summary>
+    /// Is <paramref name="partition"/> definitively gone? A CONJUNCTION of three signals, each of
+    /// which always answers, so the verdict has no arming condition and no silent skip:
+    /// <list type="number">
+    ///   <item>no storage provider reports the backing store present — the same global-OR fold
+    ///     <c>PartitionWriteGuardValidator</c> applies, where only a <c>true</c> is evidence of
+    ///     presence;</item>
+    ///   <item>the partition ROOT node does not read back;</item>
+    ///   <item>the partition has no child paths.</item>
+    /// </list>
+    ///
+    /// <para>The conjunction is what makes it safe. Any ONE of these alone has a legitimate negative:
+    /// a provider that cannot tell answers <c>null</c>, a root row can go missing while the space is
+    /// alive (#638 — the very state the bootstrap repairs), and a read can fault. Requiring all three
+    /// means a false "gone" needs a partition with no store, no root and no content — which is not a
+    /// partition. A fault anywhere is read as the SAFE answer (present), so an unreachable store
+    /// keeps its record.</para>
+    /// </summary>
+    private IObservable<bool> TargetPartitionIsGone(string partition, ILogger? logger)
+    {
+        // 🚨 Every leg ends in DefaultIfEmpty(present) as well as Catch(present). A probe that
+        // COMPLETES WITHOUT EMITTING is not caught by Timeout — Timeout faults on silence, not on a
+        // clean finish (#2901) — and a Zip leg that never emits would park this record's
+        // reconciliation forever inside a boot pass. Empty means "no answer", which reads as the
+        // SAFE answer here: the partition is present, so nothing is declared stale.
+        var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>().ToList();
+        var storePresent = providers.Count == 0
+            ? Observable.Return(false)
+            : Observable.CombineLatest(providers.Select(p => p.PartitionExists(partition)
+                    .Take(1)
+                    .Timeout(TimeSpan.FromSeconds(5))
+                    .Catch<bool?, Exception>(_ => Observable.Return<bool?>(true))
+                    .DefaultIfEmpty(true)))
+                .Take(1)
+                .Select(results => results.Any(r => r == true))
+                .DefaultIfEmpty(true);
+
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        var rootPresent = storage is null
+            ? Observable.Return(true)
+            : storage.Read(partition, hub.JsonSerializerOptions)
+                .Take(1)
+                .DefaultIfEmpty(null!)
+                .Select(node => node is not null)
+                .Catch<bool, Exception>(_ => Observable.Return(true))
+                .DefaultIfEmpty(true);
+
+        var childrenPresent = storage is null
+            ? Observable.Return(true)
+            : storage.ListChildPaths(partition)
+                .Take(1)
+                .Select(children => children.NodePaths.Any() || children.DirectoryPaths.Any())
+                .Catch<bool, Exception>(_ => Observable.Return(true))
+                .DefaultIfEmpty(true);
+
+        return Observable.Zip(storePresent, rootPresent, childrenPresent,
+                (store, root, children) => (store, root, children))
+            .Select(t =>
+            {
+                var gone = !t.store && !t.root && !t.children;
+                if (gone)
+                    logger?.LogDebug(
+                        "[PackageRepair] partition '{Partition}' is definitively gone "
+                        + "(store={Store}, root={Root}, children={Children})",
+                        partition, t.store, t.root, t.children);
+                return gone;
+            });
+    }
+
+    /// <summary>One recorded install: its id, its target partition and the manifest recorded for it.</summary>
+    private sealed record InstalledRecord(string PackageId, string Partition, PackageManifest Manifest);
 
     /// <summary>
     /// Every recorded install, one entry per partition. Reads the <c>Package</c> records the
@@ -111,7 +221,10 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                 .Select(node => (Node: node,
                     Manifest: node.ContentAs<PackageManifest>(hub.JsonSerializerOptions)))
                 .Where(x => x.Manifest is not null)
-                .Select(x => new InstalledRecord(PartitionOf(x.Node, x.Manifest!), x.Manifest!))
+                .Select(x => new InstalledRecord(
+                    x.Node.Id,
+                    PackageInstaller.TargetPartitionOf(x.Node.Id, x.Manifest!),
+                    x.Manifest!))
                 .Where(r => !string.IsNullOrWhiteSpace(r.Partition))
                 .GroupBy(r => r.Partition, StringComparer.OrdinalIgnoreCase)
                 .Select(g => g.First())
@@ -121,15 +234,6 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                 logger?.LogWarning(ex, "[PackageRepair] listing installed packages failed");
                 return Observable.Return((IReadOnlyList<InstalledRecord>)[]);
             });
-
-    /// <summary>
-    /// The target partition of an install record. The record's id IS the package id, and the
-    /// installer targets a partition of that name — the recorded manifest's
-    /// <see cref="PackageManifest.TargetPartition"/> wins when present so a package whose partition
-    /// differs from its id still repairs correctly.
-    /// </summary>
-    private static string PartitionOf(MeshWeaver.Mesh.MeshNode node, PackageManifest manifest) =>
-        string.IsNullOrWhiteSpace(manifest.TargetPartition) ? node.Id : manifest.TargetPartition!;
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -41,6 +41,23 @@ public static class PackageInstaller
     /// <summary>The NodeType of an install record.</summary>
     public const string PackageNodeType = "Package";
 
+    /// <summary>
+    /// The partition an install record targets. The record's id IS the package id and the installer
+    /// targets a partition of that name, so <see cref="PackageManifest.TargetPartition"/> wins only
+    /// when the package declares one.
+    ///
+    /// <para>🚨 ONE definition, deliberately (#3451). Both the boot reconciliation
+    /// (<see cref="InstalledPackageRepairService"/>) and the partition-teardown handler
+    /// (<see cref="InstallRecordPartitionTeardownHandler"/>) decide "which partition is this record
+    /// about?", and two copies of that rule is how one of them would go on re-asserting into a
+    /// partition the other had just declared gone.</para>
+    /// </summary>
+    /// <param name="recordId">The install record's node id (the package id).</param>
+    /// <param name="manifest">The manifest recorded for that install.</param>
+    /// <returns>The target partition name.</returns>
+    internal static string TargetPartitionOf(string recordId, PackageManifest manifest) =>
+        string.IsNullOrWhiteSpace(manifest.TargetPartition) ? recordId : manifest.TargetPartition!;
+
     /// <summary>Bounded concurrency for the per-node upsert fan-out (mirrors <c>NodeCopyHelper</c>).</summary>
     public const int DefaultBatchSize = 8;
 

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -122,6 +122,17 @@ public static class PluginCatalogConfigurationExtensions
                 .AddSingleton<InstalledPackageRepairService>()
                 .AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(
                     sp => sp.GetRequiredService<InstalledPackageRepairService>())
+                // 🚨 Referential integrity for install records (#3451). A record lives in the
+                // `Plugins` partition and therefore OUTLIVES the partition it points at, so deleting
+                // an installed space used to leave the repair pass above aiming at nothing on every
+                // boot, forever. Core deliberately knows nothing about `Plugins/Package`, so the
+                // discriminator comes from THIS side: the catalog registers its own structural
+                // post-deletion handler next to the platform's partition teardown.
+                .AddSingleton<Mesh.Services.INodePostDeletionHandler>(sp =>
+                    new InstallRecordPartitionTeardownHandler(
+                        sp.GetRequiredService<IMessageHub>(),
+                        sp.GetService<ILoggerFactory>()
+                            ?.CreateLogger<InstallRecordPartitionTeardownHandler>()))
                 // Auto-discovery of a configured repo's modules (#833). Registered LAST of the
                 // package services because its boot scan deliberately waits for
                 // InstanceAutoRegistrationService.Completed — both touch the same partitions. Inert

--- a/test/Memex.Portal.Shared.Test/InstallRecordFollowsItsPartitionTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstallRecordFollowsItsPartitionTest.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>An install record must not outlive the partition it points at</b>
+/// (Systemorph/MeshWeaver#3451, the second half).
+///
+/// <para>A package's install record lives at <c>Plugins/{packageId}</c> — in the RECORDS partition,
+/// never in the package's own — so deleting the installed space left the record behind, aimed at a
+/// partition that no longer exists. Nothing reconciled it, and
+/// <c>InstalledPackageRepairService</c> re-drove <c>PackageInstaller.EnsureDeclaredAccess</c> at that
+/// dead partition on EVERY boot: a permanent per-boot error for every partition anyone had ever
+/// deleted (21 of them on one portal when this was filed), and the writer that re-armed the
+/// resurrection race on every restart.</para>
+///
+/// <para><b>The fix is referential integrity maintained by the side that owns the reference.</b> Core
+/// deliberately knows nothing about <c>Plugins/Package</c> — teaching the delete pipeline about it
+/// would re-introduce exactly the coupling #3436 removed — so the plugin catalog registers its OWN
+/// <c>INodePostDeletionHandler</c>, matching the same structural partition-root predicate the
+/// platform's partition teardown uses.</para>
+/// </summary>
+public class InstallRecordFollowsItsPartitionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The <c>Store/Plugin</c> stand-in: a partition-root NodeType that declares no
+    /// <c>OwnsPartition</c>, because what provisioned its partition was the installer.</summary>
+    private const string PluginLikeNodeType = "TestStore/InstalledPlugin";
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            .AddMeshNodes(new MeshNode(PluginLikeNodeType)
+            {
+                Name = "Installed plugin root",
+                NodeType = MeshNode.NodeTypePath,
+                State = MeshNodeState.Active,
+                Content = new NodeTypeDefinition { DefaultNamespace = "", RestrictedToNamespaces = [""] },
+            });
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private IStorageAdapter Persistence => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+    private static string NewPackageId() => "recpkg" + Guid.NewGuid().ToString("N")[..8];
+
+    private static string RecordPath(string packageId) =>
+        $"{PackageInstaller.InstalledPartition}/{packageId}";
+
+    /// <summary>
+    /// Writes what an install leaves behind: the record in the <c>Plugins</c> partition, the
+    /// partition root, and one child so the delete has a real subtree to drain.
+    /// </summary>
+    private async Task<string> Install()
+    {
+        var packageId = NewPackageId();
+        var manifest = new PackageManifest
+        {
+            Id = packageId,
+            Name = $"Package {packageId}",
+            Version = "1.0.0",
+            TargetPartition = packageId,
+        };
+
+        await Access.RunAsSystem(() => NodeFactory.CreateOrUpdateNode(
+                MeshNode.FromPath(RecordPath(packageId)) with
+                {
+                    NodeType = PackageInstaller.PackageNodeType,
+                    Name = manifest.Name,
+                    State = MeshNodeState.Active,
+                    Content = manifest,
+                }))
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        await CreateAsSystem(new MeshNode(packageId)
+        {
+            Name = manifest.Name,
+            NodeType = PluginLikeNodeType,
+            State = MeshNodeState.Active,
+        });
+        await CreateAsSystem(new MeshNode("Page", packageId)
+        {
+            Name = "Page",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = "# page" },
+        });
+
+        (await Exists(RecordPath(packageId))).Should().BeTrue(
+            "the fixture must actually record the install, or the assertions below prove nothing");
+        Output.WriteLine($"installed '{packageId}' with record {RecordPath(packageId)}");
+        return packageId;
+    }
+
+    private async Task<CreateNodeResponse> CreateAsSystem(MeshNode node)
+    {
+        var response = await Access
+            .RunAsSystem(() => ObserveNodeOperation(new CreateNodeRequest(node)))
+            .FirstAsync()
+            .Select(d => d.Message)
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+        response.Success.Should().BeTrue($"the fixture write '{node.Path}' must land: {response.Error}");
+        return response;
+    }
+
+    private async Task DeleteAsSystem(string path)
+    {
+        var response = await Access
+            .RunAsSystem(() => ObserveNodeOperation(
+                new DeleteNodeRequest(path)
+                {
+                    Recursive = true,
+                    IncludeSatellites = true,
+                    ConfirmWarnings = true,
+                    DeletedBy = WellKnownUsers.System,
+                }))
+            .FirstAsync()
+            .Select(d => d.Message)
+            .Timeout(TestTimeouts.CrossSilo)
+            .Await();
+        Output.WriteLine($"delete {path} success={response.Success} error={response.Error}");
+        response.Success.Should().BeTrue($"the delete itself must succeed: {response.Error}");
+    }
+
+    private async Task<bool> Exists(string path) =>
+        await Persistence.Exists(path).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+    /// <summary>
+    /// 🚨 <b>THE FALSIFIER.</b> On the pre-fix code the delete succeeds, the partition's nodes are
+    /// gone, and <c>Plugins/{packageId}</c> is still there — pointing at nothing, and re-asserting
+    /// <c>{packageId}/_Policy</c> on every boot for the rest of the instance's life.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task DeletingAnInstalledPartition_RemovesItsInstallRecord()
+    {
+        var packageId = await Install();
+
+        await DeleteAsSystem(packageId);
+
+        (await Exists(RecordPath(packageId))).Should().BeFalse(
+            $"'{RecordPath(packageId)}' names a partition that no longer exists. A record that "
+            + "outlives its partition is a dangling reference the boot repair pass keeps writing "
+            + "into forever — a permanent per-boot error for every partition anyone ever deleted, "
+            + "and the writer that re-armed the resurrection race on every restart (#3451)");
+    }
+
+    /// <summary>
+    /// The positive control that keeps the assertion above honest: a NESTED node is not a partition
+    /// root, and deleting one must never remove the install record. A handler that fired on every
+    /// delete would pass the test above while uninstalling a package on its first page deletion.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task DeletingANestedNode_LeavesTheInstallRecordAlone()
+    {
+        var packageId = await Install();
+
+        await DeleteAsSystem($"{packageId}/Page");
+
+        (await Exists(RecordPath(packageId))).Should().BeTrue(
+            "only a partition ROOT ends an install — deleting a page out of an installed package "
+            + "leaves the package installed");
+    }
+
+    /// <summary>
+    /// The second control: the handler must remove the record for the partition that was deleted and
+    /// no other. A handler that removed every record on any partition delete would pass both tests
+    /// above.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task DeletingADifferentPartition_LeavesOtherInstallRecordsAlone()
+    {
+        var kept = await Install();
+        var deleted = await Install();
+
+        await DeleteAsSystem(deleted);
+
+        (await Exists(RecordPath(deleted))).Should().BeFalse("its partition is gone");
+        (await Exists(RecordPath(kept))).Should().BeTrue(
+            $"'{kept}' was not touched — the teardown must be scoped to the partition that was "
+            + "actually deleted");
+    }
+
+    /// <summary>
+    /// The registration itself, asserted on the mesh this repository ships and stated WITHOUT naming
+    /// the new type — so this file compiles, and fails, against the pre-fix source too. Two
+    /// structural teardowns must reach an arbitrary partition root (the platform's backing-store
+    /// drop and the catalog's install-record removal), and only ONE of them may reach the records
+    /// partition itself.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public void TwoStructuralTeardownsCoverAnArbitraryPartitionRoot()
+    {
+        var handlers = Mesh.ServiceProvider.GetServices<INodePostDeletionHandler>().ToList();
+        var probe = new MeshNode("ProbePartition")
+        {
+            NodeType = "TestProbe/UnknownInMeshType",
+            State = MeshNodeState.Active,
+        };
+        var recordsPartition = new MeshNode(PackageInstaller.InstalledPartition)
+        {
+            NodeType = "Space",
+            State = MeshNodeState.Active,
+        };
+
+        handlers.Count(h => h.Matches(probe)).Should().Be(2,
+            "a partition root fires TWO structural teardowns — the platform's backing-store drop and "
+            + "the catalog's install-record removal (#3451) — and a NodeType neither of them could "
+            + "have enumerated must reach both");
+        handlers.Count(h => h.Matches(recordsPartition)).Should().Be(1,
+            "the RECORDS partition is excluded from the install-record teardown: its records go with "
+            + "it, and cascading each one first would race the drain that just removed them — only "
+            + "the platform's backing-store drop applies there");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/PartitionResurrectionTest.cs
+++ b/test/MeshWeaver.Graph.Test/PartitionResurrectionTest.cs
@@ -1,0 +1,323 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A deleted partition must not come back — and the seam it used to come back through is NOT
+/// a node write</b> (Systemorph/MeshWeaver#3451, the remaining half of #3436).
+///
+/// <para><b>Why the existing exclusion could not see it.</b> The delete pipeline already holds
+/// <c>RecentlyDeletedRegistry.BeginSubtreeDeletion</c> across the WHOLE operation — plan, drain,
+/// the partition drop (step 5 runs inside the scope) and the success response — and
+/// <c>SubtreeDeletionGuardStorageAdapter</c> refuses every in-process write at or under the root
+/// while it is open. Both of those guard <see cref="IStorageAdapter"/> WRITES. The resurrection did
+/// not happen through a write: <c>EnsurePartitionBootstrap</c> → <c>HealPartitionRoot</c> opened
+/// with <see cref="IPartitionStorageProvider.EnsurePartitionProvisioned"/> — the API whose own
+/// contract calls it "the ONLY trigger for partition creation" — which is DDL and crosses no storage
+/// adapter at all. Nothing in the registry, the tombstone or the guard was ever consulted for it.</para>
+///
+/// <para><b>Why a probe was never going to close it.</b> #3436 gated the heal on "does the backing
+/// store still exist?". The drop is step 5, AFTER the drain, so a probe taken while the delete was
+/// draining answered a truthful <c>true</c> — and authorised a <c>CREATE SCHEMA</c> that ran after
+/// the <c>DROP</c>. That is the whole race, and it is what
+/// <see cref="PartitionStore.StaleExistenceProbeFor"/> models below: one property, no thread
+/// choreography, and the same input the real race produces. A test that had to interleave two
+/// pipelines to see the bug would be measuring its own timing; this measures the invariant —
+/// <b>a stale <c>true</c> must not be able to bring a partition back.</b></para>
+///
+/// <para>The fixture's root carries a NodeType declared HERE, for the same reason
+/// <c>PartitionTeardownCoverageTest</c> does: the real victims were <c>Store/Plugin</c> roots, a
+/// type that lives in mesh CONTENT and sets no <c>OwnsPartition</c>, so anything keyed on
+/// <c>src/</c> knowledge would be green while the actual shape stayed uncovered.</para>
+/// </summary>
+public class PartitionResurrectionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The <c>Store/Plugin</c> stand-in — a partition-root NodeType that does NOT declare
+    /// <c>OwnsPartition</c>, because what provisioned its partition was an installer.</summary>
+    private const string PluginLikeNodeType = "TestStore/PluginLike";
+
+    /// <summary>
+    /// A provider that MODELS a per-partition backing store — the Postgres schema, in miniature.
+    /// Not a mock of a core interface: <see cref="IPartitionStorageProvider"/> IS the extension
+    /// point a storage backend implements, and provisioning / probing / dropping a partition is
+    /// exactly its contract. Read-only, so it never joins the write chain and the in-memory store
+    /// stays the store of record.
+    /// </summary>
+    private sealed class PartitionStore(IStorageAdapter adapter) : IPartitionStorageProvider
+    {
+        private readonly ConcurrentDictionary<string, byte> provisioned =
+            new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentQueue<string> events = new();
+
+        /// <inheritdoc />
+        public string Name => "test-partition-store";
+
+        /// <inheritdoc />
+        public bool IsReadOnly => true;
+
+        /// <inheritdoc />
+        public IStorageAdapter Adapter => adapter;
+
+        /// <summary>
+        /// The partition whose existence probe answers the PRE-DROP truth (<c>true</c>) no matter
+        /// what the store actually holds — a probe that was read before step 5's
+        /// <c>DROP SCHEMA</c> and acted on after it. Null (the default) means every probe answers
+        /// honestly.
+        /// </summary>
+        public string? StaleExistenceProbeFor { get; set; }
+
+        /// <summary>The ordered ledger of provisioning / drop calls, for the assertions.</summary>
+        public IReadOnlyList<string> Events => events.ToArray();
+
+        /// <summary>Does this partition's backing store exist right now?</summary>
+        public bool IsProvisioned(string @namespace) => provisioned.ContainsKey(@namespace);
+
+        /// <summary>Provisions a partition the way <c>PackageInstaller</c> does — the fixture's
+        /// stand-in for an install, and the call the bootstrap must never make.</summary>
+        public IObservable<System.Reactive.Unit> EnsurePartitionProvisioned(string @namespace)
+            => Observable.Defer(() =>
+            {
+                provisioned[@namespace] = 1;
+                events.Enqueue($"provision:{@namespace}");
+                return Observable.Return(System.Reactive.Unit.Default);
+            });
+
+        /// <inheritdoc />
+        public IObservable<bool?> PartitionExists(string @namespace)
+            => Observable.Defer(() => Observable.Return<bool?>(
+                string.Equals(@namespace, StaleExistenceProbeFor, StringComparison.OrdinalIgnoreCase)
+                    ? true
+                    : provisioned.ContainsKey(@namespace)));
+
+        /// <inheritdoc />
+        public IObservable<System.Reactive.Unit> DeletePartition(string @namespace)
+            => Observable.Defer(() =>
+            {
+                provisioned.TryRemove(@namespace, out _);
+                events.Enqueue($"drop:{@namespace}");
+                return Observable.Return(System.Reactive.Unit.Default);
+            });
+    }
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(new MeshNode(PluginLikeNodeType)
+            {
+                Name = "Plugin-like root",
+                NodeType = MeshNode.NodeTypePath,
+                State = MeshNodeState.Active,
+                Content = new NodeTypeDefinition { DefaultNamespace = "", RestrictedToNamespaces = [""] },
+            })
+            .ConfigureServices(services => services
+                .AddSingleton<IPartitionStorageProvider>(sp =>
+                    new PartitionStore(sp.GetRequiredService<IStorageAdapter>())));
+
+    private PartitionStore Store => Mesh.ServiceProvider
+        .GetServices<IPartitionStorageProvider>()
+        .OfType<PartitionStore>()
+        .Single();
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private IStorageAdapter Persistence => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+    private static string NewPartition() => "resurrect" + Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// Installs a partition the way the package installer does: provision the backing store first
+    /// (the installer's own <c>EnsurePartitionsProvisioned</c>, NOT
+    /// <c>OwnsPartitionProvisioningValidator</c> — this root type declares no
+    /// <c>OwnsPartition</c>), then write the root and one child as SYSTEM.
+    /// </summary>
+    private async Task<string> InstallPartition(bool withRoot = true)
+    {
+        var partition = NewPartition();
+        await Store.EnsurePartitionProvisioned(partition)
+            .Timeout(TestTimeouts.Quick).Await();
+
+        if (withRoot)
+            await CreateAsSystem(new MeshNode(partition)
+            {
+                Name = "A plugin-like partition root",
+                NodeType = PluginLikeNodeType,
+                State = MeshNodeState.Active,
+            });
+
+        Output.WriteLine($"installed partition '{partition}' (root={withRoot})");
+        return partition;
+    }
+
+    private async Task<CreateNodeResponse> CreateAsSystem(MeshNode node)
+    {
+        var response = await Access
+            .RunAsSystem(() => ObserveNodeOperation(new CreateNodeRequest(node)))
+            .FirstAsync()
+            .Select(d => d.Message)
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+        Output.WriteLine($"create {node.Path} success={response.Success} error={response.Error}");
+        return response;
+    }
+
+    private static MeshNode Child(string partition, string id) =>
+        new(id, partition)
+        {
+            Name = id,
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = $"# {id}" },
+        };
+
+    private async Task DeletePartitionAsSystem(string path)
+    {
+        var response = await Access
+            .RunAsSystem(() => ObserveNodeOperation(
+                new DeleteNodeRequest(path)
+                {
+                    Recursive = true,
+                    IncludeSatellites = true,
+                    ConfirmWarnings = true,
+                    DeletedBy = WellKnownUsers.System,
+                }))
+            .FirstAsync()
+            .Select(d => d.Message)
+            .Timeout(TestTimeouts.CrossSilo)
+            .Await();
+        Output.WriteLine($"delete {path} success={response.Success} error={response.Error}");
+        response.Success.Should().BeTrue($"the delete itself must succeed: {response.Error}");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE FALSIFIER for the DDL side-channel.</b> On the pre-fix code the bootstrap opens with
+    /// <c>EnsurePartitionProvisioned</c> on every provider — so a stale <c>true</c> from the
+    /// existence probe puts the partition's backing store straight back, AFTER the delete dropped
+    /// it. No storage guard sees that call: it is not a write.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task AStaleExistenceProbe_DoesNotReProvisionADeletedPartitionsStore()
+    {
+        var partition = await InstallPartition();
+        await CreateAsSystem(Child(partition, "Page"));
+
+        await DeletePartitionAsSystem(partition);
+        Store.IsProvisioned(partition).Should().BeFalse(
+            "the delete must drop the partition's backing store first — otherwise this test would "
+            + "be asserting about a partition that was never torn down (#3436 is the fix that makes "
+            + "this line pass)");
+
+        // The delete-window race, stated as its input: the probe was read BEFORE step 5's drop, so
+        // it truthfully answers `true`, and the bootstrap acts on it afterwards.
+        Store.StaleExistenceProbeFor = partition;
+
+        await CreateAsSystem(Child(partition, "Recovered"));
+
+        Store.IsProvisioned(partition).Should().BeFalse(
+            "a child write must never re-provision a partition's backing store. The bootstrap is a "
+            + "REPAIR, and a repair that can call EnsurePartitionProvisioned is a SECOND trigger for "
+            + "partition creation behind OwnsPartitionProvisioningValidator's back — the one seam "
+            + "neither the subtree-deletion scope nor SubtreeDeletionGuardStorageAdapter can see, "
+            + "because provisioning is DDL and crosses no storage adapter (#3451). "
+            + $"Provider ledger: {string.Join(", ", Store.Events)}");
+    }
+
+    /// <summary>
+    /// The visible half of the incident: a bare <c>Space</c> shell over a partition that was
+    /// deleted. The exclusion that refuses it is the delete's own tombstone — marked synchronously
+    /// at the delete source for every path INCLUDING the root, and cleared only by a real re-create
+    /// — so it OUTLIVES the drop, which is exactly what #3436 asked for and what the subtree scope
+    /// (released with the operation) could not provide.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task AStaleExistenceProbe_DoesNotResurrectADeletedPartitionsRoot()
+    {
+        var partition = await InstallPartition();
+        await CreateAsSystem(Child(partition, "Page"));
+
+        await DeletePartitionAsSystem(partition);
+        (await Persistence.Exists(partition).FirstAsync().Timeout(TestTimeouts.Convergence).Await())
+            .Should().BeFalse("the delete removed the root — that is the state the heal runs over");
+
+        Store.StaleExistenceProbeFor = partition;
+
+        await CreateAsSystem(Child(partition, "Recovered"));
+
+        (await Persistence.Exists(partition).FirstAsync().Timeout(TestTimeouts.Convergence).Await())
+            .Should().BeFalse(
+                $"'{partition}' was deleted, so no child write may heal a root over it. That is how "
+                + "four deleted partitions came back on the systemorph staff portal as bare Space "
+                + "shells with a fresh _Policy 67 ms later — a policy granting Delete to nobody who "
+                + "could have deleted the original, so the shell was undeletable through the "
+                + "ordinary API (#3436/#3451)");
+    }
+
+    /// <summary>
+    /// The in-flight window, driven through the REAL exclusion rather than a simulated one: a
+    /// <c>BeginSubtreeDeletion</c> scope is open on the partition (exactly what
+    /// <c>HandleDeleteNodeRequest</c> holds from before the plan until after the drop), the root row
+    /// is already gone, and the probe still answers <c>true</c> because the drop has not run yet.
+    /// Pre-fix the bootstrap provisions the store from inside that window and only THEN has its row
+    /// write refused by the storage guard — so the guard was closing the visible half while the
+    /// invisible half sailed through.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task WhileTheDeletionScopeIsOpen_TheHealNeitherProvisionsNorRoots()
+    {
+        // A partition mid-teardown: nodes drained, store about to be dropped, no root row.
+        var partition = await InstallPartition(withRoot: false);
+        await Store.DeletePartition(partition).Timeout(TestTimeouts.Quick).Await();
+        Store.StaleExistenceProbeFor = partition;
+
+        var registry = Mesh.ServiceProvider.GetRequiredService<RecentlyDeletedRegistry>();
+        using (registry.BeginSubtreeDeletion(partition))
+        {
+            registry.IsUnderActiveDeletion(partition, out _).Should().BeTrue(
+                "the scope must actually be open, or this test asserts nothing");
+
+            await CreateAsSystem(Child(partition, "MidFlight"));
+        }
+
+        Store.IsProvisioned(partition).Should().BeFalse(
+            "a write racing a delete must not re-provision the partition's backing store — the "
+            + "subtree-deletion scope was open for the whole create, and provisioning is the one "
+            + "effect that scope never reached (#3451). "
+            + $"Provider ledger: {string.Join(", ", Store.Events)}");
+        (await Persistence.Exists(partition).FirstAsync().Timeout(TestTimeouts.Convergence).Await())
+            .Should().BeFalse("nor may a Space root be minted for a subtree that is being deleted");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The positive control — the case that could falsify the fix.</b> The bootstrap exists to
+    /// repair a LIVE partition whose root row went missing (#638/#902: a create that wrote the row
+    /// and then failed leaves the bare partition address unroutable, and the first child write is
+    /// what heals it). Nothing here was deleted, so the heal must still run — a fix that simply
+    /// stopped healing would pass every assertion above while breaking the feature.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task AMissingRootOverALivePartition_IsStillHealed()
+    {
+        var partition = await InstallPartition(withRoot: false);
+
+        var response = await CreateAsSystem(Child(partition, "First"));
+        response.Success.Should().BeTrue($"the child write must succeed: {response.Error}");
+
+        (await Persistence.Exists(partition).FirstAsync().Timeout(TestTimeouts.Convergence).Await())
+            .Should().BeTrue(
+                "the partition's backing store is there and nothing deleted it, so the missing root "
+                + "is a half-completed create the bootstrap must repair — that repair is the whole "
+                + "reason EnsurePartitionBootstrap exists, and it must survive #3451");
+        Store.IsProvisioned(partition).Should().BeTrue(
+            "and the store it healed over is the one the installer provisioned — untouched");
+    }
+}


### PR DESCRIPTION
Closes #3451.

`Pairs-with: none` — no public top-level type or public member is removed from `src/`. The renamed
method (`ProvisionAndCreateRoot` → `HealPartitionRoot`) and the extracted
`PackageInstaller.TargetPartitionOf` are `private`/`internal`; the only public addition is a new type
(`InstallRecordPartitionTeardownHandler`).

## Why the window was still open despite the registry and the guard

Both halves of #3451 turned out to be one sentence: **the resurrection never went through a write.**

`RecentlyDeletedRegistry.BeginSubtreeDeletion` really does scope the entire delete — plan, drain, the
partition drop (step 5 runs inside the scope) and the success response — and
`SubtreeDeletionGuardStorageAdapter` really does refuse every in-process write at or under the root
while it is open. Both guard `IStorageAdapter` **writes**.

`EnsurePartitionBootstrap` → `ProvisionAndCreateRoot` opened with
`IPartitionStorageProvider.EnsurePartitionProvisioned` — the API whose own contract calls it *"the
ONLY trigger for partition creation"*. That is DDL. It crosses no storage adapter, so no scope, no
tombstone and no guard was ever consulted for it. #3436 tried to make the call safe by probing the
store first, but a probe is **read at one instant and acted on at another**: the drop is step 5,
*after* the drain, so a probe taken while the delete was draining answers a truthful `true` and
authorises a `CREATE SCHEMA` that runs after the `DROP`.

Measured on the in-memory harness, the provider ledger for one deleted partition read:

```
provision:P, drop:P, provision:P, provision:P
```

— the store came back **twice**, from a repair, after its own teardown had removed it.

## Both halves are closed

**(a) The delete-window race — two changes, the first structural.**

1. **A repair can no longer create a partition.** `HealPartitionRoot` does not call
   `EnsurePartitionProvisioned` at all. In every state where the heal is legitimate that call was a
   **no-op by construction** (a ghost row means the store exists; an absent root over a live store
   means the store is already provisioned), so removing it costs nothing and removes the capability.
   What is left is a plain row write into whatever store already routes the partition — refused by
   the subtree guard while the delete is in flight, and failing loudly (`42P01`) afterwards.
2. **The heal consults the delete record, at the point of effect.** `PartitionRemovalOnRecord` asks
   the registry both questions it already answers: `IsUnderActiveDeletion` (the hard invariant, exact
   lifetime) and `IsRecentlyDeleted` (the "delete wins" tombstone, marked synchronously at the delete
   source for every path including the root, cleared only by a real re-create). The tombstone is the
   half that **outlives the drop** — what #3436 asked for: a probe-based decision taken before the
   drop is still refused when it lands after it. It gates the creator GRANT as well as the root,
   because `{P}/_Access/{creator}_Access` is the "fresh `_Policy` 67 ms later" half of the incident.

No new state, no new timer, no widened bound. `RecentlyDeletedRegistry` is registered unconditionally
by `MeshBuilder` at the mesh root, so the check resolves with `GetRequiredService` and **always
decides** — no arming condition (the failure mode #3436's first coverage-gate draft had).

**(b) The install record no longer outlives its partition.**

- **On delete — unreachable.** `AddPluginCatalog` registers `InstallRecordPartitionTeardownHandler`,
  an `INodePostDeletionHandler` matching the same structural `PartitionDefinition.IsPartitionRoot`
  predicate (minus mirrors, minus `Plugins` itself). Core learns nothing about `Plugins/Package` —
  the discriminator comes from the record side, through the seam #3436 built. Records are resolved
  from an authoritative point read of `Plugins/{partition}` unioned with a listing (for records whose
  `TargetPartition` differs from their id), and removed via the sanctioned
  `PackageInstaller.RemoveInstalledRecord`.
- **On boot — reported, not written to.** `InstalledPackageRepairService` asks `TargetPartitionIsGone`
  first: a conjunction of three always-answering signals (no provider reports the store present, the
  root does not read back, no child paths). A record failing all three is skipped and named at
  Warning with the remedy. It reports rather than deletes deliberately — the delete path knows which
  partition went, in-process, right now; a boot pass silently deleting install records on a
  three-probe heuristic would be a worse failure than the one it fixes.

Also hardened three folds with `DefaultIfEmpty`: a probe that **completes without emitting** is not
caught by `Timeout` (#2901), and a `Zip`/`CombineLatest` leg that never emits would park a create or
a boot pass.

## Falsification — both arms, measured

`PartitionResurrectionTest` (MeshWeaver.Graph.Test), `InstallRecordFollowsItsPartitionTest`
(Memex.Portal.Shared.Test). Same tests both ways; only `src/` was reverted.

| Suite | With the fix | With `src/` reverted |
|---|---|---|
| `PartitionResurrectionTest` | 4 passed, 0 failed | **3 failed**, 1 passed |
| `InstallRecordFollowsItsPartitionTest` | 4 passed, 0 failed | **3 failed**, 1 passed |

The tests that pass both ways are the positive controls that could have falsified the fix: a missing
root over a LIVE store is still healed, and deleting a nested node still leaves the install record
alone.

## Docs

Extends `Doc/Architecture/PartitionTeardown` (created by #3449) rather than adding a rival page:
a new "the seam the existing guards could never see" section with the exclusion table and the
measured ledger, and a new "the install record must not outlive its partition" section.
`DocumentationLinkIntegrityTest` passes. What's New entry: *A deleted space stays deleted*
(`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
