### PR TITLE
fix(#3544): a cancelled CD is not an unverified roll

### DIFF
--- a/.github/workflows/combo-verify.yml
+++ b/.github/workflows/combo-verify.yml
@@ -228,6 +228,8 @@ jobs:
           PREFLIGHT: ${{ needs.preflight.result }}
           VERIFY: ${{ needs.verify.result }}
           COUNT: ${{ needs.preflight.outputs.count }}
+          # The trigger's own conclusion, so "no candidate" can be told from "inputs missing".
+          TRIGGER: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion || 'dispatch' }}
         run: |
           set -euo pipefail
           echo "preflight=$PREFLIGHT verify=$VERIFY instances=${COUNT:-0}"
@@ -238,8 +240,28 @@ jobs:
             echo "- verify: \`$VERIFY\` over \`${COUNT:-0}\` instance(s)"
           } >>"$GITHUB_STEP_SUMMARY"
 
+          # 🚨 THREE outcomes, not two. `skipped` and `failure` are different facts and used to
+          # share one message — the exact collapse this gate exists to prevent, committed by the
+          # gate itself. Measured 2026-09-07: 17 of the last 30 CD runs were CANCELLED by the
+          # one-pending-slot rule, so the preflight's event condition skipped it and this job red
+          # 6 times out of 6 on main, each time telling the reader to "read the preflight job for
+          # the exact list" of a job that never ran. A gate that cries wolf on routine traffic
+          # trains people to ignore it, and then the real red is invisible too.
+          if [ "$PREFLIGHT" = "skipped" ] && [ "$TRIGGER" != "success" ]; then
+            echo "No candidate: the triggering CD run concluded '$TRIGGER', so it published nothing to verify."
+            {
+              echo
+              echo "**No candidate.** The triggering CD run concluded \`$TRIGGER\`, so there is"
+              echo "nothing to verify. This is not an unverified roll — no roll was produced."
+            } >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$PREFLIGHT" = "skipped" ]; then
+            echo "::error::the preflight was SKIPPED although the triggering CD concluded '$TRIGGER'. A candidate exists and nothing checked it — that is the skip-trapdoor this gate exists to refuse (#3544)."
+            exit 1
+          fi
           if [ "$PREFLIGHT" != "success" ]; then
-            echo "::error::the preflight did not pass, so NO instance was verified and every roll in the fleet is still UNVERIFIED (#3544). Read the preflight job for the exact list of inputs to provision."
+            echo "::error::the preflight FAILED, so NO instance was verified and every roll in the fleet is still UNVERIFIED (#3544). Read the preflight job for the exact list of inputs to provision."
             exit 1
           fi
           if [ "$VERIFY" != "success" ]; then

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-cancelled-build-no-longer-reports-itself-as-unverified.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-cancelled-build-no-longer-reports-itself-as-unverified.md
@@ -1,0 +1,18 @@
+---
+Name: A cancelled build no longer reports itself as unverified
+Category: Fix
+Description: When a build was cancelled before producing anything, the check that verifies builds reported a failure saying nothing had been verified — which was true but misleading, because there was nothing to verify. It now says so plainly instead.
+Icon: CheckmarkCircle
+Order: -20260907
+---
+
+# A cancelled build no longer reports itself as unverified
+
+Builds here are cancelled routinely — a newer one supersedes the one waiting. The check that
+verifies a build against each live installation treated that as a failure, reporting that nothing had
+been verified and pointing readers at a step that had never run. True, but the wrong conclusion: a
+cancelled build produced nothing, so there was nothing to verify.
+
+It now distinguishes the two. A cancelled build reports "no candidate" and passes. A build that
+succeeded but went unchecked still fails loudly — that one is a real gap, and it is the reason the
+check exists.


### PR DESCRIPTION
## A cancelled CD is not an unverified roll

#3544's gate landed today and has been **red on `main` 6 times out of 6** — for the wrong reason,
with a message that sends the reader to a job that never ran.

### The defect, which is the one this gate exists to prevent

The `verdict` job collapsed `skipped` and `failure` into one branch:

```bash
if [ "$PREFLIGHT" != "success" ]; then
  echo "::error::the preflight did not pass … Read the preflight job for the exact list of inputs to provision."
```

Those are different facts. **Measured: 17 of the last 30 CD runs were `cancelled`** by the
one-pending-slot rule. The preflight's event condition — correctly, per the no-skip-trapdoor rule —
skips when the trigger did not succeed, so every cancelled CD produced a red telling the reader to
consult an empty job.

A gate that cries wolf on routine traffic trains people to ignore it, and then its **real** red is
invisible too. That is the same two-states-share-one-answer collapse the gate was built to refuse,
committed by the gate itself.

### Three outcomes, not two

| preflight | trigger | verdict |
|---|---|---|
| `skipped` | not `success` | **"no candidate"**, exit 0 — the CD published nothing to verify |
| `skipped` | `success` | **RED** — a candidate exists and nothing checked it. *This is the trapdoor.* |
| `failure` | any | **RED**, naming the provisioning list |

The middle row is the point: this does **not** silence the skip. It separates the skip that means
*"there is nothing to do"* from the skip that means *"the gate did not run on something real"* — and
the second is still a hard failure.

### Falsified, all five states

Run against the step's own `run:` block extracted from the workflow (not a restatement), exit codes
read **directly** rather than through a pipe:

| case | inputs | exit | message |
|---|---|---|---|
| A | `skipped` / `cancelled` | **0** | `No candidate: the triggering CD run concluded 'cancelled'…` |
| B | `skipped` / `success` | **1** | `the preflight was SKIPPED although the triggering CD concluded 'success'…` |
| C | `failure` / `success` | **1** | `the preflight FAILED … Read the preflight job for the exact list` |
| D | `success` / `success`, 2 instances | **0** | `Every declared instance has a landed combo verdict` |
| E | `success` / `success`, **0** instances | **1** | `named ZERO instances — that is a vacuous green` |

Gates: `check-workflow-timeouts` 74 jobs / 0 violations · `check-workflow-yaml-keys` 31 files /
0 violations · `check-workflow-shell` 0 live findings.

### What this does not change

**The provisioning gap is still open and still red when it matters.** Measured independently today:
the `meshweaver-cloud` installation holds `contents`, `metadata`, `pull_requests` — **no `workflows`,
no `issues`** (read from `GET /orgs/Systemorph/installations`, the set a token is actually minted
from). So case C remains the state of the world until an operator provisions those inputs, and this
PR makes that red distinguishable from the noise it was buried in.

Refs #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
