### PR TITLE
fix(Plugins#1483): the view-pack check asserts the packs are LOADED, and covers the one that draws every input

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -915,9 +915,16 @@ uninstall_launchd() {
 # manual recovery step.
 # ---------------------------------------------------------------------------
 
-# The two packs a Blazor portal cannot render without. MODULE (assembly) names — what the landing
-# lane writes on disk; the catalog package names are DefaultViews and GraphViews.
-readonly VIEW_PACK_MODULES="MeshWeaver.Blazor.Views MeshWeaver.Blazor.Graph"
+# The packs a Blazor portal cannot render without. MODULE (assembly) names — what the landing
+# lane writes on disk; the catalog package names are DefaultViews, GraphViews and EntityViews.
+#
+# 🚨 EntityViews is here because leaving it out made this check report a portal USABLE that could
+# not draw a single input (MeshWeaver.Plugins#1483). It is not a visualisation pack: EditorView,
+# TextFieldView, NumberFieldView, DateTimeView, RadioGroupView, the comboboxes, checkboxes and
+# switches plus the Editor / EditForm / Property skins all live in it, so without it every quiz
+# option, the Subscribe coupon box and every dialog field render as the control's own ToString().
+# A portal that cannot be typed into is not a portal, and it passed check 3.
+readonly VIEW_PACK_MODULES="MeshWeaver.Blazor.Views MeshWeaver.Blazor.Graph MeshWeaver.Blazor.EntityViews"
 
 # One in-pod probe answering the whole of check 3: for each module, is it resolvable at all — landed
 # under <Modules:Root>/modules/<name>[@<generation>]/<name>.dll, or shipped in the image's own app
@@ -935,6 +942,64 @@ probe_view_packs() {
     if [ -e "$root/modules/activation.d/.pending-restart" ]; then echo "pending-restart=yes"; fi
     exit 0
   ' sh "$VIEW_PACK_MODULES" 2>/dev/null
+}
+
+# 🚨 "Resolvable on disk" is NOT "will render", and reporting the first as the second is how a
+# portal that could not draw a single form still printed `ok view packs present`. Measured on a
+# memex-local install (MeshWeaver.Plugins#1483): the probe above reported MeshWeaver.Blazor.Graph
+# PRESENT while MeshNodePickerControl still rendered as its ToString(). It was not lying about the
+# file — the file was there, in the image's own modules/ folder — it was answering a different
+# question from the one it printed.
+#
+# A pack reaches the RUNNING process only if boot put it in the EFFECTIVE MODULE SET, which is
+# exactly `Modules:Assemblies` union the landed activation sidecar (MemexConfiguration ->
+# ModuleActivationBoot.ComputeEffectiveModuleEntries). Bytes in modules/ that NEITHER names are
+# bytes nothing ever asks for, and no amount of restarting changes that.
+#
+# The portal already says which copy of which module it is about to load — one
+# `[ModuleLoad] <name> <- <path> (source=...)` line per module, at boot, written from the SAME
+# array it then loads ("the line and the load cannot disagree", MeshWeaver#2223). That report IS
+# the activation signal and it is readable from out here, so this asserts it rather than a file's
+# existence.
+#
+# 🚨 It never reports success on no evidence. With no `[ModuleLoad]` line visible at all, the boot
+# report has scrolled out of this container's log — which means this check learned NOTHING, and
+# "learned nothing" is reported as a failure naming its remedy, never as `ok`.
+assert_view_packs_loaded() {
+  local report inert="" m
+  report="$(kubectl -n "$NAMESPACE" logs "deploy/$PORTAL_DEPLOYMENT" 2>/dev/null \
+    | grep -F '[ModuleLoad] ' || true)"
+
+  if [ -z "$report" ]; then
+    warn "the portal's boot module report is NOT in this pod's log, so check 3 could not tell an
+     ACTIVATED view pack from bytes lying unused on disk — it verified nothing, and a check that
+     verified nothing is not a pass.
+     Remedy: restart the portal so the report sits at the top of a fresh log, then re-verify:
+       kubectl -n $NAMESPACE rollout restart deploy/$PORTAL_DEPLOYMENT && memex-local verify"
+    return 1
+  fi
+
+  for m in $VIEW_PACK_MODULES; do
+    printf '%s\n' "$report" | grep -qF "[ModuleLoad] $m " || inert="$inert $m"
+  done
+
+  if [ -n "$inert" ]; then
+    warn "view pack(s) are ON DISK but NOT LOADED:$inert
+     The bytes are there and the running process never asked for them, so every control they draw
+     still renders as its ToString() — the state this check used to call 'present'.
+     A module is loaded only if the image names it under Modules:Assemblies or a registry bundle
+     LANDED it (which writes the activation sidecar entry); a copy in modules/ that neither names
+     is inert, and restarting will not change it.
+     Remedy: read the boot report and see what the portal did load —
+       memex-local logs --no-follow --tail 400 | grep ModuleLoad
+     then rebuild the image from a plugins checkout that declares the pack
+     ('memex-local update --build'), or stop serving from a checkout, which can never land a
+     module BINARY (MeshWeaver#2417):
+       memex-local registry $DEFAULT_REGISTRY_URL --key mwr_..."
+    return 1
+  fi
+
+  ok "view packs loaded: $VIEW_PACK_MODULES"
 }
 
 # Has the boot reconcile FINISHED? `[DefaultInstall] reconciled…` is the line it writes when the
@@ -1137,7 +1202,10 @@ verify_usable() {
     kubectl -n "$NAMESPACE" rollout restart "deploy/$PORTAL_DEPLOYMENT"
     kubectl -n "$NAMESPACE" rollout status "deploy/$PORTAL_DEPLOYMENT" --timeout=300s || \
       warn "the activation restart did not complete — 'memex-local status'"
-    ok "view packs present and activated"
+    # 🚨 The restart is the ACT; the boot report of the pod it started is the EVIDENCE. Declaring
+    # "present and activated" straight off `rollout status` asserted the very thing this check
+    # exists to establish, without ever looking at it.
+    assert_view_packs_loaded || failed=1
   elif [ "$pending" -gt 0 ]; then
     warn "view packs are LANDED but a restart is PENDING — on disk, not in the running process, so
      controls still render as ToString().
@@ -1145,7 +1213,8 @@ verify_usable() {
        kubectl -n $NAMESPACE rollout restart deploy/$PORTAL_DEPLOYMENT"
     failed=1
   else
-    ok "view packs present: $VIEW_PACK_MODULES"
+    # Resolvable on disk was never the claim being printed — see assert_view_packs_loaded.
+    assert_view_packs_loaded || failed=1
   fi
 
   return "$failed"

--- a/deploy/homebrew/share/values.local.self-registry.yaml
+++ b/deploy/homebrew/share/values.local.self-registry.yaml
@@ -25,11 +25,28 @@ config:
     # blanking the requirement is the sanctioned other half of what the health
     # check itself suggests.
     #
-    # Cost, stated plainly: no Radzen charts, Analysis, EntityViews, GoogleMaps or
-    # Speech on a self-registry install. The way out is not a local build lane
-    # but the other mode: `memex-local registry https://memex.meshweaver.cloud
-    # --key mwr_…` makes this install a consumer of the registry that HAS the
-    # bundles, and this file stops being applied.
+    # Cost, stated plainly: no Radzen charts, Analysis, GoogleMaps or Speech on a
+    # self-registry install. The way out is not a local build lane but the other
+    # mode: `memex-local registry https://memex.meshweaver.cloud --key mwr_…`
+    # makes this install a consumer of the registry that HAS the bundles, and
+    # this file stops being applied.
+    #
+    # 🚨 EntityViews is no longer on that list, and the correction matters because
+    # the old wording read as a loss of VISUALISATIONS. It was not: EntityViews is
+    # every input control in the product — text, number, date and choice fields
+    # plus the Editor/EditForm/Property skins — so this install could render a
+    # quiz and not let anyone answer it, show the Subscribe paywall with no usable
+    # coupon box, and open dialogs whose fields printed as text
+    # (MeshWeaver.Plugins#1483). The portal image now carries EntityViews and
+    # Graph as modules/ SEEDS and names them under Modules:Assemblies, so they
+    # arrive without a registry.
+    #
+    # Index 2 stays BLANK all the same. Un-blanking it would require the module of
+    # an image that may predate the seed, and a required module that cannot land
+    # fails required_modules, answers /health 503 and times the rollout out with
+    # the portal never serving — Memex#131, the very failure this file exists to
+    # avoid. `memex-local verify` is what reports the pack now, and it asserts the
+    # portal LOADED it rather than that a file exists.
     Modules__Required__0: ""
     Modules__Required__1: ""
     Modules__Required__2: ""

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -83,13 +83,39 @@ case "$fmt" in
 esac
 EOF
 
-# kubectl exec — the in-pod module probe. Everything else is a no-op success.
+# kubectl exec — the in-pod module probe; kubectl logs — the portal's boot module report, which is
+# what tells an ACTIVATED pack from bytes lying on disk. Everything else is a no-op success.
+#
+# 🚨 The report DEFAULTS to "all three packs loaded" so the existing red states keep isolating the
+# one cause each of them is about. FAKE_NO_MODULE_LOAD is a separate flag rather than an empty
+# FAKE_MODULE_LOAD, because an empty value and an unset one are the same thing to the stub — and
+# "the report is absent" is a state a test has to be able to set on purpose.
 cat > "$STUBS/kubectl" <<'EOF'
 #!/usr/bin/env bash
 for a in "$@"; do
   if [ "$a" = "exec" ]; then
     [ -n "${FAKE_EXEC_FAILS:-}" ] && exit 1
-    printf '%s\n' "${FAKE_MODULES:-}"
+    # 🚨 Report ONLY the modules the probe actually asked about — the real in-pod script loops over
+    # the list it is handed as its last argument, so a pack the caller does not name is a pack
+    # nothing looks at. Echoing the whole fixture instead made "a missing <pack> is caught" pass for
+    # a pack that was not in VIEW_PACK_MODULES at all: a control that could not fail.
+    packs=" ${!#} "
+    printf '%s\n' "${FAKE_MODULES:-}" | while IFS= read -r line; do
+      case "$line" in
+        module=*)
+          name="${line#module=}"; name="${name%% *}"
+          case "$packs" in *" $name "*) printf '%s\n' "$line" ;; esac ;;
+        ?*) printf '%s\n' "$line" ;;
+      esac
+    done
+    exit 0
+  fi
+  if [ "$a" = "logs" ]; then
+    [ -n "${FAKE_NO_MODULE_LOAD:-}" ] && exit 0
+    if [ -n "${FAKE_MODULE_LOAD:-}" ]; then printf '%s\n' "$FAKE_MODULE_LOAD"; exit 0; fi
+    for m in MeshWeaver.Blazor.Views MeshWeaver.Blazor.Graph MeshWeaver.Blazor.EntityViews; do
+      printf '[ModuleLoad] %s ← /app/modules/%s/%s.dll (source=appsettings, mvid=…, written=…)\n' "$m" "$m" "$m"
+    done
     exit 0
   fi
 done
@@ -99,8 +125,11 @@ EOF
 chmod +x "$STUBS"/colima "$STUBS"/curl "$STUBS"/kubectl
 export PATH="$STUBS:$PATH"
 
-BOTH_PRESENT='module=MeshWeaver.Blazor.Views present
-module=MeshWeaver.Blazor.Graph present'
+# 🚨 THREE packs, not two: EntityViews joined VIEW_PACK_MODULES because a portal missing it can
+# draw no input control at all, and check 3 was calling that portal usable (Plugins#1483).
+PACKS_PRESENT='module=MeshWeaver.Blazor.Views present
+module=MeshWeaver.Blazor.Graph present
+module=MeshWeaver.Blazor.EntityViews present'
 
 # Run `memex-local verify [$VERIFY_FLAGS]` in a given state, leaving output in OUT and status in RC.
 # 🚨 Not `OUT=$(run_verify …)`: a command substitution is a SUBSHELL, so an RC assigned inside one
@@ -134,13 +163,13 @@ reports() {
 echo "── the verification can FAIL (each red state, with a remedy) ─────"
 
 reports "a 503 portal is not 'reachable'" "HTTP 503" \
-  FAKE_HTTP_ROOT=503 FAKE_HTTP_LOGIN=503 FAKE_MODULES="$BOTH_PRESENT"
+  FAKE_HTTP_ROOT=503 FAKE_HTTP_LOGIN=503 FAKE_MODULES="$PACKS_PRESENT"
 
 reports "no answer at all is reported" "did NOT answer" \
-  FAKE_HTTP_ROOT=000 FAKE_HTTP_LOGIN=000 FAKE_MODULES="$BOTH_PRESENT"
+  FAKE_HTTP_ROOT=000 FAKE_HTTP_LOGIN=000 FAKE_MODULES="$PACKS_PRESENT"
 
 reports "a deleted login page is caught" "NOT ROUTED" \
-  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=404 FAKE_MODULES="$BOTH_PRESENT"
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=404 FAKE_MODULES="$PACKS_PRESENT"
 
 # 🚨 The single most common red state a developer meets, and the one §14 misnamed. `up` and
 # `update` both restart the launchd port-forward and go STRAIGHT into the verification, so the
@@ -149,9 +178,9 @@ reports "a deleted login page is caught" "NOT ROUTED" \
 # the generic "that is not a serving portal" — which names the INGRESS. The developer is then sent
 # to `memex-local logs` to read a healthy pod, for a socket that is missing on their own Mac.
 reports "a connection failure is 'no answer', not a serving-portal fault" "did NOT answer" \
-  FAKE_CURL_FAILS=1 FAKE_MODULES="$BOTH_PRESENT"
+  FAKE_CURL_FAILS=1 FAKE_MODULES="$PACKS_PRESENT"
 
-run_verify FAKE_CURL_FAILS=1 FAKE_MODULES="$BOTH_PRESENT"
+run_verify FAKE_CURL_FAILS=1 FAKE_MODULES="$PACKS_PRESENT"
 case "$OUT" in
   *000000*) bad "a connection failure reports ONE status, not a doubled one" \
               "reported HTTP 000000 — probe_http concatenated curl's own '000' with its fallback: $OUT" ;;
@@ -216,15 +245,43 @@ reports "both view packs missing is caught" "ToString()" \
   FAKE_MODULES='module=MeshWeaver.Blazor.Views missing
 module=MeshWeaver.Blazor.Graph missing'
 
+# 🚨 The pack whose absence this check could not see (Plugins#1483). EntityViews is every input
+# control in the product — text, number, date, choice, plus the Editor/EditForm/Property skins — so
+# a portal without it can be read and not operated: no quiz can be answered, no coupon redeemed, no
+# dialog field filled in. It was not in VIEW_PACK_MODULES, so this fixture's `missing` line was
+# simply ignored and the run went green.
+reports "a missing EntityViews is caught — a portal nobody can type into is not usable" \
+  "MeshWeaver.Blazor.EntityViews" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
+  FAKE_MODULES='module=MeshWeaver.Blazor.Views present
+module=MeshWeaver.Blazor.Graph present
+module=MeshWeaver.Blazor.EntityViews missing'
+
 reports "landed-but-pending-restart is not green" "restart is PENDING" \
   FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \
-  FAKE_MODULES="$BOTH_PRESENT
+  FAKE_MODULES="$PACKS_PRESENT
 pending-restart=yes"
 
 # 🚨 The check that cannot read its own input must FAIL, never pass quietly. An unreadable pod
 # used to be indistinguishable from a healthy one, which is the skip-trapdoor shape AGENTS.md bans.
 reports "an unreadable pod fails the check, not passes it" "verified NOTHING" \
   FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_EXEC_FAILS=1
+
+# 🚨 THE STATE THIS CHECK USED TO CALL GREEN (Plugins#1483). The pack resolves on disk — it is in
+# the image's own modules/ folder — and the running process never asked for it, so every control it
+# draws still renders as its ToString(). "Resolvable" and "loaded" are different questions, and the
+# probe was printing the answer to the first under the name of the second. The boot module report
+# is what separates them, and it must be READ, not assumed.
+reports "a pack on disk but NOT in the boot report is not green" "NOT LOADED" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$PACKS_PRESENT" \
+  FAKE_MODULE_LOAD='[ModuleLoad] MeshWeaver.Blazor.Views ← /app/MeshWeaver.Blazor.Views.dll (source=appsettings)
+[ModuleLoad] MeshWeaver.Blazor.Graph ← /data/modules/MeshWeaver.Blazor.Graph@ab/MeshWeaver.Blazor.Graph.dll (source=store)'
+
+# 🚨 And the same rule one level up: with NO boot report visible the check learned nothing about
+# activation, and "learned nothing" is never a pass — the skip-trapdoor shape AGENTS.md bans, in the
+# one place where the evidence is a log that can scroll away.
+reports "no boot report means the check FAILS, never passes" "verified nothing" \
+  FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$PACKS_PRESENT" FAKE_NO_MODULE_LOAD=1
 
 # 🚨 "Still installing" must read differently from "will never arrive" — and must still not be a
 # success, because the portal cannot render at the moment the command returns. With a wait budget
@@ -239,29 +296,29 @@ VERIFY_FLAGS=""
 
 echo "── …and a green run is reachable (so the above is not vacuous) ───"
 
-run_verify FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$BOTH_PRESENT"
+run_verify FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$PACKS_PRESENT"
 if [ "$RC" -ne 0 ]; then
   bad "a healthy portal verifies green" "exited ${RC}: ${OUT}"
-elif case "$OUT" in *"view packs present"*) false ;; *) true ;; esac; then
-  bad "a healthy portal verifies green" "no 'view packs present' line in: ${OUT}"
+elif case "$OUT" in *"view packs loaded"*) false ;; *) true ;; esac; then
+  bad "a healthy portal verifies green" "no 'view packs loaded' line in: ${OUT}"
 else
   ok "a healthy portal verifies green"
 fi
 
 # A 302 to the sign-in page is the NORMAL anonymous response — treating it as red would make the
 # gate fire on every healthy install and get it deleted within a day.
-run_verify FAKE_HTTP_ROOT=302 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$BOTH_PRESENT"
+run_verify FAKE_HTTP_ROOT=302 FAKE_HTTP_LOGIN=200 FAKE_MODULES="$PACKS_PRESENT"
 if [ "$RC" -eq 0 ]; then ok "a 302 to sign-in is healthy, not a failure"
 else bad "a 302 to sign-in is healthy, not a failure" "exited ${RC}: ${OUT}"; fi
 
 echo "── argument handling ─────────────────────────────────────────────"
 
-out="$(env FAKE_MODULES="$BOTH_PRESENT" "$CLI" verify --nope 2>&1)"; rc=$?
+out="$(env FAKE_MODULES="$PACKS_PRESENT" "$CLI" verify --nope 2>&1)"; rc=$?
 if [ "$rc" -eq 0 ]; then bad "an unknown verify flag refuses" "exited 0: $out"
 else case "$out" in *"unknown flag"*) ok "an unknown verify flag refuses" ;;
      *) bad "an unknown verify flag refuses" "refused without saying why: $out" ;; esac; fi
 
-out="$(env FAKE_MODULES="$BOTH_PRESENT" "$CLI" verify --wait forever 2>&1)"; rc=$?
+out="$(env FAKE_MODULES="$PACKS_PRESENT" "$CLI" verify --wait forever 2>&1)"; rc=$?
 if [ "$rc" -eq 0 ]; then bad "--wait must be numeric" "exited 0: $out"
 else case "$out" in *"whole seconds"*) ok "--wait must be numeric" ;;
      *) bad "--wait must be numeric" "refused without saying why: $out" ;; esac; fi

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-local-portal-check-proves-the-controls-are-live.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-the-local-portal-check-proves-the-controls-are-live.md
@@ -1,0 +1,27 @@
+---
+Name: The local portal check proves the controls are live
+Category: Fix
+Description: memex-local's usability check now reads the portal's own boot report instead of looking for files on disk, and it covers the pack that draws every input — so "usable" can no longer mean a portal nobody can type into.
+Icon: Checkmark
+Order: -20260907
+---
+
+# The local portal check proves the controls are live
+
+`memex-local verify` exists to answer one question a green rollout cannot: is this portal actually
+usable? It checked three things, and the third — are the view packs there? — was answering a
+different question from the one it printed.
+
+Two gaps, one shape. It looked for two packs and there are three: the missing one is the pack that
+draws every input in the product — text, number, date, choice, plus the editor and edit-form
+layouts. A portal without it can be read and not operated: no quiz answered, no coupon redeemed, no
+dialog filled in. It passed.
+
+And for the packs it did look at, it asked whether a file existed on disk. That is not the same as
+the portal having loaded it — a pack whose bytes are present but which nothing at startup asked for
+is inert, and its controls still print as text. That state was observed and reported as *present*.
+
+The check now reads the portal's own startup report of which module it loaded from where — the same
+list the portal then loads, so the line and the load cannot disagree — and it names any pack that is
+on disk and not running. If that report is not in the log at all, the check says it could not tell
+and fails, rather than reporting a pass it did not earn.


### PR DESCRIPTION
The second defect named in Systemorph/MeshWeaver.Plugins#1483: `memex-local verify` reported a
portal USABLE that could not draw a single input control, and printed `ok update complete` after it.

`memex-local` lives here (`deploy/homebrew/bin/memex-local`), so this is the core half of that
issue. The render fix is Systemorph/MeshWeaver.Plugins#1486.

## Two gaps, one shape: the answer printed was to a different question

**1 — the probe named two packs and there are three.** `VIEW_PACK_MODULES` covered
`MeshWeaver.Blazor.Views` and `MeshWeaver.Blazor.Graph`. The one it left out,
`MeshWeaver.Blazor.EntityViews`, is every input in the product — text, number, date and choice
fields plus the Editor / EditForm / Property skins. A portal without it can be read and not
operated: no quiz answered, no coupon redeemed, no dialog field filled in. It passed check 3.

**2 — "resolvable on disk" was reported as "present".** Those are different states. A module reaches
the running process only if boot put it in the effective set — `Modules:Assemblies` ∪ the landed
activation sidecar (`ModuleActivationBoot.ComputeEffectiveModuleEntries`, called from
`memex/Memex.Portal.Shared/MemexConfiguration.cs:268`) — and bytes sitting in `modules/` that
neither names are inert. #1483's reporter observed exactly that: the probe said
`MeshWeaver.Blazor.Graph` **present** while `MeshNodePickerControl` still rendered as its
`ToString()`. The file was really there; the question being answered was not the one being printed.

## What it asserts now, and why that is reachable from a shell script

The portal already says which copy of which module it is about to load — one
`[ModuleLoad] <name> ← <path> (source=…)` line per module, at boot, written from the SAME array it
then loads, which is the whole point of `ModuleLoadReport` (*"the report and the load cannot
disagree"*, MeshWeaver#2223). That report **is** the activation signal, and `kubectl logs` can read
it. So `assert_view_packs_loaded` reads it and names any pack that is on disk and not running,
with the remedy that actually applies (rebuild an image that declares the pack, or switch to
registry mode) rather than the restart that cannot help.

🚨 **It never passes on no evidence.** With no `[ModuleLoad]` line visible at all the boot report has
scrolled out of the container's log — the check learned nothing, and "learned nothing" is reported
as a failure naming its remedy. That is the same rule the existing `FAKE_EXEC_FAILS` arm already
follows, applied to the second input this check now has.

The `--repair` arm no longer prints `view packs present and activated` straight off
`rollout status`: the restart is the ACT, the new pod's boot report is the EVIDENCE, and asserting
the thing you are trying to establish without looking at it is how this check got here.

## `values.local.self-registry.yaml`

Its cost note listed EntityViews among the missing "Radzen charts, Analysis, EntityViews, GoogleMaps
or Speech", which reads as a loss of visualisations. That framing is what let the defect sit: it is
the loss of every way to enter anything. Corrected, with the reason index 2 nonetheless stays blank
recorded beside it — un-blanking would require the module of an image that may predate the seed, and
a required module that cannot land answers `/health` 503 and times the rollout out (Memex#131).

## Verification

`bash deploy/homebrew/test/run-tests.sh` → **passed 64, failed 0**. `bash -n` and
`shellcheck -S error` clean on the CLI.

**Falsification — the four new/changed assertions against the pre-change script**
(`git show origin/main:deploy/homebrew/bin/memex-local`) → **passed 60, failed 4**:

```
FAIL  a missing EntityViews is caught — a portal nobody can type into is not usable
FAIL  a pack on disk but NOT in the boot report is not green
FAIL  no boot report means the check FAILS, never passes
FAIL  a healthy portal verifies green          # the green line now names the claim it makes
```

🚨 The first of those did **not** discriminate on my first draft, and the reason is worth recording:
the suite's `kubectl` stub echoed the whole `FAKE_MODULES` fixture regardless of which modules the
probe asked about, so a fixture line for a pack outside `VIEW_PACK_MODULES` was still read as a
missing pack — the test passed against a script that never looked at EntityViews. The stub now
models the real in-pod probe and reports only the modules named in its last argument, which is what
turns that test into a control.

Core's own `WhatsNewEntryIntegrityTest` passes with the new entry (1 passed / 0 failed, after
`dotnet build -c Release -warnaserror` of `MeshWeaver.Documentation.Test` → `0 Warning(s) 0 Error(s)`).

## Merge order

**After Systemorph/MeshWeaver.Plugins#1486.** This PR arms a detector; that PR ships the fix it
detects the absence of. Landing the detector first would red every self-registry install for a state
whose remedy is not yet buildable.

No public surface leaves `src/` — `Pairs-with: none — this diff touches `deploy/homebrew/` and one
doc page; it removes no public type or member.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
