### PR TITLE
fix(#3492): the surface detector must not silently start seeing less

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2314,6 +2314,8 @@ jobs:
       run: python3 scripts/check-type-forwards.py --self-test
     - name: "Prove the pair gate is not vacuous (self-test)"
       run: python3 scripts/check-cross-repo-pair.py --self-test
+    - name: "Prove the parser-delta control is not vacuous (self-test)"
+      run: python3 scripts/check-parser-delta.py --self-test
 
     # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
     # never interpolated into a shell command.
@@ -2344,6 +2346,21 @@ jobs:
         set -euo pipefail
         python3 scripts/check-cross-repo-pair.py \
           --surface-json "$RUNNER_TEMP/surface.json" \
+          --pr-body-file "$RUNNER_TEMP/pr-body.md"
+
+    # 🚨 #3492: the report above is only as good as the parser that produced it, and a parser can
+    # go blind while every number it prints stays plausible — a UTF-8 BOM hid 16 public types and
+    # miskeyed 124 more for the gate's entire life, under a floor with 1 450 types of slack. This
+    # step runs the MERGE BASE's own copy of the detector and this diff's copy over the SAME tree,
+    # so any difference is the parser and nothing else. A DECREASE is refused unless the body
+    # declares it; an INCREASE is a fix and passes. It runs unconditionally and asks nothing about
+    # its own inputs: a detector that cannot run is a failure, never a zero delta.
+    - name: "This diff does not shrink what the surface detector can see"
+      run: |
+        set -euo pipefail
+        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        python3 scripts/check-parser-delta.py \
+          --base "$base" \
           --pr-body-file "$RUNNER_TEMP/pr-body.md"
 
   package-pin-removal:

--- a/scripts/check-parser-delta.py
+++ b/scripts/check-parser-delta.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Refuse a change to the public-surface DETECTOR that makes it see LESS than it saw before.
+
+WHY THIS EXISTS (#3492)
+-----------------------
+`check-type-forwards.py` builds an index of every public top-level type and public member under
+`src/`, and every cross-repo surface gate is a question asked of that index. A gate can therefore
+be green for two reasons that look identical from outside: the change was safe, or **the index
+never contained the thing it would have failed on**.
+
+That is not hypothetical. A UTF-8 BOM — three bytes before the first character — defeats the
+`^`-anchored matchers:
+
+    ﻿namespace MeshWeaver.Layout;      NAMESPACE_RE is `^namespace`, so this does not match
+    ﻿public class ButtonControl        TYPE_RE's indent group is `[ \\t]*`, and U+FEFF is neither
+
+Measured on `origin/main` the night #3487 landed: **310 of 1 271** `.cs` files under `src/` carry
+a BOM; **16** public types were in NO index at all (`ButtonControl`, `HtmlControl`,
+`SplitterControl`, `INamed`, …) and **124** more were keyed under the wrong name. The blind set was
+**identical at the gate's first commit and 754 commits later** — the detector was born blind and
+nothing noticed, because a count nobody compares against anything is not a control arm.
+
+WHY THE EXISTING FLOORS DO NOT COVER IT
+---------------------------------------
+Three static floors already guard the same report, and they are the right instrument for the
+question they ask — *"did the scan read anything at all?"*, the green-on-zero-evidence shape:
+
+    MIN_PUBLIC_TYPES_AT_BASE      = 500   check-cross-repo-pair.py     measured 1 971
+    MIN_PUBLIC_INTERFACES_AT_BASE =  50   check-interface-addition.py  measured   132
+    MIN_OBLIGATIONS_AT_BASE       = 150   check-interface-addition.py  measured   452
+
+Each sits far below its true value ON PURPOSE — a floor must survive a carve-out wave. That slack
+is exactly what the BOM slipped through: it cost **17 types of 1 971** (0.9 %) and **1 interface of
+132**, against ~1 450 and ~82 of headroom. A floor 3.9× below the value can only catch a total
+collapse.
+
+Raising the constants does not fix it either. A floor tracks the CODEBASE, which grows and shrinks
+for legitimate reasons, so any floor tight enough to catch a parser bug is loose enough to red on an
+ordinary carve-out — and a gate that must be bypassed is worse than no gate. The two instruments are
+complementary, not competing: a floor catches "read nothing", this catches "reads less than it did".
+
+WHAT THIS CHECKS INSTEAD — a DIFFERENTIAL, not a floor
+-------------------------------------------------------
+Run the merge base's OWN copy of the detector and this diff's copy over the **same tree** (the
+merge base), both in `--surface-json` report mode, and compare their published denominators.
+
+The corpus is byte-identical for both runs, so **every difference is attributable to the parser
+and to nothing else**. The codebase can grow, shrink or be refactored without moving the number:
+this gate is invariant under code change by construction, and moves only when the detector's
+behaviour moves — which is exactly its subject.
+
+    detector at the merge base   ─┐
+                                  ├─→  same tree  ─→  two denominators  ─→  delta
+    detector in this diff        ─┘
+
+The verdict is deliberately ASYMMETRIC, because the two directions mean opposite things:
+
+  * a DECREASE is the failure this exists for — the detector now sees less of the same tree, so
+    every surface gate downstream is quietly guarding a smaller set. Refused, unless the pull
+    request declares it (below).
+  * an INCREASE is a fix — the detector sees more of the same tree. Printed loudly, and passed.
+    #3487's `lstrip` measures **+16 types / +111 members** here, which is the whole point.
+  * ZERO is printed with both numbers, so a pass says something rather than nothing.
+
+DECLARING AN INTENDED DECREASE
+------------------------------
+A tightening that is genuinely correct — a matcher that used to over-count — says so in the pull
+request body, in the same shape as `Pairs-with:`:
+
+    Parser-delta: publicTypesAtBase — nested records were counted as top-level; they are never
+    independently bindable by simple name, so the old number was wrong upward.
+
+The declaration names the COUNTER and a REASON, never the number: the corpus is the merge base,
+which moves while a pull request is open, so a written figure would go stale and train people to
+edit it without reading it. The measured figure is printed by this gate.
+
+🚨 NO SKIP-TRAPDOOR. This gate never asks whether an input is present. If either detector version
+cannot be run, or produces no report, that is a FAILURE naming which side and why — never a pass.
+The one path that returns 0 without running anything is a PROOF, not an assumption: when every
+subject file is byte-identical between the merge base and this diff, the delta is zero by
+construction and the two SHA-256 digests are printed to show it.
+
+WHAT IS DELIBERATELY NOT COVERED
+--------------------------------
+`check-record-signatures.py` shares the family's `^`-anchored parsing and had the same BOM hole
+(fixed in #3487, exposure zero at the time). It is NOT gated here, and the reason is structural
+rather than an oversight: it scans **the files this diff changed**, not a whole-tree index, so it
+publishes no denominator that could shrink. Its blindness is per-file and shows up as a missed
+finding on one file, which a differential over a fixed corpus cannot see. Giving it a whole-tree
+index would be a real change to that gate, not a wrapper around it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# The files whose content decides what the index contains. `check-type-forwards.py` is the
+# detector; `transitional_allow.py` is its only local import, and the temp copy of the detector
+# resolves imports from its own directory, so it must travel with it.
+SUBJECT_FILES = ("scripts/check-type-forwards.py", "scripts/transitional_allow.py")
+DETECTOR = "scripts/check-type-forwards.py"
+
+# The denominators the report publishes about the BASE tree. `*AtHead` is the same number here —
+# both runs are invoked with `--base X --head X` — so comparing one of each pair is not a gap.
+COUNTERS = (
+    "publicTypesAtBase",
+    "publicMembersAtBase",
+    "publicInterfacesAtBase",
+    "implementerObligationsAtBase",
+)
+
+# `Parser-delta:` — optionally bulleted and/or bolded, as a pull-request body naturally writes it.
+# Mirrors DECLARATION_RE in check-cross-repo-pair.py rather than inventing a second spelling.
+DECLARATION_RE = re.compile(
+    r"^[ \t]*(?:[-*+][ \t]+)?\*{0,2}parser[ \t_-]?delta\*{0,2}[ \t]*:\*{0,2}[ \t]*(?P<value>.*?)[ \t]*$",
+    re.IGNORECASE,
+)
+MIN_REASON_CHARS = 12
+
+
+class DeltaFailure(Exception):
+    """A condition that must end the run RED. Carries the operator-facing lines."""
+
+    def __init__(self, lines: list[str]):
+        super().__init__(lines[0] if lines else "parser delta check failed")
+        self.lines = lines
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], capture_output=True, text=False
+    )
+
+
+def blob_at(root: Path, ref: str, path: str) -> bytes | None:
+    """The file's bytes at `ref`, or None when the path does not exist there."""
+    r = _git(root, "show", f"{ref}:{path}")
+    return r.stdout if r.returncode == 0 else None
+
+
+def digest(data: bytes | None) -> str:
+    return "absent" if data is None else hashlib.sha256(data).hexdigest()[:16]
+
+
+def run_report(root: Path, script: Path, base: str, out: Path, label: str) -> dict:
+    """Run one detector version over ONE tree and return its report.
+
+    🚨 Every failure path raises. A detector that cannot run is not a detector that found nothing.
+    """
+    env_path = str(script.parent)
+    proc = subprocess.run(
+        [sys.executable, str(script), "--base", base, "--head", base, "--surface-json", str(out)],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        env={**_environ(), "PYTHONPATH": env_path},
+    )
+    if proc.returncode != 0:
+        raise DeltaFailure(
+            [
+                f"::error::The {label} detector exited {proc.returncode} while reporting on {base}.",
+                "  A detector that cannot run is not a detector that found nothing, so this is a",
+                "  failure rather than a zero delta.",
+                *[f"  {line}" for line in (proc.stderr or proc.stdout or "").splitlines()[-20:]],
+            ]
+        )
+    if not out.exists():
+        raise DeltaFailure(
+            [
+                f"::error::The {label} detector exited 0 but wrote no report to {out}.",
+                "  `--surface-json` is the whole interface this gate reads; an absent file means",
+                "  the version at that commit does not support it, and the delta is unknown, not zero.",
+            ]
+        )
+    try:
+        payload = json.loads(out.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeltaFailure([f"::error::The {label} report at {out} is not readable JSON: {exc}"])
+    if not isinstance(payload, dict):
+        raise DeltaFailure([f"::error::The {label} report is {type(payload).__name__}, not an object."])
+    return payload
+
+
+def _environ() -> dict:
+    import os
+
+    return dict(os.environ)
+
+
+def parse_declarations(body: str) -> set[str]:
+    """Counter names the pull-request body declares a decrease for, with a real reason.
+
+    A declaration with no reason, or a reason shorter than MIN_REASON_CHARS, is NOT a declaration —
+    the same rule `Pairs-with: none` follows, and for the same reason: a blank permits everything.
+    """
+    declared: set[str] = set()
+    for line in body.splitlines():
+        m = DECLARATION_RE.match(line)
+        if not m:
+            continue
+        value = m.group("value")
+        # `<counter> — <reason>` / `<counter> - <reason>` / `<counter>: <reason>`
+        parts = re.split(r"[ \t]*[—–\-:][ \t]*", value, maxsplit=1)
+        if len(parts) != 2:
+            continue
+        counter, reason = parts[0].strip(), parts[1].strip()
+        if counter in COUNTERS and len(reason) >= MIN_REASON_CHARS:
+            declared.add(counter)
+    return declared
+
+
+def evaluate(before: dict, after: dict, declared: set[str]) -> tuple[int, list[str]]:
+    """Returns (exit code, lines to print). Every failure path returns 1; there is no other."""
+    out: list[str] = []
+    failures: list[str] = []
+
+    out.append("Detector denominators over ONE tree, under two versions of the parser:")
+    out.append(f"  {'counter':<32} {'merge base':>12} {'this diff':>12}   delta")
+    for name in COUNTERS:
+        b, a = before.get(name), after.get(name)
+        if b is None and a is None:
+            # Neither version publishes it. Nothing to compare, and nothing to hide behind: the
+            # counters this gate knows about are named in COUNTERS, so an absent pair is a
+            # counter that does not exist yet in either version.
+            out.append(f"  {name:<32} {'—':>12} {'—':>12}   not published by either version")
+            continue
+        if b is None:
+            out.append(f"  {name:<32} {'—':>12} {a:>12}   NEW — the merge base did not publish it")
+            continue
+        if a is None:
+            failures.append(
+                f"::error::`{name}` is published by the merge base ({b}) and by this diff NOT AT ALL. "
+                "A withdrawn denominator is a control arm that stops being able to fail, which is "
+                "the whole failure mode this gate exists for. Keep publishing it, or declare the "
+                f"withdrawal with `Parser-delta: {name} — <reason>`."
+            )
+            out.append(f"  {name:<32} {b:>12} {'withdrawn':>12}   🚨")
+            continue
+        if not isinstance(b, int) or not isinstance(a, int):
+            failures.append(
+                f"::error::`{name}` is not an integer in both reports "
+                f"({type(b).__name__} vs {type(a).__name__}) — the report shape changed and the "
+                "delta cannot be computed. That is unknown, not zero."
+            )
+            continue
+        d = a - b
+        if d == 0:
+            mark = ""
+        elif d > 0:
+            mark = "  ↑ the detector sees MORE of the same tree"
+        elif name in declared:
+            mark = "  ↓ DECLARED in the pull-request body"
+        else:
+            mark = "  🚨"
+        out.append(f"  {name:<32} {b:>12} {a:>12}   {d:+}{mark}")
+        if d < 0 and name not in declared:
+            failures.append(
+                f"::error::`{name}` fell from {b} to {a} ({d}) over an IDENTICAL tree. The corpus "
+                "did not change, so this diff makes the public-surface detector see less than it "
+                "saw before, and every gate built on it is now guarding a smaller set — silently. "
+                f"If the old number was wrong upward, say so in the pull-request body:\n"
+                f"  Parser-delta: {name} — <why the old count was wrong, at least "
+                f"{MIN_REASON_CHARS} characters>"
+            )
+
+    if failures:
+        return 1, out + [""] + failures
+    return 0, out
+
+
+# ─────────────────────────────── self-test ───────────────────────────────
+#
+# 🚨 Hermetic: the fixtures are tiny scripts that emit a report, never the real detector over the
+# real tree. A self-test that needed a 1 200-file parse would be too slow to run on every job, and
+# a gate whose self-test is skipped for cost is a gate nobody has watched fail.
+
+_FIXTURE = """#!/usr/bin/env python3
+import argparse, json
+from pathlib import Path
+ap = argparse.ArgumentParser()
+ap.add_argument("--base"); ap.add_argument("--head"); ap.add_argument("--surface-json")
+a = ap.parse_args()
+Path(a.surface_json).write_text(json.dumps(%s))
+"""
+
+_FIXTURE_DIES = """#!/usr/bin/env python3
+import sys
+print("the tree could not be read", file=sys.stderr)
+sys.exit(3)
+"""
+
+_FIXTURE_SILENT = """#!/usr/bin/env python3
+import argparse
+ap = argparse.ArgumentParser()
+ap.add_argument("--base"); ap.add_argument("--head"); ap.add_argument("--surface-json")
+ap.parse_args()
+"""
+
+_HEALTHY = {
+    "publicTypesAtBase": 1964,
+    "publicMembersAtBase": 12277,
+    "publicInterfacesAtBase": 132,
+    "implementerObligationsAtBase": 452,
+}
+
+
+def _with(**over) -> dict:
+    d = dict(_HEALTHY)
+    d.update(over)
+    return d
+
+
+def self_test() -> int:
+    cases: list[tuple[str, dict, dict, str, int]] = [
+        # (label, base report, head report, pr body, expected exit)
+        (
+            "an unchanged parser is a zero delta and passes",
+            _HEALTHY, _HEALTHY, "", 0,
+        ),
+        (
+            "🚨 the #3492 shape REVERSED — the detector loses the 16 BOM'd types: RED",
+            _HEALTHY, _with(publicTypesAtBase=1948, publicMembersAtBase=12166), "", 1,
+        ),
+        (
+            "#3487's actual fix — +16 types, +111 members over the same tree: PASSES",
+            _with(publicTypesAtBase=1948, publicMembersAtBase=12166), _HEALTHY, "", 0,
+        ),
+        (
+            "a declared decrease with a real reason is accepted",
+            _HEALTHY, _with(publicTypesAtBase=1900),
+            "Parser-delta: publicTypesAtBase — nested records were counted as top-level", 0,
+        ),
+        (
+            "🚨 a declaration with a stub reason permits nothing",
+            _HEALTHY, _with(publicTypesAtBase=1900),
+            "Parser-delta: publicTypesAtBase — fix", 1,
+        ),
+        (
+            "🚨 a declaration for a DIFFERENT counter does not cover this one",
+            _HEALTHY, _with(publicTypesAtBase=1900),
+            "Parser-delta: publicMembersAtBase — this counter changed for a good stated reason", 1,
+        ),
+        (
+            "🚨 the tenth shape's own arm: obligations collapse while types are healthy: RED",
+            _HEALTHY, _with(implementerObligationsAtBase=0), "", 1,
+        ),
+        (
+            "🚨 a WITHDRAWN counter is a control arm that can no longer fail: RED",
+            _HEALTHY, {k: v for k, v in _HEALTHY.items() if k != "publicInterfacesAtBase"}, "", 1,
+        ),
+        (
+            "a counter NEW in this diff is not a decrease",
+            {k: v for k, v in _HEALTHY.items() if k != "publicInterfacesAtBase"}, _HEALTHY, "", 0,
+        ),
+        (
+            "🚨 a counter that stops being an integer is UNKNOWN, not zero: RED",
+            _HEALTHY, _with(publicTypesAtBase="1964"), "", 1,
+        ),
+        (
+            "a bulleted, bolded declaration is read like the pair gate reads Pairs-with",
+            _HEALTHY, _with(publicTypesAtBase=1900),
+            "- **Parser-delta:** publicTypesAtBase — the old number double-counted partials", 0,
+        ),
+    ]
+
+    failed = 0
+    for label, before, after, body, expected in cases:
+        code, _ = evaluate(before, after, parse_declarations(body))
+        ok = code == expected
+        failed += 0 if ok else 1
+        print(f"  {'ok  ' if ok else 'FAIL'} {label}" + ("" if ok else f"  (exit {code}, expected {expected})"))
+
+    # The two run-level failures cannot be expressed through `evaluate`, because their whole point
+    # is that no report exists to evaluate. They are exercised against real subprocesses.
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for label, source, expect_msg in (
+            ("🚨 a detector that EXITS NON-ZERO is a failure, not a zero delta", _FIXTURE_DIES, "exited 3"),
+            ("🚨 a detector that exits 0 and writes NOTHING is a failure", _FIXTURE_SILENT, "wrote no report"),
+        ):
+            script = tmp / "fixture.py"
+            script.write_text(source)
+            try:
+                run_report(Path.cwd(), script, "HEAD", tmp / "out.json", "fixture")
+            except DeltaFailure as exc:
+                ok = any(expect_msg in line for line in exc.lines)
+            else:
+                ok = False
+            failed += 0 if ok else 1
+            print(f"  {'ok  ' if ok else 'FAIL'} {label}")
+
+    print(f"\n{'✓' if not failed else '🚨'} parser-delta self-test: {len(cases) + 2} case(s), {failed} failed.")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", help="the MERGE BASE to compare against (a commit-ish)")
+    ap.add_argument(
+        "--pr-body-file",
+        help="file holding the pull-request body, which may DECLARE an intended decrease. Absent "
+        "means no declaration is in force — a merge_group build has no pull request, and nothing "
+        "reaches the queue without the pull_request run being green.",
+    )
+    ap.add_argument("--self-test", action="store_true", help="prove the gate is not vacuous")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.base:
+        ap.error("--base is required unless --self-test is given")
+
+    root = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], check=True, capture_output=True, text=True
+        ).stdout.strip()
+    )
+
+    # ── the one path that returns 0 without running anything, and it is a PROOF ──────────────
+    base_blobs = {p: blob_at(root, args.base, p) for p in SUBJECT_FILES}
+    head_blobs = {p: (root / p).read_bytes() if (root / p).exists() else None for p in SUBJECT_FILES}
+    if base_blobs == head_blobs:
+        print("The public-surface detector is byte-identical at the merge base and in this diff:")
+        for p in SUBJECT_FILES:
+            print(f"  {p}  sha256:{digest(head_blobs[p])}")
+        print("So its delta over any tree is zero by construction. Nothing to measure.")
+        return 0
+
+    if base_blobs[DETECTOR] is None:
+        print(f"{DETECTOR} does not exist at {args.base} — it is NEW in this change, so there is")
+        print("no earlier behaviour to have regressed from. Nothing to measure.")
+        return 0
+    if head_blobs[DETECTOR] is None:
+        print(f"::error::{DETECTOR} exists at {args.base} and is GONE in this diff. Every")
+        print("::error::cross-repo surface gate reads its report; removing it removes the gates.")
+        return 1
+
+    body = ""
+    if args.pr_body_file:
+        try:
+            body = Path(args.pr_body_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            # 🚨 Not a skip. The body is how an intended decrease is declared; unable to read it
+            # means unable to honour a declaration, which must not silently become "undeclared".
+            print(f"::error::Cannot read the pull-request body from {args.pr_body_file}: {exc}")
+            return 1
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        for p in SUBJECT_FILES:
+            blob = base_blobs[p]
+            if blob is not None:
+                (tmp / Path(p).name).write_bytes(blob)
+        base_script = tmp / Path(DETECTOR).name
+        head_script = root / DETECTOR
+
+        print(f"Merge base: {args.base}")
+        print("Subject files (what decides the index):")
+        for p in SUBJECT_FILES:
+            same = "same" if base_blobs[p] == head_blobs[p] else "CHANGED"
+            print(f"  {p}  {digest(base_blobs[p])} -> {digest(head_blobs[p])}  [{same}]")
+        print()
+
+        try:
+            before = run_report(root, base_script, args.base, tmp / "before.json", "merge base")
+            after = run_report(root, head_script, args.base, tmp / "after.json", "this diff")
+        except DeltaFailure as exc:
+            for line in exc.lines:
+                print(line)
+            return 1
+
+    code, lines = evaluate(before, after, parse_declarations(body))
+    for line in lines:
+        print(line)
+    if code == 0:
+        print()
+        print("✓ This diff does not shrink what the public-surface detector can see.")
+    return code
+
+
+if __name__ == "__main__":
+    # `shutil` is imported for the temp-dir contract this file relies on; keep the reference so a
+    # linter cannot quietly drop it and change the failure mode of an unrelated edit.
+    assert shutil is not None
+    raise SystemExit(main())

--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
@@ -816,6 +816,127 @@ shape, `publicInterfacesAtBase` and `implementerObligationsAtBase` (floors 50 an
 request, so without them *"this diff changed nothing"* and *"the scan read nothing"* would produce
 the same JSON.
 
+### 🚨 A floor catches "read nothing". It cannot catch "reads LESS than it did" (#3492)
+
+Those three floors are the right instrument for the question they ask, and they were never able to
+ask this one. Measured on `origin/main`:
+
+| control arm | floor | measured | slack |
+|---|---:|---:|---:|
+| `publicTypesAtBase` | 500 | 1 971 | ~1 450 |
+| `publicInterfacesAtBase` | 50 | 132 | ~82 |
+| `implementerObligationsAtBase` | 150 | 452 | ~302 |
+
+The slack is deliberate — a floor must survive a carve-out wave without going red. It is also
+exactly what a UTF-8 BOM walked through. Three bytes before the first character defeat both
+`^`-anchored matchers:
+
+```
+﻿namespace MeshWeaver.Layout;      NAMESPACE_RE is `^namespace` — no match, so the file's
+                                   types are keyed with an EMPTY namespace…
+﻿public class ButtonControl        …and TYPE_RE's indent group is `[ \t]*`, which U+FEFF is not
+```
+
+`re.match(r"\s", "\ufeff")` is `None` and `"\ufeff".isspace()` is `False`, so neither pattern
+forgives it. **310 of 1 271** `.cs` files under `src/` carry a BOM. The damage splits in two, and
+the halves fail differently:
+
+- **16 types were in NO index at all.** A *block-scoped* namespace indents its types by four
+  columns; with the namespace lost, `expected` falls to `0`, the indent comparison rejects every
+  declaration, and `ButtonControl`, `HtmlControl`, `SplitterControl`, `INamed`, `MeshException` and
+  eleven others simply were not there.
+- **124 more were MISKEYED.** A *file-scoped* namespace leaves its types at column 0, so they were
+  indexed — under `Name` instead of `Namespace.Name`. The index also held **123 phantom keys**
+  naming nothing real.
+
+That is 0.9 % of the types and 0.8 % of the interfaces: far inside every floor's slack.
+
+**How long, and what it cost — both measured rather than assumed.** The blind set was
+**140 types (16 + 124), byte-identically the same set**, at the gate's first commit (`51adbeef3`,
+#2689) and 754 commits later. The detector was born blind. Whether anything escaped was then
+answered two ways, because one was not enough:
+
+| measurement | result |
+|---|---|
+| `truth(51adbeef3) − truth(HEAD)` — public types that left `src/` across the window | **0** |
+| every `--diff-filter=DR` event on `src/**/*.cs` in the window, re-parsed at its parent | **6 file events, 0 carrying a BOM, 0 blind** |
+| every in-place modification (460 file-commits): a BOM'd file losing or renaming a line-1 declaration, or a namespace rename the gate saw identically on both sides | **0** |
+| `src/**/*.cs` files that gained or lost a BOM (the one edit that can move a key) | **1**, and it moved nothing — `RegistryUpdateReconciler.cs` line 1 is `using System.Reactive;`, so the BOM had hidden neither a namespace nor a declaration |
+
+🚨 **The endpoint comparison alone would have been wrong to trust**, and that is the part worth
+keeping. It cannot see a type born and removed *inside* the window — and that happened: `780beff47`
+(#3361) renamed the whole `MeshWeaver.ContainerRegistry` assembly to `MeshWeaver.ContainerImages`,
+and the assembly exists at neither endpoint, so seven public types changed namespace invisibly to an
+endpoint diff. Same shape as the defect being investigated: *absence of a match read as absence of a
+subject.* The per-event pass is what closes it.
+
+**Verdict: zero escapes, and not by luck** — no public type left `src/` at all in the 754 commits
+the gate has existed. The gate was blind in 140 places and had not yet been asked the question it
+would have answered wrongly. A reprieve, not a defence.
+
+### The control that generalises: a DIFFERENTIAL over a fixed corpus
+
+`scripts/check-parser-delta.py` runs **the merge base's own copy of the detector** and **this
+diff's copy** over the **same tree** (the merge base), both in `--surface-json` report mode, and
+compares the denominators.
+
+```
+detector at the merge base  ─┐
+                             ├─→  ONE tree  ─→  two sets of denominators  ─→  delta
+detector in this diff       ─┘
+```
+
+The corpus is byte-identical for both runs, so **every difference is attributable to the parser and
+to nothing else**. The codebase can grow, shrink or be refactored without moving the number: the
+control is invariant under code change *by construction*, and moves only when the detector's
+behaviour moves — which is its subject. That is what a floor cannot be, because a floor is a
+statement about the codebase.
+
+The verdict is deliberately **asymmetric**, because the directions mean opposite things:
+
+| delta | meaning | verdict |
+|---|---|---|
+| **negative** | the detector sees less of the same tree; every gate downstream now guards a smaller set | **RED**, unless declared |
+| **positive** | the detector sees more of the same tree — a fix | printed loudly, **passes** |
+| zero | nothing changed | printed with both numbers, so a pass says something |
+
+An intended tightening declares itself in the pull-request body, in the shape `Pairs-with:` already
+established:
+
+```
+Parser-delta: publicTypesAtBase — nested records were counted as top-level; they are never
+independently bindable by simple name, so the old number was wrong upward.
+```
+
+The declaration names the **counter and a reason, never the number** — the corpus is the merge base,
+which moves while a pull request is open, so a written figure would go stale and train people to
+edit it without reading it. It is also **per counter**: declaring `publicTypesAtBase` does not
+silence `implementerObligationsAtBase`.
+
+🚨 **No skip-trapdoor.** The step runs unconditionally and asks nothing about its own inputs. A
+detector that exits non-zero, or exits 0 and writes no report, is a **failure** naming which side —
+never a zero delta. The one path that returns 0 without running anything is a *proof*: when every
+subject file is byte-identical between the merge base and the diff, the delta is zero by
+construction, and the two SHA-256 digests are printed to show it.
+
+**Both arms, measured on the real repository rather than argued:**
+
+| arm | result |
+|---|---|
+| `--self-test` | **13 cases, 0 failed** — including a stub reason, a declaration naming the *wrong* counter, a **withdrawn** counter, a counter that stops being an integer, a detector that exits 3, and one that exits 0 writing nothing |
+| base `cac18fd9c` (pre-#3487) vs merged `main` | `publicTypesAtBase` **+16**, `publicMembersAtBase` **+111** — #3487's `lstrip`, reproduced as a positive delta over an identical tree, and **passed** |
+| base merged `main` vs a working tree with that `lstrip` **reverted** | **RED, exit 1**, on all four counters: `-16` types, `-111` members, `-1` interface, `-1` obligation |
+
+The third row is the one that matters: the control was watched failing on the reintroduced defect,
+not merely reasoned about.
+
+**What it deliberately does NOT cover.** `check-record-signatures.py` shares this family's
+`^`-anchored parsing and had the same BOM hole (fixed in #3487; exposure was **zero files** at the
+time). It is not gated here, for a structural reason rather than an oversight: it scans **the files
+this diff changed**, not a whole-tree index, so it publishes no denominator that could shrink. Its
+blindness shows up as a missed finding on one file, which a differential over a fixed corpus cannot
+see. Giving it a whole-tree index would be a real change to that gate, not a wrapper around it.
+
 ## See also
 
 [Repository Dependency Direction](/Doc/Architecture/RepositoryDependencyDirection) ·

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-checks-now-notice-when-they-start-seeing-less.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-checks-now-notice-when-they-start-seeing-less.md
@@ -1,0 +1,53 @@
+---
+Name: The checks now notice when they start seeing less
+Category: Feature
+Description: Every cross-repo surface check reads one index of the platform's public API. If that index quietly shrinks, the checks stay green — because they are looking at a smaller world, not because the change was safe. They now measure that directly.
+Icon: Ruler
+Order: -20260907
+---
+
+# The checks now notice when they start seeing less
+
+A gate can be green for two reasons that look exactly alike from outside: *the change was safe*, or
+*the thing that would have failed was never in the list.*
+
+The platform's cross-repo checks — the ones that stop a change removing a public type here from
+breaking a repository that uses it — all ask their question of one index: every public type and
+public member declared under `src/`. The index is built by reading the source files. So the checks
+are only ever as good as that reading, and a reading can go wrong in a way that produces no error,
+no warning and a perfectly plausible number.
+
+## What happened
+
+Three invisible bytes at the start of a file — a byte-order mark, which many editors add without
+being asked — put the very first character out of reach of a pattern anchored to the start of a
+line. 310 of the platform's 1 271 compiled source files carry one.
+
+The effect was not that the index failed. It was that the index held **1 955 types where the truth
+was 1 971**: sixteen public types were in it nowhere at all, and a hundred and twenty-four more were
+filed under the wrong name. The checks read that number, found it healthy, and answered
+confidently.
+
+Nothing slipped through — that was measured rather than hoped for, two different ways, across every
+one of the 754 changes made while the gap was open. But it was a reprieve, not a defence: the checks
+had simply not yet been asked the question they would have got wrong.
+
+## What changed
+
+The reading now has to prove it did not get worse.
+
+Whenever a change touches the code that builds the index, the platform runs **the previous version
+of that code and the new version over the identical set of files**, and compares what each one
+found. Because both are reading exactly the same files, any difference is the reading — not the
+codebase.
+
+- Seeing **fewer** things than before stops the change, and says which counter dropped and by how
+  much. If the old number really was too high, that gets written down as a sentence in the change
+  itself, per counter, with a reason.
+- Seeing **more** is a fix, and passes. The repair that started all this measures **+16 types and
+  +111 members** over an identical set of files — which is the entire point of it.
+- Seeing the same is printed with both numbers, so a pass says something instead of nothing.
+
+There was already a check that the index is not *empty*. That one catches "nothing was read". This
+one catches "less was read than last time", which is the failure that actually happened, and which
+no threshold on a single number can see: the gap was under one percent of the total.


### PR DESCRIPTION
Closes #3492.

`Pairs-with: none` — measured, not asserted. `scripts/check-type-forwards.py --base origin/main`
reports `removed: []`; this diff adds one script, two doc files and two workflow steps, and removes
no `public` type or member from `src/`.

**Parser-delta: none** — this change does not touch the detector, and the new gate says so on its own
diff, by proof rather than by assumption:

```
The public-surface detector is byte-identical at the merge base and in this diff:
  scripts/check-type-forwards.py  sha256:037e8cf1e9da5313
  scripts/transitional_allow.py  sha256:956c537e907c9f7b
So its delta over any tree is zero by construction. Nothing to measure.
```

---

## The gap: a floor answers "read nothing", never "reads less than it did"

#3492's verification bar was *"the index must publish how many types it found **and fail on a
suspicious drop**."* #3487 delivered the first half — `publicTypesAtBase`, `publicMembersAtBase`,
`publicInterfacesAtBase`, `implementerObligationsAtBase` are all published. Nothing compares them to
anything, which is the PR's own standard turned on itself: **"A count nobody compares against
anything is not a control arm."**

There *are* three floors, and they are the right instrument for a different question:

| control arm | floor | measured on `origin/main` | slack |
|---|---:|---:|---:|
| `publicTypesAtBase` | 500 | 1 971 | ~1 450 |
| `publicInterfacesAtBase` | 50 | 132 | ~82 |
| `implementerObligationsAtBase` | 150 | 452 | ~302 |

The slack is deliberate — a floor must survive a carve-out wave. It is also exactly what the BOM
walked through: **17 types of 1 971 (0.9 %)** and **1 interface of 132**. Raising the constants does
not fix it, because a floor tracks the *codebase*, which legitimately grows and shrinks, so any floor
tight enough to catch a parser bug is loose enough to red on an ordinary deletion — and a gate that
must be bypassed is worse than no gate.

## The fix: a differential over a fixed corpus, not a floor

`scripts/check-parser-delta.py` runs **the merge base's own copy of the detector** and **this diff's
copy** over the **same tree** (the merge base), both in `--surface-json` report mode, and compares
the denominators.

```
detector at the merge base  ─┐
                             ├─→  ONE tree  ─→  two sets of denominators  ─→  delta
detector in this diff       ─┘
```

The corpus is byte-identical for both runs, so **every difference is attributable to the parser and
to nothing else.** The codebase can grow, shrink or be refactored without moving the number: the
control is invariant under code change *by construction*, and moves only when the detector's
behaviour moves — which is its subject. That is precisely what a floor cannot be.

The verdict is deliberately **asymmetric**, because the two directions mean opposite things:

| delta | meaning | verdict |
|---|---|---|
| **negative** | the detector sees less of the same tree; every gate downstream now guards a smaller set | **RED**, unless declared |
| **positive** | the detector sees more of the same tree — a fix | printed loudly, **passes** |
| zero | nothing changed | printed with both numbers, so a pass says something |

An intended tightening declares itself in the body, in the shape `Pairs-with:` already established:

```
Parser-delta: publicTypesAtBase — nested records were counted as top-level; they are never
independently bindable by simple name, so the old number was wrong upward.
```

It names the **counter and a reason, never the number**: the corpus is the merge base, which moves
while a pull request is open, so a written figure would go stale and train people to edit it without
reading it. It is **per counter** — declaring `publicTypesAtBase` does not silence
`implementerObligationsAtBase`.

## 🚨 No skip-trapdoor

The step runs **unconditionally** and asks nothing about its own inputs. A detector that exits
non-zero, or exits 0 and writes no report, is a **failure naming which side** — never a zero delta.
The single path that returns 0 without running anything is a *proof*, not an assumption: when every
subject file is byte-identical, the delta is zero by construction and both SHA-256 digests are
printed (the block at the top of this body is this PR's own).

`SUBJECT_FILES` is complete rather than assumed: `check-type-forwards.py` has exactly one local
import (`transitional_allow`), and `check-interface-addition.py` / `check-cross-repo-pair.py` parse
**no C# at all** — they read the JSON report and the PR body. One detector, two files.

## Falsification — both arms, on the real repository

| arm | result |
|---|---|
| `--self-test` | **13 cases, 0 failed** |
| base `cac18fd9c` (pre-#3487) vs merged `main` | `publicTypesAtBase` **+16**, `publicMembersAtBase` **+111** over an identical tree — #3487's `lstrip` reproduced as a positive delta, **passed** |
| base merged `main` vs a working tree with that `lstrip` **reverted** | **RED, exit 1** on all four counters: `-16` types, `-111` members, `-1` interface, `-1` obligation |
| the same revert **with** `Parser-delta: publicTypesAtBase — …` in the body | that one counter accepted, **the other three still RED** — the declaration is per counter, not a blanket |

The third row is the one that matters: the control was **watched failing on the reintroduced
defect**, not merely reasoned about. The file was restored byte-for-byte afterwards
(`git diff --quiet` clean).

The self-test's 13 cases include a stub reason, a declaration naming the *wrong* counter, a
**withdrawn** counter (a control arm that stops being able to fail), a counter that stops being an
integer, a detector that exits 3, and one that exits 0 writing nothing. It is hermetic — tiny fixture
scripts, not the real 1 271-file parse — so it runs on every job rather than being skipped for cost.

## The other two unknowns this issue raised, answered on the issue

Both were measured with the gate's own parser and are written up in
`Doc/Architecture/CrossRepoPairGate` and on #3492:

- **How long?** The blind set was **140 types (16 invisible + 124 miskeyed), byte-identically the
  same set**, at the gate's first commit (`51adbeef3`, #2689) and 754 commits later. The detector
  was born blind.
- **Did anything escape?** **No — zero, by two independent measurements**, because one was not
  enough. 🚨 The endpoint comparison `truth(base) − truth(HEAD)` cannot see a type born and removed
  *inside* the window, and that happened: `780beff47` (#3361) renamed the whole
  `MeshWeaver.ContainerRegistry` assembly to `MeshWeaver.ContainerImages`, and the assembly exists at
  neither endpoint. The per-event pass over all 6 `--diff-filter=DR` file events (0 with a BOM, 0
  blind) plus all 460 in-place modifications is what closes it. The honest reason for zero is not
  luck: **no public type left `src/` at all** in those 754 commits.

## What this deliberately does NOT cover

`check-record-signatures.py` shares the family's `^`-anchored parsing and had the same BOM hole
(fixed in #3487; exposure **zero files** at the time). It is not gated here, for a structural reason
rather than an oversight: **it scans the files this diff changed, not a whole-tree index**, so it
publishes no denominator that could shrink. Its blindness is per-file and a differential over a fixed
corpus cannot see it. Giving it a whole-tree index would be a real change to that gate, not a wrapper
around it — stated in the script's own docstring so the next reader does not assume it is covered.

No `AGENTS.md` line: the rule bites only someone editing the detector, and the gate's error message
names the exact sentence to write. The doc page carries the reasoning.

## Verification

- `check-parser-delta.py --self-test` — 13/13
- `check-workflow-timeouts.py` — 69 jobs, 0 violations (the new steps sit in an existing job capped at 10 min; the gate runs in **3 s**)
- `check-workflow-shell.py` — 0 live findings, 0 stale entries
- `actionlint .github/workflows/dotnet-test.yml` — clean
- `MeshWeaver.Documentation.Test` built Release `-warnaserror`: **0 Warning(s), 0 Error(s)**
