### PR TITLE
fix(#3461): a publication refuses to seal over another publisher's bytes

### DIFF
--- a/.github/scripts/carry-forward-bundles.sh
+++ b/.github/scripts/carry-forward-bundles.sh
@@ -43,26 +43,58 @@ if [ "${1:-}" = "--self-test" ]; then
   ST=$(mktemp -d); trap 'rm -rf "$ST"' EXIT
   ME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
   mkdir -p "$ST/bin"
+  # The stub models the two calls this script makes — `file download` and the `file show` whose
+  # ONE query it reads back — and REFUSES anything else, so the script and the stub cannot drift
+  # apart silently. Metadata lives in a sidecar named after the file.
   cat > "$ST/bin/az" <<'AZ'
 #!/usr/bin/env bash
-account=""; share=""; path=""; dest=""
+action="$3"
+account=""; share=""; path=""; dest=""; query=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --account-name) account="$2"; shift 2;; --share-name) share="$2"; shift 2;;
-    --path) path="$2"; shift 2;; --dest) dest="$2"; shift 2;; *) shift;;
+    --path) path="$2"; shift 2;; --dest) dest="$2"; shift 2;;
+    --query) query="$2"; shift 2;; *) shift;;
   esac
 done
 file="$MOCK_AZ_ROOT/$account/$share/$path"
-[ -f "$file" ] || exit 1
-mkdir -p "$(dirname "$dest")"; cp "$file" "$dest"
+case "$action" in
+  download)
+    [ -f "$file" ] || exit 1
+    mkdir -p "$(dirname "$dest")"; cp "$file" "$dest" ;;
+  show)
+    if [ "$query" != "[[metadata.digest || '-', metadata.publication || '-']]" ]; then
+      echo "stub-az: unmodelled query '$query' — teach the stub rather than loosening it" >&2; exit 64
+    fi
+    [ -f "$file" ] || exit 1
+    [ -f "$file.meta.unreadable" ] && exit 1
+    # knack renders `[[a || '-', b || '-']]` as ONE tab-separated row, '-' where the value is
+    # absent. The sidecar already holds that shape; a file with no metadata at all is '-\t-'.
+    if [ -f "$file.meta" ]; then cat "$file.meta"; else printf -- '-\t-\n'; fi ;;
+  *)
+    echo "stub-az: unmodelled action '$action'" >&2; exit 64 ;;
+esac
 AZ
   chmod +x "$ST/bin/az"; PATH="$ST/bin:$PATH"; export MOCK_AZ_ROOT="$ST/remote"
   REMOTE="$ST/remote/acct/share/prebuilt-bundles/ID1/plugins"
   FAILED=0
-  ok()   { printf '  OK   %s\n' "$1"; }
+  PASSED=0
+  ok()   { printf '  OK   %s\n' "$1"; PASSED=$((PASSED + 1)); }
   bad()  { printf '  FAIL %s\n' "$1"; FAILED=$((FAILED + 1)); }
 
-  setup() {  # <listing lines…> — the sealed publication holds a bundle for each
+  digest_of() { if command -v sha256sum > /dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+                else shasum -a 256 "$1" | awk '{print $1}'; fi; }
+  stamp() {  # <bundle> <publication> — record the stamp publish-bake-bundles.sh writes
+    printf '%s\t%s\n' "$(digest_of "$REMOTE/$1")" "$2" > "$REMOTE/$1.meta"
+  }
+
+  setup() {  # <listing lines…> — the sealed publication holds a bundle for each, all from ONE run
+    rm -rf "$ST/bake" "$ST/remote" "$ST/listing"
+    mkdir -p "$ST/bake" "$REMOTE"
+    for b in "$@"; do echo "published $b" > "$REMOTE/$b"; stamp "$b" "Systemorph-MeshWeaver-1-1"; done
+    printf '%s\n' "$@" > "$ST/listing"
+  }
+  setup_unstamped() {  # a publication sealed before the stamp existed
     rm -rf "$ST/bake" "$ST/remote" "$ST/listing"
     mkdir -p "$ST/bake" "$REMOTE"
     for b in "$@"; do echo "published $b" > "$REMOTE/$b"; done
@@ -116,12 +148,73 @@ AZ
   OUT=$(run); RC=$?
   [ "$RC" -ne 0 ] && ok "a missing bake directory is refused" || bad "missing bake dir should be fatal"
 
+  echo "refusals (the carried set must come from ONE publication — MeshWeaver#3461):"
+  setup Store.zip Edu.zip Chess.zip
+  rebuilt Edu.zip
+  OUT=$(run); RC=$?
+  if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q "carry-forward consistency: 2 of 2 carried bundle(s) stamped, all from publication"; then
+    ok "a settled publication carries forward, and the check SAYS how many it proved (2 of 2)"
+  else
+    bad "one-publication control (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
+
+  # THE DEFECT: the publication is replaced between the listing and the downloads, so the bundles
+  # carried forward come from two bakes. Sealing them would claim one publication for both.
+  setup Store.zip Edu.zip Chess.zip
+  rebuilt Edu.zip
+  echo "republished Chess.zip" > "$REMOTE/Chess.zip"; stamp Chess.zip "Systemorph-MeshWeaver.Plugins-2-1"
+  OUT=$(run); RC=$?
+  if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "name 2 DIFFERENT publications"; then
+    ok "bundles carried from TWO publications are refused, and both are named"
+  else
+    bad "two-publication carry-forward should be fatal (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
+
+  setup Store.zip Edu.zip
+  rebuilt Edu.zip
+  # The bytes moved but the stamp did not — a replaced download, or a stamp that no longer
+  # describes the file. Either way what arrived is not what the publication records.
+  printf '%s\t%s\n' "0000000000000000000000000000000000000000000000000000000000000000" \
+    "Systemorph-MeshWeaver-1-1" > "$REMOTE/Store.zip.meta"
+  OUT=$(run); RC=$?
+  if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "what arrived here hashes to"; then
+    ok "a carried bundle whose bytes do not match the recorded digest is refused"
+  else
+    bad "digest mismatch should be fatal (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
+
+  setup Store.zip Edu.zip
+  rebuilt Edu.zip; touch "$REMOTE/Store.zip.meta.unreadable"
+  OUT=$(run); RC=$?
+  if [ "$RC" -ne 0 ] && printf '%s' "$OUT" | grep -q "an unreadable stamp is not an absent one"; then
+    ok "an unreadable stamp is refused, never read as 'no stamp' (fail closed)"
+  else
+    bad "unreadable metadata should be fatal (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
+
+  # ADOPTION: a publication sealed before the stamp existed. The check has no evidence, and must
+  # SAY SO with numbers rather than reporting a consistency it never established.
+  setup_unstamped Store.zip Edu.zip
+  rebuilt Edu.zip
+  OUT=$(run); RC=$?
+  if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q "1 of 1 carried bundle(s) carry no publication stamp"; then
+    ok "an unstamped incumbent still carries forward, and the check reports that it proved NOTHING"
+  else
+    bad "unstamped incumbent (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
+
   if [ "$FAILED" -gt 0 ]; then
     echo "::error title=carry-forward self-test failed::$FAILED case(s) — this is the only thing preventing a narrowed bake from shrinking the publication."
     exit 1
   fi
   echo ""
-  echo "carry-forward self-test: 2 hydration cases, 4 refusals — all green."
+  # The denominator, computed rather than written down: a case list that silently stopped
+  # executing would otherwise keep printing the number someone typed here.
+  if [ "$PASSED" -lt 11 ]; then
+    echo "::error title=carry-forward self-test ran too few cases::$PASSED case(s) executed, at least 11 expected — a harness that quietly tests less renders the same green tick as one that tests the lane."
+    exit 1
+  fi
+  echo "carry-forward self-test: $PASSED case(s) — hydration, shrink refusals, and the one-publication postcondition — all green."
   exit 0
 fi
 
@@ -142,9 +235,40 @@ BASE=""
 case "$REST" in */*) BASE="${REST#*/}";; esac
 SRC_DIR="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
 
+# 🚨 THE CARRY-FORWARD IS AN N+1 READ OF A DIRECTORY THAT CAN BE REPLACED UNDERNEATH IT
+# (MeshWeaver#3461). The listing came from the sealed publication `bake-scope.sh` read; each
+# download below is a separate request, and `<identity>/plugins` has several publishers — core CD's
+# `plugins-bake`, the satellite's own `publish-bake`, and (measured four times in one day, more
+# often than the cross-lane case) two concurrent runs of ONE of them. If the publication is
+# replaced between the listing and a download, two things can happen:
+#
+#   a listed name has GONE          → it lands in missing[] below and this script goes RED. Loud.
+#   a listed name has NEW BYTES     → today it is carried forward silently, and the publication
+#                                     this bake then seals holds bundles from two generations. The
+#                                     seal claims one publication for bytes that came from two.
+#
+# The second is the same silent mix as the two-writer case, reached by one writer alone, and
+# publish-bake-bundles.sh's own postcondition cannot see it: that check asks "is the shelf what I
+# uploaded", and a carried-forward mix IS what this run uploaded.
+#
+# So every carried file is checked against the stamps publish-bake-bundles.sh writes — the SAME
+# two metadata values, not a third detector: `digest` (the bytes, so a truncated or replaced
+# download is caught) and `publication` (which publication put them there, so bundles carried from
+# two of them are caught). All carried files must name ONE publication.
+sha256_of() { # <file> — hex digest, portable across the CI runner and a developer's macOS
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
 carried=0
 rebuilt=0
+stamped=0
 missing=()
+corrupt=()
+publications=""
 while IFS= read -r name; do
   [ -n "$name" ] || continue
   case "$name" in */*|..|.) echo "::error::the published listing names '$name', which is not a plain file name"; exit 1;; esac
@@ -157,6 +281,40 @@ while IFS= read -r name; do
        --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
     carried=$((carried + 1))
     echo "carried forward: $name"
+    # Read the stamp of the file we just took. A read that FAILS is not "no stamp" — an unreadable
+    # answer and a permissive one must never be the same value, so it is recorded as corrupt.
+    if props=$(az storage file show --account-name "$ACCOUNT" --share-name "$SHARE" \
+         --path "$SRC_DIR/$name" --auth-mode login --backup-intent \
+         --query "[[metadata.digest || '-', metadata.publication || '-']]" -o tsv --only-show-errors); then
+      # 🚨 The query is a list-of-ONE-ROW and the fields carry a '-' guard, both for the reason
+      # publish-bake-bundles.sh sets out at length: knack's format_tsv renders a top-level list as
+      # ROWS (so `[a, b]` prints two LINES, and `$2` reads empty for every file), and a null field
+      # renders as the literal string 'None'. Measured against azure-cli 2.90.0. The field count is
+      # asserted so a rendering change is a refusal, never a wrong answer.
+      fields=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print NF }')
+      if [ "${fields:-0}" -ne 2 ]; then
+        corrupt+=("$name (az answered '$props' — one tab-separated row of TWO fields was expected; the CLI's --query rendering has changed)")
+        continue
+      fi
+      remote_digest=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $1 }')
+      remote_pub=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
+      if [ "$remote_digest" = "-" ]; then remote_digest=""; fi
+      if [ "$remote_pub" = "-" ]; then remote_pub=""; fi
+    else
+      corrupt+=("$name (its metadata could not be read — an unreadable stamp is not an absent one)")
+      continue
+    fi
+    if [ -n "$remote_digest" ]; then
+      local_digest=$(sha256_of "$BAKE_DIR/$name")
+      if [ "$local_digest" != "$remote_digest" ]; then
+        corrupt+=("$name (the publication says $remote_digest, what arrived here hashes to $local_digest)")
+        continue
+      fi
+    fi
+    if [ -n "$remote_pub" ]; then
+      stamped=$((stamped + 1))
+      case " $publications " in *" $remote_pub "*) ;; *) publications="$publications $remote_pub";; esac
+    fi
   else
     missing+=("$name")
   fi
@@ -167,6 +325,31 @@ if [ "${#missing[@]}" -gt 0 ]; then
   for m in "${missing[@]}"; do echo "::error::could not carry forward: $m"; done
   echo "::error::Re-run this workflow to take the full-bake path (bake-scope.sh falls back to a full bake whenever the publication cannot be read), or fix access to the target."
   exit 1
+fi
+
+if [ "${#corrupt[@]}" -gt 0 ]; then
+  echo "::error title=Carry-forward failed — a carried bundle is not the one the publication holds::${#corrupt[@]} of $carried carried file(s) could not be shown to be the bytes the sealed publication under $ACCOUNT/$SHARE/$SRC_DIR records. Publishing them would seal a bundle set nobody produced."
+  for c in "${corrupt[@]}"; do echo "::error::$c"; done
+  exit 1
+fi
+
+# ONE publication, or none at all. Counting the distinct stamps is what tells "carried from the
+# publication the listing came from" apart from "carried from two, because it was replaced while
+# this ran" — the second is the silent mix, and it is refused.
+pubcount=$(printf '%s' "$publications" | tr ' ' '\n' | grep -c '[^[:space:]]' || true)
+if [ "$pubcount" -gt 1 ]; then
+  echo "::error title=Carry-forward failed — the publication was replaced while this read it::$carried bundle(s) were carried forward from $ACCOUNT/$SHARE/$SRC_DIR and they name $pubcount DIFFERENT publications:$publications. The sealed publication was replaced between the listing this run was given and the downloads it made, so the set about to be sealed would hold bundles from two bakes under one sentinel (MeshWeaver#3461) — one seal, one generation, self-consistent to every consumer and wrong. Re-run this workflow once the publisher has settled; nothing has been written."
+  exit 1
+fi
+# 🚨 The denominator, printed on EVERY path — including the one that proves nothing. A publication
+# sealed before publish-bake-bundles.sh stamped its files carries no `publication` metadata at all,
+# and this check then has no evidence either way. It says so, loudly and with numbers, rather than
+# reporting a consistency it did not establish; the next publication of this source stamps every
+# file and the check becomes enforceable with no action from anyone.
+if [ "$carried" -gt 0 ] && [ "$stamped" -eq 0 ]; then
+  echo "::warning title=Carry-forward consistency NOT established::$carried of $carried carried bundle(s) carry no publication stamp — the sealed publication under $ACCOUNT/$SHARE/$SRC_DIR predates the stamp publish-bake-bundles.sh now writes (MeshWeaver#3461). Whether they all came from ONE publication could not be checked. The next publication of source '$SOURCE' stamps them and this becomes enforceable."
+elif [ "$carried" -gt 0 ]; then
+  echo "carry-forward consistency: $stamped of $carried carried bundle(s) stamped, all from publication$publications"
 fi
 
 # The postcondition, asserted rather than assumed: the set about to be published is a SUPERSET of

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -367,9 +367,14 @@ verify_publication() { # <account> <share> <dest>
     # or a CLI shape change into "no digest recorded" — the one answer that is indistinguishable
     # from "another publisher wrote this", and the errors below would then name the wrong cause.
     # An unreadable file is refused as loudly as a foreign one; it is simply refused by name.
+    # `< /dev/null` because this runs INSIDE a `while read` loop fed by the manifest: a command
+    # that consumed stdin would swallow the remaining lines, and the loop would end early having
+    # verified a PREFIX of the publication while reporting no foreign bytes at all. The accounting
+    # assertion after the loop is the belt to that brace.
     if ! props=$(az storage file show --account-name "$account" --share-name "$share" \
         --path "$dest/$rel" --auth-mode login --backup-intent \
-        --query "[[metadata.digest || '-', metadata.publication || '-']]" -o tsv --only-show-errors); then
+        --query "[[metadata.digest || '-', metadata.publication || '-']]" -o tsv --only-show-errors \
+        < /dev/null); then
       unreadable+=("$rel")
       continue
     fi
@@ -413,9 +418,26 @@ verify_publication() { # <account> <share> <dest>
     fi
   done < "$MANIFEST"
 
-  for rel in ${overlapped[@]+"${overlapped[@]}"}; do
-    echo "::notice::under $dest: $rel — that publication wrote the very bytes this run uploaded, so two publications overlapped on this prefix (MeshWeaver#3461). Identical bytes distinguish nothing, so this file is not a mix."
-  done
+  # Each element is "<file> ← '<publication>'" and carries spaces, so it is iterated quoted, behind
+  # an emptiness test — the same shape as the `foreign` and `unreadable` loops below. (The
+  # `${a[@]+"${a[@]}"}` idiom used elsewhere in this file does preserve per-element quoting; this
+  # is written the long way because a reader should not have to know that to be sure.)
+  if [ "${#overlapped[@]}" -gt 0 ]; then
+    for rel in "${overlapped[@]}"; do
+      echo "::notice::under $dest: $rel — that publication wrote the very bytes this run uploaded, so two publications overlapped on this prefix (MeshWeaver#3461). Identical bytes distinguish nothing, so this file is not a mix."
+    done
+  fi
+
+  # 🚨 THE DENOMINATOR, ASSERTED. Every manifest line must have landed in exactly one bucket. It
+  # cannot fail by inspection — which is precisely why it is checked: the loop is fed by a
+  # redirect, so anything inside it that consumed stdin would end it EARLY, and a verification that
+  # covered the first few files would then report "no foreign bytes" and SEAL. A guard that can
+  # quietly check less than it claims is the vacuity every gate here is written to avoid.
+  local accounted=$((ours + neutral + ${#foreign[@]} + ${#unreadable[@]}))
+  if [ "$accounted" -ne "$MANIFEST_COUNT" ]; then
+    echo "::error title=Refusing to seal — the verification did not cover the publication::$account/$share/$dest: $accounted of $MANIFEST_COUNT file(s) were accounted for ($ours ours, $neutral byte-identical, ${#foreign[@]} foreign, ${#unreadable[@]} unreadable). The read-back loop ended early, so this publication has NOT been shown to be free of another publisher's bytes. Refusing."
+    return 1
+  fi
 
   # An unreadable file leaves the verdict UNDECIDABLE, so it takes precedence over all three and
   # never touches an existing sentinel: we cannot tell a mix from a clean supersession.
@@ -635,6 +657,14 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
       # writes the marker — so the arm64 lane is blocked forever by an instruction that can never
       # be carried out. Stamping is safe precisely because the refusal below is sound: only the
       # amd64 lane has ever published, and this IS that lane.
+      #
+      # 🚨 Deliberately NOT `upload_published_file`: this writes onto a publication that is NOT
+      # this run's, so stamping it with this run's `publication` token would be a lie — a later
+      # verification would read one of somebody else's files as ours. It is safe to leave
+      # unstamped because it only ever runs on a directory that IS sealed (`complete = true`), and
+      # a publisher that is mid-flight has removed the sentinel — so no concurrent
+      # `verify_publication` can be looking at this file while it is written. If this run goes on
+      # to republish, `publish_one_target` overwrites it stamped a moment later.
       az storage file upload --account-name "$ACCOUNT" --share-name "$SHARE" \
         --path "$DEST" --source "$ARCH_MARKER_LOCAL" \
         --auth-mode login --backup-intent --only-show-errors > /dev/null

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -178,6 +178,274 @@ ARCH_MARKER="architecture.txt"
 ARCH_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$ARCH_MARKER"
 printf '%s\n' "$BAKE_ARCHITECTURE" > "$ARCH_MARKER_LOCAL"
 
+# ══════════════════════ THE TWO-WRITER POSTCONDITION (MeshWeaver#3461) ══════════════════════
+#
+# 🚨 `<identity>/plugins` HAS SEVERAL WRITERS. Core CD's `plugins-bake` job publishes `bake-source:
+# plugins` at `gate.outputs.plugins_sha`, and the MeshWeaver.Plugins satellite's own `publish-bake`
+# publishes the same source at its own head. Both call this script; both write one prefix. They
+# resolve the SAME framework identity whenever the core surface has not changed between core's tip
+# and the satellite's `MW_PLATFORM_REF` pin — which is the ordinary case, because the identity is
+# breaking-change-keyed by construction.
+#
+# Measured on 2026-09-06 (25 core-CD publish jobs, 19 satellite ones): core CD wrote 20 distinct
+# identities, the satellite 2, and BOTH of the satellite's were also written by core CD — each time
+# the satellite unsealed core's publication and republished it from a different source sha
+# (`sf09fa2c9…`: 3e81b03960 → 9717e13e49; `sa55f8190…`: bbb893d673 → 88f1d44a19). Closest
+# cross-lane approach 24 minutes; no strict cross-lane time overlap in that window.
+#
+# 🚨 AND THE SAME LANE OVERLAPS WITH ITSELF, more often than the two lanes overlap with each other.
+# The same measurement found FOUR same-identity window overlaps inside the satellite's own CI on
+# that one day — three concurrent bakes on `sa55f8190…` at 08:03Z, two of which sealed 24 minutes
+# apart — against zero cross-lane ones. That is why "give the prefix a single owner" does not
+# close this: the single owner races itself. The postcondition below is publisher-agnostic on
+# purpose; it asks "are these MY bytes", never "which repo is the other one".
+#
+# Everything below `publish_one_target` is single-writer-safe and nothing more. Interleave two runs
+# on one prefix and the sealed-skip's answer is stale for whichever loses the race: both unseal,
+# both upload, and the last to write `_complete` seals a sentinel over a directory holding SOME OF
+# EACH one's bytes. That is one seal with one generation — self-consistent to every consumer, and
+# wrong. #3460's read-side generation cannot see it (there is nothing stale to refuse), the boot
+# seeder cannot see it (the sentinel is present and every listed bundle exists), and the first
+# symptom is `dependency record mismatch — built against mvid:…, live is mvid:…` on a portal that
+# renders nothing.
+#
+# 🚨 A CLAIM TOKEN CANNOT FIX THIS, and it is the obvious thing to reach for. "Stamp a per-run
+# marker before unsealing, re-read it before sealing" is check-then-act on ONE MUTABLE CELL, and
+# the cell has the wrong asymmetry: if A stamps after B, A re-reads its OWN stamp and seals
+# happily over B's bytes. The loser detects the winner; the WINNER detects nothing. There is no
+# arrangement of a single marker that fixes that, because the marker records who wrote LAST, not
+# whose bytes are on the shelf.
+#
+# So the postcondition is asserted on THE BYTES, which is what "a mix" actually means. Every file
+# this run uploads carries two metadata values:
+#
+#     digest       the SHA-256 of the exact local bytes uploaded
+#     publication  a token unique to this run (and the run that wrote it, by name)
+#
+# and `verify_publication` re-reads all of them immediately before the seal. A foreign publisher
+# that overwrote ANY file leaves ITS digest there, so:
+#
+#   * every file's digest matches ⇒ the sealed set is byte-for-byte what this run uploaded. Not a
+#     mix, by definition — there is nothing else it could be.
+#   * any file's digest differs   ⇒ REFUSE TO SEAL. The directory stays sentinel-less, which is the
+#     state every reader already skips, and `publication` NAMES the run that overwrote it.
+#
+# This is symmetric, which the claim token is not: in a genuine overlap BOTH runs find foreign
+# bytes and BOTH refuse, so no mix is ever sealed. It needs no coordination between the lanes, no
+# lease, no lock, and no staleness heuristic that could deadlock the prefix behind a cancelled run.
+#
+# 🚨 What it does NOT close, stated so the next session does not re-derive it: the interval between
+# the last verification read and the `_complete` upload. A publisher that overwrites a file inside
+# that one-upload window still lands under this run's seal. The window shrinks from the whole
+# ~90-second publication to a single file upload, and it is why #3461 stays open for the layout
+# question (a generation directory plus an atomic pointer swap, which removes republication in
+# place entirely). The refusal below is a postcondition, not mutual exclusion.
+#
+# Cost: one `az storage file show` per published file per target, at seal time — measured against
+# the ~43-file publication these lanes produce, ~1s each. That is the price of the assertion and it
+# is deliberately paid in full: verifying a SAMPLE would be a guard that passes on the files nobody
+# overwrote.
+sha256_of() { # <file> — hex digest, portable across the CI runner and a developer's macOS
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# The publication token: unique to THIS invocation, and readable as the run that made it. Metadata
+# values are ASCII, and `-o tsv` splits on tabs, so it is restricted to [A-Za-z0-9._-] — a value
+# carrying a tab or a space would silently split into two fields and compare equal to a truncation.
+PUBLICATION="$(printf '%s-%s-%s' \
+  "${GITHUB_REPOSITORY:-local}" "${GITHUB_RUN_ID:-$$}" "${GITHUB_RUN_ATTEMPT:-$(date -u +%s)}" \
+  | tr -c 'A-Za-z0-9._-' '-')"
+
+# Quoted by every refusal. It names both shapes because BOTH were measured on 2026-09-06, and the
+# more frequent one is the one the issue title does not mention.
+OVERLAP_WRITERS="One prefix, several publishers. ACROSS lanes: core CD's 'plugins-bake' job and the MeshWeaver.Plugins satellite's own 'publish-bake' both publish bake-source 'plugins' and resolve the same identity whenever the core surface has not moved between core's tip and the satellite's pin. WITHIN one lane: several main pushes bake concurrently — four same-identity window overlaps were measured in the satellite's own CI on 2026-09-06 alone, against zero cross-lane ones, so 'let the other repo finish' is not the whole answer. Find the publication named above, let it settle, and re-run this one."
+
+# The manifest of what this run publishes: "<path-under-dest><TAB><sha256>", one line per file.
+# Built ONCE — the local bytes are identical for every target — and consumed by both the upload
+# loop and the verification below, so the two can never disagree about the set.
+MANIFEST="$SENTINEL_LOCAL_DIR/manifest"
+: > "$MANIFEST"
+manifest_add() { # <path-under-dest> <local-file>
+  printf '%s\t%s\n' "$1" "$(sha256_of "$2")" >> "$MANIFEST"
+}
+for zip in "${BUNDLES[@]}"; do manifest_add "$(basename "$zip")" "$zip"; done
+for m in ${MODULES[@]+"${MODULES[@]}"}; do
+  manifest_add "$MODULES_DIR_NAME/$(basename "$m")" "$m"
+done
+manifest_add "$MODULES_DIR_NAME/$MODULES_INDEX" "$MODULES_INDEX_LOCAL"
+manifest_add "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL"
+manifest_add "$ARCH_MARKER" "$ARCH_MARKER_LOCAL"
+# The denominator every verification prints and every refusal quotes. A publication with nothing
+# in it cannot be verified into existence, and a zero here would make the sweep below pass having
+# read nothing — the exact vacuity a guard must never render as green.
+MANIFEST_COUNT=$(grep -c '[^[:space:]]' "$MANIFEST" || true)
+if [ "${MANIFEST_COUNT:-0}" -lt 1 ]; then
+  echo "::error::the publication manifest is EMPTY — nothing would be verified before the seal, so the seal would claim completeness for an unchecked directory. Refusing."
+  exit 1
+fi
+echo "publication $PUBLICATION: $MANIFEST_COUNT file(s) to publish and verify per target (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s), 3 marker/index file(s))"
+
+# Uploads ONE file of the publication, stamped with the two metadata values the postcondition
+# reads back. The digest is LOOKED UP from the manifest rather than recomputed: a file uploaded
+# that the manifest does not describe would be published and never verified, so that is fatal
+# rather than a fresh digest.
+upload_published_file() { # <account> <share> <dest> <path-under-dest> <local-file> [<upload-path>]
+  local account="$1" share="$2" dest="$3" rel="$4" src="$5" upload_path="${6:-$3/$4}" digest
+  digest=$(awk -F'\t' -v k="$rel" '$1 == k { print $2; found = 1 } END { exit !found }' "$MANIFEST") || {
+    echo "::error::'$rel' is being uploaded but the publication manifest does not describe it — it would be published and never verified. This is a bug in this script, not in the bake."
+    exit 1
+  }
+  az storage file upload --account-name "$account" --share-name "$share" \
+    --path "$upload_path" --source "$src" \
+    --metadata "digest=$digest" "publication=$PUBLICATION" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null
+}
+
+# Removes a seal that is known to cover a MIX. Called only from the mixed verdict below, and it
+# is the other half of the fix: a foreign publisher can finish and seal INSIDE a gap in this run's
+# uploads, so refusing to write our own sentinel is not enough — the sentinel already there covers
+# a directory we have since partly overwritten. Deleting it returns the prefix to the state every
+# reader skips.
+#
+# 🚨 It is NEVER called on the fully-superseded verdict. A publication whose files carry none of
+# our bytes is somebody else's, complete and consistent; deleting its seal would un-publish a good
+# publication and strand the identity unsealed until that lane's content next changes. "Some of
+# ours, some of theirs" is the only state in which the seal is provably wrong.
+unseal_mixed_publication() { # <account> <share> <dest>
+  local account="$1" share="$2" dest="$3" present
+  present=$(az storage file exists --account-name "$account" --share-name "$share" \
+    --path "$dest/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors) || present="unknown"
+  if [ "$present" != "true" ]; then
+    echo "::notice::$dest carries no $SENTINEL (exists=$present) — the mix is already unreadable to every consumer; nothing to remove."
+    return 0
+  fi
+  if az storage file delete --account-name "$account" --share-name "$share" \
+      --path "$dest/$SENTINEL" --auth-mode login --backup-intent --only-show-errors > /dev/null; then
+    echo "::warning::removed $dest/$SENTINEL — it sealed a directory holding bytes from two publications. The prefix is now unsealed (consumers skip it) rather than serving a mix; the next publication of either lane republishes it wholesale."
+    return 0
+  fi
+  echo "::error::$dest/$SENTINEL seals a MIX and could not be removed — consumers will keep adopting bytes from two publications until a publication of either lane replaces it. Remove it by hand."
+  return 1
+}
+
+# THE POSTCONDITION. Runs immediately before the seal. Every file is sorted into three buckets,
+# and the buckets are what decide the verdict:
+#
+#   OURS      the digest matches what we uploaded AND our publication token wrote it. Only this run
+#             could have put those bytes there.
+#   NEUTRAL   the digest matches ours but another publication wrote it. The bytes are the ones we
+#             uploaded, so this file is compatible with BOTH publications and distinguishes
+#             nothing. This bucket is not a curiosity: `architecture.txt` is 'linux-x64' in every
+#             bake, `modules/_index` is the same list whenever the module set is unchanged, and a
+#             bundle a narrowed bake did not touch is byte-identical across two source shas.
+#   FOREIGN   the digest differs, or there is none. Somebody else's bytes are on the shelf.
+#
+#   FOREIGN = 0                → SEAL. Every file is byte-for-byte this run's publication.
+#   OURS = 0 and FOREIGN > 0   → SUPERSEDED. Nothing that distinguishes this run survived: the
+#                                shelf is another publication, whole and self-consistent. LEAVE ITS
+#                                SEAL ALONE and go RED — a run that reports "published" having
+#                                shipped nothing is the silent-nothing outcome this script exists
+#                                to make impossible, and deleting a good seal would strand the
+#                                identity unsealed until that lane's content next changes.
+#   OURS > 0 and FOREIGN > 0   → MIX. Refuse, and remove any sentinel over it.
+#
+# 🚨 Counting NEUTRAL as OURS is the mistake that turns a clean supersession into a false "mix",
+# and a false mix DELETES a publication that was never wrong. Measured while building this: with
+# the satellite's publication whole on the shelf, `architecture.txt` alone made OURS = 1 and the
+# core lane deleted the satellite's seal.
+verify_publication() { # <account> <share> <dest>
+  local account="$1" share="$2" dest="$3" rel expected actual owner props fields ours=0 neutral=0
+  local -a foreign=() unreadable=() overlapped=()
+  while IFS=$'\t' read -r rel expected; do
+    [ -n "$rel" ] || continue
+    # 🚨 FAIL CLOSED. `|| echo ""` on the read would turn a transient fault, an expired credential
+    # or a CLI shape change into "no digest recorded" — the one answer that is indistinguishable
+    # from "another publisher wrote this", and the errors below would then name the wrong cause.
+    # An unreadable file is refused as loudly as a foreign one; it is simply refused by name.
+    if ! props=$(az storage file show --account-name "$account" --share-name "$share" \
+        --path "$dest/$rel" --auth-mode login --backup-intent \
+        --query "[[metadata.digest || '-', metadata.publication || '-']]" -o tsv --only-show-errors); then
+      unreadable+=("$rel")
+      continue
+    fi
+    # 🚨 THE RENDERING IS MEASURED, NOT ASSUMED, and getting it wrong is silent. knack's
+    # `format_tsv` treats a TOP-LEVEL list as ROWS: `--query "[a, b]" -o tsv` prints a's value and
+    # b's value on TWO LINES, not as two columns — so `awk '{print $2}'` would read EMPTY for every
+    # file, every `owner` would compare unequal to $PUBLICATION, `ours` would be 0 on every publish
+    # and this postcondition would refuse EVERY publication in the fleet as "superseded". Hence a
+    # list-of-ONE-ROW: `[[a, b]]` renders one tab-separated line. The `|| '-'` guards exist because
+    # a null field renders as the LITERAL STRING 'None', not as empty. Both measured against
+    # azure-cli 2.90.0's own jmespath + knack formatter.
+    #
+    # The field count is ASSERTED rather than trusted: if that rendering ever changes, this is a
+    # loud refusal on the next publish instead of a fleet-wide false verdict.
+    fields=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print NF }')
+    if [ "${fields:-0}" -ne 2 ]; then
+      echo "::error::az answered '$props' for $dest/$rel — one tab-separated row of TWO fields was expected from --query \"[[metadata.digest || '-', metadata.publication || '-']]\" -o tsv. The CLI's rendering has changed; this verification cannot be trusted until the parse is updated to match."
+      unreadable+=("$rel (unexpected --query rendering: $fields field(s))")
+      continue
+    fi
+    actual=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $1 }')
+    owner=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
+    if [ "$actual" = "-" ]; then actual=""; fi
+    if [ "$owner" = "-" ]; then owner=""; fi
+    if [ -z "$actual" ]; then
+      # Present, but carrying no digest at all: written by a publisher that predates this stamp
+      # (a repo still pinned to an older copy of this script) or by something else entirely.
+      # Either way its bytes cannot be established, and the seal must not claim them.
+      foreign+=("$rel (no digest recorded — written by a publisher that does not stamp one)")
+      continue
+    fi
+    if [ "$actual" != "$expected" ]; then
+      foreign+=("$rel (we uploaded $expected, the shelf holds $actual, written by publication '${owner:-<unstamped>}')")
+      continue
+    fi
+    if [ "$owner" = "$PUBLICATION" ]; then
+      ours=$((ours + 1))
+    else
+      neutral=$((neutral + 1))
+      overlapped+=("$rel ← '${owner:-<unstamped>}'")
+    fi
+  done < "$MANIFEST"
+
+  for rel in ${overlapped[@]+"${overlapped[@]}"}; do
+    echo "::notice::under $dest: $rel — that publication wrote the very bytes this run uploaded, so two publications overlapped on this prefix (MeshWeaver#3461). Identical bytes distinguish nothing, so this file is not a mix."
+  done
+
+  # An unreadable file leaves the verdict UNDECIDABLE, so it takes precedence over all three and
+  # never touches an existing sentinel: we cannot tell a mix from a clean supersession.
+  if [ "${#unreadable[@]}" -gt 0 ]; then
+    echo "::error title=Refusing to seal — the publication could not be read back::$account/$share/$dest: ${#unreadable[@]} of $MANIFEST_COUNT file(s) could not be read after being uploaded, so whether this directory holds one publication or two cannot be established. Refusing rather than assuming — that assumption is what would seal a mix."
+    local entry
+    for entry in "${unreadable[@]}"; do echo "::error::could not read back after uploading it: $entry"; done
+    return 1
+  fi
+
+  if [ "${#foreign[@]}" -eq 0 ]; then
+    echo "verified: $account/$share/$dest — $((ours + neutral))/$MANIFEST_COUNT file(s) hold this run's bytes ($ours written by publication $PUBLICATION, $neutral byte-identical from another)"
+    return 0
+  fi
+
+  local entry
+  if [ "$ours" -eq 0 ]; then
+    echo "::error title=Refusing to seal — this run's publication was entirely superseded::$account/$share/$dest holds nothing that distinguishes this run: ${#foreign[@]} of $MANIFEST_COUNT file(s) were overwritten by another publication while this one was in flight, and the remaining $neutral are byte-identical in both (MeshWeaver#3461). That publication is whole, and is left exactly as it is — sealing OUR sentinel over it would claim a bundle set that is not there. Nothing of this run reached this target."
+    for entry in "${foreign[@]}"; do echo "::error::superseded: $entry"; done
+    echo "::error::$OVERLAP_WRITERS"
+    return 1
+  fi
+
+  echo "::error title=Refusing to seal — this directory holds a MIX of two publications::$account/$share/$dest holds $ours file(s) only this run could have written and ${#foreign[@]} written by another publication ($neutral more are byte-identical in both; $MANIFEST_COUNT in total). Sealing now would write a sentinel over bytes from two bakes — one seal, one generation, self-consistent to every consumer and wrong (MeshWeaver#3461). Its first symptom is 'dependency record mismatch — built against mvid:…' on a portal that renders nothing."
+  for entry in "${foreign[@]}"; do echo "::error::overwritten during this publication: $entry"; done
+  echo "::error::$OVERLAP_WRITERS"
+  unseal_mixed_publication "$account" "$share" "$dest" || true
+  return 1
+}
+
 # The release-marker directory (must match PublishedBundleCatalogue.ReleaseMarkerDirectoryName).
 # Leading underscore so it can never collide with a framework-identity directory (s… / g…).
 RELEASES_DIR="_releases"
@@ -238,37 +506,37 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   fi
   local zip
   for zip in "${BUNDLES[@]}"; do
-    az storage file upload --account-name "$account" --share-name "$share" \
-      --path "$dest/$(basename "$zip")" --source "$zip" \
-      --auth-mode login --backup-intent --only-show-errors > /dev/null
+    upload_published_file "$account" "$share" "$dest" "$(basename "$zip")" "$zip"
     echo "published: $account/$share/$dest/$(basename "$zip")"
   done
   # The module set: every bundle, then its index — both strictly before the sentinel.
   ensure_directory "$account" "$share" "$dest/$MODULES_DIR_NAME"
   local m
   for m in ${MODULES[@]+"${MODULES[@]}"}; do
-    az storage file upload --account-name "$account" --share-name "$share" \
-      --path "$dest/$MODULES_DIR_NAME/$(basename "$m")" --source "$m" \
-      --auth-mode login --backup-intent --only-show-errors > /dev/null
+    upload_published_file "$account" "$share" "$dest" \
+      "$MODULES_DIR_NAME/$(basename "$m")" "$m"
     echo "published module: $account/$share/$dest/$MODULES_DIR_NAME/$(basename "$m")"
   done
-  az storage file upload --account-name "$account" --share-name "$share" \
-    --path "$dest/$MODULES_DIR_NAME" --source "$MODULES_INDEX_LOCAL" \
-    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  upload_published_file "$account" "$share" "$dest" \
+    "$MODULES_DIR_NAME/$MODULES_INDEX" "$MODULES_INDEX_LOCAL" "$dest/$MODULES_DIR_NAME"
   echo "module set: $account/$share/$dest/$MODULES_DIR_NAME/$MODULES_INDEX (${#MODULES[@]} bundle(s))"
   # 🚨 Both marker uploads pass the DIRECTORY as --path on purpose — the CLI appends the source
   # basename. An extensionless "$dest/$SENTINEL" --path would be silently re-interpreted as a
   # DIRECTORY and fail ParentNotFound (see the SENTINEL_LOCAL comment above).
-  az storage file upload --account-name "$account" --share-name "$share" \
-    --path "$dest" --source "$SOURCE_MARKER_LOCAL" \
-    --auth-mode login --backup-intent --only-show-errors > /dev/null
-  az storage file upload --account-name "$account" --share-name "$share" \
-    --path "$dest" --source "$ARCH_MARKER_LOCAL" \
-    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  upload_published_file "$account" "$share" "$dest" "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL" "$dest"
+  upload_published_file "$account" "$share" "$dest" "$ARCH_MARKER" "$ARCH_MARKER_LOCAL" "$dest"
+  # 🚨 THE POSTCONDITION, between the last content upload and the seal (MeshWeaver#3461). Every
+  # file above is read back and must still carry THIS run's digest; a foreign publisher that
+  # overwrote any of them makes this refuse, and the directory stays sentinel-less rather than
+  # sealed over a mix. See the long note beside verify_publication.
+  if ! verify_publication "$account" "$share" "$dest"; then
+    exit 1
+  fi
   # LAST write — the atomic completeness marker. Anything that dies before this line leaves the
   # directory sentinel-less: unreadable to portals, re-published wholesale by the next run.
   az storage file upload --account-name "$account" --share-name "$share" \
     --path "$dest" --source "$SENTINEL_LOCAL" \
+    --metadata "digest=$(sha256_of "$SENTINEL_LOCAL")" "publication=$PUBLICATION" \
     --auth-mode login --backup-intent --only-show-errors > /dev/null
   echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s), source ${SOURCE_SHA:-unknown})"
 }

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""EXECUTE publish-bake-bundles.sh with TWO publishers on one prefix, and prove what gets sealed.
+
+WHY
+---
+`prebuilt-bundles/<framework-identity>/plugins/` has TWO writers: core CD's `plugins-bake` job
+(publishing MeshWeaver.Plugins content at `gate.outputs.plugins_sha`) and the MeshWeaver.Plugins
+satellite's own `publish-bake` (publishing its own head). Both call this one script, and they
+resolve the SAME framework identity whenever the core surface has not changed between core's tip
+and the satellite's pin — the ordinary case, because the identity is breaking-change-keyed.
+
+Interleave them and `publish_one_target` seals a sentinel over a directory holding some of each
+one's bytes: one seal, one generation, self-consistent to every consumer, and WRONG. #3460's
+read-side generation cannot see it (there is nothing stale to refuse) and the boot seeder cannot
+see it (the sentinel is present and every listed bundle exists). The first symptom is
+`dependency record mismatch — built against mvid:…, live is mvid:…` on a portal that renders
+nothing. MeshWeaver#3461.
+
+Nothing executed this script's publish path before. It talks to Azure Files, it runs only on main
+in five repositories, and the first execution of any edit to it is a production publish.
+
+HOW IT STAYS HONEST
+-------------------
+* The REAL script is run, both times — a copy passes while the real thing rots. The `--script`
+  option exists so the same cases can be run against the PRE-FIX script to prove they fail there;
+  CI always runs them against the script beside this file.
+* The verdict is read off THE BYTES on the fake share, never off the script's own log: each fixture
+  bundle's content names the bake that produced it, so "the sealed directory holds bytes from two
+  bakes" is a fact about the shelf, not a claim the script makes about itself.
+* Three CONTROL cases must PASS (a settled publish, a republish of new content, an already-
+  published skip). A harness whose only cases are failures cannot tell "the script refuses
+  correctly" from "the script always refuses".
+* Every case prints its denominator — files expected, files present, files per bake — and a case
+  that finds ZERO files FAILS. A check that looked in the wrong place must go red, not green.
+* The stub `az` refuses an argument shape or a `--query` it does not implement, so the script and
+  the stub cannot drift apart silently: change the script's query and this harness goes red until
+  the stub is taught the new one.
+
+WHAT THIS HARNESS CANNOT PROVE
+------------------------------
+The stub is not Azure Files. It reproduces the parts the script depends on — an extensionless
+`--path` naming a directory, per-file metadata, the sentinel written last — and nothing else. In
+particular the exact JSON shape of the real `az storage file show` is taken from the CLI's own
+transformer (`transform_file_show_result` puts the file's metadata at the TOP level), and asserted
+only there. What the harness CAN prove about the real CLI it does: the fidelity case runs the read-
+back query through the real `jmespath` engine azure-cli evaluates `--query` with, and asserts the
+shape knack then renders as ONE tab-separated row. That case exists because the first draft of this
+change used a flat `[a, b]` — which knack prints as TWO LINES, so `$2` would have read empty for
+every file and the postcondition would have refused every publication in the fleet. The stub said
+nothing, because the stub was written to match the draft.
+
+Beyond that the script fails CLOSED on an unreadable, empty or unexpectedly-shaped answer, so a CLI
+change is a RED publish rather than a silent one — the only protection available against a shape
+this harness cannot run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import jmespath
+except ImportError:  # pragma: no cover — the CI step installs it; locally `pip install jmespath`
+    print("::error::test-publish-bake-overlap.py needs jmespath (the engine azure-cli evaluates "
+          "--query with) to assert how the publish script's read-back query renders. Refusing "
+          "rather than skipping that case: it is the one thing this harness's stub cannot prove "
+          "about the real CLI.")
+    raise SystemExit(1) from None
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_SCRIPT = HERE / "publish-bake-bundles.sh"
+
+IDENTITY = "s0123456789abcdef0123456789abcdef"
+SOURCE = "plugins"
+ACCOUNT = "portalstore"
+SHARE = "memex-data"
+TARGET = f"{ACCOUNT}/{SHARE}"
+DEST = f"prebuilt-bundles/{IDENTITY}/{SOURCE}"
+SENTINEL = "_complete"
+
+# 🚨 THE ONE `file show` QUERY, and its exact shape is load-bearing. knack's `format_tsv` renders a
+# TOP-LEVEL list as ROWS, so `--query "[a, b]" -o tsv` prints TWO LINES rather than two columns; a
+# script parsing `$2` would then read EMPTY for every file, count `ours` as zero on every publish,
+# and refuse every publication in the fleet as "superseded". A list-of-ONE-ROW renders one
+# tab-separated line. And a null field renders as the LITERAL 'None', which is why both fields
+# carry a `|| '-'` guard. Measured against azure-cli 2.90.0's own jmespath + knack formatter; the
+# fidelity case below re-asserts it with the real jmespath engine on every run.
+SHOW_QUERY = "[[metadata.digest || '-', metadata.publication || '-']]"
+
+BUNDLES = ["Chess.zip", "Edu.zip", "Store.zip"]
+MODULES = ["MeshWeaver.AI.module.nupkg", "MeshWeaver.Maps.module.nupkg"]
+# bundles + modules + modules/_index + source-commit.txt + architecture.txt
+EXPECTED_FILES = len(BUNDLES) + len(MODULES) + 3
+
+
+# ────────────────────────────── the stub `az` ──────────────────────────────
+# Written to disk and put first on PATH. It models exactly the surface publish-bake-bundles.sh
+# uses, and it REFUSES anything else rather than shrugging: an unimplemented flag or query would
+# otherwise let the script drift away from what this harness exercises.
+STUB_AZ = r'''#!/usr/bin/env python3
+import base64, hashlib, json, os, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(os.environ["MOCK_AZ_ROOT"])
+
+def die(msg):
+    sys.stderr.write("stub-az: " + msg + "\n")
+    sys.exit(64)
+
+argv = sys.argv[1:]
+if argv[:2] != ["storage"]:
+    if len(argv) < 2 or argv[0] != "storage":
+        die("only `az storage …` is modelled; got: " + " ".join(argv))
+group, verb = argv[1], argv[2] if len(argv) > 2 else ""
+opts, i = {}, 3
+while i < len(argv):
+    a = argv[i]
+    if not a.startswith("--"):
+        die("unexpected positional argument %r in: %s" % (a, " ".join(argv)))
+    vals = []
+    i += 1
+    while i < len(argv) and not argv[i].startswith("--"):
+        vals.append(argv[i]); i += 1
+    # -o tsv arrives as `-o` `tsv` only when the caller writes it that way; the script uses `-o`.
+    opts.setdefault(a, []).extend(vals)
+# `-o tsv` is written as a short flag; normalise it.
+raw = " ".join(argv)
+out_tsv = " -o tsv" in raw
+
+def flag(name, required=True):
+    v = opts.get(name)
+    if not v:
+        if required:
+            die("missing %s in: %s" % (name, raw))
+        return None
+    return v[0]
+
+def share_root():
+    return ROOT / flag("--account-name") / flag("--share-name")
+
+def meta_path(p):
+    return ROOT / ".meta" / flag("--account-name") / flag("--share-name") / (str(p) + ".json")
+
+def emit(v):
+    sys.stdout.write(v + "\n")
+
+def run_hook(when, rel):
+    on = os.environ.get("MOCK_AZ_HOOK_ON")
+    if not on or on != rel:
+        return
+    if os.environ.get("MOCK_AZ_HOOK_WHEN", "before") != when:
+        return
+    once = os.environ.get("MOCK_AZ_HOOK_ONCE")
+    if once:
+        marker = Path(once)
+        if marker.exists():
+            return
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("fired")
+    cmd = os.environ["MOCK_AZ_HOOK_CMD"]
+    env = dict(os.environ)
+    for k in ("MOCK_AZ_HOOK_ON", "MOCK_AZ_HOOK_CMD", "MOCK_AZ_HOOK_ONCE", "MOCK_AZ_HOOK_WHEN"):
+        env.pop(k, None)
+    subprocess.run(["bash", "-c", cmd], env=env, check=False)
+
+if group == "storage" and verb == "":
+    die("no verb: " + raw)
+
+sub = argv[1]          # directory | file
+action = argv[2]       # exists | create | upload | download | delete | show
+if sub == "directory":
+    name = flag("--name")
+    d = share_root() / name
+    if action == "exists":
+        if opts.get("--query", [""])[0] != "exists" or not out_tsv:
+            die("only `--query exists -o tsv` is modelled for directory exists: " + raw)
+        emit("true" if d.is_dir() else "false"); sys.exit(0)
+    if action == "create":
+        d.mkdir(parents=True, exist_ok=True); sys.exit(0)
+    die("unmodelled directory action %r" % action)
+
+if sub != "file":
+    die("unmodelled storage group %r" % sub)
+
+path = flag("--path")
+
+if action == "exists":
+    if opts.get("--query", [""])[0] != "exists" or not out_tsv:
+        die("only `--query exists -o tsv` is modelled for file exists: " + raw)
+    emit("true" if (share_root() / path).is_file() else "false"); sys.exit(0)
+
+if action == "upload":
+    src = Path(flag("--source"))
+    dest_dir = share_root() / path
+    # 🚨 The real CLI silently treats an EXTENSIONLESS --path as a DIRECTORY and appends the
+    # source basename; the script relies on that for _complete, modules/_index and the two
+    # markers. Model it by the same rule the script documents: an existing directory wins.
+    if dest_dir.is_dir():
+        target = dest_dir / src.name
+    else:
+        target = share_root() / path
+    rel = str(target.relative_to(share_root()))
+    run_hook("before", rel)
+    n = int(os.environ.get("MOCK_AZ_UPLOADS_SO_FAR_FILE_COUNT", "0"))
+    counter = os.environ.get("MOCK_AZ_UPLOAD_COUNTER")
+    if counter:
+        c = Path(counter)
+        n = (int(c.read_text()) if c.exists() else 0) + 1
+        c.write_text(str(n))
+        cap = os.environ.get("MOCK_AZ_FAIL_UPLOADS_AFTER")
+        if cap and n > int(cap):
+            sys.stderr.write("stub-az: simulated upload failure (#%d)\n" % n)
+            sys.exit(1)
+    if not target.parent.is_dir():
+        sys.stderr.write("stub-az: ParentNotFound for %s\n" % target); sys.exit(1)
+    target.write_bytes(src.read_bytes())
+    md = {}
+    for kv in opts.get("--metadata", []):
+        k, _, v = kv.partition("=")
+        md[k] = v
+    mp = meta_path(rel)
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    mp.write_text(json.dumps(md))
+    run_hook("after", rel)
+    sys.exit(0)
+
+if action == "download":
+    src = share_root() / path
+    dest = Path(flag("--dest"))
+    if not src.is_file():
+        sys.stderr.write("stub-az: ResourceNotFound %s\n" % path); sys.exit(1)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(src.read_bytes()); sys.exit(0)
+
+if action == "delete":
+    f = share_root() / path
+    if not f.is_file():
+        sys.stderr.write("stub-az: ResourceNotFound %s\n" % path); sys.exit(1)
+    f.unlink()
+    mp = meta_path(path)
+    if mp.exists():
+        mp.unlink()
+    sys.exit(0)
+
+if action == "show":
+    SHOW_QUERY = os.environ["MOCK_AZ_SHOW_QUERY"]
+    q = opts.get("--query", [None])[0]
+    if q != SHOW_QUERY or not out_tsv:
+        die("this stub models exactly one `file show` query, %r with -o tsv — the script asked "
+            "for %r. Teach the stub the new query (and re-measure how knack renders it) rather "
+            "than loosening it." % (SHOW_QUERY, q))
+    fails = os.environ.get("MOCK_AZ_SHOW_FAILS")
+    if fails and path.endswith(fails):
+        sys.stderr.write("stub-az: simulated read failure for %s\n" % path); sys.exit(1)
+    f = share_root() / path
+    if not f.is_file():
+        sys.stderr.write("stub-az: ResourceNotFound %s\n" % path); sys.exit(1)
+    mp = meta_path(path)
+    md = json.loads(mp.read_text()) if mp.exists() else {}
+    # 🚨 The rendering the REAL cli produces, measured against azure-cli 2.90.0's own jmespath +
+    # knack.output.format_tsv: `[[a || '-', b || '-']]` is ONE tab-separated row, and an absent
+    # value is '-'. A flat `[a, b]` would print two LINES instead, which is the shape the script
+    # must never go back to — see the fidelity assertion in run_cases.
+    emit("%s\t%s" % (md.get("digest") or "-", md.get("publication") or "-"))
+    sys.exit(0)
+
+die("unmodelled file action %r" % action)
+'''
+
+
+# ────────────────────────────── fixtures ──────────────────────────────
+class Bake:
+    """One producer's bake directory — every byte in it names the bake that made it."""
+
+    def __init__(self, root: Path, name: str, source_sha: str):
+        self.name = name
+        self.source_sha = source_sha
+        self.dir = root / f"bake-{name}"
+        (self.dir / "modules").mkdir(parents=True, exist_ok=True)
+        (self.dir / "framework-mvid.txt").write_text(IDENTITY + "\n")
+        for b in BUNDLES:
+            (self.dir / b).write_text(f"{b} produced by bake {name} at {source_sha}\n")
+        for m in MODULES:
+            (self.dir / "modules" / m).write_text(f"{m} produced by bake {name} at {source_sha}\n")
+
+
+class Shelf:
+    """The fake Azure Files share, read as a consumer would: by the bytes, not by the log."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.dest = root / ACCOUNT / SHARE / DEST
+
+    def sealed(self) -> bool:
+        return (self.dest / SENTINEL).is_file()
+
+    def files(self) -> dict[str, str]:
+        """path-under-dest → content, for every published file (the sentinel excluded)."""
+        out: dict[str, str] = {}
+        if not self.dest.is_dir():
+            return out
+        for p in sorted(self.dest.rglob("*")):
+            if p.is_file() and p.name != SENTINEL:
+                out[str(p.relative_to(self.dest))] = p.read_text()
+        return out
+
+    def bakes_present(self) -> dict[str, int]:
+        """bake name → how many published files came from it. THE denominator of every verdict."""
+        counts: dict[str, int] = {}
+        for content in self.files().values():
+            for token in content.split():
+                pass
+            # every fixture file says "… produced by bake <name> at <sha>"
+            parts = content.split(" produced by bake ", 1)
+            who = parts[1].split(" at ", 1)[0] if len(parts) == 2 else "<marker>"
+            counts[who] = counts.get(who, 0) + 1
+        return counts
+
+    def sealed_mix(self) -> bool:
+        """A sentinel over bytes from more than one bake — the defect, stated as a fact."""
+        if not self.sealed():
+            return False
+        return len([b for b in self.bakes_present() if b != "<marker>"]) > 1
+
+
+# ────────────────────────────── the runner ──────────────────────────────
+class Harness:
+    def __init__(self, script: Path, workdir: Path):
+        self.script = script
+        self.work = workdir
+        self.shelf_root = workdir / "share"
+        self.bin = workdir / "bin"
+        self.bin.mkdir(parents=True, exist_ok=True)
+        az = self.bin / "az"
+        az.write_text(STUB_AZ)
+        az.chmod(0o755)
+
+    def publish(self, bake: Bake, publisher: str, run_id: str, env_extra: dict | None = None):
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["MOCK_AZ_ROOT"] = str(self.shelf_root)
+        env["MOCK_AZ_SHOW_QUERY"] = SHOW_QUERY
+        env["BAKE_PUBLISH_TARGETS"] = TARGET
+        env["GITHUB_REPOSITORY"] = publisher
+        env["GITHUB_RUN_ID"] = run_id
+        env["GITHUB_RUN_ATTEMPT"] = "1"
+        env.pop("EXT_MODULES_DIR", None)
+        env.pop("GITHUB_STEP_SUMMARY", None)
+        for k in ("MOCK_AZ_HOOK_ON", "MOCK_AZ_HOOK_CMD", "MOCK_AZ_HOOK_ONCE", "MOCK_AZ_HOOK_WHEN",
+                  "MOCK_AZ_FAIL_UPLOADS_AFTER", "MOCK_AZ_UPLOAD_COUNTER", "MOCK_AZ_SHOW_FAILS"):
+            env.pop(k, None)
+        env.update({k: str(v) for k, v in (env_extra or {}).items()})
+        return subprocess.run(
+            ["bash", str(self.script), str(bake.dir), SOURCE, bake.source_sha],
+            capture_output=True, text=True, env=env,
+        )
+
+    def publish_command(self, bake: Bake, publisher: str, run_id: str,
+                        env_extra: dict | None = None) -> str:
+        """The same publication, as a shell command a stub hook can run mid-upload."""
+        assigns = {
+            "PATH": f"{self.bin}:$PATH",
+            "MOCK_AZ_ROOT": str(self.shelf_root),
+            "MOCK_AZ_SHOW_QUERY": SHOW_QUERY,
+            "BAKE_PUBLISH_TARGETS": TARGET,
+            "GITHUB_REPOSITORY": publisher,
+            "GITHUB_RUN_ID": run_id,
+            "GITHUB_RUN_ATTEMPT": "1",
+        }
+        assigns.update({k: str(v) for k, v in (env_extra or {}).items()})
+        prefix = " ".join(f'{k}="{v}"' for k, v in assigns.items())
+        return (f'{prefix} bash "{self.script}" "{bake.dir}" {SOURCE} {bake.source_sha}'
+                f' > "{self.work}/inner-{run_id}.log" 2>&1')
+
+    def reset(self):
+        if self.shelf_root.exists():
+            shutil.rmtree(self.shelf_root)
+        self.shelf_root.mkdir(parents=True, exist_ok=True)
+
+    def shelf(self) -> Shelf:
+        return Shelf(self.shelf_root)
+
+
+FAILURES: list[str] = []
+PASSES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = ""):
+    if condition:
+        PASSES.append(name)
+        print(f"  OK   {name}" + (f" — {detail}" if detail else ""))
+    else:
+        FAILURES.append(name)
+        print(f"  FAIL {name}" + (f" — {detail}" if detail else ""))
+
+
+def denominator(shelf: Shelf) -> str:
+    files = shelf.files()
+    bakes = shelf.bakes_present()
+    return (f"{len(files)}/{EXPECTED_FILES} file(s) present, sealed={shelf.sealed()}, "
+            f"by bake: {bakes or '{}'}")
+
+
+# ────────────────────────────── the cases ──────────────────────────────
+def check_query_fidelity(script: Path) -> None:
+    """The one thing the stub cannot prove: how the REAL cli renders this script's read-back query.
+
+    knack.output.format_tsv does `result if isinstance(result, list) else [result]` and then dumps
+    each element as a ROW. So a flat two-element list is two LINES, and only a list-of-one-list is
+    one row of two tab-separated columns. Asserted here with the engine azure-cli itself uses.
+    """
+    print("\nquery fidelity (the stub cannot prove this; the real jmespath engine can):")
+    text = script.read_text()
+    check("the script asks for exactly the query this harness models",
+          SHOW_QUERY in text, f"{SHOW_QUERY!r}")
+
+    rows = jmespath.compile(SHOW_QUERY).search(
+        {"name": "a.zip", "metadata": {"digest": "abc", "publication": "Systemorph-MW-1-1"}})
+    check("the query yields ONE row of TWO columns, not two rows",
+          isinstance(rows, list) and len(rows) == 1
+          and isinstance(rows[0], list) and len(rows[0]) == 2,
+          f"jmespath -> {rows!r}; knack would render {chr(9).join(rows[0])!r} on one line"
+          if isinstance(rows, list) and rows and isinstance(rows[0], list) else f"jmespath -> {rows!r}")
+
+    # A null field renders as the literal string 'None' unless it is guarded, and 'None' is not
+    # empty — so the script's fail-closed "no digest recorded" branch would never fire.
+    for label, doc in (("no metadata key", {"name": "a.zip"}),
+                       ("empty metadata", {"name": "a.zip", "metadata": {}}),
+                       ("null metadata", {"name": "a.zip", "metadata": None})):
+        got = jmespath.compile(SHOW_QUERY).search(doc)
+        check(f"an absent value is rendered '-' rather than a null ({label})",
+              got == [["-", "-"]], f"jmespath -> {got!r}")
+
+
+def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
+    # The pre-fix script reads nothing back, so it has no query to be faithful about. Every OTHER
+    # run asserts it — including `--script` pointed at a copy of the current one.
+    if not expect_defect:
+        check_query_fidelity(script)
+    h = Harness(script, work)
+    core = Bake(work, "core-cd", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    sat = Bake(work, "satellite", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    # ── CONTROL 1: one publisher, empty shelf. Must seal. ──────────────────────────────────────
+    print("\ncontrols (a harness whose only cases are failures cannot tell refusing from broken):")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1001")
+    s = h.shelf()
+    check("a settled publication seals",
+          r.returncode == 0 and s.sealed() and len(s.files()) == EXPECTED_FILES,
+          f"rc={r.returncode}, {denominator(s)}")
+    check("a settled publication holds exactly ONE bake's bytes",
+          len(s.files()) > 0 and set(s.bakes_present()) - {"<marker>"} == {"core-cd"},
+          denominator(s))
+
+    # ── CONTROL 2: a second publication of DIFFERENT content reseals cleanly. ──────────────────
+    r = h.publish(sat, "Systemorph/MeshWeaver.Plugins", "2001")
+    s = h.shelf()
+    check("a republication of new content reseals",
+          r.returncode == 0 and s.sealed() and set(s.bakes_present()) - {"<marker>"} == {"satellite"},
+          f"rc={r.returncode}, {denominator(s)}")
+
+    # ── CONTROL 3: the same content again is SKIPPED, and writes nothing. ─────────────────────
+    r = h.publish(sat, "Systemorph/MeshWeaver.Plugins", "2002")
+    s = h.shelf()
+    check("the same content is skipped, not republished",
+          r.returncode == 0 and s.sealed() and "already published; skipping" in r.stdout,
+          f"rc={r.returncode}, {denominator(s)}")
+
+    # ── OVERLAP A: the other lane dies mid-publication, having overwritten part of ours. ───────
+    print("\noverlap — the other lane is STILL IN FLIGHT when we seal:")
+    h.reset()
+    counter = work / "counter-inflight"
+    inner = h.publish_command(
+        sat, "Systemorph/MeshWeaver.Plugins", "2101",
+        {"MOCK_AZ_UPLOAD_COUNTER": counter, "MOCK_AZ_FAIL_UPLOADS_AFTER": 2},
+    )
+    r = h.publish(core, "Systemorph/MeshWeaver", "1101", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/{BUNDLES[-1]}",
+        "MOCK_AZ_HOOK_WHEN": "before",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-inflight",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    mixed = len(set(s.bakes_present()) - {"<marker>"}) > 1
+    check("the fixture really did produce a two-bake directory (the case is not vacuous)",
+          mixed, denominator(s))
+    if expect_defect:
+        check("PRE-FIX: a mix is SEALED", s.sealed_mix(), denominator(s))
+    else:
+        check("a mix is never sealed", not s.sealed_mix(), denominator(s))
+        check("the publisher refuses, naming the mix",
+              r.returncode != 0 and "holds a MIX of two publications" in r.stdout,
+              f"rc={r.returncode}")
+        check("the refusal names the overlapping publication",
+              "Systemorph-MeshWeaver.Plugins-2101" in r.stdout,
+              "the other lane's run is identified by name")
+
+    # ── OVERLAP B: the other lane finishes and SEALS, then we keep overwriting. ────────────────
+    print("\noverlap — the other lane COMPLETES inside a gap in our uploads:")
+    h.reset()
+    inner = h.publish_command(sat, "Systemorph/MeshWeaver.Plugins", "2201")
+    r = h.publish(core, "Systemorph/MeshWeaver", "1201", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/{BUNDLES[1]}",
+        "MOCK_AZ_HOOK_WHEN": "before",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-complete",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    check("the fixture really did produce a two-bake directory (the case is not vacuous)",
+          len(set(s.bakes_present()) - {"<marker>"}) > 1, denominator(s))
+    if expect_defect:
+        check("PRE-FIX: a mix is SEALED", s.sealed_mix(), denominator(s))
+    else:
+        check("a seal written by the other lane over a directory we then overwrote is REMOVED",
+              not s.sealed_mix() and not s.sealed(), denominator(s))
+        check("the publisher refuses and says the sentinel was removed",
+              r.returncode != 0 and f"removed {DEST}/{SENTINEL}" in r.stdout,
+              f"rc={r.returncode}")
+
+    # ── OVERLAP C: we are ENTIRELY superseded. The other publication must be left alone. ───────
+    print("\noverlap — we are entirely superseded (their publication is whole; leave it):")
+    h.reset()
+    inner = h.publish_command(sat, "Systemorph/MeshWeaver.Plugins", "2301")
+    r = h.publish(core, "Systemorph/MeshWeaver", "1301", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/architecture.txt",
+        "MOCK_AZ_HOOK_WHEN": "after",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-superseded",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    only_theirs = set(s.bakes_present()) - {"<marker>"} == {"satellite"}
+    check("the fixture really did leave the other lane's publication whole (not vacuous)",
+          only_theirs and len(s.files()) == EXPECTED_FILES, denominator(s))
+    if expect_defect:
+        check("PRE-FIX: the superseded run seals its own sentinel over their bytes",
+              s.sealed() and r.returncode == 0,
+              f"rc={r.returncode}, {denominator(s)}")
+    else:
+        check("a whole foreign publication keeps its seal",
+              s.sealed() and only_theirs, denominator(s))
+        check("the superseded publisher goes RED rather than claiming it published",
+              r.returncode != 0 and "entirely superseded" in r.stdout,
+              f"rc={r.returncode}")
+
+    # ── FAIL CLOSED: a file that cannot be read back is refused, not assumed unchanged. ────────
+    print("\nfail-closed (an unreadable answer is not a permissive one):")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1401", {"MOCK_AZ_SHOW_FAILS": BUNDLES[0]})
+    s = h.shelf()
+    if expect_defect:
+        check("PRE-FIX: nothing reads the publication back at all, so it seals",
+              s.sealed() and r.returncode == 0, f"rc={r.returncode}, {denominator(s)}")
+    else:
+        check("an unreadable file refuses the seal",
+              r.returncode != 0 and not s.sealed()
+              and "could not be read back" in r.stdout, f"rc={r.returncode}, {denominator(s)}")
+        check("an undecidable verdict does NOT remove a sentinel",
+              f"removed {DEST}/{SENTINEL}" not in r.stdout)
+
+    # ── UNSTAMPED: a publisher that writes no digest is not one of ours. ───────────────────────
+    print("\nan incumbent written by a publisher that stamps no digest:")
+    h.reset()
+    strip = (f'python3 -c "import json,pathlib;'
+             f"p=pathlib.Path(r'{h.shelf_root}/{ACCOUNT}/{SHARE}/{DEST}/{BUNDLES[0]}');"
+             f"m=pathlib.Path(r'{h.shelf_root}/.meta/{ACCOUNT}/{SHARE}/{DEST}/{BUNDLES[0]}.json');"
+             f'm.write_text(json.dumps({{}}))"')
+    r = h.publish(core, "Systemorph/MeshWeaver", "1501", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/architecture.txt",
+        "MOCK_AZ_HOOK_WHEN": "after",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-unstamped",
+        "MOCK_AZ_HOOK_CMD": strip,
+    })
+    s = h.shelf()
+    if expect_defect:
+        check("PRE-FIX: an unstamped file is invisible and the publication seals",
+              s.sealed() and r.returncode == 0, f"rc={r.returncode}, {denominator(s)}")
+    else:
+        check("a file carrying no digest is treated as foreign, and the seal is refused",
+              r.returncode != 0 and not s.sealed()
+              and "no digest recorded" in r.stdout, f"rc={r.returncode}, {denominator(s)}")
+
+    # ── DENOMINATOR: the verification covers the whole publication, and says so. ───────────────
+    print("\nthe verification prints its denominator:")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1601")
+    if expect_defect:
+        check("PRE-FIX: no verification runs, so there is no denominator to print",
+              "file(s) carry this run's bytes" not in r.stdout)
+    else:
+        check(f"every one of the {EXPECTED_FILES} published files is verified before the seal",
+              f"{EXPECTED_FILES}/{EXPECTED_FILES} file(s) hold this run's bytes" in r.stdout,
+              "expected/verified are both printed")
+
+    # ── SAME LANE: the shape that was actually measured most often. Two pushes to ONE repo bake
+    # ── concurrently and land on one identity; a single owner for the prefix does not touch it.
+    print("\nsame lane, two concurrent runs (four such overlaps measured in one day; zero cross-lane):")
+    h.reset()
+    later = Bake(work, "satellite-later", "cccccccccccccccccccccccccccccccccccccccc")
+    inner = h.publish_command(later, "Systemorph/MeshWeaver.Plugins", "2402")
+    r = h.publish(sat, "Systemorph/MeshWeaver.Plugins", "2401", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/{BUNDLES[1]}",
+        "MOCK_AZ_HOOK_WHEN": "before",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-samelane",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    check("the fixture really did produce a two-bake directory (the case is not vacuous)",
+          len(set(s.bakes_present()) - {"<marker>"}) > 1, denominator(s))
+    if expect_defect:
+        check("PRE-FIX: two runs of ONE repo seal a mix just as readily",
+              s.sealed_mix(), denominator(s))
+    else:
+        check("two runs of ONE repo are caught by the same postcondition",
+              not s.sealed_mix() and r.returncode != 0
+              and "holds a MIX of two publications" in r.stdout,
+              f"rc={r.returncode}, {denominator(s)}")
+        check("the refusal names same-lane concurrency, not only the other repo",
+              "WITHIN one lane" in r.stdout)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--script", type=Path, default=DEFAULT_SCRIPT,
+                    help="the publish script to execute (default: the one beside this file)")
+    ap.add_argument("--expect-defect", action="store_true",
+                    help="assert the PRE-FIX behaviour instead: overlaps seal a mix. Used to "
+                         "falsify the guard by running these same cases against the old script.")
+    args = ap.parse_args()
+
+    if not args.script.is_file():
+        print(f"::error::{args.script} does not exist — nothing to execute. A harness that cannot "
+              f"find its subject must go red, never green.")
+        return 1
+
+    print(f"publish-bake overlap harness — executing {args.script}")
+    print(f"  identity {IDENTITY}, source '{SOURCE}', {EXPECTED_FILES} file(s) per publication "
+          f"({len(BUNDLES)} bundle(s), {len(MODULES)} module(s), 3 marker/index file(s))")
+    with tempfile.TemporaryDirectory(prefix="publish-bake-overlap-") as tmp:
+        run_cases(args.script, Path(tmp), args.expect_defect)
+
+    total = len(PASSES) + len(FAILURES)
+    if total == 0:
+        print("::error::the harness ran ZERO assertions — a case list that executes nothing "
+              "renders the same green tick as one that passes. Refusing.")
+        return 1
+    print(f"\n{len(PASSES)} passed, {len(FAILURES)} failed, {total} assertion(s) total.")
+    if FAILURES:
+        print("::error title=publish-bake overlap harness failed::"
+              + "; ".join(FAILURES))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -257,6 +257,14 @@ if action == "show":
         die("this stub models exactly one `file show` query, %r with -o tsv — the script asked "
             "for %r. Teach the stub the new query (and re-measure how knack renders it) rather "
             "than loosening it." % (SHOW_QUERY, q))
+    # Reproduces the ONE way the read-back loop can end early: a command inside a `while read`
+    # loop that consumes the loop's stdin. Without the script's `< /dev/null` (and the accounting
+    # assertion behind it), the verification would cover a PREFIX of the publication and seal.
+    if os.environ.get("MOCK_AZ_EAT_STDIN") == "1":
+        try:
+            sys.stdin.read()
+        except Exception:
+            pass
     fails = os.environ.get("MOCK_AZ_SHOW_FAILS")
     if fails and path.endswith(fails):
         sys.stderr.write("stub-az: simulated read failure for %s\n" % path); sys.exit(1)
@@ -599,6 +607,21 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
         check(f"every one of the {EXPECTED_FILES} published files is verified before the seal",
               f"{EXPECTED_FILES}/{EXPECTED_FILES} file(s) hold this run's bytes" in r.stdout,
               "expected/verified are both printed")
+
+    # ── The read-back loop is fed by a redirect. A command inside it that ate stdin would end it
+    # ── early, and a verification covering a PREFIX would report no foreign bytes and SEAL.
+    print("\nthe read-back loop cannot be truncated by something eating its stdin:")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1701", {"MOCK_AZ_EAT_STDIN": "1"})
+    s = h.shelf()
+    if expect_defect:
+        check("PRE-FIX: no read-back loop exists to truncate",
+              s.sealed() and r.returncode == 0, f"rc={r.returncode}, {denominator(s)}")
+    else:
+        check("stdin-eating does not truncate the verification",
+              r.returncode == 0 and s.sealed()
+              and f"{EXPECTED_FILES}/{EXPECTED_FILES} file(s) hold this run's bytes" in r.stdout,
+              f"rc={r.returncode}, {denominator(s)} — all {EXPECTED_FILES} still verified")
 
     # ── SAME LANE: the shape that was actually measured most often. Two pushes to ONE repo bake
     # ── concurrently and land on one identity; a single owner for the prefix does not touch it.

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2008,6 +2008,24 @@ jobs:
     - name: "Execute compose-sealed-modules.sh against a republishing registry"
       run: python3 .github/scripts/test-sealed-module-compose.py
 
+    # The WRITER side of the same window (#3461). `prebuilt-bundles/<identity>/<source>/` has
+    # several publishers — core CD's `plugins-bake`, the satellite's own `publish-bake`, and (four
+    # times in one measured day, more often than the cross-lane case) two concurrent runs of ONE of
+    # them. Interleaved, publish-bake-bundles.sh used to seal a sentinel over bytes from two bakes:
+    # one seal, one generation, self-consistent to every consumer and WRONG, surfacing only as
+    # `dependency record mismatch — built against mvid:…` on a portal that renders nothing. This
+    # runs the REAL script twice, interleaved, against a stub share, and reads the verdict off the
+    # BYTES rather than off the script's own log.
+    - name: "Execute publish-bake-bundles.sh with two publishers on one prefix"
+      run: python3 .github/scripts/test-publish-bake-overlap.py
+
+    # carry-forward-bundles.sh is the other half of that publication and had NO CI execution at
+    # all: it runs only inside a node repo's publish lane, so the first execution of an edit was a
+    # production publish. Its self-test covers the shrink refusals it has always owed and the
+    # one-publication postcondition #3461 added.
+    - name: "Execute carry-forward-bundles.sh against its own fixtures"
+      run: bash .github/scripts/carry-forward-bundles.sh --self-test
+
   shared-rules:
     name: "AGENTS.md shared rule blocks"
     # 🚨 THE GAP THIS CLOSES (MeshWeaver.Plugins#705): every repo's CLAUDE.md is a one-line

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -2,7 +2,7 @@
 nodeType: Markdown
 name: Sealed Publication Reads
 category: Architecture
-description: How a consumer reads a sealed bundle publication while the publisher is replacing it — the three answers (404, 503, 412), the generation that pins one publication instance, and what is still not closed.
+description: How a sealed bundle publication is written and read while it is being replaced — the writer's byte-level postcondition that refuses to seal a mix, the three read answers (404, 503, 412), the generation that pins one publication instance, and what is still not closed.
 icon: /static/NodeTypeIcons/box.svg
 ---
 
@@ -51,11 +51,12 @@ Measured on 2026-09-06 (MeshWeaver.Plugins run 34029118937, one publish, two tar
 11:59:47  sealed: target 2/_complete (36 bundle(s))
 ```
 
-🚨 **And the prefix has TWO writers.** Core CD's `plugins-bake` job and the MeshWeaver.Plugins
+🚨 **And the prefix has SEVERAL writers.** Core CD's `plugins-bake` job and the MeshWeaver.Plugins
 satellite's own `publish-bake` both publish `bake-source: plugins`, so both write
 `prebuilt-bundles/<identity>/plugins/`. Attributing a window to "core CD is rolling" is therefore
 wrong roughly half the time — the 2026-09-06 red was the satellite's own bake, while two core CD
-runs were in flight publishing a *different* identity.
+runs were in flight publishing a *different* identity. And the more frequent overlap is not between
+the lanes at all — see "How many writers, measured" below.
 
 ## Three answers where there used to be one
 
@@ -143,16 +144,99 @@ dependency record mismatch — built against mvid:…, live is mvid:…
 failure `assert-bake-consumption.sh` exists to catch, and it is why the module lane is pinned even
 though its window is the same size as the bundle lane's.
 
+## How many writers, measured
+
+The issue that opened this ([#3461](https://github.com/Systemorph/MeshWeaver/issues/3461)) names two
+lanes and asks which should own the prefix. Measuring first changed the answer, so the numbers are
+here rather than in a comment. **2026-09-06, one day: 25 core-CD publish jobs and 19 satellite ones
+examined; every job log fetched, none expired.**
+
+| | core CD `plugins-bake` | satellite `publish-bake` |
+|---|---|---|
+| distinct framework identities written | 20 | 2 |
+| identities written by BOTH lanes | 2 | 2 |
+| closest cross-lane approach on one identity | \-- | 24 min |
+| strict cross-lane time overlaps | 0 | 0 |
+| **same-lane time overlaps on one identity** | \-- | **4** |
+
+Both shared identities were the satellite unsealing core's publication and republishing it from a
+different source sha (`sf09fa2c9…`: `3e81b03960` → `9717e13e49`; `sa55f8190…`: `bbb893d673` →
+`88f1d44a19`). They collide because the identity is **breaking-change-keyed**: four consecutive
+image pairs in that same day resolved the *same* `s<hash>`, which is exactly what lets a frozen
+satellite pin land on an identity core CD is still publishing to.
+
+🚨 **Two conclusions, and the second is the one that decides the design.**
+
+1. **Neither lane can be removed.** Core CD wrote 20 identities, 18 of them reachable by no other
+   producer — a surface change mints a new identity that the satellite, pinned to an older core,
+   cannot publish to until its pin moves. The satellite wrote the only fresh *content* for its own
+   identity, and core CD batches, so dropping it would make plugin content delivery wait on core
+   merges. "Give the prefix a single owner" costs real coverage in both directions.
+2. **The single owner would race itself anyway.** The only overlaps actually measured were
+   *within* one lane — three concurrent bakes on `sa55f8190…` at 08:03Z, two of which sealed 24
+   minutes apart, plus three more pairs the same day — against zero cross-lane ones. A rule about
+   which *repository* owns the prefix does not address that at all.
+
+So the fix is publisher-agnostic: it asks *"are the bytes on the shelf the ones I uploaded"*, never
+*"which repo is the other one"*.
+
+## The writer's postcondition
+
+`publish-bake-bundles.sh` stamps every file it uploads with two metadata values —
+
+```
+digest       the SHA-256 of the exact local bytes uploaded
+publication  a token unique to this run (repository + run id + attempt), which also NAMES it
+```
+
+— and reads all of them back immediately before writing `_complete`. Each file lands in one of three
+buckets, and the buckets are the verdict:
+
+| bucket | meaning |
+|---|---|
+| **ours** | digest matches *and* our token wrote it — only this run could have put those bytes there |
+| **neutral** | digest matches, another publication wrote it. Compatible with both; distinguishes nothing |
+| **foreign** | digest differs, or there is none. Somebody else's bytes |
+
+- **foreign = 0** → seal. The directory is byte-for-byte this publication.
+- **ours = 0, foreign > 0** → *superseded*. Nothing distinguishing survived; the shelf is another
+  publication, whole. **Leave its seal alone** and go red — a run reporting "published" having
+  shipped nothing is the silent-nothing outcome this script exists to prevent.
+- **ours > 0, foreign > 0** → a **mix**. Refuse, and delete any sentinel over it, because a
+  publisher can finish and seal inside a gap in our uploads: refusing to write *our* sentinel is not
+  enough when the one already there covers a directory we have since partly overwritten.
+
+🚨 **The neutral bucket is not a nicety.** `architecture.txt` is `linux-x64` in every bake,
+`modules/_index` is the same list whenever the module set is unchanged, and a bundle a narrowed bake
+did not touch is byte-identical across two source shas. Counting those as *ours* turns a clean
+supersession into a false "mix" — measured while building this, `architecture.txt` alone made
+`ours = 1` and the core lane deleted the satellite's perfectly good seal.
+
+🚨 **A claim token cannot do this job**, and it is the obvious thing to reach for. "Stamp a marker
+before unsealing, re-read it before sealing" is check-then-act on one mutable cell with the wrong
+asymmetry: whoever stamps *last* re-reads its own marker and seals happily over the other's bytes.
+The loser detects the winner; the winner detects nothing. No arrangement of a single marker fixes
+that, because a marker records who wrote last, not whose bytes are on the shelf.
+
+The same two stamps close the carry-forward (below): `carry-forward-bundles.sh` verifies each
+bundle it downloads against the digest the publication records, and refuses when the carried set
+names more than one `publication` — which is what "the publication was replaced while I was reading
+it" looks like from inside a narrowed bake.
+
 ## What is NOT closed
 
 Stated plainly, because a page that only lists what works is how the next session repeats this.
 
-- 🚨 **Two writers on one prefix can produce a seal whose bytes are a mix, and no reader can detect
-  it.** If core CD and the Plugins satellite overlap on `<identity>/plugins`, both unseal, both
-  upload, and the last to seal writes a sentinel over a directory holding some of each one's bytes.
-  The result is *one* seal with *one* generation — self-consistent to every consumer, and wrong.
-  Closing it needs either a single owner for the prefix or a publish that cannot interleave
-  (a generation directory plus an atomic pointer swap); both are scope calls, not code changes.
+- 🚨 **The postcondition is a postcondition, not mutual exclusion.** It leaves one window: between
+  the last verification read and the `_complete` upload. A publisher that overwrites a file inside
+  that single-upload window still lands under this run's seal. That shrinks the exposure from the
+  whole ~90-second publication to one file upload, and it is why the *layout* question stays open —
+  a generation directory plus an atomic pointer swap removes republication in place entirely, and
+  is the shape the read side already pins. Closing it is a layout migration every reader must land
+  first.
+- **A refused publication leaves the prefix unsealed**, which every consumer skips — correct, and
+  it means an overlap now costs a red lane and a re-run rather than a portal that renders nothing.
+  It is not free: the identity serves nothing until either publisher runs again.
 - **The window itself remains.** In this layout it cannot be removed — in-place replacement means
   unsealed time, and the alternative is a layout migration every reader must land first (the portal
   boot seeder, the gate's Azure-direct path, and every pinned satellite workflow copy).
@@ -174,6 +258,21 @@ the pin is removed:
   reseal storm, and a registry publishing no generation at all. It asserts `If-Match` was actually
   sent, because a script that stopped pinning would still compose two files and pass on the outputs
   alone.
+- `.github/scripts/test-publish-bake-overlap.py` — runs the REAL `publish-bake-bundles.sh` **twice,
+  interleaved**, against a stub share, and reads the verdict off the BYTES rather than off the
+  script's own log: each fixture bundle names the bake that produced it, so "the sealed directory
+  holds two bakes" is a fact about the shelf. Twenty-one assertions over eight cases — three
+  controls that must PASS (settled publish, republish of new content, already-published skip), the
+  other lane in flight, the other lane completing inside a gap, a full supersession, an unreadable
+  read-back, an unstamped incumbent, and two concurrent runs of ONE repo. `--expect-defect` runs
+  the same cases against the pre-fix script and asserts the opposite; on `main` before the fix,
+  every overlap case sealed a mix.
+- `carry-forward-bundles.sh --self-test` — eleven cases, now executed by CI for the first time
+  (this script runs only inside a node repo's publish lane, so the first execution of an edit used
+  to be a production publish). It covers the shrink refusals it has always owed plus the
+  one-publication postcondition, the digest mismatch, the fail-closed unreadable stamp, and the
+  adoption path where an incumbent predates stamping and the check reports — with numbers — that it
+  proved nothing.
 
 Related: [CI Content Bake](../CiContentBake) · [Plugin Build Contract](../PluginBuildContract) ·
 [Bake Identity Mismatch](../BakeIdentityMismatch) · [Module Build Architecture](../ModuleBuildArchitecture)

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -237,6 +237,12 @@ Stated plainly, because a page that only lists what works is how the next sessio
 - **A refused publication leaves the prefix unsealed**, which every consumer skips — correct, and
   it means an overlap now costs a red lane and a re-run rather than a portal that renders nothing.
   It is not free: the identity serves nothing until either publisher runs again.
+- 🚨 **Expect the reds, and do not read them as noise.** The four same-lane overlaps measured on
+  2026-09-06 were, every one of them, a mix being sealed in silence. Under the postcondition each
+  becomes a red publish job in the repo that lost the race. That is four reds a day the fleet did
+  not have before, and it is the correct number: the alternative is four sealed mixes a day, which
+  is what the fleet actually had. Whoever is holding the loser's re-run should not "fix" it by
+  loosening the check.
 - **The window itself remains.** In this layout it cannot be removed — in-place replacement means
   unsealed time, and the alternative is a layout migration every reader must land first (the portal
   boot seeder, the gate's Azure-direct path, and every pinned satellite workflow copy).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-publication-refuses-to-seal-over-someone-elses-bytes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-publication-refuses-to-seal-over-someone-elses-bytes.md
@@ -1,0 +1,51 @@
+---
+Name: A publication refuses to seal over someone else's bytes
+Category: Fix
+Description: When two builds published add-on content to the same shelf at the same time, the result could be a set that was half one build and half the other — sealed, self-consistent, and wrong. The publisher now checks the bytes before sealing, and refuses.
+Icon: ShieldCheckmark
+Order: -20260907
+---
+
+# A publication refuses to seal over someone else's bytes
+
+Your portal does not compile the add-on content it ships. That content is baked once by CI, put on a
+shared shelf, and adopted at boot — which is why a portal starts in seconds instead of minutes.
+
+Several builds write to that shelf, and until now they could write to the *same* place at the same
+time. When they did, the result was a set of bundles that was partly from one build and partly from
+another, closed with a completeness marker saying the whole thing belonged together. Nothing could
+tell. Every check passed: the marker was there, every file it listed existed, and each individual
+read was served from something that looked complete.
+
+The failure only showed up later, on a running portal, as views that rendered nothing — because the
+add-on code had been compiled against one set of libraries and was being loaded beside a different
+one.
+
+## What changes
+
+Every file a build publishes now carries a fingerprint of its exact contents and the name of the
+build that put it there. Immediately before closing a publication, the build reads all of them back
+and asks one question: *are these the bytes I uploaded?*
+
+- **They are** → the publication is closed as before. Nothing about a normal publish changes.
+- **Some are not** → the build **refuses to close it**, says which files were overwritten and by
+  which other build, and removes any completeness marker that had been written over the mixture.
+  The shelf goes back to the state readers already skip, and the next publish rebuilds it whole.
+- **None are** → another build replaced this one entirely. That publication is left exactly as it
+  is — it is whole and correct — and this build reports that it shipped nothing, rather than
+  claiming success.
+
+The same fingerprints protect the case where a build only recompiles part of the content and carries
+the rest forward from what is already published: if the shelf is replaced while it is reading, the
+carried files no longer agree and the build stops instead of publishing a blend of two.
+
+## What you will notice
+
+Almost certainly nothing, which is the point. Two builds landing on one shelf at the same moment now
+produces a red build and a re-run, in place of a portal that starts cleanly and then shows empty
+pages for reasons nothing recorded.
+
+One narrow gap remains, and it is written down rather than glossed over: a build that overwrites a
+file in the instant between the final check and the closing marker can still slip under it. Removing
+that entirely means changing how publications are laid out on the shelf, which every reader has to
+learn first.


### PR DESCRIPTION
Refs #3461 — **the writer-side hazard is closed for every overlap the postcondition can see, but not
in full**, so the issue stays open for the layout question. What remains is stated below and in the
doc page rather than left to be re-derived.

`Pairs-with: none` — the diff removes no public type or member from `src/` (only `.md` under
`MeshWeaver.Documentation` and three files under `.github/`).

## The defect

`prebuilt-bundles/<identity>/<source>/` has several writers. Interleave two and
`publish_one_target` seals a sentinel over a directory holding **some of each one's bytes**: one
seal, one generation, self-consistent to every consumer and wrong. #3460's read-side generation
cannot see it (there is nothing stale to refuse), the boot seeder cannot see it (the sentinel is
present and every listed bundle exists), and the first symptom is
`dependency record mismatch — built against mvid:…` on a portal that renders nothing.

## Measuring first changed the answer

The issue names two directions — a single owner, or a generation-directory layout migration — and
does not choose. **2026-09-06, one day: 25 core-CD publish jobs and 19 satellite ones examined,
every job log fetched, none expired.**

| | core CD `plugins-bake` | satellite `publish-bake` |
|---|---|---|
| distinct framework identities written | 20 | 2 |
| identities written by BOTH lanes | 2 | 2 |
| closest cross-lane approach on one identity | — | 24 min |
| strict cross-lane time overlaps | 0 | 0 |
| **same-lane time overlaps on one identity** | — | **4** |

Both shared identities were the satellite unsealing core's publication and republishing it from a
different source sha (`sf09fa2c9…`: `3e81b03960` → `9717e13e49`; `sa55f8190…`: `bbb893d673` →
`88f1d44a19`).

**Direction 1 is falsified twice over.**

1. *Neither lane can be removed.* 18 of core CD's 20 identities are reachable by no other producer —
   a surface change mints an identity the pinned satellite cannot publish to until its pin moves —
   and the satellite is the only fresh-content path for its own identity, which core CD's batching
   would otherwise gate on core merges.
2. *The single owner would race itself anyway.* The only overlaps actually observed were **within**
   one lane — three concurrent bakes on `sa55f8190…` at 08:03Z, plus three more pairs the same day —
   against **zero** cross-lane ones. A rule about which repository owns the prefix does not address
   that at all.

**Direction 2** is a layout migration `ShippedPrebuiltBundles.SeedPublishedRoot`,
`PublishedBundleCatalogue`, the gate's Azure-direct `download-batch` path and every pinned satellite
workflow copy must land first. It stays the right end state and stays open.

So the fix is **publisher-agnostic**: it asks *"are the bytes on the shelf the ones I uploaded"*,
never *"which repo is the other one"*.

## What lands

Every file `publish-bake-bundles.sh` uploads now carries two Azure Files metadata values —
`digest` (sha256 of the exact bytes) and `publication` (a token unique to the run, which also names
it) — and all of them are read back immediately before `_complete`. Three buckets, three verdicts:

| bucket | meaning |
|---|---|
| **ours** | digest matches *and* our token wrote it |
| **neutral** | digest matches, another publication wrote it — compatible with both, distinguishes nothing |
| **foreign** | digest differs, or there is none |

- **foreign = 0** → seal.
- **ours = 0, foreign > 0** → *superseded*: the shelf is another publication, whole. **Leave its
  seal alone** and go red — a run reporting "published" having shipped nothing is the
  silent-nothing outcome this script exists to prevent.
- **ours > 0, foreign > 0** → a **mix**: refuse, and delete any sentinel over it. Refusing to write
  *our* sentinel is not enough when a publisher can finish and seal inside a gap in our uploads.

Two traps worth naming, because both are the obvious thing to do:

- **A claim token cannot do this job.** "Stamp a marker before unsealing, re-read it before sealing"
  is check-then-act on one mutable cell with the wrong asymmetry — whoever stamps *last* re-reads
  its own marker and seals happily over the other's bytes. The loser detects the winner; the winner
  detects nothing.
- **Counting NEUTRAL as OURS deletes good publications.** `architecture.txt` is `linux-x64` in every
  bake and `modules/_index` is the same list whenever the module set is unchanged. Measured while
  building this: with the satellite's publication whole on the shelf, `architecture.txt` alone made
  `ours = 1` and the core lane deleted the satellite's perfectly good seal.

`carry-forward-bundles.sh` — recorded on the issue as the same root — gets the **same two stamps**
rather than a third detector: it verifies each downloaded bundle against the digest the publication
records, and refuses when the carried set names more than one `publication`, which is what "the
publication was replaced while I was reading it" looks like from inside a narrowed bake. An
incumbent that predates stamping carries forward as before, with a warning saying **with numbers**
that it established nothing; the next publication of that source makes it enforceable.

## Two silent defects caught by measuring the CLI instead of assuming it

Neither would have been visible to the harness, because the stub was written to match the draft:

- knack's `format_tsv` renders a **top-level list as ROWS**. `--query "[a, b]" -o tsv` prints two
  **lines**, not two columns — so `awk '$2'` would have read empty for every file, every `owner`
  would have compared unequal, `ours` would have been 0 on every publish, and the postcondition
  would have **refused every publication in the fleet** as "superseded".
- an absent metadata value renders as the **literal string `None`**, not empty, so the fail-closed
  "no digest recorded" branch would never have fired.

The query is now `[[metadata.digest || '-', metadata.publication || '-']]`, the field count is
asserted (a rendering change is a loud refusal, not a wrong answer), and the harness re-checks the
rendering with the real `jmespath` engine on every run.

## Coverage

`.github/scripts/test-publish-bake-overlap.py` runs the **REAL** script **twice, interleaved**,
against a stub share, and reads the verdict off **the bytes** — each fixture bundle names the bake
that produced it, so "the sealed directory holds two bakes" is a fact about the shelf, not a claim
the script makes about itself. Ten cases, three of them controls that must pass. `--expect-defect`
runs the same cases against the pre-fix script.

One case is about the guard rather than the defect: the stub can be told to **eat its caller's
stdin**, reproducing the one way a `while read` loop fed by a redirect ends early — a verification
covering a *prefix* of the publication would report "no foreign bytes" and seal. The script answers
with `< /dev/null` on the read-back call and an assertion that every manifest line landed in
exactly one bucket.

`carry-forward-bundles.sh --self-test` had **never run in CI**. Both are now steps of `CI's own
shell`, alongside the existing `compose-sealed-modules.sh` harness.

### Falsification, tests unchanged

| run | result |
|---|---|
| fixed script | **27 passed, 0 failed** |
| pre-fix script, fixed assertions | **14 passed, 12 failed** |
| pre-fix script, `--expect-defect` | **15 passed, 0 failed** — every overlap case sealed a mix |
| this script with `< /dev/null` stripped | **26 passed, 1 failed** — the loop truncates, the accounting assertion refuses |
| `carry-forward --self-test` | **11 passed, 0 failed** |

Also green locally: `check-workflow-shell.py`, `check-workflow-timeouts.py` (68 jobs, 0 violations),
`check-pr-secret-preflight.py`, `test-cd-steps.py`, `test-sealed-module-compose.py`, `actionlint`,
`shellcheck -S warning` on both scripts, and `MeshWeaver.Documentation.Test` **304/304** including
`DocumentationLinkIntegrityTest`.

## What is NOT closed — why #3461 stays open

The interval between the last verification read and the `_complete` upload. A publisher that
overwrites a file inside that **single-upload** window still lands under this run's seal. The
exposure shrinks from the whole ~90-second publication to one file upload, and this is a
**postcondition, not mutual exclusion**. Removing it is the generation-directory-plus-pointer-swap
migration, which every reader has to land first — and which composes with the generation #3460
already pins on the read side.

Also true and worth stating: a refused publication leaves the prefix **unsealed**, which every
consumer skips. That is correct, and it means an overlap now costs a red lane and a re-run rather
than a portal that renders nothing — but the identity serves nothing until either publisher runs
again.

## Docs

[Sealed Publication Reads](src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md)
gains "How many writers, measured" (the table above, so the next session does not re-measure) and
"The writer's postcondition"; its "What is NOT closed" section is rewritten to say what now is and
what still is not. What's New entry: `Category: Fix`.
