### PR TITLE
docs(#3576): the guard table records the three pin moves and their re-measured zeros

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -742,14 +742,20 @@ does not run it. Measured against every satellite's `main`, 2026-09-07:
 | MeshWeaver.Reinsurance | `1b5350d54` | ✅ | **0 violations** |
 | MeshWeaver.Manufacturing | `1b5350d54` | ✅ | 0 (adopted 2026-09-07, #3504) |
 | MeshWeaver.Plugins | `c7fef7a2d` | ✅ | 0 (adopted 2026-09-07, #3504) |
-| MeshWeaver.Crm | `0a2b9017d` | ❌ | **4** — incl. `MW_REGISTRY_KEY` |
-| MeshWeaver.SocialMedia | `0a2b9017d` | ❌ | **4** — incl. `MW_REGISTRY_KEY` |
-| MeshWeaver.Education | `8ffbe4762` | ❌ | **4** |
+| MeshWeaver.Crm | `0a2b9017d` → `c7fef7a2d` | ❌ → ✅ | **4** — incl. `MW_REGISTRY_KEY` → 0 (adopted 2026-09-07 12:30Z, `9228b8be`) |
+| MeshWeaver.SocialMedia | `0a2b9017d` → `c7fef7a2d` | ❌ → ✅ | **4** — incl. `MW_REGISTRY_KEY` → 0 (adopted 2026-09-07 12:30Z, `9dea3668`) |
+| MeshWeaver.Education | `8ffbe4762` → `c7fef7a2d` | ❌ → ✅ | **4** → 0 (adopted 2026-09-07, Education#283) |
 
 **Reinsurance is the control**, and it is what makes the table evidence rather than an assertion:
-it is the only pre-existing caller whose pin carries the guard, and it is the only pre-existing
-caller at zero. Everything else in the column is a repository that *calls the lane* and is *not
-checked by it*.
+it is the only pre-existing caller whose pin carried the guard from the start, and it was the only
+pre-existing caller at zero. Every other row was a repository that *called the lane* and was *not
+checked by it* — until the pin moved. The arrows record the move (MeshWeaver#3576), re-measured
+the same afternoon with the guard at core `main` against each repo's `origin/main`: 8/8 secrets
+asserted on Crm, 9/9 on SocialMedia, 6 of 8 reachable on Education with none unasserted — 0
+violations on all three. 🚨 A caller whose lane sha carries the guard but whose paired
+`platform-ref` does not is STILL not checked: the lane fetches the guard at `platform-ref`, and
+answers "a pin older than the guard needs the older lane" (Education#278, a Dependabot bump of
+the lane alone, red for exactly this) — which is why the two move in ONE commit.
 
 🚨 And `MW_REGISTRY_KEY` in that column is not a hypothetical: an absent `MW_REGISTRY_KEY`
 consumed by a PR-reachable job no preflight asserts is exactly Reinsurance#128 —


### PR DESCRIPTION
## What

Closes #3576. Docs only: the guard table in `Doc/Architecture/CiContentBake` ("Calling the lane is NECESSARY and NOT SUFFICIENT") still read **4 violations** for Crm, SocialMedia and Education. All three moved their `node-repo-validate` pin and its paired `platform-ref` to `c7fef7a2d` today (Crm `9228b8be` and SocialMedia `9dea3668` at 12:30Z, Education #283 at ~13:30Z), and the guard at core `main`, run against each repo's `origin/main`, reports **0 violations** on all three (8/8 secrets asserted on Crm, 9/9 on SocialMedia, 6 of 8 reachable on Education with none unasserted). The rows now record the move and the re-measured zeros, so the table stays a measurement rather than a stale claim; Reinsurance stays the control.

Also records the half-move trap #3576 warned about, now with an instance: Education #278, a Dependabot bump of the lane sha alone, went red with "a pin older than the guard needs the older lane" because the paired `platform-ref` had not moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
