### PR TITLE
fix: the embedding backfill can reach the vault key, or it silently embeds nothing

### DIFF
--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -49,4 +49,28 @@ spec:
                 name: "memex-migration-config"
             - secretRef:
                 name: "memex-migration-secrets"
+            {{- /* The Key Vault CSI-synced secrets, exactly as the portal consumes them
+                   (memex-portal/deployment.yaml). WITHOUT this the migration cannot receive
+                   `Embedding__ApiKey`, and `MeshNodeEmbeddingBackfill` — which is the ONLY thing
+                   that embeds rows written before a provider existed — skips every row.
+
+                   Measured on the `memex` release 2026-09-06, migration job memex-migration-32:
+                       [DocBackfill] 1242 documentation pages found (embeddings OFF — FTS only)
+                       [DocBackfill] done: 161 upserted (0 embedded), 1081 unchanged, 1242 total
+                       [EmbeddingBackfill] no embedding provider configured — skipped
+                       Database migration completed. Version: 55
+                   A green migration that embedded nothing: search stays lexical-only for every
+                   pre-existing row, and nothing in the run says the index is empty.
+
+                   `optional: true` because the CSI driver only materialises the synced Secret
+                   while a pod mounts the SecretProviderClass volume — on a FIRST install no portal
+                   pod has started yet, and a missing non-optional secretRef would keep the Job
+                   from starting at all. Skipping is safe there and only there: a first install has
+                   no pre-existing rows to backfill, and the run still says so out loud via
+                   `[EmbeddingBackfill] … skipped` plus EmbeddingCapabilityReporter. */}}
+            {{- range $class := (include "memex.keyVaultClasses" . | fromYamlArray) }}
+            - secretRef:
+                name: "{{ $class.syncedSecret }}"
+                optional: true
+            {{- end }}
           imagePullPolicy: "IfNotPresent"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-search-finds-things-written-before-search-existed.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-search-finds-things-written-before-search-existed.md
@@ -1,0 +1,36 @@
+---
+Name: Search finds things that were written before search did
+Category: Fix
+Description: Turning on semantic search used to leave every page and node created beforehand invisible to it, because the one job that fills in their missing vectors could not reach the embedding key. It can now, so switching search on covers the whole history instead of only what you write next.
+Icon: Checkmark
+Order: -20260906
+---
+
+# Search finds things that were written before search did
+
+A node's search vector is computed when the node is written. That is the right moment for
+everything written *after* semantic search is switched on — but it means that on the day you enable
+it, every page, document and node that already existed has no vector at all.
+
+The platform has always had an answer for this: a backfill that runs with the database migration,
+walks every schema, and fills in the missing vectors. The problem was that the backfill could not
+reach the embedding key. The portal received it; the migration did not. So the migration ran, said
+`no embedding provider configured — skipped`, and finished green having embedded nothing.
+
+That is the worst shape a gap can take. Nothing failed. The deployment was healthy, search was
+switched on, new content was indexed correctly — and the entire back catalogue silently stayed
+lexical-only, findable if you typed a word it literally contained and invisible otherwise. On one
+portal that was 1 242 documentation pages, of which 0 were embedded.
+
+The migration now reads the same key vault secrets the portal does. Enabling semantic search covers
+what you already have, not just what you write next.
+
+## What you will notice
+
+- Turning on semantic search now makes existing content searchable by meaning, not only by
+  substring — with no extra step and no re-import.
+- If the key genuinely is not available yet, the migration still says so out loud rather than
+  quietly skipping.
+
+Nothing changes for a portal that has always had an embedding provider configured: the backfill only
+touches rows whose vector is missing, so it is a no-op there.


### PR DESCRIPTION
## The defect

A node's search vector is computed **at write time**. So on the day an embedding provider is switched on, every row written before that has a NULL embedding, and `MeshNodeEmbeddingBackfill` — which runs inside the migration — is the *only* thing that fills them in.

The migration could not reach the embedding key:

- the portal's Deployment ranges over `memex.keyVaultClasses` in its `envFrom` (`memex-portal/deployment.yaml`), so it receives `Embedding__ApiKey` from the CSI-synced secret;
- the migration Job's `envFrom` was only `memex-migration-config` + `memex-migration-secrets`, and there is no `Embedding__ApiKey` in `memex-migration-secrets` at all.

`memex-migration/config.yaml` already carries the comment *"Embeddings — MUST match the portal's `Embedding__*`"*. The config keys are there; the **key** had no route.

## Measured, not inferred

`memex` release, 2026-09-06, migration job `memex-migration-32`:

```
[DocBackfill] 1242 documentation pages found (embeddings OFF — FTS only)
[DocBackfill] done: 161 upserted (0 embedded), 1081 unchanged, 1242 total
[EmbeddingBackfill] no embedding provider configured — skipped (hybrid/FTS search only)
Database migration completed. Version: 55
```

Nothing failed. The migration reported its success line, the deploy was healthy, semantic search was configured and switched on — and 1 242 documentation pages stayed lexical-only, findable only by a substring they literally contained. A green run that embedded zero rows is exactly the false-pass shape AGENTS.md forbids.

## The fix

The Job consumes the same CSI-synced secrets the portal does, derived from the **one** `keyVaultSecrets` declaration, so the two agree by construction instead of by remembering to copy a key into a second place.

`optional: true` is load-bearing and deliberate: the CSI driver only materialises the synced Secret while a pod mounts the SecretProviderClass volume, so on a **first install** no portal pod has started yet and a missing non-optional `secretRef` would stop the Job from starting at all. Skipping is correct precisely there — a first install has no pre-existing rows to backfill — and it is not a silent skip: the run still prints `[EmbeddingBackfill] … skipped` and `EmbeddingCapabilityReporter`'s line, so "no provider" stays visible rather than passing quietly.

## Verification

Rendered the chart against the **live** memex overlay (`helm template` with `values.memex.public.yaml` at `origin/main` — not the stale primary checkout, which omits `keyVaultSecrets` entirely and renders no SecretProviderClass at all):

```yaml
# migration Job — after
envFrom:
  - configMapRef: {name: "memex-migration-config"}
  - secretRef:    {name: "memex-migration-secrets"}
  - secretRef:    {name: "memex-portal-keyvault", optional: true}   # new
```

and the portal's own `envFrom` is byte-identical to before.

- `MeshWeaver.Documentation.Test` (`WhatsNewEntryIntegrityTest`, `DocumentationLinkIntegrityTest`): **Failed: 0, Passed: 2**, built `-c Release -warnaserror` with `0 Error(s)`.
- No C# touched; chart template + one What's New entry.

## Not included

Setting `config.memex_migration.Embedding__{Provider,Endpoint,Model}` is the other half and belongs in the deployment overlays (`Systemorph/Memex`); it is deliberately a separate change so the key route lands first. Without this PR that overlay change would be actively worse than nothing: `OpenAICompatible` treats the ApiKey as optional and falls back to a dummy bearer, so the migration would register a provider, 401 on every row, and log-and-skip — still green, still nothing embedded.

Pairs-with: none — chart template and documentation only; no public type or member is removed.
