### PR TITLE
fix: a deployment stops shipping a database credential it cannot use, and keeps its migration record (Memex#204, Memex#188)

### DIFF
--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -21,7 +21,20 @@ metadata:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
 spec:
   backoffLimit: 6
-  ttlSecondsAfterFinished: 600
+  # 🚨 THIS JOB IS THE ONLY EVIDENCE THAT THIS REVISION'S MIGRATION RAN — so its lifetime must
+  # outlive whoever reads it. `ttlSecondsAfterFinished` reaps a FINISHED Job whether it Completed
+  # or Failed, and at 600 s it reaped the record before the reader looked.
+  #
+  # The reader is Memex's `helm-release.yml`, whose observe step polls
+  # `kubectl get job memex-migration-<revision>` and decides `DONE` from it. Its budget is 25 min
+  # inside a deploy and 40 min on an `action: observe` re-run — both far longer than 600 s — and
+  # its error message tells the operator to re-run `observe` LATER. Measured 2026-09-07: `memex`
+  # revision 35's Job was `active=1` when run 34117537570 gave up at its budget, and by 16:20Z the
+  # Job, its pod and its events were all gone. An `observe` run at that moment reads no Job at all,
+  # which is indistinguishable from a Job that never existed — and a migration that FAILED reaps
+  # exactly the same way. 86400 s makes the artefact outlive every window that reads it; the
+  # verdict refusing to call an absent Job a success is the other half (Memex#188).
+  ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:

--- a/deploy/helm/templates/memex-migration/secrets.yaml
+++ b/deploy/helm/templates/memex-migration/secrets.yaml
@@ -13,8 +13,18 @@ stringData:
   # database and its membership tables (OrleansClusteringSetup), so pointing it at the wrong server
   # does not just fail the job — it leaves an AdoNet portal with no membership store to join.
   ConnectionStrings__memex: {{ .Values.secrets.memex_migration.ConnectionStrings__memex | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=memex" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
+  # The compose-shaped in-cluster Postgres pair — rendered only where an in-cluster Postgres
+  # exists, exactly as in memex-portal/secrets.yaml beside it (Memex#204; the full measurement and
+  # the cross-repo "read by nothing" sweep are recorded there, and in Doc/Architecture/DeploymentAKS).
+  # Unconditional, they put a present-but-EMPTY password and a DERIVED, plausible, wrong URI
+  # (`postgresql://postgres:@memex-postgres-service:5432/memex`) into every AKS migration Secret —
+  # the one shape that survives both a `keys[]` audit and a base64-length audit.
+  {{- if or .Values.postgres.enabled .Values.secrets.memex_migration.memex_postgres_password }}
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_migration.memex_postgres_password }}"
+  {{- end }}
+  {{- if or .Values.postgres.enabled .Values.secrets.memex_migration.MEMEX_URI }}
   MEMEX_URI: {{ .Values.secrets.memex_migration.MEMEX_URI | default (printf "postgresql://postgres:%s@memex-postgres-service:5432/memex" .Values.secrets.memex_migration.memex_postgres_password) | quote }}
+  {{- end }}
   # Orleans membership tables live either in a dedicated `orleans` database (explicit
   # ConnectionStrings__orleans) or — the default for an external mesh database — in the MESH
   # database's own `orleans` SCHEMA, derived below. OrleansClusteringSetup creates whichever

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -25,8 +25,37 @@ stringData:
   ConnectionStrings__memex: {{ .Values.secrets.memex_portal.ConnectionStrings__memex | default (printf "Host=memex-postgres-service;Port=5432;Username=postgres;Password=%s;Database=memex" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
   # Content indexing writes its tables into per-partition schemas in THIS same mesh database
   # (content_chunks/content_files alongside each partition's mesh_nodes) — no separate connection.
+  #
+  # ---- the compose-shaped IN-CLUSTER Postgres pair -------------------------------------------
+  # 🚨 RENDERED ONLY WHERE AN IN-CLUSTER POSTGRES EXISTS. Both members address
+  # `memex-postgres-service`, the Service that `postgres.enabled` gates — so on a deployment with
+  # `postgres.enabled: false` (every AKS namespace: the mesh lives on the Azure flexible server and
+  # is reached through ConnectionStrings__memex) they name a host this release does not render.
+  #
+  # They used to render there anyway, and that is the defect (Memex#204). Measured 2026-09-07 by
+  # base64 LENGTH only, on the two production namespaces:
+  #
+  #     MEMEX_PASSWORD   memex b64len 40   memex-cloud b64len 0
+  #     MEMEX_URI        memex b64len 112  memex-cloud b64len 76
+  #                                        → 57 bytes = postgresql://postgres:@memex-postgres-service:5432/memex
+  #
+  # The password half is the shape a `keys[]` audit cannot see — present, empty, reads as
+  # configured. The URI half is worse: `default` fires on the empty password and DERIVES a
+  # present, non-empty, plausible and WRONG value, which survives the base64-LENGTH audit too. A
+  # secret that reads as configured and is not fails at CONNECT time with a credentials error
+  # instead of at startup with "not configured" — a materially worse 3am.
+  #
+  # Nothing reads either key: swept across MeshWeaver and MeshWeaver.Plugins over all *.cs, every
+  # match in either repository is a manifest that SETS it (compose ×4, ACA bicep ×2, helm ×2). So
+  # this conditional removes a landmine and changes nothing that runs. The keys stay for the
+  # deployments that DO run the in-cluster StatefulSet — compose, local k3s, e2e — where the same
+  # values are correct rather than vestigial.
+  {{- if or .Values.postgres.enabled .Values.secrets.memex_portal.memex_postgres_password }}
   MEMEX_PASSWORD: "{{ .Values.secrets.memex_portal.memex_postgres_password }}"
+  {{- end }}
+  {{- if or .Values.postgres.enabled .Values.secrets.memex_portal.MEMEX_URI }}
   MEMEX_URI: {{ .Values.secrets.memex_portal.MEMEX_URI | default (printf "postgresql://postgres:%s@memex-postgres-service:5432/memex" .Values.secrets.memex_portal.memex_postgres_password) | quote }}
+  {{- end }}
   # ---- Orleans AdoNet clustering (HA / multi-replica) ----------------------
   # The silo THROWS at startup when Deployment:Orleans:Clustering=AdoNet but
   # ConnectionStrings:orleans is unset — so this MUST accompany the AdoNet flag.

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -418,6 +418,72 @@ a half-migrated portal; it does **not** make the ordering safe on its own, and t
 what decides whether "unsafe ordering" costs you a stalled rollout or an outage. Treat "the migration ran" as a precondition you verify, not one
 the roll guarantees.
 
+### The migration Job IS the evidence — so it must outlive the observer
+
+`helm upgrade` mints `memex-migration-<revision>`, and that Job object is the **only** durable
+record that this revision's migration ran. Memex's `helm-release.yml` reads it directly: its
+*Observe the rollout* step polls `kubectl get deploy memex-portal-deployment` **and**
+`kubectl get job memex-migration-<revision>`, and reports `DONE` only when every replica is updated
+and available at the new generation **and** the Job succeeded.
+
+🚨 **`ttlSecondsAfterFinished` reaps a FINISHED Job whether it Completed or FAILED**, and at the
+chart's original 600 s that happened well inside the reader's own window — 25 minutes inside a
+deploy, 40 on an `action: observe` re-run, with the lane's error message explicitly telling the
+operator to *"re-run with action=observe"* later. Measured 2026-09-07 on the live cluster:
+
+| | |
+|---|---|
+| `memex` revision 35, run 34117537570 | observe gave up at its 25-minute budget with `migration-job=succeeded=0 failed=0 active=1` |
+| the same namespace at 16:20Z | **no Job, no pod, no events** — `kubectl get job -n memex` returns only the `assembly-cache-prune` Jobs |
+
+An absent Job is indistinguishable from a Job that never existed, and a migration that *failed*
+reaps exactly the same way. The chart now sets **`ttlSecondsAfterFinished: 86400`** so the artefact
+outlives every window that reads it. That is one half; the other is the verdict refusing to call an
+absent Job a success (Memex#188). **Neither half alone is enough** — a longer TTL without the
+verdict change only moves the cliff, and the verdict change without the longer TTL makes a
+legitimate `observe` re-run permanently red.
+
+**A `memex-cloud` migration is measured in HOURS, not minutes, and that is not a deadlock.**
+`memex-migration-28` ran 4 h 47 m on 2026-09-07 and was healthy throughout: the tail of its log is
+`[EmbeddingBackfill] <schema>: N embedded`, walking ~137 partition schemas alphabetically. The
+portal serves normally while it runs (`2/2` Ready on `3.0.0-ci.8009`), because `DbVersionGate`
+gates on the schema version, not on the backfill. So *"the rollout finished"* and *"the Job
+finished"* are two different clocks in that namespace, minutes apart from hours — do not read a
+still-running migration Job as a stuck deploy.
+
+## Secrets the chart renders that no in-cluster Postgres backs
+
+`postgres.enabled: false` on every AKS namespace — the mesh lives on the Azure Postgres flexible
+server and is reached through `ConnectionStrings__memex`. There is no `memex-postgres-statefulset`
+and no `memex-postgres-service` in either production namespace (measured 2026-09-07: *"No resources
+found"* in both).
+
+Two keys in `memex-portal-secrets` / `memex-migration-secrets` address that absent Service, and
+until 2026-09-07 they rendered there unconditionally (Memex#204). Read by base64 **length** only —
+never by value:
+
+| key | `memex` | `memex-cloud` |
+|---|---|---|
+| `MEMEX_PASSWORD` | b64len 40 | **b64len 0** |
+| `MEMEX_URI` | b64len 112 | b64len 76 → `postgresql://postgres:@memex-postgres-service:5432/memex` |
+
+🚨 **The URI is the instructive half.** Its template `default` fires on the empty password and
+*derives* a value, so the key is **present, non-empty, plausible and wrong** — it survives a
+`keys[]` audit *and* the base64-length audit that exists because `keys[]` is insufficient. The
+shape that catches it is neither: it is a per-key statement of whether empty is legal, plus an
+expected form.
+
+Both are now gated on `postgres.enabled` (or on a value supplied explicitly, so nothing an operator
+sets is ever silently dropped). Nothing read either key — swept across `MeshWeaver` and
+`MeshWeaver.Plugins`, all `*.cs`: every match in either repository is a manifest that *sets* it
+(compose ×4, ACA bicep ×2, helm ×2). They still render for compose, local k3s and e2e, where an
+in-cluster Postgres genuinely exists and the same values are correct.
+
+**The general rule, which is the reusable part:** a secret that reads as configured and is not
+fails at **connect** time with a credentials error rather than at **startup** with "not
+configured", and the second is the one an operator can act on at 3am. Prefer *absent* to *empty*,
+and never let a `default` manufacture a plausible value out of an unconfigured input.
+
 ## Key Vault secrets are DECLARED in values — `keyVaultSecrets`
 
 Since 2026-08-30 the chart renders the `SecretProviderClass` itself, from one block in the values

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-deployment-tells-the-truth-about-its-database.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-a-deployment-tells-the-truth-about-its-database.md
@@ -1,0 +1,49 @@
+---
+Name: A deployment tells the truth about its database
+Category: Fix
+Description: A deployment that uses an external database no longer ships an empty password and a made-up connection string for a database it does not have — and the record of a finished database migration now survives long enough for the deploy that started it to read the outcome.
+Icon: Database
+Order: -20260907
+---
+
+# A deployment tells the truth about its database
+
+Two things a deployment says about its own database were misleading, in the same direction: they
+read as answered when they were not.
+
+## An unused credential is now absent instead of empty
+
+A deployment can run its database inside the cluster, or point at an external one. Every cloud
+deployment uses an external database — and yet each one still shipped the *in-cluster* pair: a
+password with nothing in it, and a connection string assembled from that empty password, naming a
+database server that deployment does not run.
+
+The empty password was the harmless half. The connection string was not: because it was **built**
+from the missing password rather than copied from anywhere, it came out looking entirely
+reasonable — the right shape, the right length, a plausible host — while pointing at nothing.
+Anything checking whether the deployment was configured saw a value and moved on. Checking that the
+value was not *empty* did not help either, because it was not empty; it was invented.
+
+Both are now shipped only where there is an in-cluster database to use them, or where somebody has
+deliberately supplied one. Nothing read them, so nothing changes about how a deployment runs — what
+changes is that the next person auditing it is told "not configured" instead of being shown a
+convincing wrong answer.
+
+**Absent beats empty, and empty beats invented.** A credential that is missing fails at startup
+with something you can act on; a credential that is empty fails later, at the moment of connecting,
+wearing the words *"authentication failed"* — which sends you looking for a wrong password instead
+of a missing one.
+
+## A finished migration leaves a record you can still read
+
+Updating a deployment runs its database migration as a one-off task, and that task is the only
+evidence the migration happened. It used to be cleaned up ten minutes after it finished — sooner
+than the deploy that started it finishes watching, and far sooner than someone checking back later.
+
+A migration on a large deployment can legitimately run for hours; one recent run took nearly five,
+working steadily through every tenant's data. The deploy watching it gives up long before that and
+says so. When somebody then goes back to check the outcome, the task must still be there — and
+"cleaned up" and "never existed" look identical, as do "finished" and "failed".
+
+The record is now kept for a day. That is what makes a later check able to answer the question at
+all, rather than quietly assuming the best.


### PR DESCRIPTION
Two chart facts about a deployment's database that **read as answered when they were not**. Both were measured on the live cluster today, read-only, and both are the private deployment repo's open issues — Memex#204 and Memex#188.

## 1 · `MEMEX_PASSWORD` / `MEMEX_URI` render where there is no in-cluster Postgres (Memex#204)

`postgres.enabled: false` on every AKS namespace, and there is no `memex-postgres-statefulset` and no `memex-postgres-service` in either production namespace (measured 2026-09-07: *"No resources found"* in both). Two keys in `memex-portal-secrets` / `memex-migration-secrets` address exactly that absent Service, and rendered there unconditionally.

Read by base64 **length** only — never by value:

| key | `memex` | `memex-cloud` |
|---|---|---|
| `MEMEX_PASSWORD` | b64len 40 | **b64len 0** |
| `MEMEX_URI` | b64len 112 | b64len 76 → `postgresql://postgres:@memex-postgres-service:5432/memex` |

🚨 **The URI is the instructive half.** Its `default` fires on the empty password and *derives* a value, so the key is **present, non-empty, plausible and wrong**. It survives a `keys[]` audit *and* the base64-length audit that exists precisely because `keys[]` is insufficient.

Both are now gated on `postgres.enabled` **or** an explicitly supplied value — so nothing an operator sets is silently dropped, and nothing is invented out of an unconfigured input. They still render for compose, local k3s and e2e, where an in-cluster Postgres exists and the same values are correct.

**Nothing reads either key.** Swept across `MeshWeaver` and `MeshWeaver.Plugins`, all `*.cs`: every match in either repository is a manifest that *sets* it — compose ×4, ACA bicep ×2, helm ×2. So this removes a landmine and changes nothing that runs.

## 2 · The migration Job is the deploy lane's only evidence, and it was reaped before the reader looked (Memex#188)

`memex-migration-<revision>` is the sole durable record that a revision's migration ran, and Memex's `helm-release.yml` *Observe the rollout* step reads that object directly — `DONE` requires the Deployment updated **and** the Job succeeded.

`ttlSecondsAfterFinished` reaps a **finished** Job whether it Completed or **Failed**, and at 600 s that is well inside the reader's own window: 25 minutes inside a deploy, 40 on an `action: observe` re-run — which the lane's own error message tells the operator to run *later*.

Measured today:

| | |
|---|---|
| `memex` revision 35, run [34117537570](https://github.com/Systemorph/Memex/actions/runs/34117537570) | observe gave up at its budget with `migration-job=succeeded=0 failed=0 active=1` |
| the same namespace at 16:20Z | **no Job, no pod, no events** — `kubectl get job -n memex` returns only the `assembly-cache-prune` Jobs |

An absent Job is indistinguishable from one that never existed, and a **failed** migration reaps identically. `ttlSecondsAfterFinished: 86400` makes the artefact outlive every window that reads it.

🚨 **This is deliberately one half of a pair.** The other half — the verdict refusing to call an absent Job a success — lands in Memex. A longer TTL alone would only move the cliff; the verdict change alone would make a legitimate `observe` re-run permanently red. Core first, because the Memex half's cost is bounded only once the evidence survives.

**Also measured, and worth stating so a long migration is not read as a stuck one:** `memex-migration-28` on `memex-cloud` ran 4 h 47 m today and was healthy throughout — the tail of its log is `[EmbeddingBackfill] <schema>: N embedded`, walking ~137 partition schemas alphabetically, while the portal served normally at `2/2` Ready. "The rollout finished" and "the Job finished" are two different clocks there.

## Verification

Positive signals, all local:

- `helm template` with `postgres.enabled=false` → **neither** key in either Secret; with `postgres.enabled=true` → **both**; with an explicit `memex_postgres_password` and postgres disabled → `MEMEX_PASSWORD` only, `MEMEX_URI` still absent.
- Rendered against the **real** `deployments/aks/memex-cloud/values.memexcloud.public.yaml`: `memex-portal-secrets` and `memex-migration-secrets` carry `ConnectionStrings__memex` + `ConnectionStrings__orleans` and nothing else.
- `deploy/aks/scripts/check-chart-invariants.sh` — *All 3 values combinations render a self-consistent deployment.*
- `deploy/aks/scripts/check-values-are-read.sh` — *All 119 config key(s) across 3 values file(s) are read by a template.*
- `deploy/aks/scripts/test-chart-drift-compare.sh` — *all classification assertions passed.*
- `dotnet build -c Release -warnaserror` on `MeshWeaver.Documentation` and `MeshWeaver.Documentation.Test`: `0 Warning(s) 0 Error(s)`; `DocumentationLinkIntegrityTest` `Passed: 1`.

Every cluster read was `kubectl get` / `kubectl logs` through `az aks command invoke`. **No secret value was read or printed** — everything above is quoted by base64 length.

## Docs

`Doc/Architecture/DeploymentAKS` gains two sections: *The migration Job IS the evidence — so it must outlive the observer*, and *Secrets the chart renders that no in-cluster Postgres backs*. What's New entry: **A deployment tells the truth about its database** (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
