### PR TITLE
fix(#3353): a failed cache read leaked the handle it had already opened

### DIFF
--- a/src/MeshWeaver.ContainerImages/ContainerBlobCache.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerBlobCache.cs
@@ -162,12 +162,19 @@ public sealed class ContainerBlobCache
 
         return fileSystem.InvokeBlocking<ContainerCacheEntry?>(_ =>
         {
+            // 🚨 Declared OUTSIDE the try so every failure path can dispose it. Ownership of this
+            // handle transfers to the caller ONLY on the successful return; until then it is ours,
+            // and the sidecar read below can still throw. A leaked descriptor here would be
+            // invisible — the pull falls through to the upstream and looks entirely healthy —
+            // while the process quietly walks toward its file-descriptor limit, one degraded cache
+            // read at a time.
+            FileStream? content = null;
             try
             {
                 // FileShare.Delete so a concurrent eviction can unlink the file while this handle
                 // holds it open: the reader keeps reading the bytes it already opened, and the
                 // name simply stops resolving for the next caller.
-                var content = new FileStream(blobPath, new FileStreamOptions
+                content = new FileStream(blobPath, new FileStreamOptions
                 {
                     Mode = FileMode.Open,
                     Access = FileAccess.Read,
@@ -175,9 +182,11 @@ public sealed class ContainerBlobCache
                     Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
                 });
                 var mediaType = File.Exists(typePath) ? File.ReadAllText(typePath).Trim() : null;
-                return new ContainerCacheEntry(
+                var entry = new ContainerCacheEntry(
                     content, content.Length,
                     string.IsNullOrEmpty(mediaType) ? null : mediaType, digest);
+                content = null; // handed to the caller, who disposes it
+                return entry;
             }
             catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
             {
@@ -186,10 +195,16 @@ public sealed class ContainerBlobCache
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 logger.LogWarning(ex,
-                    "Container registry mirror: the cache entry for {Digest} could not be opened, "
+                    "Container registry mirror: the cache entry for {Digest} could not be read, "
                     + "so this pull falls through to the upstream. Check {Directory}.",
                     digest, root);
                 return null;
+            }
+            finally
+            {
+                // Non-null only when we did NOT return the entry — a sidecar read that threw after
+                // the blob opened, or any other unwind.
+                content?.Dispose();
             }
         });
     }

--- a/test/MeshWeaver.ContainerImages.Test/MirrorCacheTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/MirrorCacheTest.cs
@@ -521,6 +521,53 @@ public class MirrorCacheTest : IDisposable
             thrown.Message);
     }
 
+    /// <summary>
+    /// 🚨 A cache read that FAILS PART-WAY THROUGH must not leak the handle it already opened.
+    ///
+    /// <para>The blob opens, then the media-type sidecar read throws — a real race with eviction,
+    /// a manual cleanup, or transient IO. The correct answer is a MISS (fall through to the
+    /// upstream, which is the source of truth), and the trap is that the answer is correct while
+    /// the descriptor stays open: the pull succeeds, nothing logs an error, and the process walks
+    /// toward its file-descriptor limit one degraded read at a time. Invisible until it is not.</para>
+    ///
+    /// <para>The leak is probed by re-opening the blob EXCLUSIVELY afterwards — .NET honours
+    /// <see cref="FileShare"/> on Unix as well as Windows, so a handle the cache still held would
+    /// refuse this open.</para>
+    /// </summary>
+    [Fact]
+    public async Task ACacheReadThatFailsMidwayDoesNotLeakTheHandleItOpened()
+    {
+        var directory = NewCacheDirectory();
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream, directory);
+        var cache = app.Services.GetRequiredService<ContainerBlobCache>();
+
+        var bytes = new byte[64];
+        Array.Fill(bytes, (byte)7);
+        var digest = DigestOf(bytes);
+        Assert.True(
+            await cache.Store(digest, "application/vnd.oci.image.manifest.v1+json", bytes)
+                .FirstAsync().ObserveCompletion(_ => { }, CancellationToken.None));
+
+        var hex = digest["sha256:".Length..];
+        var blobPath = Path.Combine(directory, "sha256", hex[..2], hex);
+        var sidecarPath = blobPath + ".type";
+
+        ContainerCacheEntry? entry;
+        // Hold the SIDECAR exclusively, so the read of it inside Open throws after the blob has
+        // already been opened — the exact window the handle could escape through.
+        using (new FileStream(sidecarPath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            entry = await cache.Open(digest).FirstAsync()
+                .ObserveCompletion(_ => { }, CancellationToken.None);
+        }
+
+        Assert.Null(entry);
+        // If the blob handle leaked, this exclusive open cannot succeed.
+        using var probe = new FileStream(blobPath, FileMode.Open, FileAccess.Read, FileShare.None);
+        Assert.Equal(bytes.Length, probe.Length);
+    }
+
     // ── eviction ──────────────────────────────────────────────────────────────────────────────
 
     /// <summary>


### PR DESCRIPTION
Harvests the one substantive finding from the Copilot review on #3495 — which arrived after that
PR merged, so it lands here.

## The defect

`ContainerBlobCache.Open` opens the blob, then reads the `.type` sidecar for the media type. If
that second read throws — a race with eviction, a manual cleanup, transient IO — the catch returned
`null` **without disposing the `FileStream` it had just opened.**

The *answer* was correct: a miss falls through to the upstream, which is the source of truth. That
is exactly what makes it dangerous. The pull succeeds, nothing logs an error, and the only thing
wrong is a descriptor that stays open — one degraded read at a time, until the process reaches its
file-descriptor limit. The eventual symptom (a portal that cannot open files) names nothing that
would lead anyone back to a cache read that "worked".

## The fix

The handle is declared outside the `try` and disposed in a `finally`, nulled at the point ownership
transfers to the caller. **Semantics unchanged**: an unreadable sidecar is still a MISS, and that is
deliberate — a manifest served without its `Content-Type` is unusable to a client, and the upstream
can answer correctly.

## Verified, and falsified both ways

`ACacheReadThatFailsMidwayDoesNotLeakTheHandleItOpened` holds the sidecar **exclusively** so the read
inside `Open` throws in exactly that window, then probes for the leak by re-opening the blob
**exclusively** — .NET honours `FileShare` on Unix as well as Windows, so a handle the cache still
held refuses that open.

- With the `finally` removed (nothing else changed): **FAILS**, on precisely that probe —
  `IOException: The process cannot access the file … because it is being used by another process`.
- With it restored: **passes**.

Full suite: **111 passed, 0 failed** (Release). Both touched projects build `-c Release
-warnaserror`: **0 Warning(s), 0 Error(s)**.

## The review's other five comments — not acted on, deliberately

All five are the same generic *"async/await in `src/` is a defect class"* pattern-match, aimed at
`ContainerImageEndpoints.Serve`, `UpstreamPassthroughResult.Copy`, `CachedContentResult.ExecuteAsync`,
`ContainerBlobFill.WriteAsync` and `UpstreamRegistryClient.Send`.

Every one of those is an **ASP.NET boundary** — a minimal-API handler or an `IResult.ExecuteAsync` —
which AGENTS.md sanctions explicitly, and which the guards that actually enforce that rule
(`HubReachableAsyncGuard`, `ObservableToTaskBridgeGuard`, `HandWovenGateRatchetGuard`) pass on. Four
of the five shapes are pre-existing and predate #3495. The reactive, pooled, `IObservable<T>` half of
this subsystem is `ContainerBlobCache` itself, and it already is exactly that. Rewriting a request
handler to return `IObservable<IResult>` and bridging at the same edge would move the `await` one
line without changing which scheduler anything runs on.

Recorded here rather than silently ignored, so the next reader does not re-litigate it.

Refs #3353, follows #3495.

`Pairs-with:` — not applicable: this diff removes zero public types and zero public members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
