### PR TITLE
review: say module-relative where the lane IS module-relative (#3514 follow-up)

### DIFF
--- a/.github/scripts/test-module-asset-landing.py
+++ b/.github/scripts/test-module-asset-landing.py
@@ -68,7 +68,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 
-# (workflow, job id, step id) — both lanes carry the same landing block and both are executed.
+# (workflow, step id) — extraction is by STEP ID alone, across every job in the file. Both lanes
+# carry the same landing block and both are executed.
 LANES = [
     (".github/workflows/node-repo-gate.yml", "ext-modules"),
     (".github/workflows/node-repo-publish-bake.yml", "ext-modules"),
@@ -326,7 +327,8 @@ def case_lands_assets(lane: str, body: str, tmp: Path) -> None:
     print(f"        denominator: 3 bundle(s) composed, 2 carrying static assets, "
           f"{total_shipped} asset file(s) shipped, {landed} landed byte-identical")
     if landed == total_shipped and len(FAILURES) == before:
-        ok(f"{lane}: {landed}/{total_shipped} shipped assets landed under /ext/<module>/wwwroot")
+        ok(f"{lane}: {landed}/{total_shipped} shipped assets landed module-relative "
+           f"under /ext/<module>/")
 
 
 def case_missing_entry_is_refused(lane: str, body: str, tmp: Path) -> None:

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -946,7 +946,7 @@ jobs:
             echo "external module composed: $name ($(basename "$b")) — $assets static asset file(s)"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
-          echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed under /ext/<module>/wwwroot"
+          echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"
           echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
           echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"
       - name: Import + compile + render + run tests for each node repo

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1002,7 +1002,7 @@ jobs:
             echo "sealing $name as module package '$pkg'"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
-          echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed under /ext/<module>/wwwroot"
+          echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"
           echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
           echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"
           echo "SEAL_MODULES_DIR=${RUNNER_TEMP:-/tmp}/seal-modules" >> "$GITHUB_ENV"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleStaticAssets.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleStaticAssets.md
@@ -142,7 +142,8 @@ about it, and runs in `dotnet-test.yml` beside the other workflow-shell gates.
   still lands beside the assets.
 
 The lane's own check is per file and prints a denominator:
-`external modules: 30 composed, 6 of them carrying static web assets, 294 asset file(s) landed`.
+`external modules: 30 composed, 6 of them carrying static web assets, 294 asset file(s) landed
+module-relative under /ext/<module>/`.
 A count that could only ever read zero is not a check — [an uncounted zero has two causes](/Doc/Architecture/NegativeControls)
 and one of them is "we looked in the wrong place".
 


### PR DESCRIPTION
Follow-up to #3535 (which closed #3514). Three Copilot findings on that PR, all correct, all
message/comment drift with **no behaviour change** — they arrived a minute after auto-merge had
already enqueued #3535, and a push would have ejected it from the queue for three strings.

* `test-module-asset-landing.py`'s `LANES` comment described a `(workflow, job id, step id)` tuple
  for a `(workflow, step id)` one. Extraction is by **step id alone, across every job in the file**
  — the property that makes the harness survive a job rename — so the comment was understating the
  guarantee as well as being wrong.
* Both lanes' summary line said `landed under /ext/<module>/wwwroot` while the copy is deliberately
  `cp -R moduleassets/.` — **module-relative**, so a second asset root would ride too. Stating
  today's only root as the contract contradicts the reason the copy is written that way, and would
  read as a bug the day the packer emits another root. Now `landed module-relative under
  /ext/<module>/`, in both lanes, in the harness's own `ok` line, and in the doc page that quotes
  it.

**Verification** (unchanged bar, re-run on this branch off `main`):
`.github/scripts/test-module-asset-landing.py` — 2 lanes × 4 cases, **both falsification arms still
red** (pre-fix body ⇒ `0/6 assets land`; `cp` removed ⇒ the lane's own check fails closed) ·
`actionlint` over all workflows · `check-workflow-shell.py` · `check-workflow-timeouts.py`
(71 jobs, 0 violations) · `MeshWeaver.Documentation.Test` **304/304**, Release `-warnaserror`.
