### PR TITLE
fix(#3542): an absent update policy fails closed, and an explicit one survives

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -25,10 +25,29 @@ namespace Memex.Portal.Shared.SelfUpdate;
 /// </summary>
 public record UpdatePolicyContent
 {
-    /// <summary>The update strategy. Defaults to <see cref="UpdatePolicyKind.Continuous"/>.</summary>
+    /// <summary>
+    /// The update strategy. A NEWLY constructed record defaults to
+    /// <see cref="UpdatePolicyKind.Continuous"/> — but an ABSENT value on a persisted record reads as
+    /// <see cref="UpdatePolicyKind.None"/>, not as Continuous (#3542).
+    ///
+    /// <para>Those two are different questions and used to have the same answer. Because
+    /// <c>None</c> is now the enum's zero value, an explicit <c>Continuous</c> is non-default and is
+    /// therefore always written out, so "the admin chose Continuous" is distinguishable from "this
+    /// record lost its policy" — and the latter fails closed instead of enabling an unattended roll.</para>
+    /// </summary>
     [Description("Update strategy")]
     [Translation("de", "Update-Strategie")]
-    public UpdatePolicyKind Policy { get; init; } = UpdatePolicyKind.Continuous;
+    // 🚨 NO initialiser, deliberately (#3542). System.Text.Json leaves an ABSENT field at whatever
+    // the property initialiser set, so `= Continuous` here made a record that lost its `policy`
+    // deserialise back to auto-update ENABLED — which is the defect, and it is NOT fixed by the enum
+    // reorder alone: the reorder governs what is WRITTEN, the initialiser governs what an absent
+    // field READS AS. Both had to go. Absent now lands on default(UpdatePolicyKind) = None.
+    //
+    // The seed path (`SeedIfAbsent`) still sets the platform default EXPLICITLY via `defaultPolicy`,
+    // so a freshly provisioned install is unchanged; what changes is that `ParseContent`'s two
+    // fallbacks — content absent, or content that failed to deserialise — now yield None instead of
+    // silently enabling unattended rolls on unreadable information.
+    public UpdatePolicyKind Policy { get; init; }
 
     /// <summary>
     /// When <c>true</c> (default) the install only rolls to builds that PASSED CI ("green").

--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
@@ -35,19 +36,37 @@ public record UpdatePolicyContent
     /// therefore always written out, so "the admin chose Continuous" is distinguishable from "this
     /// record lost its policy" — and the latter fails closed instead of enabling an unattended roll.</para>
     /// </summary>
+    /// <summary>
+    /// The update strategy AS DECLARED on the record — <c>null</c> when the record carries no
+    /// <c>policy</c> field at all. Read <see cref="Policy"/> instead; this exists so that "absent"
+    /// and "explicitly chosen" stay different facts on the wire.
+    /// </summary>
     [Description("Update strategy")]
     [Translation("de", "Update-Strategie")]
-    // 🚨 NO initialiser, deliberately (#3542). System.Text.Json leaves an ABSENT field at whatever
-    // the property initialiser set, so `= Continuous` here made a record that lost its `policy`
-    // deserialise back to auto-update ENABLED — which is the defect, and it is NOT fixed by the enum
-    // reorder alone: the reorder governs what is WRITTEN, the initialiser governs what an absent
-    // field READS AS. Both had to go. Absent now lands on default(UpdatePolicyKind) = None.
-    //
-    // The seed path (`SeedIfAbsent`) still sets the platform default EXPLICITLY via `defaultPolicy`,
-    // so a freshly provisioned install is unchanged; what changes is that `ParseContent`'s two
-    // fallbacks — content absent, or content that failed to deserialise — now yield None instead of
-    // silently enabling unattended rolls on unreadable information.
-    public UpdatePolicyKind Policy { get; init; }
+    [JsonPropertyName("policy")]
+    public UpdatePolicyKind? DeclaredPolicy { get; init; }
+
+    /// <summary>
+    /// The strategy this install actually follows. An ABSENT declaration reads as
+    /// <see cref="UpdatePolicyKind.None"/> — never as "enabled" (#3542).
+    ///
+    /// <para>🚨 Why a nullable backing field rather than reordering the enum, which was the obvious
+    /// repair and is WRONG: the hub serializer sets <c>DefaultIgnoreCondition = WhenWritingDefault</c>,
+    /// so whichever member is zero is dropped on write. Putting <c>None</c> at zero would have made an
+    /// explicit <c>None</c> unwritable — measured, it broke the MCP patch that turns auto-update OFF,
+    /// which is the safety-critical direction. A nullable field has <c>null</c> as its default, so
+    /// EVERY named member survives the round trip and only genuine absence is dropped.</para>
+    ///
+    /// <para>The consequence that matters: an install whose record lost its policy under its own
+    /// bookkeeping writes no longer rolls itself. That is how memex-cloud reached a withdrawn
+    /// <c>3.1.0-ci</c> line "on a policy record that lost its own policy".</para>
+    /// </summary>
+    [JsonIgnore]
+    public UpdatePolicyKind Policy
+    {
+        get => DeclaredPolicy ?? UpdatePolicyKind.None;
+        init => DeclaredPolicy = value;
+    }
 
     /// <summary>
     /// When <c>true</c> (default) the install only rolls to builds that PASSED CI ("green").

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-an-install-that-cannot-read-its-update-policy-no-longer-updates-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-an-install-that-cannot-read-its-update-policy-no-longer-updates-itself.md
@@ -1,0 +1,18 @@
+---
+Name: An install that cannot read its update policy no longer updates itself
+Category: Fix
+Description: If an install's update policy went missing, it used to carry on auto-updating as though someone had chosen that. It now stops and waits to be told, which is the safer of the two guesses.
+Icon: ShieldError
+Order: -20260907
+---
+
+# An install that cannot read its update policy no longer updates itself
+
+An install records whether it should update itself automatically. If that setting went missing — and
+it could, under the install's own routine bookkeeping — the install read it back as *"yes, update
+automatically"*. The most permissive answer, arrived at by losing information rather than by anyone
+choosing it. That is how one portal rolled itself onto a version line that had been withdrawn.
+
+A missing setting now reads as **do not update**. The install waits to be told instead of guessing,
+and an explicitly chosen setting — including *never update* — is always recorded, so "someone chose
+this" and "this went missing" are no longer the same thing.

--- a/src/MeshWeaver.Hosting/SelfUpdate/UpdatePolicyKind.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/UpdatePolicyKind.cs
@@ -8,14 +8,28 @@ namespace MeshWeaver.Hosting.SelfUpdate;
 /// <summary>The platform auto-update strategy — the single value on <c>Admin/UpdatePolicy</c>.</summary>
 public enum UpdatePolicyKind
 {
+    /// <summary>
+    /// Never auto-update. Updates are applied manually (operator / admin action).
+    ///
+    /// <para>🚨 <b>Deliberately the ZERO value — the order of this enum is load-bearing (#3542).</b>
+    /// The hub serializer sets <c>DefaultIgnoreCondition = WhenWritingDefault</c>, so whichever
+    /// member is zero is OMITTED when written, and an omitted field reads back as that member.
+    /// While <see cref="Continuous"/> was zero, a policy record that lost its <c>policy</c> field
+    /// read back as <i>auto-update enabled</i> — the most permissive state, reached by losing
+    /// information. That is how memex-cloud rolled onto a withdrawn line "on a policy record that
+    /// lost its own policy". With <c>None</c> at zero the same loss fails CLOSED.</para>
+    ///
+    /// <para>Members travel BY NAME (<c>EnumMemberJsonStringEnumConverter</c> is global), so records
+    /// already storing <c>"Continuous"</c> or <c>"Stable"</c> are unaffected by the reorder.</para>
+    /// </summary>
+    None,
+
     /// <summary>Always roll to the newest image on ACR, INCLUDING build-numbered continuous builds
-    /// (e.g. <c>3.0.0-ci.51</c>). This is the platform default.</summary>
+    /// (e.g. <c>3.0.0-ci.51</c>). The platform default for a NEWLY created record — but no longer
+    /// what an ABSENT value means.</summary>
     Continuous,
 
     /// <summary>Roll only to the newest CLEAN release (no build number, e.g. <c>3.0.0</c>); ignore
     /// continuous build-numbered images.</summary>
     Stable,
-
-    /// <summary>Never auto-update. Updates are applied manually (operator / admin action).</summary>
-    None,
 }

--- a/src/MeshWeaver.Hosting/SelfUpdate/UpdatePolicyKind.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/UpdatePolicyKind.cs
@@ -8,28 +8,14 @@ namespace MeshWeaver.Hosting.SelfUpdate;
 /// <summary>The platform auto-update strategy — the single value on <c>Admin/UpdatePolicy</c>.</summary>
 public enum UpdatePolicyKind
 {
-    /// <summary>
-    /// Never auto-update. Updates are applied manually (operator / admin action).
-    ///
-    /// <para>🚨 <b>Deliberately the ZERO value — the order of this enum is load-bearing (#3542).</b>
-    /// The hub serializer sets <c>DefaultIgnoreCondition = WhenWritingDefault</c>, so whichever
-    /// member is zero is OMITTED when written, and an omitted field reads back as that member.
-    /// While <see cref="Continuous"/> was zero, a policy record that lost its <c>policy</c> field
-    /// read back as <i>auto-update enabled</i> — the most permissive state, reached by losing
-    /// information. That is how memex-cloud rolled onto a withdrawn line "on a policy record that
-    /// lost its own policy". With <c>None</c> at zero the same loss fails CLOSED.</para>
-    ///
-    /// <para>Members travel BY NAME (<c>EnumMemberJsonStringEnumConverter</c> is global), so records
-    /// already storing <c>"Continuous"</c> or <c>"Stable"</c> are unaffected by the reorder.</para>
-    /// </summary>
-    None,
-
     /// <summary>Always roll to the newest image on ACR, INCLUDING build-numbered continuous builds
-    /// (e.g. <c>3.0.0-ci.51</c>). The platform default for a NEWLY created record — but no longer
-    /// what an ABSENT value means.</summary>
+    /// (e.g. <c>3.0.0-ci.51</c>). This is the platform default.</summary>
     Continuous,
 
     /// <summary>Roll only to the newest CLEAN release (no build number, e.g. <c>3.0.0</c>); ignore
     /// continuous build-numbered images.</summary>
     Stable,
+
+    /// <summary>Never auto-update. Updates are applied manually (operator / admin action).</summary>
+    None,
 }

--- a/test/Memex.Portal.Shared.Test/AbsentUpdatePolicyFailsClosedTest.cs
+++ b/test/Memex.Portal.Shared.Test/AbsentUpdatePolicyFailsClosedTest.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A policy record that has LOST its <c>policy</c> field must read as
+/// <see cref="UpdatePolicyKind.None"/> — never as "auto-update enabled" (#3542, proposal 3).
+///
+/// <para>The defect this pins is a two-part mechanism, and neither part is visible on its own. The
+/// hub serializer sets <c>DefaultIgnoreCondition = WhenWritingDefault</c>, so whichever enum member
+/// is ZERO is omitted from the persisted record; and an omitted field deserializes back to that same
+/// member. While <c>Continuous</c> was zero, a record that lost its policy under its own bookkeeping
+/// writes read back as the MOST PERMISSIVE state, reached purely by losing information. That is how
+/// memex-cloud rolled onto a withdrawn <c>3.1.0-ci</c> line "on a policy record that lost its own
+/// policy".</para>
+///
+/// <para>🚨 The two assertions below are a pair on purpose. Fail-closed alone would be satisfied by
+/// an enum nobody can express Continuous in; round-tripping alone would be satisfied by the old
+/// order. Together they say: an ABSENT policy is None, and an EXPLICIT Continuous survives — which
+/// is the distinction the old shape could not make.</para>
+/// </summary>
+public class AbsentUpdatePolicyFailsClosedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact]
+    public void AnAbsentPolicyFieldReadsAsNone()
+    {
+        // A record persisted without a `policy` field — exactly what the bookkeeping write leaves
+        // behind when the policy is at the serializer's default.
+        const string withoutPolicy = """{"latestAvailableTag":"3.0.0-ci.8009"}""";
+
+        var content = JsonSerializer.Deserialize<UpdatePolicyContent>(
+            withoutPolicy, Mesh.JsonSerializerOptions);
+
+        Assert.NotNull(content);
+        Assert.Equal(UpdatePolicyKind.None, content!.Policy);
+    }
+
+    [Fact]
+    public void AnExplicitContinuousSurvivesTheRoundTrip()
+    {
+        // The other half: because None is now the zero value, Continuous is non-default and must be
+        // WRITTEN OUT — otherwise an admin's explicit choice would decay into the absent case and be
+        // silently downgraded to None on the next read.
+        var chosen = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous };
+
+        var json = JsonSerializer.Serialize(chosen, Mesh.JsonSerializerOptions);
+        Assert.Contains("Continuous", json);
+
+        var readBack = JsonSerializer.Deserialize<UpdatePolicyContent>(json, Mesh.JsonSerializerOptions);
+        Assert.Equal(UpdatePolicyKind.Continuous, readBack!.Policy);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/PlatformUpdateStatusTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlatformUpdateStatusTest.cs
@@ -26,7 +26,7 @@ public class PlatformUpdateStatusTest
     public void NewerRecordedTag_IsAnAvailableUpdate()
     {
         var status = PlatformUpdateStatus.Derive(
-            new UpdatePolicyContent { LatestAvailableTag = "3.0.0-ci.2400" }, Running);
+            new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, LatestAvailableTag = "3.0.0-ci.2400" }, Running);
 
         Assert.Equal(PlatformUpdateAvailability.UpdateAvailable, status.Availability);
         Assert.Equal("3.0.0-ci.2400", status.LatestVersion);
@@ -36,7 +36,7 @@ public class PlatformUpdateStatusTest
     public void NoRecordedTag_IsUpToDate()
     {
         // The poller records ONLY when it finds something newer, so an empty tag IS the up-to-date signal.
-        var status = PlatformUpdateStatus.Derive(new UpdatePolicyContent(), Running);
+        var status = PlatformUpdateStatus.Derive(new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous }, Running);
 
         Assert.Equal(PlatformUpdateAvailability.UpToDate, status.Availability);
         Assert.Null(status.LatestVersion);
@@ -49,7 +49,7 @@ public class PlatformUpdateStatusTest
         // (not newer than) the running build. Comparing, rather than testing for presence, is what
         // keeps the tab from claiming an update forever after it was applied.
         var status = PlatformUpdateStatus.Derive(
-            new UpdatePolicyContent { LatestAvailableTag = Running }, Running);
+            new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, LatestAvailableTag = Running }, Running);
 
         Assert.Equal(PlatformUpdateAvailability.UpToDate, status.Availability);
         Assert.Null(status.LatestVersion);
@@ -59,7 +59,7 @@ public class PlatformUpdateStatusTest
     public void OlderRecordedTag_IsUpToDate()
     {
         var status = PlatformUpdateStatus.Derive(
-            new UpdatePolicyContent { LatestAvailableTag = "3.0.0-ci.2000" }, Running);
+            new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, LatestAvailableTag = "3.0.0-ci.2000" }, Running);
 
         Assert.Equal(PlatformUpdateAvailability.UpToDate, status.Availability);
     }
@@ -93,7 +93,8 @@ public class PlatformUpdateStatusTest
         // A git-less source drop stamps "unknown"; VersionSelect.IsNewer refuses to compare against it
         // (the same gate that stops the poller auto-rolling). The user must not be nagged on that basis.
         var status = PlatformUpdateStatus.Derive(
-            new UpdatePolicyContent { LatestAvailableTag = "3.1.0" }, "unknown");
+            new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, LatestAvailableTag = "3.1.0" },
+            "unknown");
 
         Assert.Equal(PlatformUpdateAvailability.UpToDate, status.Availability);
     }

--- a/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
@@ -99,8 +99,12 @@ public class VersionSelectTest
                 new UpdatePolicyContent { Policy = UpdatePolicyKind.Stable }, Web).Policy);
 
     [Fact]
-    public void ParseContent_Null_DefaultsToContinuous()
-        => Assert.Equal(UpdatePolicyKind.Continuous, UpdatePolicyNodeType.ParseContent(null, Web).Policy);
+    public void ParseContent_Null_FailsClosedToNone()
+        // 🚨 REVERSED by #3542, deliberately. This used to assert Continuous — i.e. content that is
+        // absent or unreadable enabled unattended rolls. That is how memex-cloud rolled onto a
+        // withdrawn 3.1.0-ci line "on a policy record that lost its own policy". A read that
+        // produced nothing must not be the most permissive answer.
+        => Assert.Equal(UpdatePolicyKind.None, UpdatePolicyNodeType.ParseContent(null, Web).Policy);
 
     [Fact]
     public void ParseContent_JsonElement_DeserializesEnumByName()


### PR DESCRIPTION
## An absent update policy fails closed — and an explicit one survives

#3542's **proposal 3**: *"an absent `policy` must read as `None`, not as 'enabled'"*.

An install records whether it auto-updates. If that field went missing — and it could, under the
install's own bookkeeping writes — it read back as **Continuous**: the most permissive state, reached
by *losing information* rather than by anyone choosing it. That is how memex-cloud rolled onto a
withdrawn `3.1.0-ci` line "on a policy record that lost its own policy".

### 🚨 The obvious repair is wrong, and I measured it before finding out the hard way

Reorder `UpdatePolicyKind` so `None` is the zero value. Absent then reads as `None` — and an explicit
`None` becomes **unwritable**, because the serializer sets `DefaultIgnoreCondition = WhenWritingDefault`
and drops whichever member is zero. The MCP patch that turns auto-update **off** then fails with

> `the patch to Admin/UpdatePolicy did not land within the confirmation window`

because the write is a no-op. That is the safety-critical direction: the repair broke something worse
than it fixed. Two tests caught it, and neither was the one I wrote.

### The shape that satisfies both halves

```csharp
[JsonPropertyName("policy")] public UpdatePolicyKind? DeclaredPolicy { get; init; }
[JsonIgnore]                 public UpdatePolicyKind  Policy
                                 => DeclaredPolicy ?? UpdatePolicyKind.None;
```

`null` is the default of a nullable, so **every named member round-trips** and only genuine absence is
dropped. Consumers keep reading `.Policy` unchanged, and **the enum is untouched** — no wire values
move, and records already storing `"Continuous"` or `"Stable"` are unaffected.

This is the same "model the third state" rule the rest of this handler family already follows: absent,
chosen-None and chosen-Continuous are three facts, and two of them used to share an answer.

### The six existing tests

One asserted the old contract head-on — `VersionSelectTest.ParseContent_Null_DefaultsToContinuous`,
now `..._FailsClosedToNone` with the reason recorded inline. The other five were testing **tag**
derivation and merely leaned on the default constructor; they now state which policy they assume
rather than depending on a default that changed underneath them. That is a better test either way.

### 🚨 Behaviour change, stated plainly

**An install whose policy record carries no `policy` field stops auto-updating until one is set.**
Installs currently rolling on an absent field will stop. That is the point — but it is a live rollout
change, not a refactor. Approved by the maintainer before landing.

### Verification

- `Memex.Portal.Shared.Test` **968/968**.
- `dotnet build -c Release -warnaserror`, exit read directly — 0 Error(s).
- New `AbsentUpdatePolicyFailsClosedTest`, **falsified both ways**: it is a *pair* on purpose —
  fail-closed alone would be satisfied by an enum nobody can express Continuous in, and round-tripping
  alone would be satisfied by the old shape. Together they pin the distinction.

### Not included

Proposal 3's other half — moving `lastCheckedAt` off the policy record so the bookkeeping writes stop
clobbering the policy in the first place — is **not** here. This fixes what an absent value *means*;
it does not stop the value going absent. **#3542 stays open** for that.

Refs #3542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
