### PR TITLE
Model the third send-as state, and let a mail carry Cc/Bcc (#3450, #3473)

### DIFF
--- a/memex/Memex.Portal.Shared/Email/NoOpEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/NoOpEmailSender.cs
@@ -41,7 +41,35 @@ public sealed class NoOpEmailSender(EmailOptions options, ILogger<NoOpEmailSende
 
     public IObservable<bool> SendEmail(
         string toAddress, string subject, string htmlBody, IReadOnlyCollection<EmailAttachment> attachments)
+        => SendEmail(new EmailMessage
+        {
+            To = [toAddress],
+            Subject = subject,
+            HtmlBody = htmlBody,
+            Attachments = attachments,
+        });
+
+    /// <summary>
+    /// 🚨 Overridden so a message with <b>Cc/Bcc</b> is handled by this sender rather than refused
+    /// by the interface default (#3473).
+    ///
+    /// <para>The default refusal exists to stop a single-address transport from quietly delivering
+    /// a DIFFERENT message than the one it was handed. That reasoning does not apply here: this
+    /// sender delivers nothing at all, to anybody, and says so. Refusing copied recipients would
+    /// break every local-dev and test send that carries one, while protecting a delivery that is
+    /// not happening either way.</para>
+    ///
+    /// <para>What it does still do is name the FULL envelope in its log line — To, Cc and Bcc
+    /// counts — so a developer reading the log sees the message that would have gone out, copies
+    /// included, instead of a line that silently describes fewer recipients than were asked for.
+    /// The <c>Email:Enabled=true</c> refusal (#2023) is unchanged and applies to the whole
+    /// envelope.</para>
+    /// </summary>
+    /// <param name="message">The message, its recipients, its attachments and its sender identity.</param>
+    public IObservable<bool> SendEmail(EmailMessage message)
     {
+        var recipients = string.Join(", ", message.AllRecipients);
+
         if (options.Enabled)
         {
             // ExplainRefusal, not Explain: this install may have the module and be missing only a
@@ -50,14 +78,18 @@ public sealed class NoOpEmailSender(EmailOptions options, ILogger<NoOpEmailSende
             var explanation = EmailDeliveryGuard.ExplainRefusal(
                 options, "This send is REFUSED rather than reported as delivered.");
             logger?.LogError(
-                "Refusing to send to {To} (subject: {Subject}, attachments: {Attachments}). {Explanation}",
-                toAddress, subject, attachments.Count, explanation);
+                "Refusing to send to {To} (subject: {Subject}, to: {ToCount}, cc: {CcCount}, "
+                + "bcc: {BccCount}, attachments: {Attachments}). {Explanation}",
+                recipients, message.Subject, message.To.Length, message.Cc.Length,
+                message.Bcc.Length, message.Attachments.Count, explanation);
             return Observable.Throw<bool>(new InvalidOperationException(explanation));
         }
 
         logger?.LogInformation(
-            "Email disabled (Email:Enabled=false) — skipping send to {To} (subject: {Subject}, attachments: {Attachments})",
-            toAddress, subject, attachments.Count);
+            "Email disabled (Email:Enabled=false) — skipping send to {To} (subject: {Subject}, "
+            + "to: {ToCount}, cc: {CcCount}, bcc: {BccCount}, attachments: {Attachments})",
+            recipients, message.Subject, message.To.Length, message.Cc.Length,
+            message.Bcc.Length, message.Attachments.Count);
         return Observable.Return(true);
     }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
@@ -223,11 +223,125 @@ Two identities exist, and the recipient can tell them apart — so the choice is
 The delegated scope needed is `Mail.Send`, and it is **already part of `EaGraphAuth.Scopes`** —
 connecting the personal assistant grants it, so there is no separate consent step for sending.
 
-- **Probe before composing**: `hub.CanSendAsUser(objectId)`, so the UI can STATE the identity rather
-  than the user discovering it in the recipient's inbox.
+- **Probe before composing**: `hub.ObserveSendAsCapability(objectId)`, so the UI can STATE the
+  identity rather than the user discovering it in the recipient's inbox.
 - **Never fall back silently.** If the user is not connected, offer `/auth/ea/connect`; the shared
   mailbox is only ever an explicitly chosen second option — and then set
   `EmailDelivery.AsSharedMailboxReplyingTo(userEmail)` so a reply still reaches the human.
+
+### 🚨 The probe has THREE answers, and only one of them may say "you have not connected"
+
+`IEmailSender.CanSendAsUser` returns `IObservable<bool>` — two answers for three states of the
+world. Both consumers wrapped it in `.Catch(_ => Observable.Return(false))`, so a probe that timed
+out or faulted became the same `false` as a probe that completed and found no credential. The send
+dialog renders `false` at open time as *"Your Microsoft 365 mailbox is not connected yet"* beside a
+Connect button — a sentence that is simply untrue on a transient fault, shown to a user who **had**
+connected. Nothing was logged, so the third state was not even greppable. That is
+[#3450](https://github.com/Systemorph/MeshWeaver/issues/3450), and it is
+[#3433](https://github.com/Systemorph/MeshWeaver/issues/3433) one layer down.
+
+`IEmailSender.ObserveSendAsCapability(userObjectId)` answers with `EmailSendAsCapability`:
+
+| `EmailSendAs` | Means | What the UI may say |
+|---|---|---|
+| `Available` | The check completed; this sender can act as the person | Name the address the mail leaves from |
+| `Unavailable` | The check completed and found nothing | *"Not connected yet"* + a Connect button — **the only truthful moment** |
+| `Undetermined` | The check produced **no answer** (timeout, transport fault, unreadable content) | *"We could not check just now"* + a retry. **Never** a claim about the mailbox |
+
+**The rendering rule lives on the answer, not in each UI.** `capability.OffersConnect` is true for
+`Unavailable` **alone** — deliberately not `!IsAvailable`, because that expression *is* the collapse
+written out. A consumer cannot re-derive the defect by accident.
+
+Faults route into the state rather than being swallowed: `hub.ObserveSendAsCapability(...)` maps a
+faulted **or silent** probe to `Undetermined` and logs it at Warning naming the user and the
+diagnostic, once, where the sender is resolved. A probe that completes without emitting is the same
+non-answer as one that threw — that is exactly how a dropped mesh read looks.
+
+**The send path is different, and is deliberately unchanged.** At send time the decision really is
+binary: send as the person, or show `AskWhichMailbox`. `hub.CanSendAsUser(...)` remains, folding
+`Undetermined` to `false`, and that is the *correct* answer there — the user is **asked** which
+mailbox rather than assumed connected. Only code that RENDERS A CLAIM must ask for the three-state
+answer.
+
+`IEmailSender.CanSendAsUser` itself is retained as the two-state shim so every existing implementer
+keeps compiling and answering exactly what it answered before. The two defaults point in opposite
+directions and never recurse: the interface's `ObserveSendAsCapability` folds `CanSendAsUser`, while
+the hub extension `CanSendAsUser` folds `ObserveSendAsCapability`. So an old sender is unchanged, and
+a sender that overrides only the new member is folded correctly at every consumer. It is not
+`[Obsolete]` for the reason given on `IEaGraphAuth`'s retiring surface — MeshWeaver.Plugins builds
+`-warnaserror` against a core checkout at a pinned ref, and the attribute would red that repo before
+its own half could land.
+
+---
+
+## Cc and Bcc — one message, not N
+
+A message with copied recipients **cannot be delivered as several mails**. Before
+[#3473](https://github.com/Systemorph/MeshWeaver/issues/3473) every `SendEmail` overload took a
+single `toAddress`, so `SendDocumentDispatch.ExportAndSend` did the only thing available to it —
+`emails.ToObservable().SelectMany(to => hub.SendEmail(to, …))`, one mail per recipient. A To with
+seven Cc, the ordinary shape of a business mail, went out as eight separate messages:
+
+- no recipient could see who else received it, because each message's visible header named one person;
+- Reply-All reached nobody but the sender, so the thread split into eight unrelated conversations;
+- **Bcc had no expressible form at all** — sending separately to a blind recipient produces a message
+  whose header does not match what anyone else got.
+
+`EmailMessage` carries the whole envelope — `To`, `Cc`, `Bcc`, `Subject`, `HtmlBody`, `Attachments`,
+`Delivery` — and `IEmailSender.SendEmail(EmailMessage)` sends it as ONE mail:
+
+```csharp
+hub.SendEmail(new EmailMessage
+    {
+        To = ["client@example.com"],
+        Cc = ["colleague@example.com", "manager@example.com"],
+        Bcc = ["archive@example.com"],
+        Subject = "Q3 review deck",
+        HtmlBody = "<p>Attached.</p>",
+        Delivery = EmailDelivery.AsUser(objectId),
+    })
+    .Subscribe(ok => Log.LogInformation("sent: {Ok}", ok),
+               ex => Log.LogError(ex, "send failed"));
+```
+
+`VisibleRecipients` is To ⧺ Cc (de-duplicated, case-insensitively) — the header every reader sees.
+`Bcc` is deliberately absent from it: a blind recipient appearing there is the disclosure the field
+exists to prevent. `AllRecipients` adds Bcc, for *"the send reached these addresses"* reporting only.
+
+🚨 **A sender that cannot carry copies REFUSES; it never drops them.** The default implementation
+forwards to the existing single-address overload when the message fits one (`To` of exactly one, no
+copies) — so every sender written before this member keeps serving every call it could already
+serve — and otherwise faults with a `NotSupportedException` naming the counts. Delivering to fewer
+people than the sender addressed is the same class of defect as stamping an undelivered mail `Sent`
+(#2023): the person is told the thing they asked for happened.
+
+The host's `NoOpEmailSender` is the one deliberate exception. It delivers nothing to anybody and
+says so, so there is no smaller message for it to deliver silently; it accepts the full envelope,
+names every count in its log line, and still refuses outright on a mail-enabled-but-unconfigured
+install.
+
+### 🚧 The consumers live in MeshWeaver.Plugins, and land after the pin moves
+
+Both seams above are **contract-side only** in this repository. Everything a person can SEE is in
+`MeshWeaver.Plugins`, which builds `-warnaserror` against a core checkout at `MW_PLATFORM_REF` — so
+the consuming half cannot compile until that pin carries these members. The order is therefore
+**core → pin → Plugins**, and it is the reason the members are additive rather than a signature
+change: an old sender at the old pin keeps compiling and answering exactly as before.
+
+What remains, precisely:
+
+| File (MeshWeaver.Plugins) | Change |
+|---|---|
+| `src/MeshWeaver.Mail.MicrosoftGraph/GraphEmailSender.cs` | Override `ObserveSendAsCapability` off `IEaGraphAuth.GetConnection`, mapping `EaConnection.Connected/NotConnected/Undetermined` straight through — it is the only implementation that can OBSERVE the third state. Override `SendEmail(EmailMessage)` to build one Graph `Message` with `ToRecipients`/`CcRecipients`/`BccRecipients` (the SDK already supports all three). |
+| `src/MeshWeaver.Markdown.Export/Layout/SendDocumentLayoutArea.cs` | At dialog open, replace the `CanSendAsUser` probe and its `.Catch(… => false)` with `host.Hub.ObserveSendAsCapability(...)`; render the Connect panel on `capability.OffersConnect`, and a third panel — `ui.sendDocument.connectUnknown` plus a `ui.sendDocument.checkAgain` retry — on `IsUndetermined`. **Leave `SubmitSend` alone**: asking which mailbox is already the right answer for an unknown. |
+| `src/MeshWeaver.Markdown.Export/Handlers/SendDocumentDispatch.cs` | Replace `SendToAll`'s per-recipient `SelectMany` with ONE `hub.SendEmail(EmailMessage)`, and give `ExportAndSend` `cc`/`bcc` parameters beside `rawEmails`. |
+
+The two localization keys the third panel needs (`ui.sendDocument.connectUnknown`,
+`ui.sendDocument.checkAgain`) ship in this change, in both `en` and `de`, so the consumer half adds
+no catalog entries of its own. They still need the mirror sync described in
+[Localization](/Doc/Architecture/Localization) — the plugins repo's React catalog compares against a
+PINNED core commit, so a key added here reddens nothing and leaves that mirror silently stale until
+`npm run sync:i18n -- --ref <merged core sha>` runs.
 
 🚨 **Mailbox data is queried LIVE from Graph and never replicated into the mesh.** Graph is the
 system of record and always current; a mirror would buy nothing and would leave personal

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-check-that-did-not-run-no-longer-says-you-are-not-connected.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-check-that-did-not-run-no-longer-says-you-are-not-connected.md
@@ -1,0 +1,28 @@
+---
+Name: A check that could not run no longer says you are not connected
+Category: Fix
+Description: When the portal cannot check whether your mailbox is connected, it now says so instead of telling you that you never connected.
+Icon: Sparkle
+Order: -20260907
+---
+
+# A check that could not run no longer says you are not connected
+
+Opening **Share ⇒ as email** starts a quick check: can this message go out from your own mailbox? If
+the answer was no, the dialog said so plainly — *"Your Microsoft 365 mailbox is not connected yet"* —
+and offered a Connect button.
+
+The trouble was that the check had only two answers for three situations. "You have not connected"
+and "the check did not finish" both arrived as *no*. So a brief hiccup — a slow moment, a connection
+that dropped — showed people who **had** connected a panel telling them they had not, and invited
+them through a setup step they had already done.
+
+Now the check keeps the three situations apart. If it cannot reach an answer, the dialog says that:
+it could not check just now, your draft is safe, and you can send either way. It no longer states
+anything about your mailbox that it does not know.
+
+Two things are deliberately unchanged. The Connect panel still appears, exactly as before, when the
+check finishes and genuinely finds no connected mailbox — that sentence is true there, and it is the
+one moment worth offering the setup. And pressing **Send** still asks which mailbox the message
+should leave from whenever your own cannot be confirmed, rather than quietly sending from somewhere
+else. Nothing sends from an identity the portal is not sure about.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-mail-with-people-in-copy-goes-out-as-one-message.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-mail-with-people-in-copy-goes-out-as-one-message.md
@@ -1,0 +1,25 @@
+---
+Name: A mail with people in copy goes out as one message
+Category: Fix
+Description: Copied recipients can now travel on the same message, so everyone sees who else received it and Reply-All reaches the group.
+Icon: Sparkle
+Order: -20260907
+---
+
+# A mail with people in copy goes out as one message
+
+Mail sent from the portal could only ever be addressed to one person at a time. Sending to several
+meant sending the message several times — one copy each, every one addressed to a single recipient.
+
+That is not the same mail. Nobody could see who else had received it, so a client had no idea their
+colleague was in the loop. Replying to everyone reached only the sender, and one conversation became
+several unrelated ones. And a blind copy — a message someone receives without the other recipients
+seeing it — had no way to be sent at all.
+
+A message now carries its own recipients: **To**, **Cc** and **Bcc**, delivered as one mail. The
+people in To and Cc can see each other, which is the whole point of copying someone in. The people in
+Bcc receive it and nobody else knows, which is the whole point of that.
+
+Where a message genuinely cannot be delivered that way, it is now **refused and reported** rather
+than quietly sent to fewer people than were addressed. A mail that reaches half the people it names,
+while telling the sender it went out, is worse than one that plainly did not go.

--- a/src/MeshWeaver.Mesh.Contract/EmailMessage.cs
+++ b/src/MeshWeaver.Mesh.Contract/EmailMessage.cs
@@ -1,0 +1,124 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One outbound message, with everything that decides who receives it and who they can see —
+/// <see cref="To"/>, <see cref="Cc"/>, <see cref="Bcc"/>, the subject, the HTML body, the
+/// attachments and the sender identity.
+///
+/// <para>🚨 <b>Why this exists (#3473).</b> Every
+/// <see cref="IEmailSender.SendEmail(string,string,string,IReadOnlyCollection{EmailAttachment},EmailDelivery)"/>
+/// overload takes ONE address, so a caller with several recipients had exactly one option: send the
+/// mail once per recipient. That is a different thing from the mail the sender approved. The
+/// recipients cannot see each other, a Reply-All reaches nobody but the sender, the thread splits
+/// into N unrelated conversations, and Bcc — whose entire definition is "on this message but not on
+/// its visible header" — has no expressible form at all. A To with seven Cc is the ordinary shape
+/// of a business mail; it is not N mails.</para>
+///
+/// <para><b>Copied recipients are a property of the MESSAGE, so they live on the message.</b> A
+/// transport that can carry them (Microsoft Graph builds exactly this envelope) maps it directly; a
+/// transport that cannot must REFUSE rather than quietly deliver something else — see
+/// <see cref="IEmailSender.SendEmail(EmailMessage)"/>. Silently dropping a Cc is the same class of
+/// defect as stamping an undelivered mail <c>Sent</c>: the sender is told the thing they asked for
+/// happened.</para>
+///
+/// <para>Immutable throughout (<see cref="ImmutableArray{T}"/> per the collections policy), so a
+/// message can be composed, logged and handed across hubs without a defensive copy.</para>
+/// </summary>
+public sealed record EmailMessage
+{
+    /// <summary>The subject line.</summary>
+    public required string Subject { get; init; }
+
+    /// <summary>The HTML body.</summary>
+    public required string HtmlBody { get; init; }
+
+    /// <summary>
+    /// The primary recipients — the people the message is addressed TO. Visible to everyone who
+    /// receives it. At least one of <see cref="To"/>, <see cref="Cc"/> or <see cref="Bcc"/> must be
+    /// non-empty for the message to be deliverable.
+    /// </summary>
+    public ImmutableArray<string> To { get; init; } = [];
+
+    /// <summary>
+    /// Copied recipients. Visible to every other recipient — that visibility is the point, and it
+    /// is what "one message" buys that N messages cannot.
+    /// </summary>
+    public ImmutableArray<string> Cc { get; init; } = [];
+
+    /// <summary>
+    /// Blind-copied recipients. They receive the message; nobody else — including the other
+    /// blind-copied recipients — sees that they did.
+    ///
+    /// <para>🚨 There is no way to approximate this with per-recipient sends: sending separately to
+    /// a Bcc address produces a message whose visible header does not match the one the other
+    /// recipients got, and a Reply-All from it addresses people the sender never chose to reveal.
+    /// Bcc is expressible only on a single message.</para>
+    /// </summary>
+    public ImmutableArray<string> Bcc { get; init; } = [];
+
+    /// <summary>Files to attach, including <c>cid:</c> inline parts. Empty by default.</summary>
+    public IReadOnlyCollection<EmailAttachment> Attachments { get; init; } = [];
+
+    /// <summary>Who the message comes from and where replies go. Defaults to the shared mailbox.</summary>
+    public EmailDelivery Delivery { get; init; } = EmailDelivery.AsSharedMailbox;
+
+    /// <summary>
+    /// The recipients every reader of the message can SEE — <see cref="To"/> then <see cref="Cc"/>,
+    /// de-duplicated case-insensitively, in that order. <see cref="Bcc"/> is deliberately absent:
+    /// this is the visible header, and a Bcc address appearing here would be the disclosure the
+    /// field exists to prevent.
+    /// </summary>
+    public ImmutableArray<string> VisibleRecipients =>
+        [.. To.Concat(Cc).Distinct(StringComparer.OrdinalIgnoreCase)];
+
+    /// <summary>
+    /// Everyone who receives the message, visible and blind alike, de-duplicated
+    /// case-insensitively. For "the send reached these addresses" reporting — never for anything a
+    /// recipient sees.
+    /// </summary>
+    public ImmutableArray<string> AllRecipients =>
+        [.. To.Concat(Cc).Concat(Bcc).Distinct(StringComparer.OrdinalIgnoreCase)];
+
+    /// <summary>True when the message carries copied recipients that only a single send can honour.</summary>
+    public bool HasCopiedRecipients => Cc.Length > 0 || Bcc.Length > 0;
+
+    /// <summary>True when nobody at all would receive this message.</summary>
+    public bool HasNoRecipients => To.Length == 0 && Cc.Length == 0 && Bcc.Length == 0;
+
+    /// <summary>
+    /// The simple case: one recipient, no copies — exactly what the single-address overloads carry.
+    /// </summary>
+    /// <param name="toAddress">The one recipient.</param>
+    /// <param name="subject">Subject line.</param>
+    /// <param name="htmlBody">HTML body.</param>
+    public static EmailMessage Addressed(string toAddress, string subject, string htmlBody) =>
+        new() { To = [toAddress], Subject = subject, HtmlBody = htmlBody };
+
+    /// <summary>
+    /// True when this message is exactly what a single-address sender can carry: one <see cref="To"/>,
+    /// no <see cref="Cc"/>, no <see cref="Bcc"/>. Used by
+    /// <see cref="IEmailSender.SendEmail(EmailMessage)"/>'s default implementation to decide whether
+    /// it may forward to the legacy overload or must refuse.
+    /// </summary>
+    public bool FitsASingleAddressSender => To.Length == 1 && Cc.Length == 0 && Bcc.Length == 0;
+
+    /// <summary>
+    /// The refusal a sender that cannot carry copied recipients gives — naming the counts, so the
+    /// operator sees WHAT could not be honoured rather than a mail that quietly went to fewer
+    /// people than it said.
+    /// </summary>
+    /// <param name="sender">The sender type that cannot carry this envelope.</param>
+    public string DescribeUnsupportedEnvelope(Type sender) =>
+        HasNoRecipients
+            ? $"This message has no recipients at all (subject: \"{Subject}\"), so "
+              + $"{sender.Name} has nobody to send it to. Nothing was sent."
+            : $"{sender.Name} can only send to a single recipient, so it cannot deliver this "
+              + $"message as ONE mail (To: {To.Length}, Cc: {Cc.Length}, Bcc: {Bcc.Length}; "
+              + $"subject: \"{Subject}\"). Sending it once per recipient would be a DIFFERENT "
+              + "message — the recipients could not see each other, Reply-All would reach nobody, "
+              + "and a Bcc would not be blind. Nothing was sent. Use a sender that implements "
+              + $"{nameof(IEmailSender)}.{nameof(IEmailSender.SendEmail)}({nameof(EmailMessage)}), "
+              + "or address the message to one recipient.";
+}

--- a/src/MeshWeaver.Mesh.Contract/EmailSendAsCapability.cs
+++ b/src/MeshWeaver.Mesh.Contract/EmailSendAsCapability.cs
@@ -1,0 +1,112 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// What is known about a sender's ability to send AS a particular person. Three states, because
+/// there are three states of the world — see <see cref="EmailSendAsCapability"/> for why the
+/// two-answer shape it replaces was a defect (#3450).
+/// </summary>
+public enum EmailSendAs
+{
+    /// <summary>
+    /// The check COMPLETED and the answer is no: this sender cannot act as that person right now
+    /// (no connected mailbox, or a sender that has no delegated path at all).
+    ///
+    /// <para>This is the ONLY state in which telling the user "your mailbox is not connected" and
+    /// offering a Connect button is truthful.</para>
+    /// </summary>
+    Unavailable,
+
+    /// <summary>The check completed and the sender can send as that person.</summary>
+    Available,
+
+    /// <summary>
+    /// The check produced NO answer — it timed out, the transport faulted, or the sender could not
+    /// interpret what it read. <b>Nothing is known</b> about whether the person connected.
+    ///
+    /// <para>A UI here must say so ("we could not check just now") and must not assert either of
+    /// the other two. Rendering this as <see cref="Unavailable"/> tells a connected user they have
+    /// not connected — that is #3450, and #3433 one layer up.</para>
+    /// </summary>
+    Undetermined,
+}
+
+/// <summary>
+/// The answer to "can this sender send as <c>userObjectId</c> right now?", carrying the
+/// <see cref="State"/> and a <see cref="Diagnostic"/> that says WHY when the answer is not a clean
+/// yes.
+///
+/// <para>🚨 <b>Why this type exists (#3450).</b> <see cref="IEmailSender.CanSendAsUser"/> returns
+/// <c>IObservable&lt;bool&gt;</c> — two answers for three states of the world. A read that never
+/// completed and a read that found no credential both arrived as <c>false</c>, and the send dialog
+/// rendered <c>false</c> as a user-visible <i>"your Microsoft 365 mailbox is not connected yet"</i>
+/// beside a Connect button. On a transient fault that statement is simply untrue, and a connected
+/// user was told to connect. Widening the answer is the fix; widening a timeout is not.</para>
+///
+/// <para>Deliberately its own small type rather than <see cref="EaGraphAccess"/>: this is a
+/// property of the SENDER, and a sender need not be the Executive Assistant's Graph one. It carries
+/// no token and no SDK type, so it stays usable from any transport.</para>
+///
+/// <para><b>The rendering rule is on the type, not in each UI.</b> <see cref="OffersConnect"/> is
+/// true for exactly one state, so a consumer cannot re-derive the #3450 collapse by writing
+/// <c>!IsAvailable</c>.</para>
+/// </summary>
+/// <param name="State">What is known.</param>
+/// <param name="Diagnostic">
+/// Why the answer is what it is — for logs, and for a message a human can act on. Required for
+/// <see cref="EmailSendAs.Undetermined"/> (an undetermined answer with nothing to say is
+/// indistinguishable from the swallow this type removes); optional otherwise. Developer-facing:
+/// it is a log/diagnostic string, never chrome a viewer reads, so it is not localized.
+/// </param>
+public sealed record EmailSendAsCapability(EmailSendAs State, string? Diagnostic = null)
+{
+    /// <summary>True only for <see cref="EmailSendAs.Available"/> — never for the other two.</summary>
+    public bool IsAvailable => State == EmailSendAs.Available;
+
+    /// <summary>True only for <see cref="EmailSendAs.Undetermined"/>.</summary>
+    public bool IsUndetermined => State == EmailSendAs.Undetermined;
+
+    /// <summary>
+    /// 🚨 Whether a UI may state "you have not connected your mailbox" and offer a Connect button.
+    ///
+    /// <para>True for <see cref="EmailSendAs.Unavailable"/> ALONE. It is deliberately not
+    /// <c>!IsAvailable</c>: that expression is the #3450 defect written out, because it folds
+    /// <see cref="EmailSendAs.Undetermined"/> — "we could not check" — into a confident claim the
+    /// viewer can see is false. An undetermined check gets its own panel that says what happened
+    /// and offers a retry.</para>
+    /// </summary>
+    public bool OffersConnect => State == EmailSendAs.Unavailable;
+
+    /// <summary>The check completed and the sender can act as this person.</summary>
+    public static EmailSendAsCapability Available { get; } = new(EmailSendAs.Available);
+
+    /// <summary>
+    /// The check COMPLETED and the answer is no. Not the fallback for a check that failed —
+    /// <see cref="Unknown(string)"/> is.
+    /// </summary>
+    /// <param name="diagnostic">Optional detail for logs.</param>
+    public static EmailSendAsCapability Unavailable(string? diagnostic = null) =>
+        new(EmailSendAs.Unavailable, diagnostic);
+
+    /// <summary>
+    /// The check produced no answer. <paramref name="diagnostic"/> is REQUIRED and must be
+    /// non-blank: it is the only thing separating a modelled unknown from the silent
+    /// <c>catch → false</c> this type exists to remove.
+    /// </summary>
+    /// <param name="diagnostic">What stopped the check from answering.</param>
+    /// <exception cref="ArgumentException">The diagnostic is null, empty or whitespace.</exception>
+    public static EmailSendAsCapability Unknown(string diagnostic) =>
+        string.IsNullOrWhiteSpace(diagnostic)
+            ? throw new ArgumentException(
+                "An undetermined send-as capability must say what stopped the check from "
+                + "answering; an unknown with nothing to say is the swallow this type removes.",
+                nameof(diagnostic))
+            : new(EmailSendAs.Undetermined, diagnostic);
+
+    /// <summary>
+    /// The undetermined answer for a check that FAULTED, naming the exception so the state is
+    /// greppable rather than merely modelled.
+    /// </summary>
+    /// <param name="error">The fault the check surfaced.</param>
+    public static EmailSendAsCapability Unknown(Exception error) =>
+        Unknown($"the send-as check faulted: {error.GetType().Name}: {error.Message}");
+}

--- a/src/MeshWeaver.Mesh.Contract/HubEmailExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubEmailExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mesh;
 
@@ -66,17 +67,85 @@ public static class HubEmailExtensions
     }
 
     /// <summary>
-    /// Whether the registered sender can send AS <paramref name="userObjectId"/> right now (the
-    /// user has connected their Microsoft 365 mailbox). Ask before composing so the UI can state
-    /// which identity will be used — never discover it at send time.
+    /// Sends ONE message with all of its recipients — To, Cc and Bcc — as a single mail (#3473).
+    /// Cold observable: subscribe to drive. Emits <c>false</c> if no sender is registered.
+    ///
+    /// <para>A sender that cannot carry copied recipients FAULTS rather than dropping them; see
+    /// <see cref="IEmailSender.SendEmail(EmailMessage)"/>. That fault is deliberately not caught
+    /// here — a caller that asked for a Cc must learn it did not happen.</para>
     /// </summary>
-    public static IObservable<bool> CanSendAsUser(this IMessageHub hub, string userObjectId)
+    /// <param name="hub">Hub whose service provider holds the registered sender.</param>
+    /// <param name="message">The message, its recipients, its attachments and its sender identity.</param>
+    public static IObservable<bool> SendEmail(this IMessageHub hub, EmailMessage message)
     {
         var sender = hub.ServiceProvider.GetService(typeof(IEmailSender)) as IEmailSender;
         return sender is null
             ? Observable.Return(false)
-            : sender.CanSendAsUser(userObjectId);
+            : sender.SendEmail(message);
     }
+
+    /// <summary>
+    /// What is KNOWN about whether the registered sender can send AS <paramref name="userObjectId"/>
+    /// right now — the three-state probe (#3450). Ask before composing so the UI can STATE which
+    /// identity will be used, never discover it at send time.
+    ///
+    /// <para>🚨 <b>A faulted or silent probe becomes <see cref="EmailSendAs.Undetermined"/> here,
+    /// and is LOGGED at Warning naming the user and the diagnostic.</b> Every consumer used to
+    /// write <c>.Catch(_ =&gt; Observable.Return(false))</c> at its own call site, which made a
+    /// transport fault indistinguishable from "this person never connected" — with nothing logged,
+    /// so the third state was not even greppable. Routing the fault into the modelled state, once,
+    /// where the sender is resolved, is what stops each consumer having to remember. It is not a
+    /// swallow: the information is carried, not discarded.</para>
+    ///
+    /// <para>A probe that completes without emitting is the same non-answer as a faulted one and
+    /// gets the same state — an empty observable is exactly how a dropped mesh read looks.</para>
+    /// </summary>
+    /// <param name="hub">Hub whose service provider holds the registered sender.</param>
+    /// <param name="userObjectId">Directory object id of the user to check.</param>
+    public static IObservable<EmailSendAsCapability> ObserveSendAsCapability(
+        this IMessageHub hub, string userObjectId)
+    {
+        if (hub.ServiceProvider.GetService(typeof(IEmailSender)) is not IEmailSender sender)
+            return Observable.Return(EmailSendAsCapability.Unavailable(
+                "No IEmailSender is registered on this deployment, so nothing can send as a user. "
+                + "This is a completed check with a negative answer, not an unknown."));
+
+        return sender.ObserveSendAsCapability(userObjectId)
+            .Take(1)
+            .Catch((Exception ex) =>
+            {
+                Logger(hub)?.LogWarning(
+                    ex,
+                    "Send-as capability check FAULTED for user {UserObjectId} on {Sender}: {Diagnostic}. "
+                    + "Reported as Undetermined — the UI must not tell this user they have not "
+                    + "connected, because nothing is known either way (#3450).",
+                    userObjectId, sender.GetType().Name, ex.Message);
+                return Observable.Return(EmailSendAsCapability.Unknown(ex));
+            })
+            .DefaultIfEmpty(EmailSendAsCapability.Unknown(
+                $"the send-as check on {sender.GetType().Name} completed without answering"));
+    }
+
+    /// <summary>
+    /// Whether the registered sender can send AS <paramref name="userObjectId"/> right now (the
+    /// user has connected their Microsoft 365 mailbox).
+    ///
+    /// <para>The two-state fold of <see cref="ObserveSendAsCapability"/>, kept because a decision
+    /// that must go one way or the other — <i>send as the person, or ask which mailbox</i> — is
+    /// genuinely binary. That is the send-time consumer, and folding is CORRECT there: an unknown
+    /// answers <c>false</c>, so the user is asked which mailbox rather than assumed connected.
+    /// Anything that RENDERS a claim about the mailbox must ask
+    /// <see cref="ObserveSendAsCapability"/> instead, because <c>false</c> here still cannot tell
+    /// "not connected" from "we could not check".</para>
+    /// </summary>
+    /// <param name="hub">Hub whose service provider holds the registered sender.</param>
+    /// <param name="userObjectId">Directory object id of the user to check.</param>
+    public static IObservable<bool> CanSendAsUser(this IMessageHub hub, string userObjectId) =>
+        hub.ObserveSendAsCapability(userObjectId).Select(capability => capability.IsAvailable);
+
+    private static ILogger? Logger(IMessageHub hub) =>
+        (hub.ServiceProvider.GetService(typeof(ILoggerFactory)) as ILoggerFactory)
+            ?.CreateLogger(typeof(HubEmailExtensions).FullName!);
 
     /// <summary>
     /// The app-relative path where a user connects their own mailbox on this deployment, or

--- a/src/MeshWeaver.Mesh.Contract/HubEmailExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubEmailExtensions.cs
@@ -110,8 +110,14 @@ public static class HubEmailExtensions
                 "No IEmailSender is registered on this deployment, so nothing can send as a user. "
                 + "This is a completed check with a negative answer, not an unknown."));
 
+        // 🚨 Deliberately NOT .Take(1). This feeds a live data-bound view — the send dialog
+        // CombineLatests it into the rendered form — and truncating a stream that a view binds to
+        // freezes the binding, which is the "Check again" affordance's whole mechanism: a sender
+        // that re-probes must be able to replace an Undetermined answer with a real one, in place.
+        // Neither operator below needs a single emission: Catch replaces only the tail after a
+        // fault, and DefaultIfEmpty fires only when the source completes having emitted nothing.
+        // The send-time caller, which genuinely wants one answer, takes its own .Take(1).
         return sender.ObserveSendAsCapability(userObjectId)
-            .Take(1)
             .Catch((Exception ex) =>
             {
                 Logger(hub)?.LogWarning(

--- a/src/MeshWeaver.Mesh.Contract/IEmailSender.cs
+++ b/src/MeshWeaver.Mesh.Contract/IEmailSender.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+
 namespace MeshWeaver.Mesh;
 
 /// <summary>
@@ -70,15 +72,86 @@ public interface IEmailSender
         => SendEmail(toAddress, subject, htmlBody, attachments);
 
     /// <summary>
-    /// Whether this sender can send AS <paramref name="userObjectId"/> right now — i.e. the user
-    /// has connected their mailbox and the stored delegated credential carries <c>Mail.Send</c>.
+    /// 🚨 <b>Deprecated in favour of <see cref="ObserveSendAsCapability"/> — two answers for three
+    /// states of the world (#3450).</b> A check that never completed and a check that found no
+    /// credential both arrive here as <c>false</c>, and the send dialog rendered that as a
+    /// user-visible <i>"your Microsoft 365 mailbox is not connected yet"</i>. On a transient fault
+    /// that statement is untrue, and a connected user was told to connect.
     ///
-    /// <para>Ask BEFORE composing, so the UI can state which identity will be used and offer to
-    /// connect Microsoft 365 when it cannot. Defaults to <c>false</c>: a sender says it can act as
-    /// a person only when it genuinely can.</para>
+    /// <para>Kept as the two-state shim over the three-state probe so every existing implementer
+    /// and caller keeps working: <see cref="ObserveSendAsCapability"/>'s default folds this member,
+    /// and <c>HubEmailExtensions.CanSendAsUser</c> folds the other way. Deliberately NOT
+    /// <c>[Obsolete]</c>, for the reason spelled out on <see cref="IEaGraphAuth"/>'s retiring
+    /// surface: MeshWeaver.Plugins builds <c>-warnaserror</c> against a core CHECKOUT at a pinned
+    /// ref, so the attribute would red that repo before its own half could land. Do NOT add a new
+    /// caller — ask <see cref="ObserveSendAsCapability"/>.</para>
+    ///
+    /// <para>Whether this sender can send AS <paramref name="userObjectId"/> right now — i.e. the
+    /// user has connected their mailbox and the stored delegated credential carries
+    /// <c>Mail.Send</c>. Defaults to <c>false</c>: a sender says it can act as a person only when
+    /// it genuinely can.</para>
     /// </summary>
+    /// <param name="userObjectId">Directory object id of the user to check.</param>
     IObservable<bool> CanSendAsUser(string userObjectId)
-        => System.Reactive.Linq.Observable.Return(false);
+        => Observable.Return(false);
+
+    /// <summary>
+    /// What is KNOWN about this sender's ability to send as <paramref name="userObjectId"/> — the
+    /// three-state answer <see cref="CanSendAsUser"/> cannot express (#3450).
+    ///
+    /// <para>Ask BEFORE composing, so the UI can state which identity will be used. The state
+    /// decides what the UI may claim, and the claim rule lives on the answer:
+    /// <see cref="EmailSendAsCapability.OffersConnect"/> is true for
+    /// <see cref="EmailSendAs.Unavailable"/> ALONE, so "you have not connected" is never rendered
+    /// for a check that simply did not complete.</para>
+    ///
+    /// <para><b>The default folds <see cref="CanSendAsUser"/>, which makes this purely additive.</b>
+    /// A sender written before this member — including every implementation in a repository that
+    /// pins an older core — keeps answering exactly what it answered before, in two states. Only a
+    /// sender that can genuinely tell an unanswered check from a negative one overrides this; it
+    /// then gets <see cref="EmailSendAs.Undetermined"/> for free at every consumer, because
+    /// <c>HubEmailExtensions.CanSendAsUser</c> folds this member rather than calling the old one.
+    /// The two defaults deliberately point in opposite directions and never recurse.</para>
+    ///
+    /// <para>🚨 An implementation must NOT collapse a fault into
+    /// <see cref="EmailSendAs.Unavailable"/> — that is the #3450 swallow written inside the sender
+    /// instead of at the call site. Surface the fault, or answer
+    /// <see cref="EmailSendAsCapability.Unknown(Exception)"/>.</para>
+    /// </summary>
+    /// <param name="userObjectId">Directory object id of the user to check.</param>
+    IObservable<EmailSendAsCapability> ObserveSendAsCapability(string userObjectId)
+        => CanSendAsUser(userObjectId)
+            .Select(can => can
+                ? EmailSendAsCapability.Available
+                : EmailSendAsCapability.Unavailable(
+                    $"{GetType().Name} answers send-as with yes/no only, so this negative is what "
+                    + "it knows — it cannot report a check that failed to complete."));
+
+    /// <summary>
+    /// Sends ONE message, with all of its recipients — <see cref="EmailMessage.To"/>,
+    /// <see cref="EmailMessage.Cc"/> and <see cref="EmailMessage.Bcc"/> — as a single mail (#3473).
+    /// Cold observable: the send runs on Subscribe and emits a single <c>true</c> on success, or
+    /// surfaces the failure via OnError.
+    ///
+    /// <para>🚨 <b>The default REFUSES what it cannot honour; it never silently drops it.</b> A
+    /// message that fits a single-address sender (one To, no copies) is forwarded to the existing
+    /// overload unchanged — so every sender written before this member keeps working for every call
+    /// it could already serve. A message with Cc, Bcc, or several To addresses cannot be delivered
+    /// as ONE mail by a sender that only knows one address, and fanning it out would deliver a
+    /// DIFFERENT message: recipients unable to see each other, Reply-All reaching nobody, and a Bcc
+    /// that is not blind. So it faults with a message naming the counts.</para>
+    ///
+    /// <para>Refusing is the same principle as <see cref="DeliversMail"/>: a sender that reports
+    /// success for something it did not do converts a capability gap into silent data loss.</para>
+    /// </summary>
+    /// <param name="message">The message, its recipients, its attachments and its sender identity.</param>
+    IObservable<bool> SendEmail(EmailMessage message)
+        => message.FitsASingleAddressSender
+            ? SendEmail(
+                message.To[0], message.Subject, message.HtmlBody,
+                message.Attachments, message.Delivery)
+            : Observable.Throw<bool>(
+                new NotSupportedException(message.DescribeUnsupportedEnvelope(GetType())));
 
     /// <summary>
     /// Where a user connects their own mailbox on THIS deployment, as an app-relative path — or

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -715,6 +715,8 @@
   "ui.sendDocument.fromLabel": "Von",
   "ui.sendDocument.connect": "Microsoft 365 verbinden",
   "ui.sendDocument.connectFirst": "Ihr Microsoft-365-Postfach ist noch nicht verbunden. Verbinden Sie es jetzt, um von Ihrer eigenen Adresse zu senden — bereits Eingegebenes bleibt erhalten.",
+  "ui.sendDocument.connectUnknown": "Wir konnten gerade nicht prüfen, ob Ihr Microsoft-365-Postfach verbunden ist. Ihr Entwurf bleibt erhalten, und Sie können ihn trotzdem senden — Sie werden gefragt, aus welchem Postfach er hinausgeht.",
+  "ui.sendDocument.checkAgain": "Erneut prüfen",
   "ui.sendDocument.signInTitle": "Zum Teilen per E-Mail anmelden",
   "ui.sendDocument.signInBody": "Das Teilen eines Dokuments per E-Mail erfordert ein angemeldetes Konto, damit Antworten Sie erreichen und Ihr Entwurf privat gespeichert wird.",
   "ui.sendDocument.fromSharedTitle": "Aus dem gemeinsamen Postfach senden?",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -715,6 +715,8 @@
   "ui.sendDocument.fromLabel": "From",
   "ui.sendDocument.connect": "Connect Microsoft 365",
   "ui.sendDocument.connectFirst": "Your Microsoft 365 mailbox is not connected yet. Connect it now to send from your own address — anything you have already typed is kept.",
+  "ui.sendDocument.connectUnknown": "We could not check whether your Microsoft 365 mailbox is connected just now. Your draft is safe, and you can send it either way — you will be asked which mailbox it goes out from.",
+  "ui.sendDocument.checkAgain": "Check again",
   "ui.sendDocument.signInTitle": "Sign in to share by email",
   "ui.sendDocument.signInBody": "Sharing a document by email needs a signed-in account, so replies reach you and your draft is kept privately.",
   "ui.sendDocument.fromSharedTitle": "Send from the shared mailbox?",

--- a/test/Memex.Portal.Shared.Test/EmailCopiedRecipientsTest.cs
+++ b/test/Memex.Portal.Shared.Test/EmailCopiedRecipientsTest.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Email;
+using MeshWeaver.Fixture;                  // TestTimeouts.Convergence
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #3473: <c>IEmailSender</c> took ONE recipient and had no Cc/Bcc, so a mail with copied
+/// recipients could not be delivered as the message the sender approved.
+///
+/// <para><b>What went wrong.</b> Every <c>SendEmail</c> overload took a single
+/// <c>toAddress</c>, so <c>SendDocumentDispatch.ExportAndSend</c> did the only thing available to
+/// it: <c>emails.ToObservable().SelectMany(to =&gt; hub.SendEmail(to, …))</c> — one mail per
+/// recipient. A To with seven Cc, the ordinary shape of a business mail, went out as eight separate
+/// messages. None of them named the others, so nobody could see who else had it, Reply-All reached
+/// only the sender, and the thread split into eight unrelated conversations. Bcc — whose entire
+/// definition is "receives the message but is not on its visible header" — had no expressible form
+/// at all: sending separately to a blind recipient produces a message whose header does not match
+/// what anyone else got.</para>
+///
+/// <para><b>The two arms.</b> <see cref="AMessageWithCcAndBcc_IsDeliveredAsOneMessage"/> shows the
+/// fixed shape with numbers, and <see cref="TheOldPerRecipientShape_SplitsOneMailIntoFour"/> shows
+/// the same four recipients through the old surface — four sends, each blind to the others. That
+/// second test is the defect, measured, and it stays green forever: it is what a single-address
+/// sender still does, which is exactly why
+/// <see cref="ASingleAddressSender_RefusesCopiedRecipients_RatherThanDroppingThem"/> makes it
+/// unreachable by accident.</para>
+/// </summary>
+public class EmailCopiedRecipientsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Primary = "client@example.com";
+    private const string CopiedOne = "colleague@example.com";
+    private const string CopiedTwo = "manager@example.com";
+    private const string Blind = "archive@example.com";
+
+    private readonly EnvelopeRecordingSender envelopeSender = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<IEmailSender>(envelopeSender));
+
+    private static EmailMessage BusinessMail() => new()
+    {
+        To = [Primary],
+        Cc = [CopiedOne, CopiedTwo],
+        Bcc = [Blind],
+        Subject = "Q3 review deck",
+        HtmlBody = "<p>Attached.</p>",
+    };
+
+    // ── The fix, with numbers ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 ONE message, four recipients — and the visibility is right in both directions.
+    ///
+    /// <para>The counts are the assertion: <b>1</b> send carrying <b>4</b> recipients, of whom
+    /// <b>3</b> can see each other and <b>1</b> cannot be seen. On the old surface the same mail was
+    /// 4 sends carrying 1 recipient each, with 0 able to see anyone — see
+    /// <see cref="TheOldPerRecipientShape_SplitsOneMailIntoFour"/>.</para>
+    /// </summary>
+    [Fact]
+    public async Task AMessageWithCcAndBcc_IsDeliveredAsOneMessage()
+    {
+        var sent = await Mesh.SendEmail(BusinessMail())
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        sent.Should().BeTrue();
+
+        var envelopes = envelopeSender.Sent;
+        Output.WriteLine($"sends: {envelopes.Count}");
+        foreach (var envelope in envelopes)
+            Output.WriteLine(
+                $"  to=[{string.Join(", ", envelope.To)}] cc=[{string.Join(", ", envelope.Cc)}] "
+                + $"bcc=[{string.Join(", ", envelope.Bcc)}]");
+
+        envelopes.Should().HaveCount(1,
+            "a message with copied recipients IS one message; sending it once per recipient "
+            + "delivers a different mail than the one the sender approved");
+
+        var only = envelopes[0];
+        only.AllRecipients.Should().HaveCount(4);
+
+        // Where they SHOULD see each other.
+        only.VisibleRecipients.Should().Equal([Primary, CopiedOne, CopiedTwo],
+            "To and Cc are the visible header — that mutual visibility is the whole point of a Cc, "
+            + "and it is precisely what N separate mails cannot express");
+
+        // Where they should NOT.
+        only.VisibleRecipients.Should().NotContain(Blind,
+            "a blind-copied recipient appearing on the visible header is the disclosure Bcc exists "
+            + "to prevent");
+        only.Bcc.Should().Equal([Blind]);
+    }
+
+    /// <summary>
+    /// The defect, measured on the surface that produced it. Four recipients through the
+    /// single-address surface become FOUR mails, and each one's visible header names exactly one
+    /// person — so no recipient learns that any other received it, and Reply-All reaches nobody.
+    ///
+    /// <para>This is not a regression test for the fix; it is the CONTROL that gives the numbers in
+    /// <see cref="AMessageWithCcAndBcc_IsDeliveredAsOneMessage"/> their meaning. It stays green,
+    /// because a single-address sender still behaves this way — which is why the contract now
+    /// refuses to route a copied message into it.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheOldPerRecipientShape_SplitsOneMailIntoFour()
+    {
+        var recorder = new SingleAddressRecordingSender();
+        IEmailSender legacy = recorder;
+        var everyone = new[] { Primary, CopiedOne, CopiedTwo, Blind };
+
+        // Verbatim the shape SendDocumentDispatch.SendToAll used.
+        var results = await everyone.ToObservable()
+            .SelectMany(to => legacy.SendEmail(to, "Q3 review deck", "<p>Attached.</p>"))
+            .ToList()
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        results.Should().HaveCount(4);
+        recorder.Sent.Should().HaveCount(4,
+            "one mail per recipient — four messages where the sender composed one");
+
+        foreach (var (to, _, _) in recorder.Sent)
+            Output.WriteLine($"  separate mail to {to}");
+
+        foreach (var address in everyone)
+            recorder.Sent.Should().Contain(s => s.To == address,
+                "each recipient got their OWN mail — that is the four-way split #3473 names");
+
+        recorder.Sent.Should().OnlyContain(s => everyone.Contains(s.To),
+            "each mail's visible header names ONE address, so no recipient can see any other, "
+            + "and Bcc has no expressible form here at all");
+    }
+
+    // ── Refusing, never dropping ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 A sender that cannot carry copied recipients REFUSES the message; it does not quietly
+    /// deliver a smaller one.
+    ///
+    /// <para>Two assertions. The fault is the first — the caller who asked for a Cc learns it did
+    /// not happen. Zero recorded sends is the second, and it is the one that discriminates: relax
+    /// the default to "forward the To and drop the rest" and this records one send whose Cc has
+    /// silently vanished, which is the same class of defect as stamping an undelivered mail
+    /// <c>Sent</c> (#2023).</para>
+    /// </summary>
+    [Fact]
+    public async Task ASingleAddressSender_RefusesCopiedRecipients_RatherThanDroppingThem()
+    {
+        var recorder = new SingleAddressRecordingSender();
+        IEmailSender legacy = recorder;
+
+        var notification = await legacy.SendEmail(BusinessMail()).Materialize()
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"refusal: {notification.Kind}: {notification.Exception?.Message}");
+
+        notification.Kind.Should().Be(NotificationKind.OnError,
+            "a Cc that cannot be honoured is a refusal, not a smaller success");
+        notification.Exception.Should().BeOfType<NotSupportedException>();
+        notification.Exception!.Message.Should().Contain("Cc: 2");
+        notification.Exception!.Message.Should().Contain("Bcc: 1",
+            "the refusal names what could not be carried, so an operator can act on it");
+
+        recorder.Sent.Should().BeEmpty(
+            "NOTHING may go out — a mail delivered to fewer people than the sender addressed is "
+            + "the silent data loss this refusal exists to prevent");
+    }
+
+    /// <summary>
+    /// The additive proof: a message that FITS a single-address sender still reaches one, through
+    /// the legacy overload, with its delivery identity intact. Without this the refusal above could
+    /// "pass" by refusing everything and breaking every existing caller.
+    /// </summary>
+    [Fact]
+    public async Task ASingleRecipientMessage_StillReachesAnOldSender()
+    {
+        var recorder = new SingleAddressRecordingSender();
+        IEmailSender legacy = recorder;
+        var identity = EmailDelivery.AsSharedMailboxReplyingTo("author@example.com");
+
+        var sent = await legacy.SendEmail(new EmailMessage
+        {
+            To = [Primary],
+            Subject = "One recipient",
+            HtmlBody = "<p>Hi.</p>",
+            Delivery = identity,
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        sent.Should().BeTrue();
+        recorder.Sent.Should().HaveCount(1);
+        recorder.Sent[0].To.Should().Be(Primary);
+        recorder.Sent[0].Delivery.ReplyToAddress.Should().Be("author@example.com",
+            "the sender identity travels with the message, not beside it");
+    }
+
+    /// <summary>A message nobody would receive is refused rather than reported as sent.</summary>
+    [Fact]
+    public async Task AMessageWithNoRecipients_IsRefused()
+    {
+        var recorder = new SingleAddressRecordingSender();
+        IEmailSender legacy = recorder;
+
+        var notification = await legacy
+            .SendEmail(new EmailMessage { Subject = "Nobody", HtmlBody = "<p/>" })
+            .Materialize().Should().Within(TestTimeouts.Convergence).Emit();
+
+        notification.Kind.Should().Be(NotificationKind.OnError);
+        notification.Exception!.Message.Should().Contain("no recipients");
+        recorder.Sent.Should().BeEmpty();
+    }
+
+    // ── The no-op sender carries the whole envelope ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The host's <see cref="NoOpEmailSender"/> ACCEPTS copied recipients when mail is switched off.
+    /// It delivers nothing to anybody and says so, so there is no smaller message for it to deliver
+    /// silently — and refusing here would break every local-dev and test send that carries a Cc,
+    /// while protecting a delivery that is not happening either way.
+    /// </summary>
+    [Fact]
+    public async Task TheNoOpSender_AcceptsCopiedRecipients_WhenMailIsOff()
+    {
+        var noOp = new NoOpEmailSender(new EmailOptions { Enabled = false });
+
+        var sent = await noOp.SendEmail(BusinessMail())
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        sent.Should().BeTrue("mail is off; nothing is claimed to have been delivered to anyone");
+    }
+
+    /// <summary>
+    /// …and still REFUSES the whole envelope on a misconfigured install (#2023), rather than
+    /// stamping a four-recipient mail delivered while nothing left the process.
+    /// </summary>
+    [Fact]
+    public async Task TheNoOpSender_RefusesTheWholeEnvelope_WhenMailClaimsToBeOn()
+    {
+        var noOp = new NoOpEmailSender(new EmailOptions { Enabled = true });
+
+        var notification = await noOp.SendEmail(BusinessMail()).Materialize()
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        notification.Kind.Should().Be(NotificationKind.OnError,
+            "a mail-enabled install with nothing to send with must fail visibly, copies included");
+    }
+
+    // ── The envelope's own rules ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Visible recipients are To then Cc, de-duplicated case-insensitively — and never Bcc.
+    /// Pinned separately because this is the property a UI renders as "who will see this".
+    /// </summary>
+    [Fact]
+    public void VisibleRecipients_AreToThenCc_DeduplicatedAndNeverBlind()
+    {
+        var message = new EmailMessage
+        {
+            To = [Primary, "CLIENT@example.com"],
+            Cc = [CopiedOne],
+            Bcc = [Blind],
+            Subject = "s",
+            HtmlBody = "b",
+        };
+
+        message.VisibleRecipients.Should().Equal([Primary, CopiedOne]);
+        message.AllRecipients.Should().Equal([Primary, CopiedOne, Blind]);
+        message.HasCopiedRecipients.Should().BeTrue();
+        message.FitsASingleAddressSender.Should().BeFalse();
+    }
+
+    /// <summary>The simple case is still simple, and still fits every sender ever written.</summary>
+    [Fact]
+    public void AddressedTo_OneRecipient_FitsASingleAddressSender()
+    {
+        var message = EmailMessage.Addressed(Primary, "s", "b");
+
+        message.FitsASingleAddressSender.Should().BeTrue();
+        message.HasCopiedRecipients.Should().BeFalse();
+        message.VisibleRecipients.Should().Equal([Primary]);
+    }
+
+    // ── Senders ──────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Records the whole envelope of every send — a real sender, not a mock.</summary>
+    private sealed class EnvelopeRecordingSender : IEmailSender
+    {
+        private readonly ConcurrentQueue<EmailMessage> sent = new();
+
+        public IReadOnlyList<EmailMessage> Sent => [.. sent];
+
+        public IObservable<bool> SendEmail(EmailMessage message)
+        {
+            sent.Enqueue(message);
+            return Observable.Return(true);
+        }
+
+        public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+            => SendEmail(EmailMessage.Addressed(toAddress, subject, htmlBody));
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody,
+            IReadOnlyCollection<EmailAttachment> attachments)
+            => SendEmail(EmailMessage.Addressed(toAddress, subject, htmlBody) with
+            {
+                Attachments = attachments,
+            });
+    }
+
+    /// <summary>
+    /// A sender written against the PRE-#3473 contract: one address per send, no envelope member.
+    /// The absence of <c>SendEmail(EmailMessage)</c> is the assertion — it is what makes the
+    /// interface's default refusal the thing under test.
+    /// </summary>
+    private sealed class SingleAddressRecordingSender : IEmailSender
+    {
+        private readonly ConcurrentQueue<(string To, string Subject, EmailDelivery Delivery)> sent = new();
+
+        public IReadOnlyList<(string To, string Subject, EmailDelivery Delivery)> Sent => [.. sent];
+
+        public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+            => SendEmail(toAddress, subject, htmlBody, [], EmailDelivery.AsSharedMailbox);
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody,
+            IReadOnlyCollection<EmailAttachment> attachments)
+            => SendEmail(toAddress, subject, htmlBody, attachments, EmailDelivery.AsSharedMailbox);
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody,
+            IReadOnlyCollection<EmailAttachment> attachments, EmailDelivery delivery)
+        {
+            sent.Enqueue((toAddress, subject, delivery));
+            return Observable.Return(true);
+        }
+    }
+}

--- a/test/Memex.Portal.Shared.Test/EmailSendAsCapabilityTest.cs
+++ b/test/Memex.Portal.Shared.Test/EmailSendAsCapabilityTest.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;                  // TestTimeouts.Convergence
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #3450, on a real monolith mesh: <c>IEmailSender.CanSendAsUser</c> had TWO answers for THREE
+/// states of the world, and the send dialog rendered the missing one as a lie.
+///
+/// <para><b>What the user saw.</b> The Share ⇒ as email dialog probes "can I send as this person?"
+/// when it OPENS. On <c>false</c> it renders <c>ui.sendDocument.connectFirst</c> — <i>"Your
+/// Microsoft 365 mailbox is not connected yet"</i> — beside a Connect button. Both consumers wrapped
+/// the probe in <c>.Catch(_ =&gt; Observable.Return(false))</c>, so a probe that TIMED OUT or FAULTED
+/// arrived as the same <c>false</c> as a probe that completed and found no credential. A connected
+/// user was told, in a sentence, that they had not connected — and nothing was logged, so the state
+/// was not even greppable. This is #3433 one layer down, on the mail seam.</para>
+///
+/// <para><b>What the fix is.</b> <see cref="IEmailSender.ObserveSendAsCapability"/> answers with
+/// three states, and the RENDERING RULE lives on the answer:
+/// <see cref="EmailSendAsCapability.OffersConnect"/> is true for
+/// <see cref="EmailSendAs.Unavailable"/> alone. A consumer cannot re-derive the collapse by writing
+/// <c>!IsAvailable</c>, because that expression is not what the UI asks.</para>
+///
+/// <para><b>The positive control that must pass BOTH ways.</b>
+/// <see cref="AnUndeterminedProbe_StillFoldsToFalse_SoTheSendPathAsksWhichMailbox"/>. The SEND path
+/// is a binary decision — send as the person, or ask which mailbox — and folding an unknown to
+/// <c>false</c> there is CORRECT: the user is asked rather than assumed. That half was never the
+/// bug and must not move. If a "fix" makes it pass, the fix broke the send path.</para>
+/// </summary>
+public class EmailSendAsCapabilityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string User = "send-as-user-object-id";
+
+    /// <summary>
+    /// The sender this test's mesh resolves. One instance per test (the base builds a mesh per
+    /// test), scripted before the probe runs — a real <see cref="IEmailSender"/> the container
+    /// hands out, not a mock of a core interface.
+    /// </summary>
+    private readonly ScriptedEmailSender sender = new();
+
+    /// <summary>Captures what the framework LOGGED, so "greppable" is asserted rather than assumed.</summary>
+    private readonly CapturingLoggerProvider logs = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services
+                .AddSingleton<IEmailSender>(sender)
+                .AddLogging(l => l.AddProvider(logs)));
+
+    // ── The three states, and what each one lets the dialog claim ─────────────────────────────────
+
+    /// <summary>
+    /// A connected user. The positive control for everything below: without it a "fix" that
+    /// answered <see cref="EmailSendAs.Undetermined"/> to everything would pass the defect test and
+    /// strand every genuinely connected user behind a "we could not check" panel.
+    /// </summary>
+    [Fact]
+    public async Task AConnectedUser_IsAvailable_AndTheDialogClaimsNothingAboutConnecting()
+    {
+        sender.Answer = _ => Observable.Return(EmailSendAsCapability.Available);
+
+        var capability = await Mesh.ObserveSendAsCapability(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"connected verdict: {capability}");
+        capability.IsAvailable.Should().BeTrue();
+        capability.OffersConnect.Should().BeFalse(
+            "a connected user must never be shown a Connect panel");
+    }
+
+    /// <summary>
+    /// A user who genuinely never connected. This is the ONE state in which
+    /// <c>ui.sendDocument.connectFirst</c> is a true sentence, and the fix must keep offering it —
+    /// otherwise it trades a false claim for a missing affordance.
+    /// </summary>
+    [Fact]
+    public async Task AUserWhoNeverConnected_IsUnavailable_AndTheDialogOffersConnect()
+    {
+        sender.Answer = _ => Observable.Return(
+            EmailSendAsCapability.Unavailable("no stored delegated credential for this user"));
+
+        var capability = await Mesh.ObserveSendAsCapability(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"never-connected verdict: {capability}");
+        capability.OffersConnect.Should().BeTrue(
+            "a completed check with a negative answer is exactly when the Connect offer is truthful");
+        capability.IsUndetermined.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 THE DEFECT, pinned. The probe FAULTS — the shape both consumers swallowed with
+    /// <c>.Catch(_ =&gt; Observable.Return(false))</c>.
+    ///
+    /// <para>Three assertions, deliberately separate. The first says what the failed probe IS
+    /// (<see cref="EmailSendAs.Undetermined"/>); the second says what the dialog may therefore NOT
+    /// claim; the third says the reason survived, so the state is greppable rather than merely
+    /// modelled. On the old code the answer was <c>false</c> at both consumers, which
+    /// <see cref="EmailSendAsCapability.OffersConnect"/> would have rendered as the Connect panel —
+    /// so the second assertion is the one that names the user-visible defect.</para>
+    /// </summary>
+    [Fact]
+    public async Task AProbeThatFaults_IsUndetermined_AndTheDialogDoesNotClaimNotConnected()
+    {
+        sender.Answer = _ => Observable.Throw<EmailSendAsCapability>(
+            new TimeoutException("the credential read did not answer within its budget"));
+
+        var capability = await Mesh.ObserveSendAsCapability(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"faulted-probe verdict: {capability}");
+
+        capability.IsUndetermined.Should().BeTrue(
+            "a probe that faulted produced NO answer about this user's mailbox");
+        capability.OffersConnect.Should().BeFalse(
+            "rendering 'your Microsoft 365 mailbox is not connected yet' here states as fact "
+            + "something nothing was learned about — that is #3450, and the user it hits is a "
+            + "CONNECTED one");
+        capability.Diagnostic.Should().NotBeNullOrWhiteSpace(
+            "an undetermined state with nothing to say is indistinguishable from the swallow it "
+            + "replaces");
+        capability.Diagnostic!.Should().Contain(nameof(TimeoutException));
+    }
+
+    /// <summary>
+    /// The other way a probe fails to answer: it completes without emitting. A dropped mesh read
+    /// looks exactly like this, and it must not be read as a negative either.
+    /// </summary>
+    [Fact]
+    public async Task AProbeThatNeverAnswers_IsUndetermined()
+    {
+        sender.Answer = _ => Observable.Empty<EmailSendAsCapability>();
+
+        var capability = await Mesh.ObserveSendAsCapability(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"silent-probe verdict: {capability}");
+        capability.IsUndetermined.Should().BeTrue();
+        capability.OffersConnect.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL — this must pass with the fix AND without it.
+    ///
+    /// <para>At SEND time the question really is binary: send as the person, or show
+    /// <c>AskWhichMailbox</c>. Folding an unknown to <c>false</c> there is the RIGHT answer, and the
+    /// code says so — <i>"The send does NOT proceed on an assumption either way."</i> So
+    /// <c>hub.CanSendAsUser</c> still answers <c>false</c> for an undetermined probe, and the user
+    /// is asked which mailbox instead of being assumed connected. A change that made this pass
+    /// would have started sending as a person whose mailbox nobody could confirm.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("faulted")]
+    [InlineData("silent")]
+    [InlineData("unavailable")]
+    public async Task AnUndeterminedProbe_StillFoldsToFalse_SoTheSendPathAsksWhichMailbox(string shape)
+    {
+        sender.Answer = shape switch
+        {
+            "faulted" => _ => Observable.Throw<EmailSendAsCapability>(new TimeoutException("no answer")),
+            "silent" => _ => Observable.Empty<EmailSendAsCapability>(),
+            _ => _ => Observable.Return(EmailSendAsCapability.Unavailable("no credential")),
+        };
+
+        var canSend = await Mesh.CanSendAsUser(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"send-time fold for '{shape}': {canSend}");
+        canSend.Should().BeFalse(
+            "the send path asks which mailbox unless it KNOWS it can send as the person — an "
+            + "unknown must never become a silent send from someone else's identity");
+    }
+
+    /// <summary>The other half of the fold: a known-available probe still sends as the person.</summary>
+    [Fact]
+    public async Task AnAvailableProbe_FoldsToTrue_SoTheSendGoesOutAsThePerson()
+    {
+        sender.Answer = _ => Observable.Return(EmailSendAsCapability.Available);
+
+        var canSend = await Mesh.CanSendAsUser(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        canSend.Should().BeTrue(
+            "without this the fold could 'pass' the control above by answering false to everything");
+    }
+
+    // ── The fault is now greppable ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// #3433 added the Warning that names the user and the diagnostic; #3450's collapse had no log
+    /// line at all, which is why nobody could tell how often it fired. Pinned here so the routing
+    /// cannot silently become a swallow again: a fault must be REPORTED as well as modelled.
+    /// </summary>
+    [Fact]
+    public async Task AFaultedProbe_IsLoggedAtWarning_NamingTheUser()
+    {
+        sender.Answer = _ => Observable.Throw<EmailSendAsCapability>(
+            new InvalidOperationException("graph transport refused the credential read"));
+
+        await Mesh.ObserveSendAsCapability(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        var warnings = logs.Entries(LogLevel.Warning);
+        foreach (var line in warnings)
+            Output.WriteLine($"warning: {line}");
+
+        warnings.Should().Contain(line => line.Contains(User, StringComparison.Ordinal),
+            "the fault must name the user it was asked about, or an operator cannot tell whose "
+            + "dialog was affected");
+        warnings.Should().Contain(
+            line => line.Contains("graph transport refused the credential read", StringComparison.Ordinal),
+            "the diagnostic is what makes the third state greppable — it was absent entirely before");
+    }
+
+    // ── Additive: an old two-state sender is unchanged ────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The compatibility proof, and the reason this change needs no cross-repo pair.
+    ///
+    /// <para><see cref="TwoStateSender"/> implements ONLY what <see cref="IEmailSender"/> required
+    /// before this change — the shape of every sender in a repository that pins an older core
+    /// (MeshWeaver.Plugins' <c>GraphEmailSender</c> and its capturing test doubles). It compiles
+    /// untouched, and it answers exactly what it answered before: no third state appears from
+    /// nowhere, and no answer changes.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AnOldTwoStateSender_KeepsItsExactAnswer(bool canSendAsUser)
+    {
+        IEmailSender legacy = new TwoStateSender(canSendAsUser);
+
+        var capability = await legacy.ObserveSendAsCapability(User)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"two-state sender ({canSendAsUser}) verdict: {capability}");
+
+        capability.IsAvailable.Should().Be(canSendAsUser);
+        capability.OffersConnect.Should().Be(!canSendAsUser,
+            "a sender that only speaks yes/no reports its negative as a completed negative — which "
+            + "is what it has always meant, and all it can mean");
+        capability.IsUndetermined.Should().BeFalse(
+            "the new state must not be invented for a sender that cannot observe it");
+    }
+
+    /// <summary>
+    /// A deployment with no sender registered at all cannot send as anybody, and that is a
+    /// COMPLETED check with a negative answer — not an unknown. Pinned because the tempting reading
+    /// ("could not resolve, so we do not know") would show every user on a mail-less deployment a
+    /// permanent "we could not check" panel.
+    /// </summary>
+    [Fact]
+    public void NoSenderRegistered_IsAnAnsweredNegative_NotAnUnknown()
+    {
+        var capability = EmailSendAsCapability.Unavailable("no sender");
+        capability.IsUndetermined.Should().BeFalse();
+        capability.OffersConnect.Should().BeTrue();
+    }
+
+    /// <summary>An unknown with nothing to say is refused at construction, not merely discouraged.</summary>
+    [Fact]
+    public void AnUnknownWithNoDiagnostic_IsRefused()
+        => Assert.Throws<ArgumentException>(() => EmailSendAsCapability.Unknown("   "));
+
+    // ── Senders ──────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A real <see cref="IEmailSender"/> whose three-state probe is scripted per test. It sends
+    /// nothing — every test here is about the PROBE, and a sender that delivered would only add a
+    /// mailbox this suite must never touch.
+    /// </summary>
+    private sealed class ScriptedEmailSender : IEmailSender
+    {
+        public Func<string, IObservable<EmailSendAsCapability>> Answer { get; set; } =
+            _ => Observable.Return(EmailSendAsCapability.Available);
+
+        public IObservable<EmailSendAsCapability> ObserveSendAsCapability(string userObjectId)
+            => Answer(userObjectId);
+
+        public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+            => Observable.Return(true);
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody,
+            IReadOnlyCollection<EmailAttachment> attachments)
+            => Observable.Return(true);
+    }
+
+    /// <summary>
+    /// A sender written against the PRE-#3450 contract: it knows only
+    /// <see cref="IEmailSender.CanSendAsUser"/>. Deliberately does not mention the new member — that
+    /// absence is the assertion.
+    /// </summary>
+    private sealed class TwoStateSender(bool canSendAsUser) : IEmailSender
+    {
+        public IObservable<bool> CanSendAsUser(string userObjectId)
+            => Observable.Return(canSendAsUser);
+
+        public IObservable<bool> SendEmail(string toAddress, string subject, string htmlBody)
+            => Observable.Return(true);
+
+        public IObservable<bool> SendEmail(
+            string toAddress, string subject, string htmlBody,
+            IReadOnlyCollection<EmailAttachment> attachments)
+            => Observable.Return(true);
+    }
+
+    /// <summary>Records formatted log lines per level — instance state, owned by the test.</summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<(LogLevel Level, string Line)> entries = new();
+
+        public IReadOnlyList<string> Entries(LogLevel level)
+        {
+            var matching = new List<string>();
+            foreach (var (entryLevel, line) in entries)
+                if (entryLevel == level)
+                    matching.Add(line);
+            return matching;
+        }
+
+        public ILogger CreateLogger(string categoryName) => new Sink(entries);
+
+        public void Dispose() { }
+
+        private sealed class Sink(ConcurrentQueue<(LogLevel, string)> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => entries.Enqueue((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/test/Memex.Portal.Shared.Test/EmailSendAsCapabilityTest.cs
+++ b/test/Memex.Portal.Shared.Test/EmailSendAsCapabilityTest.cs
@@ -195,6 +195,41 @@ public class EmailSendAsCapabilityTest(ITestOutputHelper output) : MonolithMeshT
             "without this the fold could 'pass' the control above by answering false to everything");
     }
 
+    /// <summary>
+    /// 🚨 The probe stays LIVE — the hub extension must not truncate it to one answer.
+    ///
+    /// <para>The dialog <c>CombineLatest</c>s this stream into the form it renders, so it is a live
+    /// data-bound view, and <c>.Take(1)</c> on one of those freezes the binding. It is also the
+    /// mechanism the "Check again" affordance needs: a sender that re-probes has to be able to
+    /// replace an <see cref="EmailSendAs.Undetermined"/> answer with a real one <i>in place</i>,
+    /// without the dialog being torn down and rebuilt.</para>
+    ///
+    /// <para>Neither operator in the extension needs a single emission — <c>Catch</c> replaces only
+    /// the tail after a fault, and <c>DefaultIfEmpty</c> fires only on an empty completion — so the
+    /// truncation would buy nothing and cost the retry.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheProbeStaysLive_SoARetryCanReplaceAnUndeterminedAnswerInPlace()
+    {
+        sender.Answer = _ => Observable
+            .Return(EmailSendAsCapability.Unknown("first check did not answer"))
+            .Concat(Observable.Return(EmailSendAsCapability.Available));
+
+        var answers = await Mesh.ObserveSendAsCapability(User)
+            .Take(2).ToList()
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        foreach (var answer in answers)
+            Output.WriteLine($"live probe emitted: {answer}");
+
+        answers.Should().HaveCount(2,
+            "truncating the probe to one answer freezes the dialog's binding and makes 'Check "
+            + "again' unable to replace the panel it is offered on");
+        answers[0].IsUndetermined.Should().BeTrue();
+        answers[1].IsAvailable.Should().BeTrue(
+            "the second answer must reach the view, in place, without a rebuild");
+    }
+
     // ── The fault is now greppable ───────────────────────────────────────────────────────────────
 
     /// <summary>


### PR DESCRIPTION
Two defects on the same interface — `IEmailSender` — fixed as **one coherent contract change**, so
the second does not rebase onto a signature the first moved.

`Pairs-with: none` — measured, not asserted. `scripts/check-type-forwards.py --base HEAD` reports
`removed: []`: this diff removes **0 public types and 0 public members**. Both new members are
default interface methods, so the `Cross-repo pair (public surface)` gate does not fire. See
"Purely additive" below.

---

## (1) #3450 — `CanSendAsUser` had two answers for three states

| world | before | now |
|---|---|---|
| the user connected their mailbox | `true` | `Available` |
| the check completed, no credential | `false` | `Unavailable` |
| **the check did not complete** | **`false`** | **`Undetermined`** |

The send dialog renders `false` at OPEN time as `ui.sendDocument.connectFirst` — *"Your Microsoft 365
mailbox is not connected yet"* — beside a Connect button. On a transient fault that is a
**user-visible statement that is false**, shown to a user who **had** connected. Both consumers
already wrapped the probe in `.Catch(_ => Observable.Return(false))`, so the collapse **predates**
the #3433 reactive seam and nothing was logged — the third state was not even greppable.

**The rendering rule lives on the answer, not in each UI.** `EmailSendAsCapability.OffersConnect` is
true for `Unavailable` **alone** — deliberately *not* `!IsAvailable`, because that expression is the
defect written out. A consumer cannot re-derive it by accident.

`hub.ObserveSendAsCapability(...)` routes a **faulted or silent** probe into `Undetermined` and logs
it at Warning naming the user and the diagnostic — once, where the sender is resolved, instead of
every consumer having to remember. A probe that completes without emitting gets the same state: that
is exactly how a dropped mesh read looks.

🚨 **The send path is deliberately unchanged.** `hub.CanSendAsUser(...)` still folds `Undetermined`
to `false`, so pressing Send still shows `AskWhichMailbox` rather than assuming an identity. That is
the *correct* answer for a genuinely binary decision, and it is the positive control below.

## (2) #3473 — `IEmailSender` had no Cc/Bcc

Every overload took ONE address, so `ExportAndSend` sent one mail per recipient. A To with seven Cc —
the ordinary shape of a business mail — went out as **eight** messages: no recipient could see who
else received it, Reply-All reached only the sender, the thread split eight ways, and **Bcc had no
expressible form at all**.

`EmailMessage` carries `To`/`Cc`/`Bcc`/`Subject`/`HtmlBody`/`Attachments`/`Delivery`;
`IEmailSender.SendEmail(EmailMessage)` sends it as ONE mail. `VisibleRecipients` is To ⧺ Cc and
never Bcc.

🚨 **A sender that cannot carry copies REFUSES, naming the counts — it never delivers a quietly
smaller mail.** Delivering to fewer people than the sender addressed while reporting success is the
same class of defect as stamping an undelivered mail `Sent` (#2023). The one exception is
`NoOpEmailSender`: it delivers nothing to anybody and says so, so it accepts the full envelope and
logs every count — and still refuses outright on a mail-enabled-but-unconfigured install.

---

## Purely additive — and why that is the whole design

Both members are **default interface methods whose defaults point in opposite directions and never
recurse**:

- the interface's `ObserveSendAsCapability` folds `CanSendAsUser`;
- the hub extension `CanSendAsUser` folds `ObserveSendAsCapability`.

So an **old sender** (overriding only `CanSendAsUser` — the shape of every implementation in a repo
pinning an older core) compiles untouched and answers exactly what it answered before, in two states.
A **new sender** overriding only the three-state member is folded correctly at every consumer.

This is what makes **shape 8** (an added interface member breaking external *implementers*)
inapplicable: a DIM has a body, so nothing is stranded. Every implementer found is listed in the
report. `CanSendAsUser` is kept as the two-state shim and is deliberately **not** `[Obsolete]`, for
the reason spelled out on `IEaGraphAuth`'s retiring surface — MeshWeaver.Plugins builds
`-warnaserror` against a core checkout at a pinned ref, and the attribute would red that repo before
its own half could land.

`CS0419` (shape 3) checked in **both** repos: no unqualified `<see cref>` to any member that gained
an overload. One *was* caught locally, inside `Mesh.Contract`, and fixed.

## Falsification — both arms, with numbers

Real monolith mesh (`MonolithMeshTestBase`), no mocking of core interfaces, no `Task.Delay`, no
`.ToTask()`.

**Arm 1 (#3450)** — restore the old `.Catch(… => Unavailable)` swallow:

```
Failed: 2, Passed: 11, Total: 13
  ✗ AProbeThatFaults_IsUndetermined_AndTheDialogDoesNotClaimNotConnected
      Expected value to be true because a probe that faulted produced NO answer
      about this user's mailbox, but found False.
  ✗ AProbeThatNeverAnswers_IsUndetermined
  ✓ AnUndeterminedProbe_StillFoldsToFalse_SoTheSendPathAsksWhichMailbox  (×3)  ← passes BOTH ways
```

**Arm 2 (#3473)** — make the default silently forward the first address and drop the rest:

```
Failed: 2, Passed: 7, Total: 9
  ✗ ASingleAddressSender_RefusesCopiedRecipients_RatherThanDroppingThem
      Expected value to be OnError because a Cc that cannot be honoured is a
      refusal, not a smaller success, but found OnNext.
  ✗ AMessageWithNoRecipients_IsRefused  (IndexOutOfRange — the drop shape cannot even express it)
  ✓ AMessageWithCcAndBcc_IsDeliveredAsOneMessage                              ← positive control
```

**Restored:** 22 new tests green; **54/54** across every email suite in the project
(`EmailSendAsCapabilityTest`, `EmailCopiedRecipientsTest`, `NoOpEmailSenderRefusalTest`,
`EmailMisconfigurationRefusalTest`, `InvitationEmailTest`, `OutboundSendQueueTest`) — the last four
pre-existing, proving no regression to the senders already shipping.

The Cc/Bcc numbers, stated as counts: **1** send carrying **4** recipients, **3** mutually visible,
**1** blind — against **4** sends carrying **1** each, **0** able to see anyone, which
`TheOldPerRecipientShape_SplitsOneMailIntoFour` measures as the control.

## Builds (`-c Release -warnaserror`, one project per invocation)

`MeshWeaver.Mesh.Contract` · `MeshWeaver.Messaging.Hub` · `MeshWeaver.Graph` ·
`Memex.Portal.Shared` · `Memex.Portal.Shared.Test` · `MeshWeaver.Documentation.Test` ·
`MeshWeaver.Messaging.Hub.Test` — all `0 Warning(s), 0 Error(s)`.

Guards run: `DocumentationLinkIntegrityTest` ✓ · `HubReachableAsyncGuard` ✓ (nothing added returns
`Task`/`ValueTask`) · `LocalizationTest` 58/58 ✓.

## 🚧 What is NOT in this PR, and why

**The user-visible half of both issues lives in `MeshWeaver.Plugins`**, which builds `-warnaserror`
against a core checkout at `MW_PLATFORM_REF` (`bbcb22f2`). It cannot compile until that pin carries
these members, and this session is fenced from moving any platform pin. The order is therefore
**core → pin → Plugins** — exactly the scoping in
https://github.com/Systemorph/MeshWeaver/issues/3450#issuecomment (maintainer, on the issue).

Because the change is additive, landing core alone strands nothing: no signature moved, no
implementer broke, and every consumer keeps its current behaviour until it opts in.

`SendingEmail.md` names the remaining diff **file by file** (`GraphEmailSender`,
`SendDocumentLayoutArea`, `SendDocumentDispatch`) so the next session can execute it without
re-deriving the design. The two localization keys the third panel needs
(`ui.sendDocument.connectUnknown`, `ui.sendDocument.checkAgain`) ship **here**, in `en` and `de`, so
the consumer half adds no catalog entries.

🚨 **i18n mirror handover** — this PR adds 2 catalog keys. After merge:
`npm run sync:i18n -- --ref <merged core sha>` in MeshWeaver.Plugins. The mirror guard compares
against a pinned core commit, so these keys red nothing and leave it silently stale until that runs.

## Docs

`Doc/Architecture/SendingEmail` gains two sections — the three-answer probe (with the table above and
the send-path exception) and Cc/Bcc as one message — plus the remaining-work table. Two What's New
entries, `Category: Fix`.

Refs #3450 · Refs #3473 — deliberately **not** `Closes`: each issue's user-visible half is the
Plugins consumer. Both stay open until that lands.
