### PR TITLE
fix(#3478): a process its readiness validation refuses no longer JOINS the mesh

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -338,16 +338,25 @@ public static class MemexConfiguration
             if (resolvedModules.Length > 0)
                 builder.InstallAssemblies(resolvedModules);
 
-            // 🚨 #3395 — say, once and durably, that a replica came up on the mesh's set. Written
-            // AFTER the assemblies are installed, because the claim is "this set is running", not
-            // "this set was read": a boot that dies before InstallAssemblies must not close the
-            // convergence window it never entered. Create-if-absent, so the second and every later
+            // 🚨 #3395 — say, once and durably, that a replica came up on the mesh's set. Deferred
+            // to a hosted service rather than written here, because the claim is "this set is
+            // RUNNING", not "this set was read" — a boot that dies before InstallAssemblies must
+            // not close the convergence window it never entered, and #3478 is the same rule one
+            // step further: a process its OWN validation refuses never serves anything either, so
+            // it must not make the claim. ModuleSetAdoptionService offers the write to the
+            // mesh-admission gate, which holds it while the bake is still forming a verdict, writes
+            // it when the bake passes and never writes it when the bake refuses the image. On every
+            // deployment that has not armed the bake readiness gate — the chart default — the gate
+            // is Unarmed and the write happens inline on that service's StartAsync, milliseconds
+            // later in boot than it did here. Create-if-absent, so the second and every later
             // replica writes nothing, and best-effort — a read-only volume costs the mesh-level
             // signal and nothing else.
             if (meshModuleSets.Proposed is { } adoptedSet)
-                ModuleSetStore.RecordAdoption(moduleRoot, adoptedSet,
-                    adoptedBy: Environment.MachineName,
-                    onWarn: msg => Console.Error.WriteLine($"[ModuleSet] {msg}"));
+                builder.ConfigureServices(services => services.AddModuleSetAdoption(
+                    $"module set {adoptedSet.Sequence} ('{adoptedSet.Id}')",
+                    () => ModuleSetStore.RecordAdoption(moduleRoot, adoptedSet,
+                        adoptedBy: Environment.MachineName,
+                        onWarn: msg => Console.Error.WriteLine($"[ModuleSet] {msg}"))));
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
             // consume the pending flag so the step-10 signal reads current. Best-effort: on a
             // read-only app filesystem the flag simply stays set (cosmetic), and boot proceeds.

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -3620,6 +3620,32 @@ internal static class NodeTypeCompilationHelpers
                         ok ? ActivityStatus.Succeeded : ActivityStatus.Failed,
                         activityMessages.ToImmutable(), logger!);
 
+                    // 🚨 #3478 — THE ACTIVATION PATH'S HALF OF THE JOIN POINT. This is the same
+                    // compile-state stamp the batch bake writes (the field-sets are literally
+                    // shared — ApplyCompileSuccess / ApplyCompileFailure), so it carries the same
+                    // identity into the same shared record and is gated the same way: a process
+                    // that failed its own validation must not put CompiledFrameworkVersion /
+                    // CompiledModulesHash / assembly coordinates into a node the other replicas
+                    // follow. Held while the verdict is still forming, released when it passes,
+                    // never written when it does not — and a straight pass-through on every host
+                    // that has not armed the bake readiness gate.
+                    //
+                    // Built inside a FACTORY so a refused stamp never even mints the
+                    // RequireSubscribeObservable: constructing one and dropping it would log a
+                    // never-subscribed warning about a write we deliberately did not make.
+                    var admission = hub.ServiceProvider.GetService<MeshPublicationGate>();
+                    // 🚨 …and the PROCESS-LOCAL half, published BEFORE the (possibly withheld)
+                    // stamp. The bake gate's regression retraction (#1214) asks "has this
+                    // condemned type since built on THIS image?" and used to read the shared
+                    // record as a proxy for that local fact. On a refused pod the record can no
+                    // longer move, so without this signal a regression formed against a
+                    // half-applied content update would hold the rollout until a human noticed —
+                    // trading one outage class for another. Recorded whether or not the stamp is
+                    // published, because the compile is what it attests to.
+                    if (ok)
+                        hub.ServiceProvider.GetService<LocalNodeTypeBuilds>()
+                            ?.RecordUsableBuild(hubPath);
+                    IObservable<Unit> StampCompileState() =>
                     workspace.GetMeshNodeStream().Update(curr =>
                     {
                         // 🚨 Tolerant read — NOT a bare `curr.Content is not NodeTypeDefinition`.
@@ -3662,25 +3688,31 @@ internal static class NodeTypeCompilationHelpers
                                 hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
                         };
                     })
-                    .Subscribe(
-                        saved =>
+                    .Do(saved =>
+                    {
+                        // Publish the post-compile MeshNode update onto the
+                        // mesh change feed for cross-silo cache invalidation.
+                        try
                         {
-                            // Publish the post-compile MeshNode update onto the
-                            // mesh change feed for cross-silo cache invalidation.
-                            try
-                            {
-                                hub.ServiceProvider.GetService<IMeshChangeFeed>()
-                                    ?.Publish(MeshChangeEvent.Updated(saved));
-                            }
-                            catch (Exception publishEx)
-                            {
-                                logger?.LogWarning(publishEx,
-                                    "Compile: failed to publish post-compile change-feed event for {HubPath}",
-                                    hubPath);
-                            }
-                        },
-                        ex => logger?.LogWarning(ex,
-                            "Compile: failed to write post-compile status for {HubPath}", hubPath));
+                            hub.ServiceProvider.GetService<IMeshChangeFeed>()
+                                ?.Publish(MeshChangeEvent.Updated(saved));
+                        }
+                        catch (Exception publishEx)
+                        {
+                            logger?.LogWarning(publishEx,
+                                "Compile: failed to publish post-compile change-feed event for {HubPath}",
+                                hubPath);
+                        }
+                    })
+                    .Select(_ => Unit.Default);
+
+                    (admission is null
+                            ? Observable.Defer(StampCompileState)
+                            : admission.Publish($"NodeType compile stamp for {hubPath}", StampCompileState))
+                        .Subscribe(
+                            _ => { },
+                            ex => logger?.LogWarning(ex,
+                                "Compile: failed to write post-compile status for {HubPath}", hubPath));
                     },
                     ex => logger?.LogWarning(ex,
                         "Compile: release-create observation faulted for {HubPath}", hubPath));

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshAdmission.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshAdmission.md
@@ -1,0 +1,206 @@
+---
+Name: Mesh Admission
+Category: Architecture
+Description: Readiness gates traffic; admission gates membership. Where a process actually joins the mesh, what a provisional membership that cannot stamp a generation looks like, and why a refused process stays up inert instead of exiting.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18"/><path d="M9 15h6"/><circle cx="12" cy="15" r="0.5"/></svg>
+---
+
+> **"not ready should *NEVER* run" · "validate before running"** — maintainer, 2026-09-06
+
+A readiness probe takes a pod out of the load balancer. It does **not** take the process out of the
+mesh. On 2026-09-06 that difference cost `memex.systemorph.com` a two-hour client-facing outage
+([#3478](https://github.com/Systemorph/MeshWeaver/issues/3478), [#3472](https://github.com/Systemorph/MeshWeaver/issues/3472)) —
+and it did so through a protection that was working *correctly*.
+
+## What happened
+
+A roll to `3.0.0-ci.7926` started at 19:17Z. The NodeType bake readiness gate measured a regression
+and refused readiness:
+
+```
+Health check nodetype_bake with status Unhealthy:
+  'NodeType bake regressed on this image — refusing readiness so the rollout stalls with the
+   previous image still serving. 1 NodeType(s) regressed on this image: Feedback/Feedback'
+```
+
+That verdict was right, and the rollout correctly stalled. Two hours later:
+
+| pod | image | ready | started |
+|---|---|---|---|
+| `79ddd44d77-k8qlc` | `rc9.ci.7693` | true,true,true | 18:54:57Z |
+| `79ddd44d77-xzp5d` | `rc9.ci.7693` | true,true,true | 18:57:30Z |
+| `f69cd9d56-jczb7`  | `ci.7926`     | **FALSE**,true,true | 19:17:02Z |
+
+The refused pod kept running, kept its hubs activated, and **kept stamping NodeType compile
+records**. `Crm/Offer` (19:28:04) and `Crm/Opportunity` (19:31:30) came to name assemblies stamped
+`sc273ee39f…` while the serving replicas ran `s2f227642d…`; both types went unloadable and every
+deal and offer page on the client portal was dead until 21:50Z. `compilationStatus` read `Ok`
+throughout — the types compiled, just not for the identity that had to load them.
+
+**The protection produced the outage**, not by misjudging the image but by leaving the refused
+process a participant.
+
+## Where a process actually joins
+
+The first instinct — "do not join until validated" — does not survive contact with the ordering. A
+portal process becomes *addressable* long before it can have validated anything, and the validation
+itself needs the mesh: the bake sweep reads every NodeType and its sources through mesh queries. So
+membership-for-**reading** cannot be moved after the verdict.
+
+Membership-for-**writing** can, and that is the half that does the damage. The mesh-visible acts
+that carry a process's own build identity are few and enumerable:
+
+| act | where | what it says |
+|---|---|---|
+| NodeType compile stamp, batch path | `NodeTypeBatchBake.WriteStamp` | `CompiledFrameworkVersion`, `CompiledModulesHash`, `CompiledDependencies`, assembly coordinates |
+| NodeType compile stamp, activation path | `NodeTypeCompilationHelpers` (post-compile write-back) | the same field-set — the two paths share it literally |
+| module-set adoption | `ModuleSetStore.RecordAdoption` | "a replica is serving set N" |
+
+**Assembly BYTES are deliberately not gated.** The assembly store is keyed
+`(nodeTypePath, version)` with the producing framework identity baked into the key, and
+`NodeTypeBakeStatus.ClassifyDetailed` cannot look for bytes at all until the RECORD names a
+collection, a path and a version. Bytes nobody's record points at are inert. **The pointer is the
+poison, so the pointer is what is gated.**
+
+## The mechanism
+
+`MeshPublicationGate` (`src/MeshWeaver.Mesh.Contract/Services/MeshPublicationGate.cs`) is a
+mesh-scoped singleton every one of those writes goes through. It reads its verdict from the
+registered `IMeshAdmissionAuthority` implementations — today exactly one, the NodeType bake gate —
+and takes the most restrictive answer.
+
+| admission | meaning | what a publication does |
+|---|---|---|
+| `Unarmed` | no authority is armed | runs, unchanged |
+| `Provisional` | armed, no verdict yet | **held**, released on admission |
+| `Admitted` | validation passed | runs |
+| `Refused` | validation failed | **never built, never written** |
+
+Publications are offered as a `Func<IObservable<Unit>>`, not as an observable: a refused publication
+is never *constructed*, so no storage read is issued and no `RequireSubscribeObservable` is minted
+only to be dropped. A held one is constructed at release time, so its compare-and-set reads the row
+it is about to race rather than replaying a version read before the verdict existed.
+
+### Provisional membership, stated
+
+> A provisional member may **read** the mesh and **compile**. It may not **publish**. Everything it
+> would publish is held, in offer order, and settled the instant a verdict exists.
+
+That is what makes *validate before running* implementable without reordering startup. The bake
+sweep runs exactly as before; what changed is that its 240 stamps land **after** its verdict instead
+of during it.
+
+### The second witness — why gating the compile stamp does not break self-healing
+
+The bake gate already retracts a regression when the type it condemned is afterwards seen to build
+on this image (#1214 — a bake that compiled a half-applied plugin update recorded four false
+regressions and hung a rollout until the content converged seconds later). That watch read the
+type's **shared record**, because that is where the compile watcher publishes.
+
+🚨 **Gating publication breaks that proxy, and leaving it broken would trade one outage class for
+another.** A refused pod recompiles the type successfully, the stamp is withheld — correctly, it
+names an identity the serving replicas cannot load — and a record-only watch waits forever for a row
+that will never move. #1214's *self-healing* stall becomes a *permanent* one.
+
+So the retraction now has two witnesses, and takes whichever answers first:
+
+- **`LocalNodeTypeBuilds`** — a mesh-scoped signal the compile write-back raises *before* the
+  (possibly withheld) stamp. It is strictly better evidence than the record: no round-trip, no
+  framework comparison, no freshness heuristic. The question was always process-local; the record
+  was the proxy.
+- **the record**, unchanged — a type baked by a *peer* on the same image is a real recovery the
+  local signal cannot see, and dropping it would narrow the retraction rather than widen it.
+
+## One predicate, two consumers
+
+The defect #3478 names is a **divergence**: two verdicts, one of them enforced. So admission is not
+a second gate with its own table — it is derived from the readiness predicate:
+
+```csharp
+public bool ReadinessGranted => Phase switch
+{
+    BakePhase.NotStarted => true,       // the sweep is switched OFF — the fail-OPEN state
+    BakePhase.Complete   => true,
+    BakePhase.Faulted    => AllowUnprovenBake,
+    _                    => false,      // Running, Regressed
+};
+
+public MeshAdmission Admission
+    => !GatesReadiness ? MeshAdmission.Unarmed
+        : ReadinessGranted ? MeshAdmission.Admitted
+        : Phase is BakePhase.Running or BakePhase.NotStarted ? MeshAdmission.Provisional
+        : MeshAdmission.Refused;
+```
+
+**The invariant is `Admitted ⟹ ReadinessGranted`** — admission is never more permissive than
+readiness, which is the maintainer directive reduced to one line a test can falsify over the whole
+state space.
+
+It is deliberately *less* permissive in exactly one place: an **armed gate at `NotStarted`**.
+Readiness is granted there (a probe cannot tell "switched off" from "has not started"), but no
+verdict exists, so publications are held rather than run. The incident's pod walked through exactly
+that window — its bake starts at `ApplicationStarted`, minutes after the process does.
+
+🚨 **Unarmed means unarmed.** With `PreWarm:GateReadiness` off — the chart default, every dev host
+and every test mesh — nothing consumes the bake verdict and nothing is enforced from it. Making an
+unarmed gate withhold writes would be enforcement nobody opted into, and would turn a configuration
+default into an outage. "Registered" and "armed" stay separate, exactly as they already do for the
+readiness half.
+
+## Becoming unhealthy after joining
+
+The verdict is **level-triggered**, re-read at every publication rather than latched at admission.
+A regression recorded hours after a clean sweep stops the process publishing from that moment; a
+`RetractRegression` (the type has since built on this image) resumes it. That answers the symmetric
+question with the same mechanism and no second one.
+
+Note what it does *not* do: it never withdraws a pod that is serving correctly. Withholding
+publication is not the same act as flipping readiness — the pod keeps answering requests from the
+build it already has, it simply stops telling the mesh about new ones.
+
+## Exit, or stay up inert? — the decision, and its trade-off
+
+A refused process **stays up and inert**. It does not exit.
+
+**The case for exiting** is real: a non-zero exit turns a stalled rollout into a `CrashLoopBackOff`,
+which is louder, harder to overlook, and arguably a more honest description of a process that will
+never serve.
+
+**Why inert is what ships:**
+
+- **The refusal is already real without it.** Once publication is gated, exiting adds no protection
+  — it only changes how the stall is *presented*. Loudness is not the defect #3478 describes.
+- **It destroys the diagnosis surface.** The refused pod's `/health` payload naming the regressed
+  types is the only place that verdict lives. A crash-looping pod has no readable health endpoint,
+  and its logs rotate with each restart.
+- **Each restart re-runs a full cold bake** — measured at ~2.4 s per NodeType, ~10 minutes on the
+  largest mesh we run. A backoff loop pays that repeatedly, on a cluster we pay for, to learn the
+  same verdict every time.
+- **It changes deployment behaviour on every path**, including the Monolith, Aspire and the plugin
+  tester, on evidence this change is the first to produce. `ModuleSetConvergence` declined the
+  neighbouring options ("have a behind replica restart itself, or flip readiness") for the same
+  reason, and noted they become *decidable* once the state is named. This is that state, now named.
+
+It is a **maintainer-level call and it is decidable now**: with admission derived from one
+predicate, "exit when `Admission is Refused`" is a single call in
+`DynamicTypePreWarmerHostedService`'s terminal handler. It is deliberately not taken here.
+
+## What this does not fix
+
+- **It does not stop a bad image being CHOSEN.** That is roll selection —
+  [#3479](https://github.com/Systemorph/MeshWeaver/issues/3479) — and the two are complementary:
+  that one stops the bad roll starting, this one stops a bad roll doing damage when one happens
+  anyway. Neither subsumes the other.
+- **It does not gate Orleans cluster membership or hub activation.** A refused process is still
+  addressable and its grains still activate. That is what lets the sweep read; it is also the
+  remaining, deliberate, scope boundary.
+- **It does not change the stall posture.** The old image keeps serving. That instinct was right;
+  what was missing was the refusal being real.
+
+## Related
+
+[Module Set Convergence](/Doc/Architecture/ModuleSetConvergence) ·
+[NodeType Compilation](/Doc/Architecture/NodeTypeCompilation) ·
+[Modules](/Doc/Architecture/Modules) ·
+[Deployment (AKS)](/Doc/Architecture/DeploymentAKS) ·
+[Reading CI Signals](/Doc/Architecture/ReadingCiSignals)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -238,7 +238,10 @@ this reason.
 live options on top of this design and neither is taken here: (b) empties a pod that is serving
 correctly, and both change deployment behaviour on evidence this change is the first to produce.
 They become *decidable* now that "behind" is a named state with a bounded window rather than an
-invisible one.
+invisible one. 🚨 One of them was decided by #3478 — a process whose own validation REFUSES it now
+publishes nothing at all, which is neither of these two: it neither empties a serving pod nor
+replaces it, it stops a pod that will never serve from writing what it compiled. See
+[Mesh Admission](/Doc/Architecture/MeshAdmission).
 
 **Decline to write NodeType compile records while behind.** This is option (c) from #3395's open
 item and it is now SAFE to build — the adoption record guarantees the mesh's `Current` set always
@@ -247,6 +250,7 @@ and belongs in its own change with its own falsification. It is not in this one.
 
 ## Related
 
+[Mesh Admission](/Doc/Architecture/MeshAdmission) ·
 [Modules](/Doc/Architecture/Modules) · [Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) ·
 [Module Versioning](/Doc/Architecture/ModuleVersioning) · [Plugins](/Doc/Architecture/Plugins) ·
 [Build Coordination](/Doc/Architecture/BuildCoordination) · [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-portal-refused-by-its-own-checks-no-longer-joins-the-mesh.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-portal-refused-by-its-own-checks-no-longer-joins-the-mesh.md
@@ -1,0 +1,36 @@
+---
+Name: A portal refused by its own checks no longer joins the mesh
+Category: Fix
+Description: A pod whose startup validation refused it kept running inside the mesh and kept recording what it had compiled — so a rollout the platform correctly stopped could still break pages on the version that was still serving. A refused process is now genuinely inert.
+Icon: ShieldError
+Order: -20260907
+---
+
+When a new version of the portal rolls out, it checks itself before taking traffic: it rebuilds
+every custom type in your space and refuses to serve if something that used to work no longer does.
+That check works, and when it fires the rollout stops with the previous version still serving —
+which is exactly what you want.
+
+**What it did not do was stop the refused process.** It stayed running, and it kept writing down
+what it had just compiled onto the shared records every other replica reads. So for as long as the
+stalled rollout sat there, two versions of the platform were describing the same types to each
+other, and the version that was actually serving could end up pointed at code built for the other
+one. On 2026-09-06 that took out every deal page and every offer page on a client portal for two
+hours — while the check that was supposed to be protecting it was doing its job perfectly.
+
+A process that has not passed its own validation is now **inert**, not merely kept out of the load
+balancer. It may read and it may compile — it has to, in order to check itself — but nothing it
+produces reaches the shared mesh until the check passes:
+
+- everything it compiles is **held**, in order, and written only once its validation succeeds;
+- if the validation fails, those results are **discarded and never written**;
+- it no longer announces itself as a replica running the current module set;
+- and the rule is re-checked continuously, so a version that develops a problem *after* it started
+  serving also stops recording — it keeps serving what it already has.
+
+Nothing changes for a deployment that has not switched the startup check on: it behaves exactly as
+before.
+
+The refused process deliberately stays up rather than crash-looping, so you can still open its
+health page and read which type failed and why. The full design, including that trade-off, is in
+[Mesh Admission](/Doc/Architecture/MeshAdmission).

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -1105,6 +1105,16 @@ public static class DynamicTypePreWarmer
     {
         var workspace = mesh.GetWorkspace();
         var accessService = mesh.ServiceProvider.GetService<AccessService>();
+        // 🚨 #3478 — THE SECOND WITNESS, and the reason gating publication does not break #1214.
+        // The question this watch asks is process-LOCAL — "has this condemned type since built on
+        // THIS image?" — and the record below was only ever a PROXY for it. On a pod whose bake
+        // refused it, the record can no longer move (its stamps are withheld, correctly, because
+        // they name an identity the serving replicas cannot load), so a record-only watch would
+        // wait forever and #1214's self-healing stall would become a permanent one. This observes
+        // the compile itself. The record watch stays alongside it: a type baked by a PEER on the
+        // same image is a real recovery this signal cannot see, and losing that would narrow the
+        // retraction rather than widen it.
+        var localBuilds = mesh.ServiceProvider.GetService<LocalNodeTypeBuilds>();
         // System-scoped for the same reason the sweep's reads are: watching a NodeType record
         // across partitions is infrastructure, not a user-attributable read. RunAsSystem, never
         // `Observable.Using(AccessContextScope.AsSystem, …)` — see WarmDynamicTypes (#1444/#1790).
@@ -1129,13 +1139,34 @@ public static class DynamicTypePreWarmer
                                 && NodeTypeCompilationHelpers.HasUsableBuild(
                                     n, d, NodeTypeCompilationHelpers.GuardsOf(mesh))
                                 && IsFreshSuccess(d.LastCompileSucceededAt, baseline))
+                            .Take(1)
+                            .Select(_ => "the record shows a fresh usable build")
+                            // Whichever witness answers first. The local one needs no freshness
+                            // heuristic — the compile happened here, after this subscription, so
+                            // it cannot be a replayed older success the way a record read can.
+                            .Merge(localBuilds is null
+                                ? Observable.Never<string>()
+                                : localBuilds.Built
+                                    .Where(p => string.Equals(
+                                        p, typePath, StringComparison.OrdinalIgnoreCase))
+                                    .Select(_ => "this process compiled it successfully"))
                             .Take(1));
                 })
             .Subscribe(
-                _ =>
+                witness =>
                 {
                     if (gate.RetractRegression(
-                            typePath, "rebuilt to a usable build on this image after the bake"))
+                            typePath,
+                            $"rebuilt to a usable build on this image after the bake ({witness})"))
+                    {
+                        // 🚨 #3478 — the retraction moves READINESS and MEMBERSHIP together. A
+                        // regression withdrawn because the type has since built on this image
+                        // leaves no evidence against the image, so the process may publish again;
+                        // re-reading the verdict here is what releases anything still held. The
+                        // gate is level-triggered, so this direction costs nothing to support and
+                        // is the same mechanism that answers "what if it becomes unhealthy AFTER
+                        // joining?" the other way round.
+                        mesh.ServiceProvider.GetService<MeshPublicationGate>()?.Reconsider();
                         logger?.LogWarning(
                             "DynamicTypePreWarmer: RETRACTING the regression recorded for "
                             + "{TypePath} — it has since reached a usable build on THIS image, so "
@@ -1143,6 +1174,7 @@ public static class DynamicTypePreWarmer
                             + "compile that sampled a half-applied content update — issue #1214). "
                             + "Gate now: {Detail}",
                             typePath, gate.Detail);
+                    }
                 },
                 ex => logger?.LogWarning(ex,
                     "DynamicTypePreWarmer: recovery watch for the regressed type {TypePath} "

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -209,8 +209,23 @@ public sealed class DynamicTypePreWarmerHostedService(
         // (Memex.Portal.Distributed/Program.cs) so "the gate is on" and "the gate measures
         // something" cannot drift apart silently in an operator's head.
         var gate = services.GetService<NodeTypeBakeGateState>();
+        // 🚨 #3478 — the same verdict, gating MESH MEMBERSHIP as well as traffic. Resolved off the
+        // MESH hub's provider, not the host root, so it is the very instance the compile-stamp
+        // write-backs consult (NodeTypeBatchBake / NodeTypeCompilationHelpers both read
+        // `hub.ServiceProvider`). Every phase transition below calls Reconsider(): that is the EDGE
+        // the gate's own level-triggered read cannot supply, and it is what releases the stamps a
+        // passing sweep held and discards the ones a failing sweep produced.
+        var admission = mesh.ServiceProvider.GetService<Mesh.Services.MeshPublicationGate>();
         if (sweepEnabled)
             gate?.MarkRunning("enumerating dynamic NodeTypes");
+        if (gate is { GatesReadiness: true })
+            logger.LogInformation(
+                "DynamicTypePreWarmer: mesh admission is {Admission} — until this pod's bake "
+                + "PASSES, nothing it compiles is stamped onto a shared NodeType record and no "
+                + "module-set adoption is recorded. Readiness gates traffic; this gates membership "
+                + "(#3478).",
+                gate.Admission);
+        admission?.Reconsider();
 
         // Pacing: explicit config wins; otherwise a readiness-GATED pod sweeps at full speed (it
         // serves nobody while it bakes — the initial-bake case) and an ungated pod keeps the
@@ -402,7 +417,15 @@ public sealed class DynamicTypePreWarmerHostedService(
                     // activating its hub at all, and one broken upstream would otherwise activate
                     // its whole fan-out and hold it for the pod's lifetime. Those are retracted
                     // through their blocker instead (NodeTypeBakeGateState.RetractRegression).
-                    if (gate?.MarkOutcome(outcome) == true)
+                    var gated = gate?.MarkOutcome(outcome) == true;
+                    // 🚨 #3478 — act on the verdict the moment it turns, mid-sweep. The first
+                    // regression makes this process Refused, so every stamp it has HELD so far is
+                    // discarded here and every later one is refused outright: the types compiled
+                    // before the regression was discovered must not reach the mesh either, which
+                    // is exactly what "validate before running" means for a sweep whose verdict
+                    // arrives at type 50 of 240.
+                    admission?.Reconsider();
+                    if (gate is not null && gated)
                     {
                         if (outcome.SourcesMovedDuringCompile)
                             logger.LogWarning(
@@ -477,6 +500,10 @@ public sealed class DynamicTypePreWarmerHostedService(
                             ? "the build coordination node could not be reached, so the sweep "
                               + "never started"
                             : "the warm-up stream faulted before the sweep could finish");
+                    // #3478 — a faulted sweep proved nothing, so this process is Refused unless the
+                    // operator set AllowUnprovenBake. Either way the held stamps are settled here
+                    // rather than left in limbo for the pod's lifetime.
+                    admission?.Reconsider();
                     if (gate is { GatesReadiness: true, Phase: BakePhase.Faulted })
                         logger.LogCritical(ex,
                             "DynamicTypePreWarmer: REFUSING READINESS — the warm-up stream FAULTED, "
@@ -520,6 +547,19 @@ public sealed class DynamicTypePreWarmerHostedService(
                     gate?.MarkComplete(
                         $"baked in {elapsed:hh\\:mm\\:ss} — compiled={Volatile.Read(ref compiled)} "
                         + $"alreadyBaked={Volatile.Read(ref alreadyBaked)}");
+                    // 🚨 #3478 — THE ADMISSION EDGE. A clean sweep makes this process a full
+                    // participant, and every compile stamp it held is written HERE, after the
+                    // verdict rather than before it. A sweep that ended Regressed or Faulted
+                    // discards them instead: the process stays up for diagnosis and its identity
+                    // never enters the shared mesh.
+                    admission?.Reconsider();
+                    if (gate is { GatesReadiness: true } armed && admission is { } published)
+                        logger.LogInformation(
+                            "DynamicTypePreWarmer: mesh admission is {Admission} after the sweep — "
+                            + "{Released} held publication(s) released, {Withheld} withheld "
+                            + "({Reason})",
+                            armed.Admission, published.ReleasedCount, published.WithheldCount,
+                            armed.AdmissionReason);
                     // 🚨 Say ONLY what is actually enforced. The gate STATE is registered
                     // unconditionally, so this branch runs whether or not a readiness probe consumes
                     // it. Claiming a stall that nothing enforces is worse than saying nothing: it was

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -3,7 +3,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace MeshWeaver.Hosting;
 
@@ -51,7 +53,7 @@ public enum BakePhase
 /// readiness probe that takes the pod out of rotation under load (the /health-as-readiness
 /// death-spiral this deployment already fixed once).</para>
 /// </summary>
-public sealed class NodeTypeBakeGateState
+public sealed class NodeTypeBakeGateState : IMeshAdmissionAuthority
 {
     private readonly ConcurrentDictionary<string, string> regressions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, string> unevaluated = new(StringComparer.OrdinalIgnoreCase);
@@ -139,6 +141,76 @@ public sealed class NodeTypeBakeGateState
 
     /// <summary>Human-readable status for the health payload and the logs.</summary>
     public string Detail => detail;
+
+    /// <summary>
+    /// 🚨 <b>THE readiness predicate — ONE table, and every consumer reads THIS one.</b> True when a
+    /// readiness probe over this state answers healthy.
+    ///
+    /// <para>It is stated here, beside the state it judges, for the reason
+    /// <c>IsAvailabilityFailure</c> gives in the compiler pipeline: one predicate, several
+    /// consumers, and they MUST agree. The host's <c>IHealthCheck</c>
+    /// (<c>Memex.Portal.Distributed.NodeTypeBakeHealthCheck</c>) implements exactly this table, and
+    /// <see cref="Admission"/> below is DERIVED from it — so "not ready" and "not admitted to the
+    /// mesh" cannot drift apart by construction, which is the whole of #3478's directive
+    /// (<i>"not ready should NEVER run"</i>).</para>
+    ///
+    /// <para><see cref="BakePhase.NotStarted"/> is healthy because it means the sweep is switched
+    /// OFF — the documented fail-OPEN state, since a configuration mistake must never black-hole a
+    /// pod. <see cref="BakePhase.Running"/> is NOT: a pod mid-sweep has not verified its NodeTypes
+    /// yet. <see cref="BakePhase.Faulted"/> follows <see cref="AllowUnprovenBake"/>, the operator's
+    /// explicit "serve on an unproven bake".</para>
+    /// </summary>
+    public bool ReadinessGranted => Phase switch
+    {
+        BakePhase.NotStarted => true,
+        BakePhase.Complete => true,
+        BakePhase.Faulted => AllowUnprovenBake,
+        _ => false,
+    };
+
+    /// <summary>
+    /// 🚨 <b>Whether this process may PARTICIPATE in the mesh — issue #3478.</b> Readiness gates
+    /// traffic; this gates membership, and the two are the same verdict read at different
+    /// strengths.
+    ///
+    /// <para><b>The invariant, and it is what the maintainer directive reduces to:</b>
+    /// <c>Admitted ⟹ <see cref="ReadinessGranted"/></c>. Admission is never more permissive than
+    /// readiness. It is deliberately LESS permissive in exactly one place — an armed gate at
+    /// <see cref="BakePhase.NotStarted"/>, where readiness is granted (the sweep is switched off as
+    /// far as a probe can tell) but this pod has formed no verdict yet, so its publications are
+    /// HELD rather than run. That window is the one the incident's pod walked through: its bake
+    /// started at <c>ApplicationStarted</c>, minutes after the process began.</para>
+    ///
+    /// <list type="table">
+    /// <listheader><term>Phase (armed)</term><description>Admission</description></listheader>
+    /// <item><term><see cref="BakePhase.NotStarted"/></term><description>Provisional — armed, no verdict yet</description></item>
+    /// <item><term><see cref="BakePhase.Running"/></term><description>Provisional — still measuring</description></item>
+    /// <item><term><see cref="BakePhase.Complete"/></term><description>Admitted</description></item>
+    /// <item><term><see cref="BakePhase.Regressed"/></term><description>Refused</description></item>
+    /// <item><term><see cref="BakePhase.Faulted"/></term><description>Admitted iff <see cref="AllowUnprovenBake"/>, else Refused</description></item>
+    /// </list>
+    ///
+    /// <para>🚨 <b>Unarmed means unarmed.</b> With <see cref="GatesReadiness"/> false nothing
+    /// consumes this state and nothing is enforced, so admission is
+    /// <see cref="MeshAdmission.Unarmed"/> and publications pass straight through. Making an
+    /// unarmed gate withhold writes would be enforcement nobody opted into, on every dev host and
+    /// every test mesh — the exact "registered ≠ armed" confusion this class already exists to
+    /// keep honest.</para>
+    /// </summary>
+    /// <remarks>
+    /// 🚨 The NON-TERMINAL phases are tested FIRST, and the order is load-bearing:
+    /// <see cref="BakePhase.NotStarted"/> grants readiness, so asking
+    /// <see cref="ReadinessGranted"/> first would admit an armed pod that has not measured anything
+    /// — the very window the incident's pod published through.
+    /// </remarks>
+    public MeshAdmission Admission
+        => !GatesReadiness ? MeshAdmission.Unarmed
+            : Phase is BakePhase.NotStarted or BakePhase.Running ? MeshAdmission.Provisional
+            : ReadinessGranted ? MeshAdmission.Admitted
+            : MeshAdmission.Refused;
+
+    /// <summary>Why — the bake's own <see cref="Detail"/>, prefixed with the phase.</summary>
+    public string AdmissionReason => $"NodeType bake {Phase}: {Detail}";
 
     /// <summary>Types that regressed on this image, with their compile error.</summary>
     public IReadOnlyDictionary<string, string> Regressions => regressions;
@@ -553,6 +625,18 @@ public static class NodeTypeBakeGateExtensions
             GatesReadiness = gatesReadiness,
             AllowUnprovenBake = allowUnprovenBake,
         });
+        // 🚨 #3478 — the SAME verdict, now also gating MESH MEMBERSHIP and not merely traffic.
+        // Registering the state as an IMeshAdmissionAuthority is what makes a refused pod inert
+        // instead of silent-but-active: MeshPublicationGate reads this on every mesh-visible
+        // publication, so a pod that fails its bake stamps no NodeType record and records no
+        // module-set adoption. The gate itself is registered by AddMeshCatalog and is Unarmed
+        // until an authority like this one joins, so a host that never calls this method behaves
+        // exactly as it did before.
+        services.AddSingleton<IMeshAdmissionAuthority>(
+            sp => sp.GetRequiredService<NodeTypeBakeGateState>());
+        services.TryAddSingleton(sp => new MeshPublicationGate(
+            sp.GetServices<IMeshAdmissionAuthority>(),
+            sp.GetService<Microsoft.Extensions.Logging.ILogger<MeshPublicationGate>>()));
         return services;
     }
 }

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -659,8 +659,46 @@ internal static class NodeTypeBatchBake
     /// Best-effort by design: a failed stamp is logged loudly but never fails the bake — the
     /// bytes are already on the share, and the level-triggered probe / lazy kickoffs self-heal
     /// the record on the next pass (the same restartability rule as an interrupted bake).
+    ///
+    /// <para>🚨 <b>#3478 — THIS IS THE WRITE THAT JOINED A REFUSED PROCESS TO THE MESH.</b> The
+    /// stamp carries this process's <c>CompiledFrameworkVersion</c>, <c>CompiledModulesHash</c>,
+    /// <c>CompiledDependencies</c> and assembly coordinates onto a node every other replica reads,
+    /// and the bake that produces it runs BEFORE the bake's own verdict exists — so on
+    /// <c>memex.systemorph.com</c> a pod whose readiness the bake gate then correctly refused had
+    /// already stamped <c>Crm/Offer</c> and <c>Crm/Opportunity</c> for an identity the serving
+    /// replicas could not load (#3472). It now goes through
+    /// <see cref="MeshPublicationGate"/>: HELD while the sweep is still measuring, RELEASED when
+    /// the sweep passes, and DISCARDED — never written — when it does not. The gate is Unarmed on
+    /// every host that has not armed the bake readiness gate, where this is a straight
+    /// pass-through.</para>
+    ///
+    /// <para>The whole read-modify-write is inside the deferred factory on purpose: a held stamp is
+    /// CONSTRUCTED at release time, so its compare-and-set reads the row it is about to race rather
+    /// than replaying a version it read before the verdict existed.</para>
     /// </summary>
-    private static IObservable<Unit> WriteStamp(
+    internal static IObservable<Unit> WriteStamp(
+        IMessageHub mesh,
+        MeshNode typeNode,
+        bool ok,
+        NodeCompilationResult? result,
+        Exception? error,
+        string? releasePath,
+        DateTimeOffset startedAt,
+        ILogger? logger)
+    {
+        var gate = mesh.ServiceProvider.GetService<MeshPublicationGate>();
+        IObservable<Unit> Stamp() =>
+            BuildStamp(mesh, typeNode, ok, result, error, releasePath, startedAt, logger);
+        return gate is null
+            ? Observable.Defer(Stamp)
+            : gate.Publish($"NodeType compile stamp for {typeNode.Path}", Stamp);
+    }
+
+    /// <summary>
+    /// The stamp itself, as a COLD observable — built by <see cref="WriteStamp"/> only when this
+    /// process is admitted to the mesh (or held for release when it becomes so).
+    /// </summary>
+    private static IObservable<Unit> BuildStamp(
         IMessageHub mesh,
         MeshNode typeNode,
         bool ok,

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -845,6 +845,21 @@ public static class PersistenceExtensions
         // guarantees read-after-write (see IPostCommitFlush / StoragePostCommitFlush).
         services.TryAddSingleton<MeshWeaver.Data.IPostCommitFlush>(sp =>
             new StoragePostCommitFlush(sp.GetRequiredService<IMessageHub>()));
+        // 🚨 #3478 — the mesh-ADMISSION gate every mesh-visible publication of this process's
+        // build identity goes through (NodeType compile stamps on both write-back paths; the
+        // module-set adoption record). Registered here, with the rest of the process-local mesh
+        // services, so it is ALWAYS resolvable and the call sites never have to ask whether a
+        // deployment happens to have one. It is Unarmed — a straight pass-through — until an
+        // IMeshAdmissionAuthority is registered alongside it (AddNodeTypeBakeGate), so this
+        // registration on its own changes nothing anywhere.
+        services.TryAddSingleton(sp => new MeshPublicationGate(
+            sp.GetServices<IMeshAdmissionAuthority>(),
+            sp.GetService<ILogger<MeshPublicationGate>>()));
+        // 🚨 …and the process-LOCAL half of the same change. A withheld compile stamp still happened
+        // as a COMPILE, and the bake gate's regression retraction (#1214) is asking about exactly
+        // that local fact — it had been reading the shared record as a proxy for it. Without this
+        // signal, gating publication would turn #1214's self-healing stall into a permanent one.
+        services.TryAddSingleton<LocalNodeTypeBuilds>();
         return services;
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/Services/LocalNodeTypeBuilds.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/LocalNodeTypeBuilds.cs
@@ -1,0 +1,61 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// 🚨 <b>"This NodeType reached a usable build in THIS process" — the PROCESS-LOCAL fact, published
+/// even when the shared stamp that would have recorded it is withheld.</b> Issue #3478.
+///
+/// <para><b>Why it has to exist.</b> The bake gate's regression RETRACTION (#1214) asks exactly one
+/// question: <i>has this type, which the sweep condemned, since built on THIS image?</i> Until now
+/// it answered that by watching the type's shared MeshNode record, because that is where the
+/// compile watcher publishes — the record was a PROXY for a local fact. That proxy breaks the
+/// moment a refused process stops publishing: the pod recompiles the type successfully, the stamp
+/// is withheld (correctly — it names an identity the serving replicas cannot load), and the watch
+/// waits forever for a record that will never move. #1214's incident would then be permanent
+/// instead of self-healing: a regression formed against a half-applied content update would hold
+/// the rollout until a human noticed, which is the failure that fix exists to remove.</para>
+///
+/// <para>So the retraction now observes the fact DIRECTLY. It is strictly better evidence than the
+/// record: no round-trip, no framework comparison, no freshness heuristic — the compile happened
+/// here, on this image, just now. The record-based wait stays alongside it, because a type baked by
+/// a PEER on the same image is a legitimate recovery this signal cannot see.</para>
+///
+/// <para><b>Mesh-scoped instance singleton</b> (registered by <c>AddMeshCatalog</c>), never static:
+/// two test meshes must not hear each other's compiles. Hot and non-replaying by design — a
+/// consumer subscribes before the compile it is waiting for, exactly as the record watch does.</para>
+/// </summary>
+public sealed class LocalNodeTypeBuilds : IDisposable
+{
+    private readonly Subject<string> built = new();
+    private volatile bool disposed;
+
+    /// <summary>
+    /// Emits the path of every NodeType that reached a usable build IN THIS PROCESS, whether or not
+    /// the shared record was allowed to record it.
+    /// </summary>
+    public IObservable<string> Built => built.AsObservable();
+
+    /// <summary>
+    /// Records one such build. Called from the compile write-back BEFORE the (possibly withheld)
+    /// stamp, so the signal survives a refusal — that is the entire point.
+    /// </summary>
+    /// <param name="typePath">The NodeType's mesh path.</param>
+    public void RecordUsableBuild(string typePath)
+    {
+        if (disposed || string.IsNullOrEmpty(typePath))
+            return;
+        built.OnNext(typePath);
+    }
+
+    /// <summary>Mesh teardown — later observations are dropped rather than thrown.</summary>
+    public void Dispose()
+    {
+        if (disposed)
+            return;
+        disposed = true;
+        built.OnCompleted();
+        built.Dispose();
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/MeshPublicationGate.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/MeshPublicationGate.cs
@@ -1,0 +1,405 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// How far this process has got towards being a legitimate PARTICIPANT in the mesh — as opposed to
+/// merely being a running process that can read it.
+///
+/// <para>🚨 <b>Readiness gates TRAFFIC. This gates MEMBERSHIP.</b> Issue #3478: on
+/// <c>memex.systemorph.com</c>, 2026-09-06, the NodeType bake readiness gate correctly refused an
+/// image (<c>ci.7926</c>, one regressed NodeType) and Kubernetes correctly held the rollout with the
+/// previous image serving — and the refused pod then ran for two hours INSIDE the mesh, stamping
+/// NodeType compile records with its own framework identity. Two images lived in one mesh,
+/// <c>Crm/Offer</c> and <c>Crm/Opportunity</c> adopted assemblies stamped for an identity the
+/// serving replicas could not load, and every deal and offer page on the client portal was dead
+/// (#3472). The gate's verdict was right both times; what was wrong is that a refused process was
+/// still a participant.</para>
+/// </summary>
+public enum MeshAdmission
+{
+    /// <summary>
+    /// Nothing arms this process's admission — no <see cref="IMeshAdmissionAuthority"/> is
+    /// registered, or every registered one says it is not armed. Publications pass straight
+    /// through, exactly as they did before the gate existed.
+    ///
+    /// <para>🚨 The fail-OPEN default, and deliberately so: enforcement is opt-in, exactly like the
+    /// readiness gate it mirrors. A deployment that never armed a validator has nothing to validate
+    /// against, and a gate that black-holed such a process would turn a configuration default into
+    /// an outage. "Registered" and "armed" stay separate.</para>
+    /// </summary>
+    Unarmed,
+
+    /// <summary>
+    /// Armed, and the verdict does not exist yet — the validation is still running, or has not
+    /// started. The process may read the mesh and compile; it may NOT publish. Publications are
+    /// HELD (never dropped) and released the moment the verdict is <see cref="Admitted"/>.
+    ///
+    /// <para>This is "a provisional membership that cannot stamp a generation". It is what makes
+    /// <i>validate before running</i> implementable at all: the bake sweep has to read NodeTypes
+    /// through the mesh to have anything to validate, so membership-for-reading cannot be moved
+    /// after the verdict — but membership-for-WRITING can, and that is the half that does the
+    /// damage.</para>
+    /// </summary>
+    Provisional,
+
+    /// <summary>The validation passed. This process is a full participant; publications run.</summary>
+    Admitted,
+
+    /// <summary>
+    /// The validation FAILED. Publications are refused and dropped, and held ones are discarded —
+    /// this process must leave no trace of its identity in the shared mesh.
+    ///
+    /// <para>Level-triggered, not latched: it is re-read at every publication, so a process that
+    /// becomes unhealthy AFTER being admitted stops publishing from that moment, and one whose
+    /// verdict is retracted resumes. See <see cref="MeshPublicationGate.Publish"/>.</para>
+    /// </summary>
+    Refused,
+}
+
+/// <summary>
+/// Something that can say whether this process has passed ITS validation — the input side of
+/// <see cref="MeshPublicationGate"/>.
+///
+/// <para>Several may be registered; the gate takes the MOST RESTRICTIVE answer
+/// (<see cref="MeshAdmission.Refused"/> &gt; <see cref="MeshAdmission.Provisional"/> &gt;
+/// <see cref="MeshAdmission.Admitted"/> &gt; <see cref="MeshAdmission.Unarmed"/>), because an
+/// authority that refuses is stating evidence and an authority that admits is only stating the
+/// absence of it.</para>
+///
+/// <para>The one implementation today is <c>MeshWeaver.Hosting.NodeTypeBakeGateState</c>, whose
+/// <c>Admission</c> is derived from the SAME predicate as its readiness verdict, so "not ready" and
+/// "not admitted" cannot drift apart.</para>
+/// </summary>
+public interface IMeshAdmissionAuthority
+{
+    /// <summary>This authority's current verdict. Read on every publication — never cached.</summary>
+    MeshAdmission Admission { get; }
+
+    /// <summary>Why, for the log line a refusal or a release writes.</summary>
+    string AdmissionReason { get; }
+}
+
+/// <summary>
+/// 🚨 <b>THE JOIN POINT. Every write that puts THIS process's build identity into the SHARED mesh
+/// goes through here, and runs only while this process is admitted.</b> Issue #3478.
+///
+/// <para><b>What "joining" turned out to be.</b> A portal process becomes addressable long before
+/// it can have validated anything — the bake sweep must read NodeTypes through the mesh to have
+/// something to validate — so "do not join until validated" cannot mean "do not start". It means:
+/// do not publish. The mesh-visible acts that carry this process's identity are few and
+/// enumerable:</para>
+/// <list type="bullet">
+/// <item>the NodeType compile-state stamp, on both write-back paths — the batch bake's
+/// storage-level stamp (<c>NodeTypeBatchBake.WriteStamp</c>) and the activation path's
+/// (<c>NodeTypeCompilationHelpers</c>). This is the one that produced #3472: it carries
+/// <c>CompiledFrameworkVersion</c>, <c>CompiledModulesHash</c>, <c>CompiledDependencies</c> and the
+/// assembly coordinates, and every other replica follows it.</item>
+/// <item>the module-set ADOPTION record (<c>ModuleSetStore.RecordAdoption</c>) — the durable claim
+/// "a replica is serving set N", which a process that will never serve must not make.</item>
+/// </list>
+///
+/// <para>🚨 <b>Assembly BYTES are deliberately NOT gated, and that is not an oversight.</b> The
+/// assembly store is keyed <c>(nodeTypePath, version)</c> with the producing framework identity
+/// baked into the key, and <c>NodeTypeBakeStatus.ClassifyDetailed</c> cannot look for bytes at all
+/// until the RECORD names a collection, a path and a version. Bytes nobody's record points at are
+/// inert. The pointer is the poison, so the pointer is what is gated — which keeps the change to
+/// three call sites instead of the whole compiler.</para>
+///
+/// <para><b>Cold, and a factory rather than an observable.</b> <see cref="Publish"/> takes a
+/// <c>Func&lt;IObservable&lt;Unit&gt;&gt;</c>: a refused publication is never even CONSTRUCTED, so
+/// no storage read is issued and no <c>RequireSubscribeObservable</c> is minted only to be dropped
+/// (which would log a spurious never-subscribed warning at GC). A deferred one is constructed at
+/// release time, so a compare-and-set write re-reads the row it is racing rather than replaying a
+/// version it read before the verdict existed.</para>
+///
+/// <para><b>Instance state, mesh lifetime.</b> Registered as a mesh-scoped singleton
+/// (<c>AddMeshCatalog</c>); every field is an instance field and the queue is an
+/// <see cref="ImmutableQueue{T}"/>. Nothing here is static — two test meshes must not share a
+/// verdict. The <see cref="verdict"/> lock guards a handful of field assignments and one queue
+/// swap and never awaits or subscribes inside itself, exactly like
+/// <c>NodeTypeBakeGateState.verdict</c>.</para>
+/// </summary>
+public sealed class MeshPublicationGate : IDisposable
+{
+    /// <summary>
+    /// Guards <see cref="held"/> and the counters. Writers only, and nothing subscribes or blocks
+    /// inside it: the release below takes the queue under the lock and subscribes OUTSIDE it, so a
+    /// publication's own pipeline can never run on a thread holding this.
+    /// </summary>
+    private readonly object verdict = new();
+
+    private readonly IReadOnlyList<IMeshAdmissionAuthority> authorities;
+    private readonly ILogger? logger;
+
+    /// <summary>Publications held while <see cref="MeshAdmission.Provisional"/>, in offer order.</summary>
+    private ImmutableQueue<HeldPublication> held = ImmutableQueue<HeldPublication>.Empty;
+
+    /// <summary>Subscriptions to released publications, disposed with the gate.</summary>
+    private readonly CompositeDisposable releases = new();
+
+    private int heldCount;
+    private int passedCount;
+    private int releasedCount;
+    private int refusedCount;
+    private int discardedCount;
+    private bool disposed;
+
+    /// <summary>
+    /// Constructed by DI. <paramref name="authorities"/> is empty on every host that never armed a
+    /// validator — the <see cref="MeshAdmission.Unarmed"/> pass-through — which is what keeps this
+    /// inert for dev hosts, tests and every deployment that has not switched the bake gate on.
+    /// </summary>
+    public MeshPublicationGate(
+        IEnumerable<IMeshAdmissionAuthority>? authorities = null,
+        ILogger<MeshPublicationGate>? logger = null)
+    {
+        this.authorities = authorities?.ToImmutableArray() ?? ImmutableArray<IMeshAdmissionAuthority>.Empty;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// The MOST RESTRICTIVE verdict across every registered authority, read fresh. An authority
+    /// that refuses is stating evidence; one that admits is only stating the absence of it, so the
+    /// refusal wins.
+    /// </summary>
+    public MeshAdmission Admission
+    {
+        get
+        {
+            var strongest = MeshAdmission.Unarmed;
+            foreach (var authority in authorities)
+            {
+                var admission = authority.Admission;
+                if (Rank(admission) > Rank(strongest))
+                    strongest = admission;
+            }
+            return strongest;
+        }
+    }
+
+    /// <summary>Why — the reason given by whichever authority produced <see cref="Admission"/>.</summary>
+    public string AdmissionReason
+    {
+        get
+        {
+            var strongest = MeshAdmission.Unarmed;
+            var reason = "no admission authority is armed — publications pass through";
+            foreach (var authority in authorities)
+            {
+                var admission = authority.Admission;
+                if (Rank(admission) <= Rank(strongest))
+                    continue;
+                strongest = admission;
+                reason = authority.AdmissionReason;
+            }
+            return reason;
+        }
+    }
+
+    /// <summary>Publications currently HELD awaiting a verdict. Diagnostics and tests.</summary>
+    public int HeldCount => Volatile.Read(ref heldCount);
+
+    /// <summary>Publications that ran straight through (unarmed or admitted).</summary>
+    public int PassedCount => Volatile.Read(ref passedCount);
+
+    /// <summary>Publications that were held and later RELEASED because the verdict admitted.</summary>
+    public int ReleasedCount => Volatile.Read(ref releasedCount);
+
+    /// <summary>Publications REFUSED outright — the verdict was already <see cref="MeshAdmission.Refused"/>.</summary>
+    public int RefusedCount => Volatile.Read(ref refusedCount);
+
+    /// <summary>Held publications DISCARDED because the verdict turned out to be a refusal.</summary>
+    public int DiscardedCount => Volatile.Read(ref discardedCount);
+
+    /// <summary>
+    /// Everything this process has decided NOT to put into the mesh — refused outright plus
+    /// discarded after being held. The number an operator (and the falsification test) reads as
+    /// "this is how much of my identity never reached the shared mesh".
+    /// </summary>
+    public int WithheldCount => RefusedCount + DiscardedCount;
+
+    /// <summary>
+    /// Offer one mesh-visible publication. The returned observable is COLD and the caller must
+    /// subscribe it, exactly as before — what changes is what subscribing does:
+    ///
+    /// <list type="bullet">
+    /// <item><see cref="MeshAdmission.Unarmed"/> / <see cref="MeshAdmission.Admitted"/> — the
+    /// factory is invoked and its observable is returned verbatim, so the caller's own subscription
+    /// drives the write and its errors and completion propagate exactly as they did before this
+    /// gate existed.</item>
+    /// <item><see cref="MeshAdmission.Provisional"/> — the FACTORY is queued and the caller gets an
+    /// immediate completion. The write runs when the verdict admits; it is constructed then, so it
+    /// reads the row it is about to compare-and-set rather than one it read before the verdict
+    /// existed. A caller must therefore not read "completed" as "the row has changed" — none of the
+    /// three call sites does; all three are best-effort stamps whose failure mode is already "the
+    /// level-triggered probe re-bakes it".</item>
+    /// <item><see cref="MeshAdmission.Refused"/> — the factory is never invoked, nothing is
+    /// constructed and nothing is written. Logged at Warning, naming the subject.</item>
+    /// </list>
+    ///
+    /// <para>🚨 The verdict is read at SUBSCRIBE time (<c>Observable.Defer</c>), not
+    /// at call time, and it is re-read for every publication. That is what answers "what about a
+    /// process that becomes unhealthy AFTER joining?" in the same mechanism and without a second
+    /// one: the moment the authority's verdict turns, the next publication is refused.</para>
+    /// </summary>
+    /// <param name="subject">What is being published — named in every log line. Not an identifier.</param>
+    /// <param name="publication">
+    /// Builds the cold write. Invoked at most once, and only when the publication will actually be
+    /// subscribed.
+    /// </param>
+    public IObservable<Unit> Publish(string subject, Func<IObservable<Unit>> publication)
+    {
+        ArgumentNullException.ThrowIfNull(publication);
+        return Observable.Defer(() =>
+        {
+            var admission = Admission;
+            switch (admission)
+            {
+                case MeshAdmission.Unarmed:
+                case MeshAdmission.Admitted:
+                    // Anything held before this moment is released on the same edge — so a gate
+                    // whose owner forgot to call Reconsider still drains on the next publication.
+                    Reconsider();
+                    Interlocked.Increment(ref passedCount);
+                    return publication();
+
+                case MeshAdmission.Provisional:
+                    lock (verdict)
+                    {
+                        if (disposed)
+                            return Observable.Return(Unit.Default);
+                        held = held.Enqueue(new HeldPublication(subject, publication));
+                        heldCount++;
+                    }
+                    logger?.LogDebug(
+                        "MeshPublicationGate: HOLDING '{Subject}' — this process has not been "
+                        + "admitted to the mesh yet ({Reason}). It is published when the "
+                        + "validation passes, and discarded if it does not.",
+                        subject, AdmissionReason);
+                    return Observable.Return(Unit.Default);
+
+                default:
+                    Interlocked.Increment(ref refusedCount);
+                    logger?.LogWarning(
+                        "MeshPublicationGate: REFUSING to publish '{Subject}' — this process FAILED "
+                        + "its own validation and must not participate in the mesh ({Reason}). "
+                        + "Nothing was written. This is the refusal being REAL: the process stays "
+                        + "up for diagnosis but its identity does not enter the shared mesh.",
+                        subject, AdmissionReason);
+                    // Held work is now known to be worthless — drop it on the same edge.
+                    Reconsider();
+                    return Observable.Return(Unit.Default);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Re-read the verdict and act on any HELD publications: release them when the verdict admits,
+    /// discard them when it refuses, leave them alone while it is still provisional.
+    ///
+    /// <para>The EDGE that <see cref="Publish"/>'s level-triggered read cannot supply by itself: a
+    /// process whose last publication was held and whose verdict then turns has nothing left to
+    /// drive the queue. The bake gate's owner calls this after every phase transition; the gate
+    /// also calls it from <see cref="Publish"/> so a missed call costs latency, never correctness.
+    /// Idempotent and cheap when the queue is empty, which is the normal case.</para>
+    /// </summary>
+    public void Reconsider()
+    {
+        var admission = Admission;
+        if (admission is MeshAdmission.Provisional)
+            return;
+
+        ImmutableQueue<HeldPublication> pending;
+        lock (verdict)
+        {
+            if (disposed || held.IsEmpty)
+                return;
+            pending = held;
+            held = ImmutableQueue<HeldPublication>.Empty;
+            heldCount = 0;
+        }
+
+        var queued = pending.ToImmutableArray();
+        if (admission is MeshAdmission.Refused)
+        {
+            Interlocked.Add(ref discardedCount, queued.Length);
+            logger?.LogWarning(
+                "MeshPublicationGate: DISCARDING {Count} held publication(s) — this process failed "
+                + "its validation and will not join the mesh ({Reason}). Discarded: {Subjects}",
+                queued.Length, AdmissionReason,
+                string.Join(", ", queued.Select(p => p.Subject)));
+            return;
+        }
+
+        Interlocked.Add(ref releasedCount, queued.Length);
+        logger?.LogInformation(
+            "MeshPublicationGate: ADMITTED — releasing {Count} held publication(s) ({Reason})",
+            queued.Length, AdmissionReason);
+
+        // Sequential, in offer order, and each publication's own failure is contained: these are
+        // best-effort stamps and one that cannot be written must not stop the next.
+        var release = queued
+            .Select(p => Observable
+                .Defer(p.Publication)
+                .Catch<Unit, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "MeshPublicationGate: released publication '{Subject}' failed — the next "
+                        + "level-triggered probe re-establishes it", p.Subject);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat()
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex,
+                    "MeshPublicationGate: the release pipeline faulted — some held publications "
+                    + "were not written"));
+
+        lock (verdict)
+        {
+            if (disposed)
+            {
+                release.Dispose();
+                return;
+            }
+            releases.Add(release);
+        }
+    }
+
+    /// <summary>
+    /// Mesh teardown. Held publications are dropped — a process that is going away must not write
+    /// its identity on the way out — and in-flight releases are cancelled.
+    /// </summary>
+    public void Dispose()
+    {
+        lock (verdict)
+        {
+            if (disposed)
+                return;
+            disposed = true;
+            held = ImmutableQueue<HeldPublication>.Empty;
+            heldCount = 0;
+        }
+        releases.Dispose();
+    }
+
+    /// <summary>
+    /// Restrictiveness order. <see cref="MeshAdmission.Refused"/> outranks everything: one
+    /// authority saying "this image is bad" is evidence, and no number of authorities saying
+    /// nothing can outweigh it.
+    /// </summary>
+    private static int Rank(MeshAdmission admission) => admission switch
+    {
+        MeshAdmission.Unarmed => 0,
+        MeshAdmission.Admitted => 1,
+        MeshAdmission.Provisional => 2,
+        _ => 3,
+    };
+
+    private readonly record struct HeldPublication(string Subject, Func<IObservable<Unit>> Publication);
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleSetAdoptionService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSetAdoptionService.cs
@@ -1,0 +1,137 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// Records this replica's adoption of the mesh's module set — <b>once this process has been
+/// admitted to the mesh</b>. Issue #3478.
+///
+/// <para><b>Why it moved out of boot.</b> <c>ModuleSetStore.RecordAdoption</c> writes the durable
+/// claim <i>"a replica is serving set N"</i>: it is what turns a PROPOSED set into the mesh's
+/// CURRENT one, closes <c>ModuleSetIndex.ConvergencePending</c>, and lets the modules GC prune the
+/// set records below it. Boot used to write it inline, straight after
+/// <c>MeshBuilder.InstallAssemblies</c>, on the reasoning that the claim is <i>"this set is
+/// running"</i> rather than <i>"this set was read"</i> — a boot that dies before the install must
+/// not close a convergence window it never entered.</para>
+///
+/// <para>🚨 <b>That reasoning has one more step, and #3478 is what it costs to skip it.</b> A
+/// process whose own validation REFUSES it never serves anything either, so it must not make the
+/// claim any more than a boot that died. On <c>memex.systemorph.com</c>, 2026-09-06, a pod the bake
+/// readiness gate correctly refused ran for two hours having announced itself as a serving replica.
+/// So the adoption is now OFFERED to <see cref="MeshPublicationGate"/> instead of written: held
+/// while the validation is still forming, written when it passes, and never written when it does
+/// not.</para>
+///
+/// <para><b>Unchanged where nothing is armed.</b> With no <see cref="IMeshAdmissionAuthority"/>
+/// registered — every deployment that has not switched the bake readiness gate on, which is the
+/// chart default — the gate is <see cref="MeshAdmission.Unarmed"/> and the write runs inline on
+/// this <c>StartAsync</c>, a few milliseconds later in boot than before and on the same thread.</para>
+/// </summary>
+public sealed class ModuleSetAdoptionService : IHostedService, IDisposable
+{
+    private readonly Func<Unit> record;
+    private readonly string describe;
+    private readonly MeshPublicationGate? gate;
+    private readonly ILogger? logger;
+    private IDisposable? subscription;
+
+    /// <summary>
+    /// Registers the deferred adoption. <paramref name="record"/> is the side effect itself — a
+    /// closure over <c>ModuleSetStore.RecordAdoption</c>'s arguments, so this service carries no
+    /// knowledge of the record's shape and boot keeps deciding WHAT is adopted.
+    /// </summary>
+    /// <param name="describe">What is being adopted, for the gate's log lines.</param>
+    /// <param name="record">The (synchronous, best-effort, create-if-absent) adoption write.</param>
+    /// <param name="gate">The mesh-admission gate; null on a host that has none.</param>
+    /// <param name="logger">Diagnostics.</param>
+    public ModuleSetAdoptionService(
+        string describe,
+        Func<Unit> record,
+        MeshPublicationGate? gate,
+        ILogger<ModuleSetAdoptionService>? logger = null)
+    {
+        this.describe = describe;
+        this.record = record ?? throw new ArgumentNullException(nameof(record));
+        this.gate = gate;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// Offers the adoption. Cold by construction: <see cref="MeshPublicationGate.Publish"/> invokes
+    /// the factory only when this process may publish, so a refused process never touches the
+    /// volume at all.
+    ///
+    /// <para>Deliberately here and not on <c>ApplicationStarted</c> (where the generations GC had to
+    /// move, #2684): this is one <c>File.Exists</c> plus one small temp-and-rename, the exact write
+    /// boot already performed synchronously at this point in startup, and holding it back would
+    /// delay the mesh-level convergence signal for the common unarmed deployment with nothing to
+    /// show for it. On an ARMED one nothing is written here anyway — the gate holds it.</para>
+    /// </summary>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        IObservable<Unit> Write() => Observable.Defer(() =>
+        {
+            logger?.LogInformation(
+                "ModuleSetAdoption: recording that this replica is serving {Set}", describe);
+            return Observable.Return(record());
+        });
+
+        var publication = gate is null
+            ? Observable.Defer(Write)
+            : gate.Publish($"module-set adoption ({describe})", Write);
+
+        subscription = publication.Subscribe(
+            _ => { },
+            ex => logger?.LogWarning(ex,
+                "ModuleSetAdoption: could not record adoption of {Set} — this process still runs "
+                + "that set; only the mesh-level 'a replica is serving it' signal is missing",
+                describe));
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Nothing to stop — the write is a one-shot.</summary>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        subscription?.Dispose();
+        subscription = null;
+    }
+}
+
+/// <summary>Registration helper for <see cref="ModuleSetAdoptionService"/>.</summary>
+public static class ModuleSetAdoptionServiceExtensions
+{
+    /// <summary>
+    /// Registers the deferred module-set adoption. The write is performed by the hosted service
+    /// through the mesh-admission gate, never inline at boot — see
+    /// <see cref="ModuleSetAdoptionService"/> for why.
+    /// </summary>
+    /// <param name="services">The mesh's service collection.</param>
+    /// <param name="describe">What is being adopted, for the log lines.</param>
+    /// <param name="record">The adoption write itself.</param>
+    public static IServiceCollection AddModuleSetAdoption(
+        this IServiceCollection services, string describe, Action record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        return services.AddSingleton<IHostedService>(sp => new ModuleSetAdoptionService(
+            describe,
+            () =>
+            {
+                record();
+                return Unit.Default;
+            },
+            sp.GetService<MeshPublicationGate>(),
+            sp.GetService<ILogger<ModuleSetAdoptionService>>()));
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshAdmissionIsNeverMorePermissiveThanReadinessTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshAdmissionIsNeverMorePermissiveThanReadinessTest.cs
@@ -1,0 +1,270 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>"not ready should NEVER run" — stated as an invariant a test can falsify.</b> Issue #3478,
+/// maintainer directive 2026-09-06.
+///
+/// <para>The defect the directive names is a DIVERGENCE: the bake gate refused readiness and the
+/// process kept participating. Two verdicts, one of them enforced. So the fix is not a second gate
+/// with its own table — it is deriving membership FROM the readiness predicate, and these cases pin
+/// that derivation over the whole state space rather than at the two points the incident happened
+/// to visit.</para>
+///
+/// <para>The one deliberate asymmetry is <see cref="MeshAdmission.Provisional"/>: an armed gate that
+/// has not measured yet grants readiness (<see cref="BakePhase.NotStarted"/> means "the sweep is
+/// switched off" as far as a probe can tell) but must not let this process publish, because no
+/// verdict exists. The incident's pod walked exactly through that window — its bake started at
+/// <c>ApplicationStarted</c>, minutes after the process did.</para>
+/// </summary>
+public class MeshAdmissionIsNeverMorePermissiveThanReadinessTest
+{
+    private static readonly IReadOnlyList<BakePhase> AllPhases =
+        [BakePhase.NotStarted, BakePhase.Running, BakePhase.Complete,
+         BakePhase.Regressed, BakePhase.Faulted];
+
+    /// <summary>
+    /// 🚨 THE INVARIANT. Over every phase and every flag combination: a state that is ADMITTED to
+    /// the mesh is a state a readiness probe would pass. An implementation that admits anywhere
+    /// readiness refuses reproduces #3478 by construction, whatever the rest of it does.
+    /// </summary>
+    [Fact]
+    public void AdmittedImpliesReady_ForEveryPhaseAndFlagCombination()
+    {
+        foreach (var phase in AllPhases)
+            foreach (var gates in new[] { false, true })
+                foreach (var allowUnproven in new[] { false, true })
+                {
+                    var state = AtPhase(phase, gates, allowUnproven);
+                    if (state.Admission is MeshAdmission.Admitted)
+                        state.ReadinessGranted.Should().BeTrue(
+                            $"phase {phase} (gates={gates}, allowUnproven={allowUnproven}) admits "
+                            + "this process to the mesh, so a readiness probe must pass it — "
+                            + "'not ready should NEVER run'");
+                }
+    }
+
+    /// <summary>
+    /// An ARMED gate never admits before it has measured. This is the window the refused pod used:
+    /// readiness is granted at <see cref="BakePhase.NotStarted"/>, and publishing there would let a
+    /// bad image stamp before its own sweep had a chance to refuse it.
+    /// </summary>
+    [Fact]
+    public void AnArmedGateThatHasNotMeasuredYet_IsProvisional_NotAdmitted()
+    {
+        var state = AtPhase(BakePhase.NotStarted, gatesReadiness: true, allowUnprovenBake: false);
+
+        state.ReadinessGranted.Should().BeTrue("NotStarted is the documented fail-OPEN readiness state");
+        state.Admission.Should().Be(MeshAdmission.Provisional,
+            "an armed gate with no verdict yet must HOLD publications, never run them — and never "
+            + "drop them either, because the verdict is still coming");
+    }
+
+    /// <summary>
+    /// An UNARMED gate enforces nothing — the same "registered ≠ armed" rule that keeps the log from
+    /// claiming a stall nobody implements. Every dev host, every test mesh and every deployment on
+    /// the chart default is in this state, and none of them may be black-holed by enforcement
+    /// nobody opted into.
+    /// </summary>
+    [Fact]
+    public void AnUnarmedGate_IsUnarmed_EvenWhenItRecordedARegression()
+    {
+        var state = AtPhase(BakePhase.Regressed, gatesReadiness: false, allowUnprovenBake: false);
+
+        state.Admission.Should().Be(MeshAdmission.Unarmed,
+            "nothing consumes this state, so nothing is enforced from it");
+    }
+
+    /// <summary>
+    /// The operator override moves BOTH verdicts together. <c>AllowUnprovenBake</c> says "serve on a
+    /// bake that could not be PROVEN"; a process that may serve may publish, and one that may not,
+    /// may not. A real regression outranks it in both.
+    /// </summary>
+    [Theory]
+    [InlineData(BakePhase.Faulted, true, MeshAdmission.Admitted)]
+    [InlineData(BakePhase.Faulted, false, MeshAdmission.Refused)]
+    [InlineData(BakePhase.Regressed, true, MeshAdmission.Refused)]
+    [InlineData(BakePhase.Regressed, false, MeshAdmission.Refused)]
+    public void AllowUnprovenBake_MovesReadinessAndAdmissionTogether(
+        BakePhase phase, bool allowUnproven, MeshAdmission expected)
+    {
+        var state = AtPhase(phase, gatesReadiness: true, allowUnprovenBake: allowUnproven);
+
+        state.Admission.Should().Be(expected);
+        (state.Admission is MeshAdmission.Admitted).Should().Be(state.ReadinessGranted,
+            "for a terminal phase the two verdicts are the same verdict");
+    }
+
+    // ── the gate itself ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 A REFUSED PUBLICATION IS NEVER CONSTRUCTED. Not "constructed and discarded": the factory
+    /// is not invoked at all, so no storage read is issued and no <c>RequireSubscribeObservable</c>
+    /// is minted only to be dropped (which would log a never-subscribed warning about a write we
+    /// deliberately did not make).
+    /// </summary>
+    [Fact]
+    public void ARefusedPublication_IsNeverEvenBuilt()
+    {
+        var authority = new FixedAuthority(MeshAdmission.Refused);
+        using var gate = new MeshPublicationGate([authority]);
+        var built = 0;
+
+        gate.Publish("a stamp", () => { built++; return Observable.Return(Unit.Default); })
+            .Subscribe();
+
+        built.Should().Be(0, "a refused process must not touch the mesh, not even to read it");
+        gate.RefusedCount.Should().Be(1, "the refusal is counted, never silent");
+    }
+
+    /// <summary>
+    /// A HELD publication runs exactly once, at release — after the verdict, not before it. This is
+    /// "validate before running" rather than "never run": a passing bake still records everything it
+    /// compiled.
+    /// </summary>
+    [Fact]
+    public void AHeldPublication_RunsOnceOnAdmission()
+    {
+        var authority = new FixedAuthority(MeshAdmission.Provisional);
+        using var gate = new MeshPublicationGate([authority]);
+        var ran = 0;
+
+        gate.Publish("a stamp", () => { ran++; return Observable.Return(Unit.Default); })
+            .Subscribe();
+        ran.Should().Be(0, "the verdict does not exist yet");
+
+        authority.Admission = MeshAdmission.Admitted;
+        gate.Reconsider();
+
+        ran.Should().Be(1, "the held write runs when the process is admitted");
+        gate.ReleasedCount.Should().Be(1);
+        gate.HeldCount.Should().Be(0, "the queue is drained, not replayed");
+    }
+
+    /// <summary>
+    /// A held publication whose verdict turns out to be a REFUSAL is discarded, never written — the
+    /// exact shape of the incident, where the stamps that did the damage were produced before the
+    /// regression was discovered.
+    /// </summary>
+    [Fact]
+    public void AHeldPublication_IsDiscardedWhenTheVerdictRefuses()
+    {
+        var authority = new FixedAuthority(MeshAdmission.Provisional);
+        using var gate = new MeshPublicationGate([authority]);
+        var ran = 0;
+
+        gate.Publish("a stamp", () => { ran++; return Observable.Return(Unit.Default); })
+            .Subscribe();
+        authority.Admission = MeshAdmission.Refused;
+        gate.Reconsider();
+
+        ran.Should().Be(0, "a stamp produced before the verdict must not be written after it");
+        gate.DiscardedCount.Should().Be(1);
+        gate.WithheldCount.Should().Be(1, "withheld = refused outright + discarded after holding");
+    }
+
+    /// <summary>
+    /// With no authority registered the gate is a straight pass-through — byte-for-byte the
+    /// behaviour every host had before it existed.
+    /// </summary>
+    [Fact]
+    public void AnUnarmedGate_PassesEverythingThrough()
+    {
+        using var gate = new MeshPublicationGate();
+        var ran = 0;
+
+        gate.Publish("a stamp", () => { ran++; return Observable.Return(Unit.Default); })
+            .Subscribe();
+
+        ran.Should().Be(1, "an unarmed gate enforces nothing");
+        gate.PassedCount.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The MOST RESTRICTIVE authority wins. One authority stating evidence against this image
+    /// outranks any number stating the absence of it — which is what lets a second validator be
+    /// added later without weakening the first.
+    /// </summary>
+    [Fact]
+    public void TheMostRestrictiveAuthorityWins()
+    {
+        var permissive = new FixedAuthority(MeshAdmission.Admitted);
+        var refusing = new FixedAuthority(MeshAdmission.Refused);
+        using var gate = new MeshPublicationGate([permissive, refusing]);
+
+        gate.Admission.Should().Be(MeshAdmission.Refused);
+    }
+
+    /// <summary>
+    /// Teardown drops what is held: a process on its way out must not write its identity into the
+    /// mesh as it goes.
+    /// </summary>
+    [Fact]
+    public void DisposeDropsHeldPublications()
+    {
+        var authority = new FixedAuthority(MeshAdmission.Provisional);
+        var gate = new MeshPublicationGate([authority]);
+        var ran = 0;
+
+        gate.Publish("a stamp", () => { ran++; return Observable.Return(Unit.Default); })
+            .Subscribe();
+        gate.Dispose();
+        authority.Admission = MeshAdmission.Admitted;
+        gate.Reconsider();
+
+        ran.Should().Be(0, "a disposed gate writes nothing, whatever the verdict becomes");
+    }
+
+    /// <summary>
+    /// Drives a real <see cref="NodeTypeBakeGateState"/> into <paramref name="phase"/> the way the
+    /// sweep does — never by setting a field, so the derivation under test is the production one.
+    /// </summary>
+    private static NodeTypeBakeGateState AtPhase(
+        BakePhase phase, bool gatesReadiness, bool allowUnprovenBake)
+    {
+        var state = new NodeTypeBakeGateState
+        {
+            GatesReadiness = gatesReadiness,
+            AllowUnprovenBake = allowUnprovenBake,
+        };
+        switch (phase)
+        {
+            case BakePhase.NotStarted:
+                break;
+            case BakePhase.Running:
+                state.MarkRunning("enumerating dynamic NodeTypes");
+                break;
+            case BakePhase.Complete:
+                state.MarkRunning("enumerating dynamic NodeTypes");
+                state.MarkComplete("baked in 00:01:00 — compiled=3 alreadyBaked=0");
+                break;
+            case BakePhase.Regressed:
+                state.MarkRunning("enumerating dynamic NodeTypes");
+                state.MarkOutcome(new PreWarmOutcome(
+                    "Feedback/Feedback", PreWarmStatus.CompileError, "CS0117"));
+                break;
+            default:
+                state.MarkRunning("enumerating dynamic NodeTypes");
+                state.MarkFaulted("the warm-up stream faulted before the sweep could finish");
+                break;
+        }
+        state.Phase.Should().Be(phase, "the case must actually reach the phase it claims to test");
+        return state;
+    }
+
+    /// <summary>An authority whose verdict the test moves — a stand-in for a validator, never for
+    /// <see cref="NodeTypeBakeGateState"/>, whose own derivation is exercised above.</summary>
+    private sealed class FixedAuthority(MeshAdmission admission) : IMeshAdmissionAuthority
+    {
+        public MeshAdmission Admission { get; set; } = admission;
+
+        public string AdmissionReason => $"test authority says {Admission}";
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/RefusedProcessDoesNotJoinTheMeshTest.cs
+++ b/test/MeshWeaver.Hosting.Test/RefusedProcessDoesNotJoinTheMeshTest.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>A process its own readiness validation REFUSES must not join the mesh — issue #3478.</b>
+///
+/// <para><b>The incident.</b> <c>memex.systemorph.com</c>, 2026-09-06. Two replicas served
+/// <c>3.0.0-rc9.ci.7693</c>. A roll to <c>ci.7926</c> started at 19:17Z; the NodeType bake readiness
+/// gate measured a regression (<c>Feedback/Feedback</c>) and refused readiness, and Kubernetes
+/// correctly stalled the rollout with the previous image still serving. <b>The refused pod kept
+/// running inside the mesh for two hours.</b> It stamped <c>Crm/Offer</c> at 19:28:04 and
+/// <c>Crm/Opportunity</c> at 19:31:30 with its own framework identity (<c>sc273ee39f…</c>) onto the
+/// shared NodeType records the serving replicas (<c>s2f227642d…</c>) read — and every deal and
+/// offer page on the client portal was dead until 21:50Z (#3472). Readiness gates TRAFFIC; it never
+/// gated MEMBERSHIP.</para>
+///
+/// <para><b>What these cases discriminate, and why a weaker test would prove nothing.</b> The pod
+/// in the incident was ALREADY not-ready and the outage happened anyway, so asserting "B is not
+/// ready" is vacuous. Every case here asserts on the DURABLE NodeType records, read back through
+/// the mesh's own <see cref="IStorageAdapter"/> — the same rows the serving replicas read:</para>
+/// <list type="bullet">
+/// <item><see cref="ARegressedBake_StampsNothing_TheRecordsStillCarryImageA"/> — the fix. Image B's
+/// sweep regresses ⇒ ZERO of its stamps land, on records it had already compiled BEFORE the
+/// regression was discovered.</item>
+/// <item><see cref="ACleanBake_StampsEverythingItHeld"/> — the CONTROL. The identical sweep, passing
+/// ⇒ every stamp lands. Without it the first case would pass against an implementation that simply
+/// never stamps, and the test could not see a stamp at all.</item>
+/// <item><see cref="AnUnarmedGate_StillStamps_ReproducingTheTwoImageWindow"/> — the two-image
+/// window, reproduced. With no admission authority armed the regressing sweep stamps exactly as it
+/// did on 2026-09-06, so the protection is measurably the thing that changed and not the
+/// harness.</item>
+/// <item><see cref="ARegressionFoundAfterAdmission_StopsFurtherStamping"/> — the other direction:
+/// a process that becomes unhealthy AFTER joining stops publishing, because the verdict is
+/// level-triggered rather than latched at admission.</item>
+/// </list>
+///
+/// <para>The mesh is REAL (<see cref="MonolithMeshTestBase"/>) and the write under test is the
+/// production one — <c>NodeTypeBatchBake.WriteStamp</c>, the storage-level compare-and-set the batch
+/// bake uses for every type it compiles. Only the bake VERDICT is driven directly, exactly as the
+/// sweep drives it (<c>MarkRunning</c> → <c>MarkOutcome</c> → <c>MarkComplete</c>).</para>
+/// </summary>
+public class RefusedProcessDoesNotJoinTheMeshTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The framework identity the two SERVING replicas compiled against, per #3472.</summary>
+    private const string ImageAFramework = "s2f227642d43f78eab13720c4af06a1be";
+
+    /// <summary>The module set those replicas ran — the "module generation" the issue names.</summary>
+    private const string ImageAModules = "8f251f57458afe55c000a13802e347b3";
+
+    /// <summary>Where image A's bytes live. Image B stamps a different key.</summary>
+    private const string AssemblyCollection = "nodetype-cache";
+
+    /// <summary>The revision the serving replicas' stamp left each record at.</summary>
+    private const long SeededVersion = 11;
+
+    /// <summary>The NodeTypes the incident killed, under this test's partition.</summary>
+    private static readonly IReadOnlyList<string> Types = ["Offer", "Opportunity", "Feedback"];
+
+    /// <summary>
+    /// The bake gate this process (image B) is running with. Reassigned per case — armed, unarmed —
+    /// and read through <see cref="LiveBakeGate"/> so the mesh built in the constructor always sees
+    /// the CURRENT one. The real <see cref="NodeTypeBakeGateState"/> throughout: the point is to
+    /// exercise its own <c>Admission</c> derivation, never a stand-in for it.
+    /// </summary>
+    private NodeTypeBakeGateState bake = new() { GatesReadiness = true };
+
+    /// <summary>
+    /// Registers this process's bake gate as the mesh's admission authority — the ONE wiring the
+    /// portal does (<c>AddNodeTypeBakeGate</c>) and the whole of what arms the publication gate.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services =>
+                services.AddSingleton<IMeshAdmissionAuthority>(new LiveBakeGate(() => bake)));
+
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+    private MeshPublicationGate Publication =>
+        Mesh.ServiceProvider.GetRequiredService<MeshPublicationGate>();
+
+    /// <summary>The module fingerprint THIS process would stamp — image B's module generation.</summary>
+    private string ImageBModules =>
+        Mesh.ServiceProvider.GetRequiredService<InstalledModulesFingerprint>().Hash;
+
+    // ── the scenario ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE FIX. Image B bakes; its sweep regresses on the third type; NOTHING it compiled reaches
+    /// the mesh — including the two types it had already compiled successfully before the regression
+    /// was discovered, which is precisely the pair the incident lost.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ARegressedBake_StampsNothing_TheRecordsStillCarryImageA()
+    {
+        var seeded = await SeedRecordsStampedByImageA();
+
+        // Image B's sweep: two clean compiles, then the regression that refuses the image.
+        bake.MarkRunning("enumerating dynamic NodeTypes");
+        await StampAsImageB(seeded["Offer"]);
+        await StampAsImageB(seeded["Opportunity"]);
+        bake.MarkOutcome(Regression("Feedback"));
+        Publication.Reconsider();
+        bake.MarkComplete("baked in 00:02:11 — compiled=2 alreadyBaked=0");
+        Publication.Reconsider();
+
+        bake.Phase.Should().Be(BakePhase.Regressed, "the sweep measured a real regression");
+        bake.Admission.Should().Be(MeshAdmission.Refused,
+            "a bake that refuses readiness must refuse MEMBERSHIP by the same verdict — that "
+            + "equivalence is the whole of #3478's directive");
+
+        foreach (var type in new[] { "Offer", "Opportunity" })
+            (await ReadStamp(type)).Should().Be(
+                ImageAStamp(type),
+                $"a refused process must leave {type}'s record exactly as the SERVING replicas "
+                + "stamped it — a record naming image B's assembly is what made the type "
+                + "unloadable on 2026-09-06");
+
+        Publication.WithheldCount.Should().Be(2,
+            "both stamps must be accounted for as withheld — a silently-vanished publication is "
+            + "indistinguishable from one that was never offered");
+        Publication.PassedCount.Should().Be(0, "nothing may pass while the verdict is not admitted");
+        Publication.ReleasedCount.Should().Be(0, "a refused verdict releases nothing");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL — and the arm that makes the case above non-vacuous. The identical sweep, with
+    /// no regression, stamps EVERYTHING it held. Held publications are written after the verdict,
+    /// not before it, which is "validate before running" and not "never run".
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ACleanBake_StampsEverythingItHeld()
+    {
+        var seeded = await SeedRecordsStampedByImageA();
+
+        bake.MarkRunning("enumerating dynamic NodeTypes");
+        foreach (var type in Types)
+            await StampAsImageB(seeded[type]);
+
+        // Mid-sweep the process is provisional: it has compiled, and published NOTHING.
+        Publication.HeldCount.Should().Be(Types.Count,
+            "every stamp waits for the verdict — a stamp written before the sweep ends is the "
+            + "defect, whichever way the sweep then goes");
+        foreach (var type in Types)
+            (await ReadStamp(type)).Should().Be(
+                ImageAStamp(type), "nothing is published while the verdict is still forming");
+
+        bake.MarkComplete("baked in 00:02:40 — compiled=3 alreadyBaked=0");
+        Publication.Reconsider();
+
+        bake.Admission.Should().Be(MeshAdmission.Admitted, "a clean sweep admits this process");
+        Publication.ReleasedCount.Should().Be(Types.Count, "every held stamp is written on admission");
+        Publication.WithheldCount.Should().Be(0, "a clean sweep withholds nothing");
+
+        foreach (var type in Types)
+            (await ReadStamp(type)).Should().Be(
+                ImageBStamp(type),
+                $"{type}'s record must now name image B's build — holding a stamp forever would "
+                + "trade an outage for a platform that never records what it compiled");
+    }
+
+    /// <summary>
+    /// 🚨 THE TWO-IMAGE WINDOW, REPRODUCED. With no admission authority armed — the state every
+    /// deployment that has not switched the bake readiness gate on is in, and the state the
+    /// protection is measured AGAINST — the very same regressing sweep stamps every record with
+    /// image B's identity, exactly as it did on 2026-09-06.
+    ///
+    /// <para>This is deliberately not a "revert the fix" experiment kept outside the suite: it is
+    /// the pre-fix behaviour, permanently observable, so a future change that quietly disarms the
+    /// gate cannot look like a pass. It also pins the fail-OPEN default — an unarmed deployment is
+    /// never black-holed by enforcement nobody opted into.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task AnUnarmedGate_StillStamps_ReproducingTheTwoImageWindow()
+    {
+        bake = new NodeTypeBakeGateState { GatesReadiness = false };
+        var seeded = await SeedRecordsStampedByImageA();
+
+        bake.MarkRunning("enumerating dynamic NodeTypes");
+        await StampAsImageB(seeded["Offer"]);
+        await StampAsImageB(seeded["Opportunity"]);
+        bake.MarkOutcome(Regression("Feedback"));
+        Publication.Reconsider();
+        bake.MarkComplete("baked in 00:02:11 — compiled=2 alreadyBaked=0");
+        Publication.Reconsider();
+
+        bake.Phase.Should().Be(BakePhase.Regressed, "the sweep measured the same regression");
+        bake.Admission.Should().Be(MeshAdmission.Unarmed,
+            "nothing consumes this gate's verdict, so it enforces nothing — 'registered' and "
+            + "'armed' stay separate");
+
+        foreach (var type in new[] { "Offer", "Opportunity" })
+            (await ReadStamp(type)).Should().Be(
+                ImageBStamp(type),
+                "THIS is the two-image window: one mesh, two images, and the record now points at "
+                + "an assembly the serving replicas cannot load");
+        Publication.PassedCount.Should().Be(2, "an unarmed gate is a straight pass-through");
+        Publication.WithheldCount.Should().Be(0, "an unarmed gate withholds nothing");
+    }
+
+    /// <summary>
+    /// 🚨 THE OTHER DIRECTION — a process that becomes unhealthy AFTER joining. The sweep completes
+    /// clean, the process is admitted and stamps; a later compile then regresses a
+    /// previously-healthy type, and from that moment the process publishes nothing more. The verdict
+    /// is re-read at every publication rather than latched at admission, so this needs no second
+    /// mechanism.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ARegressionFoundAfterAdmission_StopsFurtherStamping()
+    {
+        var seeded = await SeedRecordsStampedByImageA();
+
+        bake.MarkRunning("enumerating dynamic NodeTypes");
+        bake.MarkComplete("baked in 00:00:04 — compiled=0 alreadyBaked=3");
+        Publication.Reconsider();
+        bake.Admission.Should().Be(MeshAdmission.Admitted, "the sweep was clean");
+
+        await StampAsImageB(seeded["Offer"]);
+        (await ReadStamp("Offer")).Should().Be(
+            ImageBStamp("Offer"), "an admitted process publishes normally");
+
+        // A lazy compile, hours later, breaks a type that was healthy on this image.
+        bake.MarkOutcome(Regression("Feedback"));
+        bake.Admission.Should().Be(MeshAdmission.Refused,
+            "the verdict is level-triggered — admission is not a latch");
+
+        await StampAsImageB(seeded["Opportunity"]);
+        (await ReadStamp("Opportunity")).Should().Be(
+            ImageAStamp("Opportunity"),
+            "once this process is refused it publishes nothing more, whatever it published before");
+        Publication.RefusedCount.Should().Be(1, "the refusal is counted, not silent");
+    }
+
+    /// <summary>
+    /// 🚨 SELF-HEALING SURVIVES THE GATE — the arm that proves this change did not trade one outage
+    /// class for another. #1214: a bake that compiles a half-applied content update records FALSE
+    /// regressions, the platform recompiles the type by itself once the content converges, and the
+    /// gate retracts so the pod goes Ready without a human. That retraction watched the type's
+    /// SHARED RECORD — which a refused process can no longer move, because its stamps are now
+    /// withheld. A record-only watch would therefore wait forever, and #1214's self-healing stall
+    /// would become a permanent one.
+    ///
+    /// <para>The retraction now also observes the PROCESS-LOCAL fact
+    /// (<see cref="LocalNodeTypeBuilds"/>) that the record was ever a proxy for. Here the record is
+    /// deliberately never touched, so the only witness that can retract is the local one.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ALocallyRebuiltTypeRetractsItsRegression_EvenThoughTheRecordCannotMove()
+    {
+        var seeded = await SeedRecordsStampedByImageA();
+        var condemned = $"{TestPartition}/Feedback";
+
+        bake.MarkRunning("enumerating dynamic NodeTypes");
+        await StampAsImageB(seeded["Offer"]);
+        bake.MarkOutcome(Regression("Feedback"));
+        Publication.Reconsider();
+        bake.Admission.Should().Be(MeshAdmission.Refused, "the sweep condemned a healthy type");
+
+        using var watch = DynamicTypePreWarmer.WatchForRecovery(
+            Mesh, bake, condemned,
+            Mesh.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("recovery"));
+
+        // The content converged and the platform rebuilt the type HERE. Re-raised on the sanctioned
+        // poll rather than once, because the watch subscribes its second witness only after the
+        // node stream has produced a baseline — a single hot emission could precede that.
+        var builds = Mesh.ServiceProvider.GetRequiredService<LocalNodeTypeBuilds>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Do(_ => builds.RecordUsableBuild(condemned))
+            .Where(_ => bake.Regressions.Count == 0)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(20))
+            .Await();
+
+        bake.Retracted.Keys.Should().Contain(condemned,
+            "the retraction must SAY the regression was withdrawn — a silently-vanished one is "
+            + "indistinguishable from one that never happened");
+        bake.Admission.Should().NotBe(MeshAdmission.Refused,
+            "a process with no standing regression is no longer refused — readiness and membership "
+            + "move together in BOTH directions");
+    }
+
+    // ── harness ─────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A DIRECTLY-MEASURED regression on a type that was healthy before this image — the only
+    /// outcome shape that gates (a timeout is not a verdict; an already-broken type does not freeze
+    /// the platform).
+    /// </summary>
+    private static PreWarmOutcome Regression(string type) =>
+        new($"{TestPartition}/{type}", PreWarmStatus.CompileError,
+            "CS0117: 'Localizer' does not contain a definition for 'Title'")
+        {
+            WasHealthyBeforeBake = true,
+        };
+
+    /// <summary>The full stamp, as the two serving replicas left it.</summary>
+    private (string? Framework, string? Modules, string? Collection, string? Assembly, long? Version)
+        ImageAStamp(string type)
+        => (ImageAFramework, ImageAModules, AssemblyCollection, $"{type}/v11-s2f22764-A.dll", 11L);
+
+    /// <summary>The full stamp image B writes — a different framework, module set and assembly key.</summary>
+    private (string? Framework, string? Modules, string? Collection, string? Assembly, long? Version)
+        ImageBStamp(string type)
+        => (FrameworkBuildIdentity.FrameworkVersion, ImageBModules, AssemblyCollection,
+            $"{type}/v22488-sc273ee3-B.dll", 22488L);
+
+    /// <summary>
+    /// Writes each NodeType record as the SERVING replicas stamped it, storage-level (no change
+    /// feed, so no hub is woken and nothing recompiles behind the test). Returns the persisted
+    /// nodes, whose versions the compare-and-set stamp then races.
+    /// </summary>
+    private async Task<IReadOnlyDictionary<string, MeshNode>> SeedRecordsStampedByImageA()
+    {
+        var seeded = new Dictionary<string, MeshNode>();
+        foreach (var type in Types)
+        {
+            var stored = await Storage.Write(
+                new MeshNode(type, TestPartition)
+                {
+                    NodeType = MeshNode.NodeTypePath,
+                    // A real revision counter. Version 0 means "never versioned", and the
+                    // compare-and-set reads an expected version of 0 as "insert only if absent" —
+                    // so a row seeded at 0 would make every stamp lose for a reason that has
+                    // nothing to do with admission.
+                    Version = SeededVersion,
+                    Content = new NodeTypeDefinition
+                    {
+                        CompilationStatus = CompilationStatus.Ok,
+                        CompiledFrameworkVersion = ImageAFramework,
+                        CompiledModulesHash = ImageAModules,
+                        LatestAssemblyCollection = AssemblyCollection,
+                        LatestAssemblyPath = $"{type}/v11-s2f22764-A.dll",
+                        LastCompiledVersion = 11,
+                        LastCompileSucceededAt = new DateTimeOffset(
+                            2026, 9, 6, 19, 19, 38, TimeSpan.Zero),
+                    },
+                },
+                Mesh.JsonSerializerOptions).Await();
+            seeded[type] = stored!;
+        }
+        return seeded;
+    }
+
+    /// <summary>
+    /// Drives the PRODUCTION stamp for one type as image B — the same storage-level compare-and-set
+    /// the batch bake performs after every compile.
+    /// </summary>
+    private Task StampAsImageB(MeshNode typeNode) =>
+        NodeTypeBatchBake.WriteStamp(
+                Mesh,
+                typeNode,
+                ok: true,
+                new NodeCompilationResult(
+                    // A path that does not exist: ServedBuildIdentity.OfFile then leaves the MVID
+                    // stamp alone, exactly as it does for a producer with no readable file. The
+                    // assembly COORDINATES below are what discriminate the two images.
+                    AssemblyLocation: $"/nonexistent/{typeNode.Id}-B.dll",
+                    NodeTypeConfigurations: [],
+                    Collection: AssemblyCollection,
+                    ContentPath: $"{typeNode.Id}/v22488-sc273ee3-B.dll",
+                    Version: 22488),
+                error: null,
+                releasePath: null,
+                startedAt: DateTimeOffset.UtcNow,
+                // A real logger: the stamp is best-effort by design, so a compare-and-set that is
+                // REFUSED (or content that cannot be read back as a NodeTypeDefinition) is reported
+                // only in the log. Without it a case that fails here says "the record did not
+                // change" and nothing about why.
+                Mesh.ServiceProvider.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("RefusedProcessDoesNotJoinTheMesh"))
+            .Await();
+
+    /// <summary>Reads one NodeType's stamp back off the DURABLE row — what a peer replica reads.</summary>
+    private async Task<(string? Framework, string? Modules, string? Collection, string? Assembly, long? Version)>
+        ReadStamp(string type)
+    {
+        var node = await Storage.Read($"{TestPartition}/{type}", Mesh.JsonSerializerOptions)
+            .Take(1).Await();
+        var def = node?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions);
+        return (def?.CompiledFrameworkVersion, def?.CompiledModulesHash,
+            def?.LatestAssemblyCollection, def?.LatestAssemblyPath, def?.LastCompiledVersion);
+    }
+
+    /// <summary>
+    /// Reads the CURRENT bake gate on every call, so a case can install its own (armed / unarmed)
+    /// after the mesh — built in the base constructor — has already resolved its authorities. It
+    /// adds no verdict of its own: <see cref="NodeTypeBakeGateState.Admission"/> is the predicate
+    /// under test.
+    /// </summary>
+    private sealed class LiveBakeGate(Func<NodeTypeBakeGateState> current) : IMeshAdmissionAuthority
+    {
+        public MeshAdmission Admission => current().Admission;
+
+        public string AdmissionReason => current().AdmissionReason;
+    }
+}


### PR DESCRIPTION
Closes #3478

> **"not ready should *NEVER* run" · "validate before running"** — maintainer, 2026-09-06

A readiness probe takes a pod out of the load balancer. It does not take the process out of the
mesh. On 2026-09-06 the NodeType bake gate on `memex.systemorph.com` correctly refused `ci.7926`,
Kubernetes correctly stalled the rollout — and the refused pod then ran for two hours inside the
mesh, stamping NodeType compile records with its own framework identity. `Crm/Offer` and
`Crm/Opportunity` came to name assemblies stamped `sc273ee39f…` while the serving replicas ran
`s2f227642d…`, and every deal and offer page on the client portal was dead until 21:50Z (#3472).

**The protection produced the outage** — not by misjudging the image, but by leaving the refused
process a participant. This makes the refusal real.

## Where a process actually joins

"Do not join until validated" does not survive contact with the ordering: a portal becomes
addressable long before it can have validated anything, and the validation itself needs the mesh —
the bake sweep reads every NodeType and its sources through mesh queries. So membership-for-READING
cannot move after the verdict. **Membership-for-WRITING can, and that is the half that does the
damage.** The acts that carry this process's own build identity into the shared mesh are few and
enumerable:

| act | site | what it says |
|---|---|---|
| NodeType compile stamp, batch path | `NodeTypeBatchBake.WriteStamp` | `CompiledFrameworkVersion`, `CompiledModulesHash`, `CompiledDependencies`, assembly coordinates |
| NodeType compile stamp, activation path | `NodeTypeCompilationHelpers` post-compile write-back | the same field-set — the two paths share it literally |
| module-set adoption | `ModuleSetStore.RecordAdoption`, from `MemexConfiguration` | "a replica is serving set N" |

Assembly **bytes** are deliberately not gated: the store is keyed `(nodeTypePath, version)` with the
producing framework identity in the key, and `NodeTypeBakeStatus.ClassifyDetailed` cannot look for
bytes at all until the RECORD names a collection, a path and a version. Bytes nobody's record points
at are inert. The pointer is the poison, so the pointer is what is gated.

## The mechanism

`MeshPublicationGate` (`src/MeshWeaver.Mesh.Contract/Services/MeshPublicationGate.cs`) — a
mesh-scoped singleton every one of those writes goes through, reading its verdict from the
registered `IMeshAdmissionAuthority` implementations (today exactly one: the bake gate).

| admission | meaning | a publication |
|---|---|---|
| `Unarmed` | no authority armed | runs, unchanged |
| `Provisional` | armed, no verdict yet | **held**, released on admission |
| `Admitted` | validation passed | runs |
| `Refused` | validation failed | **never built, never written** |

Publications are offered as a `Func<IObservable<Unit>>`, not an observable, so a refused one is never
*constructed* — no storage read is issued and no `RequireSubscribeObservable` is minted only to be
dropped. A held one is constructed at release time, so its compare-and-set reads the row it is about
to race rather than replaying a version read before the verdict existed.

**Provisional membership, stated:** a provisional member may read the mesh and compile; it may not
publish. That is what makes *validate before running* implementable without reordering startup — the
sweep runs exactly as before, but its stamps land **after** its verdict instead of during it.

### One predicate, two consumers

The defect is a divergence — two verdicts, one enforced — so admission is derived FROM the readiness
predicate rather than being a second table:

```csharp
public bool ReadinessGranted => Phase switch {
    BakePhase.NotStarted => true, BakePhase.Complete => true,
    BakePhase.Faulted => AllowUnprovenBake, _ => false };

public MeshAdmission Admission
    => !GatesReadiness ? MeshAdmission.Unarmed
        : Phase is BakePhase.NotStarted or BakePhase.Running ? MeshAdmission.Provisional
        : ReadinessGranted ? MeshAdmission.Admitted
        : MeshAdmission.Refused;
```

**Invariant: `Admitted ⟹ ReadinessGranted`** — pinned over the whole phase × flag space by
`MeshAdmissionIsNeverMorePermissiveThanReadinessTest`. It is deliberately *less* permissive in one
place: an **armed gate at `NotStarted`**, where readiness is granted (a probe cannot tell "switched
off" from "has not started") but no verdict exists. The incident's pod published through exactly that
window — its bake starts at `ApplicationStarted`, minutes after the process does.

🚨 **Unarmed means unarmed.** With `PreWarm:GateReadiness` off — the chart default, every dev host,
every test mesh — nothing consumes the bake verdict and nothing is enforced from it. This change is
byte-for-byte inert there.

### A process that becomes unhealthy AFTER joining

The verdict is level-triggered, re-read at every publication rather than latched at admission: a
regression recorded hours after a clean sweep stops publication from that moment, and a
`RetractRegression` resumes it. Same mechanism, no second one. It never withdraws a pod that is
serving — withholding publication is not flipping readiness.

### The second witness — and the regression this change had to close

Gating the activation-path stamp breaks #1214's self-healing retraction: it watched the type's
SHARED record, which a refused pod can no longer move, so a false-positive regression would become a
permanent stall instead of clearing itself. The retraction's question was always process-LOCAL, and
the record was only ever a proxy for it — so `LocalNodeTypeBuilds` publishes the fact directly (the
compile write-back raises it *before* the possibly-withheld stamp) and the watch takes whichever
witness answers first. The record watch stays: a type baked by a PEER on the same image is a real
recovery the local signal cannot see.

## 🚨 The decision this issue asked for: exit non-zero, or stay up inert?

**A refused process stays up and INERT. It does not exit.** Stated explicitly because this is a
maintainer-level call and the disruptive option must not be taken quietly.

**The case for exiting** is real: a non-zero exit turns a stalled rollout into a `CrashLoopBackOff`,
which is louder and arguably a more honest description of a process that will never serve.

**Why inert is what ships:**

- **The refusal is already real without it.** Once publication is gated, exiting adds no protection —
  it only changes how the stall is *presented*. Loudness is not the defect #3478 describes.
- **It destroys the diagnosis surface.** The refused pod's `/health` payload naming the regressed
  types is the only place that verdict lives; a crash-looping pod has no readable health endpoint and
  its logs rotate every restart.
- **Each restart re-runs a full cold bake** (~2.4 s per NodeType, ~10 min on our largest mesh) to
  learn the same verdict again, on a cluster we pay for.
- **It changes deployment behaviour on every path** — Monolith, Aspire, the plugin tester — on
  evidence this change is the first to produce. `ModuleSetConvergence` declined the neighbouring
  options ("have a behind replica restart itself, or flip readiness") for the same reason and noted
  they become *decidable* once the state is named. This is that state, now named.

It is decidable now: with admission derived from one predicate, "exit when `Admission is Refused`" is
a single call in `DynamicTypePreWarmerHostedService`'s terminal handler. Deliberately not taken here.

## Falsification — both arms, with numbers

Scenario, exactly as the issue specifies: two replicas on image A (records stamped
`s2f227642d…` / `Offer|Opportunity|Feedback/v11-s2f22764-A.dll` / module hash
`8f251f57…`), roll to image B, B's bake regresses on `Feedback`. Assertions are on the DURABLE rows,
read back through the mesh's own `IStorageAdapter` — the rows a peer replica reads. Real mesh
(`MonolithMeshTestBase`), production write (`NodeTypeBatchBake.WriteStamp`), no mocking.

| arm | result |
|---|---|
| **Fix present, gate armed, sweep regresses** | **0** of 2 stamps landed. Both records still read image A verbatim. `WithheldCount = 2`, `PassedCount = 0`, `ReleasedCount = 0`. `Admission = Refused`. |
| **Fix present, gate armed, sweep clean (control)** | mid-sweep `HeldCount = 3`, records unchanged; after `MarkComplete`, `ReleasedCount = 3`, `WithheldCount = 0`, all 3 records now name image B. Proves the test can see a stamp and the happy path still records what it compiled. |
| **Fix present, gate UNARMED (the two-image window, kept in the suite)** | the same regressing sweep stamps **2** records with image B — `PassedCount = 2`. The pre-fix behaviour, permanently observable, so a change that quietly disarms the gate cannot look like a pass. |
| **Fix REVERTED** (`Publish` forced to `Unarmed`, measured by hand, then restored) | **3 of 4 cases fail**: `Offer` → `(3366f713…, "", nodetype-cache, Offer/v22488-sc273ee3-B.dll, 22488)` where image A's stamp had been, `Opportunity` likewise, and `HeldCount` collapses 3 → 0. **The two-image window reproduced verbatim.** The one case that still passes under the revert is the unarmed arm — correctly, since it asserts the pre-fix behaviour. |
| **Self-healing survives** | a locally rebuilt condemned type retracts its regression through `LocalNodeTypeBuilds` although the record never moves; `Admission` leaves `Refused`. |

Local verification (Release, `-warnaserror`, one project per invocation): `MeshWeaver.Mesh.Contract`,
`MeshWeaver.Compiler.Pipeline`, `MeshWeaver.Hosting`, `MeshWeaver.PluginCatalog`,
`MeshWeaver.Documentation`, `Memex.Portal.Shared` — **0 warnings, 0 errors** each.
`MeshWeaver.Hosting.Test` **393/393**, `MeshWeaver.Documentation.Test` **304/304** (link integrity,
What's New integrity and every ratchet guard), plus the 18 new cases.

## Scope boundaries (deliberate)

- **It does not stop a bad image being CHOSEN** — that is #3479, and the two are complementary:
  #3479 stops the bad roll starting, this one stops a bad roll doing damage when one happens anyway.
  Neither subsumes the other.
- **It does not gate Orleans cluster membership or hub activation.** A refused process stays
  addressable and its grains still activate — that is what lets the sweep read.
- **It does not change the stall posture.** The old image keeps serving.

## Also in this change

- `Doc/Architecture/MeshAdmission` — the design, the join-point inventory, the exit-vs-inert
  trade-off, and the scope boundaries. Cross-linked from `ModuleSetConvergence`, whose "rejected
  alternatives" section this decides one of.
- A What's New entry (`Category: Fix`).

No public type or member is removed, so no cross-repo counterpart is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
