### PR TITLE
Every pinned manifest is locked nightly, so retention cannot delete it (#3438 lock half)

### DIFF
--- a/.github/acr-retention/purge-old-ci-releases.yaml
+++ b/.github/acr-retention/purge-old-ci-releases.yaml
@@ -1,0 +1,11 @@
+version: v1.1.0
+# memex-website is DELIBERATELY absent from these filters (Memex#122, 2026-08-26).
+# Its only tag is a pinned `v1` that nothing rebuilds, so `--ago 30d` deleted the entire
+# repository; the pods kept serving from their node image cache until they were rescheduled,
+# and the public brand site then served 503 for ~11 hours.
+# The test for adding any repository here: if this tag were deleted tonight, would anything
+# recreate it? The repositories below are continuously republished. A pinned tag is not.
+steps: 
+  - cmd: acr purge --filter 'memex-migration:.*' --filter 'memex-bake:.*' --filter 'memex-portal-next:.*' --filter 'memex-portal:.*' --filter 'memex-portal-ai:.*' --ago 30d --untagged
+    disableWorkingDirectoryOverride: true
+    timeout: 3600

--- a/.github/acr-retention/purge-old-images.yaml
+++ b/.github/acr-retention/purge-old-images.yaml
@@ -1,0 +1,44 @@
+version: v1.1.0
+# 🚨 ONE task, TWO steps. Do NOT merge the filter lists into a single `acr purge`.
+#
+# The two lists are NOT symmetric and the difference is load-bearing:
+#   * mw-plugin-test  is unique to the 7d step  — the CI tester, republished many times a day.
+#   * memex-portal    is unique to the 30d step — the PRODUCTION portal image.
+# A union-merge silently moves memex-portal to `--ago 7d --keep 10`. It is pinned on the OTHER axis
+# (committed tags in the deployment overlays, Memex#141), which the pinned-digest guard cannot see —
+# exactly how Memex#122's victim was pinned, where purging a pinned tag took the public brand site
+# down for ~11 h and nothing alerted.
+#
+# 🚨 memex-website is DELIBERATELY absent from every filter (Memex#122, 2026-08-26). Its only tag is a
+# pinned `v1` that nothing rebuilds, so `--ago 30d` deleted the entire repository.
+#
+# 🚨 TWO tests before adding any repository to either step:
+#   1. If this tag were deleted tonight, would anything RECREATE it?           (Memex#122)
+#   2. Does anything PIN a digest of it?                                        (#3438)
+# Test 2 is the one mw-plugin-test passes on test 1 and fails in practice: it republishes constantly,
+# and `--keep 10` counts NEWER BUILDS, so frequent republishing is what DESTROYS a pin rather than
+# protecting it. Every satellite pins the tester and portal by digest for WEEKS at a time
+# (Doc/Architecture/ModuleBuildArchitecture) — the retention window and the intended pin lifetime are
+# in direct contradiction, and nothing but the lock reconciles them.
+#
+# 🚨 Raising --ago / --keep is NOT a fix: it moves the cliff. A pin left stable for a quarter walks
+# off the new one just the same.
+#
+# PROTECTION IS THE MANIFEST LOCK, not this policy. Live pinned digests carry
+# `--delete-enabled false`; `acr purge` skips locked manifests by default and neither step passes
+# `--include-locked`. Locking a digest is what makes a pin survive; this file only decides what is
+# eligible in the first place. Lock a digest BEFORE it is pinned, and release it when the pin moves.
+# Current locks (2026-09-06, the 3.0.0-ci.7917 wave):
+#   mw-plugin-test@sha256:642f686f…   memex-portal-ai@sha256:31aab07d…
+#
+# Both steps share one 3600 s task budget.
+#
+# Doc: Doc/Architecture/PinnedImageRetention. Incidents: Memex#122, MeshWeaver#3438 (Education,
+# Manufacturing and SocialMedia CI down simultaneously 2026-09-05T15:29Z on a purged tester digest).
+steps:
+  - cmd: acr purge --filter 'mw-plugin-test:.*' --filter 'memex-migration:.*' --filter 'memex-portal-ai:.*' --filter 'memex-portal-next:.*' --filter 'memex-bake:.*' --ago 7d --keep 10 --untagged
+    disableWorkingDirectoryOverride: true
+    timeout: 3600
+  - cmd: acr purge --filter 'memex-portal:.*' --ago 30d --untagged
+    disableWorkingDirectoryOverride: true
+    timeout: 3600

--- a/.github/acr-retention/tasks.json
+++ b/.github/acr-retention/tasks.json
@@ -1,0 +1,64 @@
+{
+  "_comment": [
+    "The `meshweaver` ACR retention tasks, as they exist in Azure. Read back with",
+    "`az acr task show`, 2026-09-07 (MeshWeaver#3438).",
+    "",
+    "🚨 THESE TASKS ARE CLOUD-ONLY. `az acr task show` returns an `EncodedTask` with",
+    "`contextPath: null` — the YAML is stored base64-encoded inside Azure with no source",
+    "repository — and an org-wide code search for `purge-old-images` returns zero hits outside",
+    "this repository's doc pages. This directory is the record, NOT the source of truth: nothing",
+    "deploys from it. `.github/scripts/acr-retention-tasks.sh verify` is what relates the two, and",
+    "`… apply` is a maintainer-run command that pushes this record back onto the registry.",
+    "",
+    "Why the record exists at all: the definitions carry the reasoning from two incidents",
+    "(Memex#122, MeshWeaver#3438) in comments that live in exactly one place — inside a base64",
+    "blob in a cloud resource nobody diffs. A `az acr task update` from any laptop replaces them",
+    "silently and completely.",
+    "",
+    "`schedule`/`status`/`timeout` here are ASSERTED by `verify`; the remaining fields are",
+    "provenance and are printed, not compared."
+  ],
+  "registry": "meshweaver",
+  "resourceGroup": "meshweaver-shared",
+  "recordedAt": "2026-09-07",
+  "recordedFrom": "az acr task show --registry meshweaver --name <task>",
+  "tasks": [
+    {
+      "name": "purge-old-images",
+      "file": "purge-old-images.yaml",
+      "status": "Enabled",
+      "schedule": "0 3 * * *",
+      "timeout": 3600,
+      "stepType": "EncodedTask",
+      "contextPath": null,
+      "platform": { "os": "linux", "architecture": "amd64" },
+      "agentConfiguration": { "cpu": 2 },
+      "creationDate": "2026-08-31T20:33:48.969331+00:00",
+      "notes": [
+        "ONE task, TWO steps: a 7d --keep 10 step over the CI image repositories, and a separate",
+        "30d step for memex-portal. The split is behaviour-preserving — merging the filter lists",
+        "under the stricter window would retune memex-portal without anyone deciding to.",
+        "Both steps share ONE 3600 s task budget; the per-step `timeout` is a per-step ceiling.",
+        "🚨 NEITHER STEP PASSES `--include-locked`, and that is the whole of the pin protection:",
+        "`acr purge` skips locked manifests by default. Adding that flag would delete every",
+        "manifest `lock-pinned-digests.py` protects."
+      ]
+    },
+    {
+      "name": "purge-old-ci-releases",
+      "file": "purge-old-ci-releases.yaml",
+      "status": "Disabled",
+      "schedule": "0 4 * * *",
+      "timeout": 3600,
+      "stepType": "EncodedTask",
+      "contextPath": null,
+      "platform": { "os": "linux", "architecture": "amd64" },
+      "notes": [
+        "SUPERSEDED and DISABLED, not deleted — its filter list was folded into",
+        "purge-old-images's two steps. Kept as the record of the Memex#122 reasoning it carries,",
+        "and so that re-enabling it is a visible act rather than a rediscovery.",
+        "Do not re-enable it: two divergent lists is the defect #3438 named."
+      ]
+    }
+  ]
+}

--- a/.github/scripts/acr-retention-tasks.sh
+++ b/.github/scripts/acr-retention-tasks.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# acr-retention-tasks.sh — show, VERIFY or re-apply the `meshweaver` ACR retention tasks.
+#
+# WHY THIS EXISTS (MeshWeaver#3438)
+# ---------------------------------
+# The registry's purge tasks are CLOUD-ONLY. `az acr task show` returns an `EncodedTask` with
+# `contextPath: null` — the YAML is a base64 blob inside an Azure resource, with no source
+# repository — and an org-wide code search for `purge-old-images` finds nothing outside this
+# repository's doc pages. So the reasoning that keeps two incidents from recurring (Memex#122's
+# "would anything recreate this tag?", #3438's "does anything PIN a digest of it?") lives in
+# comments that exist in exactly one place, that nobody diffs, and that any `az acr task update`
+# from any laptop replaces silently and completely.
+#
+# `.github/acr-retention/` is the RECORD. Nothing deploys from it: this script is the only thing
+# that relates it to the live registry.
+#
+#   show     print the live definitions, decoded                      (read-only)
+#   record   overwrite the record FROM the live registry               (read-only against Azure)
+#   verify   diff live against the record; exit 1 on drift            (read-only)
+#   apply    push the record onto the registry                        (MUTATES — maintainer only)
+#
+# 🚨 `verify` is deliberately NOT wired into CI. It needs a credential with `Microsoft.
+# ContainerRegistry/registries/tasks/read`, which is a strictly larger grant than the AcrPull the
+# pinned-digest lanes hold, and widening a CI credential to watch a file nobody deploys from is the
+# wrong trade. Run it by hand when you touch retention. If that judgement is revisited, the lane
+# must carry a `preflight` that asserts the credential — never an `if:` that asks whether it is set.
+set -uo pipefail
+
+REGISTRY="${MW_ACR_REGISTRY:-meshweaver}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECORD="$HERE/../acr-retention"
+TASKS="purge-old-images purge-old-ci-releases"
+
+usage() {
+  echo "usage: acr-retention-tasks.sh {show|record|verify|apply}" >&2
+  exit 2
+}
+
+live_yaml() {
+  # 🚨 NO `|| true` AND NO `2>/dev/null` ON THE FETCH. A swallowed error here would decode to an
+  # empty string and read as "the live task is empty", which `verify` would report as drift and
+  # `apply` would treat as a task worth overwriting. An unreadable task is a RED, never a verdict.
+  local task="$1" encoded
+  if ! encoded=$(az acr task show --registry "$REGISTRY" --name "$task" \
+                   --query "step.encodedTaskContent" -o tsv); then
+    echo "::error::cannot read task '$task' on registry '$REGISTRY'." >&2
+    echo "  Nothing was compared. This needs Microsoft.ContainerRegistry/registries/tasks/read;" >&2
+    echo "  \`az login\` first, and confirm the subscription holding $REGISTRY.azurecr.io." >&2
+    return 1
+  fi
+  if [ -z "$encoded" ]; then
+    echo "::error::task '$task' returned an EMPTY encodedTaskContent." >&2
+    echo "  That is not 'the task has no steps' — an EncodedTask always carries one. Refusing to" >&2
+    echo "  read an empty answer as a definition." >&2
+    return 1
+  fi
+  printf '%s' "$encoded" | base64 -d
+}
+
+cmd_show() {
+  local task
+  for task in $TASKS; do
+    echo "=== $task ==="
+    az acr task show --registry "$REGISTRY" --name "$task" \
+      --query "{status:status,schedule:trigger.timerTriggers[0].schedule,timeout:timeout,contextPath:step.contextPath}" \
+      -o json || return 1
+    live_yaml "$task" || return 1
+    echo
+  done
+}
+
+cmd_record() {
+  # 🚨 CAPTURE THROUGH THE SAME READER `verify` COMPARES WITH. Recording with a hand-typed
+  # `az … | base64 -d > file` and verifying through `$(…)` differ by one trailing newline, and the
+  # verifier then reports permanent drift over a byte nobody wrote. Measured 2026-09-07: the first
+  # `verify` after the first capture was red for exactly that reason.
+  local task
+  for task in $TASKS; do
+    live_yaml "$task" > "$RECORD/$task.yaml" || return 1
+    echo "  recorded $task -> .github/acr-retention/$task.yaml"
+  done
+  echo "  now update .github/acr-retention/tasks.json if status/schedule/timeout changed."
+}
+
+cmd_verify() {
+  local task drift=0 checked=0
+  for task in $TASKS; do
+    local recorded="$RECORD/$task.yaml"
+    if [ ! -f "$recorded" ]; then
+      echo "::error::no record for task '$task' — expected $recorded" >&2
+      drift=1
+      continue
+    fi
+    # 🚨 COMPARE FILE TO FILE, never `$(live_yaml …)` to a file. Command substitution strips
+    # TRAILING NEWLINES, and both live definitions end in one — so a `$(…)`-based diff reported
+    # permanent drift on a byte nobody had written, on every task, forever. A drift report that is
+    # always red is a drift report nobody reads. Measured 2026-09-07, twice, before it was believed.
+    local live="${TMPDIR:-/tmp}/acr-retention-live.$$"
+    live_yaml "$task" > "$live" || { rm -f "$live"; return 1; }
+    checked=$((checked + 1))
+    if ! diff -u "$recorded" "$live" > "${live}.diff" 2>&1; then
+      echo "::error::task '$task' DRIFTED from .github/acr-retention/$task.yaml:"
+      cat "${live}.diff"
+      echo "  Someone changed retention in the cloud without updating the record — or the record"
+      echo "  was changed without applying it. Decide which is right, then re-run \`apply\` or"
+      echo "  re-record with \`record\`. The reasoning in these comments is the only copy there is."
+      drift=1
+    else
+      echo "  $task: matches the record byte for byte."
+    fi
+    rm -f "$live" "${live}.diff"
+
+    # The window is only half the definition; the SCHEDULE and the enabled/disabled state are the
+    # other half, and a task silently disabled is a retention policy that stopped running.
+    local want_status want_schedule got_status got_schedule
+    want_status=$(python3 -c "import json,sys;d=json.load(open('$RECORD/tasks.json'));print(next(t['status'] for t in d['tasks'] if t['name']=='$task'))")
+    want_schedule=$(python3 -c "import json,sys;d=json.load(open('$RECORD/tasks.json'));print(next(t['schedule'] for t in d['tasks'] if t['name']=='$task'))")
+    got_status=$(az acr task show --registry "$REGISTRY" --name "$task" --query "status" -o tsv) || return 1
+    got_schedule=$(az acr task show --registry "$REGISTRY" --name "$task" \
+                     --query "trigger.timerTriggers[0].schedule" -o tsv) || return 1
+    if [ "$want_status" != "$got_status" ]; then
+      echo "::error::task '$task' status is '$got_status'; the record says '$want_status'."
+      drift=1
+    fi
+    if [ "$want_schedule" != "$got_schedule" ]; then
+      echo "::error::task '$task' schedule is '$got_schedule'; the record says '$want_schedule'."
+      drift=1
+    fi
+  done
+
+  # 🚨 THE DENOMINATOR. "No drift" over zero tasks compared is not a pass, and it is exactly what a
+  # renamed task or a typo'd registry produces.
+  echo "  compared $checked task definition(s) against the record."
+  if [ "$checked" -eq 0 ]; then
+    echo "::error::ZERO task definitions were compared, so this proved nothing."
+    return 1
+  fi
+
+  # The lock protection rests on ONE property of these definitions, so assert it rather than
+  # trusting the diff to have been read: `acr purge` skips locked manifests unless told otherwise.
+  #
+  # 🚨 GREP THE `cmd:` LINES, NOT THE FILE. The first draft grepped the whole recorded YAML and
+  # fired on the task's OWN COMMENT — which says, correctly, that neither step passes
+  # `--include-locked`. A guard that reds on the prose explaining why it is satisfied is a guard
+  # that gets muted. Measured 2026-09-07, first run.
+  local steps
+  steps=$(grep -h -E "^[[:space:]]*-[[:space:]]+cmd:" "$RECORD"/*.yaml)
+  if [ -z "$steps" ]; then
+    echo "::error::no \`cmd:\` step was found in any recorded task, so nothing was inspected."
+    drift=1
+  elif printf '%s\n' "$steps" | grep -q -- "--include-locked"; then
+    echo "::error::a recorded purge STEP passes --include-locked."
+    echo "  That flag deletes LOCKED manifests, which is the entire protection"
+    echo "  lock-pinned-digests.py provides. Remove it, or the pinned set is unprotected again."
+    drift=1
+  else
+    local n
+    n=$(printf '%s\n' "$steps" | grep -c .)
+    echo "  $n purge step(s) inspected; none passes --include-locked, so locked manifests are skipped."
+  fi
+  return $drift
+}
+
+cmd_apply() {
+  echo "🚨 This MUTATES shared registry infrastructure every deployment depends on."
+  echo "   Registry: $REGISTRY   Tasks: $TASKS"
+  echo "   Re-read Doc/Architecture/PinnedImageRetention before continuing."
+  printf '   Type the registry name to proceed: '
+  local confirm
+  read -r confirm
+  if [ "$confirm" != "$REGISTRY" ]; then
+    echo "aborted."
+    return 1
+  fi
+  local task
+  for task in $TASKS; do
+    local recorded="$RECORD/$task.yaml"
+    local schedule
+    schedule=$(python3 -c "import json;d=json.load(open('$RECORD/tasks.json'));print(next(t['schedule'] for t in d['tasks'] if t['name']=='$task'))")
+    echo "applying $task (schedule $schedule) from $recorded"
+    az acr task update --registry "$REGISTRY" --name "$task" \
+      --file "$recorded" --schedule "$schedule" -o none || return 1
+    local status
+    status=$(python3 -c "import json;d=json.load(open('$RECORD/tasks.json'));print(next(t['status'] for t in d['tasks'] if t['name']=='$task'))")
+    az acr task update --registry "$REGISTRY" --name "$task" \
+      --status "$status" -o none || return 1
+  done
+  echo "applied; re-verifying:"
+  cmd_verify
+}
+
+case "${1:-}" in
+  show)   cmd_show ;;
+  record) cmd_record ;;
+  verify) cmd_verify ;;
+  apply)  cmd_apply ;;
+  *)      usage ;;
+esac

--- a/.github/scripts/lock-pinned-digests.py
+++ b/.github/scripts/lock-pinned-digests.py
@@ -754,7 +754,8 @@ def apply_locks(plan: Plan, registry: Registry) -> list[str]:
             # reason, and N identical errors bury the ONE line that says which role to grant.
             remaining = plan.to_lock[index:]
             failures.append(
-                "the credential is not allowed to lock a manifest, so NOTHING was protected. "
+                "the credential is not allowed to lock a manifest. "
+                f"{plan.locked_now} of {len(plan.to_lock)} were locked before the refusal. "
                 f"az said: {detail}"
             )
             failures.extend(GRANT_HELP)

--- a/.github/scripts/lock-pinned-digests.py
+++ b/.github/scripts/lock-pinned-digests.py
@@ -1,0 +1,1335 @@
+#!/usr/bin/env python3
+"""lock-pinned-digests.py — protect every manifest the fleet PINS, by locking it in the registry.
+
+(The name on this first line is load-bearing in the same way compile-check.py's,
+check-pinned-digests.py's and check-pin-set-consistency.py's are: a lane that fetches this file at
+the platform ref can refuse a body whose first 400 bytes do not name it.)
+
+WHY THIS EXISTS (MeshWeaver#3438 requirement 1, 2026-09-07)
+-----------------------------------------------------------
+ACR's nightly `purge-old-images` task deleted the manifests MeshWeaver.Education's `main` pinned.
+Every run of that repo's `Disposable-mesh gate` then died at `manifest unknown` before a single
+content gate executed — INCLUDING `main`'s own nightly, so the repository lost its gate and its
+green baseline in the same instant. Education, Manufacturing and SocialMedia went down together at
+2026-09-05T15:29Z.
+
+`check-pinned-digests.py` (#3462) is the GUARD half: it asks, after the fact, whether each pinned
+digest still exists, and turns a mute fleet-wide wedge into one named red. It does not stop the
+deletion. THIS is the other half: it stops the deletion, by deriving protection from the live pin
+set instead of from a human remembering.
+
+    `acr purge` SKIPS LOCKED MANIFESTS BY DEFAULT. Deleting one needs the explicit
+    `--include-locked`, and neither step of `purge-old-images` passes it (verified against the live
+    task definition, 2026-09-07 — the definition is recorded in .github/acr-retention/). So
+    `deleteEnabled: false` on a manifest is a HARD protection against this exact configuration,
+    not a hint.
+
+Five manifests were locked BY HAND on 2026-09-06 to stop the bleeding. A hand list is the defect,
+not the fix: it is only ever correct on the day it is written. This job re-derives the set nightly,
+at 01:00 UTC — two hours before the 03:00 purge.
+
+🚨 IT LOCKS. IT DOES NOT UNLOCK.
+--------------------------------
+Releasing a lock is the only direction that can DESTROY data, and it is unsafe in exactly the
+situation where the extractor is wrong: a pin this scan cannot see is spelled identically to a pin
+that is not there, so "nothing pins this any more" and "I failed to read the thing that pins it"
+produce the same answer. The release arm is therefore:
+
+  * always COMPUTED and PRINTED, so the stale-lock debt is visible and cannot grow silently;
+  * never acted on unless `MW_ACR_RELEASE_UNPINNED=true` (or `--release-unpinned`) is set by a
+    person, AND the run is free of every blocker below.
+
+The asymmetry is deliberate and it is the whole safety argument: a stale lock costs one manifest's
+unshared layers; a wrong release costs an outage. Memex#122 — a purged pinned tag — served the
+public brand site 503 for ~11 hours and nothing alerted.
+
+LOCKS ARE APPLIED ON A DEGRADED RUN; RELEASES ARE NOT. A lock cannot destroy anything, so when the
+sweep is partial the safe move is to protect what WAS found and still fail red. A release on a
+partial sweep is precisely the outage. Both facts are printed.
+
+WHY `--delete-enabled false` AND NOT ALSO `--write-enabled false`
+-----------------------------------------------------------------
+`deleteEnabled: false` is exactly and only what `acr purge` skips on. `writeEnabled: false`
+additionally refuses a manifest PUT for that digest — and the release pipeline PROMOTES by
+retagging in ACR (`release.yml`: `docker buildx imagetools create --tag $ACR/$repo:$VERSION
+$ACR/$repo:$SHORT`), which is a manifest PUT of an already-present digest under a new tag. So a
+write-lock buys NO extra purge protection and may cost a promotion. (Reasoned from the mechanism,
+not measured: confirming it needs an actual retag against a write-locked manifest.) This job
+therefore locks DELETE only — the strictly smaller grant for the strictly sufficient effect — and it
+never relaxes an attribute somebody else set: a manifest already carrying `writeEnabled: false` is
+reported and left exactly as it is.
+
+THE PIN SET IS THE UNION OF TWO AXES, AND ONE OF THEM IS INVISIBLE TO THE OTHER
+-------------------------------------------------------------------------------
+  AXIS 1  digests pinned in the satellites' `.github/workflows` — what #3462 sweeps.
+  AXIS 2  image TAGS pinned in the deployment overlays (Memex#141). `check-pinned-digests.py`
+          reads `.github/workflows` and enumerates NONE of these, so a lock set built from axis 1
+          alone leaves every overlay-pinned manifest unprotected. Memex#122's victim was pinned
+          exactly that way.
+
+Measured 2026-09-07: axis 2 is `meshweaver.azurecr.io/memex-portal-ai:3.0.0-ci.7926` and its
+migration twin (memex + memex-cloud), `memex-portal-next:3.0.0-next.43`, `hosting-operator:1.0.0`,
+the pearl overlay's `3.0.0-rc9.ci.7601` pair, and core's `whisper-swiss-german:1.7.4`.
+
+🚨 NO SECOND EXTRACTOR FOR AXIS 1. This script IMPORTS `check-pin-set-consistency.py` and uses its
+`extract()`, so there is exactly one definition in this repository of what a digest pin IS.
+`check-pin-set-consistency.py` and `check-pinned-digests.py` already share their shapes on purpose;
+the self-test here asserts that the two AGREE on one fixture, so a future edit that diverges them
+reddens rather than silently splitting the fleet's idea of a pin in two.
+
+Axis 2 is a different subject with a different shape (a TAG, in a helm overlay, not a digest in a
+workflow) and it necessarily has its own reader. Its scope is deliberately narrow, and the boundary
+is measured rather than guessed: `values*.yml` / `values*.yaml` under a `deploy/` or `deployments/`
+path segment. Widening it to every YAML/JSON under `deploy/` was tried and rejected — core's
+`deploy/aks/operator/test/fixtures/**` carry image references to tags that never existed
+(`memex-portal-ai:3.0.0-rc8.ci.5000`), which would red this job nightly over test fixtures, and
+`deploy/aks/manifests/observability/log-watcher.yaml` names the FLOATING tag `:latest`, which has
+no fixed manifest to protect.
+
+WHAT MAKES IT RED (fail closed — an unswept repository must never read as a swept one)
+---------------------------------------------------------------------------------------
+  * a repository whose workflows or whose git tree could not be read;
+  * a truncated git tree (GitHub's `truncated: true`) — an unknown number of unread files;
+  * a pin-shaped declaration whose value is not a digest (I4 — placeholder vacuity);
+  * a digest whose ACR repository cannot be determined (I5 — an unclassified pin has NOT been
+    checked, and for LOCKING it is worse than unchecked: there is no manifest to lock);
+  * an overlay tag that does not resolve, or a pinned digest that is already gone;
+  * an INDETERMINATE registry answer — az failing for any reason other than the registry's own
+    `manifest unknown`;
+  * ZERO pins on either axis. Both were non-zero when this was written, so a zero means the
+    extractor stopped matching, not that pinning stopped;
+  * a lock that was requested and did not take.
+
+USAGE
+-----
+  lock-pinned-digests.py --discover                  report what it WOULD lock (no mutation)
+  lock-pinned-digests.py --discover --apply          …and actually lock it
+  lock-pinned-digests.py --repos Systemorph/A,…      scan exactly these repositories
+  lock-pinned-digests.py --check-retention-record .  assert the committed retention record still
+                                                     describes a purge a lock can protect against
+  lock-pinned-digests.py --self-test                 prove both arms fire, offline
+
+Exit 0 only when every pin found is protected and nothing was blocked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REGISTRY_DEFAULT = "meshweaver"
+HERE = Path(__file__).resolve().parent
+
+
+# ── The ONE definition of a digest pin, imported rather than rewritten ──────────────────────────
+#
+# 🚨 A third extractor would break the property `check-pin-set-consistency.py` was built with —
+# "the two scripts deliberately share their extraction SHAPES … so they can never disagree about
+# what a pin IS". Importing is how that stays true by construction rather than by review.
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, HERE / filename)
+    if spec is None or spec.loader is None:      # pragma: no cover - packaging accident
+        raise ImportError(f"cannot load {filename} from {HERE}")
+    module = importlib.util.module_from_spec(spec)
+    # 🚨 REGISTER BEFORE EXECUTING. `@dataclass` resolves its own annotations through
+    # `sys.modules[cls.__module__]`, so a module executed while absent from `sys.modules` dies on
+    # the first dataclass with `AttributeError: 'NoneType' object has no attribute '__dict__'`.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+consistency = _load("mw_pin_set_consistency", "check-pin-set-consistency.py")
+existence = _load("mw_pinned_digests", "check-pinned-digests.py")
+
+
+# ── Axis 2: an image TAG pinned in a deployment overlay ────────────────────────────────────────
+
+# Shape A — the whole reference on one line: `image: "meshweaver.azurecr.io/memex-portal-ai:3.0.0"`.
+OVERLAY_INLINE_RE = re.compile(
+    consistency.REGISTRY_HOST_RE
+    + r"/(?P<repo>[A-Za-z0-9][A-Za-z0-9._/-]*):(?P<tag>[A-Za-z0-9_][A-Za-z0-9._-]*)"
+)
+
+# Shape B — helm's split convention, `repository:` on one line and `tag:` in the same mapping:
+#
+#     image:
+#       repository: meshweaver.azurecr.io/whisper-swiss-german
+#       tag: "1.7.4"
+#
+# It is not hypothetical and it is not rare: it is how BOTH this repository's `deploy/whisper/helm`
+# and Memex's `deployments/aks/memex-cloud/whisper/helm` write their pin. A reader that saw only
+# shape A would report those overlays as pinning NOTHING — the exact "not looked at, spelled the
+# same as clean" confusion this whole family of gates exists to remove.
+OVERLAY_REPOSITORY_RE = re.compile(
+    r"^(?P<indent>[ \t]*)repository[ \t]*:[ \t]*(?P<quote>['\"]?)"
+    + consistency.REGISTRY_HOST_RE
+    + r"/(?P<repo>[A-Za-z0-9][A-Za-z0-9._/-]*?)(?P=quote)[ \t]*(?:#[^\r\n]*)?$"
+)
+OVERLAY_TAG_RE = re.compile(
+    r"^(?P<indent>[ \t]*)tag[ \t]*:[ \t]*(?P<quote>['\"]?)"
+    r"(?P<tag>[A-Za-z0-9_][A-Za-z0-9._-]*)(?P=quote)[ \t]*(?:#[^\r\n]*)?$"
+)
+
+# A `${{ … }}` / `{{ … }}` value is a template, not a pin.
+TEMPLATED_RE = re.compile(r"\{\{")
+
+# A tag that MOVES has no fixed manifest to protect, and locking whatever it happens to point at
+# today would pin the wrong bytes forever. These are reported as "floating", never locked.
+FLOATING_TAGS = {"latest", "main", "master", "edge", "stable", "nightly"}
+
+# Where a deployment overlay lives. Narrow ON PURPOSE — see the module docstring: widening this to
+# every YAML/JSON under `deploy/` drags in test fixtures whose tags never existed.
+OVERLAY_DIR_SEGMENTS = ("deploy", "deployments")
+OVERLAY_FILE_RE = re.compile(r"^values[A-Za-z0-9._-]*\.ya?ml$")
+
+
+def is_overlay_path(path: str) -> bool:
+    parts = path.split("/")
+    if not any(segment in OVERLAY_DIR_SEGMENTS for segment in parts[:-1]):
+        return False
+    return bool(OVERLAY_FILE_RE.match(parts[-1]))
+
+
+def extract_overlay_pins(text: str) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """(pins, floating) as (acr_repo, tag) pairs, from one overlay file's text."""
+    pins: list[tuple[str, str]] = []
+    floating: list[tuple[str, str]] = []
+
+    def add(repo: str, tag: str) -> None:
+        pair = (repo, tag)
+        if tag.lower() in FLOATING_TAGS:
+            if pair not in floating:
+                floating.append(pair)
+        elif pair not in pins:
+            pins.append(pair)
+
+    for match in OVERLAY_INLINE_RE.finditer(text):
+        add(match.group("repo"), match.group("tag"))
+
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        repo_match = OVERLAY_REPOSITORY_RE.match(line)
+        if not repo_match or TEMPLATED_RE.search(line):
+            continue
+        indent = len(repo_match.group("indent").replace("\t", "    "))
+        # The sibling `tag:` is in the SAME mapping block: same indent, before the block ends.
+        for follower in lines[index + 1:]:
+            if not follower.strip() or follower.lstrip().startswith("#"):
+                continue
+            follower_indent = len(follower[: len(follower) - len(follower.lstrip())]
+                                  .replace("\t", "    "))
+            if follower_indent < indent:
+                break
+            if follower_indent > indent:
+                continue
+            tag_match = OVERLAY_TAG_RE.match(follower)
+            if tag_match and not TEMPLATED_RE.search(follower):
+                add(repo_match.group("repo"), tag_match.group("tag"))
+            break
+    return pins, floating
+
+
+@dataclass
+class OverlayScan:
+    gh_repo: str
+    files: int = 0
+    pins: list[tuple[str, str, str]] = field(default_factory=list)      # (repo, tag, where)
+    floating: list[tuple[str, str, str]] = field(default_factory=list)
+    unreadable: str | None = None
+
+
+def scan_overlays_remote(gh_repo: str) -> OverlayScan:
+    scan = OverlayScan(gh_repo=gh_repo)
+    rc, out, err = consistency.gh_api(f"repos/{gh_repo}/git/trees/HEAD?recursive=1")
+    if rc != 0:
+        blob = (err + out).lower()
+        if "404" in blob or "not found" in blob or "empty" in blob:
+            # 🚨 SAME TWO-CAUSES-ONE-STATUS TRAP as `.github/workflows` (#3462): a 404 here means
+            # either an empty repository — a MEASURED ZERO — or a repository this token cannot
+            # read, which means NOBODY LOOKED. Ask about the repository before believing it.
+            rc_repo, _, err_repo = consistency.gh_api(f"repos/{gh_repo}")
+            if rc_repo != 0:
+                scan.unreadable = (
+                    "the repository itself could not be read, so its overlays were never looked "
+                    f"for. gh said: {err_repo.strip()[:200]}"
+                )
+            return scan
+        scan.unreadable = err.strip()[:300] or "unknown error reading the git tree"
+        return scan
+    try:
+        tree = json.loads(out)
+    except json.JSONDecodeError as exc:
+        scan.unreadable = f"the git tree is not JSON: {exc}"
+        return scan
+    if tree.get("truncated"):
+        # An unknown number of paths were not returned, so an absence here proves nothing.
+        scan.unreadable = ("GitHub truncated the recursive tree listing, so an unknown number of "
+                           "paths were never seen. An absence read off a truncated listing is not "
+                           "a measured zero.")
+        return scan
+    paths = [entry["path"] for entry in tree.get("tree", [])
+             if entry.get("type") == "blob" and is_overlay_path(entry.get("path", ""))]
+    for path in sorted(paths):
+        rc, body, err = consistency.gh_api(f"repos/{gh_repo}/contents/{path}")
+        if rc != 0:
+            scan.unreadable = f"could not read {path}: {err.strip()[:200]}"
+            return scan
+        try:
+            doc = json.loads(body)
+            text = base64.b64decode(doc["content"]).decode("utf-8", "replace")
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            scan.unreadable = f"could not decode {path}: {exc}"
+            return scan
+        scan.files += 1
+        pins, floating = extract_overlay_pins(text)
+        scan.pins.extend((repo, tag, path) for repo, tag in pins)
+        scan.floating.extend((repo, tag, path) for repo, tag in floating)
+    return scan
+
+
+def scan_overlays_local(root: str, gh_repo: str) -> OverlayScan:
+    scan = OverlayScan(gh_repo=gh_repo)
+    base = Path(root)
+    if not base.is_dir():
+        scan.unreadable = f"{root} is not a directory, so its overlays were never looked for."
+        return scan
+    for path in sorted(base.rglob("values*.y*ml")):
+        rel = path.relative_to(base).as_posix()
+        if not is_overlay_path(rel):
+            continue
+        scan.files += 1
+        pins, floating = extract_overlay_pins(path.read_text(encoding="utf-8", errors="replace"))
+        scan.pins.extend((repo, tag, rel) for repo, tag in pins)
+        scan.floating.extend((repo, tag, rel) for repo, tag in floating)
+    return scan
+
+
+# ── The registry, behind one seam so the self-test can drive it offline ─────────────────────────
+
+
+class Registry:
+    """Every registry interaction this job makes. Read methods first, then the one write."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._tag_cache: dict[tuple[str, str], tuple[str | None, str]] = {}
+
+    # -- reads ----------------------------------------------------------------------------------
+
+    def control_probe(self) -> None:
+        consistency.registry_control_probe(self.name)
+
+    def manifests(self, acr_repo: str) -> tuple[list["Manifest"] | None, str]:
+        rc, out, err = consistency.az(
+            ["acr", "manifest", "list-metadata", "--registry", self.name,
+             "--name", acr_repo, "-o", "json"]
+        )
+        if rc != 0:
+            return None, " ".join(err.split())[:300]
+        try:
+            raw_list = json.loads(out)
+        except json.JSONDecodeError as exc:
+            return None, f"list-metadata did not return JSON: {exc}"
+        parsed: list[Manifest] = []
+        for raw in raw_list:
+            # ACR nests the lock flags under `changeableAttributes`; some API versions also carry
+            # them flat. Read both, and default to UNLOCKED — the safe direction, because it makes
+            # the job try to lock rather than assume protection it has not seen.
+            attributes = raw.get("changeableAttributes") or {}
+            parsed.append(Manifest(
+                acr_repo=acr_repo,
+                digest=raw.get("digest", ""),
+                delete_enabled=attributes.get("deleteEnabled", raw.get("deleteEnabled", True)),
+                write_enabled=attributes.get("writeEnabled", raw.get("writeEnabled", True)),
+                tags=raw.get("tags") or [],
+            ))
+        return parsed, ""
+
+    def repositories(self) -> tuple[list[str] | None, str]:
+        rc, out, err = consistency.az(["acr", "repository", "list", "--name", self.name, "-o", "json"])
+        if rc != 0:
+            return None, " ".join(err.split())[:300]
+        try:
+            return json.loads(out), ""
+        except json.JSONDecodeError as exc:
+            return None, f"repository list did not return JSON: {exc}"
+
+    def resolve_tag(self, acr_repo: str, tag: str) -> tuple[str | None, str]:
+        """A tag's digest. (None, 'absent') when the registry says so; (None, 'INDETERMINATE: …')
+        for every other failure — a credential or a network fault is NEVER evidence of absence."""
+        key = (acr_repo, tag)
+        if key in self._tag_cache:
+            return self._tag_cache[key]
+        rc, out, err = consistency.az(
+            ["acr", "repository", "show", "--name", self.name,
+             "--image", f"{acr_repo}:{tag}", "--query", "digest", "-o", "tsv"]
+        )
+        if rc == 0 and out.strip().startswith("sha256:"):
+            result: tuple[str | None, str] = (out.strip(), "")
+        elif rc == 0:
+            result = (None, f"INDETERMINATE: az answered 0 but no digest: {out.strip()[:120]!r}")
+        else:
+            blob = err.lower()
+            if any(marker in blob for marker in consistency.ABSENT_MARKERS):
+                result = (None, "absent")
+            else:
+                result = (None, "INDETERMINATE: " + " ".join(err.split())[:300])
+        self._tag_cache[key] = result
+        return result
+
+    # -- the one write --------------------------------------------------------------------------
+
+    def set_delete_enabled(self, acr_repo: str, digest: str, enabled: bool) -> tuple[bool, str]:
+        rc, _, err = consistency.az(
+            ["acr", "repository", "update", "--name", self.name,
+             "--image", f"{acr_repo}@{digest}",
+             "--delete-enabled", "true" if enabled else "false",
+             "-o", "none"]
+        )
+        return (rc == 0, " ".join(err.split())[:300])
+
+
+@dataclass
+class Manifest:
+    acr_repo: str
+    digest: str
+    delete_enabled: bool
+    write_enabled: bool
+    tags: list[str]
+
+
+@dataclass
+class Wanted:
+    """One manifest the fleet pins, and every place that pins it."""
+
+    acr_repo: str
+    digest: str | None                 # None while an axis-2 tag is unresolved
+    sources: list[str] = field(default_factory=list)
+    tag: str | None = None             # axis 2 only
+    problem: str = ""                  # non-empty ⇒ a blocker, and nothing to lock
+
+
+@dataclass
+class Plan:
+    wanted: list[Wanted] = field(default_factory=list)
+    already_protected: list[Wanted] = field(default_factory=list)
+    to_lock: list[Wanted] = field(default_factory=list)
+    release_candidates: list[Manifest] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    locked_now: int = 0
+    released_now: int = 0
+    # The denominator, carried rather than recomputed, so the report and the verdict read the
+    # same numbers by construction.
+    axis1_sites: int = 0
+    axis1_unclassified: int = 0
+    axis2_sites: int = 0
+    axis2_pairs: dict[tuple[str, str], list[str]] = field(default_factory=dict)
+
+
+# ── Planning: pure over its inputs, so the self-test can falsify it with no network ─────────────
+
+
+def build_plan(axis1: list, axis2: list[OverlayScan]) -> Plan:
+    """Everything decidable WITHOUT the registry: what is pinned, and what was not looked at."""
+    plan = Plan()
+
+    # ---- blockers that mean "a pin was not looked at" -----------------------------------------
+    for scan in axis1:
+        if scan.unreadable:
+            plan.blockers.append(
+                f"{scan.gh_repo}: its workflows could not be read, so its digest pins were NOT "
+                f"looked for — {scan.unreadable}"
+            )
+        for bad in scan.malformed:
+            plan.blockers.append(
+                f"{scan.gh_repo} — {bad.filename}:{bad.line} `{bad.name}` is pin-shaped and its "
+                f"value {bad.value!r} is not a digest (I4). A placeholder reads as an absence to a "
+                f"looser matcher, so it is a failure here, never a silence."
+            )
+    for scan in axis2:
+        if scan.unreadable:
+            plan.blockers.append(
+                f"{scan.gh_repo}: its deployment overlays could not be read, so its TAG pins were "
+                f"NOT looked for — {scan.unreadable}"
+            )
+
+    # ---- axis 1: a classified digest pin ------------------------------------------------------
+    by_key: dict[tuple[str, str], Wanted] = {}
+    axis1_sites = 0
+    axis1_unclassified = 0
+    for scan in axis1:
+        for site in scan.sites:
+            if site.kind != "digest":
+                continue
+            axis1_sites += 1
+            where = f"{scan.gh_repo} {site.filename}:{site.line} `{site.name}`"
+            if not site.role:
+                axis1_unclassified += 1
+                plan.blockers.append(
+                    f"{where} pins {site.value} and NO ACR repository could be determined for it "
+                    "(I5). An unclassified pin has not been checked — and for locking it is worse: "
+                    "there is no manifest to protect. Bind it to its image in the file, or add it "
+                    "to ROLE_ALIASES in check-pin-set-consistency.py."
+                )
+                continue
+            key = (site.role, site.value)
+            entry = by_key.setdefault(key, Wanted(acr_repo=site.role, digest=site.value))
+            entry.sources.append(where)
+
+    # ---- axis 2: a tag pin. Its digest needs the registry, so it is only COLLECTED here. -------
+    axis2_sites = 0
+    for scan in axis2:
+        for acr_repo, tag, where in scan.pins:
+            axis2_sites += 1
+            plan.axis2_pairs.setdefault((acr_repo, tag), []).append(f"{scan.gh_repo} {where}")
+
+    plan.wanted = list(by_key.values())
+    plan.axis1_sites = axis1_sites
+    plan.axis1_unclassified = axis1_unclassified
+    plan.axis2_sites = axis2_sites
+
+    # ---- the denominator rule, per axis -------------------------------------------------------
+    unreadable_axis1 = any(scan.unreadable for scan in axis1)
+    unreadable_axis2 = any(scan.unreadable for scan in axis2)
+    if axis1_sites == 0 and not unreadable_axis1:
+        plan.blockers.append(
+            "AXIS 1 found ZERO digest pins across the whole fleet. Six repositories pinned at "
+            "least one on 2026-09-06, so zero means the extractor stopped matching, not that "
+            "pinning stopped. Run --self-test."
+        )
+    if axis2_sites == 0 and not unreadable_axis2:
+        plan.blockers.append(
+            "AXIS 2 found ZERO deployment-overlay tag pins across the whole fleet. Seven were "
+            "measured on 2026-09-07 (Memex's three overlays and this repository's whisper chart), "
+            "so zero means the overlay reader stopped matching, not that the overlays stopped "
+            "pinning. Run --self-test."
+        )
+    return plan
+
+
+def resolve_and_classify(plan: Plan, registry: Registry,
+                         inventory: dict[str, list[Manifest]],
+                         inventory_errors: dict[str, str]) -> None:
+    """Turn axis-2 tags into digests, then split the union into already-protected / to-lock."""
+    for (acr_repo, tag), wheres in sorted(plan.axis2_pairs.items()):
+        digest, detail = registry.resolve_tag(acr_repo, tag)
+        if digest is None:
+            entry = Wanted(acr_repo=acr_repo, digest=None, sources=wheres, tag=tag)
+            if detail.startswith("INDETERMINATE"):
+                entry.problem = (f"could not determine whether {acr_repo}:{tag} exists — {detail}. "
+                                 "Indeterminate is not a pass and it is not 'gone' either.")
+            else:
+                entry.problem = (
+                    f"{acr_repo}:{tag} does not resolve in the registry, so there is nothing to "
+                    "protect. This is Memex#141's shape: a committed overlay pin whose image is "
+                    "gone is inert until the one deploy that reads it — a first install."
+                )
+            plan.wanted.append(entry)
+            plan.blockers.append(f"{', '.join(wheres)}: {entry.problem}")
+            continue
+        merged = next((w for w in plan.wanted if w.acr_repo == acr_repo and w.digest == digest),
+                      None)
+        if merged is None:
+            merged = Wanted(acr_repo=acr_repo, digest=digest, tag=tag)
+            plan.wanted.append(merged)
+        merged.sources.extend(f"{where} (tag {tag})" for where in wheres)
+
+    # Which of them are already protected?
+    known: dict[tuple[str, str], Manifest] = {}
+    for acr_repo, manifests in inventory.items():
+        for manifest in manifests:
+            known[(acr_repo, manifest.digest)] = manifest
+
+    for acr_repo, error in sorted(inventory_errors.items()):
+        if acr_repo == "*":
+            plan.blockers.append(
+                f"could not enumerate the registry's repositories — {error}. NOTHING was checked "
+                "and nothing can be protected. This is not 'no manifest is locked': a gate that "
+                "cannot reach its subject has not checked it."
+            )
+        else:
+            plan.blockers.append(
+                f"could not enumerate the manifests of `{acr_repo}` — {error}. Nothing in that "
+                "repository could be checked or protected, so this run is partial."
+            )
+
+    for entry in plan.wanted:
+        if entry.problem or entry.digest is None:
+            continue
+        manifest = known.get((entry.acr_repo, entry.digest))
+        if manifest is None:
+            # 🚨 ABSENCE FROM AN INVENTORY NOBODY COULD READ IS NOT ABSENCE. Without this, one
+            # refused `az acr repository list` turns every pin in the fleet into "the manifest is
+            # gone" — the catastrophe-that-is-not-happening this whole family of gates refuses to
+            # report (check-pinned-digests.py's control probe, for the same reason).
+            if "*" in inventory_errors or entry.acr_repo in inventory_errors:
+                continue        # already a blocker, and its absence proves nothing
+            entry.problem = (
+                f"{entry.acr_repo}@{entry.digest} does not exist in the registry, so it CANNOT be "
+                "protected. Every job that pulls it dies at `manifest unknown` before it runs "
+                "anything (MeshWeaver#3438). Move the pin to a manifest that exists — as one set."
+            )
+            plan.blockers.append(f"{', '.join(entry.sources[:3])}: {entry.problem}")
+            continue
+        if manifest.delete_enabled is False:
+            plan.already_protected.append(entry)
+        else:
+            plan.to_lock.append(entry)
+
+    # Release candidates: locked, and pinned by nothing this run could see. REPORTED, not acted on
+    # unless a person has turned the arm on AND the run is clean.
+    pinned_keys = {(w.acr_repo, w.digest) for w in plan.wanted if w.digest and not w.problem}
+    for acr_repo, manifests in sorted(inventory.items()):
+        for manifest in manifests:
+            if manifest.delete_enabled is False and (acr_repo, manifest.digest) not in pinned_keys:
+                plan.release_candidates.append(manifest)
+
+
+# ── Reporting ──────────────────────────────────────────────────────────────────────────────────
+
+
+def emit(text: str) -> None:
+    print(text)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+
+
+def report(plan: Plan, axis1, axis2: list[OverlayScan], registry_name: str,
+           inventory: dict[str, list[Manifest]], apply: bool, release_enabled: bool) -> None:
+    def pins_a_digest(scan) -> bool:
+        return any(site.kind == "digest" for site in scan.sites)
+
+    # 🚨 `x not in list` on a DATACLASS compares by VALUE, and two repositories that both scanned
+    # clean with zero pins are equal by value — so a membership test would classify one of them by
+    # the other's identity. Ask the predicate, not the list.
+    pinning1 = [s for s in axis1 if pins_a_digest(s)]
+    silent1 = [s for s in axis1 if not s.unreadable and not pins_a_digest(s)]
+    unreadable1 = [s for s in axis1 if s.unreadable]
+    pinning2 = [s for s in axis2 if s.pins]
+    silent2 = [s for s in axis2 if not s.unreadable and not s.pins]
+    unreadable2 = [s for s in axis2 if s.unreadable]
+    floating = [(s.gh_repo, repo, tag, where) for s in axis2 for repo, tag, where in s.floating]
+    total_manifests = sum(len(v) for v in inventory.values())
+    locked_now = sum(1 for v in inventory.values() for m in v if m.delete_enabled is False)
+
+    emit("")
+    emit(f"### Pinned-manifest protection — {registry_name}.azurecr.io")
+    emit("")
+    emit(f"    mode                                       "
+         f"{'APPLY (locks will be written)' if apply else 'REPORT ONLY (no registry mutation)'}")
+    emit("")
+    emit("    AXIS 1 — digest pins in .github/workflows")
+    emit(f"      repositories scanned                     {len(axis1)}")
+    emit(f"      …declaring at least one digest pin       {len(pinning1)}"
+         + (f"  ({', '.join(s.gh_repo for s in pinning1)})" if pinning1 else ""))
+    emit(f"      …declaring NO digest pin                 {len(silent1)}")
+    emit(f"      …whose workflows could not be read       {len(unreadable1)}")
+    emit(f"      digest pin SITES found                   {getattr(plan, 'axis1_sites', 0)}")
+    emit(f"      …UNCLASSIFIED (I5 — not checked)         {getattr(plan, 'axis1_unclassified', 0)}")
+    emit("")
+    emit("    AXIS 2 — image TAG pins in deployment overlays")
+    emit(f"      repositories scanned                     {len(axis2)}")
+    emit(f"      …carrying an overlay that pins           {len(pinning2)}"
+         + (f"  ({', '.join(s.gh_repo for s in pinning2)})" if pinning2 else ""))
+    emit(f"      …carrying none                           {len(silent2)}")
+    emit(f"      …whose tree could not be read            {len(unreadable2)}")
+    emit(f"      overlay files considered                 {sum(s.files for s in axis2)}")
+    emit(f"      tag pin SITES found                      {getattr(plan, 'axis2_sites', 0)}")
+    emit(f"      …FLOATING tags (no fixed manifest)       {len(floating)}")
+    emit("")
+    emit("    UNION — manifests the fleet pins")
+    emit(f"      distinct manifests wanted                {len(plan.wanted)}")
+    emit(f"      …already protected (deleteEnabled false) {len(plan.already_protected)}")
+    emit(f"      …TO LOCK                                 {len(plan.to_lock)}")
+    emit(f"      …that could NOT be protected             "
+         f"{len([w for w in plan.wanted if w.problem])}")
+    emit("")
+    emit("    REGISTRY")
+    emit(f"      manifests in the registry                {total_manifests}")
+    emit(f"      …currently locked (deleteEnabled false)  {locked_now}")
+    emit(f"      …locked and pinned by NOTHING            {len(plan.release_candidates)}")
+    emit("")
+
+    for scan in axis1:
+        if scan.unreadable:
+            emit(f"  A1 {scan.gh_repo}: UNREADABLE — {scan.unreadable}")
+    for scan in axis2:
+        if scan.unreadable:
+            emit(f"  A2 {scan.gh_repo}: UNREADABLE — {scan.unreadable}")
+
+    for entry in sorted(plan.already_protected, key=lambda w: (w.acr_repo, w.digest or "")):
+        emit(f"  PROTECTED  {entry.acr_repo}@{(entry.digest or '')[:26]}…")
+        for source in entry.sources:
+            emit(f"               ← {source}")
+    for entry in sorted(plan.to_lock, key=lambda w: (w.acr_repo, w.digest or "")):
+        emit(f"  {'LOCK      ' if apply else 'WOULD LOCK'} "
+             f"{entry.acr_repo}@{(entry.digest or '')[:26]}…")
+        for source in entry.sources:
+            emit(f"               ← {source}")
+    for entry in sorted([w for w in plan.wanted if w.problem], key=lambda w: w.acr_repo):
+        emit(f"  UNPROTECTABLE {entry.acr_repo}"
+             + (f":{entry.tag}" if entry.tag else f"@{(entry.digest or '')[:26]}…"))
+        emit(f"               {entry.problem}")
+        for source in entry.sources:
+            emit(f"               ← {source}")
+    for gh_repo, repo, tag, where in floating:
+        emit(f"  FLOATING   {repo}:{tag}  ← {gh_repo} {where}")
+        emit("               a moving tag has no fixed manifest to protect; not locked.")
+
+    emit("")
+    if release_enabled:
+        emit(f"  release arm: ENABLED by MW_ACR_RELEASE_UNPINNED / --release-unpinned; "
+             f"{plan.released_now} released this run.")
+    else:
+        value = os.environ.get("MW_ACR_RELEASE_UNPINNED")
+        emit("  release arm: DISABLED — MW_ACR_RELEASE_UNPINNED is "
+             + (f"{value!r}, not 'true'." if value is not None else "unset."))
+    emit("  Unlocking is the only direction that can DESTROY data, and it is unsafe in exactly the")
+    emit("  case where this extractor is wrong: a pin it cannot see is spelled identically to a pin")
+    emit("  that is not there. The candidates below are REPORTED so the stale-lock debt is visible.")
+    for manifest in plan.release_candidates:
+        emit(f"  RELEASE CANDIDATE  {manifest.acr_repo}@{manifest.digest[:26]}…  "
+             f"tags={manifest.tags or '(none)'}")
+        emit("               🚨 a lock a PERSON placed for a reason no pin scan can see — a pin "
+             "that is about to exist — looks exactly like this. Review before releasing.")
+    if not plan.release_candidates:
+        emit("  (none — every locked manifest is pinned by something this run could see.)")
+    emit("")
+
+
+# ── Applying ───────────────────────────────────────────────────────────────────────────────────
+
+
+# The registry's words for "this credential may not write manifest attributes". Distinguished from
+# every other failure because the REMEDY is completely different — a role assignment, not a retry —
+# and because it fails identically for every manifest, so repeating it N times buries the one line
+# that says what to do.
+DENIED_MARKERS = ("authorizationfailed", "authorization failed", "denied", "forbidden",
+                  "403", "not authorized", "insufficient", "unauthorized")
+
+GRANT_HELP = [
+    "LOCKING IS A WRITE. `az acr repository update` needs the data action",
+    "`Microsoft.ContainerRegistry/registries/repositories/metadata/write`, which is in the",
+    "`Container Registry Repository Writer` role (and in Contributor/Owner). Measured 2026-09-07:",
+    "neither AcrPull nor AcrPush contains it — AcrPush is pull/read + push/write and nothing else —",
+    "so the OIDC identity the read-only pinned-digest sweep uses CANNOT lock. This is a",
+    "PROVISIONING task, not a workflow defect:",
+    "",
+    "    az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \\",
+    "      --role 'Container Registry Repository Writer' \\",
+    "      --scope /subscriptions/<sub>/resourceGroups/meshweaver-shared/providers/\\",
+    "Microsoft.ContainerRegistry/registries/meshweaver",
+    "",
+    "Until it is granted, retention can still delete every manifest listed above.",
+]
+
+
+def apply_locks(plan: Plan, registry: Registry) -> list[str]:
+    """Lock every manifest that needs it. Locks are applied even on a degraded run — a lock cannot
+    destroy anything, and protecting what WAS found is strictly better than protecting nothing."""
+    failures: list[str] = []
+    for index, entry in enumerate(plan.to_lock):
+        assert entry.digest is not None
+        ok, detail = registry.set_delete_enabled(entry.acr_repo, entry.digest, False)
+        if ok:
+            plan.locked_now += 1
+            print(f"locked {entry.acr_repo}@{entry.digest}")
+            continue
+        if any(marker in detail.lower() for marker in DENIED_MARKERS):
+            # 🚨 STOP ON THE FIRST REFUSAL. Every remaining lock fails the same way for the same
+            # reason, and N identical errors bury the ONE line that says which role to grant.
+            remaining = plan.to_lock[index:]
+            failures.append(
+                "the credential is not allowed to lock a manifest, so NOTHING was protected. "
+                f"az said: {detail}"
+            )
+            failures.extend(GRANT_HELP)
+            failures.append(
+                f"{len(remaining)} manifest(s) left unprotected: "
+                + ", ".join(f"{w.acr_repo}@{(w.digest or '')[:19]}…" for w in remaining)
+            )
+            break
+        failures.append(
+            f"could not lock {entry.acr_repo}@{entry.digest}: {detail}. It is pinned by "
+            f"{', '.join(entry.sources[:3])} and the 03:00 purge can still delete it."
+        )
+    return failures
+
+
+def apply_releases(plan: Plan, registry: Registry) -> list[str]:
+    failures: list[str] = []
+    for manifest in plan.release_candidates:
+        ok, detail = registry.set_delete_enabled(manifest.acr_repo, manifest.digest, True)
+        if ok:
+            plan.released_now += 1
+            print(f"released {manifest.acr_repo}@{manifest.digest}")
+        else:
+            failures.append(f"could not release {manifest.acr_repo}@{manifest.digest}: {detail}")
+    return failures
+
+
+# ── Inventory ──────────────────────────────────────────────────────────────────────────────────
+
+
+def read_inventory(registry: Registry) -> tuple[dict[str, list[Manifest]], dict[str, str]]:
+    inventory: dict[str, list[Manifest]] = {}
+    errors: dict[str, str] = {}
+    repos, error = registry.repositories()
+    if repos is None:
+        errors["*"] = error
+        return inventory, errors
+    for acr_repo in sorted(repos):
+        manifests, error = registry.manifests(acr_repo)
+        if manifests is None:
+            errors[acr_repo] = error
+            continue
+        inventory[acr_repo] = manifests
+    return inventory, errors
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────────────────────
+
+
+def run(repos: list[str], registry_name: str, apply: bool, release_enabled: bool,
+        local_root: str | None) -> int:
+    registry = Registry(registry_name)
+    registry.control_probe()          # dies red if the registry does not answer
+
+    axis1 = []
+    axis2: list[OverlayScan] = []
+    for gh_repo in repos:
+        if local_root:
+            axis1.append(consistency.scan_local(local_root, gh_repo))
+            axis2.append(scan_overlays_local(local_root, gh_repo))
+        else:
+            axis1.append(consistency.scan_remote(gh_repo))
+            axis2.append(scan_overlays_remote(gh_repo))
+
+    inventory, inventory_errors = read_inventory(registry)
+    plan = build_plan(axis1, axis2)
+    resolve_and_classify(plan, registry, inventory, inventory_errors)
+
+    failures: list[str] = []
+    if apply:
+        failures.extend(apply_locks(plan, registry))
+
+    release_blocked = bool(plan.blockers) or bool(failures)
+    if release_enabled and apply and not release_blocked:
+        failures.extend(apply_releases(plan, registry))
+
+    report(plan, axis1, axis2, registry_name, inventory, apply, release_enabled)
+
+    if release_enabled and release_blocked:
+        print("::error::the release arm is enabled but this run is DEGRADED, so nothing was "
+              "released.")
+        print("  A release on a partial sweep is the outage this job exists to prevent: a pin that "
+              "was not read is indistinguishable from a pin that is not there.")
+
+    for blocker in plan.blockers:
+        print(f"::error::{blocker}")
+    for failure in failures:
+        print(f"::error::{failure}")
+
+    if plan.blockers or failures:
+        return 1
+    if apply:
+        emit(f"Protected {len(plan.already_protected) + plan.locked_now} manifest(s) "
+             f"({plan.locked_now} newly locked this run); "
+             f"{plan.released_now} released.")
+    else:
+        emit(f"{len(plan.already_protected)} manifest(s) already protected, "
+             f"{len(plan.to_lock)} would be locked. No registry mutation was made.")
+    return 0
+
+
+# ── The retention record: a credential-free assertion that runs on every pull request ──────────
+
+
+def check_retention_record(root: str) -> int:
+    """Does the committed record still describe a retention policy the LOCK can protect against?
+
+    🚨 THE LOCK'S ENTIRE VALUE RESTS ON ONE PROPERTY OF THE PURGE: `acr purge` skips locked
+    manifests unless `--include-locked` is passed. Add that flag to a step and every lock this job
+    places becomes decoration — silently, with this job still reporting that it protected N
+    manifests. That is the failure mode worth a gate, and this one needs NO credential: it reads
+    `.github/acr-retention/`, the committed record of the live task definitions.
+
+    It does NOT compare against the live registry. That needs `registries/tasks/read`, a strictly
+    larger grant than the lock itself uses, and the live comparison is a maintainer's manual
+    instrument (`.github/scripts/acr-retention-tasks.sh verify`). What this covers is the half a
+    pull request can actually break: the record.
+    """
+    record = Path(root) / ".github" / "acr-retention"
+    problems: list[str] = []
+    if not record.is_dir():
+        print(f"::error::{record} does not exist — the retention record is the only copy of the "
+              "purge tasks' reasoning; the tasks themselves are cloud-only (`contextPath: null`).")
+        return 1
+    manifest_path = record / "tasks.json"
+    if not manifest_path.is_file():
+        print(f"::error::{manifest_path} is missing.")
+        return 1
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"::error::{manifest_path} is not JSON: {exc}")
+        return 1
+
+    tasks = manifest.get("tasks") or []
+    steps_seen = 0
+    for task in tasks:
+        yaml_path = record / task.get("file", "")
+        if not yaml_path.is_file():
+            problems.append(f"tasks.json names {task.get('file')!r} for task "
+                            f"{task.get('name')!r}, and that file is not in the record.")
+            continue
+        text = yaml_path.read_text(encoding="utf-8")
+        steps = [line for line in text.splitlines() if re.match(r"^\s*-\s+cmd:", line)]
+        steps_seen += len(steps)
+        if not steps:
+            problems.append(f"{yaml_path.name} declares no `cmd:` step — a recorded task with no "
+                            "step is a record of nothing.")
+        for step in steps:
+            # 🚨 THE `cmd:` LINES, NOT THE FILE. Both recorded definitions EXPLAIN in a comment
+            # that they do not pass `--include-locked`; a whole-file grep fires on that prose and
+            # reds over the sentence saying the guard is satisfied. Measured 2026-09-07.
+            if "--include-locked" in step:
+                problems.append(
+                    f"{yaml_path.name} has a purge step passing --include-locked:\n"
+                    f"      {step.strip()[:160]}\n"
+                    "    That flag DELETES LOCKED MANIFESTS, which is the entire protection "
+                    "lock-pinned-digests.py provides. Every pin the fleet holds becomes purgeable "
+                    "again, silently, while the lock job keeps reporting that it protected them.")
+            if "acr purge" not in step:
+                problems.append(f"{yaml_path.name} has a `cmd:` step that is not an `acr purge`: "
+                                f"{step.strip()[:120]} — this record is for retention tasks.")
+
+    # 🚨 THE DENOMINATOR. Zero recorded tasks, or zero steps across them, reads exactly like a
+    # clean record while having inspected nothing — the confusion #3438 is made of.
+    print(f"retention record: {len(tasks)} task(s), {steps_seen} purge step(s) inspected.")
+    if not tasks:
+        problems.append("tasks.json records ZERO tasks. The registry had two on 2026-09-07, so "
+                        "zero means the record was emptied, not that retention stopped.")
+    if tasks and steps_seen == 0:
+        problems.append("ZERO purge steps were found across every recorded task, so the "
+                        "--include-locked assertion inspected nothing.")
+
+    for problem in problems:
+        print(f"::error::{problem}")
+    if problems:
+        return 1
+    print("  no recorded purge step passes --include-locked, so `acr purge` skips locked "
+          "manifests — which is what makes a lock a protection.")
+    return 0
+
+
+# ── Self-test: both arms, offline ──────────────────────────────────────────────────────────────
+
+FIXTURE_WORKFLOW = """
+name: fixture
+env:
+  MW_PLATFORM_REF: bbcb22f256240c7132fea1e56c7df3f97564e648
+  MW_TEST_DIGEST: sha256:df19f10afc1f807441b403eb0dfa4b8645d5187b830f77ad080def7fc65b391f
+  MW_PORTAL_DIGEST: sha256:dab2a7b3a7e1523d7d728d6a9a397abef5f98b0e1e0ff8f02395a433bdedf97d
+jobs:
+  a:
+    steps:
+      - env:
+          BAKE_IMAGE: meshweaver.azurecr.io/mw-plugin-test@${{ env.MW_TEST_DIGEST }}
+          MW_PORTAL_IMAGE: ${{ format('meshweaver.azurecr.io/memex-portal-ai@{0}', env.MW_PORTAL_DIGEST) }}
+        run: echo hi
+"""
+
+FIXTURE_MALFORMED = """
+env:
+  MW_TEST_DIGEST: sha256:PLACEHOLDER
+  TESTER_IMAGE: meshweaver.azurecr.io/mw-plugin-test
+"""
+
+FIXTURE_UNCLASSIFIED = """
+env:
+  SOMETHING_DIGEST: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"""
+
+FIXTURE_OVERLAY = """
+portal:
+  image: "meshweaver.azurecr.io/memex-portal-ai:3.0.0-ci.7926"
+migration:
+  image: meshweaver.azurecr.io/memex-migration:3.0.0-ci.7926
+watcher:
+  image: meshweaver.azurecr.io/memex-log-watcher:latest
+templated:
+  image: "meshweaver.azurecr.io/memex-portal-ai:{{ .Values.tag }}"
+whisper:
+  image:
+    repository: meshweaver.azurecr.io/whisper-swiss-german
+    tag: "1.7.4"
+    pullPolicy: IfNotPresent
+other:
+  image:
+    repository: meshweaver.azurecr.io/hosting-operator
+  notATag: 9
+"""
+
+
+class FakeRegistry(Registry):
+    """The registry, as a dict — so every arm can be falsified with no network and no credential."""
+
+    def __init__(self, manifests: dict[str, list[Manifest]],
+                 tags: dict[tuple[str, str], tuple[str | None, str]],
+                 repo_error: str | None = None) -> None:
+        super().__init__("fake")
+        self._manifests = manifests
+        self._tags = tags
+        self._repo_error = repo_error
+        self.writes: list[tuple[str, str, bool]] = []
+
+    def control_probe(self) -> None:
+        return None
+
+    def repositories(self):
+        if self._repo_error:
+            return None, self._repo_error
+        return sorted(self._manifests), ""
+
+    def manifests(self, acr_repo: str):
+        return list(self._manifests.get(acr_repo, [])), ""
+
+    def resolve_tag(self, acr_repo: str, tag: str):
+        return self._tags.get((acr_repo, tag), (None, "absent"))
+
+    def set_delete_enabled(self, acr_repo: str, digest: str, enabled: bool):
+        self.writes.append((acr_repo, digest, enabled))
+        return True, ""
+
+
+TESTER = "sha256:df19f10afc1f807441b403eb0dfa4b8645d5187b830f77ad080def7fc65b391f"
+PORTAL = "sha256:dab2a7b3a7e1523d7d728d6a9a397abef5f98b0e1e0ff8f02395a433bdedf97d"
+OVERLAY_PORTAL = "sha256:" + "c" * 64
+OVERLAY_MIGRATION = "sha256:" + "d" * 64
+WHISPER = "sha256:" + "e" * 64
+STALE = "sha256:" + "f" * 64
+
+
+def _scan1(gh_repo: str, text: str):
+    scan = consistency.RepoScan(gh_repo=gh_repo)
+    sites, lanes, malformed, platform_set, platform_refs = consistency.extract("ci.yml", text)
+    scan.workflows = 1
+    scan.sites.extend(sites)
+    scan.malformed.extend(malformed)
+    return scan
+
+
+def _scan2(gh_repo: str, text: str) -> OverlayScan:
+    scan = OverlayScan(gh_repo=gh_repo, files=1)
+    pins, floating = extract_overlay_pins(text)
+    scan.pins = [(repo, tag, "deployments/aks/x/values.x.yaml") for repo, tag in pins]
+    scan.floating = [(repo, tag, "deployments/aks/x/values.x.yaml") for repo, tag in floating]
+    return scan
+
+
+def _inventory(locked: set[tuple[str, str]] | None = None,
+               extra: list[Manifest] | None = None) -> dict[str, list[Manifest]]:
+    locked = locked or set()
+
+    def make(acr_repo: str, digest: str, tags: list[str]) -> Manifest:
+        return Manifest(acr_repo, digest, (acr_repo, digest) not in locked, True, tags)
+
+    inventory = {
+        "mw-plugin-test": [make("mw-plugin-test", TESTER, ["3.0.0-ci.7917"])],
+        "memex-portal-ai": [make("memex-portal-ai", PORTAL, ["3.0.0-ci.7917"]),
+                            make("memex-portal-ai", OVERLAY_PORTAL, ["3.0.0-ci.7926"])],
+        "memex-migration": [make("memex-migration", OVERLAY_MIGRATION, ["3.0.0-ci.7926"])],
+        "whisper-swiss-german": [make("whisper-swiss-german", WHISPER, ["1.7.4"])],
+    }
+    for manifest in extra or []:
+        inventory.setdefault(manifest.acr_repo, []).append(manifest)
+    return inventory
+
+
+FAKE_TAGS = {
+    ("memex-portal-ai", "3.0.0-ci.7926"): (OVERLAY_PORTAL, ""),
+    ("memex-migration", "3.0.0-ci.7926"): (OVERLAY_MIGRATION, ""),
+    ("whisper-swiss-german", "1.7.4"): (WHISPER, ""),
+}
+
+
+def _drive(axis1, axis2, registry: FakeRegistry, apply: bool = True,
+           release_enabled: bool = False) -> tuple[Plan, list[str], FakeRegistry]:
+    """The SAME sequence `run()` performs, minus the report — so the self-test falsifies the real
+    decision path rather than a paraphrase of it. Its per-lock chatter is swallowed; the assertions
+    read `registry.writes`, which is the thing that would actually reach the registry."""
+    with contextlib.redirect_stdout(io.StringIO()):
+        inventory, inventory_errors = read_inventory(registry)
+        plan = build_plan(axis1, axis2)
+        resolve_and_classify(plan, registry, inventory, inventory_errors)
+        failures: list[str] = []
+        if apply:
+            failures.extend(apply_locks(plan, registry))
+        if release_enabled and apply and not (plan.blockers or failures):
+            failures.extend(apply_releases(plan, registry))
+    return plan, failures, registry
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(message)
+
+    # ── ARM 1: a pin present ⇒ a lock is REQUESTED, on both axes ────────────────────────────────
+    axis1 = [_scan1("Systemorph/Fixture", FIXTURE_WORKFLOW)]
+    axis2 = [_scan2("Systemorph/Memex", FIXTURE_OVERLAY)]
+    plan, fails, registry = _drive(axis1, axis2, FakeRegistry(_inventory(), FAKE_TAGS))
+    check(not plan.blockers, f"ARM 1: a clean fleet produced blockers: {plan.blockers}")
+    check(not fails, f"ARM 1: a clean fleet produced failures: {fails}")
+    locked = {(repo, digest) for repo, digest, enabled in registry.writes if enabled is False}
+    check(("mw-plugin-test", TESTER) in locked,
+          "ARM 1: an axis-1 `env:` digest pin did not produce a lock")
+    check(("memex-portal-ai", PORTAL) in locked,
+          "ARM 1: an axis-1 `format(...)`-bound digest pin did not produce a lock")
+    check(("memex-portal-ai", OVERLAY_PORTAL) in locked,
+          "ARM 1: an axis-2 inline overlay TAG pin did not produce a lock")
+    check(("memex-migration", OVERLAY_MIGRATION) in locked,
+          "ARM 1: an axis-2 unquoted overlay TAG pin did not produce a lock")
+    check(("whisper-swiss-german", WHISPER) in locked,
+          "ARM 1: helm's SPLIT repository:/tag: shape did not produce a lock — the shape both "
+          "whisper charts in the fleet actually use")
+    check(not any(enabled for _, _, enabled in registry.writes),
+          "ARM 1: a lock run wrote an UNLOCK")
+    check(len(plan.wanted) == 5, f"ARM 1: expected 5 wanted manifests, got {len(plan.wanted)}")
+
+    # A floating tag is reported and NOT locked — locking `:latest` pins bytes that move.
+    check(not any(repo == "memex-log-watcher" for repo, _, _ in registry.writes),
+          "ARM 1: a FLOATING tag (`:latest`) was locked; it has no fixed manifest to protect")
+    # A templated value is not a pin at all.
+    check(all(digest != "{{" for _, digest, _ in registry.writes),
+          "ARM 1: a `{{ … }}` template was read as a tag")
+
+    # ── ARM 2: idempotence — an already-protected manifest is not re-locked ─────────────────────
+    plan, _, registry = _drive(
+        axis1, axis2,
+        FakeRegistry(_inventory(locked={("mw-plugin-test", TESTER)}), FAKE_TAGS))
+    check(any(w.acr_repo == "mw-plugin-test" for w in plan.already_protected),
+          "ARM 2: an already-locked manifest was not recognised as protected")
+    check(("mw-plugin-test", TESTER) not in
+          {(r, d) for r, d, _ in registry.writes},
+          "ARM 2: an already-locked manifest was locked again")
+
+    # ── ARM 3: a repository that could not be READ ⇒ RED, and nothing released ──────────────────
+    #
+    # 🚨 EVERY "nothing was released" ASSERTION BELOW RUNS AGAINST `inventory_with_stale`, an
+    # inventory that HOLDS a release candidate. The first draft used the clean inventory, where
+    # there was nothing to release in the first place — so the assertion held no matter what the
+    # guard did, and sabotaging the guard (`release_enabled and apply` with the blocker test
+    # deleted) left the whole self-test GREEN. A check that cannot fail is not a check; it was
+    # found by falsifying this file rather than by reading it, 2026-09-07.
+    stale = Manifest("memex-portal-ai", STALE, False, True, ["3.0.0-ci.7574"])
+    inventory_with_stale = _inventory(extra=[stale])
+
+    broken = consistency.RepoScan(gh_repo="Systemorph/Unreadable")
+    broken.unreadable = "the repository itself could not be read"
+    plan, fails, registry = _drive([_scan1("Systemorph/Fixture", FIXTURE_WORKFLOW), broken],
+                                   axis2, FakeRegistry(inventory_with_stale, FAKE_TAGS),
+                                   release_enabled=True)
+    check(any(m.digest == STALE for m in plan.release_candidates),
+          "ARM 3: the fixture holds no release candidate, so 'nothing was released' would hold "
+          "however broken the guard is — the assertion must be able to fail")
+    check(bool(plan.blockers), "ARM 3: an unreadable repository did not produce a blocker")
+    check(any("Unreadable" in b for b in plan.blockers),
+          "ARM 3: the blocker does not name the repository nobody could read")
+    check(not any(enabled for _, _, enabled in registry.writes),
+          "ARM 3: something was RELEASED on a run with an unreadable repository — the exact "
+          "outage shape this job refuses")
+    # …and locking still happened, because a lock cannot destroy anything.
+    check(any(enabled is False for _, _, enabled in registry.writes),
+          "ARM 3: a degraded run locked NOTHING; locks are additive and must still be applied")
+
+    broken2 = OverlayScan(gh_repo="Systemorph/Memex")
+    broken2.unreadable = "GitHub truncated the recursive tree listing"
+    plan, _, registry = _drive(axis1, [broken2], FakeRegistry(inventory_with_stale, FAKE_TAGS),
+                               release_enabled=True)
+    check(any("truncated" in b for b in plan.blockers),
+          "ARM 3b: a TRUNCATED git tree was read as a measured zero")
+    check(not any(enabled for _, _, enabled in registry.writes),
+          "ARM 3b: something was released while an overlay tree was unread")
+
+    # ── ARM 4: ZERO pins ⇒ RED, per axis ───────────────────────────────────────────────────────
+    empty1 = consistency.RepoScan(gh_repo="Systemorph/NoPins")
+    empty1.workflows = 3
+    plan, _, _ = _drive([empty1], axis2, FakeRegistry(_inventory(), FAKE_TAGS))
+    check(any("AXIS 1 found ZERO" in b for b in plan.blockers),
+          "ARM 4: a fleet with zero digest pins passed — a zero denominator is not a pass")
+    plan, _, _ = _drive(axis1, [OverlayScan(gh_repo="Systemorph/Memex", files=2)],
+                        FakeRegistry(_inventory(), FAKE_TAGS))
+    check(any("AXIS 2 found ZERO" in b for b in plan.blockers),
+          "ARM 4b: a fleet with zero overlay tag pins passed")
+
+    # ── ARM 5: an UNCLASSIFIED pin (I5) ⇒ RED, and nothing released ─────────────────────────────
+    plan, _, registry = _drive([_scan1("Systemorph/Fixture", FIXTURE_WORKFLOW),
+                                _scan1("Systemorph/Odd", FIXTURE_UNCLASSIFIED)],
+                               axis2, FakeRegistry(inventory_with_stale, FAKE_TAGS),
+                               release_enabled=True)
+    check(any("I5" in b for b in plan.blockers),
+          "ARM 5: a digest whose ACR repository cannot be determined passed — an unclassified pin "
+          "has NOT been checked, and there is no manifest to lock")
+    check(not any(enabled for _, _, enabled in registry.writes),
+          "ARM 5: something was released while a pin was unclassified")
+
+    # ── ARM 6: a MALFORMED pin (I4) ⇒ RED ──────────────────────────────────────────────────────
+    plan, _, _ = _drive([_scan1("Systemorph/Fixture", FIXTURE_WORKFLOW),
+                         _scan1("Systemorph/Bad", FIXTURE_MALFORMED)],
+                        axis2, FakeRegistry(_inventory(), FAKE_TAGS))
+    check(any("I4" in b for b in plan.blockers),
+          "ARM 6: `sha256:PLACEHOLDER` read as an absence rather than a defect")
+
+    # ── ARM 7: a pinned manifest that is GONE ⇒ RED, and no lock claimed for it ─────────────────
+    thin = _inventory()
+    thin["mw-plugin-test"] = []
+    plan, fails, registry = _drive(axis1, axis2, FakeRegistry(thin, FAKE_TAGS))
+    check(any("does not exist in the registry" in b for b in plan.blockers),
+          "ARM 7: a pin naming a manifest that no longer exists passed")
+    check(("mw-plugin-test", TESTER) not in {(r, d) for r, d, _ in registry.writes},
+          "ARM 7: a lock was attempted for a manifest that is gone")
+
+    # ── ARM 8: an overlay TAG that does not resolve ⇒ RED ───────────────────────────────────────
+    plan, _, _ = _drive(axis1, axis2, FakeRegistry(_inventory(), {}))
+    check(any("does not resolve" in b for b in plan.blockers),
+          "ARM 8: an overlay tag that resolves to nothing passed")
+    plan, _, _ = _drive(axis1, axis2, FakeRegistry(
+        _inventory(), {("memex-portal-ai", "3.0.0-ci.7926"): (None, "INDETERMINATE: az died"),
+                       ("memex-migration", "3.0.0-ci.7926"): (OVERLAY_MIGRATION, ""),
+                       ("whisper-swiss-german", "1.7.4"): (WHISPER, "")}))
+    check(any("Indeterminate is not a pass" in b for b in plan.blockers),
+          "ARM 8b: an INDETERMINATE registry answer was smoothed into a verdict")
+
+    # ── ARM 9: a registry that cannot be enumerated ⇒ RED, not 'everything is unpinned' ─────────
+    plan, _, registry = _drive(axis1, axis2,
+                               FakeRegistry(inventory_with_stale, FAKE_TAGS,
+                                            repo_error="AcrPull denied"),
+                               release_enabled=True)
+    check(any("could not enumerate the registry's repositories" in b for b in plan.blockers),
+          "ARM 9: a registry that refused enumeration produced no blocker")
+    check(not any("does not exist in the registry" in b for b in plan.blockers),
+          "ARM 9: an unreadable registry was reported as 'every pinned manifest is gone' — the "
+          "catastrophe-that-is-not-happening, which is the mirror of what this job catches")
+    check(not any(enabled for _, _, enabled in registry.writes),
+          "ARM 9: a release was attempted against a registry that could not be enumerated")
+
+    # ── ARM 10: the release arm — reported always, acted on only when clean AND enabled ─────────
+    plan, _, registry = _drive(axis1, axis2, FakeRegistry(inventory_with_stale, FAKE_TAGS),
+                               release_enabled=False)
+    check([m.digest for m in plan.release_candidates] == [STALE],
+          f"ARM 10: the stale lock was not REPORTED as a release candidate: "
+          f"{[m.digest for m in plan.release_candidates]}")
+    check(not any(enabled for _, _, enabled in registry.writes),
+          "ARM 10: the release arm acted while DISABLED — it ships off by design")
+    plan, _, registry = _drive(axis1, axis2, FakeRegistry(inventory_with_stale, FAKE_TAGS),
+                               release_enabled=True)
+    check(("memex-portal-ai", STALE, True) in registry.writes,
+          "ARM 10b: the release arm was enabled on a clean run and released nothing — the arm is "
+          "inert, which would make its safety argument untestable")
+
+    # ── ARM 11: report-only makes NO registry write at all ──────────────────────────────────────
+    plan, _, registry = _drive(axis1, axis2, FakeRegistry(inventory_with_stale, FAKE_TAGS),
+                               apply=False, release_enabled=True)
+    check(registry.writes == [],
+          f"ARM 11: report-only wrote to the registry: {registry.writes}")
+
+    # ── ARM 12: the two EXISTING extractors still agree about what a pin IS ─────────────────────
+    #
+    # The property `check-pin-set-consistency.py` was built with — "the two scripts deliberately
+    # share their extraction SHAPES … so they can never disagree about what a pin IS" — is asserted
+    # here rather than left to review, because this file's correctness rests on it: it imports one
+    # of the two and the fleet's nightly existence sweep uses the other.
+    mine = {(site.name, site.value, site.role)
+            for site in consistency.extract("ci.yml", FIXTURE_WORKFLOW)[0]
+            if site.kind == "digest"}
+    theirs = {(pin.where.split(":", 1)[1], pin.digest, pin.acr_repos[0] if pin.acr_repos else None)
+              for pin in existence.extract("Systemorph/Fixture", "ci.yml", FIXTURE_WORKFLOW)[0]}
+    check(mine == theirs,
+          f"ARM 12: the two pin extractors DISAGREE about this fixture.\n"
+          f"    check-pin-set-consistency.py: {sorted(mine)}\n"
+          f"    check-pinned-digests.py:      {sorted(theirs)}\n"
+          "  They share their shapes on purpose so the fleet has ONE definition of a pin. Fix the "
+          "divergence rather than this assertion.")
+
+    # ── ARM 13: the overlay path filter is narrow, and measured ────────────────────────────────
+    check(is_overlay_path("deployments/aks/memex/values.memex.public.yaml"),
+          "ARM 13: Memex's real overlay path was rejected")
+    check(is_overlay_path("deploy/whisper/helm/values.yaml"),
+          "ARM 13: this repository's whisper chart values file was rejected")
+    check(not is_overlay_path("deploy/aks/operator/test/fixtures/audit/clean/manifest.json"),
+          "ARM 13: a TEST FIXTURE was accepted as a deployment overlay — those name tags that "
+          "never existed and would red this job nightly")
+    check(not is_overlay_path("deploy/aks/manifests/observability/log-watcher.yaml"),
+          "ARM 13: a raw manifest was accepted as an overlay")
+    check(not is_overlay_path("src/values.yaml"),
+          "ARM 13: a values file outside any deploy path was accepted")
+
+    for line in failures:
+        print(f"::error::self-test: {line}")
+    if failures:
+        return 1
+    print("self-test: 13 arms — lock requested on both axes and both overlay shapes, idempotent, "
+          "unreadable repo / truncated tree / zero pins / unclassified / malformed / gone / "
+          "unresolved tag / indeterminate / unreadable registry all RED with nothing released, "
+          "release arm off by default and live when enabled, report-only writes nothing, and the "
+          "two existing pin extractors still agree.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Lock every manifest the fleet pins.")
+    parser.add_argument("--repos", help="comma-separated owner/name list to scan")
+    parser.add_argument("--discover", action="store_true",
+                        help="enumerate the fleet from the App installation this token belongs to")
+    parser.add_argument("--root", help="read one repository from a local checkout instead")
+    parser.add_argument("--registry", default=REGISTRY_DEFAULT)
+    parser.add_argument("--apply", action="store_true",
+                        help="write the locks (default: report what it WOULD do)")
+    parser.add_argument("--release-unpinned", action="store_true",
+                        help="also RELEASE locks nothing pins any more — off by design; "
+                             "MW_ACR_RELEASE_UNPINNED=true is the other way to ask")
+    parser.add_argument("--check-retention-record", metavar="ROOT",
+                        help="assert the committed .github/acr-retention record still describes a "
+                             "purge the lock can protect against; no credential, no network")
+    parser.add_argument("--self-test", action="store_true",
+                        help="prove every arm fires and stays silent; no network")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if args.check_retention_record:
+        return check_retention_record(args.check_retention_record)
+    if args.root:
+        repos = [args.repos or "local"]
+    elif bool(args.repos) == bool(args.discover):
+        parser.error("give exactly one of --repos, --discover or --root")
+    else:
+        repos = (consistency.discover_repos() if args.discover
+                 else [r.strip() for r in args.repos.split(",") if r.strip()])
+
+    release_enabled = (args.release_unpinned
+                       or os.environ.get("MW_ACR_RELEASE_UNPINNED", "").strip().lower() == "true")
+    print(f"scanning {len(repos)} repository(ies) on both pin axes: {', '.join(repos)}")
+    return run(repos, args.registry, args.apply, release_enabled, args.root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1926,6 +1926,38 @@ jobs:
     - name: "…and this repository's own pin set is consistent"
       run: python3 .github/scripts/check-pin-set-consistency.py --root .
 
+    # 🚨 AND THE HALF THAT STOPS THE DELETION RATHER THAN REPORTING IT (MeshWeaver#3438,
+    # requirement 1). lock-pinned-digests.yml locks every manifest the fleet pins, nightly, at
+    # 01:00 — two hours before the 03:00 purge — because `acr purge` skips locked manifests and
+    # neither purge step passes `--include-locked`. That lane needs a credential and a live
+    # registry, so it cannot run on a pull request; this is where its decision path is FALSIFIED.
+    #
+    # The self-test drives the real planner through a fake registry and asserts both arms of every
+    # rule: a pin on either axis produces a lock (including helm's split `repository:`/`tag:`
+    # shape, which both whisper charts in the fleet use); an already-locked manifest is not
+    # re-locked; and an unreadable repository, a truncated git tree, zero pins on either axis, an
+    # unclassified pin (I5), a placeholder digest (I4), a manifest that is gone, an unresolvable
+    # overlay tag, an indeterminate registry answer and an unreadable registry each go RED **with
+    # nothing released**. It also asserts that the two existing pin extractors still AGREE about
+    # what a pin is — the property they were written with, now held by a test rather than by
+    # review.
+    #
+    # 🚨 The release arm's assertions run against an inventory that HOLDS a release candidate. The
+    # first draft used a clean one, where there was nothing to release however broken the guard
+    # was; sabotaging the guard left the whole self-test green. Found by falsifying this file
+    # rather than reading it, 2026-09-07.
+    - name: "Every pinned manifest gets locked, and nothing gets unlocked — the gate can fail (self-test)"
+      run: python3 .github/scripts/lock-pinned-digests.py --self-test
+
+    # The premise the lock rests on, asserted with NO credential: a lock protects only because
+    # `acr purge` skips locked manifests unless `--include-locked` is passed. The purge tasks are
+    # CLOUD-ONLY (`az acr task show` returns an EncodedTask with `contextPath: null`), so
+    # `.github/acr-retention/` is a committed record of them — and this is the half of that record
+    # a pull request can break. A step that gained `--include-locked` would turn every lock into
+    # decoration while the lock job kept reporting success.
+    - name: "…and the recorded purge still skips locked manifests"
+      run: python3 .github/scripts/lock-pinned-digests.py --check-retention-record .
+
     # 🚨 THE GAP actionlint CLOSES (MeshWeaver#3228): every check above reads a workflow with
     # `yaml.safe_load`, and **PyYAML accepts a duplicate mapping key and silently keeps the last
     # one**. So a STRUCTURAL defect — the kind GitHub itself refuses — parses cleanly here, every

--- a/.github/workflows/lock-pinned-digests.yml
+++ b/.github/workflows/lock-pinned-digests.yml
@@ -201,12 +201,22 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.fleet-token.outputs.token }}
           MW_ACR_RELEASE_UNPINNED: ${{ vars.MW_ACR_RELEASE_UNPINNED }}
+          MW_EVENT: ${{ github.event_name }}
           MW_ACR_LOCK_MODE: >-
             ${{ (github.event_name == 'push' && 'report-only')
              || (github.event.inputs.mode || 'apply') }}
         run: |
           set -uo pipefail
-          echo "mode: $MW_ACR_LOCK_MODE (event: ${{ github.event_name }})"
+          # 🚨 AN UNRECOGNISED MODE IS A RED, NEVER A FALL-THROUGH TO REPORT-ONLY. A typo in the
+          # expression above would otherwise make the nightly run stop mutating the registry while
+          # staying green — a job that protects nothing and says it protected everything, which is
+          # the failure this whole workflow exists to remove.
+          case "$MW_ACR_LOCK_MODE" in
+            apply|report-only) ;;
+            *) echo "::error::MW_ACR_LOCK_MODE is '$MW_ACR_LOCK_MODE'; expected apply|report-only."
+               exit 1 ;;
+          esac
+          echo "mode: $MW_ACR_LOCK_MODE (event: $MW_EVENT)"
           args=(--discover --registry meshweaver)
           if [ "$MW_ACR_LOCK_MODE" = "apply" ]; then
             args+=(--apply)

--- a/.github/workflows/lock-pinned-digests.yml
+++ b/.github/workflows/lock-pinned-digests.yml
@@ -1,0 +1,235 @@
+name: Lock pinned image digests
+
+# Protect every manifest the fleet PINS, by locking it in the registry — so retention cannot delete
+# what CI and the deployments depend on.
+#
+# WHY (MeshWeaver#3438, requirement 1). ACR's `purge-old-images` deleted the manifests
+# MeshWeaver.Education's `main` pinned. Every run of that repo's `Disposable-mesh gate` then died at
+# `manifest unknown` before a single content gate executed — including `main`'s OWN NIGHTLY, so the
+# repository lost its gate and its green baseline in the same instant. Education, Manufacturing and
+# SocialMedia went down together at 2026-09-05T15:29Z.
+#
+# `pinned-digests.yml` (#3462) is the GUARD half: it reports, at 05:20, which pins are already dead.
+# THIS is the half that stops the deletion:
+#
+#     `acr purge` SKIPS LOCKED MANIFESTS BY DEFAULT. `--include-locked` is the documented opt-in to
+#     delete them and NEITHER STEP of `purge-old-images` passes it (verified against the live task
+#     definition, recorded in .github/acr-retention/). So `deleteEnabled: false` is a hard
+#     protection against this exact configuration, not a hint.
+#
+# Five manifests were locked BY HAND on 2026-09-06 to stop the bleeding. A hand list is the defect,
+# not the fix — it is only ever correct on the day it is written. This derives the set nightly.
+#
+# 🚨 IT LOCKS. IT DOES NOT UNLOCK. Releasing is the only direction that can DESTROY data, and it is
+# unsafe in exactly the case where the extractor is wrong: a pin the scan cannot see is spelled
+# identically to a pin that is not there. The release arm is COMPUTED and PRINTED on every run — so
+# the stale-lock debt is visible — and acted on only when a person sets the repository variable
+# `MW_ACR_RELEASE_UNPINNED` to `true` AND the run is free of every blocker. That is not a hypothetical
+# guard: on 2026-09-07 three of the five hand-locked manifests were release candidates, because they
+# are the set MeshWeaver.Education's PENDING pin bump will name. An enabled release arm would have
+# unlocked the fix for #3438's own victim.
+#
+# 🛡️ THIS WORKFLOW MAY NOT SKIP (AGENTS.md — "a gate NEVER tests its own inputs"). GitHub paints a
+# skipped job with the same grey tick as a passed one, so:
+#   * `preflight` asserts EVERY external input and fails RED naming what to provision. It never asks
+#     "is the credential set?" in order to decide whether to check.
+#   * `protect` runs `needs: [preflight]` with NO input-shaped `if:` and NO `continue-on-error:`.
+#   * The script probes the registry with a CONTROL first and fails closed on an unreadable
+#     repository, a truncated git tree, an unclassifiable pin, an indeterminate registry answer, or
+#     a lock that did not take.
+#   * It PRINTS THE DENOMINATOR — per axis: repositories scanned, repositories that pin, pin sites
+#     found — and a ZERO on either axis is RED, because both were non-zero when this was written.
+#
+# 🚨 WHY THE `push` TRIGGER IS REPORT-ONLY. It is not a skip: the script runs in full, prints both
+# denominators, and reds on every blocker — only the `az` WRITE is withheld. A change to the
+# extractor should prove itself against the live fleet before it starts mutating a shared registry,
+# and the scheduled run two hours later applies whatever it found. The gate is live on push; the
+# mutation is not.
+#
+# WHY THERE IS NO `pull_request` TRIGGER. The live state of a registry is not a property of a pull
+# request, and a credentialed PR-reachable job would put both secrets into the Dependabot store's
+# blast radius for no gain (#3399). The script's own falsification runs on every PR instead —
+# `lock-pinned-digests.py --self-test` in dotnet-test.yml's workflow-shell lane.
+
+on:
+  schedule:
+    # 01:00 UTC — TWO HOURS before `purge-old-images` runs at 03:00, and three before the disabled
+    # `purge-old-ci-releases` slot at 04:00. The margin is deliberate: a run that overlaps the purge
+    # would race it on the one manifest that matters most. The 05:20 guard then reports, after both,
+    # whatever this could not protect.
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "apply = write the locks; report-only = say what it would do"
+        type: choice
+        options: [apply, report-only]
+        default: apply
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/lock-pinned-digests.yml'
+      - '.github/scripts/lock-pinned-digests.py'
+      - '.github/scripts/check-pin-set-consistency.py'
+      - '.github/scripts/check-pinned-digests.py'
+
+permissions:
+  contents: read
+  id-token: write     # azure/login OIDC — no long-lived registry secret in this repo
+
+jobs:
+  preflight:
+    name: Assert the inputs exist
+    runs-on: ubuntu-latest
+    # Five emptiness tests, a mint and one API call. The fleet cap is 45
+    # (check-workflow-timeouts.py) and nothing here has any business approaching it.
+    timeout-minutes: 10
+    steps:
+      # No `if:` anywhere in this job. It asserts, it does not decide whether to assert.
+      - name: Every external input, or a red build naming what to provision
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
+          MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+        run: |
+          missing=()
+          [ -n "$AZURE_CLIENT_ID" ]       || missing+=("secrets.AZURE_CLIENT_ID        OIDC app registration for azure/login. 🚨 LOCKING IS A WRITE: it needs the data action Microsoft.ContainerRegistry/registries/repositories/metadata/write, which is in 'Container Registry Repository Writer' (and Contributor/Owner) and in NEITHER AcrPull NOR AcrPush — measured 2026-09-07, AcrPush is pull/read + push/write and nothing else. If this identity only has the read-only grant the pinned-digest sweep uses, the lock step reds naming the exact 'az role assignment create'")
+          [ -n "$AZURE_TENANT_ID" ]       || missing+=("secrets.AZURE_TENANT_ID        the Systemorph AAD tenant")
+          [ -n "$AZURE_SUBSCRIPTION_ID" ] || missing+=("secrets.AZURE_SUBSCRIPTION_ID  the subscription holding meshweaver.azurecr.io")
+          [ -n "$MESHWEAVER_APP_ID" ]     || missing+=("secrets.MESHWEAVER_APP_ID          app id of the org's meshweaver-cloud GitHub App, installed on every repo in the fleet — it is how the satellites' workflows and the deployment overlays are read")
+          [ -n "$MESHWEAVER_APP_PRIVATE_KEY" ] || missing+=("secrets.MESHWEAVER_APP_PRIVATE_KEY  that App's private key (PEM); source of truth is Key Vault Systemorph/github-app-privatekey")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::the pinned-manifest lock job cannot run — provision the following, then re-run:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+          echo "All external inputs are present."
+
+      # 🚨 PRESENT is not VALID, and chart-drift.yml learned that the hard way (2026-08-17): a
+      # provisioned-but-worthless credential passed an emptiness test and every job downstream died
+      # at "Bad credentials", with the preflight above it reporting that all inputs were present.
+      # So assert the CAPABILITY the job needs — enumerating the installation's repositories —
+      # against the real API. That is also the job's fleet list: it is discovered, never committed,
+      # so a repository added to the org is protected the day the App reaches it.
+      - name: Mint an installation token for the fleet
+        id: fleet-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+
+      - name: The token can enumerate the fleet it is meant to protect
+        env:
+          GH_TOKEN: ${{ steps.fleet-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # No `2>/dev/null` and no `|| true`: a failed enumeration must print WHY. Swallowing it
+          # would turn "the token cannot read the org" into "the fleet is empty", which is the one
+          # answer this job must never produce (check-workflow-shell.py's `swallow` class).
+          if ! reachable=$(gh api --paginate /installation/repositories \
+                             --jq '.repositories[].full_name'); then
+            echo "::error::the minted installation token could not enumerate its own repositories."
+            echo "  /installation/repositories is the endpoint an installation token answers about"
+            echo "  itself, so this is the token, not the network. Confirm the meshweaver-cloud App"
+            echo "  is installed on the Systemorph org and holds Contents: Read."
+            exit 1
+          fi
+          count=$(printf '%s\n' "$reachable" | grep -c . || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::the installation reaches ZERO repositories."
+            echo "  Deriving a lock set from an empty fleet protects NOTHING while reporting success."
+            echo "  Add the fleet repositories to the meshweaver-cloud installation."
+            exit 1
+          fi
+          echo "The App reaches $count repository(ies); those are what the job will read."
+
+  protect:
+    name: Every pinned manifest is locked
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    # ~34 repositories × (a workflow listing, a recursive tree, a handful of file reads), plus one
+    # manifest listing per ACR repository (15, ~2,800 manifests on 2026-09-07) and one `az` write
+    # per manifest newly locked. Minutes, not tens of minutes; measured end-to-end well inside this.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with: { fetch-depth: 1 }
+
+      # Cross-repo reads are a GitHub App installation token minted per run, never a stored PAT — a
+      # PAT rots exactly as PATs do (chart-drift.yml carried one; HTTP 401 on all nine runs after it
+      # was provisioned, so the check never ran once, #1709). This one is minted fresh, expires in an
+      # hour, and holds Contents: Read and nothing else.
+      - name: Mint an installation token for the fleet
+        id: fleet-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+
+      - name: Ensure Azure CLI
+        # GitHub's ubuntu-latest no longer ships the Azure CLI on PATH for azure/login@v3
+        # ("Unable to locate executable file: az"). Install it if missing (idempotent).
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # ONE step, ALWAYS run. No `if:`, no `continue-on-error:`.
+      #
+      # The two policy dials are passed as VALUES the script prints, never as conditions on whether
+      # the step executes — the difference between a decision that is visible in the log and a job
+      # that is grey for a reason nobody can see:
+      #
+      #   MW_ACR_LOCK_MODE          `apply` on the schedule and on a manual run; `report-only` on a
+      #                             push, so a change to the extractor proves itself against the
+      #                             live fleet before it mutates a shared registry.
+      #   MW_ACR_RELEASE_UNPINNED   the unlock arm. SHIPS DISABLED. Unset unless a maintainer sets
+      #                             the repository variable to `true`; the script prints which it
+      #                             saw either way, and refuses to release anything at all on a run
+      #                             that carries a blocker.
+      - name: Lock every manifest the fleet pins
+        env:
+          GH_TOKEN: ${{ steps.fleet-token.outputs.token }}
+          MW_ACR_RELEASE_UNPINNED: ${{ vars.MW_ACR_RELEASE_UNPINNED }}
+          MW_ACR_LOCK_MODE: >-
+            ${{ (github.event_name == 'push' && 'report-only')
+             || (github.event.inputs.mode || 'apply') }}
+        run: |
+          set -uo pipefail
+          echo "mode: $MW_ACR_LOCK_MODE (event: ${{ github.event_name }})"
+          args=(--discover --registry meshweaver)
+          if [ "$MW_ACR_LOCK_MODE" = "apply" ]; then
+            args+=(--apply)
+          fi
+          python3 .github/scripts/lock-pinned-digests.py "${args[@]}"
+
+      # 🚨 THE PREMISE THE LOCK RESTS ON, ASSERTED RATHER THAN ASSUMED. A lock protects only
+      # because `acr purge` skips locked manifests unless `--include-locked` is passed. If a purge
+      # step ever gains that flag, every lock above becomes decoration — silently, with this job
+      # still reporting that it protected N manifests. This reads the COMMITTED record of the
+      # cloud-only task definitions (.github/acr-retention/) and needs no credential at all, so it
+      # runs here AND on every pull request in dotnet-test.yml's workflow-shell lane.
+      #
+      # It deliberately does NOT compare against the live registry: that needs
+      # `registries/tasks/read`, a strictly larger grant than the lock itself, and a step that is
+      # always red for a missing grant is a step that gets ignored. The live drift comparison is a
+      # maintainer's manual instrument — `.github/scripts/acr-retention-tasks.sh verify`.
+      #
+      # `if: ${{ !cancelled() }}` is NOT a skip-trapdoor: it asks whether the RUN was cancelled,
+      # never whether an input exists. Without it this step would be dead behind the lock step's
+      # red, and the lock step is red right now for a reason that has nothing to do with the
+      # retention record (MeshWeaver.Education's three purged pins). The job's conclusion is still
+      # the AND of both steps.
+      - name: The purge still skips locked manifests
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/lock-pinned-digests.py --check-retention-record .

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -1,7 +1,7 @@
 ---
 Name: Pinned Image Retention
 Category: Architecture
-Description: Registry retention deletes what CI pins, and republishing frequency is what destroys a pin rather than what protects it — the second clause the purge rule was missing, the guard that names a dead pin before a repo discovers it, and the retention design that stops the deletion.
+Description: Registry retention deletes what CI pins, and republishing frequency is what destroys a pin rather than what protects it — the second clause the purge rule was missing, the guard that names a dead pin, and the nightly job that locks every pinned manifest so the purge skips it.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/></svg>
 ---
 
@@ -179,19 +179,35 @@ gone left a Job in `ImagePullBackOff` 639 times in 146 minutes, with the portal 
 That one covers tags in helm overlays; this one covers digests in CI workflows. **It is not wired
 into CI** — its header says so — which is a gap on that axis, not this one.
 
-## The retention half — stop the deletion
+## The retention half — the deletion is stopped, not reported
 
-🚨 **The purge task definitions are CLOUD-ONLY. They are not infrastructure-as-code, and nothing in
-any repository describes them.** Measured 2026-09-06 three ways: `az acr task show` returns an
-`EncodedTask` with `contextPath: null` (the YAML is stored base64-encoded in Azure, with no source
-repository); an org-wide code search for `acr purge` finds only doc pages; and the deployment repo's
-tree carries no bicep, terraform or task definition for them. The shared registry itself is
-out-of-band — `deploy/aks/infra/main.bicep` treats `meshweaver.azurecr.io` as an existing
-`sharedAcrLoginServer` and only creates a registry when that is empty.
+🚨 **The purge task definitions are CLOUD-ONLY.** Established three ways rather than assumed:
+`az acr task show` returns an `EncodedTask` with **`contextPath: null`** — the YAML is stored
+base64-encoded inside Azure, with no source repository; an org-wide code search for
+`purge-old-images` returns zero hits outside this page; and the deployment repo's tree carries no
+bicep, terraform or task definition for them. The shared registry itself is out-of-band —
+`deploy/aks/infra/main.bicep` treats `meshweaver.azurecr.io` as an existing `sharedAcrLoginServer`
+and only creates a registry when that is empty.
 
-Consequence: **changing retention is a live change to shared registry infrastructure that every
-deployment depends on, applied by hand, by whoever holds the registry.** It is deliberately not
-something CI does.
+So the reasoning that keeps two incidents from recurring lived in comments that existed in exactly
+one place, that nobody diffs, and that any `az acr task update` from any laptop replaces silently
+and completely. **`.github/acr-retention/` is now the record**: the decoded task YAML byte for byte,
+plus `tasks.json` for the schedule, status and timeout that the YAML does not carry. Nothing deploys
+from it — `.github/scripts/acr-retention-tasks.sh` is the only thing that relates it to the live
+registry:
+
+```bash
+.github/scripts/acr-retention-tasks.sh show     # the live definitions, decoded        (read-only)
+.github/scripts/acr-retention-tasks.sh record   # overwrite the record FROM the cloud  (read-only)
+.github/scripts/acr-retention-tasks.sh verify   # diff live against the record         (read-only)
+.github/scripts/acr-retention-tasks.sh apply    # push the record onto the registry    (MUTATES)
+```
+
+`verify` is deliberately **not** wired into CI: it needs `registries/tasks/read`, a strictly larger
+grant than the lock job itself holds, and a step that is permanently red for a missing grant is a
+step that gets ignored. The half a pull request can actually break — the record — *is* gated, with
+no credential at all, by `lock-pinned-digests.py --check-retention-record .` in the workflow-shell
+lane.
 
 ### What must NOT be the fix
 
@@ -200,154 +216,221 @@ quarter walks off a 30-day window exactly as it walked off a 7-day one, and the 
 rarer, later and harder to attribute. The numbers are not the defect — the absence of any relation
 between retention and the pin set is.
 
-### The two tasks having diverged is itself the defect
+### One task, two steps — as applied 2026-09-06
 
-There are two purge tasks and only one of them learned Memex#122:
+There were two purge tasks and only one of them had learned Memex#122. They are now one:
+`purge-old-images` (`0 3 * * *`) carries **two steps**, and `purge-old-ci-releases` is **Disabled**,
+not deleted, so that re-enabling it is a visible act rather than a rediscovery.
 
-| Task | Schedule | Filters | Window |
-|---|---|---|---|
-| `purge-old-ci-releases` | `0 4 * * *` | `memex-migration`, `memex-bake`, `memex-portal-next`, `memex-portal`, `memex-portal-ai` | `--ago 30d --untagged` |
-| `purge-old-images` | `0 3 * * *` | `mw-plugin-test`, `memex-migration`, `memex-portal-ai`, `memex-portal-next`, `memex-bake` | `--ago 7d --keep 10 --untagged` |
+| Step | Filters | Window |
+|---|---|---|
+| CI images | `mw-plugin-test`, `memex-migration`, `memex-portal-ai`, `memex-portal-next`, `memex-bake` | `--ago 7d --keep 10 --untagged` |
+| Production portal | `memex-portal` | `--ago 30d --untagged` |
 
-Read the overlap: four of the five repositories the 30-day task names are already swept an hour
-earlier by the strictly more aggressive 7-day one, so for those four **the 30-day task is a no-op** —
-everything it would delete was deleted at 03:00. The only repository unique to it is `memex-portal`;
-the only one unique to the aggressive task is `mw-plugin-test`, and that is the one that broke.
+🚨 **Two steps, not one, and that is the point.** Unioning the filters under the stricter window
+would have dragged `memex-portal` from 30 days to `7d --keep 10` with nobody deciding to. The merge
+removed the second *task* — the "which of two lists?" question — while preserving each repository's
+effective window exactly. Both steps share **one 3600 s task budget**; the per-step `timeout` is a
+per-step ceiling, not a second hour.
 
-That is what "diverged" costs: the hardened task's reasoning does not apply to the repositories that
-matter, and a maintainer adding a repository has to know which of two lists is the one that governs.
-**One task, one filter list** removes the choice by construction. Note what that must *not* quietly
-become: see the next section before writing the merged window.
+🚨 **A correction to the reasoning recorded in that task, measured 2026-09-07.** The task's own
+comment justifies the split by saying `memex-portal` "is pinned on the OTHER axis (committed tags in
+the deployment overlays, Memex#141)". **It is not — not today.** The overlays pin `memex-portal-ai`,
+`memex-migration`, `memex-portal-next` and `hosting-operator`; an org-wide code search for
+`meshweaver.azurecr.io/memex-portal:` returns **zero** hits, and the repository's newest tag is
+`3.0.0-rc13`. The split is still right, on the plainer ground that tightening a low-churn production
+image repository is a separate decision with its own evidence — but the *stated* reason is no longer
+true, and a reason that is quietly false is how a future merge talks itself into the union.
 
-### 🚨 Merging the tasks must not tighten `memex-portal` as a side effect
-
-The two lists differ by exactly two repositories, and they are not symmetric:
-
-- `mw-plugin-test` is unique to the **7-day** task. It is the one that broke.
-- **`memex-portal` is unique to the 30-day task**, and it is the **production portal** image
-  repository.
-
-So the obvious merge — union the filters, keep the stricter window — would move `memex-portal` from
-`--ago 30d` to `--ago 7d --keep 10` **without anyone deciding to**. That is a real tightening on the
-one repository where it is least affordable, and this page's own guard cannot cover it:
-
-🚨 **`memex-portal` is pinned on the OTHER axis — committed image TAGS in the deployment overlays,
-not digests in CI workflows** (Memex#141, where a portal tag that still resolved while its migration
-twin was gone left a Job in `ImagePullBackOff` 639 times in 146 minutes). `check-pinned-digests.py`
-reads `.github/workflows` and would enumerate **none** of those, so a lock set derived from it alone
-would leave every overlay-pinned manifest unlocked while the window that deletes them got shorter.
-Memex#122's victim was pinned exactly that way.
-
-Therefore the merge below is **behaviour-preserving by design**: it removes the second *task*, not
-the second *window*. One task, one place to edit, two steps whose windows are each what they already
-are today. Changing `memex-portal`'s window is a separate decision that must be taken on its own
-evidence — never as a side effect of tidying two task definitions into one.
-
-### The mechanism that protects a pin: lock the manifest
+### The mechanism: lock the manifest
 
 `acr purge` **skips locked manifests by default** — those with `deleteEnabled` or `writeEnabled` set
-to `false` — and deleting them requires the explicit `--include-locked` flag, which neither task
-passes. So a lock is a hard protection against this exact purge configuration, not a hint.
+to `false` — and deleting them requires the explicit `--include-locked`, which **neither step
+passes** (verified against the live definitions, 2026-09-07, and asserted on every pull request
+against the committed record). So a lock is a hard protection against this exact configuration, not
+a hint.
 
-The self-maintaining shape is:
+🚨 **Lock `deleteEnabled` only. Do not also clear `writeEnabled`.** `deleteEnabled: false` is exactly
+and only what the purge skips on. `writeEnabled: false` additionally refuses a manifest PUT for that
+digest — and the release pipeline PROMOTES by retagging in ACR (`release.yml`:
+`docker buildx imagetools create --tag $ACR/$repo:$VERSION $ACR/$repo:$SHORT`), which is a manifest
+PUT of an already-present digest under a new tag. A write-lock therefore buys no extra purge
+protection and puts a promotion at risk. The five manifests locked by hand on 2026-09-06 carry
+**both** flags; two of them (`mw-plugin-test@642f686f…`, `memex-portal-ai@31aab07d…`) are the
+`3.0.0-ci.7917` wave, which is the set a `3.0.0` promotion would retag. **This is reasoned from the
+mechanism, not measured** — confirming it needs an actual retag against a write-locked manifest, and
+the change that wrote this page held read-only access to the registry. It is **worth confirming
+before the next promotion and cheap to undo either way**: `az acr repository update …
+--write-enabled true` leaves the delete-lock, and therefore the purge protection, untouched.
 
-1. Derive the live pin set. 🚨 **It is the UNION of two axes, and the guard above supplies only the
-   first**: digests pinned in the satellites' CI workflows (`check-pinned-digests.py`) *and* image
-   tags pinned in the deployment overlays (`Systemorph/Memex`'s `scripts/check-image-pins.py`). A
-   lock set built from either axis alone leaves the other axis's manifests unprotected, which is how
-   `memex-portal` and `memex-website` get deleted while every CI pin looks after itself.
-2. Lock every currently-pinned manifest.
-3. Report every locked manifest that nothing pins any more, so a pin move releases the old one.
+🚨 **The OCI read-through mirror is not this.** Core #3353/#3495/#3497 put a local content-addressed
+cache in front of ACR; its store is a **bounded LRU against `CacheMaxBytes`**, so any entry can be
+evicted at any time and a miss simply falls through upstream. It can add availability; it can never
+preserve a manifest ACR has deleted. A digest is protected by its lock alone.
 
-Step 3 is a **report, not an automatic unlock**, and the asymmetry is the reason: a wrong unlock
-costs an outage, a stale lock costs one manifest's unshared layers. A lock placed by a person for a
-reason the pin scan cannot see must not be silently removed by a scheduled job.
+## The lock job — protection is derived, not remembered
 
-### The exact commands, for the maintainer to run
+`.github/workflows/lock-pinned-digests.yml`, running `.github/scripts/lock-pinned-digests.py` at
+**01:00 UTC** — two hours before the 03:00 purge — plus `workflow_dispatch`, and report-only on any
+push to `main` that touches the script or its two extractor dependencies.
 
-Read-only first — this is the current definition, and it is worth capturing before changing it:
+It reads the fleet's live pin set and locks every manifest it names. **A hand-maintained keep-list is
+the defect, not the fix**: it is only ever correct on the day it is written, and the five hand locks
+of 2026-09-06 were already two-fifths stale a day later (see below).
 
-```bash
-az acr task show --registry meshweaver --name purge-old-images \
-  --query "step.encodedTaskContent" -o tsv | base64 -d
-az acr task show --registry meshweaver --name purge-old-ci-releases \
-  --query "step.encodedTaskContent" -o tsv | base64 -d
+### The pin set is the UNION of two axes
+
+| Axis | What it is | Read from | Measured 2026-09-07 |
+|---|---|---|---|
+| 1 | a **digest** pinned in CI | every repository's `.github/workflows` | 20 sites, 6 repositories, 5 distinct manifests |
+| 2 | an image **TAG** pinned in a deployment overlay | `values*.y{a}ml` under a `deploy/` or `deployments/` path | 11 sites, 2 repositories, 7 distinct manifests |
+
+A lock set built from axis 1 alone leaves every overlay-pinned manifest unprotected — and
+**Memex#122's victim was pinned exactly that way**. Axis 2 reads two shapes, because both occur:
+the whole reference on one line (`image: "…/memex-portal-ai:3.0.0-ci.7926"`) and helm's split
+convention (`repository:` plus a sibling `tag:`), which is how both whisper charts in the fleet
+write theirs. A reader that saw only the first would report those overlays as pinning nothing.
+
+**Axis 1 has no second extractor.** The script *imports* `check-pin-set-consistency.py` and uses its
+`extract()`, so there is one definition in this repository of what a digest pin is; the self-test
+additionally asserts that it and `check-pinned-digests.py` still **agree** on a shared fixture, so a
+future edit that diverges them reddens rather than quietly splitting the fleet's idea of a pin in
+two.
+
+**Axis 2's scope is narrow, and the boundary was measured rather than guessed.** Widening it to
+every YAML/JSON under `deploy/` was tried and rejected: this repository's
+`deploy/aks/operator/test/fixtures/**` carry image references to tags that never existed
+(`memex-portal-ai:3.0.0-rc8.ci.5000`), which would red the job nightly over test fixtures, and
+`deploy/aks/manifests/observability/log-watcher.yaml` names the floating tag `:latest`, which has no
+fixed manifest to protect. Floating tags are reported and never locked, for the same reason.
+
+### What makes it RED
+
+Fail-closed throughout — an unswept repository must never read as a swept one:
+
+- a repository whose workflows or whose git tree could not be read (a GitHub 404 has two causes and
+  they are opposite verdicts, so the repository itself is probed before any absence is believed);
+- a **truncated** recursive tree listing — an unknown number of paths were never seen, and an
+  absence read off a truncated listing is not a measured zero;
+- a pin-shaped declaration whose value is not a digest (I4 — placeholder vacuity);
+- a digest whose ACR repository cannot be determined (**I5**; for locking this is worse than
+  unchecked — there is no manifest to lock);
+- an overlay tag that does not resolve, or a pinned digest that is already gone;
+- an INDETERMINATE registry answer: `az` failing for any reason other than the registry's own
+  `manifest unknown`;
+- **ZERO pins on either axis**. Both were non-zero when this was written, so a zero means the
+  extractor stopped matching, not that pinning stopped;
+- a lock that was requested and did not take.
+
+The report prints the denominator **per axis** — repositories scanned, repositories that pin,
+repositories that do not, sites found, sites unclassified — because "0 unprotected" has two causes
+and only one of them is good news.
+
+### 🚨 It locks. It does not unlock.
+
+The unlock half is designed, implemented and **shipped disabled**. It is enabled only by a person
+setting the repository variable `MW_ACR_RELEASE_UNPINNED` to `true`, and even then it releases
+nothing on a run that carries any blocker above.
+
+The asymmetry is the whole safety argument, and it is not theoretical:
+
+> **Unlocking is the only direction that can destroy data, and it is unsafe in exactly the case where
+> the extractor is wrong** — because a pin the scan cannot see is spelled identically to a pin that
+> is not there. "Nothing pins this any more" and "I failed to read the thing that pins it" produce
+> the same answer.
+
+**The first live report-only run proved it.** Of the five manifests locked by hand, the job would
+have protected **two** and listed the other **three as release candidates**:
+
+```
+RELEASE CANDIDATE  memex-migration@sha256:7f5b6ad2…   tags=['staging-bbcb22f-34015096490-linux-x64']
+RELEASE CANDIDATE  memex-portal-ai@sha256:eb9ffcf4…   tags=['staging-bbcb22f-34015096490-linux-x64']
+RELEASE CANDIDATE  mw-plugin-test@sha256:c91d6f29…    tags=['staging-bbcb22f-34015096490-linux-x64']
 ```
 
-Lock one pinned manifest (idempotent; repeat per pinned digest — the guard's report lists them):
+That is **not an extractor defect**. Those three are the `staging-bbcb22f-…` set that
+MeshWeaver.Education's *pending* pin bump will name — locked **pre-emptively**, to protect a pin that
+does not exist yet. No derivation from the live pin set can see a pin nobody has committed. An
+enabled release arm would have unlocked the fix for #3438's own victim, on its first run, and
+`--ago 7d` would have finished the job. **A pre-emptive lock is therefore a legitimate reason for a
+lock this job cannot derive** — which is precisely why a scheduled job must never silently remove
+one, and why the release candidates are a *report* a person reads.
+
+Correspondingly, locks are applied **even on a degraded run** — a lock cannot destroy anything, so
+protecting what was found beats protecting nothing — while releases are not. Both facts are printed.
+
+### What a real run would do, measured 2026-09-07
+
+```
+    AXIS 1 — digest pins in .github/workflows
+      repositories scanned                     34
+      …declaring at least one digest pin        6
+      …declaring NO digest pin                 28
+      …whose workflows could not be read        0
+      digest pin SITES found                   20
+      …UNCLASSIFIED (I5 — not checked)          0
+
+    AXIS 2 — image TAG pins in deployment overlays
+      repositories scanned                     34
+      …carrying an overlay that pins            2   (Systemorph/Memex, Systemorph/MeshWeaver)
+      …whose tree could not be read             0
+      overlay files considered                 15
+      tag pin SITES found                      11
+
+    UNION — manifests the fleet pins
+      distinct manifests wanted                12
+      …already protected (deleteEnabled false)  2
+      …TO LOCK                                  7
+      …that could NOT be protected              3
+
+    REGISTRY
+      manifests in the registry              2831
+      …currently locked (deleteEnabled false)   5
+      …locked and pinned by NOTHING             3
+```
+
+**Seven manifests are pinned and unprotected right now**, and four of them sit in repositories the
+7-day step sweeps: the `3.0.0-ci.7926` portal/migration pair both live deployments run,
+`memex-portal-next:3.0.0-next.43`, and the pearl overlay's `3.0.0-rc9.ci.7601` pair.
+`hosting-operator:1.0.0` and `whisper-swiss-german:1.7.4` are in no filter today, so locking them is
+protection against a future filter addition rather than against tonight.
+
+**The three that could not be protected are #3438 itself** — MeshWeaver.Education's
+`memex-portal-ai@dab2a7b3…`, `memex-migration@d81df6cc…` and `mw-plugin-test@df19f10a…`, already
+deleted. The job reds on them, by construction, on the same fact the 05:20 guard reds on. Education's
+bump must move all three.
+
+🚨 **Locking is a WRITE, and the read-only sweep's credential cannot do it.**
+`az acr repository update` needs the data action
+`Microsoft.ContainerRegistry/registries/repositories/metadata/write`, which is in
+**`Container Registry Repository Writer`** (and in Contributor/Owner) and in **neither `AcrPull` nor
+`AcrPush`** — measured 2026-09-07: `AcrPush` is `pull/read` + `push/write` and nothing else. If the
+OIDC identity carries only the read grant the pinned-digest sweep uses, the job reds **once**, naming
+the exact assignment rather than repeating one refusal per manifest:
+
+```bash
+az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \
+  --role 'Container Registry Repository Writer' \
+  --scope /subscriptions/<sub>/resourceGroups/meshweaver-shared/providers/Microsoft.ContainerRegistry/registries/meshweaver
+```
+
+That is a provisioning task, not a workflow defect.
+
+### The exact commands, by hand
+
+Lock one pinned manifest (idempotent):
 
 ```bash
 az acr repository update --name meshweaver \
-  --image mw-plugin-test@sha256:<digest> \
-  --delete-enabled false --write-enabled false
+  --image mw-plugin-test@sha256:<digest> --delete-enabled false
 ```
 
-Release one that nothing pins any more:
+Release one that nothing pins any more — **a person's decision, never a scheduled job's**:
 
 ```bash
 az acr repository update --name meshweaver \
-  --image mw-plugin-test@sha256:<digest> \
-  --delete-enabled true --write-enabled true
+  --image mw-plugin-test@sha256:<digest> --delete-enabled true
 ```
-
-Collapse the two tasks into one. `az acr task update` replaces the task's inline YAML; keep the
-reasoning **in the task** as the hardened one already does, and delete the redundant task in the same
-sitting so there is only ever one list to edit.
-
-🚨 **Two steps, not one, and that is deliberate.** Unioning the filters under the stricter window
-would drag `memex-portal` from 30 days to `7d --keep 10` as a side effect — see the section above.
-This removes the second TASK while preserving each repository's current effective window exactly, so
-the change is reviewable as "one list instead of two" and nothing else:
-
-```bash
-cat > purge.yaml <<'YAML'
-version: v1.1.0
-# ONE retention task. Two diverged (MeshWeaver#3438): the hardened one's reasoning did not reach
-# `mw-plugin-test`, and for four of its five repositories it was a no-op behind a stricter task
-# running an hour earlier. A second list is a second place to forget.
-#
-# Memex#122 — if nothing would recreate a tag, never age-purge it. `memex-website` is DELIBERATELY
-# absent for that reason: its only tag is a pinned `v1` nothing rebuilds, and deleting it served the
-# public brand site 503 for ~11 hours.
-#
-# MeshWeaver#3438 — a repository that IS continuously republished still holds PINNED digests, and
-# `--keep` is counted in newer builds, so republishing is what destroys a pin. Protection is per
-# MANIFEST, not per repository: pinned manifests are locked (delete-enabled false) and `acr purge`
-# skips locked manifests unless `--include-locked` is passed. NEVER pass it here.
-#
-# TWO STEPS ON PURPOSE. Merging the lists must not silently retune a window. `memex-portal` is the
-# production portal image and was only ever on the 30-day window; it is also pinned on the OTHER
-# axis (committed tags in the deployment overlays, Memex#141), which the CI-workflow pin scan does
-# not enumerate. Tightening it is a separate decision with its own evidence.
-steps:
-  # CI images: rebuilt many times a day, pinned by digest from the satellites' workflows.
-  - cmd: acr purge --filter 'mw-plugin-test:.*' --filter 'memex-migration:.*' --filter 'memex-portal-ai:.*' --filter 'memex-portal-next:.*' --filter 'memex-bake:.*' --ago 7d --keep 10 --untagged
-    disableWorkingDirectoryOverride: true
-    timeout: 3600
-  # Production portal image: unchanged 30-day window, no --keep. Do not fold into the step above.
-  - cmd: acr purge --filter 'memex-portal:.*' --ago 30d --untagged
-    disableWorkingDirectoryOverride: true
-    timeout: 3600
-YAML
-
-az acr task update --registry meshweaver --name purge-old-images \
-  --file purge.yaml --schedule "0 3 * * *"
-az acr task delete --registry meshweaver --name purge-old-ci-releases --yes
-```
-
-🚨 Confirm the merged task on a **dry run** before trusting it, and confirm that a locked manifest is
-in fact skipped rather than reported for deletion:
-
-```bash
-az acr task update --registry meshweaver --name purge-old-images --file purge-dryrun.yaml   # same, with --dry-run
-az acr task run   --registry meshweaver --name purge-old-images
-```
-
-One dimension to check while you are in there: the per-step `timeout: 3600` is a ceiling **per
-step**, while the task's own `timeout` bounds the whole run — and both existing tasks are at 3600 s
-(measured 2026-09-06). Two steps therefore share one hour, not two. Each purge completes in minutes
-today, so this is a thing to confirm on the dry run rather than a number to change pre-emptively;
-`az acr task update --timeout <seconds>` is where it lives if it ever binds.
 
 Note what `--ago` measures: a manifest's `lastUpdateTime`, which a re-push refreshes. A digest that
 happens to be republished stays young; a digest that is merely *pinned* does not. That asymmetry is
@@ -361,3 +444,4 @@ the whole failure in one sentence.
 - [The Continuous Delivery Contract](../ContinuousDeliveryContract) — all-or-nothing publication; verify the image, never the tick
 - [A Container Registry in Memex](../ContainerRegistryInMemex) — why the boot image stays on ACR
 - [Reading CI Signals](../ReadingCiSignals) — what a green wall does and does not attest to
+- [Pin Set Consistency](../PinSetConsistency) — the other question about the same pins, and the extractor this page's lock job imports

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -404,9 +404,13 @@ bump must move all three.
 `az acr repository update` needs the data action
 `Microsoft.ContainerRegistry/registries/repositories/metadata/write`, which is in
 **`Container Registry Repository Writer`** (and in Contributor/Owner) and in **neither `AcrPull` nor
-`AcrPush`** — measured 2026-09-07: `AcrPush` is `pull/read` + `push/write` and nothing else. If the
-OIDC identity carries only the read grant the pinned-digest sweep uses, the job reds **once**, naming
-the exact assignment rather than repeating one refusal per manifest:
+`AcrPush`** — measured 2026-09-07: `AcrPush` is `pull/read` + `push/write` and nothing else.
+
+The registry's three service principals hold, between them, only `AcrPull`, `AcrPush` and
+`Container Registry Data Importer and Data Reader` — measured with `--include-inherited`, and that
+third role is `metadata/**read**` only. So on the evidence the lock will be refused until a grant is
+added. **The job's first run is the decisive measurement**, and it reds **once**, naming the exact
+assignment rather than repeating one refusal per manifest:
 
 ```bash
 az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -297,6 +297,19 @@ additionally asserts that it and `check-pinned-digests.py` still **agree** on a 
 future edit that diverges them reddens rather than quietly splitting the fleet's idea of a pin in
 two.
 
+That agreement was also measured on the **real fleet**, not only on the fixture — both scripts run
+over the same 34 repositories, their digest sets compared at a common truncation (2026-09-07):
+
+```
+guard distinct digests   5      lock distinct digests  15
+in guard, NOT in lock:   0      ← the lock job misses no axis-1 pin the guard finds
+in lock,  NOT in guard: 10      ← 7 axis-2 overlay manifests + 3 currently-locked-but-unpinned
+```
+
+Zero divergence on the axis they share, and the whole difference is the axis the guard cannot see
+plus the release candidates — the shape the design predicts, measured rather than asserted. Worth
+re-running after any change to either extractor: a fixture can be made to agree, a fleet cannot.
+
 **Axis 2's scope is narrow, and the boundary was measured rather than guessed.** Widening it to
 every YAML/JSON under `deploy/` was tried and rejected: this repository's
 `deploy/aks/operator/test/fixtures/**` carry image references to tags that never existed

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-build-a-repository-depends-on-is-protected-from-housekeeping.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-build-a-repository-depends-on-is-protected-from-housekeeping.md
@@ -1,0 +1,45 @@
+---
+Name: The build a repository depends on is protected from housekeeping
+Category: Fix
+Description: Naming a deleted build the morning after was only half an answer. Every build anything still depends on is now marked as protected each night, two hours before the housekeeping runs, so it is skipped rather than cleared away.
+Icon: LockClosed
+Order: -20260907
+---
+
+# The build a repository depends on is protected from housekeeping
+
+Each content repository, and each running deployment, is tied to one specific known-good build of
+the platform. Those builds live in an image registry, and the registry clears out old ones on a
+schedule so that storage does not grow without limit. The two arrangements disagreed: a repository
+is meant to stay on its chosen build for weeks, while the housekeeping kept only the newest handful
+and counted "old" by how many *newer* builds existed. The more often the platform was rebuilt, the
+sooner someone's chosen build was cleared away.
+
+On 5 September three repositories stopped at the same moment because that had happened. A daily
+sweep now names a missing build the morning after — but naming it is only half an answer, because by
+then it is gone.
+
+The registry's housekeeping already skips anything explicitly marked as protected. So a job now
+runs each night, two hours before the housekeeping, reads every build that anything still depends
+on, and marks each of them. Nobody has to remember to add one: the list is read fresh each night
+from the repositories themselves and from the deployment settings, which are two separate places
+and had to both be looked at — the build a deployment names is written down quite differently from
+the build a repository's checks name, and a job that read only one of them would have left the other
+kind unprotected while reporting success.
+
+It reports how much it examined, not just what it found, so "everything is protected" and "nothing
+was looked at" can be told apart. If any repository cannot be read, or any entry cannot be matched
+to a build, the run fails and says which — a partial reading must not be mistaken for a complete one.
+
+**It only ever adds protection; it never removes it.** Removing protection is the one direction that
+can lose something for good, and it is least safe in exactly the situation where the reading is
+incomplete, because "nothing depends on this any more" and "I could not read the thing that depends
+on it" look identical from the outside. The job works out which protections look unused and lists
+them for a person to review, and that is where it stops unless someone deliberately turns the other
+half on. The first live run showed why: three of the five protections that had been placed by hand
+were for a build that a *pending* change will start using, and an automatic clean-up would have
+removed exactly the ones being kept ready.
+
+The housekeeping configuration itself lives in the registry rather than in any repository, so a copy
+of it — and the reasoning behind it, from both incidents — is now kept alongside the job, together
+with a way to check that the two still agree.


### PR DESCRIPTION
Closes the remaining half of #3438. #3462 shipped the **guard** — it names a pinned digest that is
already gone. This is the half that **stops the deletion**.

`acr purge` skips locked manifests by default, and **neither step of `purge-old-images` passes
`--include-locked`** (verified against the live task definition, 2026-09-07). So `deleteEnabled:
false` on a manifest is a hard protection against this exact configuration. Five manifests were
locked **by hand** on 2026-09-06 to stop the bleeding; a hand list is the defect, not the fix — it
is only ever correct on the day it is written, and it was already two-fifths stale a day later.

`.github/workflows/lock-pinned-digests.yml` runs at **01:00 UTC** — two hours before the 03:00
purge — reads the fleet's live pin set and locks every manifest it names.

## 🚨 It locks. It does not unlock. And the first live run showed exactly why

The unlock half is **designed, implemented and shipped disabled** behind `MW_ACR_RELEASE_UNPINNED`,
a repository variable a maintainer sets. Even then it releases nothing on a run carrying any
blocker.

> Unlocking is the only direction that can **destroy** data, and it is unsafe in exactly the case
> where the extractor is wrong — because a pin the scan cannot see is spelled identically to a pin
> that is not there. "Nothing pins this any more" and "I failed to read the thing that pins it"
> produce the same answer.

That is not theoretical. Of the five hand-locked manifests, a live report-only run would have
protected **two** and listed the other **three as release candidates**:

```
RELEASE CANDIDATE  memex-migration@sha256:7f5b6ad2…   tags=['staging-bbcb22f-34015096490-linux-x64']
RELEASE CANDIDATE  memex-portal-ai@sha256:eb9ffcf4…   tags=['staging-bbcb22f-34015096490-linux-x64']
RELEASE CANDIDATE  mw-plugin-test@sha256:c91d6f29…    tags=['staging-bbcb22f-34015096490-linux-x64']
```

**Not an extractor defect.** Those three are the `staging-bbcb22f-…` set that MeshWeaver.Education's
*pending* pin bump will name — locked **pre-emptively**, protecting a pin that does not exist yet.
No derivation from the live pin set can see a pin nobody has committed. **An enabled release arm
would have unlocked the fix for #3438's own victim, on its first run**, and `--ago 7d` would have
finished the job. A pre-emptive lock is a legitimate reason for a lock this job cannot derive, which
is exactly why a scheduled job must never silently remove one.

Correspondingly: **locks are applied even on a degraded run** — a lock cannot destroy anything, so
protecting what *was* found beats protecting nothing — while **releases are not**. Both facts are
printed.

## The pin set is the UNION of two axes

| Axis | What | Read from | Measured 2026-09-07 |
|---|---|---|---|
| 1 | a **digest** pinned in CI | every repo's `.github/workflows` | 20 sites · 6 repos |
| 2 | an image **TAG** pinned in a deployment overlay | `values*.y{a}ml` under `deploy/`/`deployments/` | 11 sites · 2 repos |

A lock set from axis 1 alone leaves every overlay-pinned manifest unprotected — **Memex#122's victim
was pinned exactly that way**. Axis 2 reads both the inline shape and helm's split
`repository:`/`tag:`, which is how both whisper charts in the fleet write theirs; a reader that saw
only the first would report those overlays as pinning nothing.

**No third extractor.** The script *imports* `check-pin-set-consistency.py` and uses its
`extract()`, so there is one definition in this repo of what a digest pin is — and the self-test
asserts that it and `check-pinned-digests.py` still **agree** on a shared fixture, so a future edit
that diverges them reddens rather than quietly splitting the fleet's idea of a pin in two.

**Cross-checked on the REAL fleet, not just the fixture.** Both scripts were run over the same 34
repositories and their digest sets compared at a common truncation:

```
guard distinct digests   5      lock distinct digests  15
in guard, NOT in lock:   0      <- the lock job misses no axis-1 pin the #3462 sweep finds
in lock,  NOT in guard: 10      <- 7 axis-2 overlay manifests + the 3 currently-locked-but-unpinned
```

Zero divergence on the axis they share, and the difference is exactly the axis the guard cannot see
plus the release candidates. That is the shape the design predicts, measured rather than asserted.

**Axis 2's scope is narrow and the boundary was measured, not guessed.** Widening it to every
YAML/JSON under `deploy/` was tried and rejected: `deploy/aks/operator/test/fixtures/**` carry image
references to tags that never existed (`memex-portal-ai:3.0.0-rc8.ci.5000`), which would red this
job nightly over test fixtures, and `manifests/observability/log-watcher.yaml` names the floating
tag `:latest`, which has no fixed manifest to protect.

## What a real run would do — live, report-only, 34 repositories, 2m19s

```
    AXIS 1 — digest pins in .github/workflows
      repositories scanned                     34
      …declaring at least one digest pin        6  (Crm, Education, Manufacturing, Plugins, Reinsurance, SocialMedia)
      …declaring NO digest pin                 28
      …whose workflows could not be read        0
      digest pin SITES found                   20
      …UNCLASSIFIED (I5 — not checked)          0

    AXIS 2 — image TAG pins in deployment overlays
      repositories scanned                     34
      …carrying an overlay that pins            2  (Systemorph/Memex, Systemorph/MeshWeaver)
      …whose tree could not be read             0
      overlay files considered                 15
      tag pin SITES found                      11

    UNION — manifests the fleet pins
      distinct manifests wanted                12
      …already protected (deleteEnabled false)  2
      …TO LOCK                                  7
      …that could NOT be protected              3

    REGISTRY
      manifests in the registry              2837
      …currently locked (deleteEnabled false)   5
      …locked and pinned by NOTHING             3
```

**Seven manifests are pinned and unprotected right now**, four of them in repositories the 7-day
step sweeps: the `3.0.0-ci.7926` portal/migration pair both live deployments run,
`memex-portal-next:3.0.0-next.43`, and the pearl overlay's `3.0.0-rc9.ci.7601` pair.
`hosting-operator:1.0.0` and `whisper-swiss-german:1.7.4` are in no filter today.

**The three unprotectable ones are #3438 itself** — Education's `memex-portal-ai@dab2a7b3…`,
`memex-migration@d81df6cc…`, `mw-plugin-test@df19f10a…`, already deleted. The job reds on them by
construction, on the same fact the 05:20 guard reds on. Education's bump must move all three.

## 🚨 One provisioning task before this can lock anything

**Locking is a WRITE.** `az acr repository update` needs
`Microsoft.ContainerRegistry/registries/repositories/metadata/write`. Measured 2026-09-07:

| Role | holds `metadata/write`? |
|---|---|
| `AcrPull` | no |
| `AcrPush` (`pull/read` + `push/write`, no dataActions) | no |
| `Container Registry Data Importer and Data Reader` | no — `metadata/`**`read`** |
| `Container Registry Repository Writer` | **yes** |

The `meshweaver` registry's three service principals hold only the first three (measured with
`--include-inherited`). **So on the evidence the nightly lock will be refused until a grant is
added.** The job reds **once**, naming the exact assignment rather than repeating one refusal per
manifest:

```bash
az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \
  --role 'Container Registry Repository Writer' \
  --scope /subscriptions/<sub>/resourceGroups/meshweaver-shared/providers/Microsoft.ContainerRegistry/registries/meshweaver
```

That is a provisioning task, not a workflow defect. **This PR made no production change** — the
registry was read-only to it: no lock, no unlock, no task-definition change.

## Why `deleteEnabled` only, and a thing to check before the next promotion

`deleteEnabled: false` is exactly and only what the purge skips on. `writeEnabled: false`
additionally refuses a manifest PUT for that digest — and `release.yml` promotes by retagging
(`docker buildx imagetools create --tag $ACR/$repo:$VERSION $ACR/$repo:$SHORT`), which is a manifest
PUT of an already-present digest under a new tag. So this job locks **delete only**.

🚨 **The five hand locks set BOTH flags**, and two of them (`mw-plugin-test@642f686f…`,
`memex-portal-ai@31aab07d…`) are the `3.0.0-ci.7917` wave — the set a `3.0.0` promotion would retag.
**Reasoned from the mechanism, not measured** (confirming it needs an actual retag, and this change
held read-only access). Worth checking before the next promotion; `--write-enabled true` undoes it
and leaves the purge protection untouched.

## The retention tasks are now recorded in the repo

They are **cloud-only** — `EncodedTask`, `contextPath: null`, zero org-wide code-search hits — so the
reasoning from both incidents lived in comments that exist in exactly one place, that nobody diffs,
and that any `az acr task update` from any laptop replaces silently and completely.

`.github/acr-retention/` records both decoded definitions byte for byte plus their
schedule/status/timeout; `.github/scripts/acr-retention-tasks.sh` show/record/verify/apply relates
the record to the live registry. `verify` is deliberately **not** in CI (it needs
`registries/tasks/read`, a strictly larger grant than the lock itself, and a step permanently red
for a missing grant is a step that gets ignored). The half a pull request *can* break **is** gated,
credential-free, on every PR: `lock-pinned-digests.py --check-retention-record .` refuses a purge
step that gained `--include-locked`, which would turn every lock into decoration while the job kept
reporting success.

## Watch it fail — 28 sabotages, and two vacuous assertions found that way

Every arm was watched to go RED under a deliberate sabotage of the code it asserts:

* **19** against `--self-test` — extractor blinded (each axis, each shape), floating-tag exclusion
  removed, idempotence lost, each blocker deleted, the release guard's blocker test removed, the
  release arm firing while disabled, report-only writing, the two extractors diverged, the overlay
  path filter widened to accept a test fixture.
* **5** against `--check-retention-record` — `--include-locked` added, steps emptied, zero tasks,
  a named file deleted, the record directory gone.
* **4** against `acr-retention-tasks.sh verify` — `--include-locked`, a widened window, a silently
  disabled task, a record with no steps.

🚨 **Two real defects fell out of that, both the exact shape this issue is about.** The release arms
asserted "nothing was released" against a fixture that *had nothing to release*, so deleting the
guard left the whole suite green — a check that could not fail. And the retention verifier's
`--include-locked` grep fired on the task's own **comment** saying it does not pass
`--include-locked`; a guard that reds on the prose explaining why it is satisfied is a guard that
gets muted. Both fixed, both now covered.

## Two things #3438's premise got wrong

1. **`memex-portal` is not pinned by any deployment overlay.** The task comment and the doc justify
   the two-step split by saying it is (Memex#141). The overlays pin `memex-portal-ai`,
   `memex-migration`, `memex-portal-next` and `hosting-operator`; an org-wide code search for
   `meshweaver.azurecr.io/memex-portal:` returns **zero** hits and the repo's newest tag is
   `3.0.0-rc13`. The split is still right — tightening a low-churn production image repository is a
   separate decision with its own evidence — but the *stated* reason is no longer true, and a reason
   that is quietly false is how a future merge talks itself into the union. Corrected in the doc.
2. **The overlay axis is not only `memex-portal`-shaped.** It is 11 sites over 7 distinct manifests
   including `hosting-operator` and `whisper-swiss-german`, and one of its two shapes (helm's split
   `repository:`/`tag:`) is invisible to a single-line scan — the same "not seen reads as not
   pinned" confusion, one layer down.

**The OCI read-through mirror (#3353/#3495/#3497) is not pin protection** and nothing here relies on
it: its store is a bounded LRU against `CacheMaxBytes`, so any entry can be evicted at any time and
a miss falls through upstream. It can add availability; it can never preserve a manifest ACR has
deleted. One sentence saying so is in the doc.

## Files

* `.github/scripts/lock-pinned-digests.py` — the job, its 13-arm self-test, and the credential-free
  retention-record check
* `.github/workflows/lock-pinned-digests.yml` — 01:00 schedule (apply), `workflow_dispatch`, and
  report-only on push so a change to the extractor proves itself against the live fleet before it
  mutates a shared registry. `preflight` asserts every input and mints/uses the App token for real;
  `protect` `needs:` it with no input-shaped `if:` and no `continue-on-error:`.
* `.github/acr-retention/` + `.github/scripts/acr-retention-tasks.sh` — the record and its instrument
* `.github/workflows/dotnet-test.yml` — both static checks in the workflow-shell lane
* `Doc/Architecture/PinnedImageRetention` — rewritten from "the retention half" down

Pairs-with: none — no public type or member is removed; the diff is CI scripts, a workflow, a
retention record and documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
