### PR TITLE
docs(#3504): an unadopted repo has NO verdict — the Plugins adoption row was filled in from a pull request

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -741,10 +741,20 @@ does not run it. Measured against every satellite's `main`, 2026-09-07:
 |---|---|:---:|---|
 | MeshWeaver.Reinsurance | `1b5350d54` | ✅ | **0 violations** |
 | MeshWeaver.Manufacturing | `1b5350d54` | ✅ | 0 (adopted 2026-09-07, #3504) |
-| MeshWeaver.Plugins | `c7fef7a2d` | ✅ | 0 (adopted 2026-09-07, #3504) |
+| MeshWeaver.Plugins | *(none — `main` calls no validate lane)* | — | 🚨 **UNMEASURED: the guard does not run here.** Adoption is Plugins#1453, open. Its first execution named **3** (`MESHWEAVER_APP_ID`, `MESHWEAVER_APP_PRIVATE_KEY`, `REGISTRY_PUBLISH_TOKEN`) — all now reasoned allow entries on that branch, where the lane reads 0 |
 | MeshWeaver.Crm | `0a2b9017d` → `c7fef7a2d` | ❌ → ✅ | **4** — incl. `MW_REGISTRY_KEY` → 0 (adopted 2026-09-07 12:30Z, `9228b8be`) |
 | MeshWeaver.SocialMedia | `0a2b9017d` → `c7fef7a2d` | ❌ → ✅ | **4** — incl. `MW_REGISTRY_KEY` → 0 (adopted 2026-09-07 12:30Z, `9dea3668`) |
 | MeshWeaver.Education | `8ffbe4762` → `c7fef7a2d` | ❌ → ✅ | **4** → 0 (adopted 2026-09-07, Education#283) |
+
+🚨 **The Plugins row is the reason this table says `main` and means it.** An earlier revision read
+*"0 (adopted 2026-09-07, #3504)"* — anticipating a merge that has not happened. Measured
+2026-09-07 against `Systemorph/MeshWeaver.Plugins` `origin/main`: **no workflow calls
+`node-repo-validate.yml` and nothing invokes `check-pr-secret-preflight.py`**, so the cell recorded
+a verdict no run has produced. In the largest satellite of the fleet, that is the exact failure the
+section above describes — a repo that looks identical to one the guard passes. A column headed
+*"verdict on its `main`"* must never be filled in from a pull request; an unadopted repo has **no
+verdict**, which is a different thing from zero. The adoption is blocked on that repo's own
+platform-pin move (Plugins#1463), not on the change.
 
 **Reinsurance is the control**, and it is what makes the table evidence rather than an assertion:
 it is the only pre-existing caller whose pin carried the guard from the start, and it was the only


### PR DESCRIPTION
## A column headed "verdict on its `main`" was filled in from a pull request

`Doc/Architecture/CiContentBake` → *Calling the lane is NECESSARY and NOT SUFFICIENT* carries the
adoption table whose last column is **`check-pr-secret-preflight` verdict on its `main`**. The
MeshWeaver.Plugins cell read:

```
| MeshWeaver.Plugins | c7fef7a2d | ✅ | 0 (adopted 2026-09-07, #3504) |
```

Measured 2026-09-07 against `Systemorph/MeshWeaver.Plugins` `origin/main`:

```
$ git grep -n "node-repo-validate"        origin/main -- .github/   → (nothing)
$ git grep -n "check-pr-secret-preflight" origin/main -- .github/   → (nothing)
```

No workflow calls the lane; nothing invokes the guard. **The cell recorded a verdict no run has
produced**, and the pin column named a sha that exists only on a branch. It was anticipating
Plugins#1453, which is open and blocked on that repo's own platform-pin move (Plugins#1463, red on
`Portal hosts (shard 3)` since 11:12Z).

🚨 **Zero and UNMEASURED are different readings**, and this is the one table in the tree whose whole
job is to tell them apart — its own control arm is Reinsurance, *"the only pre-existing caller whose
pin carried the guard, and the only one at zero"*. A cell that says `0` where nothing ran makes the
largest satellite in the fleet look exactly like a repo the guard passes, which is the failure the
surrounding section is about.

## What changes

- The row names what `main` actually has: **no lane**, therefore no pin and no guard, and the
  verdict cell says **UNMEASURED** rather than a number — while still carrying the **3** violations
  the guard did name the first time it ran on the branch (`MESHWEAVER_APP_ID`,
  `MESHWEAVER_APP_PRIVATE_KEY`, `REGISTRY_PUBLISH_TOKEN`, each now a reasoned allow entry).
- A short paragraph beside the table records why it happened and the rule that prevents it: a column
  about `main` may never be filled in from a pull request.

When Plugins#1453 lands, the row becomes an ordinary measured `0` like Manufacturing's — one line,
after the fact.

## Verification

- **Manufacturing's row re-checked, and it is correct**: its `main` calls
  `node-repo-validate.yml@1b5350d547…` with the paired `platform-ref: 1b5350d547…` (read from the
  repo's `ci.yml` over the contents API). Only the Plugins row was wrong.
- **Swept for the same claim elsewhere**: `CrossRepoPairGate.md` cites #3504 only as a sibling
  shape, and `WorkflowDuplicateKeys.md` already states the true position (*"Plugins runs none of the
  three central workflow guards"*). Neither needed a change.
- Doc-only, no new internal links, so `DocumentationLinkIntegrityTest`'s subject is unchanged.

**No What's New entry**: internal engineering record, no user-visible effect — the documented skip case.

**Pairs-with: none** — doc-only; the diff removes no public type or member from `src/`.

Part of #3504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
