### PR TITLE
fix(#3472): a pinned release is admitted by its artifact identity, never by the assembly-version string — every pin was refused since 3.0.0-ci.7939

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeBuildIdentity.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeBuildIdentity.cs
@@ -185,6 +185,44 @@ public static class NodeTypeBuildIdentity
 
     /// <summary>First eight characters — the same width the assembly-store filename tag carries, so
     /// a log line and a DLL name can be compared by eye.</summary>
+    /// <summary>
+    /// Why a PINNED release (<see cref="NodeTypeDefinition.RequestedReleasePath"/>) may NOT be adopted
+    /// by this process, or <see langword="null"/> when it may — the pinned-release half of the
+    /// admission rule, decided from the release's <see cref="NodeTypeRelease.Artifacts"/>.
+    ///
+    /// <para>🚨 <b>Never from <see cref="NodeTypeRelease.FrameworkVersion"/>.</b> That field is the
+    /// framework's ASSEMBLY VERSION string (<c>3.0.0.0</c>) and its own doc says it "has never gated
+    /// adoption"; the value that does is the build IDENTITY on each artifact link. #3472 compared the
+    /// two, so from 3.0.0-ci.7939 every pin to a historical release was refused on every mesh —
+    /// "built against framework 3.0.0.0 and this process is 1deb…" — the exact producer/gate
+    /// disagreement #1696 recorded, one door over (MeshWeaver.Plugins'
+    /// <c>CodeEditRecompileTest.NodeType_RequestedReleasePath_PinsToHistoricalRelease</c> caught it;
+    /// this repository had no test that pins a release).</para>
+    ///
+    /// <para>Three answers. An artifact for THIS identity and a runnable architecture → admitted.
+    /// Artifacts present, none for this identity → refused, naming what the release offers (that is
+    /// the case #3472 exists for: bytes keyed to another framework must not load here). NO artifact
+    /// link at all → admitted, UNVERIFIED: a release written before artifact links existed states no
+    /// identity, and refusing on an absence is the inconclusive-probe mistake (#890) — the same
+    /// choice <c>ApplyAdoptedSourceStamp</c> makes for a legacy bundle. Pure.</para>
+    /// </summary>
+    public static string? PinnedReleaseRefusal(
+        NodeTypeRelease release, string liveFrameworkIdentity, string liveArchitecture)
+    {
+        if (release.Artifacts is not { Count: > 0 })
+            return null;
+        var match = ReleaseArtifactResolver.Resolve([release], liveFrameworkIdentity, liveArchitecture);
+        if (match.IsResolved)
+            return null;
+        return $"pinned release '{release.Path}' carries no artifact for framework "
+            + $"{Short(liveFrameworkIdentity)} on {liveArchitecture} — {match.DeclineReason}. {RecoveryVerb}";
+    }
+
+    /// <summary>Whether a pinned release is admitted WITHOUT an identity to check — it predates
+    /// artifact links. The caller logs it; the answer is "adopt, unverified", never a refusal.</summary>
+    public static bool IsPinnedReleaseUnverified(NodeTypeRelease release)
+        => release.Artifacts is not { Count: > 0 };
+
     private static string Short(string? identity)
         => string.IsNullOrEmpty(identity)
             ? "(none)"

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
@@ -135,25 +135,29 @@ internal static class NodeTypeContractHandler
                             // bytes for THIS framework are not available), so the recorded state
                             // is never branded a source error and the operator gets both
                             // identities in one line.
-                            if (!string.Equals(
-                                    release.FrameworkVersion,
-                                    NodeTypeCompilationHelpers.FrameworkVersion,
-                                    StringComparison.Ordinal))
+                            // 🚨 The identity lives on the release's ARTIFACT links, never on
+                            // NodeTypeRelease.FrameworkVersion — that is the assembly VERSION string
+                            // ("3.0.0.0", documented as never gating adoption), and comparing it to the
+                            // identity hash refused EVERY pin from 3.0.0-ci.7939 on (#1696's producer/
+                            // gate disagreement, one door over). A release predating artifact links is
+                            // admitted UNVERIFIED, like a legacy bundle — an absence is not a verdict.
+                            if (NodeTypeBuildIdentity.PinnedReleaseRefusal(
+                                    release, NodeTypeCompilationHelpers.FrameworkVersion,
+                                    ReleaseArchitecture.Live) is { } pinnedRefusal)
                             {
                                 logger?.LogError(
-                                    "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} was built "
-                                    + "against framework {ReleaseFramework} and this process is {LiveFramework} — "
-                                    + "refusing to adopt it. {Recovery}",
-                                    hubPath, requestedReleasePath,
-                                    release.FrameworkVersion, NodeTypeCompilationHelpers.FrameworkVersion,
-                                    NodeTypeBuildIdentity.RecoveryVerb);
+                                    "GetCompilationPathRequest at {HubPath}: {Refusal}", hubPath, pinnedRefusal);
                                 return Observable.Return(new ResolvedResponse(Fail(
                                     null,
-                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}' was built against "
-                                    + $"framework '{release.FrameworkVersion}' and this process runs "
-                                    + $"'{NodeTypeCompilationHelpers.FrameworkVersion}'."), false,
-                                    Unavailable: true));
+                                    $"Pinned release '{requestedReleasePath}' for '{hubPath}': {pinnedRefusal}"),
+                                    false, Unavailable: true));
                             }
+                            if (NodeTypeBuildIdentity.IsPinnedReleaseUnverified(release))
+                                logger?.LogWarning(
+                                    "GetCompilationPathRequest at {HubPath}: pinned release {ReleasePath} predates "
+                                    + "artifact links and states no framework identity — adopting it UNVERIFIED "
+                                    + "(this process is {LiveFramework}). Re-release to record the identity.",
+                                    hubPath, requestedReleasePath, NodeTypeCompilationHelpers.FrameworkVersion);
                             // Use the persisted integer version the IAssemblyStore.Put
                             // used, not a parse of the display Version string.
                             var releaseVersion = release.AssemblyStoreVersion ?? 0;

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildIdentityAdmission.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildIdentityAdmission.md
@@ -143,6 +143,19 @@ populated, or on `CompilationStatus == Ok` alone:
 |---|---|
 | `NodeTypeEnrichmentHelpers` — pinned release | `RequestedReleasePath` set. `NodeTypeRelease.FrameworkVersion` exists and nothing read it |
 | `NodeTypeContractHandler` — pinned release | the same, answering `GetCompilationPathRequest` |
+
+> 🚨 **Both pinned-release sites decide from the release's `Artifacts`, never from
+> `NodeTypeRelease.FrameworkVersion`.** That field is the framework's ASSEMBLY VERSION string
+> (`3.0.0.0`) and its own doc says it has never gated adoption; the identity that does lives on each
+> `ReleaseArtifact.FrameworkIdentity`. The first cut of #3472 compared the two, so from
+> `3.0.0-ci.7939` every pin to a historical release was refused on every mesh — *"built against
+> framework 3.0.0.0 and this process is 1deb…"*, #1696's producer/gate disagreement one door over. It
+> was caught by MeshWeaver.Plugins' moved suite (`CodeEditRecompileTest.NodeType_RequestedReleasePath_PinsToHistoricalRelease`)
+> on the 7991 pin bump; this repository had no test that pins a release, and now has one
+> (`PinnedReleaseAdmissionTest`). The decision is `NodeTypeBuildIdentity.PinnedReleaseRefusal`: an
+> artifact for this identity and a runnable architecture → admitted; artifacts present, none for this
+> identity → refused, naming what the release offers; no artifact link at all (a release written
+> before links existed) → admitted **unverified**, logged — an absence is not a verdict (#890).
 | `NodeTypeContractHandler` — published-release hydrate | `LatestReleasePath` + coordinates |
 | `MeshDataSource.HandleNodeTypeSchemaRequest` | coordinates |
 | `NodeTypeDataModelAreas.ResolveInstanceHubConfig` | coordinates |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-pinning-a-type-to-an-earlier-release-works-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-pinning-a-type-to-an-earlier-release-works-again.md
@@ -1,0 +1,21 @@
+---
+Name: Pinning a type to an earlier release works again
+Category: Fix
+Description: A type pinned to one of its historical releases was refused on every portal since this morning's build, with a message about being "built against framework 3.0.0.0"; the pin is honoured again, and a release that predates the identity record is adopted with a note rather than refused.
+Icon: Checkmark
+Order: -20260907
+---
+
+# Pinning a type to an earlier release works again
+
+A type can be pinned to one of its earlier releases — the record of a specific build — so that its
+instances keep running that build while newer ones are compiled. From this morning's platform
+build every such pin was refused, and the page showed an error saying the release was "built
+against framework 3.0.0.0" while the portal "runs" a long identifier.
+
+The check that refuses builds from another platform generation was reading the wrong field: the
+release's version number, not the record of which platform build produced its assembly. Those two
+values can never agree, so no pin could pass. The check now reads the assembly's own build record,
+and behaves as intended: a release built for another platform generation is still refused with
+both identities named, while a release from before that record existed is adopted with a note in
+the log asking for a fresh release, instead of being refused.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1140,32 +1140,37 @@ internal static class NodeTypeEnrichmentHelpers
                     // advance exactly as its siblings do. On a store whose key carries the
                     // framework tag this is where the pin lands today anyway; what changes is
                     // that the operator is told which two identities disagree.
-                    if (!string.Equals(
-                            release.FrameworkVersion,
-                            NodeTypeCompilationHelpers.FrameworkVersion,
-                            StringComparison.Ordinal))
+                    // 🚨 Decided from the release's ARTIFACT links (NodeTypeBuildIdentity.
+                    // PinnedReleaseRefusal), never from NodeTypeRelease.FrameworkVersion — the
+                    // assembly VERSION string that #3472 compared to the identity hash, refusing
+                    // every pin on every mesh. A release predating artifact links is admitted
+                    // UNVERIFIED, like a legacy bundle.
+                    if (NodeTypeBuildIdentity.PinnedReleaseRefusal(
+                            release, NodeTypeCompilationHelpers.FrameworkVersion,
+                            ReleaseArchitecture.Live) is { } pinnedRefusal)
                     {
                         logger?.LogError(
-                            "EnrichWithNodeType: pinned release {ReleasePath} for {NodeType} was built against "
-                            + "framework {ReleaseFramework} and this process is {LiveFramework} — refusing to "
-                            + "adopt it for instance '{InstancePath}'. {Recovery}",
-                            requestedReleasePath, nodeType, release.FrameworkVersion,
-                            NodeTypeCompilationHelpers.FrameworkVersion, node.Path,
-                            NodeTypeBuildIdentity.RecoveryVerb);
+                            "EnrichWithNodeType: pinned release {ReleasePath} for {NodeType}, instance "
+                            + "'{InstancePath}': {Refusal}",
+                            requestedReleasePath, nodeType, node.Path, pinnedRefusal);
                         var (foreignIntro, foreignCta, foreignGuidance) =
                             OverlayCopy(OverlayCause.AssemblyUnavailable);
                         return Observable.Return(
                             WithOverlaySelfHeal(
                                 WithCompilationErrorOverlay(node, nodeType,
-                                    $"Pinned release '{requestedReleasePath}' was built against framework "
-                                    + $"'{release.FrameworkVersion}' and this process runs "
-                                    + $"'{NodeTypeCompilationHelpers.FrameworkVersion}'.",
+                                    $"Pinned release '{requestedReleasePath}': {pinnedRefusal}",
                                     guidance: foreignGuidance,
                                     intro: foreignIntro,
                                     callToAction: foreignCta,
                                     activityPath: def.LastCompilationActivityPath),
                                 meshHub, nodeType, typeNode.Version, logger));
                     }
+                    if (NodeTypeBuildIdentity.IsPinnedReleaseUnverified(release))
+                        logger?.LogWarning(
+                            "EnrichWithNodeType: pinned release {ReleasePath} for {NodeType} predates artifact "
+                            + "links and states no framework identity — adopting it UNVERIFIED for instance "
+                            + "'{InstancePath}' (this process is {LiveFramework}). Re-release to record the identity.",
+                            requestedReleasePath, nodeType, node.Path, NodeTypeCompilationHelpers.FrameworkVersion);
                     // Use the persisted integer version the IAssemblyStore.Put used,
                     // not a parse of the display Version string.
                     var releaseVersion = release.AssemblyStoreVersion ?? 0;

--- a/test/MeshWeaver.Compiler.Pipeline.Test/PinnedReleaseAdmissionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/PinnedReleaseAdmissionTest.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Kernel.Hub;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// The pinned-release half of build-identity admission (#3472), decided from the release's
+/// ARTIFACT links — pinned without a mesh. The first cut compared
+/// <see cref="NodeTypeRelease.FrameworkVersion"/> (the assembly VERSION string, "3.0.0.0") to the
+/// process identity hash, so every pin to a historical release was refused on every mesh from
+/// 3.0.0-ci.7939; this repository had no test that pinned one. These are the three answers, each
+/// with the input that distinguishes it from its neighbours.
+/// </summary>
+public class PinnedReleaseAdmissionDecisionTest
+{
+    private const string Live = "s1deb0000000000000000000000000000";
+    private const string Foreign = "sc273ee39fdccbfc088f9aaf1fc548a9a";
+
+    private static NodeTypeRelease Release(params ReleaseArtifact[] artifacts) => new()
+    {
+        Path = "P/T/Release/20260907120000-abcd1234",
+        NodeTypePath = "P/T",
+        Release = "abcd1234",
+        Version = "12",
+        FrameworkVersion = "3.0.0.0",           // the assembly version — NEVER the identity
+        CreatedAt = new DateTimeOffset(2026, 9, 7, 12, 0, 0, TimeSpan.Zero),
+        Artifacts = artifacts.Length == 0 ? null : artifacts,
+    };
+
+    [Fact]
+    public void AnArtifactForThisIdentity_IsAdmitted()
+        => NodeTypeBuildIdentity.PinnedReleaseRefusal(
+                Release(new ReleaseArtifact(Live, ReleaseArchitecture.Live, 12, "assemblies", "P_T/v12.dll")),
+                Live, ReleaseArchitecture.Live)
+            .Should().BeNull("the release records an artifact built by THIS process's framework");
+
+    [Fact]
+    public void AnArtifactForAnyArchitecture_IsAdmitted()
+        => NodeTypeBuildIdentity.PinnedReleaseRefusal(
+                Release(new ReleaseArtifact(Live, ReleaseArchitecture.Any, 12, "assemblies", "P_T/v12.dll")),
+                Live, ReleaseArchitecture.Live)
+            .Should().BeNull();
+
+    [Fact]
+    public void ArtifactsForAnotherIdentityOnly_AreRefused_NamingBoth()
+    {
+        var refusal = NodeTypeBuildIdentity.PinnedReleaseRefusal(
+            Release(new ReleaseArtifact(Foreign, ReleaseArchitecture.Live, 12, "assemblies", "P_T/v12.dll")),
+            Live, ReleaseArchitecture.Live);
+        refusal.Should().NotBeNull("bytes keyed to another framework generation must not load here — the case #3472 exists for");
+        refusal.Should().Contain("P/T/Release/20260907120000-abcd1234", "the refusal names the release")
+            .And.Contain(Foreign[..9], "…and what it offers")
+            .And.Contain(Live[..9], "…against what this process is");
+    }
+
+    [Fact]
+    public void ARelease_WithNoArtifactLinksAtAll_IsAdmittedUnverified()
+    {
+        var legacy = Release();
+        NodeTypeBuildIdentity.PinnedReleaseRefusal(legacy, Live, ReleaseArchitecture.Live)
+            .Should().BeNull("a release written before artifact links states no identity — an absence is not a verdict (#890), "
+                             + "and the assembly-version string it does carry has never gated adoption");
+        NodeTypeBuildIdentity.IsPinnedReleaseUnverified(legacy).Should().BeTrue("…and the caller logs that it adopted unverified");
+        NodeTypeBuildIdentity.IsPinnedReleaseUnverified(
+                Release(new ReleaseArtifact(Live, ReleaseArchitecture.Live, 12, "assemblies", "P_T/v12.dll")))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheAssemblyVersionString_NeverDecides()
+        // Same inputs as the admitted case except the field #3472 compared, set to something that
+        // can never equal an identity hash — the answer must not move.
+        => NodeTypeBuildIdentity.PinnedReleaseRefusal(
+                Release(new ReleaseArtifact(Live, ReleaseArchitecture.Live, 12, "assemblies", "P_T/v12.dll"))
+                    with { FrameworkVersion = "9.9.9.9" },
+                Live, ReleaseArchitecture.Live)
+            .Should().BeNull("NodeTypeRelease.FrameworkVersion is the assembly version and has never gated adoption");
+}
+
+/// <summary>
+/// The same rule at the door that answers <see cref="GetCompilationPathRequest"/>: a type with two
+/// REAL releases is pinned to the older one and the handler answers the older one's coordinates; a
+/// hand-written release record that predates artifact links (the "3.0.0.0" shape every existing
+/// release carries) is admitted; one whose only artifact is for another identity is refused. The
+/// control arm (unpinned → newest) is what makes the pinned answer mean something.
+/// </summary>
+public class PinnedReleaseAdmissionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string TypePath = "type/PinnedReleaseType";
+    private const string ForeignIdentity = "sc273ee39fdccbfc088f9aaf1fc548a9a";
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private static string Source(int answer) =>
+        $"public record PinnedReleaseContent {{ public string Title {{ get; init; }} = \"\"; public int Answer() => {answer}; }}";
+
+    private async Task<NodeTypeDefinition> WaitForRelease(string? knownRelease)
+    {
+        var node = await Mesh.GetMeshNodeStream(TypePath).Should().Within(TestTimeouts.CrossSilo)
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && d.CompilationStatus == CompilationStatus.Ok
+                        && !string.IsNullOrEmpty(d.LatestReleasePath)
+                        && d.LatestReleasePath != knownRelease,
+                "a compile of the source lands a new release on the type");
+        return (NodeTypeDefinition)node.Content!;
+    }
+
+    private async Task<NodeTypeRelease> ReadRelease(string releasePath)
+    {
+        var node = await Mesh.GetMeshNodeStream(releasePath).Should().Within(TestTimeouts.Convergence)
+            .Match(n => n?.Content is NodeTypeRelease, "the release node is readable");
+        return (NodeTypeRelease)node.Content!;
+    }
+
+    private Task Pin(string? releasePath) =>
+        Mesh.GetMeshNodeStream(TypePath)
+            .Update<NodeTypeDefinition>(d => d with { RequestedReleasePath = releasePath })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+    private async Task<GetCompilationPathResponse> AskForCompilationPath()
+    {
+        var reply = await GetClient()
+            .Observe(new GetCompilationPathRequest(), o => o.WithTarget(new Address(TypePath)))
+            .Take(1)
+            .Should().Within(TestTimeouts.CrossSilo).Emit("the type's hub answers a compilation-path request");
+        return reply.Message;
+    }
+
+    [Fact]
+    public async Task APinToAnEarlierRealRelease_IsHonoured_AndAForeignOrLegacyRecordAnswersAsSpecified()
+    {
+        await MeshService.CreateNode(MeshNode.FromPath(TypePath) with
+            {
+                Name = "PinnedReleaseType",
+                NodeType = MeshNode.NodeTypePath,
+                State = MeshNodeState.Active,
+                Content = new NodeTypeDefinition
+                {
+                    Configuration = "config => config.WithContentType<PinnedReleaseContent>()",
+                },
+            })
+            .SelectMany(_ => MeshService.CreateNode(new MeshNode("api", $"{TypePath}/Source")
+            {
+                NodeType = "Code",
+                Name = "api",
+                State = MeshNodeState.Active,
+                Content = new CodeConfiguration { Language = "csharp", Code = Source(1) },
+            }))
+            .Should().Within(TestTimeouts.CrossSilo).Emit();
+
+        var v1 = (await WaitForRelease(knownRelease: null)).LatestReleasePath!;
+        var v1Release = await ReadRelease(v1);
+        v1Release.Artifacts.Should().NotBeNull("a release the pipeline writes today links its artifact");
+        v1Release.Artifacts!.Should().Contain(a => a.FrameworkIdentity == NodeTypeCompilationHelpers.FrameworkVersion,
+            "…keyed to this process's framework identity");
+        v1Release.FrameworkVersion.Should().MatchRegex(@"^\d+\.\d+\.\d+\.\d+$",
+            "the field #3472 compared is the assembly VERSION string — this is what every existing release carries");
+
+        await Mesh.GetMeshNodeStream($"{TypePath}/Source/api")
+            .Update<CodeConfiguration>(c => c with { Code = Source(2) })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        // A source edit marks the type dirty; a RELEASE is cut on request — the operator's Compile
+        // button (RequestedReleaseAt), which InstallReleaseRequestWatcher turns into the compile.
+        await Mesh.GetMeshNodeStream(TypePath)
+            .Update<NodeTypeDefinition>(d => d with { RequestedReleaseAt = DateTimeOffset.UtcNow, RequestedReleaseBy = "operator" })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var v2 = (await WaitForRelease(knownRelease: v1)).LatestReleasePath!;
+        v2.Should().NotBe(v1);
+        var v2Release = await ReadRelease(v2);
+
+        // CONTROL — unpinned, the newest build answers.
+        var newest = await AskForCompilationPath();
+        newest.Success.Should().BeTrue(newest.Error ?? "unpinned resolves");
+        newest.ContentPath.Should().Be(v2Release.AssemblyContentPath, "unpinned resolves the newest release");
+
+        // THE ARM UNDER TEST — pinned to the EARLIER real release: honoured, not refused.
+        await Pin(v1);
+        var pinned = await AskForCompilationPath();
+        pinned.Success.Should().BeTrue(
+            $"a pin to a release this process's framework built must be honoured — before the fix every pin was "
+            + $"refused as 'built against framework 3.0.0.0'; error: {pinned.Error}");
+        pinned.ContentPath.Should().Be(v1Release.AssemblyContentPath, "the pinned release's bytes, not the newest");
+
+        // LEGACY — a record with V1's coordinates but NO artifact links (what a pre-link release
+        // looks like): admitted unverified, the exact record shape the first cut refused.
+        var legacyPath = $"{TypePath}/Release/20260907000000-legacy01";
+        await MeshService.CreateNode(MeshNode.FromPath(legacyPath) with
+            {
+                Name = "legacy release",
+                NodeType = GraphNodeTypeNames.Release,
+                State = MeshNodeState.Active,
+                Content = v1Release with { Path = legacyPath, Release = "legacy01", Artifacts = null },
+            })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        await Pin(legacyPath);
+        var legacy = await AskForCompilationPath();
+        legacy.Success.Should().BeTrue($"a release predating artifact links is admitted unverified; error: {legacy.Error}");
+        legacy.ContentPath.Should().Be(v1Release.AssemblyContentPath);
+
+        // FOREIGN — the same coordinates, but the only artifact link names another identity: refused, named.
+        var foreignPath = $"{TypePath}/Release/20260907000001-foreign1";
+        await MeshService.CreateNode(MeshNode.FromPath(foreignPath) with
+            {
+                Name = "foreign release",
+                NodeType = GraphNodeTypeNames.Release,
+                State = MeshNodeState.Active,
+                Content = v1Release with
+                {
+                    Path = foreignPath, Release = "foreign1",
+                    Artifacts = [new ReleaseArtifact(ForeignIdentity, ReleaseArchitecture.Live,
+                        v1Release.AssemblyStoreVersion, v1Release.AssemblyCollection, v1Release.AssemblyContentPath)],
+                },
+            })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        await Pin(foreignPath);
+        var foreign = await AskForCompilationPath();
+        foreign.Success.Should().BeFalse("bytes keyed to another framework generation must not load here");
+        foreign.Error.Should().Contain("carries no artifact for framework").And.Contain(ForeignIdentity[..9]);
+    }
+}


### PR DESCRIPTION
## What

Both pinned-release admission guards that #3472 added (`NodeTypeEnrichmentHelpers`, `NodeTypeContractHandler`) compared `NodeTypeRelease.FrameworkVersion` — the framework's ASSEMBLY VERSION string, `3.0.0.0`, whose own doc says it *"has never gated adoption"* — against the process's framework IDENTITY hash. The two can never be equal, so from `3.0.0-ci.7939` **every pin to a historical release was refused on every mesh**: *"built against framework '3.0.0.0' and this process runs '1deb…'"*. It is #1696's producer/gate disagreement, one door over.

**How it was caught:** MeshWeaver.Plugins #1463 (pin 7938 → 7991) — `CodeEditRecompileTest.NodeType_RequestedReleasePath_PinsToHistoricalRelease` in the moved Monolith suite. This repository had no test that pins a release; #3472's own tests cover the definition-level guard only.

## Fix

- `NodeTypeBuildIdentity.PinnedReleaseRefusal(release, liveIdentity, liveArchitecture)` — pure, decided from the release's `Artifacts` through the existing artifact resolver: an artifact for this identity and a runnable architecture → admitted; artifacts present, none for this identity → refused, naming the release, what it offers and what this process is (the case #3472 exists for); **no artifact link at all → admitted UNVERIFIED and logged** — a release written before links existed states no identity, and refusing on an absence is the inconclusive-probe mistake (#890), the same choice `ApplyAdoptedSourceStamp` makes for a legacy bundle.
- Both sites call it; log/overlay shapes unchanged, messages now carry the reason.
- `BuildIdentityAdmission.md`: the pinned-release rows say where the identity lives and what happened. What's New (`Category: Fix`).

## Verification

- `PinnedReleaseAdmissionDecisionTest` (pure): admitted-by-identity, admitted-by-`any`-architecture, refused-foreign (names both identities), legacy-admitted-unverified, and *the assembly-version field never decides* (same inputs, that field set to `9.9.9.9`, same answer).
- `PinnedReleaseAdmissionTest` (Monolith, one mesh): a type with two REAL releases — control: unpinned answers V2's `ContentPath`; **pinned to V1 answers V1's** (refused before this fix); a hand-written release record with V1's coordinates and `Artifacts = null` (the shape every pre-link release carries) is admitted; the same record with only a foreign-identity artifact is refused naming it.
- `dotnet build -c Release -warnaserror`: Graph, Compiler.Pipeline, Compiler.Pipeline.Test, Documentation.Test — `0 Error(s)`; Documentation.Test green.

Implementers: none — two new `public static` methods on a static class; no interface change.
Pairs-with: none — additions only; no public type or member removed.
