### PR TITLE
docs: the Module Adoption Policy — keep what you have, load on measurement, take what ships

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -8,6 +8,8 @@ icon: /static/NodeTypeIcons/box.svg
 
 # CI Content Bake
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** "An instance must roll to the newest release that is actually baked" becomes "the newest release on which everything loads": a missing satellite bake is a boot compile, reported, not a hold. The mechanism described below is what runs until [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) lands; this page is rewritten by that change.
+
 Every `.cs` stored in a mesh node compiles **at runtime in the portal** (see
 [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation)), and until issue #1660 that was also
 the *deploy* path: every image roll changed the framework identity, invalidated every cached

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -1,0 +1,66 @@
+---
+Name: Module Adoption Policy
+Category: Architecture
+Description: The one rule for what an installation runs — keep the module you have until a newer one loads, load on what is measured rather than on what is declared, and switch the moment a new version ships. Set by the maintainer on 2026-09-07 after a day in which every production portal was held on a morning build by version strings, and the plan that implements it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><path d="M3.3 7 12 12l8.7-5"/><path d="M12 22V12"/></svg>
+---
+
+# Module Adoption Policy
+
+**Maintainer directive, 2026-09-07:** *if no plugin version is shipped, we use the old one. We make
+it load despite a newer dependency on the platform or on another module. As soon as a new module
+version ships, we start using it. We must become far more robust during deployments.*
+
+This page is the authority on what an installation runs. Every other architecture page that
+describes a floor, a hold, a skip or a decline on the module lane defers to it; where such a page
+still describes the older mechanism, it says so in a banner that names the implementing issue.
+
+## The three rules
+
+| # | Rule | What it replaces |
+|---|---|---|
+| **R1 — continuity** | An installation always runs *some* version of every module it has installed: the newest one that **loads**. If nothing newer ships for the platform it runs, the version it has keeps running. Nothing removes a working module because a newer one exists but cannot load. | A landed generation that does not load leaves the module **absent** (only image-shipped modules had a baseline to fall back to); a shelved landing overwrote the only reference to the loadable generation. |
+| **R2 — measured, never declared** | Whether a module loads is decided by **measurement** — the type-level link probe against the running platform (`ModulePlatformLink`, core #3552/#3538) and the actual load — never by a version string. A declared `minMeshVersion`, or a dependency on another module's version, is **advisory**: logged, shown on the status row, decides nothing. | `minMeshVersion` compared with `NuGetVersionComparer` at eight decision points, each of which refused, held or skipped on a miss. Because that comparator ranks `ci < rc < clean`, an `rc` or `3.0.0` floor on an installed record could never be satisfied by any `ci` build — which is how every production portal was held on the morning build for all of 2026-09-07 while every candidate would have loaded. |
+| **R3 — eager adoption** | The moment a new module version ships — a newer version on the registry, or the same version rebuilt for this platform's identity — the installation adopts it, if it loads. If it does not load, R1 applies and the row says so. | Adoption ran at boot and on catalog opens; a fallback generation was never re-examined when a loadable build for the same version appeared. |
+
+The rules compose into one sentence: **run the newest thing that loads, keep what you have until then, and never let a string decide.**
+
+## What "loads" means
+
+Two lanes, two measurements, one fallback:
+
+- **Compiled modules** (`modules/<name>@<gen>/`): `ModulePlatformLink.Check` links the entry assembly's type references against the running platform's surface before any load; the load itself is the second measurement. A refusal names the missing type. This gate exists since core #3552 and is unchanged by the policy — the policy makes it the *only* gate.
+- **NodeType content** (`prebuilt-bundles/<identity>/<source>/`): a baked assembly is adopted only for the exact framework build identity it was baked against (`PrebuiltAssemblySeeder.DeclineReason`, ordinal equality). That is also unchanged — a mismatched bake would be worse than none. What changes is the consequence of *no* bake: **the content compiles in the mesh**, which is the same code path every pull request already proves green. A missing bake is a cost (boot time), not a reason to hold a roll. `Modules:RequirePrebuilt` remains the opt-in strict mode for installations that prefer a named park to a compile.
+- **Fallback**: when the newest generation of a module does not load, the previous generation that did is loaded instead, reported as such, and kept from garbage collection. Only when *no* generation loads is the module absent — and that is the readiness probe's business (the rollout stalls on the pod, the previous pods keep serving), which is the last safety net and the one that has never failed.
+
+## What the platform roll gates on
+
+The self-updater and the CD post-promote gate select **the newest release on which no installed module is unloadable**. Concretely, per installed package: a build published for the target identity exists (it will be adopted), *or* the landed generation links against the target's surface, *or* neither can be shown — which is reported as *indeterminate*, never as clearance and never as a hold. Declared floors do not enter. A missing content bake does not enter (it is reported as "would compile at boot: …"). The sealed-set consistency check (#3175/#3221) stays: two builds of one platform assembly in one identity is a torn publication, and torn publications are refused whole.
+
+The safety net after a roll is boot-time, in this order: the link probe refuses what cannot load; the fallback keeps the previous generation; a module with no loadable generation makes the pod unhealthy and the rollout stalls, with the previous pods serving. That is what "robust during deployments" buys: the worst outcome of a wrong roll is a **stalled rollout with a named module**, never a portal that serves nothing and never an installation stuck on a month-old build because a string said so.
+
+## The implementation plan
+
+Four changes, in this order; each is one pull request against core with its tests, and each rewrites the page(s) it makes true.
+
+| Step | Issue | Change | Pages it rewrites |
+|---|---|---|---|
+| 1 | [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) | Floors become advisory at every runtime decision point (`ModuleUpdateDecision`, `LandFromBundle`, `LandCore`, boot, `ReleaseAvailability`, the status surfaces). Pack-time floor lint stays as authoring hygiene. **This also resolves the 2026-09-07 self-update deadlock without a production write.** | Modules, ReleaseGates, SelfUpdateTargetSelection, ModulePlatformLinkGate, PluginPackaging, ReleaseGateDenominator |
+| 2 | [#3649](https://github.com/Systemorph/MeshWeaver/issues/3649) | Keep the previous generation: `ModuleActivationEntry.PreviousDirectory`, boot fallback in `MeshBuilder`, GC keeps it, the module set records what loaded, status rows name it. | ModuleSetConvergence, ModulePlatformLinkGate, Modules |
+| 3 | [#3650](https://github.com/Systemorph/MeshWeaver/issues/3650) | Eager adoption: a fallback re-examines every new build for its version; a `ModulePublished` broadcast triggers the package's reconcile; a pending restart rolls the same image within the interval rules. | PluginUpdateOnGreenBuild, Modules |
+| 4 | [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) | The roll gate on measured loadability: the publication carries `platform-surface.json` per identity, `ReleaseAvailability` links landed generations against it, `ContentBakeMissing` is advisory, `RollSelection` stops at the first release with no unloadable module. | RollSelection, ReleaseStrategy, CiContentBake, ReleaseAvailability pages, SelfUpdateSchemaWall |
+
+Until step 1 lands, the mechanism the other pages describe is what runs. The one-time exit from the 2026-09-07 hold is a pipeline roll (helm-release), taken by the maintainer's decision on the same day, with the satellites baked for the target identity first so the roll adopts their bundles rather than compiling them.
+
+## What stays exactly as it is
+
+- The **content bake identity rule**: a NodeType assembly adopts only for the identity it was baked against. Wrong bytes are worse than no bytes.
+- The **seal**: a publication is real when `_complete` is written last and every listed file exists; a torn publication is refused whole (#3461, #3401).
+- **Never roll back unattended**: an older served version is never adopted over a newer landed one (`SkipOlder`).
+- **Never swap a module in a running process**: a new generation loads at the next restart; the policy makes that restart happen (step 3), it does not make the swap live.
+- **Sources follow the seal** (Plugins#1430, core #3600): a module-bearing repository's sources advance only to the commit sealed for the instance's own identity.
+- **Pack-time floor lint** (`check-module-floors.py`, `check-module-platform-floor.py`): a module built against pin X that declares a floor above X is an authoring error and still fails the pack. The floor is documentation for humans; the runtime does not read it as a gate.
+
+## Why the version string was the wrong instrument
+
+A `minMeshVersion` is a claim written before the platform it names exists. It is authored, so it can be absent or wrong; it is coarse, so a `3.0.0` line cannot express "after commit X"; and it is compared by a total order (`ci < rc < clean`) that encodes a release *policy*, not compatibility. Every one of those properties produced an outage this year: rc7 floors deadlocking a registry against its own roll (2026-08-22), a `3.0.0-rc14` floor naming a platform that never existed, and the 2026-09-07 hold. The measured link probe has none of them: it reads the bytes, it answers per type, and it cannot be out of date because it is computed against the platform actually running. What the string was *for* — telling an operator which platform a module was built against — is served by the identity the bundle already records (`frameworkMvid`) and by the status row, not by a gate.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -7,6 +7,8 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # The Module Platform Link Gate
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** The link probe becomes the ONLY platform gate on the module lane (the declared floor no longer gates first), and a refused generation no longer leaves the module absent: the previous loadable generation is loaded and named. The mechanism described below is what runs until [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) and [#3649](https://github.com/Systemorph/MeshWeaver/issues/3649) lands; this page is rewritten by that change.
+
 **A module is adopted on what this process can LOAD, never on a version string.**
 
 Until MeshWeaver#3538 the module lane had exactly one platform gate: the module's declared

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -5,6 +5,8 @@ Description: One module set per mesh at a time — how a landing wave proposes t
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/><path d="M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M19.1 4.9l-2.8 2.8M7.7 16.3l-2.8 2.8"/></svg>
 ---
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** A HELD module is no longer skipped at boot by a floor; the set records the generation that actually loaded, including a fallback to the previous one. The mechanism described below is what runs until [#3649](https://github.com/Systemorph/MeshWeaver/issues/3649) lands; this page is rewritten by that change.
+
 Replicas of one deployment used to run **different module sets**, indefinitely, and nothing made
 them converge. This page is the design that ends it: a mesh runs **one module set at a time**, a
 landing wave is what moves it, and boot adopts what the mesh declares instead of reading a record

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
@@ -7,6 +7,8 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # Module Versioning
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** Delivery is no longer keyed on SemVer alone: a rebuilt same-version bundle for this platform's identity is adopted, and a fallback generation re-examines every new build. The mechanism described below is what runs until [#3650](https://github.com/Systemorph/MeshWeaver/issues/3650) lands; this page is rewritten by that change.
+
 **A package's version is not decoration. It is the ONLY thing that decides whether anything you
 built reaches a portal that already has an older copy.** Get it wrong and the pipeline stays green,
 the bytes reach the shelf, and no installation ever asks for them.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -5,6 +5,8 @@ Description: The module lane end to end — MeshNodeProviderAttribute, the Modul
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg>
 ---
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** A declared `minMeshVersion` no longer refuses, holds or skips a module anywhere on this page's lane — loadability is measured by the link probe, and an installation keeps its previous generation when a newer one does not load. The mechanism described below is what runs until [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) and [#3649](https://github.com/Systemorph/MeshWeaver/issues/3649) lands; this page is rewritten by that change.
+
 A **module** is a compiled MeshWeaver assembly a deployment turns on by LISTING it — no code
 change, no recompile of the platform. This page is the operator- and author-facing reference for
 the whole lane: how a module declares itself, how a deployment activates and configures it, how

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -8,6 +8,8 @@ icon: /static/NodeTypeIcons/box.svg
 
 # Plugin Packaging
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** `minMeshVersion` stops being "THE landing gate": it is carried, shown and linted at pack time, and decides nothing at landing, serving or boot. The mechanism described below is what runs until [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) lands; this page is rewritten by that change.
+
 C# stored in mesh nodes compiles **at runtime, in the portal** — see
 [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation). This page is about compiling the same
 source **outside** it: in CI, ahead of time, so the bytes can be shipped rather than recomputed.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md
@@ -8,6 +8,8 @@ icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='
 
 # The Release Gate's Denominator
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** A package that stops shipping content no longer holds a release forever: a missing bake is advisory ("would compile at boot"). The mechanism described below is what runs until [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) lands; this page is rewritten by that change.
+
 > Maintainer, 2026-09-06: *"let's see that the deploy rolls only when **all** packages of all
 > plugins are baked"* — *"we kept rolling without edu being properly baked."*
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseGates.md
@@ -8,6 +8,8 @@ icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='
 
 # Release Availability Gates
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** The module floor is no longer a release gate, as a regression check or otherwise; a missing content bake is reported as a boot compile, not held; the only module-lane hold is measured loadability on the target. The mechanism described below is what runs until [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) and [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) lands; this page is rewritten by that change.
+
 A release is not safe to act on just because its version is newer. Two questions have the same
 answer, and until they were asked, both were answered by hand:
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
@@ -15,6 +15,8 @@ Tags:
 
 # Release & Self-Update Strategy
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** A hold on the Continuous channel is reserved for a module that measurably cannot load on the target; a package without a usable artifact for the release compiles at boot and is reported, it no longer holds the update. The mechanism described below is what runs until [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) lands; this page is rewritten by that change.
+
 The production model in one picture:
 
 ```

--- a/src/MeshWeaver.Documentation/Data/Architecture/RollSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RollSelection.md
@@ -7,6 +7,8 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # Roll Selection
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** "The latest platform version shipping all plugins" is re-read as "the newest release on which no installed module is UNLOADABLE": a missing bake is a boot compile (reported), a floor is advisory, and only a measured link failure against the target holds. The mechanism described below is what runs until [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) lands; this page is rewritten by that change.
+
 > **"Whenever a new platform / plugin is published, check for each environment which is the latest
 > platform version shipping all plugins, if different from current version ⇒ update."**
 > — maintainer, 2026-09-06

--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateSchemaWall.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateSchemaWall.md
@@ -7,6 +7,8 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # The Self-Update Schema Wall
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** "All plugins must be available for the correct platform version; if not, nothing goes" is superseded for the module lane by measured loadability plus the previous-generation fallback; the schema wall itself is unchanged. The mechanism described below is what runs until [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651) lands; this page is rewritten by that change.
+
 **A pull-based self-update carries the IMAGE and nothing else. So an instance rolls itself forward
 release after release until it meets the first one that bumps the database schema — and then it
 stops there, still serving, with nothing on the outside to say it stopped.**

--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
@@ -7,6 +7,8 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # Self-Update Target Selection
 
+> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** The floor table below stops mattering: `ModulePlatformFloor.DeclineReason` becomes advisory at every runtime decision point, and "declared floors are not going away, so do not design as if they were" is superseded — they stay as pack-time authoring lint only. The mechanism described below is what runs until [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) lands; this page is rewritten by that change.
+
 **A version string is a LABEL a human maintains. The CD run number is the ORDER a machine
 produced. The self-updater must rank candidates by the second, because the first can be wrong —
 and when it is wrong, SemVer makes the mistake permanent.**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-installation-keeps-running-what-it-has-and-takes-what-loads.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-installation-keeps-running-what-it-has-and-takes-what-loads.md
@@ -1,6 +1,6 @@
 ---
 Name: Your installation keeps running what it has, and takes what loads
-Category: Change
+Category: Feature
 Description: A new rule for add-ons — if no newer version ships for the platform you run, the one you have keeps running; a version string an add-on declares no longer decides whether it loads, a measurement does; and the moment a newer version that loads is published, you get it. Set on 2026-09-07 after every production portal spent a day held on a morning build by a version string.
 Icon: Box
 Order: -20260907

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-installation-keeps-running-what-it-has-and-takes-what-loads.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-07-your-installation-keeps-running-what-it-has-and-takes-what-loads.md
@@ -1,0 +1,17 @@
+---
+Name: Your installation keeps running what it has, and takes what loads
+Category: Change
+Description: A new rule for add-ons — if no newer version ships for the platform you run, the one you have keeps running; a version string an add-on declares no longer decides whether it loads, a measurement does; and the moment a newer version that loads is published, you get it. Set on 2026-09-07 after every production portal spent a day held on a morning build by a version string.
+Icon: Box
+Order: -20260907
+---
+
+# Your installation keeps running what it has, and takes what loads
+
+Three things are now true of every add-on (module) on every installation, by policy:
+
+1. **If no newer version ships for the platform you run, the version you have keeps running.** A newer build that cannot load on your platform never removes the one that can.
+2. **Whether an add-on loads is measured, not declared.** An add-on used to carry a minimum platform version as text, and a mismatch in that text blocked it — even when the add-on would have loaded perfectly. Today, 2026-09-07, that text held every production portal on the morning's build for the whole day. From now on the platform checks the add-on's bytes against what is actually running; the declared version is shown on the add-on's row for information and decides nothing.
+3. **The moment a newer version that loads is published, you get it** — within minutes, not at your next restart of convenience.
+
+The rule and the plan that implements it are on [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy). Until the first step lands, the existing behaviour applies and the pages describing it carry a banner saying so.


### PR DESCRIPTION
## What

`Doc/Architecture/ModuleAdoptionPolicy` — the maintainer's rule of 2026-09-07 for what an installation runs, and the plan that implements it:

- **R1 continuity**: an installation runs the newest module version that loads; if nothing newer ships for its platform, it keeps the one it has.
- **R2 measured, never declared**: loadability is the type-level link probe and the load itself; a declared `minMeshVersion` or module-version dependency is advisory.
- **R3 eager adoption**: a newly shipped version that loads is adopted within minutes.

Four implementation issues, in order: #3648 (floors advisory at every runtime decision point — also the exit from today's self-update deadlock without a production write), #3649 (keep the previous generation as the boot fallback), #3650 (eager adoption + a publish broadcast), #3651 (the roll gate on measured loadability against the target's published surface; a missing bake is a boot compile, not a hold).

Twelve architecture pages that state the superseded rule (Modules, ReleaseGates, SelfUpdateTargetSelection, ModulePlatformLinkGate, RollSelection, ReleaseStrategy, ModuleVersioning, ModuleSetConvergence, PluginPackaging, ReleaseGateDenominator, CiContentBake, SelfUpdateSchemaWall) carry a banner naming the issue that rewrites them; their mechanism text stays accurate until then. Plus a What's New.

## Why now

On 2026-09-07 every production portal was held on the morning build (3.0.0-ci.8009) for the whole day: the installed `Plugins/*` records carried `rc` / `3.0.0` floors, `NuGetVersionComparer` ranks `ci < rc < clean`, and the self-updater declined all 11 candidates ("77 plugins required … every one declined") while every one would have loaded. The one-time exit is a pipeline roll; the policy is what stops it recurring.

Docs only. The survey the page rests on covered every decision point in `MeshWeaver.PluginCatalog`, `Compiler.Pipeline`, `Hosting`, `GitSync` and the self-updater, and every architecture page mentioning a floor, a hold or adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
