### PR TITLE
fix(#3511): the corpus records the five selectors MeshWeaver.Plugins#1439 closed

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-five-more-fields-now-mean-the-same-thing-on-both-backends.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-five-more-fields-now-mean-the-same-thing-on-both-backends.md
@@ -1,0 +1,39 @@
+---
+Name: Five more search fields now mean the same thing on both backends
+Category: Fix
+Description: Who created a node, when, who last changed it, its desired id and its sync behaviour were read from the node itself when a search ran in memory and from an empty content field when the same search ran against the database. The two backends now agree, and the list of fields they still disagree about is half what it was.
+Icon: Search
+Order: -20260907
+---
+
+# Five more search fields now mean the same thing on both backends
+
+The query language has two implementations — one that runs in memory and one that runs against the
+database — and a shared list records, field by field, where each of them reads a value from. When
+the two rows differ, the same search returns different results depending on which backend answered.
+
+Ten fields were on that disagreement list. Five of them have now been closed: **who created a
+node**, **when it was created**, **who last changed it**, its **desired id**, and its **sync
+behaviour**. The in-memory backend always read these from the node itself; the database backend
+looked inside the node's content, where almost nothing keeps a copy, and answered "nothing
+matches" — while the value sat right there on the node being returned.
+
+## What changes here
+
+Only the shared record. The database-side fix lives with that backend, and it is more than a longer
+list of names: those five columns exist on the main table and **not** on the tables that hold
+threads, activities, access records and comments, so the same field has to resolve differently
+depending on what is being searched. The record now says so per field, and each backend's own tests
+hold it to exactly that.
+
+## What is still on the list, and why
+
+Five names remain. Four of them — whether a node is definition-only, whether it is a satellite
+type, its pre-rendered HTML, and whether it names a main node explicitly — exist only on the
+in-memory representation. There is no column behind them, so no amount of widening reaches them.
+
+The fifth is the interesting one: the per-node **"hide this from search / from the header / from
+create"** list. It does have a real column, but it holds several values at once rather than one, so
+asking about it means asking "is this one of them" — a different question from the "is it equal to
+this" every other filter asks. It stays on the list on purpose, with that reason recorded next to
+it, rather than being closed in a way that would break the query outright.

--- a/test/MeshWeaver.Fixture/SelectorResolutionCorpus.cs
+++ b/test/MeshWeaver.Fixture/SelectorResolutionCorpus.cs
@@ -116,22 +116,48 @@ public static class SelectorResolutionCorpus
         Content("accessObject", "n.content->>'accessObject'",
             "the AccessAssignment listing in UserActivityLayoutAreas"),
 
-        // ── Divergences: on MeshNode but NOT in the SQL PropertyMap ───────────────────────────
-        // Each of these has a REAL mesh_nodes column that MapSelector does not know about, so SQL
-        // reads the content field of the same name — which is empty for essentially every node —
-        // while the evaluator reads the node property. Same family as Plugins#1310, where the
-        // authorship columns were left out of a SELECT list and every queried node came back with
-        // CreatedBy = null while the row held the value.
-        Divergent("createdBy", "n.content->>'createdBy'",
-            "n.created_by is a real mesh_nodes column (AuthorColumns) and MapSelector's PropertyMap "
-            + "does not list it"),
-        Divergent("createdDate", "n.content->>'createdDate'", "n.created_date, same omission"),
-        Divergent("lastModifiedBy", "n.content->>'lastModifiedBy'", "n.last_modified_by, same omission"),
-        Divergent("desiredId", "n.content->>'desiredId'", "n.desired_id is projected but unmapped"),
-        Divergent("syncBehavior", "n.content->>'syncBehavior'",
-            "n.sync_behavior is projected (SyncBehaviorColumn) but unmapped"),
+        // ── Closed by Plugins#1439: real mesh_nodes columns MapSelector now knows about ────────
+        // Each of these was a divergence — SQL read the content field of the same name, empty for
+        // essentially every node, while the evaluator read the node property. Same family as
+        // Plugins#1310, where the authorship columns were left out of a SELECT list and every
+        // queried node came back with CreatedBy = null while the row held the value.
+        //
+        // 🚨 They could not simply be added to PropertyMap, and the reason is recorded here because
+        // it is what the SqlExpression column means. A SATELLITE table (threads, activities,
+        // access, …) has NEITHER authorship NOR sync_behavior NOR exclude_from_context —
+        // PostgreSqlSchemaInitializer.GetSatelliteTableScript gives it none of them — so a single
+        // table-blind map could only ever hold the INTERSECTION of the two schemas, which is
+        // exactly why these six sat outside it. Naming a mesh_nodes-only column unconditionally
+        // would not read the wrong side, it would fail the statement with `42703 column
+        // n.created_by does not exist` on every satellite query — starting with
+        // `nodeType:Thread createdBy:{user}`, which ChatHistorySelector.razor issues on every chat
+        // page load. MapSelector is therefore TABLE-AWARE, and the expression below is the one it
+        // emits for mesh_nodes: the canonical mapping, and what the one-argument overload answers.
+        // On a satellite these four still resolve to `n.content->>'<name>'`, which is what
+        // ThreadQueries deliberately relies on for a thread's own content.createdBy.
+        AgreedOnMeshNodes("createdBy", "n.created_by",
+            "n.created_by (AuthorColumns) — mesh_nodes only; a satellite keeps the content read"),
+        AgreedOnMeshNodes("createdDate", "n.created_date",
+            "n.created_date (AuthorColumns) — mesh_nodes only, and TIMESTAMPTZ, so the comparison "
+            + "must not be case-folded"),
+        AgreedOnMeshNodes("lastModifiedBy", "n.last_modified_by",
+            "n.last_modified_by (AuthorColumns) — mesh_nodes only"),
+        AgreedOnMeshNodes("syncBehavior", "n.sync_behavior",
+            "n.sync_behavior (SyncBehaviorColumn) — mesh_nodes only, and SMALLINT holding a "
+            + "SyncBehavior, so the value converts by enum name the way state does"),
+        // desired_id is the one of the six that IS on every table, satellite DDL included, and both
+        // SELECT lists already project it. It was simply never mapped.
+        Agreed("desiredId", "n.desired_id"),
+
+        // ── Divergences PropertyMap alone cannot close ─────────────────────────────────────────
         Divergent("excludeFromContext", "n.content->>'excludeFromContext'",
-            "n.exclude_from_context is projected (ExcludeFromContextColumn) but unmapped"),
+            "n.exclude_from_context IS a real mesh_nodes column, and it is still read from the "
+            + "content — the ONLY one of #1439's six left open, for a reason of TYPE rather than "
+            + "of omission. It is TEXT[] while every comparison the generator emits is scalar "
+            + "(LOWER(x) = @p0, x != @p0, x IN (…)), so mapping it would trade a silent-empty for "
+            + "`42883 operator does not exist: text[] = text`. Closing it means giving the selector "
+            + "ARRAY semantics (containment), which is a different change from widening a map. "
+            + "Nothing queries it today: the context opt-outs are filtered through excludedNodeTypes"),
         Divergent("isDefinitionOnly", "n.content->>'isDefinitionOnly'",
             "MeshNode-only: no column, so SQL can never answer it and the two cannot be reconciled "
             + "by widening PropertyMap alone"),
@@ -152,6 +178,16 @@ public static class SelectorResolutionCorpus
     private static SelectorCase Agreed(string selector, string sql) =>
         new(selector, SelectorSide.NodeField, SelectorSide.NodeField, sql,
             "a node field on both sides");
+
+    /// <summary>
+    /// A node field on both sides <b>for <c>mesh_nodes</c></b> — the canonical table, and the one
+    /// <c>MapSelector(selector)</c>'s single-argument overload answers for. The column does not
+    /// exist on a satellite table, where the SQL side still reads the content field of the same
+    /// name; see the comment on the cases that use this for why that is correct rather than a
+    /// residual gap.
+    /// </summary>
+    private static SelectorCase AgreedOnMeshNodes(string selector, string sql, string note) =>
+        new(selector, SelectorSide.NodeField, SelectorSide.NodeField, sql, note);
 
     private static SelectorCase Content(string selector, string sql, string note) =>
         new(selector, SelectorSide.ContentField, SelectorSide.ContentField, sql, note);

--- a/test/MeshWeaver.Hosting.Test/SweepSelectorReachesTheCompileStatusTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SweepSelectorReachesTheCompileStatusTest.cs
@@ -205,18 +205,23 @@ public class SweepSelectorReachesTheCompileStatusTest
     public void TheProvidersDisagreeOnExactlyTheRecordedSelectors()
         => string.Join(", ", SelectorResolutionCorpus.KnownDivergences.Select(c => c.Selector))
             .Should().Be(
-                "createdBy, createdDate, lastModifiedBy, desiredId, syncBehavior, "
-                + "excludeFromContext, isDefinitionOnly, isSatelliteType, preRenderedHtml, "
+                "excludeFromContext, isDefinitionOnly, isSatelliteType, preRenderedHtml, "
                 + "hasExplicitMainNode",
                 "🚨 #3511 does NOT close every divergence, and the residue is pinned so it cannot "
                 + "grow in silence. Each of these is a MeshNode property that MapSelector's "
                 + "PropertyMap does not list, so Postgres reads the content field of the same name "
                 + "— empty for essentially every node — while this evaluator reads the property. "
-                + "The first six have a REAL mesh_nodes column behind them (created_by, "
-                + "created_date, last_modified_by, desired_id, sync_behavior, "
-                + "exclude_from_context), so those are a Plugins fix: widen PropertyMap. The last "
-                + "four exist only on MeshNode and cannot be reconciled that way. Adding a name "
-                + "here is a claim that a provider changed — do not do it to make a test pass");
+                + "Adding a name here is a claim that a provider changed; REMOVING one is a claim "
+                + "that a divergence was CLOSED, and neither is ever done to make a test pass. "
+                + "Five names left in MeshWeaver.Plugins#1439, which widened PropertyMap for "
+                + "createdBy, createdDate, lastModifiedBy, desiredId and syncBehavior and pinned "
+                + "each one there; the last four exist only on MeshNode and have no column at all, "
+                + "so no widening can reach them. excludeFromContext is the interesting one and it "
+                + "stays: exclude_from_context IS a real column, but it is TEXT[] while every "
+                + "comparison that generator emits is scalar, so mapping it would trade a "
+                + "silent-empty for `42883 operator does not exist: text[] = text`. Closing it "
+                + "means giving the selector ARRAY semantics, which is a different change from "
+                + "widening a map");
 
     /// <summary>
     /// 🚨 <b>The fallback widens what reaches the SORT comparator, and the comparator has to be


### PR DESCRIPTION
## The corpus records the five selectors MeshWeaver.Plugins#1439 closed

`SelectorResolutionCorpus` recorded **ten** selectors the two query providers disagree about.
MeshWeaver.Plugins#1439 closes five of them — `createdBy`, `createdDate`, `lastModifiedBy`,
`desiredId` and `syncBehavior` now read the real `mesh_nodes` column instead of an empty content
field of the same name — so those rows are flipped and the residue ratchet drops from ten names
to five.

The corpus is measured behaviour, so this is the half of #3511's issue text that said: *"Adding
these to `PropertyMap` changes what an existing query means, so flip the corresponding rows in the
same change set."*

## What the rows now say, and why the `SqlExpression` column needed a note

🚨 The plugins-side fix could **not** be a longer list of names, and the reason belongs here
because it is what `SqlExpression` now MEANS.

A satellite table — `threads`, `activities`, `access`, … — has **neither authorship nor
`sync_behavior` nor `exclude_from_context`** (`PostgreSqlSchemaInitializer.GetSatelliteTableScript`
gives it none of them). So the SQL side's map could only ever hold the **intersection** of the two
schemas, which is precisely why these six sat outside it. Naming a mesh_nodes-only column
unconditionally would not read the wrong side — it would fail the statement with `42703 column
n.created_by does not exist` on every satellite query, starting with `nodeType:Thread
createdBy:{user}`, which `ChatHistorySelector.razor` issues on every chat page load.

`MapSelector` is therefore **table-aware**, and the expression recorded here is the one it emits
for `mesh_nodes` — what its single-argument overload answers, which is the mapping this corpus has
always described. Four of the five still fall back to the content read on a satellite, which is
what `ThreadQueries` deliberately relies on for a thread's own `content.createdBy`. `desiredId` is
on every table and is plainly `Agreed`.

## `excludeFromContext` stays, and its note is corrected

It was recorded as *"projected but unmapped"* — an omission. It is not. `exclude_from_context` is
**`TEXT[]`** while every comparison that generator emits is scalar (`LOWER(x) = @p0`, `x != @p0`,
`x IN (…)`), so mapping it would trade a silent-empty for
`42883 operator does not exist: text[] = text`. Closing it means giving the selector **array
semantics** (containment), which is a different change from widening a map — and nothing queries it
today: the context opt-outs are filtered through `excludedNodeTypes`, never through this selector.

## The ratchet

`TheProvidersDisagreeOnExactlyTheRecordedSelectors` says *"adding a name here is a claim that a
provider changed"*. **Removing** one is a claim that a divergence was closed, and the claim is
backed: MeshWeaver.Plugins#1439 pins each of the five to its column, measured **failing first** on
the un-fixed generator (all five plus `MapOrderByForUnionWrap("createdDate")` read the content
field), then green. That comment now states both directions.

## Verification

| | |
|---|---|
| `MeshWeaver.Fixture` | `dotnet build -c Release -warnaserror` → `0 Error(s)` |
| `MeshWeaver.Hosting.Test` | `dotnet build -c Release -warnaserror` → `0 Error(s)` |
| `SweepSelectorReachesTheCompileStatusTest` | **37 / 37 passed** (was 36/37 with the flip and the stale ratchet) |
| `MeshWeaver.Documentation` | `0 Error(s)`; `DocumentationLinkIntegrityTest` passed |

## Pairing

Nothing public leaves `src/` here — this is test-fixture data plus one test expectation, so no
`Pairs-with:` is owed. The plugins half is Systemorph/MeshWeaver.Plugins#1439's PR; neither blocks
the other, because MeshWeaver.Plugins' `MW_PLATFORM_REF` does not yet carry `SelectorResolutionCorpus`
at all (measured: the pin `aa4075832` predates #3534's merge), so no plugins test consumes these
rows today.

Refs Systemorph/MeshWeaver.Plugins#1439, #3511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
