### PR TITLE
fix: a module is adopted on what this platform can LOAD, not on a version string (#3538, #3518)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.IdentityModel.Tokens.Jwt;
+﻿using System.Collections.Immutable;
+using System.IdentityModel.Tokens.Jwt;
 using Memex.Portal.Shared.Api;
 using Memex.Portal.Shared.Authentication;
 using Memex.Portal.Shared.Email;
@@ -78,7 +79,17 @@ public static class MemexConfiguration
         // nothing and cannot differ: the reader is a stateless file reader that starts nothing and
         // writes nothing, and the registration is this same one-liner over the same resolved
         // module root.
-        var report = new PendingModuleActivations(app.Configuration).Read();
+        var report = new PendingModuleActivations(app.Configuration)
+        {
+            // 🚨 #3538 — the modules InstallAssemblies REFUSED (link probe declined, or the
+            // registration threw). GetServices, never GetRequiredService: an absent registration
+            // means "nothing was refused", and a diagnostic that throws is worse than the silence
+            // it replaces — the same rule the construction above follows.
+            QuarantinedModules = app.Services.GetServices<IncompatibleModule>()
+                .Select(m => m.Name)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase),
+        }.Read();
 
         if (report.IsUndetermined)
         {
@@ -95,6 +106,15 @@ public static class MemexConfiguration
                 + "absent (a 404 with no error) until the package is re-installed: {Detail}",
                 report.Unresolvable.Count,
                 ModuleActivationStatus.DescribeUnresolvable(report.Unresolvable));
+
+        if (report.HasQuarantined)
+            logger.LogError(
+                "🚨 {Count} activated module(s) were REFUSED against this platform build and are "
+                + "contributing nothing — their bytes are linked against a platform this "
+                + "deployment is not running, so no restart loads them; the platform update that "
+                + "satisfies them is itself that restart (#3538): {Detail}",
+                report.Quarantined.Count,
+                ModuleActivationReport.DescribeQuarantined(report.Quarantined));
 
         if (report.HasPending)
             logger.LogWarning(

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -125,6 +125,18 @@ The two landing paths differ exactly as they already did for the declared floor:
   apply this same measurement against *their* platform, and this process's boot never loads them.
   Refusing here would recreate the 2026-08-22 three-way deadlock the shelf exists to break.
 
+🚨 **The surface here carries the ACTIVE generation of every landed module, and it is rebuilt per
+landing.** A wave lands its modules ONE AT A TIME, and a module may legitimately reference a
+SIBLING module that landed thirty seconds ago and that this process has not loaded
+(restart-as-activation). A surface that knew only `/app` — or one captured at the wave's first
+landing — would not carry that sibling, and the platform-prefix rule below would refuse a module
+that is perfectly fine. On a real deployment that reads as a feature silently missing after an
+upgrade, which is the same class of confidently-wrong verdict this gate exists to replace. The
+ACTIVE generation specifically, through the one resolution rule (`ModuleDirectoryFor`) — a
+superseded generation is still on the volume until the GC reclaims it and can legitimately lack a
+type its successor has, so listing directories would make the verdict depend on the filesystem's
+ordering.
+
 ### At boot — the generation is parked, not the portal
 
 `MeshBuilder.InstallAssemblies` probes each module **before** `Assembly.LoadFrom`. A refusal is
@@ -192,6 +204,7 @@ missing type — and lands it through the real `ModuleLandingService`.
 | `UnreadableBytes_AreRefused_NotWavedThroughAsUnknown` | `Indeterminate` fails closed |
 | `ALinkableModule_ReportsANonZeroDenominator` | a clean verdict actually checked something |
 | `AWholePlatformAssemblyThisDeploymentLacks_IsRefused` | the coarse-grained shape, and that a private dependency is *named unchecked* rather than refused |
+| `AModuleReferencingASiblingModuleLandedMomentsEarlier_IsNotRefused` | the FALSE-refusal direction: a sibling module is not an absent platform assembly |
 | `AnUnloadableModule_IsParked_AndTheOthersStillInstall` | the blast radius: one module, not the portal |
 | `AParkedModule_ReadsAsQuarantined_NeverAsRestartRequired` | the false-promise rule |
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -1,0 +1,206 @@
+---
+Name: The Module Platform Link Gate
+Category: Architecture
+Description: A module's platform requirement is not a version string an author writes — it is the set of types its bytes are linked against. This is the gate that measures that requirement against the platform actually running, refuses a module the process cannot load, and parks the generation instead of the portal.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12h6"/><path d="M12 9v6"/></svg>
+---
+
+# The Module Platform Link Gate
+
+**A module is adopted on what this process can LOAD, never on a version string.**
+
+Until MeshWeaver#3538 the module lane had exactly one platform gate: the module's declared
+`minMeshVersion` FLOOR, compared as SemVer against the running platform's version. That gate is a
+*claim* — a string a module author writes by hand. The module's real requirement is not a version
+at all. It is **the set of types its bytes are linked against**, which the compiler records exactly,
+without anyone having to say anything, in the assembly's own metadata.
+
+Those two are not the same thing, and the gap between them took a production portal down for a day.
+
+## What it cost, measured
+
+memex-cloud ran core `3.0.0-rc9.ci.7693` (main of 2026-09-03). It adopted the pre-installed
+**DefaultViews** view pack's `MeshWeaver.Graph.Views`, whose bytes were compiled on 09-06 against a
+`MeshWeaver.Mesh.Contract` that carries `CodeOutputCurrency` — a type added to core on 09-04
+(`2dc5868b2`). The pack declared `minMeshVersion: 3.0.0-rc8`; the running version satisfied it; the
+bytes landed and loaded.
+
+They could not possibly work. Three things followed, and none of them named the install:
+
+- **Every code cell on the deployment rendered an error.**
+  `System.TypeLoadException: Could not load type 'MeshWeaver.Mesh.CodeOutputCurrency' from assembly
+  'MeshWeaver.Mesh.Contract, Version=3.0.0.0'` — thrown from `CodeViews.BuildContent`, on every
+  render, for every user, deterministically. Reported by a paying learner (MeshWeaver#3518).
+- **The module INSTALLED cleanly.** Its `MeshNodeProviderAttribute` touches none of the missing
+  surface, so MeshWeaver#2234's per-module install isolation — which catches a module whose
+  *registration* throws — saw a perfectly healthy module. Nothing was unhealthy until a *render*
+  reached the linked type, which is the JIT's first look at it.
+- **Nothing rolled back.** The generation stayed active, and the only evidence of what had happened
+  lived in a pod log.
+
+## Why the declared floor can never answer this
+
+Three properties make `minMeshVersion` structurally unable to decide loadability:
+
+1. **It is authored, so it can be wrong or absent.** An absent floor is "no constraint" — which is
+   right, since inventing one would be a claim the author never made — so a module that says
+   nothing is admitted on no evidence at all.
+2. **It is coarse.** A floor names a release; a break is a single type or member. A module built
+   one commit after a type was added has the same declared floor as one built a month before it.
+3. **It is a claim about the FUTURE.** `minMeshVersion: 3.0.0-rc8` asserts that every platform from
+   rc8 onward has what the module needs. That assertion is made *before* the platform it will run
+   on exists, and this is precisely the direction the module lane deliberately permits: a module
+   built against a newer platform is allowed to load on an older one, because that permission is
+   what makes an ex-post Store install possible at all.
+
+The recorded `frameworkMvid` cannot substitute for it either. That is an opaque *identity*, not an
+ordering: equality proves the same build, and anything else proves nothing. Gating modules on MVID
+equality would forbid every legitimate cross-build install — the whole point of the module lane.
+See [Module Versioning](../ModuleVersioning) for what the pack lane records and why.
+
+## What the gate does instead: measure
+
+`ModulePlatformLink` (`src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs`)
+reads the module's **type references** straight out of its metadata — no `Assembly.Load`, no module
+initializer, no type loading, no side effect — and resolves each one against the copy this process
+would actually bind to.
+
+The verdict is a **three-state**, and the third state is the point:
+
+| State | Meaning | What callers do |
+|---|---|---|
+| `Linkable` | every referenced type in every resolved platform assembly exists | load it |
+| `Unlinkable` | a referenced type is absent, or a whole referenced platform assembly is | refuse, naming the type |
+| `Indeterminate` | the check could not be MADE (unreadable bytes; a platform copy that would not parse) | refuse |
+
+`ModuleLinkVerdict.MayLoad` is true for `Linkable` **and nothing else**. It is written as an
+explicit predicate rather than left to each call site precisely so that nobody can spell the check
+as `!= Unlinkable` and quietly admit `Indeterminate`. *"I could not determine whether this loads"*
+and *"this loads"* are different facts, and a gate that reports the first as the second is a gate
+that cannot fail.
+
+### The denominator is part of the verdict
+
+A clean answer over zero checked references is indistinguishable from a check that never ran, so
+the verdict carries what was measured: how many type references were resolved, which platform
+assemblies were read, and — named, never silently folded into "fine" — which referenced assemblies
+were **not** checked.
+
+An assembly is in the denominator when the *platform* carries it. Two categories are deliberately
+outside it:
+
+- **The module's own closure.** Assemblies travelling *with* the module were built together with it;
+  their mutual agreement is not this gate's question.
+- **A private dependency the deployment does not carry.** That is a different defect — it fails as
+  a `FileNotFoundException` at first use, with a different remedy — so it is reported as unchecked
+  rather than guessed about.
+
+The one exception: an unresolved assembly whose simple name is the **platform's own**
+(`MeshWeaver.`) is refused. That is the whole-assembly shape of the same defect and a certain load
+failure.
+
+### What it does NOT see
+
+**Member-level skew.** A method or constructor signature that moved on a type that still exists —
+MeshWeaver#2234's original `MissingMethodException` — is invisible here, because this checks TYPE
+references. That shape is caught at install by
+`IncompatibleModule`, and the two are complementary halves rather than
+one check. Stating this explicitly matters: a gate whose blind spot is undocumented gets read as
+covering more than it does.
+
+## Where it runs, and what it protects
+
+### At landing — the floor, measured
+
+`ModuleLandingService.LandCore` consults it beside the declared floor, **from memory, before a
+single byte touches the disk**. A refusal therefore costs no generation directory, and the
+generation already running keeps running.
+
+The two landing paths differ exactly as they already did for the declared floor:
+
+- **Adopt** (`LandModule` — the install funnel, the auto-update reconcile): an unloadable module is
+  **refused**. Declined bytes must never reach a disk the next boot loads from.
+- **Shelve** (`ShelveModule` — the registry publish endpoint): the same verdict **holds** instead.
+  A registry stocks modules for platforms other than its own; the bytes land and serve, consumers
+  apply this same measurement against *their* platform, and this process's boot never loads them.
+  Refusing here would recreate the 2026-08-22 three-way deadlock the shelf exists to break.
+
+### At boot — the generation is parked, not the portal
+
+`MeshBuilder.InstallAssemblies` probes each module **before** `Assembly.LoadFrom`. A refusal is
+recorded as an `IncompatibleModule` — the same record a module whose
+registration threw produces — so it is reported three ways that already existed: written to stderr
+at boot (the only channel that exists before the logging pipeline is up), registered in DI for any
+host to surface, and classified `RequiredModuleState.Incompatible` so a module declared under
+`Modules:Required` is named on `/health` rather than silently absent.
+
+The blast radius is the point. One module that cannot link costs **that module's contribution and
+nothing else** — never every other module, never the portal, never every render on it.
+
+🚨 **The surface is the application closure PLUS every directory the boot is loading from.** A
+store-landed module lives in its own generation directory and may legitimately reference another
+module landed beside it; measuring against `/app` alone would report that sibling as an absent
+platform assembly and quarantine a module that is perfectly fine. The runtime's own resolution
+surface is what has to be measured.
+
+### How it composes with the generation pin
+
+`ModuleGenerationPin` (MeshWeaver#2509) copies the generation a replica
+is about to load into process-local storage, so a sibling replica's GC cannot reclaim bytes this
+process still lazily loads. The two are sequential and independent: the link probe decides
+**whether** a generation may be loaded, and the pin decides **from where**. The probe runs against
+the resolved load path before `InstallAssemblies` touches it, so a refused generation is never
+pinned and never copied — and a pinned one is measured exactly as the shared one would have been.
+Neither changes the other's answer.
+
+## How a quarantined module reads on a surface
+
+`ModuleActivationReport` now carries a **fourth** state beside pending, unresolvable and deferred:
+`Quarantined`. It is kept apart for the same reason as the others — the remedies differ, and every
+one of these states was previously mis-rendered as "restart required":
+
+| State | What it means | Remedy |
+|---|---|---|
+| `Pending` | landed on the volume, not loaded here | a restart |
+| `Unresolvable` | activated, but its bytes are gone | re-install the package |
+| `Deferred` | landed, but in no proposed module set | the landing wave must complete |
+| **`Quarantined`** | **refused: its bytes need a platform this deployment is not running** | **a platform update — which is itself the restart that loads it** |
+
+A quarantined module must never be reported as pending. Its assembly genuinely is not loaded, so
+the pending derivation finds it — and a restart re-runs the same measurement on the same bytes and
+refuses again. "Restart required" would be a prompt no restart can clear, which is the same false
+promise the held-entry and missing-bytes rules already exist to prevent.
+
+On the package card the person who installed it sees one localized line
+(`ui.moduleBuiltForNewerPlatform`) instead of a feature that is silently absent. Platform-owned
+chrome, so it follows the **viewer's** language — see [Localization](../Localization).
+
+## What proves it
+
+`test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs`. Every test compiles **real** assemblies
+with Roslyn and drives the **real** gate; nothing is mocked and no rule is re-derived locally.
+
+The repro compiles a module against a **stand-in `MeshWeaver.Mesh.Contract`** carrying a type the
+platform running the test does not have — memex-cloud's shape verbatim: same assembly simple name,
+missing type — and lands it through the real `ModuleLandingService`.
+
+| Test | What it pins |
+|---|---|
+| `AModuleBuiltAgainstANewerPlatform_IsRefusedAtLanding_NamingTheMissingType` | the refusal, the named type, and that nothing landed |
+| `AModuleBuiltAgainstThisPlatform_LandsAsBefore` | the gate is a gate, not a wall |
+| `AnUnloadableModule_IsShelvedRatherThanRefused_OnThePublishPath` | the shelf still stocks what it cannot run |
+| `UnreadableBytes_AreRefused_NotWavedThroughAsUnknown` | `Indeterminate` fails closed |
+| `ALinkableModule_ReportsANonZeroDenominator` | a clean verdict actually checked something |
+| `AWholePlatformAssemblyThisDeploymentLacks_IsRefused` | the coarse-grained shape, and that a private dependency is *named unchecked* rather than refused |
+| `AnUnloadableModule_IsParked_AndTheOthersStillInstall` | the blast radius: one module, not the portal |
+| `AParkedModule_ReadsAsQuarantined_NeverAsRestartRequired` | the false-promise rule |
+
+## Related
+
+- [Module Versioning](../ModuleVersioning) — what the pack lane records, what the build derives.
+- [Module Build Architecture](../ModuleBuildArchitecture) — the one build shape, every repo.
+- [NodeType Compilation](../NodeTypeCompilation) — the *other* identity lane, where MVID equality
+  IS the gate, and why that is right there and wrong here.
+- [The Cross-Repo Pair Gate](../CrossRepoPairGate) — the compile-time half of "two halves must move
+  together". This is the run-time half, and it catches what no source gate can see: bytes already
+  built, meeting a platform that is not theirs.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-view-pack-built-for-a-newer-platform-no-longer-breaks-every-page.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-view-pack-built-for-a-newer-platform-no-longer-breaks-every-page.md
@@ -1,0 +1,57 @@
+---
+Name: A view pack built for a newer platform no longer breaks every page
+Category: Fix
+Description: An installed module whose code needs a newer platform than your installation runs used to load anyway and then fail on every page that touched it. Now it is refused before it loads, only that module is missing, and the card says why.
+Icon: Checkmark
+Order: -20260907
+---
+
+# A view pack built for a newer platform no longer breaks every page
+
+If your installation had picked up a module — a view pack, an app's code — that was **built against
+a newer platform than the one you are running**, the module loaded anyway. Nothing checked whether
+the code it referenced was actually there. The failure only appeared later, when someone opened a
+page: every render that touched that module threw an error, on every page, for every person, until
+somebody read a server log and worked out which module was responsible.
+
+That happened on a live portal. Every code cell showed *"This area failed to render"* for a full
+day. The module reported itself as installed and healthy the whole time.
+
+## What changes
+
+**A module is now checked against the platform you are actually running — before it loads.** Not
+against a version number the module's author wrote down, but against the real question: does this
+installation have the code this module was built against? That answer is already recorded in the
+module's own files, so it can be measured exactly rather than assumed.
+
+**A module that fails the check is set aside, and nothing else is affected.** It does not load, it
+contributes nothing, and every other module and every page keeps working exactly as before. The
+difference is between *"one view pack is missing"* and *"everything on the portal is broken"*.
+
+**The package card tells you, in your language.** Instead of a feature that is silently absent, the
+card says the version you have was built for a newer platform and will start working when your
+installation updates. You are not left guessing why something you installed did nothing.
+
+**"Restart required" is no longer shown when a restart cannot help.** A set-aside module used to be
+reported as waiting for a restart — a prompt that no restart could ever clear, because the restart
+would reach the same conclusion. It is now reported as what it is: waiting for the platform.
+
+**An installation that cannot answer the question refuses rather than guesses.** If the module's
+files cannot be read at all, that is *"I could not determine whether this works"*, and it is treated
+exactly like *"this does not work"* — never quietly as *"this is fine"*.
+
+## What this does not change
+
+**Installing a module built for a different platform is still allowed and still normal.** Modules
+are meant to be installable across platform versions; only the ones this installation genuinely
+cannot run are held back, and they start working by themselves at the update that makes them
+runnable — no re-install, nothing to clean up.
+
+**A registry still carries modules it cannot run itself.** An installation acting as a registry for
+others goes on stocking and serving modules built for newer platforms. It simply does not load them
+into itself.
+
+**One kind of mismatch is still invisible until it happens.** The check compares the *types* a
+module uses. A change to a method's arguments on a type that still exists is not visible to it —
+that case is still caught when the module registers itself, which sets aside that one module in the
+same way.

--- a/src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs
+++ b/src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs
@@ -42,10 +42,67 @@ namespace MeshWeaver.Mesh;
 /// exception names one. Null when the failure is of another kind.</param>
 public sealed record IncompatibleModule(string Entry, string Name, string Error, string? MissingMember)
 {
+    /// <summary>
+    /// True when the module was refused BEFORE it was ever loaded, because its bytes link against
+    /// a platform this deployment is not running (#3538) — as opposed to a module that DID load
+    /// and whose registration threw (#2234).
+    ///
+    /// <para>🚨 <b>The distinction decides whether a ROLLOUT stalls.</b> A module the IMAGE ships
+    /// that cannot install is a fault the previous generation does not share and that this
+    /// deployment can fix by moving both halves together, so a rollout must stall on it. A
+    /// STORE-delivered module built for a platform this one is not running is the declared floor's
+    /// case exactly: no rollout of this deployment can conjure that platform, and stalling one
+    /// would recreate the 2026-08-22 three-way deadlock in a new place. It is reported and named
+    /// (never Healthy), and it starts working by itself at the platform update — which is itself a
+    /// restart.</para>
+    ///
+    /// <para>An INIT property, not a fifth positional parameter: replacing a public record's
+    /// constructor signature is what <see cref="MissingMethodException"/>-aborts a host compiled
+    /// against the previous platform — which is the very incident this record exists for. Default
+    /// <c>false</c> keeps every existing producer's meaning unchanged.</para>
+    /// </summary>
+    public bool RefusedBeforeLoad { get; init; }
+
     // MissingMethodException / MissingFieldException render as: Method not found: 'Void Ns.T..ctor(...)'.
     // TypeLoadException names the type instead. Both put the thing that is missing in quotes, which is
     // the one detail that turns "a module failed" into "this build lacks this signature".
     private static readonly Regex QuotedMember = new("'([^']+)'", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Builds the record from a LINK verdict — the module was never loaded at all because its
+    /// bytes reference types this platform does not carry (#3538).
+    ///
+    /// <para>🚨 The other half of this record's job, and the half that used to be missing. An
+    /// install failure is what happens when the module's registration TOUCHES the missing surface;
+    /// a view pack whose <see cref="MeshNodeProviderAttribute"/> touches none of it installs
+    /// perfectly and then throws <see cref="TypeLoadException"/> at every render that reaches the
+    /// linked type — which is how memex-cloud served dead code cells to every user for a day while
+    /// every module reported installed. A module refused HERE is in exactly the same state as one
+    /// that failed to install: it contributes nothing, it is reported, and nothing else is
+    /// affected.</para>
+    ///
+    /// <para>🚨 <b>A distinct NAME, deliberately not an overload of <see cref="From"/>.</b> An
+    /// added overload is one of the break shapes no gate in this fleet sees: a dependent repo's
+    /// <c>&lt;see cref="IncompatibleModule.From"/&gt;</c> becomes ambiguous and fails
+    /// <c>CS0419</c> under <c>-warnaserror</c>, in a different repository, on pull requests that
+    /// did not make the change (see Doc/Architecture/CrossRepoPairGate). Naming it costs nothing
+    /// and removes the shape entirely.</para>
+    /// </summary>
+    /// <param name="entry">The raw entry or resolved path that was going to be installed.</param>
+    /// <param name="verdict">The refusal — <see cref="ModuleLinkState.Unlinkable"/> or
+    /// <see cref="ModuleLinkState.Indeterminate"/>.</param>
+    public static IncompatibleModule FromLinkRefusal(string entry, ModuleLinkVerdict verdict)
+    {
+        ArgumentNullException.ThrowIfNull(verdict);
+        return new IncompatibleModule(
+            entry,
+            Path.GetFileNameWithoutExtension(entry) is { Length: > 0 } name ? name : verdict.Module,
+            verdict.Report(),
+            verdict.MissingTypes.IsDefaultOrEmpty ? null : verdict.MissingTypes[0])
+        {
+            RefusedBeforeLoad = true,
+        };
+    }
 
     /// <summary>Builds the record from a failed install, extracting the missing member when named.</summary>
     public static IncompatibleModule From(string entry, Exception exception)

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -168,8 +168,47 @@ public record MeshBuilder
         // equally hazardous step, isolated per module just below.
         var pending = new List<PendingModuleInstall>();
         var incompatible = new List<IncompatibleModule>();
+        // 🚨 #3538 — THE LINK PROBE, before a single Assembly.LoadFrom. Per-module isolation above
+        // catches a module that THROWS while installing; it cannot catch one that installs cleanly
+        // and is linked against types this platform does not have, because nothing touches those
+        // types until a render does. memex-cloud adopted a MeshWeaver.Graph.Views built against a
+        // core three days newer than its own, installed it without a murmur, and then threw
+        // `TypeLoadException: Could not load type 'MeshWeaver.Mesh.CodeOutputCurrency'` on EVERY
+        // code cell for every user until a human read a pod log. The requirement was never a
+        // version string — it is the set of types the bytes are linked against, and that is in the
+        // module's own metadata, so it can be MEASURED here instead of taken on trust.
+        //
+        // One surface per call, so 40 modules read each platform assembly's type list once. A
+        // baseline (image) module sits IN the application closure, so every platform assembly is
+        // its own sibling and it checks trivially clean — which is right, it ships with the
+        // platform by construction.
+        //
+        // 🚨 The surface is the application closure PLUS every directory this batch is loading
+        // from — never the app closure alone. A store-landed module lives in its own generation
+        // directory and may legitimately reference ANOTHER module landed beside it; measuring it
+        // against /app alone would report that sibling as an absent platform assembly and
+        // quarantine a module that is perfectly fine. The runtime's resolution surface is what has
+        // to be measured, and at boot that is exactly these directories.
+        var surface = assemblyLocations is { Length: > 0 }
+            ? ModulePlatformSurface.OfRunningProcess([
+                AppContext.BaseDirectory,
+                .. assemblyLocations
+                    .Select(location => Path.GetDirectoryName(Path.GetFullPath(location)))
+                    .Where(directory => !string.IsNullOrEmpty(directory))
+                    .Select(directory => directory!)
+                    .Distinct(StringComparer.OrdinalIgnoreCase),
+            ])
+            : null;
         foreach (var location in assemblyLocations)
         {
+            // Fail CLOSED on Indeterminate: MayLoad is true for Linkable and nothing else, so a
+            // check that could not be made can never be read as a check that passed.
+            if (surface is not null && ModulePlatformLink.Check(location, surface) is { MayLoad: false } verdict)
+            {
+                incompatible.Add(ReportIncompatible(location, verdict));
+                continue;
+            }
+
             try
             {
                 var assembly = Assembly.LoadFrom(location);
@@ -322,6 +361,18 @@ public record MeshBuilder
     private static IncompatibleModule ReportIncompatible(string entry, Exception exception)
     {
         var module = IncompatibleModule.From(entry, exception);
+        Console.Error.WriteLine($"[MeshWeaver.Mesh.IncompatibleModule] {module.Report()}");
+        return module;
+    }
+
+    /// <summary>
+    /// Records a module the LINK PROBE refused (#3538) — never loaded, so nothing of it ran — and
+    /// writes it to the same stderr channel, for the same reason: this runs before the logging
+    /// pipeline exists.
+    /// </summary>
+    private static IncompatibleModule ReportIncompatible(string entry, ModuleLinkVerdict verdict)
+    {
+        var module = IncompatibleModule.FromLinkRefusal(entry, verdict);
         Console.Error.WriteLine($"[MeshWeaver.Mesh.IncompatibleModule] {module.Report()}");
         return module;
     }

--- a/src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs
@@ -1,0 +1,469 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Whether a module's bytes can be LINKED against the platform this process is running — the
+/// measured answer that replaced the declared one (#3538).
+/// </summary>
+public enum ModuleLinkState
+{
+    /// <summary>Every type this module references from a platform assembly exists in the copy this
+    /// process would bind to. The module may load.</summary>
+    Linkable,
+
+    /// <summary>At least one referenced type is ABSENT from the platform copy that would be bound —
+    /// or a whole referenced platform assembly is not here at all. Loading it produces a
+    /// <see cref="TypeLoadException"/> the first time the code path is reached, which is a RENDER,
+    /// hours after the install.</summary>
+    Unlinkable,
+
+    /// <summary>🚨 The third state, modelled on purpose: the check could not be MADE. Never folded
+    /// into <see cref="Linkable"/> — "I could not determine whether this loads" and "this loads"
+    /// are different facts, and a gate that reports the first as the second is a gate that cannot
+    /// fail. Every caller treats this exactly as <see cref="Unlinkable"/>.</summary>
+    Indeterminate,
+}
+
+/// <summary>
+/// What <see cref="ModulePlatformLink"/> measured about one module — the verdict AND its
+/// denominator, so a reader can tell "checked 412 type references and found none missing" from
+/// "checked nothing".
+/// </summary>
+/// <param name="State">The verdict.</param>
+/// <param name="Module">The module's assembly simple name.</param>
+/// <param name="MissingTypes">Types the module references that the platform copy does not have,
+/// each as <c>Full.Type.Name (AssemblySimpleName)</c>. Empty unless
+/// <see cref="ModuleLinkState.Unlinkable"/>.</param>
+/// <param name="CheckedTypeReferences">How many type references were actually resolved against a
+/// platform assembly — the DENOMINATOR. A zero here with a
+/// <see cref="ModuleLinkState.Linkable"/> verdict means nothing was checked, which the report
+/// says out loud.</param>
+/// <param name="CheckedAssemblies">The platform assemblies whose surface was read.</param>
+/// <param name="UncheckedAssemblies">Referenced assemblies that are neither the platform's nor the
+/// module's own closure — its private dependencies. Named, never silently folded into "fine":
+/// they are out of this check's denominator, and a missing one fails later as a
+/// <c>FileNotFoundException</c>, which is a different defect with a different remedy.</param>
+/// <param name="Detail">Why the state is <see cref="ModuleLinkState.Indeterminate"/>, or null.</param>
+public sealed record ModuleLinkVerdict(
+    ModuleLinkState State,
+    string Module,
+    ImmutableArray<string> MissingTypes,
+    int CheckedTypeReferences,
+    ImmutableArray<string> CheckedAssemblies,
+    ImmutableArray<string> UncheckedAssemblies,
+    string? Detail = null)
+{
+    /// <summary>True only for <see cref="ModuleLinkState.Linkable"/> — the one state a caller may
+    /// load on. Written as an explicit predicate so no call site can spell the check as
+    /// <c>!= Unlinkable</c> and quietly admit <see cref="ModuleLinkState.Indeterminate"/>.</summary>
+    public bool MayLoad => State == ModuleLinkState.Linkable;
+
+    /// <summary>
+    /// The operator-facing sentence: which module, what it wants that this build does not have,
+    /// and what was actually measured. English by design — this goes to stderr and
+    /// <c>/health</c>, which are operator channels; the VIEWER-facing rendering of the same fact
+    /// is localized where the catalog renders it.
+    /// </summary>
+    public string Report() => State switch
+    {
+        ModuleLinkState.Linkable =>
+            $"Module '{Module}' links against this platform ({CheckedTypeReferences} type "
+            + $"reference(s) checked across {CheckedAssemblies.Length} platform assembly/assemblies"
+            + Unchecked() + ").",
+        ModuleLinkState.Unlinkable =>
+            $"Module '{Module}' was built against a platform this deployment is NOT running and "
+            + "CANNOT be loaded here: it references "
+            + string.Join(", ", MissingTypes)
+            + ", which the copy this process would bind to does not have. Loading it anyway "
+            + "throws TypeLoadException at the first render that touches it — every render, "
+            + "forever, with nothing connecting it to the install. Move the platform and the "
+            + "module together: this module becomes loadable when the platform updates. "
+            + $"({CheckedTypeReferences} type reference(s) checked across "
+            + $"{CheckedAssemblies.Length} platform assembly/assemblies" + Unchecked() + ")",
+        _ =>
+            $"Module '{Module}': whether it links against this platform could NOT be determined "
+            + $"({Detail}). Not loading it: an unanswerable check is not a passed one.",
+    };
+
+    private string Unchecked() =>
+        UncheckedAssemblies.IsDefaultOrEmpty
+            ? string.Empty
+            : $"; {UncheckedAssemblies.Length} referenced assembly/assemblies are neither the "
+              + "platform's nor this module's own closure and were NOT checked: "
+              + string.Join(", ", UncheckedAssemblies);
+}
+
+/// <summary>
+/// The type surface of the platform a module would be loaded INTO — one instance per check batch,
+/// caching what it reads.
+///
+/// <para>🚨 An INSTANCE, never a static cache. The surface it describes is a property of THIS
+/// process's loaded assemblies and probe directories; a process-wide static would survive mesh
+/// disposal and bleed one test's fabricated platform into the next one's.</para>
+/// </summary>
+public sealed class ModulePlatformSurface
+{
+    private readonly ImmutableDictionary<string, string> _files;
+    private readonly ImmutableDictionary<string, Assembly> _loaded;
+    // Per-instance memo of what each platform assembly exports. ConcurrentDictionary because a
+    // caller may check several modules in parallel; an instance field, so its lifetime is the
+    // batch's.
+    private readonly ConcurrentDictionary<string, ImmutableHashSet<string>?> _types =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private ModulePlatformSurface(
+        ImmutableDictionary<string, string> files, ImmutableDictionary<string, Assembly> loaded)
+    {
+        _files = files;
+        _loaded = loaded;
+    }
+
+    /// <summary>
+    /// The surface of the RUNNING process: every loaded assembly (the copies a module actually
+    /// binds to), plus every managed DLL sitting in <paramref name="probeDirectories"/> for the
+    /// platform assemblies this process has not touched yet.
+    /// </summary>
+    /// <param name="probeDirectories">Directories to add — production passes the application base
+    /// directory. Missing directories are skipped.</param>
+    public static ModulePlatformSurface OfRunningProcess(params string[] probeDirectories)
+        => Of(AppDomain.CurrentDomain.GetAssemblies(), probeDirectories);
+
+    /// <summary>
+    /// The pure form: an explicit set of loaded assemblies and probe directories. The seam a test
+    /// fabricates an OLDER platform through — which is the only way to reproduce the defect
+    /// without two builds of the product.
+    /// </summary>
+    /// <param name="loadedAssemblies">The assemblies a module would bind to, in precedence order;
+    /// the first of a simple name wins, exactly as the loader resolves it.</param>
+    /// <param name="probeDirectories">Directories searched for assemblies not among the loaded.</param>
+    public static ModulePlatformSurface Of(
+        IEnumerable<Assembly> loadedAssemblies, params string[] probeDirectories)
+    {
+        ArgumentNullException.ThrowIfNull(loadedAssemblies);
+        var loaded = ImmutableDictionary.CreateBuilder<string, Assembly>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in loadedAssemblies)
+        {
+            var name = assembly.GetName().Name;
+            if (!string.IsNullOrEmpty(name))
+                loaded.TryAdd(name, assembly);
+        }
+
+        var files = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in probeDirectories ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory))
+                continue;
+            foreach (var file in Directory.EnumerateFiles(directory, "*.dll"))
+                files.TryAdd(Path.GetFileNameWithoutExtension(file), file);
+        }
+
+        return new ModulePlatformSurface(files.ToImmutable(), loaded.ToImmutable());
+    }
+
+    /// <summary>Whether this platform carries an assembly of that simple name at all.</summary>
+    public bool Carries(string assemblyName) =>
+        _loaded.ContainsKey(assemblyName) || _files.ContainsKey(assemblyName);
+
+    /// <summary>
+    /// The full type names <paramref name="assemblyName"/> exposes here — type definitions AND
+    /// exported/forwarded types, because a forwarded type is present as far as the loader is
+    /// concerned and reading only definitions would report a type-forward as a missing type.
+    /// Null when the assembly is carried but its surface could not be read.
+    /// </summary>
+    public ImmutableHashSet<string>? TypesOf(string assemblyName) =>
+        _types.GetOrAdd(assemblyName, ReadTypes);
+
+    private ImmutableHashSet<string>? ReadTypes(string assemblyName)
+    {
+        // Prefer the FILE of the loaded copy: it is the exact bytes bound, and metadata gives both
+        // definitions and forwarders without loading a single type.
+        var path = _loaded.TryGetValue(assemblyName, out var assembly)
+                   && !string.IsNullOrEmpty(assembly.Location)
+                   && File.Exists(assembly.Location)
+            ? assembly.Location
+            : _files.GetValueOrDefault(assemblyName);
+
+        // No file to read (a single-file or dynamically loaded platform). Null, never an EMPTY set:
+        // an empty surface would read as "this assembly has no types" and report every reference
+        // as missing. The caller asks HasReadableFile first and falls back to reflection.
+        if (path is null)
+            return null;
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return null;
+            var metadata = peReader.GetMetadataReader();
+            var names = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+            foreach (var handle in metadata.TypeDefinitions)
+                names.Add(FullNameOf(metadata, metadata.GetTypeDefinition(handle)));
+            foreach (var handle in metadata.ExportedTypes)
+                names.Add(FullNameOf(metadata, metadata.GetExportedType(handle)));
+            return names.ToImmutable();
+        }
+        catch (Exception exception) when (exception is IOException or BadImageFormatException
+                                              or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Whether the loaded copy of <paramref name="assemblyName"/> has
+    /// <paramref name="fullTypeName"/>, asked through reflection — the fallback for a platform
+    /// assembly with no readable file.</summary>
+    internal bool LoadedCopyHasType(string assemblyName, string fullTypeName) =>
+        _loaded.TryGetValue(assemblyName, out var assembly)
+        && assembly.GetType(fullTypeName, throwOnError: false, ignoreCase: false) is not null;
+
+    /// <summary>Whether a file-backed surface exists for <paramref name="assemblyName"/> — i.e.
+    /// whether <see cref="TypesOf"/> is authoritative rather than the empty fallback.</summary>
+    internal bool HasReadableFile(string assemblyName) =>
+        (_loaded.TryGetValue(assemblyName, out var assembly)
+         && !string.IsNullOrEmpty(assembly.Location) && File.Exists(assembly.Location))
+        || _files.ContainsKey(assemblyName);
+
+    private static string FullNameOf(MetadataReader metadata, TypeDefinition type)
+    {
+        var name = metadata.GetString(type.Name);
+        var declaring = type.GetDeclaringType();
+        if (!declaring.IsNil)
+            return FullNameOf(metadata, metadata.GetTypeDefinition(declaring)) + "+" + name;
+        var ns = metadata.GetString(type.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+
+    private static string FullNameOf(MetadataReader metadata, ExportedType type)
+    {
+        var name = metadata.GetString(type.Name);
+        if (type.Implementation.Kind == HandleKind.ExportedType)
+            return FullNameOf(metadata,
+                metadata.GetExportedType((ExportedTypeHandle)type.Implementation)) + "+" + name;
+        var ns = metadata.GetString(type.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+}
+
+/// <summary>
+/// 🚨 <b>The module lane's platform gate: measured, not declared (#3538).</b>
+///
+/// <para><b>What went wrong.</b> A module was adopted on the strength of its declared
+/// <c>minMeshVersion</c> FLOOR alone — a string its author writes. memex-cloud, running a core of
+/// 2026-09-03, therefore adopted <c>DefaultViews</c>' <c>MeshWeaver.Graph.Views</c>, whose bytes
+/// were compiled on 09-06 against a <c>MeshWeaver.Mesh.Contract</c> that has
+/// <c>CodeOutputCurrency</c> — a type added on 09-04. The floor said <c>3.0.0-rc8</c>; the running
+/// <c>3.0.0-rc9.ci.7693</c> satisfied it; the bytes could not possibly load. The module INSTALLED
+/// cleanly (its <c>MeshNodeProviderAttribute</c> never touches the missing type), so #2234's
+/// install isolation saw nothing, and the defect surfaced as
+/// <c>TypeLoadException: Could not load type 'MeshWeaver.Mesh.CodeOutputCurrency'</c> on EVERY
+/// render of every code cell, for every user, until someone read a pod log.</para>
+///
+/// <para><b>Why a version string can never answer this.</b> A floor is a CLAIM about API
+/// compatibility. The actual requirement is not a version but a SET OF TYPES: the ones the
+/// module's bytes are linked against. Those are recorded in the assembly's own metadata, exactly
+/// and without a producer having to say anything, so the requirement can be MEASURED against the
+/// platform copies this process would bind to. That is what this class does — metadata only, no
+/// <c>Assembly.Load</c>, no module initializer, no type loading, no side effect.</para>
+///
+/// <para><b>What is in the denominator, and what is deliberately not.</b> A referenced assembly is
+/// checked when the PLATFORM carries it. An assembly travelling in the module's OWN closure is not
+/// checked — it was built together with the module, and their agreement is not this gate's
+/// question. An assembly that is in neither is NAMED in the verdict and left unchecked: it is a
+/// private dependency whose absence fails as a <c>FileNotFoundException</c>, a different defect
+/// with a different remedy. The one exception is an assembly whose simple name is the PLATFORM's
+/// own (<see cref="PlatformAssemblyPrefix"/>) that this deployment does not carry at all — that is
+/// the whole-assembly shape of the same defect and is refused.</para>
+///
+/// <para><b>Member-level skew is NOT covered and must not be assumed to be.</b> This checks TYPE
+/// references. A method or constructor signature that moved on a type that still exists (#2234's
+/// original <c>MissingMethodException</c>) is invisible here; that shape is caught at install by
+/// <see cref="IncompatibleModule"/>, and the two are complementary halves rather than one
+/// check.</para>
+/// </summary>
+public static class ModulePlatformLink
+{
+    /// <summary>The assembly-name prefix that makes an assembly the PLATFORM's rather than a
+    /// module's private dependency. A reference to one of these that the deployment does not carry
+    /// at all is refused, rather than counted as an unchecked private dependency.</summary>
+    public const string PlatformAssemblyPrefix = "MeshWeaver.";
+
+    /// <summary>
+    /// Checks a module's entry assembly ON DISK against <paramref name="surface"/>.
+    ///
+    /// <para>The module's own closure is taken to be the managed DLLs sitting BESIDE it — which is
+    /// exactly what a landed generation directory is. A baseline (image) module therefore has the
+    /// whole application closure as its "siblings" and checks trivially clean, which is right: it
+    /// ships with the platform by construction.</para>
+    /// </summary>
+    /// <param name="modulePath">Path to the module's entry DLL.</param>
+    /// <param name="surface">The platform this module would be loaded into.</param>
+    public static ModuleLinkVerdict Check(string modulePath, ModulePlatformSurface surface)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(modulePath);
+        ArgumentNullException.ThrowIfNull(surface);
+        var moduleName = Path.GetFileNameWithoutExtension(modulePath);
+        var directory = Path.GetDirectoryName(Path.GetFullPath(modulePath));
+        var siblings = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        if (directory is not null && Directory.Exists(directory))
+            foreach (var file in Directory.EnumerateFiles(directory, "*.dll"))
+                siblings.Add(Path.GetFileNameWithoutExtension(file));
+
+        try
+        {
+            using var stream = File.OpenRead(modulePath);
+            return Check(stream, moduleName, siblings.ToImmutable(), surface);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
+                                              or BadImageFormatException)
+        {
+            return Indeterminate(moduleName,
+                $"{exception.GetType().Name}: {exception.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Checks a module's entry assembly held as BYTES — the landing path, where the bundle is in
+    /// memory and nothing has touched the disk yet, so a refusal costs no generation directory.
+    /// </summary>
+    /// <param name="entryBytes">The entry assembly's bytes.</param>
+    /// <param name="moduleName">The module's assembly simple name (for the report).</param>
+    /// <param name="closure">The simple names of the assemblies travelling WITH the module,
+    /// including the entry itself — references to those are out of the denominator.</param>
+    /// <param name="surface">The platform this module would be loaded into.</param>
+    public static ModuleLinkVerdict Check(
+        byte[] entryBytes, string moduleName, IReadOnlySet<string> closure,
+        ModulePlatformSurface surface)
+    {
+        ArgumentNullException.ThrowIfNull(entryBytes);
+        ArgumentNullException.ThrowIfNull(closure);
+        ArgumentNullException.ThrowIfNull(surface);
+        using var stream = new MemoryStream(entryBytes, writable: false);
+        return Check(stream, moduleName, closure, surface);
+    }
+
+    private static ModuleLinkVerdict Check(
+        Stream module, string moduleName, IReadOnlySet<string> closure,
+        ModulePlatformSurface surface)
+    {
+        List<string> missing = [];
+        var checkedRefs = 0;
+        var checkedAssemblies = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        var uncheckedAssemblies = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+
+        PEReader? peReader = null;
+        MetadataReader metadata;
+        try
+        {
+            peReader = new PEReader(module);
+            if (!peReader.HasMetadata)
+            {
+                peReader.Dispose();
+                return Indeterminate(moduleName,
+                    "the file carries no managed metadata — it is not a managed assembly");
+            }
+            metadata = peReader.GetMetadataReader();
+        }
+        catch (Exception exception) when (exception is BadImageFormatException or IOException)
+        {
+            peReader?.Dispose();
+            return Indeterminate(moduleName, $"{exception.GetType().Name}: {exception.Message}");
+        }
+
+        using (peReader)
+        {
+            foreach (var handle in metadata.TypeReferences)
+            {
+                var reference = metadata.GetTypeReference(handle);
+                if (ResolveScope(metadata, reference) is not { } assemblyName)
+                    continue; // same-assembly or module-scoped reference — nothing external to check
+
+                // The module's own closure: built together with the entry, so their agreement is
+                // not this gate's question.
+                if (closure.Contains(assemblyName))
+                    continue;
+
+                if (!surface.Carries(assemblyName))
+                {
+                    if (assemblyName.StartsWith(PlatformAssemblyPrefix, StringComparison.Ordinal))
+                    {
+                        // A whole PLATFORM assembly this deployment does not have — the
+                        // coarse-grained shape of the same defect, and a certain load failure.
+                        missing.Add($"{FullName(metadata, reference)} ({assemblyName} — this "
+                                    + "deployment carries no such platform assembly)");
+                        checkedAssemblies.Add(assemblyName);
+                        checkedRefs++;
+                        continue;
+                    }
+
+                    uncheckedAssemblies.Add(assemblyName);
+                    continue;
+                }
+
+                var fullName = FullName(metadata, reference);
+                checkedAssemblies.Add(assemblyName);
+                checkedRefs++;
+
+                if (surface.HasReadableFile(assemblyName))
+                {
+                    var types = surface.TypesOf(assemblyName);
+                    if (types is null)
+                        return Indeterminate(moduleName,
+                            $"the platform's copy of '{assemblyName}' could not be read, so "
+                            + "whether it carries the types this module links against is unknown");
+                    if (!types.Contains(fullName))
+                        missing.Add($"{fullName} ({assemblyName})");
+                }
+                else if (!surface.LoadedCopyHasType(assemblyName, fullName))
+                {
+                    missing.Add($"{fullName} ({assemblyName})");
+                }
+            }
+        }
+
+        return new ModuleLinkVerdict(
+            missing.Count == 0 ? ModuleLinkState.Linkable : ModuleLinkState.Unlinkable,
+            moduleName,
+            [.. missing.Distinct(StringComparer.Ordinal).OrderBy(m => m, StringComparer.Ordinal)],
+            checkedRefs,
+            [.. checkedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)],
+            [.. uncheckedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)]);
+    }
+
+    private static ModuleLinkVerdict Indeterminate(string moduleName, string detail) =>
+        new(ModuleLinkState.Indeterminate, moduleName, [], 0, [], [], detail);
+
+    /// <summary>
+    /// The simple name of the ASSEMBLY a type reference resolves to, or null when the reference is
+    /// not to another assembly. A NESTED type's scope is its declaring TypeReference, so the walk
+    /// climbs until it reaches an assembly reference.
+    /// </summary>
+    private static string? ResolveScope(MetadataReader metadata, TypeReference reference)
+    {
+        var scope = reference.ResolutionScope;
+        while (scope.Kind == HandleKind.TypeReference)
+            scope = metadata.GetTypeReference((TypeReferenceHandle)scope).ResolutionScope;
+        return scope.Kind == HandleKind.AssemblyReference
+            ? metadata.GetString(
+                metadata.GetAssemblyReference((AssemblyReferenceHandle)scope).Name)
+            : null;
+    }
+
+    /// <summary>The reference's full name in the shape a type definition carries it —
+    /// <c>Namespace.Type</c>, nested as <c>Namespace.Outer+Inner</c>.</summary>
+    private static string FullName(MetadataReader metadata, TypeReference reference)
+    {
+        var name = metadata.GetString(reference.Name);
+        if (reference.ResolutionScope.Kind == HandleKind.TypeReference)
+            return FullName(metadata,
+                metadata.GetTypeReference((TypeReferenceHandle)reference.ResolutionScope))
+                + "+" + name;
+        var ns = metadata.GetString(reference.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -580,6 +580,7 @@
   "ui.removeInstallRecord": "Installationseintrag entfernen",
   "ui.requiresGlobalAdmin": "Erfordert Global Admin",
   "ui.restartRequiredToActivate": "Neustart erforderlich, um dieses Paket vollständig zu aktivieren",
+  "ui.moduleBuiltForNewerPlatform": "Hier nicht aktiv: Diese Version wurde für eine neuere Plattform gebaut. Sie wird aktiv, sobald diese Installation aktualisiert wird.",
   "ui.orphanedInstallRecords": "Verwaiste Installationseinträge",
   "ui.requestAccess": "Zugriff anfragen",
   "ui.resetToDefault": "Auf Standard zurücksetzen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -580,6 +580,7 @@
   "ui.removeInstallRecord": "Remove install record",
   "ui.requiresGlobalAdmin": "Requires Global Admin",
   "ui.restartRequiredToActivate": "Restart required to finish activating this package",
+  "ui.moduleBuiltForNewerPlatform": "Not running here: this version was built for a newer platform. It activates when this installation updates.",
   "ui.orphanedInstallRecords": "Orphaned install records",
   "ui.requestAccess": "Request Access",
   "ui.resetToDefault": "Reset to default",

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -770,6 +770,18 @@ public static class CatalogLayoutAreas
                 .WithStyle("color: var(--warning-foreground, #9d5d00); font-size: 12px; "
                            + "display: block; margin-top: 6px;"));
 
+        // 🚨 The FOURTH state, and the one that used to be invisible (#3538). A module whose bytes
+        // are linked against a platform this deployment is not running is refused at load: it
+        // contributes nothing, and — crucially — a restart re-runs the same measurement and
+        // refuses again, so the line above would be a promise no restart can keep. Saying it here
+        // is what turns "installed, and the feature simply is not there" into a fact the person
+        // who installed it can read. Localized like every other line on this card: it is
+        // platform-owned chrome, so it follows the VIEWER's language.
+        else if (activation.IsQuarantinedForPackage($"{PackageInstaller.InstalledPartition}/{pkg.Id}"))
+            card = card.WithView(Controls.Body($"⚠️ {host.Localize("ui.moduleBuiltForNewerPlatform")}")
+                .WithStyle("color: var(--error-foreground, #a4262c); font-size: 12px; "
+                           + "display: block; margin-top: 6px;"));
+
         return card;
     }
 

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -769,25 +769,42 @@ public sealed class ModuleLandingService : IDisposable
     }
 
     /// <summary>
-    /// This process's platform surface, read ONCE and reused for every landing (#3538).
+    /// The surface a landing module is measured against (#3538): the application closure, this
+    /// process's loaded assemblies, and the ACTIVE generation of every module this deployment has
+    /// landed.
     ///
-    /// <para>🚨 <b><c>AppContext.BaseDirectory</c>, never <c>baseDirectory</c>.</b> The platform is
-    /// the APP closure; this service's root is the (possibly separate, possibly read-write) volume
-    /// the <c>modules/</c> tree lives on. Naming the wrong one would measure a module against the
-    /// directory it is being written into.</para>
+    /// <para>🚨 <b><c>AppContext.BaseDirectory</c>, never <c>baseDirectory</c>, for the platform
+    /// half.</b> The platform is the APP closure; this service's root is the (possibly separate,
+    /// possibly read-write) volume the <c>modules/</c> tree lives on. Naming the wrong one would
+    /// measure a module against the directory it is being written into.</para>
     ///
-    /// <para><b>An INSTANCE field, not a static</b> — the surface it describes is a property of
-    /// THIS process, and a process-wide static would outlive the mesh and bleed one test's
-    /// fabricated platform into the next one's (Doc/Architecture/NoStaticState). Built lazily
-    /// rather than in the constructor because the constructor can run before the deployment's
-    /// modules are loaded; the file probe above covers what the loaded snapshot has not seen yet,
-    /// and it is only ever touched from <see cref="LandCore"/>, which runs on this service's cap-1
-    /// pool — one at a time, by construction, with no gate of any kind.</para>
+    /// <para>🚨 <b>The landed modules belong in it, and it is REBUILT per landing.</b> A wave lands
+    /// its modules ONE AT A TIME, and a module may legitimately reference a SIBLING module that
+    /// landed thirty seconds ago and that this process has not loaded (restart-as-activation). A
+    /// surface that knew only <c>/app</c> — or one captured at the wave's first landing — would
+    /// not carry that sibling, and the platform-prefix rule would refuse the module for "no such
+    /// platform assembly": a false refusal, and exactly the confidently-wrong verdict this gate
+    /// exists to replace. The cost is a sidecar read plus the metadata of the assemblies THIS
+    /// module references, on the cap-1 IO pool, off every render path.</para>
+    ///
+    /// <para>The ACTIVE generation specifically, through the one resolution rule
+    /// (<see cref="ModuleDirectoryFor"/>) — not every directory under <c>modules/</c>. Superseded
+    /// generations are still on the volume until the GC reclaims them, and an older one can
+    /// legitimately lack a type its successor has; measuring against whichever directory an
+    /// unordered listing happened to yield first would make the verdict depend on the filesystem.</para>
     /// </summary>
-    private ModulePlatformSurface PlatformSurface() =>
-        platformSurface ??= ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory);
-
-    private ModulePlatformSurface? platformSurface;
+    private ModulePlatformSurface PlatformSurface()
+    {
+        var landed = ModuleActivationSidecar.Read(baseDirectory,
+                msg => logger?.LogWarning("{Message}", msg))
+            .Entries
+            .Where(entry => entry.Enabled && !string.IsNullOrWhiteSpace(entry.Name))
+            .Select(entry => ModuleDirectoryFor(baseDirectory, entry.Name, entry))
+            .Where(Directory.Exists)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return ModulePlatformSurface.OfRunningProcess([AppContext.BaseDirectory, .. landed]);
+    }
 
     private static void ValidateFileName(string? value, string what)
     {

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -403,9 +404,12 @@ public sealed class ModuleLandingService : IDisposable
     /// <param name="version">The package version the bundle was served at — recorded on the
     /// activation entry so the auto-update reconcile can answer "already landed" without a
     /// download (<see cref="ModuleActivationEntry.Version"/>).</param>
-    /// <param name="minMeshVersion">The module's declared platform FLOOR — the gate: an
-    /// unsatisfied floor (<see cref="ModulePlatformFloor.DeclineReason(string?)"/>) refuses the
-    /// landing. Null = no constraint declared.</param>
+    /// <param name="minMeshVersion">The module's declared platform FLOOR — one of the two gates:
+    /// an unsatisfied floor (<see cref="ModulePlatformFloor.DeclineReason(string?)"/>) refuses the
+    /// landing. Null = no constraint declared, which is NOT the same as no constraint: the second
+    /// gate (<see cref="MeshWeaver.Mesh.ModulePlatformLink"/>, #3538) measures the module's actual
+    /// link requirements against this platform's surface and refuses bytes this process could not
+    /// load, whatever the floor says.</param>
     public IObservable<Unit> LandModule(
         string name,
         IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
@@ -588,11 +592,36 @@ public sealed class ModuleLandingService : IDisposable
         // verdict HOLDS instead of refusing: the bytes land for CONSUMERS, whose own gates apply
         // this very function against their platforms, while this process's boot keeps applying it
         // per entry and so never loads what it records here.
-        var held = ModulePlatformFloor.DeclineReason(minMeshVersion);
+        //
+        // 🚨 #3538 — AND THE FLOOR THAT IS MEASURED RATHER THAN DECLARED. `minMeshVersion` is a
+        // CLAIM its author writes; the module's real requirement is the SET OF TYPES its bytes are
+        // linked against, which its own metadata states exactly. memex-cloud (core of 09-03)
+        // adopted a MeshWeaver.Graph.Views compiled on 09-06 against a Mesh.Contract carrying
+        // `CodeOutputCurrency` (added 09-04) because the declared floor `3.0.0-rc8` was satisfied
+        // by the running `3.0.0-rc9.ci.7693` — every render of every code cell then threw
+        // TypeLoadException, for every user, until a human read a pod log. So the bytes are
+        // MEASURED against this platform's surface, from memory, BEFORE anything touches the disk:
+        // a refusal here costs no generation directory and leaves the previous generation running.
+        // The verdict is tri-state and `MayLoad` is true for Linkable ALONE — a check that could
+        // not be made parks the module exactly like one that failed.
+        var held = ModulePlatformFloor.DeclineReason(minMeshVersion) ?? LinkHoldReason();
         if (held is not null && !holdAboveFloor)
         {
             logger?.LogWarning("Module '{Name}' REFUSED at landing: {Reason}", name, held);
             throw new InvalidOperationException($"Module '{name}' refused: {held}");
+        }
+
+        string? LinkHoldReason()
+        {
+            var entryBytes = assemblies.First(a =>
+                string.Equals(a.FileName, entryDll, StringComparison.OrdinalIgnoreCase)).Bytes;
+            // The module's own closure travels WITH it, so a reference into it is not this gate's
+            // question — the two were built together. Only the PLATFORM side is measured.
+            var closure = assemblies
+                .Select(a => Path.GetFileNameWithoutExtension(a.FileName))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var verdict = ModulePlatformLink.Check(entryBytes, name, closure, PlatformSurface());
+            return verdict.MayLoad ? null : verdict.Report();
         }
 
         // 🚨 The same-identity trap-door: modules/<name>/<name>.dll wins over the app folder in
@@ -738,6 +767,27 @@ public sealed class ModuleLandingService : IDisposable
             "Module '{Name}' UNINSTALLED: activation disabled — takes effect at the next restart",
             name);
     }
+
+    /// <summary>
+    /// This process's platform surface, read ONCE and reused for every landing (#3538).
+    ///
+    /// <para>🚨 <b><c>AppContext.BaseDirectory</c>, never <c>baseDirectory</c>.</b> The platform is
+    /// the APP closure; this service's root is the (possibly separate, possibly read-write) volume
+    /// the <c>modules/</c> tree lives on. Naming the wrong one would measure a module against the
+    /// directory it is being written into.</para>
+    ///
+    /// <para><b>An INSTANCE field, not a static</b> — the surface it describes is a property of
+    /// THIS process, and a process-wide static would outlive the mesh and bleed one test's
+    /// fabricated platform into the next one's (Doc/Architecture/NoStaticState). Built lazily
+    /// rather than in the constructor because the constructor can run before the deployment's
+    /// modules are loaded; the file probe above covers what the loaded snapshot has not seen yet,
+    /// and it is only ever touched from <see cref="LandCore"/>, which runs on this service's cap-1
+    /// pool — one at a time, by construction, with no gate of any kind.</para>
+    /// </summary>
+    private ModulePlatformSurface PlatformSurface() =>
+        platformSurface ??= ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory);
+
+    private ModulePlatformSurface? platformSurface;
 
     private static void ValidateFileName(string? value, string what)
     {

--- a/src/MeshWeaver.PluginCatalog/ModulePlatformFloor.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePlatformFloor.cs
@@ -5,8 +5,19 @@ using MeshWeaver.Plugin.Packaging;
 namespace MeshWeaver.PluginCatalog;
 
 /// <summary>
-/// The ONE platform gate of the MODULE lane (#1664): a module bundle may land when the RUNNING
-/// platform version satisfies the module's declared <c>minMeshVersion</c> FLOOR.
+/// The DECLARED platform gate of the MODULE lane (#1664): a module bundle may land when the
+/// RUNNING platform version satisfies the module's declared <c>minMeshVersion</c> FLOOR.
+///
+/// <para>🚨 <b>It is no longer the only one, and it never could have been the whole answer
+/// (#3538).</b> This is a CLAIM — a version string a module author writes by hand — and a claim
+/// about the future at that: it asserts that every platform from that release onward has what the
+/// module needs. memex-cloud satisfied a declared <c>3.0.0-rc8</c> floor with
+/// <c>3.0.0-rc9.ci.7693</c> and adopted bytes linked against a type added three days later; every
+/// render of every code cell then threw <c>TypeLoadException</c>. The module's REAL requirement is
+/// the set of TYPES its bytes are linked against, which its own metadata states exactly — so it is
+/// MEASURED, by <c>MeshWeaver.Mesh.ModulePlatformLink</c>, beside this. Both gates run at landing
+/// and at boot; this one first, because it is a string comparison and the other reads metadata.
+/// See <c>Doc/Architecture/ModulePlatformLinkGate</c>.</para>
 ///
 /// <para><b>Deliberately NOT the MVID gate.</b> MVID equality is BAKE semantics — a NodeType
 /// assembly is compiled in-process against exact framework references, so only the identical build

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -48,6 +48,39 @@ public sealed record ModuleActivationReport(
     /// </summary>
     public ImmutableList<PendingModuleActivation> Deferred { get; init; } = [];
 
+    /// <summary>
+    /// 🚨 The modules this process REFUSED TO LOAD because their bytes are linked against a
+    /// platform it is not running (#3538) — a FOURTH state, and again not folded into
+    /// <see cref="Pending"/> for the same reason as the other two: a restart re-runs the same
+    /// measurement and reaches the same verdict, so "restart required" would be a prompt no
+    /// restart can clear.
+    ///
+    /// <para>The remedy is different again, and it is the only one of the four that is not the
+    /// operator's: this module becomes loadable when the PLATFORM updates, and the platform update
+    /// is itself a restart. Until then the module contributes nothing and says so — which is the
+    /// whole point, because the alternative that shipped was contributing a
+    /// <c>TypeLoadException</c> to every render that touched it.</para>
+    ///
+    /// <para>An init-only property rather than a positional parameter — replacing a public
+    /// record's constructor signature is what <see cref="MissingMethodException"/>-aborts a host
+    /// compiled against the previous platform.</para>
+    /// </summary>
+    public ImmutableList<PendingModuleActivation> Quarantined { get; init; } = [];
+
+    /// <summary>True when the state is KNOWN and a module was refused as unloadable against this
+    /// platform build.</summary>
+    public bool HasQuarantined => !IsUndetermined && !Quarantined.IsEmpty;
+
+    /// <summary>
+    /// Whether the install record at <paramref name="packagePath"/> landed a module this process
+    /// refused to load (#3538) — the per-PACKAGE question a package card asks so it can say
+    /// "built for a newer platform" instead of a bare "installed" or, worse, a "restart required"
+    /// that no restart clears.
+    /// </summary>
+    /// <param name="packagePath">The install record's mesh path. Blank matches nothing.</param>
+    public bool IsQuarantinedForPackage(string? packagePath) =>
+        !IsUndetermined && ModuleActivationStatus.IsPendingForPackage(Quarantined, packagePath);
+
     /// <summary>One line naming which module set the mesh is on and whether a replica has booted
     /// onto it yet (<see cref="ModuleSetStore.Describe"/>), or null on a deployment with no set
     /// records. The mesh-level half of the report; <see cref="Pending"/> is the per-pod half.</summary>
@@ -96,7 +129,33 @@ public sealed record ModuleActivationReport(
                 ? ModuleActivationStatus.DescribeUnresolvable(Unresolvable)
                     + (HasPending ? "; " + ModuleActivationStatus.Describe(Pending) : string.Empty)
                 : ModuleActivationStatus.Describe(Pending))
-              + (HasDeferred ? "; " + DescribeDeferred(Deferred) : string.Empty);
+              + (HasDeferred ? "; " + DescribeDeferred(Deferred) : string.Empty)
+              + (HasQuarantined ? "; " + DescribeQuarantined(Quarantined) : string.Empty);
+
+    /// <summary>
+    /// One human-readable line naming the modules this process refused to load because their bytes
+    /// need a platform it is not running (#3538) — kept apart from every other line because the
+    /// remedy is apart from every other remedy: the PLATFORM has to move.
+    /// </summary>
+    /// <param name="quarantined">The refused modules.</param>
+    /// <param name="maxNamed">How many are named before the line truncates.</param>
+    public static string DescribeQuarantined(
+        IReadOnlyCollection<PendingModuleActivation> quarantined, int maxNamed = 10)
+    {
+        ArgumentNullException.ThrowIfNull(quarantined);
+        if (quarantined.Count == 0)
+            return "no module was refused against this platform build";
+        var names = quarantined
+            .Select(p => p.Name)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return $"{names.Length} module(s) were REFUSED against this platform build — their bytes "
+            + "are linked against a platform this deployment is not running, so they contribute "
+            + "nothing and no restart changes that; the platform update that satisfies them is "
+            + "itself the restart that loads them: "
+            + string.Join(", ", names.Take(maxNamed))
+            + (names.Length > maxNamed ? $" (+{names.Length - maxNamed} more)" : string.Empty);
+    }
 
     /// <summary>
     /// One human-readable line naming the modules a landing wave landed but never proposed
@@ -144,6 +203,20 @@ public sealed class PendingModuleActivations(string moduleRoot)
 
     /// <summary>The deployment root whose <c>modules/</c> sidecar is read.</summary>
     public string ModuleRootPath { get; } = moduleRoot;
+
+    /// <summary>
+    /// The simple names of modules this process REFUSED to load (#3538) — production passes the
+    /// registered <see cref="Mesh.IncompatibleModule"/> set, which is what
+    /// <c>MeshBuilder.InstallAssemblies</c> recorded for every module its link probe declined and
+    /// every module whose registration threw.
+    ///
+    /// <para>🚨 Without it such a module reads as PENDING — its assembly is genuinely not loaded —
+    /// and the surface promises a restart that re-runs the same measurement and refuses again.
+    /// An init-only property, not a constructor parameter: replacing the constructor signature is
+    /// a binary break for a host compiled against the previous platform.</para>
+    /// </summary>
+    public IReadOnlySet<string> QuarantinedModules { get; init; } =
+        ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// The current report. Recomputed per call — the state changes underneath a running process
@@ -238,16 +311,31 @@ public sealed class PendingModuleActivations(string moduleRoot)
             // actually load rather than the one on paper.
             LandedDllExists);
 
+        var notYetLoaded = ModuleActivationStatus.NotYetLoaded(
+            onMeshSet, loadedAssemblyNames, loadedModuleGenerations,
+            ModulePlatformFloor.DeclineReason, LandedDllExists);
+
+        // 🚨 #3538 — a module this process REFUSED to load is not pending, it is quarantined. Its
+        // assembly is genuinely absent from the loaded set, so the pending derivation above finds
+        // it and would promise a restart; a restart re-runs the same measurement on the same bytes
+        // and refuses again. Same false-promise rule as a held entry and a missing DLL, one state
+        // further on — and the only one whose remedy is a PLATFORM update rather than an operator
+        // action.
+        ImmutableList<PendingModuleActivation> quarantined = QuarantinedModules.Count == 0
+            ? []
+            : [.. notYetLoaded.Where(p => QuarantinedModules.Contains(p.Name))];
+
         return new ModuleActivationReport(
-            ModuleActivationStatus.NotYetLoaded(
-                onMeshSet, loadedAssemblyNames, loadedModuleGenerations,
-                ModulePlatformFloor.DeclineReason, LandedDllExists),
+            quarantined.IsEmpty
+                ? notYetLoaded
+                : [.. notYetLoaded.Where(p => !QuarantinedModules.Contains(p.Name))],
             UndeterminedReason: null,
             ModuleActivationStatus.Unresolvable(
                 onMeshSet, loadedAssemblyNames, loadedModuleGenerations,
                 ModulePlatformFloor.DeclineReason, LandedDllExists))
         {
             Deferred = deferred.ToImmutable(),
+            Quarantined = quarantined,
             MeshModuleSet = ModuleSetStore.Describe(sets)
                 + (setNotes.Count > 0 ? " — " + string.Join("; ", setNotes) : string.Empty),
         };

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MeshWeaver.Domain;
 using Microsoft.Extensions.DependencyInjection;
 using MeshWeaver.Graph;
@@ -176,7 +177,17 @@ public static class PluginCatalogConfigurationExtensions
                 // can resolve it from hub.ServiceProvider — the Store's install step is the
                 // surface where the missing last step is actually met.
                 .AddSingleton(sp => new PendingModuleActivations(
-                    ModuleRoot.Resolve(sp.GetService<IConfiguration>())))
+                    ModuleRoot.Resolve(sp.GetService<IConfiguration>()))
+                {
+                    // 🚨 #3538 — the modules MeshBuilder.InstallAssemblies refused: its link probe
+                    // declined them, or their registration threw. Without this set they read as
+                    // PENDING, and every surface promises a restart that re-runs the same
+                    // measurement and refuses again.
+                    QuarantinedModules = sp.GetServices<IncompatibleModule>()
+                        .Select(m => m.Name)
+                        .Where(n => !string.IsNullOrWhiteSpace(n))
+                        .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase),
+                })
                 // The COUNT that proves the distribution lane works (#1782 gap 4). Adoption's only
                 // evidence used to be a log line, and the most important miss — "the registry does
                 // not advertise this package for my lane" — had no line at all. With lazy

--- a/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
@@ -157,8 +157,23 @@ public static class RequiredModuleStatus
                 module => string.Equals(module.Name, name, StringComparison.OrdinalIgnoreCase));
             if (broken is not null)
             {
+                // 🚨 A module REFUSED BEFORE LOADING because its bytes need a platform this
+                // deployment is not running (#3538) is the declared FLOOR's case, not #2234's — and
+                // the two must not classify alike. #2234 is "the image and its module set
+                // disagree", which this deployment CAN fix by moving both together, so a rollout
+                // stalls. A store-delivered module built for another platform is one no rollout of
+                // this deployment can conjure: stalling on it would recreate the 2026-08-22
+                // three-way deadlock in a new place, and in the rollback direction it would stall
+                // the very roll that resolves it. ExpectedLater — named, reported, NOT Healthy —
+                // exactly as a floor-held entry is. An IMAGE-shipped module that cannot link is
+                // still Incompatible: that is a build defect the previous generation does not
+                // share, which is precisely what a rollout must not complete over.
                 verdicts.Add(new RequiredModuleVerdict(
-                    entry!, name, RequiredModuleState.Incompatible, broken.Report()));
+                    entry!, name,
+                    broken.RefusedBeforeLoad && !imageShips.Contains(name)
+                        ? RequiredModuleState.ExpectedLater
+                        : RequiredModuleState.Incompatible,
+                    broken.Report()));
                 continue;
             }
 

--- a/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A module is adopted on what it CAN LOAD, never on a version string (#3538, #3518).</b>
+///
+/// <para><b>The incident these reproduce.</b> memex-cloud ran a core of 2026-09-03 and adopted
+/// <c>DefaultViews</c>' <c>MeshWeaver.Graph.Views</c>, whose bytes were compiled on 09-06 against a
+/// <c>MeshWeaver.Mesh.Contract</c> carrying <c>CodeOutputCurrency</c> — a type added on 09-04. The
+/// only gate was the module's declared <c>minMeshVersion: 3.0.0-rc8</c> floor, which the running
+/// <c>3.0.0-rc9.ci.7693</c> satisfied, so the bytes landed and loaded. They installed CLEANLY —
+/// the module's <c>MeshNodeProviderAttribute</c> touches none of the missing surface, so #2234's
+/// per-module install isolation saw nothing — and then EVERY render of every code cell threw
+/// <c>TypeLoadException: Could not load type 'MeshWeaver.Mesh.CodeOutputCurrency'</c>, for every
+/// user, until a human read a pod log.</para>
+///
+/// <para><b>Why the declared floor can never answer it.</b> A floor is a CLAIM about API
+/// compatibility that an author writes by hand. The module's real requirement is not a version at
+/// all — it is the SET OF TYPES its bytes are linked against, and that set is stated exactly, by
+/// the compiler, in the assembly's own metadata. So it is MEASURED against the platform copies
+/// this process would actually bind to (<see cref="ModulePlatformLink"/>), metadata only, with no
+/// <c>Assembly.Load</c> and no type loading.</para>
+///
+/// <para><b>What makes these able to FAIL.</b> Every one compiles REAL assemblies with Roslyn and
+/// runs the REAL gate. The landing tests compile a module against a stand-in
+/// <c>MeshWeaver.Mesh.Contract</c> that carries a type the platform running this test does NOT
+/// have — the memex-cloud shape verbatim, same assembly simple name, missing type — and drive the
+/// REAL <see cref="ModuleLandingService"/>. Neutralising the gate (making
+/// <c>ModuleLinkVerdict.MayLoad</c> true for every state) flips
+/// <see cref="AModuleBuiltAgainstANewerPlatform_IsRefusedAtLanding_NamingTheMissingType"/>,
+/// <see cref="UnreadableBytes_AreRefused_NotWavedThroughAsUnknown"/> and
+/// <see cref="AnUnloadableModule_IsParked_AndTheOthersStillInstall"/>. Removing the positive
+/// controls' counterpart — <see cref="AModuleBuiltAgainstThisPlatform_LandsAsBefore"/> and
+/// <see cref="ALinkableModule_ReportsANonZeroDenominator"/> — is what stops the gate from passing
+/// by refusing everything, or by checking nothing.</para>
+/// </summary>
+public class ModulePlatformLinkTest : IDisposable
+{
+    /// <summary>The platform assembly the stand-in impersonates: a REAL one this process has
+    /// loaded, so the test measures against the copy a module would actually bind to.</summary>
+    private const string ContractAssembly = "MeshWeaver.Mesh.Contract";
+
+    /// <summary>A type no build of <see cref="ContractAssembly"/> has ever carried — the stand-in
+    /// for <c>CodeOutputCurrency</c> as it looked from a platform three days behind.</summary>
+    private const string FutureType = "MeshWeaver.Mesh.CodeOutputCurrencyFromTheFuture";
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-linkprobe-" + Guid.NewGuid().ToString("N"));
+
+    private readonly ModuleLandingService landing;
+
+    /// <summary>Creates the per-test deployment root and the REAL landing service over it.</summary>
+    public ModulePlatformLinkTest()
+    {
+        Directory.CreateDirectory(root);
+        landing = new ModuleLandingService(baseDirectory: root);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        landing.Dispose();
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // ───────────────────────────────────────────────────── the floor is the BUILD platform
+
+    /// <summary>
+    /// 🚨 <b>THE repro of #3538, at the landing.</b> A module compiled against a
+    /// <c>MeshWeaver.Mesh.Contract</c> that has a type this platform's copy does not is REFUSED,
+    /// and the refusal NAMES the type — the sentence that was missing from the memex-cloud
+    /// incident, where the only evidence was a <c>TypeLoadException</c> per render.
+    ///
+    /// <para>The declared floor is deliberately left absent, so the ONLY thing that can refuse
+    /// this is the measured one. Before the fix, an absent floor was "no constraint" and these
+    /// bytes landed.</para>
+    /// </summary>
+    [Fact]
+    public async Task AModuleBuiltAgainstANewerPlatform_IsRefusedAtLanding_NamingTheMissingType()
+    {
+        var module = ModuleBuiltAgainstAFuturePlatform("MeshWeaver.Test.FutureViewPack");
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await landing.LandModule(
+                    "MeshWeaver.Test.FutureViewPack",
+                    [("MeshWeaver.Test.FutureViewPack.dll", module)],
+                    minMeshVersion: null)
+                .Timeout(TestTimeouts.Convergence).Await());
+
+        Assert.Contains(FutureType, refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(ContractAssembly, refusal.Message, StringComparison.Ordinal);
+        // 🚨 And nothing landed: the previous generation is what keeps serving. A refusal that
+        // still wrote the bytes would leave the next boot to load them.
+        Assert.Empty(ModuleActivationSidecar.Read(root).Entries);
+    }
+
+    /// <summary>
+    /// The positive control, and the reason the gate above is a gate rather than a wall: a module
+    /// compiled against THIS platform's real contract lands exactly as it always did.
+    /// </summary>
+    [Fact]
+    public async Task AModuleBuiltAgainstThisPlatform_LandsAsBefore()
+    {
+        var module = ModuleBuiltAgainstThisPlatform("MeshWeaver.Test.CurrentViewPack");
+
+        await landing.LandModule(
+                "MeshWeaver.Test.CurrentViewPack",
+                [("MeshWeaver.Test.CurrentViewPack.dll", module)])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        var entry = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal("MeshWeaver.Test.CurrentViewPack", entry.Name);
+        Assert.True(entry.Enabled);
+    }
+
+    /// <summary>
+    /// 🚨 The SHELF path is unchanged in kind: a registry stocking a module for OTHER platforms
+    /// must still carry bytes IT cannot load. They land and serve; this process's boot refuses
+    /// them, which is exactly what the floor already did (2026-08-22's three-way deadlock).
+    /// </summary>
+    [Fact]
+    public async Task AnUnloadableModule_IsShelvedRatherThanRefused_OnThePublishPath()
+    {
+        var module = ModuleBuiltAgainstAFuturePlatform("MeshWeaver.Test.ShelvedViewPack");
+
+        var outcome = await landing.ShelveModule(
+                "MeshWeaver.Test.ShelvedViewPack",
+                [("MeshWeaver.Test.ShelvedViewPack.dll", module)])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        Assert.True(outcome.Held);
+        Assert.Contains(FutureType, outcome.HoldReason!, StringComparison.Ordinal);
+        // The bytes ARE on the shelf — consumers fetch them and apply this same measurement
+        // against THEIR platform.
+        Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+    }
+
+    /// <summary>
+    /// 🚨 <b>The third state, and it fails CLOSED.</b> Bytes that are not a readable managed
+    /// assembly answer <see cref="ModuleLinkState.Indeterminate"/> — "I could not determine
+    /// whether this loads" — and that is NEVER folded into "it loads". A gate whose unknown reads
+    /// as a pass is a gate that cannot fail.
+    /// </summary>
+    [Fact]
+    public async Task UnreadableBytes_AreRefused_NotWavedThroughAsUnknown()
+    {
+        var verdict = ModulePlatformLink.Check(
+            [0x4D, 0x5A, 0x90], "MeshWeaver.Test.Garbage",
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MeshWeaver.Test.Garbage" },
+            ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory));
+
+        Assert.Equal(ModuleLinkState.Indeterminate, verdict.State);
+        Assert.False(verdict.MayLoad);
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await landing.LandModule(
+                    "MeshWeaver.Test.Garbage", [("MeshWeaver.Test.Garbage.dll", [0x4D, 0x5A, 0x90])])
+                .Timeout(TestTimeouts.Convergence).Await());
+        Assert.Contains("could NOT be determined", refusal.Message, StringComparison.Ordinal);
+    }
+
+    // ───────────────────────────────────────────────────── the probe itself, and its denominator
+
+    /// <summary>
+    /// 🚨 <b>The denominator, printed.</b> A clean verdict over ZERO checked references is
+    /// indistinguishable from a check that never ran — the sweep-with-no-denominator shape this
+    /// codebase keeps meeting. A linkable module must therefore report that it actually resolved
+    /// references against real platform assemblies.
+    /// </summary>
+    [Fact]
+    public void ALinkableModule_ReportsANonZeroDenominator()
+    {
+        var path = Write("MeshWeaver.Test.CountedViewPack",
+            ModuleBuiltAgainstThisPlatform("MeshWeaver.Test.CountedViewPack"));
+
+        var verdict = ModulePlatformLink.Check(
+            path, ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory));
+
+        Assert.Equal(ModuleLinkState.Linkable, verdict.State);
+        Assert.True(verdict.CheckedTypeReferences > 0,
+            "a Linkable verdict over zero checked references is a check that never ran: "
+            + verdict.Report());
+        Assert.Contains(ContractAssembly, verdict.CheckedAssemblies);
+    }
+
+    /// <summary>
+    /// The coarse-grained half of the same defect: a module referencing a whole PLATFORM assembly
+    /// this deployment does not carry. Refused, because that is a certain load failure — while a
+    /// non-platform assembly it does not carry is a private dependency, NAMED as unchecked rather
+    /// than guessed about.
+    /// </summary>
+    [Fact]
+    public void AWholePlatformAssemblyThisDeploymentLacks_IsRefused()
+    {
+        var path = Write("MeshWeaver.Test.OrphanViewPack",
+            ModuleBuiltAgainstAFuturePlatform("MeshWeaver.Test.OrphanViewPack"));
+
+        // A surface with NO probe directory and NO loaded assemblies carries nothing at all.
+        var verdict = ModulePlatformLink.Check(
+            path, ModulePlatformSurface.Of(Array.Empty<System.Reflection.Assembly>()));
+
+        Assert.Equal(ModuleLinkState.Unlinkable, verdict.State);
+        Assert.Contains(verdict.MissingTypes,
+            m => m.Contains("no such platform assembly", StringComparison.Ordinal));
+        // System.* is not the platform's, so it is reported as UNCHECKED rather than missing.
+        Assert.Contains(verdict.UncheckedAssemblies,
+            a => a.StartsWith("System.", StringComparison.Ordinal));
+    }
+
+    // ───────────────────────────────────────────────────── the generation is parked, not the portal
+
+    /// <summary>
+    /// 🚨 <b>THE repro of #3518's blast radius.</b> An unloadable module costs THAT module and
+    /// nothing else: it is never loaded, it is recorded as
+    /// <see cref="IncompatibleModule"/> naming the type it wanted, the module beside it installs
+    /// normally, and <c>InstallAssemblies</c> does not throw. That is the difference between "one
+    /// view pack is absent" and "every render on the portal throws".
+    /// </summary>
+    [Fact]
+    public void AnUnloadableModule_IsParked_AndTheOthersStillInstall()
+    {
+        var bad = Write("MeshWeaver.Test.ParkedViewPack",
+            ModuleBuiltAgainstAFuturePlatform("MeshWeaver.Test.ParkedViewPack"));
+        // A real, loadable assembly standing in for the module that must keep working.
+        var goodName = typeof(MeshWeaver.Plugin.Packaging.BundleReader).Assembly.GetName().Name!;
+        var good = Write(goodName,
+            File.ReadAllBytes(typeof(MeshWeaver.Plugin.Packaging.BundleReader).Assembly.Location));
+
+        var services = new ServiceCollection();
+        var builder = new MeshBuilder(configure => configure(services), new Address("mesh", "test"));
+
+        // Does not throw: a module that cannot load is a reason to lose THAT module.
+        builder.InstallAssemblies(bad, good);
+
+        var provider = services.BuildServiceProvider();
+        var parked = Assert.Single(provider.GetServices<IncompatibleModule>());
+        Assert.Equal("MeshWeaver.Test.ParkedViewPack", parked.Name);
+        Assert.Contains(FutureType, parked.Report(), StringComparison.Ordinal);
+        Assert.Contains("CONTRIBUTING NOTHING", parked.Report(), StringComparison.Ordinal);
+
+        Assert.Contains(provider.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, goodName, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A parked module reads as QUARANTINED on every surface, never as PENDING. "Restart required"
+    /// would be a promise no restart can keep — a restart re-runs the same measurement on the same
+    /// bytes and refuses again — which is the same false-prompt rule a held entry and a missing
+    /// DLL already follow.
+    /// </summary>
+    [Fact]
+    public async Task AParkedModule_ReadsAsQuarantined_NeverAsRestartRequired()
+    {
+        await landing.LandModule(
+                "MeshWeaver.Test.CurrentViewPack",
+                [("MeshWeaver.Test.CurrentViewPack.dll",
+                    ModuleBuiltAgainstThisPlatform("MeshWeaver.Test.CurrentViewPack"))])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        var report = new PendingModuleActivations(root)
+        {
+            QuarantinedModules = ImmutableHashSet.Create(
+                StringComparer.OrdinalIgnoreCase, "MeshWeaver.Test.CurrentViewPack"),
+        }.Read(
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            loadedModuleGenerations: ImmutableDictionary<string, string>.Empty);
+
+        Assert.False(report.HasPending);
+        Assert.True(report.HasQuarantined);
+        Assert.Equal("MeshWeaver.Test.CurrentViewPack", Assert.Single(report.Quarantined).Name);
+        Assert.Contains("REFUSED against this platform build", report.Describe(),
+            StringComparison.Ordinal);
+        // A blank package path matches nothing — never a wildcard that would put another
+        // package's quarantine on this card.
+        Assert.False(report.IsQuarantinedForPackage(null));
+    }
+
+    /// <summary>
+    /// 🚨 A REQUIRED module refused because it needs another platform must NOT stall a rollout.
+    /// That is the declared floor's rule, and it exists because no rollout of this deployment can
+    /// conjure the platform the module was built for — in the rollback direction, stalling would
+    /// hold the very roll that resolves it (the 2026-08-22 three-way deadlock, one lane over).
+    ///
+    /// <para>An IMAGE-shipped module that cannot link stays <c>Incompatible</c> and DOES stall:
+    /// that is a build defect the previous generation does not share.</para>
+    /// </summary>
+    [Fact]
+    public void ARequiredStoreModuleRefusedForItsPlatform_DoesNotStallARollout()
+    {
+        var refused = IncompatibleModule.FromLinkRefusal(
+            "/data/modules/MeshWeaver.Test.ParkedViewPack@1/MeshWeaver.Test.ParkedViewPack.dll",
+            ModulePlatformLink.Check(
+                ModuleBuiltAgainstAFuturePlatform("MeshWeaver.Test.ParkedViewPack"),
+                "MeshWeaver.Test.ParkedViewPack",
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    { "MeshWeaver.Test.ParkedViewPack" },
+                ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory)));
+
+        Assert.True(refused.RefusedBeforeLoad);
+
+        // 🚨 The entries carry '.dll'. `Classify` derives the module name with
+        // Path.GetFileNameWithoutExtension, which on a suffix-less DOTTED assembly name strips the
+        // last segment ("MeshWeaver.Test.ParkedViewPack" → "MeshWeaver.Test") — so a suffix-less
+        // entry matches no module and every verdict here would be ExpectedLater by accident. The
+        // Name assertions below are what make that failure visible instead of green.
+        var storeDelivered = RequiredModuleStatus.Classify(
+            requiredEntries: ["MeshWeaver.Test.ParkedViewPack.dll"],
+            baselineEntries: [],
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            resolvesFromDeployment: _ => false,
+            activation: null,
+            landedDllExists: _ => false,
+            platformGate: _ => null,
+            incompatibleModules: [refused]);
+        Assert.Empty(RequiredModuleStatus.Incompatible(storeDelivered));
+        var expected = Assert.Single(RequiredModuleStatus.ExpectedLater(storeDelivered));
+        Assert.Equal("MeshWeaver.Test.ParkedViewPack", expected.Name);
+        // And it says WHY — the link refusal, not a generic "not installed".
+        Assert.Contains(FutureType, expected.Reason, StringComparison.Ordinal);
+
+        // The image's OWN pack, unlinkable against the image it shipped in, still stalls.
+        var imageShipped = RequiredModuleStatus.Classify(
+            requiredEntries: ["MeshWeaver.Test.ParkedViewPack.dll"],
+            baselineEntries: ["MeshWeaver.Test.ParkedViewPack.dll"],
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            resolvesFromDeployment: _ => false,
+            activation: null,
+            landedDllExists: _ => false,
+            platformGate: _ => null,
+            incompatibleModules: [refused]);
+        var stalls = Assert.Single(RequiredModuleStatus.Incompatible(imageShipped));
+        Assert.Equal("MeshWeaver.Test.ParkedViewPack", stalls.Name);
+    }
+
+    // ───────────────────────────────────────────────────────────── harness
+
+    /// <summary>
+    /// A module compiled against a STAND-IN <c>MeshWeaver.Mesh.Contract</c> that carries
+    /// <see cref="FutureType"/> — the assembly a platform three days ahead would have shipped. The
+    /// bytes therefore reference a type by the same assembly simple name this process has loaded,
+    /// and that copy does not have it: memex-cloud's exact shape, and one no version comparison
+    /// can see.
+    /// </summary>
+    private static byte[] ModuleBuiltAgainstAFuturePlatform(string moduleName)
+    {
+        var future = Emit(ContractAssembly, """
+            namespace MeshWeaver.Mesh;
+            /// <summary>The type a newer platform has and this one does not.</summary>
+            public enum CodeOutputCurrencyFromTheFuture { Unknown, Current, Stale }
+            """, excludeReference: ContractAssembly);
+
+        return Emit(moduleName, """
+            using MeshWeaver.Mesh;
+            public static class CodeViews
+            {
+                public static string BuildContent(CodeOutputCurrencyFromTheFuture currency)
+                    => currency.ToString();
+            }
+            """,
+            excludeReference: ContractAssembly,
+            extra: MetadataReference.CreateFromImage(future));
+    }
+
+    /// <summary>A module compiled against the REAL contract this process is running, using a type
+    /// it genuinely has — the control that proves the gate does not simply refuse everything.</summary>
+    private static byte[] ModuleBuiltAgainstThisPlatform(string moduleName) =>
+        Emit(moduleName, """
+            using MeshWeaver.Mesh;
+            public static class CodeViews
+            {
+                public static string BuildContent(MeshNode node) => node.Id;
+            }
+            """);
+
+    /// <summary>Compiles one source file into an assembly named <paramref name="assemblyName"/>,
+    /// against this process's own reference set.</summary>
+    /// <param name="assemblyName">The emitted assembly's simple name.</param>
+    /// <param name="source">The C# to compile.</param>
+    /// <param name="excludeReference">A reference assembly to LEAVE OUT — how a stand-in of the
+    /// same simple name is substituted for the platform's own.</param>
+    /// <param name="extra">References to add, e.g. the stand-in.</param>
+    private static byte[] Emit(
+        string assemblyName, string source, string? excludeReference = null,
+        MetadataReference? extra = null)
+    {
+        var platform = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            .Where(p => excludeReference is null
+                        || !string.Equals(Path.GetFileNameWithoutExtension(p), excludeReference,
+                            StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+        if (extra is not null)
+            platform.Add(extra);
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source)],
+            platform,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var buffer = new MemoryStream();
+        var result = compilation.Emit(buffer);
+        Assert.True(result.Success, string.Join(
+            Environment.NewLine,
+            result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return buffer.ToArray();
+    }
+
+    /// <summary>Writes an assembly into its OWN directory under the test root, so its "siblings"
+    /// are exactly its own closure — the shape a landed generation directory has.</summary>
+    private string Write(string assemblyName, byte[] bytes)
+    {
+        var directory = Path.Combine(root, "emitted", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
@@ -176,6 +176,49 @@ public class ModulePlatformLinkTest : IDisposable
         Assert.Contains("could NOT be determined", refusal.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// 🚨 <b>A module referencing a SIBLING MODULE is not the defect, and must not be refused as
+    /// one.</b> A wave lands its modules one at a time, and the sibling this one needs may have
+    /// landed thirty seconds ago and not be loaded here at all (restart-as-activation). Measuring
+    /// against the application closure alone would find no <c>MeshWeaver.Test.SiblingLib</c>
+    /// anywhere, hit the platform-prefix rule, and refuse a module that is perfectly fine — a
+    /// false refusal, which on a real deployment means a feature silently missing after an
+    /// upgrade.
+    ///
+    /// <para>The surface therefore carries the ACTIVE generation of every landed module, rebuilt
+    /// per landing. Pinning the sibling's landing FIRST is what makes this able to fail: measure
+    /// against <c>/app</c> only, and the second landing throws.</para>
+    /// </summary>
+    [Fact]
+    public async Task AModuleReferencingASiblingModuleLandedMomentsEarlier_IsNotRefused()
+    {
+        var sibling = Emit("MeshWeaver.Test.SiblingLib", """
+            namespace MeshWeaver.Test;
+            public static class SiblingApi { public static int Answer => 42; }
+            """);
+        await landing.LandModule(
+                "MeshWeaver.Test.SiblingLib", [("MeshWeaver.Test.SiblingLib.dll", sibling)])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        // Compiled against the sibling — and the sibling is NOT in the application closure and is
+        // NOT loaded in this process. Only the landed generation can answer for it.
+        var dependent = Emit("MeshWeaver.Test.DependentPack", """
+            using MeshWeaver.Test;
+            public static class DependentViews
+            {
+                public static int Show() => SiblingApi.Answer;
+            }
+            """, extra: MetadataReference.CreateFromImage(sibling));
+
+        await landing.LandModule(
+                "MeshWeaver.Test.DependentPack", [("MeshWeaver.Test.DependentPack.dll", dependent)])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        var landedNames = ModuleActivationSidecar.Read(root).Entries.Select(e => e.Name).ToArray();
+        Assert.Contains("MeshWeaver.Test.SiblingLib", landedNames);
+        Assert.Contains("MeshWeaver.Test.DependentPack", landedNames);
+    }
+
     // ───────────────────────────────────────────────────── the probe itself, and its denominator
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
@@ -79,7 +79,11 @@ public class ModulePublishShelfTest : IDisposable
             [
                 new NuGetPackageWriter.Entry(
                     NuGetPackageWriter.ModuleEntryPathFor("MeshWeaver.Speech.dll"),
-                    () => new MemoryStream("SPEECH"u8.ToArray())),
+                    // 🚨 REAL assembly bytes since #3538: the landing MEASURES the module's link
+                    // requirements against this platform, so a short literal is refused as
+                    // unreadable metadata — correctly, and these tests are about the FLOOR.
+                    () => new MemoryStream(
+                        File.ReadAllBytes(typeof(BundleReader).Assembly.Location))),
             ],
             manifestJson);
         return buffer.ToArray();

--- a/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
@@ -344,9 +344,20 @@ public class ModuleSetConvergenceTest : IDisposable
 
     /// <summary>Lands one module through the REAL landing service — a fresh generation plus the
     /// activation entry, exactly as an auto-update or an install does.</summary>
+    /// <remarks>
+    /// 🚨 REAL assembly bytes, not a three-byte MZ stand-in. Since #3538 the landing MEASURES the
+    /// module's link requirements against this platform's surface, so bytes that are not a managed
+    /// assembly are refused — correctly, and this test is about generations, not about that gate.
+    /// Any assembly whose references this process carries works; the packaging assembly is the
+    /// same one <c>ServedModuleBytesTest</c> uses for the same reason.
+    /// </remarks>
     private async Task Land(string name) =>
-        await landing.LandModule(name, [(name + ".dll", [0x4D, 0x5A, 0x90])])
+        await landing.LandModule(name, [(name + ".dll", RealAssemblyBytes)])
             .Timeout(TestTimeouts.Convergence).Await();
+
+    /// <summary>A real, loadable managed assembly's bytes — see <see cref="Land"/>.</summary>
+    private static byte[] RealAssemblyBytes =>
+        File.ReadAllBytes(typeof(MeshWeaver.Plugin.Packaging.BundleReader).Assembly.Location);
 
     /// <summary>Closes a landing wave — the coordination step that moves the mesh's set.</summary>
     private async Task<ModuleSet?> ProposeWave() =>

--- a/test/Memex.Portal.Shared.Test/PluginBundlePublishAssetsTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundlePublishAssetsTest.cs
@@ -161,7 +161,11 @@ public class PluginBundlePublishAssetsTest : IDisposable
     /// </summary>
     private static byte[] BuildBundle(bool withAssets)
     {
-        var assembly = Encoding.UTF8.GetBytes("not-a-real-assembly-but-real-bytes");
+        // 🚨 A REAL managed assembly since #3538: the landing measures the module's link
+        // requirements against this platform's surface, and bytes that are not an assembly at all
+        // are refused as INDETERMINATE — the fail-closed third state. This test is about static
+        // assets riding along, so it hands the landing something it can actually read.
+        var assembly = File.ReadAllBytes(typeof(BundleReader).Assembly.Location);
         var entries = new List<NuGetPackageWriter.Entry>
         {
             new(NuGetPackageWriter.ModuleEntryPathFor(Module + ".dll"),


### PR DESCRIPTION
Closes #3538
Closes #3518

## The defect

memex-cloud (core of 2026-09-03) adopted DefaultViews' `MeshWeaver.Graph.Views`, compiled on 09-06 against a `MeshWeaver.Mesh.Contract` carrying `CodeOutputCurrency` — a type added on 09-04 (`2dc5868b2`).

The only platform gate was the module's **declared** `minMeshVersion: 3.0.0-rc8`, which the running `3.0.0-rc9.ci.7693` satisfied. So bytes that could not possibly load landed, and loaded. They installed **cleanly** — the pack's `MeshNodeProviderAttribute` touches none of the missing surface, so #2234's per-module install isolation saw a healthy module — and then threw `TypeLoadException: Could not load type 'MeshWeaver.Mesh.CodeOutputCurrency'` on **every render of every code cell, for every user**, until somebody read a pod log. #3518 is the same failure seen from the render end.

**A declared floor can never answer this.** It is a claim an author writes by hand, about platforms that do not exist yet — and the module lane *deliberately permits* a module built against a newer platform to load on an older one, because that permission is what makes an ex-post Store install possible. The module's real requirement is not a version at all: it is **the set of types its bytes are linked against**, which the compiler already recorded exactly in the assembly's own metadata.

`frameworkMvid` cannot substitute either: it is an opaque identity, not an ordering. Equality proves the same build; anything else proves nothing.

## The fix

**1. The floor is measured, not declared.** New `ModulePlatformLink` (`src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs`) reads the module's type references straight out of its metadata — no `Assembly.Load`, no module initializer, no type loading, no side effect — and resolves each against the copy this process would actually bind to.

The verdict is **tri-state**, and `MayLoad` is true for `Linkable` **alone** — written as an explicit predicate precisely so no call site can spell the check as `!= Unlinkable` and quietly admit `Indeterminate`:

| State | Meaning | Callers |
|---|---|---|
| `Linkable` | every referenced type in every resolved platform assembly exists | load it |
| `Unlinkable` | a referenced type is absent, or a whole referenced platform assembly is | refuse, naming the type |
| `Indeterminate` | the check could not be **made** | refuse — fail closed |

The verdict also carries its **denominator**: references checked, assemblies read, and the assemblies deliberately *not* checked (the module's own closure; private dependencies, whose absence is a different defect with a different remedy). A clean answer over zero checked references is indistinguishable from a check that never ran.

**2. The generation is parked, not the portal.**

- **At landing** (`ModuleLandingService.LandCore`) — from memory, *before a byte touches disk*, so a refusal costs no generation directory and the generation already running keeps running. Adopt **refuses**; the registry shelf **holds**, exactly as the declared floor already does, because a registry must go on stocking what it cannot itself run (the 2026-08-22 three-way deadlock).
- **At boot** (`MeshBuilder.InstallAssemblies`) — *before* `Assembly.LoadFrom`. A refusal is recorded as `IncompatibleModule`, the record #2234 already surfaces on stderr, in DI and on `/health`. One unloadable module costs **that module's contribution and nothing else**.

🚨 **The measured surface is never `/app` alone — in both places.** A store-landed module may legitimately reference *another module* landed beside it, and measuring against the application closure alone would report that sibling as an absent platform assembly and refuse a module that is fine. At boot the surface is `/app` plus every directory the boot is loading from; at landing it is `/app` plus the **active** generation of every landed module (through the one resolution rule, `ModuleDirectoryFor` — a superseded generation is still on the volume until the GC reclaims it and can legitimately lack a type its successor has), rebuilt **per landing**, because a wave lands its modules one at a time and the sibling may have landed thirty seconds ago and not be loaded here at all.

**3. A legible, localized diagnostic.** A refused module reads as **quarantined**, never as pending — a restart re-runs the same measurement on the same bytes and refuses again, so "restart required" would be a prompt no restart can clear (the same false-promise rule held entries and missing bytes already follow). The package card says why in the **viewer's** language: `ui.moduleBuiltForNewerPlatform`, added to both `strings.en.json` and `strings.de.json`.

**4. It must not deadlock a roll.** A **required** *store-delivered* module refused this way is `ExpectedLater`, not `Incompatible`: no rollout of this deployment can conjure the platform it was built for, and stalling one would recreate the 2026-08-22 deadlock in the rollback direction. An **image-shipped** module that cannot link still stalls — that is a build defect the previous generation does not share. `IncompatibleModule.RefusedBeforeLoad` (init-only, default `false`, so every existing producer's meaning is unchanged) is the discriminator.

## What it does NOT see

**Member-level skew** — a method or constructor signature that moved on a type that still exists (#2234's original `MissingMethodException`). This checks *type* references; that shape is caught at install by `IncompatibleModule`. The two are complementary halves, and this is stated explicitly in the code and the doc page rather than left to be assumed.

## Tests that fail before and pass after

`test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs` — 10 tests. Every one compiles **real** assemblies with Roslyn and drives the **real** gate; nothing is mocked, no rule is re-derived locally. The repro compiles a module against a **stand-in `MeshWeaver.Mesh.Contract`** carrying a type the platform running the test does not have — the incident's shape verbatim: same assembly simple name, missing type — and lands it through the real `ModuleLandingService`.

| Test | Pins |
|---|---|
| `AModuleBuiltAgainstANewerPlatform_IsRefusedAtLanding_NamingTheMissingType` | the refusal, the named type, and that **nothing landed** |
| `AModuleBuiltAgainstThisPlatform_LandsAsBefore` | it is a gate, not a wall |
| `AnUnloadableModule_IsShelvedRatherThanRefused_OnThePublishPath` | the shelf still stocks what it cannot run |
| `UnreadableBytes_AreRefused_NotWavedThroughAsUnknown` | `Indeterminate` fails **closed** |
| `ALinkableModule_ReportsANonZeroDenominator` | a clean verdict actually checked something |
| `AWholePlatformAssemblyThisDeploymentLacks_IsRefused` | the coarse shape; a private dependency is *named unchecked*, not refused |
| `AModuleReferencingASiblingModuleLandedMomentsEarlier_IsNotRefused` | the FALSE-refusal direction: a sibling module is not an absent platform assembly |
| `AnUnloadableModule_IsParked_AndTheOthersStillInstall` | the blast radius: one module, not the portal |
| `AParkedModule_ReadsAsQuarantined_NeverAsRestartRequired` | the false-promise rule |
| `ARequiredStoreModuleRefusedForItsPlatform_DoesNotStallARollout` | the roll cannot deadlock; an image-shipped one still stalls |

**Negative controls, both measured, both directions:**

- Neutralising the gate (`MayLoad => true`) flips 4 of the 10 — `AModuleBuiltAgainstANewerPlatform_…`, `UnreadableBytes_…`, `AnUnloadableModule_IsShelvedRatherThanRefused_…` and `AnUnloadableModule_IsParked_…`. The rest are probe-level and denominator assertions that do not route through `MayLoad`.
- Reverting the landing surface to `/app` only fails `AModuleReferencingASiblingModuleLandedMomentsEarlier_IsNotRefused`. That is the FALSE-refusal direction — the way this change could itself have broken a deployment — so it gets its own control rather than an argument.

Three existing tests handed the landing three-byte `MZ` stand-ins for assemblies (`ModuleSetConvergenceTest`, `ModulePublishShelfTest`, `PluginBundlePublishAssetsTest`); they now hand it a real one, because the landing genuinely reads the assembly now. `ServedModuleBytesTest` already used that idiom.

## Verified locally

- `dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.Mesh.Contract`, `MeshWeaver.PluginCatalog`, `MeshWeaver.Documentation`, `Memex.Portal.Shared`, `Memex.Portal.Shared.Test` — **0 Warning(s), 0 Error(s)** each.
- `Memex.Portal.Shared.Test` module lane (10 new + `ModuleSetConvergence`, `ModulePublishShelf`, `PluginBundlePublishAssets`, `ModuleGenerationDivergence`, `ServedModuleBytes`, `ModuleUpdateIdentity`, `ModuleGcOffReadinessPath`): **64 passed, 0 failed**.
- `MeshWeaver.Documentation.Test` in full — `DocumentationLinkIntegrityTest` plus the async / hand-woven-gate / blocking-bridge ratchets: **304 passed, 0 failed**.
- `LocalizationTest`: **58 passed, 0 failed**.

## Surface

Additive only — no public type or member removed or renamed, and no member added to a public interface or abstract class. New: `ModuleLinkState`, `ModuleLinkVerdict`, `ModulePlatformSurface`, `ModulePlatformLink`; `IncompatibleModule.FromLinkRefusal` + `RefusedBeforeLoad`; `ModuleActivationReport.Quarantined` / `HasQuarantined` / `IsQuarantinedForPackage` / `DescribeQuarantined`; `PendingModuleActivations.QuarantinedModules`.

`FromLinkRefusal` is deliberately **not** an overload of `From`: an added overload is one of the break shapes no gate in this fleet sees — a dependent repo's `<see cref="IncompatibleModule.From"/>` becomes ambiguous and fails `CS0419` under `-warnaserror`, in another repository, on PRs that did not make the change.

Pairs-with: none — nothing is removed or renamed; every change is additive, and MeshWeaver.Plugins' only call site (`RequiredModuleStatusTest`, `IncompatibleModule.From(entry, exception)`) keeps its meaning unchanged because `RefusedBeforeLoad` defaults to `false`.

## Design conserved

`src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md` — what it cost measured, why the declared floor is structurally unable to answer it, the three states and the denominator, both run sites, how it composes with `ModuleGenerationPin` (#2509), the four report states, and the documented blind spot. Plus a `Category: Fix` What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
