### PR TITLE
ci(#3568): the platform-pin lane asks for permission to write the file it edits

### DIFF
--- a/.github/workflows/node-repo-platform-ref-bump.yml
+++ b/.github/workflows/node-repo-platform-ref-bump.yml
@@ -33,6 +33,15 @@ name: Node repo platform-ref bump (reusable)
 # above, silently, on the day the App loses a grant. `ArmedMergeMustTriggerMainsPushLanesGuard`
 # fails core's build if anyone puts it back.
 #
+# 🚨 THE APP INSTALLATION MUST GRANT `workflows`, not just `contents` and `pull_requests` (#3568).
+# The pin lives in the calling repo's OWN workflow file (`workflow-file`, default
+# `.github/workflows/ci.yml`), so this lane's entire diff is under `.github/workflows/**`, and
+# GitHub refuses an App push that touches that path without the grant — by name, at the push, on
+# the last step. The mint below asks for it explicitly so a missing grant is reported by the step
+# that wanted it. Provisioning it is a repository-settings act (Settings → GitHub Apps → the
+# installation → Repository permissions → Workflows: Read and write); nothing in CI can grant it,
+# and nothing in CI can read whether it is granted.
+#
 # Caller contract:
 #
 #   name: Bump the platform pin
@@ -140,11 +149,36 @@ jobs:
           private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          # Requested explicitly so an installation missing either fails HERE, on a step whose name
-          # says what it wanted, rather than degrading to a token that pushes fine and then opens a
-          # pull request nothing runs on.
+          # Requested explicitly so an installation missing any of them fails HERE, on a step whose
+          # name says what it wanted, rather than degrading to a token that pushes fine and then
+          # opens a pull request nothing runs on.
           permission-contents: write
           permission-pull-requests: write
+          # 🚨 THIS LANE'S ENTIRE DIFF IS A WORKFLOW FILE, so `contents: write` alone cannot push it
+          # (#3568). `workflow-file` defaults to `.github/workflows/ci.yml` — the pin lives in the
+          # workflow's own `env:` — and GitHub refuses an App push that touches
+          # `.github/workflows/**` without this grant, by name:
+          #
+          #   ! [remote rejected] chore/platform-ref-<sha> -> chore/platform-ref-<sha>
+          #     (refusing to allow a GitHub App to create or update workflow
+          #      `.github/workflows/ci.yml` without `workflows` permission)
+          #
+          # Measured 2026-09-07: that is EVERY run this lane has ever had — MeshWeaver.Plugins
+          # 34083504064 at 04:32:51Z and MeshWeaver.SocialMedia at 04:51:24Z, the only two runs the
+          # API lists for either caller. So the lane has never once moved a pin, and it failed at
+          # the LAST step, three minutes in, naming a permission nobody had asked for.
+          #
+          # It stayed invisible because the lane is right about everything else: it refuses to
+          # `continue-on-error`, so it went red honestly — at 04:17Z, on a schedule, against
+          # nobody's branch, where nothing surfaces a scheduled red. "The pin is not being
+          # maintained" is exactly the statement this lane exists to make, and it made it daily
+          # into an empty room while MeshWeaver.Plugins' MW_PLATFORM_REF drifted 117 commits behind
+          # core main — inside the staleness gate's bounds, and therefore silent.
+          #
+          # Requesting it here is the same discipline the two lines above already state: if the
+          # installation lacks the grant, this step fails with the permission in its own name,
+          # instead of a push failing later with a message about something nobody requested.
+          permission-workflows: write
 
       # The checkout carries the minted token, so the later `git push` is the App's push. With the
       # default credential the push would be GITHUB_TOKEN's, and the branch would exist with no

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-daily-platform-pin-update-can-actually-write-its-change.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-daily-platform-pin-update-can-actually-write-its-change.md
@@ -1,0 +1,41 @@
+---
+Name: The daily platform-pin update can finally write the change it proposes
+Category: Fix
+Description: Every add-on repository pins the exact platform build it is tested against, and a scheduled job was supposed to propose moving that pin forward each day. It had never once succeeded — it was not allowed to edit the file the pin lives in — and because it ran overnight against nobody's branch, its daily failure was never seen.
+Icon: Wrench
+Order: -20260907
+---
+
+# The daily platform-pin update can finally write the change it proposes
+
+Each add-on repository records the exact platform build it is compiled and tested against. Pinning
+it on purpose is what makes an add-on's build reproducible, and what makes a platform regression
+show up as a reviewable proposal rather than as a silently changed build input.
+
+A scheduled job proposes moving that pin forward once a day. **It had never once succeeded.**
+
+## What was wrong
+
+The pin is recorded inside the repository's own build-configuration file, so proposing a move means
+editing that file — and the job's credential was granted permission to change ordinary files but
+**not** build configuration. Every attempt was refused at the final step, three minutes in, naming
+a permission nobody had asked for.
+
+The job was otherwise well behaved: it refused to paper over its own failure, so it went red
+honestly, every night. But it ran overnight, on a schedule, against nobody's changes, where a
+failure is not attached to anything anyone is looking at. *"The pin is not being maintained"* is
+precisely the statement the job exists to make, and it had been making it daily into an empty
+room.
+
+## What changes
+
+The credential now asks for the permission the job structurally requires, and it asks **up front**
+— so if it is ever missing again, the failure is reported by the step whose name says what it
+wanted, rather than by a push failing later for a reason that reads as unrelated.
+
+## What this does not do by itself
+
+Asking for a permission is not the same as having it. The grant is a repository setting, and no
+job can give it to itself or even read whether it has it. If it has not been granted, this change
+turns a confusing late failure into an obvious early one — which is the point — but the pin still
+will not move until someone grants it.


### PR DESCRIPTION
## The lane's entire diff is a workflow file, and its token could not push one

`node-repo-platform-ref-bump.yml` mints an App token with `contents: write` and
`pull-requests: write`. The **only** file it ever edits is the caller's own
`.github/workflows/ci.yml` — `workflow-file`'s default, because the pin lives in the workflow's own
`env:`. GitHub refuses an App push touching `.github/workflows/**` without the `workflows` grant,
so **the lane has never once moved a pin**, in either repo that calls it.

## Measured, 2026-09-07

```
! [remote rejected] chore/platform-ref-c7fef7a2d -> chore/platform-ref-c7fef7a2d
  (refusing to allow a GitHub App to create or update workflow
   `.github/workflows/ci.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/Systemorph/MeshWeaver.Plugins'
```

| caller | run | when | conclusion |
|---|---|---|---|
| `MeshWeaver.Plugins` | 34083504064 | 04:32:51Z | failure — the line above |
| `MeshWeaver.SocialMedia` | — | 04:51:24Z | failure — identical, branch `chore/platform-ref-37f431a8c` |

Those are the **only** runs the API lists for either caller, so this is the lane's state since the
callers were added — not a regression.

## 🚨 Why it stayed invisible, which is the interesting half

The lane is right about everything else. Its header argues at length that it must never
`continue-on-error` — *"a red here is the actionable, once-per-day statement that the pin is not
being maintained"* — and it does not. **It went red honestly, every night.** At 04:17Z, on a
schedule, against nobody's branch, on satellite repos, where nothing surfaces a scheduled red.

So the statement the lane exists to make has been made daily into an empty room. The cost is the
exact failure mode its header names as its reason for existing: `MeshWeaver.Plugins`'
`MW_PLATFORM_REF` is `aa4075832`, **117 commits behind core `main`** — inside the staleness gate's
bounds, and therefore silent, but only just. Three separate in-flight changes are currently waiting
on a pin move that was supposed to be automatic.

This is worth stating plainly because it is not the usual shape: **no gate was skipped, nothing was
tolerated, no `if:` swallowed anything.** The gate fired correctly and nobody was in the room. A
red that nothing is attached to is a different failure from a red that is suppressed, and it needs
a different remedy.

## The fix

One line, and it is the discipline the step's own comment already states:

```yaml
# Requested explicitly so an installation missing any of them fails HERE, on a step whose
# name says what it wanted, rather than degrading to a token that pushes fine and then
# opens a pull request nothing runs on.
permission-contents: write
permission-pull-requests: write
permission-workflows: write     # ← this lane's entire diff is under .github/workflows/**
```

The comment had the intent exactly right and then omitted the one permission the lane structurally
requires.

## What this does NOT do, stated up front

**Asking for a permission is not having it.** `permission-workflows` on
`actions/create-github-app-token` narrows the token to what the *installation* already grants; if
the installation does not carry `workflows`, this step now fails at the **mint** rather than at the
push.

That is strictly better and is the outcome the step's own comment asks for — the failure is
reported by the step whose name says what it wanted, on the first thing that runs, rather than
three minutes later with a message about a permission nobody requested. But it is not the same as
the pin moving, so it should not be read as one. **A red at the mint step is a provisioning task,
not a workflow bug**, and the header now says so with the exact settings path, because nothing in
CI can grant this and nothing in CI can read whether it is granted.

## No caller change

The push and the PR are both the App's — the checkout carries the minted token, and every later
step passes `GH_TOKEN: ${{ steps.bump-token.outputs.token }}`. The callers' job-level
`permissions:` block scopes `GITHUB_TOKEN`, which does none of this, so the documented caller
contract is unchanged.

## Verification

| | |
|---|---|
| `.github/scripts/check-workflow-timeouts.py` | 71 jobs checked, 2 reusable-call exempt, **0 violations**, cap 45 min |
| workflow parses | `yaml.safe_load` OK; the `bump` job keeps its literal `timeout-minutes: 10` |
| public surface | none — a workflow and a What's New entry, so no `Pairs-with:` and no `Implementers:` is owed |

Closes #3568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
