### PR TITLE
fix(#3542): a bookkeeping write that cannot read the policy record refuses it

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -942,7 +942,6 @@ public class SelfUpdateHostedService : IHostedService
     protected virtual IObservable<Unit> RecordHold(string tag, UpdatabilityVerdict? verdict)
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
-        var jsonOptions = _hub.JsonSerializerOptions;
         // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
         // `AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper hides the shape. The write here
         // is CROSS-HUB, which is the worst case for `Using` — Rx disposes the scope when the inner
@@ -950,20 +949,24 @@ public class SelfUpdateHostedService : IHostedService
         // subscriber (the self-update poller's tick) keeps `system-security` latched. RunAsSystem
         // opens and closes inside one Subscribe; the Update is still ISSUED as System, which is what
         // the cross-hub patch stamps.
+        // 🚨 The TYPED write (#3542). `cur` is null ONLY when the node carries no content at all;
+        // content that is present but unreadable faults instead of arriving as null, so a record
+        // this build cannot parse is REFUSED here rather than replaced by a default — see
+        // UpdatePolicyNodeType.ParseContent.
         return accessService.RunAsSystem(
             () => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
-                .Update(node =>
+                .Update<UpdatePolicyContent>((node, cur) =>
                 {
-                    var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
+                    var current = cur ?? new UpdatePolicyContent();
                     return node with
                     {
                         Content = verdict is null
-                            ? cur with
+                            ? current with
                             {
                                 HeldTag = null, HeldReason = null,
                                 HeldIndeterminate = false, HeldAt = null,
                             }
-                            : cur with
+                            : current with
                             {
                                 HeldTag = tag,
                                 HeldReason = verdict.HoldReason,
@@ -1094,27 +1097,22 @@ public class SelfUpdateHostedService : IHostedService
     protected virtual IObservable<Unit> RecordCheck(SelfUpdateTrigger trigger, SelfUpdateVerdict verdict)
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
-        var jsonOptions = _hub.JsonSerializerOptions;
         // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
-        // RecordHold below (#1444/#1790).
+        // RecordHold below (#1444/#1790). Typed write — see RecordHold (#3542).
         return accessService.RunAsSystem(
             () => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
-                .Update(node =>
+                .Update<UpdatePolicyContent>((node, cur) => node with
                 {
-                    var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
-                    return node with
+                    Content = (cur ?? new UpdatePolicyContent()) with
                     {
-                        Content = cur with
-                        {
-                            LastCheckedAt = DateTimeOffset.UtcNow,
-                            LastCheckVerdict = verdict.Message,
-                            LastCheckTrigger = trigger.ToString(),
-                            // 🚨 Written on EVERY check, so it CLEARS itself the moment the tag
-                            // resolves again — the same unconditional-clearing rule the availability
-                            // hold follows. A healed strand that lingered would be a stale scare.
-                            UnresolvedInstalledTag = verdict.UnresolvedInstalledTag,
-                        },
-                    };
+                        LastCheckedAt = DateTimeOffset.UtcNow,
+                        LastCheckVerdict = verdict.Message,
+                        LastCheckTrigger = trigger.ToString(),
+                        // 🚨 Written on EVERY check, so it CLEARS itself the moment the tag
+                        // resolves again — the same unconditional-clearing rule the availability
+                        // hold follows. A healed strand that lingered would be a stale scare.
+                        UnresolvedInstalledTag = verdict.UnresolvedInstalledTag,
+                    },
                 })
                 .Select(_ => Unit.Default));
     }
@@ -1126,18 +1124,17 @@ public class SelfUpdateHostedService : IHostedService
     protected virtual IObservable<Unit> RecordAvailable(string tag)
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
-        var jsonOptions = _hub.JsonSerializerOptions;
         // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
-        // RecordHold above (#1444/#1790).
+        // RecordHold above (#1444/#1790). Typed write — see RecordHold (#3542).
         return accessService.RunAsSystem(
             () => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
-                .Update(node =>
+                .Update<UpdatePolicyContent>((node, cur) => node with
                 {
-                    var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
-                    return node with
+                    Content = (cur ?? new UpdatePolicyContent()) with
                     {
-                        Content = cur with { LatestAvailableTag = tag, CheckedAt = DateTimeOffset.UtcNow },
-                    };
+                        LatestAvailableTag = tag,
+                        CheckedAt = DateTimeOffset.UtcNow,
+                    },
                 })
                 .Select(_ => Unit.Default));
     }

--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -27,19 +27,9 @@ namespace Memex.Portal.Shared.SelfUpdate;
 public record UpdatePolicyContent
 {
     /// <summary>
-    /// The update strategy. A NEWLY constructed record defaults to
-    /// <see cref="UpdatePolicyKind.Continuous"/> — but an ABSENT value on a persisted record reads as
-    /// <see cref="UpdatePolicyKind.None"/>, not as Continuous (#3542).
-    ///
-    /// <para>Those two are different questions and used to have the same answer. Because
-    /// <c>None</c> is now the enum's zero value, an explicit <c>Continuous</c> is non-default and is
-    /// therefore always written out, so "the admin chose Continuous" is distinguishable from "this
-    /// record lost its policy" — and the latter fails closed instead of enabling an unattended roll.</para>
-    /// </summary>
-    /// <summary>
     /// The update strategy AS DECLARED on the record — <c>null</c> when the record carries no
     /// <c>policy</c> field at all. Read <see cref="Policy"/> instead; this exists so that "absent"
-    /// and "explicitly chosen" stay different facts on the wire.
+    /// and "explicitly chosen" stay different facts on the wire (#3542).
     /// </summary>
     [Description("Update strategy")]
     [Translation("de", "Update-Strategie")]
@@ -60,6 +50,12 @@ public record UpdatePolicyContent
     /// <para>The consequence that matters: an install whose record lost its policy under its own
     /// bookkeeping writes no longer rolls itself. That is how memex-cloud reached a withdrawn
     /// <c>3.1.0-ci</c> line "on a policy record that lost its own policy".</para>
+    ///
+    /// <para>🚨 Reading an absent policy as <c>None</c> made the CONSEQUENCE safe; it did not stop
+    /// the record from losing the field. What did is that every bookkeeping write now goes through
+    /// the framework's TYPED write (<c>Update&lt;UpdatePolicyContent&gt;</c>), which refuses a node
+    /// whose content it cannot read instead of writing a default over it — see
+    /// <see cref="UpdatePolicyNodeType.ParseContent"/>.</para>
     /// </summary>
     [JsonIgnore]
     public UpdatePolicyKind Policy
@@ -294,19 +290,21 @@ public static class UpdatePolicyNodeType
     /// <see cref="PlatformUpdateStatus"/> shape, and for its reason: impersonation is an
     /// <c>AsyncLocal</c>, and <c>Observable.Using</c> would dispose it on whichever thread the
     /// sequence terminates on, leaving the caller running as System).</para>
+    ///
+    /// <para>🚨 The TYPED write, never <c>ParseContent</c> + the untyped overload — see
+    /// <see cref="ParseContent"/> for what that shape destroys.</para>
     /// </summary>
     public static IObservable<Unit> RecordVerification(IMessageHub hub, ComboVerification verdict)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var jsonOptions = hub.JsonSerializerOptions;
         return Observable.Create<Unit>(observer =>
         {
             using (AccessContextScope.AsSystem(accessService))
                 return hub.GetWorkspace().GetMeshNodeStream(NodePath)
-                    .Update(node =>
+                    .Update<UpdatePolicyContent>((node, cur) =>
                     {
-                        var cur = ParseContent(node.Content, jsonOptions);
-                        var verifications = cur.ComboVerifications
+                        var current = cur ?? new UpdatePolicyContent();
+                        var verifications = current.ComboVerifications
                             .RemoveAll(v => string.Equals(
                                 v.CandidateTag, verdict.CandidateTag,
                                 StringComparison.OrdinalIgnoreCase))
@@ -316,7 +314,7 @@ public static class UpdatePolicyNodeType
                             .ToImmutableList();
                         return node with
                         {
-                            Content = cur with { ComboVerifications = verifications },
+                            Content = current with { ComboVerifications = verifications },
                         };
                     })
                     .Select(_ => Unit.Default)
@@ -324,25 +322,52 @@ public static class UpdatePolicyNodeType
         });
     }
 
-    /// <summary>Parses the policy content from a node (handles both typed content and raw
-    /// <see cref="JsonElement"/>); returns defaults when absent/unparseable.</summary>
+    /// <summary>Parses the policy content from a node (handles typed content, a degraded
+    /// <see cref="JsonElement"/>, an as-written <c>JsonNode</c> and a same-named record from another
+    /// build); returns defaults when absent or unreadable. 🚨 READ-ONLY — see
+    /// <see cref="ParseContent"/>.</summary>
     public static UpdatePolicyContent Parse(MeshNode? node, JsonSerializerOptions options) =>
         ParseContent(node?.Content, options);
 
-    /// <summary>Parses the policy content from a node's <c>Content</c> value.</summary>
+    /// <summary>
+    /// Parses the policy content from a node's <c>Content</c> value, defaulting when it is absent
+    /// or cannot be read.
+    ///
+    /// <para>🚨 <b>READ-ONLY. A WRITE MUST NEVER BE BUILT ON THIS.</b> Every write on
+    /// <c>Admin/UpdatePolicy</c> is the framework's TYPED write —
+    /// <c>stream.Update&lt;UpdatePolicyContent&gt;((node, cur) =&gt; node with { Content = (cur ??
+    /// new UpdatePolicyContent()) with { … } })</c> — and never
+    /// <c>Update(node =&gt; … ParseContent(node.Content, …) …)</c>.</para>
+    ///
+    /// <para>A read must stay bad-data tolerant: a settings tab that throws is worse than one
+    /// showing the fail-closed <see cref="UpdatePolicyKind.None"/>. That tolerance is exactly what
+    /// makes it wrong for a write. This method answers <c>new UpdatePolicyContent()</c> for BOTH
+    /// "there is no content" and "the content is present and this build cannot read it", and a
+    /// bookkeeping write built on it PERSISTS that empty record — a failed READ becoming a write
+    /// that erases the admin's policy, the latest available tag, every combo verdict and any live
+    /// availability hold. That is #3542's proposal 3, and it survived #3607, which changed only
+    /// what an ABSENT policy MEANS.</para>
+    ///
+    /// <para>Measured on <c>origin/main</c> at <c>5453be493</c>: with the record holding
+    /// <c>{"policy":"None","latestAvailableTag":"3.0.0-ci.8009","comboVerifications":"corrupt"}</c>
+    /// — one field this build cannot deserialize — one <c>RecordAvailable</c>-shaped write
+    /// completed silently and left
+    /// <c>{"requireCiGreen":true,"latestAvailableTag":"3.0.0-ci.9999","comboVerifications":[]}</c>.
+    /// The <c>policy</c> field was gone: precisely the production state #3542 opens on.</para>
+    ///
+    /// <para>The typed overload is the framework's own answer to exactly this and needs no local
+    /// guard: <c>null</c> there means ABSENT and only absent, while content that is present but
+    /// unreadable faults the observable with a <c>MeshNodeStreamException</c> carrying the path,
+    /// the runtime type and a JSON excerpt — <b>the write does not happen</b>. Every bookkeeping
+    /// caller already wraps its write in a <c>.Catch</c> that logs and carries on (#1020: a
+    /// bookkeeping write may never gate the roll), so an unreadable record is refused loudly and
+    /// left intact instead of overwritten silently.</para>
+    /// </summary>
     public static UpdatePolicyContent ParseContent(object? content, JsonSerializerOptions options) =>
-        content switch
-        {
-            UpdatePolicyContent c => c,
-            JsonElement je => TryDeserialize(je, options) ?? new UpdatePolicyContent(),
-            _ => new UpdatePolicyContent(),
-        };
-
-    private static UpdatePolicyContent? TryDeserialize(JsonElement je, JsonSerializerOptions options)
-    {
-        try { return JsonSerializer.Deserialize<UpdatePolicyContent>(je.GetRawText(), options); }
-        catch { return null; }
-    }
+        // ObjectAsExtensions.As<T>, not a hand-rolled JsonElement switch: it also covers the
+        // as-written JsonNode DOM and a same-named record from another collectible assembly, both
+        // of which the switch answered with a silent default.
+        content.As<UpdatePolicyContent>(options) ?? new UpdatePolicyContent();
 
     /// <summary>True if the exception (or any inner) reports an "already exists" outcome — the
     /// idempotent-create success signal.</summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -669,19 +669,32 @@ The first emission is the current state; subsequent emissions arrive as the hub 
 
 ---
 
-## Writes — `GetMeshNodeStream(path).Update(...)`
+## Writes — `GetMeshNodeStream(path).Update<TContent>(...)`
 
-Application code writes through the stream handle; the framework turns the lambda into a patch on the owning hub:
+Application code writes through the stream handle; the framework turns the lambda into a patch on the owning hub. **A lambda that reads `Content` names its type** — that is the typed overload, and it is the shape to write:
 
 ```csharp
-workspace.GetMeshNodeStream(targetPath).Update(node =>
-{
-    var content = node.ContentAs<MyContent>(hub.JsonSerializerOptions, logger);
-    if (node.Content is not null && content is null) return node;  // never clobber unreadable content
-    return node with { Content = (content ?? new MyContent()) with { Status = "done" } };
-})
-.Subscribe(_ => { }, ex => logger.LogWarning(ex, "Update failed for {Path}", targetPath));
+workspace.GetMeshNodeStream(targetPath)
+    .Update<MyContent>((node, content) => node with
+    {
+        // `content` is null ONLY when the node carries no content at all.
+        Content = (content ?? new MyContent()) with { Status = "done" },
+    })
+    .Subscribe(_ => { }, ex => logger.LogWarning(ex, "Update failed for {Path}", targetPath));
 ```
+
+### 🚨 A read may tolerate bad data. A write may not. Do not build one on the other.
+
+`ContentAs<T>` / `As<T>` answer `null` for content they cannot read, because a *read* must stay bad-data tolerant — a settings tab that throws is worse than one that shows a fail-closed default. **That same tolerance destroys data on a write.** `node.Content as T ?? new T()`, or any helper that returns a default for content it could not parse, makes "there is nothing here" and "I could not read what is here" the *same answer* — and the write then persists a default-valued record over every field the caller never touched.
+
+The typed overload removes the choice: `null` means ABSENT and only absent, while content that is present but unreadable **faults the observable** with a `MeshNodeStreamException` naming the path, the runtime type and a JSON excerpt. The write does not happen, the record is left intact, and the caller's `.Subscribe(onNext, onError)` — or its `.Catch` — logs the reason.
+
+Two production instances, both silent until the data was gone:
+
+- `ThreadInput.AppendUserInput` read `node.Content as MeshThread ?? new MeshThread()`; whenever the content arrived as JSON the write reset `Status` to `Idle` and a round the test was trying to prevent got dispatched.
+- The self-update poller's bookkeeping wrote `LastCheckedAt` on `Admin/UpdatePolicy` through a parser that defaulted on failure. One routine check erased the admin's auto-update policy, the latest available tag, every combo verdict and any live availability hold — the policy record that "lost its own policy" ahead of a portal rolling itself onto a withdrawn version line (#3542).
+
+Reach for the untyped `Update(node => …)` only when the lambda does **not** read `Content` — setting `Name`, `State`, a `Requested*` field on a node whose content it never inspects.
 
 Under the hood the handle diffs `current` vs `update(current)` and ships an RFC 7396 JSON-merge patch (`PatchDataChangeRequest` on the stream protocol) to the owning hub, which merges it against its authoritative state on its single-threaded action block. That plumbing is **internal** — application code never posts `PatchDataChangeRequest`/`PatchDataRequest` itself.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-update-settings-survive-the-portals-own-bookkeeping.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-update-settings-survive-the-portals-own-bookkeeping.md
@@ -1,0 +1,24 @@
+---
+Name: Your update settings survive the portal's own bookkeeping
+Category: Fix
+Description: The portal writes to its update record every time it checks for a new version. If it could not read what was already there, it used to write a blank record over it — losing the auto-update setting, the version it had found and every compatibility verdict. It now leaves the record alone and says so.
+Icon: ShieldCheckmark
+Order: -20260907
+---
+
+# Your update settings survive the portal's own bookkeeping
+
+Every time the portal checks for a new version it notes the result on the same record that holds
+your auto-update setting: when it last looked, what it found, whether an update is being held back,
+and which candidate versions were verified against your installed modules.
+
+To add a note it first has to read what is already there. If that read failed — a field written in a
+shape this build does not recognise is enough — the portal treated it as *"there is nothing here"*
+and wrote a fresh, blank record. One routine check was enough to erase the auto-update setting, the
+newest version it had found, an active hold and every recorded compatibility verdict, silently and
+with no way to tell afterwards that anything had been lost.
+
+Reading and writing are now different questions. A record the portal cannot read is **left exactly
+as it is**: the bookkeeping note is refused, the reason is written to the log naming the record and
+what could not be read, and the update check itself carries on unaffected. Nothing the portal could
+not read gets replaced by something it made up.

--- a/test/Memex.Portal.Shared.Test/AbsentUpdatePolicyFailsClosedTest.cs
+++ b/test/Memex.Portal.Shared.Test/AbsentUpdatePolicyFailsClosedTest.cs
@@ -14,15 +14,21 @@ namespace Memex.Portal.Shared.Test;
 /// <para>The defect this pins is a two-part mechanism, and neither part is visible on its own. The
 /// hub serializer sets <c>DefaultIgnoreCondition = WhenWritingDefault</c>, so whichever enum member
 /// is ZERO is omitted from the persisted record; and an omitted field deserializes back to that same
-/// member. While <c>Continuous</c> was zero, a record that lost its policy under its own bookkeeping
-/// writes read back as the MOST PERMISSIVE state, reached purely by losing information. That is how
-/// memex-cloud rolled onto a withdrawn <c>3.1.0-ci</c> line "on a policy record that lost its own
-/// policy".</para>
+/// member. <c>Continuous</c> IS the enum's zero — it still is, deliberately (reordering the enum
+/// would make an explicit <c>None</c> unwritable, which is the safety-critical direction) — so a
+/// record that lost its policy under its own bookkeeping writes read back as the MOST PERMISSIVE
+/// state, reached purely by losing information. That is how memex-cloud rolled onto a withdrawn
+/// <c>3.1.0-ci</c> line "on a policy record that lost its own policy". The cure is the NULLABLE
+/// backing field: <c>null</c> is the default that gets dropped, and it reads as <c>None</c>.</para>
 ///
 /// <para>🚨 The two assertions below are a pair on purpose. Fail-closed alone would be satisfied by
 /// an enum nobody can express Continuous in; round-tripping alone would be satisfied by the old
-/// order. Together they say: an ABSENT policy is None, and an EXPLICIT Continuous survives — which
+/// shape. Together they say: an ABSENT policy is None, and an EXPLICIT Continuous survives — which
 /// is the distinction the old shape could not make.</para>
+///
+/// <para>This pins what an absent field MEANS. What stops the field from GOING absent is
+/// <c>UnreadablePolicyRecordIsNotClobberedTest</c>: a bookkeeping write that could not read the
+/// record refuses instead of writing a default over it.</para>
 /// </summary>
 public class AbsentUpdatePolicyFailsClosedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -43,9 +49,10 @@ public class AbsentUpdatePolicyFailsClosedTest(ITestOutputHelper output) : Monol
     [Fact]
     public void AnExplicitContinuousSurvivesTheRoundTrip()
     {
-        // The other half: because None is now the zero value, Continuous is non-default and must be
-        // WRITTEN OUT — otherwise an admin's explicit choice would decay into the absent case and be
-        // silently downgraded to None on the next read.
+        // The other half: the DECLARED policy is nullable, so its default is null and every named
+        // member — Continuous included — is non-default and must be WRITTEN OUT. Otherwise an
+        // admin's explicit choice would decay into the absent case and be silently downgraded to
+        // None on the next read.
         var chosen = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous };
 
         var json = JsonSerializer.Serialize(chosen, Mesh.JsonSerializerOptions);

--- a/test/Memex.Portal.Shared.Test/UnreadablePolicyRecordIsNotClobberedTest.cs
+++ b/test/Memex.Portal.Shared.Test/UnreadablePolicyRecordIsNotClobberedTest.cs
@@ -1,0 +1,266 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 A FAILED READ MUST NOT BECOME A WRITE — #3542, proposal 3, the half #3607 did not close.
+///
+/// <para>#3607 made an ABSENT <c>policy</c> field read as <see cref="UpdatePolicyKind.None"/> rather
+/// than as "enabled". That fixed what an absent field MEANS; it did not stop the record from losing
+/// the field. What loses it is a bookkeeping write built on
+/// <c>UpdatePolicyNodeType.ParseContent</c>, which answers <c>new UpdatePolicyContent()</c> for BOTH
+/// "there is no content" and "the content is present and this build cannot read it" — and the write
+/// then PERSISTS that empty record over the admin's policy, the latest available tag, every combo
+/// verdict and any live availability hold.</para>
+///
+/// <para><b>Measured before the fix, on <c>origin/main</c> at 5453be493.</b> Seeded
+/// <c>{"policy":"None","latestAvailableTag":"3.0.0-ci.8009","comboVerifications":"corrupt"}</c> —
+/// one field this build cannot deserialize, which is why the record reaches the write lambda as an
+/// untyped <c>JsonElement</c> ("stayed an untyped JsonElement", logged by the stream cache). One
+/// <c>RecordAvailable</c>-shaped write then completed SILENTLY and left
+/// <c>{"requireCiGreen":true,"latestAvailableTag":"3.0.0-ci.9999","comboVerifications":[]}</c>: no
+/// <c>policy</c> at all — the production state #3542 opens on, from a single bookkeeping write.</para>
+///
+/// <para><b>The fix is the framework's own typed write</b>, not a bespoke guard:
+/// <c>Update&lt;UpdatePolicyContent&gt;((node, cur) =&gt; …)</c> hands the lambda <c>null</c> only
+/// when the content is ABSENT and faults with a <c>MeshNodeStreamException</c> when it is present
+/// and unreadable — the write does not happen. Every bookkeeping caller already wraps its write in a
+/// <c>.Catch</c> that logs and carries on (#1020: a bookkeeping write may never gate the roll), so
+/// an unreadable record is refused loudly and left intact.</para>
+///
+/// <para>🚨 Moving <c>lastCheckedAt</c> to a separate node — the other repair #3542 proposes — would
+/// NOT have closed this. The three sibling writes (<c>RecordAvailable</c>, <c>RecordHold</c>,
+/// <c>RecordVerification</c>) have the same shape on the same record, so the defect is
+/// read-failure-becomes-a-default, not the co-location. Hence all four are pinned here.</para>
+///
+/// <para>🚨 Every arm has a positive control on a READABLE record. Without them, "the write was
+/// refused" would be satisfied by a write that never works at all.</para>
+/// </summary>
+public class UnreadablePolicyRecordIsNotClobberedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A real record carrying an explicit policy and a real tag, with ONE field this build
+    /// cannot deserialize (<c>comboVerifications</c> is an
+    /// <c>ImmutableList&lt;ComboVerification&gt;</c>) — a field written by a build whose content
+    /// type differed. The record as a whole is then unreadable.</summary>
+    private const string UnreadableRecord =
+        """{"policy":"None","requireCiGreen":true,"latestAvailableTag":"3.0.0-ci.8009","comboVerifications":"written-by-a-shape-this-build-cannot-read"}""";
+
+    private const string ReadableRecord =
+        """{"$type":"UpdatePolicyContent","policy":"None","requireCiGreen":true,"latestAvailableTag":"3.0.0-ci.8009"}""";
+
+    private const string Candidate = "3.0.0-ci.9999";
+
+    /// <summary>🚨 <see cref="TestTimeouts.Convergence"/>, never a literal: a hand-written 30 s is
+    /// both a guess about machine speed AND the framework's own write bound (#2819).</summary>
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddUpdatePolicyType();
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    public static IEnumerable<object[]> EveryBookkeepingWrite() =>
+    [
+        ["RecordAvailable"], ["RecordCheck"], ["RecordHold"], ["RecordVerification"],
+    ];
+
+    /// <summary>
+    /// THE REGRESSION. Each of the four writes on <c>Admin/UpdatePolicy</c>, against a record this
+    /// build cannot read: the write must be REFUSED, and the stored bytes must still carry the
+    /// admin's <c>policy</c> and the tag that was there.
+    /// </summary>
+    [Theory(Timeout = 180000)]
+    [MemberData(nameof(EveryBookkeepingWrite))]
+    public async Task AnUnreadableRecordIsRefused_NotOverwritten(string write)
+    {
+        await Seed(UnreadableRecord);
+
+        var fault = await RunWrite(write);
+
+        Output.WriteLine($"{write} -> {fault?.GetType().Name ?? "COMPLETED"}: {fault?.Message}");
+        fault.Should().NotBeNull(
+            $"{write} read a record it could not parse, so it must refuse rather than write a "
+            + "default-valued record over it");
+
+        // 🚨 A single read is sound HERE and only here: the refusal happens INSIDE the update
+        // lambda, which has therefore already run against this hub's mirror, and no patch was
+        // posted — so there is no later emission to wait for. The positive control below, where a
+        // real write does have to propagate, waits on the condition instead.
+        var after = await ReadRawJson();
+        Output.WriteLine($"after {write}: {after}");
+        after.Should().Contain("\"policy\"",
+            "the admin's explicit choice must survive a bookkeeping write that could not read it — "
+            + "losing this field is how memex-cloud rolled itself onto a withdrawn line (#3542)");
+        after.Should().Contain("3.0.0-ci.8009",
+            "nothing on the record may be replaced by a default the write invented");
+    }
+
+    /// <summary>
+    /// THE POSITIVE CONTROL, one per write. On a READABLE record the very same call must land AND
+    /// leave the policy alone — otherwise the assertion above would pass for a write that is simply
+    /// broken.
+    /// </summary>
+    [Theory(Timeout = 180000)]
+    [MemberData(nameof(EveryBookkeepingWrite))]
+    public async Task AReadableRecordIsWritten_AndKeepsItsPolicy(string write)
+    {
+        await Seed(ReadableRecord);
+
+        var fault = await RunWrite(write);
+
+        Output.WriteLine($"{write} -> {fault?.GetType().Name ?? "COMPLETED"}: {fault?.Message}");
+        fault.Should().BeNull($"{write} must still land on a record it CAN read");
+
+        // 🚨 Waits for the write's OWN field on the live stream — never a one-shot read, which is
+        // free to answer with the pre-write snapshot and assert something it never observed
+        // (measured while writing this: all three poller arms "failed" that way while the write had
+        // in fact landed).
+        var content = await WaitForContent(c => Landed(write, c));
+
+        content.DeclaredPolicy.Should().Be(UpdatePolicyKind.None,
+            "a bookkeeping write touches only its own fields");
+    }
+
+    private static bool Landed(string write, UpdatePolicyContent c) => write switch
+    {
+        "RecordAvailable" => c.LatestAvailableTag == Candidate,
+        "RecordCheck" => c.LastCheckedAt is not null,
+        "RecordHold" => c.HeldTag == Candidate,
+        "RecordVerification" => c.ComboVerifications.Count == 1,
+        _ => throw new ArgumentOutOfRangeException(nameof(write), write, "unknown write"),
+    };
+
+    /// <summary>Runs one of the four PRODUCTION writes and returns the fault it produced, or null
+    /// when it completed. Nothing here re-implements a write shape: <c>RecordVerification</c> is the
+    /// public API, and the other three are the poller's own <c>protected virtual</c> members reached
+    /// through a derived class.</summary>
+    private Task<Exception?> RunWrite(string write)
+    {
+        var poller = new ExposedPoller(Mesh);
+        var run = write switch
+        {
+            "RecordAvailable" => poller.Available(Candidate),
+            "RecordCheck" => poller.Check(),
+            "RecordHold" => poller.Hold(Candidate),
+            "RecordVerification" => UpdatePolicyNodeType.RecordVerification(
+                Mesh,
+                new ComboVerification
+                {
+                    CandidateTag = Candidate,
+                    Verdict = ComboVerdictKind.Green,
+                    VerifiedAt = DateTimeOffset.UtcNow,
+                }),
+            _ => throw new ArgumentOutOfRangeException(nameof(write), write, "unknown write"),
+        };
+        return run
+            .Select(_ => (Exception?)null)
+            .Catch((Exception ex) => Observable.Return<Exception?>(ex))
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>The poller with its three bookkeeping writes exposed. Nothing else is overridden —
+    /// the writes under test are the production ones, byte for byte.</summary>
+    private sealed class ExposedPoller(IMessageHub hub)
+        : SelfUpdateHostedService(hub, new NoTags(), new NoPatch(), new SelfUpdateOptions())
+    {
+        public IObservable<Unit> Available(string tag) => RecordAvailable(tag);
+
+        public IObservable<Unit> Check() =>
+            RecordCheck(SelfUpdateTrigger.SafetyNet, SelfUpdateVerdict.DetectOnly(Candidate));
+
+        public IObservable<Unit> Hold(string tag) =>
+            RecordHold(tag, UpdatabilityVerdict.Unavailable("a package cannot survive this release"));
+    }
+
+    private sealed class NoTags : IAcrTagLister
+    {
+        public Task<IReadOnlyList<string>> ListTagsAsync(string repository, CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class NoPatch : IDeploymentUpdater
+    {
+        public bool CanPatch => false;
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+            Task.FromResult<DateTimeOffset?>(null);
+
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    /// <summary>The stored bytes, not a parse of them: "the record still carries its policy" is a
+    /// fact about what is ON the node, and reading it through the parser that fails closed to
+    /// <c>None</c> would answer <c>None</c> for a record that has no policy at all.</summary>
+    private Task<string> ReadRawJson() =>
+        RawContent()
+            .Select(c => c switch
+            {
+                null => "<null>",
+                JsonElement je => je.GetRawText(),
+                _ => JsonSerializer.Serialize(c, Mesh.JsonSerializerOptions),
+            })
+            .Catch((Exception ex) => Observable.Return($"<read faulted: {ex.Message}>"))
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+
+    private Task<UpdatePolicyContent> WaitForContent(Func<UpdatePolicyContent, bool> settled) =>
+        RawContent()
+            .Select(c => UpdatePolicyNodeType.ParseContent(c, Mesh.JsonSerializerOptions))
+            .Where(settled)
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+
+    private IObservable<object?> RawContent() =>
+        Observable.Create<object?>(observer =>
+        {
+            using (Access.ImpersonateAsSystem())
+                return Mesh.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                    .Where(n => n is not null)
+                    .Select(n => (object?)n.Content)
+                    .Subscribe(observer);
+        });
+
+    private Task Seed(string json)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var node = new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+        {
+            NodeType = UpdatePolicyNodeType.NodeType,
+            Name = "Update Policy",
+            State = MeshNodeState.Active,
+            Content = JsonDocument.Parse(json).RootElement.Clone(),
+        };
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return meshService.CreateNode(node).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/UpdatePolicyMcpPatchTest.cs
+++ b/test/Memex.Portal.Shared.Test/UpdatePolicyMcpPatchTest.cs
@@ -203,15 +203,14 @@ public class UpdatePolicyMcpPatchTest(ITestOutputHelper output) : MonolithMeshTe
     /// the operator's patch targets, so a genuine base/live conflict is possible on either side.</summary>
     private Task ToggleStormWriter(UpdatePolicyKind value)
     {
-        var jsonOptions = Mesh.JsonSerializerOptions;
         return Observable.Create<MeshNode>(observer =>
             {
                 using (Access.ImpersonateAsSystem())
                     return Mesh.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
-                        .Update(node =>
+                        // The TYPED write, as every production writer on this node is (#3542).
+                        .Update<UpdatePolicyContent>((node, cur) => node with
                         {
-                            var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
-                            return node with { Content = cur with { Policy = value } };
+                            Content = (cur ?? new UpdatePolicyContent()) with { Policy = value },
                         })
                         .Subscribe(observer);
             })
@@ -224,18 +223,20 @@ public class UpdatePolicyMcpPatchTest(ITestOutputHelper output) : MonolithMeshTe
     /// the poller's bookkeeping fields, preserves Policy.</summary>
     private Task RecordAvailable(string tag)
     {
-        var jsonOptions = Mesh.JsonSerializerOptions;
         return Observable.Create<MeshNode>(observer =>
             {
                 using (Access.ImpersonateAsSystem())
                     return Mesh.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
-                        .Update(node =>
+                        // 🚨 Mirrors SelfUpdateHostedService.RecordAvailable EXACTLY, which since
+                        // #3542 is the TYPED write — a mirror that drifts back to
+                        // `ParseContent` + the untyped overload stops testing the production shape.
+                        .Update<UpdatePolicyContent>((node, cur) => node with
                         {
-                            var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
-                            return node with
+                            Content = (cur ?? new UpdatePolicyContent()) with
                             {
-                                Content = cur with { LatestAvailableTag = tag, CheckedAt = DateTimeOffset.UtcNow },
-                            };
+                                LatestAvailableTag = tag,
+                                CheckedAt = DateTimeOffset.UtcNow,
+                            },
                         })
                         .Subscribe(observer);
             })


### PR DESCRIPTION
Refs #3542 — proposal 3's **first** part. (The second, "an absent `policy` must read as `None`", landed as #3607; nothing here reopens it, and the enum is deliberately **not** reordered.)

## The residue, measured — #3607 did not close it

The brief asked me to check whether #3607 had already closed the clobber. It has not, and here is the measurement, taken on `origin/main` at `5453be493` (the merge commit of #3607) before any change:

Seed `Admin/UpdatePolicy` with a real record carrying one field this build cannot deserialize:

```json
{"policy":"None","requireCiGreen":true,"latestAvailableTag":"3.0.0-ci.8009","comboVerifications":"written-by-a-shape-this-build-cannot-read"}
```

The stream cache says what happens next, in a Warning nobody was reading:

```
MeshNodeStreamCache.GetStream: Content for Admin/UpdatePolicy stayed an untyped JsonElement
after deserialization — downstream 'Content is X'/'as X' consumers will fail
```

Then **one** `RecordAvailable`-shaped bookkeeping write, which **completed silently**, leaving:

```json
{"requireCiGreen":true,"latestAvailableTag":"3.0.0-ci.9999","checkedAt":"…","comboVerifications":[]}
```

`policy` is **gone** — the production state #3542 opens on ("a policy record that lost its own policy"), reproduced from a single routine check. Along with it went `latestAvailableTag`, and in the general case every `ComboVerification` and any live `HeldTag`/`HeldReason`.

## Why, and why it is not the field's location

All four writes on the node — `RecordCheck`, `RecordAvailable`, `RecordHold` (`SelfUpdateHostedService`) and `RecordVerification` (`UpdatePolicyNodeType`) — read through `UpdatePolicyNodeType.ParseContent`, which answers `new UpdatePolicyContent()` for **both** "there is no content" and "the content is present and this build cannot read it". Those are different facts. The write then persists that empty record.

**So I did not move `lastCheckedAt`**, which is the issue's other suggestion, and the evidence is what decided it: the three sibling writes have the same shape on the same record, so moving one field would leave `RecordAvailable`, `RecordHold` and `RecordVerification` erasing it exactly as before. The defect is *a failed read becoming a default that gets written*, not the co-location.

## The fix invents nothing

The framework already has the primitive built for this exact class, and these four sites had simply never been migrated to it. From `MeshNodeStreamHandle.Update<TContent>`'s own docs:

> 🚨 **`null` means ABSENT, never "could not be read".** … Conflating the two is what turns "the content did not deserialise" into "the content was empty, write a fresh one" — the write that destroys the real record.

All four now use it. Unreadable content faults with a `MeshNodeStreamException` naming the path, the runtime type and a JSON excerpt — **the write does not happen** — and every caller already wraps its bookkeeping write in a `.Catch` that logs and carries on (#1020: a bookkeeping write may never gate the roll). Refused loudly, record left intact:

```
MeshNode Deserialization at 'Admin/UpdatePolicy': Update<UpdatePolicyContent> refused to write:
content is untyped JSON (JsonElement) and could not be read as 'UpdatePolicyContent'.
The write was NOT applied — writing a default-valued record here would persist those defaults
over every field the caller never touched.
```

## Also in this change

- `ParseContent` is reimplemented on `ObjectAsExtensions.As<T>`, so a **read** additionally covers the as-written `JsonNode` DOM and a same-named record from another collectible assembly — both of which the hand-rolled `JsonElement` switch answered with a silent default — and it now documents that it must never feed a write.
- `UpdatePolicyMcpPatchTest`'s two "mirrors the production shape exactly" helpers move to the typed write, so the mirror keeps testing the shape it claims to.
- `AbsentUpdatePolicyFailsClosedTest`'s prose asserted "`None` is now the enum's zero value". It is not — `Continuous` still is, deliberately, because reordering would make an explicit `None` unwritable under `DefaultIgnoreCondition = WhenWritingDefault`. Corrected, and the duplicate `<summary>` block left on `DeclaredPolicy` is removed.
- **Work product conserved:** `Doc/Architecture/CqrsAndContentAccess` → "Writes" now teaches the typed overload as *the* write shape and states the asymmetry plainly — a read may tolerate bad data, a write may not, and building one on the other is what destroys the record. It cites both production instances (`AppendUserInput`'s `Status` reset, and this one).

## Verification

`UnreadablePolicyRecordIsNotClobberedTest` drives all four **production** writes against a real mesh — `RecordVerification` through its public API, the other three through a derived class exposing the poller's own `protected virtual` members. Each has a positive control on a readable record, because "the write was refused" would otherwise be satisfied by a write that never works.

**Falsified.** Reverting *only* the two `src` files and re-running: exactly the **4 refusal arms fail**, the 4 positive controls pass. With the fix: **8/8**. Then **93/93** across every self-update suite in the project (`ComboGateRollTest`, `ComboVerdictRecordingTest`, `SelfUpdateStrandRecoveryTest`, `UpdatePolicyMcpPatchTest`, `NonAdminUpdateStatusTest`, `PlatformUpdateStatusTest`, `VersionSelectTest`, `AbsentUpdatePolicyFailsClosedTest`).

One thing worth recording, because it wasted a cycle: the three poller arms first failed their *positive control* with a one-shot read of the node — the write had landed and the read answered with the pre-write snapshot. Fixed by waiting on the condition (`.Where(settled).FirstAsync().Timeout(…)`), which is the house rule; the refusal arms keep the single read deliberately, and say why in a comment — a refusal happens inside the update lambda, so no patch is posted and there is no later emission to wait for.

`dotnet build -c Release -warnaserror`, one project per invocation: `Memex.Portal.Shared` and `Memex.Portal.Shared.Test`, both `0 Warning(s) 0 Error(s)`. `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` green after the doc edits.

What's New: `Category: Fix` — "Your update settings survive the portal's own bookkeeping".

**#3542 stays open** after this: proposal 3 is then complete, but the issue also still carries the ~1300 `[MergeGuard] Admin/UpdatePolicy: refused stale/reordered cross-hub write` events, which have no fix on `main` and are a separate root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
