### PR TITLE
compile: a module's content this mesh does not TRACK never compiles here — it parks, named (#3583)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -231,6 +231,17 @@ internal static class NodeTypeCompilationHelpers
             }),
                 pendingNode =>
                 {
+                    // Set by the on-demand adoption pass below when a bundle entry for THIS type
+                    // was found on this mesh's framework identity — adopted or not. Read once, in
+                    // DispatchOrPark, to tell "the bake is here and was refused" from "the bake has
+                    // not landed" (MeshWeaver#3583). Written from the seeder's pool threads.
+                    var offered = 0;
+                    void OnOffered(string path)
+                    {
+                        if (string.Equals(path, hubPath, StringComparison.OrdinalIgnoreCase))
+                            Interlocked.Exchange(ref offered, 1);
+                    }
+
                     // 🅿️ PARKED short-circuit. A prior compile of this NodeType reached a
                     // terminal failed state, so we do NOT re-run Roslyn — that is the
                     // containment that turns a broken type from a portal-wide recompile storm
@@ -360,7 +371,7 @@ internal static class NodeTypeCompilationHelpers
 
                     var attempt = new SingleAssignmentDisposable();
                     onDemandAdoptionSubs.Add(attempt);
-                    attempt.Disposable = prebuiltConsumer.SeedForTypes([hubPath])
+                    attempt.Disposable = prebuiltConsumer.SeedForTypes([hubPath], OnOffered)
                         .Take(1)
                         .Timeout(OnDemandAdoptionBudget)
                         .SelectMany(AdoptionLanded)
@@ -494,29 +505,106 @@ internal static class NodeTypeCompilationHelpers
                             return;
                         }
 
-                        logger?.LogDebug(
-                            "Compile watcher: saw Pending for {HubPath} — posting DispatchCompileTrigger to OWN hub (system identity)",
-                            hubPath);
-                        // 🚨 Compilation runs under SYSTEM identity — circumventing
-                        // RLS by design. The access check that gates compilation is
-                        // upstream: the user has to be permitted to flip
-                        // RequestedReleaseAt on the NodeType's MeshNode (checked by
-                        // the owning hub's AccessControl pipeline at submit time).
-                        // Once requested, the compile activity runs as
-                        // system-security so it can read every source file across
-                        // the mesh, write the activity log without per-flag RLS
-                        // probing, and emit the compiled assembly. NOT FromNode —
-                        // compile-as-the-last-editor-of-the-NodeType would deny
-                        // access to source files owned by other users.
-                        using (MeshWeaver.Mesh.Security.AccessContextScope.AsSystem(accessService))
+                        // 🚨 THE UNTRACKED-MODULE GATE (MeshWeaver#3583). A module is delivered as a
+                        // prebuilt bundle; "compile the live source instead" — the fallback every
+                        // route above ends in — is honest only on a mesh whose copy of that source
+                        // TRACKS the module's repository. On a partition nothing syncs, the "live
+                        // source" is whatever an install left behind: memex's Feedback partition held
+                        // four of the bundle's five files and no _GitSync, every Feedback bundle was
+                        // refused on fingerprint, and the portal compiled the leftover copy on every
+                        // roll — old code, reading as current, with no line anywhere saying so. The
+                        // maintainer's rule (2026-09-07): a module whose sources this mesh does not
+                        // sync is never self-baked here — it ERRORS, named.
+                        //
+                        // Two facts decide it, both cheap and both already in hand:
+                        //   • is this a MODULE's content? A bundle entry on this identity named the
+                        //     type (the witness above — adopted, current or DECLINED), or the record
+                        //     carries adoption provenance from an earlier identity (the bake for
+                        //     this one has not landed yet). Authored content — never adopted, never
+                        //     offered — is not a module's and compiles exactly as before.
+                        //   • does the partition TRACK a source? IPartitionSourceTracking, the one-bit
+                        //     seam the sync layer implements; a mesh with no implementation has no
+                        //     notion of tracking (local, CI, the bake host) and compiles as before.
+                        // The park mirrors the RequirePrebuilt one above — deterministic, named, the
+                        // attempt counter at zero — and lifts through the same doors: a source change
+                        // (the sync that was missing) or a release request after the rebake.
+                        // Whether the answer could be read is NOT a verdict: a fault or a timeout
+                        // compiles, as this mesh did before the gate existed.
+                        var pendingDefinition = pendingNode!.ContentAs<NodeTypeDefinition>(
+                            hub.JsonSerializerOptions, logger);
+                        var offeredByBundle = Volatile.Read(ref offered) == 1;
+                        if (pendingDefinition is null || !IsModuleContent(pendingDefinition, offeredByBundle))
                         {
-                            // Fire-and-forget. ActionBlock picks it up and runs
-                            // HandleDispatchCompile on the hub's thread; the
-                            // delivery.AccessContext is stamped with system identity
-                            // so every downstream write inside the activity bypasses
-                            // RLS.
-                            hub.Post(new DispatchCompileTrigger(pendingNode!),
-                                o => o.WithTarget(hub.Address));
+                            Dispatch();
+                            return;
+                        }
+
+                        var tracking = new SingleAssignmentDisposable();
+                        onDemandAdoptionSubs.Add(tracking);
+                        tracking.Disposable = PartitionTracksSources(hub, hubPath)
+                            .Timeout(OnDemandAdoptionBudget)
+                            .Finally(() => onDemandAdoptionSubs.Remove(tracking))
+                            .Subscribe(
+                                tracked =>
+                                {
+                                    if (tracked)
+                                    {
+                                        Dispatch();
+                                        return;
+                                    }
+                                    var reason = PrebuiltAssemblySeeder.UntrackedPartitionParkReason(
+                                        hubPath, offeredByBundle);
+                                    logger?.LogError(
+                                        "Compile watcher: {HubPath} is a module's content in a partition this "
+                                        + "mesh does not track, and no prebuilt build for it landed — PARKING "
+                                        + "with a named refusal instead of compiling (offered by a bundle: "
+                                        + "{Offered}). {Reason}",
+                                        hubPath, offeredByBundle, reason);
+                                    var registry = hub.ServiceProvider.GetService<NodeTypeCompileParkRegistry>()
+                                        ?? parkRegistry;
+                                    registry?.OnCompileFailed(
+                                        hub, hubPath, reason, deterministic: true,
+                                        recipientUserId: null, sources: pendingDefinition.CurrentSourceVersions,
+                                        logger);
+                                    SettleAsError(reason, formedUnderLiveInputs: true);
+                                },
+                                ex =>
+                                {
+                                    logger?.LogWarning(ex,
+                                        "Compile watcher: whether {HubPath}'s partition tracks a source could "
+                                        + "not be read within {Budget}s — compiling, as this mesh did before "
+                                        + "the gate existed (a stranded type is worse than a redundant compile).",
+                                        hubPath, OnDemandAdoptionBudget.TotalSeconds);
+                                    Dispatch();
+                                });
+                        return;
+
+                        void Dispatch()
+                        {
+                            logger?.LogDebug(
+                                "Compile watcher: saw Pending for {HubPath} — posting DispatchCompileTrigger to OWN hub (system identity)",
+                                hubPath);
+                            // 🚨 Compilation runs under SYSTEM identity — circumventing
+                            // RLS by design. The access check that gates compilation is
+                            // upstream: the user has to be permitted to flip
+                            // RequestedReleaseAt on the NodeType's MeshNode (checked by
+                            // the owning hub's AccessControl pipeline at submit time).
+                            // Once requested, the compile activity runs as
+                            // system-security so it can read every source file across
+                            // the mesh, write the activity log without per-flag RLS
+                            // probing, and emit the compiled assembly. NOT FromNode —
+                            // compile-as-the-last-editor-of-the-NodeType would deny
+                            // access to source files owned by other users.
+                            using (MeshWeaver.Mesh.Security.AccessContextScope.AsSystem(accessService))
+                            {
+                                // Fire-and-forget. ActionBlock picks it up and runs
+                                // HandleDispatchCompile on the hub's thread; the
+                                // delivery.AccessContext is stamped with system identity
+                                // so every downstream write inside the activity bypasses
+                                // RLS.
+                                hub.Post(new DispatchCompileTrigger(pendingNode!),
+                                    o => o.WithTarget(hub.Address));
+                            }
                         }
                     }
                 },
@@ -2383,6 +2471,46 @@ internal static class NodeTypeCompilationHelpers
     /// </summary>
     internal static string? ModulesHashOf(IMessageHub hub) =>
         hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash;
+
+    /// <summary>
+    /// Whether a NodeType is a MODULE's content — delivered as a prebuilt bundle rather than
+    /// authored on this mesh (MeshWeaver#3583). True when a bundle entry on this identity named it
+    /// in the pass that just ran (<paramref name="offeredByBundle"/>: adopted, current or declined),
+    /// or when the record carries adoption provenance from an earlier identity
+    /// (<see cref="NodeTypeDefinition.AdoptedSourceFingerprint"/> survives a local compile;
+    /// <see cref="NodeTypeDefinition.BuildProvenance"/> is reset by one, so it only ever ADDS).
+    /// Authored content — never offered, never adopted — is not a module's. Pure.
+    /// </summary>
+    internal static bool IsModuleContent(NodeTypeDefinition def, bool offeredByBundle) =>
+        offeredByBundle
+        || def.AdoptedSourceFingerprint is { Length: > 0 }
+        || def.BuildProvenance is not BuildProvenance.Compiled;
+
+    /// <summary>The partition a NodeType path belongs to — its top-level segment.</summary>
+    internal static string PartitionOf(string nodeTypePath)
+    {
+        var slash = nodeTypePath.IndexOf('/');
+        return slash > 0 ? nodeTypePath[..slash] : nodeTypePath;
+    }
+
+    /// <summary>
+    /// Whether the partition of <paramref name="nodeTypePath"/> tracks a source on this mesh —
+    /// any registered <see cref="IPartitionSourceTracking"/> answering true. ONE emission. A mesh
+    /// with no implementation registered has no notion of tracking (a local mesh, CI's disposable
+    /// meshes, the bake host) and answers true: compiling stays legal there, exactly as it was.
+    /// </summary>
+    internal static IObservable<bool> PartitionTracksSources(IMessageHub hub, string nodeTypePath)
+    {
+        var providers = hub.ServiceProvider.GetServices<IPartitionSourceTracking>().ToArray();
+        if (providers.Length == 0)
+            return Observable.Return(true);
+        var partition = PartitionOf(nodeTypePath);
+        return providers
+            .Select(p => p.IsTracked(partition).Take(1))
+            .CombineLatest()
+            .Select(answers => answers.Any(tracked => tracked))
+            .Take(1);
+    }
 
     /// <summary>
     /// The surface-id resolver over THIS mesh's environment (process surface manifest + the

--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -72,6 +72,36 @@ public static class PrebuiltAssemblySeeder
     }
 
     /// <summary>
+    /// The NAMED refusal the compile watcher parks a MODULE's NodeType with when its partition
+    /// tracks no source on this mesh and no prebuilt build for it landed (MeshWeaver#3583) — the
+    /// sibling of <see cref="RequiredParkReason"/> for a mesh that CAN compile but must not compile
+    /// THIS: the "live source" of a partition nothing syncs is whatever an install left behind, and
+    /// compiling it serves old code that reads as current. Two shapes, because the fix differs:
+    /// <paramref name="offered"/> means a bundle for this identity DID name the type and was
+    /// declined (its source fingerprint disagrees with the files here — the files are stale, not
+    /// the bundle), otherwise no bundle for this identity named it at all (the bake has not landed).
+    /// Pure.
+    /// </summary>
+    public static string UntrackedPartitionParkReason(string nodeTypePath, bool offered)
+    {
+        var slash = nodeTypePath.IndexOf('/');
+        var partition = slash > 0 ? nodeTypePath[..slash] : nodeTypePath;
+        var finding = offered
+            ? $"the prebuilt bundle for framework {LiveFrameworkMvid}/{ReleaseArchitecture.Live} "
+              + "names this type but was DECLINED: its source fingerprint disagrees with the "
+              + "files this mesh holds, and nothing syncs those files"
+            : $"no prebuilt bundle for framework {LiveFrameworkMvid}/{ReleaseArchitecture.Live} "
+              + "names this type";
+        return $"Untracked module content: NodeType '{nodeTypePath}' is a module's content, but "
+            + $"partition '{partition}' tracks no source on this mesh (no configured sync source), "
+            + $"and {finding}. This mesh does not compile a module's content it does not track — "
+            + "a local build of an install's leftover copy would serve old code as if it were "
+            + $"current. Fix: add a sync source for '{partition}' (Partition Sync administration) "
+            + $"and sync it, or publish/rebake the package for this framework identity; then "
+            + "request a release to retry (MeshWeaver#3583).";
+    }
+
+    /// <summary>
     /// Why a prebuilt assembly may NOT be adopted, or null when it may.
     ///
     /// <para>🚨 This is the whole safety argument, kept as one pure function so it can be tested

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -792,6 +792,59 @@ set on a mesh nobody can see:
 > **memex** and **memex-cloud** (#2194 item 3 records the same) — two instances, saying nothing about
 > `pearl`, `atioz`, local installs, or any external instance the registry serves.
 
+#### 🚨 A module's content this mesh does not TRACK never compiles here — it errors, named
+
+Every route above ends in the same fallback: when the bundle is refused, or no bundle for this
+framework identity has landed, **compile the live source instead**. That fallback is honest on
+exactly one kind of partition — one whose files TRACK the module's repository (a configured
+`_GitSync`), because there "the live source" is the repository at some commit and a local build of
+it is the same code the bake would have produced. On a partition nothing syncs, "the live source" is
+whatever an install left behind. Measured on **memex**, 2026-09-07 (#3583): the `Feedback` partition
+held four of the bundle's five files and no `_GitSync`; every `Feedback` bundle was refused on
+fingerprint (the bundle knew about the fifth file); and on every roll the portal compiled the
+leftover copy — old code, reading as current, with no line anywhere saying so. The maintainer's rule
+is the one this section implements: **a module whose sources this mesh does not sync is never
+self-baked here — it errors, and the error names the fix.**
+
+The decision is taken in the ONE place every compile passes through, the compile watcher's
+`DispatchOrPark` (the same gate that parks a `Modules:RequirePrebuilt` mesh), from two facts that are
+already in hand there:
+
+1. **Is this a MODULE's content?** Either a bundle entry on this identity NAMED the type in the
+   adoption pass that just ran — adopted, already current, or *declined* — or the record carries
+   adoption provenance from an earlier identity (`AdoptedSourceFingerprint` survives a local
+   compile; `BuildProvenance` is reset by one, so it only ever adds). The pass reports the first
+   through a witness the consumer exposes (`IPrebuiltAssemblyConsumer.SeedForTypes(paths, onOffered)`,
+   defaulted so an older consumer reads as "nothing offered"). Authored content — never offered,
+   never adopted — is not a module's and compiles exactly as before.
+2. **Does the partition TRACK a source?** `IPartitionSourceTracking` (MeshWeaver.Graph.Contract),
+   the one-bit seam the sync layer implements — the GitHub provider answers *true* when at least one
+   `_GitSync` of the partition names a repository (a config node with an empty repository is the
+   settings tab's "not configured" state, not tracking). It is the SAME object that feeds the
+   Partition Sync administration page, so the page and the gate cannot disagree. A mesh with no
+   implementation registered — a local mesh, CI's disposable meshes, the bake host — has no notion of
+   tracking and compiles as before.
+
+Module content **and** an untracked partition → the type PARKS with
+`PrebuiltAssemblySeeder.UntrackedPartitionParkReason`: deterministic, the attempt counter at zero,
+the reason naming the partition, whether a bundle was declined or simply absent, and the two fixes —
+add a sync source for the partition and sync it, or publish/rebake the package for this identity —
+"then request a release to retry". It lifts through the same doors as every other park: a source
+change (the sync that was missing) re-drives it, and a release request after the rebake re-runs the
+adoption pass, which now adopts. `RequestedReleaseForce` does NOT bypass it: a force means "build
+the live source", and on such a partition the live source is the problem.
+
+Whether the answer could be read is never a verdict: a fault or a timeout while asking the tracking
+seam compiles, as the mesh did before the gate existed — a stranded type is worse than a redundant
+compile, and the refusal is only ever formed from a positive *false*.
+
+| partition tracks a source | module content (offered / adopted before) | outcome |
+|---|---|---|
+| yes | yes | compile the live source (today's behaviour — Crm and Edu on the production portals) |
+| no | **yes** | **PARK, named** (#3583 — Feedback on memex) |
+| no | no | compile (authored content in a user's own space) |
+| unknown (no seam registered) | any | compile (local / CI / bake host) |
+
 #### 🚨 The path the fingerprint actually travels — and why it was INERT for months
 
 The comparison above shipped complete, and for months it could not fire. Nothing was broken in it;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-portal-no-longer-rebuilds-a-module-it-does-not-sync.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-portal-no-longer-rebuilds-a-module-it-does-not-sync.md
@@ -1,0 +1,22 @@
+---
+Name: A portal no longer rebuilds a module it does not sync — it tells you
+Category: Fix
+Description: When a module's prebuilt build is missing or refused on a partition your portal does not sync from a repository, the module now shows a clear error naming the fix, instead of silently compiling an old copy of its files and serving that as current.
+Icon: Checkmark
+Order: -20260907
+---
+
+# A portal no longer rebuilds a module it does not sync — it tells you
+
+Modules arrive on your portal as prebuilt bundles. When a bundle could not be used — it was built
+from newer files than your portal holds, or no bundle for your portal's current platform build had
+landed yet — the portal used to fall back to compiling the module's files itself. On a partition
+your portal syncs from the module's repository that is fine: the files are current. On a partition
+nothing syncs, the files are whatever an install left behind, and the portal was quietly building
+old code and serving it as if it were current. Nothing on screen said so.
+
+Now the portal refuses to do that. The module's pages show a compilation error that names the
+partition, says whether the bundle was declined or simply absent, and lists the two ways to fix it:
+add a sync source for the partition (Partition Sync administration) and sync it, or publish/rebake
+the module for this platform build — then request a release to retry. Content you author yourself
+is not affected, and a partition that does sync from a repository keeps working exactly as before.

--- a/src/MeshWeaver.GitSync/GitHubPartitionSyncSourceProvider.cs
+++ b/src/MeshWeaver.GitSync/GitHubPartitionSyncSourceProvider.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
@@ -12,7 +13,7 @@ namespace MeshWeaver.GitSync;
 /// removal (clear its repository URL instead); additional sources are removable.
 /// </summary>
 public sealed class GitHubPartitionSyncSourceProvider(GitHubSyncService sync, IMessageHub hub)
-    : IPartitionSyncSourceProvider
+    : IPartitionSyncSourceProvider, IPartitionSourceTracking
 {
     /// <inheritdoc />
     public string Kind => "GitHub";
@@ -23,6 +24,17 @@ public sealed class GitHubPartitionSyncSourceProvider(GitHubSyncService sync, IM
     /// <inheritdoc />
     public IObservable<IReadOnlyList<MeshNode>> WatchSyncSources(string partition)
         => sync.WatchConfigNodes(partition);
+
+    /// <inheritdoc />
+    /// <remarks>A <c>_GitSync</c> node whose <see cref="GitHubSyncConfig.RepositoryUrl"/> is empty
+    /// is the "not configured" state the settings tab shows (the primary node is created before a
+    /// repository is chosen and is protected from removal), so existence alone is not tracking —
+    /// the repository is. Same source of truth as <see cref="WatchSyncSources"/>, so the compile
+    /// gate and the administration page can never disagree about a partition.</remarks>
+    public IObservable<bool> IsTracked(string partition)
+        => sync.WatchConfigNodes(partition)
+            .Select(nodes => nodes.Any(n =>
+                n.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions)?.RepositoryUrl is { Length: > 0 }));
 
     /// <inheritdoc />
     public string Describe(MeshNode source)

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -81,9 +81,17 @@ public static class GitHubSyncConfiguration
         services.AddSingleton<GitHubWebhookProcessor>();
         // Surfaces the per-space GitHub sync sources on the partition administration page
         // (PartitionSyncAdminLayoutArea resolves all IPartitionSyncSourceProvider from DI).
-        services.AddSingleton<IPartitionSyncSourceProvider>(sp => new GitHubPartitionSyncSourceProvider(
+        // ONE provider instance, TWO seams: the administration GUI's rich one and the compile
+        // control plane's one-bit one (IPartitionSourceTracking — whether a partition tracks a
+        // repository at all). Registered as the same object so the two can never answer
+        // differently about a partition.
+        services.AddSingleton(sp => new GitHubPartitionSyncSourceProvider(
             sp.GetRequiredService<GitHubSyncService>(),
             sp.GetRequiredService<IMessageHub>()));
+        services.AddSingleton<IPartitionSyncSourceProvider>(sp =>
+            sp.GetRequiredService<GitHubPartitionSyncSourceProvider>());
+        services.AddSingleton<IPartitionSourceTracking>(sp =>
+            sp.GetRequiredService<GitHubPartitionSyncSourceProvider>());
         // Wiring a _GitSync makes the partition SYSTEM-OWNED — retract any privileged account
         // grant that predates it. See SystemOwnedAccessRetractionHandler for the seven-second
         // window this closes (create the Space, get Admin, wire the sync).

--- a/src/MeshWeaver.Graph.Contract/IPartitionSourceTracking.cs
+++ b/src/MeshWeaver.Graph.Contract/IPartitionSourceTracking.cs
@@ -1,0 +1,33 @@
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// Whether a partition's content TRACKS an external source on this mesh — at least one CONFIGURED
+/// sync source (a <c>{partition}/_GitSync</c> naming a repository, or another provider's
+/// equivalent) brings the partition's files here and keeps them current.
+///
+/// <para><b>Who asks, and why it is a separate seam.</b> The compile control plane
+/// (<c>NodeTypeCompilationHelpers</c>' compile watcher) asks it before it compiles a MODULE's
+/// content locally: a module is delivered as a prebuilt bundle, and when the bundle is refused
+/// (its source fingerprint disagrees with the files this mesh holds) or has not landed for this
+/// framework identity, "compile the live source instead" is only honest on a mesh whose copy of
+/// that source TRACKS the module's repository. On a partition nothing syncs, the "live source" is
+/// whatever an install left behind — last month's files, or four of five — and compiling it
+/// produces old code that reads as current (MeshWeaver#3583). The administration GUI asks the
+/// richer <c>IPartitionSyncSourceProvider</c> (the same providers, one class per kind); this
+/// contract is the one-bit answer the compiler layer can depend on without a reference to the
+/// sync layer above it.</para>
+///
+/// <para><b>Contract.</b> Emits <see langword="true"/> when at least one source of this kind is
+/// configured for the partition (a config node with its repository set — a config node that
+/// exists but names no repository is NOT tracking anything), <see langword="false"/> otherwise;
+/// re-emits when a source is added, removed or reconfigured; never stalls — a partition with no
+/// sources emits <see langword="false"/> promptly. A mesh with NO implementation registered has no
+/// notion of tracking at all (a local mesh, CI's disposable meshes, the bake host), and the
+/// compile gate treats that as "compiling is legal here", exactly as it always was.</para>
+/// </summary>
+public interface IPartitionSourceTracking
+{
+    /// <summary>Live answer for <paramref name="partition"/> (the top-level path segment):
+    /// whether at least one configured source of this kind tracks it.</summary>
+    IObservable<bool> IsTracked(string partition);
+}

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -737,4 +737,10 @@ internal sealed class PrebuiltAssemblyConsumer(
 {
     public IObservable<int> SeedForTypes(IReadOnlyCollection<string> typePaths)
         => ShippedPrebuiltBundles.SeedForTypes(mesh, typePaths, logger);
+
+    /// <inheritdoc />
+    public IObservable<int> SeedForTypes(IReadOnlyCollection<string> typePaths, Action<string> onOffered)
+        => ShippedPrebuiltBundles.SeedForTypes(
+            mesh, typePaths, logger, imageDirectory: null, publishedRoot: null,
+            onCovered: null, onMatched: onOffered);
 }

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -224,6 +224,22 @@ public static class ShippedPrebuiltBundles
         IMessageHub mesh, IReadOnlyCollection<string> typePaths, ILogger? logger,
         string? imageDirectory, string? publishedRoot,
         Action<string>? onCovered)
+        => SeedForTypes(mesh, typePaths, logger, imageDirectory, publishedRoot, onCovered, onMatched: null);
+
+    /// <summary>
+    /// <see cref="SeedForTypes(IMessageHub, IReadOnlyCollection{string}, ILogger, string, string, Action{string})"/>
+    /// with the SECOND witness exposed: <paramref name="onMatched"/> is invoked once for every
+    /// requested path a bundle entry NAMED on this mesh's framework identity — adopted, already
+    /// current, or declined per entry — from the seeder's pool threads (thread-safe, like
+    /// <paramref name="onCovered"/>). A bundle declined WHOLE on framework identity names nothing:
+    /// its entries are another identity's, and "offered" would be a lie the compile gate then acts
+    /// on. Same binary-compatibility shape as the overload above: every argument required, so the
+    /// shipped call sites keep resolving to the signature they were compiled against.
+    /// </summary>
+    public static IObservable<int> SeedForTypes(
+        IMessageHub mesh, IReadOnlyCollection<string> typePaths, ILogger? logger,
+        string? imageDirectory, string? publishedRoot,
+        Action<string>? onCovered, Action<string>? onMatched)
         => Observable.Defer(() =>
         {
             if (typePaths.Count == 0)
@@ -254,7 +270,11 @@ public static class ShippedPrebuiltBundles
                 covered.TryAdd(path, 0);
                 onCovered?.Invoke(path);
             }
-            void WitnessMatched(string path) => matched.TryAdd(path, 0);
+            void WitnessMatched(string path)
+            {
+                matched.TryAdd(path, 0);
+                onMatched?.Invoke(path);
+            }
 
             var seeds = new List<IObservable<SeedTally>>
             {

--- a/src/MeshWeaver.Mesh.Contract/Services/IPrebuiltAssemblyConsumer.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IPrebuiltAssemblyConsumer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
@@ -22,4 +24,21 @@ public interface IPrebuiltAssemblyConsumer
     /// <summary>Attempts to adopt pre-built assemblies for exactly <paramref name="typePaths"/>;
     /// emits the adopted count (0 when nothing matched or nothing is configured).</summary>
     IObservable<int> SeedForTypes(IReadOnlyCollection<string> typePaths);
+
+    /// <summary>
+    /// <see cref="SeedForTypes(IReadOnlyCollection{string})"/> with a per-path witness:
+    /// <paramref name="onOffered"/> is invoked once for every requested path a bundle entry NAMED
+    /// — adopted now, already current, or DECLINED — from the consumer's own worker threads, so an
+    /// implementation must be thread-safe. The count is unchanged and still authoritative; the
+    /// witness answers the one question the count cannot: "was there a bundle for this type at
+    /// all?" — which is what separates "the bake has not landed for this identity" from "the bake
+    /// is here and was refused" when the compile watcher decides whether a local compile is honest
+    /// (<c>IPartitionSourceTracking</c>, MeshWeaver#3583).
+    ///
+    /// <para>Defaulted so that an implementation predating the witness keeps its contract; it then
+    /// reads as "nothing offered", which degrades in the direction the gate tolerates — a compile,
+    /// never a park.</para>
+    /// </summary>
+    IObservable<int> SeedForTypes(IReadOnlyCollection<string> typePaths, Action<string> onOffered)
+        => SeedForTypes(typePaths);
 }

--- a/test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj
@@ -17,6 +17,10 @@
     <!-- The pipeline is exercised against a real mesh, so the suite still composes a host
          (AddGraph) exactly as it did inside MeshWeaver.Graph.Test. -->
     <ProjectReference Include="..\..\src\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
+    <!-- The untracked-module gate asks the sync layer whether a partition tracks a repository
+         (IPartitionSourceTracking); its test registers the REAL GitHub provider and a real
+         _GitSync node rather than a stand-in, so the seam is exercised end to end. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.NuGet\MeshWeaver.NuGet.csproj" />

--- a/test/MeshWeaver.Compiler.Pipeline.Test/UntrackedModuleContentNeverCompilesHereTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/UntrackedModuleContentNeverCompilesHereTest.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// The untracked-module gate (MeshWeaver#3583): a MODULE's NodeType in a partition this mesh does
+/// not sync from a repository never compiles here — it parks at <see cref="CompilationStatus.Error"/>
+/// with a reason naming the partition and the fix — while the same type in a partition that DOES
+/// track a repository, and authored content anywhere, compile exactly as before.
+///
+/// <para><b>A controlled experiment, in one mesh.</b> Three types differ from each other in exactly
+/// one fact each: <c>untracked/Widget</c> carries adoption provenance and its partition has no
+/// <c>_GitSync</c>; <c>tracked/Widget</c> is the same record under a partition whose <c>_GitSync</c>
+/// names a repository; <c>untracked/Authored</c> shares the untracked partition but was never
+/// adopted. Asserting only the park would pass just as well against a watcher that had stopped
+/// compiling anything at all — the two compiling arms are what make the refusal mean something.
+/// The tracking answer comes from the REAL GitHub provider over a REAL config node, not a
+/// stand-in: the seam the gate depends on is part of what is under test.</para>
+/// </summary>
+public class UntrackedModuleContentNeverCompilesHereTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>The coordinates every type starts with. A compile REPLACES them (a real Roslyn
+    /// pass writes a real MVID); a park leaves them untouched — so the MVID is the witness of
+    /// whether Roslyn ran, independently of the status.</summary>
+    private const string StaleMvid = "0000aaaa0000aaaa";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGitHubSyncTypes()
+            .ConfigureServices(services =>
+            {
+                services.AddGitHubSyncServices();
+                return services;
+            });
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private NodeTypeCompileParkRegistry Parks =>
+        Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+
+    private async Task CreateType(string path, bool adoptedBefore)
+    {
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = path[(path.LastIndexOf('/') + 1)..],
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                CompilationStatus = CompilationStatus.Ok,
+                LatestAssemblyCollection = "assemblies",
+                LatestAssemblyPath = $"adopted/{path.Replace('/', '_')}.dll",
+                LatestAssemblyMvid = StaleMvid,
+                CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+                // Adoption provenance from an EARLIER identity: the bake for this one has not
+                // landed, which is the roll-before-bake shape. AdoptedSourceFingerprint is the
+                // field that survives a local compile, so it is the durable "this is a module's"
+                // mark the gate reads.
+                AdoptedSourceFingerprint = adoptedBefore ? "bundlefingerprint0000000" : null,
+                BuildProvenance = adoptedBefore ? BuildProvenance.AdoptedVerified : BuildProvenance.Compiled,
+            },
+        };
+        await MeshService.CreateNode(node).Should().Within(TestTimeouts.Convergence).Emit();
+        await Mesh.GetMeshNodeStream(path).Should().Within(TestTimeouts.Convergence)
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && string.Equals(d.LatestAssemblyMvid, StaleMvid, StringComparison.Ordinal));
+    }
+
+    /// <summary>A real <c>{partition}/_GitSync</c> naming a repository — what the settings tab
+    /// writes when a Space is connected. The seam is then read back directly, so a false negative
+    /// in the arm below cannot be mistaken for a defect in the gate.</summary>
+    private async Task TrackPartition(string partition)
+    {
+        await MeshService.CreateNode(new MeshNode(GitHubSyncService.ConfigId, partition)
+            {
+                Name = "GitHub Sync",
+                NodeType = GitHubSyncService.ConfigNodeType,
+                State = MeshNodeState.Active,
+                Content = new GitHubSyncConfig
+                {
+                    RepositoryUrl = "https://github.com/Systemorph/Example",
+                    Branch = "main",
+                },
+            })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var tracked = await NodeTypeCompilationHelpers.PartitionTracksSources(Mesh, $"{partition}/Widget")
+            .Should().Within(TestTimeouts.Convergence).Emit("the seam answers once, promptly");
+        tracked.Should().BeTrue("a _GitSync naming a repository is what 'tracked' means");
+    }
+
+    /// <summary>The operator's door — the UI Compile button / the compile tool: a FORCED release
+    /// request. Force means "build the live source, not whatever a bundle resolves", so it skips
+    /// the on-demand adoption pass and lands straight on the gate; on an untracked module partition
+    /// the live source is the problem, which is why the gate does not exempt it.</summary>
+    private Task RequestForcedRelease(string path) =>
+        Mesh.GetMeshNodeStream(path)
+            .Update<NodeTypeDefinition>(d => d with
+            {
+                RequestedReleaseAt = DateTimeOffset.UtcNow,
+                RequestedReleaseForce = true,
+                RequestedReleaseBy = "operator",
+            })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+    /// <summary>The record after the request settled: an <c>Error</c>, or an <c>Ok</c> whose MVID
+    /// is no longer the seeded one (the seeded Ok is what the stream starts with, so it is not a
+    /// settle).</summary>
+    private async Task<NodeTypeDefinition> Settled(string path)
+    {
+        var node = await Mesh.GetMeshNodeStream(path).Should().Within(TestTimeouts.CrossSilo)
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && (d.CompilationStatus == CompilationStatus.Error
+                            || (d.CompilationStatus == CompilationStatus.Ok
+                                && !string.Equals(d.LatestAssemblyMvid, StaleMvid, StringComparison.Ordinal))),
+                "every route into a compile settles: a Roslyn pass or a named park");
+        return (NodeTypeDefinition)node.Content!;
+    }
+
+    [Fact]
+    public async Task AModuleTypeInAnUntrackedPartition_Parks_WhileTrackedAndAuthoredTypesCompile()
+    {
+        const string untrackedModule = "untracked/Widget";
+        const string trackedModule = "tracked/Widget";
+        const string authored = "untracked/Authored";
+
+        await TrackPartition("tracked");
+        await CreateType(untrackedModule, adoptedBefore: true);
+        await CreateType(trackedModule, adoptedBefore: true);
+        await CreateType(authored, adoptedBefore: false);
+
+        // ── THE ARM UNDER TEST: module content, partition tracks nothing → parked, named. ──
+        await RequestForcedRelease(untrackedModule);
+        var parked = await Settled(untrackedModule);
+        parked.CompilationStatus.Should().Be(CompilationStatus.Error,
+            "a module's content this mesh does not sync is never self-baked here (#3583)");
+        parked.CompilationError.Should().Contain("tracks no source")
+            .And.Contain("partition 'untracked'", "the reason names the partition to fix")
+            .And.Contain("add a sync source", "…and the fix")
+            .And.Contain("MeshWeaver#3583");
+        parked.LatestAssemblyMvid.Should().Be(StaleMvid,
+            "no Roslyn pass ran — a park leaves the coordinates exactly as they were");
+        Parks.IsParked(untrackedModule).Should().BeTrue("the refusal is a deterministic park");
+        Parks.GetCompileAttemptCount(untrackedModule).Should().Be(0,
+            "the park registry's attempt counter is the observable proof no compile was dispatched");
+
+        // ── CONTROL 1: the SAME record, in a partition whose _GitSync names a repository. ──
+        await RequestForcedRelease(trackedModule);
+        var compiled = await Settled(trackedModule);
+        compiled.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            $"a tracked partition's live source is the repository's, so compiling it is honest; "
+            + $"error: {compiled.CompilationError}");
+        compiled.LatestAssemblyMvid.Should().NotBe(StaleMvid, "a real Roslyn pass wrote real coordinates");
+        Parks.IsParked(trackedModule).Should().BeFalse();
+
+        // ── CONTROL 2: AUTHORED content in the untracked partition — never adopted, never offered. ──
+        await RequestForcedRelease(authored);
+        var authoredBuild = await Settled(authored);
+        authoredBuild.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            $"content a user authored is not a module's, whatever partition it lives in; "
+            + $"error: {authoredBuild.CompilationError}");
+        authoredBuild.LatestAssemblyMvid.Should().NotBe(StaleMvid);
+        Parks.IsParked(authored).Should().BeFalse();
+    }
+}
+
+/// <summary>The two pure halves of the gate, pinned without a mesh.</summary>
+public class UntrackedModuleContentDecisionTest
+{
+    private static NodeTypeDefinition Authored() => new() { Configuration = "config => config" };
+
+    [Fact]
+    public void AuthoredContent_NeverOfferedNeverAdopted_IsNotAModules()
+        => NodeTypeCompilationHelpers.IsModuleContent(Authored(), offeredByBundle: false)
+            .Should().BeFalse("a user's own NodeType compiles wherever it lives");
+
+    [Fact]
+    public void ATypeABundleEntryNamed_IsAModules_WhateverTheRecordSays()
+        => NodeTypeCompilationHelpers.IsModuleContent(Authored(), offeredByBundle: true)
+            .Should().BeTrue("a bundle that names the type — adopted or DECLINED — is the module's own statement");
+
+    [Fact]
+    public void ATypeAdoptedUnderAnEarlierIdentity_IsAModules_EvenAfterALocalCompile()
+        => NodeTypeCompilationHelpers.IsModuleContent(
+                Authored() with { AdoptedSourceFingerprint = "abc", BuildProvenance = BuildProvenance.Compiled },
+                offeredByBundle: false)
+            .Should().BeTrue("AdoptedSourceFingerprint survives ApplyCompileSuccess; BuildProvenance does not");
+
+    [Theory]
+    [InlineData(BuildProvenance.AdoptedVerified)]
+    [InlineData(BuildProvenance.AdoptedUnverified)]
+    [InlineData(BuildProvenance.AdoptionRefused)]
+    public void AnyAdoptionProvenance_IsAModules(BuildProvenance provenance)
+        => NodeTypeCompilationHelpers.IsModuleContent(Authored() with { BuildProvenance = provenance }, false)
+            .Should().BeTrue();
+
+    [Theory]
+    [InlineData("Feedback/Feedback/Source/FeedbackContent", "Feedback")]
+    [InlineData("Crm/Migration", "Crm")]
+    [InlineData("Solo", "Solo")]
+    public void ThePartition_IsTheTopLevelSegment(string path, string partition)
+        => NodeTypeCompilationHelpers.PartitionOf(path).Should().Be(partition);
+
+    [Fact]
+    public void TheReason_NamesThePartition_TheFinding_AndBothFixes()
+    {
+        var declined = PrebuiltAssemblySeeder.UntrackedPartitionParkReason("Feedback/Feedback/Source/FeedbackContent", offered: true);
+        declined.Should().Contain("partition 'Feedback'").And.Contain("tracks no source")
+            .And.Contain("DECLINED", "an offered-and-refused bundle says the FILES are stale, not the bundle")
+            .And.Contain("add a sync source").And.Contain("rebake").And.Contain("MeshWeaver#3583");
+
+        var absent = PrebuiltAssemblySeeder.UntrackedPartitionParkReason("Feedback/Feedback/Source/FeedbackContent", offered: false);
+        absent.Should().Contain("no prebuilt bundle", "no bundle for this identity named the type — the bake has not landed")
+            .And.NotContain("DECLINED");
+    }
+}


### PR DESCRIPTION
## What

A module's content in a partition this mesh does not TRACK never compiles here — it parks at `Error` with a reason naming the partition, the finding and both fixes. Closes the "self-bake" half of #3583; maintainer's rule 2026-09-07: *"see that you don't try to bring self-bake ⇒ just error, for modules where we don't sync src"*.

**Measured on memex:** the `Feedback` partition held four of the bundle's five files and no `_GitSync`; every Feedback bundle was refused on source fingerprint (#2813); on every roll the portal compiled the leftover copy — old code, reading as current, with no line anywhere saying so.

## How

The decision is taken in the ONE gate every compile passes through — the compile watcher's `DispatchOrPark`, beside the existing `Modules:RequirePrebuilt` park — from two facts already in hand there:

1. **Module content?** A bundle entry on this identity NAMED the type in the adoption pass that just ran (adopted, already current, or *declined*) — a new witness `IPrebuiltAssemblyConsumer.SeedForTypes(paths, onOffered)` (default-implemented: an older consumer reads as "nothing offered" ⇒ compile) — or the record carries adoption provenance from an earlier identity (`AdoptedSourceFingerprint` survives a local compile). Authored content compiles exactly as before.
2. **Partition tracks a source?** `IPartitionSourceTracking` (`MeshWeaver.Graph.Contract`), the one-bit seam the GitHub provider implements from the SAME `WatchConfigNodes` the Partition Sync admin page reads — a `_GitSync` naming a repository. No implementation registered (local, CI, the bake host) ⇒ no notion of tracking ⇒ compile as before.

Module content **and** untracked ⇒ `PrebuiltAssemblySeeder.UntrackedPartitionParkReason`: deterministic park, attempt counter at zero, coordinates untouched. Lifts through the same doors as every park (a source change — the sync that was missing — or a release request after the rebake). `RequestedReleaseForce` does not bypass it (a force means "build the live source", and here the live source is the problem). A fault or timeout reading the seam **compiles** — a refusal is only ever formed from a positive *false*.

| tracks a source | module content | outcome |
|---|---|---|
| yes | yes | compile (today — Crm/Edu on the production portals) |
| no | **yes** | **park, named** |
| no | no | compile (authored content) |
| no seam registered | any | compile (local / CI / bake) |

## Verification

- `UntrackedModuleContentNeverCompilesHereTest`: three types in ONE mesh differing in one fact each — untracked+adopted parks with the named reason and untouched MVID (`GetCompileAttemptCount == 0`); tracked+adopted compiles through a REAL `_GitSync` node and the REAL GitHub provider (`AddGitHubSyncServices`, no stand-in); untracked+authored compiles. Plus the pure decision (`IsModuleContent`, `PartitionOf`) and reason facts. 11/11 green, Release.
- `dotnet build -c Release -warnaserror`: Hosting, GitSync, Compiler.Pipeline.Test, Documentation.Test — `0 Error(s)` each. `MeshWeaver.Documentation.Test` 305/305 (link integrity, What's New front matter, the timeout-literal ratchet).
- Doc: `NodeTypeCompilation.md` → "A module's content this mesh does not TRACK never compiles here"; What's New (`Category: Fix`).

Implementers: `IPrebuiltAssemblyConsumer.SeedForTypes(IReadOnlyCollection<string>, Action<string>)` — added WITH a default implementation (delegates to the one-argument form), so no implementer is obliged; the only implementer in the fleet (`PrebuiltAssemblyConsumer`, MeshWeaver.Hosting) overrides it. `IPartitionSourceTracking` is a NEW interface (one implementer, `GitHubPartitionSyncSourceProvider`, this PR).
Pairs-with: none — no public type or member removed; additions only.
