### PR TITLE
feat(cd): run combo verification per candidate × instance, and land the verdict

### DIFF
--- a/.github/scripts/check-combo-verify-preflight.py
+++ b/.github/scripts/check-combo-verify-preflight.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Prove the combo-verify preflight can FAIL, and fails naming what to provision.
+
+WHY THIS EXISTS
+---------------
+`combo-verify.yml` is the producer half of the combo gate (MeshWeaver#3544). Its `preflight` job is
+the ONLY thing standing between "no credential was provisioned" and a lane that quietly verifies
+nothing — and the whole file fires on `workflow_run` / `workflow_dispatch`, never on
+`pull_request`, so an edit to it merges on the strength of being valid YAML and first executes in
+production. That is the same blind spot `check-workflow-shell.py` was written for (#2642): CI's own
+shell, unopened by anything.
+
+A gate you have never seen fail is not a gate. This script EXECUTES the preflight's real `run:`
+text — extracted from the shipped YAML by path, never retyped — under five input scenarios and
+asserts the exit code AND that the message names the specific shortfall:
+
+  1. nothing provisioned                    → RED, naming vars.COMBO_VERIFY_INSTANCES
+  2. the instance list set, a secret absent → RED, naming that secret
+  3. the list present but an EMPTY array    → RED. This is the one that matters most: an empty
+                                              array yields an empty matrix, an empty matrix SKIPS
+                                              the verify job, and GitHub paints a skipped job the
+                                              same colour as a passed one. "The gate never ran" and
+                                              "the gate passed" must never be the same pixel.
+  4. an instance with no admin token        → RED, naming the instance. Otherwise the shortfall
+                                              surfaces deep inside the verify job as an HTTP 401
+                                              that names no secret — the shape that made an absent
+                                              MW_REGISTRY_KEY read as a script bug (Reinsurance#128).
+  5. everything provisioned                 → GREEN, and it emits the matrix it promised.
+
+🚨 It resolves the step BY PATH into the parsed workflow (`jobs.preflight.steps[0].run`) and
+asserts a sentinel is present, so if the preflight is renamed, reordered or moved into a script
+this fails LOUD instead of silently testing nothing — the "a guard whose subject moved and whose
+roots did not" failure mode.
+
+Usage:
+    python3 .github/scripts/check-combo-verify-preflight.py            # run the scenarios
+    python3 .github/scripts/check-combo-verify-preflight.py --self-test  # prove the harness detects
+                                                                         # a gutted preflight
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - the CI step installs PyYAML; locally `pip install pyyaml`
+    print("::error::check-combo-verify-preflight.py needs PyYAML (pip install pyyaml)")
+    raise SystemExit(1)
+
+WORKFLOW = ".github/workflows/combo-verify.yml"
+
+# The sentinel proves we extracted the preflight's assertion block and not some neighbouring step.
+SENTINEL = "missing=()"
+
+FULLY_PROVISIONED = {
+    "AZURE_CLIENT_ID": "cid",
+    "AZURE_TENANT_ID": "tid",
+    "AZURE_SUBSCRIPTION_ID": "sid",
+    "MESHWEAVER_APP_ID": "app",
+    "MESHWEAVER_APP_PRIVATE_KEY": "pem",
+    "COMBO_VERIFY_INSTANCES": (
+        '[{"name":"memex","baseUrl":"https://memex.systemorph.com"},'
+        '{"name":"memex-cloud","baseUrl":"https://memex.meshweaver.cloud"}]'
+    ),
+    "COMBO_VERIFY_SOURCES": "plugins=https://github.com/Systemorph/MeshWeaver.Plugins",
+    "COMBO_VERIFY_KEYS": '{"memex":"mwi_a","memex-cloud":"mwi_b"}',
+    "COMBO_VERIFY_TOKENS": '{"memex":"mw_a","memex-cloud":"mw_b"}',
+}
+
+# (label, env overrides, expected exit code, text the output MUST contain)
+SCENARIOS = [
+    (
+        "nothing provisioned",
+        {name: "" for name in FULLY_PROVISIONED},
+        1,
+        "vars.COMBO_VERIFY_INSTANCES",
+    ),
+    (
+        "instance list present, the keys secret absent",
+        {**FULLY_PROVISIONED, "COMBO_VERIFY_KEYS": ""},
+        1,
+        "secrets.COMBO_VERIFY_KEYS",
+    ),
+    (
+        "list present but an EMPTY array (the vacuous-green shape)",
+        {**FULLY_PROVISIONED, "COMBO_VERIFY_INSTANCES": "[]"},
+        1,
+        "not a non-empty JSON array",
+    ),
+    (
+        "an instance in the list has no admin token",
+        {**FULLY_PROVISIONED, "COMBO_VERIFY_TOKENS": '{"memex":"mw_a"}'},
+        1,
+        "no mw_ admin token for instance 'memex-cloud'",
+    ),
+    (
+        "everything provisioned",
+        FULLY_PROVISIONED,
+        0,
+        "2 instance(s) will be verified",
+    ),
+]
+
+
+def read_preflight(root: Path) -> str:
+    path = root / WORKFLOW
+    if not path.is_file():
+        raise SystemExit(f"::error::{WORKFLOW} does not exist under {root}")
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        script = doc["jobs"]["preflight"]["steps"][0]["run"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise SystemExit(
+            f"::error::{WORKFLOW}: could not resolve jobs.preflight.steps[0].run ({exc}). "
+            "The preflight moved and this guard did not — it would otherwise pass having "
+            "checked nothing."
+        ) from exc
+    if SENTINEL not in script:
+        raise SystemExit(
+            f"::error::{WORKFLOW}: jobs.preflight.steps[0].run does not contain '{SENTINEL}', so "
+            "it is not the assertion block this guard exercises. Point the guard at the step that "
+            "asserts the inputs, or restore the assertion."
+        )
+    return script
+
+
+def run_scenario(script: str, env_overrides: dict[str, str]) -> tuple[int, str, str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        github_output = os.path.join(tmp, "github_output")
+        Path(github_output).touch()
+        env = dict(os.environ)
+        env.update(env_overrides)
+        env["GITHUB_OUTPUT"] = github_output
+        proc = subprocess.run(
+            ["bash", "-c", script], env=env, capture_output=True, text=True, check=False
+        )
+        return proc.returncode, proc.stdout + proc.stderr, Path(github_output).read_text()
+
+
+def check(script: str) -> int:
+    failures = 0
+    for label, overrides, want_code, want_text in SCENARIOS:
+        code, output, gh_output = run_scenario(script, overrides)
+        ok = code == want_code and want_text in output
+        print(f"[{'PASS' if ok else 'FAIL'}] {label}: exit={code} (want {want_code})")
+        if not ok:
+            failures += 1
+            print(f"::error::combo-verify preflight scenario '{label}' behaved wrongly — "
+                  f"exit {code}, want {want_code}; message {'contains' if want_text in output else 'DOES NOT contain'} "
+                  f"{want_text!r}")
+            print("  " + output.replace("\n", "\n  "))
+        elif want_code == 0:
+            if "instances=" not in gh_output or "count=" not in gh_output:
+                failures += 1
+                print("::error::the passing scenario emitted no matrix — an empty matrix skips the "
+                      "verify job, and a skipped job is painted green")
+            else:
+                print("  " + gh_output.strip().replace("\n", " | "))
+    return failures
+
+
+def self_test() -> int:
+    """A gutted preflight — one that accepts anything — must be CAUGHT by the scenarios above."""
+    gutted = 'echo "instances=[]" >>"$GITHUB_OUTPUT"; echo "count=0" >>"$GITHUB_OUTPUT"; exit 0'
+    failures = check(gutted)
+    if failures == 0:
+        print("::error::--self-test: a preflight that asserts nothing passed every scenario, so "
+              "this guard proves nothing about the real one.")
+        return 1
+    print(f"--self-test: a gutted preflight failed {failures} scenario(s) — the guard can fail.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root (default: cwd)")
+    parser.add_argument("--self-test", action="store_true",
+                        help="prove the guard detects a preflight that asserts nothing")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    script = read_preflight(Path(args.root).resolve())
+    failures = check(script)
+    if failures:
+        print(f"::error::{failures} combo-verify preflight scenario(s) behaved wrongly.")
+        return 1
+    print(f"check-combo-verify-preflight: {len(SCENARIOS)} scenario(s), 0 violation(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-combo-verify.py
+++ b/.github/scripts/check-combo-verify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prove the combo-verify preflight can FAIL, and fails naming what to provision.
+"""Prove the combo-verify lane's shell: the preflight can FAIL, and the verdict merge cannot lose data.
 
 WHY THIS EXISTS
 ---------------
@@ -32,15 +32,30 @@ asserts a sentinel is present, so if the preflight is renamed, reordered or move
 this fails LOUD instead of silently testing nothing — the "a guard whose subject moved and whose
 roots did not" failure mode.
 
+PART TWO — THE VERDICT MERGE
+----------------------------
+`combo-verify-instance.sh` lands a verdict by read-merge-write, because an RFC 7396 merge patch
+replaces an array WHOLESALE. So the whole list is re-sent on every landing, and a defect in the jq
+that builds it does not fail — it silently DELETES an instance's recorded verdict history.
+
+There is a live trap: `MeshOperations.Get` has TWO node shapes. Normally the body is the bare node;
+when the node's NodeType carries a recorded compile error it is
+`{"node": {...}, "compilationError": "..."}` instead. Reading `.content.comboVerifications` off the
+wrapper yields null, null merges as an empty list, and the landing would replace up to eight
+verdicts with one. This part extracts the jq program FROM the shipped script and runs it over both
+shapes plus an instance that has no verdicts yet, asserting the rule
+`UpdatePolicyNodeType.RecordVerification` applies in-process: upsert by `candidateTag`
+(case-insensitive), newest first, capped at `MaxRecordedVerifications` = 8.
+
 Usage:
-    python3 .github/scripts/check-combo-verify-preflight.py            # run the scenarios
-    python3 .github/scripts/check-combo-verify-preflight.py --self-test  # prove the harness detects
-                                                                         # a gutted preflight
+    python3 .github/scripts/check-combo-verify.py              # run both parts
+    python3 .github/scripts/check-combo-verify.py --self-test  # prove each part detects its defect
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -50,10 +65,11 @@ from pathlib import Path
 try:
     import yaml
 except ImportError:  # pragma: no cover - the CI step installs PyYAML; locally `pip install pyyaml`
-    print("::error::check-combo-verify-preflight.py needs PyYAML (pip install pyyaml)")
+    print("::error::check-combo-verify.py needs PyYAML (pip install pyyaml)")
     raise SystemExit(1)
 
 WORKFLOW = ".github/workflows/combo-verify.yml"
+LANDER = ".github/scripts/combo-verify-instance.sh"
 
 # The sentinel proves we extracted the preflight's assertion block and not some neighbouring step.
 SENTINEL = "missing=()"
@@ -106,6 +122,108 @@ SCENARIOS = [
         "2 instance(s) will be verified",
     ),
 ]
+
+
+# The jq program that builds the patch body, delimited in the shipped script by these two markers.
+MERGE_START = 'jq -n --slurpfile p "$policy" --slurpfile v "$verdict" \''
+MERGE_END = "' >\"$request\""
+
+
+def read_merge_program(root: Path) -> str:
+    """The jq program the lander actually ships, read out of it rather than retyped."""
+    path = root / LANDER
+    if not path.is_file():
+        raise SystemExit(f"::error::{LANDER} does not exist under {root}")
+    text = path.read_text(encoding="utf-8")
+    start = text.find(MERGE_START)
+    if start < 0:
+        raise SystemExit(
+            f"::error::{LANDER}: could not find the verdict-merge jq invocation. It moved and this "
+            "guard did not — it would otherwise pass having checked nothing."
+        )
+    start += len(MERGE_START)
+    end = text.find(MERGE_END, start)
+    if end < 0:
+        raise SystemExit(
+            f"::error::{LANDER}: the verdict-merge jq program is not terminated by {MERGE_END!r}")
+    program = text[start:end]
+    if "comboVerifications" not in program or "ascii_downcase" not in program:
+        raise SystemExit(
+            f"::error::{LANDER}: the extracted jq program does not look like the verdict merge "
+            f"(no comboVerifications / no case-insensitive tag test):\n{program}"
+        )
+    return program
+
+
+def existing_verdicts() -> list:
+    rows = [
+        {"candidateTag": f"3.0.0-ci.{7900 + i}", "verdict": "Green",
+         "verifiedAt": f"2026-08-0{1 + i}T00:00:00+00:00"}
+        for i in range(9)
+    ]
+    # Same tag as the incoming verdict, different case: the upsert must REPLACE it, not duplicate it.
+    rows.append({"candidateTag": "3.0.0-CI.7999", "verdict": "Red",
+                 "verifiedAt": "2026-07-01T00:00:00+00:00"})
+    return rows
+
+
+INCOMING = {"candidateTag": "3.0.0-ci.7999", "verdict": "Green",
+            "verifiedAt": "2026-09-07T12:00:00+00:00"}
+
+BARE_NODE = {"id": "UpdatePolicy",
+             "content": {"comboVerifications": existing_verdicts(), "mode": "Auto"}}
+
+# (label, the body /api/mesh/get returns, expected list length)
+NODE_SHAPES = [
+    ("the bare node", BARE_NODE, 8),
+    ("the compile-error wrapper {node, compilationError}",
+     {"node": BARE_NODE, "compilationError": "boom"}, 8),
+    ("an instance with no verdicts yet", {"id": "UpdatePolicy", "content": {"mode": "Auto"}}, 1),
+]
+
+
+def run_merge(program: str, policy: dict) -> dict:
+    with tempfile.TemporaryDirectory() as tmp:
+        pol = Path(tmp) / "policy.json"
+        ver = Path(tmp) / "verdict.json"
+        pol.write_text(json.dumps(policy))
+        ver.write_text(json.dumps(INCOMING))
+        proc = subprocess.run(
+            ["jq", "-n", "--slurpfile", "p", str(pol), "--slurpfile", "v", str(ver), program],
+            capture_output=True, text=True, check=False)
+        if proc.returncode != 0:
+            raise SystemExit(f"::error::the verdict-merge jq failed: {proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+def check_merge(program: str) -> int:
+    failures = 0
+    for label, policy, want_len in NODE_SHAPES:
+        body = run_merge(program, policy)
+        rows = json.loads(body["fields"])["content"]["comboVerifications"]
+        tags = [r["candidateTag"] for r in rows]
+        lowered = [t.lower() for t in tags]
+        stamps = [r["verifiedAt"] for r in rows]
+        problems = []
+        if body.get("path") != "Admin/UpdatePolicy":
+            problems.append(f"patched {body.get('path')!r}, not Admin/UpdatePolicy")
+        if len(rows) != want_len:
+            problems.append(f"{len(rows)} verdict(s), want {want_len}")
+        if len(lowered) != len(set(lowered)):
+            problems.append(f"duplicate candidateTag after the upsert: {tags}")
+        if INCOMING["candidateTag"] not in tags:
+            problems.append("the incoming verdict is not in the list it would land")
+        if stamps != sorted(stamps, reverse=True):
+            problems.append(f"not newest-first: {stamps}")
+        if len(rows) > 8:
+            problems.append("over MaxRecordedVerifications = 8")
+        if problems:
+            failures += 1
+            print(f"[FAIL] merge over {label}: " + "; ".join(problems))
+            print(f"::error::the verdict merge would corrupt Admin/UpdatePolicy for {label}")
+        else:
+            print(f"[PASS] merge over {label}: {len(rows)} verdict(s), newest {tags[0]}")
+    return failures
 
 
 def read_preflight(root: Path) -> str:
@@ -166,14 +284,31 @@ def check(script: str) -> int:
 
 
 def self_test() -> int:
-    """A gutted preflight — one that accepts anything — must be CAUGHT by the scenarios above."""
+    """Each part must be shown to FIRE on its own defect. An unproven guard is no guard."""
     gutted = 'echo "instances=[]" >>"$GITHUB_OUTPUT"; echo "count=0" >>"$GITHUB_OUTPUT"; exit 0'
-    failures = check(gutted)
-    if failures == 0:
+    preflight_failures = check(gutted)
+    if preflight_failures == 0:
         print("::error::--self-test: a preflight that asserts nothing passed every scenario, so "
               "this guard proves nothing about the real one.")
         return 1
-    print(f"--self-test: a gutted preflight failed {failures} scenario(s) — the guard can fail.")
+    print(f"--self-test: a gutted preflight failed {preflight_failures} scenario(s) "
+          "— part one can fail.")
+
+    # The un-hardened merge: reads `.content` off the body without unwrapping `{node, ...}`. It is
+    # correct for the bare node and DELETES the history for the wrapper — the exact defect the
+    # shipped program's `(.node // .)` exists to prevent.
+    naive = ('($v[0].candidateTag // "" | ascii_downcase) as $tag '
+             '| (($p[0].content.comboVerifications // []) '
+             '| map(select((.candidateTag // "" | ascii_downcase) != $tag))) + [$v[0]] '
+             '| sort_by(.verifiedAt) | reverse | .[0:8] '
+             '| { path: "Admin/UpdatePolicy", '
+             'fields: ({ content: { comboVerifications: . } } | tojson) }')
+    merge_failures = check_merge(naive)
+    if merge_failures == 0:
+        print("::error::--self-test: a merge that never unwraps {node, compilationError} passed "
+              "every shape, so part two proves nothing about the real one.")
+        return 1
+    print(f"--self-test: the un-hardened merge failed {merge_failures} shape(s) — part two can fail.")
     return 0
 
 
@@ -187,12 +322,13 @@ def main() -> int:
     if args.self_test:
         return self_test()
 
-    script = read_preflight(Path(args.root).resolve())
-    failures = check(script)
+    root = Path(args.root).resolve()
+    failures = check(read_preflight(root)) + check_merge(read_merge_program(root))
     if failures:
-        print(f"::error::{failures} combo-verify preflight scenario(s) behaved wrongly.")
+        print(f"::error::{failures} combo-verify check(s) behaved wrongly.")
         return 1
-    print(f"check-combo-verify-preflight: {len(SCENARIOS)} scenario(s), 0 violation(s).")
+    print(f"check-combo-verify: {len(SCENARIOS)} preflight scenario(s) + "
+          f"{len(NODE_SHAPES)} verdict-merge shape(s), 0 violation(s).")
     return 0
 
 

--- a/.github/scripts/combo-verify-instance.sh
+++ b/.github/scripts/combo-verify-instance.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Verify ONE candidate against ONE live instance, and LAND the verdict on that instance.
+#
+# The producer half of the combo gate (issue #3544). `ComboVerificationGate` on every portal
+# consults `Admin/UpdatePolicy` → `content.comboVerifications` before it applies a self-update, and
+# until this script existed nothing in the fleet ever wrote one: `mw-combo-verify` was built, was
+# documented in Doc/Architecture/CandidateReleaseProtocol, and was invoked by no workflow — so every
+# roll ran UNVERIFIED and the gate that exists to notice could not.
+#
+# 🚨 The verdict is LANDED BEFORE the exit code is decided. A Red that never reaches the instance is
+# worse than no verdict at all: the instance's gate would clear a candidate this run proved cannot
+# serve it.
+#
+# 🚨 Every failure here is LOUD and names what to do. There is no `|| true` and no `2>/dev/null` on
+# anything whose value is then read — the shape that turns "the call failed" into "the answer is
+# empty" (MeshWeaver#2642) and leaves no trace in the log or the exit code.
+#
+# Inputs, all environment. A missing one is a PREFLIGHT failure in the workflow, never a skip here.
+#   INSTANCE_NAME   the instance's name, for the summary and the artifact names
+#   BASE_URL        e.g. https://memex.systemorph.com  (no trailing slash)
+#   INSTANCE_KEY    mwi_… — the instance-registry key. Reads roll-target + combo.
+#   ADMIN_TOKEN     mw_…  — an API token of a GLOBAL ADMIN on that instance. Lands the verdict.
+#   ACR             e.g. meshweaver.azurecr.io
+#   SOURCES         space-separated name=url pairs for --source
+#   GITHUB_TOKEN    read access to the module repositories
+#   GATE_TIMEOUT    seconds; comfortably under the job's timeout-minutes so the TOOL's budget
+#                   fires first and says what did not complete
+#   PLATFORM        docker platform to verify, e.g. linux/amd64
+#   WORK_ROOT       materialisation root
+set -euo pipefail
+
+fail() { echo "::error::[$INSTANCE_NAME] $*"; exit 1; }
+note() { echo "[$INSTANCE_NAME] $*"; }
+
+out_dir=${GITHUB_WORKSPACE:-$PWD}
+summary=${GITHUB_STEP_SUMMARY:-/dev/null}
+
+# ── 1. Which candidate would THIS instance roll to? ───────────────────────────────────────────
+# Asked OF THE INSTANCE rather than derived here, because "the newest tag" is not the question the
+# gate answers: ReleaseAvailabilityService already walks the completeness rule and names the release
+# this environment would actually take. Re-deriving it here would be a second rule.
+roll=$out_dir/combo-rolltarget-$INSTANCE_NAME.json
+roll_code=$(curl -sS -o "$roll" -w '%{http_code}' --connect-timeout 15 --max-time 120 \
+  -H "Authorization: Bearer $INSTANCE_KEY" "$BASE_URL/api/plugins/roll-target") || roll_code=000
+[ "$roll_code" = "200" ] \
+  || fail "GET $BASE_URL/api/plugins/roll-target -> HTTP $roll_code. $(head -c 400 "$roll")"
+
+CANDIDATE=$(jq -r '.selected // ""' <"$roll")
+CURRENT=$(jq -r '.current // "?"' <"$roll")
+if [ -z "$CANDIDATE" ] || [ "$CANDIDATE" = "null" ]; then
+  # A real, reportable outcome — and deliberately NOT silence. The instance has nothing to roll to,
+  # so there is nothing to verify; the summary says so by name.
+  note "NOTHING TO VERIFY — the instance selects no roll target (current=$CURRENT)."
+  # shellcheck disable=SC2016  # the backticks are MARKDOWN for the step summary, not a subshell
+  printf '### %s — nothing to verify\n\nThe instance selects no roll target (currently on `%s`).\n' \
+    "$INSTANCE_NAME" "$CURRENT" >>"$summary"
+  exit 0
+fi
+note "candidate=$CANDIDATE (currently on $CURRENT)"
+
+# ── 2. What does the instance actually run? ────────────────────────────────────────────────────
+combo=$out_dir/combo-$INSTANCE_NAME.json
+combo_code=$(curl -sS -o "$combo" -w '%{http_code}' --connect-timeout 15 --max-time 180 \
+  -H "Authorization: Bearer $INSTANCE_KEY" "$BASE_URL/api/plugins/combo") || combo_code=000
+if [ "$combo_code" != "200" ]; then
+  fail "GET $BASE_URL/api/plugins/combo -> HTTP $combo_code. $(head -c 400 "$combo") ::: A 404 here means the instance runs a portal image from before #3544 added the route — roll it to an image that serves /api/plugins/combo first. There is deliberately NO fallback: the only other source (Hosting/ModuleInventory) drops readAt, isComplete, caveats and the per-module sync detail, so a verdict derived from it would be about something other than this instance's real module set."
+fi
+jq -e 'has("modules")' >/dev/null <"$combo" \
+  || fail "the combo read from $BASE_URL is not an InstanceCombo: $(head -c 400 "$combo")"
+if [ "$(jq -r '.isComplete' <"$combo")" != "true" ]; then
+  # Stated, never swallowed. The reader folds an unreadable source into caveats rather than
+  # faulting, and the verifier can then only answer NotVerifiable — which fails this script below.
+  note "the instance reports an INCOMPLETE combo: $(jq -c '.caveats' <"$combo")"
+fi
+note "combo: $(jq -r '.modules | length' <"$combo") module(s), readAt=$(jq -r '.readAt' <"$combo")"
+
+# ── 3. Verify ─────────────────────────────────────────────────────────────────────────────────
+verdict=$out_dir/combo-verdict-$INSTANCE_NAME.json
+src_args=()
+for s in $SOURCES; do src_args+=(--source "$s"); done
+
+set +e
+dotnet run --project tools/MeshWeaver.ComboVerifier/MeshWeaver.ComboVerifier.csproj \
+  -c Release --no-build -- \
+  "$combo" "$ACR/memex-portal-ai:$CANDIDATE" \
+  --tag "$CANDIDATE" \
+  --verdict "$verdict" \
+  --work-root "$WORK_ROOT/$INSTANCE_NAME" \
+  --platform "$PLATFORM" \
+  --gate-timeout "$GATE_TIMEOUT" \
+  "${src_args[@]}"
+verify_exit=$?
+set -e
+
+[ -f "$verdict" ] || fail "mw-combo-verify exited $verify_exit and wrote no verdict file — nothing was verified, so there is nothing to land."
+KIND=$(jq -r '.verdict' <"$verdict")
+note "verdict=$KIND for $CANDIDATE (tool exit $verify_exit)"
+
+# ── 4. LAND it. Read-merge-write, mirroring UpdatePolicyNodeType.RecordVerification exactly. ───
+# 🚨 An RFC 7396 merge patch REPLACES an array wholesale, so the whole list has to be sent. The
+# merge rule is not invented here — upsert by candidateTag (case-insensitive), newest first, capped
+# at MaxRecordedVerifications = 8 — it is the one RecordVerification applies in-process.
+policy=$out_dir/combo-policy-$INSTANCE_NAME.json
+get_code=$(curl -sS -o "$policy" -w '%{http_code}' --connect-timeout 15 --max-time 120 \
+  -X POST "$BASE_URL/api/mesh/get" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"path":"Admin/UpdatePolicy"}') || get_code=000
+[ "$get_code" = "200" ] \
+  || fail "POST $BASE_URL/api/mesh/get Admin/UpdatePolicy -> HTTP $get_code. $(head -c 400 "$policy")"
+# 🚨 The mesh API ships its OWN failures with HTTP 200 — the body is the verdict, not the status.
+if ! jq -e 'type == "object"' >/dev/null <"$policy"; then
+  fail "reading Admin/UpdatePolicy did not return a node: $(head -c 400 "$policy")"
+fi
+
+request=$out_dir/combo-patch-$INSTANCE_NAME.json
+jq -n --slurpfile p "$policy" --slurpfile v "$verdict" '
+  ($v[0].candidateTag // "" | ascii_downcase) as $tag
+  | (($p[0].content.comboVerifications // [])
+      | map(select((.candidateTag // "" | ascii_downcase) != $tag)))
+    + [$v[0]]
+  | sort_by(.verifiedAt) | reverse | .[0:8]
+  | { path: "Admin/UpdatePolicy", fields: ({ content: { comboVerifications: . } } | tojson) }
+' >"$request"
+
+patched=$out_dir/combo-patched-$INSTANCE_NAME.txt
+patch_code=$(curl -sS -o "$patched" -w '%{http_code}' --connect-timeout 15 --max-time 120 \
+  -X POST "$BASE_URL/api/mesh/patch" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  -d "@$request") || patch_code=000
+[ "$patch_code" = "200" ] \
+  || fail "POST $BASE_URL/api/mesh/patch -> HTTP $patch_code. $(head -c 400 "$patched")"
+grep -q 'Patched:' "$patched" \
+  || fail "the verdict did not land on Admin/UpdatePolicy: $(head -c 400 "$patched")"
+note "landed: $(head -c 200 "$patched")"
+
+{
+  # shellcheck disable=SC2016  # the backticks are MARKDOWN for the step summary, not a subshell
+  printf '### %s — `%s` → **%s**\n\n' "$INSTANCE_NAME" "$CANDIDATE" "$KIND"
+  jq -r '"- modules: \(.modules | length), passed: \([.modules[] | select(.outcome == "Passed")] | length), failed: \([.modules[] | select(.outcome == "Failed")] | length)"' <"$verdict"
+  jq -r '.modules[] | select(.outcome != "Passed") | "  - `\(.moduleId)` \(.outcome): \(.failures | join("; "))"' <"$verdict"
+  jq -r '.caveats[]? | "  - caveat: \(.)"' <"$verdict"
+} >>"$summary"
+
+# 🚨 Exit AFTER landing, and Green is the ONLY pass. A Red says this candidate cannot serve the
+# modules this instance runs — delivery promoted something a live instance must refuse. A
+# NotVerifiable says nothing was checked at all, which is the one outcome a gate must never paint
+# green: it is "the gate never ran" wearing the colour of "the gate passed".
+[ "$KIND" = "Green" ] \
+  || fail "verdict is $KIND for $CANDIDATE. It IS landed on $BASE_URL, so the instance's own gate will act on it; this run is red because a candidate a live instance cannot take has not been delivered."
+note "GREEN"

--- a/.github/scripts/combo-verify-instance.sh
+++ b/.github/scripts/combo-verify-instance.sh
@@ -108,14 +108,22 @@ get_code=$(curl -sS -o "$policy" -w '%{http_code}' --connect-timeout 15 --max-ti
 [ "$get_code" = "200" ] \
   || fail "POST $BASE_URL/api/mesh/get Admin/UpdatePolicy -> HTTP $get_code. $(head -c 400 "$policy")"
 # 🚨 The mesh API ships its OWN failures with HTTP 200 — the body is the verdict, not the status.
+# ("Not found: Admin/UpdatePolicy" and "Error: …" are plain strings, so they are not objects.)
 if ! jq -e 'type == "object"' >/dev/null <"$policy"; then
   fail "reading Admin/UpdatePolicy did not return a node: $(head -c 400 "$policy")"
 fi
+# 🚨 …and it has TWO node shapes. When the node's NodeType carries a recorded compile error the
+# body is {"node": {…}, "compilationError": "…"} instead of the bare node. Reading
+# `.content.comboVerifications` off the wrapper yields null, and null merges as an EMPTY list —
+# which would silently DELETE the up-to-eight verdicts already recorded on that instance and
+# replace them with this one. Unwrap, and then assert the field is readable.
+jq -e '(.node // .) | has("content")' >/dev/null <"$policy" \
+  || fail "Admin/UpdatePolicy has no readable content — refusing to merge, because a null here would replace the instance's recorded verdicts with an empty list: $(head -c 400 "$policy")"
 
 request=$out_dir/combo-patch-$INSTANCE_NAME.json
 jq -n --slurpfile p "$policy" --slurpfile v "$verdict" '
   ($v[0].candidateTag // "" | ascii_downcase) as $tag
-  | (($p[0].content.comboVerifications // [])
+  | (($p[0] | (.node // .) | .content.comboVerifications // [])
       | map(select((.candidateTag // "" | ascii_downcase) != $tag)))
     + [$v[0]]
   | sort_by(.verifiedAt) | reverse | .[0:8]

--- a/.github/workflows/combo-verify.yml
+++ b/.github/workflows/combo-verify.yml
@@ -1,0 +1,253 @@
+﻿# ─────────────────────────────────────────────────────────────────────────────────────────────
+# COMBO VERIFICATION — the PRODUCER half of the combo gate (issue #3544).
+#
+# `ComboVerificationGate` on every portal consults `Admin/UpdatePolicy` → `content.comboVerifications`
+# before it applies a self-update, and asks the question an artifact cannot answer: *may THIS
+# instance roll to that image, given the modules it actually runs?* Producing a verdict needs
+# docker, a materialisation root and repo credentials a portal pod does not have, so the producer
+# is off-cluster BY DESIGN — `tools/MeshWeaver.ComboVerifier` (`mw-combo-verify`).
+#
+# 🚨 Until this workflow, that producer was wired to NOTHING. Measured 2026-09-07: zero references
+# to `mw-combo-verify` anywhere under `.github/` in this repo or MeshWeaver.Plugins; the only
+# `IComboGateRunner` in either repo was a test fake; `Admin/UpdatePolicy.comboVerifications` was
+# `[]` on memex-cloud. So every roll in the fleet ran UNVERIFIED — the portal said so in its own
+# log ("nothing has checked whether that image can serve the modules this instance runs") and
+# applied the update anyway. The gate built to prevent a MissingMethodException-at-boot roll was
+# never once consulted with data.
+#
+# 🚨 WHY THIS IS ITS OWN WORKFLOW AND NOT A JOB IN main-cd.yml. The preflight below fails RED until
+# an operator provisions the per-instance credentials, which is the correct state and the whole
+# point of the no-skip-trapdoor rule — but a red inside main-cd would sit on the workflow that
+# publishes the fleet's images and would be read as "delivery failed". Here the red says exactly
+# what it is, and image delivery is untouched.
+#
+# 🚨 NO SKIP TRAPDOORS. There is no `continue-on-error:` on any input step and no `if:` anywhere
+# that asks whether a secret or variable is set. GitHub paints a skipped job the same colour as a
+# passed one, so "the gate never ran" and "the gate passed" would become indistinguishable. The
+# ONE condition in this file is on the EVENT (did CD actually succeed, i.e. is there a candidate at
+# all), byte-identical in intent to main-cd's own. And because a `needs:`-failure SKIPS the verify
+# job, the `verdict` job below runs `if: always()` and fails EXPLICITLY on anything that is not a
+# success — a skip cannot read green.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+name: Combo verification (candidate × instance)
+
+on:
+  workflow_run:
+    workflows: ["Continuous Delivery (main)"]
+    types: [completed]
+    # 🚨 REQUIRED, and not decoration. workflow_run fires on completions from EVERY branch, and this
+    # workflow keeps one concurrency group — GitHub holds exactly one pending run per group, so an
+    # off-branch arrival evicts the on-branch run waiting behind it. Measured on main-cd.yml
+    # (2026-09-02): six consecutive CD runs cancelled, nothing promoted for four hours, every
+    # dashboard green. WorkflowRunTriggerBranchFilterGuard fails this file without it.
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  # Never cancel: a run that is mid-`docker run` inside a candidate image has already spent the
+  # expensive part, and a cancelled verification lands no verdict at all.
+  group: combo-verify
+  cancel-in-progress: false
+
+env:
+  ACR: meshweaver.azurecr.io
+  # The fleet runs amd64. A verdict is about ONE architecture — a run pinned to the wrong one is
+  # NotVerifiable at best and a lie at worst (measured: the same combo and tag reads Green unpinned
+  # on an arm64 host and NotVerifiable pinned to linux/amd64, because the emulated tester dies 139).
+  PLATFORM: linux/amd64
+  # Comfortably under the job's timeout-minutes, so the tool's own budget fires FIRST and says what
+  # did not complete. The tool defaults to 45 minutes, which is exactly the fleet's hard job cap —
+  # i.e. the default can only ever be pre-empted by the runner, with no diagnosis.
+  GATE_TIMEOUT: "1500"
+
+jobs:
+  preflight:
+    name: "Assert the inputs exist"
+    # 🚨 The ONE sanctioned condition, and it is a check on the EVENT: when CD did not succeed there
+    # is no candidate to verify against. It is NEVER a check on whether a secret is set.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      instances: ${{ steps.assert.outputs.instances }}
+      count: ${{ steps.assert.outputs.count }}
+    steps:
+      - name: Every external input, or a red build naming what to provision
+        id: assert
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
+          MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          COMBO_VERIFY_INSTANCES: ${{ vars.COMBO_VERIFY_INSTANCES }}
+          COMBO_VERIFY_SOURCES: ${{ vars.COMBO_VERIFY_SOURCES }}
+          COMBO_VERIFY_KEYS: ${{ secrets.COMBO_VERIFY_KEYS }}
+          COMBO_VERIFY_TOKENS: ${{ secrets.COMBO_VERIFY_TOKENS }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AZURE_CLIENT_ID:-}" ]       || missing+=("secrets.AZURE_CLIENT_ID          OIDC app registration for azure/login (already provisioned for main-cd)")
+          [ -n "${AZURE_TENANT_ID:-}" ]       || missing+=("secrets.AZURE_TENANT_ID          the Systemorph AAD tenant (already provisioned for main-cd)")
+          [ -n "${AZURE_SUBSCRIPTION_ID:-}" ] || missing+=("secrets.AZURE_SUBSCRIPTION_ID    the subscription holding ACR meshweaver (already provisioned for main-cd)")
+          [ -n "${MESHWEAVER_APP_ID:-}" ]     || missing+=("secrets.MESHWEAVER_APP_ID        the org App whose installation token reads the module repositories (already provisioned for chart-drift)")
+          [ -n "${MESHWEAVER_APP_PRIVATE_KEY:-}" ] || missing+=("secrets.MESHWEAVER_APP_PRIVATE_KEY  that App's private key, PEM (already provisioned for chart-drift)")
+          [ -n "${COMBO_VERIFY_INSTANCES:-}" ] || missing+=("vars.COMBO_VERIFY_INSTANCES      JSON array of the instances to verify: [{\"name\":\"memex\",\"baseUrl\":\"https://memex.systemorph.com\"}, …]")
+          [ -n "${COMBO_VERIFY_SOURCES:-}" ]   || missing+=("vars.COMBO_VERIFY_SOURCES        space-separated name=url for --source, e.g. plugins=https://github.com/Systemorph/MeshWeaver.Plugins")
+          [ -n "${COMBO_VERIFY_KEYS:-}" ]      || missing+=("secrets.COMBO_VERIFY_KEYS        JSON object {instance name: mwi_… instance-registry key}, one per instance above")
+          [ -n "${COMBO_VERIFY_TOKENS:-}" ]    || missing+=("secrets.COMBO_VERIFY_TOKENS      JSON object {instance name: mw_… API token of a GLOBAL ADMIN on that instance}, one per instance above")
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Combo verification cannot run — provision the following, then re-run:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            echo "Until then EVERY self-update in the fleet rolls UNVERIFIED (issue #3544): the" >&2
+            echo "portal's combo gate has no verdict to consult and applies the update anyway." >&2
+            exit 1
+          fi
+
+          # PRESENT is not VALID. A malformed list would otherwise produce an EMPTY matrix, and an
+          # empty matrix skips the verify job — which GitHub paints green. Assert the shape here.
+          if ! jq -e 'type == "array" and length > 0' >/dev/null <<<"$COMBO_VERIFY_INSTANCES"; then
+            echo "::error::vars.COMBO_VERIFY_INSTANCES is not a non-empty JSON array: $COMBO_VERIFY_INSTANCES"
+            exit 1
+          fi
+          if ! jq -e 'all(.[]; has("name") and has("baseUrl"))' >/dev/null <<<"$COMBO_VERIFY_INSTANCES"; then
+            echo "::error::every entry of vars.COMBO_VERIFY_INSTANCES needs a name and a baseUrl: $COMBO_VERIFY_INSTANCES"
+            exit 1
+          fi
+
+          # …and every instance must have BOTH credentials. A name present in the list but absent
+          # from either map would fail deep inside the verify job wearing an HTTP 401 that names no
+          # secret — the shape that made an absent MW_REGISTRY_KEY read as a script bug.
+          for key_name in $(jq -r '.[].name' <<<"$COMBO_VERIFY_INSTANCES"); do
+            jq -e --arg n "$key_name" '.[$n] | type == "string" and length > 0' >/dev/null <<<"$COMBO_VERIFY_KEYS" \
+              || { echo "::error::secrets.COMBO_VERIFY_KEYS has no mwi_ key for instance '$key_name'"; exit 1; }
+            jq -e --arg n "$key_name" '.[$n] | type == "string" and length > 0' >/dev/null <<<"$COMBO_VERIFY_TOKENS" \
+              || { echo "::error::secrets.COMBO_VERIFY_TOKENS has no mw_ admin token for instance '$key_name'"; exit 1; }
+          done
+
+          count=$(jq -r 'length' <<<"$COMBO_VERIFY_INSTANCES")
+          {
+            echo "instances=$(jq -c '.' <<<"$COMBO_VERIFY_INSTANCES")"
+            echo "count=$count"
+          } >>"$GITHUB_OUTPUT"
+          echo "All external inputs are present; $count instance(s) will be verified."
+
+  verify:
+    name: "Verify ${{ matrix.instance.name }} against its roll target"
+    # 🚨 `needs: preflight` and NOTHING else gating it. No `if:` — the preflight either asserted
+    # every input or went red; this job never asks a second time.
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: ${{ fromJSON(needs.preflight.outputs.instances) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: |
+          set -euo pipefail
+          command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          bash .github/scripts/acr-login.sh
+
+      - name: Token for the module repositories
+        id: repo-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: Systemorph
+
+      - name: Build the verifier
+        run: dotnet build tools/MeshWeaver.ComboVerifier/MeshWeaver.ComboVerifier.csproj -c Release
+
+      - name: "Verify, and LAND the verdict on ${{ matrix.instance.name }}"
+        env:
+          INSTANCE_NAME: ${{ matrix.instance.name }}
+          BASE_URL: ${{ matrix.instance.baseUrl }}
+          COMBO_VERIFY_KEYS: ${{ secrets.COMBO_VERIFY_KEYS }}
+          COMBO_VERIFY_TOKENS: ${{ secrets.COMBO_VERIFY_TOKENS }}
+          SOURCES: ${{ vars.COMBO_VERIFY_SOURCES }}
+          GITHUB_TOKEN: ${{ steps.repo-token.outputs.token }}
+          WORK_ROOT: ${{ runner.temp }}/combo
+        run: |
+          set -euo pipefail
+          INSTANCE_KEY=$(jq -r --arg n "$INSTANCE_NAME" '.[$n]' <<<"$COMBO_VERIFY_KEYS")
+          ADMIN_TOKEN=$(jq -r --arg n "$INSTANCE_NAME" '.[$n]' <<<"$COMBO_VERIFY_TOKENS")
+          # Never echoed, but a value pulled out of a JSON secret is no longer masked by the
+          # runner, so mask the extracted halves explicitly.
+          echo "::add-mask::$INSTANCE_KEY"
+          echo "::add-mask::$ADMIN_TOKEN"
+          export INSTANCE_KEY ADMIN_TOKEN
+          bash .github/scripts/combo-verify-instance.sh
+
+      - name: Keep the work root of a failed verification
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: combo-work-${{ matrix.instance.name }}
+          path: |
+            combo-${{ matrix.instance.name }}.json
+            combo-verdict-${{ matrix.instance.name }}.json
+          if-no-files-found: ignore
+
+  verdict:
+    name: "Combo verification ran, or said why not"
+    # 🚨 THE ANTI-SKIP JOB. `needs:` a failed preflight SKIPS `verify`, and GitHub paints a skipped
+    # job the same colour as a passed one. This job runs whatever happened and fails EXPLICITLY on
+    # anything that is not a success, so the run's conclusion can never say "verified" about a
+    # verification that did not happen. It also prints THE DENOMINATOR — how many instances were
+    # supposed to be verified — because a zero nobody can read is indistinguishable from a pass.
+    if: always()
+    needs: [preflight, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: The verdict, and it can fail
+        env:
+          PREFLIGHT: ${{ needs.preflight.result }}
+          VERIFY: ${{ needs.verify.result }}
+          COUNT: ${{ needs.preflight.outputs.count }}
+        run: |
+          set -euo pipefail
+          echo "preflight=$PREFLIGHT verify=$VERIFY instances=${COUNT:-0}"
+          {
+            echo "## Combo verification"
+            echo
+            echo "- preflight: \`$PREFLIGHT\`"
+            echo "- verify: \`$VERIFY\` over \`${COUNT:-0}\` instance(s)"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          if [ "$PREFLIGHT" != "success" ]; then
+            echo "::error::the preflight did not pass, so NO instance was verified and every roll in the fleet is still UNVERIFIED (#3544). Read the preflight job for the exact list of inputs to provision."
+            exit 1
+          fi
+          if [ "$VERIFY" != "success" ]; then
+            echo "::error::combo verification did not succeed for every instance (result: $VERIFY). A candidate a live instance cannot take is not delivered; read the per-instance jobs for the module that failed."
+            exit 1
+          fi
+          if [ "${COUNT:-0}" -lt 1 ]; then
+            echo "::error::the preflight passed but named ZERO instances — that is a vacuous green, not a verification."
+            exit 1
+          fi
+          echo "Every declared instance has a landed combo verdict for its roll target."

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1968,6 +1968,17 @@ jobs:
     - name: "Every job is capped at 45 minutes"
       run: python3 .github/scripts/check-workflow-timeouts.py --root .
 
+    # 🚨 combo-verify.yml fires on `workflow_run` / `workflow_dispatch`, NEVER on `pull_request`, so
+    # nothing else on this PR opens it — the same blind spot #2642 cost 33 hours on. Its `preflight`
+    # is the only thing between "no per-instance credential was provisioned" and a lane that
+    # verifies nothing, and the shortfall that matters most is an EMPTY instance list: an empty
+    # matrix skips the verify job, and GitHub paints a skipped job the same colour as a passed one.
+    # This EXECUTES the preflight's real `run:` text over five input scenarios. Self-test first.
+    - name: "The combo-verify preflight can fail (self-test)"
+      run: python3 .github/scripts/check-combo-verify-preflight.py --self-test
+    - name: "The combo-verify preflight fails naming what to provision"
+      run: python3 .github/scripts/check-combo-verify-preflight.py --root .
+
     # 🚨 A Dependabot run resolves `secrets.X` against a SECOND, SEPARATE store (Settings → Secrets
     # and variables → **Dependabot**), which is a PARTIAL mirror of the Actions one — and there is no
     # Dependabot *variables* store, so only `secrets.` is doubled. #3399 (a recurrence of #2249) had

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1973,11 +1973,16 @@ jobs:
     # is the only thing between "no per-instance credential was provisioned" and a lane that
     # verifies nothing, and the shortfall that matters most is an EMPTY instance list: an empty
     # matrix skips the verify job, and GitHub paints a skipped job the same colour as a passed one.
-    # This EXECUTES the preflight's real `run:` text over five input scenarios. Self-test first.
-    - name: "The combo-verify preflight can fail (self-test)"
-      run: python3 .github/scripts/check-combo-verify-preflight.py --self-test
-    - name: "The combo-verify preflight fails naming what to provision"
-      run: python3 .github/scripts/check-combo-verify-preflight.py --root .
+    # This EXECUTES the preflight's real `run:` text over five input scenarios — and the lander's
+    # real verdict-merge jq over the two node shapes `/api/mesh/get` can return, because that merge
+    # re-sends the WHOLE verdict list (RFC 7396 replaces an array wholesale) and reading the
+    # `{node, compilationError}` wrapper as if it were the bare node would silently DELETE an
+    # instance's recorded history rather than fail. Self-test first: both parts must be shown to
+    # fire on their own defect.
+    - name: "The combo-verify preflight and verdict merge can fail (self-test)"
+      run: python3 .github/scripts/check-combo-verify.py --self-test
+    - name: "The combo-verify preflight names what to provision, and the verdict merge loses nothing"
+      run: python3 .github/scripts/check-combo-verify.py --root .
 
     # 🚨 A Dependabot run resolves `secrets.X` against a SECOND, SEPARATE store (Settings → Secrets
     # and variables → **Dependabot**), which is a PARTIAL mirror of the Actions one — and there is no

--- a/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Text.Json;
 using Memex.Portal.Shared.SelfUpdate;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
@@ -50,6 +51,33 @@ public static class ReleaseGateEndpoints
     /// </summary>
     public const string SelectRoute = "/api/plugins/roll-target";
 
+    /// <summary>
+    /// 🚨 Route the instance's COMBO is served at (#3544): <c>GET /api/plugins/combo</c> — <i>which
+    /// modules, at which refs, does this instance actually run?</i>
+    ///
+    /// <para>It exists for the same reason as its two siblings and for one caller in particular:
+    /// the combo GATE (<c>ComboVerificationGate</c>) consults a verdict that only an off-cluster
+    /// producer can mint, because producing one needs docker, a materialisation root and repo
+    /// credentials a portal pod does not have. That producer — <c>mw-combo-verify</c> — needs the
+    /// instance's combo as its FIRST input, and until this route existed there was no way to get
+    /// it out of a running portal: <c>InstanceComboReader</c> had no HTTP, MCP or layout surface at
+    /// all, so nothing ever ran the verifier and every roll in the fleet was UNVERIFIED (#3544).</para>
+    ///
+    /// <para>🚨 <b>The bytes are the contract.</b> The body is an <see cref="InstanceCombo"/>
+    /// serialized with <see cref="InstanceComboAssembler.Json"/> — the very options
+    /// <c>mw-combo-verify</c> deserializes with — so the response IS <c>combo.json</c> and no caller
+    /// has to reshape it. There is deliberately no lossy alternative: the nearest existing node
+    /// (<c>Hosting/ModuleInventory</c>) drops <c>readAt</c>, <c>isComplete</c>, <c>caveats</c> and
+    /// the per-module sync detail, and a verdict derived from it would be about something other
+    /// than this instance's real module set.</para>
+    ///
+    /// <para>Auth is the same <c>mwi_</c> instance key, failing CLOSED, for the same reason: a
+    /// combo names every module repository and pinned commit this deployment carries, which is
+    /// deployment inventory rather than public information — strictly narrower than nothing, and
+    /// the same class the two routes above already return.</para>
+    /// </summary>
+    public const string ComboRoute = "/api/plugins/combo";
+
     /// <summary>Maps the instance-key-gated release gate. Call alongside <c>MapPluginBundles</c>.</summary>
     public static IEndpointRouteBuilder MapReleaseGate(this IEndpointRouteBuilder endpoints)
     {
@@ -58,6 +86,8 @@ public static class ReleaseGateEndpoints
             .AllowAnonymous();
         endpoints.MapGet(SelectRoute, (HttpContext http, string? current, CancellationToken ct) =>
                 Selection(http, current, ct))
+            .AllowAnonymous();
+        endpoints.MapGet(ComboRoute, (HttpContext http, CancellationToken ct) => Combo(http, ct))
             .AllowAnonymous();
         return endpoints;
     }
@@ -190,4 +220,51 @@ public static class ReleaseGateEndpoints
                 });
             });
     }
+
+    /// <summary>
+    /// The instance's own combo, authenticated exactly like <see cref="Verdict"/> and
+    /// <see cref="Selection"/>. See <see cref="ComboRoute"/> for why it exists and why the bytes
+    /// are the contract.
+    /// </summary>
+    private static Task<IResult> Combo(HttpContext http, CancellationToken ct)
+    {
+        var authenticator = http.RequestServices
+            .GetRequiredService<InstanceRegistryAuthenticator>();
+
+        var logger = http.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ReleaseGateEndpoints));
+
+        return authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
+            .SelectMany(outcome => outcome.IsUnavailable
+                ? Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger))
+                : outcome.Instance is null
+                    ? Observable.Return(Results.Json(
+                        new { error = "A registered instance key is required (Authorization: Bearer mwi_… or Basic)." },
+                        statusCode: StatusCodes.Status401Unauthorized))
+                    : StateCombo(http, logger))
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Instance combo read faulted after the response had already been sent"),
+                ct)!;
+    }
+
+    private static IObservable<IResult> StateCombo(HttpContext http, ILogger? logger) =>
+        http.RequestServices.GetRequiredService<InstanceComboReader>().Read()
+            .Select(combo =>
+            {
+                // 🚨 Information, and stated rather than swallowed. The reader never faults — an
+                // unreadable source sets IsComplete=false and a caveat — so an incomplete combo
+                // would otherwise leave the portal silent while the verifier folds it into a
+                // NotVerifiable nobody can attribute. THE DENOMINATOR travels with it.
+                if (!combo.IsComplete)
+                    logger?.LogInformation(
+                        "Instance combo served INCOMPLETE: {Modules} module(s), caveats: {Caveats}",
+                        combo.Modules.Count, string.Join(" | ", combo.Caveats));
+
+                // The producer deserializes with these exact options, so this response IS
+                // combo.json. Results.Json would re-serialize with ASP.NET's options instead.
+                return (IResult)Results.Content(
+                    JsonSerializer.Serialize(combo, InstanceComboAssembler.Json), "application/json");
+            });
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md
@@ -138,9 +138,15 @@ It lives in its own workflow rather than inside `main-cd.yml` for one reason: th
 and will persist until an operator provisions the credentials, and a red inside the workflow that
 publishes the fleet's images would be read as "delivery failed".
 
-`check-combo-verify-preflight.py` executes the preflight's real `run:` text over five scenarios —
-including the empty-instance-list case, whose empty matrix would otherwise skip `verify` into a
-green — and runs on every platform PR, because `combo-verify.yml` itself never fires on one.
+`check-combo-verify.py` runs on every platform PR — because `combo-verify.yml` itself never fires on
+one — and opens both halves of the lane's shell. It executes the preflight's real `run:` text over
+five scenarios, including the empty-instance-list case whose empty matrix would otherwise skip
+`verify` into a green; and it executes the lander's real verdict-merge `jq` over both node shapes
+`/api/mesh/get` can return. That second half guards a data-loss path rather than a wrong answer: the
+merge re-sends the WHOLE list, so reading the `{node, compilationError}` wrapper as if it were the
+bare node yields null, null merges as an empty list, and the landing would replace up to eight
+recorded verdicts with one. Both halves carry a `--self-test` that substitutes the defect and
+requires the guard to catch it.
 
 ## The three verdicts, and the fourth state
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md
@@ -75,6 +75,73 @@ So `ComboVerificationGate` has two modes, and they are the same code path:
 assembly policy — as one optional service, so the gate is identical whether it produced the verdict
 or read one somebody else landed.
 
+## Who actually produces one: `combo-verify.yml`
+
+For most of this page's life the answer was **nobody**, and that made every sentence above
+describe a mechanism that never ran. Measured 2026-09-07 (issue #3544):
+
+- zero references to `mw-combo-verify` anywhere under `.github/` in this repo or MeshWeaver.Plugins;
+- `RecordVerification` called from exactly one place, the in-process producer path;
+- no production `IComboGateRunner` registered anywhere — the only implementation in either repo was
+  a test fake, so `ResolveRunner()` returned null on every portal;
+- `Admin/UpdatePolicy.comboVerifications` was `[]` on memex-cloud, and both portals said so in their
+  own words: *"no combo-gate runner is registered on this host, so it produces no verdicts of its
+  own — they are landed here by mw-combo-verify."*
+
+So every self-update rolled `UNVERIFIED`, said so in the log, and **applied the update anyway**. The
+gate built to prevent a `MissingMethodException`-at-boot roll was never once consulted with data.
+
+`.github/workflows/combo-verify.yml` is the producer. It runs off the CD workflow's completion, and
+per instance it does exactly the three steps
+[Candidate Release Protocol](/Doc/Architecture/CandidateReleaseProtocol) describes:
+
+1. **Ask the instance what it would roll to** — `GET /api/plugins/roll-target`. The candidate is
+   asked OF the instance rather than derived in CI, because "the newest tag" is not the question the
+   gate answers: `ReleaseAvailabilityService` already walks the completeness rule and names the
+   release this environment would actually take. Re-deriving it would be a second rule.
+2. **Ask the instance what it runs** — `GET /api/plugins/combo`, added by #3544 beside its two
+   `mwi_`-gated siblings. Its body is an `InstanceCombo` serialized with
+   `InstanceComboAssembler.Json`, i.e. it **is** `combo.json`, byte-for-byte what `mw-combo-verify`
+   deserializes. Before it existed, `InstanceComboReader` had no HTTP, MCP or layout surface at all
+   and the producer's first input was simply unobtainable from a running portal.
+3. **Verify, then LAND the verdict** — `mw-combo-verify combo.json <acr>/memex-portal-ai:<candidate>`,
+   then a read-merge-write onto `Admin/UpdatePolicy` through `/api/mesh/get` + `/api/mesh/patch`.
+
+🚨 **The verdict is landed BEFORE the job's exit code is decided.** A Red that never reaches the
+instance is worse than no verdict at all — the instance's own gate would then clear a candidate that
+run had already proved it cannot serve.
+
+🚨 **An RFC 7396 merge patch replaces an array wholesale**, so the whole list is sent and the merge
+rule is not reinvented in CI: upsert by `candidateTag` (case-insensitive), newest first, capped at
+`MaxRecordedVerifications` = 8 — the rule `UpdatePolicyNodeType.RecordVerification` applies
+in-process.
+
+🚨 **Green is the only pass.** A `Red` fails the job (delivery promoted a candidate a live instance
+must refuse) and a `NotVerifiable` fails it too — that outcome means *nothing was checked*, which is
+"the gate never ran" wearing the colour of "the gate passed".
+
+### Why it is its own workflow, and why its preflight is red until provisioned
+
+The lane needs two credentials per instance that nothing in CI holds today: an `mwi_`
+instance-registry key (reads `roll-target` and `combo`) and an `mw_` API token of a **global admin**
+on that instance (lands the verdict; the token authenticates as its owner and carries no scope of
+its own). The declaration of *which* instances to verify does not exist in this repo either.
+
+A gate must never test its own inputs, so none of that is expressed as `continue-on-error` or
+`if: secrets.X != ''`. A `preflight` job asserts every input and fails **RED naming what to
+provision**; `verify` `needs:` it and carries no input condition at all. Because a `needs:` failure
+*skips* `verify`, and GitHub paints a skipped job the same colour as a passed one, a third job —
+`verdict` — runs `if: always()` and fails explicitly on anything that is not a success, and prints
+the instance count so a zero cannot read as a pass.
+
+It lives in its own workflow rather than inside `main-cd.yml` for one reason: that red is correct
+and will persist until an operator provisions the credentials, and a red inside the workflow that
+publishes the fleet's images would be read as "delivery failed".
+
+`check-combo-verify-preflight.py` executes the preflight's real `run:` text over five scenarios —
+including the empty-instance-list case, whose empty matrix would otherwise skip `verify` into a
+green — and runs on every platform PR, because `combo-verify.yml` itself never fires on one.
+
 ## The three verdicts, and the fourth state
 
 `ComboVerification` is explicit that Green, Red and NotVerifiable are never conflated. The roll-side

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-something-now-checks-an-update-before-your-portal-takes-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-something-now-checks-an-update-before-your-portal-takes-it.md
@@ -1,0 +1,46 @@
+---
+Name: Something now checks an update before your portal takes it
+Category: Fix
+Description: Your portal has always had a gate that asks whether a new platform version can still serve the modules you actually run — and nothing in the fleet ever answered it, so every update rolled out unchecked and said so in a log nobody was reading. Delivery now runs that check per instance and lands the answer where the gate looks.
+Icon: ShieldCheckmark
+Order: -20260907
+---
+
+# Something now checks an update before your portal takes it
+
+Your portal updates itself. Before it does, it consults a verdict about the specific combination in
+front of it: *can this new platform version still serve the modules this instance has installed?* A
+new version can be perfectly good in general and still be wrong for one instance, because that
+instance carries modules pinned at particular commits.
+
+The verdict has to be produced somewhere else. Producing one means pulling the candidate image,
+materialising every module at the exact ref this instance runs, and executing the module tests
+inside that image — which needs a machine with Docker, a scratch disk and repository access. A
+portal does not have those, deliberately.
+
+The tool that does it was written, documented and built — and connected to nothing. No workflow
+anywhere in the fleet ever ran it, so no verdict was ever produced, and the gate consulted an empty
+list every time. The portal was honest about it in its own log:
+
+> applied update 3.1.0-ci.7841 … UNVERIFIED — no combo verification has been recorded for
+> '3.1.0-ci.7841' on this instance … nothing has checked whether that image can serve the modules
+> this instance runs.
+
+Note the first word. It applied the update anyway. A gate that is never given data does not hold
+anything back.
+
+Delivery now runs the check. After a release is published, each declared instance is asked which
+version it would roll to and which modules it actually runs; the candidate is verified against that
+exact combination on a build machine; and the answer is written back to the instance, where its own
+gate reads it before the next update check. A verdict that says the candidate cannot serve an
+instance now holds that instance back — and the run that produced it goes red, so the problem is
+seen by the people shipping rather than only by the portal refusing.
+
+Two smaller things came with it. Your portal can now state its own module inventory to an
+authenticated operator, which is what made the check possible at all. And the "nothing was
+checkable" outcome is treated as a failure rather than a pass — a check that could not run is not a
+check that passed.
+
+Until an operator provisions the per-instance credentials the check needs, the new workflow fails
+with a message naming exactly what is missing. That red is the point: it is the difference between
+"we looked" and "nobody ever looked".

--- a/test/Memex.Portal.Shared.Test/ReleaseGateAuthTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseGateAuthTest.cs
@@ -122,4 +122,38 @@ public class ReleaseGateAuthTest
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
+
+    // ── the COMBO route (#3544) ─────────────────────────────────────────────────────────────────
+    // The strictest of the three, and the one most worth pinning: its body names every module
+    // REPOSITORY and every pinned COMMIT this deployment carries. Same auth, same fail-closed
+    // order, same 401-not-404 discipline.
+
+    [Fact]
+    public async Task TheComboRouteRejectsAnUnauthenticatedCaller()
+    {
+        using var response = await Get(ReleaseGateEndpoints.ComboRoute, authorization: null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TheComboRouteRejectsAnUnparseableBearer()
+    {
+        using var response = await Get(ReleaseGateEndpoints.ComboRoute, "Bearer not-an-instance-key");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TheComboRouteAuthenticatesBeforeItReadsTheInstanceCombo()
+    {
+        // InstanceComboReader is NOT registered here, so a 500 would mean the handler resolved it
+        // before authenticating — i.e. an unauthenticated caller could make the portal walk three
+        // mesh-wide queries. The reader is touched only inside the authenticated branch.
+        var basic = Convert.ToBase64String(Encoding.UTF8.GetBytes("user:nope"));
+
+        using var response = await Get(ReleaseGateEndpoints.ComboRoute, "Basic " + basic);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
 }


### PR DESCRIPTION
## The gate consults a verdict that nothing in the fleet produces

Every portal's `ComboVerificationGate` consults `Admin/UpdatePolicy` → `content.comboVerifications`
before it applies a self-update. **Nothing ever wrote one.** Measured 2026-09-07:

- zero references to `mw-combo-verify` / `ComboVerify` anywhere under `.github/` in this repo **or**
  MeshWeaver.Plugins — no workflow invoked it;
- `RecordVerification` called from exactly one place, `ComboVerificationGate.cs:187`, i.e. the
  in-process producer path;
- **no production `IComboGateRunner` registered anywhere** — the only implementation in either repo
  is `ComboGateRollTest.FakeGateRunner`, so `ResolveRunner()` returns `null` on every portal;
- `Admin/UpdatePolicy.comboVerifications` is `[]` on memex-cloud, and both portals say so in their
  own words: *"no combo-gate runner is registered on this host, so it produces no verdicts of its
  own — they are landed here by mw-combo-verify."*

So every roll ran `UNVERIFIED`, logged that it had, **and applied the update anyway**. The gate built
to stop a `MissingMethodException`-at-boot roll was never once consulted with data.

And it could not have been wired as it stood: **`InstanceComboReader` had no HTTP, MCP or layout
surface at all**, so the producer's first input — the instance's own combo — was unobtainable from a
running portal. `execute-script` takes a node path, not inline C#; the nearest readable node
(`Hosting/ModuleInventory`) drops `readAt`, `isComplete`, `caveats` and the per-module sync detail,
so a verdict derived from it would be about something other than the instance's real module set.

## What this adds

**`GET /api/plugins/combo`** on `ReleaseGateEndpoints`, beside its two `mwi_`-gated siblings. The
body is an `InstanceCombo` serialized with `InstanceComboAssembler.Json` — the exact options
`mw-combo-verify` deserializes with — so the response **is** `combo.json`, byte-for-byte, and no
caller reshapes it. Same fail-closed instance-key auth and the same authenticate-before-you-resolve-
anything order as its siblings, for the same reason (a combo names every module repository and
pinned commit this deployment carries).

**`.github/workflows/combo-verify.yml`.** Off the CD workflow's completion, per instance:

1. `GET /api/plugins/roll-target` — the candidate is asked **of the instance**, because
   `ReleaseAvailabilityService` already walks the completeness rule and names the release that
   environment would actually take; re-deriving "the newest tag" in CI would be a second rule.
2. `GET /api/plugins/combo` — what it actually runs.
3. `mw-combo-verify`, then **land** the verdict by read-merge-write on `Admin/UpdatePolicy`
   (`/api/mesh/get` + `/api/mesh/patch`). An RFC 7396 merge patch replaces an array wholesale, so
   the whole list is sent — upsert by `candidateTag` (case-insensitive), newest first, capped at 8,
   the rule `UpdatePolicyNodeType.RecordVerification` applies in-process, not a new one.

🚨 **Landed before the exit code is decided.** A Red that never reaches the instance is worse than no
verdict — the instance's own gate would then clear a candidate this run proved it cannot serve.
🚨 **Green is the only pass.** `Red` fails the job (delivery promoted something a live instance must
refuse); `NotVerifiable` fails it too, because that outcome means *nothing was checked* — "the gate
never ran" wearing the colour of "the gate passed".

## No skip trapdoors

No `continue-on-error:` on any input step, and **no `if:` anywhere that asks whether a secret or
variable is set.** A `preflight` job asserts every input and fails **RED naming what to provision**;
`verify` `needs:` it and carries no input condition at all. The one `if:` in the file is on the
EVENT (did CD succeed, i.e. is there a candidate), the same shape `main-cd.yml`'s own preflight uses.

Because a `needs:`-failure *skips* `verify`, and GitHub paints a skipped job the same colour as a
passed one, a third job — `verdict` — runs `if: always()` and fails **explicitly** on anything that
is not a success, and prints the instance count so a zero cannot read as a pass.

It is **its own workflow**, not a job in `main-cd.yml`, for one reason: the red is correct and will
persist until an operator provisions the credentials, and a red inside the workflow that publishes
the fleet's images would be read as "delivery failed". Image delivery is untouched.

## Verification, and the negative control

`.github/scripts/check-combo-verify-preflight.py` **executes the preflight's real `run:` text**
(extracted from the shipped YAML by path, never retyped, with a sentinel so a moved preflight fails
loud instead of testing nothing) over five scenarios. Run locally:

```
[PASS] nothing provisioned: exit=1 → names vars.COMBO_VERIFY_INSTANCES
[PASS] instance list present, the keys secret absent: exit=1 → names secrets.COMBO_VERIFY_KEYS
[PASS] list present but an EMPTY array (the vacuous-green shape): exit=1
[PASS] an instance in the list has no admin token: exit=1 → names 'memex-cloud'
[PASS] everything provisioned: exit=0 → emits instances=[…] | count=2
```

**The gate was made to fail before it was made to pass**: `--self-test` substitutes a preflight that
asserts nothing and requires the harness to catch it — a gutted preflight fails 5 of 5 scenarios.
The empty-array case is the one that matters most: an empty matrix skips `verify`, and a skipped job
is green.

Also run clean locally: `check-workflow-timeouts.py` (74 jobs, 0 violations — the three new jobs are
capped 5/40/5), `check-workflow-shell.py` (0 live findings), `check-pr-secret-preflight.py`,
`actionlint`, `shellcheck` on the new script, `ReleaseGateAuthTest` (10/10, 3 of them new),
`MeshWeaver.Documentation.Test` (304/304). `dotnet build -c Release -warnaserror` clean on
`Memex.Portal.Shared`, `MeshWeaver.ComboVerifier`, `MeshWeaver.Documentation` and
`Memex.Portal.Shared.Test`.

`WorkflowRunTriggerBranchFilterGuard` caught a real defect in the first draft (a `workflow_run`
trigger sharing a concurrency group with no `branches:` filter) — fixed, and it now passes.

## 🚨 Provisioning the maintainer must do (the preflight names each one)

```bash
gh variable set COMBO_VERIFY_INSTANCES --repo Systemorph/MeshWeaver \
  --body '[{"name":"memex","baseUrl":"https://memex.systemorph.com"},{"name":"memex-cloud","baseUrl":"https://memex.meshweaver.cloud"}]'
gh variable set COMBO_VERIFY_SOURCES --repo Systemorph/MeshWeaver \
  --body 'plugins=https://github.com/Systemorph/MeshWeaver.Plugins'
gh secret set COMBO_VERIFY_KEYS --repo Systemorph/MeshWeaver \
  --body '{"memex":"mwi_…","memex-cloud":"mwi_…"}'
gh secret set COMBO_VERIFY_TOKENS --repo Systemorph/MeshWeaver \
  --body '{"memex":"mw_…","memex-cloud":"mw_…"}'
```

`COMBO_VERIFY_KEYS` holds each portal's **instance-registry key** (`mwi_…`); `COMBO_VERIFY_TOKENS`
holds an **API token of a global admin** on each portal (`mw_…`). The `mw_` tokens are minted
**cookie-only**, per portal: Settings → Security → API Tokens → Generate, or `POST /api/tokens` with
a browser session. They authenticate as their owner and carry no scope, so the owner must be a
global admin (`Permission.All` at scope `Admin`) to patch `Admin/UpdatePolicy`. `AZURE_*` and
`MESHWEAVER_APP_*` are already provisioned (main-cd / chart-drift).

**Ordering note, stated rather than discovered:** `/api/plugins/combo` ships in the portal image, so
each instance must be rolled to an image built from this commit before its verification can succeed.
Until then the script fails with a message that says exactly that. There is deliberately no lossy
fallback.

## Public surface

Additive only — a new `public const string ComboRoute` and two private handlers. No public type or
member removed; nothing added to a public interface.

Pairs-with: none — nothing is removed from `src/`; the change is additive.

## Work products conserved

`src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md` gains
*"Who actually produces one: `combo-verify.yml`"* — the measurement, the three steps, why Green is
the only pass, and why the preflight is red until provisioned. Plus a What's New entry
(`Category: Fix`).

Closes #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
