### PR TITLE
fix(cd): "incomplete because a publish is in flight" is a third verdict, not a stuck delivery (#3513)

### DIFF
--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -41,6 +41,7 @@ from pathlib import Path
 WORKFLOW = ".github/workflows/main-cd.yml"
 STEP_ID = "release"
 DECIDE_STEP_ID = "decide"
+VERDICT_STEP_ID = "verdict"
 
 SHORT_SHA = "aaf95af"
 VERSION = "3.0.0-rc8.ci.6360"
@@ -113,12 +114,42 @@ def fixture(tagged: bool) -> list[dict]:
 # will still be there after someone edits the other.
 GH_STUB = """#!/usr/bin/env bash
 echo "gh $*" >> "$GH_CALLS"
-# The ONE read the decide step makes through gh: "is an older run of this workflow on this sha
-# still running?" (MeshWeaver#3376). A case supplies the answer the real `--jq` would have
-# produced (the older run's URL, or nothing) in GH_RUNS_RESULT; every other invocation stays
-# silent, exactly as before.
+# Two reads are modelled, because two steps make them:
+#  * `actions/runs?head_sha=…` — "is a run of this workflow live on this sha?", asked by `decide`
+#    (older runs only, MeshWeaver#3376) and by `verdict` (any live run, MeshWeaver#3513). A case
+#    supplies the answer the real `--jq` would have produced in GH_RUNS_RESULT.
+#  * `commits/main` — main's tip, which `verdict` uses to tell "superseded" from "stuck".
+# GH_RUNS_FAIL makes ONLY the first one fail, so a case can drive the fail-closed arm without
+# also breaking the tip resolution. Every other invocation stays silent and succeeds, exactly as
+# before — the safety property (this stub can mutate nothing) is unchanged.
+#
+# 🚨 GH_RUNS_FIXTURE runs the step's OWN `--jq` program, with real jq, over a real
+# `workflow_runs` payload. That is deliberately stronger than answering GH_RUNS_RESULT: the whole
+# discriminator lives in that filter, and its most dangerous defect — dropping `.id != $RUN_ID`,
+# so every reconcile finds ITSELF "in flight" and the alarm is silenced forever — is invisible to
+# any case that hands the step a pre-computed answer.
 case "$*" in
-  *actions/runs*) printf '%s' "${GH_RUNS_RESULT:-}" ;;
+  *actions/runs*)
+    if [ -n "${GH_RUNS_FAIL:-}" ]; then
+      echo "gh: HTTP 502 (https://api.github.com/repos/x/y/actions/runs)" >&2
+      exit 1
+    fi
+    if [ -n "${GH_RUNS_FIXTURE:-}" ]; then
+      prog=""
+      while [ $# -gt 0 ]; do
+        [ "$1" = "--jq" ] && prog="$2"
+        shift
+      done
+      if [ -z "$prog" ]; then
+        echo "stub gh: an actions/runs call with no --jq — the harness models the filter, not the payload" >&2
+        exit 97
+      fi
+      jq -r "$prog" < "$GH_RUNS_FIXTURE"
+      exit 0
+    fi
+    printf '%s' "${GH_RUNS_RESULT:-}"
+    ;;
+  *commits/main*) printf '%s' "${GH_TIP_RESULT:-}" ;;
 esac
 exit 0
 """
@@ -154,7 +185,8 @@ def die(msg: str):
 
 
 # ── running one case ────────────────────────────────────────────────────────────────────────
-def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: bool = False):
+def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: bool = False,
+             runs: list[dict] | None = None):
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         binp = tmp / "bin"
@@ -187,7 +219,11 @@ def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: b
         e.setdefault("SHA", "abc1234000000000000000000000000000000000")
         e.setdefault("RUN_ID", "1000")
         e.setdefault("WORKFLOW_NAME", "Continuous Delivery (main)")
+        e.setdefault("REPO", "Systemorph/MeshWeaver")
         e.pop("GH_RUNS_RESULT", None)
+        e.pop("GH_RUNS_FAIL", None)
+        e.pop("GH_RUNS_FIXTURE", None)
+        e.pop("GH_TIP_RESULT", None)
         e["GH_CALLS"] = str(calls)
         # Belt AND braces: the stub above shadows `gh` on PATH, and these leave a real `gh` — if one
         # is ever reached another way — with no credential to write with.
@@ -198,6 +234,10 @@ def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: b
             e["AZ_FAIL"] = "1"
         else:
             e.pop("AZ_FAIL", None)
+        if runs is not None:
+            rf = tmp / "runs.json"
+            rf.write_text(json.dumps({"workflow_runs": runs}))
+            e["GH_RUNS_FIXTURE"] = str(rf)
         e.update(env)
 
         p = subprocess.run(["bash", "-c", body], env=e, capture_output=True, text=True)
@@ -294,6 +334,177 @@ def run_decide_cases(root, case) -> None:
          rc == 0 and "publish=true" in outputs, f"rc={rc} out={outputs!r} log={log}")
 
 
+# ── the VERDICT step: the one that told main it was broken when it was not ───────────────────
+# The runs the cases below replay, verbatim from the API on 2026-09-07. 7962/7964 are the
+# `workflow_run` twins that were mid-publish; 7963/7965 are the scheduled reconciles that accused
+# them of a stuck delivery.
+CD = "Continuous Delivery (main)"
+SHA_7962 = "6577052de389ff15ad3c94c78cb132e17d542590"
+SHA_7964 = "93dd88941" + "0" * 31
+
+
+def wf_run(rid: int, status: str, started: str, name: str = CD) -> dict:
+    return {
+        "id": rid,
+        "name": name,
+        "status": status,
+        "run_started_at": started,
+        "html_url": f"https://github.com/Systemorph/MeshWeaver/actions/runs/{rid}",
+    }
+
+
+def run_verdict_cases(root, case) -> None:
+    """
+    🚨 <b>MeshWeaver#3513 — the hourly reconcile red on its own twin's in-flight publish.</b>
+
+    `delivery-verdict` used to conclude "delivery is stuck" from four gate outputs that describe
+    main at ONE INSTANT (`reason=reconcile publish=false complete=false green=true`). That triple
+    is also what a reconcile looks like while its `workflow_run` twin is halfway through creating
+    the image set — so on 2026-09-07 runs 7963 and 7965 each failed main's CD with an accusation
+    that was false forty minutes before the same commits sealed.
+
+    The step now asks its own question before making the claim, and these cases are the two arms
+    that make the answer worth anything: it must STILL go red when nothing is publishing (the
+    coverage that must not be lost), and it must NOT go red on the 7963/7965 shape. Every case
+    drives the step's REAL `--jq` filter over a real `workflow_runs` payload, because the filter
+    IS the discriminator — an answer handed to it would prove nothing about it.
+    """
+    body = extract_step(root, VERDICT_STEP_ID)
+
+    # A stub is only evidence about what it stubs. If the step stops probing the run list, or stops
+    # being able to say "stuck" at all, every case below would pass having tested nothing.
+    for needle, why in (
+        ("actions/runs", "no longer probes the run list, so the in-flight arm tests nothing"),
+        ("Delivery is stuck", "no longer carries the stuck accusation, so the red arm tests nothing"),
+    ):
+        if needle not in body:
+            die(f"step `{VERDICT_STEP_ID}` {why} (missing `{needle}`). Update the harness with the step.")
+
+    # The 7963 shape, exactly: a scheduled reconcile, main green, image set incomplete, published
+    # nothing. Everything below varies ONLY what the run list answers.
+    shape = {
+        "REASON": "reconcile", "PUBLISH": "false", "COMPLETE": "false", "GREEN": "true",
+        "CONCLUSION": "completed/success", "SHA": SHA_7962, "SHORT": "6577052",
+        "GATE_RESULT": "success", "UPSTREAM_EVENT": "", "UPSTREAM_BRANCH": "",
+        "GITHUB_EVENT_NAME": "schedule", "RUN_ID": "34071948741", "GH_TOKEN": "",
+    }
+    me = wf_run(34071948741, "in_progress", "2026-09-07T01:06:58Z")          # run 7963 itself
+    twin = wf_run(34069402974, "in_progress", "2026-09-07T00:18:33Z")        # run 7962, mid-publish
+    done = wf_run(34067890019, "completed", "2026-09-06T23:48:02Z")
+    other = wf_run(34069999999, "in_progress", "2026-09-07T01:00:00Z", name="MeshWeaver Build and Test")
+
+    # ── ARM 1: THE COVERAGE THAT MUST NOT BE LOST ────────────────────────────────────────────
+    # A genuinely incomplete set with NO publish in flight. This is the state the job exists for,
+    # and it is the arm that would silently disappear if the fix had been "skip while busy".
+    rc, log, outputs = run_step(body, shape, None, runs=[me, done])
+    case("a green, incomplete main with NOTHING in flight is still RED",
+         rc != 0 and "Delivery is stuck" in log, f"rc={rc} log={log}")
+    case("...and the red now carries the negative finding that makes it a measurement",
+         "NO run of this workflow is queued or in progress" in log, f"log={log}")
+    case("...and it claims no deferral",
+         "deferred_to=" not in outputs, f"out={outputs!r}")
+
+    # 🚨 THE SELF-EXCLUSION CASE. The reconcile is ITSELF `in_progress` in the very list it reads.
+    # Drop `.id != $RUN_ID` from the filter and this alarm is disabled forever, in every state,
+    # with a green tick — strictly worse than the false red it was fixed for. ARM 1 above already
+    # contains `me`; this asserts the point on a list where the self run is the ONLY candidate.
+    rc, log, outputs = run_step(body, shape, None, runs=[me])
+    case("a reconcile does NOT count ITSELF as the publication in flight",
+         rc != 0 and "Delivery is stuck" in log, f"rc={rc} log={log}")
+
+    # A live run of a DIFFERENT workflow on the same commit is not a publication either — a
+    # re-run of Build-and-Test must never silence CD's delivery alarm.
+    rc, log, outputs = run_step(body, shape, None, runs=[me, other])
+    case("a live run of ANOTHER workflow on the same sha does not count",
+         rc != 0 and "Delivery is stuck" in log, f"rc={rc} log={log}")
+
+    # A run that has FINISHED is not in flight. Without the status filter, every commit that ever
+    # had a CD run would read as "publishing".
+    rc, log, outputs = run_step(body, shape, None, runs=[me, done, wf_run(34068000000, "completed", "x")])
+    case("a COMPLETED run on the same sha does not count as in flight",
+         rc != 0 and "Delivery is stuck" in log, f"rc={rc} log={log}")
+
+    # ── ARM 2: THE 7963 / 7965 SHAPE ─────────────────────────────────────────────────────────
+    rc, log, outputs = run_step(body, shape, None, runs=[me, twin, done])
+    case("run 7963's exact conditions no longer red — its twin 7962 was mid-publish",
+         rc == 0, f"rc={rc} log={log}")
+    case("...and the step does not accuse delivery of being stuck",
+         "Delivery is stuck" not in log, f"log={log}")
+    case("...and it names the run, its status, and since when — not a bare 'skipping'",
+         all(s in log for s in ("34069402974", "in_progress", "2026-09-07T00:18:33Z")), f"log={log}")
+    case("...and it states its own falsification condition, so nobody reads it as a disabled alarm",
+         "suppressed ONLY while" in log and "goes RED" in log, f"log={log}")
+    case("...and it hands the run id to the summary step as a POSITIVE finding",
+         "deferred_to=34069402974" in outputs and "deferred_status=in_progress" in outputs,
+         f"out={outputs!r}")
+
+    # Run 7965, the second false red of the night, on the other commit.
+    twin_7964 = wf_run(34072269844, "in_progress", "2026-09-07T01:12:30Z")
+    me_7965 = wf_run(34073867519, "in_progress", "2026-09-07T01:42:12Z")
+    rc, log, outputs = run_step(body,
+                                {**shape, "SHA": SHA_7964, "SHORT": "93dd889", "RUN_ID": "34073867519"},
+                                None, runs=[me_7965, twin_7964])
+    case("run 7965's exact conditions no longer red either — twin 7964 was mid-publish",
+         rc == 0 and "34072269844" in log and "Delivery is stuck" not in log, f"rc={rc} log={log}")
+
+    # A run WAITING for a runner is not stuck delivery either, and the message must say which of
+    # the two it saw rather than flattening them into one word.
+    rc, log, outputs = run_step(body, shape, None,
+                                runs=[me, wf_run(34069402974, "queued", "2026-09-07T01:05:00Z")])
+    case("a QUEUED run counts as a live publication, and is reported as queued",
+         rc == 0 and "queued" in log, f"rc={rc} log={log}")
+
+    # A NEWER live run counts too. The gate's #3376 probe looks only at OLDER runs because it has
+    # to break a deferral tie; this step decides nothing, so any live run falsifies "nobody is
+    # publishing it". Encoded as a case so a future edit cannot quietly narrow it back.
+    rc, log, outputs = run_step(body, shape, None,
+                                runs=[me, wf_run(34079999999, "in_progress", "2026-09-07T01:07:30Z")])
+    case("a NEWER live run on this sha falsifies 'stuck' just as an older one does",
+         rc == 0 and "34079999999" in log, f"rc={rc} log={log}")
+
+    # ── ARM 3: THE PROBE MUST NOT BECOME A SKIP-TRAPDOOR ─────────────────────────────────────
+    # An unanswerable probe is not reassurance. If this ever passes, the fix has reintroduced the
+    # exact defect AGENTS.md names: a gate that cannot run looking like a gate that passed.
+    rc, log, outputs = run_step(body, {**shape, "GH_RUNS_FAIL": "1"}, None, runs=[me, twin])
+    case("a FAILING probe fails the step — it never silences the alarm",
+         rc != 0, f"rc={rc} log={log}")
+    case("...and it names the probe as what went unanswered, not the delivery",
+         "probe" in log and "FAILED" in log, f"log={log}")
+    case("...and it claims no deferral it could not observe",
+         "deferred_to=" not in outputs, f"out={outputs!r}")
+
+    # ── THE PROBE IS NOT A BLANKET SILENCER ──────────────────────────────────────────────────
+    # It sits inside ONE branch. Every other verdict must be exactly as loud as before, even with
+    # a publication live on the commit — otherwise "a run is in flight" becomes a universal excuse.
+    rc, log, outputs = run_step(body, {**shape, "REASON": "push", "GREEN": "false",
+                                       "CONCLUSION": "completed/failure"}, None, runs=[me, twin])
+    case("a push path on a RED main is still red, live run or not",
+         rc != 0 and "settled RED" in log, f"rc={rc} log={log}")
+    rc, log, outputs = run_step(body, {**shape, "REASON": "", "GATE_RESULT": "failure"},
+                                None, runs=[me, twin])
+    case("an EMPTY gate verdict is still red, live run or not",
+         rc != 0 and "NO verdict" in log, f"rc={rc} log={log}")
+    rc, log, outputs = run_step(body, {**shape, "REASON": "", "GATE_RESULT": "skipped",
+                                       "GITHUB_EVENT_NAME": "workflow_run",
+                                       "UPSTREAM_EVENT": "pull_request", "UPSTREAM_BRANCH": "feat/x"},
+                                None, runs=[me, twin])
+    case("a PR-triggered workflow_run is still the legitimate no-op it always was",
+         rc == 0 and "not applicable" in log, f"rc={rc} log={log}")
+
+    # The superseded-burst branch still resolves the tip through the API this step also uses for
+    # the probe — proof the two reads did not get crossed when REPO moved into `env:`.
+    rc, log, outputs = run_step(body, {**shape, "REASON": "push", "GREEN": "false",
+                                       "CONCLUSION": "completed/cancelled",
+                                       "GH_TIP_RESULT": "f" * 40}, None, runs=[me])
+    case("a cancelled, superseded push is still a green no-op",
+         rc == 0 and "superseded" in log, f"rc={rc} log={log}")
+    rc, log, outputs = run_step(body, {**shape, "REASON": "push", "GREEN": "false",
+                                       "CONCLUSION": "completed/cancelled",
+                                       "GH_TIP_RESULT": SHA_7962}, None, runs=[me])
+    case("a cancelled TIP is still red",
+         rc != 0 and "is the TIP" in log, f"rc={rc} log={log}")
+
+
 def main() -> int:
     root = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
     try:
@@ -301,6 +512,11 @@ def main() -> int:
         import yaml  # noqa: F401
     except ImportError as exc:
         die(f"this harness cannot run — {exc}. pip install jmespath pyyaml.")
+    # The verdict cases run the step's OWN `--jq` filter through real jq. Without it every one of
+    # them would fail on the stub's exit 127 rather than on the logic — say so plainly instead.
+    if subprocess.run(["bash", "-c", "command -v jq"], capture_output=True).returncode != 0:
+        die("this harness cannot run — `jq` is not on PATH, and the verdict cases execute the "
+            "step's real --jq filter over a workflow_runs fixture. Install jq.")
 
     body = extract_step(root, STEP_ID)
     # A stub is only evidence about the call it stubs. If the step stopped making that call, the
@@ -361,10 +577,15 @@ def main() -> int:
     run_decide_cases(root, case)
 
     print()
+    print(f"── step `{VERDICT_STEP_ID}` ──")
+    run_verdict_cases(root, case)
+
+    print()
     if failures:
         print(f"::error::{len(failures)} case(s) failed: {', '.join(failures)}")
         return 1
-    print(f"all cases passed against {WORKFLOW} steps `{STEP_ID}` + `{DECIDE_STEP_ID}` (extracted, not copied)")
+    print(f"all cases passed against {WORKFLOW} steps `{STEP_ID}` + `{DECIDE_STEP_ID}` "
+          f"+ `{VERDICT_STEP_ID}` (extracted, not copied)")
     return 0
 
 

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2700,10 +2700,10 @@ jobs:
               :
             else
               # 🚨 FAIL CLOSED, and say which question went unanswered. An unanswerable probe must
-              # never silence this alarm — that would make the probe a skip-trapdoor, indistinguish-
-              # able from a pass, which is the defect this whole job is an instance of. Same posture
-              # as the unresolved-tip branch further down, and for the same reason: the outcome that
-              # must not be missed is the stuck one.
+              # never silence this alarm — that would make the probe a skip-trapdoor, which GitHub
+              # renders identically to a pass, and that is the defect this whole job is an instance
+              # of. Same posture as the unresolved-tip branch further down, and for the same reason:
+              # the outcome that must not be missed is the stuck one.
               echo "::error::main \`$SHORT\` is GREEN, has an INCOMPLETE image set, and this reconcile published nothing — and the probe that separates 'a publication is in flight' from 'delivery is stuck' FAILED (gh api on actions/runs). Refusing to guess: an unanswered probe must never be read as reassurance. Read the run list for \`$SHORT\` by hand, and chase the API failure — it is the bug, whichever way the delivery turns out."
               exit 1
             fi

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2569,8 +2569,17 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Job-level permissions REPLACE the workflow-level map, so every one this job needs is here:
+    #   contents — `commits/main`, the tip resolution that tells "superseded" from "stuck"
+    #   actions  — `actions/runs?head_sha=…`, the live-publication probe that tells "a publish is
+    #              in flight" from "nobody is publishing" (MeshWeaver#3513)
+    # It checks out nothing and pushes nothing, so id-token and packages are deliberately absent.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: A green, incomplete main must never end a reconcile unpublished
+        id: verdict
         env:
           REASON: ${{ needs.gate.outputs.reason }}
           PUBLISH: ${{ needs.gate.outputs.publish }}
@@ -2586,6 +2595,15 @@ jobs:
           GATE_RESULT: ${{ needs.gate.result }}
           UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
           UPSTREAM_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # 🚨 Passed through `env:` rather than written as `${{ github.repository }}` inside the
+          # body, and that is load-bearing rather than stylistic: `test-cd-steps.py` EXTRACTS this
+          # step from this file by its `id:` and executes it against fixtures, and it REFUSES a
+          # body carrying a `${{ }}` expression it would have to rewrite. A step it cannot execute
+          # is a step whose only first run is in production, on a schedule — which is how the two
+          # false reds below reached main's CD history in the first place.
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           set -euo pipefail
           echo "gate=$GATE_RESULT reason=$REASON publish=$PUBLISH complete=$COMPLETE green=$GREEN sha=$SHORT"
@@ -2621,7 +2639,84 @@ jobs:
 
           if [ "$REASON" = "reconcile" ] && [ "$PUBLISH" != "true" ] \
              && [ "$COMPLETE" = "false" ] && [ "$GREEN" = "true" ]; then
-            echo "::error::main \`$SHORT\` is GREEN and has an INCOMPLETE image set, and this reconcile published nothing. Delivery is stuck: every self-updating install stays on the previous image. This job exists because that state is otherwise INVISIBLE — the run reports success and every image job simply reads as skipped."
+            # 🚨 "INCOMPLETE" IS A SNAPSHOT. "STUCK" IS A CLAIM ABOUT THE FUTURE. (MeshWeaver#3513)
+            #
+            # The four gate outputs above describe main at ONE INSTANT: green, no complete image
+            # set, this tick published nothing. From that alone the step used to conclude "delivery
+            # is stuck", which is a claim about what will happen NEXT — and it is false whenever the
+            # set is incomplete *because a publication is halfway through creating it*.
+            #
+            # Measured 2026-09-07, twice in forty minutes. Run 7963 (schedule, 01:07Z) and run 7965
+            # (schedule, 01:42Z) each fired this error. Neither delivery was stuck: their own
+            # `workflow_run` twins — 7962 on `6577052` and 7964 on `93dd889` — were mid-publish,
+            # between `Build + push` and `Promote`, and both sealed (01:38:49Z and 02:32:25Z). The
+            # gate had ALREADY worked this out correctly and said so in its log:
+            #
+            #     ⏳ An older run of this workflow is still publishing `6577052`:
+            #        …/actions/runs/34069402974 — deferring, so one commit yields ONE image set
+            #
+            # …but `decision false "…"` writes only a BOOLEAN. The reason the gate declined never
+            # reached this step, so this step re-derived a diagnosis from `publish=false` and got a
+            # different one. It recurs on every hour whose top a publish straddles (7940 on
+            # `62039c9` at 21:24Z is the same shape), and it costs the one thing a CD history must
+            # have: a red that always means something.
+            #
+            # 🚨 THE FIX IS NOT TO SKIP THE CHECK WHEN A RUN IS IN FLIGHT. GitHub paints a skipped
+            # job exactly like a passed one, and the window in which publishes happen IS the window
+            # this alarm exists to watch — silencing it there would delete most of its coverage.
+            # So the step CONCLUDES instead of declining to conclude, and it does so on a THIRD
+            # verdict, from evidence it gathers ITSELF, at verdict time:
+            #
+            #   • a run of this workflow is `queued`/`in_progress` on this exact commit
+            #        ⇒ INCOMPLETE BECAUSE A PUBLICATION IS IN FLIGHT — not a defect. Green, named.
+            #   • no such run
+            #        ⇒ INCOMPLETE AND NOBODY IS FIXING IT — the original red, unchanged, now
+            #          carrying the negative finding that makes it a measurement.
+            #   • the probe could not be answered
+            #        ⇒ RED, fail-closed. See below.
+            #
+            # It re-reads rather than trusting a relayed gate output ON PURPOSE. The gate's reading
+            # is itself a snapshot, taken before every leg ran; a verdict resting on it would be the
+            # same instrument-reads-a-snapshot-as-a-fact defect one level along. This probe is the
+            # freshest reading available at the moment the claim is made, and the claim it supports
+            # is exactly as narrow as the reading.
+            #
+            # 🚨 AND IT IS SELF-LIMITING WITHOUT A TIMER — no sleep, no retry, no widened window.
+            # Suppression lasts precisely as long as a run is observably live, and a run cannot be
+            # live indefinitely: every job in this repo carries a literal `timeout-minutes` ≤ 45,
+            # so GitHub itself terminates a hung publication, after which the next hourly tick finds
+            # nothing in flight and reds. The bound is GitHub's, enforced by GitHub — never a number
+            # written here to make a red go away.
+            #
+            # `.id != $RUN_ID` excludes this run and NOTHING ELSE. The gate's own #3376 probe looks
+            # only at OLDER runs because it must break a tie between two runs that would both defer;
+            # this step decides nothing and acts on nothing, so any live run on this commit — older
+            # or newer, push lane or reconcile lane — is a fact that falsifies "nobody is publishing
+            # it", and all of them count.
+            if LIVE=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=50" \
+                        --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\" and .id != $RUN_ID and (.status == \"in_progress\" or .status == \"queued\"))]
+                              | sort_by(.id) | .[0] // empty
+                              | \"\(.id) \(.status) \(.run_started_at) \(.html_url)\""); then
+              :
+            else
+              # 🚨 FAIL CLOSED, and say which question went unanswered. An unanswerable probe must
+              # never silence this alarm — that would make the probe a skip-trapdoor, indistinguish-
+              # able from a pass, which is the defect this whole job is an instance of. Same posture
+              # as the unresolved-tip branch further down, and for the same reason: the outcome that
+              # must not be missed is the stuck one.
+              echo "::error::main \`$SHORT\` is GREEN, has an INCOMPLETE image set, and this reconcile published nothing — and the probe that separates 'a publication is in flight' from 'delivery is stuck' FAILED (gh api on actions/runs). Refusing to guess: an unanswered probe must never be read as reassurance. Read the run list for \`$SHORT\` by hand, and chase the API failure — it is the bug, whichever way the delivery turns out."
+              exit 1
+            fi
+            if [ -n "$LIVE" ]; then
+              read -r LIVE_ID LIVE_STATUS LIVE_SINCE LIVE_URL <<< "$LIVE"
+              echo "deferred_to=$LIVE_ID" >> "$GITHUB_OUTPUT"
+              echo "deferred_status=$LIVE_STATUS" >> "$GITHUB_OUTPUT"
+              echo "deferred_since=$LIVE_SINCE" >> "$GITHUB_OUTPUT"
+              echo "⏳ main \`$SHORT\` has an INCOMPLETE image set and this reconcile published nothing — because run $LIVE_ID is \`$LIVE_STATUS\` on this exact commit since $LIVE_SINCE ($LIVE_URL). That is a publication in progress, not a stuck delivery, and deferring to it is what keeps one commit to ONE image set (MeshWeaver#3376)."
+              echo "   This verdict is suppressed ONLY while a run is observably live on \`$SHORT\`. If that run does not complete the set, the next hourly reconcile finds nothing in flight and this job goes RED — no timer, no retry, nothing to un-stick by hand."
+              exit 0
+            fi
+            echo "::error::main \`$SHORT\` is GREEN and has an INCOMPLETE image set, this reconcile published nothing, and NO run of this workflow is queued or in progress on \`$SHORT\` — so nobody is publishing it. Delivery is stuck: every self-updating install stays on the previous image. This job exists because that state is otherwise INVISIBLE — the run reports success and every image job simply reads as skipped."
             exit 1
           fi
 
@@ -2654,7 +2749,7 @@ jobs:
           # hole and it must stay loud. So the discriminator is tip-ness, not colour.
           if [ "$REASON" = "push" ] && [ "$PUBLISH" != "true" ] && [ "$GREEN" != "true" ] \
              && [ "${CONCLUSION#*/}" = "cancelled" ]; then
-            TIP=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha' || echo "")
+            TIP=$(gh api "repos/$REPO/commits/main" --jq '.sha' || echo "")
             if [ -z "$TIP" ]; then
               # \U0001f6a8 Say what is true, not what is convenient. Tip-ness was NOT established, so
               # claiming it (either way) would be the same sin this step exists to correct: a
@@ -2728,6 +2823,11 @@ jobs:
           SHORT: ${{ needs.gate.outputs.short_sha }}
           GATE_RESULT: ${{ needs.gate.result }}
           PROMOTE_RESULT: ${{ needs.promote.result }}
+          # The third verdict (MeshWeaver#3513). Empty unless the step above found a live
+          # publication on this commit — so this is a POSITIVE finding, never a default.
+          DEFERRED_TO: ${{ steps.verdict.outputs.deferred_to }}
+          DEFERRED_STATUS: ${{ steps.verdict.outputs.deferred_status }}
+          DEFERRED_SINCE: ${{ steps.verdict.outputs.deferred_since }}
         run: |
           # 🚨 NO-OP is keyed on the gate having been SKIPPED — never on an empty reason. An empty
           # reason is ALSO what a gate that errored, was cancelled, or produced no outputs looks
@@ -2735,6 +2835,12 @@ jobs:
           # broken run with the one label that says nothing was due. (Caught in review.)
           if [ "$GATE_RESULT" = "skipped" ]; then
             echo "### ⚪ NO-OP — the gate did not run: not a push to main, so no delivery was due" >> "$GITHUB_STEP_SUMMARY"
+          # 🚨 Ahead of the generic "NO PUBLISH", because those are two different facts and the
+          # summary is where a human decides whether to care. `🕐 NO PUBLISH … (reason: reconcile)`
+          # on a commit whose image set is incomplete reads as the stuck state; naming the run that
+          # IS publishing it is the whole content of MeshWeaver#3513's third verdict.
+          elif [ -n "$DEFERRED_TO" ]; then
+            echo "### ⏳ DEFERRED for \`${SHORT}\` — run [${DEFERRED_TO}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${DEFERRED_TO}) is \`${DEFERRED_STATUS}\` on this commit since ${DEFERRED_SINCE}. The image set is incomplete because that publication is still creating it — a correct no-op, not a stuck delivery (#3513)." >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PUBLISH" = "true" ] && [ "$PROMOTE_RESULT" = "success" ]; then
             echo "### ✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PUBLISH" = "true" ]; then

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -303,6 +303,25 @@ other-workflow case, the completed-run case, the fail-closed case, and one case 
 branch. Sabotaging the fix three ways (drop `.id != $RUN_ID`; make the branch exit 0 without
 probing; treat an unanswerable probe as "in flight") reds 7, 16 and 3 cases respectively.
 
+**Two corrections to the report, both measured, because the denominator matters.** #3513 lists run
+7940 (`62039c9`, 21:24Z) as a third instance. It is not: its gate read `publish=true`, it *did*
+publish, its migration-image leg failed, and its red came from the "a publishing run must have RUN
+every leg" step. Same for 7946 — a genuine red about a genuinely failed build. The false-red
+population is **7963 and 7965**, and the probe cannot reach either of those reds, because the stuck
+branch requires `publish != true`.
+
+🚨 **And one sibling of this shape is still OPEN, in the same branch.** The reconcile's
+`⏭️ differs from the newest published set only in image-irrelevant paths` decision also produces
+`reason=reconcile publish=false complete=false green=true`, so it too reads as "stuck" — and unlike
+the in-flight case there is nothing live to find, so it stays red on every tick until a relevant
+commit lands. It is now **reachable**: the `--detail` fix made the relevance probe resolve a newest
+published set (`Newest published set: 8ef74ed` in run 7963's gate log, where it used to read
+`<none>` and fail open). It was deliberately NOT folded into this change: whether a tip whose only
+delta is `clients/react-native` or `clients/voice-gateway` counts as *deliverable* is a policy call,
+not a reading of evidence, and the verdict cannot see `relevant` at all — `gate` exposes it as a
+step output, never a job output. Fixing it means adding that output and deciding the policy, in a
+change that says so.
+
 **The recurring shape to carry away.** An instrument that reads a snapshot and reports it as a fact
 is wrong in one direction only — it converts *transient* into *terminal*. The other three instances
 found the same night were a run's `created_at` read as its start time (it is QUEUE time; the 45-min

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -212,6 +212,104 @@ by construction: it can only be seen on main, after the merge, and what you woul
 precisely what is missing. The credential is the only place a pre-merge check can stand, and it is
 causal rather than correlated — with `GITHUB_TOKEN` the trigger is suppressed 100% of the time.
 
+### 🚨 "INCOMPLETE" is a snapshot; "STUCK" is a claim about the future — the third verdict
+
+`delivery-verdict` is the job that makes a green-but-shipped-nothing reconcile loud. It reaches its
+verdict from four `gate` outputs — `reason`, `publish`, `complete`, `green` — and until #3513 it
+concluded **"delivery is stuck"** from `reason=reconcile publish=false complete=false green=true`.
+
+Those four facts describe main at **one instant**. "Stuck" is a claim about what happens **next**,
+and the two come apart in exactly one situation, which happens every day: the image set is
+incomplete *because a publication is halfway through creating it*.
+
+**Measured 2026-09-07, twice inside forty minutes.** The hourly `schedule` reconcile fires at
+`:23`; a `workflow_run` publish takes ~20 min to reach `promote` and ~80 min to seal. When one
+straddles the top of the hour, the reconcile reads the intermediate state as a terminal one:
+
+| run | event | head | outcome |
+|---|---|---|---|
+| 7962 | `workflow_run` | `6577052` | publishing; **sealed 01:38:49Z** |
+| **7963** | `schedule` | `6577052` | **FAILED 01:07:47Z** — "delivery is stuck" |
+| 7964 | `workflow_run` | `93dd889` | publishing; **sealed 02:32:25Z** |
+| **7965** | `schedule` | `93dd889` | **FAILED 01:43:01Z** — same message |
+| 7966 | `schedule` | `93dd889` | success — arrived *after* 7964 finished |
+
+Nothing was wrong either time. 7940 on `62039c9` at 21:24Z is the same shape the evening before.
+
+🚨 **The gate had already worked it out and the verdict could not hear it.** `gate`'s own #3376
+probe found the twin and logged the right answer —
+
+```text
+⏳ An older run of this workflow is still publishing `6577052`:
+   …/actions/runs/34069402974 — deferring, so one commit yields ONE image set
+```
+
+— but `decision false "…"` writes only a **boolean**. The *reason* the gate declined reached the
+step summary and the log and nothing the verdict could read, so the verdict re-derived a diagnosis
+from `publish=false` and got a different one. That is the general defect, not a CD quirk: **a
+consumer that reconstructs a producer's conclusion from a coarse output will eventually reconstruct
+a different one.**
+
+**Why "skip the check while a run is in flight" is the wrong fix.** GitHub paints a skipped job the
+same colour as a passed one, so a skip converts a false red into an invisible hole — and the window
+in which publishes happen *is* the window this alarm exists to watch. Silencing it there deletes
+most of its coverage. The job must **conclude**, not decline to conclude.
+
+**The shape that ships.** `delivery-verdict` asks the question its claim depends on, itself, at
+verdict time, and answers with a third verdict:
+
+```bash
+gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=50" \
+  --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\" and .id != $RUN_ID
+                                   and (.status == \"in_progress\" or .status == \"queued\"))]
+        | sort_by(.id) | .[0] // empty
+        | \"\(.id) \(.status) \(.run_started_at) \(.html_url)\""
+```
+
+| finding | verdict |
+|---|---|
+| a run of this workflow is `queued`/`in_progress` on this exact commit | **incomplete because a publication is in flight** — green, naming the run, its status and its start |
+| no such run | **incomplete and nobody is fixing it** — the original red, now carrying the negative finding that makes it a measurement |
+| the probe could not be answered | **red, fail-closed** — an unanswered probe is never reassurance |
+
+Four properties are load-bearing, and each closes a way this could have become a band-aid:
+
+- **It re-reads; it does not relay.** Piping the gate's `⏳` decision through as an output would have
+  been shorter and would have repeated the defect one level along — the gate's reading is *also* a
+  snapshot, taken before any leg ran. The probe is the freshest reading available at the moment the
+  claim is made, and the claim is exactly as narrow as the reading.
+- **It is self-limiting without a timer.** No sleep, no retry, no widened window. Suppression lasts
+  precisely as long as a run is *observably live*, and a run cannot be live indefinitely: every job
+  in this repo carries a literal `timeout-minutes` ≤ 45, so GitHub itself terminates a hung
+  publication, after which the next hourly tick finds nothing in flight and reds. **The bound is
+  GitHub's, enforced by GitHub** — never a number written here to make a red go away.
+- **`.id != $RUN_ID` excludes this run and nothing else.** Dropping it is the catastrophic edit:
+  every reconcile would find *itself* "in flight" and the alarm would be silenced forever, with a
+  green tick — strictly worse than the false red. `gate`'s #3376 probe looks only at **older** runs
+  because it must break a tie between two runs that would otherwise both defer; this step decides
+  nothing and acts on nothing, so **any** live run on the commit — older or newer, push lane or
+  reconcile lane — is a fact that falsifies "nobody is publishing it".
+- **The probe sits inside one branch.** Every other verdict (red main, empty gate output, cancelled
+  tip, the legitimate PR-triggered no-op) is exactly as loud as before, live run or not. "A run is
+  in flight" must never become a universal excuse.
+
+🚨 **The coverage is provably unchanged for the case the job exists to catch**, and "provably" is
+literal: `.github/scripts/test-cd-steps.py` EXTRACTS this step from `main-cd.yml` by its `id: verdict`
+and executes it against fixtures, driving the step's **real `--jq` filter** over a real
+`workflow_runs` payload — a hand-supplied answer would prove nothing about the filter, which is the
+whole discriminator. Both arms are cases: *a green, incomplete main with nothing in flight is still
+RED*, and *run 7963's exact conditions no longer red*. So are the self-exclusion case, the
+other-workflow case, the completed-run case, the fail-closed case, and one case per untouched
+branch. Sabotaging the fix three ways (drop `.id != $RUN_ID`; make the branch exit 0 without
+probing; treat an unanswerable probe as "in flight") reds 7, 16 and 3 cases respectively.
+
+**The recurring shape to carry away.** An instrument that reads a snapshot and reports it as a fact
+is wrong in one direction only — it converts *transient* into *terminal*. The other three instances
+found the same night were a run's `created_at` read as its start time (it is QUEUE time; the 45-min
+cut is per **job**, from that job's own start), a merge time read from a commit's committer date,
+and a status read twenty minutes stale and asserted as current. The cure is never a wait: it is to
+**re-read at the moment of the claim, and to state the claim only as far as the reading reaches.**
+
 ## The standing trap — verify the IMAGE, never the tick
 
 CD's `workflow_run` trigger reacts to a **real push**, and — more exactly — to one that

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -791,6 +791,24 @@ nothing. The two together are what makes off-branch triggers destructive.
 Guarded by `WorkflowRunTriggerBranchFilterGuard`, which carries a control arm: if its block matcher
 ever stops recognising `workflow_run:`, it fails rather than passing having examined nothing.
 
+### The other direction: a CD red on main that means nothing
+
+The section above is delivery stopping behind green ticks. The inverse cost the same evening: the
+hourly `main-cd` reconcile fired **"main `<sha>` is GREEN and has an INCOMPLETE image set, and this
+reconcile published nothing — delivery is stuck"** twice inside forty minutes (runs 7963 and 7965,
+2026-09-07), on two commits that both sealed shortly afterwards. The set was incomplete because the
+reconcile's own `workflow_run` twin was **mid-publish** — a scheduled job reasoning about a state
+its sibling was halfway through creating, and reporting the intermediate as a defect.
+
+**A red that means nothing is expensive in the same way a green that means nothing is**: it is
+mixed in with reds that mean everything, and people were reading CD conclusions to decide a release
+that night. `delivery-verdict` now probes the run list before making the claim and reaches a **third
+verdict** — *incomplete because a publication is in flight* — distinct from *incomplete and nobody
+is fixing it*; only the second is a defect, and it is still red. Before treating any CD red on main
+as an incident, read whether the run named one. Mechanism, and why "skip while a run is in flight"
+would have been the wrong fix:
+[Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract).
+
 ## 🚨 A queue ejection is not a red on the PR — read the steward's comment, not the PR's checks
 
 With the merge queue on, a pull request's own checks can be entirely green while the PR is *not

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-delivery-alarm-no-longer-fires-at-a-delivery-in-progress.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-delivery-alarm-no-longer-fires-at-a-delivery-in-progress.md
@@ -12,7 +12,7 @@ Every hour, a check asks one question about the platform: *does the newest code 
 of deployable images?* If it does not, nobody's installation can move forward, and that is worth
 waking someone for. So when the answer is no, the check goes red and says delivery is stuck.
 
-Building that set takes about twenty minutes and sealing it about eighty. For a stretch of every
+Building that set takes about twenty minutes and sealing it about eighty minutes. For a stretch of every
 such build, the honest answer to the question is "no" — not because anything is wrong, but because
 the set is being assembled right then. The hourly check had no way to see that. When a build
 straddled the top of an hour, it read a half-finished set as a broken one and reported a stall.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-delivery-alarm-no-longer-fires-at-a-delivery-in-progress.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-delivery-alarm-no-longer-fires-at-a-delivery-in-progress.md
@@ -1,0 +1,53 @@
+---
+Name: A delivery alarm no longer fires at a delivery in progress
+Category: Fix
+Description: The hourly check that watches for a stalled release was reporting a stall whenever a release happened to be halfway through. It now tells the two apart, and the real stall is still reported loudly.
+Icon: Alert
+Order: -20260907
+---
+
+# A delivery alarm no longer fires at a delivery in progress
+
+Every hour, a check asks one question about the platform: *does the newest code have a complete set
+of deployable images?* If it does not, nobody's installation can move forward, and that is worth
+waking someone for. So when the answer is no, the check goes red and says delivery is stuck.
+
+Building that set takes about twenty minutes and sealing it about eighty. For a stretch of every
+such build, the honest answer to the question is "no" — not because anything is wrong, but because
+the set is being assembled right then. The hourly check had no way to see that. When a build
+straddled the top of an hour, it read a half-finished set as a broken one and reported a stall.
+
+On 7 September it did this twice inside forty minutes, on two commits that both completed normally a
+short while later. Nothing was stuck either time.
+
+## Why a red that means nothing costs something
+
+The check is worth having: an installation that quietly stays on yesterday's build is invisible
+otherwise, and this is what makes it visible. That value comes entirely from the red being
+believable. A red that has to be reasoned away sits in the same list as the reds that must not be —
+and it arrived on an evening when people were reading exactly this signal to decide whether to
+ship.
+
+## What changed
+
+The obvious repair would have been to stay quiet while a build is running. That trades a false
+alarm for a blind spot: a check that says nothing looks precisely like a check that found nothing,
+and the minutes while a build is running are the minutes this check exists to watch.
+
+So instead of declining to answer, it now answers a third way. Before reporting a stall it looks at
+whether a build is actually under way on that exact code, and reports what it finds:
+
+- **A build is running or waiting to start** — the set is incomplete because it is being created.
+  Reported as a normal outcome, naming the build and when it started.
+- **No build is running** — nobody is completing the set. Reported as a stall, exactly as before,
+  and now saying that it checked.
+- **The question could not be answered** — reported as a stall. An unanswered question is never
+  treated as reassurance.
+
+Nothing waits, retries or is given more time to settle; the quiet period lasts precisely as long as
+a build is visibly running, and a build that hangs is ended by the platform's own limits, after
+which the next hourly check reports the stall.
+
+The behaviour of both outcomes is now exercised by the test suite on every change: that a genuinely
+incomplete set with no build running is still reported as a stall, and that the two September runs'
+conditions no longer are.


### PR DESCRIPTION
Closes #3513.

## The defect

The hourly `main-cd` reconcile red on its own `workflow_run` twin's in-flight publish — twice inside forty minutes on 2026-09-07, on a night when people were reading CD conclusions to decide a release.

| run | event | head | outcome |
|---|---|---|---|
| 7962 | `workflow_run` | `6577052` | publishing; **sealed 01:38:49Z** |
| **7963** | `schedule` | `6577052` | **FAILED 01:07:47Z** — "delivery is stuck" |
| 7964 | `workflow_run` | `93dd889` | publishing; **sealed 02:32:25Z** |
| **7965** | `schedule` | `93dd889` | **FAILED 01:43:01Z** — same message |
| 7966 | `schedule` | `93dd889` | success — arrived *after* 7964 finished |

`delivery-verdict` derived a claim about the **future** ("delivery is stuck") from four gate outputs that describe main at **one instant** (`reason=reconcile publish=false complete=false green=true`). Those four facts are also exactly what a reconcile looks like while its twin is halfway through creating the image set.

**The gate had already worked it out and the verdict could not hear it.** From run 7963's own gate log:

```
⏳ An older run of this workflow is still publishing `6577052`:
   https://github.com/Systemorph/MeshWeaver/actions/runs/34069402974 — deferring,
   so one commit yields ONE image set (MeshWeaver#3376).
```

`decision false "…"` writes only a **boolean**. The reason reached the log and the step summary and nothing the verdict could read, so the verdict re-derived a diagnosis from `publish=false` and got a different one.

## The shape chosen — a third verdict, not a skip

Skipping the reconcile while a run is in flight would trade a false red for an invisible hole (GitHub paints a skipped job the same colour as a passed one), and the window in which publishes happen **is** the window this alarm exists to watch. So the step **concludes** instead of declining to conclude. It asks the question its claim depends on, itself, at verdict time:

| finding | verdict |
|---|---|
| a run of this workflow is `queued`/`in_progress` on this exact commit | **incomplete because a publication is in flight** — green, naming the run, its status and its start |
| no such run | **incomplete and nobody is fixing it** — the original red, now carrying the negative finding that makes it a measurement |
| the probe could not be answered | **red, fail-closed** — an unanswered probe is never reassurance |

Four properties, each closing a way this could have become a band-aid:

- **It re-reads; it does not relay.** Piping the gate's `⏳` decision through as an output would have been shorter and would have repeated the defect one level along — the gate's reading is *also* a snapshot.
- **Self-limiting without a timer.** No sleep, no retry, no widened window. Suppression lasts exactly as long as a run is *observably live*, and every job here carries a literal `timeout-minutes` ≤ 45 — so **GitHub** ends a hung publication, after which the next tick finds nothing in flight and reds.
- **`.id != $RUN_ID` excludes this run and nothing else.** Dropping it is the catastrophic edit: every reconcile would find *itself* in flight and the alarm would be silenced forever, with a green tick.
- **The probe sits inside one branch.** Red main, empty gate output, cancelled tip and the legitimate PR no-op are exactly as loud as before, live run or not.

## Verification — both arms, demonstrated

`.github/scripts/test-cd-steps.py` **extracts** this step from `main-cd.yml` by its new `id: verdict` and executes it against fixtures, driving the step's **real `--jq` filter** over a real `workflow_runs` payload. A hand-supplied answer would prove nothing about the filter, and the filter is the whole discriminator. 22 cases:

```
  PASS  a green, incomplete main with NOTHING in flight is still RED      ← coverage kept
  PASS  ...and the red now carries the negative finding that makes it a measurement
  PASS  a reconcile does NOT count ITSELF as the publication in flight
  PASS  a live run of ANOTHER workflow on the same sha does not count
  PASS  a COMPLETED run on the same sha does not count as in flight
  PASS  run 7963's exact conditions no longer red — its twin 7962 was mid-publish   ← the false red
  PASS  run 7965's exact conditions no longer red either — twin 7964 was mid-publish
  PASS  a QUEUED run counts as a live publication, and is reported as queued
  PASS  a NEWER live run on this sha falsifies 'stuck' just as an older one does
  PASS  a FAILING probe fails the step — it never silences the alarm
  PASS  a push path on a RED main is still red, live run or not
  PASS  an EMPTY gate verdict is still red, live run or not
  PASS  a PR-triggered workflow_run is still the legitimate no-op it always was
  PASS  a cancelled, superseded push is still a green no-op / a cancelled TIP is still red
```

**A gate nobody has watched fail is not a gate**, so the fix was sabotaged three ways and each reds:

| sabotage | cases red |
|---|---|
| drop `.id != $RUN_ID` from the probe's filter | 7 |
| make the branch `exit 0` without probing — the "just skip it" fix | 16 |
| treat an unanswerable probe as "in flight" | 3 |

**Live against the real API**, not only fixtures — the exact probe, on a sha with a CD run in flight and on `6577052` today:

```
── 19b077868…  (CD run 7976 in_progress)
   probe answer='34085298189 in_progress 2026-09-07T05:02:30Z …/runs/34085298189'
   ⇒ VERDICT: deferred (publication in flight)
── 6577052de…  (7962 completed/success, 7963 completed/failure)
   probe answer=''
   ⇒ VERDICT: stuck (RED)
```

## Coverage, provably unchanged

The red is suppressed **only** by a `queued`/`in_progress` run of this workflow on main's exact HEAD — i.e. only when something demonstrably *is* completing the set. The genuinely-stuck case (`#2543`'s family) has no such run and still reds, which is the first case in the list above. Worst case on a hung publication is one hour of extra latency, bounded by GitHub's own job cap rather than by anything written here.

## Gates

- `check-workflow-timeouts.py --root .` — 71 jobs, 0 violations, cap 45
- `check-workflow-shell.py` — 0 live findings
- `check-pr-secret-preflight.py` — 0 violations
- `actionlint` on `main-cd.yml` — clean
- `MeshWeaver.Documentation.Test` (link integrity, embed integrity, all `main-cd.yml` guards) — 75 passed, 0 failed
- `dotnet build -c Release -warnaserror` — 0 Warning(s), 0 Error(s)

## Work product committed

- `Doc/Architecture/ContinuousDeliveryContract` → **"INCOMPLETE is a snapshot; STUCK is a claim about the future — the third verdict"**: the measurement, why the gate's correct answer could not reach the verdict, why "skip while busy" is the wrong fix, and the four load-bearing properties.
- `Doc/Architecture/ReadingCiSignals` → the inverse of its "delivery stops behind green ticks" section: a CD red on main that means nothing, and to check whether the run named an in-flight publication before treating it as an incident.
- A What's New entry (`Category: Fix`).

Pairs-with: none — CI and documentation only; the diff removes no public type or member from `src/` (no `.cs` file is touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
