### PR TITLE
fix(#3604): the node menu offers only areas this hub can render

### DIFF
--- a/src/MeshWeaver.Documentation/Data/GUI/NodeMenu.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/NodeMenu.md
@@ -119,6 +119,35 @@ Portal (LayoutAreaView)
    │  PortalLayoutBase renders items in menu
 ```
 
+### An entry is never offered for an area this hub cannot render
+
+🚨 **Most of the default entries link to a renderer the platform does not own.** Delete, Copy, Move,
+Versions, Pin, Import, Stop sync, Access control and Groups all render from
+`MeshWeaver.Graph.Views`, which ships as the optional **`DefaultViews`** package — the platform keeps
+the area name and the menu descriptor, the package brings the view. On a mesh without that package
+every one of those entries used to be offered anyway, and every click landed on the layout engine's
+diagnostic page: *"Area not found — No renderer is registered for area `Delete`"* (MeshWeaver#3604).
+
+`DefaultNodeMenuProvider` therefore drops, as its last step, any entry that is a plain navigation to
+**this node's own area URL** for an area no named renderer serves
+(`NodeMenuItemsExtensions.WithoutUnrenderableAreas`). The check is deliberately narrow: an
+**action** entry is never dropped (Recycle runs in place and its href is the node's landing page), nor
+is a submenu parent, a separator, a group, or an entry linking anywhere but `/{node}/{area}` — an
+absolute href such as Cast's `/RemoteControl/Start/Cast?target=…` names an area this hub was never
+asked about.
+
+🚨 **It fails OPEN, and the Overview probe is why.** `HasNamedRenderer` answers a boolean about
+something it had to read, and "this definition is empty, or is not the one that serves this node"
+must never be collapsed into "this area has no renderer" — that direction silently deletes Delete,
+Copy and Move from every portal at once. A node hub always carries `Overview` (registered by the same
+`AddDefaultLayoutAreas` call that registers this menu, and nothing can unregister it), so a
+definition that does not know `Overview` is one that cannot be trusted to answer for the rest: every
+entry is kept, and the visible diagnostic page remains the outcome.
+
+Contributed providers are not filtered — a provider owns the applicability of what it emits, which is
+what `RequiredPermission` already expresses. If you contribute an entry pointing at an area, register
+its renderer on the same hub.
+
 ---
 
 ## Adding Custom Menu Items

--- a/src/MeshWeaver.Documentation/Data/GUI/NodeMenu.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/NodeMenu.md
@@ -136,13 +136,20 @@ is a submenu parent, a separator, a group, or an entry linking anywhere but `/{n
 absolute href such as Cast's `/RemoteControl/Start/Cast?target=…` names an area this hub was never
 asked about.
 
-🚨 **It fails OPEN, and the Overview probe is why.** `HasNamedRenderer` answers a boolean about
-something it had to read, and "this definition is empty, or is not the one that serves this node"
-must never be collapsed into "this area has no renderer" — that direction silently deletes Delete,
-Copy and Move from every portal at once. A node hub always carries `Overview` (registered by the same
-`AddDefaultLayoutAreas` call that registers this menu, and nothing can unregister it), so a
-definition that does not know `Overview` is one that cannot be trusted to answer for the rest: every
-entry is kept, and the visible diagnostic page remains the outcome.
+🚨 **It fails OPEN, and the Overview probe is why.** The one rule is
+`MeshNodeLayoutAreas.CanRenderArea`. `HasNamedRenderer` answers a boolean about something it had to
+read, and "this definition is empty, or is not the one that serves this node" must never be collapsed
+into "this area has no renderer" — that direction silently deletes Delete, Copy and Move from every
+portal at once. A node hub always carries `Overview` (registered by the same `AddDefaultLayoutAreas`
+call that registers this menu, and nothing can unregister it), so a definition that does not know
+`Overview` is one that cannot be trusted to answer for the rest: every entry is kept, and the visible
+diagnostic page remains the outcome.
+
+**The node header's button row is the second way in, and it uses the same probe.**
+`MeshNodeLayoutAreas.BuildHeaderActionRow` renders Edit / Copy / Move / Delete as buttons carrying
+the identical `/{node}/{area}` hrefs, so hiding the menu entry alone would have left the dead link
+one click away. Each button is gated on `CanRenderArea` for its own area. On a portal carrying the
+package, neither surface changes at all.
 
 Contributed providers are not filtered — a provider owns the applicability of what it emits, which is
 what `RequiredPermission` already expresses. If you contribute an entry pointing at an area, register

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-node-menu-no-longer-offers-what-it-cannot-do.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-node-menu-no-longer-offers-what-it-cannot-do.md
@@ -1,0 +1,32 @@
+---
+Name: The node menu no longer offers what it cannot do
+Category: Fix
+Description: Delete, Copy, Move and several other entries render from an optional package. Where that package is not installed, they were still offered and every click landed on an error page. The menu now only offers what this portal can actually carry out.
+Icon: Bug
+Order: -20260907
+---
+
+# The node menu no longer offers what it cannot do
+
+Open any node's action menu and you are offered a set of operations — Edit, Copy, Move, Delete,
+Versions, Files and so on. Several of those pages are not part of the platform itself: they arrive
+with an optional package, the same way a chart type or a map does. On a portal that has the package,
+everything works. On one that does not, the entries were offered exactly the same way — and clicking
+one landed on a diagnostic page reading *"Area not found — no renderer is registered for area
+Delete"*.
+
+The menu now asks, for each entry it is about to offer, whether this portal actually has the page
+behind it, and quietly leaves out the ones it does not. Nothing changes on a portal that has the
+package: every entry that worked before still appears, in the same place, in the same order.
+
+Two details were decided deliberately rather than by default.
+
+An entry that runs a command in place rather than navigating — Recycle is the one that does — is
+never affected, and neither is a submenu heading, a separator, or an entry that links somewhere other
+than this node's own page. Only an entry that would take you to a page on this node, where no such
+page exists, is left out.
+
+And the check errs towards showing you too much rather than too little. If the portal cannot answer
+the question reliably, every entry stays — because the failure mode of guessing "no" is that Delete,
+Copy and Move quietly vanish everywhere, which is far worse than the error page this replaces. That
+possibility is recognised by a specific signal, not assumed away.

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -294,14 +294,10 @@ public static class NodeMenuItemsExtensions
     /// <c>/RemoteControl/Start/Cast?target=…</c>, a plugin front door, a search URL — names an area
     /// this hub's layout definition was never asked about, so it is left alone.</para>
     ///
-    /// <para>🚨 FAILS OPEN, which is the whole point of the Overview probe. <c>HasNamedRenderer</c>
-    /// answers a boolean about something it had to READ, and "the definition is empty / not the one
-    /// that serves this node" must never be collapsed into "this area has no renderer" — that
-    /// direction silently deletes Delete, Copy and Move from every portal at once. A node hub
-    /// ALWAYS carries Overview (<c>AddDefaultLayoutAreas</c> registers it in the same call that
-    /// registers this menu, and nothing can unregister it), so a definition that does not know
-    /// Overview is a definition we cannot trust to answer for the rest — in that case every entry
-    /// is kept and the diagnostic page remains the (visible) outcome.</para>
+    /// <para>🚨 FAILS OPEN — see <see cref="MeshNodeLayoutAreas.CanRenderArea"/>, which owns that
+    /// rule and the Overview probe behind it. "The definition is empty / not the one that serves
+    /// this node" must never collapse into "this area has no renderer": that direction silently
+    /// deletes Delete, Copy and Move from every portal at once.</para>
     /// </summary>
     /// <param name="layout">The layout definition of the hub the menu is being rendered on.</param>
     /// <param name="menuPath">The node path the menu belongs to — the href prefix entries must match.</param>
@@ -309,9 +305,7 @@ public static class NodeMenuItemsExtensions
     /// <returns>The entries whose target this hub can actually render.</returns>
     internal static ImmutableList<NodeMenuItemDefinition> WithoutUnrenderableAreas(
         LayoutDefinition? layout, string menuPath, ImmutableList<NodeMenuItemDefinition> items)
-        => layout is null || !layout.HasNamedRenderer(MeshNodeLayoutAreas.OverviewArea)
-            ? items
-            : items.RemoveAll(item => TargetsUnrenderableArea(layout, menuPath, item));
+        => items.RemoveAll(item => TargetsUnrenderableArea(layout, menuPath, item));
 
     /// <summary>
     /// True when <paramref name="item"/> is a plain navigation to <paramref name="menuPath"/>'s own
@@ -319,14 +313,14 @@ public static class NodeMenuItemsExtensions
     /// <see cref="WithoutUnrenderableAreas"/> for every condition and why each is there.
     /// </summary>
     private static bool TargetsUnrenderableArea(
-        LayoutDefinition layout, string menuPath, NodeMenuItemDefinition item)
+        LayoutDefinition? layout, string menuPath, NodeMenuItemDefinition item)
         => !item.IsAction
            && !item.IsSubmenuParent
            && item.Area is { Length: > 0 }
            && item.Area[0] != '_'
            && string.Equals(item.Href, MeshNodeLayoutAreas.BuildUrl(menuPath, item.Area),
                StringComparison.Ordinal)
-           && !layout.HasNamedRenderer(item.Area);
+           && !MeshNodeLayoutAreas.CanRenderArea(layout, item.Area);
 
     /// <summary>
     /// Default provider for the "Mesh" menu — mesh-level operations.

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -266,8 +266,67 @@ public static class NodeMenuItemsExtensions
             // and can HIDE any of these. A divider decided from a partial view is wrong in both
             // directions, so the aggregator derives them from the final list instead
             // (WithSectionDividers).
-            return (IReadOnlyCollection<NodeMenuItemDefinition>)items.ToImmutable();
+            //
+            // 🚨 Last: drop the entries whose RENDERER is not on this mesh. Most of the areas above
+            // are rendered by the OPTIONAL MeshWeaver.Graph.Views module, not by the platform —
+            // see WithoutUnrenderableAreas.
+            return (IReadOnlyCollection<NodeMenuItemDefinition>)
+                WithoutUnrenderableAreas(host.LayoutDefinition, menuPath, items.ToImmutable());
         });
+
+    /// <summary>
+    /// Removes the entries that point at an area THIS hub has no renderer for — the node menu must
+    /// never offer an operation the mesh cannot perform (issue #3604).
+    ///
+    /// <para>Why this is needed at all: the platform assembles the node menu, but most of the
+    /// RENDERERS it links to are not the platform's. Delete, Copy, Move, Versions, Pin, Import,
+    /// StopSync, Access control and Groups all render from <c>MeshWeaver.Graph.Views</c>, which is
+    /// shipped as the optional <c>DefaultViews</c> PACKAGE. On a mesh that does not carry it, every
+    /// one of those entries was still offered and every click landed on the layout engine's
+    /// diagnostic page — <c>"Area not found — No renderer is registered for area `Delete`"</c>. The
+    /// item is the platform's to emit, so the check is the platform's to make.</para>
+    ///
+    /// <para>🚨 Deliberately narrow. An entry is dropped ONLY when it is an ordinary navigation
+    /// (never an <see cref="NodeMenuItemDefinition.IsAction"/> command — Recycle runs in place and
+    /// lands on the node's own page — and never a submenu parent), its area is a real area name
+    /// (not <c>_separator</c> / <c>_group:</c>), and its <see cref="NodeMenuItemDefinition.Href"/>
+    /// is EXACTLY this node's URL for that area. An entry linking anywhere else — Cast's
+    /// <c>/RemoteControl/Start/Cast?target=…</c>, a plugin front door, a search URL — names an area
+    /// this hub's layout definition was never asked about, so it is left alone.</para>
+    ///
+    /// <para>🚨 FAILS OPEN, which is the whole point of the Overview probe. <c>HasNamedRenderer</c>
+    /// answers a boolean about something it had to READ, and "the definition is empty / not the one
+    /// that serves this node" must never be collapsed into "this area has no renderer" — that
+    /// direction silently deletes Delete, Copy and Move from every portal at once. A node hub
+    /// ALWAYS carries Overview (<c>AddDefaultLayoutAreas</c> registers it in the same call that
+    /// registers this menu, and nothing can unregister it), so a definition that does not know
+    /// Overview is a definition we cannot trust to answer for the rest — in that case every entry
+    /// is kept and the diagnostic page remains the (visible) outcome.</para>
+    /// </summary>
+    /// <param name="layout">The layout definition of the hub the menu is being rendered on.</param>
+    /// <param name="menuPath">The node path the menu belongs to — the href prefix entries must match.</param>
+    /// <param name="items">The assembled entries.</param>
+    /// <returns>The entries whose target this hub can actually render.</returns>
+    internal static ImmutableList<NodeMenuItemDefinition> WithoutUnrenderableAreas(
+        LayoutDefinition? layout, string menuPath, ImmutableList<NodeMenuItemDefinition> items)
+        => layout is null || !layout.HasNamedRenderer(MeshNodeLayoutAreas.OverviewArea)
+            ? items
+            : items.RemoveAll(item => TargetsUnrenderableArea(layout, menuPath, item));
+
+    /// <summary>
+    /// True when <paramref name="item"/> is a plain navigation to <paramref name="menuPath"/>'s own
+    /// area page and no renderer on <paramref name="layout"/> serves that area. See
+    /// <see cref="WithoutUnrenderableAreas"/> for every condition and why each is there.
+    /// </summary>
+    private static bool TargetsUnrenderableArea(
+        LayoutDefinition layout, string menuPath, NodeMenuItemDefinition item)
+        => !item.IsAction
+           && !item.IsSubmenuParent
+           && item.Area is { Length: > 0 }
+           && item.Area[0] != '_'
+           && string.Equals(item.Href, MeshNodeLayoutAreas.BuildUrl(menuPath, item.Area),
+               StringComparison.Ordinal)
+           && !layout.HasNamedRenderer(item.Area);
 
     /// <summary>
     /// Default provider for the "Mesh" menu — mesh-level operations.

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -593,26 +593,35 @@ public static class MeshNodeLayoutAreas
 
         if (canEdit)
         {
-            row = row.WithView(Controls.Button(host.Localize("common.edit"))
-                .WithAppearance(Appearance.Neutral)
-                .WithIconStart(FluentIcons.Edit())
-                .WithNavigateToHref(BuildUrl(nodePath, EditArea)));
+            // 🚨 Each button is gated on its area actually rendering HERE — the same probe the node
+            // menu uses, for the same reason: Copy, Move and Delete render from the optional
+            // MeshWeaver.Graph.Views (DefaultViews) package, and this row is the SECOND way into
+            // those areas (#3604 named it). CanRenderArea fails OPEN, so on a portal carrying the
+            // package nothing changes at all.
+            if (CanRenderArea(host.LayoutDefinition, EditArea))
+                row = row.WithView(Controls.Button(host.Localize("common.edit"))
+                    .WithAppearance(Appearance.Neutral)
+                    .WithIconStart(FluentIcons.Edit())
+                    .WithNavigateToHref(BuildUrl(nodePath, EditArea)));
 
-            row = row.WithView(Controls.Button(host.Localize("menu.copy"))
-                .WithAppearance(Appearance.Neutral)
-                .WithIconStart(FluentIcons.Copy())
-                .WithNavigateToHref(BuildUrl(nodePath, CopyArea)));
+            if (CanRenderArea(host.LayoutDefinition, CopyArea))
+                row = row.WithView(Controls.Button(host.Localize("menu.copy"))
+                    .WithAppearance(Appearance.Neutral)
+                    .WithIconStart(FluentIcons.Copy())
+                    .WithNavigateToHref(BuildUrl(nodePath, CopyArea)));
 
-            row = row.WithView(Controls.Button(host.Localize("menu.move"))
-                .WithAppearance(Appearance.Neutral)
-                .WithIconStart(FluentIcons.ArrowMove())
-                .WithNavigateToHref(BuildUrl(nodePath, MoveArea)));
+            if (CanRenderArea(host.LayoutDefinition, MoveArea))
+                row = row.WithView(Controls.Button(host.Localize("menu.move"))
+                    .WithAppearance(Appearance.Neutral)
+                    .WithIconStart(FluentIcons.ArrowMove())
+                    .WithNavigateToHref(BuildUrl(nodePath, MoveArea)));
 
-            row = row.WithView(Controls.Button(host.Localize("common.delete"))
-                .WithAppearance(Appearance.Neutral)
-                .WithStyle("color: var(--error, #d32f2f);")
-                .WithIconStart(FluentIcons.Delete())
-                .WithNavigateToHref(BuildUrl(nodePath, DeleteArea)));
+            if (CanRenderArea(host.LayoutDefinition, DeleteArea))
+                row = row.WithView(Controls.Button(host.Localize("common.delete"))
+                    .WithAppearance(Appearance.Neutral)
+                    .WithStyle("color: var(--error, #d32f2f);")
+                    .WithIconStart(FluentIcons.Delete())
+                    .WithNavigateToHref(BuildUrl(nodePath, DeleteArea)));
         }
 
         return row;
@@ -673,6 +682,36 @@ public static class MeshNodeLayoutAreas
             url += $"?{queryString}";
         return url;
     }
+
+    /// <summary>
+    /// Whether <paramref name="area"/> has a renderer on <paramref name="layout"/> — the ONE probe
+    /// behind every "do not offer what this hub cannot do" decision (issue #3604), used by the node
+    /// menu (<c>NodeMenuItemsExtensions.WithoutUnrenderableAreas</c>) and by the header's own
+    /// Edit / Copy / Move / Delete buttons.
+    ///
+    /// <para>Why it is needed: the platform emits those affordances, but the RENDERERS for Delete,
+    /// Copy, Move, Versions, Pin, Import, Stop sync, Access control and Groups ship in the optional
+    /// <c>MeshWeaver.Graph.Views</c> (<c>DefaultViews</c>) package. On a mesh without it, each one
+    /// was still offered and every click landed on the layout engine's diagnostic page —
+    /// <c>"Area not found — No renderer is registered for area `Delete`"</c>.</para>
+    ///
+    /// <para>🚨 <b>It FAILS OPEN, and the <see cref="OverviewArea"/> probe is the whole reason.</b>
+    /// <c>HasNamedRenderer</c> answers a boolean about something it had to READ, and "this
+    /// definition is empty, or is not the one that serves this node" must never be collapsed into
+    /// "this area has no renderer" — that direction silently removes Delete, Copy and Move from
+    /// every portal at once. A node hub ALWAYS carries <see cref="OverviewArea"/>
+    /// (<c>AddDefaultLayoutAreas</c> registers it in the same call that registers the menu, and
+    /// nothing can unregister it), so a definition that does not know Overview is one that cannot be
+    /// trusted to answer for the rest: everything is kept, and the visible diagnostic page remains
+    /// the outcome.</para>
+    /// </summary>
+    /// <param name="layout">The layout definition of the hub the affordance is rendered on.</param>
+    /// <param name="area">The area name the affordance navigates to.</param>
+    /// <returns><c>true</c> when the area renders here, or when the definition cannot be trusted to say.</returns>
+    internal static bool CanRenderArea(LayoutDefinition? layout, string area)
+        => layout is null
+           || !layout.HasNamedRenderer(OverviewArea)
+           || layout.HasNamedRenderer(area);
 
     /// <summary>
     /// Returns the Edit menu item if the user has Update permission.

--- a/test/MeshWeaver.Graph.Test/NodeMenuOffersOnlyRenderableAreasTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeMenuOffersOnlyRenderableAreasTest.cs
@@ -130,3 +130,51 @@ public class NodeMenuHidesUnrenderableAreasTest(ITestOutputHelper output)
         Assert.Contains(items, m => m.Area == MeshNodeLayoutAreas.FilesArea);
     }
 }
+
+/// <summary>
+/// The probe itself, in isolation — <see cref="MeshNodeLayoutAreas.CanRenderArea"/> is the ONE
+/// rule behind both the node menu and the header's Edit / Copy / Move / Delete buttons, and its
+/// fail-open direction is the half that cannot be observed end to end (a definition that has lost
+/// Overview is not a state a working mesh can be driven into).
+/// </summary>
+public class CanRenderAreaTest
+{
+    private static LayoutDefinition Definition(params string[] areas)
+    {
+        var layout = new LayoutDefinition(null!);
+        foreach (var area in areas)
+            layout = layout.WithNamedRenderer(area,
+                (LayoutAreaHost _, RenderingContext _, EntityStore _) =>
+                    Observable.Empty<EntityStoreAndUpdates>());
+        return layout;
+    }
+
+    /// <summary>The everyday answer: registered here ⇒ offer it.</summary>
+    [Fact]
+    public void ARegisteredAreaCanRender()
+        => Assert.True(MeshNodeLayoutAreas.CanRenderArea(
+            Definition(MeshNodeLayoutAreas.OverviewArea, MeshNodeLayoutAreas.DeleteArea),
+            MeshNodeLayoutAreas.DeleteArea));
+
+    /// <summary>The defect #3604 reported: nothing serves it ⇒ do not offer it.</summary>
+    [Fact]
+    public void AnUnregisteredAreaCannotRender()
+        => Assert.False(MeshNodeLayoutAreas.CanRenderArea(
+            Definition(MeshNodeLayoutAreas.OverviewArea),
+            MeshNodeLayoutAreas.DeleteArea));
+
+    /// <summary>
+    /// 🚨 The direction that matters. A definition that does not know Overview is one this probe
+    /// cannot trust — every node hub carries Overview — so "cannot tell" answers YES, and the
+    /// visible diagnostic page stays. Answering NO here would strip Delete, Copy and Move from
+    /// every portal at once.
+    /// </summary>
+    [Fact]
+    public void ADefinitionThatCannotAnswerSaysYes()
+    {
+        Assert.True(MeshNodeLayoutAreas.CanRenderArea(
+            Definition(), MeshNodeLayoutAreas.DeleteArea));
+        Assert.True(MeshNodeLayoutAreas.CanRenderArea(
+            layout: null, MeshNodeLayoutAreas.DeleteArea));
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NodeMenuOffersOnlyRenderableAreasTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeMenuOffersOnlyRenderableAreasTest.cs
@@ -1,0 +1,132 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Shared plumbing for the two halves of the controlled experiment below — identical mesh,
+/// identical node, identical viewer; the ONLY difference between the two concrete classes is
+/// whether a renderer for <c>Delete</c> is registered.
+/// </summary>
+public abstract class NodeMenuRenderableAreaTestBase(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>The node whose menu is read. Plain — no NodeType, so it takes the default chain.</summary>
+    protected const string Node = "MenuRendererProbe";
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddLayoutClient()
+            .WithTypes(typeof(MenuControl), typeof(NodeMenuItemDefinition));
+
+    /// <summary>
+    /// The rendered <c>$Menu:Node</c> entries, read through the layout client exactly as the portal
+    /// reads them — the assertion is on what a USER is offered, not on what a provider returned.
+    /// </summary>
+    protected IObservable<IReadOnlyList<NodeMenuItemDefinition>> NodeMenu(Address nodeAddress)
+        => GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(
+                nodeAddress, new LayoutAreaReference(MeshNodeLayoutAreas.OverviewArea))
+            .GetControlStream(MenuControl.GetMenuArea(NodeMenuItemsExtensions.NodeMenuContext))
+            .Where(x => x is MenuControl)
+            .Select(x => (IReadOnlyList<NodeMenuItemDefinition>)((MenuControl)x!).Items);
+
+    /// <summary>
+    /// Waits until the node menu has rendered — Edit is a platform-registered entry, so its
+    /// presence means "the menu is up and this viewer has rights", never "the assertion is ready to
+    /// pass vacuously".
+    /// </summary>
+    protected async Task<IReadOnlyList<NodeMenuItemDefinition>> RenderedMenu()
+        => await NodeMenu(new Address(Node))
+            .Where(i => i.Any(m => m.Area == MeshNodeLayoutAreas.EditArea))
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence);
+}
+
+/// <summary>
+/// CONTROL half of issue #3604. With a renderer for <c>Delete</c> registered — which is what the
+/// optional <c>MeshWeaver.Graph.Views</c> (<c>DefaultViews</c>) package does on a real portal — the
+/// Delete entry IS offered.
+///
+/// <para>🚨 This half is what makes the other half a measurement rather than a tautology. The
+/// Delete entry is gated on <c>Permission.Delete</c>, so "Delete is absent" would also be the
+/// outcome if the test viewer simply lacked that right, and the experiment would then pass having
+/// observed nothing. Same mesh, same node, same viewer, one variable.</para>
+/// </summary>
+public class NodeMenuOffersDeleteWhenRenderedTest(ITestOutputHelper output)
+    : NodeMenuRenderableAreaTestBase(output)
+{
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            // Stands in for the DefaultViews package's node-wide registration.
+            .ConfigureDefaultNodeHub(config => config.AddLayout(layout => layout
+                .WithView(MeshNodeLayoutAreas.DeleteArea,
+                    (LayoutAreaHost _, RenderingContext _) =>
+                        Observable.Return((UiControl?)Controls.Markdown("delete confirmation")))))
+            .AddMeshNodes(new MeshNode(Node) { Name = "Probe" });
+
+    /// <summary>The entry is offered when something on this hub actually renders it.</summary>
+    [HubFact]
+    public async Task DeleteIsOffered_WhenARendererIsRegistered()
+    {
+        var items = await RenderedMenu();
+        Assert.Contains(items, m => m.Area == MeshNodeLayoutAreas.DeleteArea);
+    }
+}
+
+/// <summary>
+/// Issue #3604 — "The Delete menu item leads to a dead area". The platform assembles the node menu,
+/// but the renderers for Delete, Copy, Move, Versions and Pin ship in the OPTIONAL
+/// <c>MeshWeaver.Graph.Views</c> (<c>DefaultViews</c>) package. On a mesh without it — this one —
+/// every one of those entries used to be offered and every click landed on the layout engine's
+/// diagnostic page: <c>"Area not found — No renderer is registered for area `Delete`"</c>.
+///
+/// <para>Pinned here end to end, through the layout client, because the defect is only visible in
+/// the RENDERED menu: the provider produced a perfectly valid entry, and the hub it pointed at
+/// simply had nothing to serve it.</para>
+/// </summary>
+public class NodeMenuHidesUnrenderableAreasTest(ITestOutputHelper output)
+    : NodeMenuRenderableAreaTestBase(output)
+{
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(new MeshNode(Node) { Name = "Probe" });
+
+    /// <summary>
+    /// No renderer for Delete anywhere on this mesh ⇒ the entry is not offered. The control class
+    /// above proves the viewer holds <c>Permission.Delete</c>, so the absence is attributable to
+    /// the missing renderer and to nothing else.
+    /// </summary>
+    [HubFact]
+    public async Task DeleteIsNotOffered_WhenNothingRendersIt()
+    {
+        var items = await RenderedMenu();
+        Assert.DoesNotContain(items, m => m.Area == MeshNodeLayoutAreas.DeleteArea);
+    }
+
+    /// <summary>
+    /// 🚨 The filter must not become a menu-wide cull. Recycle is an ACTION whose href is the
+    /// node's own landing page rather than an area URL, and the platform renders its progress card
+    /// itself — it stays, and so does every other entry the platform can actually serve.
+    /// </summary>
+    [HubFact]
+    public async Task PlatformRenderedEntriesSurvive()
+    {
+        var items = await RenderedMenu();
+        Assert.Contains(items, m => m.Area == MeshNodeLayoutAreas.RecycleArea);
+        Assert.Contains(items, m => m.Area == MeshNodeLayoutAreas.FilesArea);
+    }
+}


### PR DESCRIPTION
Closes #3604.

## The issue's premise is half wrong, and the measurement says which half

#3604 states that "no renderer is registered for that area **anywhere**" and that a
repository-wide search for `WithView(…DeleteArea…)` returns no hit in any repo. That is
false. `DeleteViews.Delete` lives in `MeshWeaver.Plugins/src/MeshWeaver.Graph.Views/DeleteViews.cs`
and is registered node-wide by `GraphViewsModuleAttribute` — on Plugins `main` since
2026-08-29 (`8b6fe740 feat(views): DeleteViews joins the module, registered node-wide`).

**Measured on the live memex portal today:** `get @Doc/Architecture/area/Delete` returns
`DeleteViews.Delete`'s own placeholder — `<p …>Loading delete confirmation…</p>` — so the
renderer is registered and the area works there. The same node's `$Menu:Node` carries Pin
and Versions, both module-provided, confirming the package is installed.

## What is actually broken, and it is core's

`MeshWeaver.Graph.Views` ships as the **optional `DefaultViews` package**
(`.github/workflows/ci.yml` in Plugins: `{"package": "DefaultViews", "module": "MeshWeaver.Graph.Views", …}`),
not as part of the base image's compiled surface. The platform assembles the node menu and
emits the entry; the package brings the view. On a mesh without the package — the reporter's
memex-local self-registry install — Delete, Copy, Move, Versions, Pin, Import, Stop sync,
Access control and Groups are all offered and all dead-end on
`Area not found — No renderer is registered for area \`Delete\``.

So the defect is real and generic, and it is not "Delete has no renderer": it is **the
platform asserting a capability it never verified.**

## The fix

`DefaultNodeMenuProvider` drops, as its last step, any entry that is a plain navigation to
THIS node's own area URL for an area no named renderer serves
(`NodeMenuItemsExtensions.WithoutUnrenderableAreas`).

Narrow on purpose — an entry is dropped only when **all** of: not an action
(`IsAction`; Recycle runs in place and its href is the landing page), not a submenu parent,
area is a real name (not `_separator` / `_group:`), and `Href` is EXACTLY
`BuildUrl(menuPath, Area)`. Cast's `/RemoteControl/Start/Cast?target=…` and every plugin
front door name an area this hub was never asked about, so they are untouched. Only
`DefaultNodeMenuProvider`'s own items are filtered; a contributed provider owns the
applicability of what it emits.

**It fails OPEN, via the Overview probe.** `HasNamedRenderer` answers a boolean about
something it had to READ, and "this definition is empty, or is not the one serving this
node" must never collapse into "this area has no renderer" — that direction silently
deletes Delete, Copy and Move from every portal at once. A node hub always carries
Overview (`AddDefaultLayoutAreas` registers it in the same call that registers this menu,
and nothing can unregister it), so a definition that does not know Overview is one that
cannot answer for the rest: every entry is kept and the diagnostic page stays.

## How it was falsified

`test/MeshWeaver.Graph.Test/NodeMenuOffersOnlyRenderableAreasTest.cs` is a controlled
experiment — one mesh per arm, same node, same viewer, one variable: whether a `Delete`
renderer is registered node-wide. The control arm exists precisely because "Delete is
absent" would also be the outcome if the test viewer lacked `Permission.Delete`, and the
experiment would then pass having observed nothing.

With `WithoutUnrenderableAreas` temporarily replaced by `=> items;`, rebuilt:

```
Failed  NodeMenuHidesUnrenderableAreasTest.DeleteIsNotOffered_WhenNothingRendersIt [650 ms]
Passed  NodeMenuHidesUnrenderableAreasTest.PlatformRenderedEntriesSurvive          [200 ms]
Passed  NodeMenuOffersDeleteWhenRenderedTest.DeleteIsOffered_WhenARendererIsRegistered [204 ms]
```

Restored:

```
Passed  NodeMenuOffersDeleteWhenRenderedTest.DeleteIsOffered_WhenARendererIsRegistered [822 ms]
Passed  NodeMenuHidesUnrenderableAreasTest.DeleteIsNotOffered_WhenNothingRendersIt     [222 ms]
Passed  NodeMenuHidesUnrenderableAreasTest.PlatformRenderedEntriesSurvive              [220 ms]
```

Exactly one assertion moved, and it is the one the fix is about.

## Verification

- `dotnet build -c Release -warnaserror src/MeshWeaver.Graph/MeshWeaver.Graph.csproj` → `0 Warning(s) 0 Error(s)`
- `dotnet build -c Release -warnaserror test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj` → `0 Warning(s) 0 Error(s)`
- `dotnet build -c Release -warnaserror test/MeshWeaver.Documentation.Test/…` → `0 Warning(s) 0 Error(s)`;
  `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` pass.
- No new user-visible string, so no localization key is added and the plugins i18n mirror is
  untouched (it is 18 keys stale per #3596 — deliberately not addressed here).

## What this does NOT do

It does not give a package-less install a working Delete — it cannot; core does not own that
view by design. It removes the false offer. Restoring the operation on such an install means
installing `DefaultViews` (see Plugins#1468 for the local self-registry case). The Delete
subtree question (#3604's scope note 1, "including its N children") lives with the view and is
therefore not core's either.

`Pairs-with: none` — no public type or member is removed; the one added member is
`internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
