### PR TITLE
review(#3558): the warning accuses only a name that was actually named, and the test document is disposed

### DIFF
--- a/src/MeshWeaver.Graph/OverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/OverviewLayoutArea.cs
@@ -132,27 +132,31 @@ public static class OverviewLayoutArea
             ? typeProp.GetString()
             : null;
 
-        // Not a per-emission flood: this branch is reached only on the already-degraded path, and a
-        // node whose type registers late leaves it for good on the very next emission.
+        // Two genuinely different states, and conflating them misleads — in the rendered notice AND
+        // in the log. NO discriminator means the content is free-form JSON: legal by design
+        // (ContentDiscriminatorValidator: "content WITHOUT a $type stays legal"), permanent, and
+        // nothing to wait for. There is no name that "resolves nowhere", so there is nothing to
+        // report — a warning here would accuse a legal shape, once per render, for ever (Copilot
+        // review). The notice on screen is the whole story.
+        if (string.IsNullOrEmpty(discriminator))
+            return Controls.Markdown(
+                $"**{host.Localize("overview.untypedContent")}**\n\n"
+                + host.Localize("overview.untypedContentHint"));
+
+        // A discriminator WAS named and resolves on neither route. Not a per-emission flood: this
+        // branch is reached only on the already-degraded path, and a node whose type registers late
+        // leaves it for good on the very next emission.
         host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>()?.LogWarning(
             "OverviewLayoutArea: content discriminator '$type': '{TypeName}' on {Path} (NodeType "
             + "'{NodeType}') resolves on neither the NodeType route nor the name route — the property "
             + "overview renders the unresolved-type notice instead of a form. Either the NodeType's "
             + "runtime compile has not registered it YET (transient — the view re-renders when it "
             + "does), or no declaration will ever claim this discriminator.",
-            discriminator ?? "(absent)", node.Path, node.NodeType ?? "(none)");
+            discriminator, node.Path, node.NodeType ?? "(none)");
 
-        // Two genuinely different states, and conflating them misleads. NO discriminator means the
-        // content is free-form JSON — legal by design (ContentDiscriminatorValidator: "content
-        // WITHOUT a $type stays legal"), permanent, and nothing to wait for. An UNRESOLVABLE one
-        // means a type was named and is not known here — which may still resolve.
-        return string.IsNullOrEmpty(discriminator)
-            ? Controls.Markdown(
-                $"**{host.Localize("overview.untypedContent")}**\n\n"
-                + host.Localize("overview.untypedContentHint"))
-            : Controls.Markdown(
-                $"⚠️ **{host.Localize("overview.unresolvedType", discriminator)}**\n\n"
-                + host.Localize("overview.unresolvedTypeHint"));
+        return Controls.Markdown(
+            $"⚠️ **{host.Localize("overview.unresolvedType", discriminator)}**\n\n"
+            + host.Localize("overview.unresolvedTypeHint"));
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/OverviewUnresolvedContentTypeTest.cs
+++ b/test/MeshWeaver.Graph.Test/OverviewUnresolvedContentTypeTest.cs
@@ -65,7 +65,16 @@ public class OverviewUnresolvedContentTypeTest(ITestOutputHelper output) : HubTe
     protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
         => base.ConfigureClient(configuration).AddLayoutClient(d => d);
 
-    private static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement.Clone();
+    /// <summary>
+    /// 🚨 <c>using</c>, and <c>Clone()</c> — both load-bearing. <see cref="JsonDocument"/> owns
+    /// pooled memory and is <see cref="IDisposable"/>; the clone is what makes the returned element
+    /// independent of it, so the document can be released immediately (Copilot review).
+    /// </summary>
+    private static JsonElement Json(string raw)
+    {
+        using var document = JsonDocument.Parse(raw);
+        return document.RootElement.Clone();
+    }
 
     /// <summary>A discriminator no declaration in this process claims.</summary>
     private static UiControl UnresolvableContentTypeView(LayoutAreaHost host, RenderingContext ctx)


### PR DESCRIPTION
Follow-up to **#3571** (closed **#3558**). Both findings came from the automatic review on that PR, and both are real; they could not land on it because the merge queue refuses a push to a queued branch, and dequeuing restarts the builds of the whole group for other people's PRs.

## 1. The warning accused a legal shape

`UnresolvableContentType` logged one `LogWarning` for *both* states it renders, including content with **no `$type` at all**. That content is free-form JSON, which `ContentDiscriminatorValidator` declares legal ("content WITHOUT a `$type` stays legal"). There is no name that "resolves nowhere" there, so the line accused a legal, permanent shape — once per render, for ever, on a node nobody can fix because nothing is wrong with it.

The two states were already separated in the rendered notice; they are now separated in the log too. The untyped branch returns before the warning, and the notice on screen is the whole story. The warning that remains fires only when a discriminator **was** named and resolved on neither route — which is the diagnosable case, and the one whose text tells the reader how to tell "not yet" from "never".

## 2. The test's `JsonDocument` was never disposed

`JsonDocument.Parse(raw).RootElement.Clone()` leaves the document — which owns pooled memory and is `IDisposable` — to the finalizer. `Clone()` is what makes the returned element independent of it, so the document can be released immediately: `using var`.

## Measurement

| | result |
|---|---|
| `dotnet build -c Release -warnaserror` on `MeshWeaver.Graph` and `MeshWeaver.Graph.Test`, on merged `main` | `0 Error(s)` |
| `OverviewUnresolvedContentTypeTest` + `OverviewLayoutAreaTest` | `Passed! - Failed: 0, Passed: 14` |

No behaviour the four regression cases pin has changed — the rendered notices are identical, and this only moves which of them also logs.

Pairs-with: none — no public type or member is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
