### PR TITLE
fix(cd): the publication record declares its upstreams, and a repo refuses a wake from itself (Plugins#1484)

### DIFF
--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -549,6 +549,15 @@ jobs:
             # A dependency republished for an identity: bake against THAT image, so this repo's
             # publication lands under the same identity its upstream just sealed. Never the pin
             # and never the tag — either could name a different framework than the upstream's.
+            # 🚨 Our OWN publication is not an upstream. memex routes a publication to the
+            # repositories that declared its source, never the source itself; a wake that names
+            # us as the source is a sender defect (the 2026-09-07 loop: crm woke crm, rebaked the
+            # same digest, registered it, was woken again). Refused RED, never baked: a bake here
+            # would re-register the same bytes and hand the sender its next trigger.
+            if [ -n "${UPSTREAM_SOURCE:-}" ] && [ "$(printf '%s' "$UPSTREAM_SOURCE" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "${{ inputs.bake-source }}" | tr '[:upper:]' '[:lower:]')" ]; then
+              echo "::error::woken by our OWN publication (client_payload.source '${UPSTREAM_SOURCE}' is this repo's bake-source) — a source never depends on itself. The control instance's PlatformBuildInboxWatcher must route a publication to its declared dependents only; this run bakes nothing."
+              exit 1
+            fi
             [ -n "${UPSTREAM_IMAGE:-}" ] || { echo "::error::meshweaver-upstream-published payload carries no client_payload.image — cannot know which framework the upstream '${UPSTREAM_SOURCE:-?}' was sealed for."; exit 1; }
             echo "ref=${UPSTREAM_IMAGE}" >> "$GITHUB_OUTPUT"
             echo "woken by upstream '${UPSTREAM_SOURCE:-?}' publishing; baking against its image ${UPSTREAM_IMAGE}"
@@ -1280,6 +1289,7 @@ jobs:
           IDENTITY: ${{ needs.publish-bake.outputs.identity }}
           RELEASED_VERSION: ${{ github.event.client_payload.version }}
           SELF: ${{ inputs.content-repository || github.repository }}
+          UPSTREAMS: ${{ inputs.upstream-sources }}
         run: |
           set -euo pipefail
           missing=()
@@ -1296,10 +1306,18 @@ jobs:
           # which commit, against which tester + portal. `version` is the platform tag the identity
           # was baked for when this run was itself a release-follow — memex carries it into the
           # event so dependents resolve the same set by name.
+          # `upstreams` is the caller's `upstream-sources` — the ONE declaration of "this repo depends
+          # on those sources" (the same list the seed asserts sealed publications for). memex keeps
+          # it on the source's Hosting/Publication record and routes the wave on it: a publication
+          # from X wakes exactly the registered repositories whose upstreams name X, never X itself.
+          # Sent as a JSON array of normalised names; empty for a root (nothing wakes it but the
+          # platform release). Before this field the wave went to EVERY registry source, the
+          # publisher included — the 2026-09-07 self-feeding dispatch storm (Plugins#1484).
+          UPSTREAMS_JSON=$(printf '%s' "${UPSTREAMS:-}" | tr ',;' '  ' | tr -s '[:space:]' '\n' | sed '/^$/d' | tr '[:upper:]' '[:lower:]' | awk '!seen[$0]++' | jq -R . | jq -cs .)
           BODY=$(jq -cn --arg repo "$SELF" --arg s "$SOURCE" --arg sha "$GITHUB_SHA" --arg id "${IDENTITY:-}" \
             --arg i "$IMAGE" --arg d "$digest" --arg pi "$PLATFORM_IMAGE" --arg v "${RELEASED_VERSION:-}" \
-            --arg run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            '{event:"bundle-publication", repo:$repo, source:$s, sha:$sha, identity:$id, image:$i, digest:$d, platformImage:$pi, version:$v, run:$run}')
+            --arg run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --argjson up "$UPSTREAMS_JSON" \
+            '{event:"bundle-publication", repo:$repo, source:$s, sha:$sha, identity:$id, image:$i, digest:$d, platformImage:$pi, version:$v, run:$run, upstreams:$up}')
           SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.*= /sha256=/')
           code=$(curl -sS -o /tmp/resp -w '%{http_code}' --connect-timeout 10 --max-time 60 \
             -X POST "$URL" -H 'Content-Type: application/json' \

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -686,14 +686,34 @@ register release and publish event"*) is three sentences:**
    into the same inbox (`register-publication`, its last job). Nothing runs after that call, and no
    pipeline sends a `repository_dispatch` to another repository.
 2. **memex REGISTERS the release** as a durable node — `Hosting/PlatformBuilds/<version>` for a
-   platform build, `Hosting/Publications/<identity>/<source>` for a bundle publication — the source
-   of truth for "what is published for which identity" (what the self-update availability check reads).
-3. **memex PUBLISHES the event** from that registration: `FrameworkReleaseBroadcaster` sends
-   `meshweaver-framework-released` (platform) or `meshweaver-upstream-published` (bundle publication,
-   `client_payload.version` = the identity) to the subscribed repositories — the repositories the
-   control instance's `Hosting/Deployment` records name as registry sources. The subscribers' CI
-   receives it, resolves both images from the version, builds and publishes for that identity — and
-   ends by calling memex (1).
+   platform build, and for a bundle publication `Hosting/PlatformBuilds/<source>` (NodeType
+   `Hosting/Publication`: the source, its repository, the sealed identity + digest and the
+   **upstreams the record declares** — the lane's `upstream-sources`, sent as `upstreams`). That
+   record is the source of truth for "what is published for which identity" and for "who depends on
+   whom".
+3. **memex PUBLISHES the event** from that registration, and **the two events have DIFFERENT
+   audiences.** A platform release concerns every registry source, so `meshweaver-framework-released`
+   goes to every repository the control instance's `Hosting/Deployment` records name as a registry
+   source. A bundle publication concerns only what depends on it, so `meshweaver-upstream-published`
+   goes to the **registered repositories whose declared upstreams name the publishing source — never
+   the publisher itself, never a repository that does not depend on it** (the graph is directed:
+   Reinsurance depends on Crm, never the reverse, and nothing depends on itself), and a re-registration
+   of an identity + digest already on record is the same sealed bytes, **not an event**. The
+   subscribers' CI receives it, resolves both images from the payload, builds and publishes for that
+   identity — and ends by calling memex (1).
+
+   🚨 **Why the audience is a rule and not a list (2026-09-07, MeshWeaver.Plugins#1484).** Until that
+   day a publication was fanned out to the RELEASE audience. Crm published → memex woke Crm and
+   Reinsurance → both rebaked unchanged inputs, sealed the same digest and registered it again →
+   memex woke both again: one crm digest broadcast 8–10 times, a run on each satellite every 3–5 s,
+   100+ runs per satellite in an hour, the App's API limit exhausted, the organisation's Actions
+   queue backed up behind it. A loop like that has no terminating condition, so the fix is not a
+   throttle but the two pure rules above (`DependentsOf`, `IsRepeat`, pinned by `DeploymentTests`),
+   plus a refusal on the receiving side: the lane reds a wake whose `client_payload.source` is its own
+   `bake-source` instead of baking (a bake would re-register the same bytes and hand the sender its
+   next trigger). A repository that has registered no declaration is woken by nobody's publication
+   and rebakes on its schedule poll — the warning on memex names `upstream-sources` as the input that
+   joins the wave.
 
 ```
  pipeline (core CD | a node repo's publish-bake)        memex (control instance)              subscriber CI
@@ -701,9 +721,13 @@ register release and publish event"*) is three sentences:**
  promote / seal ✅                                       WebhookInbox Hosting/PlatformBuilds
    └─ ONE signed POST ──(platform-build |──────────────▶│ verify HMAC
       bundle-publication)… and FINISH                    ├─ REGISTER  Hosting/PlatformBuilds/<version>
-                                                         │            Hosting/Publications/<identity>/<source>
-                                                         ├─ subscribers = Hosting/Deployment records'
-                                                         │              pluginRepos[].isRegistrySource
+                                                         │            Hosting/PlatformBuilds/<source>  (Hosting/Publication:
+                                                         │              repo, identity, digest, declared upstreams)
+                                                         ├─ audience: platform-build     → every registry source
+                                                         │            (Deployment records' pluginRepos[].isRegistrySource)
+                                                         │            bundle-publication → registered repos whose
+                                                         │            upstreams name <source>; never <source> itself;
+                                                         │            same identity+digest again = no event
                                                          └─ PUBLISH   repository_dispatch ─────────────▶ on: repository_dispatch:
                                                             meshweaver-framework-released |               types: [meshweaver-framework-released,
                                                             meshweaver-upstream-published                        meshweaver-upstream-published]
@@ -721,8 +745,9 @@ under `.github/workflows` — there is no ledger — and
 wires the platform half (broadcast + system identity + subscribers from the records) and is
 observed firing before core withdraws its dispatcher (MeshWeaver#3185, this change); a Plugins
 follow-up makes the watcher REGISTER the nodes named in (2) and handle `event: bundle-publication`
-(register + `meshweaver-upstream-published`, dependency-scoped through the registry's package
-`requires` graph so a publication cannot wake its own upstream); each node repository passes
+(register + `meshweaver-upstream-published` — LANDED as MeshWeaver.Plugins#1484's fix: dependency-scoped
+through the DECLARED upstreams the record carries, not the package `requires` graph, so a publication
+cannot wake its publisher or a non-dependent); each node repository passes
 `webhook-url` / `webhook-secret` to the lane when it moves its pin (the lane is RED, naming them,
 until it does — a sealed publication memex was not told about is silent drift). Once Plugins receives
 the platform event and publishes its own bundles on it, core CD's `plugins-bake` job is a SECOND

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-publication-wave-has-a-direction.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-publication-wave-has-a-direction.md
@@ -1,0 +1,24 @@
+---
+nodeType: WhatsNew
+title: A bundle publication reaches the repositories that depend on it — and never its own publisher
+category: Fix
+date: 2026-09-07
+---
+
+When a node repository seals a bundle publication, its build lane registers the record with the
+control instance, which wakes the repositories that must rebake against it. On 2026-09-07 that wake
+went to the whole fleet, the publisher included: Crm published, memex woke Crm and Reinsurance, both
+rebaked the same inputs and registered the same digest, and memex woke both again — a run on each
+repository every few seconds, the GitHub App's API limit exhausted, and the organisation's Actions
+queue backed up behind the storm.
+
+The publication record now carries the repository's **declared upstreams** (the lane's
+`upstream-sources`, the one place a repository says what it depends on), and the control instance
+routes a publication to exactly the registered repositories whose upstreams name its source — never
+the publisher, never a repository that does not depend on it, and never twice for the same sealed
+identity and digest. On the receiving side the lane refuses, red, a wake that names the repository's
+own source, instead of baking the same bytes again.
+
+A repository joins the directed wave with its next publication after moving to a lane that sends the
+declaration; until then it rebakes on its schedule poll, and the control instance's log says so. The
+platform-release wave is unchanged: a new framework concerns every registry source.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-publication-wave-has-a-direction.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-publication-wave-has-a-direction.md
@@ -1,9 +1,12 @@
 ---
-nodeType: WhatsNew
-title: A bundle publication reaches the repositories that depend on it — and never its own publisher
-category: Fix
-date: 2026-09-07
+Name: A bundle publication reaches the repositories that depend on it, never its own publisher
+Category: Fix
+Description: A node repository's publication now wakes only the repositories that declared it as an upstream; the publisher itself is never woken, and the same sealed digest is never dispatched twice.
+Icon: ArrowRouting
+Order: -20260907
 ---
+
+# A bundle publication reaches the repositories that depend on it, never its own publisher
 
 When a node repository seals a bundle publication, its build lane registers the record with the
 control instance, which wakes the repositories that must rebake against it. On 2026-09-07 that wake


### PR DESCRIPTION
Counterpart of Systemorph/MeshWeaver.Plugins#1485 (fixes MeshWeaver.Plugins#1484 — the 2026-09-07 `meshweaver-upstream-published` storm).

## What happened
memex fanned a bundle publication out to the **release** audience — every registry-source repo, the **publisher included**. Crm published → memex woke Crm and Reinsurance → both rebaked unchanged inputs, sealed the same digest, registered it again → memex woke both again: a run on each satellite every 3–5 s, 100+ runs per repo in an hour, the App's API limit exhausted, the org's Actions queue backed up (core builds queued 20+ min).

## This half (the lane)
- `node-repo-publish-bake.yml` / `register-publication`: the record carries **`upstreams`** — the caller's `upstream-sources`, normalised to a JSON array. The ONE declaration of "this repo depends on those sources"; memex keeps it on the source's `Hosting/Publication` node and routes the wave on it (a publication from X wakes the registered repos whose upstreams name X, never X itself).
- `node-repo-publish-bake.yml` / resolve: a wake whose `client_payload.source` is this repo's own `bake-source` is **refused red** — a bake would re-register the same bytes and hand the sender its next trigger.
- `ContinuousDeliveryContract.md`: the two events have different audiences, and why that is a rule, not a list. What's New (Fix).

Satellites join the directed wave when they move their lane pin (Reinsurance must declare `upstream-sources: plugins crm`; Crm keeps `plugins`). Until then they rebake on their schedule poll — the memex warning names the input.

## Verification
actionlint (only the two pre-existing style notes at lines 923/1031), `check-workflow-timeouts` (0 violations), `check-pr-secret-preflight` (0), `check-workflow-shell` (0 live), `check-workflow-yaml-keys` (0).

Pairs-with: none — no public type or member of `src/` changes (workflow + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wcdEWF5KYS7mvvnoZzURh
