### PR TITLE
fix(#3451 follow-up): no partition providers means the store is PRESENT, never gone

### DIFF
--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -148,7 +148,8 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
     /// alive (#638 — the very state the bootstrap repairs), and a read can fault. Requiring all three
     /// means a false "gone" needs a partition with no store, no root and no content — which is not a
     /// partition. A fault anywhere is read as the SAFE answer (present), so an unreachable store
-    /// keeps its record.</para>
+    /// keeps its record — and so does a host that registers no partition providers at all, where
+    /// signal 1 cannot be evaluated and must therefore not be counted as evidence of absence.</para>
     /// </summary>
     private IObservable<bool> TargetPartitionIsGone(string partition, ILogger? logger)
     {
@@ -158,8 +159,14 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
         // reconciliation forever inside a boot pass. Empty means "no answer", which reads as the
         // SAFE answer here: the partition is present, so nothing is declared stale.
         var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>().ToList();
+        // 🚨 NO providers ⇒ PRESENT, not absent (Copilot catch). A host on non-partitioned
+        // persistence registers none, so a "false" here would leave the verdict resting on
+        // root-absent + no-children alone — and an empty, rootless partition is precisely the #638
+        // state the bootstrap exists to REPAIR, not a partition that is gone. Same fail-open rule
+        // PartitionWriteGuardValidator applies (`providers.Count == 0 ⇒ allow`): a host that cannot
+        // tell must never declare a record stale.
         var storePresent = providers.Count == 0
-            ? Observable.Return(false)
+            ? Observable.Return(true)
             : Observable.CombineLatest(providers.Select(p => p.PartitionExists(partition)
                     .Take(1)
                     .Timeout(TimeSpan.FromSeconds(5))


### PR DESCRIPTION
Follow-up to #3467 (which closed #3451). Copilot raised this on that PR after it had already been
taken into the merge queue, so it lands as its own change rather than by dequeuing a green,
in-flight PR and restarting every build behind it.

## The finding

`InstalledPackageRepairService.TargetPartitionIsGone` read `providers.Count == 0` as *"the backing
store is not present"*. A host on non-partitioned persistence registers **no**
`IPartitionStorageProvider` at all, so on such a host the three-signal conjunction collapsed to
root-absent + no-children — and an empty, rootless partition is precisely the #638 state the
partition bootstrap exists to **repair**, not a partition that is gone. That host would have
declared a live install record stale and skipped its access re-assert.

## The fix

Absence of providers is now the fail-open answer (**present**), which is the same rule
`PartitionWriteGuardValidator` already applies with `providers.Count == 0 ⇒ allow`. A host that
cannot evaluate a signal must never count that signal as evidence of absence.

Net effect on a host with no providers: `TargetPartitionIsGone` always answers `false`, so the boot
reconciliation behaves exactly as it did before #3467 — nothing is skipped, nothing is reported
stale.

## Verification

`dotnet build MeshWeaver.slnx -c Release -warnaserror` clean; `Memex.Portal.Shared.Test` 819 passed
and `MeshWeaver.Graph.Test` 1380 passed, both 0 failed, with the change applied.

`Pairs-with: none` — no public type or member is removed from `src/`; this is a one-line behaviour
change inside a private method plus its comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
