### PR TITLE
fix(#3583): a publication's repository marker records whose CONTENT was baked

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -35,6 +35,10 @@
 #                          memex-data PVC, mounted at /data — so the portal reads
 #                          /data/prebuilt-bundles/... when PreWarm__PrebuiltBundleRoot is
 #                          /data/prebuilt-bundles).
+#   BAKE_CONTENT_REPOSITORY  owner/name of the repository the BAKED CONTENT came from — recorded in
+#                          repository.txt so an instance can attribute the seal (see the marker
+#                          below). Defaults to $GITHUB_REPOSITORY, which is the LANE's repository
+#                          and therefore right only when the lane bakes its own content.
 #
 # AUTH: `az login` must already have happened (the CD jobs use OIDC). Data-plane access uses
 # --auth-mode login with --backup-intent, which requires the identity to hold the
@@ -181,9 +185,25 @@ printf '%s\n' "${SOURCE_SHA:-unknown}" > "$SOURCE_MARKER_LOCAL"
 # in core). A local run records nothing rather than a guess; the gate attributes such a seal by
 # commit instead. Listed and uploaded BEFORE architecture.txt, which stays the LAST upload before
 # the postcondition — the overlap harness hooks its second publisher onto that file.
+#
+# 🚨 It is the CONTENT repository, NEVER $GITHUB_REPOSITORY (MeshWeaver#3583). The two differ in
+# exactly the case the marker exists for: core CD's `plugins-bake` bakes MeshWeaver.Plugins content
+# from a run whose $GITHUB_REPOSITORY is Systemorph/MeshWeaver, so the lane's own name stamped a
+# `plugins` seal as the PLATFORM's. SealedSyncGate.BelongsTo takes the marker branch whenever it is
+# non-empty and never falls back to commit attribution, so a Plugins green build then found no seal
+# attributable to Plugins, `mine` was empty, and the gate returned Go — inert for the one repository
+# it was written for, while the satellite's own publish-bake stamped the SAME prefix correctly. The
+# same trap one field over from the content sha, which node-repo-publish-bake.yml already warns
+# about ("The CONTENT commit, not $GITHUB_SHA. They differ exactly when content-repository is set").
+#
+# The fallback to $GITHUB_REPOSITORY is correct ONLY for a lane baking its OWN repository's content
+# — which is every node repo and core's `meshweaver-content` bake. Both live callers now pass the
+# value explicitly, so nothing in the fleet relies on the fallback; it is here for an older
+# workflow copy that has not been re-pinned yet, where the lane's own name is the best available
+# answer and was the whole answer before this variable existed.
 REPO_MARKER="repository.txt"
 REPO_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$REPO_MARKER"
-printf '%s\n' "${GITHUB_REPOSITORY:-}" > "$REPO_MARKER_LOCAL"
+printf '%s\n' "${BAKE_CONTENT_REPOSITORY:-${GITHUB_REPOSITORY:-}}" > "$REPO_MARKER_LOCAL"
 
 ARCH_MARKER="architecture.txt"
 ARCH_MARKER_LOCAL="$SENTINEL_LOCAL_DIR/$ARCH_MARKER"

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -483,6 +483,37 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
           r.returncode == 0 and s.sealed() and "already published; skipping" in r.stdout,
           f"rc={r.returncode}, {denominator(s)}")
 
+    # ── ATTRIBUTION: repository.txt records the CONTENT repository, not the LANE. #3583 ────────
+    #
+    # This is the marker SealedSyncGate.BelongsTo reads, and it takes the marker branch whenever the
+    # marker is non-empty — it never falls back to commit attribution. So a `plugins` seal stamped
+    # with core CD's own repository name is not attributable to MeshWeaver.Plugins at all: the
+    # gate's `mine` list comes back empty and it returns Go, inert for the one repository it exists
+    # to hold. The two cases are one variable apart: same lane, same bake; only whose CONTENT it is
+    # differs.
+    print("\nattribution — the repository marker names whose CONTENT was baked (#3583):")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1301",
+                  {"BAKE_CONTENT_REPOSITORY": "Systemorph/MeshWeaver.Plugins"})
+    marker = h.shelf().files().get("repository.txt", "").strip()
+    check("the case is not vacuous — a marker was written at all",
+          r.returncode == 0 and marker != "", f"rc={r.returncode}, repository.txt={marker!r}")
+    if expect_defect:
+        check("PRE-FIX: a bake of another repository's content is stamped with the LANE",
+              marker == "Systemorph/MeshWeaver", f"repository.txt={marker!r}")
+    else:
+        check("a bake of another repository's content records THAT repository",
+              marker == "Systemorph/MeshWeaver.Plugins", f"repository.txt={marker!r}")
+
+    # The control for it: a lane baking its OWN content still records itself, so the fix cannot be
+    # "always write something else".
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1302")
+    marker = h.shelf().files().get("repository.txt", "").strip()
+    check("a bake of the lane's own content records the lane",
+          r.returncode == 0 and marker == "Systemorph/MeshWeaver",
+          f"rc={r.returncode}, repository.txt={marker!r}")
+
     # ── OVERLAP A: the other lane dies mid-publication, having overwritten part of ours. ───────
     print("\noverlap — the other lane is STILL IN FLIGHT when we seal:")
     h.reset()

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2018,6 +2018,10 @@ jobs:
           BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}
           BAKE_ARCHITECTURE: ${{ matrix.arch }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          # This lane bakes the PLATFORM's OWN content, so the content repository IS this
+          # repository. Stated explicitly rather than left to the script's fallback, so no live
+          # publisher depends on a default that is only right by coincidence (MeshWeaver#3583).
+          BAKE_CONTENT_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           # The third argument is the CONTENT identity (the commit this bake was taken from).

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1192,6 +1192,14 @@ jobs:
         if: steps.scope.outputs.scope != 'none'
         env:
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
+          # 🚨 The CONTENT repository, exactly as the checkout above resolves it — NOT
+          # github.repository (MeshWeaver#3583). They differ in precisely the case the marker is
+          # for: core CD bakes MeshWeaver.Plugins content from a run whose github.repository is
+          # Systemorph/MeshWeaver, and stamping the lane's own name made SealedSyncGate unable to
+          # attribute the `plugins` seal to Plugins — so the gate fell open for the one repository
+          # it was written for. Same expression as the checkout's `repository:` on purpose: one
+          # answer to "whose content is this", used by both.
+          BAKE_CONTENT_REPOSITORY: ${{ inputs.content-repository || github.repository }}
         # Contract: layout <base>/prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip,
         # every bundle first, the `_complete` sentinel strictly LAST; an already-sealed identity
         # with the same source sha skips (the surface identity is breaking-change-keyed, so

--- a/src/MeshWeaver.Documentation/Data/Architecture/SyncRefContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SyncRefContract.md
@@ -138,6 +138,37 @@ makes the two agree rather than introducing a new risk. Resolving the branch ins
 recoverable step backwards for landing a tree *no build ever proved* — which is what five hours of
 dark Store looked like.
 
+## The seal's attribution marker: whose CONTENT, never whose LANE
+
+`SealedSyncGate` holds a module-bearing repository's sources at the commit sealed for this
+instance's framework identity. To do that it has to answer one question about each sealed source on
+the shelf — *is this a publication of the repository whose green build just arrived?* — and it
+answers it from `repository.txt`, a marker `publish-bake-bundles.sh` writes beside the bundles.
+
+**That marker records the repository the baked CONTENT came from. It is not
+`$GITHUB_REPOSITORY`** — and the difference is not academic, because it is exactly the case the
+marker exists for. Core CD's `plugins-bake` job bakes **MeshWeaver.Plugins** content
+(`content-repository: Systemorph/MeshWeaver.Plugins`) from a run whose `$GITHUB_REPOSITORY` is
+`Systemorph/MeshWeaver`. Stamping the lane's own name therefore filed the `plugins` seal under the
+platform — and `SealedSyncGate.BelongsTo` takes the marker branch whenever the marker is non-empty
+and never falls back to commit attribution, so a Plugins green build found *no* seal attributable to
+Plugins, `mine` came back empty, and `Decide` returned `Go`. **The gate was inert for the one
+repository it was written for**, while MeshWeaver.Plugins' own `publish-bake` — the second writer of
+that same prefix — stamped it correctly. Two writers, two different answers, one directory
+(MeshWeaver#3583).
+
+The value is now passed in as `BAKE_CONTENT_REPOSITORY`, from the same
+`inputs.content-repository || github.repository` expression the content CHECKOUT resolves — one
+answer to "whose content is this", used by both — and both live publishers set it explicitly, so
+nothing depends on the script's fallback. The fallback to `$GITHUB_REPOSITORY` remains only for a
+lane whose workflow copy has not been re-pinned yet, where the lane's own name is the whole answer
+the old script had.
+
+🚨 **This is the same trap one field over from the content sha**, which the bake lane already warns
+about in its own words — *"The CONTENT commit, not `$GITHUB_SHA`. They differ exactly when
+`content-repository` is set (the platform baking Plugins)."* Anything the publication records about
+*what was baked* is a fact about the content, and `github.*` describes the lane.
+
 ## How to check it is still true
 
 - `test/MeshWeaver.Hosting.Test/BuildTriggeredSyncPinsTheBuiltCommitTest.cs` pins both halves: the
@@ -150,6 +181,13 @@ dark Store looked like.
 - After any wave that moves plugin sources, the readiness sweep is one call:
   `search 'nodeType:NodeType content.compilationStatus:Error'`. A `searched: false` envelope is a
   FAILED sweep, not a clean one.
+- `.github/scripts/test-publish-bake-overlap.py` EXECUTES the publish script and reads the marker off
+  the resulting bytes, in both directions: a bake of another repository's content records that
+  repository, and a lane baking its own content still records itself. Run it against the pre-fix
+  script (`--script <copy>`) and the first case goes red — which is how the attribution defect above
+  was falsified rather than assumed.
+- On the shelf: `<publishedRoot>/<live framework identity>/plugins/repository.txt`. If it reads
+  `Systemorph/MeshWeaver`, that seal predates the fix and the gate cannot attribute it to Plugins.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-published-build-now-records-whose-content-it-holds.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-published-build-now-records-whose-content-it-holds.md
@@ -1,0 +1,35 @@
+---
+Name: A published build now records whose content it holds
+Category: Fix
+Description: A prepared build recorded the name of the pipeline that produced it instead of the name of the project whose content went into it — so the safeguard that keeps a portal's content and its prepared build in step could never recognise its own subject.
+Icon: ArrowSyncCheckmark
+Order: -20260907
+---
+
+# A published build now records whose content it holds
+
+When this platform prepares content for a portal, it stores the result once and stamps it with two
+facts: which commit the content came from, and which project the content belongs to. A portal reads
+those stamps to decide one thing — whether the newest content from a project is content it can
+actually run, or content it should wait for.
+
+The second stamp was wrong in exactly the case it exists for. Most of the time the pipeline
+preparing the content and the project the content belongs to are the same thing, and the stamp was
+taken from the pipeline. But the platform's own pipeline also prepares content for a *separate*
+project, and there the two are different — so that content was filed under the platform's name
+rather than its own.
+
+The consequence was silent and complete: the safeguard looked for a prepared build belonging to that
+project, found none filed under its name, and concluded there was nothing to wait for. It let every
+update through. A portal could therefore pick up new content minutes after it was written while the
+prepared build it needed was still the one from before — and each page then had to be rebuilt from
+scratch every time the portal restarted, instead of starting from the prepared build.
+
+The stamp now records the project whose content was prepared, taken from the same place the content
+itself is fetched from, so the two can no longer disagree. Both pipelines state it explicitly rather
+than relying on a default that happened to be right for one of them.
+
+The check that proves it runs the real publishing script and reads the stamp back off the stored
+bytes, in both directions — content prepared for another project records that project, and a
+pipeline preparing its own content still records itself. Pointed at the previous version of the
+script, the first of those goes red, which is how the fault was confirmed rather than assumed.


### PR DESCRIPTION
Addresses the core half of #3583. Does **not** close it — see "What remains".

## What was measured

#3583 describes sources tracking Plugins HEAD while bundles are baked once per framework
identity, so every Plugins merge un-adopts its NodeTypes until the next roll. Merged **#3600**
(`SealedSyncGate` + `SealedPublicationIndex`) is aimed exactly at that race: it holds a
module-bearing repository's sync source unless the registry has a seal *of that repository*
at the built commit, under this instance's framework identity.

**The gate cannot see its own subject.** `SealedSyncGate.BelongsTo`
(`src/MeshWeaver.GitSync/SealedSyncGate.cs`) attributes a sealed source by its
`repository.txt` marker whenever that marker is non-empty, and never falls back to commit
attribution in that case. The marker is written by
`.github/scripts/publish-bake-bundles.sh` — from `$GITHUB_REPOSITORY`.

That is the LANE's repository, and it is wrong in precisely the case the marker exists for:

- `.github/workflows/main-cd.yml` `plugins-bake` calls `node-repo-publish-bake.yml` with
  `content-repository: Systemorph/MeshWeaver.Plugins`.
- That reusable workflow checks out `repository: ${{ inputs.content-repository || github.repository }}`
  and passes `steps.content.outputs.sha` — the CONTENT commit — as the script's third argument,
  under a comment that already warns about this exact trap: *"The CONTENT commit, not
  `$GITHUB_SHA`. They differ exactly when `content-repository` is set (the platform baking
  Plugins)."*
- Under `workflow_call`, `$GITHUB_REPOSITORY` is the CALLER's — `Systemorph/MeshWeaver`.

So the `plugins` seal produced by core CD was filed under the platform. A MeshWeaver.Plugins
green build then found no seal attributable to Plugins, `mine.Count == 0`, and `Decide`
returned `Verdict.Go`: **the gate fell open for the one repository it was written for.**
Meanwhile MeshWeaver.Plugins' own `publish-bake` — the second writer of the same
`<identity>/plugins` prefix — stamps it correctly. Two writers, two different answers, one
directory.

## The fix

The value arrives as `BAKE_CONTENT_REPOSITORY`, resolved from the SAME
`inputs.content-repository || github.repository` expression the content checkout uses — one
answer to "whose content is this", used by both. Both live publishers set it explicitly
(`node-repo-publish-bake.yml` for every satellite and for core's `plugins-bake`;
`main-cd.yml` for the platform's own `meshweaver-content` bake), so nothing in the fleet
depends on the script's fallback. The fallback to `$GITHUB_REPOSITORY` stays only for a lane
whose workflow copy has not been re-pinned yet, where the lane's own name is the whole answer
the old script had.

## How it was falsified

`.github/scripts/test-publish-bake-overlap.py` already EXECUTES the real publish script
against a stub `az` and reads the verdict off the bytes on a fake share. A case was added
there, in both directions.

Against the fixed script — `30 passed, 0 failed`:

```
attribution — the repository marker names whose CONTENT was baked (#3583):
  OK   the case is not vacuous — a marker was written at all — rc=0, repository.txt='Systemorph/MeshWeaver.Plugins'
  OK   a bake of another repository's content records THAT repository — repository.txt='Systemorph/MeshWeaver.Plugins'
  OK   a bake of the lane's own content records the lane — rc=0, repository.txt='Systemorph/MeshWeaver'
```

Against `HEAD`'s script (`--script <copy of the pre-fix file>`) — `29 passed, 1 failed`, and
the one that moved is the one the fix is about:

```
  OK   the case is not vacuous — a marker was written at all — rc=0, repository.txt='Systemorph/MeshWeaver'
  FAIL a bake of another repository's content records THAT repository — repository.txt='Systemorph/MeshWeaver'
  OK   a bake of the lane's own content records the lane — rc=0, repository.txt='Systemorph/MeshWeaver'
```

The second case is the control: the fix cannot be "always write something else".

## What remains on #3583 — do not close it on this

1. **Already-drifted sources are not repaired.** A gate that holds FUTURE syncs never rolls
   back a source that already ran ahead. The instance observed in #3583 stays where it is
   until its next sealed build.
2. **The gate can only arm on a seal a post-fix lane wrote.** A pre-#3600 seal has no marker
   at all and falls to commit attribution, which does not match once the sources have moved.
   Earliest arming is a `<identity>/plugins` publication written by a lane carrying this
   change, under an identity a portal actually runs.
3. **`ModuleDiscoveryService.FirstImport` still imports at branch tip** for a newly
   provisioned module Space, consulting no seal. `SyncRefContract.md` records it as known
   residue.
4. **The readiness gate still conflates "regressed" with "source moved ahead of bundle".**
   `NodeTypeBakeStatus.ClassifyDetailed` / `NodeTypeBakeGateState.MarkOutcome` /
   `DynamicTypePreWarmer.ClassifyCompileFailure` read none of `BuildProvenance`,
   `AdoptedSourceFingerprint` or `CurrentSourceFingerprint`, so a declined bundle whose source
   then fails to compile lands as a `Regressed` image verdict and freezes self-update. That is
   #3583's third option, it is a policy call (it stops a genuinely-dark package blocking a
   rollout), and it is deliberately NOT taken here.
5. **The instance-side half is `MeshWeaver.Plugins#1430`** (owned elsewhere).

**Next discriminator, one reading:** after the next Plugins merge, look on a portal for the
`GitHubWebhookProcessor` warning *"… sync source(s) HELD — the build is not sealed for this
instance's framework identity …"*. Present ⇒ the gate is armed and firing. Absent, alongside
*"importing N sync source(s) AT THAT COMMIT"* ⇒ still inert. Equivalent one-file read:
`<publishedRoot>/<live identity>/plugins/repository.txt` — if it says `Systemorph/MeshWeaver`,
that seal predates this fix.

## Verification

- `python3 .github/scripts/test-publish-bake-overlap.py` → `30 passed, 0 failed` (it is the
  step CI already runs).
- `dotnet build -c Release -warnaserror test/MeshWeaver.Documentation.Test/…` →
  `0 Warning(s) 0 Error(s)`; `WhatsNewEntryIntegrityTest` and `DocumentationLinkIntegrityTest`
  both pass over the new `SyncRefContract` section and the What's New entry.
- No C# changed, so no localization key and no plugins i18n mirror sync.

`Pairs-with: none` — no public type or member is removed; the change is one shell variable,
two workflow `env:` entries, a test case and documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
