### PR TITLE
fix(#3561): a first-time sign-in never adopts a local part that names someone else's User node

### DIFF
--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/UserContextMiddleware.cs
@@ -185,6 +185,27 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
                         + "evidence that the user is unknown, and must never drive onboarding.",
                         userContext.Email, lookup.UnavailableReason);
                 }
+                else if (hub.ServiceProvider.GetService<UserIdentityCache>()?.OwnerEmailOf(userContext.ObjectId)
+                             is { } ownerEmail
+                         && LocalPartCollides(ownerEmail, userContext.Email))
+                {
+                    // 🚨 The index answered, this email has no User node, and the local part the
+                    // claims yielded ALREADY NAMES SOMEONE ELSE'S node (MeshWeaver#3561: the admin
+                    // `rbuergi@systemorph.com` and a personal `rbuergi@icloud.com` both became home
+                    // `rbuergi` — same breadcrumbs, same notifications, same installed copies).
+                    // The partition key is the data boundary, so adopting it is handing this
+                    // sign-in another person's space. Anonymous instead, exactly like the
+                    // email-shaped refusal below: least privilege, and the onboarding path is
+                    // where this account gets a username of its own.
+                    logger.LogWarning(
+                        "UserContextMiddleware: refusing the local-part id '{ObjectId}' for {Email} — "
+                        + "a mesh User node with that id belongs to {OwnerEmail}. Treating as anonymous; "
+                        + "this account needs its own username (MeshWeaver#3561).",
+                        userContext.ObjectId, userContext.Email, ownerEmail);
+                    userService.SetContext(AnonymousContext with { Locale = requestLocale });
+                    await next(context);
+                    return;
+                }
             }
 
             // Defence-in-depth: if anything upstream slipped an email-shaped
@@ -584,6 +605,17 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
                         "ResolveHttpCaller: mesh user index UNAVAILABLE for {Email} ({Reason}) — "
                         + "keeping the claim-derived identity; this is NOT evidence the user is unknown.",
                         ctx.Email, lookup.UnavailableReason);
+                else if (services.GetService<UserIdentityCache>()?.OwnerEmailOf(ctx.ObjectId) is { } ownerEmail
+                         && LocalPartCollides(ownerEmail, ctx.Email))
+                {
+                    // Same refusal as the middleware path (MeshWeaver#3561): the claim-derived local
+                    // part names another email's User node — never that person's partition.
+                    logger?.LogWarning(
+                        "ResolveHttpCaller: refusing the local-part id '{ObjectId}' for {Email} — a mesh User "
+                        + "node with that id belongs to {OwnerEmail}; treating as anonymous (MeshWeaver#3561).",
+                        ctx.ObjectId, ctx.Email, ownerEmail);
+                    return AnonymousContext;
+                }
             }
             if (LooksLikeEmail(ctx.ObjectId))
             {
@@ -657,6 +689,16 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
             Roles = user.FindAll(ClaimTypes.Role).Select(c => c.Value).ToList()
         };
     }
+
+    /// <summary>
+    /// Whether a candidate partition id is TAKEN: the mesh <c>User</c> node carrying that id belongs
+    /// to <paramref name="ownerEmail"/>, and that is not the signing-in <paramref name="email"/>
+    /// (compared case-insensitively — mail addresses are). No owner, or the same address, is no
+    /// collision. Pure (MeshWeaver#3561).
+    /// </summary>
+    public static bool LocalPartCollides(string? ownerEmail, string? email) =>
+        !string.IsNullOrEmpty(ownerEmail)
+        && !string.Equals(ownerEmail, email, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Normalises an email-shaped identifier to its local part — the post-v10

--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/UserIdentityCache.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/UserIdentityCache.cs
@@ -167,6 +167,15 @@ public readonly record struct UserIdentityLookup(MeshNode? Node, string? Unavail
 /// </summary>
 public sealed class UserIdentityCache : IDisposable
 {
+    /// <summary>
+    /// The SAME nodes keyed by their <c>Id</c> — the username, i.e. the partition key — with the
+    /// email each carries. Answers the other direction of the question the email index answers:
+    /// "who owns this id?", which is what stops a first-time sign-in from adopting a local part
+    /// that already belongs to someone else (MeshWeaver#3561).
+    /// </summary>
+    private readonly ConcurrentDictionary<string, (MeshNode Node, string Email)> _byId =
+        new(StringComparer.OrdinalIgnoreCase);
+
     private readonly ConcurrentDictionary<string, MeshNode> _byEmail =
         new(StringComparer.OrdinalIgnoreCase);
     private readonly IDisposable _subscription;
@@ -312,9 +321,13 @@ public sealed class UserIdentityCache : IDisposable
             case QueryChangeType.Initial:
             case QueryChangeType.Reset:
                 _byEmail.Clear();
+                _byId.Clear();
                 foreach (var node in change.Items)
                     if (TryGetEmail(node, out var email))
+                    {
                         _byEmail[email] = node;
+                        if (!string.IsNullOrEmpty(node.Id)) _byId[node.Id] = (node, email);
+                    }
                 // The index is authoritative from here on: a miss now genuinely means "no mesh
                 // User node carries this email". Set LAST, after the snapshot is applied, so a
                 // concurrent reader never sees "hydrated" over a half-built index.
@@ -324,12 +337,18 @@ public sealed class UserIdentityCache : IDisposable
             case QueryChangeType.Updated:
                 foreach (var node in change.Items)
                     if (TryGetEmail(node, out var email))
+                    {
                         _byEmail[email] = node;
+                        if (!string.IsNullOrEmpty(node.Id)) _byId[node.Id] = (node, email);
+                    }
                 break;
             case QueryChangeType.Removed:
                 foreach (var node in change.Items)
+                {
                     if (TryGetEmail(node, out var email))
                         _byEmail.TryRemove(email, out _);
+                    if (!string.IsNullOrEmpty(node.Id)) _byId.TryRemove(node.Id, out _);
+                }
                 break;
         }
     }
@@ -362,6 +381,20 @@ public sealed class UserIdentityCache : IDisposable
             node,
             Volatile.Read(ref _hydrated),
             Volatile.Read(ref _subscriptionFailure));
+    }
+
+    /// <summary>
+    /// The email of the mesh <c>User</c> node whose <c>Id</c> is <paramref name="id"/>, or
+    /// <c>null</c> when no such node is indexed — or when the index has not hydrated, since an
+    /// answer off an empty index would be a guess. The caller compares it with the signing-in
+    /// email: a different owner means the id is TAKEN and must not be adopted as a partition key
+    /// (MeshWeaver#3561 — two accounts whose emails differ only by domain shared one home).
+    /// </summary>
+    public string? OwnerEmailOf(string? id)
+    {
+        if (string.IsNullOrEmpty(id) || !Volatile.Read(ref _hydrated))
+            return null;
+        return _byId.TryGetValue(id, out var owner) ? owner.Email : null;
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/LocalPartCollisionTest.cs
+++ b/test/Memex.Portal.Shared.Test/LocalPartCollisionTest.cs
@@ -1,0 +1,25 @@
+using MeshWeaver.Hosting.AspNetCore.Portal;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the decision behind MeshWeaver#3561: a first-time sign-in whose email has no mesh
+/// <c>User</c> node must not adopt a local part that already names SOMEONE ELSE'S node as its
+/// partition key. On memex.meshweaver.cloud (2026-09-07) <c>rbuergi@systemorph.com</c> and
+/// <c>rbuergi@icloud.com</c> both became home <c>rbuergi</c>. The comparison is by mail address,
+/// case-insensitively, and only an actual owner can collide.
+/// </summary>
+public class LocalPartCollisionTest
+{
+    [Theory]
+    [InlineData("rbuergi@systemorph.com", "rbuergi@icloud.com", true)]
+    [InlineData("Roger@example.org", "roger@other.example", true)]
+    [InlineData("rbuergi@systemorph.com", "rbuergi@systemorph.com", false)]
+    [InlineData("RBuergi@Systemorph.com", "rbuergi@systemorph.com", false)]
+    [InlineData(null, "rbuergi@icloud.com", false)]
+    [InlineData("", "rbuergi@icloud.com", false)]
+    public void ALocalPartCollidesOnlyWhenAnotherAddressOwnsIt(string? owner, string email, bool collides) =>
+        UserContextMiddleware.LocalPartCollides(owner, email).Should().Be(collides,
+            "the partition key is the data boundary: a taken id is refused, the owner's own address is not");
+}


### PR DESCRIPTION
## What

Fixes #3561. When the identity index has no `User` node for a signing-in email, `UserContextMiddleware` fell back to the email's **local part** as the partition key — and never asked whether that id already belonged to someone else. `UserIdentityCache` now indexes the User nodes by id as well (`OwnerEmailOf`), and both resolution paths (the middleware and `ResolveHttpCaller`) refuse a claim-derived id that a **different** email owns: the request runs as Anonymous, exactly like the existing email-shaped refusal, with a Warning naming the owner. `LocalPartCollides` is the pure decision.

## Why

memex.meshweaver.cloud, 2026-09-07: `rbuergi@systemorph.com` (the platform admin) and `rbuergi@icloud.com` (a personal Microsoft account, fresh browser profile, interactive sign-in) both landed on home `rbuergi` — same breadcrumbs, the same notification badge, "Included in your Dedicated plan", the same installed copies. The partition key is the data boundary; anyone controlling `<id>@<any domain>` for an existing `<id>` got that user's space. #3561 has the measurements.

## Not in this PR

The refused sign-in still needs a username of its own; that is the onboarding path (#3516's username-taken handling), which this change routes to by refusing rather than adopting. An index that has not hydrated answers `null` here and the existing unavailable-index fallback applies unchanged.

## Tests

`LocalPartCollisionTest` (Memex.Portal.Shared.Test): a taken id collides, the owner's own address (any casing) does not, no owner does not. `dotnet test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
