### PR TITLE
docs(#3413): a layout area that never renders is silent in every sink — collect the message trace in the shard lane

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1388,8 +1388,21 @@ jobs:
         # outside the test-method window (so the trx never sees them either). This trace answers
         # the question those cannot: was InitializeHubRequest processed, was an UpdateStreamRequest
         # ever posted, was anything deferred. See Doc/Architecture/ReadingCiSignals.
-        if [ -f /tmp/meshweaver-msg-trace.log ]; then
-          cp /tmp/meshweaver-msg-trace.log collected-logs/_meshweaver-msg-trace.log
+        # 🚨 Derive the directory the SAME way the writer does, never a literal. MessageTrace
+        # writes to `Path.Combine(Path.GetTempPath(), "meshweaver-msg-trace.log")`
+        # (MessageService.cs:27, and identically in OrleansRoutingService and RoutingGrain), and on
+        # Unix `GetTempPath()` returns $TMPDIR when it is set and /tmp only when it is not. A
+        # hard-coded /tmp therefore works by the coincidence that GitHub's ubuntu images leave
+        # TMPDIR unset — and the day anything sets it (a container action, a setup step, a
+        # self-hosted runner) this `-f` test answers false, the copy is skipped, and the step stays
+        # GREEN having collected nothing. That is precisely the failure class this whole step exists
+        # to make visible, so it must not be the shape of the collector itself.
+        msg_trace="${TMPDIR:-/tmp}/meshweaver-msg-trace.log"
+        if [ -f "$msg_trace" ]; then
+          cp "$msg_trace" collected-logs/_meshweaver-msg-trace.log
+          echo "collected the per-message trace from $msg_trace"
+        else
+          echo "no per-message trace at $msg_trace (MESHWEAVER_MSG_TRACE is off unless set for the run)"
         fi
         # Native-crash mini dumps (DOTNET_DbgEnableMiniDump) — present only when a
         # test host died on a signal; the exit-marker gate reds the shard, this is

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1374,6 +1374,23 @@ jobs:
         if [ -f /tmp/meshweaver-memory-delta.log ]; then
           cp /tmp/meshweaver-memory-delta.log collected-logs/_meshweaver-memory-delta.log
         fi
+        # Per-MESSAGE trace (MessageTrace, MeshWeaver.Messaging.Hub/MessageService.cs): the
+        # ROUTED / DEFERRED gates=[…] / GATE_FAILED / DROPPED_GATE_STUCK line for every delivery.
+        # OFF unless MESHWEAVER_MSG_TRACE=1 is set for the run, so this copy is a no-op on an
+        # ordinary shard and costs nothing — but when a wedge needs it, flipping ONE env var is
+        # then the whole job, instead of also having to change this workflow first.
+        #
+        # 🚨 It is the instrument the "observable emitted nothing at all" class actually needs, and
+        # it was reachable in node-repo-module-pack.yml and NOT here (#3413): a layout area that
+        # never renders is silent in every other sink, because LayoutAreaHost's two
+        # "delivered nothing" diagnostics carry no exception (so the fault sink's
+        # `exception is not null && level >= Warning` gate refuses them — the #890 shape) and fire
+        # outside the test-method window (so the trx never sees them either). This trace answers
+        # the question those cannot: was InitializeHubRequest processed, was an UpdateStreamRequest
+        # ever posted, was anything deferred. See Doc/Architecture/ReadingCiSignals.
+        if [ -f /tmp/meshweaver-msg-trace.log ]; then
+          cp /tmp/meshweaver-msg-trace.log collected-logs/_meshweaver-msg-trace.log
+        fi
         # Native-crash mini dumps (DOTNET_DbgEnableMiniDump) — present only when a
         # test host died on a signal; the exit-marker gate reds the shard, this is
         # the forensic payload.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -522,11 +522,21 @@ cost four sessions and what leaves #3413 open.
 **The instrument that does answer it** is `MessageTrace`
 (`MeshWeaver.Messaging.Hub/MessageService.cs`): `MESHWEAVER_MSG_TRACE=1` makes every delivery write
 a `ROUTED` / `DEFERRED gates=[…]` / `GATE_FAILED` / `DROPPED_GATE_STUCK` line to
-`$TMPDIR/meshweaver-msg-trace.log` — enough to say whether the sync sub-hub processed its
+`Path.Combine(Path.GetTempPath(), "meshweaver-msg-trace.log")` — enough to say whether the sync
+sub-hub processed its
 `InitializeHubRequest`, whether `PushRenderResult` ever posted an `UpdateStreamRequest`, and whether
 anything was deferred. It is off by default (a lock + file append per message). Both
 `node-repo-module-pack.yml` **and** `dotnet-test.yml` now copy the file into the shard artifact when
 it exists, so turning it on for a run is a one-variable change and needs no workflow edit.
+
+🚨 **Write `Path.GetTempPath()`, never `$TMPDIR`, when you say where it lands.** They coincide on the
+runners today and are not the same thing: on Unix `GetTempPath()` returns `$TMPDIR` *when that is
+set* and `/tmp` when it is not, and on Windows it is `%TEMP%`. The collector derives the directory
+the same way (`"${TMPDIR:-/tmp}"`) rather than hard-coding `/tmp`, because a literal would work by
+the coincidence that GitHub's ubuntu images leave `TMPDIR` unset — and on the day something sets it,
+the `-f` test answers false, the copy is skipped, and the step stays **green having collected
+nothing**. That is the failure class this whole instrument exists to expose, so it must not be the
+shape of the collector.
 
 🚨 **And know which questions the sinks cannot answer.** *Neither* Plugins sink carries a compile
 **success**: `Compile success for …` is `LogInformation`, so the trace log (faults only) never sees

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -506,6 +506,28 @@ that **for a fault the trace log is the sink, and reaching it is a property of t
 level or the wording**. An `ILogger.LogError` about an exception that does not pass the exception is
 invisible there.
 
+🚨 **The same blind spot has a SECOND live instance, and it is the reason "the observable emitted
+nothing at all" is undiagnosable.** `LayoutAreaHost` carries two diagnostics written for exactly the
+wedge where a layout area never delivers a frame — `COMPLETED WITHOUT RENDERING` (`LogError`) and
+`was torn down having never rendered` (`LogWarning`). Both pass **no exception**, so both are
+refused by the trace sink's `exception is not null && logLevel >= Warning` gate, and both fire on a
+pool thread or during teardown, where `outputHelper` is null / `IsInTestMethod()` is false and the
+trx sink is closed too. Measured on the #3413 occurrence (run `34034828870`, shard 5): across all
+**450** trx results and the whole 4,050-line trace, `never rendered` → **0** and
+`COMPLETED WITHOUT` → **0**. In a `HubTestBase` test the disposal one is `LogDebug` regardless — the
+`Hub.IsDisposing` branch (#2679) — and mesh teardown is exactly how such a test disposes its layout
+host. So a layout area that renders nothing is silent in **every** sink, which is what made #1081
+cost four sessions and what leaves #3413 open.
+
+**The instrument that does answer it** is `MessageTrace`
+(`MeshWeaver.Messaging.Hub/MessageService.cs`): `MESHWEAVER_MSG_TRACE=1` makes every delivery write
+a `ROUTED` / `DEFERRED gates=[…]` / `GATE_FAILED` / `DROPPED_GATE_STUCK` line to
+`$TMPDIR/meshweaver-msg-trace.log` — enough to say whether the sync sub-hub processed its
+`InitializeHubRequest`, whether `PushRenderResult` ever posted an `UpdateStreamRequest`, and whether
+anything was deferred. It is off by default (a lock + file append per message). Both
+`node-repo-module-pack.yml` **and** `dotnet-test.yml` now copy the file into the shard artifact when
+it exists, so turning it on for a run is a one-variable change and needs no workflow edit.
+
 🚨 **And know which questions the sinks cannot answer.** *Neither* Plugins sink carries a compile
 **success**: `Compile success for …` is `LogInformation`, so the trace log (faults only) never sees
 it and the post-hoc job log never sees it either unless the test that logged it failed. Core's live


### PR DESCRIPTION
## Why

Investigating #3413 (`EditorTest.TestEditorWithoutResult` timed out at exactly its 10 s budget
having emitted nothing) I could not establish the cause — but I could establish **why the failing
run's artifacts were unable to say anything**, and that turned out to be the #890 defect shape a
second time.

`LayoutAreaHost` carries two diagnostics written for exactly this wedge:

- `COMPLETED WITHOUT RENDERING` (`LogError`)
- `was torn down having never rendered` (`LogWarning`)

Both pass **no exception object**, so the trace sink's documented gate —
`exception is not null && logLevel >= LogLevel.Warning`, in both `XUnitFileOutputHelper.Log` and
`LoggingBuilderExtensions` — refuses them; and both fire on a pool thread or during teardown, where
`outputHelper` is null / `IsInTestMethod()` is false and the trx sink is closed too. In a
`HubTestBase` test the disposal one is `LogDebug` regardless (the `Hub.IsDisposing` branch, #2679),
and mesh teardown is precisely how such a test disposes its layout host.

**Measured** on the #3413 occurrence (run
[`34034828870`](https://github.com/Systemorph/MeshWeaver/actions/runs/34034828870), shard 5): across
all **450** trx results and the whole **4,050-line** trace, `never rendered` → **0** and
`COMPLETED WITHOUT` → **0**. (`grep FAULT-BUDGET` → 0, so nothing was suppressed — the silence is
real.) A layout area that renders nothing is silent in *every* sink. That is what made #1081 cost
four sessions, and it is what leaves #3413 open.

## What this changes

**1. `dotnet-test.yml` collects the per-message trace.** `MessageTrace`
(`MeshWeaver.Messaging.Hub/MessageService.cs`) writes `ROUTED` / `DEFERRED gates=[…]` /
`GATE_FAILED` / `DROPPED_GATE_STUCK` per delivery to `$TMPDIR/meshweaver-msg-trace.log` when
`MESHWEAVER_MSG_TRACE=1`. That answers the exact three-way question this failure class poses — was
`InitializeHubRequest` processed, was an `UpdateStreamRequest` ever posted, was anything deferred.

`node-repo-module-pack.yml` already copies that file into its artifact (two places);
`dotnet-test.yml` collected only `_meshweaver-test-trace.log` and `_meshweaver-memory-delta.log`.
This closes that asymmetry, so turning the trace on for a run is a **one-variable** change instead
of a variable *plus* a workflow edit. The variable stays OFF by default (a lock + file append per
message), so the copy is a **no-op on every ordinary run**.

**2. `ReadingCiSignals.md` records the second instance.** That page already carries the #890 lesson
— *"for a fault the trace log is the sink, and reaching it is a property of the CALL, not of the
level or the wording"* — with a "know which questions the sinks cannot answer" section. This adds
the `LayoutAreaHost` instance beside it with the measurement, plus where the message trace is now
collected, so the next session checks rather than rediscovers.

## What this deliberately does NOT do

- **It does not fix #3413** — hence `Refs`, not `Closes`. The cause is still not established; the
  exclusions and the refutation of the standing hypothesis are recorded in
  [this comment](https://github.com/Systemorph/MeshWeaver/issues/3413#issuecomment-5562611015).
- **It does not touch the render path.** Making `LayoutAreaHost`'s diagnostics reach the sink (and
  say *which stage* the pipeline reached) is the right follow-up, but it changes the render path of
  every area in the platform and deserves its own issue and review — not a drive-by on a flake
  investigation.
- No test was re-run, no budget widened, no retry/delay/spin added, no assertion relaxed, nothing
  added to `.github/known-flakes.json` (still `"entries": []`).

## Verification

| check | result |
|---|---|
| `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` | **`0 Warning(s)`, `0 Error(s)`**, 14.5 s (real compile, not a no-op) |
| `DocumentationLinkIntegrityTest` | **`Passed! - Failed: 0, Passed: 1`**, `.trx` written |
| `check-workflow-timeouts.py` | 68 jobs checked, **0 violations** |
| `check-workflow-shell.py` | 0 live findings |
| `check-shared-rules.py` | exit 0 |
| YAML parse of `dotnet-test.yml` | OK, 12 jobs |

No `public` type or member is removed from `src/` — `Pairs-with: none — the diff touches only a
workflow and a documentation page; no compiled surface changes.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
