### PR TITLE
ci(#3568): the pin-bump lane's failure lands where a person reads it

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -83,6 +83,56 @@ remember it cannot see a name present with an EMPTY value, which the in-run asse
 
 Full reference: [DependabotSecretStore.md](../../../src/MeshWeaver.Documentation/Data/Architecture/DependabotSecretStore.md).
 
+### 🚨 A SCHEDULED lane's honest red is red in an EMPTY ROOM — same defect, other end
+
+The skip-trapdoor above is *"the gate could not fail"*. This is its twin: **the gate failed
+correctly and nobody was told**, and from outside the two are indistinguishable, because both
+produce silence.
+
+Measured 2026-09-07 on `node-repo-platform-ref-bump.yml`. That lane had **every** property this page
+demands — a minted App token, an assert that fails RED naming what to provision, no
+`continue-on-error` anywhere, and a header arguing (correctly) that tolerating a failure there would
+be worse than none. It had also **never once succeeded**: total runs in its entire history,
+MeshWeaver.Plugins **1** (run 34083504064), MeshWeaver.SocialMedia **1**, both failed at the push
+because the `meshweaver-cloud` installation holds `contents`/`metadata`/`pull_requests` and nothing
+else (`GET /orgs/Systemorph/installations` — the *installation's* granted set is what an installation
+token is minted from, and the authoritative read). A scheduled run hangs off no pull request, no
+reviewer and no check list, so it went red daily into nothing.
+
+What the silence cost, in one morning: the pin froze at 04:32Z, drifted 120 → 153, and at 08:23Z the
+staleness ratchet reddened **all 16 open pull requests** in the repo at once on a gate none of their
+diffs could reach; nothing sealed, so a corrected course quiz never reached its learners and the
+session chasing *that* was three repositories away from the cause.
+
+**So a lane that runs on `schedule:` (or `workflow_dispatch`, or any trigger with no pull request
+attached) must route its failure onto an artefact that outlives the run** — here, one tracking issue
+in the calling repo, labelled for that subject alone. Three properties, each with an
+attractive-looking removal, each now guarded:
+
+- **branch on the job's RESULT, not `if: failure()`** — a failure-only reporter never clears a stale
+  alert, and an alert that is no longer true is how the next real one gets skimmed past;
+- **write an issue, not a log line** — the log line goes into the same empty room the red went into;
+- **no `continue-on-error` and no input-shaped `if:` on the reporter** — an alerting path that
+  swallows its own failure re-creates the silence one level up.
+
+Two mechanics worth knowing before you add one. A **label of its own**, never the repo's shared
+`ci-failure`: listing by a shared label finds whatever unrelated alert is open, comments this
+subject's story onto it, and then *closes* it on the next success. And in a reusable workflow the
+reporter's `issues: write` must be granted by the **caller** — a called workflow can only narrow what
+it was given, and omitting it does not degrade quietly: the run ends in **`startup_failure` with zero
+jobs created** (measured, run 34137399515). Loud, which is right, but it means the caller's grant and
+its `uses:` sha move in one commit.
+
+🚨 **The tempting alternative — "page earlier" — is the wrong instrument.** Lowering the staleness
+bound so it warns before it breaches fires on every open pull request for a condition none of their
+diffs caused: the breach's own harm, more often. A gate that fires constantly gets bypassed. The
+approach signal already existed and *was* the daily lane; what was missing is an **observer of the
+mover**. Note also that the breach red teaches the wrong lesson while the mover is dead — *"the pin
+is stale, move it"* → hand bump → mover still dead → recurrence.
+
+Full reference:
+[PlatformRefBumpLane.md](../../../src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md).
+
 **Legitimate `continue-on-error` (do not "fix" these):** the `Publish Test Results` reporter (the
 TRX summarize step is the real gate; a GitHub-API 429 must not fail the run) and the green-marker
 push/prune (losing a marker costs a redundant run, never correctness). The test is *what does a
@@ -329,6 +379,9 @@ Full reference:
 - [ ] No `continue-on-error` on a gate's input step; no `if:` asking whether a secret/variable is
       set. Fork-PR exemption expressed once, on the event.
 - [ ] Missing external inputs fail a `preflight` job RED, naming what to provision.
+- [ ] A lane on `schedule:`/`workflow_dispatch` routes its failure to a durable artefact (an
+      issue on its own label, cleared on success) — an honest red nobody reads is the same defect as
+      a gate that cannot fail.
 - [ ] Adding a `secrets.X` to a pull-request job? A preflight in the same repo asserts it
       (`check-pr-secret-preflight.py` reds otherwise), and `vars.` vs `secrets.` is the right
       namespace — only `secrets.` has a second store.

--- a/.github/workflows/node-repo-platform-ref-bump.yml
+++ b/.github/workflows/node-repo-platform-ref-bump.yml
@@ -42,6 +42,31 @@ name: Node repo platform-ref bump (reusable)
 # installation → Repository permissions → Workflows: Read and write); nothing in CI can grant it,
 # and nothing in CI can read whether it is granted.
 #
+# 🚨🚨 A LANE THAT FAILS WHERE NOBODY LOOKS IS THE SAME DEFECT AS A GATE THAT CANNOT FAIL (#3568,
+# MeshWeaver.Plugins#1462). Everything above is about the lane being HONESTLY red — no
+# `continue-on-error`, no input-shaped `if:`, an assert that fails naming what to provision. It was
+# all of that, and it still went unnoticed for the whole of its existence, because *honestly red on
+# a schedule* is red in an empty room: a scheduled run is attached to no pull request, no reviewer
+# and no check list. Measured 2026-09-07: MeshWeaver.Plugins had exactly ONE run of this lane ever
+# (34083504064) and it failed; MeshWeaver.SocialMedia the same. Nothing anywhere said so. The pin
+# then drifted to 153 commits past the 120-commit staleness bound, which reddened all 16 open pull
+# requests in the repo on a gate none of their diffs could reach, and starved the registry of a
+# sealed publication until a person hand-moved the pin.
+#
+# So the failure now lands on an artefact a person reads: `report` opens (and keeps current) ONE
+# tracking issue in the CALLING repo, labelled `platform-pin-bump-failure`, and closes it on the
+# next success. That is why the caller must grant `issues: write` alongside the other two — a called
+# workflow cannot widen what its caller was given, so the grant has to be written in the caller's
+# job. It is `${{ github.token }}`'s grant, not the App's: the `meshweaver-cloud` installation holds
+# `contents`/`metadata`/`pull_requests` and nothing else (measured 2026-09-07 via
+# `GET /orgs/Systemorph/installations`), so an App-token issue write would fail for a second missing
+# grant while reporting the first.
+#
+# 🚨 The report job is NOT tolerated-on-failure either, and that is the point rather than an
+# oversight. If it cannot write the issue, the run stays red with the reason named — an alerting
+# path that swallows its own failure re-creates, one level up, exactly the silence it was added to
+# end.
+#
 # Caller contract:
 #
 #   name: Bump the platform pin
@@ -50,7 +75,7 @@ name: Node repo platform-ref bump (reusable)
 #     workflow_dispatch:
 #   jobs:
 #     bump:
-#       permissions: {contents: write, pull-requests: write}
+#       permissions: {contents: write, pull-requests: write, issues: write}
 #       uses: Systemorph/MeshWeaver/.github/workflows/node-repo-platform-ref-bump.yml@<sha>
 #       with:
 #         workflow-file: .github/workflows/ci.yml
@@ -319,4 +344,97 @@ jobs:
                 "The pin exists so a platform regression lands on the commit that moves it rather than on whoever pushed next — so this is a **PR, not a push**, and the full gate suite runs on it exactly as it would for a hand-written bump." \
                 "" \
                 "If CI is red here, the platform changed under the module: fix it on this branch, do not close and re-bump later. A pin that lags is a gate reporting on a framework nobody runs.")"
+          fi
+
+  # ───────────────────────── the failure has an audience ─────────────────────────
+  #
+  # `if: ${{ !cancelled() }}` and NOT `if: failure()`, because this job has two jobs: it files the
+  # alert when the bump failed AND clears it when the bump worked. A failure-only variant leaves a
+  # stale issue standing after the lane recovers, and a standing alert that is no longer true is how
+  # the next real one gets skimmed past.
+  #
+  # A cancelled run says nothing about the pin — neither open nor close.
+  report:
+    name: A failed bump is visible, not just red in an empty room
+    needs: [bump]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # REPLACES the caller's map for this job: no checkout, no push, no pull request here — the
+    # alert only reads and writes issues. `issues: write` must be granted by the CALLER (a called
+    # workflow can only narrow what it was given); without it this job fails, naming the line to add,
+    # which is the correct way for a missing grant to surface.
+    permissions:
+      issues: write
+    steps:
+      - name: File the tracking issue, or close it because the bump worked
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUMP_RESULT: ${{ needs.bump.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PIN_KEY: ${{ inputs.pin-key }}
+          WORKFLOW_FILE: ${{ inputs.workflow-file }}
+          UPSTREAM: ${{ inputs.upstream-repo }}
+        run: |
+          set -euo pipefail
+
+          label=platform-pin-bump-failure
+          title="ci: the automated ${PIN_KEY} bump is not moving the pin"
+
+          # A label of ITS OWN, never the repo's general `ci-failure`. Listing by a shared label
+          # would find whatever unrelated alert happens to be open and comment the pin's story onto
+          # it — and, worse, close it on the next success. The label IS the state store, so it has
+          # to name exactly one subject.
+          #
+          # `--force` is update-or-create, so this is idempotent. A transient 5xx here must not
+          # swallow the alert it is decorating, and it cannot hide one either: the `--label` on the
+          # create below fails loudly if the label genuinely does not exist.
+          gh label create "$label" --repo "$GITHUB_REPOSITORY" \
+            --description "The scheduled platform-pin bump lane cannot move the pin" \
+            --color B60205 --force \
+            || echo "::warning::could not ensure the $label label (continuing to file the alert)"
+
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "$label" --state open \
+            --limit 1 --json number --jq '.[0].number // empty')
+
+          if [ "$BUMP_RESULT" = "success" ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --repo "$GITHUB_REPOSITORY" --reason completed \
+                --comment "The bump lane succeeded in [run ${GITHUB_RUN_ID}](${RUN_URL}); the pin is being moved automatically again. Reopened automatically if it stops."
+              echo "::notice::bump succeeded — closed #$existing"
+            else
+              echo "bump succeeded and no alert was open — nothing to do"
+            fi
+            exit 0
+          fi
+
+          # ONE issue, kept current, rather than a comment per night. The lane runs daily, so
+          # appending would produce a year of identical comments and bury the one sentence that
+          # matters; the issue's own age already measures how long the pin has been unmaintained.
+          body=$(printf '%s\n' \
+            "The scheduled lane that keeps \`${PIN_KEY}\` in \`${WORKFLOW_FILE}\` current **failed**, so this repo's platform pin is not being moved by anything." \
+            "" \
+            "| | |" \
+            "|---|---|" \
+            "| latest failed run | [${GITHUB_RUN_ID}](${RUN_URL}) |" \
+            "| pin | \`${PIN_KEY}\` in \`${WORKFLOW_FILE}\` |" \
+            "| tracks | \`${UPSTREAM}@main\` |" \
+            "" \
+            "**What this costs while it is open.** Every pin move is a hand move. The pin drifts against ${UPSTREAM}'s \`main\` at that repo's merge rate, and when it crosses the staleness bound the ratchet reds **every open pull request here at once**, on a gate none of their diffs can reach — and nothing seals, so downstream consumers keep the previous publication." \
+            "" \
+            "**Read the failing step in the linked run.** Two shapes have actually occurred:" \
+            "" \
+            "* *the token mint fails naming a permission* — the \`meshweaver-cloud\` App installation is missing it. The pin lives in a file under \`.github/workflows/\`, so the push needs **Workflows: Read and write**, which is a GitHub App settings change plus an installation approval. Nothing in CI can grant it and nothing in CI can read whether it is granted." \
+            "* *the push is rejected* with \`refusing to allow a GitHub App to create or update workflow … without \\\`workflows\\\` permission\` — same missing grant, on a lane sha that predates the explicit request." \
+            "" \
+            "This issue closes itself on the lane's next success. Do **not** close it after a hand bump: the hand bump clears the drift and leaves the mover dead, which is the state that produced this issue." \
+            "" \
+            "<!-- platform-pin-bump-failure -->")
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+            echo "::error::the platform-pin bump failed again — #$existing updated with $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --label "$label" --body "$body"
+            echo "::error::the platform-pin bump failed — tracking issue filed"
           fi

--- a/.github/workflows/node-repo-platform-ref-bump.yml
+++ b/.github/workflows/node-repo-platform-ref-bump.yml
@@ -67,6 +67,11 @@ name: Node repo platform-ref bump (reusable)
 # path that swallows its own failure re-creates, one level up, exactly the silence it was added to
 # end.
 #
+# 🚨 A caller that bumps the `uses:` sha WITHOUT adding `issues: write` does not get a quieter lane:
+# GitHub refuses the whole run with `startup_failure` before a single job is created. Measured
+# deliberately on MeshWeaver.Plugins run 34137399515 — zero jobs, zero check runs. Loud, which is
+# correct, but it means the caller's grant and its `uses:` sha move in ONE commit.
+#
 # Caller contract:
 #
 #   name: Bump the platform pin
@@ -362,8 +367,8 @@ jobs:
     timeout-minutes: 5
     # REPLACES the caller's map for this job: no checkout, no push, no pull request here — the
     # alert only reads and writes issues. `issues: write` must be granted by the CALLER (a called
-    # workflow can only narrow what it was given); without it this job fails, naming the line to add,
-    # which is the correct way for a missing grant to surface.
+    # workflow can only narrow what it was given); without it GitHub refuses the run outright with
+    # `startup_failure` — measured on MeshWeaver.Plugins run 34137399515, zero jobs created.
     permissions:
       issues: write
     steps:

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md
@@ -92,7 +92,7 @@ on:
   workflow_dispatch:
 jobs:
   bump:
-    permissions: {contents: write, pull-requests: write}
+    permissions: {contents: write, pull-requests: write, issues: write}
     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-platform-ref-bump.yml@<sha>
     with:
       workflow-file: .github/workflows/ci.yml
@@ -107,6 +107,98 @@ Every input is passed explicitly even where it matches the lane's default: a def
 lane the calling repo did not open is a value nobody here has agreed to, and a new *required* input
 on a reusable lane is a silent startup failure for any caller that omits it. Never `secrets:
 inherit` — that hands the lane every secret the calling repo owns.
+
+`issues: write` is the third grant and it is not optional: it is what the reporting job below writes
+the alert with. A called workflow can only *narrow* what its caller was given, so the grant has to
+be written here, in the caller's job, and a caller that bumps the `uses:` sha without adding it gets
+a red report job naming the missing line.
+
+## The lane had never once worked (2026-09-07)
+
+Everything above was in place, and the lane had still never moved a pin. Measured across both
+callers on 2026-09-07: MeshWeaver.Plugins had **one** run of it in its entire history —
+[34083504064](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34083504064), scheduled,
+04:32:51Z — and MeshWeaver.SocialMedia one, at 04:51:24Z. Both failed, three minutes in, on the last
+step:
+
+```text
+! [remote rejected] chore/platform-ref-c7fef7a2d -> chore/platform-ref-c7fef7a2d
+  (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml`
+   without `workflows` permission)
+```
+
+**This can never not happen.** `MW_PLATFORM_REF` lives *in a workflow file*, so the lane's entire
+diff is always under `.github/workflows/**`, and GitHub refuses an App push to that path without the
+`workflows` grant. The `meshweaver-cloud` installation does not have it — measured first-hand, and
+this is the reading that settles it because it is the *installation's* granted set, which is what an
+installation access token is minted from:
+
+```console
+$ gh api orgs/Systemorph/installations --jq '.installations[]|select(.app_slug=="meshweaver-cloud")'
+{"app_id":4220566,"app_slug":"meshweaver-cloud","id":144517285,
+ "permissions":{"contents":"write","metadata":"read","pull_requests":"write"},
+ "repository_selection":"all"}
+```
+
+`workflows`: absent. `issues`: absent too — which is why the alert below is written with
+`${{ github.token }}` and not with the App token. An App-token issue write would fail for a *second*
+missing grant while trying to report the first.
+
+The mint now requests `permission-workflows: write` explicitly, so the refusal moves to the step
+whose own name says what it wanted, instead of arriving four steps later as a push rejection about a
+permission nobody had asked for.
+
+### 🚨 Honestly red is not the same as visible — the empty-room failure
+
+This is the part worth carrying to other lanes. The bump lane had **every** property the CI rules
+demand of a gate: a minted App token, an assert that fails RED naming what to provision, and no
+`continue-on-error` anywhere. Its own header even argues, correctly, that a tolerated failure here
+would be worse than none. And it *was* red — every night, honestly, exactly as designed.
+
+Nobody saw it. A scheduled run hangs off no pull request, no reviewer, and no check list: it is red
+in an empty room. **From outside, that is indistinguishable from a gate that cannot fail**, which is
+the shape the CI rules forbid — and it produced the same class of
+outcome. The pin froze at 04:32Z and drifted unattended (120 → 130 → 139 → 153) until, at 08:23Z,
+the staleness ratchet went red on MeshWeaver.Plugins' `main` and therefore on **all 16 open pull
+requests at once**, each for a reason its own diff could not reach. Nothing sealed, so the registry's
+Education publication stayed at a pre-fix `sourceCommit`, and the session debugging *that* was
+looking at a quiz-dialog regression in a third repository. One rejected `git push` is the whole
+chain, and the four hours between are the cost of the silence rather than of the defect.
+
+So the lane now routes its own failure onto an artefact that outlives the run: a `report` job opens
+**one** tracking issue in the calling repo, labelled `platform-pin-bump-failure`, keeps it current
+(edited, not commented, so a daily schedule does not bury the one sentence that matters), and
+**closes it on the next success**.
+
+Three properties make that true rather than decorative, and each is pinned by
+`ArmedMergeMustTriggerMainsPushLanesGuard` because each has an attractive-looking removal:
+
+| Property | Why the obvious alternative is wrong |
+|---|---|
+| it branches on `needs.bump.result`, not `if: failure()` | a failure-only reporter leaves a stale alert standing after the lane recovers, and an alert that is no longer true is how the next real one gets skimmed past |
+| it writes an **issue**, not a log line | the log line goes into the same empty room the red already went into |
+| it carries no `continue-on-error` and no input-shaped `if:` | an alerting path that swallows its own failure re-creates, one level up, the exact silence it was added to end |
+
+🚨 **Do not close that issue after a hand bump.** A hand bump clears the drift and leaves the mover
+dead — which is precisely the state that produced the issue. The issue closes itself when the lane
+next succeeds.
+
+### Should the staleness bound page when it is *approached*?
+
+It was considered and **rejected as the wrong instrument**, and the reasoning is worth recording
+because the question comes back every time the ratchet fires.
+
+The approach signal already exists: it is this lane. A daily bump keeps the pin within ~24 h of
+core's tip by construction, so the 24 h / 120-commit bound is a *backstop* for the case where the
+mover stopped — not a schedule anybody is supposed to ride. Adding a second, earlier threshold
+would fire on every open pull request in the repo, for a condition none of their diffs caused,
+which is the same harm the breach itself does — only more often. A gate that fires constantly gets
+bypassed, and one that must be bypassed is worse than none.
+
+What was actually missing is not an earlier threshold but an **observer of the mover**, and that is
+what the `report` job is. The breach red also taught the wrong lesson while the mover was dead: it
+says *"the pin is stale, move it"*, a person hand-moves it, the mover stays dead, and the whole
+thing recurs — twice on 2026-09-07 alone.
 
 ### Why `repository_dispatch` is deliberately not in the contract
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformRefBumpLane.md
@@ -109,9 +109,14 @@ on a reusable lane is a silent startup failure for any caller that omits it. Nev
 inherit` — that hands the lane every secret the calling repo owns.
 
 `issues: write` is the third grant and it is not optional: it is what the reporting job below writes
-the alert with. A called workflow can only *narrow* what its caller was given, so the grant has to
-be written here, in the caller's job, and a caller that bumps the `uses:` sha without adding it gets
-a red report job naming the missing line.
+the alert with. A called workflow can only *narrow* what its caller was given, so the grant has to be
+written here, in the caller's job.
+
+🚨 **Omitting it does not degrade to a quieter lane — GitHub refuses the whole run.** Measured
+deliberately on MeshWeaver.Plugins run 34137399515: `conclusion: startup_failure`, **zero jobs and
+zero check runs created**. That is the right failure (a permission a called workflow cannot widen
+must be visible, not silently narrowed), but it means the grant and the `uses:` sha move in **one
+commit**.
 
 ## The lane had never once worked (2026-09-07)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-automation-that-keeps-a-repo-on-a-current-platform-says-when-it-stops.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-automation-that-keeps-a-repo-on-a-current-platform-says-when-it-stops.md
@@ -1,0 +1,33 @@
+---
+Name: The automation that keeps a repo on a current platform now says when it stops
+Category: Fix
+Description: A nightly job kept every satellite repository building against a recent platform. It had never once succeeded — and because it failed on a schedule rather than on anyone's pull request, nothing said so until an unrelated repository's course content went stale.
+Icon: AlertUrgent
+Order: -20260907
+---
+
+Each repository that ships modules pins **which** platform commit it compiles against, and a nightly
+job is what keeps that pin from falling behind. That job had never worked. Not once, in either
+repository that runs it — the pin lives inside a workflow file, and the identity the job pushes as
+was never granted permission to touch one, so every attempt was refused at the last step.
+
+The job was not sloppy about it. It refused to swallow the error, it went red honestly, and it did
+so every night. But a nightly job hangs off no pull request and no review, so its red landed in an
+empty room — **which, from outside, looks exactly like a job that had nothing to do.**
+
+What that cost, on one morning: the pin froze, drifted for four hours, and then crossed the bound
+that stops the repository. Every open pull request there went red at once, on a check none of their
+changes could have caused. Nothing was published while that lasted, so a corrected course quiz
+finished, merged and verified in another repository simply never reached the people taking the
+course — and the session investigating *that* was looking at a quiz bug, three repositories away
+from the cause.
+
+Two changes. The job now asks for the permission it needs **up front**, so a missing grant is
+reported by the step that wanted it instead of arriving four steps later as a push rejection about
+something nobody requested. And when it fails, it now opens a tracking issue in the repository it
+was supposed to help — kept current rather than repeated nightly, and closed automatically the
+moment the job works again.
+
+The last part matters more than it looks: clearing the symptom by hand moves the pin and leaves the
+automation just as dead as before, which is how the same morning happened twice. The issue stays
+open until the thing that was supposed to prevent it actually runs.

--- a/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
@@ -385,13 +385,28 @@ public class ArmedMergeMustTriggerMainsPushLanesGuard
             + "pushed with the default credential. The pull request would then be the App's and the "
             + "commit the default token's — and a push GITHUB_TOKEN made starts nothing either.");
 
-        foreach (var permission in new[] { "permission-contents: write", "permission-pull-requests: write" })
+        foreach (var permission in new[]
+                 {
+                     "permission-contents: write",
+                     "permission-pull-requests: write",
+                     // 🚨 The third one is not decoration (#3568, MeshWeaver.Plugins#1464). The pin
+                     // this lane edits lives in the CALLER'S OWN WORKFLOW FILE, so every diff it
+                     // will ever produce is under `.github/workflows/**` — a path GitHub refuses an
+                     // App push to without `workflows`, by name, at the push, on the last step.
+                     // That is not a hypothetical: it is EVERY run this lane has ever had
+                     // (MeshWeaver.Plugins 34083504064, MeshWeaver.SocialMedia the same morning).
+                     // Requesting it here moves the refusal to the mint, where the step's own name
+                     // says what it wanted; dropping the line restores a push rejection that reads
+                     // as a token bug about a permission nobody asked for.
+                     "permission-workflows: write",
+                 })
         {
             Assert.True(
                 lines.Any(l => l.Contains(permission, StringComparison.Ordinal)),
                 $"node-repo-platform-ref-bump.yml's token mint no longer requests '{permission}'. "
-                + "Pushing the bump branch needs Contents: write and opening the pull request needs "
-                + "Pull requests: write; requesting both explicitly is what makes a missing grant "
+                + "Pushing the bump branch needs Contents: write, opening the pull request needs "
+                + "Pull requests: write, and touching a file under .github/workflows/ needs "
+                + "Workflows: write; requesting all three explicitly is what makes a missing grant "
                 + "fail at the mint instead of somewhere downstream.");
         }
 
@@ -401,6 +416,69 @@ public class ArmedMergeMustTriggerMainsPushLanesGuard
             + "a tolerated mint failure costs one PR its arm and the assertion lives on in "
             + "arm-credential.yml — nothing else asserts this credential. A tolerated failure here "
             + "means the pin silently stops being bumped, which is the state the lane exists to end.");
+    }
+
+    /// <summary>
+    /// A scheduled lane's honest red is red in an EMPTY ROOM, and that is the same defect as a gate
+    /// that cannot fail — the two are indistinguishable from outside, because both produce silence.
+    ///
+    /// <para><b>Measured, 2026-09-07.</b> The bump lane had every property the guards above assert:
+    /// a minted App token, an assert that fails naming what to provision, and no
+    /// <c>continue-on-error</c> anywhere. It ran once in MeshWeaver.Plugins (run 34083504064), once
+    /// in MeshWeaver.SocialMedia, failed both times at the push for want of the App's
+    /// <c>workflows</c> grant — and <b>nothing anywhere said so</b>. A scheduled run hangs off no
+    /// pull request, no reviewer and no check list. The pin then drifted 153 commits past the
+    /// 120-commit staleness bound, reddening all 16 open pull requests in that repo on a gate none
+    /// of their diffs could reach.</para>
+    ///
+    /// <para>So the lane must route its own failure onto an artefact a person reads. This guard
+    /// pins the three properties that make that true, because each one has an attractive-looking
+    /// removal: the reporting job must exist, it must branch on the bump's RESULT (an
+    /// <c>if: failure()</c>-only variant never clears a stale alert, and a standing alert that is no
+    /// longer true is how the next real one gets skimmed past), and it must write something durable
+    /// rather than another log line into the same empty room.</para>
+    /// </summary>
+    [Fact]
+    public void ThePlatformRefBumpLaneReportsItsOwnFailureSomewhereAPersonReads()
+    {
+        var path = Path.Combine(WorkflowsDir(), "node-repo-platform-ref-bump.yml");
+        Assert.True(File.Exists(path), $"{path} is missing — the bump lane is the subject of this guard.");
+
+        var lines = ExecutableLines(File.ReadAllText(path));
+
+        Assert.True(
+            lines.Any(l => l.Contains("needs.bump.result", StringComparison.Ordinal)),
+            "node-repo-platform-ref-bump.yml no longer branches on `needs.bump.result`. Its reporting "
+            + "job must both FILE the alert when the bump failed and CLOSE it when the bump worked. A "
+            + "failure-only reporter leaves a stale issue standing after the lane recovers, and an "
+            + "alert that is no longer true is how the next real one gets skimmed past.");
+
+        Assert.True(
+            lines.Any(l => l.Contains("gh issue create", StringComparison.Ordinal))
+            && lines.Any(l => l.Contains("gh issue close", StringComparison.Ordinal)),
+            "node-repo-platform-ref-bump.yml no longer opens and closes a tracking issue. A scheduled "
+            + "lane that fails writes its red to a run nobody is looking at: measured 2026-09-07, this "
+            + "lane had failed on every run it had ever had, in two repositories, and the first symptom "
+            + "anyone saw was 16 unrelated pull requests going red on the staleness ratchet hours "
+            + "later. The failure needs an artefact that outlives the run.");
+
+        // The alert must not be tolerated either. `continue-on-error` is already refused file-wide by
+        // the guard above; what this adds is the OTHER shape of the same trapdoor — an `if:` that asks
+        // whether the reporter's own credential is present, which renders exactly like a lane with
+        // nothing to report (AGENTS.md, "a gate NEVER tests its own inputs").
+        var inputShapedIf = lines
+            .Where(l => l.StartsWith("if:", StringComparison.Ordinal) || l.Contains(" if:", StringComparison.Ordinal))
+            .Where(l => l.Contains("secrets.", StringComparison.Ordinal)
+                        || l.Contains("vars.", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            inputShapedIf.Length == 0,
+            "node-repo-platform-ref-bump.yml carries an `if:` that asks whether a secret or variable is "
+            + $"set: {string.Join(" | ", inputShapedIf)}.\n"
+            + "GitHub paints a skipped job the same colour as a passed one, so 'the lane never ran' and "
+            + "'the lane had nothing to do' become indistinguishable — which is the exact state this "
+            + "lane spent its whole existence in. Assert the input and fail RED naming it instead.");
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## The lane was honestly red, every night, and that was the whole problem

`node-repo-platform-ref-bump.yml` has **never moved a pin**. Measured 2026-09-07 over both callers:

| repo | runs, ever | conclusion |
|---|---|---|
| MeshWeaver.Plugins | **1** ([34083504064](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34083504064), 04:32:51Z, schedule) | failure at step 7 of 7 |
| MeshWeaver.SocialMedia | **1** (04:51:24Z) | failure, same step |

```
! [remote rejected] chore/platform-ref-c7fef7a2d -> chore/platform-ref-c7fef7a2d
  (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml`
   without `workflows` permission)
```

It can never *not* happen — `MW_PLATFORM_REF` lives **in** a workflow file, so every diff this lane
will ever produce is under `.github/workflows/**`.

**The grant is genuinely absent**, measured first-hand off the *installation's* granted set (which is
what an installation access token is minted from, so this is the reading that settles it):

```console
$ gh api orgs/Systemorph/installations --jq '.installations[]|select(.app_slug=="meshweaver-cloud")'
{"app_id":4220566,"app_slug":"meshweaver-cloud","id":144517285,
 "permissions":{"contents":"write","metadata":"read","pull_requests":"write"},
 "repository_selection":"all"}
```

`workflows`: absent. `issues`: absent too — which is why the alert here is written with
`${{ github.token }}` rather than the App token; an App-token issue write would fail for a *second*
missing grant while trying to report the first.

#3573 already made the mint request `permission-workflows: write`, so the refusal now lands on the
step whose own name says what it wanted. **This PR fixes the other half: the silence.**

## Honestly red on a schedule is red in an empty room

The lane had *every* property the CI rules demand of a gate — a minted App token, an assert that
fails RED naming what to provision, no `continue-on-error` anywhere, and a header that argues
(correctly) that tolerating a failure here would be worse than none. It was all of that, and nobody
saw it, because a scheduled run hangs off no pull request, no reviewer and no check list.

**From outside, that is indistinguishable from a gate that cannot fail**, and it produced the same
class of outcome:

```
04:32Z  push rejected → MW_PLATFORM_REF frozen; drift climbs unattended 120 → 130 → 139 → 153
08:23Z  the staleness ratchet reds Plugins main → and therefore all 16 OPEN PULL REQUESTS at once,
        each on a gate none of their own diffs could reach
        → nothing seals → the registry's Education publication stays pre-fix
        → a corrected course quiz never reaches its learners; the session debugging THAT is three
          repositories away from the cause
```

One rejected `git push` is the whole chain. The four hours in between are the cost of the *silence*,
not of the defect.

## What this changes

* **`report`** — a second job that opens **one** tracking issue in the *calling* repo (label
  `platform-pin-bump-failure`), keeps it current by **editing** rather than commenting so a daily
  schedule cannot bury the one sentence that matters, and **closes it on the next success**.
* **The caller grants `issues: write`** beside the other two. A called workflow can only *narrow*
  what its caller was given, so it has to be written in the caller's job; the header and the doc page
  say so, and a caller that bumps the `uses:` sha without it gets a red `report` job naming the line.
* **The reporter is not tolerated on failure either.** No `continue-on-error`, no input-shaped `if:`.
  An alerting path that swallows its own failure re-creates, one level up, the exact silence it was
  added to end.

Three design choices, each pinned by a guard because each has an attractive-looking removal:

| property | why the obvious alternative is wrong |
|---|---|
| branches on `needs.bump.result`, not `if: failure()` | a failure-only reporter leaves a stale alert standing after the lane recovers, and an alert that is no longer true is how the next real one gets skimmed past |
| writes an **issue**, not a log line | the log line goes into the same empty room the red already went into |
| no `continue-on-error`, no input-shaped `if:` | GitHub paints a skipped job the same colour as a passed one |

## Guard, and its negative controls

`ArmedMergeMustTriggerMainsPushLanesGuard` gains `permission-workflows: write` to its asserted mint
set (#3573's line had **nothing** holding it) and a new test,
`ThePlatformRefBumpLaneReportsItsOwnFailureSomewhereAPersonReads`.

Each assertion was made to fail, observed red with the right message, then restored green:

| break | verdict |
|---|---|
| drop `permission-workflows: write` | ❌ *"token mint no longer requests 'permission-workflows: write'"* |
| `gh issue close` → `gh issue comment` | ❌ *"no longer opens and closes a tracking issue"* |
| `needs.bump.result` → a literal | ❌ *"no longer branches on `needs.bump.result`"* |
| `if: ${{ secrets.MESHWEAVER_APP_ID != '' }}` | ❌ *"carries an `if:` that asks whether a secret or variable is set"* |
| all restored | ✅ 7 passed |

`check-workflow-timeouts.py` (75 jobs, 0 violations, the new job capped at 5), `check-workflow-shell.py`,
`check-workflow-yaml-keys.py`, `DocumentationLinkIntegrityTest` — all green.
`dotnet build -c Release -warnaserror test/MeshWeaver.Documentation.Test` → **0 Warning(s), 0 Error(s)**.

## 🚨 One maintainer act is still required and nothing in CI can do it

**GitHub App `meshweaver-cloud` → Permissions → Repository permissions → Workflows: Read and write →
save → approve the pending permission request on the Systemorph installation.** UI only: an App's
permissions are not settable through the API, and `GITHUB_TOKEN` has no `workflows` permission key.
Until then every pin move stays a hand move — but it is now a hand move with an open issue in each
affected repo saying why, instead of nothing at all.

## Should the staleness bound page when it is *approached*?

Considered and **rejected as the wrong instrument**; the reasoning is on the doc page so it does not
have to be re-derived every time the ratchet fires. The approach signal already exists — it *is* this
lane; a daily bump keeps the pin within ~24 h by construction, and the 24 h / 120-commit bound is a
backstop for the case where the mover stopped. A second, earlier threshold would fire on every open
PR in the repo for a condition none of their diffs caused, which is the breach's own harm, more
often; a gate that fires constantly gets bypassed. What was missing is an **observer of the mover**,
which is what `report` is. The breach red was also teaching the wrong lesson while the mover was
dead — *"the pin is stale, move it"* → hand bump → mover still dead → recurrence, twice on 2026-09-07.

Refs Systemorph/MeshWeaver.Plugins#1464, Systemorph/MeshWeaver.Plugins#1462 (one defect, two issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
