### PR TITLE
fix(#3548): the migration Job mounts the SecretProviderClass it reads, so its vault values are current

### DIFF
--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -67,10 +67,64 @@ spec:
                    pod has started yet, and a missing non-optional secretRef would keep the Job
                    from starting at all. Skipping is safe there and only there: a first install has
                    no pre-existing rows to backfill, and the run still says so out loud via
-                   `[EmbeddingBackfill] … skipped` plus EmbeddingCapabilityReporter. */}}
+                   `[EmbeddingBackfill] … skipped` plus EmbeddingCapabilityReporter.
+
+                   🚨 The envFrom alone gives the Job a value, not a CURRENT value — which is why
+                   the volumeMounts below are not optional decoration. See their comment. */}}
             {{- range $class := (include "memex.keyVaultClasses" . | fromYamlArray) }}
             - secretRef:
                 name: "{{ $class.syncedSecret }}"
                 optional: true
             {{- end }}
           imagePullPolicy: "IfNotPresent"
+          {{- /* 🚨 THE JOB MOUNTS THE SPC ITSELF — this is what makes the values above CURRENT
+                 (MeshWeaver#3548).
+
+                 The synced Secret the envFrom reads is materialised and rotated by the CSI driver
+                 FOR THE PODS THAT MOUNT THE SecretProviderClass VOLUME. Until this block existed
+                 that was the portal pods and nobody else: the Job mounted nothing, started the
+                 instant `helm upgrade` applied, and `envFrom` is resolved once at container start.
+                 So on any deploy that CHANGES an SPC mapping, the Job read the value from BEFORE
+                 the change — and the backfill logs-and-skips per row rather than failing.
+
+                 Measured on the `memex` release 2026-09-07, job memex-migration-33, the deploy that
+                 repointed `Embedding__ApiKey` from the Azure object to the OpenRouter one:
+                     [DocBackfill] 1274 documentation pages found (embeddings ON)
+                     EmbeddingRequestException: … HTTP 401 (Unauthorized) — the bearer was
+                       rejected …                                              × 1260
+                     [DocBackfill] done: 1274 upserted (0 embedded), 0 unchanged, 1274 total
+                     Database migration completed.
+                 1,260 refusals and a GREEN Job. A portal pod that started minutes later held the
+                 SAME key name and got 200s, so the vault was right and the Job's copy was stale.
+
+                 A CSI mount is set up before ANY container in the pod starts, and NodePublishVolume
+                 fetches the objects from the vault at that moment — so the driver refreshes the
+                 synced Secret before the kubelet resolves this container's envFrom. The Job then
+                 gets the current objects BY CONSTRUCTION, independent of the portal pods' rotation
+                 poll. That is the whole point: not a retry, not a second `helm upgrade`, an
+                 ordering that cannot be lost.
+
+                 Same volumeName/mountPath as the portal, from the one `memex.keyVaultClasses`
+                 block, so the class, the volume, the mount and the envFrom can never disagree on a
+                 name. Rendered only when a class is declared — a namespace with no Key Vault gets
+                 the pod spec it had before. */}}
+          {{- $keyVaultClasses := (include "memex.keyVaultClasses" . | fromYamlArray) }}
+          {{- if $keyVaultClasses }}
+          volumeMounts:
+            {{- range $class := $keyVaultClasses }}
+            - name: "{{ $class.volumeName }}"
+              mountPath: "{{ $class.mountPath }}"
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      {{- if $keyVaultClasses }}
+      volumes:
+        {{- range $class := $keyVaultClasses }}
+        - name: "{{ $class.volumeName }}"
+          csi:
+            driver: "secrets-store.csi.k8s.io"
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "{{ $class.name }}"
+        {{- end }}
+      {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -269,7 +269,11 @@ replicas:
 #
 # 🚨 A declared object that does NOT exist in the vault fails the whole mount:
 # the pod stays ContainerCreating and the rollout stalls while the OLD pod
-# keeps serving. Create the vault secret BEFORE declaring it here.
+# keeps serving. Create the vault secret BEFORE declaring it here. Since
+# MeshWeaver#3548 the run-once migration Job mounts these classes too — it
+# CONSUMES their values, so it must be the one that fetches them — which means
+# a missing vault object stalls the migration as well, loudly, instead of
+# letting it run green against whatever the last mount left behind.
 #
 # 🚨 A new or changed vault value needs the pod to RESTART (the driver reads
 # the vault at pod start) — see Doc/Architecture/DeploymentAKS → "KeyVault CSI

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -277,6 +277,22 @@ Operational facts about the in-pod updater (learned the hard way — each cost a
   pod's mount populates the synced k8s Secret, but that pod's `envFrom` snapshot predates it; the
   second restart reads the populated Secret. Verify with `printenv <key> | md5sum` in the NEWEST
   pod (sort by `creationTimestamp`).
+- **🚨 A workload that READS a synced Secret must MOUNT the class that feeds it.** The driver
+  fetches and rotates *for the pods that mount the SecretProviderClass volume*. A pod that only
+  lists the synced Secret in `envFrom` is a **free rider**: it reads whatever some other pod's
+  mount last wrote, and `envFrom` is resolved once, at container start. The migration Job was
+  exactly that until #3548 — it mounted nothing and starts the instant `helm upgrade` applies, i.e.
+  before the portal pods that own the rotation have rolled. So on the `memex` release of
+  2026-09-07, the deploy that repointed `Embedding__ApiKey` from the Azure object to the OpenRouter
+  one ran the embedding backfill with the PREVIOUS key: **1,260 × HTTP 401,
+  `1274 upserted (0 embedded)`, and `Database migration completed`** — a green Job that
+  authenticated with a stale credential and embedded nothing, while a portal pod started minutes
+  later held the same key name and got 200s. The cure is structural, not a retry: a CSI mount is
+  set up before ANY container in the pod starts and fetches from the vault at that moment, so a
+  mounting pod's `envFrom` resolves against a freshly written Secret by construction. The chart now
+  renders the volume + volumeMount for the Job from the same `memex.keyVaultClasses` block that
+  renders its `envFrom`, and `KeyVaultCsiFreshnessGuard` fails any pod-bearing template that reads
+  a class without mounting it.
 - **🚨 Namespace ↔ instance mapping**: this cluster hosts several instances whose Deployments all
   share names (`memex-portal-deployment`): namespace `memex` = the systemorph.com company portal,
   `memex-cloud` = **memex.meshweaver.cloud** (SPC `<database>-portal-ai-secrets`, KeyVault

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-deploy-that-changes-a-key-no-longer-runs-the-backfill-with-the-old-one.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-deploy-that-changes-a-key-no-longer-runs-the-backfill-with-the-old-one.md
@@ -1,0 +1,35 @@
+---
+Name: A deploy that changes a key no longer runs the backfill with the old one
+Category: Fix
+Description: The database migration read its vault-backed settings from a copy another pod was responsible for refreshing, so a deploy that changed one of them ran with the previous value — and reported success. It now fetches them itself, before it starts.
+Icon: Key
+Order: -20260907
+---
+
+# A deploy that changes a key no longer runs the backfill with the old one
+
+Some settings a deployment needs — an API key for the search index's embedding provider, for
+instance — are held in a key vault rather than in the deployment's own configuration. The platform
+reads them through a driver that fetches from the vault and hands the values to the pods that ask
+for them.
+
+"Ask for them" is the part that mattered. The driver fetches for the pods that **mount** the vault
+declaration; a pod that only reads the resulting copy gets whatever the last fetching pod left
+behind. The run-once database migration was in the second group, and it starts the moment an
+upgrade is applied — before the portal pods that do the fetching have rolled. So on a deploy that
+*changed* one of those values, the migration ran with the value from before the change.
+
+The visible symptom was the worst kind: nothing. On 7 September a deploy repointed the embedding
+key to a different provider. The migration's backfill authenticated with the previous key, was
+refused 1,260 times, wrote every page without an embedding, and finished with "Database migration
+completed". The vault was correct all along — a portal pod that started minutes later used the same
+setting successfully. Only the migration's copy was stale, and its own report said everything had
+gone fine.
+
+The migration now mounts the vault declaration itself. That mount happens before anything in the
+pod starts and fetches from the vault at that moment, so the values it reads are current by
+construction — not by a retry, a second upgrade, or lucky timing. A check in the build now refuses
+any workload that reads one of these settings without fetching it.
+
+One consequence worth knowing: if a declared vault entry does not exist, the migration now stops
+and says so, exactly as the portal already did, instead of starting with whatever was left over.

--- a/test/MeshWeaver.Documentation.Test/KeyVaultCsiFreshnessGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/KeyVaultCsiFreshnessGuard.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A workload that READS a CSI-synced Key Vault Secret must MOUNT the SecretProviderClass
+/// that feeds it</b> (Systemorph/MeshWeaver#3548).
+///
+/// <para><b>What went wrong.</b> The Secrets Store CSI driver materialises and rotates the synced
+/// Kubernetes Secret <i>for the pods that mount the SPC volume</i>. A pod that only lists the
+/// synced Secret in <c>envFrom</c> is a FREE RIDER: it reads whatever some other pod's mount last
+/// wrote, and <c>envFrom</c> is resolved once, at container start. The migration Job was exactly
+/// that — it mounted nothing, started the instant <c>helm upgrade</c> applied, and the portal pods
+/// that own the rotation had not rolled yet. So on the 2026-09-07 <c>memex</c> release, the deploy
+/// that repointed <c>Embedding__ApiKey</c> from the Azure object to the OpenRouter one ran the
+/// embedding backfill with the PREVIOUS key: 1,260 × HTTP 401, <c>1274 upserted (0 embedded)</c>,
+/// and <c>Database migration completed</c> — a GREEN job that authenticated with a stale
+/// credential and embedded nothing. A portal pod that started minutes later held the same key name
+/// and got 200s, so the vault was right and only the Job's copy was stale.</para>
+///
+/// <para><b>Why a guard and not a comment.</b> That is this repo's central failure mode — a check
+/// that cannot fail. The backfill logs-and-skips per row rather than throwing, so the Job's exit
+/// code says nothing about whether it had a working key, and no amount of reading the logs
+/// afterwards makes the deploy safe. The cure is structural: a CSI mount is set up before ANY
+/// container in the pod starts and fetches from the vault at that moment, so a mounting pod's
+/// <c>envFrom</c> resolves against a freshly-written Secret BY CONSTRUCTION. This guard is what
+/// stops the next workload from taking the free ride.</para>
+///
+/// <para>The check is over the chart's <b>own</b> Key Vault plumbing — the
+/// <c>memex.keyVaultClasses</c> helper, the single place the SPC name, the synced Secret, the
+/// volume name and the mount path are resolved together so those four can never disagree. Only
+/// templates that declare a POD are examined: <c>secretproviderclass.yaml</c> legitimately names
+/// <c>syncedSecret</c> (it is the declaration) and mounts nothing.</para>
+/// </summary>
+public class KeyVaultCsiFreshnessGuard
+{
+    private const string Templates = "deploy/helm/templates";
+
+    /// <summary>The envFrom half: this template reads a class's synced Secret.</summary>
+    private const string ReadsSyncedSecret = "$class.syncedSecret";
+
+    /// <summary>The mount half: the CSI volume, and the mount that makes the driver fetch.</summary>
+    private const string CsiDriver = "secrets-store.csi.k8s.io";
+    private const string MountsClassPath = "$class.mountPath";
+
+    /// <summary>Kinds that carry a pod template — the only ones that can mount anything.</summary>
+    private static readonly Regex PodBearingKind =
+        new(@"^kind:\s*""?(Deployment|Job|CronJob|StatefulSet|DaemonSet|ReplicaSet|Pod)""?",
+            RegexOptions.Multiline);
+
+    [Fact]
+    public void EveryWorkloadThatReadsAKeyVaultSyncedSecret_AlsoMountsItsCsiVolume()
+    {
+        var root = FindRepoRoot();
+        var dir = Path.Combine(root, Templates);
+
+        var templates = Directory.EnumerateFiles(dir, "*.yaml", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        // 🚨 The guard asserts its own denominator. A rename of the templates directory, or of the
+        // helper the whole scheme is keyed on, would otherwise leave this passing having examined
+        // nothing — the skip-trapdoor shape AGENTS.md forbids.
+        Assert.True(templates.Length > 0,
+            $"{Templates} contains no .yaml templates — this guard would pass having checked "
+            + "nothing. Point it at wherever the chart moved.");
+
+        var declaringHelper = Path.Combine(root, Templates, "memex-portal", "_keyvault.tpl");
+        Assert.True(File.Exists(declaringHelper),
+            $"{Path.GetRelativePath(root, declaringHelper)} is gone — the '{ReadsSyncedSecret}' "
+            + "marker this guard keys on comes from the memex.keyVaultClasses helper. If the helper "
+            + "moved, move the guard with it rather than letting it match nothing.");
+
+        var readers = templates
+            .Select(f => (Path: f, Body: ExecutableLinesOf(File.ReadAllText(f))))
+            .Where(t => PodBearingKind.IsMatch(t.Body)
+                        && t.Body.Contains(ReadsSyncedSecret, StringComparison.Ordinal))
+            .ToArray();
+
+        // Two workloads read the classes today: the portal Deployment and the migration Job. If
+        // that count reaches zero the wiring was rewritten — a human question, never a pass.
+        Assert.True(readers.Length >= 2,
+            $"expected at least two pod-bearing templates to read '{ReadsSyncedSecret}' (the portal "
+            + $"Deployment and the migration Job); found {readers.Length}. Either the Key Vault "
+            + "wiring was rewritten (move this guard with it) or a reader was lost.");
+
+        var freeRiders = readers
+            .Where(t => !t.Body.Contains(CsiDriver, StringComparison.Ordinal)
+                        || !t.Body.Contains(MountsClassPath, StringComparison.Ordinal))
+            .Select(t => Path.GetRelativePath(root, t.Path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(freeRiders.Length == 0,
+            "these workloads read a Key Vault CSI-synced Secret through envFrom but do not mount "
+            + $"the SecretProviderClass volume that feeds it: {string.Join(", ", freeRiders)}. The "
+            + "driver only fetches and rotates for the pods that MOUNT the class, and envFrom is "
+            + "resolved once at container start — so such a pod silently reads whatever another "
+            + "pod's mount last wrote. On a deploy that CHANGES an SPC mapping that value is the "
+            + "PREVIOUS one, and the workload runs green against a stale credential (#3548: 1,260 × "
+            + "HTTP 401 and a completed migration). Add the volume + volumeMount from the same "
+            + "`memex.keyVaultClasses` block that renders the envFrom.");
+    }
+
+    /// <summary>
+    /// Strips YAML comments AND whole Helm comment blocks (<c>{{- /* … */}}</c>) before probing,
+    /// for the same reason <see cref="MigrationWorkloadModelGuard"/> strips comments: these
+    /// templates explain their own history at length, and a guard that matched the prose would pass
+    /// on the comment describing the fix rather than on the fix. The Helm blocks span many lines,
+    /// so a line-prefix filter is not enough here.
+    /// </summary>
+    private static string ExecutableLinesOf(string yaml)
+    {
+        var withoutHelmComments = Regex.Replace(
+            yaml, @"\{\{-?\s*/\*.*?\*/\s*-?\}\}", string.Empty, RegexOptions.Singleline);
+        return string.Join("\n", withoutHelmComments.Split('\n')
+            .Where(line => !line.TrimStart().StartsWith('#')));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
## Which half, and where it lives — measured first

The issue asked whether the chart/Job half is here or in the private `Systemorph/Memex` repo. **It is here**: `deploy/helm/templates/memex-migration/job.yaml` is the only definition of that workload, and `Memex` carries per-environment *overlays* (`deployments/aks/<ns>/values.*.public.yaml`, `portal-patch.json`), not the template. `chart-drift.yml` compares the live ConfigMap and portal Deployment against this chart, so nothing in Memex needs to move for this fix. No `az`, `kubectl` or `helm upgrade` was run — this is a template change, verified with `helm template` / `helm lint` locally.

## The defect

The Secrets Store CSI driver materialises and rotates the synced Kubernetes Secret **for the pods that MOUNT the SecretProviderClass volume**. #3468 gave the migration Job `envFrom` on that Secret (`optional: true`) but no mount, which made it a **free rider**: it reads whatever the portal pods' mount last wrote, and `envFrom` is resolved once, at container start. The Job starts the instant `helm upgrade` applies — before the portal pods have rolled — so on any deploy that *changes* an SPC mapping it runs with the value from before the change.

Verified against the issue's own measurement (`memex` release 2026-09-07, job `memex-migration-33`, the deploy that repointed `Embedding__ApiKey` from the Azure object to the OpenRouter one):

```
[DocBackfill] 1274 documentation pages found (embeddings ON)
EmbeddingRequestException: … HTTP 401 (Unauthorized) — the bearer was rejected …   × 1260
[DocBackfill] done: 1274 upserted (0 embedded), 0 unchanged, 1274 total
Database migration completed.
```

**The green is the defect's signature.** `MeshNodeEmbeddingBackfill` logs-and-skips per row rather than throwing, so the Job's exit code says nothing about whether it had a working key — a check that cannot fail. A portal pod that started minutes later held the same key name and got 200s, so the vault was right and only the Job's copy was stale. `memex-cloud`, whose synced Secret had no prior `Embedding__ApiKey`, embedded everything in the same deploy.

## The fix — structural, not a retry

The Job now renders the CSI volume + `volumeMount` from the **same** `memex.keyVaultClasses` block that renders its `envFrom`, so the class name, the synced-Secret name, the volume name and the mount path cannot disagree. A CSI mount is set up before *any* container in the pod starts and `NodePublishVolume` fetches from the vault at that moment, so the kubelet resolves this container's `envFrom` against a freshly written Secret **by construction** — no second `helm upgrade`, no rotation-poll timing, nothing to retry.

Deliberately not done: a retry loop, a wait-for-key init container, or a "re-run the backfill later" job — each would leave the stale read in place and paper over it.

One consequence, documented in `values.yaml` and `DeploymentAKS.md`: a declared vault object that does not exist now stalls the migration too, exactly as it already stalls the portal. That is the correct direction — loudly stuck beats green-and-wrong.

## The gate

`KeyVaultCsiFreshnessGuard` generalises the invariant: **every pod-bearing chart template that reads `$class.syncedSecret` must also carry `secrets-store.csi.k8s.io` and `$class.mountPath`.** `secretproviderclass.yaml` names `syncedSecret` legitimately (it is the declaration) and is excluded by the `kind:` filter, not by an allow-list. The guard asserts its own denominator — the templates directory is non-empty, `_keyvault.tpl` still exists, and at least two workloads read a class — so it cannot pass having examined nothing.

## Measurement

| | result |
|---|---|
| `helm template` with two declared classes | Job renders `volumeMounts` (2) + `volumes` (2, CSI) — see below |
| `helm template` with chart defaults (no Key Vault) | byte-identical to before: no `volumeMounts`, no `volumes` |
| `helm lint` | `1 chart(s) linted, 0 chart(s) failed` |
| guard **with** the fix | `Passed! - Failed: 0, Passed: 1` |
| guard **with the mount block removed** (negative control) | `Failed: 1` — *"these workloads read a Key Vault CSI-synced Secret through envFrom but do not mount the SecretProviderClass volume that feeds it: deploy/helm/templates/memex-migration/job.yaml"* |
| `MigrationWorkloadModelGuard` + `DocumentationLinkIntegrityTest` + What's New | `Passed! - Failed: 0, Passed: 6` |

```yaml
          imagePullPolicy: "IfNotPresent"
          volumeMounts:
            - name: "kv-secrets"
              mountPath: "/mnt/secrets-store"
              readOnly: true
      volumes:
        - name: "kv-secrets"
          csi:
            driver: "secrets-store.csi.k8s.io"
            readOnly: true
            volumeAttributes:
              secretProviderClass: "memex-portal-keyvault"
```

Pairs-with: none — a Helm template, a values comment, a doc page and a new guard; no public surface changes.

Closes #3548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
