### PR TITLE
fix(#3561): the identity index goes unhydrated while a Reset rebuilds it

### DIFF
--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/UserIdentityCache.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/UserIdentityCache.cs
@@ -320,6 +320,12 @@ public sealed class UserIdentityCache : IDisposable
         {
             case QueryChangeType.Initial:
             case QueryChangeType.Reset:
+                // 🚨 UNHYDRATED while the snapshot is rebuilt. A Reset lands on an index that was
+                // already authoritative; clearing it with the flag still up would let a concurrent
+                // lookup read the half-built index as a definitive "no such user" — the cold-cache
+                // ambiguity #974 exists to prevent — and OwnerEmailOf as "nobody owns this id".
+                // Down first, rebuild, then up again LAST (below).
+                Volatile.Write(ref _hydrated, false);
                 _byEmail.Clear();
                 _byId.Clear();
                 foreach (var node in change.Items)


### PR DESCRIPTION
## What

Follow-up to #3590 (the review point Copilot raised there, which could not be pushed onto the queued branch): `UserIdentityCache.Apply` now marks the index **unhydrated** before it clears and rebuilds on `Initial`/`Reset`, and hydrated again only after the snapshot is fully applied.

## Why

A `Reset` lands on an index that was already authoritative. Clearing it with the flag still up left a window where a concurrent `Lookup` read the half-built index as a definitive "no such user" — the cold-cache ambiguity #974 exists to prevent — and `OwnerEmailOf` (from #3590) as "nobody owns this id". Down first, rebuild, up last; the existing unavailable-index fallbacks cover the window.

`dotnet test` on Memex.Portal.Shared.Test: 873 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
