### PR TITLE
fix(#3649): a module generation that cannot load here falls back to the previous one

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -89,6 +89,9 @@ public static class MemexConfiguration
                 .Select(m => m.Name)
                 .Where(n => !string.IsNullOrWhiteSpace(n))
                 .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase),
+            // #3649 — the modules it loaded from their PREVIOUS generation: present, one version
+            // behind, and never "restart required".
+            FallbackModules = [.. app.Services.GetServices<FallbackModule>()],
         }.Read();
 
         if (report.IsUndetermined)
@@ -121,6 +124,12 @@ public static class MemexConfiguration
                 "{Count} activated module(s) are landed but not loaded in this process — whatever "
                 + "they contribute (endpoints included) is absent until a restart: {Detail}",
                 report.Pending.Count, ModuleActivationStatus.Describe(report.Pending));
+
+        // 🚨 #3649 — once per boot, on the logger: the loader already said it on stderr before the
+        // pipeline was up, and this is the line an operator's log query finds. A Warning, not an
+        // Error: the module is running, one version behind, and nothing here is broken.
+        foreach (var fallback in app.Services.GetServices<FallbackModule>())
+            logger.LogWarning("[MeshWeaver.Mesh.FallbackModule] {Report}", fallback.Report());
     }
 
     /// <summary>
@@ -304,6 +313,7 @@ public static class MemexConfiguration
             // both: skip, say so on stderr, and boot. A module that is genuinely required makes
             // itself known as a missing FEATURE, which is diagnosable — a portal that will not
             // start is not.
+            void WarnPin(string msg) => Console.Error.WriteLine($"[ModuleActivation] {msg}");
             var loadableModules = effectiveModules
                 // 🚨 ONE resolution, shared with the existence gate above
                 // (ModuleActivationBoot.ResolveLoadPath): a store-landed module resolves to the
@@ -319,12 +329,24 @@ public static class MemexConfiguration
                 // still lazily loads dependency DLLs from it (first chat after that was
                 // FileNotFoundException 'OpenAI' — the 2026-08-27 outage). Baseline entries stay
                 // un-pinned: they resolve into the image's own immutable closure.
+                //
+                // 🚨 #3649: a store-landed entry that still holds its PREVIOUS generation hands
+                // the loader a way back — resolved (and pinned) LAZILY, only when the head
+                // generation is refused before loading or fails to load. Pinning every previous
+                // generation up front would double the per-boot copy for a path taken only when
+                // something is wrong. The loader then runs the previous generation, records a
+                // FallbackModule, and says so on stderr; the module is present, one version
+                // behind, instead of absent.
                 .Select(module => (
                     Module: module,
                     Path: module.Landed is not null
-                        ? ModuleGenerationPin.PinnedLoadPath(moduleRoot, module.Landed,
-                            onWarn: msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"))
-                        : ModuleActivationBoot.ResolveLoadPath(moduleRoot, module)))
+                        ? ModuleGenerationPin.PinnedLoadPath(moduleRoot, module.Landed, onWarn: WarnPin)
+                        : ModuleActivationBoot.ResolveLoadPath(moduleRoot, module),
+                    Previous: module.Landed is { } landed
+                              && ModuleActivationBoot.PreviousGeneration(landed) is { } previous
+                              && ModuleActivationBoot.LandedModuleDllExists(moduleRoot, previous)
+                        ? previous
+                        : null))
                 .Where(candidate =>
                 {
                     if (File.Exists(candidate.Path))
@@ -337,7 +359,16 @@ public static class MemexConfiguration
                     return false;
                 })
                 .ToArray();
-            var resolvedModules = loadableModules.Select(candidate => candidate.Path).ToArray();
+            var resolvedModules = loadableModules
+                .Select(candidate => new ModuleInstallCandidate(candidate.Path)
+                {
+                    Version = candidate.Module.Landed?.Version,
+                    PreviousVersion = candidate.Previous?.Version,
+                    Previous = candidate.Previous is { } previous
+                        ? () => ModuleGenerationPin.PinnedLoadPath(moduleRoot, previous, onWarn: WarnPin)
+                        : null,
+                })
+                .ToArray();
 
             // 🚨 #2223 — SAY WHICH COPY IS BEING LOADED. A view-pack fix can merge, build, land in
             // the module store and still not run, because a baseline Modules:Assemblies entry
@@ -348,7 +379,8 @@ public static class MemexConfiguration
             // and boots: a pod that refuses to start cannot be given the fix for what is wrong
             // with it.
             ModuleLoadReport.Write(
-                ModuleLoadReport.Describe(moduleRoot, loadableModules),
+                ModuleLoadReport.Describe(moduleRoot,
+                    loadableModules.Select(candidate => (candidate.Module, candidate.Path))),
                 Console.WriteLine,
                 Console.Error.WriteLine);
 
@@ -364,7 +396,7 @@ public static class MemexConfiguration
             // Configuration must mean "the deployment supplied nothing", never "the host forgot".
             builder.WithConfiguration(configuration);
             if (resolvedModules.Length > 0)
-                builder.InstallAssemblies(resolvedModules);
+                builder.InstallModules(resolvedModules);
 
             // 🚨 #3395 — say, once and durably, that a replica came up on the mesh's set. Deferred
             // to a hosted service rather than written here, because the claim is "this set is
@@ -379,10 +411,15 @@ public static class MemexConfiguration
             // later in boot than it did here. Create-if-absent, so the second and every later
             // replica writes nothing, and best-effort — a read-only volume costs the mesh-level
             // signal and nothing else.
+            // 🚨 #3649 — the adoption records what this process ACTUALLY LOADED per module: the
+            // set's generation where it loaded, the previous one where the loader fell back. Read
+            // off the container, because the FallbackModule records exist only after
+            // InstallModules ran; so the mesh's records say what runs, and the GC references it.
             if (meshModuleSets.Proposed is { } adoptedSet)
                 builder.ConfigureServices(services => services.AddModuleSetAdoption(
                     $"module set {adoptedSet.Sequence} ('{adoptedSet.Id}')",
-                    () => ModuleSetStore.RecordAdoption(moduleRoot, adoptedSet,
+                    sp => ModuleSetStore.RecordAdoption(moduleRoot, adoptedSet,
+                        ModuleSetStore.RunningGenerationsOf(adoptedSet, sp.GetServices<FallbackModule>()),
                         adoptedBy: Environment.MachineName,
                         onWarn: msg => Console.Error.WriteLine($"[ModuleSet] {msg}"))));
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —

--- a/src/MeshWeaver.Connection.Orleans/ModulesAssemblyLoadContext.cs
+++ b/src/MeshWeaver.Connection.Orleans/ModulesAssemblyLoadContext.cs
@@ -5,29 +5,48 @@ namespace MeshWeaver.Connection.Orleans;
 
 /// <summary>
 /// Collectible <see cref="AssemblyLoadContext"/> for loading mesh module assemblies on
-/// demand. Resolves dependencies first from the default context, then from the current
-/// working directory, then from a configured base path.
+/// demand. Resolves a dependency through the PLATFORM first — whatever the default context can
+/// supply for the name, loaded yet or not — then from the current working directory, then from
+/// a configured base path.
+///
+/// <para>🚨 <b>Why "can supply" and not "has already loaded" (#3662).</b> The first step used to
+/// scan <see cref="AssemblyLoadContext.Default"/>'s loaded assemblies for the name. A platform
+/// assembly the process had not touched yet matched nothing there, so a bundle copy of it in the
+/// module directory won this context — and when the platform later loaded its own copy, the
+/// process held two assemblies of one identity: every type crossing the boundary failed as an
+/// <c>InvalidCastException</c> between two types of the same full name. The portal image carries
+/// 214 platform assemblies and the tester image 88; a bundle may legitimately carry one the tester
+/// lacks (<c>MeshWeaver.ContentCollections.Indexing</c>, <c>MeshWeaver.Blazor</c>), and on the
+/// portal that copy must lose to the platform's. Asking the default context to RESOLVE the name
+/// is the answer that is right on both: the platform serves what it has, and the module's own
+/// copy is used only for what the platform has not got.</para>
 /// </summary>
-/// <param name="basePath">Fallback directory probed for an assembly DLL when it cannot be
-/// found in the default context or the current working directory.</param>
+/// <param name="basePath">Fallback directory probed for an assembly DLL when the platform cannot
+/// supply it and it is not in the current working directory.</param>
 public class ModulesAssemblyLoadContext(string basePath) : AssemblyLoadContext(true){
 
     /// <summary>
-    /// Resolves and loads the requested assembly, preferring an already-loaded copy in the
-    /// default context, then a DLL in the current working directory, then one under
-    /// the configured <c>basePath</c>.
+    /// Resolves and loads the requested assembly: the platform's copy when the default context
+    /// can resolve the name (already loaded or not), else a DLL in the current working directory,
+    /// else one under the configured <c>basePath</c>.
     /// </summary>
     /// <param name="assemblyName">The name of the assembly to resolve.</param>
     /// <returns>The loaded assembly, or <c>null</c> if it could not be located.</returns>
     protected override Assembly? Load(AssemblyName assemblyName)
     {
-        // Check if the assembly is already loaded
-        var loadedAssembly = AssemblyLoadContext.Default.Assemblies
-            .FirstOrDefault(a => a.GetName().Name == assemblyName.Name);
-
-        if (loadedAssembly != null)
-            return loadedAssembly;
-
+        // The platform first — RESOLVED, not merely "already loaded". A name the default context
+        // can bind (the trusted platform assemblies, the application's own closure) is served from
+        // there whether or not anything has loaded it yet, so a same-named copy beside the module
+        // can never split the identity. The three exceptions are the default context's ways of
+        // saying "I have no such assembly"; anything else is a real fault and propagates.
+        try
+        {
+            return AssemblyLoadContext.Default.LoadFromAssemblyName(assemblyName);
+        }
+        catch (Exception e) when (e is FileNotFoundException or FileLoadException or BadImageFormatException)
+        {
+            // Not the platform's: fall through to the module's own closure.
+        }
 
         var assemblyPath = Path.Combine(Directory.GetCurrentDirectory(), $"{assemblyName.Name}.dll");
         if (File.Exists(assemblyPath))
@@ -36,7 +55,6 @@ public class ModulesAssemblyLoadContext(string basePath) : AssemblyLoadContext(t
         assemblyPath = Path.Combine(basePath, $"{assemblyName.Name}.dll");
         if (File.Exists(assemblyPath))
             return LoadFromAssemblyPath(assemblyPath);
-
 
         return null;
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -149,6 +149,49 @@ host to surface, and classified `RequiredModuleState.Incompatible` so a module d
 The blast radius is the point. One module that cannot link costs **that module's contribution and
 nothing else** — never every other module, never the portal, never every render on it.
 
+### The previous generation runs when the newest cannot (MeshWeaver#3649)
+
+Refusing a generation is not the same as losing the module. Until #3649 it was, for every module
+the image did not also ship: the refused generation was the activation entry's only pointer, the
+generation that had loaded last time was unreferenced, and the next GC pass reclaimed it. A shelved
+landing built for a newer platform therefore took a working Store-only module away for good. Rule
+R1 of the [Module Adoption Policy](../ModuleAdoptionPolicy) is the opposite: **an installation runs
+the newest generation of every module that loads, and keeps the one it has until a newer one does.**
+
+- **The landing keeps what it displaces.** `ModuleLandingService.LandCore` records the entry it
+  replaces as `ModuleActivationEntry.PreviousDirectory` (with `PreviousVersion` and
+  `PreviousFrameworkMvid`). When the displaced generation is itself measured unloadable here and
+  holds a fallback of its own, that fallback carries forward — two unloadable landings in a row
+  cannot push the loadable generation out of reach. Measured on the bytes, like every other
+  decision point; there is no persisted "held" flag to go stale.
+- **The loader falls back.** Boot hands `MeshBuilder.InstallModules` a `ModuleInstallCandidate`
+  per module: the newest generation, and a *lazy* resolver for the previous one (the portal pins
+  a generation to process-local storage before loading it, and pinning every previous generation
+  up front would double that copy for a path taken only when something is wrong). When the newest
+  is refused before loading or `Assembly.LoadFrom` throws, the previous generation goes through
+  the same probe and load; when it succeeds the module is installed from it and a `FallbackModule`
+  is registered — never an `IncompatibleModule` — with one
+  `[MeshWeaver.Mesh.FallbackModule] '<name>' runs its previous generation v1.2.3 (gen A) because
+  v1.3.0 (gen B) cannot load here: …` line on stderr, re-logged as a Warning once the pipeline is
+  up. Only when neither loads is the module incompatible, exactly as before. A generation whose
+  assembly *loaded* and whose registration then threw (#2234's shape) is never swapped: two
+  assemblies of one simple name cannot coexist in the default load context.
+- **The GC keeps it.** `CollectGarbage` references `PreviousDirectory` exactly like `Directory`,
+  and the running generations the adoption records (below).
+- **The set records what runs.** The wave still proposes the head generation; the adoption
+  (`ModuleSetStore.RecordAdoption` with `RunningGenerationsOf(set, fallbacks)`) records the
+  generation each module actually loaded, `ModuleSetIndex.RunningGenerations` /
+  `FallbackGenerations` read it back, and `ModuleSetStore.Describe` names the modules that run a
+  previous generation.
+- **Uninstall clears both** pointers and deletes both directories.
+
+The fallback is **present, not incompatible**: `Modules:Required` classifies it `Present`, the
+readiness probe stays Healthy, and the package card says which version runs. It is also **not
+pending**: a restart re-measures the same bytes and falls back again, so `PendingModuleActivations`
+subtracts a fallback whose refused generation is still the one the set activates — and counts it
+pending again the moment the set moves on to a generation other than the refused one, which a
+restart genuinely tries. What makes that restart happen is MeshWeaver#3650 (rule R3).
+
 🚨 **The surface is the application closure PLUS every directory the boot is loading from.** A
 store-landed module lives in its own generation directory and may legitimately reference another
 module landed beside it; measuring against `/app` alone would report that sibling as an absent
@@ -177,6 +220,7 @@ one of these states was previously mis-rendered as "restart required":
 | `Unresolvable` | activated, but its bytes are gone | re-install the package |
 | `Deferred` | landed, but in no proposed module set | the landing wave must complete |
 | **`Quarantined`** | **refused: its bytes need a platform this deployment is not running** | **a platform update — which is itself the restart that loads it** |
+| **`Fallbacks`** (MeshWeaver#3649) | **present and running its PREVIOUS generation; the newest one landed but does not load here** | **none — a build that loads here, or a platform update, takes over by itself** |
 
 A quarantined module must never be reported as pending. Its assembly genuinely is not loaded, so
 the pending derivation finds it — and a restart re-runs the same measurement on the same bytes and
@@ -207,6 +251,15 @@ missing type — and lands it through the real `ModuleLandingService`.
 | `AModuleReferencingASiblingModuleLandedMomentsEarlier_IsNotRefused` | the FALSE-refusal direction: a sibling module is not an absent platform assembly |
 | `AnUnloadableModule_IsParked_AndTheOthersStillInstall` | the blast radius: one module, not the portal |
 | `AParkedModule_ReadsAsQuarantined_NeverAsRestartRequired` | the false-promise rule |
+| `ARequiredModuleRunningItsPreviousGeneration_IsPresent_NeverIncompatible` | a fallback (MeshWeaver#3649) is `Present` — the probe stays Healthy |
+
+The fallback itself is proven end-to-end in
+`test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs` (the `#3649` section):
+a loadable generation is landed, a generation built for a newer platform is shelved over it, and a
+boot composed as the portal composes it runs the previous one and reports it; both generations
+unloadable stays incompatible; the GC keeps the fallback and reclaims it after an uninstall; the
+adoption records what loaded; the projection onto the mesh's set carries the pointer; the
+activation report names the row and never calls it "restart required".
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -106,9 +106,9 @@ ModuleActivationSidecar.Read(moduleRoot)          // what has LANDED — a movin
 ModuleSetStore.Read(moduleRoot)                   // what the MESH runs — stable between waves
 ModuleActivationBoot.ProjectOntoMeshSet(...)      // the convergence
 ModuleActivationBoot.ComputeEffectiveModuleEntries(...)
-ModuleGenerationPin.PinnedLoadPath(...)           // unchanged (#2509)
-MeshBuilder.InstallAssemblies(...)
-ModuleSetStore.RecordAdoption(...)                // AFTER the install — see below
+ModuleGenerationPin.PinnedLoadPath(...)           // unchanged (#2509); the PREVIOUS generation is pinned lazily
+MeshBuilder.InstallModules(...)                   // the set's generation, or the previous one when that cannot load (#3649)
+ModuleSetStore.RecordAdoption(...)                // AFTER the install — records what LOADED, see below
 ```
 
 `ProjectOntoMeshSet` has three rules, and each is a deliberate refusal to guess:
@@ -121,6 +121,12 @@ ModuleSetStore.RecordAdoption(...)                // AFTER the install — see b
   is the torn set.
 - A **disabled** entry passes through untouched. An uninstall deletes the folder, so honouring it is
   not optional and never waits for a set.
+- The entry's **`PreviousDirectory`** — the generation boot falls back to when the set's does not
+  load here (MeshWeaver#3649) — travels with it onto the set's generation, and is dropped only when
+  it names that very generation (the mid-wave shape: the entry moved to D with the set's G as its
+  fallback, so G is the head now). A fallback that names an *older* generation than the set's — a
+  landing that carried it forward past a displaced generation measured unloadable — is kept, and is
+  exactly what boot runs if the set's generation does not load either.
 
 🚨 **One degradation, and it is reported.** The set can only pin what is on the volume. If the pinned
 generation's bytes are gone — a replica on the PREVIOUS platform build sweeping by the entries alone
@@ -136,9 +142,17 @@ A deployment with **no** set records — every deployment until its first wave a
 gets the list back unchanged. Pre-#3395 behaviour, byte for byte, is the migration path; the first
 completed wave proposes sequence 1 and the mechanism starts.
 
-**Adoption is recorded after `InstallAssemblies`, not after the read.** The claim is *"this set is
+**Adoption is recorded after `InstallModules`, not after the read.** The claim is *"this set is
 running"*, not *"this set was read"* — a boot that dies earlier must not close a convergence window
-it never entered.
+it never entered. And since MeshWeaver#3649 the claim says *what* is running: the adoption record
+carries `Generations` — the set's generation for every module that loaded as proposed, the
+**previous** generation for every module the loader fell back on because the set's does not load on
+this platform. `ModuleSetIndex.RunningGenerations` reads it back, `FallbackGenerations` lists the
+difference, and `ModuleSetStore.Describe` names the modules that run a previous generation, so the
+boot line and the status surfaces say what the mesh runs and not only what it proposed. The
+proposal itself is unchanged — a wave proposes what it landed; whether that loads is measured at
+every boot, so a replica on a newer platform where the set's generation *does* load adopts it
+(rule R3).
 
 ## The window, and why it is bounded
 
@@ -189,6 +203,13 @@ LOADED. `ModuleLandingService.CollectGarbage` therefore unions
 sweep would reclaim the very bytes the whole mesh is executing: the 2026-08-27 outage, from the
 other side. A set directory that cannot be read counts as a read fault for the same fail-closed
 reason the entries do.
+
+🚨 Two more references since MeshWeaver#3649, for the same reason: every entry's
+**`PreviousDirectory`** — the generation boot falls back to when the head one does not load here,
+which for a Store-only module is the only generation that runs — and the **running generations**
+the current set's adoption recorded (`ReferencedGenerations` includes `RunningGenerations`). A
+sweep that trusted the head pointers alone would reclaim the generation a replica is executing
+because a newer one exists that cannot load — the shape #3649 removes.
 
 The same pass prunes set records below the CURRENT set — never below the proposal, which would take
 the mesh's own generations out of the reference set.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -142,6 +142,21 @@ never reach disk), and a refusal of any module whose entry DLL name collides wit
 assembly — `ResolveModulePath` probes `modules/<name>/` first, so such a module would silently
 shadow the platform's own binary at the next boot.
 
+**The fallback rule (MeshWeaver#3649).** A landed generation that does not load on the running
+platform — refused by the [link probe](../ModulePlatformLinkGate) before loading, or faulting in
+`Assembly.LoadFrom` — no longer leaves the module absent. Every landing records the entry it
+displaces as `PreviousDirectory` (with `PreviousVersion` / `PreviousFrameworkMvid`); boot hands
+`MeshBuilder.InstallModules` both generations and the loader runs the previous one when the head
+one cannot load here, registering a `FallbackModule` — present, running, one version behind — and
+saying so on stderr and, once the pipeline is up, as a Warning. The GC references the previous
+generation like the head one; the mesh-set adoption records the generation that actually loaded;
+the status row reads *"runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load here: …"*, the
+readiness probe stays Healthy, and nothing says "restart required" (a restart falls back again).
+Only when no generation loads is the module incompatible, as before; an uninstall clears both
+pointers. This is rule R1 of the [Module Adoption Policy](../ModuleAdoptionPolicy): *an
+installation runs the newest generation of every module that loads, and keeps the one it has until
+a newer one does.*
+
 ### 🚨 "Keeps loading across ordinary platform updates" is a promise the PLATFORM owes (#2370)
 
 The semver floor above is not a weaker gate than MVID equality — it is a **different contract**, and

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-module-version-that-does-not-load-here-no-longer-takes-your-working-copy-away.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-module-version-that-does-not-load-here-no-longer-takes-your-working-copy-away.md
@@ -1,0 +1,37 @@
+---
+Name: A module version that does not load here no longer takes your working copy away
+Category: Feature
+Description: When a newer version of an installed module cannot load on the platform your installation runs, the installation keeps running the version it has instead of losing the module. The status row names both versions; nothing asks you to restart, and the newer version takes over by itself once a build that loads here ships.
+Icon: ArrowSync
+Order: -20260908
+---
+
+# A module version that does not load here no longer takes your working copy away
+
+Every module you install is kept as a *generation* on your installation's volume, and the newest
+one is the one that loads at boot. Until now, when that newest generation could not load on the
+platform your installation runs — because it was built against a newer platform than yours, which
+the platform measures before loading anything — the module was simply **absent**: the previous
+generation, the one that had been working, was no longer referenced by anything, and the next
+housekeeping pass removed it. Unless the platform image happened to ship a copy of the module
+itself, a feature you had installed disappeared because a newer version of it existed.
+
+The rule is now the one an installation would expect: **it runs the newest version of every
+installed module that loads, and keeps the one it has until a newer one does.**
+
+- The generation a new landing replaces is kept as the module's *fallback*, and housekeeping never
+  removes a fallback while it is the one that loads.
+- At boot, when the newest generation is refused or fails to load, the fallback is loaded in its
+  place and the module is **present** — its features work, the readiness probe stays healthy, and
+  the module counts as running for everything that checks whether it is.
+- The module's status row says exactly what happened: *runs v1.2.3 (gen A); v1.3.0 (gen B) landed
+  but does not load here: …*, naming the type the newer version needs and your platform lacks.
+  The package card carries the same note. Nothing reports "restart required" — a restart would
+  measure the same bytes and fall back again — and nothing reports "not running here", because it
+  is running.
+- Only when *no* generation of a module loads is it absent, exactly as before.
+- Uninstalling a module clears both generations.
+
+The newer version starts running by itself once a build of it that loads on your platform ships,
+or once your platform updates. What the installation runs is also recorded with the mesh's module
+set, so every replica and every status page agree on which generation is actually live.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -143,12 +143,46 @@ public record MeshBuilder
     }
 
     /// <summary>
-    /// Installs mesh nodes from the specified assembly locations.
+    /// Installs mesh nodes from the specified assembly locations — each path is one generation
+    /// with no fallback, which is every baseline entry and every caller that installs a module by
+    /// hand. The boot path that also knows a module's PREVIOUS generation calls
+    /// <see cref="InstallModules"/> instead.
     /// </summary>
     /// <param name="assemblyLocations">Paths to assemblies containing MeshNodeProviderAttribute definitions.</param>
     /// <returns>The builder for method chaining.</returns>
-    public MeshBuilder InstallAssemblies(params string[] assemblyLocations)
+    public MeshBuilder InstallAssemblies(params string[] assemblyLocations) =>
+        InstallModules([.. assemblyLocations.Select(location => new ModuleInstallCandidate(location))]);
+
+    /// <summary>
+    /// Installs mesh nodes from the given module candidates — the newest generation of each, or,
+    /// when that one cannot load on this platform and the candidate names a previous generation,
+    /// the previous one (#3649).
+    ///
+    /// <para>🚨 <b>A distinct name, deliberately not an overload of <see cref="InstallAssemblies"/>.</b>
+    /// Dependent repositories carry <c>&lt;see cref="MeshBuilder.InstallAssemblies"/&gt;</c> in
+    /// their own doc comments; an added overload turns every one of those into a CS0419 under
+    /// <c>-warnaserror</c>, on pull requests that did not make the change (see
+    /// <see cref="IncompatibleModule.FromLinkRefusal"/> for the same rule). The string form stays
+    /// byte-for-byte what it was and forwards here.</para>
+    ///
+    /// <para><b>The fallback rule.</b> A candidate's <see cref="ModuleInstallCandidate.Location"/>
+    /// is measured by the link probe and then loaded. If it is refused BEFORE loading, or
+    /// <c>Assembly.LoadFrom</c> itself throws, and the candidate resolves a
+    /// <see cref="ModuleInstallCandidate.Previous"/> generation, that generation goes through the
+    /// same probe and load; when it succeeds the module is installed from it and recorded as a
+    /// <see cref="FallbackModule"/> — present, running, and behind — with one
+    /// <c>[MeshWeaver.Mesh.FallbackModule]</c> line on stderr naming both generations and why.
+    /// Only when neither loads is the module an <see cref="IncompatibleModule"/>, exactly as
+    /// before. 🚨 A generation whose assembly LOADED and whose registration then threw (#2234's
+    /// shape) is never swapped for the previous one: two assemblies of one simple name cannot
+    /// coexist in the default load context, so the fallback exists only for a newest generation
+    /// that never made it into the process — which is the link probe's case, the whole of #3649.</para>
+    /// </summary>
+    /// <param name="modules">The candidates, in install order.</param>
+    /// <returns>The builder for method chaining.</returns>
+    public MeshBuilder InstallModules(IReadOnlyList<ModuleInstallCandidate> modules)
     {
+        ArgumentNullException.ThrowIfNull(modules);
         // A module's NATIVE payload is unreachable without this (#1728): Assembly.LoadFrom never
         // consults the module's deps.json, so nothing probes modules/<Name>/runtimes/<rid>/native/.
         // Subscribed here — before anything from a module folder is loaded — and idempotent.
@@ -168,6 +202,7 @@ public record MeshBuilder
         // equally hazardous step, isolated per module just below.
         var pending = new List<PendingModuleInstall>();
         var incompatible = new List<IncompatibleModule>();
+        var fallbacks = new List<FallbackModule>();
         // 🚨 #3538 — THE LINK PROBE, before a single Assembly.LoadFrom. Per-module isolation above
         // catches a module that THROWS while installing; it cannot catch one that installs cleanly
         // and is linked against types this platform does not have, because nothing touches those
@@ -189,42 +224,64 @@ public record MeshBuilder
         // against /app alone would report that sibling as an absent platform assembly and
         // quarantine a module that is perfectly fine. The runtime's resolution surface is what has
         // to be measured, and at boot that is exactly these directories.
-        var surface = assemblyLocations is { Length: > 0 }
-            ? ModulePlatformSurface.OfRunningProcess([
-                AppContext.BaseDirectory,
-                .. assemblyLocations
-                    .Select(location => Path.GetDirectoryName(Path.GetFullPath(location)))
-                    .Where(directory => !string.IsNullOrEmpty(directory))
-                    .Select(directory => directory!)
-                    .Distinct(StringComparer.OrdinalIgnoreCase),
-            ])
+        var probeDirectories = modules
+            .Select(module => Path.GetDirectoryName(Path.GetFullPath(module.Location)))
+            .Where(directory => !string.IsNullOrEmpty(directory))
+            .Select(directory => directory!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var surface = modules.Count > 0
+            ? ModulePlatformSurface.OfRunningProcess([AppContext.BaseDirectory, .. probeDirectories])
             : null;
-        foreach (var location in assemblyLocations)
+        foreach (var module in modules)
         {
-            // Fail CLOSED on Indeterminate: MayLoad is true for Linkable and nothing else, so a
-            // check that could not be made can never be read as a check that passed.
-            if (surface is not null && ModulePlatformLink.Check(location, surface) is { MayLoad: false } verdict)
+            var newest = TryLoad(module.Location, surface);
+            if (newest.Loaded is not null)
             {
-                incompatible.Add(ReportIncompatible(location, verdict));
+                pending.Add(newest.Loaded);
                 continue;
             }
 
-            try
+            // 🚨 #3649 — the newest generation never made it into the process. Before this the
+            // module was simply ABSENT from here on (unless the image shipped a baseline copy),
+            // and the generation that DID load last time was unreferenced and reclaimed by the
+            // next GC pass. Rule R1: an installation runs the newest generation that LOADS, and
+            // keeps the one it has until a newer one does.
+            var previous = newest.NeverLoaded ? ResolvePrevious(module) : null;
+            if (previous is not null)
             {
-                var assembly = Assembly.LoadFrom(location);
-                var moduleAttributes = assembly.GetCustomAttributes<MeshNodeProviderAttribute>().ToArray();
-                pending.Add(new PendingModuleInstall(
-                    assembly,
-                    moduleAttributes.SelectMany(a => a.Nodes).ToArray(),
-                    moduleAttributes.SelectMany(a => a.AddressTypes).ToArray(),
-                    moduleAttributes.SelectMany(a => a.HubConfigurations).ToArray(),
-                    moduleAttributes.SelectMany(a => a.DefaultNodeHubConfigurations).ToArray(),
-                    moduleAttributes.SelectMany(a => a.BuilderConfigurations).ToArray()));
+                // The previous generation lives in its own directory, which the surface above
+                // does not carry: a fresh one for the retry, so a sibling module it references is
+                // measured as present rather than as an absent platform assembly.
+                var previousDirectory = Path.GetDirectoryName(Path.GetFullPath(previous));
+                var retry = TryLoad(previous, ModulePlatformSurface.OfRunningProcess([
+                    AppContext.BaseDirectory,
+                    .. probeDirectories,
+                    .. string.IsNullOrEmpty(previousDirectory) ? [] : new[] { previousDirectory },
+                ]));
+                if (retry.Loaded is not null)
+                {
+                    pending.Add(retry.Loaded);
+                    var fallback = new FallbackModule(
+                        newest.Refused!.Name, module.Location, previous, newest.Refused.Error)
+                    {
+                        Version = module.Version,
+                        PreviousVersion = module.PreviousVersion,
+                    };
+                    // stderr, once per boot: the logging pipeline does not exist yet (see
+                    // ReportIncompatible). The portal re-logs it as a Warning once it does.
+                    Console.Error.WriteLine($"[MeshWeaver.Mesh.FallbackModule] {fallback.Report()}");
+                    fallbacks.Add(fallback);
+                    continue;
+                }
+
+                Console.Error.WriteLine(
+                    $"[MeshWeaver.Mesh.FallbackModule] '{newest.Refused!.Name}': the previous "
+                    + $"generation '{previous}' cannot load here either ({retry.Refused!.Error}) — "
+                    + "no generation of this module loads on this platform, so it is absent.");
             }
-            catch (Exception exception)
-            {
-                incompatible.Add(ReportIncompatible(location, exception));
-            }
+
+            incompatible.Add(Report(newest.Refused!));
         }
 
         // 🚨 A node's GlobalServiceConfigurations delegate is invoked IMMEDIATELY by
@@ -327,11 +384,16 @@ public record MeshBuilder
         // dropped, so /health and RequiredModuleStatus would report a replica missing that module's
         // features as healthy: the exact invisible-skip this record exists to prevent, reintroduced
         // one code path over.
-        if (incompatible.Count > 0)
+        if (incompatible.Count > 0 || fallbacks.Count > 0)
         {
             result.ConfigureServices(services =>
             {
                 foreach (var module in incompatible)
+                    services.AddSingleton(module);
+                // A fallback is registered as its own record, never as an IncompatibleModule: it
+                // is running, and the surfaces that read the incompatible set (the readiness
+                // probe, the package card's "not running here") must not read it as degraded.
+                foreach (var module in fallbacks)
                     services.AddSingleton(module);
                 return services;
             });
@@ -351,31 +413,105 @@ public record MeshBuilder
         IReadOnlyCollection<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations);
 
     /// <summary>
-    /// Records a module that could not install, and writes it to stderr.
+    /// The outcome of probing and loading ONE generation: what was materialised, or why not.
+    /// </summary>
+    /// <param name="Loaded">The module's contributions, when the generation loaded and
+    /// materialised cleanly.</param>
+    /// <param name="Refused">The record of the failure, otherwise.</param>
+    /// <param name="NeverLoaded">True when the generation's assembly never entered the process —
+    /// refused by the link probe, or <c>Assembly.LoadFrom</c> threw — which is the ONLY state a
+    /// previous generation can be tried from: an assembly that loaded and then failed to
+    /// materialise holds its simple name in the default load context, and a second assembly of
+    /// that name cannot be loaded beside it.</param>
+    private sealed record LoadAttempt(
+        PendingModuleInstall? Loaded, IncompatibleModule? Refused, bool NeverLoaded);
+
+    /// <summary>
+    /// Probes one generation against <paramref name="surface"/> and loads it. Records a failure
+    /// without reporting it — the caller decides whether the failure is a fault (nothing else
+    /// loads) or a fallback (the previous generation does), and the two are reported differently.
+    /// </summary>
+    private static LoadAttempt TryLoad(string location, ModulePlatformSurface? surface)
+    {
+        // Fail CLOSED on Indeterminate: MayLoad is true for Linkable and nothing else, so a
+        // check that could not be made can never be read as a check that passed.
+        if (surface is not null && ModulePlatformLink.Check(location, surface) is { MayLoad: false } verdict)
+            return new LoadAttempt(null, IncompatibleModule.FromLinkRefusal(location, verdict), NeverLoaded: true);
+
+        Assembly assembly;
+        try
+        {
+            assembly = Assembly.LoadFrom(location);
+        }
+        catch (Exception exception)
+        {
+            return new LoadAttempt(null, IncompatibleModule.From(location, exception), NeverLoaded: true);
+        }
+
+        try
+        {
+            var moduleAttributes = assembly.GetCustomAttributes<MeshNodeProviderAttribute>().ToArray();
+            return new LoadAttempt(
+                new PendingModuleInstall(
+                    assembly,
+                    moduleAttributes.SelectMany(a => a.Nodes).ToArray(),
+                    moduleAttributes.SelectMany(a => a.AddressTypes).ToArray(),
+                    moduleAttributes.SelectMany(a => a.HubConfigurations).ToArray(),
+                    moduleAttributes.SelectMany(a => a.DefaultNodeHubConfigurations).ToArray(),
+                    moduleAttributes.SelectMany(a => a.BuilderConfigurations).ToArray()),
+                null,
+                NeverLoaded: false);
+        }
+        catch (Exception exception)
+        {
+            return new LoadAttempt(null, IncompatibleModule.From(location, exception), NeverLoaded: false);
+        }
+    }
+
+    /// <summary>
+    /// The previous generation's entry DLL for a candidate whose newest generation never loaded,
+    /// or null when there is none to try. A resolver that throws is "none", said on stderr: the
+    /// fallback is protection for the module, never a new way to take the boot down.
+    /// </summary>
+    private static string? ResolvePrevious(ModuleInstallCandidate module)
+    {
+        if (module.Previous is null)
+            return null;
+        try
+        {
+            var previous = module.Previous();
+            return string.IsNullOrWhiteSpace(previous) || !File.Exists(previous) ? null : previous;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"[MeshWeaver.Mesh.FallbackModule] '{Path.GetFileNameWithoutExtension(module.Location)}': "
+                + $"resolving the previous generation threw ({exception.GetType().Name}: "
+                + $"{exception.Message}) — no fallback is attempted.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a module that could not install to stderr and hands it back for registration.
     ///
     /// <para>🚨 stderr, not a logger: this runs BEFORE the logging pipeline exists, which is
     /// exactly why #2234's crash left a container log containing only the createdump DSO listing
     /// and cost most of a day to diagnose. The one channel that works at this point is the one the
     /// container captures.</para>
     /// </summary>
-    private static IncompatibleModule ReportIncompatible(string entry, Exception exception)
+    private static IncompatibleModule Report(IncompatibleModule module)
     {
-        var module = IncompatibleModule.From(entry, exception);
         Console.Error.WriteLine($"[MeshWeaver.Mesh.IncompatibleModule] {module.Report()}");
         return module;
     }
 
     /// <summary>
-    /// Records a module the LINK PROBE refused (#3538) — never loaded, so nothing of it ran — and
-    /// writes it to the same stderr channel, for the same reason: this runs before the logging
-    /// pipeline exists.
+    /// Records a module that could not install, and writes it to stderr — see
+    /// <see cref="Report(IncompatibleModule)"/>.
     /// </summary>
-    private static IncompatibleModule ReportIncompatible(string entry, ModuleLinkVerdict verdict)
-    {
-        var module = IncompatibleModule.FromLinkRefusal(entry, verdict);
-        Console.Error.WriteLine($"[MeshWeaver.Mesh.IncompatibleModule] {module.Report()}");
-        return module;
-    }
+    private static IncompatibleModule ReportIncompatible(string entry, Exception exception) =>
+        Report(IncompatibleModule.From(entry, exception));
 
     private IEnumerable<MeshNode> InstallServices(IEnumerable<MeshNode> nodes)
     {

--- a/src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs
@@ -1,0 +1,108 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// One module as the boot loader is asked to install it: the generation it SHOULD run, and — when
+/// the deployment still holds one — the generation it ran BEFORE, to fall back on when the newest
+/// cannot load on this platform (#3649, rule R1 of the module adoption policy).
+///
+/// <para>🚨 <b>Why a fallback and not a refusal.</b> Until #3649 a landed generation that did not
+/// load here — refused by the link probe, or faulting in <c>Assembly.LoadFrom</c> — left the module
+/// ABSENT unless the image happened to ship a baseline copy (#2548). A Store-only module has no
+/// such copy, so a shelved landing built for a newer platform took a working module away: the
+/// previous generation was still on the volume, but nothing referenced it any more and the next GC
+/// pass removed it. The maintainer's rule of 2026-09-07 is the opposite: <i>an installation always
+/// runs SOME version of every module it has installed — the newest one that loads</i>.</para>
+///
+/// <para>The previous generation is resolved LAZILY, through <see cref="Previous"/>, because the
+/// portal pins every generation it loads to process-local storage (a per-boot copy of the whole
+/// directory, #2509) and copying every module's previous generation on every boot would double
+/// that cost for a path that is taken only when the newest generation fails. A candidate with no
+/// <see cref="Previous"/> installs exactly as a bare path always did.</para>
+/// </summary>
+/// <param name="Location">The entry DLL of the generation to load — the newest one landed.</param>
+public sealed record ModuleInstallCandidate(string Location)
+{
+    /// <summary>
+    /// Resolves the entry DLL of the PREVIOUS generation, or null when the deployment holds none
+    /// (a first install, a legacy fixed-folder module, a baseline entry). Invoked at most once, and
+    /// only after <see cref="Location"/> was refused before loading or failed to load — never for
+    /// a generation that loaded. A resolver that throws counts as "no previous generation" and
+    /// is reported on stderr, because at this point in boot nothing else exists to report to.
+    /// </summary>
+    public Func<string?>? Previous { get; init; }
+
+    /// <summary>The package version <see cref="Location"/> was landed at, for the report — a
+    /// row that says "v1.3.0 (gen B) does not load here" is one an operator can act on; a bare
+    /// generation id is not. Null when unrecorded.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>The package version the previous generation was landed at, for the report.</summary>
+    public string? PreviousVersion { get; init; }
+}
+
+/// <summary>
+/// One module that is RUNNING ITS PREVIOUS GENERATION because the newest one landed cannot load on
+/// this platform (#3649) — registered as an enumerable DI singleton beside
+/// <see cref="InstalledModuleAssembly"/> and <see cref="IncompatibleModule"/>, so every status
+/// surface can name it as what it is: present, and behind.
+///
+/// <para>🚨 It is NOT an <see cref="IncompatibleModule"/>. That record means "contributes nothing,
+/// this replica is degraded", and it is what turns a required module Incompatible and a package
+/// card into "not running here". A fallback module IS running — its assembly is loaded, its nodes
+/// and services are registered, its features work — so a readiness probe stays Healthy on it and
+/// <c>Modules:Required</c> classifies it Present. What the record carries is the one fact a
+/// person needs beside "present": which generation this is, which one it is not, and why.</para>
+///
+/// <para>🚨 Nor is it "restart required". A restart re-runs the same measurement on the same
+/// bytes and falls back again; the prompt would be one no restart can clear. The newest
+/// generation starts running by itself when a build of it that loads here ships, or when the
+/// platform moves — both of which are restarts (#3650 makes the first of those happen).</para>
+/// </summary>
+/// <param name="Name">The module's assembly simple name.</param>
+/// <param name="Entry">The entry DLL of the newest generation — the one that does NOT load here.</param>
+/// <param name="PreviousEntry">The entry DLL of the generation that loaded instead.</param>
+/// <param name="Reason">Why the newest generation cannot load here — the link probe's report
+/// naming the missing type, or the load exception's type and message.</param>
+public sealed record FallbackModule(string Name, string Entry, string PreviousEntry, string Reason)
+{
+    /// <summary>The package version of the newest generation, when recorded.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>The package version of the generation that loaded, when recorded.</summary>
+    public string? PreviousVersion { get; init; }
+
+    /// <summary>The generation directory leaf of the newest generation (<c>&lt;name&gt;@&lt;id&gt;</c>)
+    /// — the same string the activation record's <c>Directory</c> carries, so a surface can match
+    /// this record against the record that landed it.</summary>
+    public string Generation => LeafOf(Entry);
+
+    /// <summary>The generation directory leaf of the generation that loaded.</summary>
+    public string PreviousGeneration => LeafOf(PreviousEntry);
+
+    /// <summary>
+    /// The boot-log line: which module, which generation it runs, which one it does not, and why.
+    /// Written to stderr by <c>MeshBuilder.InstallModules</c> (nothing else exists that early) and
+    /// re-logged as a Warning once the logging pipeline is up.
+    /// </summary>
+    public string Report() =>
+        $"'{Name}' runs its previous generation {Label(PreviousVersion, PreviousGeneration)} because "
+        + $"{Label(Version, Generation)} cannot load here: {Reason}";
+
+    /// <summary>
+    /// The status-row sentence — "runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load
+    /// here: …" — shared by every surface so an operator and a package card never read two
+    /// different stories about one module.
+    /// </summary>
+    public string Describe() =>
+        $"runs {Label(PreviousVersion, PreviousGeneration)}; {Label(Version, Generation)} landed "
+        + $"but does not load here: {Reason}";
+
+    private static string Label(string? version, string generation) =>
+        string.IsNullOrWhiteSpace(version) ? $"({generation})" : $"v{version} ({generation})";
+
+    private static string LeafOf(string entry)
+    {
+        var directory = Path.GetDirectoryName(entry);
+        return string.IsNullOrEmpty(directory) ? entry : Path.GetFileName(directory);
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -591,6 +591,7 @@
   "ui.requiresGlobalAdmin": "Erfordert Global Admin",
   "ui.restartRequiredToActivate": "Neustart erforderlich, um dieses Paket vollständig zu aktivieren",
   "ui.moduleBuiltForNewerPlatform": "Hier nicht aktiv: Diese Version wurde für eine neuere Plattform gebaut. Sie wird aktiv, sobald diese Installation aktualisiert wird.",
+  "ui.moduleRunsPreviousVersion": "Läuft mit der vorherigen Version {0}: Version {1} ist installiert, lädt aber auf dieser Plattform nicht. Sie wird aktiv, sobald ein hier ladbarer Build erscheint.",
   "ui.moduleDeclaresNewerPlatform": "Deklariert Plattform ≥ {0}; diese Installation läuft mit {1}. Nur ein Hinweis — ob es lädt, wird gemessen, nicht deklariert.",
   "ui.orphanedInstallRecords": "Verwaiste Installationseinträge",
   "ui.requestAccess": "Zugriff anfragen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -592,6 +592,7 @@
   "ui.restartRequiredToActivate": "Restart required to finish activating this package",
   "ui.moduleBuiltForNewerPlatform": "Not running here: this version was built for a newer platform. It activates when this installation updates.",
   "ui.moduleDeclaresNewerPlatform": "Declares platform ≥ {0}; this installation runs {1}. Advisory only — whether it loads is measured, not declared.",
+  "ui.moduleRunsPreviousVersion": "Running the previous version {0}: version {1} is installed but does not load on this platform. It activates once a build that loads here ships.",
   "ui.orphanedInstallRecords": "Orphaned install records",
   "ui.requestAccess": "Request Access",
   "ui.resetToDefault": "Reset to default",

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -782,6 +782,17 @@ public static class CatalogLayoutAreas
                 .WithStyle("color: var(--error-foreground, #a4262c); font-size: 12px; "
                            + "display: block; margin-top: 6px;"));
 
+        // 🚨 #3649 — the FIFTH state, and the first that is not a fault: the newest generation
+        // does not load on this platform, so this installation runs the previous one. The module
+        // works; the line says which version that is and that the newer one is waiting on a
+        // build that loads here. Neither "restart required" (a restart falls back again) nor
+        // "not running here" (it is running). Localized: platform-owned chrome follows the VIEWER.
+        else if (activation.FallbackForPackage($"{PackageInstaller.InstalledPartition}/{pkg.Id}") is { } fallback)
+            card = card.WithView(Controls.Body(
+                    $"ℹ️ {host.Localize("ui.moduleRunsPreviousVersion", fallback.PreviousVersion ?? "?", fallback.Version ?? "?")}")
+                .WithStyle("color: var(--warning-foreground, #9d5d00); font-size: 12px; "
+                           + "display: block; margin-top: 6px;"));
+
         // 🚨 #3648 — what the module DECLARES, beside whatever state it is in, never instead of
         // it. A declared minMeshVersion above the running platform used to be a hidden hold (boot
         // skipped the entry, the card said nothing); now the entry loads or not on what the link

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -49,6 +49,30 @@ public sealed record ModuleActivationEntry
     /// </summary>
     public string? Directory { get; init; }
 
+    /// <summary>
+    /// The generation this module ran BEFORE <see cref="Directory"/> was landed — the one boot
+    /// falls back to when <see cref="Directory"/> cannot load on this platform (#3649, rule R1 of
+    /// the module adoption policy: <i>an installation runs the newest generation that LOADS, and
+    /// keeps the one it has until a newer one does</i>).
+    ///
+    /// <para>Set by <see cref="ModuleLandingService"/> from the entry a landing displaces, whenever
+    /// a NEW generation lands for a module that already had one. Referenced by the modules GC
+    /// exactly like <see cref="Directory"/>, so the generation that loads is never reclaimed while
+    /// the one that does not is the entry's head — which is what a shelved landing built for a
+    /// newer platform used to do to a Store-only module: overwrite the only reference to its
+    /// loadable bytes, and the next GC pass took them away. Cleared by an uninstall together with
+    /// <see cref="Directory"/>. Absent = no previous generation is held.</para>
+    /// </summary>
+    public string? PreviousDirectory { get; init; }
+
+    /// <summary>The package version <see cref="PreviousDirectory"/> was landed at, so a status
+    /// row can say "runs v1.2.3; v1.3.0 landed but does not load here". Null when unrecorded.</summary>
+    public string? PreviousVersion { get; init; }
+
+    /// <summary>The framework MVID <see cref="PreviousDirectory"/> was built against — diagnostic,
+    /// like <see cref="FrameworkMvid"/>.</summary>
+    public string? PreviousFrameworkMvid { get; init; }
+
     /// <summary>The framework MVID (MeshWeaver.Graph's ModuleVersionId) the landed assemblies
     /// were built against, as the producer recorded it — DIAGNOSTIC metadata only: it names the
     /// exact build behind the bytes when something needs debugging, but it is never a gate.
@@ -478,6 +502,9 @@ public static class ModuleActivationBoot
     ///     GENERATION — the legacy fixed <c>modules/&lt;name&gt;/</c> folder, which
     ///     <see cref="ModuleSetStore.GenerationsOf"/> excludes by design because there is nothing
     ///     to pin; deferring it would silently disable it.</item>
+    ///   <item>The entry's <see cref="ModuleActivationEntry.PreviousDirectory"/> — the generation
+    ///     boot falls back to when the head one does not load here (#3649) — travels with it onto
+    ///     the set's generation, and is dropped only when it names that very generation.</item>
     /// </list>
     ///
     /// <para>A null <paramref name="meshSet"/> — a deployment on which no landing wave has ever
@@ -545,7 +572,17 @@ public static class ModuleActivationBoot
                     continue;
                 }
 
-                var onSet = entry with { Directory = generation };
+                // 🚨 #3649 — the fallback pointer travels WITH the entry onto the set's generation,
+                // and is dropped only when it names that very generation (the common mid-wave
+                // shape: the entry moved to D with PreviousDirectory = the set's G, so G is the
+                // head now and needs no fallback to itself). Where it names an OLDER generation
+                // than the set's — a landing that carried its fallback forward because the
+                // displaced generation was measured unloadable — that older one is exactly what
+                // boot must fall back to if the set's generation does not load here either.
+                var previous = string.Equals(entry.PreviousDirectory, generation, StringComparison.Ordinal)
+                    ? entry with { PreviousDirectory = null, PreviousVersion = null, PreviousFrameworkMvid = null }
+                    : entry;
+                var onSet = previous with { Directory = generation };
                 if (landedDllExists is null || landedDllExists(onSet))
                 {
                     projected.Add(onSet);
@@ -758,6 +795,42 @@ public static class ModuleActivationBoot
     /// </summary>
     public static bool LandedModuleDllExists(string baseDirectory, ModuleActivationEntry entry) =>
         File.Exists(LandedDllPath(baseDirectory, entry));
+
+    /// <summary>
+    /// The PREVIOUS generation of <paramref name="entry"/> as an entry of its own — the same name,
+    /// with <see cref="ModuleActivationEntry.Directory"/>, <see cref="ModuleActivationEntry.Version"/>
+    /// and <see cref="ModuleActivationEntry.FrameworkMvid"/> taken from the <c>Previous*</c>
+    /// fields and no previous of its own — or null when the entry holds none (#3649).
+    ///
+    /// <para>One derivation, so every reader of the fallback (the boot loader pinning it, the GC
+    /// referencing it, the landing carrying it forward, the existence check) resolves it through
+    /// the SAME rule <see cref="LandedDllPath"/> applies to the head generation. Re-deriving the
+    /// path per caller is how the gate and the loader came to disagree in #1949.</para>
+    /// </summary>
+    public static ModuleActivationEntry? PreviousGeneration(ModuleActivationEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        if (string.IsNullOrWhiteSpace(entry.PreviousDirectory)
+            || string.Equals(entry.PreviousDirectory, entry.Directory, StringComparison.Ordinal))
+            return null;
+        return entry with
+        {
+            Directory = entry.PreviousDirectory,
+            Version = entry.PreviousVersion,
+            FrameworkMvid = entry.PreviousFrameworkMvid,
+            PreviousDirectory = null,
+            PreviousVersion = null,
+            PreviousFrameworkMvid = null,
+        };
+    }
+
+    /// <summary>
+    /// Whether the entry holds a previous generation whose entry DLL is on the volume — the
+    /// generation boot can fall back to when the head one does not load here (#3649). False for
+    /// an entry with no previous generation, and for one whose previous bytes are gone.
+    /// </summary>
+    public static bool PreviousLandedModuleDllExists(string baseDirectory, ModuleActivationEntry entry) =>
+        PreviousGeneration(entry) is { } previous && LandedModuleDllExists(baseDirectory, previous);
 
     /// <summary>
     /// The file the boot loader loads for one <see cref="EffectiveModule"/> — the SAME resolution

--- a/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivationStatus.cs
@@ -232,6 +232,13 @@ public static class ModuleActivationStatus
     /// generation it loaded that module from, and the two differ. Unknown is never a mismatch — see
     /// the note on the five-argument <see cref="NotYetLoaded(ModuleActivationList, IReadOnlySet{string},
     /// IReadOnlyDictionary{string, string}, Func{string, string}, Func{ModuleActivationEntry, bool})"/>.</para>
+    ///
+    /// <para>🚨 A module running its PREVIOUS generation (#3649) is such an entry BY CONSTRUCTION:
+    /// the set activates the head generation, the loader refused it and loaded the previous one.
+    /// This derivation cannot tell that apart from an ordinary update, and does not try — the
+    /// loader's <see cref="Mesh.FallbackModule"/> records can, and
+    /// <see cref="PendingModuleActivations"/> subtracts them, so the row reads "runs the previous
+    /// generation" and never "restart required" (a restart would fall back again).</para>
     /// </summary>
     private static bool RunsAnOlderGeneration(
         ModuleActivationEntry entry,

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -42,6 +42,14 @@ namespace MeshWeaver.PluginCatalog;
 /// platform that lacks their types… which for the adopt path is the point of the install, so a
 /// hold there would be a package whose binary half silently never arrives.</para>
 ///
+/// <para><b>The generation a landing displaces is KEPT, as the new entry's fallback (#3649).</b>
+/// <see cref="ModuleActivationEntry.PreviousDirectory"/> names it, the GC references it, and boot
+/// loads it when the head generation does not load on the running platform — so a shelved landing
+/// built for a newer platform leaves the module RUNNING its previous version instead of absent,
+/// and the next GC pass no longer reclaims the only bytes that load. Carried forward past a
+/// displaced generation that is itself measured unloadable here, so two unloadable landings in a
+/// row cannot push the loadable one out of reach. Cleared by an uninstall.</para>
+///
 /// <para><b>The same-identity trap-door is refused too.</b> <c>MeshBuilder.ResolveModulePath</c>
 /// resolves <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c> BEFORE the app folder, so landing a
 /// module named after an APP-CLOSURE assembly (e.g. <c>MeshWeaver.Graph</c>) would silently
@@ -203,6 +211,14 @@ public sealed class ModuleLandingService : IDisposable
             .Where(e => !string.IsNullOrWhiteSpace(e.Directory))
             .Select(e => e.Directory!)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // 🚨 #3649: an entry's PREVIOUS generation is referenced exactly like its head one. It is
+        // the generation boot falls back to when the head does not load on this platform — for a
+        // Store-only module the ONLY generation that runs — and reclaiming it is precisely how a
+        // shelved landing built for a newer platform used to take a working module away.
+        foreach (var previous in activation.Entries
+                     .Where(e => !string.IsNullOrWhiteSpace(e.PreviousDirectory))
+                     .Select(e => e.PreviousDirectory!))
+            referenced.Add(previous);
         // 🚨 #3395: the activation entries are NOT the whole reference set any more. The mesh's
         // module set deliberately pins an OLDER generation than the entry while a wave's landings
         // wait to be proposed — and that older generation is what every running replica LOADED. A
@@ -615,6 +631,12 @@ public sealed class ModuleLandingService : IDisposable
                 + "advisory (#3648), the link probe decides at placement: {Advisory}",
                 name, minMeshVersion, ModulePlatformFloor.RunningVersion ?? "(unknown)", advisory);
 
+        // Read ONCE: the surface below is measured against the landed set, and the previous
+        // generation (#3649) is taken from the same read, so the two cannot disagree about which
+        // generation this module currently has.
+        var landedBefore = ModuleActivationSidecar.Read(baseDirectory,
+            msg => logger?.LogWarning("{Message}", msg));
+        var surface = PlatformSurface(landedBefore);
         var held = LinkHoldReason();
         if (held is not null && !holdUnloadable)
         {
@@ -631,8 +653,36 @@ public sealed class ModuleLandingService : IDisposable
             var closure = assemblies
                 .Select(a => Path.GetFileNameWithoutExtension(a.FileName))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var verdict = ModulePlatformLink.Check(entryBytes, name, closure, PlatformSurface());
+            var verdict = ModulePlatformLink.Check(entryBytes, name, closure, surface);
             return verdict.MayLoad ? null : verdict.Report();
+        }
+
+        // 🚨 #3649 — THE PREVIOUS GENERATION IS KEPT, never overwritten. The entry this landing
+        // displaces becomes the new entry's fallback: boot loads the head generation, and when
+        // that one cannot load on the running platform it loads this one instead and says so.
+        // Until now the pointer simply moved, the displaced generation was unreferenced, and the
+        // next GC pass reclaimed it — so a shelved landing built for a newer platform took a
+        // working Store-only module away for good (rule R1 of the module adoption policy).
+        //
+        // Carried FORWARD when the displaced generation is itself measured unloadable here and
+        // holds a fallback of its own: two unloadable landings in a row must not push the one
+        // generation that loads out of reach. Measured on the bytes, like every other decision
+        // point — a persisted "held" flag would go stale the moment the platform moved.
+        var displaced = landedBefore.Entries.FirstOrDefault(e =>
+            e.Enabled
+            && string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(e.Directory));
+        var previous = displaced is null ? null : PreviousToKeep(displaced);
+
+        ModuleActivationEntry PreviousToKeep(ModuleActivationEntry current)
+        {
+            var older = ModuleActivationBoot.PreviousGeneration(current);
+            if (older is null || !ModuleActivationBoot.LandedModuleDllExists(baseDirectory, older))
+                return current;
+            var currentDll = ModuleActivationBoot.LandedDllPath(baseDirectory, current);
+            if (!File.Exists(currentDll))
+                return older; // the displaced bytes are gone; its own fallback is what is left
+            return ModulePlatformLink.Check(currentDll, surface).MayLoad ? current : older;
         }
 
         // 🚨 The same-identity trap-door: modules/<name>/<name>.dll wins over the app folder in
@@ -697,6 +747,9 @@ public sealed class ModuleLandingService : IDisposable
             MinMeshVersion = minMeshVersion,
             Enabled = true,
             Directory = generation,
+            PreviousDirectory = previous?.Directory,
+            PreviousVersion = previous?.Version,
+            PreviousFrameworkMvid = previous?.FrameworkMvid,
         };
         // 🚨 THIS MODULE'S OWN FILE, and nothing else (#2090). The landing used to read the whole
         // shared activation index, append to it and rename the result over the live file — a
@@ -718,17 +771,18 @@ public sealed class ModuleLandingService : IDisposable
             logger?.LogInformation(
                 "Module '{Name}' LANDED into modules/{Generation}/ ({Count} assemblies, declared "
                 + "floor {MinMeshVersion} — advisory, platform {Running}; built against framework "
-                + "MVID {FrameworkMvid} — diagnostic) — activation recorded, RESTART REQUIRED to "
-                + "load it",
+                + "MVID {FrameworkMvid} — diagnostic; previous generation {Previous} kept as the "
+                + "fallback) — activation recorded, RESTART REQUIRED to load it",
                 name, generation, assemblies.Count, minMeshVersion ?? "(none)",
-                ModulePlatformFloor.RunningVersion ?? "(unknown)", frameworkMvid ?? "(unrecorded)");
+                ModulePlatformFloor.RunningVersion ?? "(unknown)", frameworkMvid ?? "(unrecorded)",
+                previous?.Directory ?? "(none)");
         else
             logger?.LogInformation(
                 "Module '{Name}' SHELVED into modules/{Generation}/ ({Count} assemblies) but HELD "
                 + "from local activation: {Reason}. It SERVES to consumers from here; this "
-                + "process's boot parks it until a platform update carries the types it links "
-                + "against, and that same boot then loads it",
-                name, generation, assemblies.Count, held);
+                + "process's boot runs the previous generation {Previous} until a platform update "
+                + "carries the types it links against, and that same boot then loads it",
+                name, generation, assemblies.Count, held, previous?.Directory ?? "(none)");
 
         return new ModuleLandingOutcome(Held: held is not null, HoldReason: held);
     }
@@ -746,21 +800,30 @@ public sealed class ModuleLandingService : IDisposable
                 $"Module '{name}' was not landed by the store lane (no activation entry) — "
                 + "publish-laid-out module folders are managed by the deployment, not uninstall.");
 
-        // The generation pointer is CLEARED on uninstall — a disabled entry must not keep its
-        // directory 'referenced', or the GC pass could never reclaim it. Written to THIS module's own
-        // file, never through the shared index (#2090): an uninstall racing another module's
-        // landing used to drop whichever entry lost.
+        // BOTH generation pointers are CLEARED on uninstall — a disabled entry must not keep its
+        // directory (or its fallback's, #3649) 'referenced', or the GC pass could never reclaim
+        // them. Written to THIS module's own file, never through the shared index (#2090): an
+        // uninstall racing another module's landing used to drop whichever entry lost.
         ModuleActivationSidecar.WriteEntry(baseDirectory,
-            existing with { Enabled = false, Directory = null });
+            existing with
+            {
+                Enabled = false,
+                Directory = null,
+                PreviousDirectory = null,
+                PreviousVersion = null,
+                PreviousFrameworkMvid = null,
+            });
         ModuleActivationSidecar.SetPendingRestart(baseDirectory, true);
 
         // Best-effort immediate delete: on a shared volume the files of a LOADED module refuse
-        // deletion (SMB keeps them open) — that is fine, the cleared pointer above makes the
+        // deletion (SMB keeps them open) — that is fine, the cleared pointers above make the
         // next GC pass (ModuleGenerationsGcHostedService, after a pod's ApplicationStarted)
-        // reclaim the generation once no pod holds it.
+        // reclaim the generations once no pod holds them.
         var targets = new List<string> { Path.Combine(baseDirectory, "modules", name) };
         if (!string.IsNullOrWhiteSpace(existing.Directory))
             targets.Add(Path.Combine(baseDirectory, "modules", existing.Directory!));
+        if (!string.IsNullOrWhiteSpace(existing.PreviousDirectory))
+            targets.Add(Path.Combine(baseDirectory, "modules", existing.PreviousDirectory!));
         foreach (var target in targets.Where(Directory.Exists))
         {
             try
@@ -805,10 +868,9 @@ public sealed class ModuleLandingService : IDisposable
     /// legitimately lack a type its successor has; measuring against whichever directory an
     /// unordered listing happened to yield first would make the verdict depend on the filesystem.</para>
     /// </summary>
-    private ModulePlatformSurface PlatformSurface()
+    private ModulePlatformSurface PlatformSurface(ModuleActivationList activation)
     {
-        var landed = ModuleActivationSidecar.Read(baseDirectory,
-                msg => logger?.LogWarning("{Message}", msg))
+        var landed = activation
             .Entries
             .Where(entry => entry.Enabled && !string.IsNullOrWhiteSpace(entry.Name))
             .Select(entry => ModuleDirectoryFor(baseDirectory, entry.Name, entry))

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -73,7 +73,20 @@ public sealed record ModuleSetAdoption(
     long Sequence,
     string Id,
     DateTime AdoptedAtUtc,
-    string? AdoptedBy = null);
+    string? AdoptedBy = null)
+{
+    /// <summary>
+    /// Module simple name → the generation the adopting replica ACTUALLY LOADED (#3649): the
+    /// set's own generation for every module that loaded as proposed, and the PREVIOUS generation
+    /// for every module that fell back because the set's one does not load on this platform. So
+    /// a reader of the set records learns what the mesh RUNS, not only what it proposed — and the
+    /// GC references what runs. Null on a record written before this field existed, which reads
+    /// as "the set's generations, as far as anyone recorded". An init-only property, not a fifth
+    /// positional parameter: replacing a public record's constructor signature is a binary break
+    /// for a host compiled against the previous platform.
+    /// </summary>
+    public ImmutableSortedDictionary<string, string>? Generations { get; init; }
+}
 
 /// <summary>
 /// Everything the <c>modules/sets/</c> directory says, read in one pass: which set the mesh has
@@ -95,6 +108,30 @@ public sealed record ModuleSetIndex(
 {
     /// <summary>An empty deployment's index — no proposal, no adoption, no conflict.</summary>
     public static readonly ModuleSetIndex Empty = new(null, null, []);
+
+    /// <summary>
+    /// Module simple name → the generation the replica that adopted <see cref="Current"/>
+    /// actually loaded (#3649) — <see cref="ModuleSet.Generations"/> of the current set for every
+    /// module that loaded as proposed, the previous generation for every module that fell back.
+    /// Empty when no set is current, or when the adoption record predates the field. What the
+    /// mesh RUNS, as opposed to what it proposed; an init-only property, for binary compatibility
+    /// with hosts compiled against the three-argument record.
+    /// </summary>
+    public ImmutableSortedDictionary<string, string> RunningGenerations { get; init; } =
+        ImmutableSortedDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The modules of <see cref="Current"/> that RUN A PREVIOUS GENERATION on the adopting replica
+    /// (#3649): name → the generation loaded, for every module whose running generation differs
+    /// from the set's. Empty when every module loaded as proposed.
+    /// </summary>
+    public ImmutableSortedDictionary<string, string> FallbackGenerations =>
+        Current is null
+            ? ImmutableSortedDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase)
+            : RunningGenerations
+                .Where(kv => Current.Generations.TryGetValue(kv.Key, out var proposed)
+                             && !string.Equals(proposed, kv.Value, StringComparison.Ordinal))
+                .ToImmutableSortedDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// True while the mesh has declared a set that NO replica has booted onto yet — the
@@ -207,7 +244,7 @@ public static class ModuleSetStore
         }
 
         var proposals = new List<ModuleSet>();
-        var adopted = new HashSet<string>(StringComparer.Ordinal);
+        var adopted = new Dictionary<string, ModuleSetAdoption>(StringComparer.Ordinal);
         foreach (var file in files)
         {
             if (file.EndsWith(ProposedSuffix, StringComparison.Ordinal))
@@ -228,7 +265,12 @@ public static class ModuleSetStore
             else if (file.EndsWith(AdoptedSuffix, StringComparison.Ordinal)
                      && TryRead<ModuleSetAdoption>(file, onCorrupt) is { } adoption)
             {
-                adopted.Add(Key(adoption.Sequence, adoption.Id));
+                // Create-if-absent means one record per set, so a second file for the same key
+                // is the same bytes; first read wins and nothing is lost.
+                adopted.TryAdd(Key(adoption.Sequence, adoption.Id), adoption with
+                {
+                    Generations = adoption.Generations?.WithComparers(StringComparer.OrdinalIgnoreCase),
+                });
             }
         }
 
@@ -259,10 +301,15 @@ public static class ModuleSetStore
 
         var newest = bySequence.Values.OrderByDescending(p => p.Sequence).First();
         var current = bySequence.Values
-            .Where(p => adopted.Contains(Key(p.Sequence, p.Id)))
+            .Where(p => adopted.ContainsKey(Key(p.Sequence, p.Id)))
             .OrderByDescending(p => p.Sequence)
             .FirstOrDefault();
-        return new ModuleSetIndex(newest, current, conflicts);
+        // #3649 — what the adopting replica RAN. An adoption written before the field existed
+        // carries no generations, and then the set's own are the best anyone recorded.
+        var running = current is null
+            ? ImmutableSortedDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase)
+            : adopted[Key(current.Sequence, current.Id)].Generations ?? current.Generations;
+        return new ModuleSetIndex(newest, current, conflicts) { RunningGenerations = running };
     }
 
     /// <summary>
@@ -322,6 +369,26 @@ public static class ModuleSetStore
         ModuleSet set,
         string? adoptedBy = null,
         Action<string>? onWarn = null)
+        => RecordAdoption(baseDirectory, set, runningGenerations: null, adoptedBy, onWarn);
+
+    /// <summary>
+    /// As the four-argument form, recording what this process ACTUALLY LOADED per module (#3649)
+    /// — the set's generation where it loaded, the previous generation where boot fell back — so
+    /// the mesh's records say what runs and the GC references it. An overload, not a new optional
+    /// parameter: the four-argument signature is binary API for hosts compiled against it.
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root.</param>
+    /// <param name="set">The set this process loaded.</param>
+    /// <param name="runningGenerations">Module simple name → the generation loaded, as
+    /// <see cref="RunningGenerationsOf"/> derives it; null records the set's own generations.</param>
+    /// <param name="adoptedBy">Diagnostics — which process.</param>
+    /// <param name="onWarn">The loud channel for a failed record.</param>
+    public static void RecordAdoption(
+        string baseDirectory,
+        ModuleSet set,
+        IReadOnlyDictionary<string, string>? runningGenerations,
+        string? adoptedBy = null,
+        Action<string>? onWarn = null)
     {
         ArgumentNullException.ThrowIfNull(set);
         var path = PathOf(baseDirectory, set.Sequence, set.Id, AdoptedSuffix);
@@ -329,8 +396,13 @@ public static class ModuleSetStore
         {
             if (File.Exists(path))
                 return;
+            var generations = (runningGenerations ?? set.Generations)
+                .ToImmutableSortedDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
             WriteOnce(path, JsonSerializer.Serialize(
-                new ModuleSetAdoption(set.Sequence, set.Id, DateTime.UtcNow, adoptedBy), Json));
+                new ModuleSetAdoption(set.Sequence, set.Id, DateTime.UtcNow, adoptedBy)
+                {
+                    Generations = generations,
+                }, Json));
         }
         catch (Exception ex)
         {
@@ -358,7 +430,35 @@ public static class ModuleSetStore
             foreach (var generation in set?.Generations.Values ?? Enumerable.Empty<string>())
                 if (!string.IsNullOrWhiteSpace(generation))
                     referenced.Add(generation);
+        // #3649 — and what the adopting replica actually RUNS, which for a module that fell back
+        // is a generation neither retained set names.
+        foreach (var generation in index?.RunningGenerations.Values ?? Enumerable.Empty<string>())
+            if (!string.IsNullOrWhiteSpace(generation))
+                referenced.Add(generation);
         return referenced;
+    }
+
+    /// <summary>
+    /// What a process that installed <paramref name="set"/> actually runs (#3649): the set's own
+    /// generation for every module, overridden by the generation that LOADED for every module in
+    /// <paramref name="fallbacks"/> — the records <c>MeshBuilder.InstallModules</c> registered for
+    /// the modules whose head generation did not load here. The one derivation, shared by the
+    /// boot path that records the adoption and the tests that read it back.
+    /// </summary>
+    /// <param name="set">The set the process booted onto.</param>
+    /// <param name="fallbacks">The fallback records the loader registered.</param>
+    public static ImmutableSortedDictionary<string, string> RunningGenerationsOf(
+        ModuleSet set, IEnumerable<MeshWeaver.Mesh.FallbackModule> fallbacks)
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        ArgumentNullException.ThrowIfNull(fallbacks);
+        var running = set.Generations.ToBuilder();
+        running.KeyComparer = StringComparer.OrdinalIgnoreCase;
+        foreach (var fallback in fallbacks)
+            if (running.ContainsKey(fallback.Name)
+                && !string.IsNullOrWhiteSpace(fallback.PreviousGeneration))
+                running[fallback.Name] = fallback.PreviousGeneration;
+        return running.ToImmutable();
     }
 
     /// <summary>
@@ -414,7 +514,16 @@ public static class ModuleSetStore
                   + $"{proposed.Generations.Count} module(s)) and NO replica has booted onto it yet "
                   + $"— it was proposed at {proposed.ProposedAtUtc:O}"
                 : $"the mesh is on module set {proposed.Sequence} ('{proposed.Id}', "
-                  + $"{proposed.Generations.Count} module(s))";
+                  + $"{proposed.Generations.Count} module(s))"
+                  + DescribeFallbacks(index.FallbackGenerations);
+
+    /// <summary>The "; N module(s) run a previous generation: …" suffix, or nothing (#3649).</summary>
+    private static string DescribeFallbacks(ImmutableSortedDictionary<string, string> fallbacks) =>
+        fallbacks.Count == 0
+            ? string.Empty
+            : $"; {fallbacks.Count} module(s) run a PREVIOUS generation because the set's does not "
+              + "load on this platform: "
+              + string.Join(", ", fallbacks.Select(kv => $"{kv.Key} ({kv.Value})"));
 
     private static string Key(long sequence, string? id) => $"{sequence}:{id}";
 

--- a/src/MeshWeaver.PluginCatalog/ModuleSetAdoptionService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSetAdoptionService.cs
@@ -124,11 +124,28 @@ public static class ModuleSetAdoptionServiceExtensions
         this IServiceCollection services, string describe, Action record)
     {
         ArgumentNullException.ThrowIfNull(record);
+        return services.AddModuleSetAdoption(describe, _ => record());
+    }
+
+    /// <summary>
+    /// As <see cref="AddModuleSetAdoption(IServiceCollection, string, Action)"/>, handing the write
+    /// the mesh's service provider — so it can record what the loader ACTUALLY installed (#3649:
+    /// the <see cref="MeshWeaver.Mesh.FallbackModule"/> records, registered by
+    /// <c>MeshBuilder.InstallModules</c> and unknowable at the point boot registers this service).
+    /// An overload, not a changed parameter: the <see cref="Action"/> form is binary API.
+    /// </summary>
+    /// <param name="services">The mesh's service collection.</param>
+    /// <param name="describe">What is being adopted, for the log lines.</param>
+    /// <param name="record">The adoption write itself, given the built container.</param>
+    public static IServiceCollection AddModuleSetAdoption(
+        this IServiceCollection services, string describe, Action<IServiceProvider> record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
         return services.AddSingleton<IHostedService>(sp => new ModuleSetAdoptionService(
             describe,
             () =>
             {
-                record();
+                record(sp);
                 return Unit.Default;
             },
             sp.GetService<MeshPublicationGate>(),

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -88,6 +88,32 @@ public sealed record ModuleActivationReport(
     public bool HasFloorAdvisories => !IsUndetermined && !FloorAdvisories.IsEmpty;
 
     /// <summary>
+    /// 🚨 The modules that RUN THEIR PREVIOUS GENERATION here because the one the mesh's set
+    /// activates does not load on this platform (#3649) — a FIFTH state, and the first one that
+    /// is not a fault: the module is present and working, one version behind. Not folded into
+    /// <see cref="Pending"/> (a restart re-runs the same measurement and falls back again, so
+    /// "restart required" would be a prompt no restart clears) and not into
+    /// <see cref="Quarantined"/> (that one contributes nothing; this one contributes everything
+    /// its previous version did). Each row names both generations and why. Init-only, for the
+    /// same binary-compatibility reason as the properties above.
+    /// </summary>
+    public ImmutableList<ModuleFallback> Fallbacks { get; init; } = [];
+
+    /// <summary>True when the state is KNOWN and a module runs its previous generation.</summary>
+    public bool HasFallbacks => !IsUndetermined && !Fallbacks.IsEmpty;
+
+    /// <summary>
+    /// The fallback row for the module the install record at <paramref name="packagePath"/>
+    /// landed, or null when that module runs the generation the set activates (or the state is
+    /// undetermined). Blank matches nothing — never a wildcard.
+    /// </summary>
+    public ModuleFallback? FallbackForPackage(string? packagePath) =>
+        IsUndetermined || string.IsNullOrWhiteSpace(packagePath)
+            ? null
+            : Fallbacks.FirstOrDefault(f => string.Equals(
+                f.PackagePath?.Trim('/'), packagePath.Trim('/'), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
     /// The declared-floor advisory for the module the install record at
     /// <paramref name="packagePath"/> landed, or null when it declares none above the running
     /// platform (or the state is undetermined). Blank matches nothing — never a wildcard.
@@ -158,7 +184,34 @@ public sealed record ModuleActivationReport(
                 : ModuleActivationStatus.Describe(Pending))
               + (HasDeferred ? "; " + DescribeDeferred(Deferred) : string.Empty)
               + (HasQuarantined ? "; " + DescribeQuarantined(Quarantined) : string.Empty)
+              + (HasFallbacks ? "; " + DescribeFallbacks(Fallbacks) : string.Empty)
               + (HasFloorAdvisories ? "; " + DescribeFloorAdvisories(FloorAdvisories) : string.Empty);
+
+    /// <summary>
+    /// One human-readable line naming the modules that run their PREVIOUS generation (#3649) —
+    /// one named row per module, "X runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load
+    /// here: …" — kept apart from every other line because it asks for nothing of the operator:
+    /// the module works, and the newest generation starts running by itself when a build of it
+    /// that loads here ships or the platform moves.
+    /// </summary>
+    /// <param name="fallbacks">The fallback rows.</param>
+    /// <param name="maxNamed">How many are named before the line truncates.</param>
+    public static string DescribeFallbacks(
+        IReadOnlyCollection<ModuleFallback> fallbacks, int maxNamed = 10)
+    {
+        ArgumentNullException.ThrowIfNull(fallbacks);
+        if (fallbacks.Count == 0)
+            return "no module runs a previous generation";
+        var rows = fallbacks
+            .OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(f => $"{f.Name} {f.Reason}")
+            .ToArray();
+        return $"{rows.Length} module(s) run a PREVIOUS generation because the one the mesh's set "
+            + "activates does not load on this platform — present and working, one version "
+            + "behind; no restart changes that, a build that loads here does: "
+            + string.Join("; ", rows.Take(Math.Max(1, maxNamed)))
+            + (rows.Length > maxNamed ? $"; …(+{rows.Length - maxNamed})" : string.Empty);
+    }
 
     /// <summary>
     /// One human-readable line naming the modules that DECLARE a platform above the one running
@@ -250,6 +303,27 @@ public sealed record ModuleFloorAdvisory(
     string Name, string? PackagePath, string DeclaredFloor, string? RunningVersion, string Reason);
 
 /// <summary>
+/// One module that runs its PREVIOUS generation on this replica (#3649): which generation runs,
+/// which one landed and does not load here, and why — the row every status surface renders.
+/// </summary>
+/// <param name="Name">The module's assembly simple name, as the activation entry records it.</param>
+/// <param name="PackagePath">The mesh path of the install record that landed it, when recorded.</param>
+/// <param name="Version">The package version of the generation that does NOT load here, when recorded.</param>
+/// <param name="Generation">The generation directory leaf that does NOT load here.</param>
+/// <param name="PreviousVersion">The package version of the generation that runs, when recorded.</param>
+/// <param name="PreviousGeneration">The generation directory leaf that runs.</param>
+/// <param name="Reason">The row's sentence (<see cref="MeshWeaver.Mesh.FallbackModule.Describe"/>):
+/// "runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load here: …".</param>
+public sealed record ModuleFallback(
+    string Name,
+    string? PackagePath,
+    string? Version,
+    string Generation,
+    string? PreviousVersion,
+    string PreviousGeneration,
+    string Reason);
+
+/// <summary>
 /// Reads the restart-as-activation state for THIS process: the persisted activation sidecar
 /// compared against the assemblies actually loaded here (#1979).
 ///
@@ -284,6 +358,20 @@ public sealed class PendingModuleActivations(string moduleRoot)
     /// </summary>
     public IReadOnlySet<string> QuarantinedModules { get; init; } =
         ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The modules this process installed from their PREVIOUS generation (#3649) — production
+    /// passes the registered <see cref="Mesh.FallbackModule"/> set, which is what
+    /// <c>MeshBuilder.InstallModules</c> recorded for every module whose head generation did not
+    /// load here and whose previous one did.
+    ///
+    /// <para>🚨 Without it such a module reads as PENDING: the generation the set activates is
+    /// not the one loaded here, which is the update half of "not loaded" (#3395) — and the
+    /// surface would promise a restart that re-runs the same measurement and falls back again.
+    /// It is pending only when the set has since moved to a generation OTHER than the one the
+    /// loader refused, which a restart genuinely tries. Init-only, for binary compatibility.</para>
+    /// </summary>
+    public IReadOnlyCollection<Mesh.FallbackModule> FallbackModules { get; init; } = [];
 
     /// <summary>
     /// The current report. Recomputed per call — the state changes underneath a running process
@@ -394,6 +482,31 @@ public sealed class PendingModuleActivations(string moduleRoot)
             ? []
             : [.. notYetLoaded.Where(p => QuarantinedModules.Contains(p.Name))];
 
+        // 🚨 #3649 — a module running its PREVIOUS generation is not pending either: its entry on
+        // the mesh's set names the generation the loader REFUSED, so a restart measures the same
+        // bytes and falls back again. It becomes pending again only when the set moves on to a
+        // generation other than the refused one — that is what a restart would genuinely try,
+        // and R3 (#3650) is what makes that restart happen. The row is derived from the entry the
+        // set activates, so it carries the install record's path for the package card.
+        var fallbackRows = ImmutableList.CreateBuilder<ModuleFallback>();
+        var settledFallbacks = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var fallback in FallbackModules)
+        {
+            var entry = onMeshSet.Entries.FirstOrDefault(e =>
+                e.Enabled && string.Equals(e.Name, fallback.Name, StringComparison.OrdinalIgnoreCase));
+            if (entry is null)
+                continue;
+            fallbackRows.Add(new ModuleFallback(
+                fallback.Name, entry.PackagePath,
+                fallback.Version ?? entry.Version, fallback.Generation,
+                fallback.PreviousVersion ?? entry.PreviousVersion, fallback.PreviousGeneration,
+                fallback.Describe()));
+            if (string.Equals(entry.Directory, fallback.Generation, StringComparison.Ordinal))
+                settledFallbacks.Add(fallback.Name);
+        }
+        if (settledFallbacks.Count > 0)
+            notYetLoaded = [.. notYetLoaded.Where(p => !settledFallbacks.Contains(p.Name))];
+
         // 🚨 #3648 — the declared floor is ADVISORY, so it is a LINE, never a bucket. Every enabled
         // entry the mesh's set activates whose recorded minMeshVersion ranks above the running
         // platform is listed here — loaded or not — so the status row and the health payload can
@@ -420,6 +533,7 @@ public sealed class PendingModuleActivations(string moduleRoot)
         {
             Deferred = deferred.ToImmutable(),
             Quarantined = quarantined,
+            Fallbacks = fallbackRows.ToImmutable(),
             FloorAdvisories = floorAdvisories,
             MeshModuleSet = ModuleSetStore.Describe(sets)
                 + (setNotes.Count > 0 ? " — " + string.Join("; ", setNotes) : string.Empty),

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -187,6 +187,11 @@ public static class PluginCatalogConfigurationExtensions
                         .Select(m => m.Name)
                         .Where(n => !string.IsNullOrWhiteSpace(n))
                         .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase),
+                    // 🚨 #3649 — the modules it loaded from their PREVIOUS generation because the
+                    // head one does not load here. Without this set they read as PENDING (the
+                    // generation the set activates is not the one loaded), and every surface
+                    // promises a restart that falls back again.
+                    FallbackModules = [.. sp.GetServices<FallbackModule>()],
                 })
                 // The COUNT that proves the distribution lane works (#1782 gap 4). Adoption's only
                 // evidence used to be a log line, and the most important miss — "the registry does

--- a/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
@@ -79,6 +79,13 @@ public sealed record RequiredModuleVerdict(
 /// here" verdict is the measured one — the link probe's refusal, which arrives as
 /// <see cref="Mesh.IncompatibleModule"/>.</para>
 ///
+/// <para>🚨 <b>A module running its PREVIOUS generation is <see cref="RequiredModuleState.Present"/>
+/// (#3649).</b> When the generation the mesh's set activates does not load here, boot loads the
+/// previous one and records a <see cref="Mesh.FallbackModule"/> — never an
+/// <see cref="Mesh.IncompatibleModule"/>: the assembly IS loaded and its features work, so the
+/// loaded-names check answers Present and a readiness probe stays Healthy. What it is not is
+/// current, and that is the status row's business, not the probe's.</para>
+///
 /// <para>Pure and total — the caller supplies configuration, the loaded set, the activation record,
 /// the existence check and the floor's wording — so the whole contract is testable with no
 /// filesystem and no host.</para>

--- a/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
@@ -392,6 +392,50 @@ public class ModulePlatformLinkTest : IDisposable
         Assert.Equal("MeshWeaver.Test.ParkedViewPack", stalls.Name);
     }
 
+    /// <summary>
+    /// 🚨 #3649 — a REQUIRED module running its PREVIOUS generation is <c>Present</c>. The loader
+    /// registers a <see cref="FallbackModule"/> for it, never an <see cref="IncompatibleModule"/>:
+    /// its assembly is loaded and its features work, so the readiness probe stays Healthy and a
+    /// rollout is not stalled on a module that is merely one version behind.
+    /// </summary>
+    [Fact]
+    public void ARequiredModuleRunningItsPreviousGeneration_IsPresent_NeverIncompatible()
+    {
+        var fallback = new FallbackModule(
+            "MeshWeaver.Test.FallbackPack",
+            "/data/modules/MeshWeaver.Test.FallbackPack@b/MeshWeaver.Test.FallbackPack.dll",
+            "/data/modules/MeshWeaver.Test.FallbackPack@a/MeshWeaver.Test.FallbackPack.dll",
+            "it references " + FutureType)
+        {
+            Version = "1.3.0",
+            PreviousVersion = "1.2.3",
+        };
+        Assert.Equal("MeshWeaver.Test.FallbackPack@b", fallback.Generation);
+        Assert.Equal("MeshWeaver.Test.FallbackPack@a", fallback.PreviousGeneration);
+        Assert.StartsWith(
+            "runs v1.2.3 (MeshWeaver.Test.FallbackPack@a); v1.3.0 (MeshWeaver.Test.FallbackPack@b) "
+            + "landed but does not load here:", fallback.Describe(), StringComparison.Ordinal);
+
+        // What the loader hands the probe for such a module: the name IS loaded, and the
+        // incompatible set does NOT carry it.
+        var verdicts = RequiredModuleStatus.Classify(
+            requiredEntries: ["MeshWeaver.Test.FallbackPack.dll"],
+            baselineEntries: [],
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                { "MeshWeaver.Test.FallbackPack" },
+            resolvesFromDeployment: _ => false,
+            activation: null,
+            landedDllExists: _ => true,
+            platformGate: _ => null,
+            incompatibleModules: []);
+
+        var verdict = Assert.Single(verdicts);
+        Assert.Equal("MeshWeaver.Test.FallbackPack", verdict.Name);
+        Assert.Equal(RequiredModuleState.Present, verdict.State);
+        Assert.Empty(RequiredModuleStatus.Incompatible(verdicts));
+        Assert.Empty(RequiredModuleStatus.ExpectedLater(verdicts));
+    }
+
     // ───────────────────────────────────────────────────────────── harness
 
     /// <summary>

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
@@ -2,9 +2,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
 using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -229,5 +239,495 @@ public class ConfiguredModuleActivationTest
     {
         // One source, no overrides — today's default, and it must stay silent.
         Assert.Empty(MeshBuilderModuleActivation.ShadowedRequired(Config(ImageBaseline)));
+    }
+
+    // ───────── #3649: a generation that cannot load here falls back to the previous one ─────────
+    //
+    // Rule R1 of the module adoption policy (maintainer, 2026-09-07): an installation runs the
+    // newest generation of every module that LOADS, and keeps the one it has until a newer one
+    // does. Before this, a landed generation the link probe refused left the module ABSENT unless
+    // the image shipped a baseline copy — a Store-only module has none — and the shelved landing
+    // overwrote the only reference to the loadable generation, which the next GC pass then took
+    // away. Every test here lands REAL assemblies through the REAL landing service, boots the way
+    // MemexConfiguration.ConfigureMemexMesh boots, and drives the REAL loader.
+
+    /// <summary>The platform assembly the stand-in impersonates — a real one this process has
+    /// loaded, so the probe measures against the copy a module would actually bind to.</summary>
+    private const string ContractAssembly = "MeshWeaver.Mesh.Contract";
+
+    /// <summary>A type no build of <see cref="ContractAssembly"/> has ever carried: what a module
+    /// compiled against a platform three days ahead links to.</summary>
+    private const string FutureType = "MeshWeaver.Mesh.CodeOutputCurrencyFromTheFuture";
+
+    private const string PackagePath = "Plugins/fallback-pack";
+
+    /// <summary>
+    /// 🚨 THE repro of #3649. A loadable generation is landed, then a generation built for a NEWER
+    /// platform is shelved over it (the registry lane, where an unloadable module holds instead
+    /// of refusing). Boot refuses the shelved generation, loads the previous one, and says so —
+    /// and the module is PRESENT, never incompatible.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheNewestGenerationCannotLoadHere_ThePreviousOneLoads_AndIsReported()
+    {
+        using var deployment = new Deployment();
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+
+        // The landing kept the displaced generation as the fallback, with its version.
+        var entry = Entry(deployment);
+        Assert.Equal(b, entry.Directory);
+        Assert.Equal(a, entry.PreviousDirectory);
+        Assert.Equal("1.2.3", entry.PreviousVersion);
+
+        var (services, _) = Boot(deployment);
+
+        var installed = Assert.Single(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+        Assert.Equal(a, Path.GetFileName(Path.GetDirectoryName(installed.Assembly.Location)));
+
+        var fallback = Assert.Single(services.GetServices<FallbackModule>());
+        Assert.Equal(deployment.Module, fallback.Name);
+        Assert.Equal(b, fallback.Generation);
+        Assert.Equal(a, fallback.PreviousGeneration);
+        Assert.Equal("1.3.0", fallback.Version);
+        Assert.Equal("1.2.3", fallback.PreviousVersion);
+        // The report names both generations and the type the newest one wanted — the sentence the
+        // incident was missing.
+        Assert.StartsWith(
+            $"'{deployment.Module}' runs its previous generation v1.2.3 ({a}) because v1.3.0 ({b}) "
+            + "cannot load here:", fallback.Report(), StringComparison.Ordinal);
+        Assert.Contains(FutureType, fallback.Reason, StringComparison.Ordinal);
+
+        // 🚨 Present, not incompatible: nothing registers the module as degraded.
+        Assert.Empty(services.GetServices<IncompatibleModule>());
+    }
+
+    /// <summary>
+    /// The other half of "as today": when NO generation loads here, the module is incompatible
+    /// exactly as it was before #3649 — named, refused before load, contributing nothing.
+    /// </summary>
+    [Fact]
+    public async Task WhenNoGenerationLoadsHere_TheModuleIsIncompatible_AsBefore()
+    {
+        using var deployment = new Deployment();
+        var first = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.1");
+        Assert.Equal(first, Entry(deployment).PreviousDirectory);
+
+        var (services, _) = Boot(deployment);
+
+        Assert.Empty(services.GetServices<FallbackModule>());
+        var parked = Assert.Single(services.GetServices<IncompatibleModule>());
+        Assert.Equal(deployment.Module, parked.Name);
+        Assert.True(parked.RefusedBeforeLoad);
+        Assert.Contains(FutureType, parked.Report(), StringComparison.Ordinal);
+        Assert.DoesNotContain(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// 🚨 Two unloadable landings in a row must not push the loadable generation out of reach. The
+    /// landing MEASURES the generation it displaces: when that one cannot load here and holds a
+    /// fallback of its own, the fallback carries forward — so the entry keeps pointing at the one
+    /// generation that runs, and boot runs it.
+    /// </summary>
+    [Fact]
+    public async Task TwoUnloadableLandingsInARow_KeepTheLoadableGenerationAsTheFallback()
+    {
+        using var deployment = new Deployment();
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var c = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.1");
+
+        var entry = Entry(deployment);
+        Assert.Equal(c, entry.Directory);
+        Assert.Equal(a, entry.PreviousDirectory);
+        Assert.Equal("1.2.3", entry.PreviousVersion);
+
+        var (services, _) = Boot(deployment);
+        Assert.Equal(a, Assert.Single(services.GetServices<FallbackModule>()).PreviousGeneration);
+    }
+
+    /// <summary>
+    /// 🚨 The fallback generation is REFERENCED: the GC keeps it while it is the one that loads.
+    /// Reclaiming it is precisely how a shelved landing used to take a working module away for
+    /// good. The negative control — an uninstall clears the references and both go — is what
+    /// keeps this from passing by never collecting anything.
+    /// </summary>
+    [Fact]
+    public async Task GarbageCollection_KeepsTheFallbackGeneration()
+    {
+        using var deployment = new Deployment();
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+
+        ModuleLandingService.CollectGarbage(deployment.Root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+
+        Assert.True(Directory.Exists(deployment.GenerationDirectory(a)),
+            "the previous generation — the only one that loads here — was reclaimed");
+        Assert.True(Directory.Exists(deployment.GenerationDirectory(b)));
+
+        await deployment.Landing.RemoveModule(deployment.Module).Timeout(TestTimeouts.Convergence).Await();
+        ModuleLandingService.CollectGarbage(deployment.Root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+
+        Assert.False(Directory.Exists(deployment.GenerationDirectory(a)));
+        Assert.False(Directory.Exists(deployment.GenerationDirectory(b)));
+    }
+
+    /// <summary>
+    /// The mesh's set still PROPOSES the head generation — that is what the wave landed — but the
+    /// ADOPTION records what the replica actually loaded, so a reader of the set records learns
+    /// what runs, the GC references it, and the mesh-set line says so.
+    /// </summary>
+    [Fact]
+    public async Task TheAdoptedSet_RecordsTheGenerationThatActuallyLoaded()
+    {
+        using var deployment = new Deployment();
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var proposed = await deployment.Landing.ProposeModuleSet().Timeout(TestTimeouts.Convergence).Await();
+        Assert.NotNull(proposed);
+        Assert.Equal(b, proposed.Generations[deployment.Module]);
+
+        Boot(deployment);
+
+        var index = ModuleSetStore.Read(deployment.Root);
+        Assert.NotNull(index.Current);
+        Assert.False(index.ConvergencePending);
+        Assert.Equal(b, index.Current.Generations[deployment.Module]);
+        Assert.Equal(a, index.RunningGenerations[deployment.Module]);
+        Assert.Equal(a, Assert.Single(index.FallbackGenerations).Value);
+        Assert.Contains(a, ModuleSetStore.ReferencedGenerations(index));
+        Assert.Contains("PREVIOUS generation", ModuleSetStore.Describe(index), StringComparison.Ordinal);
+        Assert.Contains(a, ModuleSetStore.Describe(index), StringComparison.Ordinal);
+
+        // …and the GC, which reads the set records, keeps it on that evidence alone.
+        ModuleLandingService.CollectGarbage(deployment.Root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+        Assert.True(Directory.Exists(deployment.GenerationDirectory(a)));
+    }
+
+    /// <summary>An uninstall clears BOTH pointers: a disabled entry must not keep either
+    /// generation referenced, or the GC could never reclaim them.</summary>
+    [Fact]
+    public async Task Uninstall_ClearsBothGenerationPointers()
+    {
+        using var deployment = new Deployment();
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+
+        await deployment.Landing.RemoveModule(deployment.Module).Timeout(TestTimeouts.Convergence).Await();
+
+        var entry = Entry(deployment);
+        Assert.False(entry.Enabled);
+        Assert.Null(entry.Directory);
+        Assert.Null(entry.PreviousDirectory);
+        Assert.Null(entry.PreviousVersion);
+        Assert.Null(entry.PreviousFrameworkMvid);
+        Assert.False(Directory.Exists(deployment.GenerationDirectory(a)));
+        Assert.False(Directory.Exists(deployment.GenerationDirectory(b)));
+    }
+
+    /// <summary>
+    /// The projection onto the mesh's set carries the fallback pointer with the entry, and drops
+    /// it only when it names the set's own generation (the mid-wave shape: the entry moved to D
+    /// with the set's G as its fallback — G is the head now and needs no fallback to itself).
+    /// </summary>
+    [Fact]
+    public void TheProjectionOntoTheMeshSet_CarriesTheFallbackPointer_UnlessItNamesTheSetsGeneration()
+    {
+        const string name = "MeshWeaver.Test.Projected";
+        var set = new ModuleSet(1, "set-1",
+            ImmutableSortedDictionary.CreateRange(StringComparer.OrdinalIgnoreCase,
+                [KeyValuePair.Create(name, name + "@g")]),
+            DateTime.UtcNow);
+
+        static ModuleActivationList Record(string head, string previous) => new()
+        {
+            Entries =
+            [
+                new ModuleActivationEntry
+                {
+                    Name = name, Directory = head, PreviousDirectory = previous, PreviousVersion = "1.0.0",
+                },
+            ],
+        };
+
+        var midWave = ModuleActivationBoot.ProjectOntoMeshSet(Record(name + "@d", name + "@g"), set)
+            .Entries.Single();
+        Assert.Equal(name + "@g", midWave.Directory);
+        Assert.Null(midWave.PreviousDirectory);
+        Assert.Null(midWave.PreviousVersion);
+
+        var carried = ModuleActivationBoot.ProjectOntoMeshSet(Record(name + "@d", name + "@a"), set)
+            .Entries.Single();
+        Assert.Equal(name + "@g", carried.Directory);
+        Assert.Equal(name + "@a", carried.PreviousDirectory);
+        Assert.Equal("1.0.0", carried.PreviousVersion);
+    }
+
+    /// <summary>
+    /// A module running its previous generation is a NAMED ROW on the activation report, never
+    /// "restart required" (a restart re-measures the same bytes and falls back again) and never
+    /// "not running here" (it is running). Without the loader's record the same state reads as an
+    /// ordinary pending update — the false prompt the record exists to remove — and once the
+    /// record has moved past the refused generation, a restart genuinely tries something new and
+    /// the module is pending again.
+    /// </summary>
+    [Fact]
+    public async Task TheActivationReport_NamesAFallback_AndNeverCallsItRestartRequired()
+    {
+        using var deployment = new Deployment();
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var (services, _) = Boot(deployment);
+        var fallbacks = services.GetServices<FallbackModule>().ToArray();
+        var loaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { deployment.Module };
+        var generations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [deployment.Module] = a,
+        };
+
+        var report = new PendingModuleActivations(deployment.Root) { FallbackModules = fallbacks }
+            .Read(loaded, generations);
+
+        Assert.False(report.IsUndetermined, report.UndeterminedReason);
+        Assert.True(report.HasFallbacks);
+        var row = Assert.Single(report.Fallbacks);
+        Assert.Equal(deployment.Module, row.Name);
+        Assert.Equal(PackagePath, row.PackagePath);
+        Assert.Equal(a, row.PreviousGeneration);
+        Assert.Equal(b, row.Generation);
+        Assert.Equal("1.2.3", row.PreviousVersion);
+        Assert.Equal("1.3.0", row.Version);
+        Assert.StartsWith($"runs v1.2.3 ({a}); v1.3.0 ({b}) landed but does not load here:",
+            row.Reason, StringComparison.Ordinal);
+        Assert.Same(row, report.FallbackForPackage(PackagePath));
+        Assert.Null(report.FallbackForPackage(null));
+        Assert.False(report.HasPending, "a restart re-measures the same bytes and falls back again");
+        Assert.False(report.IsPendingForPackage(PackagePath));
+        Assert.False(report.HasQuarantined, "it is running");
+        Assert.Contains("PREVIOUS generation", report.Describe(), StringComparison.Ordinal);
+
+        var blind = new PendingModuleActivations(deployment.Root).Read(loaded, generations);
+        Assert.True(blind.HasPending, "without the loader's record the state reads as an ordinary update");
+
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.1");
+        var movedOn = new PendingModuleActivations(deployment.Root) { FallbackModules = fallbacks }
+            .Read(loaded, generations);
+        Assert.True(movedOn.HasPending, "the record moved past the refused generation — a restart tries the new one");
+        Assert.True(movedOn.HasFallbacks);
+    }
+
+    /// <summary>
+    /// A REQUIRED module running its previous generation is <see cref="RequiredModuleState.Present"/>:
+    /// the readiness probe stays Healthy on a fallback. Classified off the real loader's output —
+    /// the loaded set and the incompatible set it registered — so the verdict cannot agree with
+    /// itself while the loader diverges.
+    /// </summary>
+    [Fact]
+    public async Task ARequiredModuleRunningItsPreviousGeneration_IsPresent()
+    {
+        using var deployment = new Deployment();
+        await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var (services, _) = Boot(deployment);
+
+        var verdicts = RequiredModuleStatus.Classify(
+            requiredEntries: [deployment.Module + ".dll"],
+            baselineEntries: [],
+            loadedAssemblyNames: services.GetServices<InstalledModuleAssembly>()
+                .Select(m => m.Assembly.GetName().Name!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase),
+            resolvesFromDeployment: _ => false,
+            activation: ModuleActivationSidecar.Read(deployment.Root),
+            landedDllExists: entry => ModuleActivationBoot.LandedModuleDllExists(deployment.Root, entry),
+            platformGate: _ => null,
+            incompatibleModules: [.. services.GetServices<IncompatibleModule>()]);
+
+        var verdict = Assert.Single(verdicts);
+        Assert.Equal(deployment.Module, verdict.Name);
+        Assert.Equal(RequiredModuleState.Present, verdict.State);
+        Assert.Empty(RequiredModuleStatus.Incompatible(verdicts));
+        Assert.Empty(RequiredModuleStatus.ExpectedLater(verdicts));
+    }
+
+    // ───────────────────────────────────────────────────────────── harness
+
+    /// <summary>A per-test deployment root with the REAL landing service over it. The module name
+    /// is unique per test: the loader puts what it loads into the default load context, and two
+    /// different assemblies of one simple name cannot both live there.</summary>
+    private sealed class Deployment : IDisposable
+    {
+        public string Root { get; } =
+            Path.Combine(Path.GetTempPath(), "mw-fallback-" + Guid.NewGuid().ToString("N"));
+
+        public string PinRoot => Path.Combine(Root, "pinned");
+
+        public string Module { get; } = "MeshWeaver.Test.Fallback" + Guid.NewGuid().ToString("N")[..8];
+
+        public ModuleLandingService Landing { get; }
+
+        public Deployment()
+        {
+            Directory.CreateDirectory(Root);
+            Landing = new ModuleLandingService(baseDirectory: Root);
+        }
+
+        public string GenerationDirectory(string generation) => Path.Combine(Root, "modules", generation);
+
+        public void Dispose()
+        {
+            Landing.Dispose();
+            try { Directory.Delete(Root, recursive: true); }
+            catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        }
+    }
+
+    private static ModuleActivationEntry Entry(Deployment deployment) =>
+        ModuleActivationSidecar.Read(deployment.Root).Entries
+            .Single(e => string.Equals(e.Name, deployment.Module, StringComparison.Ordinal));
+
+    /// <summary>Lands a generation on the ADOPT path (refuses what cannot load) and returns its
+    /// generation directory leaf.</summary>
+    private static async Task<string> Land(Deployment deployment, byte[] bytes, string version)
+    {
+        await deployment.Landing.LandModule(
+                deployment.Module, [(deployment.Module + ".dll", bytes)],
+                packagePath: PackagePath, version: version)
+            .Timeout(TestTimeouts.Convergence).Await();
+        return Entry(deployment).Directory!;
+    }
+
+    /// <summary>Lands a generation on the SHELF path (holds what cannot load) and returns its
+    /// generation directory leaf. Asserts it was held — every shelved generation here is one
+    /// built for a newer platform.</summary>
+    private static async Task<string> Shelve(Deployment deployment, byte[] bytes, string version)
+    {
+        var outcome = await deployment.Landing.ShelveModule(
+                deployment.Module, [(deployment.Module + ".dll", bytes)],
+                packagePath: PackagePath, version: version)
+            .Timeout(TestTimeouts.Convergence).Await();
+        Assert.True(outcome.Held, "the shelved generation was expected to be unloadable here");
+        return Entry(deployment).Directory!;
+    }
+
+    /// <summary>
+    /// One replica's boot, composed EXACTLY as <c>MemexConfiguration.ConfigureMemexMesh</c>
+    /// composes it — read the record, read the mesh's sets, project, compute the union, pin the
+    /// head generation, hand the loader a LAZY pin of the previous one, install, record the
+    /// adoption off what the loader registered. Re-deriving any of it here would let this test
+    /// agree with itself while the portal diverges.
+    /// </summary>
+    private static (IServiceProvider Services, ModuleSetIndex Sets) Boot(Deployment deployment)
+    {
+        var root = deployment.Root;
+        var persisted = ModuleActivationSidecar.Read(root);
+        var sets = ModuleSetStore.Read(root);
+        var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(
+            persisted,
+            sets.Proposed,
+            onDeferred: null,
+            landedDllExists: entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
+        var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
+            baselineEntries: null,
+            onMeshSet,
+            ModulePlatformFloor.DeclineReason,
+            entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
+        var candidates = effective
+            .Select(module =>
+            {
+                var landed = module.Landed!;
+                var previous = ModuleActivationBoot.PreviousGeneration(landed) is { } older
+                               && ModuleActivationBoot.LandedModuleDllExists(root, older)
+                    ? older
+                    : null;
+                return new ModuleInstallCandidate(
+                    ModuleGenerationPin.PinnedLoadPath(root, landed, deployment.PinRoot))
+                {
+                    Version = landed.Version,
+                    PreviousVersion = previous?.Version,
+                    Previous = previous is null
+                        ? null
+                        : () => ModuleGenerationPin.PinnedLoadPath(root, previous, deployment.PinRoot),
+                };
+            })
+            .ToArray();
+
+        var services = new ServiceCollection();
+        var builder = new MeshBuilder(configure => configure(services), new Address("mesh", "test"));
+        builder.InstallModules(candidates);
+        var provider = services.BuildServiceProvider();
+
+        if (sets.Proposed is { } adopted)
+            ModuleSetStore.RecordAdoption(root, adopted,
+                ModuleSetStore.RunningGenerationsOf(adopted, provider.GetServices<FallbackModule>()),
+                adoptedBy: "replica");
+        return (provider, sets);
+    }
+
+    /// <summary>A module compiled against a STAND-IN <see cref="ContractAssembly"/> carrying
+    /// <see cref="FutureType"/> — the memex-cloud shape: same assembly simple name as one this
+    /// process has loaded, and that copy does not have the type.</summary>
+    private static byte[] ModuleBuiltAgainstAFuturePlatform(string moduleName)
+    {
+        var future = Emit(ContractAssembly, """
+            namespace MeshWeaver.Mesh;
+            /// <summary>The type a newer platform has and this one does not.</summary>
+            public enum CodeOutputCurrencyFromTheFuture { Unknown, Current, Stale }
+            """, excludeReference: ContractAssembly);
+
+        return Emit(moduleName, """
+            using MeshWeaver.Mesh;
+            public static class CodeViews
+            {
+                public static string BuildContent(CodeOutputCurrencyFromTheFuture currency)
+                    => currency.ToString();
+            }
+            """,
+            excludeReference: ContractAssembly,
+            extra: MetadataReference.CreateFromImage(future));
+    }
+
+    /// <summary>A module compiled against the REAL contract this process runs — the generation
+    /// that loads.</summary>
+    private static byte[] ModuleBuiltAgainstThisPlatform(string moduleName) =>
+        Emit(moduleName, """
+            using MeshWeaver.Mesh;
+            public static class CodeViews
+            {
+                public static string BuildContent(MeshNode node) => node.Id;
+            }
+            """);
+
+    /// <summary>Compiles one source file into an assembly named <paramref name="assemblyName"/>,
+    /// against this process's own reference set.</summary>
+    private static byte[] Emit(
+        string assemblyName, string source, string? excludeReference = null,
+        MetadataReference? extra = null)
+    {
+        var platform = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            .Where(p => excludeReference is null
+                        || !string.Equals(Path.GetFileNameWithoutExtension(p), excludeReference,
+                            StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+        if (extra is not null)
+            platform.Add(extra);
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source)],
+            platform,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var buffer = new MemoryStream();
+        var result = compilation.Emit(buffer);
+        Assert.True(result.Success, string.Join(
+            Environment.NewLine,
+            result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return buffer.ToArray();
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/ModulesAssemblyLoadContextTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/ModulesAssemblyLoadContextTest.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using MeshWeaver.Connection.Orleans;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>The module load context resolves through the PLATFORM before its own directory (#3662,
+/// half B).</b>
+///
+/// <para><b>What went wrong.</b> <see cref="ModulesAssemblyLoadContext.Load"/> used to prefer a
+/// copy ALREADY LOADED in the default context, then the working directory, then the module
+/// directory. A platform assembly the process had not touched yet — and the portal image carries
+/// 214 of them, most of them cold at any moment — matched nothing in the first step, so a bundle
+/// copy of it in the module directory won the module's context; when the platform later loaded
+/// its own copy, the process held two assemblies of one identity, and every type that crossed the
+/// boundary failed with an <c>InvalidCastException</c> between two types of the same full name.
+/// That is the hazard MeshWeaver.Plugins' <c>platform-shipped.txt</c> exists to prevent at pack
+/// time; this is the same rule enforced at load time.</para>
+///
+/// <para><b>The rule.</b> Ask the default context to RESOLVE the name first — a platform assembly
+/// is served by the platform whether or not it is loaded yet — and fall through to the working
+/// directory and the module directory only when the platform cannot supply the name at all.
+/// Deterministic unit tests over the real context: no cluster, no mocks.</para>
+/// </summary>
+public class ModulesAssemblyLoadContextTest : IDisposable
+{
+    private readonly string moduleDirectory =
+        Path.Combine(Path.GetTempPath(), "mw-module-alc-" + Guid.NewGuid().ToString("N"));
+
+    private readonly ModulesAssemblyLoadContext context;
+
+    public ModulesAssemblyLoadContextTest()
+    {
+        Directory.CreateDirectory(moduleDirectory);
+        context = new ModulesAssemblyLoadContext(moduleDirectory);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        context.Unload();
+        try { Directory.Delete(moduleDirectory, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// 🚨 THE repro. A platform assembly this process has NOT loaded yet, with a same-named decoy
+    /// sitting in the module directory: the platform's copy is served, from the default context,
+    /// and the decoy is never touched. Before the fix the first step found nothing loaded, the
+    /// second found nothing in the working directory, and the third loaded the decoy.
+    /// </summary>
+    [Fact]
+    public void ANameThePlatformHas_IsServedFromTheDefaultContext_EvenWithACopyInTheModuleDirectory()
+    {
+        var (name, platformPath) = PlatformAssemblyNotYetLoaded();
+        Assert.DoesNotContain(AssemblyLoadContext.Default.Assemblies,
+            a => string.Equals(a.GetName().Name, name, StringComparison.OrdinalIgnoreCase));
+        File.WriteAllBytes(Path.Combine(moduleDirectory, name + ".dll"),
+            Emit(name, "public static class Decoy { }"));
+
+        var loaded = context.LoadFromAssemblyName(new AssemblyName(name));
+
+        Assert.Same(AssemblyLoadContext.Default, AssemblyLoadContext.GetLoadContext(loaded));
+        Assert.Equal(name, loaded.GetName().Name);
+        Assert.False(loaded.Location.StartsWith(moduleDirectory, StringComparison.OrdinalIgnoreCase),
+            $"the module directory's decoy was loaded instead of the platform's {platformPath}");
+        Assert.Null(loaded.GetType("Decoy", throwOnError: false));
+    }
+
+    /// <summary>
+    /// The positive control for the fall-through: a name the platform LACKS is served from the
+    /// module directory, into the module's own collectible context — which is what the context is
+    /// for. Removing the fall-through is what this catches.
+    /// </summary>
+    [Fact]
+    public void ANameThePlatformLacks_IsServedFromTheModuleDirectory()
+    {
+        var name = "MeshWeaver.Test.ModuleOnly" + Guid.NewGuid().ToString("N")[..8];
+        File.WriteAllBytes(Path.Combine(moduleDirectory, name + ".dll"),
+            Emit(name, "public static class Only { }"));
+
+        var loaded = context.LoadFromAssemblyName(new AssemblyName(name));
+
+        Assert.Same(context, AssemblyLoadContext.GetLoadContext(loaded));
+        Assert.StartsWith(moduleDirectory, loaded.Location, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(loaded.GetType("Only", throwOnError: false));
+        Assert.DoesNotContain(AssemblyLoadContext.Default.Assemblies,
+            a => string.Equals(a.GetName().Name, name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>A name nobody has — neither the platform, the working directory nor the module
+    /// directory — still resolves to null rather than throwing out of <c>Load</c>.</summary>
+    [Fact]
+    public void ANameNobodyHas_IsNotFound_NotAThrowFromLoad()
+    {
+        var name = "MeshWeaver.Test.Nowhere" + Guid.NewGuid().ToString("N")[..8];
+        Assert.Throws<FileNotFoundException>(() => context.LoadFromAssemblyName(new AssemblyName(name)));
+    }
+
+    // ───────────────────────────────────────────────────────────── harness
+
+    /// <summary>
+    /// A platform (TPA) assembly this process has not loaded — measured, not assumed: the test
+    /// asserts the precondition, because an already-loaded name is served by the OLD order too
+    /// and would prove nothing.
+    /// </summary>
+    private static (string Name, string Path) PlatformAssemblyNotYetLoaded()
+    {
+        var loaded = AssemblyLoadContext.Default.Assemblies
+            .Select(a => a.GetName().Name)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var candidate = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            .Select(p => (Name: Path.GetFileNameWithoutExtension(p), Path: p))
+            .Where(p => p.Name.StartsWith("System.", StringComparison.Ordinal) && !loaded.Contains(p.Name))
+            .OrderBy(p => p.Name, StringComparer.Ordinal)
+            .FirstOrDefault();
+        Assert.False(candidate == default, "every platform assembly is already loaded — nothing to measure with");
+        return candidate;
+    }
+
+    /// <summary>Compiles one source file into an assembly named <paramref name="assemblyName"/>,
+    /// against this process's own reference set.</summary>
+    private static byte[] Emit(string assemblyName, string source)
+    {
+        var references = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            // Never reference the assembly being impersonated: the decoy must not depend on
+            // the platform copy of itself.
+            .Where(p => !string.Equals(Path.GetFileNameWithoutExtension(p), assemblyName,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var buffer = new MemoryStream();
+        var result = compilation.Emit(buffer);
+        Assert.True(result.Success, string.Join(
+            Environment.NewLine,
+            result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return buffer.ToArray();
+    }
+}


### PR DESCRIPTION
Implements rule R1 (continuity) of the [Module Adoption Policy](https://github.com/Systemorph/MeshWeaver/blob/docs/module-adoption-policy/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md): *an installation runs the newest generation of every installed module that loads, and keeps the one it has until a newer one does.* Plus half B of #3662 as a separate commit.

> 🚨 **Stacked on #3661** (`fix/3648-module-floors-advisory`). Retarget to `main` after #3661 merges; the diff here is the three commits on top of it.

## What changed

**Continuity (#3649)**
- `ModuleActivationEntry` gains `PreviousDirectory`, `PreviousVersion`, `PreviousFrameworkMvid`. `ModuleLandingService.LandCore` records the entry a landing displaces; when that generation is itself **measured** unloadable here and holds a fallback of its own, the fallback carries forward, so two unloadable landings in a row cannot push the loadable generation out of reach. `RemoveCore` clears both pointers and deletes both directories.
- `MeshBuilder.InstallModules(IReadOnlyList<ModuleInstallCandidate>)` — a **distinct name**, deliberately not an `InstallAssemblies` overload: MeshWeaver.Plugins carries `<see cref="MeshBuilder.InstallAssemblies"/>` in a dozen doc comments and an overload would fail them with CS0419 under `-warnaserror` (the rule `IncompatibleModule.FromLinkRefusal` already documents). `InstallAssemblies(params string[])` is unchanged and forwards. A candidate carries the newest generation and a **lazy** resolver for the previous one (the portal pins a generation per boot; pinning every previous one up front would double that copy for a path taken only when something is wrong). When the newest is refused before load or `Assembly.LoadFrom` throws, the previous generation goes through the same probe and load; on success the module is installed from it and a `FallbackModule` is registered — never an `IncompatibleModule` — with one `[MeshWeaver.Mesh.FallbackModule] '{Name}' runs its previous generation {Prev} because {Newest} cannot load here: {Reason}` line on stderr (re-logged as a Warning by the portal once the pipeline is up). Both unloadable → `Incompatible`, exactly as before. A generation that *loaded* and then failed to register is never swapped (two assemblies of one simple name cannot coexist in the default ALC).
- `ModuleLandingService.CollectGarbage` references `PreviousDirectory` like `Directory`, plus the running generations the adoption records.
- `ModuleSetStore`: the adoption records what actually loaded (`ModuleSetAdoption.Generations`, `RecordAdoption` overload, `RunningGenerationsOf`); `ModuleSetIndex.RunningGenerations` / `FallbackGenerations` read it back; `ReferencedGenerations` includes it; `Describe` names the modules running a previous generation. `AddModuleSetAdoption` gains an `Action<IServiceProvider>` overload so boot records off the loader's registrations.
- Status surfaces: `ModuleActivationReport.Fallbacks` is a named row — *runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load here: …* — subtracted from `Pending` while the set still activates the refused generation (a restart falls back again), pending again once the set moves on; never `Quarantined`. `FallbackForPackage` feeds the package card (`ui.moduleRunsPreviousVersion`, en + de). `RequiredModuleStatus` keeps a fallback `Present`, so the readiness probe stays Healthy. `ModuleActivationStatus.RunsAnOlderGeneration` documents that a fallback is such an entry by construction and the reader separates it.
- Boot (`MemexConfiguration.ConfigureMemexMesh`) builds the candidates, pins the previous generation only when it is the one that loads, and records the adoption off the `FallbackModule` set.
- Docs: `ModulePlatformLinkGate`, `ModuleSetConvergence`, `Modules`; What's New `2026-09-08-a-module-version-that-does-not-load-here-no-longer-takes-your-working-copy-away`.

**Half B of #3662** — `ModulesAssemblyLoadContext.Load` asks the default context to **resolve** the name first (`AssemblyLoadContext.Default.LoadFromAssemblyName` under `FileNotFoundException`/`FileLoadException`/`BadImageFormatException`) and falls through to the working directory and the module directory only when the platform cannot supply it — so a bundle copy of a platform assembly the process has not loaded yet can no longer split the identity.

## Tests

| Project | Run | Result |
|---|---|---|
| `MeshWeaver.Compiler.Pipeline.Test` | full project | **710 / 710** (13 existing + 9 new in `ConfiguredModuleActivationTest`) |
| `Memex.Portal.Shared.Test` | every class touching the changed APIs (`ModulePlatformLinkTest`, `ModuleSetConvergenceTest`, `ModuleFloorAdvisoryTest`, `ModuleFloorAdvisoryFunnelTest`, `ModuleGenerationDivergenceTest`, `ModuleGcOffReadinessPathTest`, `ModulePublishShelfTest`, `ModuleUpdateIdentityTest`, `PluginBundleAnchorTest`, `PluginBundlePublishAssetsTest`, `ConfigurationHandOverTest`, `AboutSettingsTabTest`, `LocalizationTest`) | **84 / 84** |
| `MeshWeaver.Hosting.Orleans.Test` | `ModulesAssemblyLoadContextTest` (new) | **3 / 3** |
| `MeshWeaver.Documentation.Test` | `WhatsNewEntryIntegrityTest` | **1 / 1** |

`ConfiguredModuleActivationTest` (#3649 section) lands real Roslyn-compiled assemblies through the real `ModuleLandingService` — a loadable generation, then one compiled against a stand-in `MeshWeaver.Mesh.Contract` carrying a type this platform lacks, shelved over it — and boots the way the portal boots: newest refused → previous loads and is reported; no generation loads → `Incompatible`; two unloadable landings keep the loadable fallback; GC keeps the fallback and reclaims it after uninstall; the adopted set records what loaded; uninstall clears both pointers; the projection onto the mesh's set carries the pointer; the activation report names the row and is never "restart required"; a required fallback is `Present`. `ModulePlatformLinkTest` pins the `RequiredModuleStatus` contract (there is no `RequiredModuleStatusTest` class; that is where `Classify` is tested). `ModulesAssemblyLoadContextTest`: a platform assembly not yet loaded with a same-named decoy in the module directory is served from the default context; a name the platform lacks is served from the module directory; a name nobody has is not found.

Every touched project builds clean with `-warnaserror`.

Closes #3649
Part of #3662 (half B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
