### PR TITLE
docs(#3504): calling the shared lane is necessary and not sufficient — the pin must carry the guard

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -203,10 +203,30 @@ BEFORE the cap does.
 
 **Never hand-roll (or copy-paste) a node repo's CI.** The shared jobs live here as `workflow_call`
 workflows — `.github/workflows/node-repo-{validate,compile-check,gate,tag-modules,publish-bake}.yml`
-— and MeshWeaver.Plugins / .Education / .Reinsurance / .SocialMedia call them, keeping only
-repo-specific policy (digest pin, gating, `repository_dispatch` receiver, their own `scripts/`).
-Adopting one renames that repo's required-status-check contexts to `<caller job> / <name>` — do it
-in the same change.
+— and MeshWeaver.Plugins / .Education / .Reinsurance / .SocialMedia / .Crm / .Manufacturing call
+them, keeping only repo-specific policy (digest pin, gating, `repository_dispatch` receiver, their
+own `scripts/`). Adopting one renames that repo's required-status-check contexts to
+`<caller job> / <name>` — do it in the same change.
+
+🚨 **`node-repo-validate` is not one lane among several — it is where the FLEET-WIDE guards run**,
+so a copy of it opts out of every guard the lane grows LATER: silently, retroactively, and
+invisibly from inside the repo that made the copy. `check-workflow-timeouts.py` and
+`check-pr-secret-preflight.py` both live inside it and neither existed when the older copies were
+made — nobody chose to skip them, the copy chose, months of commits later. #3504 found Plugins (the
+largest satellite, most lanes, most secrets) running **no** secret preflight at all, and its first
+execution named three violations.
+
+🚨 **Calling the lane is NECESSARY and NOT SUFFICIENT — the PIN must carry the guard**, and this is
+the half an adoption table cannot see. Measured over every satellite's `main`, 2026-09-07: three
+pre-existing callers (Crm, SocialMedia, Education) pin a `node-repo-validate` sha that predates
+`check-pr-secret-preflight.py`, so they call the lane and are not checked by it — **4 violations
+each, `MW_REGISTRY_KEY` among them**, which is precisely Reinsurance#128's absent secret. The
+control that makes that a measurement rather than an assertion: Reinsurance, the ONE pre-existing
+caller whose pin carries the guard, is the ONE at zero. Read a caller's staleness line ("Shared CI
+logic pinned to `<sha>` — cut N days ago") as a coverage report, not a tidiness one, and bump every
+`uses:` with its paired `platform-ref` in one commit. Full table:
+[CiContentBake.md](../../../src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md) →
+"Node repos run the same lane".
 
 Full contract:
 [CiContentBake.md](../../../src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md) and

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -710,16 +710,57 @@ which is the part that must never drift.
 ## Node repos run the same lane — as reusable workflows
 
 Every satellite content repo (MeshWeaver.Plugins, MeshWeaver.Education, MeshWeaver.Reinsurance,
-MeshWeaver.SocialMedia) bakes and publishes its own content through the SAME contract, and since
-#1707 the jobs live HERE, as reusable `workflow_call` workflows the satellites call instead of
-vendoring. Adoption is **per job and still in progress**: the target is that every repo calls
-`node-repo-publish-bake` (the lane whose script contract must not drift), while a repo whose
-variant of a gate carries repo-specific machinery (Plugins' Tests-area ratchet, Education's
-course checks) keeps that job vendored until the machinery generalizes. As of 2026-08-17
-**MeshWeaver.SocialMedia and MeshWeaver.Plugins are merged and green end-to-end including
-publish-bake** (SocialMedia calls the full set, Plugins calls publish-bake only);
-MeshWeaver.Reinsurance and MeshWeaver.Education are in flight; MeshWeaver.Manufacturing is
-deliberately deferred.
+MeshWeaver.SocialMedia, MeshWeaver.Crm, MeshWeaver.Manufacturing) bakes and publishes its own
+content through the SAME contract, and since #1707 the jobs live HERE, as reusable `workflow_call`
+workflows the satellites call instead of vendoring. Adoption is **per job**: the target is that
+every repo calls `node-repo-publish-bake` (the lane whose script contract must not drift), while a
+repo whose variant of a gate carries repo-specific machinery (Plugins' Tests-area ratchet,
+Education's course checks) keeps that job vendored until the machinery generalizes.
+
+## 🚨 `node-repo-validate` is not one lane among several — it is where the FLEET-WIDE guards run
+
+The other lanes do a repo's own work. `node-repo-validate` also carries the checks that apply to
+every repository, and that makes a hand-rolled copy of it a different kind of mistake:
+
+> **The guards live INSIDE the shared lane. A hand-rolled copy therefore opts out of every guard
+> that lane grows LATER — silently, retroactively, and invisibly from the repo that made the copy.**
+
+`check-workflow-timeouts.py` (the 45-minute cap) and `check-pr-secret-preflight.py` (every
+PR-reachable `secrets.NAME` is asserted by a preflight) are both invoked *inside* it. Neither
+existed when the older copies were made, so nobody chose to skip them — the copy chose, months of
+commits later. **A repo that forked a lane before a guard was written looks identical to one that
+passes it.**
+
+### Calling the lane is NECESSARY and NOT SUFFICIENT — the PIN must carry the guard
+
+🚨 This is the second half of the same trap, and it is the one an adoption table cannot see. The
+lane is pinned by a 40-character sha; a caller whose pin PREDATES a guard calls the lane and still
+does not run it. Measured against every satellite's `main`, 2026-09-07:
+
+| repo | `node-repo-validate` pin | secret guard in that pin | `check-pr-secret-preflight` verdict on its `main` |
+|---|---|:---:|---|
+| MeshWeaver.Reinsurance | `1b5350d54` | ✅ | **0 violations** |
+| MeshWeaver.Manufacturing | `1b5350d54` | ✅ | 0 (adopted 2026-09-07, #3504) |
+| MeshWeaver.Plugins | `c7fef7a2d` | ✅ | 0 (adopted 2026-09-07, #3504) |
+| MeshWeaver.Crm | `0a2b9017d` | ❌ | **4** — incl. `MW_REGISTRY_KEY` |
+| MeshWeaver.SocialMedia | `0a2b9017d` | ❌ | **4** — incl. `MW_REGISTRY_KEY` |
+| MeshWeaver.Education | `8ffbe4762` | ❌ | **4** |
+
+**Reinsurance is the control**, and it is what makes the table evidence rather than an assertion:
+it is the only pre-existing caller whose pin carries the guard, and it is the only pre-existing
+caller at zero. Everything else in the column is a repository that *calls the lane* and is *not
+checked by it*.
+
+🚨 And `MW_REGISTRY_KEY` in that column is not a hypothetical: an absent `MW_REGISTRY_KEY`
+consumed by a PR-reachable job no preflight asserts is exactly Reinsurance#128 —
+`compose-sealed-modules.sh: --registry-url needs --registry-key`, a message that names no secret at
+all, one job after a GREEN preflight. The three repos above are one Dependabot pull request away
+from the same log.
+
+**So a lane pin is not only a reproducibility knob.** The staleness reporter in each caller's
+preflight ("Shared CI logic pinned to `<sha>` — cut N days ago") exists for this: a pin nobody bumps
+is worse than a moving ref, because the divergence is silent. Bump every `uses:` and its paired
+`platform-ref` in ONE commit.
 
 | Workflow | Job it unifies |
 |---|---|

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-two-repositories-were-running-checks-nobody-had-given-them.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-two-repositories-were-running-checks-nobody-had-given-them.md
@@ -1,0 +1,53 @@
+---
+Name: Two repositories stopped skipping checks nobody knew they skipped
+Category: Fix
+Description: A repository that copied a shared CI lane instead of calling it opts out of every check that lane gains afterwards — quietly, and long after the copy was made. Two repositories were doing that, one of them the largest. Both now call the lane.
+Icon: ShieldCheckmark
+Order: -20260907
+---
+
+# Two repositories stopped skipping checks nobody knew they skipped
+
+The platform keeps one copy of the checks every content repository has to pass, and each repository
+*calls* it. A repository that instead copies the steps into its own configuration gets an identical
+result on the day it does so — and then stops getting anything the shared copy gains afterwards.
+
+Nobody decides to skip the new check. The copy decides, months of commits later. And from inside
+the repository that made the copy there is nothing to see: **a repository that forked a lane before
+a check was written looks exactly like one that passes it.**
+
+## What was found
+
+Two of the shared checks are the fleet's, not any one repository's: *no build job may run longer
+than 45 minutes*, and *every secret a pull-request job uses is checked for before anything needs
+it*. That second one exists because a missing secret otherwise surfaces deep in a build, in a
+message that names no secret at all.
+
+Both live inside the shared lane. Neither existed when the older copies were made. So:
+
+- **the plugin catalogue — the largest repository, with the most build lanes and the most
+  secrets — was running the secret check nowhere at all.** Running it for the first time named three
+  findings immediately.
+- the manufacturing repository was running neither.
+
+Both now call the shared lane. Each finding is either fixed or written down with the reason it is
+safe, and the written-down form expires by itself: the check refuses an entry once the thing it
+excused is gone.
+
+## The part that was less obvious
+
+Calling the lane is necessary and **not sufficient**. Each repository pins the exact version of the
+lane it calls, so a repository whose pin is older than a check calls the lane and still does not run
+that check.
+
+Measured across every satellite repository: three of them are in that position today. The
+repository whose pin is current is also the only one with nothing to report — which is what makes
+that a measurement rather than a guess. A pin that nobody moves is not a tidiness problem; it is a
+coverage one, and it now reads that way in the documentation and in each build's own summary.
+
+## And the checks were made to fail first
+
+Every check touched here was deliberately broken and observed to go red before being fixed and
+observed green — including one whose first version could **not** have failed on the thing it names,
+because it was reading a neighbouring value instead of its own. A check that has only ever seen its
+passing path is not a check.


### PR DESCRIPTION
## The durable half of #3504 — plus the second trap, which the issue's own table cannot see

Closes #3504. The two adoptions land in their own repos:

- Systemorph/MeshWeaver.Manufacturing#63
- Systemorph/MeshWeaver.Plugins#1453

### What #3504 found, and what was measured on the way

`node-repo-validate` is not one lane among several — it is where the **fleet-wide** guards run
(`check-workflow-timeouts.py`, `check-pr-secret-preflight.py`). That makes a hand-rolled copy of it
a different kind of mistake from a copy of any other lane:

> **The guards live INSIDE the shared lane. A hand-rolled copy therefore opts out of every guard
> that lane grows LATER — silently, retroactively, and invisibly from the repo that made the copy.**

Confirmed on both repos' `main`, 2026-09-07, and the first execution of the secret guard named
**three** violations in Plugins and **two** in Manufacturing.

🚨 **One correction to the issue's own table.** It records Manufacturing as running both guards
"inline in `ci.yml`". It does not — both names appear in `ci.yml` exactly once each, **inside a
comment**. That is what a `grep`-shaped measurement reads as coverage, and it is the same shape as
everything else on this page: the denominator was the file, not the executed steps.

### 🚨 The second trap: calling the lane is NECESSARY and NOT SUFFICIENT

A lane is pinned by a 40-character sha. **A caller whose pin predates a guard calls the lane and
still does not run it** — and an adoption matrix, which asks only *does this repo call the lane*,
cannot see that by construction.

Measured over every satellite's `main`, 2026-09-07:

| repo | `node-repo-validate` pin | secret guard in that pin | verdict on its `main` |
|---|---|:---:|---|
| MeshWeaver.Reinsurance | `1b5350d54` | ✅ | **0 violations** |
| MeshWeaver.Manufacturing | `1b5350d54` | ✅ | 0 (adopted, #63) |
| MeshWeaver.Plugins | `c7fef7a2d` | ✅ | 0 (adopted, #1453) |
| MeshWeaver.Crm | `0a2b9017d` | ❌ | **4** — incl. `MW_REGISTRY_KEY` |
| MeshWeaver.SocialMedia | `0a2b9017d` | ❌ | **4** — incl. `MW_REGISTRY_KEY` |
| MeshWeaver.Education | `8ffbe4762` | ❌ | **4** |

**Reinsurance is the control**, and it is what makes this evidence rather than an assertion: it is
the only pre-existing caller whose pin carries `check-pr-secret-preflight.py`, and it is the only
pre-existing caller at zero. Every other row is a repository that *calls the lane* and is *not
checked by it*.

`MW_REGISTRY_KEY` in that column is not hypothetical. An absent `MW_REGISTRY_KEY` consumed by a
PR-reachable job that no preflight asserts **is** Reinsurance#128 —
`compose-sealed-modules.sh: --registry-url needs --registry-key`, a message that names no secret at
all, one job after a **green** preflight. Three repos are one Dependabot pull request away from the
same log.

So a caller's staleness line — *"Shared CI logic pinned to `<sha>` — cut N days ago"* — is a
**coverage** report, not a tidiness one.

### How this was measured (so it can be re-run)

Per repo, against `origin/main`, not a working tree:

```bash
git -C <repo> show origin/main:.github/workflows/ci.yml | grep 'node-repo-validate.yml@'
git -C MeshWeaver show <that sha>:.github/workflows/node-repo-validate.yml \
  | grep -c check-pr-secret-preflight            # 0 ⇒ the pin predates the guard
python3 .github/scripts/check-pr-secret-preflight.py --root <extracted origin/main workflows>
```

The extraction step matters: two of these repos' local checkouts were 19 and 52 commits behind, and
reading a working tree would have measured a tree nobody runs.

### What lands here

- `CiContentBake.md` → "Node repos run the same lane": the guards-live-inside-the-lane rule, the
  pin-freshness half with the table and its control, and the adoption paragraph corrected (it still
  described 2026-08-17 state and called Manufacturing "deliberately deferred").
- `.claude/skills/ci/SKILL.md` → the same two rules, at the point an agent authoring satellite CI
  reads.
- A What's New entry.

Green locally: `check-shared-rules.py --local` (3 blocks, 7 repos, all identical),
`MeshWeaver.Documentation.Test` **304/304** including `DocumentationLinkIntegrityTest`, and
`-c Release -warnaserror` on `MeshWeaver.Documentation.Test` — `0 Error(s)`, `0 Warning(s)`.

### Not done here, deliberately

Crm, SocialMedia and Education are **not** fixed by this PR. Each needs a lane-pin bump plus its own
allow entries, in its own repository, and bumping a pin changes what that repo's gates execute — a
scope call for whoever owns those repos, not a side effect of a documentation change. The table
above is the list, with the exact numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
