### PR TITLE
The Homebrew install asks, registers, and the answers actually reach the next boot

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -249,6 +249,11 @@ write_registry_file() {
   memex_portal:
     PluginCatalog__BootstrapKey: \"$key\""
   fi
+  # The id line only exists when one was PINNED. Absent, the portal's first-run wizard asks for a
+  # name and mints the guid it registers under — see Doc/Architecture/FirstRunSetup.
+  local instance_id_line=""
+  [ -n "$id" ] && instance_id_line="  instanceId: \"$id\"
+"
   # Subshell: the umask must not leak into the rest of this process (the overlay, the cert files
   # and every later write keep their own modes).
   ( umask 077; cat > "$REGISTRY_FILE" ) <<YAML
@@ -262,8 +267,7 @@ write_registry_file() {
 # (Admin ▸ Instance grants) — see Doc/Architecture/PluginRegistry.
 pluginCatalog:
   registryUrl: "$url"
-  instanceId: "$id"
-  homeUrl: "https://${HOSTNAME_LOCAL}"
+${instance_id_line}  homeUrl: "https://${HOSTNAME_LOCAL}"
 ${secrets}
 YAML
   chmod 600 "$REGISTRY_FILE"
@@ -337,9 +341,15 @@ cmd_registry() {
         ""|mwr_*) ;;
         *) die "registry: '--key' must be a REGISTRATION key (mwr_…); an instance key (mwi_) or a personal token (mw_) cannot register an install — or pass no key at all for an open (free-tier) registration" ;;
       esac
-      [ -n "$id" ] || id="$(default_instance_id)"
-      case "$id" in
-        *[!a-z0-9-]*|"") die "registry: --id must be lower-case letters, digits and dashes (got '$id')" ;;
+      # 🚨 NOT defaulted any more. An id is claimed GLOBALLY on the registry and never re-issued,
+      # so guessing one from <user>-<host> is a permanent claim made on the operator's behalf — and
+      # it OUTRANKS the id the first-run wizard mints (deployment config beats the instance
+      # manifest), so the wizard would ask, register a guid, and then be silently overridden.
+      # Unstated means "the wizard asks"; `--id` stays the way to pin one deliberately.
+      # An EMPTY id is now the ordinary case — it means "the wizard asks" — so only a STATED one is
+      # validated. Keeping "" in the refusal list is what made the no---id path die here.
+      case "${id:-ok}" in
+        *[!a-z0-9-]*) die "registry: --id must be lower-case letters, digits and dashes (got '$id')" ;;
       esac
       write_registry_file "${url%/}" "$key" "$id"
       if [ -n "$key" ]; then
@@ -2075,6 +2085,12 @@ cmd_setup() {
   ok "First-run setup is waiting."
   echo "  URL:   ${url}?token=${token}"
   echo "  Token: ${token}"
+  echo
+  info "The wizard asks in two steps:"
+  info "  1. a NAME for this instance. Its id is a guid the portal mints and registers for you —"
+  info "     ids are claimed permanently, so it does not ask you to invent one."
+  info "  2. everything else, chosen from what your plan grants: plugins, database, sign-in,"
+  info "     model keys, modules. Then it restarts configured."
   echo
   info "SQLite is pre-selected and needs nothing else running — it lands at"
   info "  Data Source=/data/memex.db   (on the same PVC that survives 'memex-local update')."

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -405,6 +405,24 @@ if grep -q 'instanceId: "my-box"$' "$rfile" 2>/dev/null \
    && grep -q '^pluginCatalog:$' "$rfile" 2>/dev/null && grep -q '^secrets:$' "$rfile" 2>/dev/null; then
   ok "the file carries pluginCatalog.{registryUrl,instanceId} and the bootstrap-key secret"
 else bad "the file carries pluginCatalog.{registryUrl,instanceId} and the bootstrap-key secret" "$(cat "$rfile" 2>/dev/null)"; fi
+# 🚨 WITHOUT --id the file must carry NO instanceId, because the portal's first-run wizard asks for
+# the name and mints the guid it registers under. An id here is deployment configuration, which
+# OUTRANKS the instance manifest — so a defaulted <user>-<host> would let the wizard ask, register a
+# guid, and then be silently overridden by a value the operator never chose. Ids are claimed
+# globally and never re-issued, so guessing one is a permanent claim made on their behalf.
+reg https://memex.example.test
+if [ "$RC" -eq 0 ] && [ -f "$rfile" ]; then ok "registry <url> with no --id still writes the file"
+else bad "registry <url> with no --id still writes the file" "exited ${RC}: ${OUT}"; fi
+if grep -q 'instanceId:' "$rfile" 2>/dev/null; then
+  bad "no --id leaves the instance id to the wizard" "the file pre-claims an id: $(cat "$rfile" 2>/dev/null)"
+else ok "no --id leaves the instance id to the wizard"; fi
+if grep -q 'registryUrl: "https://memex.example.test"$' "$rfile" 2>/dev/null; then
+  ok "…and still records the registry the wizard should default to"
+else bad "…and still records the registry the wizard should default to" "$(cat "$rfile" 2>/dev/null)"; fi
+
+# Restore the pinned-id file for the mode/status assertions that follow.
+reg https://memex.example.test/ --key mwr_abcdefghijklmnop --id my-box
+
 case "$(ls -l "$rfile" 2>/dev/null | cut -c1-10)" in
   -rw-------) ok "the registry file is 0600 (it holds a secret)" ;;
   *) bad "the registry file is 0600 (it holds a secret)" "$(ls -l "$rfile" 2>/dev/null)" ;;

--- a/memex/Memex.Portal.Shared/Setup/SetupComposition.cs
+++ b/memex/Memex.Portal.Shared/Setup/SetupComposition.cs
@@ -280,7 +280,12 @@ public static class SetupComposition
             Storage = new InstanceStorageSelection
             {
                 Type = storageOption!.Type,
-                ConnectionString = Blank(answers.ConnectionString),
+                // 🚨 Encrypted, because a connection string carries a password. It sits in the same
+                // file as the sign-in secrets and provider keys, and leaving this one readable while
+                // protecting those was an inconsistency, not a decision — see the projection.
+                ConnectionString = Blank(answers.ConnectionString) is { } cs
+                    ? Protect(cs, protector, storageOption.DisplayName, strings, problems)
+                    : null,
                 BasePath = Blank(answers.BasePath),
             },
             BootModules = answers.BootModules,

--- a/src/MeshWeaver.Mesh.Contract/InstanceManifestProjection.cs
+++ b/src/MeshWeaver.Mesh.Contract/InstanceManifestProjection.cs
@@ -38,6 +38,10 @@ public static class InstanceManifestProjection
     /// <c>EmbeddingOptions</c> binds it.</summary>
     public const string EmbeddingSection = "Embedding";
 
+    /// <summary>The section the registered identity lands on — what the plugin catalog reads to
+    /// know who this instance is and which key it fetches with.</summary>
+    public const string PluginCatalogSection = "PluginCatalog";
+
     /// <summary>
     /// The tenant value a blank Microsoft tenant must become.
     ///
@@ -63,14 +67,47 @@ public static class InstanceManifestProjection
         if (manifest is not { State: InstanceSetupState.Complete })
             return entries;
 
-        ProjectStorage(manifest.Storage, entries);
+        ProjectIdentity(manifest.Identity, protector, entries);
+        ProjectStorage(manifest.Storage, protector, entries);
         ProjectSignIn(manifest.SignIn, protector, entries);
         ProjectAi(manifest.Ai, protector, entries);
         return entries;
     }
 
+    /// <summary>
+    /// The registered identity, as the plugin catalog reads it.
+    ///
+    /// <para>🚨 <b><c>RegistryToken</c> is the load-bearing one, and without it the wizard's whole
+    /// registration is ORPHANED.</b> <c>InstanceAutoRegistrationService</c> runs on the configured
+    /// boot and registers whenever it sees an instance id and no token — so an instance that had
+    /// just registered through the wizard would register a SECOND time, under whatever id the
+    /// deployment happens to carry, and claim another id permanently (ids are global and never
+    /// re-issued). Projecting the token instead takes that service's own
+    /// <c>RegistrationPreflight.Skip</c> branch — <i>"a registry token is already configured — the
+    /// explicit token wins"</i> — so the boot uses the registration the operator already made.</para>
+    ///
+    /// <para>Nothing is projected until the key can be DECRYPTED. A registry token that is still
+    /// ciphertext authenticates nothing: every fetch would 401, the catalog would look empty, and
+    /// the instance would appear to have been granted nothing — while the id sits claimed. Dropping
+    /// the whole identity instead leaves auto-registration to report the real problem.</para>
+    /// </summary>
+    private static void ProjectIdentity(
+        InstanceIdentitySelection? identity, IProviderKeyProtector? protector,
+        IDictionary<string, string?> entries)
+    {
+        if (identity is not { IsRegistered: true })
+            return;
+        if (Reveal(identity.InstanceKey, protector) is not { } key)
+            return;
+
+        entries[$"{PluginCatalogSection}:RegistryUrl"] = identity.RegistryUrl;
+        entries[$"{PluginCatalogSection}:InstanceId"] = identity.Id;
+        entries[$"{PluginCatalogSection}:RegistryToken"] = key;
+    }
+
     private static void ProjectStorage(
-        InstanceStorageSelection? storage, IDictionary<string, string?> entries)
+        InstanceStorageSelection? storage, IProviderKeyProtector? protector,
+        IDictionary<string, string?> entries)
     {
         if (storage is null || string.IsNullOrWhiteSpace(storage.Type))
             return;
@@ -78,13 +115,19 @@ public static class InstanceManifestProjection
         entries[$"{StorageSection}:Type"] = storage.Type;
         if (!string.IsNullOrWhiteSpace(storage.BasePath))
             entries[$"{StorageSection}:BasePath"] = storage.BasePath;
-        // 🚨 The connection string is NOT decrypted here and is never encrypted in the manifest:
-        // it is the one credential the host needs before the master key can be of any use — the
-        // database is where everything else lives. A deployment with a secret store names it
-        // instead (SecretName), and the named secret arrives as an ordinary configuration value
-        // that outranks this projection anyway.
-        if (!string.IsNullOrWhiteSpace(storage.ConnectionString))
-            entries[$"{StorageSection}:ConnectionString"] = storage.ConnectionString;
+        // 🚨 The connection string CARRIES A PASSWORD, so it is revealed exactly like every other
+        // secret in this file. An earlier comment here claimed it could not be encrypted because
+        // "the host needs it before the master key can be of any use" — that was simply wrong: the
+        // master key is resolved from the deployment or from instance.key BEFORE this projection
+        // runs, which is how the sign-in secrets and provider keys in the SAME manifest are already
+        // encrypted. Leaving this one in the clear meant a manifest that is copied onto a new
+        // volume, backed up, or pasted into an issue carried a live database password in plaintext
+        // beside ciphertext that was carefully protected.
+        //
+        // Reveal() passes an UNENCRYPTED value through unchanged, so a manifest written before this
+        // (or hand-authored) keeps working.
+        if (Reveal(storage.ConnectionString, protector) is { } connectionString)
+            entries[$"{StorageSection}:ConnectionString"] = connectionString;
     }
 
     private static void ProjectSignIn(

--- a/test/Memex.Portal.Shared.Test/InstanceManifestProjectionTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstanceManifestProjectionTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using MeshWeaver.AI;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
@@ -54,6 +55,42 @@ public class InstanceManifestProjectionTest
         Assert.Equal("Sqlite", entries["Graph:Storage:Type"]);
         Assert.Equal("Data Source=/data/memex.db", entries["Graph:Storage:ConnectionString"]);
     }
+
+    [Fact]
+    public void TheConnectionString_IsStoredEncrypted_AndRevealedForUse()
+    {
+        // 🚨 It carries a PASSWORD and lives in the same file as the sign-in secrets and provider
+        // keys. Leaving it readable while protecting those was an inconsistency, not a decision: a
+        // manifest gets copied to a new volume, backed up, and pasted into an issue when an
+        // instance will not boot.
+        var stored = Protector.Protect("Host=db;Username=postgres;Password=hunter2");
+        Assert.StartsWith("enc:v1:", stored);
+
+        var entries = InstanceManifestProjection.ToConfiguration(
+            Complete() with
+            {
+                Storage = new InstanceStorageSelection { Type = "PostgreSql", ConnectionString = stored },
+            },
+            Protector);
+
+        // Revealed for the host that must actually open the database…
+        Assert.Equal("Host=db;Username=postgres;Password=hunter2", entries["Graph:Storage:ConnectionString"]);
+    }
+
+    [Fact]
+    public void APlaintextConnectionString_FromAnOlderOrHandWrittenManifest_StillWorks()
+        // Reveal() passes an untagged value through unchanged, so this is not a breaking change for
+        // a manifest written before the encryption, or one an operator authored by hand.
+        => Assert.Equal("Host=db;Database=memex",
+            InstanceManifestProjection.ToConfiguration(
+                Complete() with
+                {
+                    Storage = new InstanceStorageSelection
+                    {
+                        Type = "PostgreSql", ConnectionString = "Host=db;Database=memex",
+                    },
+                },
+                Protector)["Graph:Storage:ConnectionString"]);
 
     [Fact]
     public void ABlankMicrosoftTenant_BecomesTheWordCommon_NeverEmpty()
@@ -226,6 +263,68 @@ public class InstanceManifestProjectionTest
 
         Assert.False(entries.ContainsKey("Embedding:Provider"));
     }
+
+    [Fact]
+    public void TheRegisteredIdentity_ProjectsTheTokenThatSTOPSASecondRegistration()
+    {
+        // 🚨 The whole point. InstanceAutoRegistrationService runs on the configured boot and
+        // registers whenever it sees an instance id and NO token — so without this projection an
+        // instance that had just registered through the wizard registers a SECOND time, under
+        // whatever id the deployment happens to carry, and claims another id permanently. Ids are
+        // global and never re-issued. With the token present that service takes its own Skip branch
+        // ("a registry token is already configured — the explicit token wins").
+        var entries = InstanceManifestProjection.ToConfiguration(
+            Complete() with
+            {
+                Identity = new InstanceIdentitySelection
+                {
+                    Id = "0f8fad5b-d9cb-469f-a165-70867728950e",
+                    Name = "Roland laptop",
+                    RegistryUrl = "https://memex.meshweaver.cloud",
+                    InstanceKey = Protector.Protect("mwi_realkey"),
+                    Plan = "free",
+                },
+            },
+            Protector);
+
+        Assert.Equal("https://memex.meshweaver.cloud", entries["PluginCatalog:RegistryUrl"]);
+        Assert.Equal("0f8fad5b-d9cb-469f-a165-70867728950e", entries["PluginCatalog:InstanceId"]);
+        Assert.Equal("mwi_realkey", entries["PluginCatalog:RegistryToken"]);
+    }
+
+    [Fact]
+    public void AnIdentityWhoseKeyCannotBeDecrypted_ProjectsNOTHING()
+    {
+        // 🚨 Not "projects the id without the token" — that is the shape that would register a
+        // second time. A registry token that is still ciphertext authenticates nothing either: every
+        // fetch 401s, the catalog looks empty, and the instance appears to have been granted
+        // nothing while its id sits claimed. Dropping the whole identity leaves auto-registration to
+        // report the real problem instead.
+        var other = new ProviderKeyProtector(new LiteralMasterKeyProvider("a-different-key"));
+        var entries = InstanceManifestProjection.ToConfiguration(
+            Complete() with
+            {
+                Identity = new InstanceIdentitySelection
+                {
+                    Id = "0f8fad5b-d9cb-469f-a165-70867728950e",
+                    Name = "Roland laptop",
+                    RegistryUrl = "https://memex.meshweaver.cloud",
+                    InstanceKey = other.Protect("mwi_realkey"),
+                },
+            },
+            Protector);
+
+        Assert.False(entries.ContainsKey("PluginCatalog:RegistryToken"));
+        Assert.False(entries.ContainsKey("PluginCatalog:InstanceId"));
+    }
+
+    [Fact]
+    public void NoIdentityAtAll_ProjectsNoPluginCatalogKeys()
+        // The ordinary state of every deployment configured through appsettings — it must stay
+        // byte-identical, and in particular must not have an empty registry token invented for it.
+        => Assert.False(
+            InstanceManifestProjection.ToConfiguration(Complete(), Protector)
+                .Keys.Any(k => k.StartsWith("PluginCatalog:", StringComparison.OrdinalIgnoreCase)));
 
     private static InstanceManifest Complete() => new()
     {

--- a/test/Memex.Portal.Shared.Test/InstanceManifestProjectionTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstanceManifestProjectionTest.cs
@@ -322,9 +322,9 @@ public class InstanceManifestProjectionTest
     public void NoIdentityAtAll_ProjectsNoPluginCatalogKeys()
         // The ordinary state of every deployment configured through appsettings — it must stay
         // byte-identical, and in particular must not have an empty registry token invented for it.
-        => Assert.False(
-            InstanceManifestProjection.ToConfiguration(Complete(), Protector)
-                .Keys.Any(k => k.StartsWith("PluginCatalog:", StringComparison.OrdinalIgnoreCase)));
+        => Assert.DoesNotContain(
+            InstanceManifestProjection.ToConfiguration(Complete(), Protector).Keys,
+            k => k.StartsWith("PluginCatalog:", StringComparison.OrdinalIgnoreCase));
 
     private static InstanceManifest Complete() => new()
     {


### PR DESCRIPTION
Driving a **fresh install end to end** — the flow a `brew install` actually produces — found the seam
that made the wizard's registration orphaned, plus a secret sitting in the clear beside encrypted ones.

## 1. The identity was never projected

`InstanceManifestProjection` carried `Storage`, `SignIn` and `Ai` — but **not `Identity`**. So the
configured boot knew nothing about the registration the operator had just completed.

`InstanceAutoRegistrationService` registers whenever it sees an instance id and **no token**. So the
instance registered a **second time**, under whatever id the deployment happened to carry —
in registry mode `<user>-<host>` — **claiming another id permanently.** Ids are global and never
re-issued.

Projecting `PluginCatalog:{RegistryUrl,InstanceId,RegistryToken}` takes that service's own `Skip`
branch instead: *"a registry token is already configured — the explicit token wins"*.

🚨 Nothing is projected when the key cannot be **decrypted**. An id without a working token is the
double-registration shape again, and a ciphertext token 401s every fetch while the id sits claimed —
so the whole identity is dropped and auto-registration reports the real problem.

## 2. `memex-local` pre-claimed an instance id

`registry <url>` defaulted `instanceId` to `<user>-<host>` — a permanent global claim made on the
operator's behalf, and one that **outranks** the guid the wizard mints (deployment config beats the
instance manifest). The wizard would ask, register a guid, and be silently overridden.

Unstated now means *"the wizard asks"*; `--id` still pins one deliberately. The new test immediately
caught that the id validator still refused an **empty** id, which is now the ordinary case.

## 3. The connection string was in the clear

It carries a password, in the same file whose sign-in secrets and provider keys are `enc:v1:`
encrypted. The comment claiming it *couldn't* be encrypted — *"needed before the master key can be of
any use"* — was wrong: the key is resolved from the deployment or `instance.key` **before** this
projection runs, which is exactly how those other secrets are already protected.

`Reveal()` passes an untagged value through unchanged, so manifests written before this (or authored
by hand) keep working.

## Verified by running it

Browser-driven against a **local** registry — nothing reaches `memex.meshweaver.cloud`, so no real id
is claimed:

```
1. landed on    : /setup        "Welcome — let's name this instance"
   minted id    : ccdec1df-05cc-415f-89fc-af33436fd0af
2. after register: "Set up this instance"
   databases    : Sqlite*, PostgreSql, FileSystem   (* pre-selected)
   plugins      : Plugins/Store, Plugins/PostgreSql, Plugins/Chess
   dev-login    : disabled — already configured by this deployment
3. after install: "Setup complete — restarting"

manifest: Complete · PostgreSql · packages ['Plugins/PostgreSql']
          connection string enc:v1:…  · instance key enc:v1:…
          neither the password nor the key readable in the file
```

61/61 setup suites · 61/61 `deploy/homebrew/test/run-tests.sh`.

`Pairs-with: none — additive; no public type or member removed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
