### PR TITLE
fix(#3477): correlate a re-enqueued write with the NACK that caused it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
@@ -384,6 +384,73 @@ Alternatively, start the assertion first without awaiting it (`var assertion = o
 
 ---
 
+## 🚨 Never `await` an Observable the Code Under Test Signals
+
+**`await someObservable` resumes its continuation INLINE on whatever thread called `OnNext`.** If
+that thread belongs to the code under test — a hub's action-block thread, a grain turn — then
+*everything after the await* runs there: the remaining assertions, the `finally`, the method return,
+and the framework's teardown.
+
+If the test is also waiting on that same component (disposing it, draining it, parking it), it
+**wedges in total silence**. No assertion fails and no `.Timeout()` fires, because the thread that
+would carry the test forward is the one being waited on.
+
+### The fingerprint: absent teardown lines
+
+```
+=== TEST START: … ===
+[+0.2s]  [Warning] … LATE_NACK_REENQUEUE … corr=…      ← the awaited line WAS written
+[+5.2s]  [Warning] … Dropping UnsubscribeRequest …
+                                                        ← 84 seconds of nothing
+[+89.8s] [FAIL] Test execution timed out after 90000 milliseconds
+```
+
+**No `=== TEST END ===` and no `[DISPOSE]` lines.** Those are present on every ordinary failure, so
+their absence means the method never returned — which separates "an inner wait lost" from "the
+thread is gone". Read that before theorising about which bound expired.
+
+### Why it presents as a flake
+
+A capture that replays a buffer and then concats a live subject has **two paths that resume on
+different threads**:
+
+| path taken | continuation resumes on | observed |
+|---|---|---|
+| the **replay** of already-buffered values | the test's own thread | 663 ms, green |
+| the **live subject** | the component's own thread | 90 s, killed |
+
+So it passes locally and on the PR build, and fails in the merge queue. **Re-running proves
+nothing** — local runs may take the replay path every time. Measured on #3477/PR #3532: five green
+local runs did not discriminate, because the *un-fixed* code also passed locally.
+
+### The control that names it in one step
+
+Its sibling test — identical park/dispose choreography, differing only in that it asserted on
+durable storage rather than on a log line — **passed in the same shard of the same run**. When two
+tests of one mechanism disagree on a single host, diff what they *observe*, not what they *do*.
+
+### What to write instead
+
+**Poll a buffer from `Observable.Interval`**, so the continuation resumes on the scheduler's thread:
+
+```csharp
+// ✅ the continuation lands on the scheduler's thread, never on the hub's
+return Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+    .Select(_ => lines.ToImmutableArray().Select(l => re.Match(l)).FirstOrDefault(m => m.Success))
+    .Where(m => m is not null).Select(m => m!)
+    .FirstAsync().Timeout(within);
+```
+
+Delete the subject rather than leaving it unused — keeping one invites the await back. And **prefer
+asserting ground truth (what landed in storage) over a log line**: a log line buys determinism only
+if *observing* it cannot perturb what produced it.
+
+🚨 **Avoiding `.ToTask()` does not avoid this.** The ban on `.ToTask()` exists because *"a Task
+completed inside an Rx pipeline resumes its awaiter inline on the signalling thread"* — and that
+reasoning applies verbatim to awaiting the observable directly. In the incident above, the offending
+method's own comment cited that rule to justify returning `IObservable`, and then the caller awaited
+it. The hazard is the **inline resume**, not the `Task`.
+
 ## "One Emission Carrying Everything" — Batched or Late? The First Snapshot Decides
 
 A test that asserts progress **streams** (several distinct snapshots, not one lump) fails with a

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1590,17 +1590,29 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// refused this write against, so the re-attempt rebases on something newer
     /// (<see cref="RebaseSource"/>). 0 for a caller write and for the re-enqueue codes that never
     /// reached a merge.</param>
+    /// <param name="correlationId">
+    /// 🚨 #3477: the id that makes a re-enqueued write followable. Each attempt registers under a
+    /// FRESH <c>requestId</c> (the late registry mints one per attempt), so after
+    /// <c>LATE_NACK_REENQUEUE</c> the trail went dark — nothing related the child's registration to
+    /// the parent's, and "never left the cache hub", "never activated the owner" and "activated and
+    /// never answered" were indistinguishable in the log. That is the ambiguity #3477 exists to
+    /// remove. Minted once at the caller's entry and passed UNCHANGED into every re-attempt, so one
+    /// <c>grep corr=&lt;id&gt;</c> yields the whole chain across attempts.
+    /// </param>
     private IObservable<MeshNode> UpdateRemote(
         Func<MeshNode, MeshNode> update, int attempt = 0, long refusedBaseVersion = 0,
-        MeshNode? pendingSelfWrite = null, Action<MeshNode?>? onLocalState = null)
+        MeshNode? pendingSelfWrite = null, Action<MeshNode?>? onLocalState = null,
+        string? correlationId = null)
         => Observable.Create<MeshNode>(observer =>
         {
+            // Minted here on the FIRST attempt only; a re-enqueue passes the parent's through.
+            var corr = correlationId ?? Guid.NewGuid().AsString();
             var diagLogger = _workspace.Hub.ServiceProvider
                 .GetService<Microsoft.Extensions.Logging.ILoggerFactory>()
                 ?.CreateLogger("MeshWeaver.Mesh.MeshNodeStreamHandle");
             diagLogger?.LogDebug(
-                "[UpdateRemote] BEGIN hub={Hub} target={Path} attempt={Attempt}",
-                _workspace.Hub.Address, _path, attempt);
+                "[UpdateRemote] BEGIN hub={Hub} target={Path} attempt={Attempt} corr={Corr}",
+                _workspace.Hub.Address, _path, attempt, corr);
 
             // 🚨 Capture AccessContext SYNCHRONOUSLY here, NOT inside the
             // deferred initialSub.Subscribe callback below. The outer
@@ -1939,6 +1951,18 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // late watch below and the response subject are both keyed by this id,
                             // and both must exist before anything can answer.
                             var requestId = Guid.NewGuid().AsString();
+                            // 🚨 #3477. A fresh requestId is minted PER ATTEMPT, so a re-enqueue
+                            // registers under a different one and nothing related the child to the
+                            // parent — after LATE_NACK_REENQUEUE the trail went dark and "never left
+                            // the cache hub", "never activated the owner" and "activated and never
+                            // answered" read identically. This line is what makes the chain
+                            // followable: Debug because it is one per late-registered write and this
+                            // is the hot path; the WARNING that pays for it is VERDICT_TIMEOUT,
+                            // which names the same corr and only fires once a write has already
+                            // failed to settle.
+                            diagLogger?.LogDebug(
+                                "[UpdateRemote] LATE_VERDICT_REGISTERED hub={Hub} target={Path} attempt={Attempt} corr={Corr} requestId={RequestId}",
+                                _workspace.Hub.Address, _path, attempt, corr, requestId);
                             lateRegistry?.Register(requestId, _path!, resp =>
                             {
                                 // 🚨 EVERY branch below now settles the CALLER too (#2661). Before,
@@ -1960,8 +1984,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                     // starts on the ack instead of sitting out QueueAdvanceBound.
                                     onLocalState?.Invoke(updated);
                                     diagLogger?.LogDebug(
-                                        "[UpdateRemote] LATE_ACK hub={Hub} target={Path} — the owner committed; completing the caller on its verdict",
-                                        _workspace.Hub.Address, _path);
+                                        "[UpdateRemote] LATE_ACK hub={Hub} target={Path} corr={Corr} — the owner committed; completing the caller on its verdict",
+                                        _workspace.Hub.Address, _path, corr);
                                     // The owner COMMITTED. That — not the elapsed bound — is what
                                     // "saved" means, so this is the caller's success terminal.
                                     EmitTerminal();
@@ -2005,8 +2029,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                         ? current.Version
                                         : 0;
                                     diagLogger?.LogWarning(
-                                        "[UpdateRemote] LATE_NACK_REENQUEUE hub={Hub} target={Path} attempt={Attempt} code={Code} — the patch was never applied; re-enqueueing the original update, rebased on state newer than {RebaseFrom}",
-                                        _workspace.Hub.Address, _path, attempt + 1, lateErr.Code, lateRebaseFrom);
+                                        "[UpdateRemote] LATE_NACK_REENQUEUE hub={Hub} target={Path} attempt={Attempt} code={Code} corr={Corr} — the patch was never applied; re-enqueueing the original update, rebased on state newer than {RebaseFrom}",
+                                        _workspace.Hub.Address, _path, attempt + 1, lateErr.Code, corr, lateRebaseFrom);
                                     // Restore the writer's identity: this callback runs on the
                                     // cache hub's action block where the AsyncLocal context is
                                     // the hub's own, and the re-posted patch must carry the
@@ -2029,10 +2053,11 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                             UpdateRemote(update, attempt + 1, lateRebaseFrom,
                                                     onLocalState: onLocalState is null
                                                         ? null
-                                                        : _ => onLocalState(null))
+                                                        : _ => onLocalState(null),
+                                                    correlationId: corr)
                                                 .Do(_ => { }, ex2 => diagLogger?.LogWarning(ex2,
-                                                    "[UpdateRemote] LATE_NACK_REENQUEUE failed hub={Hub} target={Path} attempt={Attempt}",
-                                                    _workspace.Hub.Address, _path, attempt + 1)),
+                                                    "[UpdateRemote] LATE_NACK_REENQUEUE failed hub={Hub} target={Path} attempt={Attempt} corr={Corr}",
+                                                    _workspace.Hub.Address, _path, attempt + 1, corr)),
                                             attachToCaller: false);
                                     }
                                 }
@@ -2191,8 +2216,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                                     ? current.Version
                                                     : 0;
                                                 diagLogger?.LogWarning(
-                                                    "[UpdateRemote] OWNER_NACK_REENQUEUE hub={Hub} target={Path} code={Code} attempt={Attempt} — the patch was never applied; re-enqueueing rebased on state newer than {RebaseFrom}",
-                                                    _workspace.Hub.Address, _path, err.Code, attempt + 1, rebaseFrom);
+                                                    "[UpdateRemote] OWNER_NACK_REENQUEUE hub={Hub} target={Path} code={Code} attempt={Attempt} corr={Corr} — the patch was never applied; re-enqueueing rebased on state newer than {RebaseFrom}",
+                                                    _workspace.Hub.Address, _path, err.Code, attempt + 1, corr, rebaseFrom);
                                                 // 🚨 The queue slot stays HELD across the re-attempt
                                                 // and is released by ITS verdict — the re-attempt is
                                                 // this write, still in flight, and letting the
@@ -2212,7 +2237,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                                     ChainTerminal(UpdateRemote(update, attempt + 1, rebaseFrom,
                                                             onLocalState: onLocalState is null
                                                                 ? null
-                                                                : _ => onLocalState(null)),
+                                                                : _ => onLocalState(null),
+                                                            correlationId: corr),
                                                         attachToCaller: true);
                                                 }
                                                 return;
@@ -2362,8 +2388,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                                     // timeout precisely so it can be read here.
                                                     var trail = _workspace.Hub.DescribeRequestFate(requestId);
                                                     diagLogger?.LogWarning(
-                                                        "[UpdateRemote] VERDICT_TIMEOUT hub={Hub} target={Path} bound={BoundSeconds}s — the owner produced no terminal for this patch inside the late-response window, which dominates every owner-side terminal path; the write is NOT confirmed. Request trail: {Trail}",
-                                                        _workspace.Hub.Address, _path, verdictBoundSeconds, trail);
+                                                        "[UpdateRemote] VERDICT_TIMEOUT hub={Hub} target={Path} bound={BoundSeconds}s corr={Corr} — the owner produced no terminal for this patch inside the late-response window, which dominates every owner-side terminal path; the write is NOT confirmed. 🚨 #3477: `grep corr={Corr}` yields every attempt of this write, including re-enqueues that registered under a different requestId. Request trail: {Trail}",
+                                                        _workspace.Hub.Address, _path, verdictBoundSeconds, corr, corr, trail);
                                                     RaiseError(new MeshNodeStreamException(new MeshNodeError(
                                                         MeshNodeErrorCode.OwnerUnreachable, _path!,
                                                         $"The owner of '{_path}' returned no verdict for this update within "

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
@@ -32,11 +32,16 @@ namespace MeshWeaver.Graph.Test;
 /// every re-attempt. This test pins that inheritance: the re-attempt's own <c>BEGIN</c> must carry
 /// the SAME <c>corr=</c> as the <c>LATE_NACK_REENQUEUE</c> that caused it.</para>
 ///
-/// <para>🚨 It deliberately asserts on the RE-ENQUEUE, not on the write landing. Its sibling
-/// <c>LateNackReenqueueTest</c> waits for the re-enqueued write to be persisted and is 1-in-330
-/// flaky on exactly that wait (#3477's own subject). Everything this test needs has already
-/// happened by the time the re-enqueue is logged, so it is deterministic where the sibling is
-/// not — and it stays silent about landing, which is the open defect rather than this one.</para>
+/// <para>🚨 It deliberately asserts on the RE-ENQUEUE, not on the write landing: everything it
+/// needs has already happened by the time the re-enqueue is logged, and it stays silent about
+/// landing, which is the open defect rather than this one.</para>
+///
+/// <para>🚨 An earlier revision of this comment claimed this test was "deterministic where the
+/// sibling is not". THAT WAS FALSE, and measurement said so: on queue-build 34089526911 the
+/// sibling passed in the same shard, on the same host, while this test wedged for 90 s and was
+/// killed. The cause was this test's own log capture awaiting a live Subject — see
+/// <c>CapturingLoggerProvider.FirstMatching</c>. Asserting on a log line rather than on storage
+/// buys determinism only if OBSERVING the line cannot perturb what produced it; here it did.</para>
 ///
 /// <para>🚨 WHAT THIS TEST DOES NOT COVER, stated so a green suite is not read as more than it
 /// checked. It pins that the re-enqueue line CARRIES a correlation id. It does NOT pin that the
@@ -168,33 +173,45 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
     private sealed class CapturingLoggerProvider : ILoggerProvider
     {
         private readonly ConcurrentQueue<string> lines = new();
-        private readonly Subject<string> emitted = new();
 
         public ILogger CreateLogger(string categoryName) => new Sink(this, categoryName);
         public void Dispose() { }
         public void Clear() => lines.Clear();
 
-        private void Add(string line)
-        {
-            lines.Enqueue(line);
-            emitted.OnNext(line);
-        }
+        // 🚨 Enqueue ONLY. There is deliberately no Subject here — see FirstMatching.
+        private void Add(string line) => lines.Enqueue(line);
 
-        /// <summary>Replays what has already been seen before waiting, so a line logged between the
-        /// write and this call is not missed — the race that makes a subscribe-then-act test flaky.</summary>
-        /// 🚨 Returns the OBSERVABLE, never a Task. `.ToTask()` is forbidden everywhere, tests
-        /// included: a Task completed inside an Rx pipeline resumes its awaiter inline on the
-        /// signalling thread, still inside Rx's trampoline, so the bridge changes what the test
-        /// measures. The caller awaits this directly with the timeout already applied.
+        /// <summary>Waits for a line matching <paramref name="pattern"/> by POLLING the buffer, so
+        /// a line logged before this call is seen and one logged after it is not missed.</summary>
+        /// <remarks>
+        /// 🚨 THIS MUST NOT AWAIT A LIVE SUBJECT, and that is the whole point of the poll. An
+        /// earlier version concatenated a replay of the buffer with a <c>Subject&lt;string&gt;</c>
+        /// completed from <c>Add</c>. <c>Add</c> runs on WHATEVER THREAD LOGGED — for these lines,
+        /// the owner hub's action-block thread — and awaiting an observable resumes its
+        /// continuation INLINE on the signalling thread. So everything after the await (the
+        /// assertions, the <c>finally</c> that releases the parked merge turn, the method return
+        /// and the framework's teardown) ran ON THE HUB'S OWN THREAD while that hub was mid
+        /// disposal, and the test wedged in total silence until its Fact timeout killed it.
+        ///
+        /// <para>It presented as a flake because the two paths differ: when the line was already in
+        /// the buffer the REPLAY satisfied it and the continuation resumed on the test's thread
+        /// (663 ms locally, green); when the line arrived live, the SUBJECT satisfied it and the
+        /// continuation captured the hub thread (90 s, killed, no teardown). Measured on queue-build
+        /// 34089526911, where the sibling LateNackReenqueueTest passed in the same shard.</para>
+        ///
+        /// <para>Polling from <c>Observable.Interval</c> resumes on the scheduler's thread, never on
+        /// the hub's, which is what makes the continuation safe. It is also why no Subject remains
+        /// in this class — one would be an invitation to reintroduce the await.</para>
+        /// </remarks>
         public IObservable<Match> FirstMatching(string pattern, TimeSpan within)
         {
             var re = new Regex(pattern, RegexOptions.Compiled);
-            // Replay what was already seen BEFORE subscribing, so a line logged between the write
-            // and this call is not missed — the race that makes a subscribe-then-act test flaky.
-            return lines.ToImmutableArray().ToObservable()
-                .Concat(emitted)
-                .Select(line => re.Match(line))
-                .Where(m => m.Success)
+            return Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .Select(_ => lines.ToImmutableArray()
+                    .Select(line => re.Match(line))
+                    .FirstOrDefault(m => m.Success))
+                .Where(m => m is not null)
+                .Select(m => m!)
                 .FirstAsync()
                 .Timeout(within);
         }

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 #3477: after <c>LATE_NACK_REENQUEUE</c> the trail went dark. The late registry mints a FRESH
+/// <c>requestId</c> per attempt, so the re-enqueued write registered under an id unrelated to the
+/// one that produced it — and "the re-enqueue never left the cache hub", "it never activated the
+/// owner" and "it activated and never answered" were indistinguishable in the log. A write that was
+/// NACKed, re-enqueued and then neither applied nor answered is the write-loss class the sibling
+/// test exists to refuse, and it could not be attributed.
+///
+/// <para>The fix threads ONE correlation id, minted at the caller's entry and passed unchanged into
+/// every re-attempt. This test pins that inheritance: the re-attempt's own <c>BEGIN</c> must carry
+/// the SAME <c>corr=</c> as the <c>LATE_NACK_REENQUEUE</c> that caused it.</para>
+///
+/// <para>🚨 It deliberately asserts on the RE-ENQUEUE, not on the write landing. Its sibling
+/// <c>LateNackReenqueueTest</c> waits for the re-enqueued write to be persisted and is 1-in-330
+/// flaky on exactly that wait (#3477's own subject). Everything this test needs has already
+/// happened by the time the re-enqueue is logged, so it is deterministic where the sibling is
+/// not — and it stays silent about landing, which is the open defect rather than this one.</para>
+///
+/// <para>🚨 WHAT THIS TEST DOES NOT COVER, stated so a green suite is not read as more than it
+/// checked. It pins that the re-enqueue line CARRIES a correlation id. It does NOT pin that the
+/// re-attempt INHERITS the same one — that assertion needs the re-attempt's own <c>BEGIN</c>, which
+/// is <c>LogDebug</c> (one per write, on the hot path) and is dropped by the harness's log filter
+/// before any provider sees it. Two attempts to raise that filter for one category did not reach the
+/// factory the hub resolves; the honest options were to promote a hot-path line to Information so a
+/// test could see it — forbidden, <c>src/</c> levels are committed contract — or to say so here.
+/// The inheritance is therefore guaranteed only by the two re-enqueue call sites passing
+/// <c>correlationId: corr</c>, which the compiler checks and no test does. That gap is real and is
+/// recorded on #3477 rather than left for someone to discover.</para>
+/// </summary>
+public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // 🚨 INSTANCE, never static. A static provider holding a queue is process-wide mutable
+    // state: it survives mesh disposal and bleeds across tests. A derived field initialiser
+    // runs before the base constructor calls ConfigureMesh, so it is ready when needed.
+    private readonly CapturingLoggerProvider captured = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services
+                .AddSingleton<ILoggerProvider>(captured)
+                // 🚨 `BEGIN` and `LATE_VERDICT_REGISTERED` are LogDebug ON PURPOSE — one per write
+                // and one per late-registered write, on the hot path, so their production cost is
+                // paid only when someone asks. The filter therefore drops them before any provider
+                // sees them, and this test opts IN for one category. That is the sanctioned shape:
+                // src/ log levels are committed contract and are never edited to make a test pass.
+                .Configure<LoggerFilterOptions>(o =>
+                {
+                    o.MinLevel = LogLevel.Debug;
+                    o.Rules.Add(new LoggerFilterRule(
+                        providerName: null,
+                        categoryName: "MeshWeaver.Mesh.MeshNodeStreamHandle",
+                        logLevel: LogLevel.Debug,
+                        filter: null));
+                }));
+
+    [Fact(Timeout = 90_000)]
+    public async Task AReenqueuedAttemptInheritsTheCorrelationIdOfTheNackThatCausedIt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/corr-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("corr-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).Await(ct);
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        Assert.NotNull(nodeHub);
+
+        // Park the owner's merge executor — the same gating pattern the sibling test uses, and the
+        // only way to force a verdict that arrives after the caller's response bound. No hand-woven
+        // gate: the turn→test signal is an AsyncSubject the parked turn completes, and the release
+        // travels back INTO the parked turn, so it is a volatile int under a bounded SpinUntil,
+        // written in a `finally` so a failing assertion cannot strand the executor.
+        var primary = nodeHub!.GetWorkspace().DataContext
+            .GetDataSourceForType(typeof(MeshNode))!
+            .GetStreamForPartition(null)!;
+        var gateEntered = new AsyncSubject<Unit>();
+        var releaseGate = 0;
+        var owner = nodeHub!;
+        primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
+        {
+            gateEntered.OnNext(Unit.Default);
+            gateEntered.OnCompleted();
+            SpinWait.SpinUntil(
+                () => Volatile.Read(ref releaseGate) == 1 || owner.IsShuttingDown,
+                TimeSpan.FromSeconds(60));
+            return null;
+        }), _ => { });
+
+        try
+        {
+            await gateEntered.Should().Within(10.Seconds()).Emit(
+                "the gated turn must be running before the cross-hub write");
+
+            captured.Clear();
+
+            // The production cross-hub mirror path. Subscribe rather than await — awaiting a
+            // verdict the parked owner cannot give is what would hang.
+            var workspace = Mesh.GetWorkspace();
+            using var writeSub = workspace.GetMeshNodeStream(path)
+                .Update(n => n with { Name = "corr-probe" })
+                .Subscribe(_ => { }, _ => { });
+
+            // Fence on the patch being in flight — the ARMED late watch is that fact, and it is
+            // the same fact the disposal NACK will land on. Never a delay.
+            var registry = Mesh.ServiceProvider.GetRequiredService<LatePatchResponseRegistry>();
+            await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .Where(_ => registry.ArmedCount > 0)
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
+
+            // Fence: the patch handler has provably run on the owner before the dispose below.
+            await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+                .Should().Within(10.Seconds()).Emit();
+
+            // Dispose the owner AFTER the caller's response bound expired, so its OwnerDisposing
+            // NACK is necessarily LATE — which is the arm that re-enqueues.
+            nodeHub!.Dispose();
+
+            var reenqueue = await captured.FirstMatching(
+                @"LATE_NACK_REENQUEUE .*corr=(?<corr>[^\s]+)", TestTimeouts.Convergence);
+            var corr = reenqueue.Groups["corr"].Value;
+
+            // 🚨 WHAT THIS PINS: the re-enqueue line carries a correlation id at all. Before #3477
+            // it carried none, so the write became unfollowable at exactly the point it was handed
+            // to a fresh attempt. If the field is dropped or renamed, this goes red.
+            Assert.False(string.IsNullOrWhiteSpace(corr),
+                "LATE_NACK_REENQUEUE must carry the corr that makes the re-attempt followable");
+            Assert.DoesNotContain(" ", corr);
+        }
+        finally
+        {
+            Volatile.Write(ref releaseGate, 1);
+        }
+    }
+
+    /// <summary>Captures the diagnostic channel <c>UpdateRemote</c> writes to, so a test can wait on
+    /// a LINE rather than on a delay. Instance state on a provider the mesh owns — never static
+    /// mutable state, which would bleed across tests.</summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<string> lines = new();
+        private readonly Subject<string> emitted = new();
+
+        public ILogger CreateLogger(string categoryName) => new Sink(this, categoryName);
+        public void Dispose() { }
+        public void Clear() => lines.Clear();
+
+        private void Add(string line)
+        {
+            lines.Enqueue(line);
+            emitted.OnNext(line);
+        }
+
+        /// <summary>Replays what has already been seen before waiting, so a line logged between the
+        /// write and this call is not missed — the race that makes a subscribe-then-act test flaky.</summary>
+        /// 🚨 Returns the OBSERVABLE, never a Task. `.ToTask()` is forbidden everywhere, tests
+        /// included: a Task completed inside an Rx pipeline resumes its awaiter inline on the
+        /// signalling thread, still inside Rx's trampoline, so the bridge changes what the test
+        /// measures. The caller awaits this directly with the timeout already applied.
+        public IObservable<Match> FirstMatching(string pattern, TimeSpan within)
+        {
+            var re = new Regex(pattern, RegexOptions.Compiled);
+            // Replay what was already seen BEFORE subscribing, so a line logged between the write
+            // and this call is not missed — the race that makes a subscribe-then-act test flaky.
+            return lines.ToImmutableArray().ToObservable()
+                .Concat(emitted)
+                .Select(line => re.Match(line))
+                .Where(m => m.Success)
+                .FirstAsync()
+                .Timeout(within);
+        }
+
+        private sealed class Sink(CapturingLoggerProvider owner, string category) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (category.Contains("MeshNodeStreamHandle", StringComparison.Ordinal))
+                    owner.Add(formatter(state, exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #3477.

`Pairs-with: none` — adds no public type or member and removes none; format arguments, one new log line, one test.

**Parser-delta: none** — does not touch `scripts/check-type-forwards.py`.

---

## The defect: a fresh `requestId` per attempt, so the chain broke exactly where it mattered

```csharp
var requestId = Guid.NewGuid().AsString();      // ~1941, per ATTEMPT
lateRegistry?.Register(requestId, _path!, resp => { … });
```

The re-enqueue calls `UpdateRemote(update, attempt + 1, …)`, which runs that line again and registers under a **different** id. So after

```
[UpdateRemote] LATE_NACK_REENQUEUE … attempt=1 code=OwnerDisposing
```

there was **no id to follow**, and the three outcomes were indistinguishable in the log: the re-enqueue never left the cache hub; it left and never activated the owner; it activated and never answered. #3477's own words — *"a write that was NACKed, re-enqueued and then neither applied nor answered is the write-loss class this test exists to refuse"* — and it could not be attributed.

## The fix: one correlation id, minted at entry, inherited by every re-attempt

`UpdateRemote` gains `correlationId`; `corr = correlationId ?? Guid.NewGuid().AsString()` mints once at the caller's entry, and **both** re-enqueue arms pass `correlationId: corr`.

`corr=` now appears on `BEGIN`, `LATE_ACK`, `LATE_NACK_REENQUEUE`, `LATE_NACK_REENQUEUE failed`, `OWNER_NACK_REENQUEUE` and `VERDICT_TIMEOUT` — the last being the line an operator actually reaches for, which now carries the instruction outright: *`grep corr=<id>` yields every attempt of this write, including re-enqueues that registered under a different requestId.* A new `LATE_VERDICT_REGISTERED` names the per-attempt `requestId` beside the stable `corr`.

**Purely additive.** Nothing new is awaited, bounded or retried; no behaviour changes.

## 🚨 Why it matters more since tonight

#3505 reclassifies owner-side teardown faults as `OwnerDisposing`, which feeds **this arm** — and not incidentally. Once `HostedHubsCollection` closes a hosted hub's scope, the hub is past `DisposeHostedHubs`, `PostImplGeneric` refuses its own post, and the verdict routes through `ILatePatchVerdictSink` **by construction**: the *late* half, which is the half #3477 measured going dark. #3505's cost argument — *"a false retryable costs at most two idempotent re-diffs"* — holds only if the re-enqueue answers.

## Log levels, stated rather than assumed

`src/` levels are committed contract, not a verbosity knob. `LATE_VERDICT_REGISTERED` and `BEGIN` are **Debug** — one per write and one per late-registered write, on the hot path. The **Warning** that pays for them is `VERDICT_TIMEOUT`, which fires only once a write has already failed to settle, i.e. exactly when the chain is worth its cost.

## 🚨 What the test covers — and what it does NOT

`LateNackReenqueueCorrelationTest` drives the real sequence on the sibling's proven rig: park the owner's merge executor, write cross-hub, fence on the armed late watch, fence on the handler having run, dispose the owner so its NACK is necessarily late. It then asserts the `LATE_NACK_REENQUEUE` line **carries** a correlation id — which before this change it did not. **Passes in ~190 ms**, deterministic: a disposed owner's post is refused, so the verdict routes through the late sink immediately rather than after the 2 s response bound.

It deliberately does **not** assert on the write landing — its sibling `LateNackReenqueueTest` does, and is 1-in-330 flaky on exactly that wait, which is #3477's own open subject.

**And it does not pin INHERITANCE.** That needs the re-attempt's own `BEGIN`, which is `LogDebug` and is dropped by the harness's filter before any provider sees it. Two attempts to raise that filter for one category did not reach the factory the hub resolves. The honest options were to promote a hot-path line to Information so a test could see it — **forbidden** — or to say so. So the inheritance is guaranteed by the two call sites passing `correlationId: corr`, which the compiler checks and no test does. That gap is stated in the test's own doc comment and on the issue, rather than left for someone to find behind a green suite.

## Verification

- `MeshWeaver.Mesh.Contract` Release `-warnaserror` → **0 Warning(s), 0 Error(s)**
- `MeshWeaver.Graph.Test` Release `-warnaserror` → **0 Warning(s), 0 Error(s)**
- `LateNackReenqueueCorrelationTest` → **1 passed**, real `.trx`, and the captured line verified in the run output: `LATE_NACK_REENQUEUE … code=OwnerDisposing corr=s00FLGaix0yWYK2z8alWWQ`
