### PR TITLE
The CD ledger closes itself, and the parser-delta gate reaches the merge queue

### DIFF
--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -42,6 +42,7 @@ WORKFLOW = ".github/workflows/main-cd.yml"
 STEP_ID = "release"
 DECIDE_STEP_ID = "decide"
 VERDICT_STEP_ID = "verdict"
+HEAL_STEP_ID = "heal"
 
 SHORT_SHA = "aaf95af"
 VERSION = "3.0.0-rc8.ci.6360"
@@ -128,7 +129,22 @@ echo "gh $*" >> "$GH_CALLS"
 # discriminator lives in that filter, and its most dangerous defect — dropping `.id != $RUN_ID`,
 # so every reconcile finds ITSELF "in flight" and the alarm is silenced forever — is invisible to
 # any case that hands the step a pre-computed answer.
+#  * `issue list` — "is there an open ci-failure issue?", asked by the `heal` step. A case supplies
+#    the number the real `--jq` would have produced in GH_ISSUE_RESULT (empty = none open).
+#  * `issue close` — the ledger close (#3176). GH_CLOSE_FAIL makes ONLY that call fail, so a case
+#    can drive the "a failed close must not red a run that delivered" arm without also breaking
+#    the comment that has to survive it.
 case "$*" in
+  *"issue list"*) printf '%s' "${GH_ISSUE_RESULT:-}" ;;
+  # Matched explicitly and BEFORE the reads below: a heal comment quotes a run URL, and a body
+  # containing `actions/runs` would otherwise fall into the run-list arm and answer a fixture.
+  *"issue comment"*) ;;
+  *"issue close"*)
+    if [ -n "${GH_CLOSE_FAIL:-}" ]; then
+      echo "gh: HTTP 403 (https://api.github.com/repos/x/y/issues/1)" >&2
+      exit 1
+    fi
+    ;;
   *actions/runs*)
     if [ -n "${GH_RUNS_FAIL:-}" ]; then
       echo "gh: HTTP 502 (https://api.github.com/repos/x/y/actions/runs)" >&2
@@ -186,7 +202,7 @@ def die(msg: str):
 
 # ── running one case ────────────────────────────────────────────────────────────────────────
 def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: bool = False,
-             runs: list[dict] | None = None):
+             runs: list[dict] | None = None, calls_out: list[str] | None = None):
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         binp = tmp / "bin"
@@ -224,6 +240,10 @@ def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: b
         e.pop("GH_RUNS_FAIL", None)
         e.pop("GH_RUNS_FIXTURE", None)
         e.pop("GH_TIP_RESULT", None)
+        # Same discipline as the four above: a knob left over from the caller's environment would
+        # silently change what a case measures.
+        e.pop("GH_ISSUE_RESULT", None)
+        e.pop("GH_CLOSE_FAIL", None)
         e["GH_CALLS"] = str(calls)
         # Belt AND braces: the stub above shadows `gh` on PATH, and these leave a real `gh` — if one
         # is ever reached another way — with no credential to write with.
@@ -241,6 +261,11 @@ def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: b
         e.update(env)
 
         p = subprocess.run(["bash", "-c", body], env=e, capture_output=True, text=True)
+        # What the step ASKED GitHub to do is the subject of the ledger cases: a step that prints
+        # "closing" and calls no `gh issue close` is exactly the defect #3176 records, and it is
+        # invisible in stdout.
+        if calls_out is not None:
+            calls_out.extend(calls.read_text().splitlines())
         # The job summary is part of what a decision step SAYS, so a case asserting on the
         # decision's wording must be able to see it.
         return p.returncode, p.stdout + p.stderr + summary.read_text(), out.read_text()
@@ -505,6 +530,81 @@ def run_verdict_cases(root, case) -> None:
          rc != 0 and "is the TIP" in log, f"rc={rc} log={log}")
 
 
+# ── the HEAL step: the one that told a human to close an issue and then never closed one ─────
+def run_heal_cases(root, case) -> None:
+    """
+    🚨 <b>MeshWeaver#3176 — an alert that cannot be resolved stops being an alert.</b>
+
+    `verify-images` reports a successful heal onto whichever `ci-failure` issue is open, and the
+    comment used to end *"Close this issue if nothing else is outstanding"* — advice, to nobody in
+    particular, from a bot. Nobody ever did. Meanwhile `gate` and `alert-on-failure` both append to
+    whichever `ci-failure` issue is OPEN, so the first one filed absorbed every attempt and every
+    heal from then on: #3176 reached 324 comments over four days and a dozen unrelated causes, and
+    its title had been false since the first day.
+
+    The two properties an alert has — its EXISTENCE means delivery is broken, its AGE is the
+    outage's age — are both destroyed by that. These cases hold the fix to the only standard that
+    matters here: the step must actually CALL `gh issue close`. A step that merely prints the word
+    "closing" is the defect, not the fix, and stdout cannot tell them apart — so every case asserts
+    on the recorded `gh` invocations.
+    """
+    body = extract_step(root, HEAL_STEP_ID)
+
+    # A stub is only evidence about what it stubs, and this needle is the whole subject: if the
+    # step stops closing, these cases must not keep passing while the ledger goes immortal again.
+    for needle, why in (
+        ("gh issue close", "no longer closes the ledger, which IS #3176 — every case below would pass vacuously"),
+        ("gh issue comment", "no longer records the heal, so the delivery record these cases assert is gone"),
+    ):
+        if needle not in body:
+            die(f"step `{HEAL_STEP_ID}` {why} (missing `{needle}`). Update the harness with the step.")
+
+    env = {
+        "SHORT_SHA": "1a2b3c4",
+        "PORTAL_VERSION": "3.0.0-ci.7989",
+        # Deliberately free of `actions/runs`: the stub answers that shape from a fixture, and a
+        # comment body is not a read.
+        "RUN_URL": "https://example.invalid/run/1",
+        "GH_TOKEN": "",
+    }
+
+    # ── ARM 1: THE FIX. An open ledger is commented on AND CLOSED. ────────────────────────
+    calls: list[str] = []
+    rc, log, _ = run_step(body, {**env, "GH_ISSUE_RESULT": "3176"}, None, calls_out=calls)
+    joined = "\n".join(calls)
+    case("a successful heal records itself on the open ci-failure issue",
+         rc == 0 and "gh issue comment 3176" in joined, f"rc={rc} calls={calls} log={log}")
+    case("...and CLOSES it, rather than asking a human to (#3176)",
+         "gh issue close 3176" in joined, f"the ledger was left open: calls={calls} log={log}")
+    case("...and says the next failure gets a FRESH issue, so the advice is not merely dropped",
+         "FRESH" in joined, f"calls={calls}")
+
+    # ── ARM 2: THE COVERAGE THAT MUST NOT BE LOST. No open issue ⇒ touch nothing. ─────────
+    # Without this, "it closes the ledger" would also pass if the step closed something on every
+    # green run — and the number it would close is whatever `--jq` answered, i.e. nothing sane.
+    calls = []
+    rc, log, _ = run_step(body, {**env, "GH_ISSUE_RESULT": ""}, None, calls_out=calls)
+    joined = "\n".join(calls)
+    case("no open ci-failure issue is a silent no-op, not a close of nothing",
+         rc == 0 and "issue close" not in joined and "issue comment" not in joined,
+         f"rc={rc} calls={calls} log={log}")
+
+    # ── ARM 3: a failed CLOSE must not red a run that DELIVERED. ────────────────────
+    # `verify-images` is a delivery leg: `delivery-verdict` refuses a publish whose legs did not all
+    # succeed, and `alert-on-failure` files an issue on any failure. So a 403 on the close would
+    # file an alert about the alerting, on a run that shipped. The heal COMMENT must still be
+    # written — that is the record — and the run must stay green with a warning.
+    calls = []
+    rc, log, _ = run_step(body, {**env, "GH_ISSUE_RESULT": "3176", "GH_CLOSE_FAIL": "1"},
+                          None, calls_out=calls)
+    joined = "\n".join(calls)
+    case("a REFUSED close leaves the run green (it would otherwise alert about the alerting)",
+         rc == 0, f"rc={rc} log={log}")
+    case("...and says so as a warning rather than silently",
+         "::warning::" in log and "close" in log, f"log={log}")
+    case("...and the heal comment is still written, so the delivery record survives",
+         "gh issue comment 3176" in joined, f"calls={calls}")
+
 def main() -> int:
     root = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
     try:
@@ -581,11 +681,15 @@ def main() -> int:
     run_verdict_cases(root, case)
 
     print()
+    print(f"── step `{HEAL_STEP_ID}` ──")
+    run_heal_cases(root, case)
+
+    print()
     if failures:
         print(f"::error::{len(failures)} case(s) failed: {', '.join(failures)}")
         return 1
     print(f"all cases passed against {WORKFLOW} steps `{STEP_ID}` + `{DECIDE_STEP_ID}` "
-          f"+ `{VERDICT_STEP_ID}` (extracted, not copied)")
+          f"+ `{VERDICT_STEP_ID}` + `{HEAL_STEP_ID}` (extracted, not copied)")
     return 0
 
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -372,6 +372,66 @@ jobs:
         fi
         python3 scripts/check-type-forwards.py "${args[@]}"
 
+    # 🚨 THE CONTROL ARM FOR THE GATE ABOVE, and it lives HERE — in the one job that runs on
+    # `merge_group` — for the reason #3508 records rather than for tidiness.
+    #
+    # WHAT IT CHECKS (#3492): the detector above is only as good as the parser that produced its
+    # index, and a parser can go blind while every number it prints stays plausible — a UTF-8 BOM
+    # hid 16 public types and miskeyed 124 more for the gate's entire life, under a floor with
+    # 1 450 types of slack. This step runs the MERGE BASE's own copy of `check-type-forwards.py`
+    # and this diff's copy over the SAME tree, so any difference is attributable to the parser and
+    # to nothing else. A DECREASE is refused; an INCREASE is a fix and passes. It asks nothing
+    # about its own inputs: a detector that cannot run is a FAILURE, never a zero delta. On the
+    # overwhelming majority of pull requests both subject files are byte-identical and it returns
+    # in a second, on a printed SHA-256 proof rather than an assumption.
+    #
+    # 🚨 WHY IT MOVED HERE (#3508). It shipped inside `cross-repo-pair`, which runs on
+    # `pull_request` only. So the pull request it should first have covered — #3503, the one that
+    # night that actually changed the parser — escaped through BOTH exits at once: its own
+    # `pull_request` run executed the workflow file as it stood when the branch was cut, which did
+    # not contain the step; and its `merge_group` run skipped the whole job on that `if:`. A gate
+    # added to main is absent from every pull request already in flight, and the queue is the ONLY
+    # build that sees the change at the moment it lands. That makes `merge_group` coverage the
+    # difference between a gate and a gate-shaped comment. `record-signatures` has no fork or
+    # dependabot clause either, so moving it closes those two exits as well.
+    #
+    # 🚨 THE STRICT/DECLARING SPLIT IS ON THE EVENT, NEVER ON AN INPUT'S PRESENCE — the same shape
+    # the two gates above already use for `--pr`, and the only exemption AGENTS.md sanctions. On
+    # `pull_request` the body is supplied, so an intended decrease declared as
+    # `Parser-delta: <counter> — <reason>` is honoured. A `merge_group` entry genuinely has no
+    # single pull request (its ref can carry several), so the STRICT rule applies there: any
+    # decrease is refused. The two are complementary and every build gets exactly one of them —
+    # there is no path on which neither runs, which is the property #3508 is about. The one thing
+    # to know before declaring a decrease: it will be honoured on the pull request and refused in
+    # the queue, so a genuine parser tightening lands only if it does not shrink a published
+    # counter. Doc/Architecture/CrossRepoPairGate → "A gate added to main".
+    - name: "Prove the parser-delta control is not vacuous (self-test)"
+      run: python3 scripts/check-parser-delta.py --self-test
+    - name: "This diff does not shrink what the surface detector can see"
+      env:
+        EVENT: ${{ github.event_name }}
+        # A pull-request body is attacker-controlled text: it reaches the script through a FILE
+        # written from the environment, never interpolated into a shell command.
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        set -euo pipefail
+        # Already fetched above; repeated explicitly so the steps can be reordered.
+        git fetch --no-tags --depth=200 origin "${{ github.event_name == 'merge_group' && 'main' || github.base_ref }}"
+        # 🚨 The MERGE BASE, not the base branch tip — the same reasoning as both gates above. The
+        # corpus this control measures over is the merge base's tree, and against the tip a parser
+        # change somebody else landed while this pull request is open would read as this diff's.
+        base=$(git merge-base "origin/${{ github.event_name == 'merge_group' && 'main' || github.base_ref }}" HEAD)
+        echo "Comparing against merge base $base"
+        args=(--base "$base")
+        if [ "$EVENT" = "pull_request" ]; then
+          printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+          echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes — a declared decrease can be honoured."
+          args+=(--pr-body-file "$RUNNER_TEMP/pr-body.md")
+        else
+          echo "Event is '$EVENT', which carries no single pull request: the STRICT rule applies — any decrease is refused, declared or not."
+        fi
+        python3 scripts/check-parser-delta.py "${args[@]}"
+
   precheck:
     name: "Check for an already-green tree"
     timeout-minutes: 5
@@ -2405,8 +2465,6 @@ jobs:
       run: python3 scripts/check-type-forwards.py --self-test
     - name: "Prove the pair gate is not vacuous (self-test)"
       run: python3 scripts/check-cross-repo-pair.py --self-test
-    - name: "Prove the parser-delta control is not vacuous (self-test)"
-      run: python3 scripts/check-parser-delta.py --self-test
 
     # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
     # never interpolated into a shell command.
@@ -2439,20 +2497,13 @@ jobs:
           --surface-json "$RUNNER_TEMP/surface.json" \
           --pr-body-file "$RUNNER_TEMP/pr-body.md"
 
-    # 🚨 #3492: the report above is only as good as the parser that produced it, and a parser can
-    # go blind while every number it prints stays plausible — a UTF-8 BOM hid 16 public types and
-    # miskeyed 124 more for the gate's entire life, under a floor with 1 450 types of slack. This
-    # step runs the MERGE BASE's own copy of the detector and this diff's copy over the SAME tree,
-    # so any difference is the parser and nothing else. A DECREASE is refused unless the body
-    # declares it; an INCREASE is a fix and passes. It runs unconditionally and asks nothing about
-    # its own inputs: a detector that cannot run is a failure, never a zero delta.
-    - name: "This diff does not shrink what the surface detector can see"
-      run: |
-        set -euo pipefail
-        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
-        python3 scripts/check-parser-delta.py \
-          --base "$base" \
-          --pr-body-file "$RUNNER_TEMP/pr-body.md"
+    # 🚨 THE PARSER-DELTA CONTROL THAT GUARDS THE REPORT ABOVE HAS MOVED (#3508). It used to sit
+    # here, and this job runs on `pull_request` ONLY — so a pull request already green when the
+    # control landed was exempt from it on BOTH of its builds: absent from its own `pull_request`
+    # run (that run executes the workflow file as it stood then), and skipped in the queue by this
+    # very `if:`. Measured on #3503 — the one pull request that night that changed the parser. It
+    # now lives in `record-signatures`, which runs on `pull_request` AND `merge_group`, so the queue
+    # build enforces it at the moment the change actually lands.
 
   package-pin-removal:
     name: "Satellite package pins (removal declared)"
@@ -2965,6 +3016,7 @@ jobs:
         echo "::error::A public surface changed in a way that breaks ALREADY-PUBLISHED modules — see the 'Public surface (binary compatibility)' job for the exact types."
         echo "::error::A moved public type needs [assembly: TypeForwardedTo] left behind in its ORIGINAL assembly (a forwarder keeps one type identity; a shim mints a second and reintroduces the is/as trap-door). A forwarder cannot rename, so the type keeps its original name."
         echo "::error::Do NOT satisfy this by rebuilding the consumer: the point is that modules ALREADY shipped bind the old name. If a forwarder is impossible (it would need a reference cycle), the move has to be reverted or the whole set republished atomically — see #2398."
+        echo "::error::The same job also carries the parser-delta control (#3492), so a red here can instead mean this diff makes the public-surface DETECTOR see less of the same tree — every gate built on it would then be guarding a smaller set, silently. That step prints both denominators and names the counter that fell. On a merge_group build the strict rule applies and no declaration is read (#3508)."
         exit 1
 
     # ── …and a red Clients workflow decides it too ──────────────────────────────────────────

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -904,7 +904,7 @@ jobs:
             # `gh issue create` prints the issue URL (it has no --json); the number is its tail.
             url=$(gh issue create --repo "$GITHUB_REPOSITORY" --label ci-failure \
               --title "CD: main \`$SHORT\` has an incomplete image set" \
-              --body "main's HEAD \`$SHORT\` is missing part of its deployment image set in ACR, so every self-updating install stays on the previous image. The CD reconciler will attempt to publish it; this issue collects those attempts. Close it once CD is green again.")
+              --body "main's HEAD \`$SHORT\` is missing part of its deployment image set in ACR, so every self-updating install stays on the previous image. The CD reconciler will attempt to publish it; this issue collects those attempts. It CLOSES ITSELF as soon as a CD run reports a successful heal (#3176) — a later failure files a fresh issue rather than appending here.")
             issue="${url##*/}"
           fi
 
@@ -2514,17 +2514,62 @@ jobs:
       #
       # The condition is now the fact the comment actually asserts: main's HEAD has a complete image
       # set, whoever put it there.
-      - name: Report a successful heal
+      #
+      # 🚨 AND IT CLOSES THE LEDGER, because asking a human to do it produced an IMMORTAL issue
+      # (#3176). The comment used to end "Close this issue if nothing else is outstanding" and then
+      # close nothing, while `alert-on-failure` and `gate` both append to whichever `ci-failure`
+      # issue is OPEN. So the first one ever filed collected every attempt and every heal from then
+      # on: #3176 reached 324 comments spanning four days and a dozen unrelated causes, and its
+      # title — one commit's incomplete image set — had been false for most of its life.
+      #
+      # What that costs is the two things an alert is FOR. Its AGE stops meaning anything (an issue
+      # opened on the 3rd says nothing about a hole opened on the 7th), and so does its EXISTENCE:
+      # an open `ci-failure` issue is the state "delivery is broken", and one that is open
+      # permanently cannot express it. The maintainer's own root-cause comment had to open by
+      # restating the issue's premise, because the premise had expired.
+      #
+      # Closing is the whole fix, and it is not a loss of history: the issue and its comments stay,
+      # searchable, exactly where they were. The next failure files a FRESH issue — `gate` and
+      # `alert-on-failure` both create one when none is open — so from here an issue's title names
+      # its own cause, its age is the outage's age, and closing it also hands the reconciler a fresh
+      # heal budget (the same effect the exhausted-budget comment asks a human for).
+      #
+      # 🚨 THE COMMENT IS FATAL, THE CLOSE IS A WARNING, and that asymmetry is reasoned rather
+      # than convenient — AGENTS.md's test is *what does a failure here hide?*. A lost heal COMMENT
+      # hides the delivery record, so it stays fatal, as it has always been. A failed close hides
+      # NOTHING: the issue simply stays open, which is exactly the behaviour that shipped for
+      # months, and the very next successful heal finds the same open issue and closes it. Making it
+      # fatal would instead red `verify-images`, which `delivery-verdict` and `alert-on-failure`
+      # both read as a broken delivery — an alert about the alerting, on a run that delivered.
+      - name: Report a successful heal, and CLOSE the ledger
+        id: heal
         if: needs.promote.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Through `env:`, never `${{ }}` inside the body: `test-cd-steps.py` EXTRACTS this step
+          # from this file by its `id:` and EXECUTES it against fixtures, and it refuses a body
+          # carrying an expression it would have to rewrite. This step's only prior run was in
+          # production, on a schedule — the same shape that let the release-version recovery fail
+          # nine times out of nine before anyone read it.
+          SHORT_SHA: ${{ needs.gate.outputs.short_sha }}
+          PORTAL_VERSION: ${{ needs.portal-image.outputs.version }}
         run: |
           set -euo pipefail
           issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-failure --state open \
             --limit 1 --json number --jq '.[0].number // empty')
-          [ -n "$issue" ] || exit 0
-          gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body "✅ **Healed \`${{ needs.gate.outputs.short_sha }}\`** ([run]($RUN_URL)) — main's HEAD now has the complete image set (portal \`${{ needs.portal-image.outputs.version }}\`), verified against ACR. Installs pick it up on the build-completion event, or within one safety-net check interval if that event never reaches them (#2494). Close this issue if nothing else is outstanding."
+          if [ -z "$issue" ]; then
+            echo "No open ci-failure issue — delivery was never recorded as broken, so there is no ledger to close."
+            exit 0
+          fi
+          # printf, not a multi-line string literal: this whole step is a YAML block scalar, so a
+          # body line starting at column 1 would end the block — and indenting it would bury the
+          # text in a markdown code fence. Same reasoning as the ledger writes in `gate`.
+          gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body "$(printf '%s\n\n%s' \
+            "✅ **Healed \`$SHORT_SHA\`** ([run]($RUN_URL)) — main's HEAD now has the complete image set (portal \`$PORTAL_VERSION\`), verified against ACR. Installs pick it up on the build-completion event, or within one safety-net check interval if that event never reaches them (#2494)." \
+            "**Closing this issue**, because the delivery hole it records is filled. A later failure files a FRESH \`ci-failure\` issue rather than appending here (#3176), so an alert's title names its own cause and its age is the outage's age. Reopening is never needed — and closing also hands the reconciler a fresh heal budget.")"
+          gh issue close "$issue" --repo "$GITHUB_REPOSITORY" \
+            || echo "::warning::could not close ci-failure issue #$issue (the heal comment above is written, so the record is intact; the issue stays open and the next successful heal closes it)"
 
   # ───────────────────────────── FAILURE ALERTING ────────────────────────────
   # A red CD after a green merge is otherwise INVISIBLE (nobody watches the Actions tab), and the
@@ -2541,8 +2586,10 @@ jobs:
   #   release is unarmed), and `verify-images` (a registry MISSING an image, even when every
   #   publish leg reported success).
   # - Idempotent: one open `ci-failure` issue collects repeat failures as comments; a new issue is
-  #   only created when none is open (close the issue once CD is green again). The reconciler
-  #   writes its attempt ledger to the same issue, so the whole story is in one place.
+  #   only created when none is open. The reconciler writes its attempt ledger to the same issue,
+  #   so the whole story of ONE outage is in one place — and `verify-images` CLOSES it on the
+  #   successful heal (#3176), so the next outage gets its own issue instead of inheriting a
+  #   four-day thread whose title stopped being true on day one.
   # ─────────────────────────── DELIVERY VERDICT ───────────────────────────
   # 🚨 The gate for "green, and shipped NOTHING".
   #
@@ -2894,7 +2941,7 @@ jobs:
           * an IMAGE job / promote / verify-images: no complete image set was published. Publication is all-or-nothing, so every self-updating install stays on the PREVIOUS image until a CD run promotes the full set.
           * preflight / notify-platform-update: the images may be fine, but the release EVENT did not reach the control instance, so no node repo re-bakes against this commit until its own schedule poll (#2235). Read the job's ::error:: line - it names what to provision or what refused the delivery.
 
-          The hourly reconciler will re-attempt main's HEAD on its own (bounded at 3 attempts per commit, logged here); you do NOT need to force a merge to trigger delivery. Close this issue once CD is green."
+          The hourly reconciler will re-attempt main's HEAD on its own (bounded at 3 attempts per commit, logged here); you do NOT need to force a merge to trigger delivery. This issue CLOSES ITSELF when a CD run reports a successful heal (#3176) - a later failure files a fresh issue rather than appending here, so this one's title and age stay true to its own cause."
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-failure --state open \
             --limit 1 --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -159,7 +159,44 @@ bounded at **3 attempts per commit**, with the `ci-failure` issue as the ledger 
 The slot is consumed when an attempt *starts*, so a run that dies without reporting cannot buy
 infinite retries; a new HEAD resets the budget naturally (the marker carries the SHA); on exhaustion
 it stops, says so **once** (`🛑 Automatic healing STOPPED …`) and labels the issue `cd-unhealed`. A
-successful heal comments `✅ Healed <sha>` on the same issue, so the ledger cannot only grow.
+successful heal comments `✅ Healed <sha>` on the same issue **and CLOSES it**, so the ledger cannot
+only grow — see below.
+
+### 🚨 The ledger must CLOSE itself, or an alert stops being an alert (#3176)
+
+The heal comment used to end *"Close this issue if nothing else is outstanding"* and then close
+nothing. `gate` and `alert-on-failure` both append to whichever `ci-failure` issue is **open**, so
+the first one ever filed absorbed every attempt and every heal from then on. #3176 reached **324
+comments across four days and a dozen unrelated causes**, and its title — one commit's incomplete
+image set — had been false since its first day. The maintainer's own root-cause comment had to open
+by *restating the issue's premise*, because the premise had expired.
+
+That destroys both of the things an alert is for:
+
+| property | what it should mean | what an immortal ledger made it mean |
+|---|---|---|
+| **existence** | delivery is broken right now | nothing — the issue is always open |
+| **age** | how long the outage has lasted | how long ago the *first ever* outage was |
+
+So `verify-images` now closes it on the successful heal. **Nothing is lost:** the issue and every
+comment stay exactly where they were, searchable; the next failure files a **fresh** issue (both
+`gate` and `alert-on-failure` create one when none is open), so an alert's title names its own cause
+and its age is its own outage's age. Closing also hands the reconciler a **fresh heal budget** — the
+same effect the `🛑 Automatic healing STOPPED` comment asks a human for.
+
+🚨 **The comment is fatal, the close is a warning**, and the asymmetry is reasoned rather than
+convenient (AGENTS.md's test is *what does a failure here hide?*). A lost heal **comment** hides the
+delivery record. A failed **close** hides nothing: the issue simply stays open — which is the
+behaviour that shipped for months — and the very next successful heal finds the same open issue and
+closes it, so a transient 403 is self-correcting. Making the close fatal would instead red
+`verify-images`, which both `delivery-verdict` and `alert-on-failure` read as a broken delivery: an
+alert about the alerting, on a run that delivered.
+
+The step carries `id: heal` and takes every value through `env:`, because
+`.github/scripts/test-cd-steps.py` **extracts it from the workflow and executes it** against a
+stubbed `gh`. Its cases assert on the recorded `gh` invocations rather than on stdout — a step that
+prints the word *closing* and calls no `gh issue close` is the defect, not the fix, and the two are
+identical in a log. The harness refuses to run at all if the step stops calling `gh issue close`.
 
 **It cannot publish an untested tree.** The `workflow_run` path still requires
 `event == 'push' && head_branch == 'main'` — that gate is what stops a **fork's** `pull_request` run

--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
@@ -1007,6 +1007,67 @@ this diff changed**, not a whole-tree index, so it publishes no denominator that
 blindness shows up as a missed finding on one file, which a differential over a fixed corpus cannot
 see. Giving it a whole-tree index would be a real change to that gate, not a wrapper around it.
 
+### 🚨 A gate added to `main` reaches NEITHER build of a pull request already green (#3508)
+
+The control above landed correct and non-vacuous, and then **did not run on the one pull request
+that night which actually changed the parser** (#3503). Not because it was wrong — because of
+*where* it was wired. A pull request has two builds, and a gate added afterwards misses both:
+
+1. **Its own `pull_request` run** executes the workflow file **as it stood on the merge ref at the
+   time it ran**. A job or step added to `main` later is simply not in that file. Re-running the
+   run does not help: it re-runs the same file.
+2. **Its `merge_group` run** — the one build that sees the change at the moment it lands — skipped
+   the entire `cross-repo-pair` job, whose `if:` is `pull_request` only, for the perfectly good
+   reason that its *other* input is the pull-request BODY.
+
+Both exits close on the same pull request, so a gate lands and every pull request already green at
+that moment is **permanently exempt from it, silently, and invisibly from the pull request**. On
+#3503 the comparison happened to have been run by hand and written into the body — authorship luck,
+not a property of the system.
+
+Measured on the queue run for #3546 (`gh-readonly-queue/main/pr-3546-…`, run `34093021863`):
+
+| job | on `merge_group` |
+|---|---|
+| `Public surface (binary compatibility)` (`record-signatures`) | `completed/success` |
+| `Cross-repo pair (public surface)` | `completed/**skipped**` |
+
+**The fix is placement, and only exit (2) can be closed.** Exit (1) is structural: a build executes
+the file it was cut from, and nothing changes that. So the parser-delta control moved into
+`record-signatures`, the job that already runs on `pull_request` **and** `merge_group` — and which
+carries no fork or dependabot clause either, so the move closes those two exits as well.
+
+**The strict/declaring split is written on the EVENT**, the only exemption AGENTS.md sanctions, and
+it is the same shape the two gates beside it already use for `--pr`:
+
+| event | form | why |
+|---|---|---|
+| `pull_request` | `--pr-body-file` supplied | the body is where an intended decrease is declared |
+| `merge_group` | **no body — STRICT: any decrease is refused** | a queue entry has no single pull request (its ref can carry several), and nothing should shrink the detector at the moment it lands |
+
+Every build gets exactly one of the two; there is no path on which neither runs, which is the whole
+property #3508 is about. **The one thing to know before declaring a decrease:** it is honoured on
+the pull request and refused in the queue, so a genuine parser tightening lands only if it does not
+shrink a published counter. That is a deliberate trade — the queue is where the change becomes
+`main`, and a declaration read there would have to be attributed across a multi-entry group that
+carries several pull requests' diffs at once.
+
+**How the move was falsified** (a gate that cannot fail is not a gate — the acceptance test the
+issue names is the point of the issue):
+
+| arm | result |
+|---|---|
+| clean tree, `merge_group` | **exit 0** on the byte-identical proof, both SHA-256 digests printed |
+| a planted blindness in the detector's git-tree reader (`MeshWeaver.Layout/` skipped), `merge_group` | **exit 1** — `publicTypesAtBase` `1975 → 1710` (−265), and −1817 / −11 / −46 on the other three |
+| the same plant, `pull_request`, empty body | **exit 1**, identical verdict |
+| the same plant, `pull_request`, body declaring all four counters | **exit 0** — `↓ DECLARED in the pull-request body`, so the declaring arm is not lost |
+
+Each row executed the step's own `run:` block extracted from `dotnet-test.yml`, not a restatement
+of it.
+
+**The sibling shape is #3504**: a repository that hand-rolled a lane opts out of every guard that
+lane grows *later*. Same defect one level up, and invisible from the side that is uncovered.
+
 ## See also
 
 [Repository Dependency Direction](/Doc/Architecture/RepositoryDependencyDirection) ·

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-delivery-alert-closes-itself-and-a-new-gate-reaches-the-queue.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-delivery-alert-closes-itself-and-a-new-gate-reaches-the-queue.md
@@ -1,0 +1,45 @@
+---
+Name: A delivery alert now closes itself, and a new CI gate reaches the merge queue
+Category: Fix
+Description: The issue that tracks a broken image publication stayed open forever and collected four days of unrelated causes; and a gate added to main was skipped on exactly the change it was written for. Both are placement bugs, and both are fixed.
+Icon: CheckmarkCircle
+Order: -20260907
+---
+
+Two CI signals were reporting things they could not actually mean.
+
+**A delivery alert that could never be resolved.** When a build fails to publish a complete set of
+deployment images, CI files a GitHub issue so somebody notices — and the reconciler that re-attempts
+the publication writes its attempts onto the same issue. When the hole was filled, the bot commented
+*"Close this issue if nothing else is outstanding"* — advice, to nobody in particular — and closed
+nothing.
+
+Nobody ever did. Because every later failure appends to whichever alert issue is **open**, the first
+one ever filed absorbed every attempt and every heal from then on: **324 comments spanning four days
+and a dozen unrelated causes**, under a title describing one commit's problem that had stopped being
+true on day one. That takes away the only two things an alert says. Its *existence* is supposed to
+mean "delivery is broken right now", and an issue that is open permanently cannot mean that. Its
+*age* is supposed to be the outage's age, and it was measuring the age of an unrelated outage from
+the previous week.
+
+The successful heal now closes the issue. Nothing is lost — the thread and every comment stay where
+they were — and the next failure opens a **fresh** one, so an alert's title names its own cause and
+its age is its own. A close that is refused by the API is a warning rather than a failure: the issue
+just stays open and the next heal closes it, and turning a hiccup in the alerting into a red build
+would report a broken delivery on a run that delivered.
+
+**A gate that missed the one change it was written for.** A pull request has two builds, and a check
+added to `main` afterwards can miss *both*: its own build runs the workflow file as it stood when the
+branch was cut, and the merge-queue build — the one that sees the change at the moment it lands —
+skipped the job the new check had been put in. So the check went live, and every pull request already
+green at that moment was silently exempt from it, including the single one that changed the code the
+check exists to watch. No harm that time, by luck.
+
+The check has moved into the job that runs on **both** events, so the queue build now enforces it at
+the moment a change becomes `main`. Where a declaration in the pull-request body can relax it, that
+still works on the pull request; in the queue — which can carry several pull requests at once — the
+strict rule applies. It was verified the way the report says it should be: watched passing on a clean
+tree, then watched **failing** on a deliberately blinded parser, then watched passing again.
+
+Both fixes are exercised by a test that extracts the workflow steps and runs them, so neither can
+quietly stop doing its job.


### PR DESCRIPTION
Closes #3176
Closes #3508

Two CI signals that could not mean what they claimed. Both are **placement**, not logic — and both are the same shape: *a mechanism that cannot express the state it exists to report.*

---

## #3176 — the CD alert could never be resolved, so it stopped being an alert

`verify-images` reports a successful heal onto whichever `ci-failure` issue is open, and the comment ended **"Close this issue if nothing else is outstanding"** — advice, to nobody in particular, from a bot — and closed nothing.

Nobody ever did. Because `gate` and `alert-on-failure` both append to whichever `ci-failure` issue is **open**, the first one ever filed absorbed every attempt and every heal from then on: **#3176 reached 324 comments across four days and a dozen unrelated causes**, under a title describing one commit's incomplete image set that had stopped being true on its first day. The maintainer's own root-cause comment on it had to open by *restating the issue's premise*, because the premise had expired.

That takes away both of the things an alert says:

| property | what it should mean | what an immortal ledger made it mean |
|---|---|---|
| **existence** | delivery is broken right now | nothing — the issue is always open |
| **age** | how long the outage has lasted | how long ago the *first ever* outage was |

**The heal now closes it.** Nothing is lost — the thread and every comment stay exactly where they were, searchable — and the next failure files a **fresh** issue (both `gate` and `alert-on-failure` create one when none is open), so an alert's title names its own cause and its age is its own outage's age. Closing also hands the reconciler a **fresh heal budget**, the same effect the `🛑 Automatic healing STOPPED` comment asks a human for.

🚨 **The comment is fatal, the close is a warning**, and the asymmetry is AGENTS.md's own test — *what does a failure here hide?* A lost heal **comment** hides the delivery record. A failed **close** hides nothing: the issue stays open (the behaviour that shipped for months) and the very next successful heal closes it, so a transient 403 is self-correcting. A fatal close would instead red `verify-images`, which `delivery-verdict` and `alert-on-failure` both read as a broken delivery — *an alert about the alerting, on a run that delivered*.

### How it is falsified

The step gained `id: heal` and takes every value through `env:`, because `.github/scripts/test-cd-steps.py` **extracts it from the workflow and executes it** against a stubbed `gh`. Its cases assert on the **recorded `gh` invocations**, never on stdout — a step that prints the word *closing* and calls no `gh issue close` is the defect, and the two are identical in a log.

| arm | assertion |
|---|---|
| an open ledger | `gh issue comment 3176` **and** `gh issue close 3176` were both called |
| no open ledger | neither was called — a silent no-op, not a close of nothing |
| the close 403s | the run stays **green**, the heal comment is still written, and a `::warning::` says so |
| the step stops calling `gh issue close` | the harness **refuses to run**, `::error::` + exit 1 |

Negative control, run: deleting the `gh issue close` line makes the harness exit **1** naming it; restoring it returns exit **0**, `all cases passed … steps release + decide + verdict + heal (extracted, not copied)`.

---

## #3508 — a gate added to `main` reached neither build of the one PR it was written for

A pull request has two builds, and a gate added afterwards misses **both**:

1. its own `pull_request` run executes the workflow file **as it stood on the merge ref when it ran** — a step added to `main` later is simply not in that file, and re-running re-runs the same file;
2. its `merge_group` run — the only build that sees the change *at the moment it lands* — skipped the whole `cross-repo-pair` job, whose `if:` is `pull_request` only (correctly: its *other* input is the PR body).

Measured on the queue run for #3546 (`gh-readonly-queue/main/pr-3546-…`, run [34093021863](https://github.com/Systemorph/MeshWeaver/actions/runs/34093021863)):

| job | on `merge_group` |
|---|---|
| `Public surface (binary compatibility)` (`record-signatures`) | `completed/success` |
| `Cross-repo pair (public surface)` | `completed/`**`skipped`** |

**Exit (1) is structural and cannot be closed. Exit (2) is placement.** So the parser-delta control moves into `record-signatures`, which already runs on `pull_request` **and** `merge_group` — and carries no fork or dependabot clause, so the move closes those two exits as well.

**The strict/declaring split is written on the EVENT** — the only exemption AGENTS.md sanctions, and the same shape the two gates beside it already use for `--pr`:

| event | form | why |
|---|---|---|
| `pull_request` | `--pr-body-file` supplied | the body is where an intended decrease is declared |
| `merge_group` | **no body — STRICT: any decrease is refused** | a queue entry has no single pull request (its ref can carry several), and nothing should shrink the detector at the moment it lands |

Every build gets exactly **one** of the two; there is no path on which neither runs, which is the property #3508 is about. **No new skip that reads as a pass.**

🚦 **The one trade, stated rather than hidden:** a declared decrease is honoured on the pull request and refused in the queue, so a genuine parser tightening lands only if it does not shrink a published counter. That is deliberate — the queue is where the change becomes `main`, and a declaration read there would have to be attributed across a multi-entry group carrying several pull requests' diffs at once. It is written into `Doc/Architecture/CrossRepoPairGate` beside the fix.

### How it is falsified

The acceptance test the issue names is the point of the issue, so each row below **executed the step's own `run:` block extracted from `dotnet-test.yml`**, not a restatement of it:

| arm | result |
|---|---|
| clean tree, `EVENT=merge_group` | **exit 0** on the byte-identical proof, both SHA-256 digests printed |
| a planted blindness in the detector's git-tree reader (`MeshWeaver.Layout/` skipped), `merge_group` | **exit 1** — `publicTypesAtBase` `1975 → 1710` (**−265**), and −1817 / −11 / −46 on the other three |
| the same plant, `pull_request`, empty body | **exit 1**, identical verdict |
| the same plant, `pull_request`, body declaring all four counters | **exit 0** — `↓ DECLARED in the pull-request body`, so the declaring arm is not lost |
| plant reverted | exit 0 again |

The extraction also prints where the step now lives, which is the other half of the claim:

```
step lives in job `record-signatures`; that job's if:
  "github.event_name == 'pull_request' || github.event_name == 'merge_group'"
Event is 'merge_group', which carries no single pull request:
  the STRICT rule applies — any decrease is refused, declared or not.
```

**Cost:** 3 s when the detector changed, and a printed proof when it did not.

---

## Also verified locally

`check-workflow-timeouts.py` (71 jobs, 0 violations, no new job) · `check-workflow-shell.py` + its self-test · `actionlint -shellcheck= -pyflakes=` (the flags CI uses) — clean on both workflows · `check-parser-delta.py --self-test` (13 cases) · `check-type-forwards.py --self-test` (76) · `check-cross-repo-pair.py --self-test` (28) · `check-pr-secret-preflight.py` (no secret added) · `MeshWeaver.Documentation.Test` `WhatsNewEntryIntegrity` + `DocumentationLinkIntegrity` — `0 Warning(s), 0 Error(s)`, 2 passed.

No `.cs` changed.

Pairs-with: none — this diff removes no public type or member from `src/`; it touches two workflows, one CI harness and three docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
