### PR TITLE
fix(GitSync): a module-bearing repo's sources advance only to the commit sealed for this instance (Plugins#1430)

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -178,6 +178,15 @@ ARCH_MARKER="architecture.txt"
 ARCH_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$ARCH_MARKER"
 printf '%s\n' "$BAKE_ARCHITECTURE" > "$ARCH_MARKER_LOCAL"
 
+# The PRODUCING REPOSITORY marker (MeshWeaver.Plugins#1430) — same contract as the two above: not
+# part of the reader's contract, written BEFORE the sentinel. It is what lets an instance attribute
+# a sealed source to the repository whose green builds it receives, so its sync sources advance only
+# to the commit sealed for its own identity (SealedPublicationIndex / SealedSyncGate in core). A
+# local run records nothing rather than a guess; the gate attributes such a seal by commit instead.
+REPO_MARKER="repository.txt"
+REPO_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$REPO_MARKER"
+printf '%s\n' "${GITHUB_REPOSITORY:-}" > "$REPO_MARKER_LOCAL"
+
 # ══════════════════════ THE TWO-WRITER POSTCONDITION (MeshWeaver#3461) ══════════════════════
 #
 # 🚨 `<identity>/plugins` HAS SEVERAL WRITERS. Core CD's `plugins-bake` job publishes `bake-source:
@@ -296,6 +305,7 @@ done
 manifest_add "$MODULES_DIR_NAME/$MODULES_INDEX" "$MODULES_INDEX_LOCAL"
 manifest_add "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL"
 manifest_add "$ARCH_MARKER" "$ARCH_MARKER_LOCAL"
+manifest_add "$REPO_MARKER" "$REPO_MARKER_LOCAL"
 # The denominator every verification prints and every refusal quotes. A publication with nothing
 # in it cannot be verified into existence, and a zero here would make the sweep below pass having
 # read nothing — the exact vacuity a guard must never render as green.
@@ -564,6 +574,7 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   # DIRECTORY and fail ParentNotFound (see the SENTINEL_LOCAL comment above).
   upload_published_file "$account" "$share" "$dest" "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL" "$dest"
   upload_published_file "$account" "$share" "$dest" "$ARCH_MARKER" "$ARCH_MARKER_LOCAL" "$dest"
+  upload_published_file "$account" "$share" "$dest" "$REPO_MARKER" "$REPO_MARKER_LOCAL" "$dest"
   # 🚨 THE POSTCONDITION, between the last content upload and the seal (MeshWeaver#3461). Every
   # file above is read back and must still carry THIS run's digest; a foreign publisher that
   # overwrote any of them makes this refuse, and the directory stays sentinel-less rather than

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -174,18 +174,20 @@ printf '%s\n' "${SOURCE_SHA:-unknown}" > "$SOURCE_MARKER_LOCAL"
 # The ARCHITECTURE marker — same contract as the content marker: not part of the reader's
 # contract (SeedPublishedRoot seeds only what the sentinel lists), written BEFORE the sentinel so
 # a sealed directory always carries one, and read by the cross-architecture guard below.
-ARCH_MARKER="architecture.txt"
-ARCH_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$ARCH_MARKER"
-printf '%s\n' "$BAKE_ARCHITECTURE" > "$ARCH_MARKER_LOCAL"
-
-# The PRODUCING REPOSITORY marker (MeshWeaver.Plugins#1430) — same contract as the two above: not
-# part of the reader's contract, written BEFORE the sentinel. It is what lets an instance attribute
-# a sealed source to the repository whose green builds it receives, so its sync sources advance only
-# to the commit sealed for its own identity (SealedPublicationIndex / SealedSyncGate in core). A
-# local run records nothing rather than a guess; the gate attributes such a seal by commit instead.
+# The PRODUCING REPOSITORY marker (MeshWeaver.Plugins#1430) — same contract as the content marker:
+# not part of the reader's contract, written BEFORE the sentinel. It is what lets an instance
+# attribute a sealed source to the repository whose green builds it receives, so its sync sources
+# advance only to the commit sealed for its own identity (SealedPublicationIndex / SealedSyncGate
+# in core). A local run records nothing rather than a guess; the gate attributes such a seal by
+# commit instead. Listed and uploaded BEFORE architecture.txt, which stays the LAST upload before
+# the postcondition — the overlap harness hooks its second publisher onto that file.
 REPO_MARKER="repository.txt"
 REPO_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$REPO_MARKER"
 printf '%s\n' "${GITHUB_REPOSITORY:-}" > "$REPO_MARKER_LOCAL"
+
+ARCH_MARKER="architecture.txt"
+ARCH_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$ARCH_MARKER"
+printf '%s\n' "$BAKE_ARCHITECTURE" > "$ARCH_MARKER_LOCAL"
 
 # ══════════════════════ THE TWO-WRITER POSTCONDITION (MeshWeaver#3461) ══════════════════════
 #
@@ -304,8 +306,8 @@ for m in ${MODULES[@]+"${MODULES[@]}"}; do
 done
 manifest_add "$MODULES_DIR_NAME/$MODULES_INDEX" "$MODULES_INDEX_LOCAL"
 manifest_add "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL"
-manifest_add "$ARCH_MARKER" "$ARCH_MARKER_LOCAL"
 manifest_add "$REPO_MARKER" "$REPO_MARKER_LOCAL"
+manifest_add "$ARCH_MARKER" "$ARCH_MARKER_LOCAL"
 # The denominator every verification prints and every refusal quotes. A publication with nothing
 # in it cannot be verified into existence, and a zero here would make the sweep below pass having
 # read nothing — the exact vacuity a guard must never render as green.
@@ -573,8 +575,8 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   # basename. An extensionless "$dest/$SENTINEL" --path would be silently re-interpreted as a
   # DIRECTORY and fail ParentNotFound (see the SENTINEL_LOCAL comment above).
   upload_published_file "$account" "$share" "$dest" "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL" "$dest"
-  upload_published_file "$account" "$share" "$dest" "$ARCH_MARKER" "$ARCH_MARKER_LOCAL" "$dest"
   upload_published_file "$account" "$share" "$dest" "$REPO_MARKER" "$REPO_MARKER_LOCAL" "$dest"
+  upload_published_file "$account" "$share" "$dest" "$ARCH_MARKER" "$ARCH_MARKER_LOCAL" "$dest"
   # 🚨 THE POSTCONDITION, between the last content upload and the seal (MeshWeaver#3461). Every
   # file above is read back and must still carry THIS run's digest; a foreign publisher that
   # overwrote any of them makes this refuse, and the directory stays sentinel-less rather than

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -97,8 +97,8 @@ SHOW_QUERY = "[[metadata.digest || '-', metadata.publication || '-']]"
 
 BUNDLES = ["Chess.zip", "Edu.zip", "Store.zip"]
 MODULES = ["MeshWeaver.AI.module.nupkg", "MeshWeaver.Maps.module.nupkg"]
-# bundles + modules + modules/_index + source-commit.txt + architecture.txt
-EXPECTED_FILES = len(BUNDLES) + len(MODULES) + 3
+# bundles + modules + modules/_index + source-commit.txt + architecture.txt + repository.txt
+EXPECTED_FILES = len(BUNDLES) + len(MODULES) + 4
 
 
 # ────────────────────────────── the stub `az` ──────────────────────────────
@@ -666,7 +666,7 @@ def main() -> int:
 
     print(f"publish-bake overlap harness — executing {args.script}")
     print(f"  identity {IDENTITY}, source '{SOURCE}', {EXPECTED_FILES} file(s) per publication "
-          f"({len(BUNDLES)} bundle(s), {len(MODULES)} module(s), 3 marker/index file(s))")
+          f"({len(BUNDLES)} bundle(s), {len(MODULES)} module(s), 4 marker/index file(s))")
     with tempfile.TemporaryDirectory(prefix="publish-bake-overlap-") as tmp:
         run_cases(args.script, Path(tmp), args.expect_defect)
 

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -10,6 +10,9 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -332,6 +335,16 @@ public sealed class GitHubWebhookProcessor
                 // "43 sync config(s) in the mesh, 0 selected, 0 skipped": a healthy-looking count,
                 // no skips, and no clue that nothing was ever even a candidate. Hence {Targeting}
                 // here, and the Warning ConfigsTargeting raises (#1856).
+                // 🚨 What THIS instance's identity has sealed (MeshWeaver.Plugins#1430) — read once
+                // per delivery. A module-bearing repository's sources advance only to the commit
+                // sealed for this instance; the green build alone proved the tree compiles
+                // somewhere, not here. Repositories the instance runs no publication of are
+                // unaffected (SealedSyncGate: no attributable seal ⇒ today's behaviour).
+                var identity = PrebuiltAssemblySeeder.LiveFrameworkMvid;
+                var sealedForThisIdentity = SealedPublicationIndex.ReadFor(
+                    hub.ServiceProvider.GetService<IConfiguration>()?[ShippedPrebuiltBundles.PublishedRootConfigKey],
+                    identity, logger);
+                var held = 0;
                 var picked = new List<PushTarget>();
                 var skipped = new List<string>();
                 foreach (var node in match.Configs)
@@ -340,6 +353,13 @@ public sealed class GitHubWebhookProcessor
                     if (SkipReason(cfg, branch, headSha) is { } reason)
                     {
                         skipped.Add($"{node.Path} ({reason})");
+                        continue;
+                    }
+                    if (SealedSyncGate.Decide(repo, headSha, cfg?.LastSyncCommitSha, sealedForThisIdentity, identity)
+                        is { Proceed: false } hold)
+                    {
+                        held++;
+                        skipped.Add($"{node.Path} ({hold.HoldReason})");
                         continue;
                     }
                     if (ToPushTarget(node) is not { } pushTarget)
@@ -359,6 +379,15 @@ public sealed class GitHubWebhookProcessor
                     + "{Targeting} targeting this repository, {Selected} selected, {Skipped} skipped{SkipDetail}.",
                     repo, branch, headSha, match.Candidates, match.Configs.Count, targets.Count,
                     skipped.Count, skipped.Count == 0 ? string.Empty : " — " + string.Join("; ", skipped));
+                if (held > 0)
+                    // Its own line, at Warning: a source held back by the seal is content that
+                    // quietly stops arriving until the registry seals this commit for this identity
+                    // — an operator must be able to find it without reading the skip detail.
+                    logger?.LogWarning(
+                        "Green build of {Repo}@{Branch} ({Sha}): {Held} sync source(s) HELD — the build is "
+                        + "not sealed for this instance's framework identity {Identity}; they advance when it is "
+                        + "(MeshWeaver.Plugins#1430).",
+                        repo, branch, headSha, held, identity);
 
                 return targets;
             });

--- a/src/MeshWeaver.GitSync/SealedSyncGate.cs
+++ b/src/MeshWeaver.GitSync/SealedSyncGate.cs
@@ -1,0 +1,92 @@
+using MeshWeaver.Hosting;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// 🚨 A module-bearing repository's sources advance only to the commit SEALED for this instance
+/// (MeshWeaver.Plugins#1430). An instance pins its module set at boot from the publication sealed
+/// under its own framework identity; its sources, by contrast, used to follow every green build of
+/// the repository — so #1413's Payments split reached both production Stores' <c>Store/*</c> sources
+/// while they ran a platform with no Payments module, and four Store types sat in compile Error for
+/// nine hours. The green build proves a tree compiles somewhere; the seal proves it compiles HERE.
+///
+/// <para>Pure: the caller supplies what the registry sealed for this identity
+/// (<see cref="SealedPublicationIndex.ReadFor"/>) and this decides, per sync source. Three
+/// outcomes, stated as data:</para>
+/// <list type="bullet">
+///   <item><description>No sealed source is attributable to the repository — the instance runs no
+///   publication of it (a course repo, a repo whose seal predates both markers and is on neither
+///   known commit): today's behaviour, import at the built commit.</description></item>
+///   <item><description>A sealed source of the repository is at the built commit: proceed — the
+///   seal and the build agree on the tree.</description></item>
+///   <item><description>Otherwise: HOLD, and say why (built at S, sealed at C / not sealed). The
+///   source waits for the seal; "cannot tell" is never "clear to proceed".</description></item>
+/// </list>
+///
+/// <para><b>Attribution.</b> A sealed source belongs to the repository when its repository marker
+/// names it, or — for seals that predate that marker — when its source commit is the built commit
+/// or the commit the sync source already sits on. Once the gate has run, a source only ever sits on
+/// sealed commits, so the second leg keeps attributing older seals until they are republished.</para>
+/// </summary>
+public static class SealedSyncGate
+{
+    /// <summary>The decision: proceed, or hold with the reason a skipped Space is logged with.</summary>
+    public sealed record Verdict(bool Proceed, string? HoldReason)
+    {
+        /// <summary>Import at the built commit.</summary>
+        public static Verdict Go { get; } = new(true, null);
+    }
+
+    /// <summary>
+    /// Decides whether a sync source of <paramref name="repo"/> may import the green build at
+    /// <paramref name="headSha"/>, given what this instance's identity has sealed.
+    /// </summary>
+    /// <param name="repo">The repository the green build is of.</param>
+    /// <param name="headSha">The built commit.</param>
+    /// <param name="lastSyncSha">The commit the sync source currently sits on, or null.</param>
+    /// <param name="sealedForThisIdentity">What the registry sealed under this instance's framework identity.</param>
+    /// <param name="identity">This instance's framework identity — log copy only.</param>
+    public static Verdict Decide(
+        RepoIdentity repo, string headSha, string? lastSyncSha,
+        IReadOnlyList<SealedSource> sealedForThisIdentity, string identity)
+    {
+        var mine = sealedForThisIdentity
+            .Where(s => BelongsTo(s, repo, headSha, lastSyncSha))
+            .ToList();
+        if (mine.Count == 0)
+            return Verdict.Go;
+        if (mine.Any(s => s.IsSealed && SameCommit(s.SourceCommit, headSha)))
+            return Verdict.Go;
+        var witness = mine.OrderByDescending(s => s.IsSealed).ThenBy(s => s.Source, StringComparer.Ordinal).First();
+        var reason = witness.IsSealed
+            ? $"built at {Short(headSha)}, not sealed for this instance (identity {identity}: "
+              + $"'{witness.Source}' is sealed at {(witness.SourceCommit is null ? "an unknown commit" : Short(witness.SourceCommit))})"
+            : $"built at {Short(headSha)}, and this instance's publication of '{witness.Source}' is not sealed "
+              + $"(identity {identity}: {witness.Refusal})";
+        return new Verdict(false, reason);
+    }
+
+    /// <summary>Whether a sealed source is the repository's — by its repository marker, or by commit
+    /// for a seal that predates the marker. Pure.</summary>
+    public static bool BelongsTo(SealedSource sealedSource, RepoIdentity repo, string headSha, string? lastSyncSha)
+    {
+        if (sealedSource.Repository is { Length: > 0 } recorded)
+            return repo.Matches(Parse(recorded));
+        return SameCommit(sealedSource.SourceCommit, headSha)
+            || (lastSyncSha is { Length: > 0 } && SameCommit(sealedSource.SourceCommit, lastSyncSha));
+    }
+
+    /// <summary><c>owner/name</c> → <see cref="RepoIdentity"/>; anything else is an identity that matches nothing.</summary>
+    public static RepoIdentity Parse(string ownerSlashName)
+    {
+        var parts = ownerSlashName.Trim().Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 2 ? new RepoIdentity(parts[0], parts[1]) : new RepoIdentity("", "");
+    }
+
+    private static bool SameCommit(string? a, string? b) =>
+        !string.IsNullOrEmpty(a) && !string.IsNullOrEmpty(b)
+        && (a.StartsWith(b, StringComparison.OrdinalIgnoreCase) || b.StartsWith(a, StringComparison.OrdinalIgnoreCase))
+        && Math.Min(a.Length, b.Length) >= 7;
+
+    private static string Short(string sha) => sha.Length > 8 ? sha[..8] : sha;
+}

--- a/src/MeshWeaver.Hosting/SealedPublicationIndex.cs
+++ b/src/MeshWeaver.Hosting/SealedPublicationIndex.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// One source's publication under ONE framework identity, as the registry sealed it for the
+/// instance running that identity: which producing repository it came from (when the lane
+/// recorded it), the commit it was baked from, and whether it is sealed at all.
+/// </summary>
+/// <param name="Source">The bake-source segment (<c>plugins</c>, <c>education</c>, …).</param>
+/// <param name="Repository">The producing repository as <c>owner/name</c>, from
+/// <see cref="SealedPublicationIndex.RepositoryMarkerFileName"/>; null when the seal predates that
+/// marker.</param>
+/// <param name="SourceCommit">The producing repository's commit the publication was baked from,
+/// from <see cref="SealedPublicationIndex.SourceCommitMarkerFileName"/>; null when absent or
+/// recorded as unknown.</param>
+/// <param name="IsSealed">True when the completion sentinel is present and every bundle it lists
+/// is on disk — the same rule the boot seeder judges by.</param>
+/// <param name="Refusal">Why <paramref name="IsSealed"/> is false, or null.</param>
+public sealed record SealedSource(
+    string Source, string? Repository, string? SourceCommit, bool IsSealed, string? Refusal);
+
+/// <summary>
+/// Reads what the registry SEALED for one framework identity — the publication set the instance
+/// running that identity boots from (<see cref="ShippedPrebuiltBundles.SeedPublishedRoot"/>) —
+/// as data a decision can be made on, per source: producing repository, source commit, sealed or
+/// not. It is the reading behind "may this instance's sources advance to that commit?"
+/// (MeshWeaver.Plugins#1430): an instance whose module set is pinned at boot must not import
+/// sources built past the publication it runs, and the seal's own markers are the only statement
+/// of which commit that is.
+///
+/// <para>Markers are written by <c>publish-bake-bundles.sh</c> strictly BEFORE the sentinel, so a
+/// sealed directory always carries them. The repository marker is newer than the commit marker;
+/// a seal without it is attributed by commit instead (see <c>SealedSyncGate</c>).</para>
+///
+/// <para>Pure over the file system and never throws: an unreadable root reads as "nothing sealed",
+/// which callers treat as "no evidence" — never as permission.</para>
+/// </summary>
+public static class SealedPublicationIndex
+{
+    /// <summary>The producing repository's commit, one line — <c>unknown</c> when the lane had none.</summary>
+    public const string SourceCommitMarkerFileName = "source-commit.txt";
+
+    /// <summary>The producing repository as <c>owner/name</c>, one line.</summary>
+    public const string RepositoryMarkerFileName = "repository.txt";
+
+    /// <summary>
+    /// Every source directory under <c>&lt;publishedRoot&gt;/&lt;identity&gt;/</c>, read as
+    /// <see cref="SealedSource"/>s. Empty when the root or the identity directory is absent.
+    /// </summary>
+    public static IReadOnlyList<SealedSource> ReadFor(
+        string? publishedRoot, string? identity, ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(publishedRoot) || string.IsNullOrWhiteSpace(identity))
+            return [];
+        var identityDirectory = Path.Combine(publishedRoot, identity);
+        try
+        {
+            if (!Directory.Exists(identityDirectory))
+                return [];
+            return Directory.EnumerateDirectories(identityDirectory)
+                .OrderBy(d => d, StringComparer.Ordinal)
+                .Select(d => ReadSource(d, logger))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "SealedPublicationIndex: could not read the publications under {Directory} — "
+                + "treating the identity as having none sealed", identityDirectory);
+            return [];
+        }
+    }
+
+    private static SealedSource ReadSource(string sourceDirectory, ILogger? logger)
+    {
+        var source = Path.GetFileName(sourceDirectory)!;
+        var repository = ReadMarker(Path.Combine(sourceDirectory, RepositoryMarkerFileName));
+        var commit = ReadMarker(Path.Combine(sourceDirectory, SourceCommitMarkerFileName));
+        if (string.Equals(commit, "unknown", StringComparison.OrdinalIgnoreCase))
+            commit = null;
+        var sentinel = Path.Combine(sourceDirectory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        if (!File.Exists(sentinel))
+            return new SealedSource(source, repository, commit, false, "no completion sentinel");
+        try
+        {
+            var missing = File.ReadAllLines(sentinel)
+                .Select(l => l.Trim())
+                .Where(l => l.Length > 0)
+                .FirstOrDefault(name => !File.Exists(Path.Combine(sourceDirectory, name)));
+            return missing is null
+                ? new SealedSource(source, repository, commit, true, null)
+                : new SealedSource(source, repository, commit, false,
+                    $"the seal lists '{missing}', which is not on disk");
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "SealedPublicationIndex: could not read the seal of {Directory}", sourceDirectory);
+            return new SealedSource(source, repository, commit, false, $"the seal could not be read: {ex.GetType().Name}");
+        }
+    }
+
+    private static string? ReadMarker(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var value = File.ReadAllText(path).Trim();
+            return value.Length == 0 ? null : value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.Hosting/SealedPublicationIndex.cs
+++ b/src/MeshWeaver.Hosting/SealedPublicationIndex.cs
@@ -33,8 +33,11 @@ public sealed record SealedSource(
 /// sealed directory always carries them. The repository marker is newer than the commit marker;
 /// a seal without it is attributed by commit instead (see <c>SealedSyncGate</c>).</para>
 ///
-/// <para>Pure over the file system and never throws: an unreadable root reads as "nothing sealed",
-/// which callers treat as "no evidence" — never as permission.</para>
+/// <para>Pure over the file system and never throws: an unreadable or absent root reads as
+/// "nothing sealed for this identity". That is a statement about THIS reading, not a verdict —
+/// the gate that consumes it (<c>SealedSyncGate</c>) treats "no seal attributable to the
+/// repository" as "this gate does not apply" and keeps today's behaviour; only a seal that IS
+/// attributable and is at another commit, or torn, holds a source.</para>
 /// </summary>
 public static class SealedPublicationIndex
 {

--- a/test/MeshWeaver.Documentation.Test/SealedSyncGateTest.cs
+++ b/test/MeshWeaver.Documentation.Test/SealedSyncGateTest.cs
@@ -1,0 +1,119 @@
+#pragma warning disable CS1591
+using System.Collections.Generic;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// The decision behind MeshWeaver.Plugins#1430: a module-bearing repository's sync sources advance
+/// only to the commit SEALED for this instance's framework identity. Stated as data in both
+/// directions — what proceeds, what is held and why, and what is not this gate's business.
+///
+/// <para>The incident it exists for: 2026-09-06 22:39Z, #1413's Payments split reached both
+/// production Stores' <c>Store/*</c> sources (green build → import) while the instances ran a
+/// platform whose sealed module set had no Payments module; four Store types compile-errored for
+/// nine hours. The green build proves the tree compiles somewhere; the seal proves it compiles here.</para>
+/// </summary>
+public class SealedSyncGateTest
+{
+    private static readonly RepoIdentity Plugins = new("Systemorph", "MeshWeaver.Plugins");
+    private const string Built = "1234567890abcdef1234567890abcdef12345678";
+    private const string Sealed = "abcdef1234567890abcdef1234567890abcdef12";
+    private const string Identity = "s9c0b05d61cb34bbffde9ad7a32ab1a8b";
+
+    private static SealedSource Source(string name, string? repository, string? commit, bool sealedState = true, string? refusal = null)
+        => new(name, repository, commit, sealedState, refusal);
+
+    [Fact]
+    public void NothingSealedForThisIdentity_IsNotThisGatesBusiness()
+        => SealedSyncGate.Decide(Plugins, Built, null, [], Identity).Proceed
+            .Should().BeTrue("an instance that runs no publication of the repository keeps today's behaviour");
+
+    [Fact]
+    public void ASealOfAnotherRepository_DoesNotHoldThisOne()
+        => SealedSyncGate.Decide(Plugins, Built, null,
+                [Source("education", "Systemorph/MeshWeaver.Education", Sealed)], Identity).Proceed
+            .Should().BeTrue("the education seal says nothing about the plugins repository");
+
+    [Fact]
+    public void TheSealAtTheBuiltCommit_Proceeds()
+        => SealedSyncGate.Decide(Plugins, Built, Sealed,
+                [Source("plugins", "Systemorph/MeshWeaver.Plugins", Built)], Identity).Proceed
+            .Should().BeTrue("the seal and the build agree on the tree");
+
+    [Fact]
+    public void TheRepositoryMarkerIsMatchedLikeGitHubDoes_CaseInsensitively()
+        => SealedSyncGate.Decide(Plugins, Built, null,
+                [Source("plugins", "systemorph/meshweaver.plugins", Built)], Identity).Proceed
+            .Should().BeTrue();
+
+    [Fact]
+    public void ASealAtAnotherCommit_Holds_AndSaysWhere()
+    {
+        var verdict = SealedSyncGate.Decide(Plugins, Built, Sealed,
+            [Source("plugins", "Systemorph/MeshWeaver.Plugins", Sealed)], Identity);
+        verdict.Proceed.Should().BeFalse("the instance's module set was sealed at another commit");
+        verdict.HoldReason.Should().Contain("built at 12345678")
+            .And.Contain("not sealed for this instance")
+            .And.Contain("'plugins' is sealed at abcdef12")
+            .And.Contain(Identity);
+    }
+
+    [Fact]
+    public void ATornPublication_Holds_RatherThanGuessing()
+    {
+        var verdict = SealedSyncGate.Decide(Plugins, Built, null,
+            [Source("plugins", "Systemorph/MeshWeaver.Plugins", Built, sealedState: false, refusal: "no completion sentinel")], Identity);
+        verdict.Proceed.Should().BeFalse("cannot tell is never clear to proceed");
+        verdict.HoldReason.Should().Contain("is not sealed").And.Contain("no completion sentinel");
+    }
+
+    [Fact]
+    public void ASealWithoutARepositoryMarker_IsAttributedByTheBuiltCommit()
+        => SealedSyncGate.Decide(Plugins, Built, null, [Source("plugins", null, Built)], Identity).Proceed
+            .Should().BeTrue("a seal at the built commit is this build's seal, marker or not");
+
+    [Fact]
+    public void ASealWithoutARepositoryMarker_IsAttributedByTheCommitTheSourceSitsOn_AndHolds()
+    {
+        // The source sits on the sealed commit (the last import the gate admitted); the new build is
+        // not sealed yet — hold, exactly as with the marker.
+        var verdict = SealedSyncGate.Decide(Plugins, Built, Sealed, [Source("plugins", null, Sealed)], Identity);
+        verdict.Proceed.Should().BeFalse();
+        verdict.HoldReason.Should().Contain("sealed at abcdef12");
+    }
+
+    [Fact]
+    public void ASealWithoutARepositoryMarker_OnAnUnrelatedCommit_IsNoEvidence()
+        => SealedSyncGate.Decide(Plugins, Built, Sealed, [Source("plugins", null, "0000000000000000000000000000000000000000")], Identity).Proceed
+            .Should().BeTrue("a seal that names neither the build nor the source's commit cannot be attributed — it is not evidence either way");
+
+    [Fact]
+    public void ASealAtAnUnknownCommit_ForThisRepository_Holds()
+    {
+        var verdict = SealedSyncGate.Decide(Plugins, Built, null,
+            [Source("plugins", "Systemorph/MeshWeaver.Plugins", null)], Identity);
+        verdict.Proceed.Should().BeFalse("the lane recorded no commit — the seal cannot be matched to the build");
+        verdict.HoldReason.Should().Contain("an unknown commit");
+    }
+
+    [Fact]
+    public void OneSealAtTheBuiltCommitAmongOthers_Proceeds()
+        => SealedSyncGate.Decide(Plugins, Built, Sealed,
+                [Source("plugins-old", "Systemorph/MeshWeaver.Plugins", Sealed), Source("plugins", "Systemorph/MeshWeaver.Plugins", Built)], Identity)
+            .Proceed.Should().BeTrue("any sealed source of the repository at the built commit is enough");
+
+    [Theory]
+    [InlineData("Systemorph/MeshWeaver.Plugins", "Systemorph", "MeshWeaver.Plugins")]
+    [InlineData(" Systemorph/MeshWeaver.Plugins ", "Systemorph", "MeshWeaver.Plugins")]
+    [InlineData("MeshWeaver.Plugins", "", "")]
+    [InlineData("a/b/c", "", "")]
+    public void TheRepositoryMarkerParsesAsOwnerSlashName_OrMatchesNothing(string marker, string owner, string name)
+    {
+        var parsed = SealedSyncGate.Parse(marker);
+        parsed.Owner.Should().Be(owner);
+        parsed.Repo.Should().Be(name);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/SealedPublicationIndexTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SealedPublicationIndexTest.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The reading behind MeshWeaver.Plugins#1430: what the registry sealed for one framework identity,
+/// per source — repository and commit from the lane's markers, sealed by the same rule the boot
+/// seeder judges by (sentinel present, every listed bundle on disk).
+/// </summary>
+public class SealedPublicationIndexTest : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), "sealed-index-" + Guid.NewGuid().ToString("N"));
+    private const string Identity = "s9c0b05d61cb34bbffde9ad7a32ab1a8b";
+
+    private string Source(string name, bool sentinel, string? commit, string? repository, params string[] bundles)
+    {
+        var dir = Path.Combine(root, Identity, name);
+        Directory.CreateDirectory(dir);
+        foreach (var b in bundles)
+            File.WriteAllText(Path.Combine(dir, b), "zip");
+        if (commit is not null)
+            File.WriteAllText(Path.Combine(dir, SealedPublicationIndex.SourceCommitMarkerFileName), commit + "\n");
+        if (repository is not null)
+            File.WriteAllText(Path.Combine(dir, SealedPublicationIndex.RepositoryMarkerFileName), repository + "\n");
+        if (sentinel)
+            File.WriteAllText(Path.Combine(dir, ShippedPrebuiltBundles.CompletionSentinelFileName), string.Join("\n", bundles) + "\n");
+        return dir;
+    }
+
+    [Fact]
+    public void ASealedSource_ReadsItsMarkersAndIsSealed()
+    {
+        Source("plugins", sentinel: true, "abcdef1234567890", "Systemorph/MeshWeaver.Plugins", "Edu.zip", "Store.zip");
+        var read = SealedPublicationIndex.ReadFor(root, Identity).Single();
+        read.Source.Should().Be("plugins");
+        read.Repository.Should().Be("Systemorph/MeshWeaver.Plugins");
+        read.SourceCommit.Should().Be("abcdef1234567890");
+        read.IsSealed.Should().BeTrue();
+        read.Refusal.Should().BeNull();
+    }
+
+    [Fact]
+    public void NoSentinel_IsNotSealed_AndSaysSo()
+    {
+        Source("plugins", sentinel: false, "abcdef1234567890", null, "Edu.zip");
+        var read = SealedPublicationIndex.ReadFor(root, Identity).Single();
+        read.IsSealed.Should().BeFalse();
+        read.Refusal.Should().Contain("no completion sentinel");
+        read.Repository.Should().BeNull("the seal predates the repository marker");
+    }
+
+    [Fact]
+    public void AListedBundleMissingFromDisk_IsTorn()
+    {
+        var dir = Source("plugins", sentinel: true, "abcdef1234567890", null, "Edu.zip", "Store.zip");
+        File.Delete(Path.Combine(dir, "Store.zip"));
+        var read = SealedPublicationIndex.ReadFor(root, Identity).Single();
+        read.IsSealed.Should().BeFalse();
+        read.Refusal.Should().Contain("Store.zip");
+    }
+
+    [Fact]
+    public void AnUnknownCommitMarker_ReadsAsNoCommit()
+    {
+        Source("plugins", sentinel: true, "unknown", null, "Edu.zip");
+        SealedPublicationIndex.ReadFor(root, Identity).Single().SourceCommit.Should().BeNull();
+    }
+
+    [Fact]
+    public void AnAbsentRootOrIdentity_ReadsAsNothingSealed()
+    {
+        SealedPublicationIndex.ReadFor(null, Identity).Should().BeEmpty();
+        SealedPublicationIndex.ReadFor(root, null).Should().BeEmpty();
+        SealedPublicationIndex.ReadFor(Path.Combine(root, "absent"), Identity).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EverySourceUnderTheIdentity_IsRead_InOrder()
+    {
+        Source("plugins", sentinel: true, "aaaaaaaaaaaaaaaa", "Systemorph/MeshWeaver.Plugins", "Edu.zip");
+        Source("education", sentinel: true, "bbbbbbbbbbbbbbbb", "Systemorph/MeshWeaver.Education", "Course.zip");
+        SealedPublicationIndex.ReadFor(root, Identity).Select(s => s.Source).Should().Equal("education", "plugins");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
## What

Fixes MeshWeaver.Plugins#1430 (its instance-side half; builds on #3553, which pinned the import to the built sha). A **module-bearing repository's sync sources advance only to the commit sealed for this instance's own framework identity**.

- `SealedPublicationIndex` (Hosting) reads what the registry sealed for one identity, per source: producing repository (`repository.txt`), source commit (`source-commit.txt`), sealed or torn — judged by the boot seeder's own rule (sentinel present, every listed bundle on disk).
- `SealedSyncGate` (GitSync, pure) decides per sync source at the green-build delivery: no seal attributable to the repository → today's behaviour (a course repo, or an instance that runs no publication of it); a sealed source of the repository at the built commit → proceed; otherwise **hold**, with the reason in the skip line — *built at S, not sealed for this instance (identity …; 'plugins' is sealed at C)*, or *… is not sealed (torn: …)*. "Cannot tell" is never "clear to proceed".
- `GitHubWebhookProcessor.MatchingBuildTargets` reads the index once per delivery, classifies held sources beside the other skips (the audit line still adds up), and logs one Warning naming how many were held and for which identity.
- `publish-bake-bundles.sh` writes `repository.txt` beside `source-commit.txt` (before the sentinel, listed in the manifest, uploaded like the other markers). Seals that predate it are attributed by commit: the built commit, or the commit the source already sits on — which, once the gate has run, is always a sealed one.

## Why

2026-09-06 22:39Z: #1413's Payments split reached both production Stores' `Store/*` sources through the green-build import while the instances ran a platform whose sealed module set had no Payments module. Four Store types sat in compile Error for nine hours. The green build proves a tree compiles somewhere; the seal proves it compiles here. This makes "the sources an instance runs" and "the module set it runs" the same publication by construction — what Education's disposable mesh already does by hand, which is why it could not reproduce the incident while production could.

## Landing

Core-side: no Space syncs from core (0 configs on both production portals — measured by meshweaver-7a), so this merge writes into no portal; instances pick the gate up with the next platform roll. The first delivery it governs on a live portal is the next Plugins green build after that roll.

## Tests

`SealedSyncGateTest` — proceed / hold / not-this-gate's-business, each stated as data, both directions; the hold reasons; attribution with and without the repository marker; the marker parser. `SealedPublicationIndexTest` — sealed, no sentinel, torn, unknown commit, absent root, ordering. 37 + 6 green (with the existing `GreenBuildPublishSignalTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
