### PR TITLE
fix(test): guard TestCluster.Primary, which Orleans 10.3.1 makes nullable

### DIFF
--- a/test/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs
+++ b/test/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs
@@ -230,8 +230,13 @@ public class SharedOrleansFixture : IAsyncLifetime
         // Without this, response routing tries to activate a grain for the client address → fails.
         // Access silo's IRoutingService via reflection (InProcessSiloHandle.SiloHost.Services)
         // Try multiple paths to find the silo's IRoutingService
+        // 🚨 TestCluster.Primary is SiloHandle? from Microsoft.Orleans.TestingHost 10.3.1 on
+        // (it was non-nullable at 10.1.0). Propagate the null rather than asserting: this whole
+        // block is already best-effort — the `if (siloRouting != null)` below is the existing
+        // posture, because a cluster shape without a reachable primary simply skips the silo-side
+        // registration instead of failing the fixture.
         var primarySilo = Cluster.Primary;
-        var siloHost = primarySilo.GetType().GetProperty("SiloHost")?.GetValue(primarySilo) as IHost;
+        var siloHost = primarySilo?.GetType().GetProperty("SiloHost")?.GetValue(primarySilo) as IHost;
         var siloRouting = siloHost?.Services.GetService<IRoutingService>()
             ?? siloHost?.Services.GetService<IMessageHub>()?.ServiceProvider.GetService<IRoutingService>();
         if (siloRouting != null)

--- a/test/MeshWeaver.Hosting.Orleans.TestBase/TwoSiloCacheUpdateFixture.cs
+++ b/test/MeshWeaver.Hosting.Orleans.TestBase/TwoSiloCacheUpdateFixture.cs
@@ -109,7 +109,13 @@ public class TwoSiloCacheUpdateFixture : IAsyncLifetime
     {
         get
         {
-            var primary = Cluster.Primary;
+            // 🚨 TestCluster.Primary is SiloHandle? from Microsoft.Orleans.TestingHost 10.3.1
+            // on (it was non-nullable at 10.1.0). Assert rather than propagate: this property's
+            // contract is to RETURN a hub, so an absent primary is a broken fixture and must say
+            // so here — the same posture as the throw that already guards SiloHost below.
+            var primary = Cluster.Primary
+                ?? throw new InvalidOperationException(
+                    "The test cluster has no primary silo — the fixture never started one.");
             var siloHost = primary.GetType().GetProperty("SiloHost")?.GetValue(primary) as IHost
                 ?? throw new InvalidOperationException("Could not access primary silo host");
             return siloHost.Services.GetRequiredService<IMessageHub>();


### PR DESCRIPTION
Unblocks half of #3519 — the weekly dependency sweep, which is red on **two independent causes**:

| cause | fixed by |
|---|---|
| `Aspire 13.4.6 -> 13.5.3` drags in `JsonPatch.Net 5.0.2` (OSMF maintenance fee) — caught by `Dependency licences` | #3537 |
| `Microsoft.Orleans 10.2.2 -> 10.3.1` reds `Build solution (once)` on 2x `CS8602` | **this PR** |

## What actually changed upstream

`Microsoft.Orleans.TestingHost` annotates `TestCluster.Primary` as `SiloHandle?` from **10.3.1**; it is non-nullable at the **10.1.0** we pin today (note the pin skew — the rest of Orleans is already 10.2.2). Both fixtures dereference the local they take from it.

## Verified against both package sets, not reasoned about

```
Orleans 10.3.1 + current code -> 2 Error(s)   <- reproduces CI exactly, same file(line,col)
                                 TwoSiloCacheUpdateFixture.cs(113,28): error CS8602
                                 SharedOrleansFixture.cs(234,24):      error CS8602
Orleans 10.3.1 + this change  -> 0 Warning(s), 0 Error(s)
Orleans 10.2.2 + this change  -> 0 Warning(s), 0 Error(s)   <- main's pins; the no-regression half
```

Both dependents (`MeshWeaver.Testing.Xunit`, `MeshWeaver.Hosting.Orleans.Test`) also build clean at `Release -warnaserror`. The bump was applied locally only to produce the first two rows and reverted before committing — **this PR moves no package version.**

## The two sites are treated differently on purpose

Each matches the posture already present a few lines below it:

- **`SharedOrleansFixture`** *propagates* the null (`primarySilo?.`). Its silo-side registration is best-effort and already ends in `if (siloRouting != null)`, so a cluster shape without a reachable primary should skip that registration, not fail the fixture.
- **`TwoSiloCacheUpdateFixture`** *asserts* (`?? throw`). The property's contract is to return a hub, and it already throws when `SiloHost` is absent — so an absent primary is a broken fixture and has to say so there.

Making both the same would have been wrong in one of the two places.

## Notes

- No public surface removed or added, so the cross-repo pair gate does not apply.
- No What's New entry: test-base only, no user-visible surface — measured precedent is #3531 (test hygiene, no entry), against #3535/#3534/#3533 which change behaviour and do have one.

Pairs-with: none — test-base internals only; no public type or member leaves `src/`.
