### PR TITLE
fix(#3567): the arbiter is woken by a stand-down nobody is queued behind

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -327,6 +327,58 @@ only writer, so undoing its own commit is the only place this can be closed. The
 clause is load-bearing: a holder *mid-bake* has no registration left either, its own grant having
 consumed it.
 
+### …and the mirror image of it: a stand-down DECIDED before the grant and APPLIED after it (#3567)
+
+That refusal closes the interleaving in which the stand-down has **already happened** when the grant
+is published. It cannot close the one in which the stand-down is *decided* first and *applied* last,
+because there the publication was legitimate at the moment it happened — the candidate was still
+registered. What arrives late is the stand-down.
+
+`WithdrawBuildClaim` runs on the **candidate's** hub, which does not own `Admin/Build`. So its
+`stream.Update` lambda is evaluated against *that hub's mirror* and travels to the owner as an RFC
+7396 merge patch of the fields it changed (`MeshNodeStreamHandle.UpdateQueued` →
+`ComputeMergePatchDiff`) — and **a field the lambda leaves unchanged is absent from the patch**,
+which by RFC 7396 leaves the owner's value untouched. Its hand-back half is conditional on exactly
+such a field (`state.ClaimedBy == holder && state.Status is Planning`), so on a mirror the grant has
+not reached yet the patch carries the registration removal and **no `claimedBy` at all**. The
+arbiter, by contrast, writes the node it *owns*, so its lambda is serialised against fresh state.
+**That asymmetry is the bug** — it is the general shape, not a build-protocol quirk:
+[Conditional Writes Across Hubs](../ConditionalWritesAcrossHubs).
+
+| order | outcome |
+|---|---|
+| stand-down decided **and applied** before the grant | `ApplyGrant` refuses, `HandBackAStoodDownGrant` drops the lock. Closed above. |
+| grant applied, **then** stand-down decided | the hand-back half is true → the holder is cleared. Always worked. |
+| **stand-down decided before the grant, applied after it** | patch carries no `claimedBy` → **the holder survives**. #3567. |
+
+A candidate cannot evaluate a condition the owner will apply, so it states a **fact** the owner acts
+on — the `RequestedX`-plus-owner-watcher shape, and `RequestedStatus` is the same idea one field over
+on this record:
+
+- **`BuildState.StoodDown`** — holders that withdrew, keyed by holder id and written
+  **unconditionally** by `BuildNodeType.StandDown`. Its own key makes it merge-safe against every
+  other candidate, and being unconditional makes it true whatever the owner's state turns out to be.
+  It is the half that is always there to be read.
+- **`ReleaseStoodDownClaim`** — the arbiter releases a `Planning` claim whose holder has stood down,
+  and consumes the mark. A **`Building`** holder is never released: a mark from an earlier life of
+  the same id must not pull the lock out from under a running compile.
+- **`ApplyGrant`** also refuses a marked winner — the same refusal stated off the fact rather than
+  off the absence of a registration, which the in-flight patch may not have delivered yet.
+- **`DropLockHeldByStoodDown`** drops the claim LOCK when the mirror released, so the two records
+  agree; the debris lands on either, so fixing one alone just moves the wedge.
+- Marks are **consumed**, never accumulated: on release, on re-registration (`RequestBuildClaim`
+  clears its own key) and otherwise aged out on `ClaimStaleAfter`, the claim's own budget.
+
+🚨 **A decision the arbiter is never woken to take is not a fix.** The mark lands on a node with
+`RequestedClaims` **empty** — the grant consumed the follower's registration on its way in — so the
+own-stream trigger has to ask about more than "is anyone queued?", or the emission carrying the mark
+is filtered away and the release waits for the two-minute stale tick. `ArbitrationTrigger` is that
+predicate, named so it can be tested as the expression the arbiter actually subscribes: it wakes a
+pass for a pending registration **or** a stood-down holder, and the mark is part of the change key,
+not merely of the filter, because it arrives on a node whose other trigger fields did not move.
+(On a host with a durable store the withdraw's flush also publishes on `IStorageAdapter.Changes`,
+which is why this only ever showed up where the mirror *is* the claim.)
+
 There is deliberately **no timer and no bound bolted onto the wait**. A bound would end the wait by
 guessing, and a follower that guesses "the build finished" certifies a share it never probed — a
 silent wrong answer, strictly worse than a hang that announces itself. Both doors are level-triggered
@@ -448,10 +500,16 @@ resting on those two fields rests equally on the passing run. What is measured i
 **`ClaimedBy` stays set, one root emission in 15 s, nothing after.** A reader waiting on such a root
 waits forever.
 
-**The mechanism is open.** Whether the holder cannot act or was never told to is precisely the
-question still live on `MeshWeaver.Plugins#1193` — so this page names the SHAPE, not a cause. The
-permanent diagnostic landed as `MeshWeaver.Plugins#1401` (diagnostic only, no production code) and
-the repro recipe is on #1193; reproduce from those rather than re-deriving.
+**The mechanism is CLOSED (#3567) — the holder was never told to act, and could not have been.** The
+stand-down was decided on the candidate's own mirror and applied as a merge patch that carried no
+`claimedBy`, so a grant the arbiter committed inside that window survived it; the takeover rule then
+defended the live-but-idle holder by design. That is the third interleaving tabulated under
+*"a stand-down decided before the grant and applied after it"* above, and the fix is there too: the
+candidate records `StoodDown` as an unconditional fact and the arbiter releases on it — the general
+shape is [Conditional Writes Across Hubs](../ConditionalWritesAcrossHubs). The permanent diagnostic
+that produced the reading above landed as
+`MeshWeaver.Plugins#1401` (diagnostic only, no production code); the repro recipe is on #1193, which
+closes once that repo's `MW_PLATFORM_REF` carries the fix.
 
 🚨 It reproduced **with #3408 already in the core**, so #3408 does not remove it and #3131 did not
 close it: fourth and fifth are independent, and neither subsumes the other.

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -174,8 +174,9 @@ public static class BuildNodeType
     /// <summary>
     /// The claim arbiter — runs on each Build node's OWN hub.
     ///
-    /// <para>Two triggers, one decision procedure: every own-stream emission (a candidate
-    /// registered, a holder released) and a slow periodic tick (a dead holder emits nothing — the
+    /// <para>Two triggers, one decision procedure: every own-stream emission that
+    /// <see cref="ArbitrationTrigger"/> calls actionable (a candidate registered, a holder
+    /// released, a holder STOOD DOWN) and a slow periodic tick (a dead holder emits nothing — the
     /// stale steal can only come from a timer). Both funnel into <see cref="ArbitrateDurably"/>,
     /// which re-reads the durable row and does nothing when there is nothing to do, so redundant
     /// triggers write nothing.</para>
@@ -211,12 +212,10 @@ public static class BuildNodeType
         var onEmission = ActivityControlPlaneExtensions.SubscribeHubWatcher(
             hub,
             () => workspace.GetMeshNodeStream()
-                .Select(node => node?.ContentAs<BuildState>(hub.JsonSerializerOptions))
-                .Where(state => state?.RequestedClaims is { Count: > 0 })
-                .Select(state => string.Join(
-                    "|",
-                    state!.RequestedClaims!.Keys.OrderBy(k => k, StringComparer.Ordinal)
-                        .Append(state.ClaimedBy ?? string.Empty)))
+                .Select(node => ArbitrationTrigger(
+                    node?.ContentAs<BuildState>(hub.JsonSerializerOptions)))
+                .Where(key => key is not null)
+                .Select(key => key!)
                 .DistinctUntilChanged()
                 // A registration inside the settle window arbitrates to "not yet" (#1424), and no
                 // further emission is coming if nobody else registers — so every trigger also
@@ -261,6 +260,57 @@ public static class BuildNodeType
 
         return new System.Reactive.Disposables.CompositeDisposable(
             onEmission, onDurableChange, staleTick);
+    }
+
+    /// <summary>
+    /// The arbiter's MIRROR trigger, as a pure function of the state: <c>null</c> when a pass would
+    /// have nothing to decide, otherwise a key that CHANGES whenever the decision would. Named so a
+    /// test drives the same expression <see cref="InstallClaimArbiter"/> subscribes, rather than a
+    /// re-spelling of it that is free to drift.
+    ///
+    /// <para>Two states are actionable, and the second is the one #1193 added. <b>A pending
+    /// registration</b> may be grantable. <b>A holder that has STOOD DOWN</b>
+    /// (<see cref="StoodDownHolder"/>) must be released before anyone can be granted at all — and
+    /// it is actionable with <see cref="BuildState.RequestedClaims"/> EMPTY, which is precisely the
+    /// measured shape (<c>ClaimedBy=&lt;the follower&gt;, Status=Planning, RequestedClaims=[]</c>).
+    /// A trigger gated on a pending registration alone cannot see it: the grant consumed the
+    /// follower's registration on its way in, so the stand-down mark lands on a node with nothing
+    /// queued and the emission is filtered away.</para>
+    ///
+    /// <para>🚨 <b>Why that mattered even with <see cref="ReleaseStoodDownClaim"/> in place.</b> The
+    /// release would then have waited for whatever woke the arbiter next: on a host WITH a durable
+    /// store the withdraw's flush publishes on <see cref="IStorageAdapter.Changes"/> and the pass
+    /// runs at once, but on a host without one (a monolith test, a dev box — the fail-open
+    /// <c>GrantOnMirror</c> path) the only remaining wake-ups are the re-check some EARLIER
+    /// trigger happened to schedule and the <see cref="HeartbeatInterval"/> tick. A decision
+    /// procedure that is right and a trigger that never delivers it read exactly alike from the
+    /// unit test — <c>TheArbiterReleasesAStoodDownHolder_EvenWithNobodyQueued</c> passes either
+    /// way — so the trigger says the same thing the pass does, here, once.</para>
+    ///
+    /// <para>The stand-down holder is part of the KEY, not merely the filter: the mark arrives on a
+    /// node whose other trigger fields did not move (the grant had already emptied
+    /// <see cref="BuildState.RequestedClaims"/> and set <see cref="BuildState.ClaimedBy"/>), so a
+    /// key that omitted it would be swallowed by <c>DistinctUntilChanged</c> — the filter would
+    /// pass and nothing would fire.</para>
+    /// </summary>
+    /// <param name="state">The Build node's state as this hub's mirror currently holds it.</param>
+    /// <returns>The trigger key, or <c>null</c> when this state warrants no pass.</returns>
+    internal static string? ArbitrationTrigger(BuildState? state)
+    {
+        var pending = state?.RequestedClaims;
+        var stoodDown = StoodDownHolder(state);
+        if (pending is not { Count: > 0 } && stoodDown is null)
+            return null;
+
+        var candidates = pending is null
+            ? Enumerable.Empty<string>()
+            : pending.Keys.OrderBy(k => k, StringComparer.Ordinal);
+
+        return string.Join(
+            "|",
+            candidates
+                .Append(state!.ClaimedBy ?? string.Empty)
+                .Append(stoodDown ?? string.Empty));
     }
 
     /// <summary>
@@ -334,7 +384,10 @@ public static class BuildNodeType
                 // The candidate could not clear it itself (see ReleaseStoodDownClaim), so it is
                 // owed here. The release publishes on the mirror's change feed, which is this
                 // arbiter's own trigger, so the next candidate is elected immediately rather than
-                // at the slow tick — level-triggered, no timer, no retry.
+                // at the slow tick — level-triggered, no timer, no retry. The mark's ARRIVAL is a
+                // trigger on the same feed for the same reason (see ArbitrationTrigger): it lands
+                // on a node with nothing queued, so a trigger that asked only about pending
+                // registrations would have left this pass waiting for the stale tick.
                 if (StoodDownHolder(state) is { } stoodDown)
                     return workspace.GetMeshNodeStream()
                         .Update(node => ReleaseStoodDownClaim(node, options, DateTime.UtcNow))

--- a/test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs
@@ -425,4 +425,99 @@ public class BuildGrantPublicationTest
 
         BuildNodeType.ApplyGrant(mirror, Granted(), Options).Should().BeSameAs(mirror);
     }
+
+    // ── the WAKE-UP: a decision the arbiter is never woken to take is not a fix ─────────────────
+
+    /// <summary>
+    /// 🚨 The half the release above cannot supply for itself. <c>ReleaseStoodDownClaim</c> is right
+    /// about the wedged state, and <see cref="TheArbiterReleasesAStoodDownHolder_EvenWithNobodyQueued"/>
+    /// passes whether or not a pass is ever RUN on it — a correct decision procedure and a trigger
+    /// that never delivers it read exactly alike from a unit test. This is the trigger, and the
+    /// state it has to see is the measured one: <c>RequestedClaims</c> EMPTY, because the grant
+    /// consumed the follower's registration on its way in.
+    ///
+    /// <para>The arbiter's own-stream trigger used to ask only "is anyone queued?", so the
+    /// stand-down mark landed on a node it filtered away. On a host WITH a durable store the
+    /// withdraw's flush still published on <c>IStorageAdapter.Changes</c> and the pass ran at once;
+    /// on one without — a monolith test, a dev box, the fail-open <c>GrantOnMirror</c> path, where
+    /// the mirror IS the claim — the only wake-ups left were a re-check some EARLIER trigger
+    /// happened to schedule and the <c>HeartbeatInterval</c> tick two minutes out.</para>
+    /// </summary>
+    [Fact]
+    public void AStandDownMarkWakesTheArbiter_WithNobodyQueued()
+    {
+        BuildNodeType.ArbitrationTrigger(Wedged()).Should().NotBeNull(
+            "the wedged state is exactly what an arbitration pass is owed for, and nothing else is "
+            + "going to wake one — there is nobody queued left to register");
+    }
+
+    /// <summary>
+    /// …and the mark belongs to the KEY, not merely to the filter. It arrives on a node whose other
+    /// trigger fields did NOT move — the grant had already emptied <c>RequestedClaims</c> and set
+    /// <c>ClaimedBy</c> — so a key that omitted it would be swallowed by <c>DistinctUntilChanged</c>:
+    /// the filter would pass and still nothing would fire.
+    /// </summary>
+    [Fact]
+    public void TheStandDownMark_ChangesTheTriggerKey()
+    {
+        var queuedBehindTheWedge = Wedged() with
+        {
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add("next-image", new BuildClaimRequest("fp-next", T0)),
+        };
+
+        BuildNodeType.ArbitrationTrigger(queuedBehindTheWedge with { StoodDown = null })
+            .Should().NotBe(
+                BuildNodeType.ArbitrationTrigger(queuedBehindTheWedge),
+                "the two differ only in the mark, and they need different arbitration");
+    }
+
+    /// <summary>
+    /// The negative control, and what makes this a trigger rather than a poll: a node with nobody
+    /// queued and nothing to release wakes NOTHING. A key that fired on every emission would be a
+    /// poll wearing a filter's clothes.
+    /// </summary>
+    [Fact]
+    public void AQuietBuildNode_WakesNoArbitrationPass()
+    {
+        BuildNodeType.ArbitrationTrigger(Granted()).Should().BeNull();
+        BuildNodeType.ArbitrationTrigger(new BuildState()).Should().BeNull();
+        BuildNodeType.ArbitrationTrigger(null).Should().BeNull();
+    }
+
+    /// <summary>
+    /// A holder MID-BAKE carrying a mark wakes nothing either — the same line
+    /// <see cref="ARunningBake_IsNeverReleasedByAStandDownMark"/> draws, stated at the trigger so
+    /// the pass is not even run. Waking on a state the pass would decline is how a trigger turns
+    /// into a retry loop.
+    /// </summary>
+    [Fact]
+    public void ARunningBakeCarryingAMark_WakesNoArbitrationPass()
+    {
+        BuildNodeType.ArbitrationTrigger(Wedged() with { Status = BuildStatus.Building })
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// The pre-existing trigger is untouched: a pending registration still wakes a pass, and the
+    /// key still tracks BOTH the candidate set and the holder — a candidate joining the queue and
+    /// the holder releasing are each a state the election decides differently.
+    /// </summary>
+    [Fact]
+    public void APendingRegistration_StillWakesTheArbiter_AndTheHolderIsPartOfTheKey()
+    {
+        var queued = new BuildState
+        {
+            ClaimedBy = Winner,
+            Status = BuildStatus.Building,
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add("next-image", new BuildClaimRequest("fp-next", T0)),
+        };
+
+        BuildNodeType.ArbitrationTrigger(queued).Should().NotBeNull();
+        BuildNodeType.ArbitrationTrigger(queued with { ClaimedBy = null })
+            .Should().NotBe(
+                BuildNodeType.ArbitrationTrigger(queued),
+                "the holder releasing is what makes the queued candidate grantable");
+    }
 }


### PR DESCRIPTION
## #3570 gave the arbiter the right decision. This gives it the wake-up.

#3567's fix landed this morning as **#3570** and it is correct: a candidate records `StoodDown` as
an unconditional fact and `BuildNodeType.ReleaseStoodDownClaim` frees a `Planning` claim whose
holder carries the mark. What it did not carry is the other half — **something has to wake the
arbiter for the pass to happen at all**, and its own-stream trigger asked one question:

```csharp
.Where(state => state?.RequestedClaims is { Count: > 0 })   // "is anyone queued?"
```

The mark lands on a node with `RequestedClaims` **EMPTY**. The grant consumed the follower's
registration on its way in — that is the measured shape itself,
`ClaimedBy=<the follower> Status=Planning RequestedClaims=[] Ready=[fp-stand-down]`. So the emission
carrying the stand-down was **filtered away**, and the release waited for whatever woke the arbiter
next.

### Why it did not show up as a second red

On a host **with** a durable store the withdraw's flush of `Admin/Build` also publishes on
`IStorageAdapter.Changes`, which `InstallClaimArbiter` subscribes — so the pass ran at once and
every real deployment was fine. Where the mirror **is** the claim (a monolith test, a dev box, the
fail-open `GrantOnMirror` path) that feed does not exist, and the only wake-ups left were the
re-check some **earlier** trigger happened to schedule (`GrantSettleWindow + 1 s`, and only if a
qualifying emission had fired inside that window) and the `HeartbeatInterval` tick — **two minutes**.
`MeshWeaver.Plugins`' `Follower_StandsDown_SoTheNextBuildCanStillBeClaimed` asserts within
**fifteen seconds**, on exactly that host.

🚨 **This is the failure mode the unit test cannot see by construction.**
`TheArbiterReleasesAStoodDownHolder_EvenWithNobodyQueued` (#3570's own) passes whether or not any
pass is ever RUN on that state — a correct decision procedure and a trigger that never delivers it
read exactly alike from a pure-function test.

## The fix

`BuildNodeType.ArbitrationTrigger(BuildState?)` — the trigger extracted as a pure function and
named, so a test drives **the expression the arbiter actually subscribes** rather than a re-spelling
free to drift (the same convention `ArbitrateOnMirror` already follows in this file). It returns
`null` when a pass would have nothing to decide, and otherwise a key that changes whenever the
decision would:

- a **pending registration** — as before, unchanged;
- **or a stood-down holder** (`StoodDownHolder`, i.e. `ClaimedBy` marked and `Planning`).

The stand-down is part of the **KEY**, not merely of the filter. It arrives on a node whose other
trigger fields did not move — the grant had already emptied `RequestedClaims` and set `ClaimedBy` —
so a key that omitted it would be swallowed by `DistinctUntilChanged`: the filter would pass and
still nothing would fire.

A **`Building`** holder carrying a mark wakes nothing, the same line
`ARunningBake_IsNeverReleasedByAStandDownMark` draws, stated at the trigger so the pass is not even
run. Waking on a state the pass would decline is how a trigger turns into a retry loop; and the
release itself already terminates — it clears `ClaimedBy` and consumes the mark, after which the
trigger is `null` again unless someone is queued, in which case the next pass grants them.

**No timer, no retry, no widened bound, no relaxed assertion, no allow-file entry.** This *removes*
a reliance on a timer: the release becomes level-triggered on the state that needs it, which is what
`ArbitrateDurably`'s own comment already claimed.

## Coverage — failed before, passes after

`test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs`, five tests in that file's existing family:
the state is **built, never raced for**, no wall-clock and no concurrency.

| test | before | after |
|---|---|---|
| `AStandDownMarkWakesTheArbiter_WithNobodyQueued` — the measured shape wakes a pass | **FAIL** | pass |
| `TheStandDownMark_ChangesTheTriggerKey` — so `DistinctUntilChanged` cannot swallow it | **FAIL** | pass |
| `AQuietBuildNode_WakesNoArbitrationPass` — the negative control: a trigger, not a poll | pass | pass |
| `ARunningBakeCarryingAMark_WakesNoArbitrationPass` | pass | pass |
| `APendingRegistration_StillWakesTheArbiter_AndTheHolderIsPartOfTheKey` — the old behaviour intact | pass | pass |

Measured locally, same binary, only the trigger expression differing (the pre-fix expression
restored verbatim as a control):

```
pre-fix control : Failed: 2, Passed: 18, Total: 20
  AStandDownMarkWakesTheArbiter_WithNobodyQueued — Expected value not to be <null>
  TheStandDownMark_ChangesTheTriggerKey          — Did not expect value to be "next-image|pod-7/2c9f"
with the fix    : Failed: 0, Passed: 20, Total: 20
```

The three that pass in both are the controls — they say the trigger did not become a poll.

## Docs

`Doc/Architecture/BuildCoordination` still carried, at the bottom of the fifth-cause section:

> **The mechanism is open.** Whether the holder cannot act or was never told to is precisely the
> question still live on `MeshWeaver.Plugins#1193` — so this page names the SHAPE, not a cause.

That is now false, and it is the page anyone debugging this reads first. It records the closed
mechanism, the **third interleaving** and its table (decided-before / applied-after), the fix
(`StoodDown` → `ReleaseStoodDownClaim` → `ApplyGrant`'s second refusal → `DropLockHeldByStoodDown`,
marks consumed), and the wake-up above — and points at
[Conditional Writes Across Hubs](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/ConditionalWritesAcrossHubs.md),
the page #3570 added for the general shape. `DocumentationLinkIntegrityTest` passed.

## Verification

`MeshWeaver.Graph`, `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation` (which also builds
`MeshWeaver.Hosting`, Graph's dependent) and `MeshWeaver.Documentation.Test` all build
`-c Release -warnaserror` → **0 Error(s), 0 Warning(s)**. `BuildGrantPublicationTest` 20/20;
`DocumentationLinkIntegrityTest` 1/1.

## Surface

Additive and **internal only**: one `internal static` method on the static `BuildNodeType`, plus a
private lambda replaced by a call to it. **No public type or member leaves `src/`**, so no
`Pairs-with:` is owed; **no interface or abstract member is added**, so no `Implementers:` is owed.

## What's New — deliberately none

The user-visible half of #3567 shipped this morning with #3570's entry
(*"A rollout can no longer be left holding a build nobody will run"*), and this changes nothing a
user of any deployment can observe: every deployment has an `IStorageAdapter`, so its arbiter was
already woken by the durable change feed. What this fixes is the host where the mirror is the whole
world — a test host and a dev box — plus a doc page that said the cause was unknown. A second entry
for the same day and the same symptom would be noise.

## What this still does not close

`MeshWeaver.Plugins#1193` closes when that repo's `MW_PLATFORM_REF` carries **both** core commits —
#3570's `e113077df`/`9e51db003` (merged as `45e39473f`) and this one. That pin bump is a separate
wave.

Closes #3567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
