### PR TITLE
fix(#3438): the pinned-manifest lock reads the attribute back — an exit code is not a locked manifest

### DIFF
--- a/.github/scripts/lock-pinned-digests.py
+++ b/.github/scripts/lock-pinned-digests.py
@@ -389,6 +389,30 @@ class Registry:
         self._tag_cache[key] = result
         return result
 
+    def read_delete_enabled(self, acr_repo: str, digest: str) -> tuple[bool | None, str]:
+        """The manifest's CURRENT `deleteEnabled`, read back. `None` is INDETERMINATE — the
+        registry did not answer, which is never evidence that a lock took.
+
+        🚨 This exists because the only thing this whole job does is set that one attribute, and
+        until #3438's follow-up the job believed `az`'s EXIT CODE that it had. An exit code is a
+        statement about the request, not about the manifest: a `-o none` write that returns 0
+        without the attribute changing (a subscription-level policy, an API version whose
+        `--delete-enabled` is inert, a proxy that accepted and dropped it) would leave the job
+        reporting `Protected N manifest(s)` over manifests the 03:00 purge can still delete. That is
+        AGENTS.md's "a verification step that cannot fail is not a verification step", applied to
+        the job's own postcondition."""
+        rc, out, err = consistency.az(
+            ["acr", "repository", "show", "--name", self.name,
+             "--image", f"{acr_repo}@{digest}",
+             "--query", "changeableAttributes.deleteEnabled", "-o", "tsv"]
+        )
+        if rc != 0:
+            return None, "INDETERMINATE: " + " ".join(err.split())[:300]
+        answer = out.strip().lower()
+        if answer in ("true", "false"):
+            return answer == "true", ""
+        return None, f"INDETERMINATE: az answered 0 but not a boolean: {out.strip()[:120]!r}"
+
     # -- the one write --------------------------------------------------------------------------
 
     def set_delete_enabled(self, acr_repo: str, digest: str, enabled: bool) -> tuple[bool, str]:
@@ -746,8 +770,24 @@ def apply_locks(plan: Plan, registry: Registry) -> list[str]:
         assert entry.digest is not None
         ok, detail = registry.set_delete_enabled(entry.acr_repo, entry.digest, False)
         if ok:
-            plan.locked_now += 1
-            print(f"locked {entry.acr_repo}@{entry.digest}")
+            # 🚨 THE WRITE'S EXIT CODE IS NOT THE POSTCONDITION. Read the attribute back and require
+            # it to actually be `false`; an INDETERMINATE read (`None`) is not a confirmation
+            # either. Without this the job's central claim — "N manifests are protected" — rested
+            # on `az` having accepted a request, which is the one failure mode that would leave
+            # every lock decoration while the report stayed green.
+            protected, why = registry.read_delete_enabled(entry.acr_repo, entry.digest)
+            if protected is False:
+                plan.locked_now += 1
+                print(f"locked {entry.acr_repo}@{entry.digest}")
+                continue
+            failures.append(
+                f"{entry.acr_repo}@{entry.digest}: the lock WRITE succeeded and the manifest still "
+                + ("reads deleteEnabled=true" if protected is True
+                   else f"cannot be confirmed locked ({why})")
+                + ". It is pinned by "
+                + f"{', '.join(entry.sources[:3])} and the 03:00 purge can still delete it. A write "
+                "that returns 0 without taking is exactly what this read-back exists to catch."
+            )
             continue
         if any(marker in detail.lower() for marker in DENIED_MARKERS):
             # 🚨 STOP ON THE FIRST REFUSAL. Every remaining lock fails the same way for the same
@@ -998,6 +1038,11 @@ class FakeRegistry(Registry):
         self._tags = tags
         self._repo_error = repo_error
         self.writes: list[tuple[str, str, bool]] = []
+        # Whether a write actually MOVES the attribute. Default true (a healthy registry); an arm
+        # sets it false to drive the "exit 0, nothing changed" case the read-back must catch.
+        self.writes_take = True
+        # Set to a message to make the read-back INDETERMINATE — which must not confirm a lock.
+        self.read_back_error: str | None = None
 
     def control_probe(self) -> None:
         return None
@@ -1015,7 +1060,24 @@ class FakeRegistry(Registry):
 
     def set_delete_enabled(self, acr_repo: str, digest: str, enabled: bool):
         self.writes.append((acr_repo, digest, enabled))
+        if not self.writes_take:
+            # The sabotage this fixture exists to express: `az` exits 0 and the attribute does not
+            # move. Nothing about the WRITE distinguishes it from a real one.
+            return True, ""
+        for manifests in self._manifests.values():
+            for manifest in manifests:
+                if manifest.acr_repo == acr_repo and manifest.digest == digest:
+                    manifest.delete_enabled = enabled
         return True, ""
+
+    def read_delete_enabled(self, acr_repo: str, digest: str):
+        if self.read_back_error:
+            return None, self.read_back_error
+        for manifests in self._manifests.values():
+            for manifest in manifests:
+                if manifest.acr_repo == acr_repo and manifest.digest == digest:
+                    return manifest.delete_enabled, ""
+        return None, "INDETERMINATE: not in the fixture inventory"
 
 
 TESTER = "sha256:df19f10afc1f807441b403eb0dfa4b8645d5187b830f77ad080def7fc65b391f"
@@ -1252,6 +1314,39 @@ def self_test() -> int:
     check(registry.writes == [],
           f"ARM 11: report-only wrote to the registry: {registry.writes}")
 
+    # ── ARM 11b: a WRITE THAT RETURNS 0 AND DOES NOT TAKE ⇒ RED, and nothing counted ────────────
+    #
+    # 🚨 The arm the whole job rests on. `az acr repository update` exiting 0 is a statement about
+    # the REQUEST; the postcondition is the manifest's attribute. Before the read-back this case
+    # was indistinguishable from a successful lock — the job printed `locked …`, counted it, and
+    # reported `Protected N manifest(s)` over manifests the 03:00 purge could still delete. Deleting
+    # the read-back must make this arm go red, which is what makes it a real assertion.
+    registry = FakeRegistry(_inventory(), FAKE_TAGS)
+    registry.writes_take = False
+    plan, fails, registry = _drive(axis1, axis2, registry)
+    check(bool(fails),
+          "ARM 11b: a lock write that exits 0 WITHOUT moving deleteEnabled produced no failure — "
+          "the job would report protection it does not have")
+    check(any("still reads deleteEnabled=true" in f for f in fails),
+          f"ARM 11b: the failure does not say the manifest is still unlocked: {fails}")
+    check(plan.locked_now == 0,
+          f"ARM 11b: {plan.locked_now} lock(s) were COUNTED although none took")
+
+    # ── ARM 11c: a read-back that cannot answer is NOT a confirmation ───────────────────────────
+    #
+    # Same rule one step further in: INDETERMINATE is not `false`. A registry that accepts the write
+    # and then refuses to say what the attribute is has not shown the lock took, and reporting it as
+    # protected would be the "not checked reads as clean" failure this job exists to remove.
+    registry = FakeRegistry(_inventory(), FAKE_TAGS)
+    registry.read_back_error = "INDETERMINATE: the registry did not answer"
+    plan, fails, registry = _drive(axis1, axis2, registry)
+    check(bool(fails),
+          "ARM 11c: a lock whose read-back is INDETERMINATE was accepted as protected")
+    check(any("cannot be confirmed locked" in f for f in fails),
+          f"ARM 11c: the failure does not name the unconfirmed read-back: {fails}")
+    check(plan.locked_now == 0,
+          f"ARM 11c: {plan.locked_now} unconfirmed lock(s) were counted as protected")
+
     # ── ARM 12: the two EXISTING extractors still agree about what a pin IS ─────────────────────
     #
     # The property `check-pin-set-consistency.py` was built with — "the two scripts deliberately
@@ -1287,11 +1382,12 @@ def self_test() -> int:
         print(f"::error::self-test: {line}")
     if failures:
         return 1
-    print("self-test: 13 arms — lock requested on both axes and both overlay shapes, idempotent, "
+    print("self-test: 15 arms — lock requested on both axes and both overlay shapes, idempotent, "
           "unreadable repo / truncated tree / zero pins / unclassified / malformed / gone / "
           "unresolved tag / indeterminate / unreadable registry all RED with nothing released, "
-          "release arm off by default and live when enabled, report-only writes nothing, and the "
-          "two existing pin extractors still agree.")
+          "release arm off by default and live when enabled, report-only writes nothing, a lock "
+          "write that exits 0 without taking and one whose read-back cannot answer are both RED "
+          "and counted as protecting NOTHING, and the two existing pin extractors still agree.")
     return 0
 
 

--- a/.github/scripts/lock-pinned-digests.py
+++ b/.github/scripts/lock-pinned-digests.py
@@ -775,14 +775,18 @@ def apply_locks(plan: Plan, registry: Registry) -> list[str]:
             # either. Without this the job's central claim — "N manifests are protected" — rested
             # on `az` having accepted a request, which is the one failure mode that would leave
             # every lock decoration while the report stayed green.
-            protected, why = registry.read_delete_enabled(entry.acr_repo, entry.digest)
-            if protected is False:
+            # `delete_enabled`, named for what it HOLDS rather than for what it implies: PROTECTED
+            # is `delete_enabled is False`, and a local called `protected` holding the opposite
+            # polarity is how a future reader talks themselves into `== True` being success.
+            # `None` is INDETERMINATE and is neither.
+            delete_enabled, why = registry.read_delete_enabled(entry.acr_repo, entry.digest)
+            if delete_enabled is False:
                 plan.locked_now += 1
                 print(f"locked {entry.acr_repo}@{entry.digest}")
                 continue
             failures.append(
                 f"{entry.acr_repo}@{entry.digest}: the lock WRITE succeeded and the manifest still "
-                + ("reads deleteEnabled=true" if protected is True
+                + ("reads deleteEnabled=true" if delete_enabled is True
                    else f"cannot be confirmed locked ({why})")
                 + ". It is pinned by "
                 + f"{', '.join(entry.sources[:3])} and the 03:00 purge can still delete it. A write "

--- a/.github/workflows/lock-pinned-digests.yml
+++ b/.github/workflows/lock-pinned-digests.yml
@@ -36,7 +36,13 @@ name: Lock pinned image digests
 #   * `protect` runs `needs: [preflight]` with NO input-shaped `if:` and NO `continue-on-error:`.
 #   * The script probes the registry with a CONTROL first and fails closed on an unreadable
 #     repository, a truncated git tree, an unclassifiable pin, an indeterminate registry answer, or
-#     a lock that did not take.
+#     a lock that did not take. 🚨 That LAST one is an assertion, not a phrase: `apply_locks` READS
+#     `deleteEnabled` BACK after every write and requires `false`. `az`'s exit code is a statement
+#     about the REQUEST, and a write that returns 0 without the attribute moving would leave this
+#     job reporting `Protected N manifest(s)` over manifests the 03:00 purge can still delete —
+#     which is precisely the failure it exists to remove, pointed at itself. An INDETERMINATE
+#     read-back is not a confirmation either. Two `--self-test` arms drive both cases and were
+#     falsified by deleting the read-back.
 #   * It PRINTS THE DENOMINATOR — per axis: repositories scanned, repositories that pin, pin sites
 #     found — and a ZERO on either axis is RED, because both were non-zero when this was written.
 #

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -433,6 +433,78 @@ az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \
 
 That is a provisioning task, not a workflow defect.
 
+### 🚨 The lock asserts its own postcondition — an exit code is not a locked manifest
+
+The whole job does exactly one thing: set `deleteEnabled: false` on a manifest. Until 2026-09-07 it
+believed **`az`'s exit code** that it had:
+
+```python
+def set_delete_enabled(...):
+    rc, _, err = az(["acr", "repository", "update", …, "--delete-enabled", "false", "-o", "none"])
+    return (rc == 0, …)          # ← the only evidence the job had
+```
+
+An exit code is a statement about the **request**, not about the manifest. A write that returns 0
+without the attribute moving — a subscription policy, an API version whose `--delete-enabled` is
+inert, a proxy that accepts and drops it — would leave the job printing `locked …` per manifest and
+`Protected N manifest(s)` at the end, over manifests the 03:00 purge could still delete. That is
+[a verification step that cannot fail](../ReadingCiSignals), pointed at the job's own reason for
+existing.
+
+So `apply_locks` now **reads the attribute back** and requires it to be `false`. Three outcomes, and
+only one of them counts:
+
+| Read-back | Verdict |
+|---|---|
+| `deleteEnabled == false` | protected — counted, and `locked …` printed |
+| `deleteEnabled == true` | **RED**: "the lock WRITE succeeded and the manifest still reads deleteEnabled=true" |
+| the registry did not answer | **RED**: "cannot be confirmed locked" — INDETERMINATE is not a confirmation |
+
+Two self-test arms drive it (`--self-test`, which runs on every pull request in `dotnet-test.yml`'s
+workflow-shell lane): a fixture whose write exits 0 without taking, and one whose read-back cannot
+answer. Both were **falsified** — deleting the read-back turns them red with
+`5 lock(s) were COUNTED although none took`, which is what makes them assertions rather than
+decoration.
+
+This matters more than it looks, because **the write half has never actually run**. Both runs so far
+were report-only or blocked, and the `metadata/write` grant below is (on the role evidence) still
+missing. The first `apply` run is the decisive measurement, and it must not be able to report
+success without having achieved it.
+
+### Two questions about the lock job, settled by measurement rather than reasoning
+
+🚨 **"Should the scan read each repo's DEFAULT branch rather than every branch?" — it already does,
+and changing that would be actively harmful.** `check-pin-set-consistency.py:scan_remote` calls
+`repos/{repo}/contents/.github/workflows` with **no `?ref=`**, and the GitHub contents API defaults
+to the repository's default branch. Verified by running the extractor against
+`Systemorph/MeshWeaver.Education` on 2026-09-07: it returns the three pins on `main`
+(`47dc1750…` / `24ea2fc6…` / `4cef7b67…`) and nothing else.
+
+Reading *every* branch would be a defect in both directions: a stale branch's pin would make the job
+red forever on a commit nobody will merge, **and** — worse — it would enter the lock set, so a
+manifest nothing live pins would be protected on the strength of an abandoned branch. The derivation
+is only sound because its input is what the fleet actually runs.
+
+🚨 **"A lock job that fails because a pin is already dead should NAME the stale pin, not just die."
+— it already names it**, with repository, file, line, variable and digest:
+
+```
+##[error]Systemorph/MeshWeaver.Education ci.yml:45 `MW_PORTAL_DIGEST`:
+         memex-portal-ai@sha256:dab2a7b3… does not exist in the registry, so it CANNOT be
+         protected. … Move the pin to a manifest that exists — as one set.
+```
+
+And the red was **correct, and transient**. Education's `main` sat at `53f0a65df` (2026-09-04T12:12Z)
+until `d622e7dc9` merged PR #274 at **2026-09-07T05:52:00Z** — `d622e7dc9`'s first parent is
+`53f0a65df`, and that commit's `ci.yml:45/46/64` carries exactly the three purged digests. So at
+00:07Z and 01:18Z the default branch really did declare three manifests that no longer exist. Note
+the trap this hid behind: those pins' *commit dates* (2026-09-06/07) belong to the branch they were
+authored on, not to the moment they reached `main` — reading a commit date as a merge time makes the
+job look like it read stale content when it read correctly.
+
+Locks are still applied on a degraded run, so those three never blocked the protection of anything
+else.
+
 ### The exact commands, by hand
 
 Lock one pinned manifest (idempotent):

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-registry-lock-proves-it-took.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-registry-lock-proves-it-took.md
@@ -1,0 +1,27 @@
+---
+Name: The nightly registry lock now proves it worked
+Category: Fix
+Description: The job that protects the images CI depends on used to report success as soon as the registry accepted its request. It now reads the setting back and confirms it actually changed — so "protected" can no longer mean "asked politely".
+Icon: ShieldCheckmark
+Order: -20260907
+---
+
+# The nightly registry lock now proves it worked
+
+Behind the scenes, a nightly job protects the container images this platform's build and deployment
+pipelines depend on, so that the registry's own housekeeping cannot delete them out from under a
+running deployment. Protecting one means flipping a single setting on the image.
+
+Until now the job decided it had succeeded the moment the registry **accepted the request**. That is
+not the same thing as the setting having changed — an accepted request that quietly has no effect
+looks identical from the outside, and the job would have gone on reporting a number of protected
+images while the housekeeping could still remove every one of them.
+
+It now reads the setting back after every write and requires it to actually say "protected". A write
+that is accepted but does not take is reported as a failure, naming the image and what still pins
+it. So is a read that cannot answer: not being able to confirm something is not the same as having
+confirmed it, and the job no longer treats the two alike.
+
+This matters more than it sounds, because the writing half of that job had never actually run — the
+runs so far were all report-only. The first real one is the measurement that counts, and it can no
+longer pass without having done the work.


### PR DESCRIPTION
## An exit code is not a locked manifest

`lock-pinned-digests.yml` does exactly one thing: set `deleteEnabled: false` on a manifest, so
`acr purge` — which skips locked manifests unless `--include-locked` is passed — cannot delete what
the fleet pins. Until now it believed **`az`'s exit code** that it had:

```python
def set_delete_enabled(...):
    rc, _, err = az(["acr", "repository", "update", …, "--delete-enabled", "false", "-o", "none"])
    return (rc == 0, …)          # the only evidence the job had
```

An exit code is a statement about the **request**. A write that returns 0 without the attribute
moving leaves the job printing `locked …` per manifest and `Protected N manifest(s)` at the end, over
manifests the 03:00 purge can still delete. The workflow header already **claimed** it "fails closed
on … a lock that did not take"; nothing enforced it.

🚨 **This is load-bearing right now.** The WRITE half of this job has **never actually run** — both
runs so far were report-only or blocked, and the `metadata/write` grant is still outstanding. The
first `apply` run is the decisive measurement of whether locking works at all, and it must not be
able to report success without having achieved it.

### The change

`apply_locks` reads `deleteEnabled` back after every write. Three outcomes, one of which counts:

| Read-back | Verdict |
|---|---|
| `false` | protected — counted, `locked …` printed |
| `true` | **RED** — "the lock WRITE succeeded and the manifest still reads deleteEnabled=true" |
| no answer | **RED** — "cannot be confirmed locked"; INDETERMINATE is not a confirmation |

Two `--self-test` arms drive it (that suite runs on every PR, in `dotnet-test.yml`'s workflow-shell
lane) — a fixture whose write exits 0 without taking, and one whose read-back cannot answer. **Both
were falsified**: deleting the read-back turns them red with

```
::error::self-test: ARM 11b: 5 lock(s) were COUNTED although none took
::error::self-test: ARM 11c: 5 unconfirmed lock(s) were counted as protected
```

which is what makes them assertions rather than decoration.

### Two questions settled by measurement, and recorded so they are not re-derived

🚨 **"Should the scan read each repo's DEFAULT branch rather than every branch?" — it already does,
and changing it would be actively harmful.** `check-pin-set-consistency.py:scan_remote` calls
`repos/{repo}/contents/.github/workflows` with **no `?ref=`**, and the contents API defaults to the
default branch. Verified by running the extractor live against `Systemorph/MeshWeaver.Education` on
2026-09-07 — it returns exactly the three pins on `main` (`47dc1750…` / `24ea2fc6…` / `4cef7b67…`).

Reading *every* branch would be wrong in **both** directions: red forever on a commit nobody will
merge, **and** — worse — a manifest nothing live pins entering the lock set on the strength of an
abandoned branch.

🚨 **"A lock job that fails because a pin is already dead should NAME the stale pin, not just die."
— it already names it**, with repository, file, line, variable and digest:

```
##[error]Systemorph/MeshWeaver.Education ci.yml:45 `MW_PORTAL_DIGEST`:
         memex-portal-ai@sha256:dab2a7b3… does not exist in the registry, so it CANNOT be
         protected. … Move the pin to a manifest that exists — as one set.
```

And the red was **correct, and transient**. Education's `main` sat at `53f0a65df`
(2026-09-04T12:12Z) until `d622e7dc9` merged PR #274 at **2026-09-07T05:52:00Z** — `d622e7dc9`'s
first parent is `53f0a65df`, whose `ci.yml:45/46/64` carries exactly the three purged digests. So at
00:07Z and 01:18Z the default branch really did declare three manifests that no longer exist; the
bump has since landed and the extractor now returns the three live ones.

**The trap that hid this:** those pins' *commit dates* (2026-09-06/07) belong to the branch they were
authored on, not to the moment they reached `main`. Reading a commit date as a merge time makes the
job look like it read stale content when it read correctly. `git log --first-parent` / the merge
commit's first parent is what actually answers.

So no change was warranted on either count, and both are now written down in the doc.

### Still the maintainer's, unchanged by this PR

1. **The RBAC grant.** `az acr repository update` needs
   `Microsoft.ContainerRegistry/registries/repositories/metadata/write`, which is in
   `Container Registry Repository Writer` and in **neither** `AcrPull` nor `AcrPush`. The registry's
   three service principals hold only `AcrPull`, `AcrPush` and
   `Container Registry Data Importer and Data Reader` (`metadata/read` only). Until it is granted,
   the lock step reds once naming the exact `az role assignment create`.
2. **The `latest`-tag retention policy.** Four of five filtered repositories have no `:latest` at
   all; the survivor (`mw-plugin-test`) is seven weeks old and survives only by being quiet. Whether
   `latest` is meant to exist on these repositories — and, if so, that all five move together to one
   promoted set — is a fleet-wide reference-set decision. A moving tag is also outside #3507's lock
   model entirely, since no file names it.

### Verification

- `--self-test`: **15 arms**, green; the two new ones falsified by removing the read-back.
- `check-workflow-timeouts.py --root .`: 71 jobs, 0 violations, cap 45.
- `check-workflow-shell.py --root .`: 0 live findings.
- `DocumentationLinkIntegrityTest` passes; `MeshWeaver.Documentation.Test` builds clean with
  `-warnaserror`.

Doc: `Doc/Architecture/PinnedImageRetention`. What's New entry included.

Part of #3438 (the retention policy and the RBAC grant stay open — both are the maintainer's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
