### PR TITLE
fix(#3474): a create is an import too — a repo file's compile verdict never becomes a type's initial live state

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -674,6 +674,28 @@ completely silent: nothing anywhere named a NodeType that is broken and will not
 > token that happened to match the importing deployment's live inputs would suppress precisely the
 > retry it exists to grant.
 
+> 🚨 **A CREATE is an import too.** The ownership rule (`NodeTypeOperationalContent`) used to run
+> only inside the owner's *update* merge, and the installer's bulk path writes to persistence with
+> no merge at all — so a type definition created from a file (a package installed into a fresh
+> mesh, a first import) landed with the file's embedded verdict as its INITIAL live state. Measured
+> 2026-09-06 (#3474): MeshWeaver.Plugins' node files, last written by GitSync before the export
+> strip existed, carried `compilationStatus: Ok`, a foreign `compiledFrameworkVersion` and
+> `latestAssemblyPath`, and for Store a standing `requestedReleaseForce: true`. Every fresh
+> disposable mesh framework-stale-kicked Store's core types into a FORCED live-source compile at
+> boot (#2824 honours the flag off the node), the boot sweep then adopted the shipped prebuilt over
+> that compile, and every `Edu/Exercise` instance came up bound to a foreign assembly path and never
+> answered. Now the two repo→mesh importers strip it where a repo file becomes a node — the
+> installer's `AsAuthored` (every package file, both parse sites) and GitSync's `ParseFile`
+> (every imported repo file, AND the static-repo snapshot: `ParseSnapshot` builds the nodes an
+> `InMemoryStaticRepoSource` serves for the `serveFromPartition` partitions by mapping every
+> file through `ParseFile`, so that path is covered only for as long as the two stay joined) — and
+> `PackageInstaller.BulkSave` and `PreserveLiveOperational(incoming, live: null)` strip as well:
+> with no live node there is nothing to prefer, and the operational members are ABSENT until this
+> mesh writes them. 🚨 Deliberately NOT in the owner's generic create handlers: an in-process
+> creator (a move, a restore, a test fixture) legitimately carries compile state, and the
+> file-backed persistence reads the mesh's OWN nodes back through the same parser registry —
+> the rule is about files that come from a repo, so it sits at the two seams where they enter.
+
 ### 🚨 An ADOPTED build must say whether it was ever checked against the source
 
 Adoption — taking a prebuilt assembly from a bundle instead of compiling — is what makes installs

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-fresh-install-never-inherits-a-repo-files-compile-verdict.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-fresh-install-never-inherits-a-repo-files-compile-verdict.md
@@ -1,0 +1,26 @@
+---
+Name: A fresh install never inherits a repo file's compile verdict
+Category: Fix
+Description: Creating a type definition from a package or repo file now drops the embedded compile state, exactly as an update already did.
+Icon: Sparkle
+Order: -20260906
+---
+
+# A fresh install never inherits a repo file's compile verdict
+
+Since August, syncing a type definition has kept its authored content and its compile state apart:
+exports leave the compile bookkeeping out of the repo file, and an update keeps whatever the live
+mesh last recorded. One path was missed. When a type was **created** — a package installed into a
+fresh mesh, or a repo imported for the first time — there was no live state to keep, and the file's
+embedded verdict was written as the type's initial state instead.
+
+Older repo files still carry such verdicts, and on a fresh mesh they did real damage: a type could
+arrive claiming it was compiled against a framework this mesh never ran, pointing at an assembly
+that does not exist here, or still asking for a forced rebuild from months ago. The mesh then
+rebuilt types it had a perfectly good prebuilt for, adopted a second build over the first, and left
+instances of some types bound to nothing — a course exercise that rendered its navigation and no
+exercise.
+
+Now a create is treated as an import too. A type definition created from a file starts with no
+compile state at all, and the mesh records its own as it compiles or adopts, the same as it always
+did after an update. Nothing changes for repo files that are already clean.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -691,6 +691,17 @@ public sealed class GitHubSyncService
             problem = $"Failed to parse '{path}': {ex.Message} — file skipped.";
         });
         if (parsed is null) return Observable.Return(((MeshNode?)null, false, problem));
+        // #3474 — the repo→mesh half of the NodeType content ownership rule, at the seam where a
+        // repo file becomes a node: the file's MESH-OWNED compile bookkeeping never enters the
+        // mesh. An UPDATE keeps the live node's values regardless (PreserveLiveOperational); a
+        // CREATE has no live node, and until this line a first import wrote the file's verdict
+        // verbatim as the type's initial live state — a repo whose files predate the export strip
+        // (SerializeAll → StripOperational) is exactly the case the export side cannot reach.
+        // 🚨 This line also covers the STATIC-REPO path: ParseSnapshot builds the nodes an
+        // InMemoryStaticRepoSource serves (the serveFromPartition partitions — Agent, Model,
+        // Harness, Skill) by mapping every file through THIS method. Split the two and that path
+        // silently regains the file's verdict, with no test near it.
+        parsed = NodeTypeOperationalContent.WithoutOperational(parsed, hub.JsonSerializerOptions);
         if (isRoot)
         {
             var root = parsed with

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -5151,7 +5151,10 @@ public static class MeshExtensions
     private static MeshNode UpdateAccordingToSourceNode(
         MeshNode state, MeshNode sourceNode, JsonSerializerOptions options)
     {
-        if (state is null) return sourceNode;
+        // A create is an import too: with no live state there is no operational value to prefer,
+        // so the source's embedded compile verdict is dropped rather than written as the type's
+        // initial live state (NodeTypeOperationalContent.PreserveLiveOperational, live: null).
+        if (state is null) return NodeTypeOperationalContent.WithoutOperational(sourceNode, options);
         sourceNode = PreserveMeshOwnedOperational(state, sourceNode, options);
         return state with
         {

--- a/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
+++ b/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace MeshWeaver.Mesh;
 
@@ -44,6 +46,11 @@ public static class NodeTypeOperationalContent
     /// both casings denote the same member. Pinned against the <c>NodeTypeDefinition</c> record by
     /// <c>NodeTypeOperationalContentTest</c> in the Graph test suite, so the list cannot silently
     /// drift from the record.
+    ///
+    /// <para>🚨 The case-insensitive comparer is load-bearing TWICE: for the JSON paths above, and
+    /// for <see cref="WithTypedMembersReset"/>, which matches CLR PascalCase property names against
+    /// these camelCase entries. Tightened to <c>StringComparer.Ordinal</c>, every JSON-shaped test
+    /// would still pass while the typed import path silently stripped nothing.</para>
     /// </summary>
     public static readonly IReadOnlySet<string> MemberNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
@@ -100,16 +107,122 @@ public static class NodeTypeOperationalContent
     }
 
     /// <summary>
+    /// <see cref="StripOperational"/> for the IMPORT seams (#3474): the same members removed, but
+    /// the content comes back in the SHAPE it arrived in — a raw <see cref="JsonElement"/> stays a
+    /// raw element, a typed record stays that type with the members reset to their defaults. Export
+    /// keeps <see cref="StripOperational"/>, which serialises the result at once and for which a
+    /// <see cref="JsonObject"/> IS the file. An import hands the node on to a pipeline that tells a
+    /// typed definition from a raw element apart at every step — the installer's unchanged-check
+    /// compares two typed definitions on their authored members and aligns a raw element to its
+    /// typed peer, <c>ImportWriteOrder</c> reads the discriminator, the bake reads the record — and
+    /// none of it knows a <see cref="JsonObject"/>: handed one, a re-install of an unchanged snapshot
+    /// read as "changed" and rewrote the type (the gate's idempotence check), and the mesh-driven
+    /// bake saw an empty dependency record. Returns the same instance when nothing is removed.
+    /// </summary>
+    public static MeshNode WithoutOperational(MeshNode node, JsonSerializerOptions options)
+    {
+        if (!IsNodeTypeNode(node) || node.Content is null)
+            return node;
+        switch (node.Content)
+        {
+            case JsonElement:
+            {
+                var stripped = StripOperational(node, options);
+                return ReferenceEquals(stripped, node)
+                    ? node
+                    : node with { Content = JsonSerializer.SerializeToElement(stripped.Content, options) };
+            }
+            case JsonNode:
+                return StripOperational(node, options);
+            default:
+                return WithTypedMembersReset(node, options);
+        }
+    }
+
+    /// <summary>
+    /// The typed half of <see cref="WithoutOperational"/>: a record clone with every operational
+    /// property reset to its default (null, false, zero) and any extension-data entry of an
+    /// operational name dropped. Reflection, because this assembly cannot name the definition type;
+    /// the member list is the same <see cref="MemberNames"/>, matched case-insensitively against
+    /// the property names. Content that is not a record (no <c>&lt;Clone&gt;$</c>) falls back to the
+    /// JSON shape.
+    /// </summary>
+    private static MeshNode WithTypedMembersReset(MeshNode node, JsonSerializerOptions options)
+    {
+        var typed = node.Content!;
+        var type = typed.GetType();
+        var clone = type.GetMethod("<Clone>$", BindingFlags.Instance | BindingFlags.Public);
+        if (clone is null)
+        {
+            // A non-record content type degrades to the JSON shape — the very shape whose
+            // downstream cost this method exists to avoid (an unchanged re-install reads as
+            // changed, the bake reads an empty record). Leaking the verdict would be worse, so the
+            // choice stands; the only definition type today is a record, so this does not fire.
+            // If it ever does, give the type a record's copy semantics rather than widening this.
+            return StripOperational(node, options);
+        }
+        object? copy = null;
+        foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (!property.CanRead || property.SetMethod is null)
+                continue;
+            if (MemberNames.Contains(property.Name))
+            {
+                var current = property.GetValue(typed);
+                var blank = property.PropertyType.IsValueType
+                    ? Activator.CreateInstance(property.PropertyType)
+                    : null;
+                if (Equals(current, blank))
+                    continue;
+                copy ??= clone.Invoke(typed, null);
+                property.SetValue(copy, blank);
+            }
+            else if (property.GetCustomAttribute<JsonExtensionDataAttribute>() is not null
+                     && property.GetValue(typed) is IDictionary<string, JsonElement> extra
+                     && extra.Keys.Any(MemberNames.Contains))
+            {
+                copy ??= clone.Invoke(typed, null);
+                var kept = extra.Where(kv => !MemberNames.Contains(kv.Key))
+                    .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
+                property.SetValue(copy, kept.Count == 0 ? null : kept);
+            }
+        }
+        return copy is null ? node : node with { Content = copy };
+    }
+
+    /// <summary>
     /// The INCOMING (repo) node with the LIVE node's operational members carried over — the import
     /// ownership rule. Authored members come from the repo; each operational member ends up exactly
     /// as the mesh last wrote it: the live value when the live node has one, ABSENT when it does not
     /// (a stale value embedded in the file never survives, in either direction). Returns the same
     /// instance when nothing would change, so an authored-identical import stays a no-op upsert.
+    ///
+    /// <para>🚨 <b>A CREATE is an import too.</b> With no live node (<paramref name="live"/> null)
+    /// the mesh has written nothing yet, so every operational member must be ABSENT — the file's
+    /// verdict is exactly as stale as it is on an update, and a fresh mesh has no live value to
+    /// prefer over it. This used to pass the incoming node through untouched, which meant the ONE
+    /// path the export-side strip cannot protect (a repo whose files predate it) wrote a
+    /// weeks-old <c>compilationStatus: Ok</c> / <c>compiledFrameworkVersion</c> /
+    /// <c>latestAssemblyPath</c> / <c>requestedReleaseForce: true</c> as the type's INITIAL live
+    /// state on every fresh install. Measured 2026-09-06 on the Education disposable meshes (portal
+    /// build bbcb22f25, MeshWeaver.Plugins node files last written by GitSync on 2026-07-18): Store's
+    /// five core types framework-stale-kicked into a FORCED live-source compile at every boot (the
+    /// stale <c>requestedReleaseForce: true</c> is what #2824 honours), the boot sweep then adopted
+    /// the shipped prebuilt over that compile, and every <c>Edu/Exercise</c> instance came up bound
+    /// to a foreign <c>latestAssemblyPath</c> and never answered. The rule is applied where a REPO
+    /// FILE becomes a node — the installer's <c>AsAuthored</c> (every package file) and GitSync's
+    /// <c>ParseFile</c> — plus the installer's direct-to-persistence <c>BulkSave</c>, and here for
+    /// any merge asked to create. Deliberately NOT in the owner's generic create handlers: an
+    /// in-process creator (a move, a restore, a fixture) legitimately carries compile state, and
+    /// the file-backed persistence reads the mesh's OWN nodes back through the same parser
+    /// registry — the rule is about files that come from a repo.</para>
     /// </summary>
     public static MeshNode PreserveLiveOperational(
         MeshNode incoming, MeshNode? live, JsonSerializerOptions options)
     {
-        if (!IsNodeTypeNode(incoming) || live is null
+        if (live is null)
+            return WithoutOperational(incoming, options);
+        if (!IsNodeTypeNode(incoming)
             || ContentObject(incoming, options) is not { } original)
             return incoming;
         var liveContent = ContentObject(live, options);

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -2541,8 +2541,16 @@ public static class PackageInstaller
             if (persistence is null)
                 return WriteAll(batch, ImmutableDictionary<string, MeshNode>.Empty);
             var now = DateTimeOffset.UtcNow;
+            // This path writes to persistence DIRECTLY — no owner merge runs — so the create-time
+            // ownership rule has to be applied here by hand: a NodeType file's embedded compile
+            // bookkeeping (compilationStatus, compiledFrameworkVersion, latestAssemblyPath,
+            // requestedReleaseForce, …) must not become the type's initial live state. Measured
+            // 2026-09-06 (Education mesh gates, portal bbcb22f25): the July verdicts GitSync had
+            // written into MeshWeaver.Plugins' node files installed verbatim into every fresh mesh,
+            // framework-stale-kicked Store's core types into a forced live-source compile at boot
+            // and left every Edu/Exercise instance bound to a foreign assembly path.
             var stamped = batch
-                .Select(n => n with
+                .Select(n => MeshWeaver.Mesh.NodeTypeOperationalContent.WithoutOperational(n, options) with
                 {
                     State = MeshNodeState.Active,
                     CreatedDate = n.CreatedDate == default ? now : n.CreatedDate,
@@ -3486,7 +3494,29 @@ public static class PackageInstaller
     /// the wrongly-installed materialised value is what the unchanged-skip then compared against.</para>
     /// </summary>
     // Internal for the InstallAuthoredContentTest pin (InternalsVisibleTo).
+    //
+    // 🚨 #3474 — the ONE seam every package file passes through on its way into a mesh (both
+    // ParseCanonical and ParseNode call it), which is why the repo→mesh half of the NodeType
+    // content ownership rule lives here: a NodeType file's MESH-OWNED compile bookkeeping
+    // (compilationStatus, compiledFrameworkVersion, latestAssemblyPath, requestedReleaseForce, …
+    // — NodeTypeOperationalContent.MemberNames) is stripped before the node is written. GitSync
+    // strips it on export, and an UPDATE keeps the live node's values — but a CREATE has no live
+    // node, and until this line a fresh install wrote the file's verdict verbatim as the type's
+    // initial live state. Measured 2026-09-06 (Education mesh gates, portal bbcb22f25):
+    // MeshWeaver.Plugins' node files, last written by GitSync on 2026-07-18 before the export
+    // strip existed, carried a July `compilationStatus: Ok`, a foreign framework + assembly path
+    // and for Store `requestedReleaseForce: true`; every fresh mesh framework-stale-kicked Store's
+    // core types into a FORCED live-source compile at boot (#2824 honours the flag) and left every
+    // Edu/Exercise instance bound to a foreign assembly path. NOT in the owner's create handlers:
+    // in-process creators (a move, a restore, a fixture) legitimately carry state, and the
+    // file-backed persistence reads the mesh's OWN nodes through the same parser registry — the
+    // rule is about FILES that come from a repo, so it sits where a package file becomes a node.
     internal static MeshNode AsAuthored(
+        MeshNode parsed, PackageFile file, ILogger? logger, JsonSerializerOptions? options = null)
+        => NodeTypeOperationalContent.WithoutOperational(
+            AsAuthoredContent(parsed, file, logger, options), options ?? JsonSerializerOptions.Default);
+
+    private static MeshNode AsAuthoredContent(
         MeshNode parsed, PackageFile file, ILogger? logger, JsonSerializerOptions? options = null)
     {
         if (parsed.Content is null || !parsed.Content.GetType().Assembly.IsCollectible)

--- a/test/Memex.Portal.Shared.Test/InstallNeverInheritsRepoCompileVerdictTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstallNeverInheritsRepoCompileVerdictTest.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A fresh install never inherits a repo file's compile verdict (MeshWeaver#3474).
+///
+/// <para>The NodeType content ownership split — the repo owns the authored definition, the mesh owns
+/// the compile bookkeeping (<see cref="NodeTypeOperationalContent"/>) — was enforced on export (strip)
+/// and on update (keep the live node's values). A package installed into a FRESH mesh has no live node,
+/// and every install path wrote the file's embedded verdict verbatim as the type's initial live state.</para>
+///
+/// <para><b>Measured 2026-09-06 on the Education disposable meshes</b> (portal bbcb22f25): the
+/// MeshWeaver.Plugins node files GitSync had written on 2026-07-18 — before the export strip existed —
+/// carried <c>compilationStatus: Ok</c>, <c>compiledFrameworkVersion: eec04a05…</c> (a framework no
+/// portal runs), <c>latestAssemblyPath: Store_Catalog/v201-eec04a05-….dll</c> (a path into a mesh that
+/// no longer exists) and, on Store's core types, a standing <c>requestedReleaseForce: true</c> from
+/// 2026-07-19. Every fresh mesh installed them verbatim: Store's core types framework-stale-kicked into a
+/// FORCED live-source compile at every boot, the boot sweep then adopted the shipped prebuilt over that
+/// compile, and every <c>Edu/Exercise</c> instance came up bound to a foreign assembly path and never
+/// answered — every Education mesh gate red, and nothing in the log named it, because the file looked
+/// like a type that had already compiled fine.</para>
+///
+/// <para>This test installs exactly that file shape through the real installer and reads the type back:
+/// the file's verdict must not be there, the authored definition must, and the mesh must then reach its
+/// OWN verdict — a build whose framework is this process's, not the file's.</para>
+/// </summary>
+public class InstallNeverInheritsRepoCompileVerdictTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    private const string Package = "VerdictPkg";
+    private const string TypePath = $"{Package}/Catalog";
+    private const string JulyFramework = "eec04a058bd644f1b2b5eda01e952b5c";
+    private const string JulyAssemblyPath = "Store_Catalog/v201-eec04a05-870bdb050e1e.dll";
+    private const string JulyRequestedAt = "2026-07-19T11:32:29.8663063+00:00";
+
+    /// <summary><c>Store/Catalog/index.json</c> as MeshWeaver.Plugins main shipped it on 2026-09-06,
+    /// reduced to a configuration this mesh can compile.</summary>
+    private const string RepoFileWithVerdict = """
+        {
+          "id": "Catalog",
+          "namespace": "VerdictPkg",
+          "path": "VerdictPkg/Catalog",
+          "nodeType": "NodeType",
+          "name": "Catalog",
+          "state": "Active",
+          "content": {
+            "$type": "NodeTypeDefinition",
+            "description": "authored description",
+            "configuration": "config => config",
+            "compilationStatus": "Ok",
+            "compiledFrameworkVersion": "eec04a058bd644f1b2b5eda01e952b5c",
+            "lastCompileStartedAt": "2026-07-19T11:32:00+00:00",
+            "lastCompileSucceededAt": "2026-07-19T11:32:29+00:00",
+            "lastCompiledVersion": 201,
+            "latestReleasePath": "Store/Catalog/Release/20260719113229-abcdefgh",
+            "latestAssemblyCollection": "local",
+            "latestAssemblyPath": "Store_Catalog/v201-eec04a05-870bdb050e1e.dll",
+            "requestedReleaseForce": true,
+            "requestedReleaseAt": "2026-07-19T11:32:29.8663063+00:00",
+            "lastReleaseRequestHandledAt": "2026-07-19T11:32:29.8663063+00:00"
+          }
+        }
+        """;
+
+    private static void AssertTheFilesVerdictIsAbsent(NodeTypeDefinition def, string when)
+    {
+        def.Configuration.Should().Be("config => config", $"the authored configuration is kept ({when})");
+        def.Description.Should().Be("authored description", $"the authored description is kept ({when})");
+        def.CompiledFrameworkVersion.Should().NotBe(JulyFramework,
+            $"a framework identity this mesh never ran must not be recorded as the type's build ({when})");
+        def.LatestAssemblyPath.Should().NotBe(JulyAssemblyPath,
+            $"an assembly path into a mesh that no longer exists must not land ({when})");
+        def.RequestedReleaseForce.Should().BeFalse(
+            $"a months-old FORCED release must not make this mesh compile from source ({when}; #2824 honours the flag)");
+        def.RequestedReleaseAt.Should().NotBe(DateTimeOffset.Parse(JulyRequestedAt),
+            $"the file's release request is not this mesh's ({when})");
+        def.LastReleaseRequestHandledAt.Should().NotBe(DateTimeOffset.Parse(JulyRequestedAt),
+            $"the file's handled stamp is not this mesh's ({when})");
+        def.LastCompiledVersion.Should().NotBe(201, $"the file's compile version is not this mesh's ({when})");
+    }
+
+    [Fact(Timeout = 300_000)]
+    public async Task InstallingAPackageWhoseNodeFileCarriesAVerdict_LandsTheAuthoredDefinitionOnly()
+    {
+        var result = await PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = Package,
+                    Name = Package,
+                    Kind = PackageKind.NodeRepo,
+                    TargetPartition = Package,
+                    SourceFolder = Package,
+                    Version = "1.0.0",
+                },
+                [
+                    new PackageFile($"{Package}.md", $"# {Package}"),
+                    new PackageFile($"{TypePath}.json", RepoFileWithVerdict),
+                ],
+                "HEAD")
+            .Should().Within(180.Seconds())
+            .Emit("the install itself must complete before anything about the type can be read");
+        result.WrittenPaths.Should().Contain(TypePath, "the type node is what this test is about");
+
+        // 1. As installed: none of the file's verdict landed, all of the authored definition did.
+        var installed = await Mesh.GetWorkspace().GetMeshNodeStream(TypePath)
+            .Where(n => n?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions) is not null)
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .Await();
+        var installedDef = installed!.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+        Output.WriteLine(
+            $"as installed: status={installedDef.CompilationStatus} framework={installedDef.CompiledFrameworkVersion ?? "(null)"} "
+            + $"assembly={installedDef.LatestAssemblyPath ?? "(null)"} force={installedDef.RequestedReleaseForce}");
+        AssertTheFilesVerdictIsAbsent(installedDef, "as installed");
+
+        // 2. The mesh then reaches its OWN verdict for the type — a build of THIS framework, never
+        //    the file's. This is the difference between "stale green" and a type that actually runs.
+        await Mesh.GetWorkspace().GetMeshNodeStream(TypePath)
+            .Should().Within(180.Seconds())
+            .Match(
+                n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions) is
+                    { CompilationStatus: CompilationStatus.Ok, CompiledFrameworkVersion: { Length: > 0 } } def
+                    && def.CompiledFrameworkVersion != JulyFramework
+                    && !string.IsNullOrEmpty(def.LatestAssemblyPath)
+                    && def.LatestAssemblyPath != JulyAssemblyPath,
+                "the type must compile on THIS mesh and record this mesh's framework and assembly — "
+                + "the file's July verdict claimed a build that did not exist here, which is exactly the "
+                + "\"stale green\" that parks a type on a cold cache");
+        var compiled = (await Mesh.GetWorkspace().GetMeshNodeStream(TypePath).FirstAsync().Timeout(TestTimeouts.Convergence).Await())!
+            .ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+        AssertTheFilesVerdictIsAbsent(compiled, "after the mesh compiled it");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeTypeOperationalContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeOperationalContentTest.cs
@@ -168,8 +168,89 @@ public class NodeTypeOperationalContentTest
         var live = TypeNode(Parse(json));
         Assert.Same(incoming, NodeTypeOperationalContent.PreserveLiveOperational(incoming, live, CamelCase));
 
-        // No live node (a create) and non-NodeType nodes pass through untouched.
-        Assert.Same(incoming, NodeTypeOperationalContent.PreserveLiveOperational(incoming, null, CamelCase));
+        // No live node (a create) with NO operational member embedded, and non-NodeType nodes,
+        // pass through untouched.
+        var clean = TypeNode(Parse("""{"$type":"NodeTypeDefinition","configuration":"c"}"""));
+        Assert.Same(clean, NodeTypeOperationalContent.PreserveLiveOperational(clean, null, CamelCase));
+        var page = new MeshNode("Page", "Store") { NodeType = "Store/Page", Content = Parse(json) };
+        Assert.Same(page, NodeTypeOperationalContent.PreserveLiveOperational(page, null, CamelCase));
+    }
+
+    [Fact]
+    public void Preserve_WithNoLiveNode_ACreateIsAnImportToo_TheFilesVerdictNeverLands()
+    {
+        // 2026-09-06: MeshWeaver.Plugins' node files carried the verdicts GitSync wrote on 2026-07-18
+        // (compilationStatus Ok, a foreign compiledFrameworkVersion + latestAssemblyPath, and for
+        // Store a standing requestedReleaseForce). Every FRESH mesh installed them verbatim — the
+        // export-side strip cannot reach a file that predates it, and this seam let the create
+        // through — so Store's core types framework-stale-kicked into a forced live-source compile
+        // at every boot and every Edu/Exercise instance bound a foreign assembly path. With no live
+        // node there is nothing to prefer: the operational members must be ABSENT.
+        var incoming = TypeNode(Parse(
+            """
+            {"$type":"NodeTypeDefinition","configuration":"c","sources":["Store/Catalog/Source/A"],
+             "compilationStatus":"Ok","compiledFrameworkVersion":"eec04a058bd644f1b2b5eda01e952b5c",
+             "latestAssemblyCollection":"local","latestAssemblyPath":"Store_Catalog/v201-eec04a05-870bdb050e1e.dll",
+             "requestedReleaseForce":true,"requestedReleaseAt":"2026-07-19T11:32:29+00:00",
+             "lastReleaseRequestHandledAt":"2026-07-19T11:32:29+00:00"}
+            """));
+        var created = NodeTypeOperationalContent.PreserveLiveOperational(incoming, null, CamelCase);
+        // A raw element in, a raw element out — the import pipeline downstream (the installer's
+        // unchanged-check, ImportWriteOrder, the bake) knows a raw element and a typed definition,
+        // and neither of them as a JsonObject.
+        var content = Assert.IsType<JsonElement>(created.Content);
+        var names = content.EnumerateObject().Select(p => p.Name).ToArray();
+        foreach (var member in NodeTypeOperationalContent.MemberNames)
+            Assert.DoesNotContain(member, names, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("c", content.GetProperty("configuration").GetString());
+        Assert.Equal("Store/Catalog/Source/A", content.GetProperty("sources")[0].GetString());
+    }
+
+    [Fact]
+    public void Preserve_WithNoLiveNode_KeepsATypedDefinitionTyped_WithItsVerdictReset()
+    {
+        // The installer parses a NodeType file into a TYPED definition (the type is registered
+        // statically), and its unchanged-check compares two typed definitions on their authored
+        // members. Handed a JsonObject instead, a re-install of an unchanged snapshot read as
+        // "changed" and rewrote the type — the gate's idempotence check went red.
+        var incoming = TypeNode(new NodeTypeDefinition
+        {
+            Configuration = "config => config",
+            Description = "authored",
+            Sources = ["Store/Catalog/Source/A"],
+            CompilationStatus = CompilationStatus.Ok,
+            CompiledFrameworkVersion = "eec04a058bd644f1b2b5eda01e952b5c",
+            LatestAssemblyCollection = "local",
+            LatestAssemblyPath = "Store_Catalog/v201-eec04a05-870bdb050e1e.dll",
+            LastCompiledVersion = 201,
+            RequestedReleaseForce = true,
+            RequestedReleaseAt = DateTimeOffset.Parse("2026-07-19T11:32:29+00:00"),
+            LastReleaseRequestHandledAt = DateTimeOffset.Parse("2026-07-19T11:32:29+00:00"),
+        });
+        var created = NodeTypeOperationalContent.PreserveLiveOperational(incoming, null, CamelCase);
+        var def = Assert.IsType<NodeTypeDefinition>(created.Content);
+        Assert.Equal("config => config", def.Configuration);
+        Assert.Equal("authored", def.Description);
+        Assert.Equal(["Store/Catalog/Source/A"], def.Sources);
+        Assert.Null(def.CompilationStatus);
+        Assert.Null(def.CompiledFrameworkVersion);
+        Assert.Null(def.LatestAssemblyCollection);
+        Assert.Null(def.LatestAssemblyPath);
+        Assert.Null(def.LastCompiledVersion);
+        Assert.False(def.RequestedReleaseForce);
+        Assert.Null(def.RequestedReleaseAt);
+        Assert.Null(def.LastReleaseRequestHandledAt);
+        // …and every other operational property is at its default as well.
+        foreach (var property in typeof(NodeTypeDefinition).GetProperties()
+                     .Where(p => NodeTypeOperationalContent.MemberNames.Contains(p.Name)))
+        {
+            var blank = property.PropertyType.IsValueType ? Activator.CreateInstance(property.PropertyType) : null;
+            Assert.Equal(blank, property.GetValue(def));
+        }
+
+        // A typed definition that carries no verdict comes back as the SAME instance.
+        var clean = TypeNode(new NodeTypeDefinition { Configuration = "c" });
+        Assert.Same(clean, NodeTypeOperationalContent.PreserveLiveOperational(clean, null, CamelCase));
     }
 
     // ── The change-detection token ignores the operational members ──────────────────────────


### PR DESCRIPTION
Closes #3474 — see the issue for the measured chain (Education runs 34043979410 / 34042620439 / 34055233934).

**What:** the node-type content ownership rule (`NodeTypeOperationalContent`) only ever ran on UPDATE. A type definition CREATED from a repo file — a package installed into a fresh mesh, a first import — wrote the file's embedded compile verdict as its initial live state: `PreserveLiveOperational(incoming, live: null)` passed the node through, `UpdateAccordingToSourceNode` returned the source before the rule, and `PackageInstaller.BulkSave` writes to persistence with no merge at all.

**Why it mattered:** MeshWeaver.Plugins' node files (GitSync, 2026-07-18, before the export strip) carry `compilationStatus: Ok`, a foreign `compiledFrameworkVersion` / `latestAssemblyPath` and, for Store, `requestedReleaseForce: true`. On the bbcb22f25 wave every fresh mesh framework-stale-kicked Store's core types into a FORCED source compile at boot (#2824 honours the flag), adopted the shipped prebuilt over it at the sweep, and left every `Edu/Exercise` instance bound to a foreign assembly path — every Education mesh gate red, Education #275/#276.

**Fix — at the seams where a repo file becomes a node** (the mirror of the export strip): `PackageInstaller.AsAuthored` (every package file, both parse sites), `GitHubSyncService.ParseFile` (every imported repo file), `PackageInstaller.BulkSave`, and the contract's own create branch (`PreserveLiveOperational(live: null)`, `UpdateAccordingToSourceNode(state: null)`). Deliberately **not** in the owner's generic create handlers: in-process creators (a move, a restore, a fixture — six suites seed exactly that, and the first push of this PR broke them) legitimately carry compile state, and the file-backed persistence reads the mesh's own nodes back through the same parser registry.

**Shape:** the import seams strip through a new `WithoutOperational` that keeps the content's shape — a raw `JsonElement` stays raw, a typed definition stays typed with the members reset (reflection; Mesh.Contract cannot name the type). `StripOperational`'s `JsonObject` is the file an export wants but a third shape to everything downstream of an import: handed one, the installer's unchanged-check rewrote an unchanged snapshot (`PluginGateRunnerTest` idempotence) and the mesh-driven bake saw an empty dependency record (`BakeEquivalenceTest`) — the second CI cycle of this PR, both green again with the shape kept.

**Tests:** `NodeTypeOperationalContentTest` (re-pinned no-live case + the raw-element and typed create cases) and the new `InstallNeverInheritsRepoCompileVerdictTest` (Memex.Portal.Shared.Test): installs the July `Store/Catalog` file shape through the real installer, reads the type back with none of the file's verdict and all of its authored definition, then sees the mesh reach its OWN verdict on this framework. Locally green: Graph.Test ownership (13) + ExecuteTimeInterlock + CompileStateMirror, LeavingHubAdoptionSweep (2), OrleansCompileActivityAccess (8), BakeEquivalence + the stale-stamp gate test (3), the timeout ratchet (3), the installer test (1).

**Docs:** WhatsNew `2026-09-06-a-fresh-install-never-inherits-a-repo-files-compile-verdict`, a 🚨 note in `Doc/Architecture/NodeTypeCompilation` next to the existing ownership rule.

**Pairs-with:** MeshWeaver.Plugins#1422 — drop the members from the 13 files and gate them. Behaviour changes behind an unchanged signature: a dependent whose package content still carries the fields is unaffected by this half alone — it is simply no longer harmed by them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
