### PR TITLE
fix(#3472): a process refuses a build keyed to a framework identity that is not its own, and stops reporting Ok for it

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/CellSurfaceAssemblyProvider.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CellSurfaceAssemblyProvider.cs
@@ -153,6 +153,25 @@ internal sealed class CellSurfaceAssemblyProvider(
             return Observable.Return<CellSurfaceAssembly?>(null);
         }
 
+        // ── 🚨 #3472 — the adopt-time framework-identity gate, third enforcement site. ──
+        // The cell surface is the most directly armed load path there is (every script submission
+        // in the session can then call the pack's functions by bare name), it loads straight
+        // through NodeAssemblyLoadContext with no enrichment, and it takes a lifetime LEASE — so
+        // an ABI-stale assembly joined here stays mapped and executable for the whole session.
+        // It gated on CompilationStatus == Ok alone, and Ok is a claim scoped to
+        // CompiledFrameworkVersion: the pair is what has to be read, never the verdict by itself.
+        //
+        // Error, not Warning, and for the same reason as the provenance refusal above: this is a
+        // verdict about the bytes that only a rebuild or a rebake changes.
+        if (NodeTypeBuildIdentity.Refuses(definition))
+        {
+            logger.LogError(
+                "{Summary} It is NOT being joined into this kernel session's cell surface. {Recovery}",
+                NodeTypeBuildIdentity.RefusalSummary(node.Path, definition),
+                NodeTypeBuildIdentity.RecoveryVerb);
+            return Observable.Return<CellSurfaceAssembly?>(null);
+        }
+
         if (definition.CompilationStatus is not CompilationStatus.Ok
             || definition.LastCompiledVersion is null)
         {

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeBuildIdentity.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeBuildIdentity.cs
@@ -1,0 +1,192 @@
+using MeshWeaver.Mesh.Services;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// THE adopt-time framework-identity gate: may THIS process load the build a NodeType's record
+/// names, and what status may it honestly report for that record — Systemorph/MeshWeaver#3472.
+///
+/// <para>One predicate, two consumers, deliberately shaped like
+/// <c>MeshPublicationGate</c>'s (#3478/#3491): a divergence is what caused the incident, so the
+/// serve-time refusal and the reported status are DERIVED from a single comparison rather than
+/// being two tables that can drift apart.</para>
+///
+/// <h3>What happened</h3>
+///
+/// <para>On 2026-09-06, <c>Crm/Offer</c> and <c>Crm/Opportunity</c> on a client portal read
+/// <c>compilationStatus: Ok</c> while every one of their per-instance hubs was dead — one timing
+/// out on activation, the other answering "Area not found". Their records named assemblies stamped
+/// <c>sc273ee39f…</c>; the replicas serving the portal ran <c>s2f227642d…</c>. Every deal page and
+/// every offer page was dead for about two and a half hours, and the NodeType's own self-report was
+/// green throughout. <c>Doc/Architecture/MeshAdmission</c> carries the membership half of the chain
+/// (a readiness-refused pod that kept publishing); this is the adoption half.</para>
+///
+/// <h3>Why <c>Ok</c> was a lie, stated precisely</h3>
+///
+/// <para>🚨 <b><see cref="CompilationStatus.Ok"/> is a claim SCOPED to
+/// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>, persisted as though it were
+/// absolute.</b> "The last compile succeeded" is true and process-independent; "these bytes can be
+/// loaded" is only ever answerable relative to a process. The record has always carried both halves
+/// — the verdict and its scope — in two separate fields, and every instrument read the first one.
+/// That is the whole defect, and it is why no amount of care at the WRITER can fix it alone: the
+/// pod that wrote <c>Ok</c> could load what it had just built.</para>
+///
+/// <para>So the answer is split, and each half is necessary:</para>
+///
+/// <list type="number">
+///   <item><b>The writer half.</b> A persisted <c>Ok</c> that names an assembly must name the
+///     framework identity of the process that persisted it — the identity travels with the
+///     coordinates, exactly as <c>NodeTypeContractHandler.ResolvedStoreVersion</c> already argues
+///     the store-key VERSION must ("the path and the version are ONE reference, so they must come
+///     from ONE source"). The framework identity is the fourth member of that reference and was
+///     left out of it: a hydrate carried a foreign stamp forward over bytes the store had just
+///     resolved under the LIVE tag, producing a record that says <c>Ok</c>, names loadable bytes,
+///     and declares them unloadable. <c>HasUsableBuild</c> is then false forever, every activation
+///     takes the ABI-stale recompile path, and after <c>MaxRecompileAttempts</c> the instance binds
+///     the fallback configuration for the grain's whole life — which is "Area not found", under a
+///     green tick.</item>
+///   <item><b>The reader half — this class.</b> Foreign-<c>Ok</c> records still ARRIVE from
+///     elsewhere: a peer replica on another image (#3395), a node repo that COMMITS a record (the
+///     plugins repo ships <c>Store/Catalog</c> with a July framework hash), a prebuilt bundle. This
+///     process must not repeat their <c>Ok</c>, and it must not load their bytes.</item>
+/// </list>
+///
+/// <para>🚨 <b>Nothing here is ever written.</b> <see cref="CompilationStatus.Foreign"/> is derived
+/// at read time and persisted by no one. Writing a reader-relative verdict into a shared record is
+/// how #3395's ping-pong was made — two replicas, two identities, each correctly overwriting the
+/// other's answer forever. That is also what makes this compose with <c>MeshPublicationGate</c>
+/// instead of duplicating it: that gate decides WHETHER this process may publish; this one adds
+/// nothing to publish.</para>
+///
+/// <h3>What refusing means</h3>
+///
+/// <para>🚨 <b>Refusing is not "the type is dead" — the fallback is a LOCAL COMPILE</b>, and every
+/// call site already has that path because it is the same one a store MISS takes today. That is not
+/// a coincidence: on a store whose key carries the framework tag (which
+/// <c>FileSystemAssemblyStore</c>'s <c>v{version}-{FrameworkTag}-*.dll</c> glob does) a
+/// foreign-identity record already misses. This gate makes that guarantee EXPLICIT and
+/// store-independent, so it no longer rests on an eight-character substring inside one
+/// implementation's glob pattern — with a second implementation (<c>BlobAssemblyStore</c>) living
+/// in a module this repository cannot compile, and no test anywhere asserting the property.</para>
+///
+/// <para>Pure and hub-free, so every row is unit-testable with no mesh and no timing, and so the
+/// enforcement sites cannot drift about what "foreign" means. Sibling gate on the orthogonal axis
+/// (bytes vs SOURCE rather than bytes vs FRAMEWORK): <see cref="NodeTypeExecutionGate"/>.</para>
+/// </summary>
+public static class NodeTypeBuildIdentity
+{
+    /// <summary>
+    /// Why this process may NOT load the build <paramref name="definition"/> names, or
+    /// <c>null</c> when it may — compared against an EXPLICIT live identity so a test can stage a
+    /// framework roll without rebuilding the framework (the same seam
+    /// <see cref="NodeTypeBakeStatus.Classify"/> and
+    /// <c>PrebuiltAssemblySeeder.DeclineReason</c> expose, for the same reason).
+    ///
+    /// <para>The comparison is deliberately the SAME clause
+    /// <c>NodeTypeCompilationHelpers.HasUsableBuild</c> already applies on the one load path that
+    /// was guarded — an ordinal equality, with an ABSENT identity refused. Extending it to the
+    /// paths that were not guarded is therefore consistency, not a new policy: a record whose
+    /// identity is absent cannot be shown ABI-compatible with anything, and the framework has
+    /// treated it as unusable since #464.</para>
+    ///
+    /// <para>🚨 A record that names NO assembly is not refused. There is nothing to load, so there
+    /// is nothing to refuse; the caller's own "no build recorded" branch is the right answer and
+    /// it already exists at every site. Answering a refusal there would report an identity problem
+    /// for a type that simply has not been built.</para>
+    /// </summary>
+    public static string? RefusalReason(NodeTypeDefinition? definition, string liveFrameworkVersion)
+    {
+        if (definition is null)
+            return null;
+        if (string.IsNullOrEmpty(definition.LatestAssemblyCollection)
+            || string.IsNullOrEmpty(definition.LatestAssemblyPath))
+            return null;
+        if (string.Equals(
+                definition.CompiledFrameworkVersion, liveFrameworkVersion, StringComparison.Ordinal))
+            return null;
+        return string.IsNullOrEmpty(definition.CompiledFrameworkVersion)
+            ? $"its record names an assembly but records NO framework build identity, so those "
+              + $"bytes cannot be shown ABI-compatible with the live framework "
+              + $"{Short(liveFrameworkVersion)}"
+            : $"its record names an assembly built against framework "
+              + $"{Short(definition.CompiledFrameworkVersion)} and this process is "
+              + $"{Short(liveFrameworkVersion)}";
+    }
+
+    /// <summary><see cref="RefusalReason(NodeTypeDefinition?, string)"/> against the LIVE framework
+    /// identity of this process.</summary>
+    public static string? RefusalReason(NodeTypeDefinition? definition)
+        => RefusalReason(definition, NodeTypeCompilationHelpers.FrameworkVersion);
+
+    /// <summary>Convenience for the call sites that only need the yes/no.</summary>
+    public static bool Refuses(NodeTypeDefinition? definition)
+        => RefusalReason(definition) is not null;
+
+    /// <summary>
+    /// The refusal as ONE English sentence, for the LOG line — the machine/operator-facing surface,
+    /// which stays English by house rule (log lines ship to Loki).
+    ///
+    /// <para>🚨 Both identities, always. The pair is what makes a refusal checkable by hand against
+    /// the CD run that produced the bytes, and naming only one is how the 2026-09-06 bake gate's
+    /// "regressed on this image" sent three investigations to the wrong repository.</para>
+    /// </summary>
+    public static string RefusalSummary(string nodeTypePath, NodeTypeDefinition definition, string liveFrameworkVersion)
+        => $"Adoption refused for NodeType '{nodeTypePath}': "
+           + (RefusalReason(definition, liveFrameworkVersion) ?? "no refusal")
+           + $" (record names {definition.LatestAssemblyCollection}/{definition.LatestAssemblyPath}). "
+           + "An assembly compiled for one framework identity is not loadable by a process running "
+           + "another — the failure would surface as a TypeLoadException inside a collectible ALC "
+           + "at activation, with no compile error and nothing to grep (#3472).";
+
+    /// <summary><see cref="RefusalSummary(string, NodeTypeDefinition, string)"/> against the LIVE
+    /// framework identity.</summary>
+    public static string RefusalSummary(string nodeTypePath, NodeTypeDefinition definition)
+        => RefusalSummary(nodeTypePath, definition, NodeTypeCompilationHelpers.FrameworkVersion);
+
+    /// <summary>
+    /// The recovery verb, stated wherever the refusal is. A refusal that does not say what happens
+    /// next reads as "the type is dead", and here it is emphatically not.
+    /// </summary>
+    public const string RecoveryVerb =
+        "Nothing further is required: this is the state the compile watcher already heals. The "
+        + "type's own hub rebuilds it against the live framework and restamps the record, exactly "
+        + "as it does after any ordinary platform roll. On a `Modules:RequirePrebuilt` mesh no "
+        + "local compile is possible — rebake and republish the package for THIS framework "
+        + "identity.";
+
+    /// <summary>
+    /// 🚨 <b>The status this PROCESS may honestly report for this record</b> — criterion 2 of
+    /// #3472, and the one function every reporting surface must go through.
+    ///
+    /// <para>Everything except a successful build with a recorded assembly passes through
+    /// untouched: <see cref="CompilationStatus.Error"/> is still "correct the code",
+    /// <see cref="CompilationStatus.Pending"/> / <see cref="CompilationStatus.Compiling"/> are
+    /// still in flight, <see cref="CompilationStatus.Unavailable"/> is still "could not be
+    /// determined". A successful build whose identity is this process's is still
+    /// <see cref="CompilationStatus.Ok"/>. A successful build whose identity is NOT is
+    /// <see cref="CompilationStatus.Foreign"/> — never <c>Ok</c>, and never <c>Error</c>.</para>
+    ///
+    /// <para>An <c>Ok</c> that records no assembly at all stays <c>Ok</c>: a marker type, or a type
+    /// whose compile produced no bytes, claims nothing about a build and so cannot be claiming a
+    /// foreign one.</para>
+    /// </summary>
+    public static CompilationStatus? ReportedStatus(
+        NodeTypeDefinition? definition, string liveFrameworkVersion)
+        => definition?.CompilationStatus is not CompilationStatus.Ok
+            ? definition?.CompilationStatus
+            : RefusalReason(definition, liveFrameworkVersion) is null
+                ? CompilationStatus.Ok
+                : CompilationStatus.Foreign;
+
+    /// <summary><see cref="ReportedStatus(NodeTypeDefinition?, string)"/> against the LIVE framework
+    /// identity of this process.</summary>
+    public static CompilationStatus? ReportedStatus(NodeTypeDefinition? definition)
+        => ReportedStatus(definition, NodeTypeCompilationHelpers.FrameworkVersion);
+
+    /// <summary>First eight characters — the same width the assembly-store filename tag carries, so
+    /// a log line and a DLL name can be compared by eye.</summary>
+    private static string Short(string? identity)
+        => string.IsNullOrEmpty(identity)
+            ? "(none)"
+            : identity[..Math.Min(8, identity.Length)];
+}

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
@@ -125,6 +125,35 @@ internal static class NodeTypeContractHandler
                                     $"Pinned release '{requestedReleasePath}' for '{hubPath}' could not be resolved."), false,
                                     Unavailable: true));
                             }
+                            // 🚨 ADOPT-TIME IDENTITY GATE (#3472), pinned-release arm. A release
+                            // records the framework it was built for (NodeTypeRelease.
+                            // FrameworkVersion) and nothing read it: this branch resolved by
+                            // AssemblyStoreVersion and loaded whatever came back, ahead of the
+                            // HasUsableBuild gate that guards the non-pinned sibling. A pin to a
+                            // release from another framework generation is not honourable here —
+                            // it answers exactly as an unresolvable pin does (Unavailable: the
+                            // bytes for THIS framework are not available), so the recorded state
+                            // is never branded a source error and the operator gets both
+                            // identities in one line.
+                            if (!string.Equals(
+                                    release.FrameworkVersion,
+                                    NodeTypeCompilationHelpers.FrameworkVersion,
+                                    StringComparison.Ordinal))
+                            {
+                                logger?.LogError(
+                                    "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} was built "
+                                    + "against framework {ReleaseFramework} and this process is {LiveFramework} — "
+                                    + "refusing to adopt it. {Recovery}",
+                                    hubPath, requestedReleasePath,
+                                    release.FrameworkVersion, NodeTypeCompilationHelpers.FrameworkVersion,
+                                    NodeTypeBuildIdentity.RecoveryVerb);
+                                return Observable.Return(new ResolvedResponse(Fail(
+                                    null,
+                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}' was built against "
+                                    + $"framework '{release.FrameworkVersion}' and this process runs "
+                                    + $"'{NodeTypeCompilationHelpers.FrameworkVersion}'."), false,
+                                    Unavailable: true));
+                            }
                             // Use the persisted integer version the IAssemblyStore.Put
                             // used, not a parse of the display Version string.
                             var releaseVersion = release.AssemblyStoreVersion ?? 0;
@@ -162,6 +191,27 @@ internal static class NodeTypeContractHandler
                     && !string.IsNullOrEmpty(def.LatestAssemblyCollection)
                     && !string.IsNullOrEmpty(def.LatestAssemblyPath))
                 {
+                    // 🚨 ADOPT-TIME IDENTITY GATE (#3472). A record naming an assembly built for a
+                    // framework identity that is not this process's must never be hydrated: those
+                    // bytes would fail as a TypeLoadException inside a collectible ALC at
+                    // activation — no compile error, no overlay, nothing to grep — and the write-
+                    // back would restamp Ok over the foreign identity, which is the record shape
+                    // two CRM types wore through a two-and-a-half-hour client-facing outage.
+                    // Refusing is NOT "the type is dead": it takes the SAME branch a store miss
+                    // takes, which compiles the live source here and stamps this process's own
+                    // identity. On a store whose key carries the framework tag the miss already
+                    // happens; this makes the guarantee explicit rather than resting on an
+                    // eight-character substring inside one store implementation's glob.
+                    if (NodeTypeBuildIdentity.Refuses(def))
+                    {
+                        logger?.LogError(
+                            "{Summary} Compiling it here instead. {Recovery}",
+                            NodeTypeBuildIdentity.RefusalSummary(node.Path, def),
+                            NodeTypeBuildIdentity.RecoveryVerb);
+                        return compilationService.CompileAndGetConfigurations(node)
+                            .Select(result => new ResolvedResponse(
+                                BuildResponse(hubPath, node, result), true));
+                    }
                     var compileVersion = def.LastCompiledVersion ?? node.Version;
                     return ResolveAssembly(hub, def.LatestAssemblyCollection, node.Path, compileVersion)
                         .SelectMany(localPath =>
@@ -701,7 +751,30 @@ internal static class NodeTypeContractHandler
             // older-than-framework DLLs). Hydrate paths
             // (freshCompile=false) keep the persisted value — they
             // must never erase an ABI-staleness marker.
-            CompiledFrameworkVersion = freshCompile
+            //
+            // 🚨 AND THE IDENTITY TRAVELS WITH THE COORDINATES (#3472). ResolvedStoreVersion
+            // argues, three fields up, that "the path and the version are ONE reference, so they
+            // must come from ONE source" — pairing retained bytes with a key that was never
+            // theirs is the #1368 defect. The framework identity is the FOURTH member of that
+            // reference and it was left out of the rule: a hydrate that RESOLVED bytes carried a
+            // foreign stamp forward over them, producing a record that says Ok, names bytes the
+            // store just handed us, and declares those bytes unloadable. HasUsableBuild is then
+            // false forever, every per-instance activation takes the ABI-stale recompile path,
+            // and after MaxRecompileAttempts the instance binds the fallback configuration for
+            // the grain's whole life — "Area not found", under a green compilationStatus. That is
+            // the exact shape two CRM types wore on a client portal for two and a half hours on
+            // 2026-09-06.
+            //
+            // So the identity is decided by the SAME predicate the coordinates are: a reference
+            // that came from the response names bytes THIS process resolved, and this process
+            // resolved them under its own framework identity — the assembly store's key carries
+            // the framework tag, and NodeTypeBuildIdentity refuses the resolve outright when the
+            // record's identity is not ours. A reference that was RETAINED (the producer uploaded
+            // nothing: memory:// compile, Null store, unreadable bytes) keeps the persisted
+            // identity, because retained coordinates and a live identity would be the same
+            // record-names-something-that-is-not-there defect reached the other way round — and
+            // it is the only case where an ABI-staleness marker is real and must not be erased.
+            CompiledFrameworkVersion = freshCompile || ReferenceCameFromResponse(response)
                 ? NodeTypeCompilationHelpers.FrameworkVersion
                 : def.CompiledFrameworkVersion
         };
@@ -727,10 +800,27 @@ internal static class NodeTypeContractHandler
         // store, unreadable bytes). Taking the version from the response while the PATH fell
         // back to def would pair the retained bytes with a key that was never theirs — the same
         // record-names-an-empty-shelf defect, just reached the other way round.
+        => StoreVersionFromResponse(response)          // path came from the response: take its key
+           ?? def.LastCompiledVersion ?? curr.Version; // path retained: retain its key
+
+    /// <summary>
+    /// The store key the response CARRIES, or null when the producer supplied no reference at all.
+    /// Extracted so <see cref="ResolvedStoreVersion"/> and the
+    /// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/> stamp read the LITERAL same
+    /// predicate: the coordinates, the store key and the framework identity are one reference, and
+    /// two of them deciding "came from the response" differently is how a record starts describing
+    /// a build that is not the one being served (#1368, #3472).
+    /// </summary>
+    private static long? StoreVersionFromResponse(GetCompilationPathResponse response)
         => !string.IsNullOrEmpty(response.ContentPath)
            && long.TryParse(response.Version, out var v) && v > 0
-            ? v                                        // path came from the response: take its key
-            : def.LastCompiledVersion ?? curr.Version; // path retained: retain its key
+            ? v
+            : null;
+
+    /// <summary>Whether this response carried a store reference of its own — see
+    /// <see cref="StoreVersionFromResponse"/>.</summary>
+    private static bool ReferenceCameFromResponse(GetCompilationPathResponse response)
+        => StoreVersionFromResponse(response) is not null;
 
     private static GetCompilationPathResponse Fail(string? version, string error, ActivityLog? log = null) =>
         new(Success: false,

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildIdentityAdmission.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildIdentityAdmission.md
@@ -1,0 +1,212 @@
+---
+Name: Build Identity Admission
+Category: Architecture
+Description: A process must refuse a compiled assembly keyed to a framework build identity that is not its own — and compilationStatus must not read Ok for a type whose hubs cannot activate. The adoption half of the 2026-09-06 outage.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 4 6v6c0 4.5 3.2 8.3 8 9 4.8-.7 8-4.5 8-9V6z"/><path d="m9 12 2 2 4-4"/></svg>
+---
+
+> **"a NodeType's self-report is not proof"** — AGENTS.md, written before the day it was proved.
+
+[Mesh Admission](/Doc/Architecture/MeshAdmission) is the **membership** half of the 2026-09-06
+outage: a pod its readiness gate had refused kept running and kept publishing. This is the
+**adoption** half — what a healthy process must refuse to *load*, and what it may honestly *report*
+about a build it cannot load. The two compose; neither subsumes the other
+([#3472](https://github.com/Systemorph/MeshWeaver/issues/3472)).
+
+## What happened
+
+`Crm/Offer` and `Crm/Opportunity` on `memex.systemorph.com` reported `compilationStatus: Ok`
+throughout a two-and-a-half-hour window in which every one of their per-instance hubs was dead —
+`Crm/Offer` timed out on activation, `Crm/Opportunity` answered *"Area not found"*. Their two
+healthy siblings, compiled from the same sources, differed in exactly one field:
+
+| type | `compiledFrameworkVersion` | behaviour |
+|---|---|---|
+| `Crm/Client`, `Crm/Mail` | `s2f227642d…` | renders |
+| `Crm/Offer`, `Crm/Opportunity` | **`sc273ee39f…`** | dead |
+
+Every deal page and every offer page of a client portal was down, and every instrument that a
+deploy is gated on read green.
+
+## Why `Ok` was a lie, stated precisely
+
+🚨 **`CompilationStatus.Ok` is a claim SCOPED to `CompiledFrameworkVersion`, persisted as though it
+were absolute.**
+
+- *"The last compile succeeded"* is true, and process-independent.
+- *"These bytes can be loaded"* is only ever answerable **relative to a process**.
+
+The record has always carried both halves — the verdict and its scope — in two separate fields.
+Every instrument read the first one. That is the entire defect, and it is why no amount of care at
+the **writer** fixes it alone: the pod that wrote `Ok` could load what it had just built. It was
+telling the truth about itself.
+
+So the answer is split, and each half is necessary.
+
+## Half one — the writer: the identity travels with the coordinates
+
+`NodeTypeContractHandler.ResolvedStoreVersion` already argues the rule, for the store-key version:
+
+> The path and the version are ONE reference, so they must come from ONE source. Taking the version
+> from the response while the PATH fell back to `def` would pair the retained bytes with a key that
+> was never theirs.
+
+**The framework identity is the fourth member of that reference, and it was left out of it.**
+`ApplyResolvedSuccess` decided the assembly path and the store key by "did the response carry a
+reference", and decided `CompiledFrameworkVersion` by a different predicate (`freshCompile`). On the
+HYDRATE path those disagree — and a hydrate only *succeeds* when the assembly store resolved bytes,
+under a key whose framework tag is this process's own. The result:
+
+```text
+compilationStatus        Ok
+latestAssemblyPath       <bytes the store just handed us>
+compiledFrameworkVersion <somebody ELSE's identity>
+```
+
+A record that says `Ok`, names loadable bytes, and declares those bytes unloadable.
+`HasUsableBuild` is then false **forever**; every per-instance activation takes the ABI-stale
+recompile path; after `MaxRecompileAttempts` the instance binds the fallback configuration — and a
+hub resolves its configuration exactly once, so that is *"Area not found"* for the grain's whole
+lifetime. Worse, this handler **races** the activity write-back, so it re-imposes the foreign stamp
+over each correct one and the type never converges.
+
+The fix is one predicate for all four fields, extracted so they cannot drift:
+
+```csharp
+private static long? StoreVersionFromResponse(GetCompilationPathResponse response)
+    => !string.IsNullOrEmpty(response.ContentPath)
+       && long.TryParse(response.Version, out var v) && v > 0 ? v : null;
+
+CompiledFrameworkVersion = freshCompile || ReferenceCameFromResponse(response)
+    ? NodeTypeCompilationHelpers.FrameworkVersion
+    : def.CompiledFrameworkVersion
+```
+
+🚨 **The retained branch still retains.** When the producer supplied no reference (a `memory://`
+compile, a Null store, unreadable bytes) the coordinates are kept — and the identity is kept *with*
+them. That is the one case where an ABI-staleness marker is real, and stamping a live identity over
+retained coordinates would be the same record-describes-a-build-it-is-not-serving defect reached
+the other way round.
+
+## Half two — the reader: `NodeTypeBuildIdentity`
+
+Foreign-`Ok` records still **arrive**, and no writer-side rule can stop them:
+
+- a peer replica on another image ([#3395](https://github.com/Systemorph/MeshWeaver/issues/3395)'s
+  ping-pong — the incident's own mechanism);
+- a node repo that **commits** a record (MeshWeaver.Plugins ships `Store/Catalog` with a July
+  framework hash);
+- a prebuilt bundle.
+
+`NodeTypeBuildIdentity` (`src/MeshWeaver.Compiler.Pipeline/NodeTypeBuildIdentity.cs`) is one pure
+predicate with two consumers — deliberately the shape `MeshPublicationGate` uses, and for the same
+reason: the defect is a **divergence**, so the refusal and the reported status are derived from one
+comparison rather than being two tables that can drift.
+
+| call | answers |
+|---|---|
+| `RefusalReason(def[, live])` | why this process may not load the build the record names, or `null` |
+| `ReportedStatus(def[, live])` | the status this process may honestly report |
+
+`ReportedStatus` folds the pair: a successful build with a recorded assembly whose identity is not
+this process's reports **`CompilationStatus.Foreign`**; everything else passes through untouched.
+
+### Why a fourth state rather than reusing one
+
+Each candidate carries a different remedy, and all three are wrong:
+
+| state | says | why not |
+|---|---|---|
+| `Error` | *correct the code* | the code is fine — conflating the two is [#641](https://github.com/Systemorph/MeshWeaver/issues/641)'s defect in the other direction |
+| `Unavailable` | *retry or wait* | the state is fully determined, and waiting is precisely what does not help |
+| `Ok` | *it is fine* | the lie |
+
+`Foreign` says **"recompile here"**, which is the remedy — and which the compile watcher already
+drives on its own.
+
+### 🚨 It is DERIVED, and it is never persisted
+
+Nothing writes `Foreign`. Writing a reader-relative verdict into a shared record is exactly how
+#3395's ping-pong was made — two replicas, two identities, each correctly overwriting the other's
+answer forever. **The record keeps saying what the compiler did; only the report is scoped.** That
+is also what makes this compose with `MeshPublicationGate` instead of duplicating it: that gate
+decides *whether* this process may publish; this one adds nothing to publish.
+
+## Where it is enforced
+
+`NodeTypeCompilationHelpers.HasUsableBuild` has carried the framework equality since
+[#464](https://github.com/Systemorph/MeshWeaver/issues/464) — on **one** of the seven paths that
+load a NodeType's assembly. The other six gated on the two assembly-coordinate fields being
+populated, or on `CompilationStatus == Ok` alone:
+
+| site | was gated on |
+|---|---|
+| `NodeTypeEnrichmentHelpers` — pinned release | `RequestedReleasePath` set. `NodeTypeRelease.FrameworkVersion` exists and nothing read it |
+| `NodeTypeContractHandler` — pinned release | the same, answering `GetCompilationPathRequest` |
+| `NodeTypeContractHandler` — published-release hydrate | `LatestReleasePath` + coordinates |
+| `MeshDataSource.HandleNodeTypeSchemaRequest` | coordinates |
+| `NodeTypeDataModelAreas.ResolveInstanceHubConfig` | coordinates |
+| `MeshOperations.ResolveHubConfigForSchema` | `CompilationStatus == Ok` |
+| `CellSurfaceAssemblyProvider` | `CompilationStatus == Ok` — and it takes a lifetime **lease** |
+
+🚨 **What stood between those and a foreign load was an eight-character substring inside one store
+implementation's glob.** `FileSystemAssemblyStore.TryGetAssemblyPath` looks up
+`v{version}-{FrameworkTag}-*.dll`, so a foreign-identity record already misses there — which is why
+the six were never observed to break. That is a property nothing asserted, in one of two
+implementations; the other, `BlobAssemblyStore`, ships in a module this repository cannot compile.
+An implicit guard is not a guard.
+
+**Refusing is not "the type is dead".** Every site takes exactly the branch a **store miss** already
+takes — which is a local compile, a fallback configuration, or a no-answer — so behaviour on a
+tag-carrying store is unchanged and the operator gains a line naming **both** identities. Naming
+only one is how the bake gate's *"regressed on this image"* sent three investigations to the wrong
+repository on the same night.
+
+## Where the honest status is reported
+
+| surface | before | now |
+|---|---|---|
+| `get_diagnostics` (`FormatDiagnosticsFromDef`) | `status: "Ok"` | `status: "Foreign"`, with both identities in `error` |
+| compile-progress overlay | `Ok` ⇒ **redirect** to the page that cannot render, which bounces back | holds, and says why — localized (`ui.compileForeignFramework`) |
+| NodeType overview progress line | ✓ **Compiled**, printing the foreign hash beside the green tick as decoration | ⚠ built for another platform build |
+
+## 🚨 What this does NOT reach, measured
+
+**`search 'nodeType:NodeType compilationStatus:Error'` cannot see this, and on some hosts it cannot
+see anything.** Two findings, both measured while building this change:
+
+1. **The sweep never returns the value.** `MeshOperations`' search envelope projects
+   `Path/Name/NodeType/Version/LastModified` only — `compilationStatus` is a WHERE clause and
+   nothing more. To read the value you must `get` the node or call `get_diagnostics`.
+2. 🚨 **On an in-memory or FileSystem-backed host the filter matches NOTHING.**
+   `QueryEvaluator.GetDirectPropertyValue` resolves a selector by reflection against `MeshNode`,
+   which has no `compilationStatus` property and no `Content` fallback — so the comparison is
+   `null == "Error"`, and the sweep returns `count: 0` for a mesh full of broken types. The
+   translation that makes the sweep work lives in `PostgreSqlSqlGenerator`, which is not in this
+   repository. **A green sweep on a dev Monolith is evidence of nothing.**
+
+Both are noted here rather than fixed: changing the query evaluator's selector resolution changes
+every query in the platform, and the projection is what keeps a search result small. The instrument
+that *is* reader-relative is `get_diagnostics`, which now answers `Foreign`.
+
+## What this does not fix
+
+- **It does not stop two images sharing one mesh.** That is
+  [Mesh Admission](/Doc/Architecture/MeshAdmission) (membership) and
+  [#3479](https://github.com/Systemorph/MeshWeaver/issues/3479) (roll selection).
+- **It does not bind a record to bytes it does not name.** When the framework moved and the store
+  holds bytes under the live tag, `DecideStaleBuildAction` still answers `Skip` — nothing here has
+  hashed those bytes, and restamping on them would assert validity for a build the lane never
+  examined. That boundary is unchanged and deliberate; see `ResolveStaleBuildAction`. It is also
+  why a record can sit at `Ok` with a foreign identity **indefinitely**, which is what makes half
+  two necessary rather than cosmetic.
+- **It does not make a foreign record heal without an activation.** The instance-activation
+  self-heal is still the path that corrects it.
+
+## Related
+
+[Mesh Admission](/Doc/Architecture/MeshAdmission) ·
+[NodeType Compilation](/Doc/Architecture/NodeTypeCompilation) ·
+[Module Set Convergence](/Doc/Architecture/ModuleSetConvergence) ·
+[Modules](/Doc/Architecture/Modules) ·
+[Reading CI Signals](/Doc/Architecture/ReadingCiSignals)

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshAdmission.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshAdmission.md
@@ -185,6 +185,19 @@ It is a **maintainer-level call and it is decidable now**: with admission derive
 predicate, "exit when `Admission is Refused`" is a single call in
 `DynamicTypePreWarmerHostedService`'s terminal handler. It is deliberately not taken here.
 
+## The other half: what a HEALTHY process must refuse to adopt
+
+This page is about **membership** — a refused process must not publish. Its counterpart is
+**adoption**: a healthy, admitted process must never *load* an assembly compiled for a framework
+build identity that is not its own, and must never report `compilationStatus: Ok` for a type whose
+hubs cannot activate. Neither subsumes the other — this one stops a refused process producing the
+foreign records, that one stops any process consuming them, whatever their origin (a peer replica,
+a node repo's committed record, a prebuilt bundle).
+
+See [Build Identity Admission](/Doc/Architecture/BuildIdentityAdmission) for the gate, for why
+`Ok` was a lie that no writer-side rule can fix alone, and for the derived-never-persisted
+`CompilationStatus.Foreign` that keeps a reader-relative verdict out of the shared record.
+
 ## What this does not fix
 
 - **It does not stop a bad image being CHOSEN.** That is roll selection —
@@ -199,6 +212,7 @@ predicate, "exit when `Admission is Refused`" is a single call in
 
 ## Related
 
+[Build Identity Admission](/Doc/Architecture/BuildIdentityAdmission) ·
 [Module Set Convergence](/Doc/Architecture/ModuleSetConvergence) ·
 [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation) ·
 [Modules](/Doc/Architecture/Modules) ·

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-page-no-longer-reports-ok-when-it-cannot-open.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-page-no-longer-reports-ok-when-it-cannot-open.md
@@ -1,0 +1,49 @@
+---
+Name: A type no longer reports "Ok" when its pages cannot open
+Category: Fix
+Description: A custom type could report a clean, successful build while every one of its pages was dead — because "the build succeeded" and "this portal can open it" are two different questions and only the first was being asked. The portal now refuses code built for a different platform version, says so plainly, and rebuilds it.
+Icon: ShieldError
+Order: -20260907
+---
+
+Your custom types are compiled by the portal, and the result is recorded on the type: *the build
+succeeded, here is the code it produced.* What that record never said is **which platform version
+the code was built for** — well, it did, in a separate field that nothing read alongside the
+verdict.
+
+So a type could sit there reporting a clean, successful build while every page of every record of
+that type was dead. On 2026-09-06 exactly that happened to two types on a client portal: their code
+had been built for a different platform version than the one actually serving, so no page could
+open — and the type's own status, the deploy checks, the diagnostics and the "compiling…" page all
+said it was fine. Every deal page and every offer page was down for two and a half hours behind a
+green tick.
+
+**"The build succeeded" and "this portal can open it" are different questions**, and the second one
+can only ever be answered by the portal asking it. Both are now answered:
+
+- **Code built for a different platform version is refused, not loaded.** Loading it would fail
+  deep inside the runtime in a way that produces no error at all — the page simply comes up empty,
+  permanently, for as long as that page's session lives. Every place the portal picks up compiled
+  code now checks first.
+- **Refusing does not mean the type is broken.** It falls back to compiling the type here, against
+  the version that is actually running — which is what already happens after any ordinary platform
+  update.
+- **The status stops claiming to be Ok.** A type in this state now reports a distinct state of its
+  own, naming both platform versions, in the diagnostics and on the type's page. It is deliberately
+  not reported as a compile *error*: nothing is wrong with your code, and telling you to fix it
+  would send you looking for a bug that is not there.
+- **The "compiling…" page stops bouncing you.** It used to read the green status and redirect you
+  straight back to the page that could not open, which sent you back to it. It now stays put and
+  explains, in your language.
+- **And the record itself was being written wrong.** In one case the portal loaded perfectly good
+  code and then wrote down someone else's platform version next to it, which pinned the type in
+  that state with nothing able to get it out. The version a record names now always comes from the
+  same place the code does.
+
+Nothing changes for a type whose code was built by the portal that is serving it, which is every
+type on a portal running one version.
+
+The full design — including why this needed a new state rather than a redefinition of "Ok", and why
+it is worked out fresh by each portal instead of being written onto the shared record — is in
+[Build Identity Admission](/Doc/Architecture/BuildIdentityAdmission), alongside its companion
+[Mesh Admission](/Doc/Architecture/MeshAdmission).

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1124,6 +1124,48 @@ internal static class NodeTypeEnrichmentHelpers
                                     activityPath: def.LastCompilationActivityPath),
                                 meshHub, nodeType, typeNode.Version, logger));
                     }
+                    // 🚨 ADOPT-TIME IDENTITY GATE (#3472). A release RECORDS the framework it
+                    // was built for and, until now, nothing read it: this branch resolved by
+                    // AssemblyStoreVersion and loaded whatever came back — ahead of the
+                    // HasUsableBuild gate that guards its non-pinned sibling a few lines below,
+                    // and this is the most directly armed of the six such paths (it configures a
+                    // live per-instance hub). Bytes from another framework generation would fail
+                    // as a TypeLoadException inside a collectible ALC, which the loader records as
+                    // an EMPTY configuration list — and a hub resolves its configuration exactly
+                    // once, so that instance serves "Area not found" for its whole lifetime.
+                    //
+                    // The answer is the one an unresolvable pin already gets: the assembly for
+                    // THIS framework is not available. Nothing is wrong with the source, so the
+                    // AssemblyUnavailable copy is right, and the overlay self-heals on a version
+                    // advance exactly as its siblings do. On a store whose key carries the
+                    // framework tag this is where the pin lands today anyway; what changes is
+                    // that the operator is told which two identities disagree.
+                    if (!string.Equals(
+                            release.FrameworkVersion,
+                            NodeTypeCompilationHelpers.FrameworkVersion,
+                            StringComparison.Ordinal))
+                    {
+                        logger?.LogError(
+                            "EnrichWithNodeType: pinned release {ReleasePath} for {NodeType} was built against "
+                            + "framework {ReleaseFramework} and this process is {LiveFramework} — refusing to "
+                            + "adopt it for instance '{InstancePath}'. {Recovery}",
+                            requestedReleasePath, nodeType, release.FrameworkVersion,
+                            NodeTypeCompilationHelpers.FrameworkVersion, node.Path,
+                            NodeTypeBuildIdentity.RecoveryVerb);
+                        var (foreignIntro, foreignCta, foreignGuidance) =
+                            OverlayCopy(OverlayCause.AssemblyUnavailable);
+                        return Observable.Return(
+                            WithOverlaySelfHeal(
+                                WithCompilationErrorOverlay(node, nodeType,
+                                    $"Pinned release '{requestedReleasePath}' was built against framework "
+                                    + $"'{release.FrameworkVersion}' and this process runs "
+                                    + $"'{NodeTypeCompilationHelpers.FrameworkVersion}'.",
+                                    guidance: foreignGuidance,
+                                    intro: foreignIntro,
+                                    callToAction: foreignCta,
+                                    activityPath: def.LastCompilationActivityPath),
+                                meshHub, nodeType, typeNode.Version, logger));
+                    }
                     // Use the persisted integer version the IAssemblyStore.Put used,
                     // not a parse of the display Version string.
                     var releaseVersion = release.AssemblyStoreVersion ?? 0;

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1538,12 +1538,33 @@ public static class MeshDataSourceExtensions
             .Timeout(TimeSpan.FromSeconds(10))
             .SelectMany(node =>
             {
-                if (node?.Content is not NodeTypeDefinition def
+                // ContentAs, never a CLR type test: a NodeType node whose Content arrived
+                // un-materialized IS a NodeType node, and reading it with `is` answers "no
+                // definition" for a type that has one (AGENTS.md, the untyped-payload rule).
+                var def = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+                if (def is null
                     || string.IsNullOrEmpty(def.LatestAssemblyCollection)
                     || string.IsNullOrEmpty(def.LatestAssemblyPath))
                     return Observable.Empty<GetDataResponse>();
 
-                var version = def.LastCompiledVersion ?? node.Version;
+                // 🚨 ADOPT-TIME IDENTITY GATE (#3472). The schema probe loads the type's assembly
+                // and spins a transient hub over the types it finds; it never consulted
+                // HasUsableBuild, so a record naming a foreign-framework build was loaded here on
+                // the two coordinate fields alone. Refusing answers exactly as a store miss does
+                // (no schema response — the caller's own not-found path), which is where this
+                // lands today on any store whose key carries the framework tag.
+                if (NodeTypeBuildIdentity.Refuses(def))
+                {
+                    hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger(typeof(MeshDataSourceExtensions))
+                        .LogError(
+                        "{Summary} No schema is answered from those bytes. {Recovery}",
+                        NodeTypeBuildIdentity.RefusalSummary(node!.Path, def),
+                        NodeTypeBuildIdentity.RecoveryVerb);
+                    return Observable.Empty<GetDataResponse>();
+                }
+
+                var version = def.LastCompiledVersion ?? node!.Version;
                 var store = string.Equals(def.LatestAssemblyCollection, FrameworkAssemblyStore.CollectionName, StringComparison.Ordinal)
                     ? (IAssemblyStore)FrameworkAssemblyStore.Instance
                     : hub.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;

--- a/src/MeshWeaver.Graph/NodeTypeDataModelAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeDataModelAreas.cs
@@ -193,6 +193,23 @@ internal static class NodeTypeDataModelAreas
         var def = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
         var compilationService = hub.ServiceProvider.GetService<IMeshNodeCompilationService>();
 
+        // 🚨 ADOPT-TIME IDENTITY GATE (#3472). This is one of the six load paths that never
+        // consulted NodeTypeCompilationHelpers.HasUsableBuild, so a record naming an assembly
+        // built for another framework generation was loaded here on nothing but the two
+        // coordinate fields being populated. Refusing takes the branch a store miss already
+        // takes — the node's own (static / previously bound) configuration — so a data-model
+        // area degrades exactly as it does when the bytes are cold, never worse.
+        if (def != null && NodeTypeBuildIdentity.Refuses(def))
+        {
+            hub.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(NodeTypeDataModelAreas))
+                .LogError(
+                "{Summary} The data-model area falls back to this node's own configuration. {Recovery}",
+                NodeTypeBuildIdentity.RefusalSummary(node.Path, def),
+                NodeTypeBuildIdentity.RecoveryVerb);
+            return Observable.Return(node.HubConfiguration);
+        }
+
         if (def != null
             && compilationService != null
             && !string.IsNullOrEmpty(def.LatestAssemblyCollection)

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -174,14 +174,22 @@ public static class NodeTypeLayoutAreas
                             $"*{host.Localize("ui.noNodeTypeDefinition")}*")
                         .WithId(AreaFrameClassifier.CompileProgressId);
 
+                // 🚨 THE SCOPED STATUS, never the raw field (#3472). `Ok` is a claim scoped
+                // to CompiledFrameworkVersion: a record that compiled successfully for ANOTHER
+                // platform build reads Ok here and used to redirect the viewer straight back to
+                // the page that cannot render — which then bounces them back to this overlay.
+                // That loop is what a client saw for two and a half hours on 2026-09-06 while
+                // every instrument reported green.
+                var reportedStatus = NodeTypeBuildIdentity.ReportedStatus(def);
+
                 // Compile finished cleanly → redirect to the now-addressable page. The user
                 // only landed here because activation could not complete mid-compile; once
                 // it's Ok the real view resolves, so send them there. "When it ends, we redirect."
-                if (def.CompilationStatus == CompilationStatus.Ok)
+                if (reportedStatus == CompilationStatus.Ok)
                     return (UiControl?)Controls.Redirect(redirectOnOk);
 
                 var nodeName = node.Name ?? node.Id;
-                var (icon, header, body) = RenderProgressLines(def);
+                var (icon, header, body) = RenderProgressLines(host, def, reportedStatus);
                 var stack = Controls.Stack
                     .WithStyle("padding: 12px; gap: 8px;")
                     // Title carries the NodeType name: "⏳ Compiling… — <NodeType>".
@@ -399,7 +407,14 @@ public static class NodeTypeLayoutAreas
         return views;
     }
 
-    private static (string Icon, string Header, string Body) RenderProgressLines(NodeTypeDefinition def)
+    /// <param name="reportedStatus">The status this PROCESS may honestly report —
+    /// <c>NodeTypeBuildIdentity.ReportedStatus</c>, never the raw field. 🚨 The green
+    /// "✓ Compiled" line below was rendered from the raw <c>CompilationStatus</c> alone and
+    /// PRINTED <c>CompiledFrameworkVersion</c> beside it as decoration, without ever comparing it
+    /// — so a type whose every per-instance hub was dead showed the operator a green tick with
+    /// the evidence against it in the same sentence (#3472).</param>
+    private static (string Icon, string Header, string Body) RenderProgressLines(
+        LayoutAreaHost host, NodeTypeDefinition def, CompilationStatus? reportedStatus)
     {
         var hasSource = !string.IsNullOrWhiteSpace(def.Configuration)
             || !string.IsNullOrWhiteSpace(def.HubConfiguration)
@@ -409,7 +424,7 @@ public static class NodeTypeLayoutAreas
         // routing grain re-used the existing assembly without re-running Roslyn.
         // Surface that as a discrete state so the operator sees "we didn't burn
         // CPU to re-prove this assembly works."
-        if (def.CompilationStatus == CompilationStatus.Ok
+        if (reportedStatus == CompilationStatus.Ok
             && !string.IsNullOrEmpty(def.LatestAssemblyCollection)
             && !string.IsNullOrEmpty(def.LatestAssemblyPath))
         {
@@ -419,8 +434,16 @@ public static class NodeTypeLayoutAreas
                 $"Using cached assembly `{coll}/{path}` (compile version `{def.LastCompiledVersion}`, framework `{def.CompiledFrameworkVersion}`).");
         }
 
-        return def.CompilationStatus switch
+        return reportedStatus switch
         {
+            // 🚨 Localized, unlike its English-only siblings on this operator page: this
+            // arm is the one a VIEWER of an ordinary content page reaches, because a foreign
+            // build is precisely the state in which every instance of the type falls back to
+            // this overlay instead of rendering.
+            CompilationStatus.Foreign => ("⚠", host.Localize("ui.compileForeignFramework"),
+                host.Localize("ui.compileForeignFrameworkBody",
+                    Short(def.CompiledFrameworkVersion),
+                    Short(NodeTypeCompilationHelpers.FrameworkVersion))),
             CompilationStatus.Compiling => ("⏳", "Compiling…",
                 $"Running Roslyn against {(def.Sources?.Count ?? 0)} source binding(s). The activity log below streams diagnostics live."),
             CompilationStatus.Pending => ("▶", "Compile queued",
@@ -444,6 +467,13 @@ public static class NodeTypeLayoutAreas
                    "This NodeType has no `Configuration` / `HubConfiguration` / `Sources` — instances activate against the default node-hub config.")
         };
     }
+
+    /// <summary>First eight characters of a framework build identity — the same width the
+    /// assembly-store filename tag carries, so a page and a DLL name compare by eye.</summary>
+    private static string Short(string? identity)
+        => string.IsNullOrEmpty(identity)
+            ? "(none)"
+            : identity[..Math.Min(8, identity.Length)];
 
     /// <summary>
     /// Shared shell for every primary NodeType area: a horizontal splitter with the

--- a/src/MeshWeaver.Mesh.Contract/Services/CompilationStatus.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/CompilationStatus.cs
@@ -52,5 +52,32 @@ public enum CompilationStatus
     /// Appended LAST so the persisted ordinal of every existing member is
     /// unchanged.</para>
     /// </summary>
-    Unavailable
+    Unavailable,
+
+    /// <summary>
+    /// 🚨 <b>DERIVED, NEVER PERSISTED.</b> The last compile SUCCEEDED — for a framework build
+    /// identity that is not this process's, so the bytes it named cannot be loaded here. Nothing is
+    /// wrong with the source and nothing is unavailable; the remedy is a local recompile against
+    /// the live framework, which the compile watcher drives on its own.
+    ///
+    /// <para><b>Why a fourth state rather than reusing one.</b> Each of the three candidates
+    /// carries a different remedy, and all three are wrong here.
+    /// <see cref="Error"/> says <i>correct the code</i> — the code is fine, and conflating the two
+    /// is exactly the #641 defect in the other direction. <see cref="Unavailable"/> says <i>retry
+    /// or wait</i> — the state is fully determined and waiting is precisely what does not help.
+    /// <see cref="Ok"/> is the lie this member exists to stop: on 2026-09-06 two CRM types on a
+    /// client portal read <c>Ok</c> for two and a half hours while every one of their per-instance
+    /// hubs was dead, because <c>Ok</c> is a claim scoped to
+    /// <c>NodeTypeDefinition.CompiledFrameworkVersion</c> and every instrument read only the
+    /// verdict, never its scope (Systemorph/MeshWeaver#3472).</para>
+    ///
+    /// <para>🚨 <b>It is computed by the READER and is never written to a record.</b> "Can this
+    /// build be loaded" is answerable only relative to a process, so two replicas on two images
+    /// legitimately disagree — and persisting a reader-relative verdict into a shared record is how
+    /// the same incident's ping-pong (#3395) was made. The record keeps saying what the compiler
+    /// did; only the report is scoped. <c>NodeTypeBuildIdentity.ReportedStatus</c> is the one
+    /// function that derives it. Appended LAST so the persisted ordinal of every existing member is
+    /// unchanged.</para>
+    /// </summary>
+    Foreign
 }

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -2818,7 +2818,24 @@ public class MeshOperations
             .Timeout(TimeSpan.FromSeconds(5))
             .SelectMany(node =>
             {
-                var def = (NodeTypeDefinition)node!.Content!;
+                // ContentAs, never a cast: the Where above already accepted this node, but the
+                // value can still arrive as raw JSON on a hub that did not register the type.
+                var def = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+                if (def is null)
+                    return Observable.Return<NodeCompilationResult?>(null);
+                // 🚨 ADOPT-TIME IDENTITY GATE (#3472). One of the six load paths that gated on
+                // CompilationStatus == Ok alone. Ok is a claim SCOPED to CompiledFrameworkVersion,
+                // and reading only the verdict is what let two CRM types report green through a
+                // two-and-a-half-hour outage. Refusing answers as a store miss does — no hub
+                // configuration, so the schema falls back to the node's own registrations.
+                if (NodeTypeBuildIdentity.Refuses(def))
+                {
+                    logger.LogError(
+                        "{Summary} No hub configuration is recovered from those bytes for the schema probe. {Recovery}",
+                        NodeTypeBuildIdentity.RefusalSummary(node!.Path, def),
+                        NodeTypeBuildIdentity.RecoveryVerb);
+                    return Observable.Return<NodeCompilationResult?>(null);
+                }
                 var version = def.LastCompiledVersion ?? node.Version;
                 var store = string.Equals(def.LatestAssemblyCollection, FrameworkAssemblyStore.CollectionName, StringComparison.Ordinal)
                     ? (IAssemblyStore)FrameworkAssemblyStore.Instance
@@ -4090,13 +4107,23 @@ public class MeshOperations
     private string FormatDiagnosticsFromDef(
         Graph.Configuration.NodeTypeDefinition def, string nodeTypePath)
     {
-        var status = def.CompilationStatus ?? CompilationStatus.Unknown;
+        // 🚨 THE SCOPED STATUS, not the raw field (#3472). `Ok` is a claim scoped to
+        // NodeTypeDefinition.CompiledFrameworkVersion, and reporting the verdict without its
+        // scope is what let two CRM types answer green for two and a half hours while every one
+        // of their per-instance hubs was dead. NodeTypeBuildIdentity.ReportedStatus is the one
+        // function that folds the pair; it derives, it never writes, so two replicas on two
+        // images each answer honestly about THEMSELVES instead of overwriting each other.
+        var status = NodeTypeBuildIdentity.ReportedStatus(def) ?? CompilationStatus.Unknown;
         return FormatDiagnostics(
             status,
             nodeTypePath,
             error: status is CompilationStatus.Error or CompilationStatus.Unavailable
                 ? def.CompilationError
-                : null,
+                // Foreign carries WHICH two identities disagree — the pair is what makes the
+                // verdict checkable by hand against the CD run that produced the bytes.
+                : status is CompilationStatus.Foreign
+                    ? NodeTypeBuildIdentity.RefusalSummary(nodeTypePath, def)
+                    : null,
             startedAt: status == CompilationStatus.Compiling ? def.LastCompileStartedAt : null,
             lastCompiledAt: status == CompilationStatus.Ok ? def.LastCompileSucceededAt : null,
             hub.JsonSerializerOptions,
@@ -4699,6 +4726,29 @@ public class MeshOperations
                             + "assembly lookup timed out) — this is NOT a compile failure and NOTHING "
                             + "is known to be wrong with the source. See `error` for what timed out. "
                             + "Trigger a fresh compile and re-call GetDiagnostics."
+                    },
+                    options);
+            case CompilationStatus.Foreign:
+                // 🚨 #3472. The sibling of the Ok branch's #2471 warning, one axis over:
+                // there the record could describe a build a pod was not SERVING; here it
+                // describes a build this process cannot LOAD AT ALL. Never "Ok" — the compile
+                // did succeed, for somebody else — and never "Error", which would send the
+                // reader to correct source code that is fine (the #641 mistake).
+                return JsonSerializer.Serialize(
+                    new
+                    {
+                        status = "Foreign",
+                        nodeTypePath,
+                        error,
+                        mvid = publishedAssemblyMvid,
+                        message = "The last compile SUCCEEDED — for a framework build identity that "
+                            + "is NOT this process's, so these bytes cannot be loaded here and every "
+                            + "per-instance hub of this type binds the fallback configuration (which "
+                            + "renders as 'Area not found'). This is NOT a source error and NOT an "
+                            + "availability problem: see `error` for the two identities that disagree. "
+                            + "The compile watcher rebuilds it against the live framework on its own; "
+                            + "on a `Modules:RequirePrebuilt` mesh, rebake the package for THIS "
+                            + "identity."
                     },
                     options);
             case CompilationStatus.Unknown:

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -505,6 +505,8 @@
   "ui.compileTypesReady": "{0} von {1} Typen kompiliert",
   "ui.compileNowCompiling": "Wird gerade kompiliert: {0}",
   "ui.compileQueued": "{0} weitere in der Warteschlange",
+  "ui.compileForeignFramework": "Für einen anderen Plattform-Build kompiliert",
+  "ui.compileForeignFrameworkBody": "Die letzte Kompilierung war ERFOLGREICH — für den Plattform-Build `{0}`, während dieses Portal `{1}` ausführt. Diese Bytes können hier nicht geladen werden, daher lassen sich die Seiten dieses Typs noch nicht darstellen. **Am Code ist nichts falsch.** Dieser Typ wird automatisch gegen die laufende Plattform neu gebaut.",
   "ui.noNodeTypeDefinition": "Dieser Knoten hat keine NodeTypeDefinition — nichts zu kompilieren.",
   "ui.noConfiguration": "Keine Konfiguration definiert.",
   "ui.noConfigLambda": "Kein Konfigurations-Lambda definiert.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -505,6 +505,8 @@
   "ui.compileTypesReady": "{0} of {1} types compiled",
   "ui.compileNowCompiling": "Now compiling: {0}",
   "ui.compileQueued": "{0} more queued",
+  "ui.compileForeignFramework": "Built for another platform build",
+  "ui.compileForeignFrameworkBody": "The last compile SUCCEEDED — for platform build `{0}`, while this portal runs `{1}`. Those bytes cannot be loaded here, so the pages of this type cannot render yet. **Nothing is wrong with the code.** This type is rebuilt against the running platform automatically.",
   "ui.noNodeTypeDefinition": "This node has no NodeTypeDefinition — nothing to compile.",
   "ui.noConfiguration": "No Configuration defined.",
   "ui.noConfigLambda": "No configuration lambda defined.",

--- a/test/MeshWeaver.Compiler.Pipeline.Test/AdoptTimeFrameworkIdentityTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/AdoptTimeFrameworkIdentityTest.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Immutable;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🔴 <b>The adopt-time framework-identity guard — Systemorph/MeshWeaver#3472.</b>
+///
+/// <para>On 2026-09-06 <c>Crm/Offer</c> and <c>Crm/Opportunity</c> on a client portal reported
+/// <c>compilationStatus: Ok</c> for two and a half hours while every one of their per-instance hubs
+/// was dead — one timing out on activation, the other answering "Area not found". Their records
+/// named assemblies stamped <c>sc273ee39f…</c>; the replicas serving the portal ran
+/// <c>s2f227642d…</c>. Every deal page and every offer page was dead, and the NodeType's own
+/// self-report was green throughout.</para>
+///
+/// <para><b>The two properties this file pins</b>, which are the issue's two acceptance criteria:</para>
+///
+/// <list type="number">
+///   <item>An assembly compiled for framework identity X is never adopted or served by a process
+///     whose identity is Y — refused loudly, with a LOCAL COMPILE as the fallback.</item>
+///   <item>🚨 <c>compilationStatus</c> must not read <c>Ok</c> for a type whose hubs cannot
+///     activate. <c>Ok</c> is a claim SCOPED to
+///     <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>, persisted as though it were
+///     absolute; every instrument read the verdict and none of them read the scope.</item>
+/// </list>
+///
+/// <para>These are unit pins on the pure functions that decide both, so the properties are
+/// checkable with no mesh and no timing and a regression names itself.
+/// <c>ForeignFrameworkBuildIsRefusedAndRebuiltTest</c> carries the end-to-end half on a real mesh:
+/// a real compiled pack, its identity staged foreign, converging back to a live-identity build.</para>
+/// </summary>
+public class AdoptTimeFrameworkIdentityTest
+{
+    /// <summary>The identity the incident's serving replicas ran.</summary>
+    private const string Live = "s2f227642d43f78eab13720c4af06a1be";
+
+    /// <summary>The identity the incident's records named — a real, sealed-green CD set's
+    /// identity, which is the point: nothing about these bytes says "from a bad build".</summary>
+    private const string Foreign = "sc273ee39fdccbfc088f9aaf1fc548a9a";
+
+    /// <summary><c>Crm/Offer</c>'s record as measured at 20:21Z on 2026-09-06, reduced to the
+    /// fields that decide this: a successful compile, an assembly named, and the identity it was
+    /// built for.</summary>
+    private static NodeTypeDefinition TheOutageRecord() => new()
+    {
+        Configuration = "config => config.WithContentType<OfferContent>()",
+        Sources = ["shared=@Crm/Source"],
+        CompilationStatus = CompilationStatus.Ok,
+        LastCompiledVersion = 22488,
+        LatestReleasePath = "Crm/Offer/Release/20260906192804-abc",
+        LatestAssemblyCollection = "local",
+        LatestAssemblyPath = "Crm_Offer/v22488-sc273ee3-72a0cd75fee5.dll",
+        CompiledFrameworkVersion = Foreign,
+        CompiledSources = ImmutableDictionary<string, long>.Empty.Add("Crm/Source/Offer", 42),
+    };
+
+    private static NodeTypeDefinition Healthy() =>
+        TheOutageRecord() with
+        {
+            LatestAssemblyPath = "Crm_Offer/v22488-s2f22764-72a0cd75fee5.dll",
+            CompiledFrameworkVersion = Live,
+        };
+
+    // ── Criterion 1: the refusal ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AForeignBuildIsRefused_AndTheRefusalNamesBothIdentities()
+    {
+        var reason = NodeTypeBuildIdentity.RefusalReason(TheOutageRecord(), Live);
+
+        reason.Should().NotBeNull(
+            "an assembly compiled for one framework identity is not loadable by a process running "
+            + "another — the failure surfaces as a TypeLoadException inside a collectible ALC at "
+            + "activation, with no compile error and nothing to grep, and the loader records it as "
+            + "an EMPTY configuration list. A hub resolves its configuration exactly once, so that "
+            + "one refused load pins 'Area not found' for the grain's whole lifetime");
+        reason.Should().Contain("sc273ee3").And.Contain("s2f22764",
+            "BOTH identities, always. The pair is what makes a refusal checkable by hand against "
+            + "the CD run that produced the bytes; the 2026-09-06 bake gate named only one "
+            + "('regressed on this image') and sent three investigations to the wrong repository");
+    }
+
+    [Fact]
+    public void TheProcessesOwnBuildIsNotRefused()
+        => NodeTypeBuildIdentity.RefusalReason(Healthy(), Live).Should().BeNull(
+            "THE CONTROL. Without it every assertion in this file would pass just as well against "
+            + "a gate that refused everything — which would take every dynamic NodeType in the "
+            + "mesh off its own bytes");
+
+    [Fact]
+    public void ARecordThatNamesNoAssemblyIsNotRefused()
+    {
+        var neverBuilt = TheOutageRecord() with
+        {
+            CompilationStatus = null,
+            LatestAssemblyCollection = null,
+            LatestAssemblyPath = null,
+            CompiledFrameworkVersion = null,
+        };
+
+        NodeTypeBuildIdentity.RefusalReason(neverBuilt, Live).Should().BeNull(
+            "there is nothing to load, so there is nothing to refuse. The caller's own "
+            + "'no build recorded' branch is the right answer and it already exists at every "
+            + "site; answering a refusal here would report an identity problem for a type that "
+            + "has simply never been built");
+    }
+
+    [Fact]
+    public void ARecordThatNamesAnAssemblyButNoIdentityIsRefused()
+    {
+        var unstamped = TheOutageRecord() with { CompiledFrameworkVersion = null };
+
+        NodeTypeBuildIdentity.RefusalReason(unstamped, Live).Should().NotBeNull(
+            "an absent identity cannot be shown ABI-compatible with anything. This is deliberately "
+            + "the SAME clause NodeTypeCompilationHelpers.HasUsableBuild has applied since #464 on "
+            + "the one load path that was guarded — extending it to the six that were not is "
+            + "consistency, not a new policy");
+    }
+
+    [Fact]
+    public void ANullDefinitionIsNotAVerdict()
+        => NodeTypeBuildIdentity.RefusalReason(null, Live).Should().BeNull(
+            "nothing was read, so nothing was compared. A probe that cannot reach a verdict must "
+            + "not answer its scariest branch on its own inability to run (#890, #2901) — and "
+            + "every load site already binds no assembly when the definition is unreadable");
+
+    // ── Criterion 2: the status a process may honestly report ───────────────────────────────────
+
+    [Fact]
+    public void AForeignOkNeverReportsOk()
+    {
+        var def = TheOutageRecord();
+
+        def.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            "the RECORD keeps saying what the compiler did, and it did succeed — for somebody "
+            + "else. Nothing here rewrites it: a reader-relative verdict written into a shared "
+            + "record is how #3395's ping-pong was made, two replicas each correctly overwriting "
+            + "the other's answer forever");
+
+        NodeTypeBuildIdentity.ReportedStatus(def, Live).Should().Be(CompilationStatus.Foreign,
+            "🚨 THE REGRESSION. A status that says Ok for a type that cannot load is a lie with a "
+            + "green tick, and a whole fleet of instruments then repeats it — the deploy sweep, "
+            + "get_diagnostics, the compile-progress overlay's redirect and the NodeType overview "
+            + "page all read this field, and all four read green through the outage");
+    }
+
+    [Fact]
+    public void AnHonestOkStillReportsOk()
+        => NodeTypeBuildIdentity.ReportedStatus(Healthy(), Live).Should().Be(CompilationStatus.Ok,
+            "THE CONTROL for criterion 2. A gate that never says Ok would take every page in the "
+            + "mesh off the air, and would pass the assertion above unchanged");
+
+    [Fact]
+    public void AnOkThatRecordsNoAssemblyStaysOk()
+    {
+        var marker = new NodeTypeDefinition
+        {
+            Description = "a marker type — nothing was built, so nothing foreign is claimed",
+            CompilationStatus = CompilationStatus.Ok,
+        };
+
+        NodeTypeBuildIdentity.ReportedStatus(marker, Live).Should().Be(CompilationStatus.Ok,
+            "a type that claims no build cannot be claiming a foreign one");
+    }
+
+    [Theory]
+    [InlineData(CompilationStatus.Error)]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    [InlineData(CompilationStatus.Unavailable)]
+    [InlineData(CompilationStatus.Unknown)]
+    public void EveryOtherStatusPassesThroughUnchanged(CompilationStatus status)
+        => NodeTypeBuildIdentity.ReportedStatus(TheOutageRecord() with { CompilationStatus = status }, Live)
+            .Should().Be(status,
+                "each of these carries a DIFFERENT remedy and the scope does not change any of "
+                + "them: Error is still 'correct the code', Pending/Compiling are still in "
+                + "flight, Unavailable is still 'could not be determined'. Folding a framework "
+                + "mismatch into Error would send an author to fix source that compiles fine — "
+                + "the #641 defect, in the other direction");
+
+    [Fact]
+    public void ANullStatusStaysNull()
+        => NodeTypeBuildIdentity.ReportedStatus(TheOutageRecord() with { CompilationStatus = null }, Live)
+            .Should().BeNull(
+                "a never-compiled record is what the first-build kickoff keys on; forging a "
+                + "status here would suppress the compile it is waiting to start");
+
+    // ── The WRITER half: the identity travels with the coordinates ──────────────────────────────
+
+    /// <summary>
+    /// 🔴 <b>The live defect behind criterion 2, and it needs no second image to reach.</b>
+    ///
+    /// <para><c>NodeTypeContractHandler.ApplyResolvedSuccess</c> wrote
+    /// <c>CompilationStatus = Ok</c> on the HYDRATE path while carrying
+    /// <c>CompiledFrameworkVersion</c> forward unchanged. A hydrate only succeeds when the assembly
+    /// store RESOLVED bytes — under a key whose framework tag is this process's own — so the record
+    /// ended up saying <c>Ok</c>, naming bytes the store had just handed over, and declaring those
+    /// bytes unloadable. <c>HasUsableBuild</c> is then false forever, every per-instance activation
+    /// takes the ABI-stale recompile path, and after <c>MaxRecompileAttempts</c> the instance binds
+    /// the fallback configuration for the grain's whole life. That is "Area not found", under a
+    /// green <c>compilationStatus</c> — and the contract handler RACES the activity write-back, so
+    /// it re-imposes the foreign stamp over each correct one and the type never converges.</para>
+    ///
+    /// <para>The rule is the one <c>ResolvedStoreVersion</c> already argues for the store-key
+    /// version: "the path and the version are ONE reference, so they must come from ONE source".
+    /// The framework identity is the fourth member of that reference and was left out of it.</para>
+    /// </summary>
+    [Fact]
+    public void ResolvedSuccessNeverLeavesOkStandingOverAForeignIdentity()
+    {
+        var def = TheOutageRecord();
+        var node = new MeshNode("Offer", "Crm") { Content = def, NodeType = MeshNode.NodeTypePath };
+
+        // The hydrate response: the store resolved bytes for (path, LastCompiledVersion) — which
+        // it can only do under THIS process's framework tag — and the handler echoes the record's
+        // own coordinates back as the reference.
+        var hydrated = new GetCompilationPathResponse(
+            Success: true,
+            AssemblyLocation: "/cache/Crm_Offer/v22488.dll",
+            Collection: "local",
+            Version: "22488",
+            Error: null,
+            HubConfiguration: null)
+        { ContentPath = def.LatestAssemblyPath };
+
+        var stamped = NodeTypeContractHandler.ApplyResolvedSuccess(
+            def, hydrated, freshCompile: false, node);
+
+        stamped.CompiledFrameworkVersion.Should().Be(
+            NodeTypeCompilationHelpers.FrameworkVersion,
+            "the identity travels with the coordinates. This write took its assembly path and its "
+            + "store key from the RESPONSE, so it is describing bytes this process resolved under "
+            + "its own framework tag — stamping a foreign identity over them fabricates an "
+            + "ABI-staleness the store has just disproved, and pins the type in a state nothing "
+            + "converges out of");
+
+        NodeTypeBuildIdentity.ReportedStatus(stamped).Should().Be(CompilationStatus.Ok,
+            "and the whole point of fixing the writer is that the record it leaves behind is one "
+            + "this process can honestly report Ok for");
+    }
+
+    /// <summary>
+    /// The other half of the same rule, and the reason it is not simply "always stamp live": when
+    /// the producer supplied NO reference (a <c>memory://</c> compile, a Null store, unreadable
+    /// bytes) the coordinates are RETAINED — and a live identity over retained coordinates would
+    /// be the same record-describes-a-build-it-is-not-serving defect reached the other way round.
+    /// This is the only case where an ABI-staleness marker is real, and it must not be erased.
+    /// </summary>
+    [Fact]
+    public void ResolvedSuccessOnARetainedReferenceKeepsTheStaleMarker()
+    {
+        var def = TheOutageRecord();
+        var node = new MeshNode("Offer", "Crm") { Content = def, NodeType = MeshNode.NodeTypePath };
+
+        var noReference = new GetCompilationPathResponse(
+            Success: true,
+            AssemblyLocation: null,
+            Collection: null,
+            Version: null,
+            Error: null,
+            HubConfiguration: null);
+
+        var stamped = NodeTypeContractHandler.ApplyResolvedSuccess(
+            def, noReference, freshCompile: false, node);
+
+        stamped.LatestAssemblyPath.Should().Be(def.LatestAssemblyPath,
+            "nothing was uploaded, so the persisted coordinates are retained — the existing rule");
+        stamped.CompiledFrameworkVersion.Should().Be(Foreign,
+            "and the identity is retained WITH them. The two fields are one reference and they "
+            + "must come from one source; deciding 'came from the response' differently for the "
+            + "path and for the identity is how a record starts describing a build that is not "
+            + "the one being served (#1368)");
+    }
+
+    /// <summary>
+    /// #2895's no-op, preserved. A hydrate of a record that already names this process's identity
+    /// must still reproduce the persisted definition EXACTLY, so
+    /// <c>MeshNodeStreamExtensions.UpdateOwn</c>'s <c>SerializedEquals</c> gate absorbs the whole
+    /// write — no node version, no change-feed fan-out, no Postgres row. Kept here as well as in
+    /// <c>HydrateIsNotACompileTest</c> because this change touches the very field that decides it.
+    /// </summary>
+    [Fact]
+    public void AHydrateOfOurOwnBuildIsStillANoOp()
+    {
+        var def = Healthy() with { CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion };
+        var node = new MeshNode("Offer", "Crm") { Content = def, NodeType = MeshNode.NodeTypePath };
+
+        var hydrated = new GetCompilationPathResponse(
+            Success: true,
+            AssemblyLocation: "/cache/Crm_Offer/v22488.dll",
+            Collection: def.LatestAssemblyCollection,
+            Version: "22488",
+            Error: null,
+            HubConfiguration: null)
+        { ContentPath = def.LatestAssemblyPath };
+
+        NodeTypeContractHandler.ApplyResolvedSuccess(def, hydrated, freshCompile: false, node)
+            .Should().Be(def,
+                "a hydrate that observed no new fact must mint no version. The identity stamp is "
+                + "the live one either way here, so the write still reproduces what is persisted");
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ForeignFrameworkBuildIsRefusedTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ForeignFrameworkBuildIsRefusedTest.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Kernel.Hub;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🔴 <b>The outage shape, end to end on a real mesh — Systemorph/MeshWeaver#3472.</b>
+///
+/// <para>An assembly published under framework identity X, a process running identity Y: on
+/// 2026-09-06 that pairing killed every deal page and every offer page of a client portal for two
+/// and a half hours, while <c>compilationStatus</c> read <c>Ok</c> on both types throughout.</para>
+///
+/// <para><b>Why the cell surface is the site under test.</b> It is the most directly armed load
+/// path in the platform — it loads straight through <c>NodeAssemblyLoadContext</c> with no
+/// enrichment, takes a lifetime LEASE that keeps the assembly mapped for the whole session, and
+/// from that moment every script submission can call the pack's functions by bare name. It is also
+/// one of the six load paths that gated on <c>CompilationStatus == Ok</c> alone and never consulted
+/// <c>NodeTypeCompilationHelpers.HasUsableBuild</c>, which is where the framework comparison lived.
+/// <c>CellSurfaceRefusedBuildTest</c> is its twin on the orthogonal axis (bytes vs SOURCE, #2820);
+/// this one is bytes vs FRAMEWORK.</para>
+///
+/// <para>🚨 <b>A controlled experiment, not one observation.</b> The pack is compiled FOR REAL by
+/// this mesh and proved to be on the cell surface first; the refusal arm then differs from it in
+/// EXACTLY one field of the NodeType node — <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>
+/// — with the bytes, the assembly coordinates and <c>CompilationStatus.Ok</c> untouched. Asserting
+/// only the refusal would pass just as well against a provider that had stopped joining anything at
+/// all, which would silently empty every kernel session's reference set.</para>
+/// </summary>
+public class ForeignFrameworkBuildIsRefusedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string TypePath = "type/ForeignFrameworkPack";
+
+    /// <summary>The identity the incident's records named. Any value that is not this process's own
+    /// would do; using the real one keeps the test readable against the issue.</summary>
+    private const string AnotherProcessesIdentity = "sc273ee39fdccbfc088f9aaf1fc548a9a";
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private ICellSurfaceAssemblyProvider Provider =>
+        Mesh.ServiceProvider.GetRequiredService<ICellSurfaceAssemblyProvider>();
+
+    private async Task<bool> CellSurfaceContainsThePack()
+    {
+        var resolved = await Provider.ResolveCellSurfaceAssemblies()
+            .Take(1)
+            .Should().Within(60.Seconds()).Emit("resolution always emits — worst case an empty set");
+        try
+        {
+            return resolved.Any(a =>
+                string.Equals(a.NodeTypePath, TypePath, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            foreach (var entry in resolved)
+                entry.Lease.Dispose();
+        }
+    }
+
+    private async Task<NodeTypeDefinition> ReadDefinition()
+    {
+        var node = await Mesh.GetMeshNodeStream(TypePath)
+            .Take(1)
+            .Should().Within(60.Seconds()).Emit("the NodeType node is readable");
+        return node.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)!;
+    }
+
+    [Fact(Timeout = 180_000)]
+    public async Task AnAssemblyBuiltForAnotherFrameworkIdentityIsNotServed_AndDoesNotReadOk()
+    {
+        await MeshService.CreateNode(MeshNode.FromPath(TypePath) with
+            {
+                Name = "ForeignFrameworkPack",
+                NodeType = MeshNode.NodeTypePath,
+                State = MeshNodeState.Active,
+                Content = new NodeTypeDefinition
+                {
+                    CellSurface = true,
+                    Configuration = "config => config.WithContentType<ForeignFrameworkPackContent>()"
+                },
+            })
+            .SelectMany(_ => MeshService.CreateNode(new MeshNode("api", $"{TypePath}/Source")
+            {
+                NodeType = "Code",
+                Name = "api",
+                State = MeshNodeState.Active,
+                Content = new CodeConfiguration
+                {
+                    Language = "csharp",
+                    Code = """
+                        public record ForeignFrameworkPackContent { public string Title { get; init; } = ""; }
+                        public static class ForeignFrameworkPackApi { public static int TheAnswer() => 7; }
+                        """,
+                },
+            }))
+            .Should().Within(60.Seconds()).Emit();
+
+        await Mesh.GetMeshNodeStream(TypePath)
+            .Should().Within(120.Seconds())
+            .Match(n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)
+                is { CompilationStatus: CompilationStatus.Ok or CompilationStatus.Error });
+
+        var honest = await ReadDefinition();
+        honest.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            $"the pack must compile; error: {honest.CompilationError}");
+
+        // ── THE CONTROL ARM ─────────────────────────────────────────────────────────────────────
+        // A record THIS mesh really produced, read by the process that produced it.
+        NodeTypeBuildIdentity.RefusalReason(honest).Should().BeNull(
+            "the gate must not refuse this process's own build — without this half every "
+            + "assertion below would pass against a gate that refused everything, which would "
+            + "take every dynamic NodeType in the mesh off its own bytes");
+        NodeTypeBuildIdentity.ReportedStatus(honest).Should().Be(CompilationStatus.Ok,
+            "and it must still report Ok for it");
+        (await CellSurfaceContainsThePack()).Should().BeTrue(
+            "a compiled cellSurface pack joins every session's reference set");
+
+        // ── CRITERION 2, on data the pipeline really wrote, with nothing mutated ─────────────────
+        // The SAME record, read by a process running another framework build — which is exactly
+        // what the two surviving replicas were doing on 2026-09-06.
+        NodeTypeBuildIdentity.ReportedStatus(honest, AnotherProcessesIdentity)
+            .Should().Be(CompilationStatus.Foreign,
+                "🚨 compilationStatus must not read Ok for a type whose hubs cannot activate. `Ok` "
+                + "is a claim SCOPED to CompiledFrameworkVersion, and the record carries both "
+                + "halves — the verdict and its scope — in two separate fields. Every instrument "
+                + "read the first one, and read green for two and a half hours");
+        honest.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            "and the RECORD is not rewritten to say so. A reader-relative verdict written into a "
+            + "shared record is how #3395's ping-pong was made: two replicas, two identities, each "
+            + "correctly overwriting the other's answer forever. The record keeps saying what the "
+            + "compiler did; only the report is scoped");
+
+        // ── CRITERION 1, at a real load site ────────────────────────────────────────────────────
+        // Stage the incident verbatim: ONE field moves. Same bytes on the shelf, same assembly
+        // coordinates, same CompilationStatus.Ok.
+        await Mesh.GetMeshNodeStream(TypePath)
+            .Update<NodeTypeDefinition>(d => d with { CompiledFrameworkVersion = AnotherProcessesIdentity })
+            .Should().Within(60.Seconds()).Emit();
+        await Mesh.GetMeshNodeStream(TypePath).Should().Within(60.Seconds())
+            .Match(n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)
+                is { CompiledFrameworkVersion: AnotherProcessesIdentity });
+
+        var onCellSurface = await CellSurfaceContainsThePack();
+
+        // 🚨 Read the record back and require it to STILL be foreign before judging the resolution
+        // above. The NodeType's own framework-stale kickoff is watching this field, so a healed
+        // record would make the resolution a measurement of the wrong state — and a test that
+        // cannot tell those apart is the flake it would later be blamed for. This is the guard,
+        // not a retry: if the premise did not hold, the assertion says so instead of passing.
+        var stillForeign = await ReadDefinition();
+        stillForeign.CompiledFrameworkVersion.Should().Be(AnotherProcessesIdentity,
+            "the premise of the assertion below: the record was foreign while the cell surface "
+            + "was resolved. The framework-stale kickoff's store probe finds bytes under the LIVE "
+            + "tag and answers Skip, which is exactly why this state is durable — and why the "
+            + "record can sit at Ok with a foreign identity indefinitely");
+
+        onCellSurface.Should().BeFalse(
+            "🚨 THE REGRESSION. An assembly compiled for one framework identity must never be "
+            + "served by a process running another: loading it fails as a TypeLoadException inside "
+            + "a collectible ALC, which CompileResultFromAssembly records as an EMPTY configuration "
+            + "list — and a hub resolves its configuration exactly once, so one refused load pins "
+            + "'Area not found' for the grain's whole lifetime. The bytes here are still perfectly "
+            + "loadable BY THEIR OWN PROCESS, and that is the point: the only thing that changed is "
+            + "which framework identity the record names");
+
+        NodeTypeBuildIdentity.ReportedStatus(stillForeign).Should().Be(CompilationStatus.Foreign,
+            "and this process must not repeat the record's Ok while refusing to load what it names");
+    }
+}


### PR DESCRIPTION
Closes #3472

> **"a NodeType's self-report is not proof"** — AGENTS.md, written before the day it was proved.

#3491 (`MeshPublicationGate`, `d54cf3d80`) is the **membership** half of 2026-09-06: a pod its
readiness gate had refused kept running and kept publishing. This is the **adoption** half — what a
healthy, admitted process must refuse to *load*, and what it may honestly *report* about a build it
cannot load. It composes with that gate rather than duplicating it: **that** one decides *whether*
this process may publish; **this** one adds nothing to publish.

## Criterion 2 first, because it is the one that needed a design

🚨 **`CompilationStatus.Ok` is a claim SCOPED to `CompiledFrameworkVersion`, persisted as though it
were absolute.** *"The last compile succeeded"* is true and process-independent. *"These bytes can be
loaded"* is only ever answerable **relative to a process**. The record has always carried both halves
— the verdict and its scope — in two separate fields, and every instrument read the first one.

That is why **no writer-side rule fixes it alone**: the pod that wrote `Ok` could load what it had
just built. It was telling the truth about itself. So the answer is split, and each half is necessary.

### Half one — the writer, and a live defect that needs no second image

`NodeTypeContractHandler.ResolvedStoreVersion` already argues the rule, for the store-key version:

> The path and the version are ONE reference, so they must come from ONE source.

**The framework identity is the fourth member of that reference and was left out of it.**
`ApplyResolvedSuccess` decided the assembly path and the store key by *"did the response carry a
reference"* and decided `CompiledFrameworkVersion` by a different predicate (`freshCompile`). On the
HYDRATE path those disagree — and a hydrate only *succeeds* when the assembly store **resolved**
bytes, under a key whose framework tag is this process's own. The record then reads:

```text
compilationStatus        Ok
latestAssemblyPath       <bytes the store just handed us>
compiledFrameworkVersion <somebody ELSE's identity>
```

`Ok`, naming loadable bytes, declaring them unloadable. `HasUsableBuild` is false **forever**; every
per-instance activation takes the ABI-stale recompile path; after `MaxRecompileAttempts` the instance
binds the fallback configuration — and a hub resolves its configuration exactly once, so that is
*"Area not found"* for the grain's whole lifetime, under a green tick. The handler also **races** the
activity write-back, so it re-imposes the foreign stamp over each correct one and the type never
converges. One extracted predicate (`StoreVersionFromResponse` / `ReferenceCameFromResponse`) now
decides all four fields, so they cannot drift. The **retained** branch still retains — that is the
only case where an ABI-staleness marker is real, and stamping live over retained coordinates would be
the same #1368 defect reached the other way round.

### Half two — the reader: `CompilationStatus.Foreign`, derived and never persisted

Foreign-`Ok` records still **arrive**, and no writer rule can stop them: a peer replica on another
image (#3395), a node repo that COMMITS a record (Plugins ships `Store/Catalog` with a July hash), a
prebuilt bundle. `NodeTypeBuildIdentity.ReportedStatus` folds the pair.

**Why a fourth state rather than a redefinition** — each candidate carries a different, wrong remedy:

| state | says | why not |
|---|---|---|
| `Error` | *correct the code* | the code is fine — #641's defect in the other direction |
| `Unavailable` | *retry or wait* | the state is fully determined; waiting is what does not help |
| `Ok` | *it is fine* | the lie |

`Foreign` says **"recompile here"**, which is the remedy, and which the compile watcher already
drives. 🚨 **Nothing writes it.** Writing a reader-relative verdict into a shared record is exactly
how #3395's ping-pong was made — two replicas, two identities, each correctly overwriting the other's
answer forever. The record keeps saying what the compiler did; only the *report* is scoped.

Reported through: `get_diagnostics` (`status: "Foreign"`, both identities in `error`), the
compile-progress overlay (which used to read the green status and **redirect** the viewer back to the
page that cannot render, which bounced them back — now it holds and explains, localized), and the
NodeType overview progress line (which showed ✓ **Compiled** while *printing the foreign hash beside
it as decoration*).

## Criterion 1 — the refusal, at seven load paths instead of one

`HasUsableBuild` has carried the framework equality since #464 — on **one** of the seven paths that
load a NodeType's assembly. The other six gated on the two coordinate fields being populated, or on
`CompilationStatus == Ok` alone: both pinned-release branches (`NodeTypeEnrichmentHelpers`,
`NodeTypeContractHandler` — `NodeTypeRelease.FrameworkVersion` **exists** and nothing read it), the
published-release hydrate, `MeshDataSource.HandleNodeTypeSchemaRequest`,
`NodeTypeDataModelAreas.ResolveInstanceHubConfig`, `MeshOperations.ResolveHubConfigForSchema`, and
`CellSurfaceAssemblyProvider` (which takes a lifetime **lease**).

🚨 **What stood between those and a foreign load was an eight-character substring inside one store
implementation's glob** — `FileSystemAssemblyStore`'s `v{version}-{FrameworkTag}-*.dll`. Nothing
asserted that property, and the other implementation (`BlobAssemblyStore`) ships in a module this
repository cannot compile. An implicit guard is not a guard.

**Refusing is not "the type is dead".** Every site takes exactly the branch a **store miss** already
takes — a local compile, a fallback configuration, or a no-answer — so behaviour on a tag-carrying
store is unchanged, and the operator gains a line naming **both** identities. Naming only one is how
the bake gate's *"regressed on this image"* sent three investigations to the wrong repository that
same night.

## Falsification — three arms, with numbers

Two pure arms on the functions that decide it, one end-to-end on a real mesh (`MonolithMeshTestBase`,
a real Roslyn compile, no mocking).

| arm | result |
|---|---|
| **Fix present** | `AdoptTimeFrameworkIdentityTest` **17/17**, `ForeignFrameworkBuildIsRefusedTest` **1/1**, and `HydrateIsNotACompileTest` (#2895's no-op pins) **6/6** unchanged |
| **Writer REVERTED** (`CompiledFrameworkVersion = freshCompile ? live : def.…`) | **1 failed / 23** — `ResolvedSuccessNeverLeavesOkStandingOverAForeignIdentity`: the record kept `sc273ee39fdccbfc088f9aaf1fc548a9a`, the incident's own identity, where the live one belonged. The other 22, including all six #2895 no-op pins, stayed green — the change does not touch the hydrate no-op |
| **Reader REVERTED** (`ReportedStatus => definition?.CompilationStatus`) | **1 failed / 17** — `AForeignOkNeverReportsOk`. The other 16, including the `Ok`-control and the five pass-through statuses, stayed green |
| **Cell-surface gate REVERTED** (real mesh) | **1 failed / 1** — *"Expected value to be false … but found True"*: the foreign-identity assembly was joined into the kernel session's cell surface and leased |
| **Controls, always asserted first** | this process's own build is **not** refused and **does** report `Ok`; the pack **is** on the cell surface with an honest build. Without them every assertion would pass against a gate that refused everything |

The mesh test asserts the premise **after** the measurement — it re-reads the record and requires it
to still be foreign before judging the resolution — so a healed record makes the test *say so*
instead of passing. Not a retry: the framework-stale kickoff's store probe answers `Skip` here
(bytes exist under the live tag), which is exactly why the state is durable.

**Local verification** (Release, `-warnaserror`, one project per invocation): `MeshWeaver.Mesh.Contract`,
`MeshWeaver.Compiler.Pipeline`, `MeshWeaver.Graph`, `MeshWeaver.Mesh.Operations`,
`MeshWeaver.Messaging.Hub`, `MeshWeaver.Hosting`, `MeshWeaver.Documentation`, `Memex.Portal.Shared` —
**0 warnings, 0 errors** each. `MeshWeaver.Compiler.Pipeline.Test` **673/673**, `MeshWeaver.Graph.Test`
**1382/1382**, `MeshWeaver.Hosting.Test` **404/404**, `MeshWeaver.Documentation.Test` **304/304**
(link integrity, What's New integrity, every localization guard), `OrleansCompileActivityAccessTest`
**8/8** — including `FrameworkStaleAssembly_SelfHealsOnInstanceActivation`, the test the
`ResolveStaleBuildAction` invariant note says goes red when this rule is relaxed.

## 🚨 Two findings that falsify a premise, both measured while building this

**#3472's own hypotheses.** (a) *a pod on a different platform build compiled these types* was
confirmed on the issue and is the incident's mechanism. (b) *the watcher adopted a prebuilt published
under a foreign identity* was **not** needed to explain anything observed — and this change found the
third route the issue did not name: **the writer can mint the foreign-`Ok` record itself**, with one
image, no bundle and no peer, through `ApplyResolvedSuccess`'s hydrate path.

🚨 **`search 'nodeType:NodeType compilationStatus:Error'` — AGENTS.md's stated sweep instrument —
cannot see this, and on some hosts cannot see anything.** Not changed here (both fixes have blast
radius far beyond this issue), documented instead:

1. **The sweep never returns the value.** `MeshOperations`' search envelope projects
   `Path/Name/NodeType/Version/LastModified` only; `compilationStatus` is a WHERE clause and nothing
   more.
2. 🚨 **On an in-memory or FileSystem-backed host the filter matches NOTHING.**
   `QueryEvaluator.GetDirectPropertyValue` resolves a selector by reflection against `MeshNode`,
   which has no `compilationStatus` property and no `Content` fallback — so the comparison is
   `null == "Error"` and the sweep returns `count: 0` for a mesh full of broken types. The
   translation that makes it work is in `PostgreSqlSqlGenerator`, which is not in this repository.
   **A green sweep on a dev Monolith is evidence of nothing.** The instrument that *is*
   reader-relative is `get_diagnostics`, which now answers `Foreign`.

Also filed for the record in the doc page: `MeshDataSource.HandleNodeTypeSchemaRequest` and
`MeshOperations.ResolveHubConfigForSchema` were reading `node.Content is NodeTypeDefinition` /
`(NodeTypeDefinition)node.Content` — the forbidden payload cast. Both are now `ContentAs`.

## Scope boundaries (deliberate)

- **It does not stop two images sharing one mesh** — that is #3491 (membership) and #3479 (roll
  selection).
- **It does not bind a record to bytes it does not name.** `DecideStaleBuildAction` still answers
  `Skip` when the framework moved and the store holds live-tag bytes; nothing has hashed those bytes,
  and restamping would assert validity for a build the lane never examined. That boundary is
  unchanged — and it is *why* a record can sit at `Ok` with a foreign identity indefinitely, which is
  what makes half two necessary rather than cosmetic.
- **It does not make a foreign record heal without an activation.** The instance-activation self-heal
  is still the path that corrects it.

## Also in this change

- `Doc/Architecture/BuildIdentityAdmission` — the design, the seven load paths, the fourth-state
  argument, and the two sweep findings. Cross-linked from `MeshAdmission`, which now names its
  counterpart.
- A What's New entry (`Category: Fix`).
- Two localization keys (`ui.compileForeignFramework`, `…Body`) in both catalogs. 🚨 **The Plugins
  mirror needs the hand-over after this merges**: `npm run sync:i18n -- --ref <merged core sha>`. It
  reds nothing today (the guard compares against a pinned core commit), which is exactly why it has
  to be said here.

No public type or member is removed, and no interface gains a member, so neither cross-repo gate
applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
