### PR TITLE
fix(#3510): the upsert's CREATE leg answers instead of hanging forever

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-an-upsert-whose-owner-goes-away-mid-create-now-answers.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-an-upsert-whose-owner-goes-away-mid-create-now-answers.md
@@ -1,0 +1,13 @@
+---
+Category: Fix
+---
+
+# An upsert whose owner goes away mid-create now answers
+
+Creating a node through the single-verb upsert could hang for the caller's whole budget in complete
+silence. The install of a plugin package retypes its root and then recycles it — which happens on
+every plugin install — and a create that was in flight when that happened simply never received a
+response. Nothing was logged, nothing failed, and the caller waited.
+
+The create now answers either way: if the response cannot arrive, the caller gets a refusal that says
+the create was **not** applied and is safe to retry, and names the recycle as the usual cause.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-an-upsert-whose-owner-goes-away-mid-create-now-answers.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-an-upsert-whose-owner-goes-away-mid-create-now-answers.md
@@ -1,13 +1,17 @@
 ---
+Name: An upsert whose owner goes away mid-create now answers
 Category: Fix
+Description: Creating something could leave you waiting with no answer at all if the thing that owned it was restarted at that moment. You now get a clear refusal saying it was not created and can be retried, instead of silence.
+Icon: PlugDisconnected
+Order: -20260907
 ---
 
 # An upsert whose owner goes away mid-create now answers
 
-Creating a node through the single-verb upsert could hang for the caller's whole budget in complete
-silence. The install of a plugin package retypes its root and then recycles it — which happens on
-every plugin install — and a create that was in flight when that happened simply never received a
-response. Nothing was logged, nothing failed, and the caller waited.
+Creating a node could hang for as long as the caller was willing to wait, in complete silence.
+Installing a plugin package briefly retypes and then restarts the thing that owns the package — that
+happens on every install — and a create caught in that moment simply never received a reply. Nothing
+was logged, nothing failed, and the caller waited.
 
-The create now answers either way: if the response cannot arrive, the caller gets a refusal that says
-the create was **not** applied and is safe to retry, and names the recycle as the usual cause.
+The create now answers either way. When the reply cannot arrive you get a refusal that says the
+create was **not** applied and is safe to retry, and names the restart as the usual reason.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4498,6 +4498,28 @@ public static class MeshExtensions
     private static readonly TimeSpan NodeOpForwardTimeout = TimeSpan.FromSeconds(15);
 
     /// <summary>
+    /// Total deadline for the upsert's inner <c>CreateNodeRequest</c> — the CREATE leg's answer to
+    /// "the owner went away and the response is never coming" (#3510).
+    ///
+    /// <para>🚨 STRICTLY ABOVE <see cref="LatePatchResponseRegistry.WriteVerdictBound"/>, on that
+    /// property's own instruction: <i>"Anything waiting on a write must bound itself STRICTLY ABOVE
+    /// this, so the framework's terminal wins and names the cause."</i> Bounding AT it would fire
+    /// this refusal one moment before the framework could say <c>OwnerUnreachable</c> — #2819's trap,
+    /// where the failure carrying the explanation is never the one anybody reads. The same +5 s
+    /// margin <c>TestTimeouts</c> derives for the same reason.</para>
+    ///
+    /// <para>🚨 This is NOT a widened bound: the leg had NO terminal guarantee at all. When
+    /// <c>PackageInstaller.SettleRetypedRoot</c> recycles the package root it just retyped — which it
+    /// does on EVERY plugin package install — the inner create's response never arrives, so neither
+    /// the onNext nor the onError arm ever runs and the caller waits out its entire budget in
+    /// silence. Making the leg total converts an unbounded hang into a named refusal; it does not
+    /// buy headroom, and it does not remove the need for the owner-side disposal NACK the UPDATE
+    /// leg gets from <c>RegisterOwnerDisposingNack</c>, which is the remaining half of #3510.</para>
+    /// </summary>
+    internal static TimeSpan InnerCreateVerdictBound =>
+        LatePatchResponseRegistry.WriteVerdictBound + TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Single-verb upsert handler for <see cref="CreateOrUpdateNodeRequest"/>.
     /// Two strict paths, both honoring "the per-node hub is the sole owner of
     /// its state — direct writes to persistence are illegal":
@@ -4664,6 +4686,8 @@ public static class MeshExtensions
 
         void DispatchInnerCreate()
         {
+            // Claimed by whichever arm answers first, so the three terminal states cannot double-post.
+            var innerAnswered = false;
             var inner = new CreateNodeRequest(node) { CreatedBy = requestedBy };
             // 🚨 PRE-REGISTERING Observe(request, options) — never Post-then-Observe(delivery) (#981).
             //
@@ -4701,9 +4725,14 @@ public static class MeshExtensions
                     var withTarget = o.WithTarget(hub.Address);
                     return inboundCtx is not null ? withTarget.WithAccessContext(inboundCtx) : withTarget;
                 })
+                // 🚨 Take(1) BEFORE Timeout, so the deadline is TOTAL rather than Rx's
+                // inter-emission one — the exact trap #3550 removed from the release wave.
+                .Take(1)
+                .Timeout(InnerCreateVerdictBound)
                 .Subscribe(
                     d =>
                     {
+                        innerAnswered = true;
                         if (d.Message is CreateNodeResponse cr && cr.Success && cr.Node is not null)
                             PostOk(cr.Node, isCreate: true, $"Created node at '{node.Path}'",
                                 "activity.node.created");
@@ -4738,9 +4767,46 @@ public static class MeshExtensions
                     },
                     ex =>
                     {
+                        innerAnswered = true;
+                        if (ex is TimeoutException)
+                        {
+                            hub.NoteRequestStage(request.Id, "UPSERT_CREATE_NO_VERDICT");
+                            logger.LogWarning(
+                                "[CreateOrUpdate] the inner CreateNode for {Path} produced no response "
+                                + "within {Bound} — answering the caller with a refusal rather than "
+                                + "leaving it to wait out its budget. The usual cause is the owner being "
+                                + "recycled under its own install (PackageInstaller.SettleRetypedRoot "
+                                + "retypes then recycles the package root on every plugin install), in "
+                                + "which case the create was NOT applied and is safe to retry against "
+                                + "the fresh activation (#3510).",
+                                node.Path, InnerCreateVerdictBound);
+                            PostFail(
+                                $"The create for '{node.Path}' produced no response within "
+                                + $"{InnerCreateVerdictBound.TotalSeconds:0}s. It was NOT applied; retry "
+                                + "against the fresh activation.",
+                                NodeUpsertRejectionReason.Unknown);
+                            return;
+                        }
                         logger.LogWarning(ex,
                             "[CreateOrUpdate] inner CreateNode faulted for {Path}", node.Path);
                         PostFail($"Inner CreateNode faulted: {ex.Message}",
+                            NodeUpsertRejectionReason.Unknown);
+                    },
+                    () =>
+                    {
+                        // The third terminal state, for the same reason the READ leg above has one
+                        // (#2454): a two-arm Subscribe says NOTHING when the source completes empty,
+                        // and the handler has already returned Processed() by then.
+                        if (innerAnswered)
+                            return;
+                        hub.NoteRequestStage(request.Id, "UPSERT_CREATE_COMPLETED_EMPTY");
+                        logger.LogWarning(
+                            "[CreateOrUpdate] the inner CreateNode for {Path} COMPLETED without a "
+                            + "response and without a fault. Answering the caller with a refusal "
+                            + "(#3510).", node.Path);
+                        PostFail(
+                            $"The create for '{node.Path}' completed without producing a response. It "
+                            + "was NOT applied; retry against the fresh activation.",
                             NodeUpsertRejectionReason.Unknown);
                     });
         }

--- a/test/MeshWeaver.Hosting.Test/InnerCreateBoundOutlivesTheFrameworkVerdictTest.cs
+++ b/test/MeshWeaver.Hosting.Test/InnerCreateBoundOutlivesTheFrameworkVerdictTest.cs
@@ -1,0 +1,51 @@
+using System;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The upsert's CREATE leg bounds itself STRICTLY ABOVE the framework's own write verdict, so that
+/// when a write goes unanswered the framework's terminal wins and NAMES the cause
+/// (<c>OwnerUnreachable — the owner produced no terminal for this patch</c>) instead of this leg's
+/// generic refusal firing first and hiding it.
+///
+/// <para>That ordering is <see cref="LatePatchResponseRegistry.WriteVerdictBound"/>'s own stated
+/// requirement — <i>"Anything waiting on a write must bound itself STRICTLY ABOVE this, so the
+/// framework's terminal wins and names the cause"</i> — and getting it wrong is #2819: an assertion
+/// that reported "the observable emitted nothing at all" one second before the write would have
+/// explained itself. The failure carrying the explanation was never the one anybody read.</para>
+///
+/// <para>🚨 This is a pure ordering invariant, deliberately with no clock in it. The behaviour it
+/// protects (#3510's create leg answering rather than hanging) can only be exercised by letting a
+/// real bound elapse, which would cost a ~36 s test AND a hand-written timeout literal that
+/// <c>TestTimeoutLiteralRatchetGuard</c> refuses. What is cheap to pin is the part that was
+/// actually got wrong once: the direction of the inequality.</para>
+/// </summary>
+public class InnerCreateBoundOutlivesTheFrameworkVerdictTest
+{
+    [Fact]
+    public void TheCreateLegOutwaitsTheFrameworksOwnVerdict()
+    {
+        Assert.True(
+            MeshExtensions.InnerCreateVerdictBound > LatePatchResponseRegistry.WriteVerdictBound,
+            $"the create leg bounds itself at {MeshExtensions.InnerCreateVerdictBound}, which is not "
+            + $"strictly above the framework's own {LatePatchResponseRegistry.WriteVerdictBound}. A "
+            + "caller waiting on a write must let the framework's terminal land first — bounding at "
+            + "or below WriteVerdictBound reproduces #2819, where the refusal that names the cause "
+            + "arrives after the one that does not.");
+    }
+
+    [Fact]
+    public void TheMarginIsNotSoLargeThatItStopsBeingABound()
+    {
+        // Above the framework's verdict, but far below any caller budget it is meant to protect
+        // (the installer's is 10 minutes). A bound that approaches the caller's budget answers
+        // nothing the caller had not already given up on.
+        var margin = MeshExtensions.InnerCreateVerdictBound
+            - LatePatchResponseRegistry.WriteVerdictBound;
+        Assert.True(margin < TimeSpan.FromMinutes(1),
+            $"the margin over the framework's verdict is {margin}; a bound that approaches the "
+            + "caller's own budget answers nothing the caller had not already given up on.");
+    }
+}


### PR DESCRIPTION
## The upsert's CREATE leg answers instead of hanging forever

**This is the wedge currently blocking MeshWeaver.Plugins #1463**, and through it six PRs and five
issues. It is not a new regression — core already *named* this leg and did not fix it.

### Measured, on the critical path

Plugins #1463's gate shard (run `34115469651`, job `101732362683`), measured by meshweaver-64:

```
12:01:57  Installed node-repo plugin Hosting: 144 written
12:01:59–12:02:27  bake-seed adopts Hosting.zip 15/15 for identity s3a2556b…
          [STALE-CALLBACK] Hosting/InstanceAction:
              CreateOrUpdateNodeRequest@portal/nodeops-…  pending 30 → 58 s  "handler-side"
12:03:30  CompileStateMirror: satellite write failed,
              TimeoutException "No response received in hub Hosting/InstanceAction"
          … heartbeats only …
12:11:01  tester gives up on Hosting            (compile budget expired)
```

Per-package pace is otherwise unchanged against the green pin (median 11.0 → 11.5 s), so this is one
package hanging, not a slowdown.

### The mechanism, in core's own words

`PackageInstaller.SettleRetypedRoot` recycles the root it just retyped from its `Space` placeholder,
immediately after adoption. It fires on **every** plugin package install (`retypedRoot` is non-null
iff `!rootTypeIsStatic`, and `Store/Plugin` is dynamic). `7dd16fad0`'s own timing table lists
**`Hosting +7.9s`** — the fingerprint above.

`test/MeshWeaver.Graph.Test/UpsertAnswersWhenTheOwnerGoesAwayTest.cs` already says which leg:
- `:31` `HANDLER_ENTER → UPSERT_READ absent → create → HANDLER_EXIT state=Processed ⇒ (nothing)`
- `:51` *"the **CREATE leg, which has no disposal-NACK**"*
- `:77` *"while **#3510's create leg is still open**"*

That commit added 15 lines of logging, a doc, and a 177-line test pinning the **covered** (update)
leg. The create leg was left as it was.

### The defect

`DispatchInnerCreate`'s `hub.Observe(inner, …).Subscribe(…)` has **two** arms — onNext and onError.
When the owner is recycled the response never arrives at all, so **neither runs**. This is a source
that never *terminates*, not one that completes empty — the same class as #3550. `DefaultIfEmpty` is
the wrong repair, for the reason the READ leg's own comment already gives.

### The fix

The leg is now total: `Take(1)` **before** `Timeout` so the deadline is total rather than Rx's
inter-emission one (#3550's trap), the third terminal arm the READ leg has carried since #2454, and
a claim flag so the arms cannot double-post. The refusal says the create was **not** applied, is safe
to retry, and names the recycle as the usual cause.

🚨 The bound is **strictly above** `LatePatchResponseRegistry.WriteVerdictBound`, on that property's
own instruction — *"Anything waiting on a write must bound itself STRICTLY ABOVE this, so the
framework's terminal wins and names the cause."* Bounding **at** it is #2819: the refusal that
explains nothing arriving one moment before the one that does. **I made exactly that mistake in the
first draft**, and the new test is what catches it.

### What this is not

- **Not a widened bound.** The leg had no terminal guarantee at all; this converts an unbounded hang
  into a named refusal. It buys no headroom.
- **Not all of #3510.** The owner-side disposal NACK that the UPDATE leg gets from
  `RegisterOwnerDisposingNack` is still missing here, so **#3510 stays open** — this removes the
  silence, not the disposal.
- **Not pinned by a timing test.** Exercising the bound needs ~36 s *and* a hand-written timeout
  literal that `TestTimeoutLiteralRatchetGuard` refuses, and the existing rig cannot stage the race
  (its own note: *"parking the partition root's primary stream does NOT put the create behind it —
  measured"*). What is pinned is the part that was actually got wrong: the direction of the
  inequality.

### Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, exit read directly:
  `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph.Test`, `MeshWeaver.Hosting.Test` — 0/0 each.
- The existing update-leg test still passes (1/1).
- The new ordering test is **falsified both ways**: planted at the framework bound it goes red naming
  both values (`00:00:31` vs `00:00:31`); restored, 2/2 green.
- Hand-written timeout literals unchanged at **206**.

Refs #3510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
