### PR TITLE
ci: a repo-root file and a NOOP_DIRS divergence stop rebuilding everything

### DIFF
--- a/.github/scripts/check-noop-scope-parity.py
+++ b/.github/scripts/check-noop-scope-parity.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""check-noop-scope-parity.py — a node repo's own no-op set agrees with the platform's.
+
+WHY THIS EXISTS
+═══════════════
+`node-repo-scope.py` decides which module bundles a pull request rebuilds and which module suites
+it runs. Half of that decision reads a set the CALLER repo owns — `NOOP_DIRS` in its
+`scripts/affected-modules.py`, the top-level directories a change in which reaches no build. The
+platform carries its own copy, and the two are HAND-WRITTEN in two repositories.
+
+That copy drifts, and until 2026-09-07 the drift was invisible from inside the repo paying for it:
+
+  * MeshWeaver.SocialMedia run 34122662676 —
+        scope: full — this script's NOOP_DIRS has drifted from scripts/affected-modules.py's —
+        only theirs: (none); only ours: app.
+    …on EVERY pull request since `app` was added to the platform's set. The lane narrowed nothing,
+    for months, and the only trace was one line in the log of the job it disabled.
+  * MeshWeaver.Manufacturing and MeshWeaver.Reinsurance carry the same divergence today.
+
+`node-repo-scope.py` no longer answers a divergence with a blanket full run — it narrows on the
+INTERSECTION, so a divergent dir is over-built rather than the whole run being. That makes the
+drift SAFE. It does not make it FREE, and it does not cover the shape that is not a divergence at
+all: a caller whose `NOOP_DIRS` literal has been RENAMED, reformatted or moved, which the platform
+reads as "cannot verify" and answers — correctly, and permanently — with the full set.
+
+So this guard asserts the two things the scope script cannot assert about itself:
+
+  1. THE SUBJECT IS STILL THERE. A caller that ships `scripts/affected-modules.py` must expose a
+     single-line `NOOP_DIRS = {…}` literal. If it does not, narrowing is OFF in that repo and
+     nothing anywhere goes red — the "a guard whose subject moved while its roots did not" shape
+     this fleet keeps paying for.
+  2. THE DIVERGENCE COSTS NOTHING. Every top-level directory THE CALLER'S TREE ACTUALLY HAS must
+     be classified identically by both sets. A name only one side carries for a directory that
+     does not exist cannot classify a changed file and is therefore not a finding — which is why
+     SocialMedia's missing `app` is reported as harmless rather than as a red.
+
+It reads only the two files and the caller's top-level directory listing: no network, no
+credential, no secret, so it runs on fork pull requests exactly as it does anywhere else.
+
+🚨 IT DOES NOT RE-DECLARE EITHER SET. The platform's `NOOP_DIRS`/`NOOP_FILES` and the parser for
+the caller's are IMPORTED from `node-repo-scope.py` — a third hand-copy is the defect this guard
+exists to find.
+
+USAGE
+    check-noop-scope-parity.py --root <caller checkout> [--platform-scope <node-repo-scope.py>]
+    check-noop-scope-parity.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_scope(path: Path):
+    """The platform's node-repo-scope module, or a hard exit naming what is missing.
+
+    🚨 NO FALLBACK. "The platform's set could not be loaded" and "the sets agree" must never look
+    alike: without the module there is nothing to compare against, and a guard that passes on a
+    missing input is the trapdoor this file's docstring is about.
+    """
+    if not path.is_file():
+        sys.exit(f"✗ cannot load the platform's no-op sets: {path} does not exist. This guard "
+                 "compares the caller's scripts/affected-modules.py against node-repo-scope.py, "
+                 "so fetch BOTH at the same platform-ref and pass --platform-scope.")
+    spec = importlib.util.spec_from_file_location("_mw_node_repo_scope", path)
+    if spec is None or spec.loader is None:
+        sys.exit(f"✗ {path} could not be loaded as a Python module.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for attr in ("NOOP_DIRS", "NOOP_FILES", "SELECTOR", "caller_noop_dirs"):
+        if not hasattr(module, attr):
+            sys.exit(f"✗ {path} carries no `{attr}` — this guard imports the platform's sets "
+                     "rather than re-declaring them, and the name it imports has moved. Update "
+                     "this guard in the same change that moved it.")
+    return module
+
+
+def check(root: Path, scope, say) -> int:
+    selector = root / scope.SELECTOR
+    say(f"platform NOOP_DIRS  : {', '.join(sorted(scope.NOOP_DIRS))}")
+    say(f"platform NOOP_FILES : {', '.join(sorted(scope.NOOP_FILES))}")
+
+    if not selector.is_file():
+        # Not a finding: a repo without the selector cannot narrow at all, and node-repo-scope.py
+        # already answers that with a FULL run and a named reason on every event. Say so with the
+        # cost attached so nobody reads the green tick as "this repo narrows".
+        say(f"\nthis repo ships no {scope.SELECTOR}, so its module lane CANNOT narrow: every "
+            "event packs and tests the full matrix, by design and out loud. Nothing to compare.")
+        return 0
+
+    theirs, unreadable = scope.caller_noop_dirs(root)
+    if theirs is None:
+        print(f"::error title=The no-op set this repo owns cannot be read::{unreadable}. "
+              f"{scope.SELECTOR} must expose a SINGLE-LINE `NOOP_DIRS = {{…}}` literal: the "
+              "platform parses it out of the source (importing it would run its argparse), and "
+              "when the parse fails node-repo-scope.py answers 'cannot verify' with a FULL run on "
+              "every pull request — silently, forever, visible only inside the job it disables. "
+              "Put the literal back on one line, or move this guard in the same change that "
+              "moved it.")
+        return 1
+
+    say(f"this repo's NOOP_DIRS: {', '.join(sorted(theirs))}")
+
+    # 🚨 SCOPED TO WHAT THE TREE ACTUALLY HAS. A name only one side carries, for a directory this
+    # repo does not have, can never classify a changed file — reporting it would be a red about
+    # nothing, and a gate that reds about nothing is one people learn to ignore.
+    present = {d.name for d in root.iterdir() if d.is_dir()}
+    only_theirs = sorted((theirs - scope.NOOP_DIRS) & present)
+    only_ours = sorted((scope.NOOP_DIRS - theirs) & present)
+    dormant = sorted((theirs ^ scope.NOOP_DIRS) - present)
+    if dormant:
+        say(f"\ndivergent but DORMANT (no such directory here, so nothing can be classified by "
+            f"it): {', '.join(dormant)}")
+
+    if not only_theirs and not only_ours:
+        say(f"\n✓ the two sets agree about every top-level directory this repo has "
+            f"({len(present)} checked).")
+        return 0
+
+    lines = []
+    if only_ours:
+        lines.append(f"the platform calls {', '.join(only_ours)} inert and this repo does not")
+    if only_theirs:
+        lines.append(f"this repo calls {', '.join(only_theirs)} inert and the platform does not")
+    print(f"::error title=This repo's no-op set diverges from the platform's::"
+          f"{'; '.join(lines)}. Every directory named there EXISTS here, so each one is scoped "
+          f"OUT of the narrowing intersection and rebuilt on every pull request that touches it. "
+          f"Nothing is under-built — the intersection is safe in both directions — this is runner "
+          f"time you are paying for. Fix: make {scope.SELECTOR}'s single-line NOOP_DIRS literal "
+          f"equal to the platform's, listed above.")
+    return 1
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+# 🚨 A GUARD OWES ITS OWN PROOF THAT IT CAN SAY NO. Every branch above is exercised against a
+# fixture, INCLUDING the two that must stay green — a guard that reds on everything is as useless
+# as one that reds on nothing.
+
+def self_test(scope_path: Path) -> int:
+    import io
+    import tempfile
+    from contextlib import redirect_stdout
+
+    scope = load_scope(scope_path)
+    failures: list[str] = []
+    ran = 0
+
+    def case(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal ran
+        ran += 1
+        print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
+        if not ok:
+            failures.append(name)
+
+    def run(root: Path) -> tuple[int, str]:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = check(root, scope, lambda *a: print(*a))
+        return rc, buf.getvalue()
+
+    literal = "NOOP_DIRS = {%s}\n" % ", ".join(f'"{d}"' for d in sorted(scope.NOOP_DIRS))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "scripts").mkdir()
+        selector = root / scope.SELECTOR
+        for d in sorted(scope.NOOP_DIRS):
+            (root / d).mkdir(exist_ok=True)
+        (root / "Alpha").mkdir()
+
+        selector.write_text(literal + "print('stub')\n", encoding="utf-8")
+        rc, out = run(root)
+        case("identical sets ⇒ green, stating how many dirs were checked",
+             rc == 0 and "agree about every top-level directory" in out, f"rc={rc} {out[-120:]}")
+
+        # ── the finding that costs runner time: a divergence over a dir that EXISTS ──
+        short = {d for d in scope.NOOP_DIRS if d != "docs"}
+        selector.write_text("NOOP_DIRS = {%s}\nprint('stub')\n"
+                            % ", ".join(f'"{d}"' for d in sorted(short)), encoding="utf-8")
+        rc, out = run(root)
+        case("a dir the platform calls inert and this repo does not ⇒ RED, naming it",
+             rc == 1 and "docs" in out, f"rc={rc} {out[-160:]}")
+
+        selector.write_text('NOOP_DIRS = {%s, "Alpha"}\nprint("stub")\n'
+                            % ", ".join(f'"{d}"' for d in sorted(scope.NOOP_DIRS)),
+                            encoding="utf-8")
+        rc, out = run(root)
+        case("…and the OTHER direction (this repo calls a real dir inert) ⇒ RED too",
+             rc == 1 and "Alpha" in out, f"rc={rc} {out[-160:]}")
+
+        # ── the divergence that costs NOTHING: SocialMedia's `app`, a dir it does not have ──
+        no_such = root / "nosuch-dormant"
+        selector.write_text('NOOP_DIRS = {%s, "%s"}\nprint("stub")\n'
+                            % (", ".join(f'"{d}"' for d in sorted(scope.NOOP_DIRS)),
+                               no_such.name), encoding="utf-8")
+        rc, out = run(root)
+        case("a divergence over a dir this repo DOES NOT HAVE is reported dormant, not red",
+             rc == 0 and "DORMANT" in out and no_such.name in out, f"rc={rc} {out[-160:]}")
+
+        # ── the subject moving: the literal is no longer parseable ──
+        selector.write_text(literal.replace("NOOP_DIRS", "NOOP_TOPS"), encoding="utf-8")
+        rc, out = run(root)
+        case("a RENAMED NOOP_DIRS literal ⇒ RED (narrowing is off and nothing else says so)",
+             rc == 1 and "SINGLE-LINE" in out, f"rc={rc} {out[-160:]}")
+        selector.write_text("NOOP_DIRS = {\n  'legacy',\n}\nprint('stub')\n", encoding="utf-8")
+        rc, out = run(root)
+        case("…and a literal reformatted onto several lines is a divergence, not a parse failure",
+             rc == 1, f"rc={rc} {out[-160:]}")
+
+        # ── a repo with no selector: not a finding, but it must SAY it cannot narrow ──
+        selector.unlink()
+        rc, out = run(root)
+        case("no affected-modules.py ⇒ green, and says the lane CANNOT narrow",
+             rc == 0 and "CANNOT narrow" in out, f"rc={rc} {out[-160:]}")
+
+    if failures:
+        print(f"\n::error title=check-noop-scope-parity self-test failed::{len(failures)} case(s).")
+        return 1
+    print(f"\n✓ check-noop-scope-parity self-test: {ran} cases green — the two REAL divergences "
+          "(one per direction), the dormant one that must NOT red, the renamed literal, and the "
+          "two green shapes.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--root", default=".", help="the caller repo checkout")
+    p.add_argument("--platform-scope", default="", dest="platform_scope",
+                   help="the platform's node-repo-scope.py (default: beside this script)")
+    p.add_argument("--self-test", action="store_true", dest="self_test")
+    args = p.parse_args()
+
+    scope_path = (Path(args.platform_scope) if args.platform_scope
+                  else Path(__file__).resolve().parent / "node-repo-scope.py")
+    if args.self_test:
+        return self_test(scope_path)
+    return check(Path(args.root).resolve(), load_scope(scope_path), print)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -98,6 +98,35 @@ from pathlib import Path
 # the two disagree, so the next drift is a full run with a named reason instead of a silent one.
 NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees"}
 
+# 🚨 A repo-ROOT path HAS NO TOP-LEVEL DIRECTORY, so NOOP_DIRS above can never reach it: both
+# no-op branches of the classifier are guarded by `"/" in f`, and a single-segment path takes
+# neither. Every root file therefore fell through to the global catch-all and ran the FULL set.
+#
+# Measured on MeshWeaver.Plugins run 34158493654 (2026-09-07), a pull request whose entire diff
+# was one file:
+#
+#     AGENTS.md  → EVERYTHING (tooling / repo-root / unknown scope)
+#     scope: full — 1 changed file(s) reach the tooling/global scope — first: AGENTS.md.
+#     34 of 34 selected module(s) still owe a test run: …
+#
+# 100 jobs, 38 bundles, 34 module suites, ~350 billable job-minutes and ~54 minutes of wall clock
+# for a documentation edit — and `AGENTS.md` is the file every agent session in this fleet edits.
+# The `docs/` entry above was added for exactly this shape and could not cover it, because the
+# fleet keeps its agent guidance at the ROOT rather than under `docs/`.
+#
+# 🚨 THIS IS A CLOSED LIST OF NAMES, NEVER A PATTERN, and that is the whole safety argument. A
+# root file this set does not name is UNKNOWN and still runs the full set — which is what keeps
+# `Directory.Build.props`, `Directory.Packages.props`, `global.json`, `nuget.config`, a `*.slnx`
+# and (measured across the fleet: `plugin-gate.allow`, `plugin-tests.allow`, `cover-prose.allow`,
+# `impersonation.allow`) every gate ALLOW FILE on the loud path where they belong. Adding a name
+# here is a deliberate claim that the file cannot change what any lane builds; a `*.md` glob, or
+# "any dotfile", would make that claim for files nobody has read yet.
+NOOP_FILES = {
+    "AGENTS.md", "CLAUDE.md", "README.md",
+    "LICENSE", "LICENSE-APACHE", "LICENSE-MIT",
+    ".gitignore", ".gitattributes", ".editorconfig",
+}
+
 SELECTOR = "scripts/affected-modules.py"        # the caller's NODE graph
 PROJECTS = "scripts/project-closure.py"          # the caller's PROJECT graph
 
@@ -208,28 +237,67 @@ def node_packages(root: Path) -> set[str]:
             if d.is_dir() and d.name not in skip and (d / "index.json").exists()}
 
 
-def assert_noop_dirs_match(root: Path) -> str | None:
-    """None when the caller's NOOP_DIRS equals ours; otherwise why we must not narrow.
+def caller_noop_dirs(root: Path) -> tuple[set[str] | None, str | None]:
+    """(the caller's NOOP_DIRS, or None with the reason it could not be READ AT ALL).
 
     Read out of the caller's source rather than imported: affected-modules.py is a CLI, and
     importing it would run its argparse. A set literal on one line is what it has always been; if
     that ever stops parsing, the honest answer is "cannot verify" — which is also a full run.
+    Shared with `check-noop-scope-parity.py`, the fleet guard that reds when this stops parsing.
     """
     try:
         text = (root / SELECTOR).read_text(encoding="utf-8")
     except OSError as exc:
-        return f"{SELECTOR} could not be read ({exc})"
+        return None, f"{SELECTOR} could not be read ({exc})"
     match = re.search(r"^NOOP_DIRS\s*=\s*\{([^}]*)\}", text, re.M)
     if not match:
-        return f"{SELECTOR} has no single-line NOOP_DIRS literal to compare against"
-    theirs = set(re.findall(r"[\"']([^\"']+)[\"']", match.group(1)))
-    if theirs != NOOP_DIRS:
-        only_theirs = ", ".join(sorted(theirs - NOOP_DIRS)) or "(none)"
-        only_ours = ", ".join(sorted(NOOP_DIRS - theirs)) or "(none)"
-        return (f"this script's NOOP_DIRS has drifted from {SELECTOR}'s — only theirs: "
-                f"{only_theirs}; only ours: {only_ours}. The two must classify a top-level dir "
-                "identically or the lanes disagree about what a change reaches")
-    return None
+        return None, f"{SELECTOR} has no single-line NOOP_DIRS literal to compare against"
+    return set(re.findall(r"[\"']([^\"']+)[\"']", match.group(1))), None
+
+
+def resolve_noop_dirs(root: Path) -> tuple[frozenset[str] | None, str | None]:
+    """(the no-op dirs BOTH sides agree on, a note about any divergence).
+
+    A `None` set means the caller's copy could not be READ AT ALL — the subject moved — and the
+    only honest answer to that is a full run. A note beside a set is a cost report, not a refusal.
+
+    🚨 DIVERGENCE USED TO MEAN "NARROW NOTHING", AND THAT SWITCHED NARROWING OFF FLEET-WIDE.
+    NOOP_DIRS is HAND-COPIED into every caller repo, so it drifts the moment one side gains an
+    entry — and the old equality check answered a drift with a blanket FULL run, forever, visible
+    only in a log line inside the very job it disabled. Measured 2026-09-07, MeshWeaver.SocialMedia
+    run 34122662676:
+
+        scope: full — this script's NOOP_DIRS has drifted from scripts/affected-modules.py's —
+        only theirs: (none); only ours: app.
+
+    …on EVERY pull request since `app` was added here — for a repo that has no `app/` directory at
+    all, so not one changed file could ever have been classified by the entry they disagree about.
+    MeshWeaver.Manufacturing and MeshWeaver.Reinsurance carry the same divergence today.
+
+    The INTERSECTION is what the safety argument actually needs, and unlike equality it is safe in
+    BOTH directions:
+      * a dir only WE call inert — the caller believes it reaches its gate, so we must not skip
+        it: the intersection drops it and it goes to EVERYTHING;
+      * a dir only THEY call inert — we believe it reaches a module, so we must not skip it: the
+        intersection drops it and it goes to EVERYTHING.
+    Either way the divergent dir is over-built, out loud, and every OTHER dir keeps narrowing.
+    "The two must classify a top-level dir identically" was the right requirement expressed as the
+    wrong remedy: they need only agree WHERE IT MATTERS, and the intersection makes them agree by
+    construction. The residual cost of a real drift is NAMED in the report so it can be closed,
+    and `check-noop-scope-parity.py` reds a caller whose divergence actually costs it something.
+    """
+    theirs, unreadable = caller_noop_dirs(root)
+    if theirs is None:
+        return None, unreadable
+    if theirs == NOOP_DIRS:
+        return frozenset(NOOP_DIRS), None
+    only_theirs = ", ".join(sorted(theirs - NOOP_DIRS)) or "(none)"
+    only_ours = ", ".join(sorted(NOOP_DIRS - theirs)) or "(none)"
+    return frozenset(NOOP_DIRS & theirs), (
+        f"NOOP_DIRS diverges from {SELECTOR}'s — only theirs: {only_theirs}; only ours: "
+        f"{only_ours}. Narrowing on the INTERSECTION, so every divergent dir above is treated as "
+        f"EVERYTHING (over-built, never skipped). Align {SELECTOR}'s literal with this script's "
+        "to stop paying for it")
 
 
 def changed_files(root: Path, diff_range: str, say) -> list[str] | None:
@@ -257,14 +325,18 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
     all_packages = sorted(node_packages(root))
     universe = [e["module"] for e in entries]
 
+    divergence: str | None = None
+
     def full(reason: str) -> dict:
         return {"lane": lane, "scope": "full", "reason": reason,
                 "modules": [{**e, "test": True} for e in entries],
-                "count": len(universe), "selected": sorted(universe), "skipped": [], "why": {}}
+                "count": len(universe), "selected": sorted(universe), "skipped": [], "why": {},
+                "tested": sorted(universe), "divergence": divergence}
 
     def refuse(reason: str) -> dict:
         return {"lane": lane, "scope": "refuse", "reason": reason, "modules": [],
-                "count": 0, "selected": [], "skipped": [], "why": {}}
+                "count": 0, "selected": [], "skipped": [], "why": {},
+                "tested": [], "divergence": divergence}
 
     # 🚨 THE ANSWER "BUILD EVERYTHING, AND EVERYTHING IS NOTHING" IS NOT AN ANSWER. `full` with a
     # count of 0 is an internal contradiction, and it is REACHABLE: a --root that does not match
@@ -287,9 +359,10 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
     if not (root / SELECTOR).is_file():
         return full(f"the caller repo ships no {SELECTOR}, so the affected closure cannot be "
                     "computed — running the full set.")
-    drift = assert_noop_dirs_match(root)
-    if drift is not None:
-        return full(f"{drift} — running the full set.")
+    noop_dirs, divergence = resolve_noop_dirs(root)
+    if noop_dirs is None:
+        # The caller's copy could not be READ — its subject moved. "Cannot verify" is a full run.
+        return full(f"{divergence} — running the full set.")
 
     if override is not None:
         files = [f for f in override if f.strip()]
@@ -316,8 +389,14 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
         if "/" in f and top in packages:
             node_files.append(f)
             report.append(f"  {f}  → node package {top}")
-        elif "/" in f and top in NOOP_DIRS:
+        elif "/" in f and top in noop_dirs:
             report.append(f"  {f}  → (reaches nothing this lane builds — {top}/)")
+        # 🚨 A repo-ROOT path reaches neither branch above — both require a "/" — so before this
+        # entry every one of them fell through to EVERYTHING (see NOOP_FILES). The list is closed:
+        # an unnamed root file is still UNKNOWN and still runs the full set, which is what keeps
+        # every gate `*.allow`, Directory.Build.props and global.json on the loud path.
+        elif "/" not in f and f in NOOP_FILES:
+            report.append(f"  {f}  → (reaches nothing any lane builds — a repo-root no-op file)")
         elif f.startswith("src/") and f.count("/") >= 2 and lane == "modules":
             src_files.append(f)
             report.append(f"  {f}  → src/ (which project decides, below)")
@@ -421,11 +500,17 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
             selected.append({**e, "test": not floor_only})
 
     chosen = {e["module"] for e in selected}
+    # 🚨 THE SECOND DENOMINATOR. `selected` answers what is BUILT; a floor-only entry is built and
+    # deliberately not tested, so "how many suites will run" is a different number and a reader
+    # who only sees the first cannot tell "nothing needed testing" from "the filter is broken and
+    # matched nothing". Both counts are stated, with names, at the point the decision is made.
+    tested = sorted(e["module"] for e in selected if e.get("test") is not False)
     return {"lane": lane, "scope": "narrowed",
             "reason": f"{len(selected)} of {len(entries)} module bundle(s) are reachable from this "
-                      f"diff ({len(files)} file(s)).",
+                      f"diff ({len(files)} file(s)); {len(tested)} of those owe a test run.",
             "modules": selected, "count": len(selected),
-            "selected": sorted(chosen), "skipped": sorted(set(universe) - chosen), "why": why}
+            "selected": sorted(chosen), "skipped": sorted(set(universe) - chosen), "why": why,
+            "tested": tested, "divergence": divergence}
 
 
 # ── self-test ────────────────────────────────────────────────────────────────────────────────
@@ -554,7 +639,15 @@ def self_test() -> int:
                       got["scope"] == "full" and got["count"] == n,
                       f"scope={got['scope']} count={got['count']}")
             for label, changed in (
-                    ("a repo-ROOT file ⇒ ALL", ["README.md"]),
+                    # 🚨 Each of these is a repo-ROOT path NOOP_FILES deliberately does NOT name,
+                    # and each is a real file in this fleet: two build-input files that change
+                    # what every project compiles, and the gate ALLOW files every satellite keeps
+                    # at its root. The narrowing must never reach them.
+                    ("an UNNAMED repo-ROOT file (a build input) ⇒ ALL",
+                     ["Directory.Build.props"]),
+                    ("a repo-ROOT global.json ⇒ ALL", ["global.json"]),
+                    ("a repo-ROOT gate ALLOW file ⇒ ALL", ["plugin-gate.allow"]),
+                    ("a repo-ROOT file nobody has classified yet ⇒ ALL", ["brand-new-thing.toml"]),
                     (".github/ (the workflow itself) ⇒ ALL", [".github/workflows/ci.yml"]),
                     ("scripts/ (the gates) ⇒ ALL", ["scripts/gen-manifests.py"]),
                     ("an UNKNOWN top-level dir (a deleted package) ⇒ ALL", ["Gone/index.json"]),
@@ -703,14 +796,73 @@ def self_test() -> int:
         check("…and it is checked even when the diff touches NO src/ path",
               got["scope"] == "full" and "does not exist" in got["reason"], f"{got['reason'][:90]}")
 
-        print("the NOOP_DIRS copy cannot drift from the caller's unnoticed:")
+        # ── the repo-ROOT no-op files (the AGENTS.md blind spot, Plugins run 34158493654) ──
+        # 🚨 THE SUBJECT OF THIS FILTER IS A LIST OF NAMES, and a name that no longer exists in the
+        # fleet would make its case pass having filtered nothing. So every name is asserted
+        # INDIVIDUALLY, off NOOP_FILES itself rather than off a hand-written copy: adding a name
+        # without an assertion is impossible, and REMOVING one turns its assertion red.
+        print(f"repo-ROOT no-op files ({len(NOOP_FILES)} named) — the blind spot NOOP_DIRS "
+              "structurally cannot cover:")
+        # 🚨 THE DENOMINATOR, ASSERTED. The loop below iterates NOOP_FILES, so DELETING a name
+        # would delete its case and the sweep would stay green having stopped covering it — the
+        # exact "a guard whose subject moved" shape. These three names are the measured ones
+        # (`AGENTS.md` is Plugins run 34158493654; every repo in the fleet carries all three), so
+        # removing any of them turns THIS case red instead of quietly shrinking the population.
+        check("NOOP_FILES still names the root files this fleet actually has",
+              {"AGENTS.md", "CLAUDE.md", "README.md"} <= NOOP_FILES and len(NOOP_FILES) >= 9,
+              f"NOOP_FILES={sorted(NOOP_FILES)}")
+        for name in sorted(NOOP_FILES):
+            got = _run(root, "modules", "pull_request", [name])
+            check(f"[modules] a {name}-only diff builds NOTHING, not everything",
+                  got["scope"] == "narrowed" and got["count"] == 0,
+                  f"scope={got['scope']} count={got['count']} — {got['reason'][:80]}")
+        got = _run(root, "modules", "pull_request", ["AGENTS.md"], extra=["--always", "Acme.Alpha"])
+        check("[modules] …and with a floor it builds the floor and TESTS NOTHING",
+              got["scope"] == "narrowed" and got["selected"] == ["Acme.Alpha"]
+              and got["tested"] == [], f"{got['selected']} tested={got.get('tested')}")
+        got = _run(root, "modules", "pull_request", ["AGENTS.md", "src/Acme.Beta/T.cs"])
+        check("[modules] a root no-op file riding along never widens a real selection",
+              got["scope"] == "narrowed" and got["selected"] == ["Acme.Beta"], f"{got['selected']}")
+        got = _run(root, "modules", "pull_request", ["AGENTS.md", "plugin-gate.allow"])
+        check("[modules] one UNNAMED root file among no-op ones still runs the full set",
+              got["scope"] == "full" and "plugin-gate.allow" in got["reason"],
+              f"scope={got['scope']} — {got['reason'][:90]}")
+
+        print("the NOOP_DIRS copy drifting from the caller's costs the DIVERGENT DIR, not the run:")
         selector_src = (root / "scripts" / "affected-modules.py").read_text(encoding="utf-8")
-        (root / "scripts" / "affected-modules.py").write_text(
-            'NOOP_DIRS = {"legacy", "e2e"}\n' + selector_src, encoding="utf-8")
-        got = _run(root, "modules", "pull_request", ["Alpha/index.json"])
-        check("a NOOP_DIRS that disagrees with the caller's ⇒ ALL, naming both sides",
-              got["scope"] == "full" and "drifted" in got["reason"], f"{got['reason'][:100]}")
-        (root / "scripts" / "affected-modules.py").write_text(selector_src, encoding="utf-8")
+        selector_path = root / "scripts" / "affected-modules.py"
+        # THEIRS is missing `app` — MeshWeaver.SocialMedia's live divergence, measured on run
+        # 34122662676, which used to answer `full` on every pull request that repo ever opened.
+        theirs_short = 'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", ".claude", ".worktrees"}\n'
+        selector_path.write_text(theirs_short + selector_src, encoding="utf-8")
+        got = _run(root, "modules", "pull_request", ["docs/guide.md"])
+        check("a caller missing one of our NOOP dirs still NARROWS on the ones both agree about",
+              got["scope"] == "narrowed" and got["count"] == 0 and got.get("divergence")
+              and "only ours: app" in got["divergence"],
+              f"scope={got['scope']} divergence={got.get('divergence')}")
+        got = _run(root, "modules", "pull_request", ["app/rn/App.tsx"])
+        check("…while the DIVERGENT dir itself is treated as EVERYTHING (over-built, never skipped)",
+              got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
+        # THEIRS carries a dir we do not — the other direction, and it must be just as safe.
+        selector_path.write_text(
+            'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees", '
+            '"vendor"}\n' + selector_src, encoding="utf-8")
+        got = _run(root, "modules", "pull_request", ["vendor/lib.js"])
+        check("a dir only THEY call inert is still EVERYTHING here (the other direction)",
+              got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
+        got = _run(root, "modules", "pull_request", ["docs/guide.md"])
+        check("…and their extra entry does not stop US narrowing on the agreed ones",
+              got["scope"] == "narrowed" and got["count"] == 0, f"scope={got['scope']}")
+        # 🚨 THE SUBJECT MOVING is the one thing that must still refuse to narrow: a literal that
+        # no longer parses means this script cannot know what the caller believes, and "cannot
+        # verify" has exactly one honest answer.
+        selector_path.write_text(
+            selector_src.replace("NOOP_DIRS", "NOOP_TOPS"), encoding="utf-8")
+        got = _run(root, "modules", "pull_request", ["docs/guide.md"])
+        check("a RENAMED NOOP_DIRS literal ⇒ ALL (the subject moved, so we cannot know)",
+              got["scope"] == "full" and "no single-line NOOP_DIRS literal" in got["reason"],
+              f"scope={got['scope']} — {got['reason'][:100]}")
+        selector_path.write_text(selector_src, encoding="utf-8")
         got = _run(root, "modules", "pull_request", ["WhatsNew/note.md"])
         check("WhatsNew/ is a NOOP dir — a note-only PR builds NOTHING, not everything",
               got["scope"] == "narrowed" and got["count"] == 0,
@@ -819,10 +971,22 @@ def main() -> int:
 
     say("")
     say(f"scope: {answer['scope']} — {answer['reason']}")
+    if answer.get("divergence"):
+        say(f"⚠ {answer['divergence']}")
     for name, reason in sorted(answer.get("why", {}).items()):
         say(f"  ▸ {name}: {reason}")
     if answer["skipped"]:
         say(f"not built ({len(answer['skipped'])}): {', '.join(answer['skipped'])}")
+    # 🚨 STATE BOTH DENOMINATORS, ALWAYS, AND NEVER LEAVE A ZERO BARE. "0 selected" and "0 tested"
+    # are the two answers a reader must be able to tell apart from "the filter matched nothing
+    # because it is broken", and the only thing that distinguishes them is the count they are
+    # measured against being printed beside them.
+    total = answer["count"] + len(answer["skipped"])
+    tested = answer.get("tested", [])
+    say(f"built {answer['count']} of {total} bundle(s): "
+        f"{', '.join(answer['selected']) if answer['selected'] else '<none>'}")
+    say(f"tested {len(tested)} of {answer['count']} selected bundle(s): "
+        f"{', '.join(tested) if tested else '<none> — no selected bundle owes a test run'}")
 
     if os.environ.get("GITHUB_OUTPUT"):
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
@@ -831,11 +995,16 @@ def main() -> int:
             fh.write("modules=" + json.dumps(answer["modules"]) + "\n")
             fh.write("selected=" + " ".join(answer["selected"]) + "\n")
     if os.environ.get("GITHUB_STEP_SUMMARY"):
-        total = answer["count"] + len(answer["skipped"])
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
             fh.write(f"### {'🧱' if answer['scope'] == 'full' else '🎯'} "
                      f"{answer['lane']}: {answer['scope']} — {answer['count']} of {total}\n\n"
-                     f"{answer['reason']}\n\n")
+                     f"{answer['reason']}\n\n"
+                     f"**Built** {answer['count']} of {total} · **tested** "
+                     f"{len(answer.get('tested', []))} of {answer['count']}"
+                     f"{' — no selected bundle owes a test run' if not answer.get('tested') else ''}"
+                     "\n\n")
+            if answer.get("divergence"):
+                fh.write(f"> ⚠ {answer['divergence']}\n\n")
             if answer["scope"] == "narrowed":
                 if answer["why"]:
                     fh.write("| built | why |\n|---|---|\n")

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -86,16 +86,21 @@ import sys
 import tempfile
 from pathlib import Path
 
-# 🚨 scripts/affected-modules.py's NOOP_DIRS, and it must stay EQUAL to it — the top-level dirs a
-# change in which can reach no build at all. Every entry NOT in this set falls through to a FULL
-# run, so adding one silently un-builds something and dropping one merely costs a full run.
+# 🚨 scripts/affected-modules.py's NOOP_DIRS — the top-level dirs a change in which can reach no
+# build at all. Every entry NOT in this set falls through to a FULL run, so adding one silently
+# un-builds something and dropping one merely costs a full run.
 # `clients/` is deliberately absent (the established selector treats it as ALL, and a client asset
-# can be embedded by a host).
+# can be embedded by a host). Measured over 120 first-parent merges to MeshWeaver.Plugins' main,
+# `clients/` is the largest remaining full-set trigger after `.github/` (11 of 45); the entry stays
+# out because this set also feeds the mesh gate and the bake, so moving it is a wider decision than
+# the module matrix — see Doc/Architecture/BuildScopeNarrowing.
 #
 # 🚨 A HAND COPY IS NOT A GUARANTEE, and this one drifted on its first day: `WhatsNew` was missing,
 # so a note-only PR ran the entire fleet's module suite — the exact case affected-modules.py added
-# it for. `assert_noop_dirs_match()` below now READS the caller's set and refuses to narrow when
-# the two disagree, so the next drift is a full run with a named reason instead of a silent one.
+# it for. `resolve_noop_dirs()` below READS the caller's set and narrows on the INTERSECTION, so a
+# drift over-builds the divergent dir out loud instead of silently, and — since 2026-09-08 —
+# instead of switching the whole narrowing off (which is what equality did, on every pull request
+# three satellites ever opened). A literal it cannot READ is still a refusal.
 NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees"}
 
 # 🚨 A repo-ROOT path HAS NO TOP-LEVEL DIRECTORY, so NOOP_DIRS above can never reach it: both

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2015,6 +2015,17 @@ jobs:
     - name: "Every PR-reachable secret is asserted by a preflight"
       run: python3 .github/scripts/check-pr-secret-preflight.py --root .
 
+    # 🚨 THE TWO SCRIPTS THAT DECIDE WHAT A SATELLITE'S PULL REQUEST DOES *NOT* REBUILD, proven
+    # here because core is the repo that OWNS them — every satellite gets them fetched at its
+    # `platform-ref`, so a break shipped from here reaches five repos' cost model at once.
+    # `node-repo-scope.py --self-test` is also run inside its own `select` job on every satellite
+    # run; running it here as well is what makes a core PR that breaks the narrowing red on the
+    # core PR, rather than on the next satellite to bump its pin.
+    - name: "The build-scope selector can say no, and every fallback still falls back (self-test)"
+      run: python3 .github/scripts/node-repo-scope.py --self-test
+    - name: "A satellite's no-op set stays comparable to ours — the gate can fail (self-test)"
+      run: python3 .github/scripts/check-noop-scope-parity.py --self-test
+
     # 🚨 The fleet pins platform images BY DIGEST, and ACR retention deletes what is pinned
     # (MeshWeaver#3438: three satellite repos dead at `manifest unknown` at once, Education's own
     # nightly among them). pinned-digests.yml sweeps the live registry on a schedule; that lane

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -167,6 +167,35 @@ jobs:
         run: python3 "$RUNNER_TEMP/check-pr-secret-preflight.py" --self-test
       - name: "Every PR-reachable secret in this repo is asserted by a preflight"
         run: python3 "$RUNNER_TEMP/check-pr-secret-preflight.py" --root .
+      # ── THE NO-OP SET THIS REPO OWNS STILL AGREES WITH THE PLATFORM'S ──
+      # 🚨 `node-repo-scope.py` decides which module bundles a pull request rebuilds and which
+      # module SUITES it runs, and half that decision reads a set the CALLER owns: NOOP_DIRS in
+      # `scripts/affected-modules.py`, hand-written in two repositories. When the caller's copy
+      # stops PARSING — renamed, reformatted, moved — the platform answers "cannot verify" with a
+      # full run on every pull request, forever, and the only trace is one line inside the log of
+      # the job it disabled. That is the "a guard whose subject moved while its roots did not"
+      # shape, and this is where it is caught. (A mere DIVERGENCE no longer costs the run: the
+      # scope script narrows on the intersection, so a divergent dir is over-built, never skipped
+      # — this reds only when a dir the repo ACTUALLY HAS is classified differently, which is
+      # runner time being spent. `app` missing from three satellites' copies is dormant in all
+      # three: none of them has an `app/`.)
+      # Static, two files and a directory listing — no credential, so it runs on forks too.
+      - name: Fetch the platform's no-op parity guard at the pinned ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLATFORM_REF: ${{ inputs.platform-ref }}
+        run: |
+          set -euo pipefail
+          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the no-op parity guard has no ref to be fetched at"; exit 1; }
+          for script in check-noop-scope-parity.py node-repo-scope.py; do
+            gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/${script}?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/${script}" \
+              || { echo "::error::could not fetch .github/scripts/${script} at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+            head -c 400 "$RUNNER_TEMP/${script}" | grep -q "${script%.py}" || { echo "::error::the fetched ${script} at ${PLATFORM_REF} does not look like the guard"; exit 1; }
+          done
+      - name: "This repo's no-op set is comparable and agrees — the gate can fail (self-test)"
+        run: python3 "$RUNNER_TEMP/check-noop-scope-parity.py" --self-test
+      - name: "This repo's no-op set agrees with the platform's"
+        run: python3 "$RUNNER_TEMP/check-noop-scope-parity.py" --root .
       # 🚨 ONE implementation of the version derivation, every repo. Fetched exactly like the two
       # guards above and like compile-check.py: asserted RED when unavailable, never fallen back to
       # a drifted per-repo copy. The fetch and the self-test run on EVERY call, whichever copy is

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
@@ -1,0 +1,203 @@
+---
+Name: What a Pull Request Rebuilds
+Category: Documentation
+Description: How node-repo-scope.py decides which module bundles a pull request rebuilds and which module suites it runs — the two blind spots that made a one-file documentation diff cost 105 jobs and 345 job-minutes, and why a divergence now costs the divergent directory rather than the whole run.
+---
+
+# What a Pull Request Rebuilds
+
+`.github/scripts/node-repo-scope.py` decides, for every node repository's `Module bundles` lane,
+**which module bundles a pull request rebuilds and which module suites it runs.** It is the one
+place in the fleet whose job is to say *no*, so it is written biased: every uncertainty resolves
+to a FULL run, out loud, naming which uncertainty it was.
+
+That bias is right and this page does not weaken it. What it documents is two places where the
+script said "I cannot tell" about a file it *could* have classified, and one place where it
+answered a disagreement by switching narrowing off entirely.
+
+> Where the narrowing sits in the wider lane: [CI Content Bake](/Doc/Architecture/CiContentBake) §
+> "Rebuild only what a change AFFECTS". What a green run does and does not prove:
+> [Reading CI Signals](/Doc/Architecture/ReadingCiSignals).
+
+## The classifier
+
+Every changed path lands in exactly one bucket:
+
+| the path looks like | bucket |
+|---|---|
+| `<node package>/…` (a top-level dir with an `index.json`) | the CONTENT half — the caller's `affected-modules.py` answers the closure |
+| `src/<project>/…` | the COMPILED half — the caller's `project-closure.py` answers the closure |
+| a top-level dir in **`NOOP_DIRS`** | reaches nothing this lane builds |
+| a repo-root file in **`NOOP_FILES`** | reaches nothing any lane builds |
+| **anything else** | EVERYTHING — the full set, naming the file |
+
+The last row is the safety net, and every entry above it is a claim that a class of path cannot
+change what a module builds.
+
+## Blind spot 1 — a repo-root file has no top-level directory
+
+`NOOP_DIRS` is matched as `"/" in f and top in NOOP_DIRS`. **A single-segment path takes neither
+no-op branch**, so before 2026-09-08 every repo-root file fell through to EVERYTHING.
+
+Measured on MeshWeaver.Plugins run 34158493654 — a pull request whose entire diff was one file:
+
+```text
+AGENTS.md  → EVERYTHING (tooling / repo-root / unknown scope)
+scope: full — 1 changed file(s) reach the tooling/global scope — first: AGENTS.md.
+34 of 34 selected module(s) still owe a test run: MeshWeaver.Graph.Views, …
+```
+
+**105 jobs. ~345 billable job-minutes. ~54 minutes of wall clock. For a documentation edit** — and
+`AGENTS.md` is the file every agent session in this fleet edits. The `docs/` entry in `NOOP_DIRS`
+was added for exactly this shape and could not cover it, because the fleet keeps its agent guidance
+at the repository root rather than under `docs/`.
+
+`NOOP_FILES` closes it, and **it is a closed list of names, never a pattern.** That is the whole
+safety argument: a root file the list does not name is still UNKNOWN and still runs the full set.
+Measured across the fleet, the root files that must stay on the loud path are `Directory.Build.props`,
+`global.json`, and every satellite's gate allow files — `plugin-gate.allow`, `plugin-tests.allow`,
+`cover-prose.allow`, `impersonation.allow`. A `*.md` glob, or "any dotfile", would have made the
+inert claim for files nobody had read.
+
+## Blind spot 2 — a disagreement answered by narrowing nothing
+
+`NOOP_DIRS` is **hand-written in two repositories**: here, and in each caller's
+`scripts/affected-modules.py`. The platform parses the caller's literal out of the source (importing
+it would run its argparse) and compared the two for **equality** — and answered any difference with
+a blanket full run.
+
+That switched narrowing off, fleet-wide, invisibly. Measured 2026-09-07, MeshWeaver.SocialMedia run
+34122662676:
+
+```text
+scope: full — this script's NOOP_DIRS has drifted from scripts/affected-modules.py's —
+only theirs: (none); only ours: app.
+```
+
+…on **every pull request that repository ever opened** since `app` was added here — for a repository
+that has no `app/` directory at all, so not one changed file could ever have been classified by the
+entry the two sides disagreed about. MeshWeaver.Manufacturing and MeshWeaver.Reinsurance carry the
+same divergence today, and it is dormant in both for the same reason.
+
+The remedy is the **intersection**, which is safe in both directions where equality never was:
+
+- a directory only the platform calls inert — the caller believes it reaches its gate, so the
+  platform must not skip it: the intersection drops it, and it goes to EVERYTHING;
+- a directory only the caller calls inert — the platform believes it reaches a module, so it must
+  not skip it: the intersection drops it, and it goes to EVERYTHING.
+
+Either way the divergent directory is **over-built, out loud, and every other directory keeps
+narrowing.** "The two must classify a top-level directory identically" was the right requirement
+expressed as the wrong remedy: they need only agree *where it matters*, and the intersection makes
+them agree by construction.
+
+**One thing is still a refusal, and must stay one.** A caller whose `NOOP_DIRS` literal cannot be
+READ — renamed, moved, reformatted onto several lines — leaves the platform unable to know what the
+caller believes, and "cannot verify" has exactly one honest answer: the full set.
+
+## Both denominators, printed
+
+`selected` answers what is BUILT. A floor-only entry — one the caller's gates compose on every run,
+which this diff does not reach — is built and deliberately **not tested**, so "how many suites will
+run" is a different number. A reader who sees only the first cannot tell *nothing needed testing*
+from *the filter is broken and matched nothing*. Both are now stated, with names, at the point the
+decision is made and again in the job summary:
+
+```text
+scope: narrowed — 4 of 4 module bundle(s) are reachable from this diff (1 file(s));
+                  0 of those owe a test run.
+built 4 of 4 bundle(s): MeshWeaver.AI, MeshWeaver.Maps, MeshWeaver.Markdown.Collaboration, MeshWeaver.Payments.Stripe
+tested 0 of 4 selected bundle(s): <none> — no selected bundle owes a test run
+```
+
+## What this does NOT touch, and why
+
+**A skipped module suite still cannot be mistaken for a passed one.** Nothing here changes the
+structure that guarantees it, and that structure is not an `if:` — it is receipts. The pack leg
+records in its own receipt which lane owns each module's suite (`none` / `inline` / `lane`), the
+tests lane drops a receipt of its own, and `node-repo-pack-verify.py` — read by `verify`, the
+lane's one stable required context `All selected bundles built`, which runs `always()` — fails the
+run when a module the pack leg DELEGATED has no test receipt, or when a test receipt arrives for a
+module that delegated nothing. Two mutually exclusive `if:`s can both be false; the receipts are
+what make that impossible to do quietly. Moving an entry from tested to untested moves it through
+that same accounting, not around it.
+
+**`clients/` stays on the loud path**, deliberately, and it is the largest remaining bucket:
+measured over 120 first-parent merges to MeshWeaver.Plugins' `main`, 45 took the full-set fallback,
+and the first global path was `.github/` in 25 of them, `clients/` in 11. `clients/` is absent from
+`NOOP_DIRS` on purpose — *a client asset can be embedded by a host* — and the set feeds the mesh
+gate and the bake as well as this lane, so narrowing it is a separate decision with a wider blast
+radius than the module matrix. The number is recorded here so that decision can be taken on
+evidence rather than re-derived.
+
+**`.github/workflows/ci.yml` stays on the loud path too**, and it is the biggest single trigger.
+That is correct: the caller's workflow file carries the module matrix, the platform pin and both
+image digests, and a pin move genuinely invalidates every bundle in the repository.
+
+## The guards
+
+Two, and each was made to fail before it was believed.
+
+**`node-repo-scope.py --self-test`** runs unconditionally in the `select` job of every satellite's
+every run, next to the answer it produces, and again in core's own `dotnet-test.yml`. 63 cases.
+The load-bearing ones for this change:
+
+- every name in `NOOP_FILES` narrows to nothing on its own — asserted by iterating the set itself,
+  so a name cannot be added without an assertion;
+- 🚨 **and the set's own denominator is asserted beside them.** Iterating `NOOP_FILES` means
+  DELETING a name would delete its case and the sweep would stay green having stopped covering it
+  — the "a guard whose subject moved while its roots did not" shape. One extra case pins the names
+  that were measured, so a removal turns that case red instead of quietly shrinking the population;
+- an UNNAMED root file — a build input, a gate allow file, something nobody has classified yet —
+  still runs the full set;
+- both divergence directions narrow on the agreed directories while the divergent one is
+  EVERYTHING;
+- a RENAMED `NOOP_DIRS` literal still refuses to narrow at all.
+
+**`check-noop-scope-parity.py`** runs in `node-repo-validate.yml`, so it reaches every satellite at
+that satellite's `platform-ref`. It imports the platform's sets from `node-repo-scope.py` rather
+than re-declaring them — a third hand-copy is the defect it exists to find — and it reds when:
+
+- the caller's `NOOP_DIRS` literal cannot be parsed (narrowing is off in that repository and
+  nothing else anywhere says so);
+- a top-level directory **the caller's tree actually has** is classified differently by the two
+  sets. Scoped to what exists on purpose: `app` missing from three satellites' copies is reported
+  as *dormant*, not red, because none of them has an `app/` and a gate that reds about nothing is
+  one people learn to ignore.
+
+It reads two files and a directory listing — no network, no credential, no secret — so it runs on
+fork pull requests exactly as it does anywhere else.
+
+### Falsification
+
+Each mechanism was reverted and the suite observed to go red before being restored:
+
+| broken | red cases |
+|---|---|
+| the `NOOP_FILES` branch deleted from the classifier | 12 |
+| `AGENTS.md` removed from `NOOP_FILES` | 4, including the denominator case |
+| the intersection reverted to the old equality refusal | 2 |
+| the closed list widened to "any root file" | 5, including the gate allow file |
+| the parity guard's own six branches | each observed red on its own fixture |
+
+## Measured effect
+
+For the diff that prompted this — MeshWeaver.Plugins run 34158493654, `AGENTS.md` alone:
+
+| | before | after |
+|---|---:|---:|
+| jobs | 105 | 31 |
+| job-minutes | 344.9 | ~130.7 |
+| `Module bundles / Module tests (…)` | 34 jobs · 152.1 min | 0 |
+| `Module bundles / Module bundle (…)` | 34 jobs · 34.4 min | 0 |
+| `Module bundles (floor) / Module tests (…)` | 4 jobs · 19.2 min | 0 |
+| `Module bundles (floor) / Module bundle (…)` | 4 jobs · 3.0 min | 4 jobs · 3.0 min — the gates compose them |
+| `Portal hosts (shard N)` | 4 jobs · 90.5 min | 4 jobs · 90.5 min — unchanged, and now the critical path |
+
+A module-touching pull request is **unchanged**: `src/MeshWeaver.Teams/…` selected 1 of 34 and
+tested 1 before this change and after it.
+
+`Portal hosts` is the largest remaining per-PR cost and does not narrow at all — it builds the three
+moved portal hosts and runs 48 platform suites on every pull request regardless of the diff. That is
+a separate decision, on a job whose suites cover the platform pin rather than this repository's
+modules.

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -865,9 +865,15 @@ evidence. So each of these resolves to a FULL bake, naming itself in the log and
 - a baseline commit this checkout cannot resolve, or one that is not an ancestor of HEAD
   (history rewritten);
 - the selector refusing — an **empty diff** is a broken range, never "nothing to do";
-- the selector answering ALL modules: a change under `scripts/`, `.github/`, a repo-root file, or
-  **a module directory that no longer exists**. That last one is why a DELETED module still
-  shrinks the publication correctly.
+- the selector answering ALL modules: a change under `scripts/`, `.github/`, a repo-root file the
+  platform's `NOOP_FILES` does not name, or **a module directory that no longer exists**. That last
+  one is why a DELETED module still shrinks the publication correctly.
+
+> 🚨 **The MODULE lane's copy of this decision — `node-repo-scope.py` — had two blind spots that
+> made "a repo-root file" and "the two `NOOP_DIRS` copies differ" cost a full run each, measured at
+> 105 jobs / 345 job-minutes for a one-file documentation diff and at *every pull request three
+> satellites ever opened*. Both are closed, with the falsification evidence and the numbers:
+> [What a Pull Request Rebuilds](/Doc/Architecture/BuildScopeNarrowing).**
 
 And one verdict that is neither: **`scope=none`**, when the sealed publication already records
 *this* commit for *this* identity. It is a positive finding — read from every target, logged with

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-documentation-edit-no-longer-rebuilds-everything.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-documentation-edit-no-longer-rebuilds-everything.md
@@ -1,0 +1,67 @@
+---
+Name: A documentation edit no longer rebuilds everything
+Category: Fix
+Description: Changing one file at the top of a repository used to rebuild every module in it and run every module's tests — 105 build jobs for a diff that touched no code. The check that decides what a change reaches could not see files that live at the root, and answered a disagreement between two repositories by rebuilding everything, everywhere.
+Icon: TargetArrow
+Order: -20260908
+---
+
+# A documentation edit no longer rebuilds everything
+
+Every content repository has a check that reads a pull request's changed files and works out which
+of its modules that change can possibly reach. Only those get rebuilt, and only those get their
+tests run. Everything it cannot classify gets rebuilt — deliberately, because guessing *narrower*
+than the truth means shipping something that was never recompiled.
+
+Two things it could have classified, it did not.
+
+## A file at the top of a repository has no folder
+
+The check recognises a harmless change by the **folder** it is in — release notes, documentation,
+the mobile app, the end-to-end tests. A file that sits at the *top* of the repository is in no
+folder at all, so it matched none of those rules and fell straight into "rebuild everything".
+
+The file that matters here is the one every repository keeps at its root for the assistants working
+in it. Editing it alone cost, measured on one real pull request: **105 build jobs, about 345 minutes
+of machine time, 54 minutes of waiting — for a one-file documentation change.**
+
+The same run now costs **31 jobs and about 131 minutes.** No module is rebuilt that the change
+cannot reach, and no module's tests run at all.
+
+The fix is a **named list**, not a pattern. A root file the list does not name is still unknown and
+still rebuilds everything — which is what keeps the files that genuinely change how a repository
+builds, and every repository's own gate settings, on the loud path where they belong. "Any markdown
+file" would have made that promise on behalf of files nobody had read.
+
+## Two copies of one list disagreed, and the answer was "rebuild everything"
+
+The list of harmless folders is written twice: once in the platform, once in each content
+repository. When the two differed at all, the platform stopped narrowing entirely and rebuilt
+everything, on every pull request, indefinitely — and the only trace was one line inside the log of
+the very job it had switched off.
+
+Three repositories were in that state. In all three the disagreement was about a folder **none of
+them has**, so it could never have applied to a single changed file. They had simply been rebuilding
+everything, for months, over nothing.
+
+A disagreement now costs only the folder it is about: that one folder is rebuilt, out loud, and
+every other folder keeps narrowing. Whichever side calls it harmless, the other side's belief wins
+— so the change can only ever build *more* than the two agree on, never less.
+
+## What did not change
+
+**A test that did not run still cannot look like a test that passed.** That guarantee never came
+from a condition on the job; it comes from receipts. Each module's build records which lane owes its
+tests, the test lane records that it ran them, and the check that gates the whole thing fails when
+those two accounts disagree — including when both are silent. Moving a module from "tested" to "not
+tested" moves it through that same bookkeeping rather than around it.
+
+A pull request that touches a module's code is completely unaffected: it selected and tested exactly
+that one module before this change, and it does the same after.
+
+## Both checks were made to fail first
+
+The rules were each deliberately broken and watched go red before being fixed and watched go green —
+including the one that guards the *list itself*. A check that walks a list can quietly stop covering
+an entry the moment someone deletes it, so a separate assertion pins the entries that were measured:
+removing one now turns that assertion red instead of silently shrinking what is checked.


### PR DESCRIPTION
## What a docs-only pull request costs today

Measured on **MeshWeaver.Plugins run 34158493654** — a green pull request whose **entire diff was `AGENTS.md`** — read straight out of `Module bundles / Select the affected bundles`:

```text
AGENTS.md  → EVERYTHING (tooling / repo-root / unknown scope)
scope: full — 1 changed file(s) reach the tooling/global scope — first: AGENTS.md. Running the full set.
34 of 34 selected module(s) still owe a test run: MeshWeaver.Graph.Views, MeshWeaver.AI.AppleIntelligence, …
```

**105 jobs · 344.9 billable job-minutes · ~54 min wall clock, for a documentation edit.**

The affected-selection is not broken and it does govern the test matrix — `test-modules`/`test-count` come from the same `select` job, and a floor-only entry is already built-but-not-tested. It ran full because it genuinely could not classify the file.

## Two blind spots, both in `.github/scripts/node-repo-scope.py`

**1 · A repo-ROOT path has no top-level directory.** Both no-op branches are guarded by `"/" in f`, so a single-segment path takes neither and falls to the `else`:

```python
elif "/" in f and top in NOOP_DIRS:      # ← a root file can never reach this
    ...
else:
    global_files.append(f)               # → EVERYTHING
```

`docs/` was added to `NOOP_DIRS` for exactly this shape and cannot cover it: the fleet keeps its agent guidance at the repository **root**, and `AGENTS.md` is the file every agent session edits.

`NOOP_FILES` closes it as a **closed list of names, never a pattern** — an unnamed root file is still UNKNOWN and still runs the full set. Measured across the fleet, that keeps `Directory.Build.props`, `global.json` and every satellite's gate `*.allow` (`plugin-gate.allow`, `plugin-tests.allow`, `cover-prose.allow`, `impersonation.allow`) exactly where they are.

**2 · A `NOOP_DIRS` divergence meant "narrow nothing".** The set is hand-copied into every caller and was compared for **equality**, with any difference answered by a blanket full run — forever, traced only by one line inside the log of the job it disabled. Measured on **MeshWeaver.SocialMedia run 34122662676**:

```text
scope: full — this script's NOOP_DIRS has drifted from scripts/affected-modules.py's —
only theirs: (none); only ours: app.
```

…on **every pull request that repository ever opened** since `app` was added here — for a repository that has no `app/` directory at all. Manufacturing and Reinsurance carry the same dormant divergence.

The remedy is the **intersection**, safe in both directions where equality never was: a directory *either* side believes is live goes to EVERYTHING, and every other directory keeps narrowing. A literal that cannot be **read** at all — renamed, moved, reformatted — stays a refusal; "cannot verify" has one honest answer.

## Measured effect

Same diff, run 34158493654:

| | before | after |
|---|---:|---:|
| jobs | 105 | **31** |
| job-minutes | 344.9 | **~130.7** |
| `Module bundles / Module tests (…)` | 34 · 152.1 min | 0 |
| `Module bundles / Module bundle (…)` | 34 · 34.4 min | 0 |
| `Module bundles (floor) / Module tests (…)` | 4 · 19.2 min | 0 |
| `Module bundles (floor) / Module bundle (…)` | 4 · 3.0 min | 4 · 3.0 min — the gates compose them |
| `Portal hosts (shard N)` | 4 · 90.5 min | unchanged, and now the critical path |

A module-touching pull request is **unchanged**: `src/MeshWeaver.Teams/…` selected 1 of 34 and tested 1, before and after.

## It cannot become a silent skip

- **The verdict is not what became conditional.** `verify` — `All selected bundles built`, the lane's one stable required context — keeps `if: always()`, and `node-repo-pack-verify.py` still reds when a module the pack leg **delegated** has no test receipt (or a receipt arrives for one that delegated nothing). Two mutually exclusive `if:`s can both be false; the receipts are what make that impossible to do quietly. Moving an entry from tested to untested moves it *through* that accounting.
- **No `github.actor != 'dependabot[bot]'` anywhere.** Nothing new is conditional on an event or an actor; the new guard is static (two files + a directory listing, no credential), so it runs on forks.
- **The selection is positive and states its denominator.** Both counts, with names, at the point the decision is made and again in the job summary:

```text
scope: narrowed — 4 of 4 module bundle(s) are reachable from this diff (1 file(s)); 0 of those owe a test run.
built 4 of 4 bundle(s): MeshWeaver.AI, MeshWeaver.Maps, MeshWeaver.Markdown.Collaboration, MeshWeaver.Payments.Stripe
tested 0 of 4 selected bundle(s): <none> — no selected bundle owes a test run
```

## The guards, and evidence each can fail

`node-repo-scope.py --self-test` **44 → 64 cases**, run unconditionally in every satellite's `select` job and now in core's own `dotnet-test.yml`.

🚨 **The `NOOP_FILES` cases iterate the set itself**, which is the vacuity trap: *deleting* a name would delete its case and leave the sweep green having stopped covering it. So one case asserts the set's **denominator** — the measured names and a floor — and a removal reds that instead.

`check-noop-scope-parity.py` (new) runs in `node-repo-validate.yml`, so it reaches every satellite at that satellite's `platform-ref`. It **imports** the platform's sets from `node-repo-scope.py` rather than re-declaring them (a third hand-copy is the defect it exists to find) and reds when a caller's literal stops parsing, or when a directory the caller **actually has** is classified differently. Scoped to what exists on purpose: `app` is *dormant* in all three satellites, so nobody is reddened about nothing.

Falsification — each mechanism reverted, suite observed red, then restored:

| broken | red cases |
|---|---|
| the `NOOP_FILES` branch deleted from the classifier | 12 |
| `AGENTS.md` removed from `NOOP_FILES` | 4, including the denominator case |
| the intersection reverted to the old equality refusal | 2 |
| the closed list widened to "any root file" | 5, including the gate allow file |
| each of the parity guard's six branches | red on its own fixture |

Run against **every satellite's `main`** (`--root` on a fresh `git archive` of each): Plugins, SocialMedia, Manufacturing, Crm, Reinsurance all **green**; Education ships no selector and says so with the cost attached.

## Deliberately NOT narrowed, with the number

Over **120 first-parent merges to MeshWeaver.Plugins' `main`**, 45 took the full-set fallback. The first global path was `.github/` in 25 (19 of them `ci.yml`, which carries the module matrix, the platform pin and both image digests — a pin move genuinely invalidates every bundle), `clients/` in 11, `scripts/` in 3, a root file in 2. `clients/` is absent from `NOOP_DIRS` on purpose (*a client asset can be embedded by a host*) and the set also feeds the mesh gate and the bake, so narrowing it is a separate decision with a wider blast radius. The measurement is recorded in the doc page so that decision is evidence-led rather than re-derived.

## Local verification

- `node-repo-scope.py --self-test` — 64 cases green
- `check-noop-scope-parity.py --self-test` — 7 cases green
- `node-repo-pack-verify.py --self-test` — green (unchanged, re-run because `test`/`tests` flow through it)
- `check-workflow-timeouts.py --root .` — 76 jobs, 0 violations
- `check-workflow-shell.py` / `check-workflow-yaml-keys.py` / `check-pr-secret-preflight.py --root .` — 0 violations
- `dotnet test test/MeshWeaver.Documentation.Test -c Release` — **325 passed, 0 failed** (`DocumentationLinkIntegrityTest` included)

Doc: `Doc/Architecture/BuildScopeNarrowing` (linked from `CiContentBake`) · What's New entry included.

Pairs-with: none — this diff removes no public type or member from `src/`; it touches two `.github/scripts` Python files, two workflows and three documentation pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCM41UknXQwgXqH39tLo9u
