### PR TITLE
fix(#3595): the migration Job renders the legacy escape hatch too — both workloads carry the same secret set

### DIFF
--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -76,6 +76,30 @@ spec:
                 name: "{{ $class.syncedSecret }}"
                 optional: true
             {{- end }}
+            {{- /* ⚠️ LEGACY ESCAPE HATCH — the SAME env sources the portal Deployment renders
+                   (memex-portal/deployment.yaml), and for the SAME reason the block above exists
+                   (MeshWeaver#3595).
+
+                   The block above covers only the classes the CHART owns. An environment whose
+                   SecretProviderClass is HAND-MADE attaches it by name through `.Values.extraEnvFrom`
+                   instead — the shape values.yaml calls "the memex-cloud AI-keys shape" — and until
+                   this block existed the Job rendered NONE of it. That is a different defect from
+                   #3548, which was STALENESS: for a key delivered this way the Job had no value at
+                   all, so `MeshNodeEmbeddingBackfill` took the not-configured path, logged-and-
+                   skipped every row, and the Job still reported `Database migration completed`.
+                   Same green run, same silent outcome, different mechanism.
+
+                   VERBATIM, and deliberately NOT `optional: true`. The chart-owned entries above
+                   are optional because the chart RENDERS their SecretProviderClass and knows a
+                   first install has no pre-existing rows to backfill. The chart owns nothing here:
+                   the operator declared this source, and the volumes below are what materialise it
+                   before this container starts. Marking it optional would recreate the very defect
+                   this block closes — an absent value read as "not configured", green and silent.
+                   The portal Deployment has identical semantics for the identical entries, so an
+                   env whose Secret is genuinely missing already fails there. */}}
+            {{- range .Values.extraEnvFrom }}
+            - {{ toYaml . | nindent 14 | trim }}
+            {{- end }}
           imagePullPolicy: "IfNotPresent"
           {{- /* 🚨 THE JOB MOUNTS THE SPC ITSELF — this is what makes the values above CURRENT
                  (MeshWeaver#3548).
@@ -109,15 +133,24 @@ spec:
                  name. Rendered only when a class is declared — a namespace with no Key Vault gets
                  the pod spec it had before. */}}
           {{- $keyVaultClasses := (include "memex.keyVaultClasses" . | fromYamlArray) }}
-          {{- if $keyVaultClasses }}
+          {{- if or $keyVaultClasses .Values.extraVolumeMounts }}
           volumeMounts:
             {{- range $class := $keyVaultClasses }}
             - name: "{{ $class.volumeName }}"
               mountPath: "{{ $class.mountPath }}"
               readOnly: true
             {{- end }}
+            {{- /* ⚠️ LEGACY: the mount half of the escape hatch, and the half that carries the
+                   whole freshness argument above for a HAND-MADE SecretProviderClass. The envFrom
+                   entry names the synced Secret; THIS is what makes the CSI driver fetch the vault
+                   objects and write that Secret before any container in this pod starts. Without
+                   it the Job would free-ride on the portal pods' mount — #3548's defect, in
+                   escape-hatch clothing. KeyVaultEscapeHatchParityGuard asserts the pair. */}}
+            {{- range .Values.extraVolumeMounts }}
+            - {{ toYaml . | nindent 14 | trim }}
+            {{- end }}
           {{- end }}
-      {{- if $keyVaultClasses }}
+      {{- if or $keyVaultClasses .Values.extraVolumes }}
       volumes:
         {{- range $class := $keyVaultClasses }}
         - name: "{{ $class.volumeName }}"
@@ -126,5 +159,11 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: "{{ $class.name }}"
+        {{- end }}
+        {{- /* ⚠️ LEGACY: the volume half — typically the secrets-store CSI volume behind a
+               hand-made SecretProviderClass. Verbatim Volume objects, mounted by
+               .Values.extraVolumeMounts above. */}}
+        {{- range .Values.extraVolumes }}
+        - {{ toYaml . | nindent 10 | trim }}
         {{- end }}
       {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -345,7 +345,13 @@ keyVaultSecrets:
 #         - vaultSecret: memex-connectionstring
 #           key: ConnectionStrings__memex
 keyVaultSecretClasses: []
-# ---- Extra env sources for the portal (verbatim EnvFromSource objects) ----
+# ---- Extra env sources for the portal AND the migration Job ----
+# (verbatim EnvFromSource objects)
+# 🚨 BOTH workloads render these, and that parity is the point (#3595):
+# the migration Job rendered none of it until then, so a key delivered this way
+# reached the portal and NOT the backfill — which logged-and-skipped every row
+# and still reported `Database migration completed`. KeyVaultEscapeHatchParityGuard
+# holds the two renders together.
 # ⚠️ LEGACY ESCAPE HATCH — kept for environments whose SecretProviderClass is
 # still hand-made. Declare the secrets under `keyVaultSecrets` above instead;
 # that renders the SecretProviderClass AND the envFrom, so the pod's secret
@@ -358,12 +364,16 @@ keyVaultSecretClasses: []
 #     - secretRef:
 #         name: memexcloud-portal-ai-secrets
 extraEnvFrom: []
-# ---- Extra volumes/mounts for the portal (verbatim Volume/VolumeMount) ----
+# ---- Extra volumes/mounts for the portal AND the migration Job ----
+# (verbatim Volume/VolumeMount)
 # ⚠️ LEGACY ESCAPE HATCH — see extraEnvFrom; `keyVaultSecrets` renders the
 # CSI volume and its mount too. The volume-shaped twin of extraEnvFrom, for
 # resources the chart does not own — typically the secrets-store CSI volume
 # behind a SecretProviderClass: the MOUNT is what makes the CSI driver sync
-# (and keep rotating) the k8s Secret that extraEnvFrom then reads. Example:
+# (and keep rotating) the k8s Secret that extraEnvFrom then reads. 🚨 So a
+# workload that lists the Secret in extraEnvFrom must also carry the volume and
+# its mount, or it free-rides on another pod's mount and reads a value that is
+# stale or absent (#3548 / #3595). Example:
 #   extraVolumes:
 #     - name: kv-ai-secrets
 #       csi:

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -145,6 +145,47 @@ volumes of one name is an invalid spec while two classes syncing into one Secret
 `syncedSecret` still defaults to the class's own name, and the vault coordinates fall back to the
 singular block's — a namespace's classes normally read one vault with one add-on identity.
 
+## Two workloads, one secret set — and the escape hatch has to reach both
+
+The portal Deployment is not the only pod that reads the environment's secrets. The **migration
+Job** reads them too, because `MeshNodeEmbeddingBackfill` — the only thing that embeds rows written
+before a provider existed — needs `Embedding__ApiKey`. So the invariant is not *"the portal gets the
+keys"*, it is **both workloads carry the same secret set, by whichever mechanism delivers it**, and
+that has now failed twice in two different ways:
+
+| | #3548 | #3595 |
+|---|---|---|
+| mechanism | chart-owned class (`keyVaultSecrets`) | hand-made class (`extraEnvFrom`) |
+| what the Job had | the value, from **before** the rotation | **no value at all** |
+| defect | **staleness** | **absence** |
+| remedy | the Job mounts the SPC, so the driver writes the Secret before the container starts | the Job renders the escape hatch — env source, volume and mount |
+
+Both produced the same observable outcome, which is why neither was caught by watching the deploy:
+the backfill **logs-and-skips per row rather than throwing**, so the Job's exit code says nothing,
+and it reported `Database migration completed` in both cases. #3548's run authenticated 1,260 times
+with a stale credential; #3595's would have embedded nothing at all on an environment whose keys
+arrive through the escape hatch.
+
+**The escape hatch is three keys and they are a set.** `extraEnvFrom` names a Secret; `extraVolumes`
+is the CSI volume behind it; `extraVolumeMounts` is the mount — and the *mount* is what makes the
+Secrets Store CSI driver fetch the vault objects and write that Secret. A pod that names the Secret
+without mounting the class free-rides on some other pod's mount, and `envFrom` is resolved once, at
+container start. Render all three or none.
+
+**Why the #3548 guard could not see #3595.** `KeyVaultCsiFreshnessGuard`'s original fact is keyed on
+`$class.syncedSecret` / `$class.mountPath` — the markers of a class the *chart* owns. A hand-made
+SecretProviderClass carries neither, so the guard was blind to the escape hatch by construction, and
+that blindness is measurable: removing the Job's `extraEnvFrom` render leaves the original fact
+**green** while the two facts added for #3595 both go red. Those two are:
+
+- *every workload that carries the chart's Key Vault secrets also renders the escape hatch* — the
+  parity half;
+- *every workload that renders `extraEnvFrom` also renders its volume and mount* — #3548's freshness
+  argument, applied to the class the chart does not own.
+
+Each asserts its own denominator, including that `values.yaml` still declares the three keys, so a
+rename there fails the guard instead of silently making it match nothing.
+
 ## The falsification test
 
 The shape is only worth having if rendering the record reproduces what is actually running. Rendering

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-search-stops-coming-up-empty-after-a-deployment-changes-its-ai-keys.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-search-stops-coming-up-empty-after-a-deployment-changes-its-ai-keys.md
@@ -1,0 +1,45 @@
+---
+Name: Search stops coming up empty after a deployment changes its AI keys
+Category: Fix
+Description: On installations that supply their AI keys through the chart's legacy escape hatch, the database migration received none of them, so everything written before the change stayed unsearchable by meaning — and the migration reported success anyway. It now receives the same keys the portal does.
+Icon: Search
+Order: -20260907
+---
+
+# Search stops coming up empty after a deployment changes its AI keys
+
+Semantic search — finding a page by what it *means* rather than by the words it literally contains
+— only works for content that has been indexed. Content written **before** an installation had an
+AI provider gets indexed by a catch-up pass that runs during a database update. That pass needs the
+installation's AI key.
+
+On installations that supply that key through the chart's older, by-name mechanism, **the update
+never received it**. Not a wrong key — no key. The catch-up pass saw "no provider configured",
+skipped every single page, and the update finished by reporting success. Nothing in the run said the
+index was empty.
+
+The visible effect is the one that is hardest to attribute: search keeps working, but it quietly
+falls back to matching literal words. A page you know exists is not found by a phrase that describes
+it. Nothing is broken, nothing is logged as an error, and there is no obvious moment when it started.
+
+## What changes
+
+**The database update now receives exactly the same secrets the portal receives.** Both delivery
+mechanisms, not just the newer one: whichever way an installation supplies its keys, both parts of
+the deployment get the same set. Where the keys come from a secure vault, the update also attaches
+that vault directly, so it reads the key that is current *now* rather than a copy some other part of
+the system happened to leave behind.
+
+**An installation that already worked keeps working, unchanged.** Installations that do not use the
+older mechanism render exactly the same deployment as before — byte for byte, verified against the
+three shipped configurations.
+
+**The gap cannot silently reopen.** A check now fails the build if one part of the deployment carries
+the environment's secrets and another does not, or if a secret source is attached without the vault
+that keeps it current. The previous check could not see this case at all.
+
+## What you may need to do
+
+If your installation's semantic search has been returning nothing for older content, the catch-up
+pass ran without a key at some point. It runs again on the next update and indexes what it missed —
+no re-install, nothing to clean up.

--- a/test/MeshWeaver.Documentation.Test/KeyVaultCsiFreshnessGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/KeyVaultCsiFreshnessGuard.cs
@@ -47,6 +47,19 @@ public class KeyVaultCsiFreshnessGuard
     private const string CsiDriver = "secrets-store.csi.k8s.io";
     private const string MountsClassPath = "$class.mountPath";
 
+    /// <summary>
+    /// The LEGACY escape hatch, for an environment whose SecretProviderClass is HAND-MADE and is
+    /// therefore attached by NAME rather than declared. These three values keys are the whole of
+    /// it, and they are a set: the env source, the volume behind it, and the mount that makes the
+    /// driver write the volume's Secret.
+    /// </summary>
+    private const string ExtraEnvFrom = ".Values.extraEnvFrom";
+    private const string ExtraVolumes = ".Values.extraVolumes";
+    private const string ExtraVolumeMounts = ".Values.extraVolumeMounts";
+
+    /// <summary>Where those keys are declared — asserted so a rename cannot silence this guard.</summary>
+    private const string Values = "deploy/helm/values.yaml";
+
     /// <summary>Kinds that carry a pod template — the only ones that can mount anything.</summary>
     private static readonly Regex PodBearingKind =
         new(@"^kind:\s*""?(Deployment|Job|CronJob|StatefulSet|DaemonSet|ReplicaSet|Pod)""?",
@@ -104,6 +117,176 @@ public class KeyVaultCsiFreshnessGuard
             + "PREVIOUS one, and the workload runs green against a stale credential (#3548: 1,260 × "
             + "HTTP 401 and a completed migration). Add the volume + volumeMount from the same "
             + "`memex.keyVaultClasses` block that renders the envFrom.");
+    }
+
+    /// <summary>
+    /// 🚨 <b>Every workload that carries the chart's Key Vault secret set carries the LEGACY
+    /// ESCAPE HATCH too</b> (Systemorph/MeshWeaver#3595).
+    ///
+    /// <para><b>What went wrong, and why the guard above could not see it.</b> The fact above is
+    /// keyed entirely on <c>$class.*</c> — the classes the CHART owns. An environment whose
+    /// SecretProviderClass is HAND-MADE owns no class: it attaches the SPC's synced Secret BY NAME
+    /// through <c>.Values.extraEnvFrom</c>, the shape <c>values.yaml</c> calls "the memex-cloud
+    /// AI-keys shape". A hand-made class carries neither marker, so the freshness guard is blind
+    /// to it BY CONSTRUCTION and cannot go red on it. Measured on <c>origin/main</c>
+    /// <c>fbf9e9be1</c>: <c>grep -rn extraEnvFrom deploy/</c> found exactly ONE rendering site in
+    /// the whole chart — the portal Deployment. The migration Job rendered none of it.</para>
+    ///
+    /// <para><b>And that is a DIFFERENT defect from #3548, with a different remedy.</b> #3548 was
+    /// STALENESS: the Job had the value, from before the rotation. This is ABSENCE: for a key
+    /// delivered through the escape hatch the Job had no value at all, so
+    /// <c>MeshNodeEmbeddingBackfill</c> took the not-configured path, logged-and-skipped every row,
+    /// and the Job still reported <c>Database migration completed</c>. Same green run, same silent
+    /// outcome, different mechanism.</para>
+    ///
+    /// <para><b>The invariant.</b> The two workloads must carry the SAME secret set, whichever
+    /// mechanism delivers it. So every pod-bearing template that reads the chart's own classes
+    /// must render the escape hatch as well — the parity is what stops the next workload from
+    /// getting half the environment's secrets, which is a state that produces a green run and an
+    /// empty index rather than a failure.</para>
+    /// </summary>
+    [Fact]
+    public void EveryWorkloadThatCarriesTheChartsKeyVaultSecrets_AlsoRendersTheLegacyEscapeHatch()
+    {
+        var root = FindRepoRoot();
+
+        AssertTheEscapeHatchKeysStillExist(root);
+
+        var readers = PodBearingTemplatesReadingTheChartsClasses(root);
+
+        var missingHatch = readers
+            .Where(t => !t.Body.Contains(ExtraEnvFrom, StringComparison.Ordinal))
+            .Select(t => Path.GetRelativePath(root, t.Path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(missingHatch.Length == 0,
+            "these workloads carry the chart-owned Key Vault secrets but render NONE of "
+            + $"`{ExtraEnvFrom}`: {string.Join(", ", missingHatch)}. An environment whose "
+            + "SecretProviderClass is hand-made delivers its keys ONLY through that escape hatch "
+            + "(values.yaml calls it the memex-cloud AI-keys shape), so such a workload receives "
+            + "part of the environment's secrets and no signal that the rest is missing — the "
+            + "embedding backfill then logs-and-skips every row and the Job still reports "
+            + "`Database migration completed` (#3595). Render the same "
+            + $"`{ExtraEnvFrom}` block the portal Deployment does, and its "
+            + $"`{ExtraVolumes}` / `{ExtraVolumeMounts}` twins with it.");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The escape hatch's own freshness half: a workload that READS
+    /// <c>.Values.extraEnvFrom</c> also renders the volume and the mount behind it.</b>
+    ///
+    /// <para>This is #3548's argument applied to the class the chart does not own, and it is why
+    /// the three values keys are a SET rather than three options. The CSI driver materialises and
+    /// rotates a synced Secret for the pods that MOUNT its SecretProviderClass; a pod that only
+    /// names the Secret in <c>envFrom</c> free-rides on some other pod's mount and resolves
+    /// <c>envFrom</c> once, at container start. Rendering the env source without its volume would
+    /// therefore hand the new workload exactly the stale credential #3548 measured — 1,260 × HTTP
+    /// 401 behind a green migration — with the guard above unable to see it, because none of it
+    /// goes through <c>$class.*</c>.</para>
+    ///
+    /// <para>Asserted in the same direction as its sibling and for the same reason: rendering
+    /// MORE of the hatch can only be safe, rendering less is the defect.</para>
+    /// </summary>
+    [Fact]
+    public void EveryWorkloadThatRendersTheEscapeHatchEnvFrom_AlsoRendersItsVolumeAndMount()
+    {
+        var root = FindRepoRoot();
+
+        AssertTheEscapeHatchKeysStillExist(root);
+
+        var templates = PodBearingTemplates(root);
+
+        var hatchReaders = templates
+            .Where(t => t.Body.Contains(ExtraEnvFrom, StringComparison.Ordinal))
+            .ToArray();
+
+        // 🚨 The denominator. Two workloads render the hatch today — the portal Deployment and the
+        // migration Job. If that reaches zero the escape hatch was removed from the chart while
+        // values.yaml still declares it (the assertion above proves it does), which is a values key
+        // consumed by nothing — the exact class of defect chart-gate exists for. Never a pass.
+        Assert.True(hatchReaders.Length >= 2,
+            $"expected at least two pod-bearing templates to render `{ExtraEnvFrom}` (the portal "
+            + $"Deployment and the migration Job); found {hatchReaders.Length}. `{Values}` still "
+            + "declares the key, so either a workload stopped rendering it — which is #3595 "
+            + "reopening — or the hatch was retired and this guard must move with it.");
+
+        var freeRiders = hatchReaders
+            .Where(t => !t.Body.Contains(ExtraVolumes, StringComparison.Ordinal)
+                        || !t.Body.Contains(ExtraVolumeMounts, StringComparison.Ordinal))
+            .Select(t => Path.GetRelativePath(root, t.Path))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(freeRiders.Length == 0,
+            $"these workloads read `{ExtraEnvFrom}` but do not render "
+            + $"`{ExtraVolumes}` / `{ExtraVolumeMounts}`: {string.Join(", ", freeRiders)}. The env "
+            + "source names a Secret the Secrets Store CSI driver writes only for the pods that "
+            + "MOUNT its SecretProviderClass, and envFrom is resolved once at container start — so "
+            + "without the volume the workload free-rides on another pod's mount and reads a value "
+            + "that is stale or absent, green and silent (#3548, #3595). The three keys are a set: "
+            + "render all three or none.");
+    }
+
+    /// <summary>
+    /// The escape hatch's keys must still be DECLARED in values.yaml. Without this a rename there
+    /// would leave both facts above matching nothing in every template and passing — a guard whose
+    /// subject moved and whose roots did not, which AGENTS.md names as the skip-trapdoor shape.
+    /// </summary>
+    private static void AssertTheEscapeHatchKeysStillExist(string root)
+    {
+        var values = Path.Combine(root, Values);
+        Assert.True(File.Exists(values),
+            $"{Values} is gone — the escape-hatch keys this guard keys on are declared there. If "
+            + "the values file moved, move the guard with it rather than letting it match nothing.");
+
+        var body = File.ReadAllText(values);
+        var undeclared = new[] { "extraEnvFrom", "extraVolumes", "extraVolumeMounts" }
+            .Where(k => !Regex.IsMatch(body, $@"^{Regex.Escape(k)}\s*:", RegexOptions.Multiline))
+            .ToArray();
+
+        Assert.True(undeclared.Length == 0,
+            $"{Values} no longer declares: {string.Join(", ", undeclared)}. These three keys are "
+            + "the legacy escape hatch and this guard is keyed on their names, so a rename here "
+            + "makes both facts match nothing and pass having checked no template. Rename them in "
+            + "the guard in the same change — or, if the hatch was retired because every "
+            + "environment moved onto `keyVaultSecretClasses`, delete this guard and say so.");
+    }
+
+    /// <summary>Pod-bearing templates that read the chart's OWN Key Vault classes.</summary>
+    private static (string Path, string Body)[] PodBearingTemplatesReadingTheChartsClasses(string root)
+    {
+        var readers = PodBearingTemplates(root)
+            .Where(t => t.Body.Contains(ReadsSyncedSecret, StringComparison.Ordinal))
+            .ToArray();
+
+        // The same denominator the first fact asserts, for the same reason: zero readers means the
+        // wiring was rewritten, which is a human question and never a pass.
+        Assert.True(readers.Length >= 2,
+            $"expected at least two pod-bearing templates to read '{ReadsSyncedSecret}' (the portal "
+            + $"Deployment and the migration Job); found {readers.Length}. Either the Key Vault "
+            + "wiring was rewritten (move this guard with it) or a reader was lost.");
+
+        return readers;
+    }
+
+    /// <summary>Every template in the chart that declares a pod, comments stripped.</summary>
+    private static (string Path, string Body)[] PodBearingTemplates(string root)
+    {
+        var dir = Path.Combine(root, Templates);
+
+        var templates = Directory.EnumerateFiles(dir, "*.yaml", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(templates.Length > 0,
+            $"{Templates} contains no .yaml templates — this guard would pass having examined "
+            + "nothing. Point it at wherever the chart moved.");
+
+        return templates
+            .Select(f => (Path: f, Body: ExecutableLinesOf(File.ReadAllText(f))))
+            .Where(t => PodBearingKind.IsMatch(t.Body))
+            .ToArray();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3595.

## The defect

The migration Job carried the chart-**owned** Key Vault classes and nothing else. An environment
whose `SecretProviderClass` is **hand-made** attaches it by name through `.Values.extraEnvFrom` —
the shape `values.yaml` itself calls *"the memex-cloud AI-keys shape"* — and the whole chart had
exactly **one** rendering site for that escape hatch: the portal Deployment.

So for a key delivered that way the Job had **no value at all**. `MeshNodeEmbeddingBackfill` — the
only thing that embeds rows written before a provider existed — took the not-configured path,
logged-and-skipped every row, and the Job still reported `Database migration completed`.

**This is ABSENCE, not #3548's STALENESS**, and it needs a different remedy. #3548 (merged as #3572)
made the Job *mount* the chart-owned SPC so its values are current; it is keyed entirely on
`memex.keyVaultClasses`, so it cannot reach a class the chart does not own.

## The fix

The Job now renders the escape hatch exactly as the portal Deployment does — `.Values.extraEnvFrom`,
and its `.Values.extraVolumes` / `.Values.extraVolumeMounts` twins. The mount is what makes the CSI
driver fetch the vault objects and write the synced Secret *before any container in the pod starts*,
so the Job gets the current value by construction, the same property #3548 established.

**Verbatim, and deliberately NOT `optional: true`.** The chart-owned entries above are optional
because the chart *renders* their SecretProviderClass and knows a first install has nothing to
backfill. The chart owns nothing here — the operator declared this source, and the volume the Job
now mounts is what materialises it. Marking it optional would recreate the exact silent-skip this
change closes. The portal Deployment has identical semantics for identical entries, so nothing can
fail here that would not already fail there.

## Measurements

**Byte-identical for every shipped configuration** (`helm template` before ⇢ after, `cmp`):

| combination | result |
|---|---|
| self-host (`deploy/helm/values.yaml`) | `cmp` **rc=0** — sha256 `3593ec21…` both sides |
| AKS overlay (`+ deploy/aks/values.aks.yaml`) | `cmp` **rc=0** |
| memex-local (`+ deploy/homebrew/share/values.local.defaults.yaml`) | `cmp` **rc=0** |

**With the escape hatch set, the diff IS the fix** — nothing else in the whole render changes:

```diff
             - secretRef:
                 name: "memex-migration-secrets"
+            - secretRef:
+                name: memexcloud-portal-ai-secrets
           imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - mountPath: /mnt/secrets-store
+              name: kv-ai-secrets
+              readOnly: true
+      volumes:
+        - csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: memexcloud-portal-ai-secrets
+          name: kv-ai-secrets
```

**Parity, parsed out of the rendered manifests** with a chart-owned class *and* the hatch declared
together — both workloads, same sources, same order (order is precedence: k8s keeps the last
`envFrom` on a clash):

```
JOB    envFrom: [configMapRef:memex-migration-config, secretRef:memex-migration-secrets,
                 secretRef:memex-portal-keyvault, secretRef:memexcloud-portal-ai-secrets,
                 configMapRef:memexcloud-extra-config]
PORTAL envFrom: [configMapRef:memex-portal-config,    secretRef:memex-portal-secrets,
                 secretRef:memex-portal-keyvault, secretRef:memexcloud-portal-ai-secrets,
                 configMapRef:memexcloud-extra-config]
JOB    volumes: [kv-secrets, kv-ai-secrets]      ← the hatch's CSI volume is mounted by the Job
```

**Gates, run locally:** `helm lint` → `1 chart(s) linted, 0 chart(s) failed` · `check-chart-invariants.sh`
→ *All 3 values combinations render a self-consistent deployment* · `check-values-are-read.sh` →
*All 119 config key(s) across 3 values file(s) are read by a template* ·
`test-chart-drift-compare.sh` → *all classification assertions passed* ·
`dotnet build -c Release -warnaserror` on `MeshWeaver.Documentation` and
`MeshWeaver.Documentation.Test` → `0 Warning(s) 0 Error(s)`.

## The guard, and its negative controls

`KeyVaultCsiFreshnessGuard` was blind to this **by construction** — it keys on
`$class.syncedSecret` / `$class.mountPath`, markers a hand-made class does not carry. Two facts
added to it:

1. `EveryWorkloadThatCarriesTheChartsKeyVaultSecrets_AlsoRendersTheLegacyEscapeHatch` — the parity half;
2. `EveryWorkloadThatRendersTheEscapeHatchEnvFrom_AlsoRendersItsVolumeAndMount` — #3548's freshness
   argument applied to the class the chart does not own.

Each asserts its own denominator (templates found, ≥2 readers, ≥2 hatch renderers) and both assert
that `values.yaml` still **declares** the three keys, so a rename there fails loudly instead of
leaving the guard matching nothing.

**Falsified, three ways** — each mutation applied to the tree, tests run, then reverted and re-run:

| control | mutation | result |
|---|---|---|
| **A** | the Job stops rendering `.Values.extraEnvFrom` (**the #3595 state itself**) | ❌ both new facts fail · ✅ **the #3548 fact still passes** — the blindness, demonstrated rather than asserted |
| **B** | the Job keeps `extraEnvFrom`, drops the volume + mount | ❌ only the freshness fact fails · ✅ the parity fact correctly stays green |
| **C** | `values.yaml` renames `extraEnvFrom` → `extraEnvSources` | ❌ both new facts fail on the denominator — a rename cannot silence the guard |
| — | restored | ✅ `Passed! - Failed: 0, Passed: 6` (with `MigrationWorkloadModelGuard`), 14/14 with the doc-integrity tests |

Control A also proves the guard does not pass on its own documentation: the mutated Job still
contains the literal `.Values.extraEnvFrom` **inside a Helm comment block**, and the scan strips
comments before matching, so it went red anyway.

## Work product conserved

`Doc/Architecture/DeploymentEnvLayers` gains *"Two workloads, one secret set — and the escape hatch
has to reach both"*: the #3548-vs-#3595 table (staleness vs absence, and why both produced a green
run), why the three values keys are a set, and why the original guard could not see this.

Pairs-with: none — this diff removes no public type and no public member from `src/`; it touches the
Helm chart, one test file and two documentation assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
