### PR TITLE
fix(#3510): a release request that never answers no longer parks the whole install

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
@@ -239,6 +239,79 @@ the deterministic repro of the read side. Two consequences for the next measurem
   something running **on this hub**, which is a much smaller set to search than "any mesh singleton
   in the process".
 
+## 🚨 2026-09-07 — the park is INSIDE the release wave, and it is not an unanswered node op (#3510)
+
+Six seals were lost to this failure between 2026-09-06 23:36Z and 2026-09-07 06:09Z — CD 7950, 7959,
+7967, 7968, 7976 failed while 7955, 7962, 7964, 7969, 7974, 7977, 7981 sealed. Roughly one started
+run in two, `Hosting` every time, always `install: TimeoutException`. The reading below is from
+**CD 7976** (`19b077868`, bake job
+[101634597130](https://github.com/Systemorph/MeshWeaver/actions/runs/34085298189)).
+
+### What the sixth occurrence measured
+
+```
+05:44:31.5  ── Hosting: installing 145 file(s)…
+05:45:28.8  Installed node-repo plugin Hosting: 144 written, 0 unchanged
+05:45:56.7  Install: Hosting: adopted 15 prebuilt assembly(ies) for 15 installed type(s)
+05:45:56.7  [PackageInstaller] recycling root Hosting …            ← by design; it SUCCEEDS
+05:45:59.6  InitializeHubRequest | Hub: Hosting                     ← the root is back, 2.9 s later
+05:46:04.5  [UpdateQueue] ADVANCE_WITHOUT_HANDOFF path=Hosting/Admin … /Backup … /LogEntry
+05:46:34.9  (last log line of any kind)
+                                     ⋯ EIGHT MINUTES OF COMPLETE SILENCE ⋯
+05:54:31.5  ── Hosting.Instance: installing 3 file(s)…              ← exactly T+600 s
+```
+
+**Nothing was pending.** `[STALE-CALLBACK]` reports every pending callback older than 30 s, every
+5 s; it fired four times for HomeAssistant minutes earlier in this very run and **zero times** during
+the eight-minute park. So the install was not waiting on a message at all — not on an unanswered
+`CreateOrUpdateNodeRequest`, which is what #3510 was originally attributed to. It was parked on an
+observable that never terminated.
+
+**The control is in the same log.** `Edu` — same shape, same run — printed
+`[PackageInstaller] warmed installed root Edu` 2.5 s after its own deferred release wave.
+`warmed installed root Hosting` **never printed**. `WarmInstalledRoots` runs immediately after
+`RequestReleases(deferredWave)`, so the park is inside the wave.
+
+### Why the wave, by elimination from code
+
+Every other composition between the deferred wave and the warm carries its own bound:
+`AffectedNodeTypes` (`TypeEnumerationBudget`, plus a `Catch`), `SeedPrebuiltAssemblies`
+(`SeedBound`), and the trigger write itself (`BaseStateWaitBound` 30 s, then verdict windows of
+`LateResponseWatchBound + VerdictBoundGrace` = 31 s across `MaxConflictRetries`, ≈124 s worst case).
+`PackageInstaller.RequestReleases`' `nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()`
+carried **none** — which `MeshNodeStreamHandle.BaseStateSource`'s remarks had already named in
+advance: *"no per-leg bound and no outer bound — so ONE non-terminating leg parks the entire package
+install, silently, until the gate's own 600 s `InstallTimeout` reports `install: TimeoutException`
+against a package that installed fine 8 minutes earlier."*
+
+### The fix, and what it is NOT
+
+`ObserveNodeTypeRelease` states its own contract in its remarks and in its closing
+`DefaultIfEmpty(false)`: **exactly one emission, always**. That covered three of Rx's four outcomes.
+The fourth — a source that neither emits nor faults nor completes — reached no handler, and neither
+`DefaultIfEmpty` nor `Catch` can see it. `NodeTypeReleaseExtensions.BoundReleaseLeg` now closes it:
+`Take(1)` (so the deadline is TOTAL, not Rx's inter-emission one) then `ReleaseRequestBound`, whose
+elapse answers `false`, logs, and **names the NodeType**.
+
+🚨 **No bound was raised and nothing is retried.** `ReleaseRequestBound` is 180 s: strictly above the
+≈124 s a legitimate trigger write can compose, and far below the installer's 600 s — the ordering
+[Bounds Must Be Ordered](../BoundsMustBeOrdered) requires, so it can only fire on a leg that is
+genuinely non-terminating and never on one that is merely slow. The outer 600 s bound knows only
+which PACKAGE did not finish; this one knows which TYPE never answered.
+
+**It does not claim to explain why a leg stops answering.** It converts an eight-minute silent park
+into a named warning and lets the install finish, which is what makes the next occurrence one grep
+instead of a full bake-log read — the same role #3512's recycle line plays. Pinned by
+`ReleaseWaveLegIsTotalTest` (pure composition, `TestScheduler`, no mesh).
+
+### What this retires
+
+The `#3510` reading in [Write Verdict Totality](../WriteVerdictTotality) — *"the upsert lane's CREATE
+leg has no disposal NACK"* — is a real totality gap and is worth closing on its own merits, but it is
+**not** what fails these seals: 7976's one stale callback took the UPDATE leg
+(`UPSERT_READ existing → update`), resolved inside 35 s, and the park that killed the run had no
+pending callback at all.
+
 ## Related
 
 - [Action-Block Wedge Prevention](../ActionBlockWedgePrevention) — the invariants a single-threaded hub

--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -346,6 +346,16 @@ measured so far — the requester gets `HubDisposedBeforeResponseException`, whi
 | update — `WriteThroughStream` | `UPSERT_WRITE_THROUGH_STREAM` | **covered.** The owner's `RegisterOwnerDisposingNack` mints `OwnerDisposing`, the writer re-enqueues against the fresh activation, the caller is answered `success=True` (pinned by `UpsertAnswersWhenTheOwnerGoesAwayTest`) |
 | create — `DispatchInnerCreate` | `UPSERT_READ absent → create` | **not covered.** No disposal-NACK registration, no `WriteVerdictBound` equivalent |
 
+🚨 **This gap is real, and it is NOT what failed the CD seals — measured 2026-09-07 on CD 7976.** The
+one stale callback in that run's Hosting window took the **UPDATE** leg
+(`UPSERT_READ existing → update` → `UPSERT_WRITE_THROUGH_STREAM`) and resolved inside 35 s, and the
+eight-minute park that actually ran out the install's 600 s bound had **no pending callback anywhere**
+— `[STALE-CALLBACK]`, which reports every callback older than 30 s every 5 s, fired zero times
+throughout it. An unanswered `CreateOrUpdateNodeRequest` IS a pending callback, so the install was not
+waiting on one. The park is inside `PackageInstaller`'s release wave, one step further on; see
+[Bake Seal — NodeOps Saturation](../BakeSealNodeOpsSaturation) → "the park is INSIDE the release
+wave". Close the create leg on its own merits, not as a fix for the seal.
+
 Measured on core CD 7950: the create leg's trail ends at `HANDLER_EXIT state=Processed` and nothing
 follows, and the run contains **zero `[CreateOrUpdate]` lines of any kind** — so neither terminal arm
 ever ran. Silence, not a fault. The install then ran out its ten-minute bound with no name for what

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-stuck-recompile-no-longer-stalls-a-whole-install.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-stuck-recompile-no-longer-stalls-a-whole-install.md
@@ -1,0 +1,44 @@
+---
+Name: A stuck recompile no longer stalls the whole installation
+Category: Fix
+Description: Installing an app or a plugin asks each of the code types it ships to rebuild. If one of those requests never came back, the installation simply stopped — for ten minutes, saying nothing, and then failed. It now finishes, and names the one type that did not answer.
+Icon: Checkmark
+Order: -20260907
+---
+
+# A stuck recompile no longer stalls the whole installation
+
+Installing an app or a plugin does two things: it writes the content, and then it asks each of the
+code types that content ships to rebuild itself. Those requests go out together and the install waits
+for all of them before it finishes.
+
+If **one** of them never came back — not refused, not failed, just never answered — the install
+waited for it forever. Everything else had already succeeded: the content was written, the other
+types had rebuilt, there was nothing left to do but finish. Instead the whole installation sat there
+for ten minutes, produced no message of any kind, and then failed with a timeout that named the
+package and nothing else.
+
+## What changes
+
+**A request that never answers is now an answer.** Each rebuild request has its own deadline, well
+beyond the longest a real one can take. If it passes, that one type is reported as *not rebuilt*, the
+installation completes, and everything that did succeed stays succeeded.
+
+**The message names the type.** Before, the only thing that ever surfaced was "this package timed
+out" — which is true of the package and useless about the cause. Now the report says which type did
+not answer, so the next step is obvious instead of being an investigation.
+
+**Nothing was made faster or more patient.** No existing deadline moved, nothing is retried, and a
+rebuild that is genuinely slow still gets all the time it always had. The new deadline sits far above
+the slowest legitimate rebuild and far below the installation's own — it can only fire for a request
+that was never going to answer at all.
+
+## What it does not do
+
+**A type that did not rebuild has not rebuilt.** It keeps the code it was already running, which is
+exactly the state it would have been in had the install failed — the difference is that the rest of
+the install now stands, and you are told which type to look at. Asking it to rebuild again (the
+Compile action on the type) is the remedy.
+
+**It does not explain why a request stopped answering.** That stays a defect to find. What changed is
+that finding it no longer costs a ten-minute stall and a full log read.

--- a/src/MeshWeaver.Graph/NodeTypeReleaseExtensions.cs
+++ b/src/MeshWeaver.Graph/NodeTypeReleaseExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
@@ -49,6 +50,84 @@ namespace MeshWeaver.Graph;
 /// </summary>
 public static class NodeTypeReleaseExtensions
 {
+    /// <summary>
+    /// 🚨 The ORDERED inner bound on ONE release request — issue #3510.
+    ///
+    /// <para><b>What it is for.</b> <see cref="ObserveNodeTypeRelease"/> promises, in its own
+    /// remarks and in its closing <c>DefaultIfEmpty(false)</c>, that it produces EXACTLY ONE
+    /// emission, always. That promise covered three of Rx's four outcomes — it emits, or it faults,
+    /// or it completes empty. The fourth is the one that bites: a source that NEITHER emits NOR faults
+    /// NOR completes. <c>DefaultIfEmpty</c> cannot see it and <c>Catch</c> cannot see it; only a
+    /// deadline can. The composed leg now carries one, so the promise is true by construction.</para>
+    ///
+    /// <para><b>What it costs when it is missing.</b> The package installer's release wave is
+    /// <c>nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()</c> — one non-terminating leg
+    /// parks the ENTIRE install, silently, until the CD bake+seal gate's own 600 s
+    /// <c>InstallTimeout</c> reports <c>install: TimeoutException</c> against a package that
+    /// finished writing its nodes eight minutes earlier. That is #3510's measured signature (core CD
+    /// 7976: <c>Installed node-repo plugin Hosting: 144 written</c> at 05:45:28Z, the install's
+    /// deferred release wave at 05:46:04Z, then NOT ONE log line and NOT ONE pending callback
+    /// anywhere for eight minutes, and no <c>warmed installed root Hosting</c> — the step that
+    /// follows the wave — ever printed), and it was named in advance by
+    /// <c>MeshNodeStreamHandle.BaseStateSource</c>'s remarks: "no per-leg bound and no outer bound".
+    /// Roughly one CD run in two lost its seal to it.</para>
+    ///
+    /// <para>🚨 <b>Ordered, not tightened</b> (Doc/Architecture/BoundsMustBeOrdered). It sits ABOVE
+    /// every bound the write it wraps already carries — <c>BaseStateWaitBound</c> 30 s, then up to
+    /// three verdict windows of <c>LateResponseWatchBound</c> + <c>VerdictBoundGrace</c> = 31 s
+    /// apiece across <c>MaxConflictRetries</c>, ≈124 s in total — so it can only ever fire when
+    /// something is genuinely non-terminating, never when a write is merely slow. And it sits far
+    /// BELOW the installer's 600 s bound, which is the point: the outer bound knows only that the
+    /// install did not finish, while this one knows WHICH NodeType never answered and says so.
+    /// Nothing here is retried, nothing is swallowed and no existing bound moves.</para>
+    /// </summary>
+    internal static readonly TimeSpan ReleaseRequestBound = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// The release leg's totality, as a PURE composition — no hub, no mesh, no wall clock — so the
+    /// property it guarantees is drivable from a <c>TestScheduler</c>
+    /// (<c>ReleaseWaveLegIsTotalTest</c>). <paramref name="leg"/> is the permission check and the
+    /// trigger write composed exactly as <see cref="ObserveNodeTypeRelease"/> composes them; this
+    /// adds the one thing that composition cannot express about itself: an answer when the leg
+    /// produces none.
+    ///
+    /// <para><c>Take(1)</c> comes FIRST on purpose. Rx's <c>Timeout(TimeSpan)</c> is an
+    /// INTER-EMISSION deadline that restarts on every <c>OnNext</c> it sees, so a chatty source
+    /// resets it forever — the exact defect <c>BaseStateSource</c> was rewritten to fix. Reducing
+    /// the sequence to at most one emission first makes the deadline a TOTAL one.</para>
+    /// </summary>
+    /// <param name="leg">The composed permission-check-then-write sequence for one NodeType.</param>
+    /// <param name="nodeTypePath">Path of the NodeType — named in the refusal, so a parked leg is
+    /// attributable from one log line instead of a full bake-log read.</param>
+    /// <param name="bound">The ordered deadline; <see cref="ReleaseRequestBound"/> in production.</param>
+    /// <param name="onError">The caller's refusal sink — invoked with the same reason that is logged.</param>
+    /// <param name="report">Warning sink (the logger in production), given the reason.</param>
+    /// <param name="scheduler">Timer seam; <see cref="Scheduler.Default"/> in production.</param>
+    internal static IObservable<bool> BoundReleaseLeg(
+        IObservable<bool> leg,
+        string nodeTypePath,
+        TimeSpan bound,
+        Action<string>? onError,
+        Action<string>? report,
+        IScheduler? scheduler = null)
+        => leg
+            .Take(1)
+            .Timeout(
+                bound,
+                Observable.Defer(() =>
+                {
+                    var reason =
+                        $"The release request for '{nodeTypePath}' produced no answer within "
+                        + $"{bound.TotalSeconds:0}s — neither the Compile check nor the trigger write "
+                        + "emitted, faulted or completed. Treating it as NOT released so the caller "
+                        + "is answered; the release did not happen and this NodeType keeps the "
+                        + "assembly it already had.";
+                    report?.Invoke(reason);
+                    onError?.Invoke(reason);
+                    return Observable.Return(false);
+                }),
+                scheduler ?? Scheduler.Default);
+
     /// <summary>
     /// Request a release of the NodeType at <paramref name="nodeTypePath"/>. Checks the caller
     /// holds <see cref="Permission.Compile"/> on the target; on success flips the
@@ -118,7 +197,12 @@ public static class NodeTypeReleaseExtensions
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Graph.NodeTypeReleaseExtensions");
 
-        return Observable.Defer(() =>
+        // 🚨 #3510 — the leg is composed here and made TOTAL by BoundReleaseLeg below. Everything
+        // between this Defer and the closing DefaultIfEmpty answers the caller for three of Rx's
+        // four outcomes; the fourth — a source that never terminates at all — is what parked the
+        // installer's whole release wave and, with it, the CD seal. See ReleaseRequestBound.
+        return BoundReleaseLeg(
+            Observable.Defer(() =>
         {
             // Capture the caller's FULL AccessContext synchronously, on the SUBSCRIBING thread —
             // before CheckPermission's reactive chain can hop schedulers (PermissionEvaluator reads
@@ -195,6 +279,11 @@ public static class NodeTypeReleaseExtensions
                 // answering must not turn into a sequence that completes without answering, or a
                 // caller composing `.FirstAsync()` on it faults instead of learning "no release".
                 .DefaultIfEmpty(false);
-        });
+            }),
+            nodeTypePath,
+            ReleaseRequestBound,
+            onError,
+            reason => logger?.LogWarning(
+                "[RequestNodeTypeRelease] {Path}: {Reason}", nodeTypePath, reason));
     }
 }

--- a/test/MeshWeaver.Graph.Test/ReleaseWaveLegIsTotalTest.cs
+++ b/test/MeshWeaver.Graph.Test/ReleaseWaveLegIsTotalTest.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#3510 — one non-terminating release leg parks the whole package install, silently, for the
+/// gate's entire ten-minute bound.</b>
+///
+/// <para><b>Measured, core CD 7976</b> (<c>19b077868</c>, bake job 101634597130 — the sixth
+/// occurrence; roughly one started run in two lost its seal to this shape). The Hosting package
+/// wrote its content fine: <c>Installed node-repo plugin Hosting: 144 written</c> at 05:45:28Z,
+/// prebuilt adoption 15/15 at 05:45:56Z, the root recycle it is designed to survive at 05:45:56Z,
+/// the deferred release wave's writes at 05:46:04Z. Then the process emitted <b>not one log line
+/// and not one pending callback anywhere</b> until the installer's own 600 s bound fired at
+/// 05:54:31Z — exactly <c>T+600s</c> from <c>── Hosting: installing 145 file(s)…</c>.</para>
+///
+/// <para><b>What that silence rules out.</b> An unanswered <c>CreateOrUpdateNodeRequest</c> — the
+/// mechanism #3510 was originally attributed to — is a PENDING CALLBACK, and a pending callback is
+/// reported every five seconds by <c>[STALE-CALLBACK]</c>. That reporter fired four times for
+/// HomeAssistant minutes earlier in the same run and <b>zero times</b> during the eight-minute park.
+/// The install was therefore not waiting on a message at all; it was parked on an observable that
+/// never terminated. The control is in the same log: <b>Edu</b>, same shape, same run, printed
+/// <c>[PackageInstaller] warmed installed root Edu</c> — the step that FOLLOWS the release wave —
+/// 2.5 s after its own deferred wave. <c>warmed installed root Hosting</c> never printed at all, so
+/// the park is inside the wave.</para>
+///
+/// <para><b>Why the wave and not something else in that segment.</b> Every other composition
+/// between the deferred wave and the warm carries its own bound —
+/// <c>AffectedNodeTypes</c> (<c>TypeEnumerationBudget</c>), <c>SeedPrebuiltAssemblies</c>
+/// (<c>SeedBound</c>), and the trigger write itself (<c>BaseStateWaitBound</c> 30 s, then verdict
+/// windows of 31 s across <c>MaxConflictRetries</c>). <c>RequestReleases</c>'
+/// <c>nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()</c> carries none, which
+/// <c>MeshNodeStreamHandle.BaseStateSource</c>'s own remarks had already named in advance: "no
+/// per-leg bound and no outer bound — so ONE non-terminating leg parks the entire package install,
+/// silently, until the gate's own 600 s <c>InstallTimeout</c> reports <c>install:
+/// TimeoutException</c> against a package that installed fine 8 minutes earlier".</para>
+///
+/// <para><b>What this pins.</b> Not "the leg is fast" — that would be a bound tuned to make a gate
+/// pass, and this repo does not do that. It pins the CONTRACT
+/// <see cref="NodeTypeReleaseExtensions.ObserveNodeTypeRelease"/> already states about itself and
+/// did not keep: <i>exactly one emission, always</i>. Rx has four outcomes, not three; the closing
+/// <c>DefaultIfEmpty(false)</c> covers "completed empty" and the two <c>Catch</c>es cover "faulted",
+/// and nothing covered "never terminated". The first test below is the DEFECT — the wave composed
+/// the way production composed it, over a leg that never answers, completing never — and the second
+/// is the fix over the identical input.</para>
+///
+/// <para>Deterministic by construction: a <see cref="TestScheduler"/> supplies virtual time, so
+/// every assertion is about ORDER and CAUSE, never about wall-clock duration. No mesh, no cluster,
+/// no sleep, no hub — the shape the issue itself asked for ("extracting the inner-write
+/// subscription into a pure composition … so its totality is drivable without a mesh at all").</para>
+/// </summary>
+public class ReleaseWaveLegIsTotalTest
+{
+    private const string Parked = "Hosting/InstanceRequest";
+    private const string Prompt = "Hosting/LogEntry";
+
+    /// <summary>What a wave's subscriber actually observed — all three Rx terminations, separately.</summary>
+    private sealed record Observed(List<IList<bool>> Waves, Exception? Error, bool Completed);
+
+    /// <summary>
+    /// The installer's wave, verbatim: every leg subscribed at once, and the wave completes when the
+    /// last of them has answered (<c>PackageInstaller.RequestReleases</c>).
+    /// </summary>
+    private static Observed RunWave(IEnumerable<IObservable<bool>> legs, TestScheduler scheduler, TimeSpan runFor)
+    {
+        var waves = new List<IList<bool>>();
+        Exception? error = null;
+        var completed = false;
+        using var subscription = legs.Merge().ToList()
+            .Subscribe(waves.Add, ex => error = ex, () => completed = true);
+        scheduler.AdvanceBy(runFor.Ticks);
+        return new Observed(waves, error, completed);
+    }
+
+    /// <summary>A leg that answers <c>true</c> promptly — a release whose trigger flip landed.</summary>
+    private static IObservable<bool> Answers(TestScheduler scheduler, TimeSpan after) =>
+        Observable.Timer(after, scheduler).Select(_ => true);
+
+    /// <summary>
+    /// 🚨 A leg that NEVER terminates: no emission, no fault, no completion. This is the fourth Rx
+    /// outcome, and it is the one that reached no handler. <c>Observable.Never</c> is exactly what a
+    /// permission fold or a write whose upstream stops talking looks like from here.
+    /// </summary>
+    private static IObservable<bool> NeverAnswers() => Observable.Never<bool>();
+
+    /// <summary>
+    /// 🚨 <b>THE DEFECT, composed the way production composed it.</b> One parked leg beside a
+    /// perfectly healthy one, merged into the wave the installer waits on: the healthy leg answers
+    /// in a second and the wave still never completes — not in three minutes, not in ten. That is
+    /// the whole of #3510's cost: the install cannot proceed to <c>warmed installed root</c>, the
+    /// gate's 600 s <c>InstallTimeout</c> is the only bound left that can fire, and it names the
+    /// PACKAGE while knowing nothing about which NodeType starved.
+    /// </summary>
+    [Fact]
+    public void UnboundedWave_WithOneLegThatNeverAnswers_NeverCompletes()
+    {
+        var scheduler = new TestScheduler();
+        var observed = RunWave(
+            [Answers(scheduler, TimeSpan.FromSeconds(1)), NeverAnswers()],
+            scheduler,
+            // Well past the installer's own 600 s bound — the park is unbounded, not merely long.
+            runFor: TimeSpan.FromSeconds(900));
+
+        observed.Completed.Should().BeFalse(
+            "Merge().ToList() completes only when EVERY leg has terminated, so one leg that never "
+            + "answers parks the whole wave — and with it the package install, for the life of the "
+            + "process (#3510, core CD 7976)");
+        observed.Error.Should().BeNull("nothing faulted — that is precisely why nothing was logged");
+        observed.Waves.Should().BeEmpty(
+            "the healthy leg answered at 1 s and its answer is stuck inside ToList's buffer: a wave "
+            + "that cannot complete cannot report the legs that DID succeed either");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE FIX, over the identical input.</b> The same parked leg, wrapped by
+    /// <see cref="NodeTypeReleaseExtensions.BoundReleaseLeg"/>: the wave completes, the healthy leg
+    /// still reports <c>true</c>, the parked one reports <c>false</c>, and the reason NAMES the
+    /// NodeType — so the next occurrence is one grep instead of a full bake-log read.
+    /// </summary>
+    [Fact]
+    public void BoundedWave_WithOneLegThatNeverAnswers_CompletesAndNamesTheLeg()
+    {
+        var scheduler = new TestScheduler();
+        var refusals = new List<string>();
+        var warnings = new List<string>();
+
+        var observed = RunWave(
+            [
+                NodeTypeReleaseExtensions.BoundReleaseLeg(
+                    Answers(scheduler, TimeSpan.FromSeconds(1)), Prompt,
+                    NodeTypeReleaseExtensions.ReleaseRequestBound,
+                    refusals.Add, warnings.Add, scheduler),
+                NodeTypeReleaseExtensions.BoundReleaseLeg(
+                    NeverAnswers(), Parked,
+                    NodeTypeReleaseExtensions.ReleaseRequestBound,
+                    refusals.Add, warnings.Add, scheduler),
+            ],
+            scheduler,
+            // Just past the ordered inner bound — and still an order of magnitude inside the
+            // installer's 600 s outer one, which is what "ordered" means.
+            runFor: NodeTypeReleaseExtensions.ReleaseRequestBound + TimeSpan.FromSeconds(1));
+
+        observed.Error.Should().BeNull(
+            "a leg that cannot answer is a REFUSAL, not a fault: RequestReleases' contract is that "
+            + "one unreleasable type can neither fail the install nor strand the types after it");
+        observed.Completed.Should().BeTrue(
+            "every leg now reaches a terminal, so the wave the installer waits on completes and the "
+            + "install proceeds to WarmInstalledRoots instead of parking out the 600 s gate bound");
+        var answers = observed.Waves.Should().ContainSingle().Which;
+        answers.Count(a => a).Should().Be(1,
+            "the healthy release still succeeded — the bound answers the parked leg, it does not "
+            + "discard the wave's real results");
+        answers.Count(a => !a).Should().Be(1,
+            "the parked leg is answered NOT-released, which is the truth: its trigger never landed");
+
+        refusals.Should().ContainSingle(
+            "exactly one leg failed to answer, and the caller's own refusal sink is told about that "
+            + "one — never about the leg that worked");
+        refusals[0].Should().Contain(Parked,
+            "the refusal must NAME the NodeType that starved. The outer 600 s InstallTimeout can "
+            + "only say which package did not finish; this is the only bound that knows which type");
+        refusals[0].Should().NotContain(Prompt);
+        warnings.Should().Equal(refusals,
+            "what the caller is told and what lands in the log are the same sentence — a diagnosis "
+            + "that differs between the two sends the reader somewhere the other one did not");
+    }
+
+    /// <summary>
+    /// The bound is ORDERED, not tightened (Doc/Architecture/BoundsMustBeOrdered): a write that is
+    /// genuinely slow — every inner bound inside one trigger write composes to ≈124 s worst case —
+    /// still answers on its own terms. A bound that converted a slow-but-real release into a
+    /// refusal would be a regression dressed as a fix.
+    /// </summary>
+    [Fact]
+    public void ALegThatAnswersLateButInsideTheBound_KeepsItsOwnAnswer()
+    {
+        var scheduler = new TestScheduler();
+        var refusals = new List<string>();
+
+        var observed = RunWave(
+            [
+                NodeTypeReleaseExtensions.BoundReleaseLeg(
+                    // 124 s: BaseStateWaitBound (30 s) plus three verdict windows of
+                    // LateResponseWatchBound + VerdictBoundGrace (31 s) across MaxConflictRetries —
+                    // the worst case a LEGITIMATE trigger write can take.
+                    Answers(scheduler, TimeSpan.FromSeconds(124)), Parked,
+                    NodeTypeReleaseExtensions.ReleaseRequestBound,
+                    refusals.Add, null, scheduler),
+            ],
+            scheduler,
+            runFor: NodeTypeReleaseExtensions.ReleaseRequestBound + TimeSpan.FromSeconds(1));
+
+        observed.Completed.Should().BeTrue();
+        observed.Waves.Should().ContainSingle().Which.Should().Equal([true]);
+        refusals.Should().BeEmpty(
+            "the write answered inside its own composed bounds, so the outer ordered bound must not "
+            + "fire — it exists for a leg that never answers, not for one that is slow");
+    }
+
+    /// <summary>
+    /// The bound is a TOTAL deadline, not Rx's inter-emission one. A leg that keeps emitting — a
+    /// re-emitting permission fold is exactly this shape, since it re-emits on every
+    /// AccessAssignment change — must not be able to reset the clock forever. <c>Take(1)</c> ahead
+    /// of the <c>Timeout</c> is what delivers that; the same trap <c>BaseStateSource</c> was
+    /// rewritten to remove.
+    /// </summary>
+    [Fact]
+    public void AChattyLegIsAnsweredByItsFirstEmission_NotByTheBound()
+    {
+        var scheduler = new TestScheduler();
+        var refusals = new List<string>();
+
+        var observed = RunWave(
+            [
+                NodeTypeReleaseExtensions.BoundReleaseLeg(
+                    Observable.Interval(TimeSpan.FromSeconds(10), scheduler).Select(_ => true),
+                    Parked,
+                    NodeTypeReleaseExtensions.ReleaseRequestBound,
+                    refusals.Add, null, scheduler),
+            ],
+            scheduler,
+            runFor: NodeTypeReleaseExtensions.ReleaseRequestBound + TimeSpan.FromSeconds(1));
+
+        observed.Completed.Should().BeTrue();
+        observed.Waves.Should().ContainSingle().Which.Should().Equal([true],
+            "the FIRST answer is the leg's answer — a source that keeps talking afterwards is not "
+            + "an unanswered leg, and must not be treated as one");
+        refusals.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #3510.

## 🚨 The established attribution is refuted by the measurement — read this first

#3510 is attributed to the upsert lane's CREATE leg ("no `OwnerDisposing` re-enqueue, so the
`CreateOrUpdateNodeRequest` is never answered"). **That gap is real, and it is not what fails these
seals.** Measured on **CD 7976** (`19b077868`, the sixth occurrence, bake job
[101634597130](https://github.com/Systemorph/MeshWeaver/actions/runs/34085298189)):

- The run's ONE stale callback in the Hosting window took the **UPDATE** leg —
  `UPSERT_READ existing → update` → `UPSERT_WRITE_THROUGH_STREAM
  path=Hosting/InstanceRequest/_Activity/compile-state` — and **resolved inside 35 s** (reported once
  at 30 089 ms, never again; the reporter re-reports every 5 s).
- During the eight-minute park that actually ran out the install's bound there was **no pending
  callback anywhere**. `[STALE-CALLBACK]` fired **four times** for HomeAssistant minutes earlier in
  the same run and **zero times** throughout the park. An unanswered `CreateOrUpdateNodeRequest` *is*
  a pending callback, so the install was not waiting on one.

The install was parked on an **observable that never terminated**, and no node op was outstanding.

## Where it parks — located, not guessed

```
05:44:31.5  ── Hosting: installing 145 file(s)…
05:45:28.8  Installed node-repo plugin Hosting: 144 written, 0 unchanged
05:45:56.7  Install: Hosting: adopted 15 prebuilt assembly(ies) for 15 installed type(s)
05:45:56.7  [PackageInstaller] recycling root Hosting …          ← by design; it SUCCEEDS
05:45:59.6  InitializeHubRequest | Hub: Hosting                   ← the root is back, 2.9 s later
05:46:04.5  ADVANCE_WITHOUT_HANDOFF path=Hosting/Admin … /Backup … /LogEntry   ← the deferred wave
05:46:34.9  (last log line of any kind, at any level)
                                   ⋯ EIGHT MINUTES OF SILENCE ⋯
05:54:31.5  ── Hosting.Instance: installing 3 file(s)…            ← exactly T+600 s
```

**The control is in the same log.** `Edu` — same shape, same run — printed
`[PackageInstaller] warmed installed root Edu` **2.5 s** after its own deferred release wave.
`warmed installed root Hosting` **never printed**. `WarmInstalledRoots` runs immediately after
`RequestReleases(deferredWave)`, so the park is inside the wave.

**Why the wave and not something else in that segment, from code:** `AffectedNodeTypes` carries
`TypeEnumerationBudget` + a `Catch`; `SeedPrebuiltAssemblies` carries `SeedBound`; the trigger write
carries `BaseStateWaitBound` (30 s) then verdict windows of `LateResponseWatchBound +
VerdictBoundGrace` (31 s) across `MaxConflictRetries`. `PackageInstaller.RequestReleases`'
`nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()` carried **none** — exactly what
`MeshNodeStreamHandle.BaseStateSource`'s remarks already named in advance:

> "no per-leg bound and no outer bound — so ONE non-terminating leg parks the entire package install,
> silently, until the gate's own 600 s `InstallTimeout` reports `install: TimeoutException` against a
> package that installed fine 8 minutes earlier."

## The defect

`ObserveNodeTypeRelease` states its own contract, in its remarks and in its closing
`DefaultIfEmpty(false)`: **exactly one emission, always**. It delivered that for three of Rx's four
outcomes — `DefaultIfEmpty` covers "completed empty", two `Catch`es cover "faulted". Nothing covered
**"never terminated at all"**, which neither operator can observe. One such leg parks
`Merge().ToList()`, and with it the install, for the life of the process.

## The fix

`NodeTypeReleaseExtensions.BoundReleaseLeg` makes the promise true by construction: `Take(1)` first —
so the deadline is TOTAL rather than Rx's inter-emission one, the exact trap `BaseStateSource` was
rewritten to remove — then `ReleaseRequestBound`, whose elapse answers `false`, logs at Warning, and
**names the NodeType**.

🚨 **Nothing is retried, nothing is swallowed, and no existing bound moves.** `ReleaseRequestBound` is
180 s: strictly above the ≈124 s a *legitimate* trigger write can compose, and far below the
installer's 600 s — the ordering [Bounds Must Be Ordered](src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md)
requires, so it can only fire on a leg that is genuinely non-terminating and never on one that is
merely slow. The outer 600 s bound knows only which PACKAGE did not finish; this one knows which TYPE
never answered.

**What it does not claim.** It does not explain *why* a leg stops answering — that stays open. It
converts a silent eight-minute park into a named warning and lets the install finish, which is what
makes the next occurrence one `grep` instead of a full bake-log read, the same role #3512's recycle
line plays.

## The test

`ReleaseWaveLegIsTotalTest` — pure composition, `TestScheduler`, **no mesh, no cluster, no wall
clock**; the shape #3510's own comment asked for ("extracting the inner-write subscription into a
pure composition … so its totality is drivable without a mesh at all"). Four facts:

| test | what it pins |
|---|---|
| `UnboundedWave_WithOneLegThatNeverAnswers_NeverCompletes` | **the defect**, composed as production composed it: a healthy leg answers at 1 s, the wave still has not completed at 900 s, nothing faulted, and even the healthy leg's answer is stuck inside `ToList`'s buffer |
| `BoundedWave_WithOneLegThatNeverAnswers_CompletesAndNamesTheLeg` | the fix over the identical input: the wave completes, the healthy leg keeps its `true`, the parked one answers `false`, and the refusal names `Hosting/InstanceRequest` and not the healthy path |
| `ALegThatAnswersLateButInsideTheBound_KeepsItsOwnAnswer` | a write answering at 124 s — the worst case its own composed bounds allow — is untouched. A bound that turned a slow-but-real release into a refusal would be a regression dressed as a fix |
| `AChattyLegIsAnsweredByItsFirstEmission_NotByTheBound` | the deadline is total, not inter-emission — a re-emitting permission fold cannot reset it forever |

## Verification

- `dotnet build -c Release -warnaserror` — `MeshWeaver.Graph`, `MeshWeaver.PluginCatalog`,
  `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test`: **0 Error(s), 0 Warning(s)** each.
- `ReleaseWaveLegIsTotalTest`: **4 passed**, 36 ms.
- `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`: **passed**.

## Work products committed

- [`BakeSealNodeOpsSaturation`](src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md)
  — the 7976 measurement, the elimination, the fix and what it is not.
- [`WriteVerdictTotality`](src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md)
  — the #3510 section now records that its create-leg reading is a real gap but **not** the cause of
  the failed seals, and points at the wave.
- What's New entry, `Category: Fix`.

No public surface is added or removed (`internal` only), so no `Pairs-with:` / `Implementers:` line
applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
