### PR TITLE
fix(#3429): decide the adoption shortfall from PATH SETS, not per-entry sums

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/InstallTimePrebuiltAdoption.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstallTimePrebuiltAdoption.md
@@ -74,9 +74,16 @@ one of:
 | 3 | bundles read, **no entry named these types** | ← **Edu's shape.** The bake did not cover this package, or the paths it baked differ from the paths the install wrote | `Information` |
 | 4 | entries **did** name these types and coverage fell short | the bytes were here and did not land: a per-type decline, a whole-bundle identity decline, a hollow bundle, a fault | `Warning` |
 
-The discriminator between 3 and 4 is `EntriesMatched` — how many bundle entries named a **requested**
-NodeType path, counted before anything can decline them. Without it a shortfall line can only guess,
-and guessing is what cost #3429 its investigation.
+The discriminator between 3 and 4 is the set of **offered-but-uncovered paths**: the pass witnesses
+every type path a bundle entry NAMED, before anything can decline it, and subtracts what the store
+ended up backing. Without it a shortfall line can only guess, and guessing is what cost #3429 its
+investigation. Answer 4 therefore also *names* those paths — the actionable subset.
+
+🚨 **Sets of paths, never sums of bundle entries.** A type carried by both the image bundle and the
+CI-published one contributes two entries and one path, so a decision or a denominator built from
+summed counters is wrong in a way nothing downstream could detect — "1 of 3 requested" for a pass
+that asked for two. That is the same confidently-wrong signal this page is about, reproduced inside
+the cure; `PrebuiltShortfallSpeaksTest.ADenominatorIsTheREQUESTEDSet_NotASumOfBundleEntries` pins it.
 
 Answer 4 is also where MeshWeaver#3472 lands: a portal adopting bytes stamped for a *different*
 framework identity is worse than adopting none, so a wrong-identity adoption and a missing one must
@@ -142,7 +149,7 @@ page's. See [Modules](../Modules) and [Module Build Architecture](../ModuleBuild
 ## Where it is pinned
 
 - `test/MeshWeaver.Hosting.Test/PrebuiltShortfallSpeaksTest.cs` — the four answers, deterministically,
-  with no mesh, no bundle and no disk, plus the level each one carries.
+  with no mesh, no bundle and no disk, plus the level each one carries and the denominator rule.
 - `test/Memex.Portal.Shared.Test/InstallTimePrebuiltAdoptionTest.cs` — a real monolith mesh, a real
   bundle written with `BundleWriter`, a package installed **after boot**. Two arms: the positive
   control (mounted bundle ⇒ adopted, and the install says so) and the defect (bundle mounted for

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -238,16 +238,23 @@ public static class ShippedPrebuiltBundles
                 .Where(p => !string.IsNullOrEmpty(p))
                 .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
-            // 🚨 #3429 — THE PASS WITNESSES ITS OWN COVERAGE, so a zero can name the types it left
-            // behind. Per-subscription (it lives inside the Defer), never static, and written from
-            // the seeder's pool threads — a ConcurrentDictionary for the same reason `onCovered`
+            // 🚨 #3429 — THE PASS WITNESSES ITSELF PER PATH, so a zero can name the types it left
+            // behind AND say which of them a bundle had actually offered. Two sets, because they
+            // answer different questions: MATCHED is "a bundle entry named this type", COVERED is
+            // "the store now backs it". Sets rather than counters on purpose — a per-entry sum
+            // double-counts a type named by two bundles (the image's and the CI-published one), and
+            // a diagnostic that reports a wrong denominator is the very failure this whole change
+            // is about. Per-subscription (they live inside the Defer), never static, and written
+            // from the seeder's pool threads — ConcurrentDictionary for the same reason `onCovered`
             // documents thread-safety. The caller's own witness is chained, never replaced.
             var covered = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
-            void Witness(string path)
+            var matched = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+            void WitnessCovered(string path)
             {
                 covered.TryAdd(path, 0);
                 onCovered?.Invoke(path);
             }
+            void WitnessMatched(string path) => matched.TryAdd(path, 0);
 
             var seeds = new List<IObservable<SeedTally>>
             {
@@ -256,7 +263,7 @@ public static class ShippedPrebuiltBundles
                         .EnumerateFiles(imageDir, "*.zip", SearchOption.TopDirectoryOnly)
                         .OrderBy(f => f, StringComparer.Ordinal)
                         .ToList(),
-                    logger, paths, Witness),
+                    logger, paths, WitnessCovered, WitnessMatched),
             };
             var sources = new List<string> { imageDir };
             if (!string.IsNullOrWhiteSpace(publishedRoot))
@@ -264,7 +271,8 @@ public static class ShippedPrebuiltBundles
                 var identityDir = Path.Combine(publishedRoot, PrebuiltAssemblySeeder.LiveFrameworkMvid);
                 sources.Add(identityDir);
                 seeds.Add(SeedBundles(mesh, identityDir,
-                    () => CompletePublishedBundlesOf(identityDir, logger), logger, paths, Witness));
+                    () => CompletePublishedBundlesOf(identityDir, logger), logger, paths,
+                    WitnessCovered, WitnessMatched));
             }
             return seeds.Concat()
                 .Aggregate(default(SeedTally), (total, one) => total + one)
@@ -281,9 +289,11 @@ public static class ShippedPrebuiltBundles
                     var uncovered = paths.Where(p => !covered.ContainsKey(p))
                         .OrderBy(p => p, StringComparer.Ordinal)
                         .ToArray();
-                    if (DescribeShortfall(tally, uncovered, sources) is not { } shortfall)
+                    var offered = uncovered.Where(matched.ContainsKey).ToArray();
+                    if (DescribeShortfall(tally, uncovered, offered, sources, paths.Count)
+                        is not { } shortfall)
                         return;
-                    if (IsShortfallAFailure(tally))
+                    if (IsShortfallAFailure(tally, offered.Length))
                         logger?.LogWarning("ShippedPrebuiltBundles: {Shortfall}", shortfall);
                     else
                         logger?.LogInformation("ShippedPrebuiltBundles: {Shortfall}", shortfall);
@@ -298,16 +308,18 @@ public static class ShippedPrebuiltBundles
     /// Whether a shortfall is a FAILURE (bytes were here and did not land) rather than an absence
     /// (no bundle on this deployment covers these types).
     ///
-    /// <para>The discriminator is <see cref="SeedTally.EntriesMatched"/> against
-    /// <see cref="SeedTally.Covered"/>: a bundle entry that named a requested NodeType and did not
-    /// end up backing it was declined per type, faulted, or timed out — each of which is a real
-    /// defect on a mesh that shipped the bytes. A whole bundle declined on framework identity, an
-    /// unreadable bundle and a hollow one are failures for the same reason (MeshWeaver#3472: a
-    /// portal adopting bytes stamped for another identity is worse than adopting none, and both
-    /// must be distinguishable from success).</para>
+    /// <para>The discriminator is <paramref name="offeredButUncovered"/> — how many UNCOVERED type
+    /// paths a bundle entry had actually named. Such a type was declined per entry, faulted, or
+    /// timed out, each a real defect on a mesh that shipped the bytes. Counting PATHS, never bundle
+    /// entries: a type named by both the image bundle and the CI-published one contributes two
+    /// entries and one path, and a comparison of per-entry sums would misread that as a shortfall
+    /// (or hide a real one). A whole bundle declined on framework identity, an unreadable bundle
+    /// and a hollow one are failures for the same reason (MeshWeaver#3472: a portal adopting bytes
+    /// stamped for another identity is worse than adopting none, and both must be distinguishable
+    /// from success).</para>
     /// </summary>
-    internal static bool IsShortfallAFailure(SeedTally tally) =>
-        tally.EntriesMatched > tally.Covered
+    internal static bool IsShortfallAFailure(SeedTally tally, int offeredButUncovered) =>
+        offeredButUncovered > 0
         || tally.BundlesDeclined > 0
         || tally.BundlesHollow > 0
         || tally.Faulted > 0;
@@ -320,9 +332,16 @@ public static class ShippedPrebuiltBundles
     /// </summary>
     /// <param name="tally">What the pass observed.</param>
     /// <param name="uncovered">The requested NodeType paths no bundle backed.</param>
+    /// <param name="offeredButUncovered">Of those, the ones a bundle entry DID name — the paths
+    /// whose bytes were present and did not land, which is the actionable subset.</param>
     /// <param name="sources">The bundle source directories the pass was pointed at.</param>
+    /// <param name="requested">How many distinct NodeType paths the pass was asked for. Passed in
+    /// rather than derived: <see cref="SeedTally.Covered"/> counts bundle ENTRIES, and a type named
+    /// by two sources would inflate a derived denominator (Copilot review, #3483).</param>
     internal static string? DescribeShortfall(
-        SeedTally tally, IReadOnlyCollection<string> uncovered, IReadOnlyCollection<string> sources)
+        SeedTally tally, IReadOnlyCollection<string> uncovered,
+        IReadOnlyCollection<string> offeredButUncovered, IReadOnlyCollection<string> sources,
+        int requested)
     {
         if (uncovered.Count == 0)
             return null;
@@ -332,7 +351,7 @@ public static class ShippedPrebuiltBundles
             named += $", … (+{uncovered.Count - NamedUncoveredPaths} more)";
         var where = sources.Count == 0 ? "(none)" : string.Join(", ", sources);
         var head =
-            $"adopted no prebuilt assembly for {uncovered.Count} of {uncovered.Count + tally.Covered} "
+            $"adopted no prebuilt assembly for {uncovered.Count} of {requested} "
             + $"requested NodeType(s) — {named}. ";
 
         if (tally.Leaving > 0)
@@ -354,7 +373,7 @@ public static class ShippedPrebuiltBundles
                 + $"framework identity {PrebuiltAssemblySeeder.LiveFrameworkMvid} — nothing was "
                 + "published for this build, so these types compile in-mesh.";
 
-        if (tally.EntriesMatched == 0)
+        if (offeredButUncovered.Count == 0)
             return head
                 + $"All {tally.BundlesSeen} bundle(s) under {where} name only NodeTypes OUTSIDE "
                 + "this set, so none of these types was ever a candidate. Either the bake did not "
@@ -362,8 +381,9 @@ public static class ShippedPrebuiltBundles
                 + "wrote — compare the bundle manifests' node paths with the names above.";
 
         return head
-            + $"{tally.EntriesMatched} bundle entry(ies) DID name these types across "
-            + $"{tally.BundlesSeen} bundle(s) under {where} and {tally.Covered} landed"
+            + $"A bundle entry under {where} DID name {offeredButUncovered.Count} of them "
+            + $"({string.Join(", ", offeredButUncovered.Take(NamedUncoveredPaths))}) across "
+            + $"{tally.BundlesSeen} bundle(s), so those bytes were present and did not land"
             + (tally.BundlesDeclined > 0
                 ? $"; {tally.BundlesDeclined} bundle(s) were declined WHOLE on framework identity "
                   + $"(live: {PrebuiltAssemblySeeder.LiveFrameworkMvid})"
@@ -402,11 +422,6 @@ public static class ShippedPrebuiltBundles
         /// <summary>Bundle files opened.</summary>
         public int BundlesSeen { get; init; }
 
-        /// <summary>Bundle ENTRIES that named one of the requested NodeType paths. The one number
-        /// that separates "the bytes were never here" from "the bytes were here and did not
-        /// land" — the two states MeshWeaver#3429 could not tell apart from a log.</summary>
-        public int EntriesMatched { get; init; }
-
         /// <summary>Bundles declined WHOLE on framework identity.</summary>
         public int BundlesDeclined { get; init; }
 
@@ -426,7 +441,6 @@ public static class ShippedPrebuiltBundles
                 SourcesConsulted = left.SourcesConsulted + right.SourcesConsulted,
                 SourcesPresent = left.SourcesPresent + right.SourcesPresent,
                 BundlesSeen = left.BundlesSeen + right.BundlesSeen,
-                EntriesMatched = left.EntriesMatched + right.EntriesMatched,
                 BundlesDeclined = left.BundlesDeclined + right.BundlesDeclined,
                 BundlesHollow = left.BundlesHollow + right.BundlesHollow,
                 Faulted = left.Faulted + right.Faulted,
@@ -455,10 +469,13 @@ public static class ShippedPrebuiltBundles
     /// <summary>The shared seeding core: the bundle files <paramref name="enumerateBundles"/>
     /// resolves (on the pool's blocking leg), through the one bundle pipeline.
     /// <paramref name="typePathFilter"/> replaces the mesh-wide NodeType enumeration when the
-    /// caller already knows which types it is consuming for (#1707 slice 3).</summary>
+    /// caller already knows which types it is consuming for (#1707 slice 3).
+    /// <paramref name="onMatched"/> witnesses every type path a bundle entry NAMED, before anything
+    /// can decline it — the half that lets a shortfall say whether the bytes were even here.</summary>
     private static IObservable<SeedTally> SeedBundles(
         IMessageHub mesh, string dir, Func<List<string>> enumerateBundles, ILogger? logger,
-        ImmutableHashSet<string>? typePathFilter = null, Action<string>? onCovered = null)
+        ImmutableHashSet<string>? typePathFilter = null, Action<string>? onCovered = null,
+        Action<string>? onMatched = null)
         => Observable.Defer(() =>
         {
             // 🚨 #3129 — NO ADOPTION PASS STARTS ON A HUB THAT IS LEAVING. Every route into
@@ -555,7 +572,8 @@ public static class ShippedPrebuiltBundles
                             return snapshot
                                 .SelectMany(existing => bundles
                                     .Select(bundle => SeedBundle(
-                                        mesh, pool, store, bundle, existing, logger, onCovered))
+                                        mesh, pool, store, bundle, existing, logger, onCovered,
+                                        onMatched))
                                     .Concat()
                                     .Aggregate(default(SeedTally), (total, one) => total + one)
                                     .Do(tally =>
@@ -631,7 +649,8 @@ public static class ShippedPrebuiltBundles
         string bundlePath,
         TypeSnapshot snapshot,
         ILogger? logger,
-        Action<string>? onCovered = null)
+        Action<string>? onCovered = null,
+        Action<string>? onMatched = null)
         => pool
             .InvokeBlocking(_ => Plugin.Packaging.BundleReader.ReadManifest(bundlePath))
             .SelectMany(manifest =>
@@ -686,12 +705,14 @@ public static class ShippedPrebuiltBundles
                     // line would then assert the opposite of what happened.
                     return Observable.Return(new SeedTally(0, 0, FilteredOut: 1));
 
-                // 🚨 #3429 — `present.Count` is carried out of both branches below as
-                // SeedTally.EntriesMatched: how many entries NAMED a requested type, counted before
-                // anything can decline them. It is the number that separates "the bytes were never
-                // here" from "the bytes were here and did not land", and without it a shortfall line
-                // can only guess — which is the guess that cost #3429 its investigation.
-                //
+                // 🚨 #3429 — every entry that NAMED a requested type is witnessed HERE, before
+                // anything can decline it. That is what separates "the bytes were never here" from
+                // "the bytes were here and did not land" — the distinction a shortfall line could
+                // otherwise only guess at, and the guess that cost #3429 its investigation.
+                if (onMatched is not null)
+                    foreach (var entry in present)
+                        onMatched(entry.NodePath);
+
                 // Sequential (Concat, never Merge) for the same reason NodeTypeBakeStatus.Probe is:
                 // the store is typically a shared network volume or blob container, and a fan-out
                 // of lookups across every type at startup is the cold burst this whole mechanism
@@ -723,8 +744,7 @@ public static class ShippedPrebuiltBundles
                                 + "already carry this build and the store holds their bytes — no "
                                 + "assembly read, no hub activated, no write",
                                 Path.GetFileName(bundlePath), alreadyCurrent);
-                            return Observable.Return(new SeedTally(0, alreadyCurrent)
-                                with { EntriesMatched = present.Count });
+                            return Observable.Return(new SeedTally(0, alreadyCurrent));
                         }
 
                         return pool
@@ -732,8 +752,7 @@ public static class ShippedPrebuiltBundles
                                 .ReadFile(bundlePath, deviating))
                             .SelectMany(payload => SeedPayloads(
                                 mesh, bundlePath, manifest.FrameworkMvid,
-                                payload.Assemblies, alreadyCurrent, logger, onCovered))
-                            .Select(tally => tally with { EntriesMatched = present.Count });
+                                payload.Assemblies, alreadyCurrent, logger, onCovered));
                     });
             })
             .Catch<SeedTally, Exception>(ex =>

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -3812,24 +3812,11 @@ public static class PackageInstaller
     private static IObservable<int> SeedPrebuiltAssemblies(
         IMessageHub hub, string packageId, IReadOnlyCollection<string> nodeTypePaths, ILogger? logger)
     {
-        var consumer = hub.ServiceProvider.GetService<IPrebuiltAssemblyConsumer>();
-        if (consumer is null)
-        {
-            // 🚨 #3429 — the silent zero that is invisible from inside the seeder, because the
-            // seeder never runs. A host reaches this by composing WITHOUT
-            // AddPrebuiltAssemblyConsumption / AddDynamicTypePreWarming; every type this package
-            // ships then compiles in-mesh no matter how many bundles are mounted beside it.
-            if (nodeTypePaths.Count > 0)
-                logger?.LogWarning(
-                    "Install: {Package}: NO prebuilt assembly was adopted for {Count} installed "
-                    + "type(s) because this host registers no {Consumer} — it consumes no bundle "
-                    + "source at all, so every one of them compiles in-mesh. Call "
-                    + "IServiceCollection.AddPrebuiltAssemblyConsumption() (or "
-                    + "AddDynamicTypePreWarming()) on this composition if it is meant to consume a "
-                    + "bake",
-                    packageId, nodeTypePaths.Count, nameof(IPrebuiltAssemblyConsumer));
-            return Observable.Return(0);
-        }
+        // 🚨 ORDER MATTERS, and it is the ORDER that makes "reported unconditionally" true. The
+        // empty-type-set check runs FIRST because it is the more specific fact and the one an
+        // operator can act on; asking about the consumer first left the (no consumer AND no types)
+        // corner logging nothing at all, so the doc above would have asserted a guarantee the code
+        // did not keep (Copilot review, #3483). Every path below now emits exactly one line.
         if (nodeTypePaths.Count == 0)
         {
             // Not a shortfall — there is nothing to adopt FOR — but it is the fact that separates
@@ -3838,6 +3825,23 @@ public static class PackageInstaller
             logger?.LogInformation(
                 "Install: {Package}: the install recognised no NodeType definition among the nodes "
                 + "it wrote, so prebuilt adoption had nothing to look for", packageId);
+            return Observable.Return(0);
+        }
+        var consumer = hub.ServiceProvider.GetService<IPrebuiltAssemblyConsumer>();
+        if (consumer is null)
+        {
+            // 🚨 #3429 — the silent zero that is invisible from inside the seeder, because the
+            // seeder never runs. A host reaches this by composing WITHOUT
+            // AddPrebuiltAssemblyConsumption / AddDynamicTypePreWarming; every type this package
+            // ships then compiles in-mesh no matter how many bundles are mounted beside it.
+            logger?.LogWarning(
+                "Install: {Package}: NO prebuilt assembly was adopted for {Count} installed "
+                + "type(s) because this host registers no {Consumer} — it consumes no bundle "
+                + "source at all, so every one of them compiles in-mesh. Call "
+                + "IServiceCollection.AddPrebuiltAssemblyConsumption() (or "
+                + "AddDynamicTypePreWarming()) on this composition if it is meant to consume a "
+                + "bake",
+                packageId, nodeTypePaths.Count, nameof(IPrebuiltAssemblyConsumer));
             return Observable.Return(0);
         }
         var bound = SeedBound(nodeTypePaths.Count);

--- a/test/Memex.Portal.Shared.Test/InstallTimePrebuiltAdoptionTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstallTimePrebuiltAdoptionTest.cs
@@ -159,27 +159,34 @@ public class InstallTimePrebuiltAdoptionTest(ITestOutputHelper output) : Monolit
     [Fact(Timeout = 300_000)]
     public async Task AfterBoot_APackageWhoseBundleIsMounted_AdoptsIt()
     {
-        MountBundle($"{Package}.zip", CoveredType);
-        var expectedMvid = ServedBuildIdentity.OfBytes(BundleBytes());
-        expectedMvid.Should().NotBeNullOrEmpty("the mounted bundle carries a real PE image");
+        try
+        {
+            MountBundle($"{Package}.zip", CoveredType);
+            var expectedMvid = ServedBuildIdentity.OfBytes(BundleBytes());
+            expectedMvid.Should().NotBeNullOrEmpty("the mounted bundle carries a real PE image");
 
-        var install = new LogSink();
-        var result = await InstallAfterBoot(install.Logger);
-        result.Written.Should().BeGreaterThan(0, "the install must have written its nodes");
+            var install = new LogSink();
+            var result = await InstallAfterBoot(install.Logger);
+            result.Written.Should().BeGreaterThan(0, "the install must have written its nodes");
 
-        await Mesh.GetWorkspace().GetMeshNodeStream(CoveredType)
-            .Should().Within(120.Seconds())
-            .Match(
-                n => string.Equals(
-                    n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)?.LatestAssemblyMvid,
-                    expectedMvid, StringComparison.Ordinal),
-                "the bytes for this type were mounted when the package installed — install-time "
-                + "adoption is the ONLY lane that can serve a package that arrives after boot");
+            await Mesh.GetWorkspace().GetMeshNodeStream(CoveredType)
+                .Should().Within(120.Seconds())
+                .Match(
+                    n => string.Equals(
+                        n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)?.LatestAssemblyMvid,
+                        expectedMvid, StringComparison.Ordinal),
+                    "the bytes for this type were mounted when the package installed — install-time "
+                    + "adoption is the ONLY lane that can serve a package that arrives after boot");
 
-        install.Dump(Output, "INSTALL");
-        install.Lines.Should().Contain(
-            l => l.Contains($"Install: {Package}: adopted 1 prebuilt", StringComparison.Ordinal),
-            "an adoption that happened must be reported, naming the package");
+            install.Dump(Output, "INSTALL");
+            install.Lines.Should().Contain(
+                l => l.Contains($"Install: {Package}: adopted 1 prebuilt", StringComparison.Ordinal),
+                "an adoption that happened must be reported, naming the package");
+        }
+        finally
+        {
+            RemoveMount();
+        }
     }
 
     /// <summary>
@@ -190,35 +197,51 @@ public class InstallTimePrebuiltAdoptionTest(ITestOutputHelper output) : Monolit
     [Fact(Timeout = 300_000)]
     public async Task AfterBoot_APackageNoBundleCovers_SaysWhy()
     {
-        // A real, well-formed, identity-matching bundle — for somebody else's types. This is
-        // exactly Edu's shape as measured: bundles mounted, none of them a candidate.
-        MountBundle("Other.zip", "SomeOtherPackage/Thing");
+        try
+        {
+            // A real, well-formed, identity-matching bundle — for somebody else's types. This is
+            // exactly Edu's shape as measured: bundles mounted, none of them a candidate.
+            MountBundle("Other.zip", "SomeOtherPackage/Thing");
 
-        var install = new LogSink();
-        await InstallAfterBoot(install.Logger);
+            var install = new LogSink();
+            await InstallAfterBoot(install.Logger);
 
-        install.Dump(Output, "INSTALL");
-        _meshLog.Dump(Output, "MESH");
+            install.Dump(Output, "INSTALL");
+            _meshLog.Dump(Output, "MESH");
 
-        install.Lines.Should().Contain(
-            l => l.StartsWith("Warning: ", StringComparison.Ordinal)
-                 && l.Contains($"Install: {Package}: adopted NO prebuilt assembly", StringComparison.Ordinal),
-            "the install lane must say, loudly and naming the PACKAGE, that it adopted nothing — "
-            + "a completed seed that covered zero used to log exactly as much as a deployment with "
-            + "no bundles at all");
+            install.Lines.Should().Contain(
+                l => l.StartsWith("Warning: ", StringComparison.Ordinal)
+                     && l.Contains($"Install: {Package}: adopted NO prebuilt assembly", StringComparison.Ordinal),
+                "the install lane must say, loudly and naming the PACKAGE, that it adopted nothing — "
+                + "a completed seed that covered zero used to log exactly as much as a deployment "
+                + "with no bundles at all");
 
-        _meshLog.Lines.Should().Contain(
-            l => l.Contains("adopted no prebuilt assembly for", StringComparison.Ordinal)
-                 && l.Contains(CoveredType, StringComparison.Ordinal),
-            "the seeder must name the UNCOVERED type paths — 'nothing adopted' without them cannot "
-            + "be acted on");
+            _meshLog.Lines.Should().Contain(
+                l => l.Contains("adopted no prebuilt assembly for 1 of 1 requested", StringComparison.Ordinal)
+                     && l.Contains(CoveredType, StringComparison.Ordinal),
+                "the seeder must name the UNCOVERED type paths and count them against what was "
+                + "REQUESTED — 'nothing adopted' without them cannot be acted on, and a denominator "
+                + "derived from per-entry sums would double-count a type two sources both carry");
 
-        _meshLog.Lines.Should().Contain(
-            l => l.Contains("name only NodeTypes OUTSIDE this set", StringComparison.Ordinal),
-            "…and the REASON, which is the half #3429 asks for: a bundle source WAS mounted and "
-            + "read, and none of its entries named a requested type. That reads differently from "
-            + "'no bundle source exists' and from 'a bundle named it and it did not land', and the "
-            + "three must never look alike again");
+            _meshLog.Lines.Should().Contain(
+                l => l.Contains("name only NodeTypes OUTSIDE this set", StringComparison.Ordinal),
+                "…and the REASON, which is the half #3429 asks for: a bundle source WAS mounted and "
+                + "read, and none of its entries named a requested type. That reads differently from "
+                + "'no bundle source exists' and from 'a bundle named it and it did not land', and "
+                + "the three must never look alike again");
+        }
+        finally
+        {
+            RemoveMount();
+        }
+    }
+
+    /// <summary>Removes the mounted bundle directory. Best-effort in a <c>finally</c>, matching this
+    /// suite's own convention (PrebuiltPublicationTest): a failing assertion must not be replaced by
+    /// a cleanup exception, and a temp root left behind on one run would accumulate across CI.</summary>
+    private void RemoveMount()
+    {
+        try { Directory.Delete(_bundleDirectory, recursive: true); } catch { /* best effort */ }
     }
 
     /// <summary>An <see cref="ILoggerProvider"/> that keeps every line, so a test can assert on what

--- a/test/MeshWeaver.Hosting.Test/PrebuiltShortfallSpeaksTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltShortfallSpeaksTest.cs
@@ -9,19 +9,26 @@ namespace MeshWeaver.Hosting.Test;
 /// <para>A seeding pass that covered nothing used to say nothing, so "ten matching assemblies on
 /// disk, none adopted" read in a log exactly like "no bundles mounted". Both are zero; only one is
 /// a defect. <see cref="ShippedPrebuiltBundles.DescribeShortfall"/> is the pure core that turns the
-/// pass's own counters into the sentence an operator acts on, and it is pinned here — with no mesh,
-/// no bundle and no disk — because a reason string that drifts is exactly as unactionable as no
-/// reason at all.</para>
+/// pass's own observations into the sentence an operator acts on, and it is pinned here — with no
+/// mesh, no bundle and no disk — because a reason string that drifts is exactly as unactionable as
+/// no reason at all.</para>
 ///
 /// <para>The complement, <see cref="ShippedPrebuiltBundles.IsShortfallAFailure"/>, decides the LEVEL:
 /// a bundle that NAMED a requested type and still did not back it is a defect on a mesh that shipped
 /// the bytes (Warning); a deployment holding types the bake never covered is a fact about the
 /// deployment (Information). Getting that backwards would either bury #3429's signal or drown the
 /// log in warnings about types nobody baked.</para>
+///
+/// <para>🚨 Both take PATH SETS, never per-entry counters. A type carried by BOTH the image bundle
+/// and the CI-published one contributes two entries and one path, so a decision or a denominator
+/// built from summed counters is wrong in a way nothing downstream could detect — the same class of
+/// confidently-wrong signal this whole change exists to remove.
+/// <see cref="ADenominatorIsTheREQUESTEDSet_NotASumOfBundleEntries"/> pins it.</para>
 /// </summary>
 public class PrebuiltShortfallSpeaksTest
 {
     private static readonly string[] Sources = ["/bundles", "/data/bake/sabc"];
+    private static readonly string[] None = [];
 
     /// <summary>A pass that covered everything it was asked for has nothing to report — the line
     /// must never fire on the healthy path, or it becomes noise nobody reads.</summary>
@@ -30,11 +37,11 @@ public class PrebuiltShortfallSpeaksTest
     {
         var tally = new ShippedPrebuiltBundles.SeedTally(3, 0)
         {
-            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 1, EntriesMatched = 3,
+            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 1,
         };
 
-        Assert.Null(ShippedPrebuiltBundles.DescribeShortfall(tally, [], Sources));
-        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally));
+        Assert.Null(ShippedPrebuiltBundles.DescribeShortfall(tally, None, None, Sources, requested: 3));
+        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally, offeredButUncovered: 0));
     }
 
     /// <summary>ANSWER 1 — this deployment has no bundle lane at all. Nothing was lost; the line
@@ -45,14 +52,15 @@ public class PrebuiltShortfallSpeaksTest
     {
         var tally = new ShippedPrebuiltBundles.SeedTally(0, 0) { SourcesConsulted = 2 };
 
-        var reason = ShippedPrebuiltBundles.DescribeShortfall(tally, ["Edu/Exercise"], Sources);
+        var reason = ShippedPrebuiltBundles.DescribeShortfall(
+            tally, ["Edu/Exercise"], None, Sources, requested: 1);
 
         Assert.NotNull(reason);
         Assert.Contains("No bundle source directory exists", reason, StringComparison.Ordinal);
         Assert.Contains(ShippedPrebuiltBundles.DirectoryConfigKey, reason, StringComparison.Ordinal);
         Assert.Contains(ShippedPrebuiltBundles.PublishedRootConfigKey, reason, StringComparison.Ordinal);
         Assert.Contains("Edu/Exercise", reason, StringComparison.Ordinal);
-        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally),
+        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally, offeredButUncovered: 0),
             "an absent mount is a deployment fact, not a failure of the bytes to land");
     }
 
@@ -66,11 +74,12 @@ public class PrebuiltShortfallSpeaksTest
             SourcesConsulted = 1, SourcesPresent = 1,
         };
 
-        var reason = ShippedPrebuiltBundles.DescribeShortfall(tally, ["Edu/Exercise"], Sources);
+        var reason = ShippedPrebuiltBundles.DescribeShortfall(
+            tally, ["Edu/Exercise"], None, Sources, requested: 1);
 
         Assert.NotNull(reason);
         Assert.Contains("hold no bundle for framework identity", reason, StringComparison.Ordinal);
-        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally));
+        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally, offeredButUncovered: 0));
     }
 
     /// <summary>🚨 ANSWER 3 — <b>EDU'S SHAPE.</b> Forty bundles mounted, read, identity-matching, and
@@ -82,18 +91,19 @@ public class PrebuiltShortfallSpeaksTest
     {
         var tally = new ShippedPrebuiltBundles.SeedTally(0, 0, FilteredOut: 40)
         {
-            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 40, EntriesMatched = 0,
+            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 40,
         };
 
         var reason = ShippedPrebuiltBundles.DescribeShortfall(
-            tally, ["Edu/Exercise", "Edu/Lesson"], Sources);
+            tally, ["Edu/Exercise", "Edu/Lesson"], None, Sources, requested: 2);
 
         Assert.NotNull(reason);
+        Assert.Contains("2 of 2 requested", reason, StringComparison.Ordinal);
         Assert.Contains("40 bundle(s)", reason, StringComparison.Ordinal);
         Assert.Contains("name only NodeTypes OUTSIDE this set", reason, StringComparison.Ordinal);
         Assert.Contains("Edu/Exercise", reason, StringComparison.Ordinal);
         Assert.Contains("Edu/Lesson", reason, StringComparison.Ordinal);
-        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally),
+        Assert.False(ShippedPrebuiltBundles.IsShortfallAFailure(tally, offeredButUncovered: 0),
             "no entry ever named these types, so nothing failed to land — the bake's coverage is "
             + "the question, and that is a fact about what was published");
     }
@@ -102,42 +112,70 @@ public class PrebuiltShortfallSpeaksTest
     /// adoption was declined, faulted or timed out. This is the arm that must be a Warning, and it
     /// is the one #3472 (a portal adopting bytes stamped for another framework identity) lands in
     /// — a wrong-identity adoption is worse than none, and both have to be distinguishable from
-    /// success.</summary>
+    /// success. The line NAMES the offered-but-uncovered paths, which is the actionable subset.</summary>
     [Fact]
-    public void EntriesMatchedButNothingLanded_IsAFailure()
+    public void EntriesMatchedButNothingLanded_IsAFailure_AndNamesThem()
     {
         var tally = new ShippedPrebuiltBundles.SeedTally(0, 0)
         {
-            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 3,
-            EntriesMatched = 2, BundlesDeclined = 1,
-        };
-
-        var reason = ShippedPrebuiltBundles.DescribeShortfall(tally, ["Edu/Exercise"], Sources);
-
-        Assert.NotNull(reason);
-        Assert.Contains("2 bundle entry(ies) DID name these types", reason, StringComparison.Ordinal);
-        Assert.Contains("declined WHOLE on framework identity", reason, StringComparison.Ordinal);
-        Assert.True(ShippedPrebuiltBundles.IsShortfallAFailure(tally),
-            "bytes present and not adopted is a defect on a mesh that shipped them");
-    }
-
-    /// <summary>A partial landing is still a failure — coverage below what the entries promised
-    /// means some per-type adoption was refused, and the count alone would hide it.</summary>
-    [Fact]
-    public void PartialLanding_IsAFailure_AndSaysHowMany()
-    {
-        var tally = new ShippedPrebuiltBundles.SeedTally(1, 0)
-        {
-            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 1, EntriesMatched = 3,
+            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 3, BundlesDeclined = 1,
         };
 
         var reason = ShippedPrebuiltBundles.DescribeShortfall(
-            tally, ["Edu/Exercise", "Edu/Lesson"], Sources);
+            tally, ["Edu/Exercise"], ["Edu/Exercise"], Sources, requested: 1);
 
         Assert.NotNull(reason);
-        Assert.Contains("3 bundle entry(ies) DID name these types", reason, StringComparison.Ordinal);
-        Assert.Contains("and 1 landed", reason, StringComparison.Ordinal);
-        Assert.True(ShippedPrebuiltBundles.IsShortfallAFailure(tally));
+        Assert.Contains("DID name 1 of them (Edu/Exercise)", reason, StringComparison.Ordinal);
+        Assert.Contains("those bytes were present and did not land", reason, StringComparison.Ordinal);
+        Assert.Contains("declined WHOLE on framework identity", reason, StringComparison.Ordinal);
+        Assert.True(ShippedPrebuiltBundles.IsShortfallAFailure(tally, offeredButUncovered: 1),
+            "bytes present and not adopted is a defect on a mesh that shipped them");
+    }
+
+    /// <summary>A partial landing is still a failure for the type that did not land — and the line
+    /// names THAT type, not the one that was fine.</summary>
+    [Fact]
+    public void PartialLanding_IsAFailure_AndNamesOnlyTheTypeThatMissed()
+    {
+        var tally = new ShippedPrebuiltBundles.SeedTally(1, 0)
+        {
+            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 1,
+        };
+
+        var reason = ShippedPrebuiltBundles.DescribeShortfall(
+            tally, ["Edu/Lesson"], ["Edu/Lesson"], Sources, requested: 2);
+
+        Assert.NotNull(reason);
+        Assert.Contains("1 of 2 requested", reason, StringComparison.Ordinal);
+        Assert.Contains("DID name 1 of them (Edu/Lesson)", reason, StringComparison.Ordinal);
+        Assert.DoesNotContain("Edu/Exercise", reason, StringComparison.Ordinal);
+        Assert.True(ShippedPrebuiltBundles.IsShortfallAFailure(tally, offeredButUncovered: 1));
+    }
+
+    /// <summary>
+    /// 🚨 THE DENOMINATOR IS THE REQUESTED SET, never a sum of bundle entries (Copilot review on
+    /// #3483). A type carried by BOTH the image bundle and the CI-published one is covered ONCE and
+    /// counted TWICE in <see cref="ShippedPrebuiltBundles.SeedTally.Covered"/>, so a denominator
+    /// derived as <c>uncovered + Covered</c> would report "1 of 3 requested" for a pass that asked
+    /// for two. That is a confidently wrong number in the one line an operator uses to decide what
+    /// to fix — the exact failure mode this change exists to remove, reproduced inside the cure.
+    /// </summary>
+    [Fact]
+    public void ADenominatorIsTheREQUESTEDSet_NotASumOfBundleEntries()
+    {
+        // Two types requested; one of them backed by two sources, so Covered == 2 for one path.
+        var tally = new ShippedPrebuiltBundles.SeedTally(1, 1)
+        {
+            SourcesConsulted = 2, SourcesPresent = 2, BundlesSeen = 2,
+        };
+        Assert.Equal(2, tally.Covered);
+
+        var reason = ShippedPrebuiltBundles.DescribeShortfall(
+            tally, ["Edu/Lesson"], None, Sources, requested: 2);
+
+        Assert.NotNull(reason);
+        Assert.Contains("1 of 2 requested", reason, StringComparison.Ordinal);
+        Assert.DoesNotContain("1 of 3 requested", reason, StringComparison.Ordinal);
     }
 
     /// <summary>A leaving hub (#3129) deliberately runs no adoption pass. Its zero has a reason of
@@ -150,7 +188,8 @@ public class PrebuiltShortfallSpeaksTest
             SourcesConsulted = 1, Leaving = 1,
         };
 
-        var reason = ShippedPrebuiltBundles.DescribeShortfall(tally, ["Edu/Exercise"], Sources);
+        var reason = ShippedPrebuiltBundles.DescribeShortfall(
+            tally, ["Edu/Exercise"], None, Sources, requested: 1);
 
         Assert.NotNull(reason);
         Assert.Contains("LEAVING", reason, StringComparison.Ordinal);
@@ -166,7 +205,8 @@ public class PrebuiltShortfallSpeaksTest
             uncovered[i] = $"Edu/Type{i:00}";
         var tally = new ShippedPrebuiltBundles.SeedTally(0, 0) { SourcesConsulted = 1 };
 
-        var reason = ShippedPrebuiltBundles.DescribeShortfall(tally, uncovered, Sources);
+        var reason = ShippedPrebuiltBundles.DescribeShortfall(
+            tally, uncovered, None, Sources, requested: 12);
 
         Assert.NotNull(reason);
         Assert.Contains("Edu/Type00", reason, StringComparison.Ordinal);
@@ -182,12 +222,12 @@ public class PrebuiltShortfallSpeaksTest
     {
         var image = new ShippedPrebuiltBundles.SeedTally(1, 2, FilteredOut: 3)
         {
-            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 4, EntriesMatched = 5,
+            SourcesConsulted = 1, SourcesPresent = 1, BundlesSeen = 4,
             BundlesDeclined = 6, BundlesHollow = 7, Faulted = 8, Leaving = 0,
         };
         var published = new ShippedPrebuiltBundles.SeedTally(10, 20, FilteredOut: 30)
         {
-            SourcesConsulted = 1, SourcesPresent = 0, BundlesSeen = 40, EntriesMatched = 50,
+            SourcesConsulted = 1, SourcesPresent = 0, BundlesSeen = 40,
             BundlesDeclined = 60, BundlesHollow = 70, Faulted = 80, Leaving = 1,
         };
 
@@ -200,7 +240,6 @@ public class PrebuiltShortfallSpeaksTest
         Assert.Equal(2, sum.SourcesConsulted);
         Assert.Equal(1, sum.SourcesPresent);
         Assert.Equal(44, sum.BundlesSeen);
-        Assert.Equal(55, sum.EntriesMatched);
         Assert.Equal(66, sum.BundlesDeclined);
         Assert.Equal(77, sum.BundlesHollow);
         Assert.Equal(88, sum.Faulted);


### PR DESCRIPTION
Follow-up to #3483 (#3429). The three Copilot findings on that PR, all accepted. They could not go into #3483 itself: it had already reached merge-queue **position 1** with #3482 and #3481 behind it when the push landed, GitHub refused the update rather than ejecting it, and a dequeue restarts every queued entry's build — not a cost worth imposing on two other sessions to improve a log line.

Pairs-with: none — removes no `public` type and no `public` member from `src/`. `SeedTally.EntriesMatched` is deleted, but `SeedTally` is `internal`.

## 1. The denominator was built from per-entry sums — the same failure mode the parent PR removes

`tally.Covered` and `EntriesMatched` count bundle **entries**. A type carried by *both* the image bundle and the CI-published root contributes two entries and one path, so:

- `uncovered.Count + tally.Covered` as the "requested" denominator could read **"1 of 3 requested"** for a pass that asked for two;
- `EntriesMatched > Covered` as the Warning/Information discriminator could misclassify in either direction.

A confidently wrong number in the one line an operator uses to decide what to fix is exactly the defect #3429 is about, reproduced inside the cure. So it is fixed at the root, not patched:

- the pass witnesses **matched paths** as a second per-subscription set, written where `present` is computed — *before* anything can decline an entry — alongside the existing covered set;
- `requested` is passed to `DescribeShortfall` explicitly;
- `IsShortfallAFailure` takes the count of **offered-but-uncovered paths**;
- `SeedTally.EntriesMatched` is gone.

The line is strictly more useful for it. Answer 4 now **names** the offered-but-uncovered paths — the types whose bytes were present and did not land — instead of quoting a count:

```
… A bundle entry under /bundles DID name 2 of them (Edu/Exercise, Edu/Lesson) across 40 bundle(s),
so those bytes were present and did not land; 1 bundle(s) were declined WHOLE on framework
identity (live: sa55f8190…). The per-entry decline is logged above with its reason.
```

Pinned by a new deterministic test, `ADenominatorIsTheREQUESTEDSet_NotASumOfBundleEntries`, which fails against the derived denominator.

## 2. A guard order that made the method's own doc false

`SeedPrebuiltAssemblies` asked about the consumer before the type set, so the *(no consumer **and** no types)* corner logged nothing at all while the XML doc above it claimed the outcome is reported unconditionally — the *prose asserts a guarantee the code does not keep* trap. The empty-type-set check now runs first (it is also the more specific and more actionable fact), so every path emits exactly one line and the doc is true.

## 3. The test's mounted bundle directory was never removed

Cleaned up in a `finally`, matching this suite's own convention (`PrebuiltPublicationTest`).

## Verification

| suite | result |
|---|---|
| `MeshWeaver.Hosting.Test` (incl. the 10-test pure suite) | **386 / 386** |
| `Memex.Portal.Shared.Test` | **828 / 828** |
| `MeshWeaver.Documentation.Test` (incl. `DocumentationLinkIntegrityTest`) | **304 / 304** |

Every touched project builds clean at `-c Release -warnaserror`, one project per invocation.

Doc updated: `Doc/Architecture/InstallTimePrebuiltAdoption` now states the sets-not-sums rule and names the test that pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
