### PR TITLE
fix(catalog): an undeclared format on a local checkout is detected from the layout — #3384's default emptied every undeclared package.json catalog

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -162,7 +162,8 @@ same way. It did not until #3384: the node's content had no format field, so the
 built a `package.json` source while `PluginUpdateWatcher` read the identical record as a node repo.
 A catalog node over a local node-repo checkout therefore rendered *"No installable packages found."*
 while its own watcher listed those packages happily. One record with two readers must have one rule;
-that rule is `PackageSources.IsNodeRepoFormat`, and both readers call it.
+that rule is `PackageSources.IsNodeRepoFormat` for a DECLARED format, wrapped by
+`PackageSources.IsNodeRepoFormatOrDetected` for the undeclared case below — and every reader calls the latter.
 
 🚨 **An UNDECLARED format on a local checkout is DETECTED from the layout, never defaulted.** #3384's
 unification turned every undeclared `package.json` catalog into an empty page: the browse view had

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -173,6 +173,10 @@ cards over `catalog/<id>/package.json`). The rule, in `PackageSources.IsNodeRepo
 layout — node-repo roots, both shapes at once, an absent or unreadable directory, a URL (nothing to
 inspect before the fetch) — is the shipped `node-repo`. Unambiguous evidence for the manifest shape
 is the only thing that overrides the default.
+The scan looks exactly ONE level down (`<child>/index.json` at the repo root and under the subdir — Space
+roots, not any `index.json` anywhere) and never deeper, and it is deliberately not more general than
+that: a repository that carries node-repo Space roots BESIDE a `package.json` catalog reads as both
+shapes, falls to the default, and must declare `package-json` on the node.
 
 ## The sync licence — what a grant now carries
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -164,6 +164,16 @@ A catalog node over a local node-repo checkout therefore rendered *"No installab
 while its own watcher listed those packages happily. One record with two readers must have one rule;
 that rule is `PackageSources.IsNodeRepoFormat`, and both readers call it.
 
+🚨 **An UNDECLARED format on a local checkout is DETECTED from the layout, never defaulted.** #3384's
+unification turned every undeclared `package.json` catalog into an empty page: the browse view had
+read package.json before, so no such catalog had ever needed a declaration (measured on the Plugins
+pin move to `3.0.0-ci.7917` — two migrated PluginCatalog tests rendered the catalog shell with zero
+cards over `catalog/<id>/package.json`). The rule, in `PackageSources.IsNodeRepoFormatOrDetected(format, repoPath, subdir)`: a declared `Format` wins; with none, `<subdir>/<id>/package.json` present and NO
+`<x>/index.json` Space root anywhere (repo root or subdir) reads as `package-json`; every other
+layout — node-repo roots, both shapes at once, an absent or unreadable directory, a URL (nothing to
+inspect before the fetch) — is the shipped `node-repo`. Unambiguous evidence for the manifest shape
+is the only thing that overrides the default.
+
 ## The sync licence — what a grant now carries
 
 A `PluginGrant` IS the **sync licence**: the right of a registered instance to REPLICATE a package

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-catalog-over-a-package-json-checkout-lists-its-packages-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-catalog-over-a-package-json-checkout-lists-its-packages-again.md
@@ -1,0 +1,18 @@
+---
+Name: A catalog over a package.json checkout lists its packages again
+Category: Fix
+Description: A plugin catalog node pointed at a local checkout of package.json packages, with no format declared, rendered an empty page since the format unification; the format is now read off the checkout's layout, and a declared format still wins.
+Icon: Wrench
+Order: -20260906
+---
+
+# A catalog over a package.json checkout lists its packages again
+
+A plugin catalog node that points at a local checkout of `package.json` packages, and declares no
+format, showed an empty catalog page after the recent change that made every reader of a catalog
+node agree on one format. The default those readers agreed on was the node-repo format, and nothing
+had ever needed to declare the manifest format before, so those catalogs went dark.
+
+The catalog now reads the format off the checkout itself when none is declared: a folder of
+`package.json` packages with no node-repo roots is treated as a manifest catalog, and everything
+else keeps the shipped default. A format you declare on the node still wins.

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -408,7 +408,8 @@ public static class CatalogLayoutAreas
     internal static IPackageSource? BuildSource(
         LayoutAreaHost host, string? sourceRepoPath, string? sourceSubdir, string? format = null) =>
         PackageSources.FromRepo(
-            host.Hub, sourceRepoPath, sourceSubdir, Logger(host), PackageSources.IsNodeRepoFormat(format));
+            host.Hub, sourceRepoPath, sourceSubdir, Logger(host),
+            PackageSources.IsNodeRepoFormatOrDetected(format, sourceRepoPath, sourceSubdir));
 
     /// <summary>
     /// The live installed-plugin inventory: every <c>Package</c> record in the install registry,

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -111,9 +111,9 @@ public static class PackageSources
     /// </summary>
     public static bool IsNodeRepoFormatOrDetected(string? format, string? sourceRepoPath, string? sourceSubdir)
     {
-        if (!string.IsNullOrWhiteSpace(format) || sourceRepoPath is not { Length: > 0 } || IsUrl(sourceRepoPath))
+        if (!string.IsNullOrWhiteSpace(format) || string.IsNullOrWhiteSpace(sourceRepoPath) || IsUrl(sourceRepoPath))
             return IsNodeRepoFormat(format);
-        return DetectedFormatIsNodeRepo(sourceRepoPath, sourceSubdir ?? "");
+        return DetectedFormatIsNodeRepo(sourceRepoPath.Trim(), (sourceSubdir ?? "").Trim());
     }
 
     /// <summary>
@@ -127,6 +127,10 @@ public static class PackageSources
     {
         try
         {
+            // A rooted subdir would make Path.Combine DROP the repo and scan outside it; that is not
+            // a layout to read, it is an input to refuse — the default, never a scan elsewhere.
+            if (Path.IsPathRooted(subdir))
+                return true;
             var subdirPath = string.IsNullOrEmpty(subdir) ? repo : Path.Combine(repo, subdir);
             static bool AnyChildHas(string root, string file) =>
                 Directory.Exists(root)
@@ -135,8 +139,10 @@ public static class PackageSources
             var anyPackage = AnyChildHas(subdirPath, "package.json");
             return anyIndex || !anyPackage;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
+            // Rendering a catalog page must never throw over a malformed path; the default is the
+            // behaviour every reader had before detection existed.
             return true;
         }
     }

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -95,6 +95,53 @@ public static class PackageSources
         !string.Equals(format ?? "node-repo", "package-json", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// The format rule for a SOURCE: a declared <paramref name="format"/> wins, exactly as
+    /// <see cref="IsNodeRepoFormat(string?)"/> reads it; an UNDECLARED format on a LOCAL checkout is
+    /// detected from the layout on disk; an undeclared format on a URL stays the shipped default
+    /// (there is nothing to inspect before the fetch).
+    ///
+    /// <para>Why detection, not a default: #3384 unified the two readers of a catalog node on the
+    /// declared format with the shipped default — and thereby turned every undeclared
+    /// <c>package.json</c> catalog into an empty page (the browse view had read package.json before,
+    /// so nothing had ever needed declaring). Measured on the Plugins pin move to 3.0.0-ci.7917:
+    /// <c>CatalogRenderTest.Catalog_ListsPackagesFromGitSource_AsCards</c> and
+    /// <c>RestartRequiredCardTest.ALandedModule_PutsTheRestartNoteOnItsPackageCard</c> rendered the
+    /// catalog shell with zero cards over a <c>catalog/&lt;id&gt;/package.json</c> checkout. The layout
+    /// says which format a checkout is; only ambiguity falls back to the default.</para>
+    /// </summary>
+    public static bool IsNodeRepoFormatOrDetected(string? format, string? sourceRepoPath, string? sourceSubdir)
+    {
+        if (!string.IsNullOrWhiteSpace(format) || sourceRepoPath is not { Length: > 0 } || IsUrl(sourceRepoPath))
+            return IsNodeRepoFormat(format);
+        return DetectedFormatIsNodeRepo(sourceRepoPath, sourceSubdir ?? "");
+    }
+
+    /// <summary>
+    /// The layout rule: a checkout is <c>package.json</c>-format when <c>&lt;subdir&gt;/&lt;id&gt;/package.json</c>
+    /// exists and NO <c>&lt;x&gt;/index.json</c> Space root exists at the repo root or under the subdir;
+    /// everything else — node-repo roots, both shapes at once, an unreadable or absent directory —
+    /// is the shipped node-repo format. Unambiguous evidence for the manifest shape is the only thing
+    /// that overrides the default.
+    /// </summary>
+    internal static bool DetectedFormatIsNodeRepo(string repo, string subdir)
+    {
+        try
+        {
+            var subdirPath = string.IsNullOrEmpty(subdir) ? repo : Path.Combine(repo, subdir);
+            static bool AnyChildHas(string root, string file) =>
+                Directory.Exists(root)
+                && Directory.EnumerateDirectories(root).Any(d => File.Exists(Path.Combine(d, file)));
+            var anyIndex = AnyChildHas(repo, "index.json") || AnyChildHas(subdirPath, "index.json");
+            var anyPackage = AnyChildHas(subdirPath, "package.json");
+            return anyIndex || !anyPackage;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Builds a package source for <paramref name="sourceRepoPath"/> (a URL or local path), or
     /// <c>null</c> when the path is empty / a URL source has no <see cref="IGitHubRepoClient"/>.
     /// <paramref name="nodeRepo"/> selects the format for BOTH a URL and a local path: <c>true</c>
@@ -168,7 +215,7 @@ public static class PackageSources
             string? repo, string? subdir, string? gitRef, string? format, string? name,
             string? autoDiscover, string? autoSync)
         {
-            var source = FromRepo(hub, repo, subdir, logger, IsNodeRepoFormat(format));
+            var source = FromRepo(hub, repo, subdir, logger, IsNodeRepoFormatOrDetected(format, repo, subdir));
             return source is null
                 ? null
                 : new ConfiguredPackageSource(source, gitRef ?? "HEAD", name ?? repo ?? "")

--- a/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
@@ -168,7 +168,7 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
         // unconditionally while the browse view read the same record as package.json.
         var source = PackageSources.FromRepo(
             hub, content.SourceRepoPath, content.SourceSubdir, logger,
-            nodeRepo: PackageSources.IsNodeRepoFormat(content.Format));
+            nodeRepo: PackageSources.IsNodeRepoFormatOrDetected(content.Format, content.SourceRepoPath, content.SourceSubdir));
         if (source is null)
         {
             logger?.LogWarning(

--- a/test/Memex.Portal.Shared.Test/UndeclaredCatalogFormatIsDetectedTest.cs
+++ b/test/Memex.Portal.Shared.Test/UndeclaredCatalogFormatIsDetectedTest.cs
@@ -1,0 +1,84 @@
+#pragma warning disable CS1591
+using System;
+using System.IO;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #3384 made the shipped node-repo format the default for every reader of a catalog node — and
+/// turned every undeclared <c>package.json</c> catalog into an empty page (measured on the Plugins
+/// pin move to 3.0.0-ci.7917: two migrated PluginCatalog tests rendered zero cards). A declared
+/// format still wins; an undeclared one on a local checkout is read off the layout.
+/// </summary>
+public class UndeclaredCatalogFormatIsDetectedTest : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), "mw-catfmt-" + Guid.NewGuid().ToString("N"));
+
+    private string Repo(string name) { var p = Path.Combine(root, name); Directory.CreateDirectory(p); return p; }
+    private static void Touch(string repo, string relative)
+    {
+        var p = Path.Combine(repo, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+        File.WriteAllText(p, "{}");
+    }
+
+    [Fact]
+    public void AnUndeclaredPackageJsonCatalog_IsReadAsPackageJson()
+    {
+        var repo = Repo("pkg");
+        Touch(repo, "catalog/pack-a/package.json");
+        Touch(repo, "catalog/pack-b/package.json");
+        Assert.False(PackageSources.IsNodeRepoFormatOrDetected(null, repo, "catalog"),
+            "two package.json manifests under the subdir and no index.json anywhere is the manifest shape — the two Plugins tests that went dark on 7917");
+        Assert.False(PackageSources.IsNodeRepoFormatOrDetected("", repo, "catalog"));
+    }
+
+    [Fact]
+    public void AnUndeclaredNodeRepoCheckout_StaysNodeRepo()
+    {
+        var repo = Repo("nr");
+        Touch(repo, "Edu/index.json");
+        Touch(repo, "Store/index.json");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, repo, null), "Space roots at the repo root — the #3384 case keeps working");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, repo, "plugins"), "a subdir that does not exist changes nothing");
+    }
+
+    [Fact]
+    public void BothShapesAtOnce_FallBackToTheShippedDefault()
+    {
+        var repo = Repo("both");
+        Touch(repo, "Edu/index.json");
+        Touch(repo, "catalog/pack-a/package.json");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, repo, "catalog"), "ambiguity is not evidence for the manifest shape");
+    }
+
+    [Fact]
+    public void ADeclaredFormat_WinsOverTheLayout()
+    {
+        var repo = Repo("declared");
+        Touch(repo, "catalog/pack-a/package.json");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected("node-repo", repo, "catalog"), "declared node-repo over a manifest layout is honoured — the operator said so");
+        var nr = Repo("declared-nr");
+        Touch(nr, "Edu/index.json");
+        Assert.False(PackageSources.IsNodeRepoFormatOrDetected("package-json", nr, null), "declared package-json over a node-repo layout is honoured too");
+    }
+
+    [Fact]
+    public void AUrlOrAnAbsentCheckout_KeepsTheShippedDefault()
+    {
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, "https://github.com/Systemorph/MeshWeaver.Plugins", "catalog"), "nothing to inspect before a fetch");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, Path.Combine(root, "does-not-exist"), "catalog"), "an absent directory is not evidence");
+        var empty = Repo("empty");
+        Directory.CreateDirectory(Path.Combine(empty, "catalog"));
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, empty, "catalog"), "an existing but EMPTY checkout is not evidence for the manifest shape either — it must not silently pick package.json");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, null, null));
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, "", null));
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); } catch (IOException) { }
+    }
+}

--- a/test/Memex.Portal.Shared.Test/UndeclaredCatalogFormatIsDetectedTest.cs
+++ b/test/Memex.Portal.Shared.Test/UndeclaredCatalogFormatIsDetectedTest.cs
@@ -75,6 +75,12 @@ public class UndeclaredCatalogFormatIsDetectedTest : IDisposable
         Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, empty, "catalog"), "an existing but EMPTY checkout is not evidence for the manifest shape either — it must not silently pick package.json");
         Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, null, null));
         Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, "", null));
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, "   ", null), "whitespace is absent, not a path to scan");
+        var pkg = Repo("rooted");
+        Touch(pkg, "catalog/pack-a/package.json");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, pkg, Path.Combine(pkg, "catalog")),
+            "a ROOTED subdir would make Path.Combine drop the repo and scan elsewhere — refused into the default");
+        Assert.True(PackageSources.IsNodeRepoFormatOrDetected(null, "\0not-a-path\0", "catalog"), "a malformed path fails closed to the default, never throws into a render");
     }
 
     public void Dispose()


### PR DESCRIPTION
## An undeclared catalog format on a local checkout is detected from the layout — #3384's default turned every undeclared package.json catalog into an empty page

**Measured on the Plugins pin move to `3.0.0-ci.7917` (MeshWeaver.Plugins#1415, run 34054242016, `Portal hosts (shard 1)`):** `CatalogRenderTest.Catalog_ListsPackagesFromGitSource_AsCards` and `RestartRequiredCardTest.ALandedModule_PutsTheRestartNoteOnItsPackageCard` render the catalog shell with **zero cards** over a `catalog/<id>/package.json` checkout — five emissions, none matching — while the same shard passes on the old pin (#1417, #1419). The variable is the set; the cause is #3384 (`3ef661981`, in 7917): it gave the catalog node a `Format` and made its ABSENCE mean node-repo for both readers. Before it, the browse view read package.json unconditionally, so no package.json catalog had ever needed a declaration. **A user's undeclared package.json catalog goes dark the same way — a live regression in the release candidate**, invisible to every surface detector (behaviour behind an unchanged signature, shape 7; the migrated-suite drift gate compares names, not behaviour).

### The fix
`PackageSources.IsNodeRepoFormatOrDetected(format, repoPath, subdir)`: a declared format wins, exactly as `IsNodeRepoFormat(format)` reads it; an undeclared format on a **local** checkout is read off the layout — `<subdir>/<id>/package.json` present and **no** `<x>/index.json` Space root at the repo root or under the subdir ⇒ package-json; node-repo roots, both shapes, an absent/empty/unreadable directory, or a URL (nothing to inspect before the fetch) ⇒ the shipped default. All three readers (browse view, `PluginUpdateWatcher`, configured sources) route through it; #3384's `CatalogSourceFormatGuard` still holds (every `FromRepo` call resolves through the rule; the one-argument rule and its theory are untouched). A separate name rather than an overload: the overload made an existing `<see cref>` ambiguous (`CS0419`), the shape that reddens a dependent's `-warnaserror` build.

### Verified
- `UndeclaredCatalogFormatIsDetectedTest`: manifest-only ⇒ package-json (the two Plugins tests' shape); node-repo-only ⇒ node-repo; both ⇒ default; declared-over-layout both ways; URL, absent and existing-but-empty directory ⇒ default. Plus the catalog reconciliation tests — 7/7.
- `MeshWeaver.Documentation.Test` 304/304 (the #3384 guard, link integrity, What's New integrity).
- `-c Release -warnaserror` clean on both test projects.

`PluginRegistry.md` carries the rule; What's New (Fix). The integration proof is Plugins#1415's `Portal hosts (shard 1)` going green on a set that carries this. Refs #3355, #3384.
