### PR TITLE
fix(#3623): five more writes refuse a record they cannot read instead of overwriting it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -674,14 +674,38 @@ The first emission is the current state; subsequent emissions arrive as the hub 
 Application code writes through the stream handle; the framework turns the lambda into a patch on the owning hub:
 
 ```csharp
-workspace.GetMeshNodeStream(targetPath).Update(node =>
-{
-    var content = node.ContentAs<MyContent>(hub.JsonSerializerOptions, logger);
-    if (node.Content is not null && content is null) return node;  // never clobber unreadable content
-    return node with { Content = (content ?? new MyContent()) with { Status = "done" } };
-})
+workspace.GetMeshNodeStream(targetPath).Update<MyContent>((node, content) =>
+    node with { Content = (content ?? new MyContent()) with { Status = "done" } })
 .Subscribe(_ => { }, ex => logger.LogWarning(ex, "Update failed for {Path}", targetPath));
 ```
+
+🚨 **Name the content type — the untyped lambda is where a failed READ becomes a written DEFAULT.**
+A read must stay bad-data tolerant, so `ContentAs<T>` / `As<T>` answer `null` rather than throw. On a
+write that same tolerance destroys the record: `node.ContentAs<T>(opts) ?? new T()` inside
+`Update(node => …)` makes *"there is nothing here"* and *"I could not read what is here"* the same
+answer, and the write then persists a default-valued record over every field the lambda never
+touched. In `Update<TContent>` the `null` means **ABSENT and only absent** — so create-on-absent is
+preserved exactly — while content that is present and unreadable faults the observable with a
+`MeshNodeStreamException` naming the path, the runtime type and a JSON excerpt, **with the write not
+applied**.
+
+All three unreadable shapes happen in a running mesh and none of them throws: untyped JSON whose
+`$type` will not resolve, the as-written `JsonObject` DOM before the materialisation pipeline
+re-types it, and a same-named record from another collectible assembly (every NodeType recompile
+mints one). From the outside all three read as *"the content was empty"*. Two production incidents
+came from exactly this: `Admin/UpdatePolicy` losing its own policy ahead of a portal rolling itself
+onto a withdrawn version line (#3542), and `ThreadInput.AppendUserInput` resetting `Status` to
+`Idle` (the CheckInbox flake). `DefaultedContentReadInsideAnUpdateLambdaGuard` holds the shape at
+**zero** across `src/` and `memex/`, with no allow file — the fix is mechanical and
+behaviour-preserving, so an exemption could only ever mean *"this one may keep destroying
+records"*.
+
+Where the write is **not** a `stream.Update` — a durable compare-and-set on a storage adapter, or a
+pure decision function feeding one — the same rule applies without the primitive: read `null` when
+`Content is null`, and REFUSE loudly when the content is present and unreadable. Refuse by writing
+nothing and logging what was withheld, not by throwing, wherever a throw would strand a lock or a
+claim the caller still has to hand back (`BuildNodeType.ApplyGrant` and `CommitGrant` are the two
+worked examples).
 
 Under the hood the handle diffs `current` vs `update(current)` and ships an RFC 7396 JSON-merge patch (`PatchDataChangeRequest` on the stream protocol) to the owning hub, which merges it against its authoritative state on its single-threaded action block. That plumbing is **internal** — application code never posts `PatchDataChangeRequest`/`PatchDataRequest` itself.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-record-the-portal-cannot-read-is-no-longer-a-record-it-overwrites.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-record-the-portal-cannot-read-is-no-longer-a-record-it-overwrites.md
@@ -1,0 +1,50 @@
+---
+Name: A record the portal cannot read is no longer a record it overwrites
+Category: Fix
+Description: Five places wrote a blank record whenever they could not read the one that was already there — including your own account, on a click that was only meant to hide a page. They now refuse the write and say so, leaving the record intact.
+Icon: Checkmark
+Order: -20260907
+---
+
+# A record the portal cannot read is no longer a record it overwrites
+
+Reading is deliberately forgiving. If a stored record cannot be understood — because it was written
+by a different version, or arrives in a shape the reader does not recognise — the portal shows a
+safe default rather than an error page. A settings tab that shows defaults is better than one that
+will not open at all.
+
+That forgiveness is exactly wrong when the next thing that happens is a **write**. Five places
+read a record, silently got the blank default because they could not read it, changed one field on
+that blank, and saved it back. Everything the record used to hold was gone — and nothing was
+logged, because from the inside it looked like saving a change to an empty record.
+
+## Where it could happen
+
+- **Your own account.** Marking a page hidden for presentation mode read your user record and, if
+  it could not read it, wrote a fresh empty one — replacing everything else on it.
+- **A repository's sync settings**, while repairing the address of a repository that had been
+  renamed.
+- **The build coordination record**, in three places: registering to build, granting a build, and
+  committing that grant to the durable lock every part of the system reads to decide who is
+  building. A blank there means "nobody is building this", so a second full build could start on
+  work already under way.
+- **A script or notebook's run log**, on every flush while it runs. The fields that would have been
+  lost are precisely the ones the log does not re-write each time: which run it is, who started it,
+  when it began — and a cancellation someone had just requested.
+
+## What changes
+
+**A record that cannot be read is refused, loudly, and left exactly as it was.** The write does not
+happen, and the refusal names the record, what it was trying to do, and what it declined to
+overwrite — so it is something you can act on instead of a field that quietly goes missing weeks
+later.
+
+**A record that genuinely is not there yet still gets created**, exactly as before. "There is
+nothing here" and "I could not read what is here" were the same answer; they are now two different
+answers, and only the first one leads to a write.
+
+## Why it will not come back
+
+A build check now scans the whole codebase for the shape that caused it and fails if a single one
+reappears — with no exemption list, because the correction is mechanical and changes nothing about
+how the code behaves when the record *is* readable.

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -942,12 +942,20 @@ public sealed class GitHubWebhookProcessor
             // scope on the SUBSCRIBING thread and disposes it wherever the work terminates, leaving
             // the subscriber running as System.
             accessService
-                .RunAsSystem(() => workspace.GetMeshNodeStream(node.Path).Update(current =>
-                {
-                    var cfg = current.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger)
-                              ?? new GitHubSyncConfig();
-                    return current with { Content = cfg with { RepositoryUrl = repointed } };
-                }))
+                // 🚨 The TYPED overload (#3623). The untyped shape read the config through
+                // `ContentAs<GitHubSyncConfig>(…) ?? new GitHubSyncConfig()`, which answers the same
+                // empty record for "no content yet" and for "content is present and this build
+                // cannot read it" — and the write then persisted that empty record, erasing the
+                // token reference, the branch, the path mapping and `LastSyncCommitSha` on a repo
+                // whose only sin was being renamed. Here `null` means ABSENT and only absent;
+                // unreadable content faults, the write does NOT happen, and the onError arm below
+                // says so — which is the right outcome, because canonical matching already covers
+                // this delivery and a repair is never worth the record.
+                .RunAsSystem(() => workspace.GetMeshNodeStream(node.Path)
+                    .Update<GitHubSyncConfig>((current, cfg) => current with
+                    {
+                        Content = (cfg ?? new GitHubSyncConfig()) with { RepositoryUrl = repointed }
+                    }))
                 .Subscribe(
                     _ => logger?.LogInformation(
                         "Repointed {Config} from '{Old}' to '{New}' — the repository was renamed.",

--- a/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
+++ b/src/MeshWeaver.Graph/BuildCoordinationExtensions.cs
@@ -83,10 +83,22 @@ public static class BuildCoordinationExtensions
     {
         var identity = hub.ServiceProvider.GetService<IClusterMembership>()?.LocalIdentity;
         return hub.EnsureBuildNode(path)
-            .SelectMany(_ => hub.GetWorkspace().GetMeshNodeStream(path).Update(curr =>
+            // 🚨 The TYPED overload (#3623). `ContentAs<BuildState>(…) ?? new BuildState()` gave the
+            // same empty state for "the node has no content yet" and for "the content is present
+            // and this build cannot read it" — and a registration written on the second reading
+            // publishes that empty state, dropping every OTHER candidate's registration, the live
+            // ClaimedBy/Status and every StoodDown mark. The build is then locked to a holder the
+            // record no longer names, which HolderStillHoldsIt defends by design (#1355). Here
+            // `null` means ABSENT and only absent; unreadable content faults the observable and the
+            // registration is refused rather than published over the real one.
+            //
+            // The former `if (curr is null) return curr!;` guard is gone because it was already
+            // dead: MeshNodeStreamExtensions.UpdateQueued runs EnsureTypedContent(node, …) — which
+            // dereferences node.Content — before it invokes any update lambda, so a null node
+            // cannot reach here through either the own or the cached write path.
+            .SelectMany(_ => hub.GetWorkspace().GetMeshNodeStream(path).Update<BuildState>((curr, content) =>
             {
-                if (curr is null) return curr!;
-                var state = curr.ContentAs<BuildState>(hub.JsonSerializerOptions) ?? new BuildState();
+                var state = content ?? new BuildState();
                 if (state.ClaimedBy == holder) return curr;
                 if (state.RequestedClaims?.ContainsKey(holder) == true) return curr;
                 return curr with

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -437,9 +437,25 @@ public static class BuildNodeType
     {
         // Holder state comes from the LOCK — never from the mirror and never from the Build node's
         // own durable row (see ClaimPath for why that row cannot hold it).
+        //
+        // 🚨 ABSENT and UNREADABLE are different facts, and conflating them here writes fiction to
+        // the one witness every cluster's arbiter decides on (#3623). `held?.ContentAs<BuildState>()
+        // ?? new BuildState()` answered the same empty state for "there is no lock row yet" —
+        // correct, that is the INSERT case at expectedVersion 0 — and for "the row is there and this
+        // build cannot read it". On the second reading the pass decides against a fiction in which
+        // nobody holds the build and nothing is stale, and then COMMITS it: WriteIfVersion succeeds,
+        // because the version it diffs against is the real row's. The live holder is evicted from
+        // the lock and a second full bake starts on a build somebody is already running.
+        //
+        // Refused instead, and loudly. Nothing is written; the arbiter is level-triggered, so the
+        // next legitimate trigger re-decides — against a row THIS pass did not overwrite.
+        var heldState = ReadLockStateOrRefuse(held, options, claimPath, logger);
+        if (heldState is null)
+            return Observable.Return(Unit.Default);   // refused — see ReadLockStateOrRefuse
+
         var decisionInput = (held ?? NewClaimNode(claimPath)) with
         {
-            Content = (held?.ContentAs<BuildState>(options) ?? new BuildState()) with
+            Content = heldState with
             {
                 RequestedClaims = pending,
             }
@@ -493,7 +509,7 @@ public static class BuildNodeType
                 // refusal is authoritative — and it is the arbiter's job, not the candidate's, to
                 // put the lock back where it found it.
                 return workspace.GetMeshNodeStream()
-                    .Update(current => ApplyGrant(current, granted, options))
+                    .Update(current => ApplyGrant(current, granted, options, logger))
                     .Take(1)
                     .SelectMany(published => HandBackAStoodDownGrant(
                         storage, options, logger, granted, claimPath, published));
@@ -596,6 +612,63 @@ public static class BuildNodeType
     }
 
     /// <summary>
+    /// The claim LOCK's state as a DECISION — absent, readable, or refused. Extracted so the
+    /// refusal the arbiter actually ships can be driven from a test, the same way
+    /// <see cref="ApplyGrant"/> and <see cref="StandDown"/> are.
+    ///
+    /// <para>🚨 ABSENT and UNREADABLE are different facts (#3623), and this is the one place the
+    /// distinction protects a DURABLE row rather than a mirror. <c>null</c> here means REFUSE:
+    /// deciding on a default-valued state would have the pass believe nobody holds the build and
+    /// nothing is stale, and the compare-and-set that follows would then COMMIT that belief — it
+    /// diffs against the real row's version, so it succeeds. The live holder is evicted from the
+    /// one witness every cluster's arbiter reads, and a second full bake starts on a build somebody
+    /// is already running.</para>
+    /// </summary>
+    /// <param name="held">The lock row as storage answered it, or <c>null</c> when there is none.</param>
+    /// <param name="options">Serializer options for content recovery.</param>
+    /// <param name="claimPath">The lock's path, for the diagnostic.</param>
+    /// <param name="logger">Diagnostics — the refusal is invisible without it.</param>
+    /// <returns>A fresh state when the row is ABSENT (the insert case, <c>expectedVersion 0</c>);
+    /// the row's state when it reads; <c>null</c> to refuse the whole pass.</returns>
+    internal static BuildState? ReadLockStateOrRefuse(
+        MeshNode? held, System.Text.Json.JsonSerializerOptions options, string claimPath,
+        ILogger? logger)
+    {
+        if (held is null)
+            return new BuildState();
+
+        var state = held.ContentAs<BuildState>(options);
+        if (state is not null)
+            return state;
+
+        logger?.LogError(
+            "Build claim {ClaimPath}: REFUSING to arbitrate — the lock row is present and could "
+            + "not be read as BuildState (runtime type {ContentType}). NOTHING was committed: "
+            + "deciding on a default-valued state would have written 'nobody holds this build' "
+            + "over the live holder, evicting it from the only witness every cluster's arbiter "
+            + "reads and starting a second bake on a build already running. The arbiter is "
+            + "level-triggered, so the next trigger re-decides — against a row this pass did not "
+            + "overwrite. Raw: {RawJson}",
+            claimPath,
+            held.Content?.GetType().FullName ?? "<null>",
+            ContentExcerpt(held.Content));
+        return null;
+    }
+
+    /// <summary>
+    /// A bounded, printable excerpt of a node's content for a diagnostic. Used only on the refusal
+    /// paths, where the whole point is that the value could NOT be read — so the raw bytes are the
+    /// only thing that identifies the offending row.
+    /// </summary>
+    private const int ContentExcerptLimit = 400;
+
+    private static string ContentExcerpt(object? content)
+    {
+        var text = content?.ToString() ?? "<null>";
+        return text.Length <= ContentExcerptLimit ? text : text[..ContentExcerptLimit] + "…";
+    }
+
+    /// <summary>
     /// A fresh, unheld claim lock — the node the compare-and-set INSERTS when nobody holds the
     /// build (<c>expectedVersion 0</c>).
     /// </summary>
@@ -614,11 +687,39 @@ public static class BuildNodeType
     /// Applies a grant this cluster WON durably onto its own mirror — the claim field set only, so
     /// nothing the mirror holds and storage has not seen yet is lost.
     /// </summary>
+    /// <param name="node">The Build node as read inside the update lambda.</param>
+    /// <param name="granted">The state this pass won durably.</param>
+    /// <param name="options">Serializer options for content recovery.</param>
+    /// <param name="logger">Diagnostics — the refusal below is invisible without it.</param>
     internal static MeshNode ApplyGrant(
-        MeshNode node, BuildState granted, System.Text.Json.JsonSerializerOptions options)
+        MeshNode node, BuildState granted, System.Text.Json.JsonSerializerOptions options,
+        ILogger? logger = null)
     {
         if (node is null) return node!;
-        var state = node.ContentAs<BuildState>(options) ?? new BuildState();
+        // 🚨 ABSENT and UNREADABLE are different facts (#3623). `?? new BuildState()` made them one,
+        // and the consequences ran both ways: with a non-null ClaimedBy every guard below then
+        // evaluated against a fiction in which nobody is registered and nobody stood down, and with
+        // a null one the method fell through and WROTE that fiction onto the mirror — a Build node
+        // whose registrations, holder, status and stand-down marks are all replaced by defaults.
+        //
+        // Refused instead: return the node untouched, exactly as the three sibling deciders on this
+        // node already do for an unreadable mirror (StandDown, ReleaseStoodDownClaim, Arbitrate).
+        // That is the recoverable outcome AND the one the protocol already handles — a refused
+        // publication is what HandBackAStoodDownGrant reads, so the lock this pass took is released
+        // rather than stranded. A throw here would strand it, which is why the framework's typed
+        // Update overload is deliberately NOT used at this call site.
+        var state = node.Content is null ? new BuildState() : node.ContentAs<BuildState>(options);
+        if (state is null)
+        {
+            logger?.LogError(
+                "Build node {Path}: REFUSING to publish the grant to {Holder} — the mirror's content "
+                + "is present and could not be read as BuildState (runtime type {ContentType}). "
+                + "NOTHING was written: publishing over a default-valued state would have dropped "
+                + "every pending registration, the live holder and every stand-down mark. The lock "
+                + "this pass took is handed back, so the next candidate elects freely.",
+                node.Path, granted.ClaimedBy, node.Content?.GetType().FullName ?? "<null>");
+            return node;
+        }
         if (state.ClaimedBy == granted.ClaimedBy && state.Status == granted.Status)
             return node;   // already reflects this grant — a redundant pass writes nothing
 

--- a/src/MeshWeaver.Graph/PresentationLayoutArea.cs
+++ b/src/MeshWeaver.Graph/PresentationLayoutArea.cs
@@ -107,10 +107,23 @@ public static class PresentationLayoutArea
 
         // The ONE mutation API: the owning user hub serialises every writer, so two marks made from
         // two tabs cannot clobber each other, and the update lambda touches only HiddenPaths.
+        //
+        // 🚨 The TYPED overload, and on this node it is the difference between a preference and an
+        // ACCOUNT (#3623). `node.ContentAs<User>(options) ?? new User()` answered the same value —
+        // an empty User — for "this node has no content yet" and for "the content is present and
+        // this build cannot read it", and the second is a real state in a running mesh (untyped
+        // JSON whose $type will not resolve, the as-written JsonObject DOM, a same-named record
+        // from another collectible assembly). The write then persisted that empty record over the
+        // viewer's OWN user node: every field this lambda never touches — display name, email,
+        // locale, every setting — replaced by defaults, silently, on a hide/show click. Here `null`
+        // means ABSENT and only absent; unreadable content faults the observable and the write does
+        // NOT happen, which the onError arm below reports.
         host.Hub.GetMeshNodeStream(viewerId!)
-            .Update(node =>
+            .Update<User>((node, content) =>
             {
-                var user = node.ContentAs<User>(options) ?? new User();
+                // Absent stays create-on-write: a user node that genuinely carries no content yet
+                // is not an error, and the mark is the first thing written to it.
+                var user = content ?? new User();
                 var marks = PresentationPreference.ApplyMark(user.HiddenPaths, hubPath, hide);
                 return ReferenceEquals(marks, user.HiddenPaths)
                     ? node

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -291,13 +291,21 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
             // inherited the script runner's AccessContext; the activity log is infrastructure
             // observability, not a user write.
             using (_accessService?.ImpersonateAsSystem())
-                stream.Update(node =>
+                stream.Update<ActivityLog>((node, content) =>
                     {
-                        // ContentAs, never `is ActivityLog`: a degraded JsonElement (a hub whose
-                        // TypeRegistry lacks the discriminator) would make a type test null, the
-                        // lambda would no-op, and the run's output would never surface.
-                        var current = node.ContentAs<ActivityLog>(options, _diagnostics)
-                                      ?? new ActivityLog("ScriptExecution");
+                        // 🚨 The TYPED overload, and on this node it is what makes the comment above
+                        // TRUE (#3623). `ContentAs<ActivityLog>(…) ?? new ActivityLog("…")` answered
+                        // the same fresh record for "this activity has no content yet" and for "the
+                        // content is present and this build cannot read it" — and on the second
+                        // reading the write below persisted that fresh record, so exactly the fields
+                        // this lambda does NOT set were the ones destroyed: the Id, HubPath, Start
+                        // and User the dispatcher stamped at creation, and any RequestedStatus a
+                        // concurrent control-plane writer had set. A cancel in flight would have
+                        // been erased by the next 100 ms log flush.
+                        //
+                        // Here `null` means ABSENT and only absent; unreadable content faults the
+                        // observable and the snapshot is NOT written, which the onError arm reports.
+                        var current = content ?? new ActivityLog("ScriptExecution");
                         return node with
                         {
                             Content = current with
@@ -316,9 +324,29 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
                     })
                     .Subscribe(
                         _ => { },
-                        ex => _diagnostics?.LogDebug(ex,
-                            "ActivityLogLogger: publishing the log snapshot for {Path} failed",
-                            activityLogPath),
+                        // 🚨 A REFUSED write is not an ordinary publish failure and must not share
+                        // its level (#3623). Everything else here is Debug on purpose — a snapshot
+                        // that loses a race with teardown is expected and worthless to report at
+                        // volume — but a Deserialization refusal says the activity record on disk
+                        // cannot be read by this build, which is a data fault that will recur on
+                        // every flush of every run against that node and which nobody can act on
+                        // without seeing it. This is a NEW branch for a NEW condition, not the
+                        // verbosity of the existing one being dialled.
+                        ex =>
+                        {
+                            if (ex is MeshNodeStreamException { Error.Code: MeshNodeErrorCode.Deserialization })
+                                _diagnostics?.LogWarning(ex,
+                                    "ActivityLogLogger: REFUSED to publish the log snapshot for {Path} "
+                                    + "— the activity record is present and could not be read as "
+                                    + "ActivityLog. NOTHING was written: a default-valued record would "
+                                    + "have erased the Id, HubPath, Start and User the dispatcher "
+                                    + "stamped, plus any RequestedStatus a cancel had just set.",
+                                    activityLogPath);
+                            else
+                                _diagnostics?.LogDebug(ex,
+                                    "ActivityLogLogger: publishing the log snapshot for {Path} failed",
+                                    activityLogPath);
+                        },
                         // 🚨 #3117 — the highest-volume terminal _Activity writer in the platform
                         // (every kernel run, script, markdown execution and test run) bypasses
                         // ActivityLogAppender.Append, so it never fired the release that retires the

--- a/test/MeshWeaver.Documentation.Test/DefaultedContentReadInsideAnUpdateLambdaGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/DefaultedContentReadInsideAnUpdateLambdaGuard.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>Zero-tolerance ratchet (#3623): an untyped <c>Update</c> lambda may not turn a FAILED READ
+/// into a WRITTEN DEFAULT.</b>
+///
+/// <para><b>The defect class.</b> A read of <c>MeshNode.Content</c> must stay bad-data tolerant —
+/// <c>ContentAs&lt;T&gt;</c> / <c>As&lt;T&gt;</c> answer <c>null</c> rather than throw, because a
+/// settings tab that throws is worse than one showing a fail-closed default. <b>That same tolerance
+/// destroys data on a WRITE.</b> Inside <c>stream.Update(node =&gt; …)</c>,
+/// <c>node.ContentAs&lt;T&gt;(opts) ?? new T()</c> makes <i>"there is nothing here"</i> and <i>"I
+/// could not read what is here"</i> the same answer, and the write then persists a default-valued
+/// record over every field the caller never touched.</para>
+///
+/// <para><b>All three unreadable shapes happen in a running mesh</b>, and none of them throws:
+/// untyped JSON whose <c>$type</c> will not resolve; the as-written <c>JsonObject</c> DOM before the
+/// materialisation pipeline re-types it; and a same-named record from another collectible assembly,
+/// which every NodeType recompile mints. From outside, all three look like "the content was empty".</para>
+///
+/// <para><b>The fix is a type argument, never care.</b>
+/// <c>Update&lt;TContent&gt;((node, content) =&gt; …)</c> — whose <c>null</c> means ABSENT and only
+/// absent, and which faults with a <c>MeshNodeStreamException</c> (path, runtime type, JSON
+/// excerpt, <b>write not applied</b>) when the content is present and unreadable. See
+/// <c>Doc/Architecture/CqrsAndContentAccess</c> → "Writes".</para>
+///
+/// <para><b>Why a guard rather than care.</b> The wrong spelling is the one that reads naturally,
+/// it compiles, it passes every test that does not seed unreadable content, and the loss is
+/// invisible at the call site AND at runtime: the write completes, nothing is logged, and the
+/// damage surfaces later as a field that "went missing". Two production incidents came from exactly
+/// this — <c>Admin/UpdatePolicy</c> losing its own policy ahead of a portal rolling itself onto a
+/// withdrawn version line (#3542), and <c>ThreadInput.AppendUserInput</c> resetting <c>Status</c> to
+/// <c>Idle</c> (the CheckInbox flake).</para>
+///
+/// <para>🚨 <b>There is no allow file, deliberately.</b> Every occurrence has a mechanical fix that
+/// preserves create-on-absent behaviour exactly, so an exemption would only ever mean "this one may
+/// keep destroying records".</para>
+/// </summary>
+public class DefaultedContentReadInsideAnUpdateLambdaGuard
+{
+    /// <summary>Production trees only. A TEST may legitimately build a defaulted record while
+    /// constructing a fixture; only shipped write paths are the subject.</summary>
+    private static readonly string[] ScannedRoots = ["src", "memex"];
+
+    /// <summary>
+    /// An UNTYPED update lambda: <c>.Update(node =&gt;</c>. The typed overloads are
+    /// <c>.Update&lt;T&gt;(…)</c> and do not match, which is the whole point — the type argument is
+    /// what removes the guess.
+    /// </summary>
+    private static readonly Regex UpdateLambda = new(
+        @"\.Update\(\s*[A-Za-z_]\w*\s*=>", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A defaulting content read: <c>ContentAs&lt;T&gt;(…) ?? new</c> or <c>… as T ?? new</c>, with
+    /// any whitespace or newline between the read and the fallback (they are almost always on
+    /// separate lines). One level of nested parentheses in the argument list is tolerated.
+    /// </summary>
+    private static readonly Regex DefaultedRead = new(
+        @"(?:ContentAs|As)\s*<\s*\w+\s*>\s*\((?:[^()]|\([^()]*\))*\)\s*\?\?\s*new\b"
+        + @"|\.Content\s+as\s+\w+\s*\?\?\s*new\b",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// How far after the lambda's <c>=&gt;</c> a read still counts as being inside it. Generous
+    /// rather than exact: a brace-matched parse would be more precise and much easier to get subtly
+    /// wrong, and the cost of overreach here is a false POSITIVE — which is loud, reviewable, and
+    /// the safe direction for a ratchet that must not silently stop enforcing.
+    /// </summary>
+    private const int LambdaWindow = 1600;
+
+    [Fact]
+    public void NoUntypedUpdateLambdaTurnsAFailedReadIntoAWrittenDefault()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var offenders = new List<string>();
+        var files = 0;
+        var lambdas = 0;
+
+        foreach (var file in SourceScan.SourceFiles(root, ScannedRoots))
+        {
+            files++;
+            // 🚨 Masked, not raw: this very rule is DESCRIBED in comments across the tree (including
+            // in the files it was applied to, which quote the old shape to say why it went), and a
+            // raw scan would flag the explanations as offences.
+            var text = SourceScan.MaskCommentsAndStrings(File.ReadAllText(file));
+
+            foreach (Match lambda in UpdateLambda.Matches(text))
+            {
+                lambdas++;
+                var length = Math.Min(LambdaWindow, text.Length - lambda.Index);
+                foreach (Match read in DefaultedRead.Matches(text.Substring(lambda.Index, length)))
+                    offenders.Add(
+                        $"{SourceScan.Relative(root, file)}:{LineOf(text, lambda.Index)} — "
+                        + Collapse(read.Value));
+            }
+        }
+
+        // 🚨 The DENOMINATOR. A zero here has two causes — "nothing offends" and "nothing was
+        // examined" — and only one of them is good news. SourceFiles already refuses an empty file
+        // set (#2844); this adds the half it cannot see: a regex that stopped matching the shape it
+        // is aimed at, e.g. after a rename of Update or a reformat of the lambda syntax.
+        Assert.True(
+            lambdas >= 40,
+            $"only {lambdas} untyped Update lambda(s) found across {files} file(s) — the scan is "
+            + "not looking at what it thinks it is. There were 72 on 2026-09-07, and they do not "
+            + "vanish in a batch: a count this low means UpdateLambda stopped matching (a rename, a "
+            + "reformat, a moved tree), so this guard is reporting green having examined nothing.");
+
+        Assert.True(
+            offenders.Count == 0,
+            "an untyped Update lambda reads Content through a DEFAULTING parse. `?? new T()` there "
+            + "makes 'there is nothing here' and 'I could not read what is here' the same answer, "
+            + "and the write persists a default-valued record over every field the caller never "
+            + "touched — silently: the write completes, nothing is logged, and the loss surfaces "
+            + "later as a field that went missing (#3542, #3623).\n\n"
+            + "FIX: `stream.Update<TContent>((node, content) => node with { Content = "
+            + "(content ?? new TContent()) with { … } })`. Its `null` means ABSENT and only absent, "
+            + "so create-on-absent is preserved exactly, and PRESENT-but-unreadable content faults "
+            + "with a MeshNodeStreamException naming the path, the runtime type and a JSON excerpt "
+            + "— with the write NOT applied. Doc/Architecture/CqrsAndContentAccess -> Writes.\n\n"
+            + "There is no allow file: the fix is mechanical and behaviour-preserving, so an "
+            + "exemption could only ever mean 'this one may keep destroying records'.\n\n"
+            + string.Join("\n", offenders.Select(o => "  " + o)));
+    }
+
+    private static int LineOf(string text, int index) =>
+        text.Take(index).Count(c => c == '\n') + 1;
+
+    private static string Collapse(string value) =>
+        Regex.Replace(value, @"\s+", " ").Trim();
+}

--- a/test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -519,5 +521,196 @@ public class BuildGrantPublicationTest
             .Should().NotBe(
                 BuildNodeType.ArbitrationTrigger(queued),
                 "the holder releasing is what makes the queued candidate grantable");
+    }
+
+    // ── a mirror this build cannot READ ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A mirror whose content is PRESENT and cannot be materialised as <c>BuildState</c> — the
+    /// third of the three shapes <c>.ContentAs&lt;T&gt;</c> exists for, modelled as JSON whose
+    /// <c>RequestedClaims</c> is a string where a map belongs.
+    ///
+    /// <para>This is a PURE decision test: nothing here goes through <c>MeshNodeStreamCache</c>, so
+    /// no degradation is logged and the untyped-content shard gate is not involved. A test that
+    /// drove a real mesh would need the other fixture shape — a value of a different REGISTERED
+    /// type — for exactly that reason; see <c>Doc/Architecture/ReadingCiSignals</c>.</para>
+    /// </summary>
+    private static MeshNode UnreadableMirror() =>
+        new("Build", "Admin")
+        {
+            NodeType = BuildNodeType.NodeType,
+            Content = JsonSerializer.Deserialize<JsonElement>(
+                """{"RequestedClaims":"written-by-a-shape-this-build-cannot-read"}"""),
+        };
+
+    /// <summary>
+    /// 🚨 The fixture is only a fixture if it is genuinely unreadable. Asserted first, because every
+    /// arm below is vacuous the moment this stops being true — a JSON shape the record happens to
+    /// tolerate would make them all pass against the very defect they exist to refuse.
+    /// </summary>
+    [Fact]
+    public void TheUnreadableFixture_IsActuallyUnreadable()
+    {
+        var mirror = UnreadableMirror();
+
+        mirror.Content.Should().NotBeNull("PRESENT is half the point — absent content is a different fact");
+        mirror.ContentAs<BuildState>(Options).Should().BeNull(
+            "'present and this build cannot read it' is the state under test; if the record "
+            + "tolerates this JSON the arms below assert nothing at all");
+    }
+
+    /// <summary>
+    /// 🚨 <b>#3623 — the write that WAS reachable.</b> <c>ApplyGrant</c> read the mirror through
+    /// <c>ContentAs&lt;BuildState&gt;(options) ?? new BuildState()</c>, so an unreadable mirror
+    /// became an EMPTY one. With a holder in the grant the candidate guard then happened to refuse —
+    /// the right outcome for the wrong reason, and silently. With NO holder every guard falls
+    /// through and the method WRITES that empty record onto the Build node: registrations, holder,
+    /// status and stand-down marks all replaced by defaults, in one merge patch, with nothing said.
+    ///
+    /// <para>This arm is the discriminating one: it fails against the pre-#3623 implementation and
+    /// passes after it.</para>
+    /// </summary>
+    [Fact]
+    public void AGrantWithNoHolder_NeverOverwritesAMirrorThisBuildCannotRead()
+    {
+        var mirror = UnreadableMirror();
+
+        BuildNodeType.ApplyGrant(mirror, Granted() with { ClaimedBy = null }, Options)
+            .Should().BeSameAs(mirror,
+                "a failed READ must never become a written DEFAULT — the same node returned is the "
+                + "only outcome that leaves the record intact");
+    }
+
+    /// <summary>
+    /// The ordinary holder-carrying grant is refused too, and now for the stated reason rather than
+    /// by accident of an empty candidate map. The refusal is what
+    /// <c>HandBackAStoodDownGrant</c> reads, so the lock the pass took is released rather than
+    /// stranded — which is why this path refuses instead of throwing.
+    /// </summary>
+    [Fact]
+    public void AGrantIsNotPublished_OverAMirrorThisBuildCannotRead()
+    {
+        var mirror = UnreadableMirror();
+
+        BuildNodeType.ApplyGrant(mirror, Granted(), Options).Should().BeSameAs(mirror);
+    }
+
+    /// <summary>
+    /// 🚨 And it SAYS so. A refusal nobody can see is the shape that made #3623 invisible in the
+    /// first place: the write simply did not happen, nothing was logged, and the loss surfaced
+    /// later as a field that "went missing". The record names the node and the holder it withheld.
+    /// </summary>
+    [Fact]
+    public void TheRefusalIsRecorded_NamingTheNodeAndTheHolder()
+    {
+        var logger = new RecordingLogger();
+
+        BuildNodeType.ApplyGrant(UnreadableMirror(), Granted(), Options, logger);
+
+        var record = Assert.Single(logger.Records);
+        record.Level.Should().Be(LogLevel.Error);
+        record.Message.Should().Contain("REFUSING to publish the grant");
+        record.Message.Should().Contain("Admin/Build");
+        record.Message.Should().Contain(Winner);
+    }
+
+    /// <summary>
+    /// 🚨 Non-vacuity for all four arms above. A readable mirror still publishes — otherwise
+    /// "the grant was refused" would be satisfied by an <c>ApplyGrant</c> that never grants
+    /// anything, and the whole arbitration would be dead with every test green.
+    /// </summary>
+    [Fact]
+    public void AReadableMirror_StillPublishesAndLogsNothing()
+    {
+        var logger = new RecordingLogger();
+        var mirror = Mirror(new BuildState
+        {
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add(Winner, new BuildClaimRequest("fp", T0)),
+        });
+
+        var published = BuildNodeType.ApplyGrant(mirror, Granted(), Options, logger)
+            .ContentAs<BuildState>(Options)!;
+
+        published.ClaimedBy.Should().Be(Winner);
+        logger.Records.Should().BeEmpty("a healthy publication is not a fault");
+    }
+
+    // ── the DURABLE half: the claim lock the compare-and-set commits against ────────────────────
+
+    /// <summary>
+    /// 🚨 #3623 on the row that matters most. <c>CommitGrant</c> read the LOCK through
+    /// <c>held?.ContentAs&lt;BuildState&gt;(options) ?? new BuildState()</c>, which answered the same
+    /// empty state for "there is no lock row yet" — correct, that is the INSERT case at
+    /// <c>expectedVersion 0</c> — and for "the row is there and this build cannot read it". On the
+    /// second reading the pass decides in a world where nobody holds the build, and then COMMITS
+    /// it: the compare-and-set diffs against the REAL row's version, so it succeeds. The live
+    /// holder is evicted from the one witness every cluster's arbiter reads.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableLockRow_RefusesTheWholePass()
+    {
+        var logger = new RecordingLogger();
+        var lockRow = new MeshNode("_Claim", "Admin/Build")
+        {
+            NodeType = BuildNodeType.NodeType,
+            Content = JsonSerializer.Deserialize<JsonElement>(
+                """{"RequestedClaims":"written-by-a-shape-this-build-cannot-read"}"""),
+        };
+        lockRow.ContentAs<BuildState>(Options).Should().BeNull("the fixture must actually be unreadable");
+
+        BuildNodeType.ReadLockStateOrRefuse(lockRow, Options, "Admin/Build/_Claim", logger)
+            .Should().BeNull("refusing the pass is the only outcome that leaves the lock row intact");
+
+        var record = Assert.Single(logger.Records);
+        record.Level.Should().Be(LogLevel.Error);
+        record.Message.Should().Contain("REFUSING to arbitrate");
+        record.Message.Should().Contain("Admin/Build/_Claim");
+    }
+
+    /// <summary>
+    /// 🚨 Non-vacuity, both halves. An ABSENT row is the insert case and must still yield a fresh
+    /// state — refusing it would mean no build is ever claimed on a cluster that has not run one —
+    /// and a READABLE row must come back as itself, holder and all.
+    /// </summary>
+    [Fact]
+    public void AnAbsentLockRowInserts_AndAReadableOneIsReturnedUnchanged()
+    {
+        var logger = new RecordingLogger();
+
+        BuildNodeType.ReadLockStateOrRefuse(null, Options, "Admin/Build/_Claim", logger)
+            .Should().NotBeNull("no lock row yet IS the insert case — expectedVersion 0");
+
+        var readable = BuildNodeType.ReadLockStateOrRefuse(
+            Lock(Granted()), Options, "Admin/Build/_Claim", logger);
+
+        readable.Should().NotBeNull();
+        readable!.ClaimedBy.Should().Be(Winner);
+        logger.Records.Should().BeEmpty("neither of these is a fault");
+    }
+
+    private sealed record LogRecord(LogLevel Level, string Message);
+
+    /// <summary>Captures level and formatted message — enough to assert that the refusal is
+    /// visible and names what it withheld.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly List<LogRecord> records = [];
+
+        public IReadOnlyList<LogRecord> Records => records;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => records.Add(new LogRecord(logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }


### PR DESCRIPTION
Closes #3623.

## The class, and why it is silent

A read of `MeshNode.Content` must stay bad-data tolerant: `ContentAs<T>` / `As<T>` answer `null`
rather than throw, because a settings tab that throws is worse than one showing a fail-closed
default. **That same tolerance destroys data on a write.** Inside `stream.Update(node => …)`,
`node.ContentAs<T>(opts) ?? new T()` makes *"there is nothing here"* and *"I could not read what is
here"* the same answer, and the write then persists a default-valued record over every field the
caller never touched. The write completes, nothing is logged, and the loss surfaces later as a field
that "went missing" — which is how `Admin/UpdatePolicy` lost its own policy ahead of a portal
rolling itself onto a withdrawn version line (#3542), and how `ThreadInput.AppendUserInput` reset
`Status` to `Idle` (the CheckInbox flake).

All three unreadable shapes happen in a running mesh and none of them throws: untyped JSON whose
`$type` will not resolve, the as-written `JsonObject` DOM before the materialisation pipeline
re-types it, and a same-named record from another collectible assembly — every NodeType recompile
mints one.

## Established per site, before changing anything

The issue named five. Each was read through to the write it feeds; two of them are worse than the
issue states and one is narrower, and both corrections are in the table.

| site | content | does the write actually happen? |
|---|---|---|
| `PresentationLayoutArea.cs` | `User` | **Yes, in BOTH directions.** `new User().HiddenPaths` is `null`; `ApplyMark(null, path, hide:true)` returns a fresh list and `hide:false` returns `ImmutableList.Empty` — neither is reference-equal to `null`, so the guard `ReferenceEquals(marks, user.HiddenPaths)` passes them both through. **A viewer's whole account record replaced by defaults on a hide *or* a show click.** The issue said "on a hide/show mark"; it is in fact not idempotent-safe in either direction. |
| `GitHubWebhookProcessor.cs` | `GitHubSyncConfig` | **Yes**, unconditionally — the token reference, branch, path mapping and `LastSyncCommitSha` of a repo whose only sin was being renamed. |
| `BuildCoordinationExtensions.cs` | `BuildState` | **Yes.** An empty state fails both early-outs, so the write lands: every OTHER candidate's registration, the live `ClaimedBy`/`Status`, the `Ready` map and every `StoodDown` mark, replaced by defaults plus this one registration. |
| `BuildNodeType.CommitGrant` | `BuildState` | **Yes, and this one is DURABLE.** Not a `stream.Update` at all — it decides on the claim LOCK read from storage and commits with `WriteIfVersion`. Deciding on an empty state means "nobody holds the build, nothing is stale", and the compare-and-set then succeeds because it diffs against the real row's version. The live holder is evicted from the one witness every cluster's arbiter reads, and a second full bake starts on a build already running. |
| `BuildNodeType.ApplyGrant` | `BuildState` | **Narrower than the issue states, and worth saying so.** With a holder-carrying grant the candidate guard happens to refuse — the right outcome for the wrong reason, and silently. It becomes a write when `granted.ClaimedBy` is `null`, and every guard in between is meanwhile evaluating a fiction. Measured by falsification below, not by argument. |
| `ActivityLogLogger.cs` | `ActivityLog` | **Yes**, on every 100 ms flush. Exactly the fields the lambda does NOT set are the ones lost: the `Id`, `HubPath`, `Start` and `User` the dispatcher stamped, and any `RequestedStatus` a concurrent cancel had just written. The comment above that write claims those "ride through untouched"; on an unreadable record it was false. |

## The fix

**Four sites take the framework primitive.** `Update<TContent>((node, content) => …)` — `null` means
ABSENT and only absent, so create-on-absent is preserved exactly, while present-but-unreadable
content faults with a `MeshNodeStreamException` naming the path, the runtime type and a JSON
excerpt, **with the write not applied**. Every one of them already had an `onError` arm, so the
refusal is reported where the failure was already reported.

**Two sites do not fit it, and here is why.** `CommitGrant` is not a `stream.Update` — it decides on
a storage read and commits a compare-and-set — and `ApplyGrant` is a pure decision function called
from inside an untyped lambda. Both now do by hand what the primitive does: `null` when `Content is
null`, and **refuse loudly** when it is present and unreadable. Both refuse by *writing nothing and
logging what was withheld*, never by throwing — a throw at `ApplyGrant` would strand the lock the
pass just took, because a refused publication is precisely what `HandBackAStoodDownGrant` reads in
order to release it. Refusing this way is also what the three sibling deciders on that node already
do (`StandDown`, `ReleaseStoodDownClaim`, `Arbitrate`); they were simply silent about it.

**The nullable-backing-field shape from #3607 does not apply here** and was deliberately not
reached for. That shape solves a different problem — an enum whose zero value is the permissive
state, so an absent field and a chosen value are indistinguishable *within one record*. Nothing
here has a defaulted member standing in for absence; the ambiguity is between "no content" and
"unreadable content", one level up, and the type argument is what resolves it.

**`ApplyGrant` gains an optional `ILogger?`** (internal, so no public surface moves) and
`CommitGrant`'s lock read is extracted as `ReadLockStateOrRefuse` — a decision, testable the same
way `ApplyGrant` and `StandDown` already are, which is the pattern this file states for itself.

## The control that covers the denominator, not the five

`DefaultedContentReadInsideAnUpdateLambdaGuard` scans `src/` and `memex/` for an untyped `.Update(x
=> …)` lambda containing `ContentAs<T>(…) ?? new` or `… .Content as T ?? new`, and holds it at
**zero**. Five bespoke tests would cover five sites; this covers the 72 untyped lambdas that exist
today and every one added tomorrow. It scans comment-masked source (the fixed files quote the old
shape to explain why it went), and it asserts its own **denominator** — fewer than 40 lambdas found
means the regex stopped matching, not that the tree got clean.

**There is no allow file, deliberately.** The correction is mechanical and preserves behaviour
exactly when the record *is* readable, so an exemption could only ever mean "this one may keep
destroying records".

## 🚨 Falsified — every new assertion made to fail against the pre-fix code

Reverted the fixes, rebuilt, re-ran; exit codes read directly, never through a pipe.

| reverted | result |
|---|---|
| `BuildCoordinationExtensions` back to the untyped lambda | the guard **fails**, naming `src/MeshWeaver.Graph/BuildCoordinationExtensions.cs:99 — ContentAs<BuildState>(hub.JsonSerializerOptions) ?? new` |
| `ApplyGrant` back to `?? new BuildState()` | `AGrantWithNoHolder_NeverOverwritesAMirrorThisBuildCannotRead` **fails** — *"Expected value to refer to the same instance … but it did not"*, i.e. it wrote; and `TheRefusalIsRecorded_NamingTheNodeAndTheHolder` fails with an empty log |
| `ReadLockStateOrRefuse` back to `?? new BuildState()` | `AnUnreadableLockRow_RefusesTheWholePass` **fails** |

Each new arm is paired with a non-vacuity control on the same input — a readable mirror still
publishes, an absent lock row still inserts, a readable one comes back holder and all — because
"the write was refused" is otherwise satisfied by an arbiter that never grants anything, and the
whole protocol would be dead with every test green. The unreadable fixture is itself asserted to be
unreadable (`TheUnreadableFixture_IsActuallyUnreadable`): a JSON shape the record happened to
tolerate would make every arm pass against the very defect they refuse.

## 🚨 One thing the next person must know, and it touches #3619

These tests model *"present but unreadable"* as **malformed JSON**, which is safe here because they
are pure decisions that never reach `MeshNodeStreamCache`. **A test that drives a REAL mesh must not
use that shape.** Once #3625 lands, an unreadable node read through the stream cache emits a
degradation record that reaches the trace log, and `check-untyped-content.sh` reds the shard on it —
correctly: the fixture really is content nothing can read.

The shape that works on a real mesh, and is a *better* model of production, is to seed a value of a
**different, registered type**: the cache types it happily, so nothing degrades and nothing is
recorded, while `ContentAs<T>` still answers `null` because it recovers a foreign runtime type only
when the short name matches. That is the same-named-record-from-another-assembly case, which is the
one that actually happens. Written up in `Doc/Architecture/ReadingCiSignals` by #3625.

**#3619's `UnreadablePolicyRecordIsNotClobberedTest` uses the malformed-JSON shape on a real mesh**
and will red its shard once both land. It needs the other fixture shape before #3625 merges.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, exit read directly:
  `MeshWeaver.Graph`, `MeshWeaver.GitSync`, `MeshWeaver.Kernel.Hub`, `MeshWeaver.Graph.Test`,
  `MeshWeaver.Documentation.Test` — all `0 Warning(s) 0 Error(s)`.
- `BuildGrantPublicationTest` **27/27** (20 pre-existing + 7 new).
- `MeshWeaver.Graph.Test` filtered to `Presentation|Build` — **172/172**.
- `MeshWeaver.Documentation.Test` **323/323** — the whole guard wall, including the new ratchet and
  `DocumentationLinkIntegrityTest` / `WhatsNewEntryIntegrityTest` after the doc edits.

## Work product conserved

`Doc/Architecture/CqrsAndContentAccess` → "Writes" now teaches the typed overload as *the* write
shape, states the read/write asymmetry plainly, cites both production instances, and names the rule
for the writes that are not `stream.Update` (refuse by writing nothing and logging, not by throwing,
wherever a throw would strand a lock the caller must hand back). **This is the same section #3619
rewrites** — whichever lands second resolves; the content agrees.

What's New: `Category: Fix` — "A record the portal cannot read is no longer a record it overwrites".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
