### PR TITLE
fix(#3498): a re-ask's NotFound is a verdict — the stream faults instead of parking until the reader's budget expires

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -776,9 +776,27 @@ public static class JsonSynchronizationStream
                                 // along so the carrier below can tell a still-draining teardown
                                 // from a fresh one.
                                 if (isTransient)
+                                {
                                     rejectedByRecycle.OnNext(new RecycleRejection(
                                         "re-ask was itself rejected while the owner was still shutting down",
                                         tag));
+                                    return;
+                                }
+                                // 🚨 Everything else is a VERDICT about the owner, exactly as it is on the
+                                // initial SubscribeRequest above: NotFound says the address does not
+                                // exist (the node was deleted — the delete's own change-feed event is
+                                // what latched this re-ask), Failed says the owner broke. Until #3498
+                                // this arm logged the verdict and dropped it: no OnError, no teardown,
+                                // so the stream parked with no value and no error while its heartbeat
+                                // kept posting to the deleted owner every interval, and a reader of the
+                                // deleted node waited out its whole budget ("never reported the node gone
+                                // within 20s" — CD 7946, MeshPluginTest.FullCrudWorkflow) although the
+                                // authoritative NotFound had been in the log 0.1 s after the delete.
+                                // Only ShuttingDown is a promise to ride out (RidingOutAShuttingDownAddress);
+                                // a verdict faults the subscribers and stops the keep-alive, so the reader
+                                // learns "gone" now and re-asks fresh if the node ever comes back.
+                                reduced.OnError(ex);
+                                keepAlive.Dispose();
                             });
                 }
             }

--- a/src/MeshWeaver.Documentation/Data/Architecture/RidingOutAShuttingDownAddress.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RidingOutAShuttingDownAddress.md
@@ -204,3 +204,30 @@ If you write code that must survive a `ShuttingDown` answer:
 - [Error Propagation & Wedges](../ErrorPropagationAndWedges) — the wedge classes a mis-classified failure produces
 - [MeshNode Stream Cache](../MeshNodeStreamCache) — the transient-fault breaker that must never cache this one
 - [Debugging Message Flow](../DebuggingMessageFlow) — read this before re-running a timed-out test
+
+## A re-ask's verdict is a verdict too (#3498)
+
+The contract above has two arms in `JsonSynchronizationStream`, and until #3498 they disagreed. The
+INITIAL `SubscribeRequest` treats every classification but `ShuttingDown` as terminal: the subscribers
+are faulted with the error and the keep-alive (heartbeat + change-feed resubscribe) is disposed, so a
+stream opened on an absent path stops at once and re-asks fresh only if the node later appears. The
+RE-ASK arm — the one the change-feed latch and the recycle ride-out use — pushed a `ShuttingDown` back
+through the re-arm carrier, and logged everything else as `resubscribe failed`, cleared its in-flight
+flag, and did nothing more. No `OnError`, no teardown.
+
+That is the shape CD run 7946 died on (`MeshPluginTest.FullCrudWorkflow_CreateGetUpdateDelete`,
+*"never reported the node gone within 20s"*): the delete's own change-feed event latched a re-ask on
+the reader's cached stream, routing answered the authoritative `NotFound` 0.1 s after the delete, the
+arm logged it and dropped it, the heartbeat kept posting to the deleted owner every interval (the second
+`NotFound` five seconds later is that heartbeat), and the reader waited out its whole budget for an
+answer that was already in the log. It is #1029's silence on the door #1029 did not close, and it is
+intermittent only because the owner's own teardown notice usually reaches the reader before the
+change-feed event latches the re-ask.
+
+Since #3498 the re-ask arm mirrors the initial one: `ShuttingDown` is still the promise it rides out;
+any other classification faults the stream's subscribers with the classified error and disposes the
+keep-alive. A reader of a deleted node learns "gone" milliseconds after the delete, and a stream never
+parks with no value and no error. `AReAsksNotFoundIsAVerdictTest` pins the sequence with the framework's
+own parts: an initial subscribe refused by a real corpse (so the carrier re-asks), the re-ask answered
+with routing's `NotFound`, and the fault required within the convergence budget — unfixed, nothing else
+in that mesh can ever emit on the stream, so the test is red by construction rather than by chance.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deleted-nodes-reader-learns-gone-at-once.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-06-a-deleted-nodes-reader-learns-gone-at-once.md
@@ -1,0 +1,11 @@
+---
+Name: A deleted node no longer leaves its readers waiting
+Category: Fix
+Description: A view or tool reading a node that has just been deleted learns it is gone at once instead of waiting out a timeout.
+Icon: Sparkle
+Order: -20260906
+---
+
+# A deleted node no longer leaves its readers waiting
+
+When a node was deleted while something was still reading it, the reader could sit in silence until its own timeout expired, although the platform had already answered that the node was gone. A page could show "Not found" only after twenty seconds, and an assistant tool call could time out instead of reporting the delete. The answer is now delivered the moment it exists, so readers of a deleted node see it disappear immediately.

--- a/test/MeshWeaver.Data.Test/AReAsksNotFoundIsAVerdictTest.cs
+++ b/test/MeshWeaver.Data.Test/AReAsksNotFoundIsAVerdictTest.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Data.TestDomain;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 A RE-ASK'S NON-TRANSIENT FAILURE IS A VERDICT, NOT A LINE IN THE LOG (issue #3498).
+///
+/// <para><b>The failure.</b> CD run 7946 died in <c>MeshPluginTest.FullCrudWorkflow_CreateGetUpdateDelete</c>
+/// with <c>"never reported the node gone within 20s"</c>. The transcript holds the answer 0.1 s after
+/// the delete — <c>RouteMessage: NotFound for RawJson → ACME/CrudTest_…</c> — followed by
+/// <c>Stream …: resubscribe failed.</c>, then the same NotFound five seconds later (the keep-alive
+/// heartbeat of a stream that was still alive), then nothing until the reader's budget expired. It is
+/// #1029's silence on the door #1029 did not close.</para>
+///
+/// <para><b>The mechanism.</b> <c>JsonSynchronizationStream</c> answers a <c>DeliveryFailure</c> on a
+/// <c>SubscribeRequest</c> in two arms that disagreed. The INITIAL subscribe treats every
+/// classification but <see cref="ErrorType.ShuttingDown"/> as terminal: it faults the subscribers and
+/// disposes the keep-alive. The RE-ASK arm — the one the change-feed latch and the recycle ride-out
+/// use — pushed a <c>ShuttingDown</c> back through the re-arm carrier and logged everything else as
+/// <c>resubscribe failed</c>, cleared its in-flight flag, and did nothing more: no <c>OnError</c>, no
+/// teardown. The stream parked with no value and no error; the heartbeat kept posting to the deleted
+/// owner; the reader waited out its budget for an answer that had already arrived.</para>
+///
+/// <para><b>What is pinned here.</b> The production sequence, with the framework's own parts and no
+/// crafted failure: the owner is recycled for real and its address held at the corpse, so the initial
+/// SubscribeRequest is refused with the genuine transient <c>ShuttingDown</c> NACK and the ride-out
+/// carrier arms a re-ask. That re-ask is answered the way routing answers a deleted node — an
+/// authoritative <c>NotFound</c> <c>DeliveryFailure</c> — and the stream MUST fault with it. Nothing
+/// else can rescue the unfixed stream: the heartbeat is off, a hub-only mesh has no change feed, and
+/// the carrier only re-arms on <c>ShuttingDown</c>. So before the fix the final wait runs out its whole
+/// budget on a parked stream — a deterministic red, not a race — and after it the verdict lands
+/// milliseconds after the NotFound.</para>
+/// </summary>
+public class AReAsksNotFoundIsAVerdictTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string OwnerType = "deleted-owner";
+    private static readonly Address OwnerAddress = new(OwnerType, "1");
+
+    /// <summary>Short so the ride-out's single re-ask is observable inside a test budget.</summary>
+    private static readonly TimeSpan TestReAskPace = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>Long enough that the heartbeat NEVER fires: the only deliveries the owner address sees
+    /// are the initial SubscribeRequest and the carrier's re-ask, which is what the counters mean.</summary>
+    private static readonly TimeSpan NoHeartbeat = TimeSpan.FromMinutes(5);
+
+    // Instance state — never static, so nothing bleeds between tests or between mesh instances.
+    private IMessageHub? corpse;
+    private int serveFromCorpse;
+    private int corpseRefusals;
+    private int answerNotFound;
+    private int notFoundAnswers;
+
+    private static MessageHubConfiguration ConfigureOwner(MessageHubConfiguration configuration)
+        => configuration.AddData(data => data.AddSource(src => src
+            .WithType<BusinessUnit>(t => t.WithInitialData(TestData.BusinessUnits))));
+
+    protected override MessageHubConfiguration ConfigureMesh(MessageHubConfiguration conf)
+        => base.ConfigureMesh(conf)
+            .WithTypes(typeof(SubscribeRequest), typeof(SubscribeAck))
+            .WithRoutes(forward => forward
+                .RouteAddress(OwnerType, (address, delivery) =>
+                {
+                    if (!OwnerAddress.Equals(address))
+                        return delivery;
+                    if (Volatile.Read(ref serveFromCorpse) == 1 && corpse is not null)
+                    {
+                        // The residue a recycle leaves: the address still resolves to the activation
+                        // that is already Dead, whose own MessageService mints the genuine transient
+                        // ShuttingDown NACK. This is what makes the stream arm a re-ask at all.
+                        Interlocked.Increment(ref corpseRefusals);
+                        corpse.DeliverMessage(delivery);
+                        return delivery.Forwarded(corpse.Address);
+                    }
+                    if (Volatile.Read(ref answerNotFound) == 1)
+                    {
+                        // The node is gone. Answer exactly as RoutingServiceBase.PostNotFound does for
+                        // a deleted path: the routing infrastructure's own NotFound NACK, ResponseFor
+                        // the request, and the delivery classified NotFound.
+                        Interlocked.Increment(ref notFoundAnswers);
+                        Mesh.Post(
+                            new DeliveryFailure(delivery)
+                            {
+                                ErrorType = ErrorType.NotFound,
+                                Message = $"No node found at '{address}'. Closest ancestor is '{OwnerType}'.",
+                            },
+                            o => o.ResponseFor(delivery));
+                        return delivery.NotFound();
+                    }
+                    return delivery;
+                })
+                .RouteAddressToHostedHub(OwnerType, ConfigureOwner));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .WithServices(services => services.Configure<SyncStreamOptions>(o =>
+            {
+                o.HeartbeatInterval = NoHeartbeat;
+                o.FirstHeartbeat = NoHeartbeat;
+                o.RecycleReAskPace = TestReAskPace;
+            }))
+            .AddData(data => data.AddHubSource(OwnerAddress, ds => ds.WithType<BusinessUnit>()));
+
+    [HubFact]
+    public async Task AReAskAnsweredNotFound_FaultsTheStreamWithTheVerdict_InsteadOfParkingIt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // 1. Activate the owner, then recycle it for real and let the teardown COMPLETE, so the
+        //    re-arm's join is a no-op and the carrier's re-ask fires on the pace alone.
+        var owner = Mesh.GetHostedHub(OwnerAddress, ConfigureOwner, HostedHubCreation.Always);
+        owner.Should().NotBeNull("the owner hub must exist before it can be recycled");
+        var teardownFinished = owner!.DisposalCompleted.FirstAsync().Timeout(TestTimeouts.CrossSilo).Await(ct);
+        owner.Post(new DisposeRequest(), o => o.WithTarget(OwnerAddress));
+        await teardownFinished;
+        owner.RunLevel.Should().Be(MessageHubRunLevel.Dead);
+
+        // 2. Hold the address at the corpse: the initial SubscribeRequest gets the genuine transient
+        //    NACK, and the stream's ride-out carrier arms ONE re-ask after the pace.
+        corpse = owner;
+        Volatile.Write(ref serveFromCorpse, 1);
+
+        // 3. Open the read. AddHubSource posts its SubscribeRequest as the client hub is built.
+        var client = GetClient();
+        var workspace = client.ServiceProvider.GetRequiredService<IWorkspace>();
+        // Subscribe BEFORE the verdict can arrive so the fault is observed, never missed: the stream
+        // faults its subscribers; a late subscriber of a faulted stream is a different contract.
+        var verdict = workspace.GetStream(typeof(BusinessUnit))
+            .Materialize()
+            .Where(n => n.Kind == NotificationKind.OnError)
+            .Replay(1);
+        using var observing = verdict.Connect();
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .Select(_ => Volatile.Read(ref corpseRefusals))
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(n => n >= 1, "the dying activation must refuse the initial SubscribeRequest, which is "
+                                + "what arms the ride-out carrier's re-ask");
+
+        // 4. The node is deleted before the re-ask lands: from here the address answers NotFound —
+        //    the authoritative verdict routing gives a deleted path.
+        Volatile.Write(ref serveFromCorpse, 0);
+        Volatile.Write(ref answerNotFound, 1);
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .Select(_ => Volatile.Read(ref notFoundAnswers))
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(n => n >= 1, "the carrier must re-ask after the pace, and that re-ask is the delivery "
+                                + "answered NotFound — the exact delivery the unfixed arm dropped");
+
+        // 5. 🚨 THE ASSERTION: the stream faults with the classified verdict. Unfixed, this waits out
+        //    its whole budget: the NotFound was logged as "resubscribe failed" and nothing else in
+        //    this mesh can ever emit on the stream again.
+        await verdict
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(n => n.Exception is DeliveryFailureException { Failure.ErrorType: ErrorType.NotFound },
+                "a re-ask answered NotFound is a verdict about the owner — the node is gone — and must "
+                + "fault the stream's subscribers exactly as the initial SubscribeRequest's NotFound "
+                + "does; parking the stream silently is #3498 (CD 7946: 'never reported the node gone "
+                + "within 20s' with the NotFound in the log 0.1 s after the delete)");
+
+        Output.WriteLine(
+            $"DIAG refusals by the corpse: {Volatile.Read(ref corpseRefusals)}; "
+            + $"NotFound answers: {Volatile.Read(ref notFoundAnswers)}");
+    }
+}


### PR DESCRIPTION
Closes #3498. A tag blocker on #3355: the first candidate set carrying #3480 (CD 7946) died on this before its seal.

## What CD 7946 showed

`Module tests (MeshWeaver.AI)` → `MeshPluginTest.FullCrudWorkflow_CreateGetUpdateDelete`, 1 of 1868:

```
[22:50:52.904] RouteMessage: NotFound for RawJson → ACME/CrudTest_5b25…   ← the authoritative answer, 0.1 s after the delete
[22:50:52.906] Stream 9SS4OI8dcU-Fy8CMvNhE9Q: resubscribe failed.          ← logged … and dropped
[22:50:57.908] RouteMessage: NotFound for RawJson → ACME/CrudTest_5b25…   ← the keep-alive heartbeat of a stream still alive
[22:51:12.909] TEST FAILED: Get(@ACME/CrudTest_…) never reported the node gone within 20s
```

## Mechanism

`JsonSynchronizationStream` answers a `DeliveryFailure` on a `SubscribeRequest` in two arms that disagreed. The **initial subscribe** treats every classification but `ShuttingDown` as terminal: `reduced.OnError(ex); keepAlive.Dispose();`. The **re-ask arm** — the one the change-feed latch and the recycle ride-out use — pushed `ShuttingDown` back through the re-arm carrier and, for anything else, logged `resubscribe failed`, cleared its in-flight flag and did nothing more. No `OnError`, no teardown: the stream parked, the heartbeat kept posting to the deleted owner, the reader waited out its budget. It is #1029's silence on the door #1029 did not close; the file is identical in 7917, 7926, 7938 and the candidate, and the failure is intermittent only because the owner's own teardown notice usually beats the delete's change-feed event to the reader (24/24 local runs of the CRUD test on both cores).

## The change

- `JsonSynchronizationStream.Resubscribe`'s error arm: `ShuttingDown` keeps its ride-out (unchanged); every other classification is a verdict and does exactly what the initial arm does — fault the subscribers with the classified error, dispose the keep-alive.
- `test/MeshWeaver.Data.Test/AReAsksNotFoundIsAVerdictTest.cs` — the sequence with the framework's own parts, on `RecycleReAskRidesOutTheDyingActivationTest`'s pattern as a sibling class (that rig is untouched): the owner recycled for real and its address held at the corpse so the initial subscribe is refused with the genuine `ShuttingDown` NACK and the carrier arms a re-ask; the re-ask answered the way `RoutingServiceBase.PostNotFound` answers a deleted path; the stream must fault with `DeliveryFailureException { ErrorType: NotFound }` within `Convergence`. Heartbeat off, no change feed in a hub-only mesh, carrier re-arms only on `ShuttingDown` — so nothing else can ever emit on the unfixed stream.
- Doc: `RidingOutAShuttingDownAddress` → "A re-ask's verdict is a verdict too (#3498)". What's New: `Category: Fix`.

## Verified (Release, `-warnaserror`)

| step | result |
|---|---|
| `MeshWeaver.Data.Test` build | 0 Error(s) |
| new test, with the fix | Passed 1/1 in 239 ms |
| **negative control: fix removed, same test** | **Failed 1/1 after 30 s — output carries `Stream …: resubscribe failed.`**, the CD transcript's line |
| fix restored | Passed 1/1 |
| whole `MeshWeaver.Data.Test` | Passed 489/489 |
| `MeshWeaver.Hosting` build | 0 Error(s) |
| `MeshWeaver.Documentation.Test` (link + What's New integrity) | Passed 304/304, entry verified embedded in the built assembly |

Pairs-with: none — the change is inside a private local function of `JsonSynchronizationStream`; no public type or member moves.
