### PR TITLE
fix(sync): a no-op patch is not a lost frame — the mirror adopts its version (#3520)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -472,7 +472,22 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
         // arriving at this point is already version-current/ahead and must be applied.
         if (current is not null && valuesEqual && value.ChangeType != ChangeType.Full)
         {
-            logger.LogDebug("[SYNC_STREAM] Skipping SetCurrent for {StreamId} - same value (patch)", StreamId);
+            // 🚨 The frame is NOT emitted, but its VERSION is adopted (#3520). This mirror's
+            // `Current.Version` is the base the loss detector in UpdateStream compares the NEXT
+            // frame's BasedOnVersion against, and the owner chained that next frame onto THIS one —
+            // it was sent, it arrived, it merely changed nothing (a layout area re-rendered with an
+            // identical control, a write that re-set a value). Leaving the version behind turned
+            // every such no-op into a proven "frame loss": the mirror re-asked for a snapshot it
+            // already held, and a render that emits a few equal frames after its Full did that on
+            // every page load — measured 164 of 164 `Frame loss detected` warnings in one Education
+            // run were preceded by exactly this skip of the frame the next patch chained onto, and
+            // not one was a real loss. The adoption is silent: no OnNext, no gate, no consumer sees
+            // a change — only the clock moves, and it moves forward (the monotonicity guard above
+            // already refused anything older).
+            current = current with { Version = value.Version };
+            logger.LogDebug(
+                "[SYNC_STREAM] Skipping SetCurrent for {StreamId} - same value (patch); version adopted → v{Version}",
+                StreamId, value.Version);
             return;
         }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -263,6 +263,16 @@ identical control on every page load. The skip now adopts the frame's version si
 the warning: a run whose loss lines all sit right after `Skipping SetCurrent … same value (patch)`
 for the chained-onto version was never losing frames.
 
+⚠️ **The trade this makes, invisible afterwards:** before #3530 the spurious detection was
+accidentally a self-heal — had `ValuesEqual` ever answered *equal* for values that differ, the
+mirror would have diverged and the very next frame's broken chain would have pulled a Full that
+corrected it. After #3530 a false-equal is permanent: the chain no longer breaks, so nothing
+re-asks. `ValuesEqual` is therefore load-bearing now. It leans the safe way — structural
+`JsonDeepEquals` for `JsonElement`, `ToJsonString` for `JsonNode`, `Equals` otherwise, and any
+exception degrades to "changed" (emit) — and `SameValuePatchKeepsTheChainTest` pins both sides:
+the no-op frame emits nothing and moves the clock, the genuinely different frame emits AND moves
+it. Keep it two-sided; an "optimisation" that made everything equal would pass a one-sided test.
+
 🚨 **`[SYNC_STREAM] Frame loss detected …` is a RESYNC counter, not a data-loss
 counter.** Every line is a gap that was *detected and answered*; the mirror converges
 on the Full that follows. A raw count therefore means nothing on its own — the two

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -249,6 +249,20 @@ legitimate version gap cannot false-trigger a resync.
 (`JsonSynchronizationStream.ToDataChanged` → `SynchronizationStream.UpdateStream`;
 test `StreamFrameLossResyncTest`.)
 
+🚨 **The mirror's side of the same rule (#3520): a frame it RECEIVES and skips still moves its
+clock.** The owner cannot skip a patch whose `Updates` are non-empty but whose diff is — a
+`JsonElement` payload written back as it was is a new element to the owner (a struct with no value
+equality) and an identical document to the mirror — so it ships `[]`, and chains the next frame
+onto it. The mirror's value dedup in `SetCurrent` rightly emits nothing for that frame, but until
+#3520 it also left `Current.Version` where it was, so the next frame's `BasedOnVersion` pointed at
+a version the mirror "never applied" and the detector fired on a loss that never happened.
+Measured on an Education gate run: 164 of 164 `Frame loss detected` warnings were preceded by
+exactly that skip of the frame the next patch chained onto — a layout area re-rendered with an
+identical control on every page load. The skip now adopts the frame's version silently (no
+`OnNext`, no consumer wakes) — test `SameValuePatchKeepsTheChainTest`. Corollary for readers of
+the warning: a run whose loss lines all sit right after `Skipping SetCurrent … same value (patch)`
+for the chained-onto version was never losing frames.
+
 🚨 **`[SYNC_STREAM] Frame loss detected …` is a RESYNC counter, not a data-loss
 counter.** Every line is a gap that was *detected and answered*; the mirror converges
 on the Full that follows. A raw count therefore means nothing on its own — the two

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-frame-that-changed-nothing-is-no-longer-read-as-a-lost-one.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-frame-that-changed-nothing-is-no-longer-read-as-a-lost-one.md
@@ -1,0 +1,29 @@
+---
+Name: A frame that changed nothing is no longer read as a lost one
+Category: Fix
+Description: A mirror that skipped a no-op patch left its clock behind, so the very next frame looked like proof of a lost one and the mirror asked for a snapshot it already held — on every page load whose layout re-rendered an identical control. The clock now moves even when nothing is emitted.
+Icon: ArrowSync
+Order: -20260907
+---
+
+# A frame that changed nothing is no longer read as a lost one
+
+Every frame an owner sends carries the version of the frame it sent before, and a mirror that
+receives a frame chained onto a version it never applied knows a frame was lost and asks for a
+fresh snapshot. That detector is right to exist — a lost frame used to be a silent, permanent
+deficit.
+
+It had one blind spot. A mirror that received a patch which changed nothing — a layout area
+re-rendered with an identical control, a value written back as it was — skipped it without
+emitting anything, and also without moving its clock. The owner had chained the next frame onto
+that skipped one, so the next frame looked like proof of a loss that never happened, and the mirror
+re-asked for a snapshot it already held.
+
+Measured on an Education gate run: 164 `Frame loss detected` warnings in one thirty-minute run,
+and 164 of them preceded by exactly this skip of the frame the next patch chained onto. Not one was
+a real loss. The cost was a round trip per page load and a warning that pointed everyone at the
+wrong subsystem for two nights.
+
+A skipped no-op frame now adopts its version silently — no emission, no consumer sees a change,
+only the clock moves — so the chain stays intact and the detector fires only on what it was built
+for.

--- a/test/MeshWeaver.Data.Test/SameValuePatchKeepsTheChainTest.cs
+++ b/test/MeshWeaver.Data.Test/SameValuePatchKeepsTheChainTest.cs
@@ -1,0 +1,101 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Systemorph/MeshWeaver#3520. A Patch that changes nothing is still SENT by the owner and chained
+/// onto by the next frame — a JsonElement payload written again is a new element (no value equality
+/// on the struct), so the owner keeps the update and ships an EMPTY diff; the JSON mirror deep-compares
+/// it as equal and skips it. Skipping without adopting the frame's version made the NEXT frame prove a
+/// "frame loss" that never happened: the mirror re-asked for a snapshot it already held. Measured on
+/// Education's disposable mesh: 164 of 164 loss warnings in one run were exactly this, none a real loss.
+/// </summary>
+public class SameValuePatchKeepsTheChainTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    public record Blob(string Id, JsonElement Payload);
+
+    private readonly ConcurrentQueue<(ChangeType Type, long Version, long BasedOn, string Change)> posted = new();
+    private readonly ConcurrentQueue<SubscribeRequest> subscribeRequests = new();
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<Blob>(t => t.WithKey(d => d.Id))))
+            .AddPostPipeline(p => p.AddPipeline((d, next) =>
+            {
+                if (d.Message is DataChangedEvent e)
+                    posted.Enqueue((e.ChangeType, e.Version, e.BasedOnVersion, e.Change.Content));
+                return next.Invoke(d);
+            }));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<Blob>(t => t.WithKey(d => d.Id))))
+            .AddPostPipeline(p => p.AddPipeline((d, next) =>
+            {
+                if (d.Message is SubscribeRequest sr)
+                    subscribeRequests.Enqueue(sr);
+                return next.Invoke(d);
+            }));
+
+    private static JsonElement Payload(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    [HubFact]
+    public async Task ANoOpPatch_IsNotAFrameLoss_TheMirrorAdoptsItsVersion()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var accessService = host.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetContext(new AccessContext { ObjectId = "alice", Name = "Alice" });
+        var collectionName = host.GetWorkspace().DataContext.GetTypeSource(typeof(Blob))!.CollectionName;
+
+        host.Post(new DataChangeRequest().WithUpdates(new Blob("doc-1", Payload("""{"a":1}"""))),
+            o => o.WithAccessContext(accessService.Context!));
+
+        // The mirror the portal's client is: a JsonElement view of the owner's store.
+        var mirror = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, CollectionsReference>(CreateHostAddress(), new CollectionsReference(collectionName));
+        // The wire shape of an EntityStore: { "$type": …, "<collection>": { "\"id\"": entity, … } }.
+        static int Count(JsonElement e, string collection)
+            => e.ValueKind == JsonValueKind.Object && e.TryGetProperty(collection, out var coll)
+               && coll.ValueKind == JsonValueKind.Object
+                ? coll.EnumerateObject().Count()
+                : -1;
+        await mirror.Where(ci => Count(ci.Value, collectionName) == 1)
+            .Take(1).Should().Within(TestTimeouts.Convergence).Emit();
+        var framesBefore = posted.Count;
+
+        // The no-op: the SAME payload, parsed again — a new JsonElement, so the owner sees a change
+        // and ships a frame whose diff is empty.
+        host.Post(new DataChangeRequest().WithUpdates(new Blob("doc-1", Payload("""{"a":1}"""))),
+            o => o.WithAccessContext(accessService.Context!));
+        await Task.Delay(500);
+        var noOpFrames = posted.Skip(framesBefore).ToArray();
+        noOpFrames.Should().NotBeEmpty(
+            "the scenario needs the owner to SEND a frame for the value-equal write — otherwise nothing chains onto it and this test proves nothing");
+
+        // The real change that chains onto the no-op frame.
+        host.Post(new DataChangeRequest().WithUpdates(new Blob("doc-2", Payload("""{"b":2}"""))),
+            o => o.WithAccessContext(accessService.Context!));
+        await mirror.Where(ci => Count(ci.Value, collectionName) == 2)
+            .Take(1).Should().Within(TestTimeouts.Convergence).Emit();
+        await Task.Delay(300);
+
+        foreach (var f in posted)
+            Output.WriteLine($"owner posted {f.Type} v{f.Version} basedOn v{f.BasedOn}: {f.Change[..Math.Min(80, f.Change.Length)]}");
+        Output.WriteLine($"subscribe requests posted by the mirror: {subscribeRequests.Count}");
+
+        subscribeRequests.Count.Should().Be(1,
+            "a value-equal Patch is not a lost frame — the mirror must not re-ask for a snapshot it already holds");
+        mirror.Current!.Version.Should().Be(posted.Last().Version,
+            "the mirror's clock must sit on the last frame the owner sent, whether or not that frame changed anything");
+    }
+}

--- a/test/MeshWeaver.Data.Test/SameValuePatchKeepsTheChainTest.cs
+++ b/test/MeshWeaver.Data.Test/SameValuePatchKeepsTheChainTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
+using System.Threading;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,6 +73,12 @@ public class SameValuePatchKeepsTheChainTest(ITestOutputHelper output) : HubTest
         await mirror.Where(ci => Count(ci.Value, collectionName) == 1)
             .Take(1).Should().Within(TestTimeouts.Convergence).Emit();
         var framesBefore = posted.Count;
+        // Both sides of the rule are pinned from here on: what the mirror EMITS to its consumers.
+        var emitted = 0;
+        using var emissions = mirror.Subscribe(_ => Interlocked.Increment(ref emitted));
+        await Task.Delay(200); // the subscription replays the current value; count only what follows
+        Interlocked.Exchange(ref emitted, 0);
+        var versionAfterFull = mirror.Current!.Version;
 
         // The no-op: the SAME payload, parsed again — a new JsonElement, so the owner sees a change
         // and ships a frame whose diff is empty.
@@ -81,6 +88,11 @@ public class SameValuePatchKeepsTheChainTest(ITestOutputHelper output) : HubTest
         var noOpFrames = posted.Skip(framesBefore).ToArray();
         noOpFrames.Should().NotBeEmpty(
             "the scenario needs the owner to SEND a frame for the value-equal write — otherwise nothing chains onto it and this test proves nothing");
+        Volatile.Read(ref emitted).Should().Be(0,
+            "a frame that changed nothing must not wake a consumer — the dedup is the point, only the clock moves");
+        mirror.Current!.Version.Should().Be(noOpFrames.Last().Version,
+            "the skipped frame's version is adopted so the chain the owner built onto it stays intact");
+        mirror.Current!.Version.Should().BeGreaterThan(versionAfterFull);
 
         // The real change that chains onto the no-op frame.
         host.Post(new DataChangeRequest().WithUpdates(new Blob("doc-2", Payload("""{"b":2}"""))),
@@ -95,6 +107,8 @@ public class SameValuePatchKeepsTheChainTest(ITestOutputHelper output) : HubTest
 
         subscribeRequests.Count.Should().Be(1,
             "a value-equal Patch is not a lost frame — the mirror must not re-ask for a snapshot it already holds");
+        Volatile.Read(ref emitted).Should().Be(1,
+            "the genuinely different patch must still reach the consumer — the other side of the same rule, so a ValuesEqual that made everything equal cannot pass");
         mirror.Current!.Version.Should().Be(posted.Last().Version,
             "the mirror's clock must sit on the last frame the owner sent, whether or not that frame changed anything");
     }


### PR DESCRIPTION
Closes #3520.

A mirror that received a patch changing nothing skipped it in `SetCurrent` without moving `Current.Version`. The owner had chained the next frame onto that skipped one, so the next frame's `BasedOnVersion` pointed at a version the mirror "never applied", the loss detector fired on a loss that never happened, and the mirror re-asked for a snapshot it already held.

**Why the owner sends such a frame:** a `JsonElement` payload written back as it was is a *new* element to the owner (a struct with no value equality) and an *identical* document to the mirror, so the owner ships `[]` and chains the next frame onto it. Layout areas re-rendered with identical controls do this on every page load.

**Measured** (Education run 34082816482, `MeshWeaver.Data.Serialization` at Debug): 164 of 164 `Frame loss detected` warnings in one run were preceded by exactly `Skipping SetCurrent … same value (patch)` for the version the next patch chained onto. Zero real losses. The cost was a round trip per page load and two nights pointed at the wrong subsystem (the issue's original framing — recorded there as the negative result).

**Change:** the skip adopts the frame's version silently — no `OnNext`, no gate, no consumer wakes; only the clock moves, and forward.

**Test:** `SameValuePatchKeepsTheChainTest` reproduces the wire shape (`Full v2`, `Patch v3 basedOn v2: []`, `Patch v4 basedOn v3`) and fails on the old code with a second `SubscribeRequest` (verified by stashing the fix). The six neighbouring resync suites and the full `MeshWeaver.Data.Test` (492) pass.

Docs: WhatsNew entry + the mirror-side rule in `Doc/Architecture/DataSyncAndCrdt.md` under *The frame chain*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**The trade, stated because it is invisible afterwards (review by the core fix session):** the spurious detection was accidentally a self-heal — had `ValuesEqual` ever answered *equal* for values that differ, the diverged mirror would have been corrected by the very next frame's broken chain. After this fix a false-equal is permanent: the chain no longer breaks, so nothing re-asks. `ValuesEqual` is load-bearing now; it leans the safe way (structural JSON equality, `Equals` otherwise, any exception → "changed"), and the test pins both sides — the no-op frame emits nothing and moves the clock, the genuinely different frame emits and moves it. Recorded beside the rule in `DataSyncAndCrdt.md`.
