### PR TITLE
review(#3548): the guard strips trailing yaml comments too, so it cannot pass on its own prose

### DIFF
--- a/test/MeshWeaver.Documentation.Test/KeyVaultCsiFreshnessGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/KeyVaultCsiFreshnessGuard.cs
@@ -107,18 +107,38 @@ public class KeyVaultCsiFreshnessGuard
     }
 
     /// <summary>
-    /// Strips YAML comments AND whole Helm comment blocks (<c>{{- /* … */}}</c>) before probing,
-    /// for the same reason <see cref="MigrationWorkloadModelGuard"/> strips comments: these
-    /// templates explain their own history at length, and a guard that matched the prose would pass
-    /// on the comment describing the fix rather than on the fix. The Helm blocks span many lines,
-    /// so a line-prefix filter is not enough here.
+    /// Strips Helm comment BLOCKS (<c>{{- /* … */}}</c>, which span many lines here), whole-line
+    /// YAML comments, and TRAILING YAML comments — for the same reason
+    /// <see cref="MigrationWorkloadModelGuard"/> strips comments: these templates explain their own
+    /// history at length, and a guard that matched the prose would pass on the comment describing
+    /// the fix rather than on the fix.
+    ///
+    /// <para>🚨 The trailing form matters as much as the leading one (Copilot review): a
+    /// line-prefix filter leaves <c>name: "x"  # {{ $class.mountPath }}</c> in the scan, so a
+    /// template could satisfy the mount half from a COMMENT while its real mount was gone — the
+    /// guard passing on its own documentation, which is the failure it exists to prevent.</para>
+    ///
+    /// <para>The trailing rule is deliberately naive about quoting: it cuts from the first
+    /// whitespace-preceded <c>#</c>, so a <c>#</c> inside a quoted value is cut too. That errs
+    /// toward removing text, and removing text can only make this guard REFUSE, never accept — a
+    /// false red is loud and fixable, a false green is the thing being guarded against. The chart's
+    /// marker lines (<c>mountPath: "{{ $class.mountPath }}"</c>, the CSI driver name) carry no
+    /// <c>#</c> at all, so nothing real is at risk today.</para>
     /// </summary>
     private static string ExecutableLinesOf(string yaml)
     {
         var withoutHelmComments = Regex.Replace(
             yaml, @"\{\{-?\s*/\*.*?\*/\s*-?\}\}", string.Empty, RegexOptions.Singleline);
         return string.Join("\n", withoutHelmComments.Split('\n')
-            .Where(line => !line.TrimStart().StartsWith('#')));
+            .Where(line => !line.TrimStart().StartsWith('#'))
+            .Select(StripTrailingComment));
+    }
+
+    /// <summary>Cuts a line at its first whitespace-preceded <c>#</c> — YAML's comment rule.</summary>
+    private static string StripTrailingComment(string line)
+    {
+        var hash = Regex.Match(line, @"(?<=^|\s)#");
+        return hash.Success ? line[..hash.Index] : line;
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
Follow-up to **#3572** (closed **#3548**). The finding came from the automatic review on that PR; it could not land there because the merge queue refuses a push to a queued branch, and dequeuing restarts the builds of the whole group for other people's PRs.

## The finding

`KeyVaultCsiFreshnessGuard.ExecutableLinesOf` stripped Helm comment BLOCKS and whole-line `#` comments — but not **trailing** ones. So a line like

```yaml
        name: "kv-secrets"   # {{ $class.mountPath }}
```

stayed in the scan, and a template could have satisfied the MOUNT half of the invariant **from a comment** while its actual mount was gone. That is the guard passing on its own documentation, which is precisely the failure mode it exists to prevent — the same shape as a CI gate that reads its input from a step allowed to skip.

## The fix

Each line is now cut at its first whitespace-preceded `#` — YAML's own comment rule.

Deliberately naive about quoting: a `#` inside a quoted value is cut too. That errs toward **removing** text, and removing text can only make this guard REFUSE, never accept. A false red is loud and fixable; a false green is the thing being guarded against. The chart's marker lines (`mountPath: "{{ $class.mountPath }}"`, the CSI driver name) carry no `#` at all, so nothing real is at risk today.

## Measurement

The guard was re-falsified with the stricter stripper — a change to the masker invalidates the previous negative control, so it was run again rather than assumed:

| | result |
|---|---|
| `dotnet build -c Release -warnaserror` on `MeshWeaver.Documentation.Test`, on merged `main` | `0 Error(s)` |
| guard **with** the migration Job's mount block | `Passed! - Failed: 0` |
| guard **with the mount block removed** (negative control) | `Failed: 1` — *"these workloads read a Key Vault CSI-synced Secret through envFrom but do not mount the SecretProviderClass volume that feeds it: deploy/helm/templates/memex-migration/job.yaml"* |
| `MigrationWorkloadModelGuard` alongside it | green |

Test-only change; no chart template and no production code is touched.

Pairs-with: none — no public type or member is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LzrcSMRzD2R5UcGDk5TKU
