### PR TITLE
docs(sigsegv): sighting #10 — the crash frame was misread; an ELF file offset is not a virtual RVA

### DIFF
--- a/.claude/skills/sigsegv/SKILL.md
+++ b/.claude/skills/sigsegv/SKILL.md
@@ -102,15 +102,23 @@ Both are SIGSEGV. They are different bugs and the dump distinguishes them in one
 | | fault address | reading | verdict |
 |---|---|---|---|
 | **Use-after-unload** | `si_code = SI_KERNEL`, `si_addr = 0`, faulting register holds a **non-canonical** value (e.g. `rax = 0x0074007300200022` — UTF-16 text where a pointer belonged) | a **#GP on a non-canonical pointer**, not a null deref — freed-and-reused memory | **OURS.** Family A below. |
-| **Zeroed MethodTable header** | `si_code = 1` (`SEGV_MAPERR`), `si_addr = 0x0`, `TRAPNO=14`/`ERR=0x4`, `RIP` inside file-backed `libcoreclr` `gc_heap::*`, instruction reading `MT->m_dwFlags` off a register that is `0` (`mov ecx,[rax]` with `RAX = 0`; `mov r9d,[rcx]` with `RCX = 0` — the register allocation varies, the dereference does not) | one 8-byte object header reads as exactly zero while its block stays coherent | **CoreCLR GC.** Not ours. |
+| **Zeroed MethodTable header** | `si_code = 1` (`SEGV_MAPERR`), `TRAPNO=14`/`ERR=0x4`, `RIP` inside file-backed `libcoreclr`, instruction reading a MethodTable field off a register that is `0` — `si_addr` is the FIELD OFFSET, so `0x0` for `MT->m_dwFlags` (`mov ecx,[rax]`, `RAX = 0`) and **`0x4` for `MT->m_BaseSize`** (`mov 0x4(%rax),%esi`, sighting #10). The register allocation and the frame both vary; the dereference does not | one 8-byte object header reads as exactly zero while its block stays coherent | **CoreCLR / upstream.** Not ours. |
 
-The second one is the FutuRe family — **nine sightings, and the collectible-ALC hypothesis has been
+🚨 **`si_addr = 0x0` is NOT part of the fingerprint** — it is only the offset of whichever MethodTable
+field the faulting code happened to read. Sighting #10 faults at `si_addr = 0x4` and is the same bug.
+Match on *"a MethodTable word that is exactly zero"*, never on the literal address.
+
+The second one is the FutuRe family — **ten sightings, and the collectible-ALC hypothesis has been
 falsified three separate ways** (RIP is in file-backed runtime code; a freed `LoaderAllocator` yields
 a non-null *unmapped* pointer, never `0x0`; a free-list item has no ALC at all). Do not keep paying
 that hypothesis forward, and **do not "fix" it by disabling concurrent GC** — that was tried
 (#1274), changed nothing measurable, and was removed. Read the instruction + registers, not the
 function name: the frame moved across `background_sweep` → `plan_phase` → `find_first_object` →
-`background_mark_simple1` (2026-09-03) while the fault did not. Measured base rate on Plugins CI over
+`background_mark_simple1` (2026-09-03) while the fault did not. 🚨 **And sighting #10 (2026-09-06)
+left `gc_heap` entirely** — `LCGMethodResolver::GetCodeInfo+0x1f7`, `si_addr = 0x4` because the null
+MethodTable is read at offset `+4` — so a `gc_heap` frame is a *symptom* of the family, never its
+definition. The portable fingerprint is **a MethodTable word that reads exactly zero**, whoever
+dereferences it. Measured base rate on Plugins CI over
 1,197 runs: **0.74 %**, `MeshWeaver.FutuRe.Test` only, `main` included. Full table:
 DebuggingNativeCrashes.md.
 
@@ -125,8 +133,16 @@ later segfaults *in whatever test is running*. Pinned by
 Every dynamic NodeType recompile mints a collectible `AssemblyLoadContext`. Unload one while a
 thread can still enter its code and you get a genuine native fault. **The canonical crash of this
 codebase**, CI run `32713409169`: a dedicated thread faulted on its **first managed call**, taking
-the prestub into `UnsafeJitFunction` and dying in `LCGMethodResolver::GetCodeInfo` — JIT-compiling a
-dynamic method whose allocator was already gone.
+the prestub into `UnsafeJitFunction` and dying in `LCGMethodResolver::GetCodeInfo`.
+
+🚨 **That last frame is now known to have been misread, and the correction matters more than the
+story.** Measured 2026-09-06 against the `10.0.11` symbols (DebuggingNativeCrashes.md, sighting #10):
+`LCGMethodResolver::GetCodeInfo+0x1f7` allocates nothing and touches no `LoaderAllocator` — it is
+`memcpy(code, dataArray->GetDataPtr(), codeSize)`, reading the **MethodTable word of a managed
+`byte[]`** that holds a dynamic method's IL. A fault there says *that array's header is garbage*, not
+*an ALC was unloaded*. So do **not** reach for `AlcLeaseRegistry` on this frame; read `si_code` /
+`si_addr` and the object at the base register first. The defect the `✅` below fixes is real and the
+shape is worth knowing — but this frame is not the evidence for it.
 
 **The cause was a timer race in a `Task`-returning override** — async *and* an unsubscribed disposal
 signal, in one defect:

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -689,6 +689,141 @@ containing #3072 (87 and 156 ahead of `17ee6d9fa`), so the #3026 fix reduced the
 it — consistent with this page's standing verdict that MeshWeaver supplies the *workload*, not the
 defect.
 
+### 2026-09-06: sighting #10 — the fault is OUTSIDE `gc_heap`, and a symbolization slip named an impossible frame
+
+`MeshWeaver.Futu-50119.dmp` (MeshWeaver.Plugins run
+[`33923006420`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33923006420), job
+`101185319665`, `Portal hosts (shard 1)`, runtime `10.0.11`, libcoreclr build-id `989b56df…` — the
+same binary as sightings #8 and #9). Filed as MeshWeaver.Plugins#1347.
+
+This is the first sighting whose faulting frame is **not** in `gc_heap`, and it is worth reading
+carefully, because the first pass at it produced a frame that **cannot exist** and a cause
+(collectible-ALC teardown) that this page has falsified three times.
+
+#### 🚨 The trap: an ELF **file offset** is not a **virtual RVA**, and here they differ by `0x1000`
+
+The first analysis reported `HostCodeHeap::AllocMemory_NoThrow+0xe7` at RVA `0x372887` and concluded
+*"the JIT allocating for a collectible ALC that is already torn down"* — which pointed straight back
+at #2136 and at `AlcLeaseRegistry`. **Every part of that is wrong, and one cheap check falsifies it:**
+
+```
+$ llvm-objdump -d --start-address=0x372860 --stop-address=0x3728a0 libcoreclr.so
+  372881: 49 8b 4e 18      movq  0x18(%r14), %rcx
+  372885: 49 03 4e 28      addq  0x28(%r14), %rcx     ← 0x372887 is INSIDE this 4-byte instruction
+  372889: 48 39 c8         cmpq  %rcx, %rax
+```
+
+**`RIP` always points at an instruction boundary**, so `0x372887` is not a possible faulting address
+at all — and `addq 0x28(%r14),%rcx` could not produce `CR2 = 0x4` in any case. The slip is that in
+this binary a `PT_LOAD` maps file offset `0x371887` at vaddr `0x372887`: **file offset = vaddr −
+`0x1000`**. The symbol table is indexed by *vaddr*; the bytes are found at a *file offset*. Resolve a
+symbol with one and read bytes with the other and you get a confidently-wrong frame that still
+"matches bytes".
+
+Three independent measurements agree on the real address:
+
+1. **`NT_FILE` in the core** gives libcoreclr's load base as `0x7f4434600000` (the mapping whose page
+   offset is `0`, not the executable segment). `RIP = 0x00007f4434973887` ⇒ RVA **`0x373887`**.
+2. The faulting bytes the first analysis itself quoted — `49 8b 07 / 8b 70 04 / 83 c6 f8` — occur at
+   **exactly one** place in the 7 MB binary, vaddr `0x373884`.
+3. `0x373887` is an instruction boundary; `0x372887` is not.
+
+```
+RVA 0x373887 -> LCGMethodResolver::GetCodeInfo(unsigned*, unsigned*, CorInfoOptions*, unsigned*) + 0x1f7
+```
+
+#### The signal and the faulting registers, re-derived
+
+`NT_SIGINFO`: `signo=11  code=1 (SEGV_MAPERR)  addr=0x4`. The `rt_sigframe`'s `sigcontext` (found by
+scanning for `TRAPNO=14`, `ERR=0x4`, `CR2=0x4` and a `RIP` inside libcoreclr's mapping — exactly one
+match in the whole core):
+
+```
+RIP = 0x00007f4434973887   (RVA 0x373887)   CR2 = 0x4   TRAPNO = 14   ERR = 0x4
+RAX = 0x0000000000000000       R15 = 0x00007f3fd1e37188
+RBX = 0x00000000ba41bf48       R13 = RDI = 0x00007f3e78d4c010
+```
+
+#### What the instruction actually does — and why "the JIT allocating code" is the wrong reading
+
+`LCGMethodResolver::GetCodeInfo` does not allocate code. It fetches a dynamic method's **IL** from a
+managed `byte[]` (`src/coreclr/vm/dynamicmethod.cpp`):
+
+```cpp
+U1ARRAYREF dataArray = (U1ARRAYREF) getCodeInfo.Call_RetOBJECTREF(args);
+DWORD codeSize = dataArray->GetNumComponents();   // movl 0x8(%r15), %ebx      -> RBX
+NewArrayHolder<BYTE> code(new BYTE[codeSize]);    // callq _Znam@plt           -> R13
+memcpy(code, dataArray->GetDataPtr(), codeSize);  // movq (%r15),%rax          -> RAX = MethodTable
+                                                  // movl 0x4(%rax),%esi  ← FAULT (MT->m_BaseSize)
+```
+
+So `R15` is the managed `byte[]`, `RAX` is **its MethodTable word**, and the fault is a read of
+`MT->m_BaseSize` at offset `+4` off a **null** MethodTable — hence `CR2 = 0x4` rather than `0x0`.
+**That is this page's invariant exactly**, reached from the application side instead of from inside
+the collector: *an object's MethodTable word reads as exactly zero.*
+
+The object is not merely header-less, it is **not a `byte[]` at all any more**:
+
+```
+0x7f3fd1e37188: 0x0000000000000000   <- R15+0, read as MethodTable  => RAX = 0
+0x7f3fd1e37190: 0x00007f43ba41bf48   <- R15+8, read as Length       => RBX = 0xba41bf48
+```
+
+`RBX` is **3,124,870,984** — the low half of a pointer, read as an IL length. No method has 3 GB of
+IL, and `R15` lies in an **anonymous** mapping (no `NT_FILE` entry), i.e. heap rather than file-backed
+runtime code. The block is a recycled/free-list-shaped run of pointers, and its contents are
+**identical at fault time and at dump time** (`[R15+8]`'s low dword still equals `RBX`), so this is
+not a stale post-hoc read.
+
+#### What the neighbouring memory names — the workload, precisely
+
+24 bytes past the dead array sits a live managed `System.String` (MethodTable, then length `33`, then
+UTF-16):
+
+```
+0x7f3fd1e371d0: 0x00007f43b668dd58     <- String MethodTable
+0x7f3fd1e371d8: 0x21 (=33)             <- length
+0x7f3fd1e371dc: "LastReleaseRequestHandledAtSetter"
+```
+
+`LastReleaseRequestHandledAt` is a property of **`NodeTypeDefinition`**
+(`src/MeshWeaver.Graph.Contract/NodeTypeDefinition.cs`), and core `src/` contains **no**
+`System.Reflection.Emit` or `DynamicMethod` of its own — so the dynamic method being JIT-compiled is a
+**property-setter stub minted by System.Text.Json's reflection-emit member accessor** while
+serializing a mesh node type.
+
+That gives the family a much sharper description than "ALC-heavy assemblies": the provoking workload
+is **LCG / collectible dynamic methods created per serialized type**, and the fault is the JIT
+fetching IL for one whose backing array has already been recycled.
+
+🚨 **Stated as a hypothesis, not a result:** System.Text.Json's `ReflectionEmitCachingMemberAccessor`
+caches these stubs behind a sliding expiration and evicts them on a timer. An eviction that makes a
+`DynamicMethod` collectible *while a JIT compilation of it is still in flight* would produce exactly
+this. **That is the next discriminator, and it is not settled here.**
+
+#### Consequences — two records on this page need correcting
+
+- **`+0x1f7` is not new.** The 2026-08-24 crash (`MeshWeaver.Hosting.Orleans.Test`, `exit=139`) that
+  #2136 was written against is recorded as `LCGMethodResolver::GetCodeInfo+0x1f7` with the **same**
+  instruction — and we now know that instruction reads a managed array's MethodTable word. Its `rax`
+  held UTF-16 text, which under the correct reading means *the array's MethodTable slot held recycled
+  string data*, the same corruption with a different garbage value. It is **not** "JIT-compiling a
+  dynamic method whose collectible-ALC allocator had already been unloaded", because the instruction
+  does no allocation and touches no `LoaderAllocator`. Whether #2136 fixed anything real is a
+  separate question this dump cannot answer; what it settles is that the *frame* was misread.
+- **The scope line "`FutuRe.Test` only" is stale.** `MeshWeaver.GitSync.Test` took the same
+  `exit=139` on Plugins#1191, run `34013024540`, 2026-09-06 — a second suite, and one that also
+  serializes node types heavily. Re-measure the base rate against the LCG workload, not the project.
+
+#### Reproducing this read
+
+Runtime binary: `https://builds.dotnet.microsoft.com/dotnet/Runtime/10.0.11/dotnet-runtime-10.0.11-linux-x64.tar.gz`.
+Symbols by build-id, no `dotnet-symbol` needed:
+`https://msdl.microsoft.com/download/symbols/_.debug/elf-buildid-sym-<build-id>/_.debug`.
+The whole read is `struct.unpack` over the ELF core plus one `llvm-objdump` — no container, no DAC.
+🚨 Index symbols by **vaddr** and bytes by **file offset**, and convert between them with the
+`PT_LOAD` table; do not assume they are equal.
+
 ## Reading the result honestly
 
 The trap in this class of bug is confirmation: the stack shows *a* plausible culprit and it is


### PR DESCRIPTION
## The frame in MeshWeaver.Plugins#1347's dump was misread, and the cause it pointed at is one this page has already falsified

`MeshWeaver.Plugins#1347` carries a careful dump analysis that lands on:

> **`HostCodeHeap::AllocMemory_NoThrow(size_t, size_t, unsigned int, size_t) + 0xe7`** … the JIT
> allocating code for a dynamic method whose heap has been torn down … **the reasonable reading is
> that #2136 gated the unload but left this allocation path reachable**

That sends the next reader straight to `AlcLeaseRegistry` and collectible-ALC teardown — the exact
hypothesis `DebuggingNativeCrashes.md` says, in bold, has been *"falsified twice over"* and *"do not
keep paying forward"*. It is worth correcting precisely, because the analysis is otherwise good and
its error is one anybody re-doing this work will repeat.

## One check falsifies the frame

```
$ llvm-objdump -d --start-address=0x372860 --stop-address=0x3728a0 libcoreclr.so
  372885: 49 03 4e 28      addq  0x28(%r14), %rcx     ← 0x372887 is INSIDE this 4-byte instruction
```

**RIP always points at an instruction boundary.** `0x372887` is not a possible faulting address, and
`addq 0x28(%r14),%rcx` cannot produce `CR2 = 0x4` in any case.

The slip: a `PT_LOAD` in this binary maps **file offset `0x371887` at vaddr `0x372887`** — they
differ by `0x1000`. Symbols are indexed by *vaddr*; bytes are found at a *file offset*. Resolve with
one and read bytes with the other and you get a frame that "matches bytes" while being impossible.

## The real frame, measured three independent ways

1. **`NT_FILE` in the core** gives libcoreclr's load base as `0x7f4434600000` (the mapping with page
   offset `0`). `RIP = 0x00007f4434973887` ⇒ RVA **`0x373887`**.
2. The faulting bytes the original analysis itself quoted (`49 8b 07 / 8b 70 04 / 83 c6 f8`) occur at
   **exactly one** place in the 7 MB binary — vaddr `0x373884`.
3. `0x373887` is an instruction boundary; `0x372887` is not.

```
RVA 0x373887 -> LCGMethodResolver::GetCodeInfo(unsigned*, unsigned*, CorInfoOptions*, unsigned*) + 0x1f7
```

I also re-recovered the `sigcontext` from the `rt_sigframe` myself (scanning for `TRAPNO=14`,
`ERR=0x4`, `CR2=0x4`, `RIP` in libcoreclr — exactly one match in the whole 4.68 GB core):

```
RIP = 0x00007f4434973887 (RVA 0x373887)   CR2 = 0x4   TRAPNO = 14   ERR = 0x4
RAX = 0x0000000000000000    R15 = 0x00007f3fd1e37188    RBX = 0x00000000ba41bf48
```

## What the instruction does — and why "the JIT allocating" is the wrong reading

`LCGMethodResolver::GetCodeInfo` allocates nothing and touches no `LoaderAllocator`. It copies a
dynamic method's **IL** out of a managed `byte[]` (`src/coreclr/vm/dynamicmethod.cpp`):

```cpp
U1ARRAYREF dataArray = (U1ARRAYREF) getCodeInfo.Call_RetOBJECTREF(args);
DWORD codeSize = dataArray->GetNumComponents();   // movl 0x8(%r15), %ebx      -> RBX
NewArrayHolder<BYTE> code(new BYTE[codeSize]);    // callq _Znam@plt           -> R13
memcpy(code, dataArray->GetDataPtr(), codeSize);  // movq (%r15),%rax          -> RAX = MethodTable
                                                  // movl 0x4(%rax),%esi  ← FAULT (MT->m_BaseSize)
```

So `RAX` is **the MethodTable word of a managed array**, and `si_addr = 0x4` is the field offset, not
a distinguishing address. **That is this page's own zeroed-MethodTable invariant** — reached from the
application side rather than from inside the collector. `RBX = 3,124,870,984` (the low half of a
pointer, read as an IL length) and an anonymous mapping for `R15` confirm the block is recycled, and
its bytes are identical at fault time and dump time, so it is not a stale post-hoc read.

## The neighbouring memory names the workload

24 bytes on sits a live `System.String`, length 33: **`LastReleaseRequestHandledAtSetter`**.
`LastReleaseRequestHandledAt` is a `NodeTypeDefinition` property, and core `src/` contains **no**
`System.Reflection.Emit`/`DynamicMethod` of its own — so the dynamic method being JIT-compiled is a
property-setter stub minted by **System.Text.Json's reflection-emit member accessor**.

That sharpens the family's scope from "ALC-heavy assemblies" to **LCG / collectible dynamic methods
minted per serialized type**. The next discriminator (recorded as a hypothesis, not a result) is
STJ's `ReflectionEmitCachingMemberAccessor`, which evicts cached stubs on a sliding timer — an
eviction that makes a `DynamicMethod` collectible *while a JIT compilation of it is in flight* would
produce exactly this.

## Two stale records corrected as a consequence

- **`+0x1f7` is not new.** The 2026-08-24 crash that **#2136** was written against is recorded at the
  same `LCGMethodResolver::GetCodeInfo+0x1f7` with the same instruction. Under the correct reading its
  `rax` (UTF-16 text) means *the array's MethodTable slot held recycled string data* — the same
  corruption with a different garbage value, **not** an unloaded ALC. Whether #2136 fixed something
  real is a separate question this dump cannot answer; what is settled is that the frame was misread.
- **"`FutuRe.Test` only" is stale** — `MeshWeaver.GitSync.Test` took the same crash on Plugins#1191
  (run `34013024540`).

## Skill change

`si_addr = 0x0` is removed from the fingerprint in `/sigsegv`: it is only the offset of whichever
MethodTable field the faulting code happened to read (`0x0` for `m_dwFlags`, `0x4` for `m_BaseSize`).
Matching on the literal address would have classified sighting #10 as a different bug. Family A's
`GetCodeInfo` claim now carries the correction inline, so the frame stops pointing at
`AlcLeaseRegistry`.

## Verification

- Symbolization reproduced from the build-id `.debug` (`989b56df…`); the four `gc_heap` RVAs already
  in the doc resolve exactly as recorded, which is the control that the method is sound.
- `MeshWeaver.Documentation.Test` (`DocumentationLinkIntegrityTest`) run after the edit.
- **No What's New entry**: internal engineering documentation and an agent skill, no user-visible
  effect.
- Docs/skill only — no public surface touched, so no `Pairs-with:` counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
