### PR TITLE
feat(#3353): the OCI mirror caches what it fetches — read-through, by digest

### DIFF
--- a/src/MeshWeaver.ContainerImages/CachedContentResult.cs
+++ b/src/MeshWeaver.ContainerImages/CachedContentResult.cs
@@ -1,0 +1,75 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// Serves a resident cache entry: the bytes the mirror already fetched, streamed from disk to the
+/// caller WITHOUT contacting the upstream at all.
+///
+/// <para>That last clause is the whole availability claim. A pull whose every digest is resident
+/// completes with the upstream unreachable, because nothing on this path talks to it.</para>
+///
+/// <para>🚨 Bounded and unbuffered for the same reasons as
+/// <see cref="UpstreamPassthroughResult"/>: the copy runs through the <c>Blob</c> pool, holding
+/// one slot for the whole transfer, and never materialises the entry. A cache hit on a 300 MB
+/// layer must be no more dangerous to the portal than a miss.</para>
+///
+/// <para><c>Docker-Content-Digest</c> is the entry's KEY, and the entry was verified against it
+/// when stored — so unlike a proxied response, this header cannot disagree with the bytes.</para>
+/// </summary>
+/// <param name="entry">The open entry; this result owns its disposal.</param>
+/// <param name="pool">The pool bounding the transfer, or null for an unbounded copy.</param>
+/// <param name="headersOnly">True for a HEAD request: the headers are the answer, and the body is
+/// deliberately not read off disk.</param>
+public sealed class CachedContentResult(
+    ContainerCacheEntry entry, IIoPool? pool, bool headersOnly) : IResult
+{
+    /// <summary>Media type used when the entry carries no recorded one — a layer, which every OCI
+    /// client treats as opaque bytes.</summary>
+    public const string DefaultMediaType = "application/octet-stream";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        await using (entry.Content)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status200OK;
+            httpContext.Response.Headers["Content-Type"] = entry.MediaType ?? DefaultMediaType;
+            httpContext.Response.Headers["Content-Length"] = entry.Length.ToString();
+            httpContext.Response.Headers["Docker-Content-Digest"] = entry.Digest;
+            httpContext.Response.Headers["Accept-Ranges"] = "bytes";
+            httpContext.Response.Headers[ContainerImageEndpoints.ApiVersionHeader] =
+                ContainerImageEndpoints.ApiVersion;
+
+            if (headersOnly)
+                return;
+
+            if (pool is null)
+            {
+                await entry.Content.CopyToAsync(
+                    httpContext.Response.Body, httpContext.RequestAborted);
+                return;
+            }
+
+            var logger = httpContext.RequestServices.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(CachedContentResult));
+            // 🚨 ObserveCompletion with cancelSource: true — identical reasoning to the upstream
+            // passthrough. The wait owns a bounded resource, so a client that gives up mid-layer
+            // must release the pool permit with it rather than leaving it held for a transfer
+            // nobody is reading.
+            await pool.Invoke(ct => entry.Content.CopyToAsync(httpContext.Response.Body, ct))
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "Container registry mirror: serving {Digest} from the cache faulted after "
+                        + "the request had already been answered", entry.Digest),
+                    cancelSource: true,
+                    httpContext.RequestAborted);
+        }
+    }
+}

--- a/src/MeshWeaver.ContainerImages/ContainerBlobCache.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerBlobCache.cs
@@ -1,0 +1,467 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Security.Cryptography;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// One resident cache entry, opened for reading. The caller OWNS <see cref="Content"/> and must
+/// dispose it — the handle is what keeps the bytes readable while eviction runs, because a sweep
+/// that unlinks the file cannot pull it out from under an open reader.
+/// </summary>
+/// <param name="Content">The entry's bytes, positioned at zero.</param>
+/// <param name="Length">The entry's length in bytes.</param>
+/// <param name="MediaType">The media type the upstream served these bytes with, when one was
+/// recorded. Essential for a manifest — a client parses by it — and absent for a layer.</param>
+/// <param name="Digest">The content digest these bytes were verified against when stored.</param>
+public sealed record ContainerCacheEntry(
+    Stream Content, long Length, string? MediaType, string Digest);
+
+/// <summary>
+/// What one eviction sweep did. Returned so a caller can log it and a test can assert on it,
+/// rather than inferring eviction from a directory listing.
+/// </summary>
+/// <param name="Ran">False when another sweep was already in flight and this one stood down.</param>
+/// <param name="EntriesBefore">Entries resident when the sweep started.</param>
+/// <param name="BytesBefore">Bytes resident when the sweep started.</param>
+/// <param name="Evicted">Entries deleted.</param>
+/// <param name="BytesEvicted">Bytes reclaimed.</param>
+public sealed record ContainerCacheSweep(
+    bool Ran, int EntriesBefore, long BytesBefore, int Evicted, long BytesEvicted);
+
+/// <summary>
+/// The read-through mirror's content-addressed cache: bytes the mirror has already fetched from
+/// the upstream, stored under their DIGEST so a second pull is served without touching the
+/// upstream at all.
+///
+/// <para><b>What is cached: digests, and only digests.</b> A blob route is a digest by
+/// construction (<see cref="RegistryRoute"/> refuses anything else), and a manifest route is
+/// cached only when the reference IS a digest. 🚨 A TAG is deliberately never cached — a tag is
+/// mutable, so a cached tag would serve yesterday's image forever and the bug would look like a
+/// stale build rather than a stale cache. Because every key is a content hash, an entry can never
+/// go stale: there is no invalidation, no TTL, and no coherence protocol to get wrong. The cost of
+/// that choice is stated plainly: a <c>pull repo:tag</c> always needs the upstream for the
+/// tag → digest step, while a <c>pull repo@sha256:…</c> can be served entirely from cache.</para>
+///
+/// <para>🚨 <b>Every stored entry is VERIFIED against the digest it is filed under</b>, hashed
+/// over the bytes as they stream past. A body that does not hash to its own name is served to the
+/// caller and DISCARDED rather than stored, so the cache cannot be poisoned by a wrong answer
+/// upstream and a resident entry is provably the bytes its digest names. That is what makes
+/// serving one during an upstream outage safe.</para>
+///
+/// <para>🚨 <b>The cache is NOT an archive, and nothing may treat it as one.</b> It is bounded
+/// (<see cref="ContainerImageOptions.CacheMaxBytes"/>) and evicts least-recently-used entries, so
+/// a digest resident today may be gone tomorrow. Its guarantee is one-directional: a hit avoids
+/// the upstream, a miss falls through to it. It can only ever ADD availability, never subtract
+/// it — which is exactly why it is safe to ship before any retention policy exists, and exactly
+/// why it must not be sold as protection against an upstream purge.</para>
+///
+/// <para>🚨 <b>Instance state only.</b> The eviction accounting below is an instance field on a
+/// mesh-scoped singleton, never <c>static</c>: process-wide cache state survives mesh disposal and
+/// bleeds across tests and tenants.</para>
+/// </summary>
+public sealed class ContainerBlobCache
+{
+    /// <summary>The only digest algorithm the cache stores under — the only one it can verify,
+    /// and the only one any registry in the fleet emits. Anything else is not cacheable and falls
+    /// through to the upstream rather than being stored unverified.</summary>
+    public const string SupportedAlgorithm = "sha256";
+
+    /// <summary>Extension of the sidecar holding an entry's media type.</summary>
+    internal const string TypeSuffix = ".type";
+
+    /// <summary>Extension of an in-progress fill. Never readable as an entry.</summary>
+    internal const string TemporarySuffix = ".tmp";
+
+    /// <summary>A temporary file older than this is crash residue and is swept.</summary>
+    private static readonly TimeSpan TemporaryFileLifetime = TimeSpan.FromHours(1);
+
+    private readonly ContainerImageOptions options;
+    private readonly ILogger<ContainerBlobCache> logger;
+    private readonly IIoPool fileSystem;
+    private readonly string? root;
+    private readonly long sweepThreshold;
+
+    // 🚨 Instance fields, never static. `bytesSinceSweep` starts AT the threshold so the very
+    // first store sweeps: without that, a process that restarts more often than it stores an
+    // eighth of the budget would never sweep at all and the directory would grow forever.
+    private long bytesSinceSweep;
+    private int sweepInFlight;
+
+    /// <summary>Creates the cache.</summary>
+    /// <param name="options">The mirror's configuration; <c>CacheDirectory</c> decides whether the
+    /// cache is on at all.</param>
+    /// <param name="services">Resolves the mesh-scoped I/O pool the cache bounds its disk work
+    /// with.</param>
+    /// <param name="logger">Reports evictions, refused fills and degraded reads.</param>
+    public ContainerBlobCache(
+        IOptions<ContainerImageOptions> options,
+        IServiceProvider services,
+        ILogger<ContainerBlobCache> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+        fileSystem = ContainerImagePools.Resolve(services, IoPoolNames.FileSystem);
+        root = string.IsNullOrWhiteSpace(this.options.CacheDirectory)
+            ? null
+            : Path.GetFullPath(this.options.CacheDirectory);
+        sweepThreshold = Math.Max(1024 * 1024, this.options.CacheMaxBytes / 8);
+        bytesSinceSweep = sweepThreshold;
+    }
+
+    /// <summary>True when a cache directory is configured. False means the mirror proxies every
+    /// pull, which is a supported mode and not a degraded one.</summary>
+    public bool IsEnabled => root is not null;
+
+    /// <summary>The resolved cache directory, or null when the cache is off.</summary>
+    public string? Directory => root;
+
+    /// <summary>
+    /// Whether <paramref name="reference"/> is a digest this cache can store — the shape
+    /// <c>sha256:&lt;64 lowercase hex&gt;</c>. Anything else (a tag, another algorithm) is not
+    /// cacheable and is proxied every time.
+    /// </summary>
+    /// <param name="reference">A manifest or blob reference.</param>
+    /// <returns>True when the reference is a storable digest.</returns>
+    public static bool IsSupportedDigest(string? reference)
+    {
+        if (reference is null)
+            return false;
+        var colon = reference.IndexOf(':');
+        if (colon != SupportedAlgorithm.Length
+            || !reference.AsSpan(0, colon).SequenceEqual(SupportedAlgorithm))
+            return false;
+        var hex = reference.AsSpan(colon + 1);
+        if (hex.Length != 64)
+            return false;
+        foreach (var c in hex)
+            if (!char.IsAsciiDigit(c) && c is not (>= 'a' and <= 'f'))
+                return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Opens the entry for <paramref name="digest"/>, or emits null on a miss.
+    ///
+    /// <para>🚨 A disk error is a MISS, not a failure. The upstream is the source of truth, so
+    /// falling through to it is the correct answer to "the cache could not be read" — the fault is
+    /// reported at warning level rather than swallowed, and the caller never sees an error it
+    /// could not act on.</para>
+    ///
+    /// <para>Cold: nothing is opened until subscribed.</para>
+    /// </summary>
+    /// <param name="digest">The content digest to look up.</param>
+    /// <returns>The open entry, or null when it is not resident.</returns>
+    public IObservable<ContainerCacheEntry?> Open(string digest)
+    {
+        if (!TryPaths(digest, out var blobPath, out var typePath))
+            return Observable.Return<ContainerCacheEntry?>(null);
+
+        return fileSystem.InvokeBlocking<ContainerCacheEntry?>(_ =>
+        {
+            try
+            {
+                // FileShare.Delete so a concurrent eviction can unlink the file while this handle
+                // holds it open: the reader keeps reading the bytes it already opened, and the
+                // name simply stops resolving for the next caller.
+                var content = new FileStream(blobPath, new FileStreamOptions
+                {
+                    Mode = FileMode.Open,
+                    Access = FileAccess.Read,
+                    Share = FileShare.Read | FileShare.Delete,
+                    Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                });
+                var mediaType = File.Exists(typePath) ? File.ReadAllText(typePath).Trim() : null;
+                return new ContainerCacheEntry(
+                    content, content.Length,
+                    string.IsNullOrEmpty(mediaType) ? null : mediaType, digest);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            {
+                return null;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning(ex,
+                    "Container registry mirror: the cache entry for {Digest} could not be opened, "
+                    + "so this pull falls through to the upstream. Check {Directory}.",
+                    digest, root);
+                return null;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Marks <paramref name="digest"/> as just used, so eviction sees a genuine LEAST-RECENTLY-USED
+    /// order rather than a least-recently-added one. The last-write timestamp IS the access
+    /// timestamp here — file access times are unreliable (a <c>noatime</c> mount records none), so
+    /// the cache maintains its own.
+    ///
+    /// <para>Cold, and meant to be subscribed OFF the response path: a touch that fails must never
+    /// affect a pull that has already been answered correctly.</para>
+    /// </summary>
+    /// <param name="digest">The digest that was just served from cache.</param>
+    /// <returns>A single unit when the timestamp has been updated.</returns>
+    public IObservable<Unit> Touch(string digest)
+    {
+        if (!TryPaths(digest, out var blobPath, out _))
+            return Observable.Return(Unit.Default);
+
+        return fileSystem.InvokeBlocking(_ =>
+        {
+            if (File.Exists(blobPath))
+                File.SetLastWriteTimeUtc(blobPath, DateTime.UtcNow);
+            return Unit.Default;
+        });
+    }
+
+    /// <summary>
+    /// Begins a streaming fill for <paramref name="digest"/>: a write-only stream that forwards
+    /// every byte to <paramref name="downstream"/> while hashing it and writing it to a temporary
+    /// file, committed only if the hash matches.
+    ///
+    /// <para>Returns null when the cache is off or the digest is not storable — the caller then
+    /// streams straight to the response, which is the pre-cache behaviour exactly.</para>
+    ///
+    /// <para>🚨 No I/O happens here. The temporary file is opened on the FIRST WRITE, inside the
+    /// caller's pool slot, so a response that never produces a body (a HEAD, an error) leaves
+    /// nothing behind and nothing is opened outside the bound that governs the transfer.</para>
+    /// </summary>
+    /// <param name="digest">The digest the bytes must hash to.</param>
+    /// <param name="mediaType">The media type to record alongside, when the upstream declared
+    /// one.</param>
+    /// <param name="downstream">The response body every byte is also written to.</param>
+    /// <returns>The fill, or null when this response is not cacheable.</returns>
+    public ContainerBlobFill? BeginFill(string digest, string? mediaType, Stream downstream)
+        => TryPaths(digest, out var blobPath, out var typePath)
+            ? new ContainerBlobFill(this, digest, mediaType, blobPath, typePath, downstream, logger)
+            : null;
+
+    /// <summary>
+    /// Stores bytes already held in memory — a manifest, which is kilobytes and was read whole in
+    /// order to record its closure. Verified against <paramref name="digest"/> exactly as a
+    /// streamed fill is.
+    ///
+    /// <para>Cold, and meant to be subscribed OFF the response path with an explicit error arm:
+    /// storing is an optimisation and must never fail a pull.</para>
+    /// </summary>
+    /// <param name="digest">The digest the bytes must hash to.</param>
+    /// <param name="mediaType">The media type the upstream served them with.</param>
+    /// <param name="bytes">The body exactly as served.</param>
+    /// <returns>True when the entry was stored, false when it was refused (hash mismatch, or the
+    /// cache is off).</returns>
+    public IObservable<bool> Store(string digest, string? mediaType, byte[] bytes)
+    {
+        if (!TryPaths(digest, out var blobPath, out var typePath))
+            return Observable.Return(false);
+
+        return fileSystem.InvokeBlocking(_ =>
+        {
+            var actual = Format(SHA256.HashData(bytes));
+            if (!string.Equals(actual, digest, StringComparison.Ordinal))
+            {
+                LogDigestMismatch(digest, actual);
+                return false;
+            }
+            var temporary = blobPath + "." + Guid.NewGuid().ToString("N") + TemporarySuffix;
+            System.IO.Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+            File.WriteAllBytes(temporary, bytes);
+            return Publish(temporary, blobPath, typePath, mediaType, bytes.LongLength);
+        });
+    }
+
+    /// <summary>
+    /// Runs one eviction sweep: deletes crash-residue temporaries and orphaned sidecars, then — if
+    /// the directory is over <see cref="ContainerImageOptions.CacheMaxBytes"/> — evicts
+    /// least-recently-used entries until it is back under 90 % of the budget.
+    ///
+    /// <para>🚨 An EXPLICIT sweep always sweeps. Only the automatic one behind a store stands down
+    /// when another is already running — because that one is opportunistic, while a caller who
+    /// asked for a sweep is entitled to have one happen. A sweep that quietly did nothing would be
+    /// indistinguishable from one that found nothing, which is the same shape as a CI gate that
+    /// passes on skipped input.</para>
+    ///
+    /// <para>Concurrent sweeps are safe: deletion is idempotent and each enumeration is its own
+    /// snapshot. Cold.</para>
+    /// </summary>
+    /// <returns>What the sweep did.</returns>
+    public IObservable<ContainerCacheSweep> Sweep()
+        => root is null
+            ? Observable.Return(new ContainerCacheSweep(false, 0, 0, 0, 0))
+            : fileSystem.InvokeBlocking(_ => SweepCore(root, standDownIfBusy: false));
+
+    /// <summary>
+    /// Accounts for a committed entry and triggers a sweep once roughly an eighth of the budget
+    /// has been added since the last one.
+    ///
+    /// <para>The true resident total is measured only INSIDE a sweep, so nothing has to be
+    /// hydrated at startup and nothing drifts in a way that matters: between sweeps the cache
+    /// overshoots the budget by at most that eighth, which is what a budget with hysteresis is
+    /// supposed to do.</para>
+    /// </summary>
+    internal void OnStored(long bytes)
+    {
+        if (Interlocked.Add(ref bytesSinceSweep, Math.Max(0, bytes)) < sweepThreshold)
+            return;
+        Interlocked.Exchange(ref bytesSinceSweep, 0);
+        // Opportunistic, so it stands down behind one already running — unlike the explicit
+        // Sweep() above, which a caller is entitled to have actually happen.
+        fileSystem.InvokeBlocking(_ => SweepCore(root!, standDownIfBusy: true)).Subscribe(
+            report =>
+            {
+                if (report is { Ran: true, Evicted: > 0 })
+                    logger.LogInformation(
+                        "Container registry mirror: evicted {Evicted} cache entr(ies), {Bytes:N0} "
+                        + "bytes, from {Directory} — it held {BytesBefore:N0} of a {Budget:N0} "
+                        + "byte budget.",
+                        report.Evicted, report.BytesEvicted, root, report.BytesBefore,
+                        options.CacheMaxBytes);
+            },
+            ex => logger.LogWarning(ex,
+                "Container registry mirror: the cache eviction sweep over {Directory} failed. "
+                + "Pulls are unaffected; the directory may exceed its {Budget:N0} byte budget "
+                + "until the next sweep.", root, options.CacheMaxBytes));
+    }
+
+    /// <summary>
+    /// Moves a completed temporary into place. The SIDECAR is written first: a reader that finds
+    /// the blob must be able to find its media type, and the blob's arrival is what makes the
+    /// entry visible.
+    /// </summary>
+    internal bool Publish(
+        string temporary, string blobPath, string typePath, string? mediaType, long size)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(mediaType))
+                File.WriteAllText(typePath, mediaType);
+            // overwrite: false — a concurrent fill of the same digest may have won the race. Its
+            // bytes are ours by definition (both were verified against the same hash), so losing
+            // the race is a success, not a conflict.
+            File.Move(temporary, blobPath, overwrite: false);
+        }
+        catch (IOException) when (File.Exists(blobPath))
+        {
+            Delete(temporary);
+            return true;
+        }
+        OnStored(size);
+        return true;
+    }
+
+    /// <summary>Deletes a path, tolerating one that is already gone.</summary>
+    internal static void Delete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // A file another process holds open. The next sweep will pick it up; there is nothing
+            // useful to do here and nothing that a pull depends on.
+        }
+    }
+
+    /// <summary>Reports a body that did not hash to the digest it was requested under.</summary>
+    internal void LogDigestMismatch(string requested, string actual) =>
+        logger.LogWarning(
+            "Container registry mirror: the body served for {Requested} hashes to {Actual}, so it "
+            + "was passed to the caller but NOT stored. A cache entry is only ever the bytes its "
+            + "digest names.", requested, actual);
+
+    /// <summary>The canonical spelling of a digest over raw hash bytes.</summary>
+    internal static string Format(byte[] hash) =>
+        SupportedAlgorithm + ":" + Convert.ToHexString(hash).ToLowerInvariant();
+
+    /// <summary>
+    /// The on-disk paths for a digest, or false when the cache is off or the digest is not
+    /// storable. Sharded on the first two hex characters so one directory never holds a hundred
+    /// thousand entries.
+    /// </summary>
+    private bool TryPaths(string digest, out string blobPath, out string typePath)
+    {
+        blobPath = string.Empty;
+        typePath = string.Empty;
+        if (root is null || !IsSupportedDigest(digest))
+            return false;
+        var hex = digest[(SupportedAlgorithm.Length + 1)..];
+        blobPath = Path.Combine(root, SupportedAlgorithm, hex[..2], hex);
+        typePath = blobPath + TypeSuffix;
+        return true;
+    }
+
+    private ContainerCacheSweep SweepCore(string directory, bool standDownIfBusy)
+    {
+        // Not a gate and not a wait — nothing ever parks here. The flag only lets the OPPORTUNISTIC
+        // sweep behind a store skip work another sweep is already doing; two concurrent sweeps are
+        // harmless (deletion is idempotent, each enumeration is its own snapshot), so an explicit
+        // sweep never stands down.
+        var idle = Interlocked.CompareExchange(ref sweepInFlight, 1, 0) == 0;
+        if (!idle && standDownIfBusy)
+            return new ContainerCacheSweep(false, 0, 0, 0, 0);
+        try
+        {
+            if (!System.IO.Directory.Exists(directory))
+                return new ContainerCacheSweep(true, 0, 0, 0, 0);
+
+            var entries = new List<(string Path, long Size, DateTime Touched)>();
+            var total = 0L;
+            var cutoff = DateTime.UtcNow - TemporaryFileLifetime;
+
+            foreach (var path in System.IO.Directory.EnumerateFiles(
+                         directory, "*", SearchOption.AllDirectories))
+            {
+                var info = new FileInfo(path);
+                if (path.EndsWith(TemporarySuffix, StringComparison.Ordinal))
+                {
+                    // Crash residue: a fill that never committed. Anything younger may still be
+                    // in flight.
+                    if (info.LastWriteTimeUtc < cutoff)
+                        Delete(path);
+                    continue;
+                }
+                if (path.EndsWith(TypeSuffix, StringComparison.Ordinal))
+                {
+                    // An orphan sidecar — its blob was evicted, or a fill failed between the two
+                    // writes. Harmless, but it would otherwise accumulate forever.
+                    if (!File.Exists(path[..^TypeSuffix.Length]))
+                        Delete(path);
+                    continue;
+                }
+                entries.Add((path, info.Length, info.LastWriteTimeUtc));
+                total += info.Length;
+            }
+
+            var before = total;
+            var evicted = 0;
+            var reclaimed = 0L;
+            if (total > options.CacheMaxBytes)
+            {
+                // 90 % rather than exactly the budget, so the next store does not immediately
+                // trip another sweep.
+                var target = (long)(options.CacheMaxBytes * 0.9);
+                foreach (var entry in entries.OrderBy(e => e.Touched))
+                {
+                    if (total <= target)
+                        break;
+                    Delete(entry.Path);
+                    Delete(entry.Path + TypeSuffix);
+                    total -= entry.Size;
+                    reclaimed += entry.Size;
+                    evicted++;
+                }
+            }
+
+            return new ContainerCacheSweep(true, entries.Count, before, evicted, reclaimed);
+        }
+        finally
+        {
+            if (idle)
+                Interlocked.Exchange(ref sweepInFlight, 0);
+        }
+    }
+}

--- a/src/MeshWeaver.ContainerImages/ContainerBlobFill.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerBlobFill.cs
@@ -1,0 +1,285 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// A write-only stream that TEES an upstream body: every byte goes to the caller's response AND to
+/// a temporary file, hashed on the way past, committed to the cache only if the finished hash
+/// equals the digest the entry is filed under.
+///
+/// <para>🚨 <b>Nothing is buffered.</b> This is the same single pass the mirror already made from
+/// the upstream socket to the client — the fill adds one write per chunk and one hash update, and
+/// never holds more than the copy's own chunk. A layer is hundreds of megabytes and must never
+/// land on the heap.</para>
+///
+/// <para>🚨 <b>Nothing here is bounded separately either.</b> The whole fill — the lazy open, every
+/// write, the flush and the move — happens INSIDE the <c>Blob</c> pool slot that
+/// <see cref="UpstreamPassthroughResult"/> already holds for the transfer. Re-entering a second
+/// pool from inside a slot this code already holds is the nested-gate deadlock
+/// <see cref="MeshWeaver.Mesh.Threading.IoPoolNames"/> warns about; riding the existing slot is
+/// both correct and the tighter bound, since the disk write cannot outlive the transfer that
+/// drives it.</para>
+///
+/// <para>🚨 <b>The fill can never fail the pull.</b> If the temporary cannot be opened or written,
+/// the fill DEGRADES: it stops caching, reports once at warning level, and keeps forwarding every
+/// byte downstream. The mirror's contract is to serve the right bytes; the cache is an
+/// optimisation on top of that and is not allowed to endanger it.</para>
+///
+/// <para>🚨 <b>An abandoned fill stores nothing.</b> A client that disconnects mid-layer, an
+/// upstream that dies, an assertion that throws — all leave the temporary file, which
+/// <see cref="DisposeAsync"/> deletes. And even if one somehow survived, the hash check would
+/// refuse it: a partial body cannot hash to the whole body's digest. Two independent reasons a
+/// truncated layer can never become a cache entry.</para>
+/// </summary>
+public sealed class ContainerBlobFill : Stream
+{
+    private readonly ContainerBlobCache owner;
+    private readonly string digest;
+    private readonly string? mediaType;
+    private readonly string blobPath;
+    private readonly string typePath;
+    private readonly string temporaryPath;
+    private readonly Stream downstream;
+    private readonly ILogger logger;
+    private readonly IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+    private FileStream? file;
+    private bool degraded;
+    private bool committed;
+    private long written;
+
+    internal ContainerBlobFill(
+        ContainerBlobCache owner,
+        string digest,
+        string? mediaType,
+        string blobPath,
+        string typePath,
+        Stream downstream,
+        ILogger logger)
+    {
+        this.owner = owner;
+        this.digest = digest;
+        this.mediaType = mediaType;
+        this.blobPath = blobPath;
+        this.typePath = typePath;
+        this.downstream = downstream;
+        this.logger = logger;
+        temporaryPath = blobPath + "." + Guid.NewGuid().ToString("N")
+                        + ContainerBlobCache.TemporarySuffix;
+    }
+
+    /// <summary>True once the bytes have been verified and filed. Read after
+    /// <see cref="CommitAsync"/>.</summary>
+    public bool Committed => committed;
+
+    /// <summary>Bytes forwarded so far.</summary>
+    public long BytesWritten => written;
+
+    /// <inheritdoc />
+    public override bool CanRead => false;
+
+    /// <inheritdoc />
+    public override bool CanSeek => false;
+
+    /// <inheritdoc />
+    public override bool CanWrite => true;
+
+    /// <inheritdoc />
+    public override long Length => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => written;
+        set => throw new NotSupportedException();
+    }
+
+    /// <inheritdoc />
+    public override void Flush() => downstream.Flush();
+
+    /// <inheritdoc />
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+        downstream.FlushAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    /// <summary>
+    /// The synchronous write, implemented synchronously.
+    ///
+    /// <para>🚨 NOT a block on <see cref="WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>.
+    /// Bridging the sync override onto the async one would be sync-over-async on whatever thread
+    /// happened to call it — the shape this repo bans outright — for no gain, since the work
+    /// underneath is a pair of stream writes either way.</para>
+    /// </summary>
+    /// <param name="buffer">The bytes to forward.</param>
+    /// <param name="offset">Offset into <paramref name="buffer"/>.</param>
+    /// <param name="count">How many bytes to forward.</param>
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        var span = buffer.AsSpan(offset, count);
+        downstream.Write(span);
+        written += count;
+
+        if (degraded)
+            return;
+        if (file is null && !TryOpen())
+            return;
+
+        try
+        {
+            file!.Write(span);
+            hash.AppendData(span);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Degrade(ex, "writing");
+        }
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        // 🚨 DOWNSTREAM FIRST, always. The caller's bytes are the contract; the cache copy is the
+        // by-product. Writing the file first would put a disk stall in front of every byte the
+        // client is waiting for.
+        await downstream.WriteAsync(buffer, cancellationToken);
+        written += buffer.Length;
+
+        if (degraded)
+            return;
+        if (file is null && !TryOpen())
+            return;
+
+        try
+        {
+            await file!.WriteAsync(buffer, cancellationToken);
+            hash.AppendData(buffer.Span);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Degrade(ex, "writing");
+        }
+    }
+
+    /// <inheritdoc />
+    public override Task WriteAsync(
+        byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    /// <summary>
+    /// Finishes the fill: flushes, hashes, and files the entry under its digest — or discards it.
+    ///
+    /// <para>🚨 It NEVER throws. By the time this runs the caller already has every byte, so a
+    /// failure here is about the cache alone and there is nothing left to fail: it is reported and
+    /// the temporary is deleted.</para>
+    /// </summary>
+    /// <param name="cancellationToken">Cancels the flush.</param>
+    /// <returns>True when the entry was stored.</returns>
+    public async Task<bool> CommitAsync(CancellationToken cancellationToken)
+    {
+        if (file is null || degraded)
+            return false;
+        try
+        {
+            await file.FlushAsync(cancellationToken);
+            await file.DisposeAsync();
+            file = null;
+
+            var actual = ContainerBlobCache.Format(hash.GetHashAndReset());
+            if (!string.Equals(actual, digest, StringComparison.Ordinal))
+            {
+                owner.LogDigestMismatch(digest, actual);
+                ContainerBlobCache.Delete(temporaryPath);
+                return false;
+            }
+
+            committed = owner.Publish(temporaryPath, blobPath, typePath, mediaType, written);
+            return committed;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+                                       or OperationCanceledException)
+        {
+            Degrade(ex, "committing");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        if (file is not null)
+        {
+            await file.DisposeAsync();
+            file = null;
+        }
+        hash.Dispose();
+        // An uncommitted fill leaves nothing behind — an aborted pull must not litter the cache
+        // directory with partial layers. NEVER disposes `downstream`: the response body belongs to
+        // the request, not to this stream.
+        if (!committed)
+            ContainerBlobCache.Delete(temporaryPath);
+        await base.DisposeAsync();
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+        file?.Dispose();
+        file = null;
+        hash.Dispose();
+        if (!committed)
+            ContainerBlobCache.Delete(temporaryPath);
+    }
+
+    private bool TryOpen()
+    {
+        try
+        {
+            System.IO.Directory.CreateDirectory(Path.GetDirectoryName(blobPath)!);
+            file = new FileStream(temporaryPath, new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+            });
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Degrade(ex, "opening");
+            return false;
+        }
+    }
+
+    private void Degrade(Exception ex, string phase)
+    {
+        degraded = true;
+        try
+        {
+            file?.Dispose();
+        }
+        catch (IOException)
+        {
+            // Already broken; the delete below is what matters.
+        }
+        file = null;
+        ContainerBlobCache.Delete(temporaryPath);
+        logger.LogWarning(ex,
+            "Container registry mirror: the cache fill for {Digest} failed while {Phase} its "
+            + "temporary file. The pull is unaffected and continues streaming from the upstream; "
+            + "this image simply is not cached.", digest, phase);
+    }
+}

--- a/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
@@ -56,10 +56,23 @@ public static class ContainerImageEndpoints
     /// </summary>
     public const int TokenLifetimeSeconds = 300;
 
+    /// <summary>
+    /// Names where the bytes came from, on every pull response: <c>hit</c> (the read-through
+    /// cache, upstream not contacted), <c>miss</c> (fetched from the upstream and stored),
+    /// <c>bypass</c> (fetched and deliberately not stored — a tag, a range, an unsupported digest
+    /// algorithm) or <c>disabled</c> (no cache is configured).
+    ///
+    /// <para>Diagnostic, not contractual: an operator reading a log or a header can tell which of
+    /// the four happened without inferring it from timings.</para>
+    /// </summary>
+    public const string CacheStatusHeader = "X-MeshWeaver-Cache";
+
     /// <summary>Set by the auth gate so handlers can name the caller in logs and records.</summary>
     private const string CallerItemKey = "ContainerImages.Caller";
 
     private const string ManifestsKind = "manifests";
+
+    private const string BlobsKind = "blobs";
 
     /// <summary>
     /// Maps the pull surface. <c>AllowAnonymous</c> at the ASP.NET layer for the same reason the
@@ -70,6 +83,20 @@ public static class ContainerImageEndpoints
     /// <returns>The route builder, for chaining.</returns>
     public static IEndpointRouteBuilder MapContainerImages(this IEndpointRouteBuilder endpoints)
     {
+        // 🚨 A cache directory configured with no ContainerBlobCache registered would proxy every
+        // pull while the configuration says it caches — a silently half-configured service, which
+        // this file refuses everywhere else. Fail at STARTUP, naming the fix, rather than serving
+        // something that looks right.
+        var configured = endpoints.ServiceProvider
+            .GetService<IOptions<ContainerImageOptions>>()?.Value;
+        if (configured?.CacheDirectory is { Length: > 0 }
+            && endpoints.ServiceProvider.GetService<ContainerBlobCache>() is null)
+            throw new InvalidOperationException(
+                $"{ContainerImageOptions.SectionName}:CacheDirectory is set but "
+                + $"{nameof(ContainerBlobCache)} is not registered. Call "
+                + $"services.{nameof(ContainerImageServiceExtensions.AddContainerImageMirror)}() "
+                + "so the read-through cache actually exists, or clear the setting.");
+
         // 🚨 The token endpoint sits OUTSIDE the challenge filter, in its own group over the same
         // prefix. The filter answers "not authenticated" with a challenge that NAMES this route —
         // so putting this route behind it makes an unauthenticated client loop: challenge → token
@@ -109,15 +136,24 @@ public static class ContainerImageEndpoints
 
         // The spec's version probe. A client hits this first and reads the challenge from it, so
         // it must answer 200 (authenticated) or 401-with-challenge — never 404.
-        group.MapGet("/", (HttpContext http) =>
+        group.MapMethods("/", PullMethods, (HttpContext http) =>
         {
             http.Response.Headers[ApiVersionHeader] = ApiVersion;
             return Results.Ok(new { });
         });
 
-        group.MapGet("/{**rest}", (HttpContext http, CancellationToken ct) => Serve(http, ct));
+        group.MapMethods(
+            "/{**rest}", PullMethods, (HttpContext http, CancellationToken ct) => Serve(http, ct));
         return endpoints;
     }
+
+    /// <summary>
+    /// The two methods a PULL uses. <c>HEAD</c> is how containerd checks a manifest before it
+    /// downloads one, and a registry that answers 405 to it makes every such client take the slow
+    /// fallback path. Nothing else is mapped: this is a pull surface, and <c>PUT</c>/<c>PATCH</c>/
+    /// <c>POST</c>/<c>DELETE</c> are refused by never existing rather than by being handled.
+    /// </summary>
+    private static readonly string[] PullMethods = ["GET", "HEAD"];
 
     /// <summary>
     /// Resolves the caller through <see cref="IContainerImageAuthenticator"/>, normalising the
@@ -238,7 +274,8 @@ public static class ContainerImageEndpoints
             return Results.NotFound();
 
         // 🚨 The allowlist is the difference between a mirror and an open read proxy for the whole
-        // upstream. Empty means NONE.
+        // upstream. Empty means NONE — and it is checked BEFORE the cache, so a repository the
+        // mirror does not serve is refused whether or not its bytes happen to be resident.
         var options = http.RequestServices.GetRequiredService<IOptions<ContainerImageOptions>>().Value;
         if (!options.Repositories.Contains(route.Repository, StringComparer.Ordinal))
         {
@@ -248,12 +285,76 @@ public static class ContainerImageEndpoints
             return Results.NotFound();
         }
 
+        // 🚨 The bound on the layer transfer. IoPoolNames.Blob, not Http: `Http` is capped at 16
+        // for short API round-trips, and one 300 MB layer parked in that pool for a minute would
+        // starve every plugin-catalog and registration call the portal makes. `Blob` IS the
+        // large-async-binary resource class (cap 128), which is exactly what a layer transfer is.
+        var pool = ContainerImagePools.Resolve(http.RequestServices, IoPoolNames.Blob);
+        var cache = http.RequestServices.GetService<ContainerBlobCache>();
+        var isHead = HttpMethods.IsHead(http.Request.Method);
+        var range = http.Request.Headers.Range.ToString();
+
+        // 🚨 Only a DIGEST is a cache key. A tag is mutable — caching one would serve a stale
+        // image forever, and the symptom would look like a stale build rather than a stale cache.
+        // A RANGE request is excluded too: a partial body cannot be verified against the whole
+        // body's digest, and an unverified entry is worse than no entry.
+        var key = route.Kind is ManifestsKind or BlobsKind
+                  && ContainerBlobCache.IsSupportedDigest(route.Reference)
+            ? route.Reference
+            : null;
+        var cacheable = cache is { IsEnabled: true } && key is not null
+                        && string.IsNullOrEmpty(range);
+
+        if (cacheable)
+        {
+            var hit = await cache!.Open(key!)
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "Container registry mirror: the cache lookup for {Path} faulted after the "
+                        + "request had already been answered", http.Request.Path),
+                    ct);
+            if (hit is not null)
+            {
+                // Off the response path, with an explicit error arm: LRU bookkeeping must never be
+                // able to fail a pull that has already been answered correctly.
+                cache.Touch(key!).Subscribe(
+                    _ => { },
+                    ex => logger?.LogWarning(ex,
+                        "Container registry mirror: could not refresh the cache timestamp for "
+                        + "{Digest}; eviction order for this entry may be stale.", key));
+                logger?.LogDebug(
+                    "Container registry mirror: served {Digest} from the cache — the upstream was "
+                    + "not contacted.", key);
+                http.Response.Headers[CacheStatusHeader] = "hit";
+                return new CachedContentResult(hit, pool, isHead);
+            }
+        }
+
+        http.Response.Headers[CacheStatusHeader] =
+            cache is not { IsEnabled: true } ? "disabled" : cacheable ? "miss" : "bypass";
+
         HttpResponseMessage upstream;
         try
         {
             upstream = await client.OpenAsync(
-                HttpMethod.Get, route.Repository, "/v2/" + rest,
-                http.Request.Headers.Range.ToString(), ct);
+                isHead ? HttpMethod.Head : HttpMethod.Get, route.Repository, "/v2/" + rest,
+                range, ct);
+        }
+        catch (UpstreamUnreachableException ex)
+        {
+            // 🚨 504, and emphatically NOT 404. "I could not fetch it" and "it does not exist" are
+            // different answers, and a consumer that cannot tell them apart writes off an artefact
+            // that is still there — or retries one that is genuinely gone. The cache could not
+            // help here: nothing matching was resident, which is why we tried the upstream at all.
+            logger?.LogWarning(ex,
+                "Container registry mirror: {Path} could not be fetched — the upstream is "
+                + "unreachable. Answering 504 (unavailable), never 404 (absent).",
+                http.Request.Path);
+            return UpstreamError(
+                http, StatusCodes.Status504GatewayTimeout, "UPSTREAM_UNAVAILABLE",
+                "the upstream registry could not be reached; this is not a statement about "
+                + "whether the requested content exists");
         }
         catch (UpstreamRegistryException ex)
         {
@@ -261,18 +362,19 @@ public static class ContainerImageEndpoints
             // tell the caller to fix ITS token, which is not the broken thing.
             logger?.LogWarning("Container registry mirror: upstream refused {Path} — {Reason}",
                 http.Request.Path, ex.Message);
-            return Results.StatusCode(StatusCodes.Status502BadGateway);
+            return UpstreamError(
+                http, StatusCodes.Status502BadGateway, "UPSTREAM_UNAUTHORIZED",
+                "the mirror's own upstream credential was refused; the caller's token is not the "
+                + "problem");
         }
 
-        // 🚨 The bound on the layer transfer. IoPoolNames.Blob, not Http: `Http` is capped at 16
-        // for short API round-trips, and one 300 MB layer parked in that pool for a minute would
-        // starve every plugin-catalog and registration call the portal makes. `Blob` IS the
-        // large-async-binary resource class (cap 128), which is exactly what a layer transfer is.
-        var pool = http.RequestServices.GetService<IMessageHub>()?.ServiceProvider
-                       .GetService<IoPoolRegistry>()?.Get(IoPoolNames.Blob)
-                   ?? IoPool.Unbounded;
-
-        if (TryReadManifestForRecording(route, upstream, options, ct, out var manifest))
+        // A manifest is read whole when it must be RECORDED or CACHED — both need the bytes, and
+        // reading once serves both. Bounded by MaxRecordedManifestBytes; a blob never takes this
+        // path under any configuration.
+        var wantsRecord = route.Kind == ManifestsKind && options.ImageRoot is { Length: > 0 };
+        var wantsManifestCache = cacheable && route.Kind == ManifestsKind;
+        if (!isHead && (wantsRecord || wantsManifestCache)
+            && TryReadManifest(upstream, options, ct, out var manifest))
         {
             byte[] body;
             try
@@ -282,43 +384,91 @@ public static class ContainerImageEndpoints
             catch (Exception ex) when (ex is HttpRequestException or IOException)
             {
                 // 🚨 The upstream connection died mid-manifest. Nothing has been written to the
-                // caller yet, so this is a clean 502 — and the response MUST be disposed here:
-                // ownership normally passes to UpstreamPassthroughResult, which is never
-                // constructed on this path, so returning without disposing leaks the connection.
+                // caller yet, so this is a clean 504 — the upstream stopped answering, which is
+                // exactly "unreachable" and must not be reported as absent. And the response MUST
+                // be disposed here: ownership normally passes to UpstreamPassthroughResult, which
+                // is never constructed on this path, so returning without disposing leaks the
+                // connection.
                 upstream.Dispose();
                 logger?.LogWarning(ex,
                     "Container registry mirror: reading the manifest for {Path} failed mid-body",
                     http.Request.Path);
-                return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return UpstreamError(
+                    http, StatusCodes.Status504GatewayTimeout, "UPSTREAM_UNAVAILABLE",
+                    "the upstream registry stopped answering mid-manifest");
             }
 
-            Record(http, client.Upstream, route, body, options.ImageRoot!, logger);
+            if (wantsRecord)
+                Record(http, client.Upstream, route, body, options.ImageRoot!, logger);
+            if (wantsManifestCache)
+                StoreManifest(cache!, key!, upstream, body, route, logger);
             // Serving the bytes we already hold, rather than re-reading a consumed stream.
             return new UpstreamPassthroughResult(upstream, pool, body);
+        }
+
+        // 🚨 A HEAD carries no body, so there is nothing to hash and nothing to store: caching one
+        // would file an empty entry under a real digest, which is the worst outcome this cache can
+        // have. Cacheable BLOB responses tee; everything else is the plain passthrough.
+        if (cacheable && !isHead && route.Kind == BlobsKind && upstream.IsSuccessStatusCode)
+        {
+            var mediaType = upstream.Content.Headers.ContentType?.ToString();
+            return new UpstreamPassthroughResult(
+                upstream, pool, downstream => cache!.BeginFill(key!, mediaType, downstream));
         }
 
         return new UpstreamPassthroughResult(upstream, pool);
     }
 
     /// <summary>
-    /// Whether this response is a MANIFEST small enough to hold in memory in order to record it.
+    /// An OCI-shaped error the mirror ITSELF produces — a failure to reach or use the upstream,
+    /// never a statement about the requested content.
+    /// </summary>
+    private static IResult UpstreamError(HttpContext http, int status, string code, string message)
+    {
+        http.Response.Headers[ApiVersionHeader] = ApiVersion;
+        return Results.Json(
+            new { errors = new[] { new { code, message } } }, statusCode: status);
+    }
+
+    /// <summary>
+    /// Stores a manifest the mirror already holds in memory, off the response path with an
+    /// explicit error arm. A store that fails costs a re-fetch next time and nothing else.
+    /// </summary>
+    private static void StoreManifest(
+        ContainerBlobCache cache, string digest, HttpResponseMessage upstream, byte[] body,
+        RegistryRoute route, ILogger? logger)
+    {
+        if (!upstream.IsSuccessStatusCode)
+            return;
+        cache.Store(digest, upstream.Content.Headers.ContentType?.ToString(), body)
+            .Subscribe(
+                stored => logger?.LogDebug(
+                    "Container registry mirror: manifest {Repository}@{Digest} {Outcome}.",
+                    route.Repository, digest, stored ? "cached" : "was not cached"),
+                ex => logger?.LogWarning(ex,
+                    "Container registry mirror: serving manifest {Repository}@{Digest} succeeded "
+                    + "but caching it failed. The pull is unaffected; the next one re-fetches.",
+                    route.Repository, digest));
+    }
+
+    /// <summary>
+    /// Whether this response is a MANIFEST small enough to hold in memory — for recording its
+    /// closure, for caching it, or both.
     ///
     /// <para>🚨 The size test is on the upstream's declared <c>Content-Length</c>, BEFORE
     /// anything is read — so a body that would not fit is never partially consumed, and streams
-    /// untouched. And it applies to manifests only: a blob is never buffered under any
-    /// configuration, which is the difference between recording an image and OOMing the portal.</para>
+    /// untouched. And the caller only reaches this for manifests: a blob is never buffered under
+    /// any configuration, which is the difference between recording an image and OOMing the
+    /// portal.</para>
     /// </summary>
-    private static bool TryReadManifestForRecording(
-        RegistryRoute route,
+    private static bool TryReadManifest(
         HttpResponseMessage upstream,
         ContainerImageOptions options,
         CancellationToken ct,
         out Task<byte[]> body)
     {
         body = Task.FromResult<byte[]>([]);
-        if (route.Kind != ManifestsKind
-            || !upstream.IsSuccessStatusCode
-            || options.ImageRoot is not { Length: > 0 }
+        if (!upstream.IsSuccessStatusCode
             || upstream.Content.Headers.ContentLength is not { } length
             || length <= 0
             || length > options.MaxRecordedManifestBytes)

--- a/src/MeshWeaver.ContainerImages/ContainerImageOptions.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageOptions.cs
@@ -51,4 +51,30 @@ public sealed class ContainerImageOptions
     /// this is still served, streamed, and simply not recorded.</para>
     /// </summary>
     public int MaxRecordedManifestBytes { get; set; } = 4 * 1024 * 1024;
+
+    /// <summary>
+    /// Directory the read-through cache stores blobs and manifests in, keyed by content digest.
+    ///
+    /// <para>🚨 EMPTY MEANS THE CACHE IS OFF, and the mirror still proxies every pull — exactly
+    /// the behaviour it had before the cache existed. Like <see cref="ImageRoot"/>, turning it on
+    /// or off is a configuration change, never a migration: nothing in the cache is authoritative,
+    /// so discarding the whole directory costs a re-fetch and nothing else.</para>
+    ///
+    /// <para>🚨 The cache is NOT an archive and must never be treated as one. It is bounded by
+    /// <see cref="CacheMaxBytes"/> and evicts least-recently-used entries, so a digest that is
+    /// resident today may not be tomorrow. It can only ever ADD availability — a miss falls
+    /// through to the upstream — never subtract it.</para>
+    /// </summary>
+    public string? CacheDirectory { get; set; }
+
+    /// <summary>
+    /// Byte budget for <see cref="CacheDirectory"/>. A sweep runs after roughly an eighth of this
+    /// has been added and evicts least-recently-used entries until the directory is back under
+    /// 90 % of the budget, so the cache overshoots between sweeps by design rather than thrashing
+    /// on every store.
+    ///
+    /// <para>Default 20 GiB — a handful of portal images and their shared base layers. This is a
+    /// disk budget, not a tuning knob for correctness: every value serves the same bytes.</para>
+    /// </summary>
+    public long CacheMaxBytes { get; set; } = 20L * 1024 * 1024 * 1024;
 }

--- a/src/MeshWeaver.ContainerImages/ContainerImagePools.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImagePools.cs
@@ -1,0 +1,27 @@
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// Resolves the mesh-scoped <see cref="IIoPool"/> the mirror bounds its I/O with. ONE place, so
+/// the endpoint, the cache and the fill cannot disagree about which pool a given leaf belongs to.
+///
+/// <para>The registry lives on the MESH's service provider, not the web host's, so the hub is
+/// asked first; a host that has one registered directly (a test rig) is honoured next; and a host
+/// with neither falls back to <see cref="IoPool.Unbounded"/> — which is never worse than the bare
+/// <c>Task.Run</c> it replaces, and keeps the mirror usable in a rig that has no mesh.</para>
+/// </summary>
+internal static class ContainerImagePools
+{
+    /// <summary>
+    /// The pool named <paramref name="name"/> (see <see cref="IoPoolNames"/>), or
+    /// <see cref="IoPool.Unbounded"/> when no registry is reachable from
+    /// <paramref name="services"/>.
+    /// </summary>
+    public static IIoPool Resolve(IServiceProvider services, string name) =>
+        services.GetService<IMessageHub>()?.ServiceProvider.GetService<IoPoolRegistry>()?.Get(name)
+        ?? services.GetService<IoPoolRegistry>()?.Get(name)
+        ?? IoPool.Unbounded;
+}

--- a/src/MeshWeaver.ContainerImages/ContainerImageServiceExtensions.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageServiceExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.ContainerImages;
+
+/// <summary>
+/// Registers the mirror's own services. The two things a host must still supply itself are the
+/// <see cref="System.Net.Http.HttpClient"/> that reaches the upstream and the
+/// <see cref="IContainerImageAuthenticator"/> that decides who may pull — the first because a
+/// portal configures its own handler pipeline, the second because it is the seam this assembly
+/// deliberately does not implement.
+/// </summary>
+public static class ContainerImageServiceExtensions
+{
+    /// <summary>
+    /// Adds the read-through cache.
+    ///
+    /// <para>🚨 A SINGLETON, and that is load-bearing rather than incidental: the cache's eviction
+    /// accounting is an INSTANCE field on it, so its lifetime must be the mesh's. A scoped or
+    /// transient registration would reset the sweep counter on every request and the directory
+    /// would grow past its budget forever — and a <c>static</c> one would outlive the mesh and
+    /// bleed across tests and tenants, which is the failure this codebase refuses outright.</para>
+    ///
+    /// <para>The cache is inert until <see cref="ContainerImageOptions.CacheDirectory"/> is set,
+    /// so registering it unconditionally costs nothing.</para>
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The collection, for chaining.</returns>
+    public static IServiceCollection AddContainerImageMirror(this IServiceCollection services)
+    {
+        services.AddSingleton<ContainerBlobCache>();
+        return services;
+    }
+}

--- a/src/MeshWeaver.ContainerImages/README.md
+++ b/src/MeshWeaver.ContainerImages/README.md
@@ -15,16 +15,54 @@ registry, and consumers present a registry token.
 
 ## What it serves
 
-| route | |
-|---|---|
-| `GET /v2/` | version probe; answers the bearer challenge when unauthenticated |
-| `GET /v2/token` | the bearer exchange the challenge's `realm` names |
-| `GET /v2/{name}/manifests/{reference}` | tag or digest; multi-arch indexes included |
-| `GET /v2/{name}/blobs/{digest}` | streamed, range-capable, bounded by `IIoPool` |
-| `GET /v2/{name}/tags/list` | |
+| route | methods | |
+|---|---|---|
+| `/v2/` | `GET` `HEAD` | version probe; answers the bearer challenge when unauthenticated |
+| `/v2/token` | `GET` | the bearer exchange the challenge's `realm` names |
+| `/v2/{name}/manifests/{reference}` | `GET` `HEAD` | tag or digest; multi-arch indexes included |
+| `/v2/{name}/blobs/{digest}` | `GET` `HEAD` | streamed, range-capable, bounded by `IIoPool` |
+| `/v2/{name}/tags/list` | `GET` `HEAD` | |
 
 **Pull only.** No push, no upload, no delete — those keep going to the upstream, so this can be
-switched off without a migration. There is **no cache**: every pull reaches the upstream.
+switched off without a migration. Also NOT implemented: `/v2/_catalog`, the referrers API,
+`tags/list` pagination, and serving a `Range` from the cache.
+
+## The read-through cache
+
+With `CacheDirectory` set, a miss fetches from the upstream, serves the bytes and stores them; the
+next pull of that digest is served from disk **without contacting the upstream at all**.
+
+- **Keyed by content digest, only.** A blob always; a manifest only when the reference IS a digest.
+  🚨 A **tag is never cached** — a tag is mutable, so a cached one would serve yesterday's image
+  forever. Every key being a content hash means there is no invalidation, no TTL and no staleness
+  by construction. The price: `pull repo:tag` always needs the upstream for the tag → digest step,
+  while `pull repo@sha256:…` can be served entirely from cache.
+- **Every entry is verified** against the digest it is filed under, hashed as the bytes stream past.
+  A mismatch is served to the caller and discarded, so the cache cannot be poisoned and a resident
+  entry is provably the bytes its digest names.
+- **Nothing negative is cached.** A 404 is never stored: a remembered absence would outlive the push
+  that fixed it.
+- **Eviction** is a least-recently-used sweep against `CacheMaxBytes`. 🚨 **This is a cache, not an
+  archive** — any entry can be evicted, so it must never be treated as protection against an
+  upstream purge. Its guarantee is one-directional: a hit avoids the upstream, a miss falls through
+  to it, so it can only ever ADD availability.
+
+`X-MeshWeaver-Cache` on every pull response reads `hit`, `miss`, `bypass` (not cacheable) or
+`disabled`.
+
+### Four outcomes, kept distinguishable
+
+| situation | answer |
+|---|---|
+| resident in the cache | `200` + bytes, upstream **not** contacted |
+| not resident, upstream has it | `200` + bytes, stored |
+| genuinely absent upstream | `404`, nothing stored |
+| upstream unreachable | `504` `UPSTREAM_UNAVAILABLE` |
+| upstream refused the mirror's OWN credential | `502` `UPSTREAM_UNAUTHORIZED` |
+
+🚨 **404 and 504 are never merged.** A mirror that answered "not found" when it could not reach the
+registry would tell a CI job that a pinned digest had been purged while the truth was a network
+blip.
 
 ### The token exchange
 
@@ -65,13 +103,19 @@ those names live inside a layer tarball and reaching them is a separate incremen
     "Repositories": [ "memex-portal-ai", "mw-plugin-test" ],
     // Where observed images are recorded. The node must already exist.
     // EMPTY MEANS RECORDING IS OFF — the mirror still proxies normally.
-    "ImageRoot": "Platform/Images"
+    "ImageRoot": "Platform/Images",
+    // EMPTY MEANS THE CACHE IS OFF — the mirror proxies every pull, as before.
+    "CacheDirectory": "/var/lib/meshweaver/container-images",
+    "CacheMaxBytes": 21474836480
   }
 }
 ```
 
 The mirror is **off** unless `Upstream`, `Username` and `Password` are all present: every route
-answers 404 rather than serving partially.
+answers 404 rather than serving partially. 🚨 And `CacheDirectory` set without
+`AddContainerImageMirror()` fails at STARTUP naming the fix — a portal whose configuration says it
+caches while it quietly proxies everything is the same half-configured failure this package refuses
+elsewhere.
 
 ## Wiring
 
@@ -80,6 +124,7 @@ services.AddSingleton<IContainerImageAuthenticator, MyAuthenticator>();
 // 🚨 A SINGLETON: the upstream token cache is an INSTANCE field on this client, so a transient
 // registration silently re-fetches a token on every request.
 services.AddSingleton<UpstreamRegistryClient>();
+services.AddContainerImageMirror();  // the read-through cache (a singleton for the same reason)
 services.Configure<ContainerImageOptions>(config.GetSection(ContainerImageOptions.SectionName));
 
 meshBuilder.AddContainerImages();   // the ContainerImage node type (recording half)

--- a/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
+++ b/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
@@ -27,6 +27,7 @@ public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IR
 {
     private readonly IIoPool? pool;
     private readonly byte[]? body;
+    private readonly Func<Stream, ContainerBlobFill?>? fill;
 
     /// <summary>
     /// A passthrough whose body copy is bounded by <paramref name="ioPool"/>, optionally serving
@@ -42,6 +43,27 @@ public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IR
     {
         pool = ioPool;
         body = preRead;
+    }
+
+    /// <summary>
+    /// A passthrough that also FILLS the read-through cache as it streams — the miss half of the
+    /// mirror.
+    ///
+    /// <para>The fill is created from the response body rather than handed in ready-made, so the
+    /// temporary file is opened inside the pool slot that bounds the transfer and never before the
+    /// transfer starts. A null return from <paramref name="cacheFill"/> means "not cacheable", and
+    /// the copy is then exactly the uncached one.</para>
+    /// </summary>
+    /// <param name="upstream">The upstream response; this result owns its disposal.</param>
+    /// <param name="ioPool">The pool bounding the transfer, or null for an unbounded copy.</param>
+    /// <param name="cacheFill">Opens the tee over the response body, or returns null to skip
+    /// caching this response.</param>
+    public UpstreamPassthroughResult(
+        HttpResponseMessage upstream, IIoPool? ioPool, Func<Stream, ContainerBlobFill?> cacheFill)
+        : this(upstream)
+    {
+        pool = ioPool;
+        fill = cacheFill;
     }
 
     /// <summary>Headers an OCI client depends on. <c>Docker-Content-Digest</c> is how a client
@@ -110,6 +132,22 @@ public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IR
     private async Task Copy(HttpContext httpContext, CancellationToken ct)
     {
         await using var source = await upstream.Content.ReadAsStreamAsync(ct);
-        await source.CopyToAsync(httpContext.Response.Body, ct);
+        // 🚨 The tee is opened HERE, inside the pool slot, and only when the response is
+        // cacheable. Everything else is the copy this method has always been.
+        var tee = fill?.Invoke(httpContext.Response.Body);
+        if (tee is null)
+        {
+            await source.CopyToAsync(httpContext.Response.Body, ct);
+            return;
+        }
+
+        await using (tee)
+        {
+            await source.CopyToAsync(tee, ct);
+            // CommitAsync never throws: by now the caller holds every byte, so a cache failure has
+            // nothing left to break. An abort before this line leaves the temporary, which
+            // DisposeAsync removes.
+            await tee.CommitAsync(ct);
+        }
     }
 }

--- a/src/MeshWeaver.ContainerImages/UpstreamRegistryClient.cs
+++ b/src/MeshWeaver.ContainerImages/UpstreamRegistryClient.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -60,7 +61,7 @@ public sealed class UpstreamRegistryClient(
         if (!string.IsNullOrEmpty(range))
             request.Headers.TryAddWithoutValidation("Range", range);
 
-        var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        var response = await Send(request, HttpCompletionOption.ResponseHeadersRead, ct);
 
         // A 401 here means OUR token went stale mid-flight, not that the caller is unauthorised —
         // drop it and try once, so a token expiring between issue and use is invisible rather than
@@ -76,9 +77,46 @@ public sealed class UpstreamRegistryClient(
                 retry.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(media));
             if (!string.IsNullOrEmpty(range))
                 retry.Headers.TryAddWithoutValidation("Range", range);
-            response = await http.SendAsync(retry, HttpCompletionOption.ResponseHeadersRead, ct);
+            response = await Send(retry, HttpCompletionOption.ResponseHeadersRead, ct);
         }
         return response;
+    }
+
+    /// <summary>
+    /// Sends one request, translating a TRANSPORT failure into
+    /// <see cref="UpstreamUnreachableException"/>.
+    ///
+    /// <para>🚨 This is the distinction the whole mirror rests on: <b>"I could not reach the
+    /// upstream" must never be answerable as "this does not exist".</b> Left unhandled, a DNS
+    /// failure or a refused connection escapes as a bare exception and the pull ends in a generic
+    /// 500 — indistinguishable, to a CI job reading a status code, from a registry that has purged
+    /// the digest. One says retry, the other says the artefact is gone; a consumer that confuses
+    /// them acts on a confident wrong answer.</para>
+    ///
+    /// <para>The caller's OWN cancellation is deliberately let through as cancellation: a client
+    /// that hung up is not an unreachable upstream.</para>
+    /// </summary>
+    private async Task<HttpResponseMessage> Send(
+        HttpRequestMessage request, HttpCompletionOption completion, CancellationToken ct)
+    {
+        try
+        {
+            return await http.SendAsync(request, completion, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException
+                                       or SocketException or OperationCanceledException)
+        {
+            logger.LogWarning(ex,
+                "Container registry mirror: the upstream {Upstream} could not be reached for "
+                + "{Path}. This is reported as unreachable, never as not-found.",
+                opts.Upstream, request.RequestUri?.AbsolutePath);
+            throw new UpstreamUnreachableException(
+                $"could not reach the upstream registry {opts.Upstream}", ex);
+        }
     }
 
     /// <summary>Every manifest media type a client may ask for, including the multi-arch
@@ -105,7 +143,7 @@ public sealed class UpstreamRegistryClient(
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
 
-        using var response = await http.SendAsync(request, ct);
+        using var response = await Send(request, HttpCompletionOption.ResponseContentRead, ct);
         if (!response.IsSuccessStatusCode)
         {
             // 🚨 Never log the credential, and never log the body — an upstream token endpoint can
@@ -142,6 +180,21 @@ public sealed class UpstreamRegistryClient(
     }
 }
 
-/// <summary>The upstream registry could not be reached or refused the mirror's own credential.
-/// Distinct from a caller-facing 401, which is about the CALLER's instance key.</summary>
+/// <summary>The upstream registry ANSWERED and refused the mirror's own credential. Distinct from
+/// a caller-facing 401, which is about the CALLER's instance key, and distinct from
+/// <see cref="UpstreamUnreachableException"/>, which is about not getting an answer at all.</summary>
 public sealed class UpstreamRegistryException(string message) : Exception(message);
+
+/// <summary>
+/// The upstream registry could not be reached: DNS, a refused connection, a dropped socket, a
+/// transport timeout.
+///
+/// <para>🚨 Its whole purpose is to stay DISTINCT from "not found". A caller that cannot tell
+/// "the registry is down" from "that digest was purged" will act on the wrong one — retrying a
+/// deletion, or writing off an artefact that is still there. The mirror answers the first with a
+/// 504 and the second with a 404, and never blurs them into a single failure.</para>
+/// </summary>
+/// <param name="message">What could not be reached.</param>
+/// <param name="innerException">The transport failure underneath.</param>
+public sealed class UpstreamUnreachableException(string message, Exception innerException)
+    : Exception(message, innerException);

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
@@ -1,7 +1,7 @@
 ---
 Name: A Container Registry in Memex
 Category: Architecture
-Description: Serving OCI images from the mesh — what it buys us that ACR cannot, the bootstrap circularity that decides the shape, and why the first increment is a read-through mirror rather than a replacement. The pull surface, the bearer handshake and closure-as-data are built; the cache, GC and the /app assembly closure are not.
+Description: Serving OCI images from the mesh — what it buys us that ACR cannot, the bootstrap circularity that decides the shape, and why the first increment is a read-through mirror rather than a replacement. The pull surface, the bearer handshake, closure-as-data and the digest-keyed read-through cache are built; push, GC, pin-protected retention and the /app assembly closure are not.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="9" width="20" height="11" rx="2"/><path d="M6 9V6a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v3"/><line x1="7" y1="14" x2="7" y2="14"/><line x1="11" y1="14" x2="11" y2="14"/><line x1="15" y1="14" x2="15" y2="14"/></svg>
 ---
 
@@ -16,10 +16,12 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 > one-producer FATAL by name; two identical fully-qualified types is `CS0433`; two identical
 > extension signatures is `CS0121`. The config section moved to `ContainerImages:` for the same
 > reason. Renamed in #3361 while nothing referenced it yet — which is the only cheap moment.
-> **Built:** `GET /v2/`, the bearer token exchange at `GET /v2/token`, `…/manifests/{reference}`,
-> `…/blobs/{digest}` (Range included) and `…/tags/list`, proxied to the upstream with the mirror's
-> own credential while the caller authenticates against memex — plus the OCI-level **closure and
-> provenance of every manifest served, recorded as `ContainerImage` nodes**.
+> **Built:** `GET`/`HEAD` on `/v2/`, `…/manifests/{reference}`, `…/blobs/{digest}` (Range included)
+> and `…/tags/list`, plus the bearer token exchange at `GET /v2/token` — proxied to the upstream
+> with the mirror's own credential while the caller authenticates against memex — plus the
+> OCI-level **closure and provenance of every manifest served, recorded as `ContainerImage`
+> nodes**, and the **digest-keyed read-through cache**: a miss fetches, serves and stores; the next
+> pull of that digest is served without the upstream being contacted at all.
 >
 > 🚨 The token exchange arrived one increment LATE, and the gap is worth recording: the first cut
 > emitted a correct-looking `WWW-Authenticate` challenge naming a realm at `/v2/token`, and **nothing
@@ -28,9 +30,10 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 > challenge, token, pull — could see it, which is why `PullSurfaceTest` is written as one
 > conversation rather than per-endpoint assertions.
 >
-> **Not built:** no push, **no cache** (every pull still goes to the upstream), no GC, and no
-> **/app assembly** closure — see "What v1 records" below for exactly where that line falls. The
-> boot image comes from the upstream, permanently. Container images live in Azure Container
+> **Not built:** no push or upload, no `/v2/_catalog`, no referrers API, no delete, no
+> pin-protected retention, and no **/app assembly** closure — see "What v1 records" below for
+> exactly where that line falls, and "The pull surface, exactly" for the endpoint-by-endpoint list.
+> The boot image comes from the upstream, permanently. Container images live in Azure Container
 > Registry (`meshweaver.azurecr.io`), named by `ACR:` in `main-cd.yml` and referenced by eight
 > workflows. This page exists so the decision is a decision rather than a recurring conversation.
 
@@ -156,9 +159,9 @@ entirely in CI and in other installations — exactly where the constraint is si
 ## The shape: a read-through mirror first
 
 ```
-   docker pull ──▶  memex /v2/…  ──▶  blob in mesh storage?
-                         │                 │ hit → stream it
-                         │                 │ miss → fetch from ACR, store, stream
+   docker pull ──▶  memex /v2/…  ──▶  digest in the cache?
+                         │                 │ hit  → stream it from disk, upstream NOT contacted
+                         │                 │ miss → fetch from ACR, verify, store, stream
                          ▼
                     closure + provenance recorded as mesh nodes
 
@@ -169,6 +172,34 @@ entirely in CI and in other installations — exactly where the constraint is si
 Pull-side only, to begin with. Pushes keep going to ACR, so CD is unchanged and the mirror can be
 turned off without a migration. Every benefit above except (4) is available from the pull side
 alone, because they all derive from *reading* manifests and layers.
+
+### The pull surface, exactly
+
+A partial surface that looks complete is worse than an obviously small one, so this is the whole
+list — what answers, and what does not.
+
+| route | methods | v1 |
+|---|---|---|
+| `/v2/` | `GET`, `HEAD` | **served** — the version probe, and where a client reads the challenge |
+| `/v2/token` | `GET` | **served** — the realm the challenge names; `Basic` in, bearer out |
+| `/v2/<name>/manifests/<tag or digest>` | `GET`, `HEAD` | **served**; cached only when the reference is a digest |
+| `/v2/<name>/blobs/<digest>` | `GET`, `HEAD` | **served**, `Range` forwarded; cached on a whole-body `GET` |
+| `/v2/<name>/tags/list` | `GET`, `HEAD` | **served**, never cached |
+
+**Not implemented, deliberately** — each of these simply has no route, so it 404s rather than
+half-working:
+
+* **the entire push family** — `POST`/`PATCH`/`PUT` `blobs/uploads/…`, manifest `PUT`. Refused *by
+  shape*: a blob reference must be a content digest, so `blobs/uploads/` never parses as a pull.
+* **`DELETE`** of anything. The mirror owns no lifecycle.
+* **`/v2/_catalog`** — repository enumeration. The allowlist already says what may be served, and a
+  catalog would be a second, drifting answer to the same question.
+* **the referrers API** (`/v2/<name>/referrers/<digest>`) — signatures and attestations. Nothing in
+  the fleet consumes it through the mirror yet.
+* **pagination on `tags/list`** (`?n=`/`?last=`) — the query string is not forwarded.
+* **serving a `Range` FROM the cache.** A range request bypasses the cache entirely: a partial body
+  cannot be verified against the whole body's digest, and an unverified entry is worse than none.
+  It is proxied, and resumable, but not accelerated.
 
 ### What v1 actually enforces
 
@@ -199,6 +230,79 @@ alone, because they all derive from *reading* manifests and layers.
   the heap; the pool is what stops a hundred concurrent pulls — a rolling restart of a large
   deployment — from each holding a socket and a buffer at once. `Http` (cap 16) would have been
   wrong: one layer parked there for a minute starves every plugin-catalog call the portal makes.
+
+### The cache: what is stored, where, and what evicts it
+
+`ContainerImages:CacheDirectory` turns it on; **empty means off, and the mirror then proxies every
+pull exactly as it did before the cache existed.** Turning it on or off is a configuration change,
+never a migration — nothing in the cache is authoritative, so discarding the whole directory costs
+a re-fetch and nothing else. 🚨 A directory configured with no cache *registered*
+(`services.AddContainerImageMirror()`) fails at STARTUP naming the fix, rather than quietly
+proxying while the configuration claims otherwise.
+
+**Keyed by content digest, and only by content digest.** A blob route is a digest by construction;
+a manifest route is cached only when the reference IS a digest.
+
+🚨 **A tag is never cached.** A tag is mutable, so a cached one would serve yesterday's image
+forever — and the symptom would read as a stale *build* rather than a stale cache. Because every
+key is a content hash, an entry can never go stale: **there is no invalidation, no TTL, and no
+coherence protocol to get wrong.** The price is stated plainly rather than hidden: a `pull
+repo:tag` always needs the upstream for the tag → digest step, while a `pull repo@sha256:…` — which
+is what every pinned CI consumer does — can be served entirely from cache.
+
+**Every entry is verified.** Bytes are hashed as they stream past, and an entry is filed only if the
+finished hash equals the digest it would be filed under. A body that hashes to something else is
+**served to the caller and discarded** — the cache cannot be poisoned by a wrong answer upstream,
+and a resident entry is provably the bytes its digest names. That is what makes serving one during
+an upstream outage safe rather than hopeful. Two independent mechanisms stop a truncated layer
+becoming an entry: the hash cannot match, and an abandoned fill's temporary file is deleted on
+dispose.
+
+**On disk**, sharded `<CacheDirectory>/sha256/<first two hex>/<hex>`, with a one-line `.type`
+sidecar carrying the media type — essential for a manifest, which a client parses by its
+`Content-Type`. A fill writes to a temporary in the same directory and `File.Move`s it into place,
+so a crash leaves a temporary (swept after an hour), never a truncated file that reads as complete.
+
+**Eviction is a bounded LRU sweep.** `ContainerImages:CacheMaxBytes` (default 20 GiB) is the budget;
+a sweep runs after roughly an eighth of it has been added, and evicts least-recently-*used* entries
+until the directory is back under 90 % of the budget. Last-use is tracked by touching the file on a
+hit, because filesystem access times are unreliable (`noatime` records none). An explicit `Sweep()`
+always sweeps; only the automatic one behind a store stands down behind a sweep already running.
+
+🚨 **The cache is NOT an archive, and this design deliberately does not claim it is one.** It is
+bounded, so any entry can be evicted — including one a pinned deployment names. Its guarantee is
+one-directional: **a hit avoids the upstream, a miss falls through to it, so it can only ever ADD
+availability and never subtract it.** That is exactly why it is safe to ship before any retention
+policy exists, and exactly why it must not be sold as protection against an upstream purge (gain
+(5) above). Making it refuse to evict a digest a live `Deployment` node names is a separate,
+later increment — and doing it *before* that would mean a second store that can lose a pinned
+digest while looking like insurance, which is worse than no insurance at all.
+
+**And nothing negative is cached.** A 404 is never stored: a remembered absence would outlive the
+push that fixed it, and the symptom would be an image that "does not exist" long after it does.
+
+#### Four outcomes, and they stay distinguishable
+
+This is the part that has to be right, because the failure mode is a *confident wrong answer*.
+
+| situation | answer | upstream contacted |
+|---|---|---|
+| digest resident in the cache | `200` + the bytes, `X-MeshWeaver-Cache: hit` | **no** |
+| digest not resident, upstream has it | `200` + the bytes, `…: miss`, entry stored | yes |
+| digest genuinely absent upstream | `404`, nothing stored | yes |
+| upstream unreachable, nothing resident | `504` + `UPSTREAM_UNAVAILABLE` | attempted |
+| upstream refused the *mirror's own* credential | `502` + `UPSTREAM_UNAUTHORIZED` | yes |
+
+🚨 **404 and 504 are never merged.** A mirror that answered "not found" when it could not reach the
+registry would tell a CI job that a pinned digest had been purged while the truth was a network
+blip — and after this fleet's own ACR retention incident, that is precisely the wrong answer to
+give confidently. The 504 body says so in words as well as in its code. `502` stays separate again:
+an upstream that *answers* and refuses our credential is an operator's problem, not a network one,
+and telling them apart is the difference between rotating a secret and waiting.
+
+`X-MeshWeaver-Cache` (`hit` / `miss` / `bypass` / `disabled`) is a diagnostic, not a contract — the
+tests assert the upstream's own request counter, because "served from cache" only means anything as
+"the upstream was not asked", and a header cannot prove that.
 
 ### What v1 records, and the line it does not cross
 
@@ -245,10 +349,12 @@ budget of its own.
 
 So acceptance (2) is *"half of it, after one more increment"* — not "done", and not "impossible".
 
-**v1 is the proxy WITHOUT the cache, deliberately.** The credential goal is met by authenticating
-the caller against memex and using the mirror's credential upstream; caching is an optimisation on
-top that can be added without changing the surface. Shipping it first would have meant storage,
-eviction and correctness work before anything was usable.
+**v1 landed in two increments, and the order mattered.** The proxy shipped first: the credential
+goal is met by authenticating the caller against memex and using the mirror's credential upstream,
+and that needed no storage at all. The cache came second, as an optimisation on top of an already
+usable surface rather than storage, eviction and correctness work in front of one. Its surface is
+additive — the routes, the handshake and the recording are unchanged, and turning the cache off
+returns the mirror to exactly the shape the first increment shipped.
 
 **The first consumer to move is satellite CI, not any cluster.** It is where the duplicated
 credentials are, it is unaffected by the bootstrap constraint, and a mirror that is wrong there
@@ -272,11 +378,19 @@ verb list.
   server-side, because anonymous pull is off. What changes is *who* needs one: a viewer authenticates
   to memex and is authorised by `AccessContext`, instead of holding registry credentials. That is the
   access-control gain in (4) — state it that way, not as "no credentials".
-- **Content addressing is a natural fit.** Digests are immutable ids, so layer dedup across
-  repositories is free if blobs are keyed by digest — the mesh is already content-addressed for
-  module builds.
-- **Garbage collection.** Untagged manifests and orphaned layers accumulate. Eviction must be
-  refused for any digest a live deployment names.
+- **Content addressing is a natural fit — and v1 takes it.** Digests are immutable ids, so layer
+  dedup across repositories is free: the cache keyspace is global, not per-repository, and two
+  allowlisted images sharing a base layer share the entry. 🚨 That is safe *because* only bytes
+  fetched through an allowlisted repository ever enter the cache, so a global keyspace grants
+  nothing the allowlist does not already grant. The visible consequence is small and worth writing
+  down: asking repository B for a digest only repository A holds is a cache HIT here where the
+  upstream would 404 — harmless while every allowlisted repository is at the same trust level, and
+  **the thing that must change first if per-repository authorization (gain (4)) is ever added.**
+  The key would then have to carry the repository, at the cost of dedup.
+- **Garbage collection.** Untagged manifests and orphaned layers accumulate. v1 evicts by a
+  least-recently-used byte budget, which bounds the directory but protects nothing. Eviction that
+  is REFUSED for any digest a live deployment names is the separate increment gain (5) describes —
+  and until it exists, the cache is explicitly not a second copy of anything.
 
 ## What would say this is working
 
@@ -288,13 +402,17 @@ Not "images pull". The measurable claims, with where each one actually stands:
 | #3334's gate can be re-expressed as an assertion over that data | **half, and the other half never** — see the mapping above: one-producer becomes data once the layer scan lands; the resolve half RUNS MSBuild and cannot be modelled |
 | a pin bump moves **one** reference instead of six literals | **the data supports it** — a tag is resolved to a digest at a deterministic node path, so a consumer carries the tag. Nothing has been converted to use it yet; `ci.yml` still carries its six literals |
 | an ACR outage still costs us nothing at boot | **yes, structurally** — the boot image never moved, and switching the mirror off is a configuration change |
+| an ACR outage is DISTINGUISHABLE from a purged digest | **yes** — `504 UPSTREAM_UNAVAILABLE` against `404`, never merged, and asserted as one experiment rather than inferred |
+| a pull survives an ACR outage | **only for a resident digest, by digest** — a cache hit never contacts the upstream, so a fully-cached `repo@sha256:…` pull completes. A `repo:tag` pull cannot: the tag → digest step has no immutable key. And nothing is guaranteed resident |
 
-🚨 **And one that is NOT yet measured: pull latency.** The mirror adds a hop, and no number for it
-against a real upstream exists. The streaming and pool behaviour are tested (a client receives the
-first bytes while the upstream is still producing the rest), but that is a correctness property, not
-a latency measurement. Nothing should DEPEND on the mirror until pull latency through it is measured
-against ACR directly — which is also what would settle whether the mirror *improves* pull
-availability, the open question the single-zone measurement above raised.
+🚨 **And one that is STILL not measured: pull latency.** The mirror adds a hop, and no number for it
+against a real upstream exists — the cache changes the shape of that question (a hit is a local disk
+read, a miss is the old hop plus a disk write) without answering it. The streaming and pool
+behaviour are tested (a client receives the first bytes while the upstream is still producing the
+rest), but that is a correctness property, not a latency measurement. Nothing should DEPEND on the
+mirror until pull latency through it is measured against ACR directly — which is also what would
+settle whether the mirror *improves* pull availability, the open question the single-zone
+measurement above raised.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-portal-keeps-a-copy-of-the-images-it-serves.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-portal-keeps-a-copy-of-the-images-it-serves.md
@@ -1,0 +1,55 @@
+---
+Name: Your portal keeps a copy of the images it has already served
+Category: Feature
+Description: Container images pulled through your portal are now kept, so the next pull of the same image is served locally instead of fetched again — and when the upstream registry is unreachable, the portal says so rather than pretending the image is gone.
+Icon: Checkmark
+Order: -20260907
+---
+
+# Your portal keeps a copy of the images it has already served
+
+Your portal could already serve container images, but it fetched every one from the upstream
+registry every time — it passed bytes along without keeping any. Pulling the same image twice cost
+the same download twice, and if the upstream registry was unavailable, so was every image.
+
+## What changes
+
+**The second pull is served from your portal.** An image pulled through it is kept, and the next
+request for the same content is answered locally without contacting the upstream registry at all.
+
+**A kept copy is checked, not assumed.** Container content is named by a fingerprint of its own
+bytes, and the portal verifies that fingerprint before keeping anything. Content that does not
+match what was asked for is passed on to whoever asked, and thrown away rather than kept — so
+anything the portal has kept is provably the right bytes, which is what makes serving it during an
+outage safe rather than hopeful.
+
+**Nothing kept can go stale.** Only content addressed by its fingerprint is kept. A *tag* — a
+moving name like `latest` — is deliberately never kept, because a tag can be pointed at something
+new tomorrow. There is nothing to expire and nothing to refresh: what is kept is either exactly
+right or not there.
+
+## The one that matters most: "I could not reach it" is not "it does not exist"
+
+If the upstream registry cannot be reached, the portal says **exactly that**, distinctly from
+saying the image is not there. Those are two very different pieces of news — one means wait and
+retry, the other means the image is genuinely gone — and a tool that confuses them sends people
+looking for the wrong problem. The portal keeps four answers separate: served from its own copy,
+fetched fresh, genuinely absent, and could-not-reach-the-registry.
+
+## What it does not do
+
+**It is a cache, not an archive, and it is important not to read it as one.** It has a size budget
+and discards the least recently used content when it runs out, so something kept today may not be
+kept tomorrow. Its promise runs one way only: having a copy avoids the fetch, and not having one
+falls back to fetching exactly as before. **It can never make images less available — but it is not
+a backup, and it is not protection against something being deleted upstream.** Refusing to discard
+content that a running deployment depends on is separate work, still to come.
+
+**A pull by moving name still needs the upstream.** Resolving `something:latest` to the exact
+content it currently points at can only be answered by the registry that owns the name. A pull that
+names exact content can be served entirely from the portal's own copy; a pull that names a tag
+cannot.
+
+**Keeping copies is off until an administrator turns it on** by naming a folder and a size budget,
+and turning it off again returns the portal to passing every pull straight through. There is
+nothing to migrate in either direction.

--- a/test/MeshWeaver.ContainerImages.Test/FakeUpstreamRegistry.cs
+++ b/test/MeshWeaver.ContainerImages.Test/FakeUpstreamRegistry.cs
@@ -42,6 +42,48 @@ internal sealed class FakeUpstreamRegistry : HttpMessageHandler
     /// <summary>The blob the mirror streams in the layer tests.</summary>
     public static readonly byte[] LayerBytes = CreateLayer(1024 * 1024);
 
+    /// <summary>
+    /// The digest <see cref="LayerBytes"/> ACTUALLY hashes to.
+    ///
+    /// <para>🚨 It is computed, not written down. The cache verifies every entry against the
+    /// digest it is filed under, so a fixture that served bytes under a made-up digest could never
+    /// exercise a successful fill — and a hard-coded constant that drifted from
+    /// <see cref="CreateLayer"/> would silently turn every caching test into a
+    /// "nothing was stored" test that still passed its status assertions.</para>
+    /// </summary>
+    public static readonly string LayerDigest = Digest(LayerBytes);
+
+    /// <summary>The digest <see cref="ManifestJson"/> hashes to — the reference a pinned pull
+    /// uses, and the only manifest reference this cache will store.</summary>
+    public static readonly string ManifestDigest = Digest(Encoding.UTF8.GetBytes(ManifestJson));
+
+    /// <summary>
+    /// A well-formed digest that names nothing in this registry. The upstream answers 404 for it,
+    /// which is the "this does not exist" outcome the mirror must keep distinct from "I could not
+    /// reach the upstream".
+    /// </summary>
+    public const string MissingDigest =
+        "sha256:dead00000000000000000000000000000000000000000000000000000000beef";
+
+    /// <summary>
+    /// A digest whose bytes DISAGREE with it — the legacy placeholder the older tests pull. Served
+    /// (a mirror forwards what the upstream says), never cached (an entry is only ever the bytes
+    /// its digest names).
+    /// </summary>
+    public const string MismatchedDigest =
+        "sha256:a000000000000000000000000000000000000000000000000000000000000000";
+
+    /// <summary>
+    /// When set, every request fails at the TRANSPORT — the shape of a registry outage, a DNS
+    /// failure or a severed network. Distinct from <see cref="RefuseMirrorCredential"/>, which is
+    /// an upstream that answers and says no.
+    /// </summary>
+    public bool Unreachable;
+
+    private static string Digest(byte[] bytes) =>
+        "sha256:" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes))
+            .ToLowerInvariant();
+
     /// <summary>How many times the mirror asked for an upstream token — the token cache's
     /// observable effect.</summary>
     public int TokenRequests;
@@ -75,6 +117,13 @@ internal sealed class FakeUpstreamRegistry : HttpMessageHandler
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
         Interlocked.Increment(ref Requests);
+        // 🚨 Counted BEFORE the outage check, deliberately: "the mirror did not contact the
+        // upstream" is the assertion the cache tests rest on, and it has to stay observable even
+        // when the upstream would have failed.
+        if (Unreachable)
+            return Task.FromException<HttpResponseMessage>(
+                new HttpRequestException("the upstream registry is unreachable"));
+
         var uri = request.RequestUri!;
         if (!string.Equals(uri.Host, Host, StringComparison.Ordinal))
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
@@ -93,14 +142,19 @@ internal sealed class FakeUpstreamRegistry : HttpMessageHandler
         foreach (var repository in new[] { Repository, UnlistedRepository })
         {
             if (path == $"/v2/{repository}/manifests/ci.7794"
-                || path == $"/v2/{repository}/manifests/latest")
-                return Task.FromResult(Manifest());
+                || path == $"/v2/{repository}/manifests/latest"
+                || path == $"/v2/{repository}/manifests/{ManifestDigest}")
+                return Task.FromResult(Manifest(request));
             if (path == $"/v2/{repository}/tags/list")
                 return Task.FromResult(Json($$"""{"name":"{{repository}}","tags":["ci.7794","latest"]}"""));
-            if (path.StartsWith($"/v2/{repository}/blobs/sha256:", StringComparison.Ordinal))
+            // 🚨 Only the digests this registry actually HOLDS. A fixture that answered every
+            // sha256 path with the same bytes could not tell "does not exist" apart from
+            // "exists" — which is one of the four outcomes under test.
+            if (path == $"/v2/{repository}/blobs/{LayerDigest}"
+                || path == $"/v2/{repository}/blobs/{MismatchedDigest}")
                 return Task.FromResult(Blob(request));
         }
-        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        return Task.FromResult(NotFound());
     }
 
     private HttpResponseMessage Token(HttpRequestMessage request)
@@ -122,18 +176,29 @@ internal sealed class FakeUpstreamRegistry : HttpMessageHandler
         return response;
     }
 
-    private static HttpResponseMessage Manifest()
+    /// <summary>An OCI-shaped 404 — the "this does not exist" answer, as ACR gives it.</summary>
+    private static HttpResponseMessage NotFound() =>
+        new(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(
+                """{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}""",
+                Encoding.UTF8, "application/json"),
+        };
+
+    private static HttpResponseMessage Manifest(HttpRequestMessage request)
     {
         var bytes = Encoding.UTF8.GetBytes(ManifestJson);
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new ByteArrayContent(bytes),
+            // A HEAD carries the headers and no body, exactly as a registry answers one.
+            Content = request.Method == HttpMethod.Head
+                ? new ByteArrayContent([])
+                : new ByteArrayContent(bytes),
         };
         response.Content.Headers.ContentType =
             new MediaTypeHeaderValue("application/vnd.oci.image.manifest.v1+json");
-        response.Headers.TryAddWithoutValidation(
-            "Docker-Content-Digest",
-            "sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        response.Content.Headers.ContentLength = bytes.Length;
+        response.Headers.TryAddWithoutValidation("Docker-Content-Digest", ManifestDigest);
         return response;
     }
 

--- a/test/MeshWeaver.ContainerImages.Test/MirrorCacheTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/MirrorCacheTest.cs
@@ -1,0 +1,630 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.ContainerImages.Test;
+
+/// <summary>
+/// The READ-THROUGH half of the mirror, driven over a real HTTP pipeline against a real in-process
+/// upstream: a pull that misses fetches, serves and caches; the next one is served without the
+/// upstream being contacted at all.
+///
+/// <para>🚨 <b>The load-bearing assertion in almost every test here is
+/// <see cref="FakeUpstreamRegistry.Requests"/>, not a header.</b> "Served from cache" is only
+/// meaningful as "the upstream was not asked", and a counter on the fake registry is the one
+/// observation that cannot be faked by the thing under test. The
+/// <c>X-MeshWeaver-Cache</c> header is asserted alongside it as a diagnostic, never instead of
+/// it.</para>
+///
+/// <para>🚨 <b>Four outcomes, and they must stay distinguishable</b> — served-from-cache,
+/// fetched-and-cached, genuinely-absent, and could-not-fetch. The last two are the pair that
+/// matters: a mirror that answered 404 when it could not reach the upstream would tell a CI job
+/// that a pinned digest had been purged when the network was merely down.
+/// <see cref="TheFourOutcomesAreDistinguishable"/> asserts that as one experiment rather than
+/// leaving it implied by four separate tests.</para>
+/// </summary>
+public class MirrorCacheTest : IDisposable
+{
+    private const string InstanceKey = "mw_instance_key";
+    private const string CallerName = "instance/ci";
+
+    private readonly List<string> temporaryDirectories = [];
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        foreach (var directory in temporaryDirectories)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                    Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A test host that still holds a handle open. The OS temp directory reclaims it.
+            }
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class InstanceKeyAuthenticator : IContainerImageAuthenticator
+    {
+        public IObservable<string?> Authenticate(string? authorizationHeader, CancellationToken ct) =>
+            Observable.Return(
+                RegistryCredential.TryReadSecret(authorizationHeader) == InstanceKey
+                    ? CallerName
+                    : null);
+    }
+
+    private string NewCacheDirectory()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(), "mw-oci-cache-" + Guid.NewGuid().ToString("N"));
+        temporaryDirectories.Add(directory);
+        return directory;
+    }
+
+    private static async Task<WebApplication> BuildMirror(
+        FakeUpstreamRegistry upstream,
+        string? cacheDirectory,
+        long cacheMaxBytes = 20L * 1024 * 1024 * 1024,
+        bool registerCache = true)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddSingleton(Options.Create(new ContainerImageOptions
+        {
+            Upstream = FakeUpstreamRegistry.Host,
+            Username = FakeUpstreamRegistry.Username,
+            Password = FakeUpstreamRegistry.Password,
+            Repositories = [FakeUpstreamRegistry.Repository],
+            CacheDirectory = cacheDirectory,
+            CacheMaxBytes = cacheMaxBytes,
+        }));
+        builder.Services.AddSingleton(_ => new HttpClient(upstream));
+        builder.Services.AddSingleton<UpstreamRegistryClient>();
+        builder.Services.AddSingleton<IContainerImageAuthenticator, InstanceKeyAuthenticator>();
+        if (registerCache)
+            builder.Services.AddContainerImageMirror();
+
+        var app = builder.Build();
+        app.MapContainerImages();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static HttpClient Authenticated(WebApplication app)
+    {
+        var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", InstanceKey);
+        return client;
+    }
+
+    private static string BlobPath(string digest) =>
+        $"/v2/{FakeUpstreamRegistry.Repository}/blobs/{digest}";
+
+    private static string ManifestPath(string reference) =>
+        $"/v2/{FakeUpstreamRegistry.Repository}/manifests/{reference}";
+
+    private static string? CacheStatus(HttpResponseMessage response) =>
+        response.Headers.TryGetValues(ContainerImageEndpoints.CacheStatusHeader, out var values)
+            ? values.Single()
+            : null;
+
+    /// <summary>
+    /// Waits for a fill to land, WITHOUT touching the upstream — the cache is asked directly.
+    ///
+    /// <para>The commit happens on the server as the response body finishes, so a client that has
+    /// read every byte can still be a moment ahead of it. Polling the real API under a bounded
+    /// timeout is the house shape for a request/response-shaped source; a <c>Task.Delay</c> would
+    /// be asserting a duration instead of the condition, and re-pulling in order to observe would
+    /// contaminate the very request counter these tests rest on.</para>
+    /// </summary>
+    private static async Task<bool> Resident(
+        WebApplication app, string digest, bool expected = true)
+    {
+        var cache = app.Services.GetRequiredService<ContainerBlobCache>();
+        var deadline = TimeSpan.FromSeconds(10);
+        if (!expected)
+        {
+            // A negative has no positive signal to wait for — one read is the whole answer, and
+            // by now the response has been fully consumed by the caller.
+            var absent = await cache.Open(digest).FirstAsync()
+                .ObserveCompletion(_ => { }, CancellationToken.None);
+            absent?.Content.Dispose();
+            return absent is not null;
+        }
+
+        var entry = await Observable.Interval(TimeSpan.FromMilliseconds(25))
+            .StartWith(0L)
+            .SelectMany(_ => cache.Open(digest))
+            .Where(e => e is not null)
+            .FirstAsync()
+            .Timeout(deadline)
+            .ObserveCompletion(_ => { }, CancellationToken.None);
+        entry?.Content.Dispose();
+        return entry is not null;
+    }
+
+    // ── the round trip ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE READ-THROUGH ROUND TRIP, end to end: a miss fetches from the upstream, serves the
+    /// bytes and caches them; the next pull is served from the cache and the upstream is NOT
+    /// contacted. The request counter is the proof — a header could say "hit" while a request went
+    /// out anyway.
+    /// </summary>
+    [Fact]
+    public async Task AMissFetchesServesAndCaches_AndTheSecondPullNeverReachesTheUpstream()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        var first = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, await first.Content.ReadAsByteArrayAsync());
+        Assert.Equal("miss", CacheStatus(first));
+        Assert.True(upstream.Requests > 0, "the first pull must reach the upstream");
+
+        Assert.True(
+            await Resident(app, FakeUpstreamRegistry.LayerDigest),
+            "the fill must have committed the blob under its digest");
+
+        var beforeSecond = upstream.Requests;
+        var second = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, await second.Content.ReadAsByteArrayAsync());
+        Assert.Equal("hit", CacheStatus(second));
+        // The whole point, stated as the assertion: nothing left the portal.
+        Assert.Equal(beforeSecond, upstream.Requests);
+        // A cache hit still names the digest a client verifies against — and here it CANNOT be
+        // wrong, because the entry was checked against it before being stored.
+        Assert.Equal(
+            FakeUpstreamRegistry.LayerDigest,
+            second.Headers.GetValues("Docker-Content-Digest").Single());
+    }
+
+    /// <summary>
+    /// 🚨 THE AVAILABILITY CLAIM, and the only form of it this v1 earns: a digest already resident
+    /// is served with the upstream completely unreachable, because that path never talks to it.
+    /// Nothing broader is claimed — see the sibling below for what happens when it is NOT resident.
+    /// </summary>
+    [Fact]
+    public async Task AResidentDigestIsStillServedWhenTheUpstreamIsUnreachable()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+        Assert.True(await Resident(app, FakeUpstreamRegistry.LayerDigest));
+
+        upstream.Unreachable = true;
+        var offline = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+
+        Assert.Equal(HttpStatusCode.OK, offline.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, await offline.Content.ReadAsByteArrayAsync());
+        Assert.Equal("hit", CacheStatus(offline));
+    }
+
+    // ── the four distinguishable outcomes ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE DISTINGUISHABILITY EXPERIMENT. Four situations, four DIFFERENT answers, asserted
+    /// pairwise distinct in one run rather than inferred from four tests that each looked right on
+    /// their own.
+    ///
+    /// <para>The pair that matters is 404 against 504. A mirror that collapsed "I could not reach
+    /// the registry" into "not found" would tell a CI job that a pinned digest had been purged
+    /// while the truth was a network blip — a confident wrong answer of exactly the kind that
+    /// costs an afternoon. And an empty 200 would be worse still, which is why the served cases
+    /// assert the BYTES.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheFourOutcomesAreDistinguishable()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        // (1) miss → fetched, served, cached.
+        var fetched = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+        var fetchedBody = await fetched.Content.ReadAsByteArrayAsync();
+        Assert.True(await Resident(app, FakeUpstreamRegistry.LayerDigest));
+
+        // (2) hit → served from cache, upstream untouched.
+        var beforeHit = upstream.Requests;
+        var cached = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+        var cachedBody = await cached.Content.ReadAsByteArrayAsync();
+        var upstreamAsked = upstream.Requests - beforeHit;
+
+        // (3) a well-formed digest this registry genuinely does not hold.
+        var absent = await client.GetAsync(BlobPath(FakeUpstreamRegistry.MissingDigest));
+
+        // (4) the upstream cannot be reached, and nothing matching is resident.
+        upstream.Unreachable = true;
+        var unreachable = await client.GetAsync(BlobPath(FakeUpstreamRegistry.MissingDigest));
+        var unreachableBody = await unreachable.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, fetched.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, fetchedBody);
+        Assert.Equal("miss", CacheStatus(fetched));
+
+        Assert.Equal(HttpStatusCode.OK, cached.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, cachedBody);
+        Assert.Equal("hit", CacheStatus(cached));
+        Assert.Equal(0, upstreamAsked);
+
+        Assert.Equal(HttpStatusCode.NotFound, absent.StatusCode);
+
+        Assert.Equal(HttpStatusCode.GatewayTimeout, unreachable.StatusCode);
+        Assert.Contains("UPSTREAM_UNAVAILABLE", unreachableBody);
+
+        // 🚨 The assertion the whole design turns on: absent and unreachable are NOT the same
+        // answer, and neither is a success.
+        Assert.NotEqual(absent.StatusCode, unreachable.StatusCode);
+        Assert.NotEqual(HttpStatusCode.OK, absent.StatusCode);
+        Assert.NotEqual(HttpStatusCode.OK, unreachable.StatusCode);
+        // …and the two success cases are the SAME bytes, which is the other half of "no confident
+        // wrong answers": a cache hit must not be a shorter or emptier success.
+        Assert.Equal(fetchedBody, cachedBody);
+    }
+
+    /// <summary>
+    /// A genuinely absent digest is 404 and leaves NOTHING behind. Negative caching is deliberately
+    /// absent: a stored 404 would outlive the push that fixed it, and the symptom would be an image
+    /// that "does not exist" long after it does.
+    /// </summary>
+    [Fact]
+    public async Task AnAbsentDigestIs404_AndIsNeverCachedAsAbsent()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        var response = await client.GetAsync(BlobPath(FakeUpstreamRegistry.MissingDigest));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.False(
+            await Resident(app, FakeUpstreamRegistry.MissingDigest, expected: false),
+            "a 404 must never become a cache entry");
+
+        // And asking again still asks the upstream — the absence was not remembered.
+        var before = upstream.Requests;
+        Assert.Equal(
+            HttpStatusCode.NotFound,
+            (await client.GetAsync(BlobPath(FakeUpstreamRegistry.MissingDigest))).StatusCode);
+        Assert.True(upstream.Requests > before);
+    }
+
+    /// <summary>
+    /// An unreachable upstream with nothing resident is 504 — never 404, and never a synthesised
+    /// success. The body names the reason so a caller reading it can tell the two apart without
+    /// guessing from a status code alone.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreachableUpstreamIs504AndSaysSo()
+    {
+        var upstream = new FakeUpstreamRegistry { Unreachable = true };
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+
+        var response = await Authenticated(app)
+            .GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+
+        Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("UPSTREAM_UNAVAILABLE", body);
+        Assert.Contains("not a statement about whether the requested content exists", body);
+    }
+
+    /// <summary>
+    /// The mirror's own credential being refused stays a 502 — an upstream that ANSWERS and says no
+    /// is a different fault from one that never answers, and an operator needs to know which.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedMirrorCredentialIs502_DistinctFrom504()
+    {
+        var upstream = new FakeUpstreamRegistry { RefuseMirrorCredential = true };
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+
+        var response = await Authenticated(app)
+            .GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+        Assert.Contains("UPSTREAM_UNAUTHORIZED", await response.Content.ReadAsStringAsync());
+    }
+
+    // ── what is and is not cacheable ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 A TAG IS NEVER CACHED. A tag is mutable, so a cached one would serve yesterday's image
+    /// forever — and the symptom would read as a stale build rather than a stale cache. Both pulls
+    /// reach the upstream, by design.
+    /// </summary>
+    [Fact]
+    public async Task ATagIsNeverCached_BecauseATagCanMove()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        var first = await client.GetAsync(ManifestPath("ci.7794"));
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal("bypass", CacheStatus(first));
+
+        var before = upstream.Requests;
+        var second = await client.GetAsync(ManifestPath("ci.7794"));
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("bypass", CacheStatus(second));
+        Assert.True(
+            upstream.Requests > before,
+            "a tag must be resolved upstream every time, never served from cache");
+    }
+
+    /// <summary>
+    /// A manifest requested BY DIGEST is cached, media type included — the sidecar exists because a
+    /// client parses a manifest by its <c>Content-Type</c>, and a cached manifest served as
+    /// <c>application/octet-stream</c> would be unusable.
+    ///
+    /// <para>This is also what makes a pinned pull (<c>repo@sha256:…</c>) fully cacheable, while a
+    /// tag pull can never be: the tag → digest step has no immutable key.</para>
+    /// </summary>
+    [Fact]
+    public async Task AManifestByDigestIsCachedWithItsMediaType()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        var first = await client.GetAsync(ManifestPath(FakeUpstreamRegistry.ManifestDigest));
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal("miss", CacheStatus(first));
+        Assert.True(await Resident(app, FakeUpstreamRegistry.ManifestDigest));
+
+        var before = upstream.Requests;
+        var second = await client.GetAsync(ManifestPath(FakeUpstreamRegistry.ManifestDigest));
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("hit", CacheStatus(second));
+        Assert.Equal(before, upstream.Requests);
+        Assert.Equal(
+            "application/vnd.oci.image.manifest.v1+json",
+            second.Content.Headers.ContentType!.MediaType);
+        Assert.Equal(
+            FakeUpstreamRegistry.ManifestJson.Trim(),
+            (await second.Content.ReadAsStringAsync()).Trim());
+    }
+
+    /// <summary>
+    /// 🚨 A body that does not hash to the digest it was requested under is SERVED and NOT STORED.
+    /// The cache's one invariant is that an entry is the bytes its digest names — it is what makes
+    /// serving one during an upstream outage safe, and it is checked rather than assumed.
+    /// </summary>
+    [Fact]
+    public async Task AMismatchedBodyIsServedButNeverStored()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        var response = await client.GetAsync(BlobPath(FakeUpstreamRegistry.MismatchedDigest));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(FakeUpstreamRegistry.LayerBytes, await response.Content.ReadAsByteArrayAsync());
+        Assert.False(
+            await Resident(app, FakeUpstreamRegistry.MismatchedDigest, expected: false),
+            "bytes that hash to something else must never be filed under this digest");
+    }
+
+    /// <summary>
+    /// A RANGE request bypasses the cache — stated here as an assertion so the limitation cannot
+    /// change silently. A partial body cannot be verified against the whole body's digest, and an
+    /// unverified entry is worse than none; serving a range FROM a resident entry is a later
+    /// increment, not a bug.
+    /// </summary>
+    [Fact]
+    public async Task ARangeRequestBypassesTheCacheEntirely()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, BlobPath(FakeUpstreamRegistry.LayerDigest));
+        request.Headers.Range = new RangeHeaderValue(0, 99);
+
+        var response = await Authenticated(app).SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+        Assert.Equal("bypass", CacheStatus(response));
+        Assert.False(
+            await Resident(app, FakeUpstreamRegistry.LayerDigest, expected: false),
+            "a 100-byte slice must never be filed as the whole layer");
+    }
+
+    /// <summary>
+    /// A HEAD is answered — containerd probes with one before it downloads a manifest — and stores
+    /// nothing. 🚨 Caching a HEAD would file an EMPTY entry under a real digest, which is the worst
+    /// outcome this cache could have: every later pull of that digest would be served zero bytes,
+    /// successfully.
+    /// </summary>
+    [Fact]
+    public async Task AHeadIsAnsweredAndCachesNothing()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, NewCacheDirectory());
+        var client = Authenticated(app);
+
+        var response = await client.SendAsync(
+            new HttpRequestMessage(HttpMethod.Head, ManifestPath("ci.7794")));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(
+            await Resident(app, FakeUpstreamRegistry.ManifestDigest, expected: false),
+            "a body-less response must never become a cache entry");
+    }
+
+    // ── configuration ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// With no cache directory the mirror proxies EVERY pull — the behaviour it had before the
+    /// cache existed. This is the falsification control for the whole suite: if the caching tests
+    /// above still passed with the cache off, they would be measuring something else.
+    /// </summary>
+    [Fact]
+    public async Task AnUnconfiguredCacheProxiesEveryPull()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, cacheDirectory: null);
+        var client = Authenticated(app);
+
+        var first = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+        var before = upstream.Requests;
+        var second = await client.GetAsync(BlobPath(FakeUpstreamRegistry.LayerDigest));
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        Assert.Equal("disabled", CacheStatus(first));
+        Assert.Equal("disabled", CacheStatus(second));
+        Assert.True(upstream.Requests > before, "with no cache, every pull reaches the upstream");
+    }
+
+    /// <summary>
+    /// 🚨 A cache directory configured with no cache registered fails at STARTUP, naming the fix.
+    /// The alternative is a portal whose configuration says it caches and which quietly proxies
+    /// everything — a half-configured service that looks identical to a working one, which is the
+    /// failure mode the rest of this mirror refuses everywhere.
+    /// </summary>
+    [Fact]
+    public async Task AConfiguredCacheWithNoServiceRegisteredFailsAtStartup()
+    {
+        var upstream = new FakeUpstreamRegistry();
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => BuildMirror(upstream, NewCacheDirectory(), registerCache: false));
+
+        Assert.Contains(nameof(ContainerBlobCache), thrown.Message);
+        Assert.Contains(nameof(ContainerImageServiceExtensions.AddContainerImageMirror),
+            thrown.Message);
+    }
+
+    // ── eviction ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 EVICTION IS LEAST-RECENTLY-USED AND BOUNDED, and the entry just used survives.
+    ///
+    /// <para>Driven against the sweep directly rather than through a hundred pulls: the policy is
+    /// what is under test, and a sweep is a real, public operation an operator can also run.</para>
+    ///
+    /// <para>What this deliberately does NOT claim: that a pinned digest is safe. The cache is
+    /// bounded, so any entry can be evicted — its guarantee is one-directional (a hit avoids the
+    /// upstream, a miss falls through to it), and it is not an archive. Refusing to evict a digest
+    /// a live deployment names is a separate, later piece of work.</para>
+    /// </summary>
+    [Fact]
+    public async Task EvictionRemovesTheLeastRecentlyUsedAndKeepsTheRest()
+    {
+        var directory = NewCacheDirectory();
+        var upstream = new FakeUpstreamRegistry();
+        // Budget of 300 bytes against four 100-byte entries: the sweep must get back under 90 % of
+        // it (270), so at least two go.
+        using var app = await BuildMirror(upstream, directory, cacheMaxBytes: 300);
+        var cache = app.Services.GetRequiredService<ContainerBlobCache>();
+
+        var digests = new List<string>();
+        for (var i = 0; i < 4; i++)
+        {
+            var bytes = new byte[100];
+            Array.Fill(bytes, (byte)i);
+            var digest = DigestOf(bytes);
+            digests.Add(digest);
+            Assert.True(
+                await cache.Store(digest, "application/octet-stream", bytes).FirstAsync()
+                    .ObserveCompletion(_ => { }, CancellationToken.None),
+                "the fixture entry must store — it hashes to its own digest by construction");
+        }
+
+        // Age them explicitly: entry 0 oldest … entry 3 newest. Touching entry 0 then makes it the
+        // most recent, which is the point — eviction must follow USE, not arrival.
+        for (var i = 0; i < 4; i++)
+            SetAge(directory, digests[i], TimeSpan.FromHours(4 - i));
+        await cache.Touch(digests[0]).FirstAsync()
+            .ObserveCompletion(_ => { }, CancellationToken.None);
+
+        var report = await cache.Sweep().FirstAsync()
+            .ObserveCompletion(_ => { }, CancellationToken.None);
+
+        Assert.NotNull(report);
+        Assert.True(report!.Ran);
+        Assert.Equal(4, report.EntriesBefore);
+        Assert.Equal(400, report.BytesBefore);
+        Assert.True(report.Evicted >= 2, $"expected at least 2 evictions, got {report.Evicted}");
+
+        // The touched entry is the most recently used, so it survives; the oldest UNTOUCHED one
+        // does not.
+        Assert.True(await Resident(app, digests[0]), "the most recently USED entry must survive");
+        Assert.False(
+            await Resident(app, digests[1], expected: false),
+            "the least recently used entry must be evicted");
+        // And what remains is inside the budget.
+        Assert.True(report.BytesBefore - report.BytesEvicted <= 300);
+    }
+
+    /// <summary>
+    /// Eviction takes the media-type sidecar with the blob. An orphan would otherwise accumulate
+    /// forever and, worse, a later entry could inherit a stale one.
+    /// </summary>
+    [Fact]
+    public async Task EvictionRemovesTheSidecarWithTheEntry()
+    {
+        var directory = NewCacheDirectory();
+        var upstream = new FakeUpstreamRegistry();
+        // Stored UNDER budget first, so nothing is evicted while the sidecar is being asserted —
+        // then the budget is lowered, which is what an operator shrinking a disk allocation does.
+        // Racing an eviction against the assertion would make this test's green meaningless.
+        using var app = await BuildMirror(upstream, directory);
+        var cache = app.Services.GetRequiredService<ContainerBlobCache>();
+
+        var bytes = new byte[100];
+        var digest = DigestOf(bytes);
+        await cache.Store(digest, "application/vnd.oci.image.manifest.v1+json", bytes)
+            .FirstAsync().ObserveCompletion(_ => { }, CancellationToken.None);
+
+        Assert.Single(Directory.GetFiles(directory, "*.type", SearchOption.AllDirectories));
+
+        app.Services.GetRequiredService<IOptions<ContainerImageOptions>>().Value.CacheMaxBytes = 10;
+        var report = await cache.Sweep().FirstAsync()
+            .ObserveCompletion(_ => { }, CancellationToken.None);
+
+        Assert.True(report!.Ran, "an explicit sweep always sweeps — it never stands down");
+        Assert.Equal(1, report.Evicted);
+        Assert.Empty(Directory.GetFiles(directory, "*", SearchOption.AllDirectories));
+    }
+
+    /// <summary>The digest bytes actually hash to — computed, never written down, for the same
+    /// reason the fixture computes its own: an entry is only ever stored under the digest its
+    /// bytes produce, so a fabricated constant would make every store silently a no-op.</summary>
+    private static string DigestOf(byte[] bytes) =>
+        "sha256:" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes))
+            .ToLowerInvariant();
+
+    private static void SetAge(string directory, string digest, TimeSpan age)
+    {
+        var hex = digest["sha256:".Length..];
+        var path = Path.Combine(directory, "sha256", hex[..2], hex);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow - age);
+    }
+}


### PR DESCRIPTION
The OCI mirror shipped as a **pass-through proxy** — correct, but every pull reached ACR and an
unreachable ACR meant no images at all. This adds the **read-through** half that makes it a mirror:
a miss fetches, serves and stores; the next pull of that digest is served **without the upstream
being contacted at all**.

Refs #3353. The design page is updated in the same change:
`Doc/Architecture/ContainerRegistryInMemex`.

## Credentials — the constraint the issue's second comment set

*"i don't want to have a ton of credentials lying around."* The cache **adds none**, in either
direction, and that is a property of the design rather than an accident:

- **Puller → mirror:** unchanged. `IContainerImageAuthenticator`, one shape (`Bearer <instance
  key>`), the key a satellite already holds for the plugin registry. The token exchange still
  **mints nothing** — it echoes the caller's own key, so revocation bites at the next exchange.
- **Mirror → ACR:** unchanged. One upstream credential, held by the mirror.
- **The cache:** **zero credentials.** It is a local directory keyed by content hash. A cache
  *hit* is strictly fewer credential uses than before — the upstream token is never even fetched.

The fleet-wide effect is the one the issue measured: each satellite drops its `ACR_USERNAME` /
`ACR_PASSWORD` pair and reuses the mesh token it already carries. Sixteen secrets, two kinds, one
of them redundant.

## Endpoints — what is implemented, and what plainly is not

| route | methods | v1 |
|---|---|---|
| `/v2/` | `GET` `HEAD` | served — version probe + bearer challenge |
| `/v2/token` | `GET` | served — the realm the challenge names |
| `/v2/<name>/manifests/<ref>` | `GET` `HEAD` | served; **cached only when the reference is a digest** |
| `/v2/<name>/blobs/<digest>` | `GET` `HEAD` | served, `Range` forwarded; cached on a whole-body `GET` |
| `/v2/<name>/tags/list` | `GET` `HEAD` | served, never cached |

`HEAD` is new here — containerd probes with one before downloading a manifest, and a 405 pushed it
onto the slow fallback.

**Not implemented** (no route at all, so each 404s rather than half-working): the entire push family
(`blobs/uploads/…`, manifest `PUT` — refused *by shape*, since a blob reference must be a digest),
`DELETE`, `/v2/_catalog`, the referrers API, `tags/list` pagination, and **serving a `Range` from
the cache** (a partial body cannot be verified against the whole body's digest, so a range request
bypasses the cache entirely — proxied and resumable, but not accelerated).

## The cache: what, where, what evicts it

**Keyed by content digest, and only by content digest.** A blob always; a manifest only when the
reference IS a digest.

🚨 **A tag is never cached.** A tag is mutable, so a cached one would serve yesterday's image
forever and the symptom would read as a stale *build* rather than a stale cache. Every key being a
content hash means **there is no invalidation, no TTL and no staleness by construction**. The price
is stated rather than hidden: `pull repo:tag` always needs the upstream for the tag → digest step;
`pull repo@sha256:…` — what every pinned CI consumer does — can be served entirely from cache.

**Every entry is verified** against the digest it is filed under, hashed as the bytes stream past. A
body that hashes to something else is **served to the caller and discarded**, so the cache cannot be
poisoned and a resident entry is *provably* the bytes its digest names — which is what makes serving
one during an outage safe rather than hopeful. A truncated layer cannot become an entry for two
independent reasons: the hash cannot match, and an abandoned fill's temporary is deleted on dispose.

**On disk:** `<CacheDirectory>/sha256/<ab>/<hex>` plus a one-line `.type` sidecar (a client parses a
manifest by its `Content-Type`). A fill writes a temporary in the same directory and `File.Move`s it
into place, so a crash leaves a temporary — swept after an hour — never a truncated file that reads
as complete. **Nothing negative is cached:** a remembered 404 would outlive the push that fixed it.

**Eviction** is a bounded least-recently-**used** sweep against `CacheMaxBytes` (default 20 GiB),
triggered after roughly an eighth of the budget has been added, evicting until the directory is back
under 90 %. Last-use is tracked by touching the file on a hit, because filesystem access times are
unreliable (`noatime` records none).

### 🚨 On #3438 — this is deliberately NOT a second copy that can lose a pinned digest

A digest-keyed cache is the natural shape for that mitigation, and it would have been easy to sell
it as one. It is not, and the page says so in as many words. **The cache is bounded, so any entry
can be evicted, including one a pinned deployment names.** Its guarantee is one-directional: a hit
avoids the upstream, a miss falls through to it — **it can only ever ADD availability, never
subtract it.** That is exactly why it is safe to ship before any retention policy exists, and
exactly why shipping a half-version of retention now would be *worse than none*: a second store that
can lose a pinned digest while looking like insurance.

Refusing to evict a digest a live `Deployment` node names is a separate increment, and #3353's gain
(5) stays open.

## Four outcomes, and they stay distinguishable

| situation | answer | upstream contacted |
|---|---|---|
| digest resident | `200` + bytes, `X-MeshWeaver-Cache: hit` | **no** |
| not resident, upstream has it | `200` + bytes, `miss`, stored | yes |
| genuinely absent upstream | `404`, nothing stored | yes |
| **upstream unreachable** | **`504` `UPSTREAM_UNAVAILABLE`** | attempted |
| upstream refused the mirror's OWN credential | `502` `UPSTREAM_UNAUTHORIZED` | yes |

🚨 **This was a live defect, not a hypothetical.** A transport failure (DNS, refused connection,
dropped socket) escaped `UpstreamRegistryClient` as a bare `HttpRequestException` and surfaced as a
generic 500. It is now a deliberate `504` whose body says, in words, that it is *not* a statement
about whether the content exists. A mirror that merged 404 and 504 would tell a CI job a pinned
digest had been purged when the network was merely down — precisely the confident-wrong-answer shape
that costs an afternoon.

## Which side of the async line each piece is on

| piece | side |
|---|---|
| `ContainerImageEndpoints.Serve` / `IssueToken` / the endpoint filter | **boundary** — minimal-API handlers, `Task` sanctioned |
| `UpstreamPassthroughResult` / `CachedContentResult` (`IResult.ExecuteAsync`) | **boundary** |
| `ContainerBlobCache` (`Open` / `Touch` / `Store` / `Sweep`) | **not a boundary** — `IObservable<T>`, every disk edge through `IIoPool`; the boundary awaits it via `ObserveCompletion` |
| `ContainerBlobFill` | inside the transfer's own `Blob` pool slot |

**Nothing buffers.** The fill is a tee `Stream`: one pass, downstream first, hashing as it goes.
It rides **inside the `Blob` pool slot the transfer already holds** rather than taking a second one —
re-entering another pool from inside a slot this code holds is the nested-gate hazard `IoPoolNames`
warns about, and the existing slot is the tighter bound anyway since the disk write cannot outlive
the transfer that drives it. A cache hit streams from disk through the same pool, with
`cancelSource: true` so a client that gives up mid-layer releases the permit with it.

No `SemaphoreSlim`, no `Observable.FromAsync`, no static collections (the eviction accounting is an
instance field on a mesh-scoped singleton — `AddContainerImageMirror()` registers it), no
`.ToTask()`, no `.GetAwaiter().GetResult()` (the synchronous `Stream.Write` override is implemented
*synchronously* rather than bridged), immutable collections throughout.

🚨 **`CacheDirectory` set without `AddContainerImageMirror()` fails at STARTUP naming the fix.** A
portal whose configuration says it caches while it quietly proxies everything is the same
half-configured shape this package refuses everywhere else.

## Verification — and falsification, both ways

Real harness: a real ASP.NET pipeline (`Microsoft.AspNetCore.TestHost`) against a real in-process
OCI registry that speaks the actual token handshake. No mocking of core interfaces, no `Task.Delay`,
no `.ToTask()`. **The load-bearing assertion is the upstream's own request counter, not a header** —
"served from cache" only means anything as "the upstream was not asked", and a header cannot prove
that.

**`MeshWeaver.ContainerImages.Test`: 110 passed, 0 failed** (Release, `--no-build` on a
freshly-built project). `MeshWeaver.Documentation.Test`: `DocumentationLinkIntegrityTest` +
`HandWovenGateRatchetGuard` + `ObservableToTaskBridgeGuard` + `HubReachableAsyncGuard` — **19 passed,
0 failed**. Both touched projects build `-c Release -warnaserror`, one per invocation: **0 Warning(s),
0 Error(s)**.

### Falsified — `src/` mutated, tests untouched

Reverting `src/` wholesale would only fail to *compile* the tests, which proves nothing. So each
claim was defeated at its own site instead:

**Round A** — `ContainerBlobCache.Open` always misses (the cache is never read): **5 failed, 105
passed**, and the five are exactly the read-through claims —
`AMissFetchesServesAndCaches_AndTheSecondPullNeverReachesTheUpstream`,
`AResidentDigestIsStillServedWhenTheUpstreamIsUnreachable`,
`AManifestByDigestIsCachedWithItsMediaType`, `EvictionRemovesTheLeastRecentlyUsedAndKeepsTheRest`,
`TheFourOutcomesAreDistinguishable`.

**Round B** — three independent defects at once: unreachable answers `404` instead of `504`; the fill
skips digest verification; a hit no longer touches the entry. **4 failed, 106 passed**, and the four
are exactly the predicted ones — `AnUnreachableUpstreamIs504AndSaysSo` and
`TheFourOutcomesAreDistinguishable` (distinguishability), `AMismatchedBodyIsServedButNeverStored`
(poisoning), `EvictionRemovesTheLeastRecentlyUsedAndKeepsTheRest` (LRU, which degraded to
least-recently-*added*).

**One finding worth recording:** `ATagIsNeverCached_BecauseATagCanMove` stayed GREEN under round B's
verification mutation. That is not a gap — the tag exclusion is defended by two independent
mechanisms (the key check *and* digest verification), so removing either alone cannot cache a tag.

Restored: **110 passed, 0 failed.**

## Not claimed

Pull **latency** is still unmeasured. The cache changes the shape of that question (a hit is a local
disk read; a miss is the old hop plus a disk write) without answering it. Nothing should depend on
the mirror until it is measured against ACR directly.

## Scope

**#3353 stays open.** The read-through mirror now works end to end for a digest-addressed pull, but
the issue's acceptance list is broader: (2) is half-done and half-impossible by construction, (3)'s
data exists but `ci.yml` still carries its six literals, and the `ACR_USERNAME`/`ACR_PASSWORD`
deletion from every satellite — the measurable form of "no credentials lying around" — has not
happened yet.

`Pairs-with:` — not applicable: this diff removes zero public types and zero public members
(`git diff origin/main...HEAD -- 'src/**/*.cs' | grep '^-.*public'` is empty), and nothing outside
this repo references `MeshWeaver.ContainerImages` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
