### PR TITLE
docs: the pre-merge checklist said "Nothing to do" about a lock CI gates

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
@@ -188,7 +188,8 @@ blind spot above. Callers opt in with `ledger: required`.
 ## Before you open the PR
 
 ```bash
-python3 scripts/gen-manifests.py           # after ANY change to a package folder
+python3 scripts/gen-manifests.py           # after ANY change to a package folder OR to a src/
+                                           # project a package bundles — both move the lock
 python3 scripts/gen-manifests.py --check   # what CI runs on your branch
 ```
 
@@ -197,9 +198,13 @@ python3 scripts/gen-manifests.py --check   # what CI runs on your branch
 
 **The question to ask before merging is not "is it green" but "will anyone receive it":**
 
-1. Did I change a package's node content? → the hash moves, the patch is derived. Nothing to do.
-2. Did I change only `src/` of a mixed package? → confirm `manifest.lock` actually moved. If it did
-   not, the change reaches nobody.
+1. Did I change a package's node content? → the hash moves and the patch is derived, but **you still
+   run `gen-manifests.py` and commit its output**. "Derived, not hand-edited" does not mean
+   "generated for you": CI regenerates-and-commits only on `main` (`finalize-versions`), and on a
+   branch it merely runs `--check`, which reds `Validate node repos` naming every stale module.
+2. Did I change only `src/` of a mixed package? → **the same applies** — editing `src/` alone moves
+   the lock of every package that bundles that project, often a dozen at once. Run the generator,
+   then confirm `manifest.lock` actually moved: if it did not, the change reaches nobody.
 3. Is this a feature or a break? → bump the MINOR or the MAJOR in `index.json` by hand.
 4. Am I tempted to edit the patch, or to re-cut an existing tag? → no.
 


### PR DESCRIPTION
`Pairs-with: none — documentation only; removes no public type or member from src/.`

One wrong sentence on the page AGENTS.md tells you to *"read before bumping anything"*.

## What happened

MeshWeaver.Plugins#1423 went red on `Validate node repos` with **15 modules carrying a stale `manifest.lock`**, from a change that touched only `src/` projects. I had concluded there was nothing for me to do. The page is where I should have learned otherwise, and it half-told me so.

**Its "Before you open the PR" block is correct** and has been all along:

```bash
python3 scripts/gen-manifests.py           # after ANY change to a package folder
```

**Ten lines below it, the checklist that closes the page contradicts that block:**

> 1. Did I change a package's node content? → the hash moves, the patch is derived. **Nothing to do.**
> 2. Did I change only `src/` of a mixed package? → **confirm** `manifest.lock` actually moved.

Item 1 says there is nothing to do. Item 2 says to *confirm* rather than to *regenerate*. The checklist is the last thing a reader sees before Related, and it is written as the decision procedure — so it wins over the block above it.

## The two things now stated

**1. "Derived, not hand-edited" is not "generated for you."** The authorship table says the patch is owned by *"the build (`gen-manifests.py`), never you"* — true of the **number**, and it should stay. What it does not say is who *invokes* the generator. Verified against `ci.yml`:

| where | what CI does |
|---|---|
| a branch / PR | `gen-manifests.py --check` — validates only, and reds `Validate node repos` naming every stale module |
| `main` | `gen-manifests.py` **+ `git add` + commit** (the `finalize-versions` step) |

So the build owns the number and settles it on the trunk; **you still run the generator and commit its output on your branch.** Both halves are true and only one was written down.

**2. The trigger phrase excluded the case that bit.** *"after ANY change to a package folder"* reads as not applying when you edited only `src/` and touched no package folder at all. But a `src/` edit moves the lock of **every package that bundles that project** — here fifteen at once (AI, Anthropic, AppleIntelligence, AzureFoundry, Chat, ClaudeCode, Copilot, Indexing, Mail, Mcp, Notifications, Observability, OpenAI, Teams, WebSearch).

## Scope

Nine lines, one file. **No mechanism changes and this is not new policy** — it is the page saying what `ci.yml` already enforces. I deliberately did not touch the authorship table: "never you" is correct about the number, and weakening it would invite the hand-edited patch the page rightly forbids.

## Why this is a PR and not a comment somewhere

AGENTS.md requires an investigation finding to be committed rather than left in a PR thread. The finding is small but the general form is the one that cost the cycle: **a recurring commit message is not documentation of a mechanism.** I had inferred that `manifest.lock` was build-derived from the `chore: regenerate manifest.lock over the merged tree` commits on `main` — those are merge-conflict resolutions, not evidence of derivation.

## Verification

`DocumentationLinkIntegrityTest` and `NoConflictMarkersGuard`: **2 / 2 pass**. `MeshWeaver.Documentation.Test` built `-c Release -warnaserror`, clean. Claims about CI behaviour checked against `.github/workflows/ci.yml` in MeshWeaver.Plugins (`--check` at lines 2383/2399; `gen-manifests.py` + commit in `finalize-versions` at 2648-2655), not from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
