### PR TITLE
fix(#3650): a shipped module version is adopted within minutes, and a fallback re-examines every new build

### DIFF
--- a/memex/Memex.Portal.Shared/Api/ModulePublishedBroadcaster.cs
+++ b/memex/Memex.Portal.Shared/Api/ModulePublishedBroadcaster.cs
@@ -1,0 +1,188 @@
+using System.Collections.Immutable;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Api;
+
+/// <summary>
+/// The registry's half of eager adoption (#3650): the moment a module bundle is published, tell
+/// every registered consumer — so "ships" → "used" is minutes, not the consumer's next boot.
+///
+/// <para><b>Who is told.</b> Every <see cref="MeshWeaverInstance"/> registered on this registry that
+/// is not disabled and recorded a <see cref="MeshWeaverInstance.HomeUrl"/> — the URL a consumer
+/// hands over when it registers (<c>PluginCatalog:HomeUrl</c>). The registry does not know which
+/// instances installed the package; it does not need to — the consumer's reconcile answers that from
+/// its own install record, and a package that is not installed there costs one record read.</para>
+///
+/// <para><b>How.</b> One <see cref="ModulePublished"/> record, POSTed to each consumer's generic
+/// webhook inbox at <see cref="ModulePublished.InboxRoute"/> — the same inbox every other event
+/// reaches an installation through — signed GitHub-style when
+/// <see cref="ModulePublished.BroadcastSecretConfigKey"/> is configured, unsigned otherwise (the
+/// consumer treats the delivery as a wake-up and reads the truth from this registry's authenticated
+/// index, so an unsigned delivery cannot make it land anything it would not have landed). A 404
+/// means the consumer has not allowlisted the target; a 401 means the two halves of the secret
+/// drifted — both are LOGGED per consumer, never thrown, because a publish that landed on the shelf
+/// has succeeded whatever the fan-out did, and the consumer's safety net
+/// (<see cref="PluginCatalogOptions.ReconcileSafetyNetInterval"/>) bounds what a lost delivery costs.</para>
+///
+/// <para>Reactive end to end: the instance listing is a mesh query as System, each POST runs on the
+/// <c>Http</c> <see cref="IIoPool"/>, deliveries run one at a time and are isolated. Cold — nothing
+/// runs until subscribed, and the publish route subscribes it detached from the publisher's own
+/// response so a slow consumer never holds a CI job.</para>
+/// </summary>
+public sealed class ModulePublishedBroadcaster
+{
+    private readonly IMessageHub hub;
+    private readonly ILogger<ModulePublishedBroadcaster>? logger;
+    private readonly HttpClient http;
+    private readonly IIoPool httpPool;
+
+    /// <summary>The named <c>HttpClient</c> the broadcast sends through, so a host (or a test) can
+    /// route it — the same seam <c>DeploymentReportService</c> uses.</summary>
+    public const string HttpClientName = "module-published-broadcast";
+
+    private static readonly TimeSpan DeliveryBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>Creates the broadcaster over the mesh's services.</summary>
+    public ModulePublishedBroadcaster(IMessageHub hub, ILogger<ModulePublishedBroadcaster>? logger = null)
+    {
+        this.hub = hub;
+        this.logger = logger;
+        httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        http = hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName)
+               ?? new HttpClient { Timeout = DeliveryBudget };
+    }
+
+    /// <summary>One consumer's delivery outcome.</summary>
+    /// <param name="InstanceId">The consumer's logical App ID.</param>
+    /// <param name="Url">Where the delivery was POSTed.</param>
+    /// <param name="Ok">Whether the consumer answered 2xx.</param>
+    /// <param name="Detail">The status and body of a refusal, or null.</param>
+    public sealed record Delivery(string InstanceId, string Url, bool Ok, string? Detail);
+
+    /// <summary>
+    /// Broadcasts <paramref name="published"/> to every reachable registered instance. Emits the
+    /// per-consumer outcomes once, as one list; never throws — a listing that cannot be made, an
+    /// unreachable consumer and a refusal are each an outcome to read.
+    /// </summary>
+    public IObservable<ImmutableArray<Delivery>> Broadcast(ModulePublished published)
+    {
+        var body = published.Serialize();
+        var secret = hub.ServiceProvider.GetService<IConfiguration>()?[ModulePublished.BroadcastSecretConfigKey];
+        return ListReachableInstances()
+            .SelectMany(instances =>
+            {
+                if (instances.Length == 0)
+                {
+                    logger?.LogInformation(
+                        "[ModulePublished] {Package} at {Version}: no registered instance records a home "
+                        + "URL — nobody to tell; consumers reconcile on their safety net and at boot.",
+                        published.Package, published.Version ?? "(unversioned)");
+                    return Observable.Return(ImmutableArray<Delivery>.Empty);
+                }
+                return Observable
+                    .Concat(instances.Select(instance => DeliverOne(instance, body, secret)))
+                    .ToList()
+                    .Select(results =>
+                    {
+                        var outcome = results.ToImmutableArray();
+                        var failed = outcome.Where(d => !d.Ok).ToArray();
+                        logger?.LogInformation(
+                            "[ModulePublished] {Package} at {Version}: {Ok}/{Total} consumer(s) told{Failed}.",
+                            published.Package, published.Version ?? "(unversioned)",
+                            outcome.Length - failed.Length, outcome.Length,
+                            failed.Length == 0
+                                ? ""
+                                : " — " + failed.Length + " refused or unreachable: "
+                                  + string.Join("; ", failed.Select(d => $"{d.InstanceId} ({d.Detail})")));
+                        return outcome;
+                    });
+            })
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "[ModulePublished] could not list the registered instances to tell about {Package} — "
+                    + "consumers reconcile on their safety net and at boot. Cause: {Cause}",
+                    published.Package, ex.Message);
+                return Observable.Return(ImmutableArray<Delivery>.Empty);
+            });
+    }
+
+    /// <summary>Every registered, enabled instance with a home URL — a mesh-wide query as System,
+    /// because instances live under whichever user registered them (#3202: fan-out is opt-in).</summary>
+    private IObservable<ImmutableArray<MeshWeaverInstance>> ListReachableInstances()
+    {
+        var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var request = new MeshQueryRequest
+        {
+            Query = MeshWideQuery.Declare($"nodeType:{MeshWeaverInstanceNodeType.NodeType}"),
+        };
+        return accessService.RunAsSystem(() => meshService.Query(request))
+            .Take(1)
+            .Timeout(DeliveryBudget)
+            .SelectMany(results => results
+                // The routing index (MeshWeaverInstance/{hashPrefix}) shares the node type; an
+                // instance RECORD lives under its owner. A query answers paths, not content, so
+                // each record is then read once — the fleet is a handful of instances.
+                .Where(result => result.State == MeshNodeState.Active
+                                 && !string.Equals(result.Namespace, MeshWeaverInstanceNodeType.IndexNamespace, StringComparison.Ordinal))
+                .Select(result => result.Path)
+                .Distinct(StringComparer.Ordinal)
+                .Select(path => accessService.RunAsSystem(() => hub.GetMeshNode(path, DeliveryBudget))
+                    .Take(1)
+                    .Select(node => node.ContentAs<MeshWeaverInstance>(hub.JsonSerializerOptions))
+                    .Catch((Exception ex) =>
+                    {
+                        logger?.LogWarning(ex,
+                            "[ModulePublished] could not read the instance record at {Path}; that consumer is not told.",
+                            path);
+                        return Observable.Return<MeshWeaverInstance?>(null);
+                    }))
+                .ToObservable()
+                .Concat()
+                .ToList())
+            .Select(instances => instances
+                .Where(instance => instance is { IsDisabled: false }
+                                   && Uri.TryCreate(instance.HomeUrl?.Trim(), UriKind.Absolute, out var url)
+                                   && url.Scheme is "http" or "https")
+                .Select(instance => instance!)
+                .ToImmutableArray());
+    }
+
+    // One consumer, already isolated: a non-2xx and a thrown exception both become Delivery(Ok:false).
+    private IObservable<Delivery> DeliverOne(MeshWeaverInstance instance, string body, string? secret)
+    {
+        var url = instance.HomeUrl.Trim().TrimEnd('/') + ModulePublished.InboxRoute;
+        return httpPool.Invoke(ct => PostAsync(instance.InstanceId, url, body, secret, ct))
+            .Catch((Exception ex) => Observable.Return(new Delivery(instance.InstanceId, url, false, ex.Message)));
+    }
+
+    private async Task<Delivery> PostAsync(string instanceId, string url, string body, string? secret, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        if (!string.IsNullOrWhiteSpace(secret))
+            request.Headers.Add(WebhookInbox.SignatureHeader, DeploymentReportService.Sign(body, secret));
+        using var response = await http.SendAsync(request, ct).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+            return new Delivery(instanceId, url, true, null);
+        var detail = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        return new Delivery(instanceId, url, false,
+            $"{(int)response.StatusCode}: {(detail.Length <= 200 ? detail : detail[..200] + "…")}");
+    }
+}

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -636,6 +636,15 @@ public static class PluginBundleEndpoints
                         plugin, accepted.Module);
                 }
 
+                // 🚨 #3650 — the bytes are on the shelf: tell every consumer NOW, so the one that
+                // installed this package reconciles it within minutes instead of at its next boot
+                // (rule R3 of Doc/Architecture/ModuleAdoptionPolicy). Detached from this response
+                // on purpose: the publisher is a CI job, and a slow or unreachable consumer must
+                // hold neither it nor the publish's own verdict — the broadcaster absorbs every
+                // per-consumer failure into a logged outcome, and a consumer the broadcast never
+                // reaches is caught by its own safety net.
+                BroadcastPublished(http, plugin, accepted, logger);
+
                 // held/holdReason let the publisher tell "shelved, will serve" apart from
                 // "activated here"; pendingRestart is honest for the held case — a restart of
                 // THIS instance would not load a held module, so nothing is pending on one.
@@ -651,6 +660,44 @@ public static class PluginBundleEndpoints
                 });
             })
             .AllowAnonymous();
+    }
+
+    /// <summary>
+    /// Fires the module-published broadcast for one accepted publish (#3650), subscribed detached
+    /// from the request: the registry names itself by its configured public URL
+    /// (<c>PluginCatalog:HomeUrl</c>) when it has one, else by the host this publish arrived on —
+    /// which is what consumers matched their <c>PluginCatalog:Registries:N:Url</c> against.
+    /// </summary>
+    private static void BroadcastPublished(
+        HttpContext http, string plugin, ModulePublish.Accepted accepted, ILogger? logger)
+    {
+        // Request services first, then the mesh's — the same two-step resolution the landing
+        // service above uses, and OPTIONAL at both steps: a host (or a test) that wires the
+        // landing service without a mesh publishes fine and simply tells nobody.
+        var rootHub = http.RequestServices.GetService<IMessageHub>();
+        var broadcaster = http.RequestServices.GetService<ModulePublishedBroadcaster>()
+                          ?? rootHub?.ServiceProvider.GetService<ModulePublishedBroadcaster>();
+        if (broadcaster is null)
+            return;
+        var configuredHome = (http.RequestServices.GetService<PluginCatalogOptions>()
+                              ?? rootHub?.ServiceProvider.GetService<PluginCatalogOptions>())?.HomeUrl;
+        var registryUrl = string.IsNullOrWhiteSpace(configuredHome)
+            ? $"{http.Request.Scheme}://{http.Request.Host}"
+            : configuredHome.Trim();
+        broadcaster.Broadcast(new ModulePublished
+            {
+                Registry = registryUrl,
+                Package = plugin,
+                Module = accepted.Module,
+                Version = accepted.Version,
+                FrameworkMvid = accepted.FrameworkMvid,
+                PublishedAt = DateTimeOffset.UtcNow,
+            })
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex,
+                    "Module publish for {Plugin}: the module-published broadcast faulted — consumers "
+                    + "reconcile on their safety net and at boot", plugin));
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -705,6 +705,17 @@ public static class MemexConfiguration
                 // types); off the thread pool so it never blocks startup.
                 .ConfigureServices(services =>
                     services.AddHostedService<ShippedReleaseSeedHostedService>())
+                // The registry's module-published broadcast (#3650): the publish route tells every
+                // registered consumer the moment a bundle lands on the shelf. Registered on every
+                // portal — it is inert where no instance is registered — because whether THIS
+                // deployment is a registry is a runtime fact (a publish token configured), not a
+                // composition-time one.
+                .ConfigureServices(services =>
+                {
+                    Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
+                        .TryAddSingleton<Api.ModulePublishedBroadcaster>(services);
+                    return services;
+                })
                 // Markdown export (PDF/DOCX/HTML + share-by-email) rides the
                 // MeshWeaver.Markdown.Export MODULE (MarkdownExportProviderAttribute →
                 // AddMarkdownExport(); node seeding is IfAbsent so the lane switch is idempotent).

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -133,20 +133,23 @@ public class SelfUpdateHostedService : IHostedService
         // any policy is available and is silently dropped — no first check at all. Take(1) gates the
         // trigger stream on that first emission; every LATER policy change is picked up without
         // re-subscribing the watch.
-        // Four trigger sources:
+        // Five trigger sources:
         //   • the one startup pass,
         //   • a build completion from the platform or ANY module the environment deploys,
         //   • an admin CHANGING the policy — enabling updates must not wait for the next
         //     publication, which could be weeks away. DistinctUntilChanged so a re-emission of the
         //     same policy is not a trigger, and Skip(1) so the replayed CURRENT policy is not one
         //     either (the startup pass already covers it),
-        //   • the safety net, so a dead event channel is bounded rather than permanent.
+        //   • the safety net, so a dead event channel is bounded rather than permanent,
+        //   • a landing wave on THIS process proposing a new module set (#3650) — a module shipped
+        //     and landed, and the restart that activates it must not wait for an unrelated roll.
         var checks = policy
             .Take(1)
             .SelectMany(_ => Observable.Merge(
                 Observable.Return(SelfUpdateTrigger.Startup),
                 BuildCompletionTicks().Do(_ => Interlocked.Increment(ref _buildEventsSeen)),
                 SafetyNetTicks(),
+                ModuleSetProposedTicks(),
                 policy.DistinctUntilChanged(content => content.Policy).Skip(1)
                     .Select(_ => SelfUpdateTrigger.PolicyChange)))
             // 🚨 Read the CURRENT policy at decision time — never WithLatestFrom. That operator only
@@ -166,6 +169,16 @@ public class SelfUpdateHostedService : IHostedService
                 // added is making "produced nothing" itself an outcome that gets reported.
                 .DefaultIfEmpty(SelfUpdateVerdict.NoOutcome())
                 .Take(1)
+                // 🚨 #3650 — after the platform half of EVERY check, the module half: a landed
+                // module generation waiting for a restart gets one, on the image this install
+                // runs, paced by the same floor. Composed here rather than inside RunOnce so the
+                // platform verdict it follows is already final (and already survived its own
+                // Catch), and so a fault in the restart is reported as what it is.
+                .SelectMany(verdict => ConsiderRestart(verdict)
+                    .Catch((Exception ex) => Observable.Return(new SelfUpdateVerdict(
+                        SelfUpdateOutcome.CheckFailed,
+                        $"{verdict.Message} The pending restart FAILED: {ex.GetType().Name}: {ex.Message}",
+                        verdict.Tag))))
                 .SelectMany(verdict => ReportCheck(check.trigger, verdict)))
             .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(
@@ -212,6 +225,101 @@ public class SelfUpdateHostedService : IHostedService
             ? Observable.Never<SelfUpdateTrigger>()
             : Observable.Interval(_options.SafetyNetCheckInterval)
                 .Select(_ => SelfUpdateTrigger.SafetyNet);
+
+    /// <summary>
+    /// Ticks once per landing wave THIS process ends with a new module set
+    /// (<see cref="ModuleLandingService.ModuleSetProposed"/>, #3650) — the event that makes "a
+    /// module version shipped" and "this install runs it" minutes apart instead of one unrelated
+    /// roll apart. Coalesced like the build events. A host with no landing service (a monolith
+    /// without the catalog) ticks never. Virtual for the same reason the other trigger seams are.
+    /// </summary>
+    protected virtual IObservable<SelfUpdateTrigger> ModuleSetProposedTicks() =>
+        Observable.Defer(() => ResolveLandingService()?.ModuleSetProposed ?? Observable.Never<ModuleSet>())
+            .Throttle(_options.EventCoalesceWindow)
+            .Select(_ => SelfUpdateTrigger.ModuleSetProposed);
+
+    /// <summary>
+    /// The module-landing service, resolved from the mesh's services — the seam through which the
+    /// pending-restart state (<see cref="ModuleActivationList.PendingRestart"/>) and the
+    /// module-set-proposed trigger reach this poller. Virtual so a test can hand in a landing
+    /// service rooted in a temp directory and raise the marker there.
+    /// </summary>
+    protected virtual ModuleLandingService? ResolveLandingService() =>
+        _hub.ServiceProvider.GetService<ModuleLandingService>();
+
+    /// <summary>
+    /// 🚨 The module half of a check (#3650): a landed module generation loads only at a restart
+    /// (restart-as-activation), and until now that restart was whatever platform roll happened
+    /// next — a module could ship, land, and sit unloaded for days behind a fleet that had nothing
+    /// newer to roll to. So after the platform half of EVERY check, when that half patched nothing
+    /// (<see cref="SelfUpdateVerdict.MayRestartAfter"/>), the activation record is read and a
+    /// pending restart is TAKEN: a roll of the image this install runs, through
+    /// <see cref="IDeploymentUpdater.RestartAsync"/>, paced by <c>MinRollInterval</c> exactly like a
+    /// roll — a restart drops the same live circuits.
+    ///
+    /// <para>The record read is the landing service's own (<see cref="ModuleLandingService.GetActivation"/>,
+    /// on its pooled IO), never a file touched from a hub thread; a read that faults decides
+    /// nothing and leaves the platform verdict as it was, with a Warning that names itself. The
+    /// marker is cleared by the boot that follows the restart (<c>ConfigureMemexMesh</c>), which is
+    /// what keeps this from restarting twice — and the floor is what keeps two replicas that both
+    /// see the marker from issuing two rollouts.</para>
+    /// </summary>
+    private IObservable<SelfUpdateVerdict> ConsiderRestart(SelfUpdateVerdict platform) =>
+        Observable.Defer(() =>
+        {
+            if (!SelfUpdateVerdict.MayRestartAfter(platform))
+                return Observable.Return(platform);
+            var landing = ResolveLandingService();
+            if (landing is null)
+                return Observable.Return(platform);
+            return landing.GetActivation()
+                .Take(1)
+                .SelectMany(activation => activation.PendingRestart
+                    ? Restart(platform)
+                    : Observable.Return(platform))
+                .Catch((Exception ex) =>
+                {
+                    _logger?.LogWarning(ex,
+                        "[SelfUpdate] could not read the module activation record to decide a pending "
+                        + "restart; the platform verdict stands and the next check asks again.");
+                    return Observable.Return(platform);
+                });
+        });
+
+    /// <summary>The restart itself: detect-only says so; the floor defers; otherwise the updater rolls
+    /// the running image, or reports that it cannot.</summary>
+    private IObservable<SelfUpdateVerdict> Restart(SelfUpdateVerdict platform)
+    {
+        var installed = ShippedReleaseSeed.InstalledPlatformVersion;
+        if (!_updater.CanPatch)
+            return Observable.Return(SelfUpdateVerdict.RestartUnavailable(
+                platform, installed, "this install does not self-patch (detect-and-notify)"));
+
+        // The same floor read Apply makes, and skipped for the same reason when the floor is off:
+        // LastRolledAtAsync is a Kubernetes GET whose answer cannot change a decision the floor
+        // does not take.
+        var lastRolled = _options.MinRollInterval <= TimeSpan.Zero
+            ? Observable.Return<DateTimeOffset?>(null)
+            : _http.Invoke(ct => _updater.LastRolledAtAsync(ct));
+        return lastRolled.SelectMany(lastRolledAt =>
+        {
+            if (SelfUpdateVerdict.RestartDeferredBy(
+                    platform, installed, lastRolledAt, _options.MinRollInterval, DateTimeOffset.UtcNow)
+                is { } deferred)
+                return Observable.Return(deferred);
+
+            _logger?.LogInformation(
+                "[SelfUpdate] a landed module generation is pending activation — restarting the "
+                + "workloads on {Installed} (last rolled {LastRolled}).",
+                installed, lastRolledAt?.ToString("O") ?? "never");
+            return _http.Invoke(ct => _updater.RestartAsync(ct))
+                .Select(restarted => restarted
+                    ? SelfUpdateVerdict.Restarted(platform, installed, lastRolledAt)
+                    : SelfUpdateVerdict.RestartUnavailable(platform, installed,
+                        "the deployment updater cannot roll the running image — it predates "
+                        + "IDeploymentUpdater.RestartAsync; update the MeshWeaver.SelfUpdate.Aks module"));
+        });
+    }
 
     /// <summary>
     /// 🚨 Reports the outcome of ONE check — the single reporting site, and the thing whose absence
@@ -265,6 +373,8 @@ public class SelfUpdateHostedService : IHostedService
                      // one. Both the terminal strand and the recovery roll carry
                      // UnresolvedInstalledTag, so the level follows the FACT rather than the outcome.
                      or SelfUpdateOutcome.InstalledTagWithdrawn
+                     // A landed module nothing will ever activate is a state an operator must see (#3650).
+                     or SelfUpdateOutcome.RestartUnavailable
                      || verdict.UnresolvedInstalledTag is not null)
                 _logger?.LogWarning("[SelfUpdate] check ({Trigger}): {Verdict}", trigger, verdict.Message);
             else

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateVerdict.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateVerdict.cs
@@ -23,6 +23,14 @@ public enum SelfUpdateTrigger
     /// <summary>The safety net (<see cref="MeshWeaver.Hosting.SelfUpdate.SelfUpdateOptions.SafetyNetCheckInterval"/>).
     /// Nothing told this install anything; it asked anyway.</summary>
     SafetyNet,
+
+    /// <summary>
+    /// A landing wave on THIS process proposed a new module set
+    /// (<see cref="ModuleLandingService.ModuleSetProposed"/>, #3650): a module version shipped
+    /// and landed, and the restart that activates it is what this check exists to take. Appended,
+    /// never inserted: the members before it keep their ordinals.
+    /// </summary>
+    ModuleSetProposed,
 }
 
 /// <summary>The outcome of exactly one self-update check.</summary>
@@ -93,6 +101,30 @@ public enum SelfUpdateOutcome
     /// <para>🚨 Appended, never inserted: the members before it keep their ordinals.</para>
     /// </summary>
     InstalledTagWithdrawn,
+
+    /// <summary>
+    /// Nothing newer was rolled, and the workloads were RESTARTED on the image they run because a
+    /// landed module generation was waiting for exactly that (<c>PendingRestart</c>, #3650). Not a
+    /// newer release — <see cref="SelfUpdateVerdict.FoundNewerRelease"/> stays false — so a
+    /// safety-net check that restarts never fires the dead-event-channel report. Appended, never
+    /// inserted.
+    /// </summary>
+    Restarted,
+
+    /// <summary>
+    /// A restart is pending and the roll floor (<c>MinRollInterval</c>) deferred it — a restart is
+    /// a roll and drops the same live circuits, so it is paced like one. Re-decided on the next
+    /// check, never scheduled. Appended, never inserted.
+    /// </summary>
+    RestartDeferred,
+
+    /// <summary>
+    /// 🚨 A restart is pending and this install CANNOT take it: it does not self-patch, or its
+    /// updater predates <see cref="IDeploymentUpdater.RestartAsync"/>. A landed module that nothing
+    /// will ever activate is a state an operator has to see, so it is reported at Warning and on
+    /// the policy node, never folded into "no newer release". Appended, never inserted.
+    /// </summary>
+    RestartUnavailable,
 }
 
 /// <summary>
@@ -268,4 +300,70 @@ public sealed record SelfUpdateVerdict(SelfUpdateOutcome Outcome, string Message
         SelfUpdateOutcome.NoOutcome,
         "the check produced NO outcome — a filter in the self-update pipeline swallowed it. "
         + "This is a defect in SelfUpdateHostedService, not a state of this install.");
+
+    // ── The pending-restart half (#3650): a module swap is a restart, and the restart happens ──
+
+    /// <summary>
+    /// The workloads were restarted on the image they run, to activate a landed module generation.
+    /// Carries the platform verdict it followed (<paramref name="after"/>) so the record still says
+    /// what the check found about the registry.
+    /// </summary>
+    public static SelfUpdateVerdict Restarted(SelfUpdateVerdict after, string installed, DateTimeOffset? lastRolledAt) => new(
+        SelfUpdateOutcome.Restarted,
+        $"{after.Message} RESTARTED on {installed}: a landed module generation was pending activation "
+        + $"(last rolled {lastRolledAt?.ToString("O") ?? "never"}); the workloads were rolled on the "
+        + "same image so it loads.",
+        installed)
+    {
+        UnresolvedInstalledTag = after.UnresolvedInstalledTag,
+    };
+
+    /// <summary>The roll floor deferred a pending restart, exactly as it defers a roll.</summary>
+    public static SelfUpdateVerdict RestartDeferred(SelfUpdateVerdict after, string installed, TimeSpan elapsed, TimeSpan floor) => new(
+        SelfUpdateOutcome.RestartDeferred,
+        $"{after.Message} A landed module generation is pending activation, but this install rolled "
+        + $"{elapsed} ago, inside the {floor} floor — deferring the restart. The next check re-decides it.",
+        installed)
+    {
+        UnresolvedInstalledTag = after.UnresolvedInstalledTag,
+    };
+
+    /// <summary>🚨 A restart is pending and this install cannot take it — named, so an operator can.</summary>
+    public static SelfUpdateVerdict RestartUnavailable(SelfUpdateVerdict after, string installed, string reason) => new(
+        SelfUpdateOutcome.RestartUnavailable,
+        $"{after.Message} A landed module generation is pending activation and this install cannot "
+        + $"restart itself ({reason}) — restart the portal workloads to load it "
+        + "(kubectl rollout restart deployment/<portal>).",
+        installed)
+    {
+        UnresolvedInstalledTag = after.UnresolvedInstalledTag,
+    };
+
+    /// <summary>
+    /// 🚨 Whether a pending restart may follow <paramref name="platform"/>'s verdict at all. Only a
+    /// check that PATCHED nothing has a restart to take: an applied roll IS the restart (the new
+    /// pods boot the landed set), a refused migration leaves the image deliberately where it is, a
+    /// failed check decided nothing, and a disabled policy means never — an operator who pins the
+    /// image restarts by hand. Pure; pinned by <c>SelfUpdateVerdictTest</c>.
+    /// </summary>
+    public static bool MayRestartAfter(SelfUpdateVerdict platform) => platform.Outcome
+        is not (SelfUpdateOutcome.Applied or SelfUpdateOutcome.MigrationFailed
+            or SelfUpdateOutcome.CheckFailed or SelfUpdateOutcome.UpdatesDisabled
+            or SelfUpdateOutcome.NoOutcome);
+
+    /// <summary>
+    /// The roll floor applied to a pending restart: the <see cref="RestartDeferred"/> verdict when
+    /// the install rolled less than <paramref name="floor"/> ago, or <c>null</c> when the restart
+    /// may proceed — a floor of zero or less never defers, and an install that never rolled (or
+    /// cannot tell) is free. The same rule <c>Apply</c> uses for a roll, stated once and pure so
+    /// the interval arithmetic is pinned without a mesh.
+    /// </summary>
+    public static SelfUpdateVerdict? RestartDeferredBy(
+        SelfUpdateVerdict after, string installed, DateTimeOffset? lastRolledAt, TimeSpan floor, DateTimeOffset now)
+    {
+        if (floor <= TimeSpan.Zero || lastRolledAt is null)
+            return null;
+        var elapsed = now - lastRolledAt.Value;
+        return elapsed < floor ? RestartDeferred(after, installed, elapsed, floor) : null;
+    }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -613,14 +613,36 @@ transport end to end — there is deliberately no second distribution channel:
 
 ### Auto-update
 
-Store-installed modules **update themselves by default**. The boot reconcile
-(`RegistryUpdateReconciler`) runs a module pass after the content pass: for every installed
+Store-installed modules **update themselves by default**, and since #3650 they do so **eagerly** —
+rule R3 of the Module Adoption Policy (`Doc/Architecture/ModuleAdoptionPolicy`): *as soon as a new
+module version ships, we start using it.* The reconcile (`RegistryUpdateReconciler`) runs a module
+pass after the content pass — at boot, the moment the registry **broadcasts** that a module was
+published (for that one package), and every 30 minutes as a safety net
+([Plugin Update on Green Build](/Doc/Architecture/PluginUpdateOnGreenBuild)). For every installed
 module-declaring package it consults the registry's bundle index and applies the one pure decision
-(`ModuleUpdateDecision`) — a newer version whose **floor this platform satisfies** lands via
-`ModuleLandingService` and flags `PendingRestart`; the same served version **built against the same
-framework** is skipped without a download; a bundle whose floor **exceeds** the running platform is
-skipped silently-with-log (it becomes installable once the platform has updated, and the same
-reconcile lands it then). Nothing is ever rolled back unattended.
+(`ModuleUpdateDecision`): a newer version lands via `ModuleLandingService` and flags
+`PendingRestart`; the same served version **built against the same framework** is skipped without a
+download; a bundle's declared floor is an **advisory** worded into the log, never a skip (#3648) —
+whether the bytes load is measured by the link probe at placement. Nothing is ever rolled back
+unattended.
+
+**The restart happens, too.** A landed generation loads only at a restart, and that restart used to
+be whatever platform roll came next. The self-updater now reads the activation record after the
+platform half of every check that patched nothing and, when `PendingRestart` is raised, rolls the
+workloads **on the image they run** (`IDeploymentUpdater.RestartAsync`) — paced by
+`SelfUpdate:MinRollInterval` exactly like a roll, because a restart drops the same live circuits. A
+landing wave this process ends (`ModuleLandingService.ModuleSetProposed`) triggers the check
+directly, so the restart follows the landing by the coalesce window plus the floor, not by the next
+unrelated publication. An install that cannot restart itself reports `RestartUnavailable` on the
+Updates tab, naming the operator's move.
+
+**A fallback is re-examined.** When the newest landed generation could not be loaded and the previous
+one runs ([the keep-the-old fallback](/Doc/Architecture/ModuleSetConvergence), #3649), the entry
+carries the refused build's identity (`ModuleActivationEntry.UnloadableFrameworkMvid`). The
+same-version branch of the decision then asks the one question such a deployment has: does the
+registry serve a *different* build of this version than the one that would not load? It **lands**
+when it does — a build for this platform appeared — and answers `SkipUnloadable` (never "already
+landed") when the registry still serves the build that was refused.
 
 #### "Already landed" means this content against this FRAMEWORK
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -1,7 +1,7 @@
 ---
 Name: Plugin Update on Green Build
 Category: Architecture
-Description: A plugin repo's CI going green reaches every installation that uses it, with nobody opening the catalog and no poll timer anywhere. An installation with GitHub access subscribes to a build node the webhook writes; an installation that installs from a registry reads that registry's own feed at startup. Both react per module, gated on content identity, so a build that changed nothing stays completely silent.
+Description: A plugin repo's CI going green reaches every installation that uses it, with nobody opening the catalog. An installation with GitHub access subscribes to a build node the webhook writes; an installation that installs from a registry reads that registry's own feed at startup, is told by the registry the moment a module is published, and reconciles on a half-hourly safety net so a lost notification is bounded. All react per module, gated on content identity, so a build that changed nothing stays completely silent.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/><path d="m9 12 2 2 4-4"/></svg>
 ---
 
@@ -87,7 +87,7 @@ There are now two inputs, by deployment shape:
 | | learns from | how | when |
 |---|---|---|---|
 | **Registry instance** (holds the GitHub credential) | its plugin repos | `PluginUpdateWatcher` subscribes to `Admin/_Build/{owner}.{repo}` | on every green build |
-| **Consumer** (registry token, no GitHub) | its registry | `RegistryUpdateReconciler` **reads** `GET /api/plugins` | at startup |
+| **Consumer** (registry token, no GitHub) | its registry | `RegistryUpdateReconciler` **reads** `GET /api/plugins` | at startup; on a **module-published broadcast** from the registry (that one package); and every **30 minutes** as a safety net (#3650) |
 
 Both hand the per-module verdict to the same `PackageUpdateReconciler`, so they can never disagree
 about what "changed" means or about who opted into an unattended install. Both are registered
@@ -107,18 +107,87 @@ the same content identity the install records carry, so **comparing the two answ
 outright**. That is the shape `BuildProtocolDriver.FollowGo` arrived at for the cross-cluster case:
 end on a fact you can read, not on a notification that cannot reach you.
 
-### 🚨 Not a poll timer
+### 🚨 Three events and a floor — never "the next boot" (#3650)
 
-The reconcile runs on an event the deployment already has — **this process starting** — and not on a
-clock. A timer answers "how stale am I willing to be", which is a question nobody asked, and it turns
-one misconfiguration into permanent background load.
+The reconcile used to run on exactly one event, **this process starting**, on the reasoning that the
+restart *is* the fan-out: plugin content and the framework image ship from the same CI, and a portal
+rolls onto each image. That bound stopped being honest when the module lane became eager — rule R3
+of the Module Adoption Policy (`Doc/Architecture/ModuleAdoptionPolicy`), maintainer 2026-09-07: *as soon
+as a new module version ships, we start using it.* A module publish is not an image roll, so "the
+next boot" could be days away; and an installation running its previous generation of a module
+([the keep-the-old fallback](/Doc/Architecture/Modules), #3649) had no event at all that would ever
+re-examine it.
 
-On these deployments the restart *is* the fan-out: plugin content and the framework image are
-published by the same CI, and the portals self-update onto each new image, so a green plugin build
-and a pod roll already arrive together. The honest bound is therefore **a consumer learns on its next
-boot** — plus immediately, on demand, whenever somebody opens the catalog page, which reads the same
-feed and offers the same **Update**. An installation that never restarts also never picks up
-framework fixes, which is a louder problem with its own alarm.
+The consumer now reconciles on three events, and everything a consumer learns still ends on a fact
+it reads — never on what it was told:
+
+| event | what runs | latency |
+|---|---|---|
+| **boot** | the full pass — content lane, module lane, module-set proposal — with its retry budget and its deferral (below) | one process start |
+| **module-published broadcast** | the module lane for **that one package**: the registry POSTs a `ModulePublished` record to the consumer's webhook inbox the moment a bundle lands on its shelf | minutes |
+| **safety net** (`PluginCatalog:ReconcileSafetyNetInterval`, default 30 min, `≤ 0` disables) | the full pass, against every configured registry | at most the interval |
+
+Every pass runs on **one serialized lane** inside the reconciler (`Subject` + `Concat`): a landing
+wave ends by proposing the mesh's module set from the activation record as it stands
+([Module Set Convergence](/Doc/Architecture/ModuleSetConvergence)), and two waves interleaving would
+let one propose the other's half-landed mix — the torn set the proposal exists to make unreachable.
+
+#### The broadcast is a wake-up, never the truth
+
+The registry does not know which installations installed a package, and it does not need to. It
+tells **every registered instance** that recorded a `HomeUrl` (`PluginCatalog:HomeUrl` at
+registration): one `ModulePublished` record — `event: module-published`, the registry's URL, the
+package, the module, the version, the framework identity — POSTed to
+`{HomeUrl}/api/hooks/Plugins/_RegistryReconcileLedger`. The target is the reconcile ledger node the
+reconciler already **owns**, so it exists on every installation with a registry configured and
+nothing new has to be seeded; the delivery lands as a durable `WebhookEvent` under its `_Inbox`, and
+the reconciler drains it on its own thread. A delivery that lands while the process is down replays
+into the first emission of the next boot's watch: at-least-once, and the decision behind it is
+idempotent.
+
+The consumer reads nothing off the record but *which registry* (matched by host against its
+configured registries — an unknown registry's delivery is dropped) and *which package*. The drain
+then reads the package's **own install record** (is it installed here, which module does it
+declare), the registry's **own authenticated bundle index**, and runs the same `ModuleUpdateDecision`
+the boot runs against the same activation record. A stale, duplicated or forged delivery therefore
+costs one authenticated index read for one installed package — which is what lets the delivery be
+**unsigned by default**. A consumer that allowlists the target *with* a `SecretConfigKey` is answered
+with a matching `X-Hub-Signature-256` when the registry configures
+`Plugins:Registry:BroadcastSecret`; a mismatch is a 401 the registry logs per consumer, never a
+silent drop (#3312).
+
+The fan-out is **reporter-class**: it runs detached from the publisher's response (a CI job must not
+wait on a slow consumer), a 404 (target not allowlisted) or an unreachable instance is one logged
+line per consumer, and nothing about it can fail the publish. Which is exactly why the floor exists.
+
+#### The safety net is the floor, not the driver
+
+A broadcast reaches an installation over a chain nobody re-verifies — the `HomeUrl` it registered,
+the `WebhookInbox:Targets` slot, the ingress between — and every joint of it fails **silently**: an
+installation whose channel is dead is byte-identical to one that is up to date. The safety net
+bounds that, the way `SelfUpdate:SafetyNetCheckInterval` bounds a dead build-event channel (#2494):
+it is not a poll that drives the update, it is the worst case a lost broadcast can cost. It cannot
+change *what* lands — the same decision runs, and an unchanged module costs one feed read and one
+index read, no download — only how late. Its default, 30 minutes, is half of
+`SelfUpdate:MinRollInterval`, so a module that ships is landed before the next restart the roll
+floor allows.
+
+A safety-net read that finds the registry **pending** (the boot deferred it, see #2888 below) does
+not run a second pass: the read itself reported to the reconciler and drained the deferral. A read
+that fails is a Warning and the next tick; it never notifies admins or marks the ledger — that is the
+boot deferral's job, and the boot's retry budget is what such a registry has already exhausted.
+
+#### The restart happens
+
+A landed generation still loads only at a restart — a module never swaps inside a running process.
+What changes is who takes the restart: the self-updater, after the platform half of every check that
+patched nothing, reads the activation record and, when `PendingRestart` is raised, rolls the
+workloads **on the image they run** (`IDeploymentUpdater.RestartAsync`), paced by
+`SelfUpdate:MinRollInterval` exactly like a roll. A wave this process ends
+(`ModuleLandingService.ModuleSetProposed`) is itself a trigger, so the check does not wait for the
+hourly safety net. See [Modules → Auto-update](/Doc/Architecture/Modules).
+
+A human opening the catalog page still reads the same feed and offers the same **Update**.
 
 ### 🚨 A boot read that fails past its budget is deferred, not dropped (#2888)
 
@@ -155,10 +224,10 @@ registry can never land an older snapshot over a newer one — the same shape as
 "one at a time" in the codebase, never a lock
 ([Removing Hand-Woven Gates](/Doc/Architecture/RemovingHandWovenGates)).
 
-What this deliberately does **not** do: retry on a timer, widen the budget, or add a new caller
-that has to remember to reconcile. The design decision above — no poll, the restart and the
-catalog open are the events — stands; the change is that a catalog open now *is* a reconcile when
-one is owed, which the log line had always claimed and the code had never done.
+What this deliberately does **not** do: widen the budget, or add a new caller that has to remember
+to reconcile. The change is that a catalog open now *is* a reconcile when one is owed, which the log
+line had always claimed and the code had never done. (The safety net above reads the feed too, and a
+successful read from it drains a pending registry through this same path — one pass, not two.)
 
 ## Why a node and not a call
 
@@ -304,6 +373,21 @@ in (the Helm chart sets this for our portals). Per package: set `AutoUpdate` on 
 package's record. Both are edits to the record's own flag — the deployment key is only the
 install-time seed.
 
+### 4. Receiving the module-published broadcast (consumers, #3650)
+
+On each **consuming** installation, allowlist the reconciler's inbox target and record the public
+URL the registry should deliver to:
+
+| key | value |
+|---|---|
+| `WebhookInbox:Targets:N` | `Plugins/_RegistryReconcileLedger` |
+| `PluginCatalog:HomeUrl` | the installation's public base URL — sent at registration and stored on its instance record |
+| `WebhookInbox:Targets:N:SecretConfigKey` | *optional* — the key holding a shared secret; then set the same value on the registry as `Plugins:Registry:BroadcastSecret` |
+| `PluginCatalog:ReconcileSafetyNetInterval` | *optional* — default `00:30:00`; `00:00:00` disables the safety net (broadcast and boot only) |
+
+Nothing is configured on the registry for the fan-out itself: its subscriber set is the instances
+registered with it. An installation that configures none of this is reached by the safety net alone.
+
 ### What you should see
 
 - **Nothing changed** → no notification, no log line beyond the build record itself. This is the
@@ -327,7 +411,11 @@ install-time seed.
 | A green build produced nothing, and the log says the fact is **NOT recorded AND the sync did not run** | The `Admin/_Build/{owner}.{repo}` write failed. GitHub was answered 200, so there is no redelivery. The payload is kept at `Admin/_MissedBuild/{owner}.{repo}` (#3374) — read it with `MissedBuildFact.WatchQuery`, and compare it against the current build record to see whether a later green run of the SAME workflow has already superseded it. If a second Warning says the miss could not be recorded either, the log line is the only witness and the fact must be replayed from GitHub. |
 | Build node updates but no installation reacts | The package is not installed on that instance. A catalog lists far more packages than any instance installs; only packages with an install record are considered. |
 | The same "Update available" reminder keeps reappearing, or the bell re-lights on one you dismissed | Before #3213 this was the norm — a new row per reconcile, forever. The reminder is now told once per candidate version: the install record carries `NotifiedModuleVersion`, and the notification's id is derived from *(record, kind, candidate)*. Seeing it again means the candidate genuinely moved (`ModuleVersion` differs from the one on the record's marker) — read the record and compare the two, rather than assuming a duplicate. |
-| The boot log says the feed of a registry could not be read after N attempts and was **recorded as PENDING**, and admins got a bell notification pointing at `Plugins/_RegistryReconcileLedger` | The registry stayed unavailable for longer than the boot's retry budget (#2888). Nothing is lost: the ledger entry for that registry reads `Pending: true`, and the reconcile runs on the next successful feed read — open the catalog page (or install anything from that registry) once the registry is back, then check the entry reads `LastReconciledVia: feed-read`. If the registry answers a *definite* refusal (401/403) instead, the entry is pending too, but no catalog open will drain it until the key or grant is fixed — the `LastFault` names which. |
+| The boot log says the feed of a registry could not be read after N attempts and was **recorded as PENDING**, and admins got a bell notification pointing at `Plugins/_RegistryReconcileLedger` | The registry stayed unavailable for longer than the boot's retry budget (#2888). Nothing is lost: the ledger entry for that registry reads `Pending: true`, and the reconcile runs on the next successful feed read — the safety net's, a catalog open, an install — once the registry is back; then check the entry reads `LastReconciledVia: feed-read`. If the registry answers a *definite* refusal (401/403) instead, the entry is pending too, but no read will drain it until the key or grant is fixed — the `LastFault` names which. |
+| A module was published and the registry's log says `{Package}: 0/N consumer(s) told — … (404: …)` for this installation | The installation has not allowlisted the inbox target (`WebhookInbox:Targets:N = Plugins/_RegistryReconcileLedger`), or its instance record carries no `HomeUrl`, or the ledger node does not exist yet (no boot pass has run against a configured registry). The safety net reconciles it within `PluginCatalog:ReconcileSafetyNetInterval` regardless; the ledger's `LastReconciledVia` then reads `safety-net` instead of `broadcast`. |
+| The registry's log says a consumer answered **401** to the broadcast | The consumer's target declares a `SecretConfigKey` and the registry's `Plugins:Registry:BroadcastSecret` does not match (or is unset). The consumer stores nothing — that is the fail-closed contract of #3312 — and is reached by its safety net meanwhile. |
+| A module landed (`RESTART REQUIRED` in the log) and the self-update check reads `RestartUnavailable` | The install cannot roll its own workloads: it does not self-patch, or its updater predates `IDeploymentUpdater.RestartAsync` (the `MeshWeaver.SelfUpdate.Aks` module needs updating). Restart the portal workloads by hand (`kubectl rollout restart deployment/<portal>`) to load the landed generation. |
+| The ledger reads `LastReconciledVia: broadcast` but `Pending: true` | Both are true: a broadcast reconciled one package on the module lane, while the boot's full pass against that registry is still owed and drains on the next successful feed read. |
 
 The webhook **never throws** on a write failure: GitHub retries a non-2xx delivery, so an unhandled
 fault would turn one bad write into a delivery storm. Failures are logged and reported as "nothing

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-module-version-that-ships-is-in-use-within-minutes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-module-version-that-ships-is-in-use-within-minutes.md
@@ -1,0 +1,70 @@
+---
+Name: A module version that ships is in use within minutes
+Category: Feature
+Description: When a module is published to the registry your installation consumes, your installation now lands it within minutes and restarts itself to load it — instead of waiting for its next reboot, which could be days away. A module that could not load on your platform is re-examined every time a new build of it appears, and a half-hourly safety net catches anything the notification missed.
+Icon: ArrowSync
+Order: -20260908
+---
+
+# A module version that ships is in use within minutes
+
+Until now, an installation learned that a module had a new version at exactly one moment: when it
+**booted**. The registry's feed was read once per process start, and if a module had shipped since,
+the new bundle landed and waited for the *next* restart to load. On an installation that only
+restarts when its platform image rolls, "the module shipped" and "the module is running" could be
+days apart — and a module that had landed but could not load on your platform was never looked at
+again until a reboot happened to follow a rebuild.
+
+Three things change, and together they make the maintainer's rule true: **as soon as a new module
+version ships, the installation starts using it.**
+
+## The registry tells you
+
+The moment a module bundle is published to a registry, the registry sends a short notification to
+every installation registered with it — to the same webhook inbox every other event reaches your
+portal through. Your installation reads nothing off that notification but *which package* to look
+at: it then reads the registry's own index, decides exactly as the boot would, and lands the
+bundle if it is newer or built for your platform. A notification that arrives while your portal is
+down is consumed at the next boot; one that is stale, duplicated or forged costs one authenticated
+index read and changes nothing.
+
+To receive it, allowlist the inbox target on the consuming installation:
+
+```
+WebhookInbox__Targets__0=Plugins/_RegistryReconcileLedger
+```
+
+and make sure the installation recorded its public URL when it registered
+(`PluginCatalog:HomeUrl`). An installation that allowlists the target *with* a `SecretConfigKey`
+must share that secret with the registry (`Plugins:Registry:BroadcastSecret`); without one the
+delivery is unsigned, which is safe for the reason above.
+
+## A safety net, every 30 minutes
+
+A notification reaches you over a chain nobody re-verifies — the URL you registered, the allowlist
+slot, the ingress in between — and every joint of it fails silently. So every
+`PluginCatalog:ReconcileSafetyNetInterval` (default 30 minutes; zero disables it) your installation
+reconciles its installed packages against each registry's feed regardless. This is not what drives
+the update — the notification does — it is the longest a lost notification can hide.
+
+## The restart happens
+
+A module never swaps inside a running process: a landed generation loads at the next restart.
+That restart is now taken by the self-updater itself. After every check that finds nothing newer to
+roll to, it reads the module activation record and, when a landed generation is waiting, rolls the
+portal workloads **on the image they already run** — paced by the same `SelfUpdate:MinRollInterval`
+floor as any other roll, so publication frequency never becomes restart frequency. An installation
+that cannot restart itself says so on the Updates tab (`RestartUnavailable`), naming the move.
+
+> On Kubernetes the restart is issued by the `MeshWeaver.SelfUpdate.Aks` module; an updater that
+> predates it reports the pending restart rather than taking it.
+
+## A fallback is re-examined
+
+When the newest landed generation of a module cannot be loaded on your platform and the previous
+one keeps running, every reconcile now checks whether the registry serves a *different* build of
+that version than the one that would not load — and lands it when it does. The catalog's decision
+names the state (`SkipUnloadable`) instead of reporting the module as "already landed".
+
+Full reference: [Plugin Update on Green Build](/Doc/Architecture/PluginUpdateOnGreenBuild) and
+[Modules](/Doc/Architecture/Modules).

--- a/src/MeshWeaver.Hosting/SelfUpdate/IDeploymentUpdater.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/IDeploymentUpdater.cs
@@ -61,6 +61,34 @@ public interface IDeploymentUpdater
     /// <returns>How the migration ended; never throws for an outcome the poller can act on.</returns>
     Task<MigrationRunOutcome> RunMigrationAsync(string versionTag, CancellationToken ct) =>
         Task.FromResult(MigrationRunOutcome.NotSupported);
+
+    /// <summary>
+    /// 🚨 Restarts the portal workloads ON THE IMAGE THEY RUN — the activation of a landed module
+    /// generation (#3650). A module never swaps inside a running process (restart-as-activation,
+    /// <c>PendingRestart</c>); until this member existed that restart waited for the next
+    /// UNRELATED platform roll, which could be days away, so "a module version ships" and "an
+    /// installation uses it" were separated by whatever the image happened to do. The poller calls
+    /// this when a check finds nothing newer to roll to but the module activation record says a
+    /// restart is pending — paced by the same <c>MinRollInterval</c> floor as any other roll.
+    ///
+    /// <para>🚨 It is NOT <see cref="PatchToVersionAsync"/> with the installed tag. The Kubernetes
+    /// implementation patches the container image with a strategic merge, and a patch whose pod
+    /// template is unchanged rolls NOTHING — the last-rolled stamp sits on the Deployment's own
+    /// metadata, outside the template, precisely so that it never triggers a rollout of its own.
+    /// A restart needs a template-level change (what <c>kubectl rollout restart</c> does:
+    /// <c>spec.template.metadata.annotations[kubectl.kubernetes.io/restartedAt]</c>), stamped
+    /// together with the last-rolled annotation so the floor sees it as the roll it is.</para>
+    ///
+    /// <para>Returns <c>true</c> when a restart was issued; <c>false</c> when this updater cannot
+    /// issue one — the default, so a host whose updater predates the seam (and the detect-only
+    /// fallback) keeps building and reports the pending restart as a state an operator has to act
+    /// on, never as a restart that happened. A default rather than an abstract member so the seam
+    /// can land in core first without turning every dependent's build red; the Kubernetes updater
+    /// in <c>MeshWeaver.SelfUpdate.Aks</c> (MeshWeaver.Plugins) implements it.</para>
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Whether a restart of the running image was issued.</returns>
+    Task<bool> RestartAsync(CancellationToken ct) => Task.FromResult(false);
 }
 
 /// <summary>

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -74,6 +74,24 @@ public sealed record ModuleActivationEntry
     /// reconcile re-lands once and records it.</summary>
     public string? Version { get; init; }
 
+    /// <summary>
+    /// 🚨 The framework identity of the NEWEST landed generation when boot could not load it and
+    /// fell back to the previous one (#3649 supplies that fallback: <c>PreviousDirectory</c> and
+    /// its siblings, the boot's link probe deciding). Null when the newest generation loads, or
+    /// was never probed — the ordinary state.
+    ///
+    /// <para>This is the one fact the update reconcile needs to honour rule R3 of
+    /// <c>Doc/Architecture/ModuleAdoptionPolicy</c> (#3650): an entry in fallback is
+    /// RE-EXAMINED on every reconcile, and an index entry serving the SAME version built against a
+    /// DIFFERENT identity than this one is a build for this platform that appeared — it lands.
+    /// Without it the same-version branch of <see cref="ModuleUpdateDecision"/> could only compare
+    /// against <see cref="FrameworkMvid"/>, and a deployment running its previous generation would
+    /// answer "already landed" for exactly the build that would have got it off the fallback.
+    /// Written by the boot that falls back, cleared by the boot that loads the newest generation;
+    /// the reconcile never writes it.</para>
+    /// </summary>
+    public string? UnloadableFrameworkMvid { get; init; }
+
     /// <summary>False = uninstalled (the record is kept for history/idempotence; the folder is
     /// deleted). Takes effect at the next restart, like every activation change.</summary>
     public bool Enabled { get; init; } = true;

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -370,6 +370,27 @@ public sealed class ModuleLandingService : IDisposable
     /// </summary>
     public IObservable<Unit> ActivationChanged => activationChanged;
 
+    private readonly Subject<ModuleSet> moduleSetProposed = new();
+    private readonly ISubject<ModuleSet> announceProposed;
+
+    /// <summary>
+    /// Fires once each time THIS process ENDS a landing wave by proposing a module set that
+    /// differs from the one already proposed (<see cref="ProposeModuleSet"/> returned a set) — the
+    /// signal that "the mesh's module set moved, and a restart is what adopts it" (#3650).
+    ///
+    /// <para>Distinct from <see cref="ActivationChanged"/> on purpose. That one fires per module,
+    /// mid-wave; a restart taken on it would boot the replicas onto the set proposed BEFORE the
+    /// wave (a landed-but-unproposed entry is deferred by
+    /// <see cref="ModuleActivationBoot.ProjectOntoMeshSet"/>, #3395) and the wave's own proposal
+    /// would then wait for the next unrelated restart. The self-updater treats this signal as a
+    /// roll of the running image, subject to the same pacing floor as any other roll.</para>
+    ///
+    /// <para>Never fires for an idempotent proposal (a wave that changed nothing), so a boot
+    /// reconcile against an up-to-date registry restarts nobody. Emitted AFTER the pool work item
+    /// completes, like <see cref="ActivationChanged"/>, through a synchronized façade.</para>
+    /// </summary>
+    public IObservable<ModuleSet> ModuleSetProposed => moduleSetProposed;
+
     /// <summary>Creates the service.</summary>
     /// <param name="logger">Diagnostics — every landing, refusal and removal is logged.</param>
     /// <param name="baseDirectory">Seam for tests: the deployment root the <c>modules/</c>
@@ -381,6 +402,7 @@ public sealed class ModuleLandingService : IDisposable
         this.logger = logger;
         this.baseDirectory = baseDirectory ?? AppContext.BaseDirectory;
         announce = Subject.Synchronize(activationChanged);
+        announceProposed = Subject.Synchronize(moduleSetProposed);
     }
 
     /// <summary>The deployment root the <c>modules/</c> tree lives under — exposed so the serving
@@ -540,6 +562,13 @@ public sealed class ModuleLandingService : IDisposable
                     + "('{Id}', {Count} module(s)). Replicas adopt it as they restart.",
                     proposed.Sequence, proposed.Id, proposed.Generations.Count);
             return proposed;
+        })
+        // Off the pool work item (cap-1: a subscriber that asked this service to read would queue
+        // behind the very item that notified it) — and only for a set that actually moved.
+        .Do(proposed =>
+        {
+            if (proposed is not null)
+                AnnounceModuleSetProposed(proposed);
         });
 
     /// <summary>
@@ -852,11 +881,36 @@ public sealed class ModuleLandingService : IDisposable
 
     private void AnnounceActivationChanged() => Announce(subject => subject.OnNext(Unit.Default));
 
+    /// <summary>The <see cref="ModuleSetProposed"/> emission, contained exactly like
+    /// <see cref="Announce"/>: a faulting subscriber never turns a proposal that landed into a
+    /// reported failure.</summary>
+    private void AnnounceModuleSetProposed(ModuleSet proposed)
+    {
+        try
+        {
+            announceProposed.OnNext(proposed);
+        }
+        catch (Exception exception)
+        {
+            logger?.LogWarning(exception,
+                "A subscriber to ModuleSetProposed faulted; the module set was proposed regardless.");
+        }
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
         Announce(subject => subject.OnCompleted());
+        try
+        {
+            announceProposed.OnCompleted();
+        }
+        catch (Exception exception)
+        {
+            logger?.LogWarning(exception, "A subscriber to ModuleSetProposed faulted on completion.");
+        }
         activationChanged.Dispose();
+        moduleSetProposed.Dispose();
         pool.Dispose();
     }
 }

--- a/src/MeshWeaver.PluginCatalog/ModulePublished.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePublished.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MeshWeaver.Graph.Configuration;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The fact a registry broadcasts to its consumers the moment a module bundle is published: "this
+/// package's module now serves at this version, built against this framework identity" (#3650,
+/// rule R3 of <c>Doc/Architecture/ModuleAdoptionPolicy</c>: <i>as soon as a new module version
+/// ships, we start using it</i>).
+///
+/// <para><b>Where it goes.</b> The same inbox every other event reaches an installation through —
+/// the generic webhook inbox (<see cref="WebhookInbox"/>, <c>POST /api/hooks/{target}</c>) — at the
+/// one node the consumer's reconciler already OWNS: its reconcile ledger
+/// (<see cref="RegistryUpdateReconciler.LedgerPath"/>). So the target exists on every installation
+/// that has a registry configured, nothing new has to be seeded, and the delivery lands as a durable
+/// <see cref="WebhookEvent"/> under <see cref="InboxTarget"/><c>/_Inbox/</c> that the reconciler
+/// drains on its own thread — a delivery that arrives while the process is down is consumed at the
+/// next boot, never lost. The registry finds its consumers by the <c>HomeUrl</c> each recorded
+/// when it registered (<c>PluginCatalog:HomeUrl</c>).</para>
+///
+/// <para>🚨 <b>A WAKE-UP, never the truth.</b> The consumer reads nothing off this record but
+/// WHICH package to look at: the reconcile that follows reads the registry's authenticated bundle
+/// index itself and runs the same <see cref="ModuleUpdateDecision"/> the boot runs, against the
+/// same activation record. A stale, duplicated or forged delivery therefore costs one authenticated
+/// index read for one installed package and changes nothing else — which is what lets the delivery
+/// be unsigned by default (a consumer that allowlists the target WITH a <c>SecretConfigKey</c> is
+/// answered with a matching HMAC when the registry configures <see cref="BroadcastSecretConfigKey"/>),
+/// and what makes the safety net (<see cref="PluginCatalogOptions.ReconcileSafetyNetInterval"/>)
+/// the floor rather than a second source of truth. Same rule as the platform's <c>Release</c> facts:
+/// the event wakes, the read decides.</para>
+/// </summary>
+public sealed record ModulePublished
+{
+    /// <summary>The <see cref="Event"/> value a delivery carries — the discriminator the inbox
+    /// drain matches on before it reads anything else.</summary>
+    public const string EventName = "module-published";
+
+    /// <summary>The consumer-side inbox target: the reconcile ledger node the reconciler owns.
+    /// An installation allowlists it as <c>WebhookInbox:Targets:N = Plugins/_RegistryReconcileLedger</c>.</summary>
+    public const string InboxTarget = RegistryUpdateReconciler.LedgerPath;
+
+    /// <summary>The route the registry POSTs to on each consumer's <c>HomeUrl</c>.</summary>
+    public const string InboxRoute = "/api/hooks/" + RegistryUpdateReconciler.LedgerPath;
+
+    /// <summary>
+    /// The registry-side configuration key holding the shared secret the broadcast is SIGNED with
+    /// (GitHub-style <c>X-Hub-Signature-256</c> over the raw body) when it is set. Optional: a
+    /// consumer that declares no <c>SecretConfigKey</c> on the target accepts the unsigned
+    /// delivery, which is safe for the reason the type doc gives. When a consumer DOES declare one
+    /// it must name the same value, or every delivery is refused with 401 — visibly, on the
+    /// registry's log, never silently dropped (#3312).
+    /// </summary>
+    public const string BroadcastSecretConfigKey = "Plugins:Registry:BroadcastSecret";
+
+    /// <summary>The serializer both halves use (Web camelCase), so the body a consumer stores is
+    /// the body the registry signed.</summary>
+    public static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Always <see cref="EventName"/>.</summary>
+    public string Event { get; init; } = EventName;
+
+    /// <summary>The registry's own base URL, as its consumers configured it — what the consumer
+    /// matches against <see cref="PluginRegistryReference.Url"/> to pick which of its registries
+    /// to reconcile against. Unknown registries are dropped.</summary>
+    public string Registry { get; init; } = "";
+
+    /// <summary>The package id whose module was published.</summary>
+    public string Package { get; init; } = "";
+
+    /// <summary>The module's entry-assembly name — informational; the consumer's own install record
+    /// says which module the package declares.</summary>
+    public string? Module { get; init; }
+
+    /// <summary>The published version — informational; the reconcile reads the index.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>The framework identity the bytes were built against — informational.</summary>
+    public string? FrameworkMvid { get; init; }
+
+    /// <summary>When the registry accepted the publish.</summary>
+    public DateTimeOffset PublishedAt { get; init; }
+
+    /// <summary>The wire body of one broadcast.</summary>
+    public string Serialize() => JsonSerializer.Serialize(this, Json);
+
+    /// <summary>
+    /// Parses an inbox delivery's body; null when it is not a module-published record (a different
+    /// event on a shared target, or noise). Never throws — an unreadable body is not this event.
+    /// </summary>
+    public static ModulePublished? TryParse(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<ModulePublished>(body, Json);
+            return parsed is { Event: EventName, Package.Length: > 0 } ? parsed : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
@@ -57,6 +57,19 @@ public enum ModuleUpdateAction
     /// <summary>The module was deliberately uninstalled here (activation entry disabled) — the
     /// reconcile must not fight the operator.</summary>
     SkipUninstalled,
+
+    /// <summary>
+    /// The entry is in FALLBACK — its newest landed generation could not be loaded on this
+    /// platform (<see cref="ModuleActivationEntry.UnloadableFrameworkMvid"/>, the boot's link
+    /// probe; #3649 keeps the previous generation running) — and the registry still serves that
+    /// same build (or states no identity, so a different one cannot be seen). Nothing travels; the
+    /// entry is re-examined on every reconcile and lands the moment a build for this platform
+    /// appears (#3650, rule R3 of <c>Doc/Architecture/ModuleAdoptionPolicy</c>). Distinct from
+    /// <see cref="SkipUpToDate"/> on purpose: "already landed" is the sentence that hid every
+    /// identity defect on this lane, and a deployment running its previous generation is not up
+    /// to date. Appended, never inserted: the members before it keep their ordinals.
+    /// </summary>
+    SkipUnloadable,
 }
 
 /// <summary>One reconcile verdict: the action and the human reason behind it.</summary>
@@ -90,6 +103,18 @@ public sealed record ModuleUpdateVerdict(ModuleUpdateAction Action, string? Reas
 /// image. So <see cref="ModuleUpdateAction.SkipUpToDate"/> means <i>this content against this
 /// framework</i>, never <i>this content</i>. An identity difference makes a bundle NEWER, never
 /// UNINSTALLABLE.</para>
+///
+/// <para>🚨 <b>An entry in FALLBACK is re-examined against the generation that could not load</b>
+/// (#3650, rule R3 of <c>Doc/Architecture/ModuleAdoptionPolicy</c>). When the boot's link probe
+/// refuses the newest landed generation and the previous one keeps running (#3649), the entry
+/// carries the refused build's identity in
+/// <see cref="ModuleActivationEntry.UnloadableFrameworkMvid"/>. The same-version branch then asks
+/// the only question that matters to such a deployment — does the registry serve a DIFFERENT build
+/// of this version than the one that would not load? — and answers <see cref="ModuleUpdateAction.Land"/>
+/// when it does (a build for this platform appeared) and
+/// <see cref="ModuleUpdateAction.SkipUnloadable"/> when it does not. Without this the fallback was
+/// permanent until the next boot happened to follow a publication, which is the gap the policy
+/// names.</para>
 /// </summary>
 public static class ModuleUpdateDecision
 {
@@ -232,6 +257,40 @@ public static class ModuleUpdateDecision
                 ? null : landed.FrameworkMvid;
             var servedMvid = string.IsNullOrWhiteSpace(bundleFrameworkMvid)
                 ? null : bundleFrameworkMvid;
+            var unloadableMvid = string.IsNullOrWhiteSpace(landed.UnloadableFrameworkMvid)
+                ? null : landed.UnloadableFrameworkMvid;
+
+            // 🚨 #3650 — an entry in FALLBACK is re-examined against the UNLOADABLE generation's
+            // identity, not the landed one. The boot could not load the newest generation and runs
+            // the previous one (#3649); what this deployment is waiting for is a build of this
+            // version for THIS platform. The registry serving the same unloadable build again is
+            // nothing new — a download would only re-land bytes the next boot would park again —
+            // while ANY other stated identity is a build that appeared, and rule R3 says it lands
+            // now, not at the next boot. Before the ordinary identity comparison on purpose: that
+            // one compares against FrameworkMvid, whose meaning in fallback is the fallback's
+            // business, and in either reading it would answer "already landed" for the one
+            // build that gets the module off its previous generation.
+            if (unloadableMvid is not null)
+            {
+                if (servedMvid is null)
+                    return new(ModuleUpdateAction.SkipUnloadable,
+                        $"version {bundleVersion} is landed but its newest generation (built against "
+                        + $"framework {unloadableMvid}) could not be loaded on this platform — the "
+                        + "previous generation is running; the registry states no framework identity "
+                        + "for what it serves, so a build for this platform cannot be seen from here");
+                if (string.Equals(servedMvid, unloadableMvid, StringComparison.Ordinal))
+                    return new(ModuleUpdateAction.SkipUnloadable,
+                        $"version {bundleVersion} is landed but its newest generation (built against "
+                        + $"framework {unloadableMvid}) could not be loaded on this platform — the "
+                        + "previous generation is running, and the registry still serves that same "
+                        + "build; a build for this platform lands as soon as the registry serves one");
+                return new(ModuleUpdateAction.Land,
+                    $"version {bundleVersion}'s newest landed generation (built against framework "
+                    + $"{unloadableMvid}) could not be loaded on this platform and the previous "
+                    + $"generation is running; the registry now serves that version built against "
+                    + $"{servedMvid} — a build for this platform appeared; landing it"
+                    + WithAdvisory(advisory));
+            }
 
             // 🚨 A STATED served identity is the only evidence a rebuild happened; an unstated one
             // is absence of evidence, and landing could never turn it into evidence — the registry

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogOptions.cs
@@ -117,8 +117,34 @@ public sealed class PluginCatalogOptions
     /// operator's chosen extras.</para>
     /// </summary>
     public bool InstallPreInstalledPackages { get; set; } = true;
-    /// <summary>This installation's public base URL, recorded on the instance node (advisory).</summary>
+    /// <summary>This installation's public base URL, recorded on the instance node (advisory).
+    /// 🚨 Since #3650 it is also where a registry DELIVERS its module-published broadcast
+    /// (<see cref="ModulePublished"/>): an installation that records none is reached by the safety
+    /// net alone.</summary>
     public string HomeUrl { get; set; } = "";
+
+    /// <summary>
+    /// 🚨 The SAFETY NET of the module lane (#3650): the longest this installation may go without
+    /// reconciling its installed packages against each configured registry's feed. Zero or
+    /// negative disables it.
+    ///
+    /// <para>The fast path is the registry's <see cref="ModulePublished"/> broadcast, delivered to
+    /// this installation's webhook inbox within seconds of a publish — and, like every event
+    /// channel, it reaches this installation over a chain nobody re-verifies (the
+    /// <see cref="HomeUrl"/> the registry recorded, a <c>WebhookInbox:Targets</c> allowlist slot,
+    /// a reachable ingress), every joint of which fails SILENTLY. An installation whose channel is
+    /// dead looks exactly like one that is up to date. This interval BOUNDS that, the way
+    /// <c>SelfUpdate:SafetyNetCheckInterval</c> bounds a dead build-event channel: it is not a poll
+    /// that drives the update — the broadcast does — it is the worst case a lost broadcast can
+    /// cost. It cannot change WHAT lands (the same <see cref="ModuleUpdateDecision"/> runs, and an
+    /// unchanged module costs one feed read and one index read, no download), only how late.</para>
+    ///
+    /// <para>Default 30 minutes — half of <c>SelfUpdate:MinRollInterval</c>, so a module that
+    /// ships is landed before the next restart the roll floor allows, and the restart that
+    /// activates it (a landed generation raises <c>PendingRestart</c>, and the self-updater rolls
+    /// the running image on it) is never held for a reconcile that has not happened yet.</para>
+    /// </summary>
+    public TimeSpan ReconcileSafetyNetInterval { get; set; } = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// The registries to actually consume: <see cref="Registries"/> (entries with a URL), or the

--- a/src/MeshWeaver.PluginCatalog/RegistryReconcileLedger.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryReconcileLedger.cs
@@ -31,6 +31,15 @@ public record RegistryReconcileEntry
     /// installation made for another reason (a catalog open, an install).</summary>
     public const string ViaFeedRead = "feed-read";
 
+    /// <summary>The registry told this installation a module was published
+    /// (<see cref="ModulePublished"/>, delivered to the reconciler's inbox) and the module lane
+    /// ran for that one package (#3650).</summary>
+    public const string ViaBroadcast = "broadcast";
+
+    /// <summary>The safety-net reconcile (<see cref="PluginCatalogOptions.ReconcileSafetyNetInterval"/>)
+    /// ran — the bound on how long a lost broadcast can hide (#3650).</summary>
+    public const string ViaSafetyNet = "safety-net";
+
     /// <summary>The registry's base URL (the configured value, trailing slash trimmed).</summary>
     public string Url { get; init; } = "";
 
@@ -59,6 +68,7 @@ public record RegistryReconcileEntry
     /// <summary>When a reconcile against this registry last completed in this process.</summary>
     public DateTimeOffset? LastReconciledAt { get; init; }
 
-    /// <summary><see cref="ViaBoot"/> or <see cref="ViaFeedRead"/>.</summary>
+    /// <summary><see cref="ViaBoot"/>, <see cref="ViaFeedRead"/>, <see cref="ViaBroadcast"/> or
+    /// <see cref="ViaSafetyNet"/>.</summary>
     public string? LastReconciledVia { get; init; }
 }

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -5,6 +5,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -42,16 +43,35 @@ namespace MeshWeaver.PluginCatalog;
 /// step with the first. That is the shape <c>BuildProtocolDriver.FollowGo</c> arrived at for the
 /// cross-cluster case (#1440/#1450): end on a fact you can read.</para>
 ///
-/// <para>🚨 <b>No poll timer.</b> The reconcile runs on an event the deployment already has — this
-/// process starting — and not on a clock. #1366 removed a staleness clock for the same reason: a
-/// timer answers "how stale am I willing to be", which is a question nobody asked, and it turns one
-/// misconfiguration into a permanent background load. On these deployments the restart IS the
-/// fan-out: plugin content and the framework image are published by the same CI, and the portals
-/// self-update onto each new image, so a green plugin build and a pod roll already arrive together.
-/// The honest bound is therefore <b>a consumer learns on its next boot</b> — plus immediately, on
-/// demand, whenever a human opens the catalog page, which reads the same feed and offers the same
-/// Update. An installation that never restarts also never picks up framework fixes, which is a
-/// louder problem with its own alarm.</para>
+/// <para>🚨 <b>Three events and a floor — never "the next boot" (#3650).</b> This service used to
+/// run the reconcile ONCE, at boot, on the reasoning that the restart is the fan-out (plugin content
+/// and the image ship from the same CI, and a portal rolls onto each image). That bound stopped
+/// being honest the day the module lane became eager (rule R3 of
+/// <c>Doc/Architecture/ModuleAdoptionPolicy</c>, maintainer 2026-09-07: <i>as soon as a new module
+/// version ships, we start using it</i>): a module publish is not an image roll, so "the next boot"
+/// could be days away, and a deployment running its previous generation of a module (#3649) had no
+/// event at all that would ever re-examine it. The reconcile now runs on:</para>
+/// <list type="bullet">
+///   <item><b>Boot</b> — one full pass per process start, as before, with its retry budget and its
+///   deferral (below).</item>
+///   <item><b>A module-published broadcast</b> — the registry POSTs a <see cref="ModulePublished"/>
+///   record to this installation's webhook inbox the moment a bundle is published; the inbox is the
+///   reconcile ledger node this service owns (<see cref="LedgerPath"/>), so the delivery lands as a
+///   durable <c>WebhookEvent</c> and is drained from here for THAT package alone
+///   (<see cref="ReconcileModule"/>). A wake-up, never the truth: the drain reads the registry's own
+///   index and runs the same decision the boot runs. "Ships" → "used" is minutes.</item>
+///   <item><b>The safety net</b> — every <see cref="PluginCatalogOptions.ReconcileSafetyNetInterval"/>
+///   (30 min), a full pass against each registry's feed. Not a poll that drives the update: the
+///   broadcast does that. It is the bound on how long a lost broadcast can hide — the
+///   <c>HomeUrl</c> the registry recorded, the inbox allowlist slot and the ingress between them all
+///   fail SILENTLY, and an installation whose broadcast channel is dead is byte-identical to one
+///   that is up to date. The same reasoning, and the same shape, as
+///   <c>SelfUpdate:SafetyNetCheckInterval</c> (#2494).</item>
+/// </list>
+/// <para>Every pass — boot, drain, broadcast, safety net — runs on ONE serialized lane
+/// (<see cref="OnLane"/>): a landing wave ends by proposing the mesh's module set (#3395), and two
+/// waves interleaving would let one propose the other's half-landed mix. A human opening the
+/// catalog page still reads the same feed and offers the same Update.</para>
 ///
 /// <para>🚨 <b>A boot read that fails past its budget is DEFERRED, not dropped
 /// (Systemorph/MeshWeaver#2888).</b> The 2026-08-31 fix taught the boot read to re-ask a transient
@@ -140,12 +160,35 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
 
     private sealed record TrackedRegistry(PluginRegistryReference Registry, RegistryReconcileEntry Entry);
 
-    /// <summary>Creates the service; the ledger write channel is live from construction so a state
-    /// change is recorded whether it arrives from the boot pass or from a later feed read.</summary>
+    /// <summary>
+    /// THE reconcile lane (#3650): every pass that lands modules and proposes the module set —
+    /// the boot pass, a deferred drain, a broadcast's single-package reconcile, a safety-net pass
+    /// — is enqueued here and runs ONE AT A TIME, in arrival order. A wave ends by proposing the
+    /// mesh's module set from the activation record as it stands (#3395); two waves interleaving
+    /// would let one of them propose the other's half-landed mix, which is the torn set the
+    /// proposal exists to make unreachable. Serialization through Rx (<c>Concat</c>), never a
+    /// lock (Doc/Architecture/RemovingHandWovenGates); synchronized because jobs arrive from the
+    /// boot thread, the inbox watch and a feed read on a caller's thread.
+    /// </summary>
+    private readonly ISubject<IObservable<Unit>> lane = Subject.Synchronize(new Subject<IObservable<Unit>>());
+
+    /// <summary>The inbox deliveries this process has already picked up, by path — a delivery is
+    /// deleted once drained, and the query re-emits until that delete lands, so the claim is what
+    /// keeps a slow delete from draining the same event twice. Instance state, immutable-swapped.</summary>
+    private ImmutableHashSet<string> claimedDeliveries = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+
+    /// <summary>Creates the service; the ledger write channel and the reconcile lane are live from
+    /// construction so a state change is recorded, and a pass runs, whether it arrives from the
+    /// boot, from a later feed read, from a broadcast or from the safety net.</summary>
     public RegistryUpdateReconciler(IMessageHub hub, ILogger<RegistryUpdateReconciler> logger)
     {
         this.hub = hub;
         this.logger = logger;
+        subscriptions.Add(lane
+            .Concat()
+            .Subscribe(_ => { }, ex => logger.LogError(ex,
+                "[RegistryUpdate] the reconcile lane faulted — no further pass runs in this process; "
+                + "installed packages keep their current version until the next boot.")));
         subscriptions.Add(ledgerDirty
             .Select(_ => Observable.Defer(WriteLedger)
                 .Catch((Exception ex) =>
@@ -237,6 +280,59 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
                 ex => logger.LogError(ex,
                     "[RegistryUpdate] the boot reconcile failed; installed packages keep their "
                     + "current version and the catalog page still offers a manual Update.")));
+
+        // #3650 — the two other events, armed after the same precondition and independent of how
+        // the boot pass went: a boot that deferred still has an inbox to drain and a floor to keep.
+        subscriptions.Add(defaultsDone
+            .ObserveOn(TaskPoolScheduler.Default)
+            .SelectMany(_ => WatchInbox(options))
+            .SubscribeOn(TaskPoolScheduler.Default)
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[RegistryUpdate] the module-published inbox watch faulted — broadcasts are not "
+                    + "drained in this process any more; each delivery stays in the inbox and is "
+                    + "consumed at the next boot, and the safety net still reconciles meanwhile.")));
+        subscriptions.Add(defaultsDone
+            .ObserveOn(TaskPoolScheduler.Default)
+            .SelectMany(_ => SafetyNet(options))
+            .SubscribeOn(TaskPoolScheduler.Default)
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[RegistryUpdate] the safety-net reconcile faulted — no further scheduled pass "
+                    + "runs in this process; broadcasts and the next boot still reconcile.")));
+    }
+
+    /// <summary>
+    /// Enqueues one reconcile pass on the serialized lane and hands back ITS completion — the
+    /// caller observes exactly the pass it asked for (the boot chain, a test), while the lane
+    /// keeps every pass from overlapping any other. A pass that faults faults its caller and
+    /// never the lane; a pass enqueued during teardown completes at once, having run nothing.
+    /// </summary>
+    private IObservable<Unit> OnLane(Func<IObservable<Unit>> pass)
+    {
+        var done = new AsyncSubject<Unit>();
+        if (subscriptions.IsDisposed)
+        {
+            logger.LogDebug("[RegistryUpdate] a reconcile pass was requested during teardown — skipped.");
+            done.OnNext(Unit.Default);
+            done.OnCompleted();
+            return done;
+        }
+        lane.OnNext(Observable.Defer(pass)
+            .DefaultIfEmpty(Unit.Default)
+            .LastAsync()
+            .Do(_ => { },
+                ex => done.OnError(ex),
+                () =>
+                {
+                    done.OnNext(Unit.Default);
+                    done.OnCompleted();
+                })
+            // Reported to the pass's own caller above; the lane itself moves on to the next pass.
+            .Catch((Exception _) => Observable.Return(Unit.Default)));
+        return done;
     }
 
     /// <summary>
@@ -321,10 +417,177 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
                                     registry.Url, f.attempt + 1, FeedReadRetries + 1))
                             : Observable.Throw<Unit>(new FeedReadExhaustedException(f.fault, f.attempt + 1))))
                     .Take(1)
-                    .SelectMany(packages => ReconcileFromFeed(
-                        registry, name, gitRef, source, bundles, packages, RegistryReconcileEntry.ViaBoot));
+                    .SelectMany(packages => OnLane(() => ReconcileFromFeed(
+                        registry, name, gitRef, source, bundles, packages, RegistryReconcileEntry.ViaBoot)));
             })
             .Catch((Exception ex) => Defer(registry, name, ex));
+    }
+
+    /// <summary>
+    /// The module-published inbox (#3650): the live listing of <c>WebhookEvent</c> deliveries under
+    /// this service's own ledger node (<see cref="ModulePublished.InboxTarget"/><c>/_Inbox</c>),
+    /// each drained once — the registry named in it matched against the configured registries, the
+    /// one package it names reconciled on the lane, the delivery deleted. Durable on both ends: a
+    /// delivery that lands while this process is down replays into the first emission of the next
+    /// boot's watch, so the inbox is at-least-once and the decision behind it idempotent. Never
+    /// completes on its own; a fault ends the watch loudly (the subscriber's error line), never
+    /// silently — a lost watch costs latency until the next boot, and the safety net still runs.
+    /// </summary>
+    private IObservable<Unit> WatchInbox(PluginCatalogOptions options)
+    {
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Never<Unit>();
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        var inbox = $"{ModulePublished.InboxTarget}/{WebhookInbox.InboxContainer}";
+        // 🚨 PATH-SCOPED and read as System: the install-records partition is System-owned, and a
+        // query with no path reaches only the partitions a caller's RLS grants — a hosted service
+        // has no caller. The same lesson as SelfUpdate's build watch (BuildCompletion.WatchQuery).
+        var query = $"path:{inbox} scope:children nodeType:{WebhookInbox.NodeType}";
+        return access.RunAsSystem(() => hub.GetQuery($"RegistryUpdate.Inbox:{hub.Address}", query))
+            .SelectMany(nodes => (nodes ?? [])
+                .Where(node => !string.IsNullOrWhiteSpace(node.Path))
+                // Oldest first within one emission: a burst of publishes from one CI wave drains
+                // in publish order, so a later version of the same package is examined last.
+                .OrderBy(node => node.ContentAs<WebhookEvent>(hub.JsonSerializerOptions)?.ReceivedAt ?? DateTimeOffset.MinValue)
+                .Where(node => ImmutableInterlocked.Update(ref claimedDeliveries, set => set.Add(node.Path)))
+                .ToArray())
+            .Select(node => Observable.Defer(() => DrainDelivery(node, options, meshService, access))
+                .Catch((Exception ex) =>
+                {
+                    logger.LogWarning(ex,
+                        "[RegistryUpdate] draining the module-published delivery {Path} failed — it "
+                        + "stays in the inbox and is retried at the next boot. Cause: {Cause}",
+                        node.Path, ex.Message);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat();
+    }
+
+    /// <summary>One delivery: parse, match its registry, reconcile that package on the lane, delete.</summary>
+    private IObservable<Unit> DrainDelivery(
+        MeshNode node, PluginCatalogOptions options, IMeshService meshService, AccessService? access)
+    {
+        var delivery = node.ContentAs<WebhookEvent>(hub.JsonSerializerOptions);
+        var published = ModulePublished.TryParse(delivery?.Body);
+        var registry = published is null
+            ? null
+            : RegistryTokenResolver.WithLegacyTokens(options, options.EffectiveRegistries)
+                .FirstOrDefault(r => SameRegistry(r.Url, published.Registry));
+
+        IObservable<Unit> reconcile;
+        if (published is null)
+        {
+            logger.LogDebug(
+                "[RegistryUpdate] inbox delivery {Path} is not a module-published record — dropped.",
+                node.Path);
+            reconcile = Observable.Return(Unit.Default);
+        }
+        else if (registry is null)
+        {
+            logger.LogInformation(
+                "[RegistryUpdate] a module-published broadcast for {Package} arrived from {Registry}, "
+                + "which this installation does not consume — dropped.",
+                published.Package, published.Registry);
+            reconcile = Observable.Return(Unit.Default);
+        }
+        else
+        {
+            logger.LogInformation(
+                "[RegistryUpdate] {Name} published module '{Module}' of {Package} at {Version} "
+                + "(framework {Framework}) — reconciling that package now.",
+                DisplayName(registry), published.Module ?? "(unnamed)", published.Package,
+                published.Version ?? "(unversioned)", published.FrameworkMvid ?? "(unrecorded)");
+            reconcile = OnLane(() => ReconcileModule(registry, published.Package)
+                .Do(_ => Mark(registry, entry => entry with
+                {
+                    LastReconciledAt = DateTimeOffset.UtcNow,
+                    LastReconciledVia = RegistryReconcileEntry.ViaBroadcast,
+                })));
+        }
+
+        // The delete is the acknowledgement — after the reconcile, so a process dying mid-pass
+        // leaves the delivery for the next boot rather than losing it. A failed delete costs one
+        // repeated pass at the next boot (the decision is idempotent), never a lost event.
+        return reconcile.SelectMany(_ => access.RunAsSystem(() => meshService.DeleteNode(node.Path))
+            .Select(_ => Unit.Default)
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "[RegistryUpdate] could not delete the drained delivery {Path}; it is re-examined "
+                    + "at the next boot.", node.Path);
+                return Observable.Return(Unit.Default);
+            }));
+    }
+
+    /// <summary>
+    /// The safety net (#3650): after each <see cref="PluginCatalogOptions.ReconcileSafetyNetInterval"/>,
+    /// one full pass against every configured registry, sequentially, on the lane — then the wait
+    /// starts again, so passes never pile up behind a slow one. Off when the interval is zero or
+    /// negative, which a deployment that genuinely wants broadcast-only opts into in configuration,
+    /// where it is visible. A registry that cannot be read this tick is logged at Warning and read
+    /// again next tick; nothing here notifies admins or marks the ledger pending — that is the boot
+    /// deferral's job, and the boot's retry budget is what such a registry has already exhausted.
+    /// </summary>
+    private IObservable<Unit> SafetyNet(PluginCatalogOptions options)
+    {
+        if (options.ReconcileSafetyNetInterval <= TimeSpan.Zero)
+        {
+            logger.LogInformation(
+                "[RegistryUpdate] the reconcile safety net is disabled ({Section}:{Key} ≤ 0) — a lost "
+                + "module-published broadcast is caught at the next boot only.",
+                PluginCatalogOptions.SectionName, nameof(PluginCatalogOptions.ReconcileSafetyNetInterval));
+            return Observable.Never<Unit>();
+        }
+        if (hub.ServiceProvider.GetService<RegistryTokenResolver>() is null)
+            return Observable.Never<Unit>();
+
+        return Observable.Defer(() => Observable.Timer(options.ReconcileSafetyNetInterval))
+            .SelectMany(_ => RegistryTokenResolver.WithLegacyTokens(options, options.EffectiveRegistries)
+                .Select(SafetyNetReconcile)
+                .ToObservable()
+                .Concat()
+                .DefaultIfEmpty(Unit.Default)
+                .LastAsync())
+            .Repeat();
+    }
+
+    /// <summary>One safety-net pass against one registry: read the feed once, reconcile on the lane.</summary>
+    private IObservable<Unit> SafetyNetReconcile(PluginRegistryReference registry)
+    {
+        var tokenResolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
+        if (tokenResolver is null)
+            return Observable.Return(Unit.Default);
+        var name = DisplayName(registry);
+        var gitRef = EffectiveRef(registry.Ref);
+        // Captured BEFORE the read: a successful ListPackages reports itself to OnFeedRead, which
+        // claims and drains a PENDING boot reconcile from that very read — that drain IS this
+        // tick's pass for the registry, and running a second one behind it would be the same work
+        // twice.
+        var wasPending = tracked.TryGetValue(Key(registry.Url), out var candidate) && candidate.Entry.Pending;
+
+        return tokenResolver.ResolveToken(registry)
+            .Take(1)
+            .SelectMany(token =>
+            {
+                var bundles = new PluginBundleClient(hub, registry.Url, token);
+                var source = new RegistryPackageSource(hub, registry.Url, token) { Bundles = bundles };
+                return source.ListPackages(gitRef)
+                    .Take(1)
+                    .SelectMany(packages => wasPending
+                        ? Observable.Return(Unit.Default)
+                        : OnLane(() => ReconcileFromFeed(
+                            registry, name, gitRef, source, bundles, packages,
+                            RegistryReconcileEntry.ViaSafetyNet)));
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "[RegistryUpdate] the safety-net pass against {Name} ({Url}) failed — installed "
+                    + "packages from it keep their current version until the next pass. Cause: {Cause}",
+                    name, registry.Url, ex.Message);
+                return Observable.Return(Unit.Default);
+            });
     }
 
     /// <summary>
@@ -378,8 +641,8 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
             {
                 var bundles = new PluginBundleClient(hub, registry.Url, token);
                 var source = new RegistryPackageSource(hub, registry.Url, token) { Bundles = bundles };
-                return ReconcileFromFeed(
-                    registry, name, readRef, source, bundles, packages, RegistryReconcileEntry.ViaFeedRead);
+                return OnLane(() => ReconcileFromFeed(
+                    registry, name, readRef, source, bundles, packages, RegistryReconcileEntry.ViaFeedRead));
             })
             // Off the reading caller's thread: that is an IO-pool continuation (a catalog render, an
             // install) and the reconcile is a partition's worth of writes.
@@ -535,6 +798,22 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
 
     private static string Key(string? url) => (url ?? "").Trim().TrimEnd('/');
 
+    /// <summary>
+    /// Whether a broadcast's <see cref="ModulePublished.Registry"/> names a configured registry:
+    /// by HOST when both parse as absolute URLs — a registry announces itself by its public URL,
+    /// which a consumer may have configured with a different scheme or a trailing slash — with the
+    /// port compared only when one side names one explicitly (a scheme's default port is not a
+    /// statement about the registry); else by the trimmed, case-insensitive URL. Pure.
+    /// </summary>
+    internal static bool SameRegistry(string? configured, string? announced)
+    {
+        if (Uri.TryCreate(Key(configured), UriKind.Absolute, out var a)
+            && Uri.TryCreate(Key(announced), UriKind.Absolute, out var b))
+            return string.Equals(a.Host, b.Host, StringComparison.OrdinalIgnoreCase)
+                   && ((a.IsDefaultPort && b.IsDefaultPort) || a.Port == b.Port);
+        return string.Equals(Key(configured), Key(announced), StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string EffectiveRef(string? gitRef) => string.IsNullOrWhiteSpace(gitRef) ? "HEAD" : gitRef;
 
     private static string DisplayName(PluginRegistryReference registry) =>
@@ -592,27 +871,8 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
                     .Take(1)
                     .SelectMany(record => record is null
                         // Not installed here → somebody else's module; nothing to reconcile.
-                        ? Observable.Return(0)
-                        : bundles.AdoptModule(pkg.Id, pkg.Module!, recordPath, unattended: true))
-                    // 🚨 A HANG is worse than a failure here: the packages run as one sequential
-                    // Concat, so a single adopt that never answers (a wedged record read, a
-                    // download that stalls) silently starves EVERY package after it — on
-                    // memex.systemorph.com the Northwind adopt was never even attempted while
-                    // earlier packages logged failures (Plugins#959). A bounded wait turns the
-                    // hang into the loud, caught failure below and the chain proceeds.
-                    .Timeout(PerPackageAdoptBudget)
-                    .Catch((Exception ex) =>
-                    {
-                        // The CAUSE goes into the message itself, not only the attached exception:
-                        // single-line log pipelines (Loki greps) see the template line alone, and
-                        // "failed" with no reason cost a night of archaeology (Plugins#959).
-                        logger.LogWarning(ex,
-                            "[RegistryUpdate] module reconcile of {Id} against {Name} failed — "
-                            + "its landed module is unchanged. Cause: {Cause}",
-                            pkg.Id, registryName, ex.Message);
-                        return Observable.Return(0);
-                    })
-                    .Select(_ => Unit.Default);
+                        ? Observable.Return(Unit.Default)
+                        : AdoptOne(bundles, registryName, pkg.Id, pkg.Module!, recordPath));
             })
             .ToObservable()
             .Concat()
@@ -625,6 +885,84 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
             // this point proposes nothing, so the mesh keeps running the set it was on.
             .SelectMany(_ => ProposeMeshModuleSet());
     }
+
+    /// <summary>
+    /// The module lane for ONE package (#3650) — what a <see cref="ModulePublished"/> broadcast
+    /// triggers: the same decision and the same landing as the boot's module pass
+    /// (<see cref="AdoptOne"/>), for the package the registry named, followed by the module-set
+    /// proposal that ends every wave. Reads nothing off the broadcast but the package id: the
+    /// install record decides whether the package is installed here and which module it declares,
+    /// and the registry's index decides whether anything is newer. A package that is not installed
+    /// here, or declares no module, costs one record read and lands nothing.
+    /// </summary>
+    internal IObservable<Unit> ReconcileModule(PluginRegistryReference registry, string packageId)
+    {
+        var tokenResolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (tokenResolver is null || storage is null || string.IsNullOrWhiteSpace(packageId))
+            return Observable.Return(Unit.Default);
+        var name = DisplayName(registry);
+        var recordPath = $"{PackageInstaller.InstalledPartition}/{packageId}";
+
+        return tokenResolver.ResolveToken(registry)
+            .Take(1)
+            .SelectMany(token =>
+            {
+                var bundles = new PluginBundleClient(hub, registry.Url, token);
+                return storage.Read(recordPath, hub.JsonSerializerOptions)
+                    .Take(1)
+                    .SelectMany(record =>
+                    {
+                        if (record is null)
+                        {
+                            logger.LogDebug(
+                                "[RegistryUpdate] {Name} published {Package}, which is not installed here — nothing to reconcile.",
+                                name, packageId);
+                            return Observable.Return(Unit.Default);
+                        }
+                        var module = record.ContentAs<PackageManifest>(hub.JsonSerializerOptions)?.Module;
+                        if (string.IsNullOrWhiteSpace(module))
+                        {
+                            logger.LogDebug(
+                                "[RegistryUpdate] {Name} published {Package}, whose install record here declares no module — nothing to reconcile.",
+                                name, packageId);
+                            return Observable.Return(Unit.Default);
+                        }
+                        return AdoptOne(bundles, name, packageId, module, recordPath);
+                    });
+            })
+            // The wave of one: ends the same way every wave ends (#3395).
+            .SelectMany(_ => ProposeMeshModuleSet());
+    }
+
+    /// <summary>
+    /// One package's module adopt on the unattended lane — the decision, the download when it
+    /// decides Land, the landing — bounded and failure-tolerant, so one package can neither hang
+    /// nor fail the packages after it. Shared by the boot pass and the broadcast drain, so the two
+    /// cannot differ in what "adopt" means.
+    /// </summary>
+    private IObservable<Unit> AdoptOne(
+        PluginBundleClient bundles, string registryName, string packageId, string moduleName, string recordPath) =>
+        bundles.AdoptModule(packageId, moduleName, recordPath, unattended: true)
+            // 🚨 A HANG is worse than a failure here: the packages run as one sequential Concat,
+            // so a single adopt that never answers (a wedged record read, a download that stalls)
+            // silently starves EVERY package after it — on memex.systemorph.com the Northwind
+            // adopt was never even attempted while earlier packages logged failures
+            // (Plugins#959). A bounded wait turns the hang into the loud, caught failure below and
+            // the chain proceeds.
+            .Timeout(PerPackageAdoptBudget)
+            .Catch((Exception ex) =>
+            {
+                // The CAUSE goes into the message itself, not only the attached exception:
+                // single-line log pipelines (Loki greps) see the template line alone, and
+                // "failed" with no reason cost a night of archaeology (Plugins#959).
+                logger.LogWarning(ex,
+                    "[RegistryUpdate] module reconcile of {Id} against {Name} failed — "
+                    + "its landed module is unchanged. Cause: {Cause}",
+                    packageId, registryName, ex.Message);
+                return Observable.Return(0);
+            })
+            .Select(_ => Unit.Default);
 
     /// <summary>
     /// Closes the landing wave by proposing the module set the activation record now describes

--- a/test/Memex.Portal.Shared.Test/ModuleUpdateIdentityTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleUpdateIdentityTest.cs
@@ -43,6 +43,10 @@ public class ModuleUpdateIdentityTest
     /// <summary>The production gate's shape, bound to a fixed running platform version.</summary>
     private static string? Gate(string? floor) => ModulePlatformFloor.DeclineReason(floor, Running);
 
+    /// <summary>A third build of the same source — the one a rebuild for THIS platform produces
+    /// after the newest landed generation turned out not to load.</summary>
+    private const string RebuiltFramework = "s0c0ffee0c0ffee0c0ffee0c0ffee0c0";
+
     private static ModuleActivationEntry Landed(
         string? version, string? frameworkMvid, bool enabled = true) => new()
         {
@@ -51,6 +55,16 @@ public class ModuleUpdateIdentityTest
             Version = version,
             Enabled = enabled,
         };
+
+    /// <summary>
+    /// An entry in FALLBACK (#3649/#3650): the newest landed generation — built against
+    /// <paramref name="unloadable"/> — could not be loaded at the last boot and the previous one
+    /// (built against <paramref name="running"/>) is what runs. What #3649's boot writes; the
+    /// decision under test only reads it.
+    /// </summary>
+    private static ModuleActivationEntry InFallback(
+        string version, string running, string unloadable, bool enabled = true) =>
+        Landed(version, running, enabled) with { UnloadableFrameworkMvid = unloadable };
 
     private static bool BytesPresent(ModuleActivationEntry _) => true;
 
@@ -243,6 +257,121 @@ public class ModuleUpdateIdentityTest
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
         Assert.Contains("never landed here", verdict.Reason);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The fallback is re-examined on every reconcile (#3650, policy rule R3)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>The acceptance criterion of #3650's first gap.</b> The newest landed generation of
+    /// 1.1.0 (built against <see cref="NewFramework"/>) could not be loaded and the previous one
+    /// runs; the registry now serves 1.1.0 built against a THIRD identity. That is a build for
+    /// this platform appearing under an unchanged version — and it lands NOW, not at whatever boot
+    /// happens to follow a publication. The reason names the build that would not load and the
+    /// one that replaces it, so the next reader of the log knows why a same-version landing ran.
+    /// </summary>
+    [Fact]
+    public void InFallback_SameVersion_ADifferentBuildThanTheUnloadableOne_Lands()
+    {
+        var verdict = Decide("1.1.0", InFallback("1.1.0", OldFramework, NewFramework), RebuiltFramework);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.Contains(NewFramework, verdict.Reason);
+        Assert.Contains(RebuiltFramework, verdict.Reason);
+        Assert.Contains("could not be loaded", verdict.Reason);
+        Assert.Contains("appeared", verdict.Reason);
+    }
+
+    /// <summary>
+    /// The registry still serves the build that would not load. Landing it again would only
+    /// re-park it at the next boot, so nothing travels — and the verdict says the deployment is
+    /// in fallback rather than "already landed", which is the sentence that hid every identity
+    /// defect on this lane. Distinct action, so a surface can render the state.
+    /// </summary>
+    [Fact]
+    public void InFallback_SameVersion_StillTheUnloadableBuild_SkipsAndSaysSo()
+    {
+        var verdict = Decide("1.1.0", InFallback("1.1.0", OldFramework, NewFramework), NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.SkipUnloadable, verdict.Action);
+        Assert.Contains(NewFramework, verdict.Reason);
+        Assert.Contains("still serves that same build", verdict.Reason);
+        Assert.DoesNotContain("already landed", verdict.Reason);
+    }
+
+    /// <summary>
+    /// 🚨 The rule is "different from the UNLOADABLE generation's", literally — the identity of the
+    /// generation that RUNS is not consulted. The registry going back to serving the previous
+    /// build is a build that loads, and landing it costs one download for a module that then
+    /// boots off its newest generation again instead of its fallback.
+    /// </summary>
+    [Fact]
+    public void InFallback_SameVersion_TheRunningGenerationsOwnBuild_StillLands()
+    {
+        var verdict = Decide("1.1.0", InFallback("1.1.0", OldFramework, NewFramework), OldFramework);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    /// <summary>The same asymmetry as outside fallback: an unstated served identity is no
+    /// evidence of a new build, so nothing lands — but the verdict still names the fallback,
+    /// never "up to date".</summary>
+    [Fact]
+    public void InFallback_SameVersion_ServedIdentityUnknown_SkipsAsUnloadable()
+    {
+        var verdict = Decide(
+            "1.1.0", InFallback("1.1.0", OldFramework, NewFramework), bundleFrameworkMvid: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipUnloadable, verdict.Action);
+        Assert.Contains("states no framework identity", verdict.Reason);
+        Assert.Contains("could not be loaded", verdict.Reason);
+    }
+
+    /// <summary>A blank marker is no marker: the ordinary identity rule decides, exactly as for
+    /// an entry written before the field existed.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void ABlankFallbackMarker_ReadsAsNotInFallback(string? marker)
+    {
+        var entry = Landed("1.1.0", OldFramework) with { UnloadableFrameworkMvid = marker };
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, Decide("1.1.0", entry, OldFramework).Action);
+        Assert.Equal(ModuleUpdateAction.Land, Decide("1.1.0", entry, NewFramework).Action);
+    }
+
+    /// <summary>Ordering: absent bytes are still the more actionable diagnosis, fallback or not.</summary>
+    [Fact]
+    public void InFallback_AbsentBytes_AreStillReportedAsAbsent()
+    {
+        var verdict = Decide(
+            "1.1.0", InFallback("1.1.0", OldFramework, NewFramework), RebuiltFramework, BytesGone);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.Contains("ABSENT", verdict.Reason);
+    }
+
+    /// <summary>An operator's uninstall still wins over everything, fallback included.</summary>
+    [Fact]
+    public void InFallback_AnUninstalledModule_StaysUninstalled()
+    {
+        var verdict = Decide(
+            "1.1.0", InFallback("1.1.0", OldFramework, NewFramework, enabled: false), RebuiltFramework);
+
+        Assert.Equal(ModuleUpdateAction.SkipUninstalled, verdict.Action);
+    }
+
+    /// <summary>A newer version lands as before; the fallback rule lives inside the same-version
+    /// branch and never widens or narrows the version comparison.</summary>
+    [Fact]
+    public void InFallback_ANewerVersion_LandsAsBefore_AndAnOlderOneIsNeverRolledBack()
+    {
+        var entry = InFallback("1.1.0", OldFramework, NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.Land, Decide("1.2.0", entry, NewFramework).Action);
+        Assert.Equal(ModuleUpdateAction.SkipOlder, Decide("1.0.0", entry, RebuiltFramework).Action);
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/RegistryUpdateReconcilerTest.cs
+++ b/test/Memex.Portal.Shared.Test/RegistryUpdateReconcilerTest.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A module-published broadcast reconciles THAT package, within the process's lifetime —
+/// not at its next boot (#3650, rule R3 of Doc/Architecture/ModuleAdoptionPolicy).</b>
+///
+/// <para>The registry POSTs a <see cref="ModulePublished"/> record to a consumer's webhook inbox
+/// the moment a bundle lands on its shelf. This fixture is the consumer half, against the REAL
+/// <see cref="RegistryUpdateReconciler"/> (started as the hosted service it is), the REAL inbox
+/// store (<see cref="WebhookInbox.Deliver"/>, the exact path the anonymous endpoint takes) and a
+/// registry that answers exactly what a real one would for a package whose bundle this consumer
+/// has never landed:</para>
+/// <list type="number">
+///   <item>The boot pass runs against the fake registry and lands nothing — the feed declares no
+///   module for either installed package, so the boot's module lane has nothing to do — and the
+///   reconcile ledger exists from then on, which is what makes it an inbox target.</item>
+///   <item>A broadcast for package A lands in the ledger's <c>_Inbox</c>. The reconciler drains
+///   it: it reads A's OWN install record (which does declare a module), consults the registry's
+///   bundle index, decides Land, and asks the registry for A's bundle — and never for B's. The
+///   ledger records the pass as <c>broadcast</c>, and the delivery is deleted.</item>
+///   <item>A broadcast from a registry this installation does not consume is dropped and deleted
+///   without a single registry request.</item>
+/// </list>
+/// <para>The witness is the registry's own request log: which bundle was asked for is the one
+/// thing a consumer cannot fake, and "asked for A, not B" is the whole claim.</para>
+/// </summary>
+public class RegistryUpdateReconcilerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RegistryUrl = "http://registry.broadcast.test";
+    private const string RegistryName = "Broadcast Test Registry";
+    private const string PackageA = "BroadcastPkgA";
+    private const string PackageB = "BroadcastPkgB";
+    private const string ModuleVersion = "mv-installed-4b2";
+    private const string Token = "mwi_broadcast_test";
+    private const string ServedFramework = "s1234567890abcdef1234567890abcdef";
+
+    private readonly FakeRegistry registry = new();
+
+    private JsonSerializerOptions Json => Mesh.JsonSerializerOptions;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            // The generic webhook inbox the portal registers (MemexConfiguration) — the WebhookEvent
+            // node type a delivery is stored as. Same production registration, not a duplicate.
+            .AddWebhookInbox()
+            .ConfigureServices(s => s
+                .AddSingleton<IHttpClientFactory>(new FakeRegistryClientFactory(registry))
+                // The registry this installation consumes — what arms the reconciler's boot pass,
+                // its inbox watch and its safety net (left at its default; it never ticks here).
+                .AddSingleton(new PluginCatalogOptions
+                {
+                    Registries =
+                    [
+                        new PluginRegistryReference { Name = RegistryName, Url = RegistryUrl, Token = Token },
+                    ],
+                }));
+
+    [Fact(Timeout = 240_000)]
+    public async Task ABroadcastForOnePackage_ReconcilesThatPackage_AndOnlyThat()
+    {
+        await SeedInstallRecord(PackageA, "ModA");
+        await SeedInstallRecord(PackageB, "ModB");
+
+        // ── 1. The boot pass ran (the hosted service started with the mesh) ───────────────────
+        await LedgerEntries()
+            .Where(entries => entries.Any(e => e.Url == RegistryUrl && e.LastReconciledVia == RegistryReconcileEntry.ViaBoot))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Empty(registry.BundleDownloads);
+        var feedReadsAfterBoot = registry.FeedReads;
+
+        // ── 2. The registry tells this installation that A's module was published ────────────
+        var delivered = await WebhookInbox.Deliver(
+                Mesh, [new WebhookInbox.WebhookTarget(ModulePublished.InboxTarget)],
+                ModulePublished.InboxTarget, "application/json", [],
+                new ModulePublished
+                {
+                    Registry = RegistryUrl,
+                    Package = PackageA,
+                    Module = "ModA",
+                    Version = "1.0.0",
+                    FrameworkMvid = ServedFramework,
+                    PublishedAt = DateTimeOffset.UtcNow,
+                }.Serialize())
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Equal(WebhookInbox.DeliveryStatus.Accepted, delivered.Status);
+
+        // ── 3. The drain reconciled A: the registry was asked for A's bundle ──────────────────
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .Select(_ => registry.BundleDownloads)
+            .Where(downloads => downloads.Contains(PackageA))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        var drained = await LedgerEntries()
+            .Where(entries => entries.Any(e => e.Url == RegistryUrl && e.LastReconciledVia == RegistryReconcileEntry.ViaBroadcast))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.NotNull(drained.Single(e => e.Url == RegistryUrl).LastReconciledAt);
+
+        // ── 4. …and only A. The broadcast is per package, and B was never asked about ─────────
+        Assert.Equal([PackageA], registry.BundleDownloads);
+        // A broadcast drain reads the bundle INDEX for its package — never the whole feed again.
+        Assert.Equal(feedReadsAfterBoot, registry.FeedReads);
+
+        // ── 5. The delivery is consumed ───────────────────────────────────────────────────────
+        await InboxDeliveries()
+            .Where(deliveries => deliveries.Count == 0)
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task ABroadcastFromAnUnknownRegistry_IsDroppedWithoutARequest()
+    {
+        await SeedInstallRecord(PackageA, "ModA");
+        await LedgerEntries()
+            .Where(entries => entries.Any(e => e.Url == RegistryUrl && e.LastReconciledVia == RegistryReconcileEntry.ViaBoot))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        var requestsBefore = registry.Requests.Count;
+
+        var delivered = await WebhookInbox.Deliver(
+                Mesh, [new WebhookInbox.WebhookTarget(ModulePublished.InboxTarget)],
+                ModulePublished.InboxTarget, "application/json", [],
+                new ModulePublished
+                {
+                    Registry = "https://somebody-else.example",
+                    Package = PackageA,
+                    Version = "1.0.0",
+                    PublishedAt = DateTimeOffset.UtcNow,
+                }.Serialize())
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Equal(WebhookInbox.DeliveryStatus.Accepted, delivered.Status);
+
+        // Consumed — and nothing was asked of the registry this installation does consume.
+        await InboxDeliveries()
+            .Where(deliveries => deliveries.Count == 0)
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Empty(registry.BundleDownloads);
+        Assert.Equal(requestsBefore, registry.Requests.Count);
+    }
+
+    /// <summary>The host-based match: a consumer configured with a trailing slash or another scheme
+    /// still recognises its registry; a different host never does.</summary>
+    [Theory]
+    [InlineData("https://memex.meshweaver.cloud", "https://memex.meshweaver.cloud/", true)]
+    [InlineData("https://memex.meshweaver.cloud", "http://memex.meshweaver.cloud", true)]
+    [InlineData("https://MEMEX.meshweaver.cloud/", "https://memex.meshweaver.cloud", true)]
+    [InlineData("https://memex.meshweaver.cloud", "https://memex.systemorph.com", false)]
+    [InlineData("http://registry:8080", "http://registry:9090", false)]
+    [InlineData("not a url", "not a url/", true)]
+    public void SameRegistry_MatchesByHost(string configured, string announced, bool expected)
+        => Assert.Equal(expected, RegistryUpdateReconciler.SameRegistry(configured, announced));
+
+    // ── harness ───────────────────────────────────────────────────────────────
+
+    private async Task SeedInstallRecord(string packageId, string module)
+    {
+        var manifest = new PackageManifest
+        {
+            Id = packageId,
+            Name = packageId,
+            Version = "1.0.0",
+            ModuleVersion = ModuleVersion,
+            TargetPartition = packageId,
+            Module = module,
+            AutoUpdate = true,
+        };
+        var record = MeshNode.FromPath($"{PackageInstaller.InstalledPartition}/{packageId}") with
+        {
+            NodeType = PackageInstaller.PackageNodeType,
+            Name = manifest.Name,
+            State = MeshNodeState.Active,
+            Content = manifest,
+        };
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        await access.RunAsSystem(() => NodeFactory.CreateOrUpdateNode(record))
+            .Timeout(TestTimeouts.Convergence);
+    }
+
+    private IObservable<IReadOnlyList<RegistryReconcileEntry>> LedgerEntries() =>
+        Mesh.GetWorkspace()
+            .GetQuery("ledger|broadcast",
+                $"path:{PackageInstaller.InstalledPartition} scope:children nodeType:{RegistryUpdateReconciler.LedgerNodeType}")
+            .Select(ns => (IReadOnlyList<RegistryReconcileEntry>)(ns ?? [])
+                .Select(n => n.ContentAs<RegistryReconcileLedger>(Json))
+                .Where(l => l is not null)
+                .SelectMany(l => l!.Registries)
+                .ToList());
+
+    private IObservable<IReadOnlyList<MeshNode>> InboxDeliveries() =>
+        Mesh.GetWorkspace()
+            .GetQuery("inbox|broadcast",
+                $"path:{ModulePublished.InboxTarget}/{WebhookInbox.InboxContainer} scope:children nodeType:{WebhookInbox.NodeType}")
+            .Select(ns => (IReadOnlyList<MeshNode>)(ns ?? []).ToList());
+
+    /// <summary>
+    /// The registry, as both the feed client and the bundle client reach it. The feed lists both
+    /// packages at the installed content identity and declares NO module for either (so the boot's
+    /// module lane is idle); the bundle index serves a module for each; a bundle download answers
+    /// 404 — the "no prebuilt bundle" a consumer treats as a logged miss — and is RECORDED, which
+    /// is the witness.
+    /// </summary>
+    private sealed class FakeRegistry : HttpMessageHandler
+    {
+        private ImmutableList<string> requests = ImmutableList<string>.Empty;
+        private ImmutableList<string> downloads = ImmutableList<string>.Empty;
+
+        public ImmutableList<string> Requests => requests;
+        public ImmutableList<string> BundleDownloads => downloads;
+
+        /// <summary>How many times the whole feed (<c>GET /api/plugins</c>) was read.</summary>
+        public int FeedReads => requests.Count(r => r.StartsWith("GET /api/plugins?", StringComparison.Ordinal));
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.PathAndQuery;
+            ImmutableInterlocked.Update(ref requests, r => r.Add($"{request.Method} {path}"));
+
+            string? body = null;
+            var status = HttpStatusCode.NotFound;
+            if (request.Method == HttpMethod.Get && path.StartsWith("/api/plugins?", StringComparison.Ordinal))
+            {
+                body = PluginRegistryPayloads.List([Served(PackageA), Served(PackageB)]);
+                status = HttpStatusCode.OK;
+            }
+            else if (request.Method == HttpMethod.Get && path.StartsWith($"{PluginBundleClient.RoutePrefix}/index.json", StringComparison.Ordinal))
+            {
+                body = JsonSerializer.Serialize(new
+                {
+                    frameworkMvid = ServedFramework,
+                    bundles = new[]
+                    {
+                        new { plugin = PackageA, version = "1.0.0", url = $"{RegistryUrl}{PluginBundleClient.RoutePrefix}/{PackageA}/1.0.0", module = "ModA", frameworkMvid = ServedFramework },
+                        new { plugin = PackageB, version = "1.0.0", url = $"{RegistryUrl}{PluginBundleClient.RoutePrefix}/{PackageB}/1.0.0", module = "ModB", frameworkMvid = ServedFramework },
+                    },
+                }, PluginRegistryPayloads.Json);
+                status = HttpStatusCode.OK;
+            }
+            else if (request.Method == HttpMethod.Get && path.StartsWith($"{PluginBundleClient.RoutePrefix}/", StringComparison.Ordinal))
+            {
+                var package = path[(PluginBundleClient.RoutePrefix.Length + 1)..].Split('/')[0];
+                ImmutableInterlocked.Update(ref downloads, d => d.Add(Uri.UnescapeDataString(package)));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body ?? "{\"error\":\"not found\"}", Encoding.UTF8, "application/json"),
+            });
+        }
+
+        private static PackageManifest Served(string packageId) => new()
+        {
+            Id = packageId,
+            Name = packageId,
+            Version = "1.0.0",
+            ModuleVersion = ModuleVersion,
+            TargetPartition = packageId,
+        };
+    }
+
+    private sealed class FakeRegistryClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/SelfUpdatePendingRestartTest.cs
+++ b/test/Memex.Portal.Shared.Test/SelfUpdatePendingRestartTest.cs
@@ -1,0 +1,331 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A module swap is a restart, and the restart HAPPENS (#3650) — the poller half, against a
+/// real monolith mesh.</b>
+///
+/// <para>A landed module generation loads only at a restart (restart-as-activation). Until this
+/// change the restart was whatever platform roll came next: a module could ship, land, raise
+/// <c>PendingRestart</c> and sit unloaded for days behind a fleet with nothing newer to roll to —
+/// which is the opposite of the maintainer's rule that a module version that ships is in use. The
+/// self-updater now treats a pending restart like a roll of the image it runs: after the platform
+/// half of every check, when that half patched nothing, it reads the activation record and — paced
+/// by the same <c>MinRollInterval</c> floor as any roll — asks the deployment updater to restart the
+/// workloads on the same image.</para>
+///
+/// <para><b>Fails on unfixed code:</b> <see cref="APendingRestart_RollsTheRunningImage"/> sees an
+/// updater that was never asked to restart and a verdict reading only "no newer release".</para>
+///
+/// <para>Only the documented IO seams are faked — the ACR listing, the k8s patcher, and the module
+/// root the landing service reads (a temp directory carrying the real marker file). The hub, the
+/// workspace, the policy node, every <c>stream.Update</c> and the whole decision path are real.</para>
+/// </summary>
+public class SelfUpdatePendingRestartTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    private static string Installed => ShippedReleaseSeed.InstalledPlatformVersion;
+
+    private static string InstalledTag => Installed.Split('+')[0];
+
+    /// <summary>Two releases behind this install plus the tag it runs — a registry with nothing
+    /// newer, in which the installed image still resolves. The premise is asserted per scenario.</summary>
+    private static string[] NothingNewer => ["1.9.0-ci.0", "2.0.0-ci.0", InstalledTag];
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The restart, and the rules it obeys
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>The acceptance criterion.</b> Nothing newer is in the registry, the module activation
+    /// record says a restart is pending, and the install never rolled: the check restarts the
+    /// workloads on the image they run, patches NO image, and says so on the policy node.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task APendingRestart_RollsTheRunningImage()
+    {
+        AssertBehindInstalled(NothingNewer.Take(2));
+        await Seed(UpdatePolicyKind.Continuous);
+        using var root = ModuleRoot.WithPendingRestart();
+        var updater = new RecordingUpdater { LastRolledAt = null };
+
+        var content = await RunOneCheck(updater, root.Landing, NothingNewer);
+
+        updater.Restarts.Should().Be(1,
+            "a landed module generation loads only at a restart, and the restart must not wait for "
+            + "an unrelated platform roll");
+        updater.Tags.Should().BeEmpty("nothing newer exists — the image stays, only the pods roll");
+        content.LastCheckVerdict.Should().Contain("no newer release",
+            "the platform half of the check still has to say what it found");
+        content.LastCheckVerdict.Should().Contain($"RESTARTED on {Installed}",
+            "the restart is the durable second sentence of the same verdict");
+    }
+
+    /// <summary>
+    /// 🚨 A restart is a roll — it drops the same live circuits — so the pacing floor applies to it
+    /// exactly as to a roll: an install that rolled five minutes ago, inside a one-hour floor,
+    /// restarts nothing now and says the next check re-decides it.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task APendingRestart_InsideTheRollFloor_IsDeferred()
+    {
+        await Seed(UpdatePolicyKind.Continuous);
+        using var root = ModuleRoot.WithPendingRestart();
+        var updater = new RecordingUpdater { LastRolledAt = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(5) };
+
+        var content = await RunOneCheck(updater, root.Landing, NothingNewer,
+            options => options with { MinRollInterval = TimeSpan.FromHours(1) });
+
+        updater.Restarts.Should().Be(0, "the floor defers a restart exactly as it defers a roll");
+        content.LastCheckVerdict.Should().Contain("deferring the restart");
+    }
+
+    /// <summary>The control: no pending restart, no restart — and the verdict is the plain
+    /// up-to-date sentence, untouched.</summary>
+    [Fact(Timeout = 240_000)]
+    public async Task NoPendingRestart_RestartsNothing()
+    {
+        await Seed(UpdatePolicyKind.Continuous);
+        using var root = ModuleRoot.Clean();
+        var updater = new RecordingUpdater { LastRolledAt = null };
+
+        var content = await RunOneCheck(updater, root.Landing, NothingNewer);
+
+        updater.Restarts.Should().Be(0);
+        content.LastCheckVerdict.Should().Contain("no newer release");
+        content.LastCheckVerdict.Should().NotContain("RESTARTED");
+    }
+
+    /// <summary>
+    /// 🚨 An updater that predates the restart seam cannot restart on the same image (a same-tag
+    /// image patch rolls nothing on Kubernetes). That is a state an operator has to see: the
+    /// verdict names it and names the move, instead of folding it into "no newer release".
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task AnUpdaterWithoutTheRestartSeam_ReportsTheRestartAsUnavailable()
+    {
+        await Seed(UpdatePolicyKind.Continuous);
+        using var root = ModuleRoot.WithPendingRestart();
+        var updater = new LegacyUpdater();
+
+        var content = await RunOneCheck(updater, root.Landing, NothingNewer);
+
+        content.LastCheckVerdict.Should().Contain("cannot restart itself");
+        content.LastCheckVerdict.Should().Contain("kubectl rollout restart",
+            "an unactionable pending restart is a module that never loads, with everything green");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Harness
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private static void AssertBehindInstalled(IEnumerable<string> tags)
+    {
+        foreach (var tag in tags)
+            VersionSelect.IsNewer(tag, Installed).Should().BeFalse(
+                $"the scenario needs {tag} to be BEHIND the running {Installed}; otherwise the check "
+                + "would roll forward and never reach the restart decision under test");
+    }
+
+    /// <summary>A module root in a temp directory, carrying the REAL marker the landing lane
+    /// raises (<c>modules/activation.d/.pending-restart</c>) — or not.</summary>
+    private sealed class ModuleRoot : IDisposable
+    {
+        private readonly string directory;
+
+        public ModuleLandingService Landing { get; }
+
+        private ModuleRoot(bool pendingRestart)
+        {
+            directory = Path.Combine(Path.GetTempPath(), "mw-3650-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            if (pendingRestart)
+                ModuleActivationSidecar.SetPendingRestart(directory, true);
+            Landing = new ModuleLandingService(logger: null, baseDirectory: directory);
+        }
+
+        public static ModuleRoot WithPendingRestart() => new(pendingRestart: true);
+
+        public static ModuleRoot Clean() => new(pendingRestart: false);
+
+        public void Dispose()
+        {
+            Landing.Dispose();
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A temp directory that outlives the test is harmless.
+            }
+        }
+    }
+
+    private sealed class FakeAcrTagLister(IReadOnlyList<string> tags) : IAcrTagLister
+    {
+        public Task<IReadOnlyList<string>> ListTagsAsync(string repository, CancellationToken ct) =>
+            Task.FromResult(tags);
+    }
+
+    /// <summary>The k8s seam, recording every image patch and every same-image restart.</summary>
+    private sealed class RecordingUpdater : IDeploymentUpdater
+    {
+        private ImmutableList<string> tags = ImmutableList<string>.Empty;
+        private int restarts;
+
+        public ImmutableList<string> Tags => tags;
+        public int Restarts => Volatile.Read(ref restarts);
+        public DateTimeOffset? LastRolledAt { get; init; }
+        public bool CanPatch => true;
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) => Task.FromResult(LastRolledAt);
+
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct)
+        {
+            ImmutableInterlocked.Update(ref tags, current => current.Add(versionTag));
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RestartAsync(CancellationToken ct)
+        {
+            Interlocked.Increment(ref restarts);
+            return Task.FromResult(true);
+        }
+    }
+
+    /// <summary>An updater compiled before the seam: the interface default answers "cannot".</summary>
+    private sealed class LegacyUpdater : IDeploymentUpdater
+    {
+        public bool CanPatch => true;
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) => Task.FromResult<DateTimeOffset?>(null);
+
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class AlwaysAvailable(IMessageHub hub, IConfiguration configuration)
+        : ReleaseAvailabilityService(hub, configuration)
+    {
+        public override IObservable<UpdatabilityVerdict> IsUpdatable(string? targetVersion) =>
+            Observable.Return(UpdatabilityVerdict.NotEnforced("this test host consumes no CI bakes"));
+    }
+
+    /// <summary>The poller with the three seams supplied directly: the availability gate, no combo
+    /// gate, and the module root under test.</summary>
+    private sealed class SeamedSelfUpdateService(
+        IMessageHub hub,
+        IAcrTagLister acr,
+        IDeploymentUpdater updater,
+        SelfUpdateOptions options,
+        ILogger<SelfUpdateHostedService>? logger,
+        ReleaseAvailabilityService gate,
+        ModuleLandingService landing)
+        : SelfUpdateHostedService(hub, acr, updater, options, logger)
+    {
+        public IObservable<Unit> Evaluations => ChecksReported;
+
+        protected override ReleaseAvailabilityService? ResolveAvailabilityGate() => gate;
+
+        protected override ComboVerificationGate? ResolveComboGate() => null;
+
+        protected override ModuleLandingService? ResolveLandingService() => landing;
+    }
+
+    private static SelfUpdateOptions FastPoll() => new()
+    {
+        RetryInterval = TimeSpan.FromMilliseconds(500),
+        EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
+        DefaultPolicy = UpdatePolicyKind.Continuous,
+    };
+
+    private async Task<UpdatePolicyContent> RunOneCheck(
+        IDeploymentUpdater updater, ModuleLandingService landing, IReadOnlyList<string> registry,
+        Func<SelfUpdateOptions, SelfUpdateOptions>? configure = null)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var options = configure?.Invoke(FastPoll()) ?? FastPoll();
+        var service = new SeamedSelfUpdateService(
+            Mesh, new FakeAcrTagLister(registry), updater, options,
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(),
+            new AlwaysAvailable(Mesh, new ConfigurationBuilder().Build()),
+            landing);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await service.Evaluations.FirstAsync().Timeout(Budget).Await(ct);
+            return await WaitForContent(c => c.LastCheckVerdict is not null);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private Task Seed(UpdatePolicyKind policy)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var node = new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+        {
+            NodeType = UpdatePolicyNodeType.NodeType,
+            Name = "Update Policy",
+            State = MeshNodeState.Active,
+            Content = new UpdatePolicyContent { Policy = policy },
+        };
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return (IDisposable)meshService.CreateNode(node).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+    }
+
+    private Task<UpdatePolicyContent> WaitForContent(Func<UpdatePolicyContent, bool> predicate) =>
+        Observable.Create<UpdatePolicyContent>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return Mesh.GetWorkspace()
+                        .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                        .Where(node => node is not null)
+                        .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
+                        .Subscribe(observer);
+            })
+            .Where(predicate)
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+}

--- a/test/Memex.Portal.Shared.Test/SelfUpdateVerdictTest.cs
+++ b/test/Memex.Portal.Shared.Test/SelfUpdateVerdictTest.cs
@@ -35,6 +35,11 @@ public class SelfUpdateVerdictTest
     [InlineData(SelfUpdateOutcome.UpdatesDisabled, false)]
     [InlineData(SelfUpdateOutcome.CheckFailed, false)]
     [InlineData(SelfUpdateOutcome.NoOutcome, false)]
+    // A restart activates a MODULE this install already landed — nothing newer was waiting in
+    // the registry, so a safety-net check that restarts must never fire the dead-channel report.
+    [InlineData(SelfUpdateOutcome.Restarted, false)]
+    [InlineData(SelfUpdateOutcome.RestartDeferred, false)]
+    [InlineData(SelfUpdateOutcome.RestartUnavailable, false)]
     public void FoundNewerRelease_IsTrueExactlyWhenAReleaseWasWaiting(
         SelfUpdateOutcome outcome, bool expected)
         => Assert.Equal(expected, new SelfUpdateVerdict(outcome, "…").FoundNewerRelease);
@@ -59,6 +64,11 @@ public class SelfUpdateVerdictTest
             SelfUpdateVerdict.ComboBlocked("3.0.1", "'Widget' does not compile against it"),
             SelfUpdateVerdict.MigrationFailed("3.0.1", MigrationRunOutcome.TimedOut),
             SelfUpdateVerdict.InstalledTagWithdrawn("3.1.0-ci.7841", "it is not in the registry"),
+            SelfUpdateVerdict.Restarted(SelfUpdateVerdict.NoNewerRelease(7, "3.0.0"), "3.0.0", null),
+            SelfUpdateVerdict.RestartDeferred(
+                SelfUpdateVerdict.NoNewerRelease(7, "3.0.0"), "3.0.0", TimeSpan.FromMinutes(5), TimeSpan.FromHours(1)),
+            SelfUpdateVerdict.RestartUnavailable(
+                SelfUpdateVerdict.NoNewerRelease(7, "3.0.0"), "3.0.0", "this install does not self-patch"),
         ];
 
         Assert.Equal(
@@ -198,5 +208,109 @@ public class SelfUpdateVerdictTest
 
         Assert.Contains("SelfUpdateHostedService", verdict.Message, StringComparison.Ordinal);
         Assert.False(verdict.FoundNewerRelease);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  A pending restart rolls the same image, within the interval rules (#3650)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private static readonly SelfUpdateVerdict UpToDate = SelfUpdateVerdict.NoNewerRelease(7, "3.0.0");
+
+    private static readonly DateTimeOffset Now = new(2026, 9, 8, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// 🚨 Only a check that PATCHED nothing has a restart to take. An applied roll IS the restart;
+    /// a refused migration leaves the image where it is on purpose; a failed check decided
+    /// nothing; a disabled policy means never; and the structural backstop is not a verdict at
+    /// all. Every other outcome — up to date, held, deferred, detect-only, combo-blocked, a strand
+    /// — may be followed by the restart of the image that IS running.
+    /// </summary>
+    [Theory]
+    [InlineData(SelfUpdateOutcome.NoNewerRelease, true)]
+    [InlineData(SelfUpdateOutcome.Held, true)]
+    [InlineData(SelfUpdateOutcome.Deferred, true)]
+    [InlineData(SelfUpdateOutcome.DetectOnly, true)]
+    [InlineData(SelfUpdateOutcome.ComboBlocked, true)]
+    [InlineData(SelfUpdateOutcome.InstalledTagWithdrawn, true)]
+    [InlineData(SelfUpdateOutcome.Applied, false)]
+    [InlineData(SelfUpdateOutcome.MigrationFailed, false)]
+    [InlineData(SelfUpdateOutcome.CheckFailed, false)]
+    [InlineData(SelfUpdateOutcome.UpdatesDisabled, false)]
+    [InlineData(SelfUpdateOutcome.NoOutcome, false)]
+    public void MayRestartAfter_OnlyWhenTheCheckPatchedNothing(SelfUpdateOutcome outcome, bool expected)
+        => Assert.Equal(expected, SelfUpdateVerdict.MayRestartAfter(new SelfUpdateVerdict(outcome, "…")));
+
+    /// <summary>Inside the floor the restart is deferred, naming how long ago the install rolled
+    /// and the floor it sits inside — the same sentence shape a deferred roll uses.</summary>
+    [Fact]
+    public void RestartDeferredBy_InsideTheFloor_Defers()
+    {
+        var verdict = SelfUpdateVerdict.RestartDeferredBy(
+            UpToDate, "3.0.0", Now - TimeSpan.FromMinutes(5), TimeSpan.FromHours(1), Now);
+
+        Assert.NotNull(verdict);
+        Assert.Equal(SelfUpdateOutcome.RestartDeferred, verdict!.Outcome);
+        Assert.Contains("00:05:00", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("01:00:00", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("deferring the restart", verdict.Message, StringComparison.Ordinal);
+        Assert.Equal("3.0.0", verdict.Tag);
+    }
+
+    /// <summary>Past the floor, at the floor, never rolled, floor disabled: the restart proceeds.</summary>
+    [Fact]
+    public void RestartDeferredBy_OutsideTheFloor_NeverRolled_OrFloorOff_Proceeds()
+    {
+        var floor = TimeSpan.FromHours(1);
+
+        Assert.Null(SelfUpdateVerdict.RestartDeferredBy(UpToDate, "3.0.0", Now - TimeSpan.FromHours(2), floor, Now));
+        Assert.Null(SelfUpdateVerdict.RestartDeferredBy(UpToDate, "3.0.0", Now - floor, floor, Now));
+        Assert.Null(SelfUpdateVerdict.RestartDeferredBy(UpToDate, "3.0.0", lastRolledAt: null, floor, Now));
+        Assert.Null(SelfUpdateVerdict.RestartDeferredBy(UpToDate, "3.0.0", Now - TimeSpan.FromSeconds(1), TimeSpan.Zero, Now));
+    }
+
+    /// <summary>
+    /// A restart verdict KEEPS the platform verdict it followed: the record still has to say what
+    /// the check found about the registry, and the restart is the second sentence, not a
+    /// replacement for the first.
+    /// </summary>
+    [Fact]
+    public void Restarted_CarriesThePlatformVerdict_AndNamesTheImage()
+    {
+        var verdict = SelfUpdateVerdict.Restarted(UpToDate, "3.0.0", Now);
+
+        Assert.Equal(SelfUpdateOutcome.Restarted, verdict.Outcome);
+        Assert.StartsWith(UpToDate.Message, verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("RESTARTED on 3.0.0", verdict.Message, StringComparison.Ordinal);
+        Assert.Equal("3.0.0", verdict.Tag);
+        Assert.False(verdict.FoundNewerRelease);
+    }
+
+    /// <summary>
+    /// 🚨 A landed module nothing will ever activate is a state an operator has to see and can
+    /// act on: the verdict names why this install cannot restart itself and the move.
+    /// </summary>
+    [Fact]
+    public void RestartUnavailable_NamesTheReason_AndTheOperatorsMove()
+    {
+        var verdict = SelfUpdateVerdict.RestartUnavailable(
+            UpToDate, "3.0.0", "this install does not self-patch (detect-and-notify)");
+
+        Assert.Equal(SelfUpdateOutcome.RestartUnavailable, verdict.Outcome);
+        Assert.Contains("does not self-patch", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("kubectl rollout restart", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A restart taken on the recovery path keeps the strand visible: the withdrawn
+    /// tag the platform verdict carried survives onto the restart verdict.</summary>
+    [Fact]
+    public void ARestartVerdict_KeepsTheUnresolvedInstalledTag()
+    {
+        var stranded = SelfUpdateVerdict.NoNewerRelease(0, "3.1.0-ci.7841")
+            .Recovering("3.1.0-ci.7841", "the installed tag is NOT among the listed tags");
+
+        Assert.Equal("3.1.0-ci.7841",
+            SelfUpdateVerdict.Restarted(stranded, "3.1.0-ci.7841", null).UnresolvedInstalledTag);
+        Assert.Equal("3.1.0-ci.7841",
+            SelfUpdateVerdict.RestartUnavailable(stranded, "3.1.0-ci.7841", "detect-only").UnresolvedInstalledTag);
     }
 }


### PR DESCRIPTION
Implements rule R3 of the Module Adoption Policy (`Doc/Architecture/ModuleAdoptionPolicy`, maintainer 2026-09-07: *as soon as a new module version ships, we start using it*). Three gaps closed, one per commit.

## What changed

**1. A fallback re-examines every new build of its version** (`ModuleUpdateDecision`)
- `ModuleActivationEntry.UnloadableFrameworkMvid` — the identity of the newest landed generation when the boot's link probe refused it and the previous generation runs. #3649 supplies the fallback itself (the boot writes and clears this field); this PR only reads it.
- In the same-version branch, an entry in fallback is compared against the **unloadable** generation's identity: a served build with any other stated identity is `Land` ("a build for this platform appeared"); the same build again, or an unstated identity, is the new `SkipUnloadable` (appended, never "already landed").

**2. A module-published broadcast reconciles that package, with a half-hourly safety net** (`RegistryUpdateReconciler`, `ModulePublished`, `ModulePublishedBroadcaster`)
- Registry side: the publish route (`POST /api/plugins/bundles/{plugin}`) fires a `ModulePublished` record to every registered, enabled instance that recorded a `HomeUrl`, at `{HomeUrl}/api/hooks/Plugins/_RegistryReconcileLedger` — the consumer's generic webhook inbox, targeted at the reconcile-ledger node the reconciler already owns. Detached from the publisher's response, reporter-class, signed with `X-Hub-Signature-256` when `Plugins:Registry:BroadcastSecret` is set.
- Consumer side: the reconciler watches that `_Inbox`, drains each delivery once (matched to a configured registry by host), runs the module lane for **that one package** (`ReconcileModule`: its own install record → the registry's authenticated bundle index → the same decision the boot runs → the module-set proposal), then deletes the delivery. A wake-up, never the truth; a stale or forged delivery costs one authenticated index read.
- Safety net: `PluginCatalog:ReconcileSafetyNetInterval` (default 30 min, ≤ 0 disables) runs the full pass against every registry — the bound on how long a lost broadcast can hide, same shape as `SelfUpdate:SafetyNetCheckInterval`. A read that finds a registry pending drains the boot deferral through `OnFeedRead` rather than running twice.
- Every pass — boot, deferred drain, broadcast, safety net — runs on **one serialized lane** (`Subject` + `Concat`), so a broadcast can never propose a module set in the middle of a boot wave (#3395's torn set).
- Ledger: `LastReconciledVia` gains `broadcast` and `safety-net`.

**3. A pending restart rolls the running image, within the roll floor** (`SelfUpdateHostedService`, `IDeploymentUpdater`)
- After the platform half of **every** check that patched nothing (`SelfUpdateVerdict.MayRestartAfter`), the poller reads the activation record through `ModuleLandingService.GetActivation()` and, when `PendingRestart` is raised, restarts the workloads on the image they run — paced by `MinRollInterval` exactly like a roll (`SelfUpdateVerdict.RestartDeferredBy`, pure).
- New trigger `SelfUpdateTrigger.ModuleSetProposed`, fed by the new `ModuleLandingService.ModuleSetProposed` signal (fires when a landing wave on this process ends with a set that moved), coalesced like build events — so the restart follows the landing, not the next unrelated publication.
- New outcomes `Restarted`, `RestartDeferred`, `RestartUnavailable` (appended; `FoundNewerRelease` stays false for all three, so a safety-net restart never fires the dead-channel report). `RestartUnavailable` logs at Warning and names the operator's move.
- `IDeploymentUpdater.RestartAsync(ct)` — **default-implemented** (`false`). A same-tag `PatchToVersionAsync` does **not** roll pods on Kubernetes (the strategic merge leaves the pod template unchanged; the last-rolled stamp sits on the Deployment's own metadata), so the restart needs its own seam. The AKS implementation belongs in `MeshWeaver.SelfUpdate.Aks` (MeshWeaver.Plugins): patch `spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]` together with the last-rolled annotation. Until it lands, an AKS portal reports `RestartUnavailable` rather than silently doing nothing.

Implementers: `IDeploymentUpdater.RestartAsync` — default implementation (`Task.FromResult(false)`); checked `KubernetesDeploymentUpdater` (MeshWeaver.Plugins) and the test fakes in both repos — none breaks, the AKS one needs the follow-up above to actually restart.

Pairs-with: none — this PR adds surface (an interface member with a default, appended enum members, a new field and a new record), removes nothing.

Mirror-sync: none — no i18n catalog key changed (every new string is a log line or a verdict message, not a UI string).

## Docs
- `Doc/Architecture/PluginUpdateOnGreenBuild` — the "not a poll timer" section is replaced by *Three events and a floor* (boot, broadcast, safety net; the wake-up-not-truth rule; the restart), plus the consumer configuration and five new failure-mode rows.
- `Doc/Architecture/Modules` → *Auto-update* — eager adoption, the restart, the fallback re-examination.
- What's New: *A module version that ships is in use within minutes* (Feature).

## Tests
All local, Debug, after `dotnet build`; CI's Release `-warnaserror` build of `Memex.Portal.Shared` and `Memex.Portal.Shared.Test` is clean.

| project | filter | result |
|---|---|---|
| `Memex.Portal.Shared.Test` | the four #3650 classes (`ModuleUpdateIdentityTest` +8, `SelfUpdateVerdictTest` +6 incl. 2 theories, `SelfUpdatePendingRestartTest` new ×4, `RegistryUpdateReconcilerTest` new ×2 +1 theory) plus the six neighbouring suites (`ModulePublishShelfTest`, `RegistryReconcileDeferralTest`, `SelfUpdateStrandRecoveryTest`, `ComboGateRollTest`, `SelfUpdateMigratesBeforeItRollsTest`, `ModuleFloorAdvisoryTest`) | **108 passed, 0 failed, 0 skipped** |
| `MeshWeaver.Documentation.Test` | `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest` | **4 passed, 0 failed** |
| `MeshWeaver.Compiler.Pipeline.Test` | `PlatformUpdateKeepsThePluginThenTakesTheRebuildTest` (the other `ModuleUpdateDecision` consumer) | **1 passed, 0 failed** |

## Not done exactly as specified, and why
- **"A roll of the same image"** cannot be `PatchToVersionAsync(installed)`: on Kubernetes a strategic-merge patch whose pod template is unchanged rolls nothing (the last-rolled annotation is on the Deployment's `metadata`, outside the template, precisely so it never triggers a rollout). Hence the new default-implemented `IDeploymentUpdater.RestartAsync`; the AKS implementation is a MeshWeaver.Plugins follow-up.
- **The broadcast is unsigned by default.** The registry holds only the hash of a consumer's instance key, so there is no shared secret to sign with unless an operator configures one on both ends (`Plugins:Registry:BroadcastSecret` ↔ the target's `SecretConfigKey`). This is safe because the consumer treats the delivery purely as a wake-up: it re-reads the registry's authenticated index and reconciles only a package it has an install record for.
- **`ModuleAdoptionPolicy` is referenced by path, not linked.** The page is on `main` (0fc77208e) but not on this PR's base branch (#3661), and `DocumentationLinkIntegrityTest` would red a link to a page absent from the tree.
- **`RegistryUpdateReconcilerTest` is new**, not extended — no class of that name existed (the spec's `git grep` finds only the other two).

Stacked on #3661 (`fix/3648-module-floors-advisory`) — retarget to `main` after #3661 merges.

Closes #3650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
