### PR TITLE
docs(#3201): how to retire a credential shadow, and the measurement that makes it safe

### DIFF
--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -315,12 +315,15 @@ fi
 # DIFFERENT value, so the secret's copy is dead and the pod authenticates with a plaintext one
 # (MeshWeaver#3201). Reading only the names is enough to see that, and is all we read.
 #
-# 🚨 And reading only the names is also all we may CLAIM. Re-measured 2026-09-04, the two sides were
-# not one credential in two places: they were valid instance keys of DIFFERENT registered instances,
-# and the secret's copy was never Key Vault-provisioned at all (that namespace's CSI-backed secret is
-# memex-kv-secrets, which does not carry this key, and the vault holds no such entry). A name-only
-# checker cannot see provenance or identity — so it reports the shadow and says the two are unknown,
-# rather than narrating a story about where either side came from.
+# 🚨 And reading only the names is also all we may CLAIM — which is exactly why the story behind this
+# example has been rewritten twice while the checker's output stayed correct. Measured 2026-09-04 the
+# two sides were valid instance keys of DIFFERENT registered instances and no CSI class mapped the key
+# at all; measured 2026-09-08, after Systemorph/Memex#180 declared it, `memex` has a THIRD copy in the
+# chart-owned synced Secret memex-portal-keyvault, that copy is byte-EQUAL to the inline entry, and it
+# is the chart's own memex-portal-secrets that now holds the odd one out. A name-only checker sees
+# none of that — not provenance, not identity, not equality — so it reports the shadow and says the
+# two are unknown, rather than narrating a story about where either side came from. That restraint is
+# the feature: the narrative aged twice, the finding did not.
 #
 # 🚨 BOTH source kinds, not just Secrets. `.Values.extraEnvFrom` takes verbatim EnvFromSource
 # objects and the chart documents `{configMapRef: {name: …}}` as one of the two shapes, so

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -121,6 +121,62 @@ hold a plugin-registry instance key inline, in plaintext, readable by anything t
 `HelmValues.Problems`, so the one shape that would put a live token into a git-synced node fails the
 render instead of shipping.
 
+### Retiring a shadow takes two steps, and the SECOND one is what changes the pod
+
+Recording a shadow does not clear it. Clearing one is two acts in a fixed order, and either alone
+leaves the pod exactly where it was:
+
+1. **give the key a declared home** — a `keyVaultSecrets` mapping, so the vault-synced Secret
+   carries it. This changes nothing observable: the inline entry still outranks every `envFrom`.
+2. **remove the inline entry** — `kubectl -n <ns> set env deployment/<name> <KEY>-`. This is the
+   step that changes which value the pod reads, and it rolls the Deployment.
+
+The trap is doing step 2 first, or doing step 2 without measuring what the pod falls through *to*.
+`PluginCatalog__RegistryToken` is the worked example (MeshWeaver#3201). Its inline entry stood over
+a chart Secret carrying a **different**, also-valid instance key — a key registered to another
+instance, with strictly more scope. Removing the inline entry before step 1 would not have restored
+a status quo; it would have silently switched the portal onto a different registered identity on one
+portal and left the other with no key at all.
+
+**So the precondition for step 2 is a measured EQUALITY, not a hope.** Before removing an inline
+credential entry, compare it against the source it will fall through to and require the answer
+`EQUAL`:
+
+```sh
+# Runs INSIDE the cluster. Values enter shell variables and never leave the pod:
+# the only thing that crosses the boundary is the verdict and the length.
+inline() { kubectl -n "$1" get deploy <deployment> -o go-template='{{range .spec.template.spec.containers}}{{if eq .name "<container>"}}{{range .env}}{{if eq .name "<KEY>"}}{{.value}}{{end}}{{end}}{{end}}{{end}}'; }
+sec()    { kubectl -n "$1" get secret "$2" -o go-template="{{index .data \"$3\"}}" | base64 -d; }
+A=$(inline <ns>); B=$(sec <ns> <synced-secret> <KEY>)
+[ "$A" = "$B" ] && echo "EQUAL (len ${#A})" || echo "DIFFER (a=${#A} b=${#B})"
+```
+
+`DIFFER` means step 1 is not done — promote the **in-use** value into the vault first, never the
+other one, and never mint a replacement as part of a cleanup.
+
+Three further things this key showed, each of which generalises:
+
+- **Precedence within `envFrom` decides which copy is the fall-through.** On `memex` the order is
+  ConfigMap, `memex-portal-secrets`, `memex-portal-keyvault`, `memex-kv-secrets`; last wins, so the
+  vault-synced class outranks the chart's Secret. That is why a chart Secret carrying a *stale* copy
+  of a key is inert rather than dangerous — but also why deleting the vault class, not the chart
+  one, is the change that would silently swap identities.
+- **Check every container, not the portal.** The language gate sidecars carry no `envFrom` at all —
+  the chart renders exactly `MESH_GRPC_URL` and `MESH_GATE_ADDRESS` on them, because reaching the
+  loopback gRPC endpoint *is* their authentication. A whole-Deployment `kubectl set env` had
+  nevertheless copied the portal's twelve inline entries onto both of them, credential included. A
+  `set env <KEY>-` defaults to every container, which is right here (the chart declares no such key
+  on a gate, so removal restores the declared shape) and would be wrong for a key a sidecar reads.
+- **Removing the shadow is not the remediation.** A credential that has sat in plaintext in a
+  Deployment spec is disclosed to everything that could `get deploy` in that namespace, whether or
+  not anyone read it. Retiring the shadow stops the *next* reader; rotating the key at its issuer is
+  what closes the disclosure, and it is a separate, deliberate act with its own blast radius.
+
+🚨 **Step 2 rolls the Deployment, so it is subject to whatever else is rolling.** `set env` mutates
+the pod template, which creates a new ReplicaSet and supersedes an in-flight rollout. Read
+`kubectl rollout status` first and hold if a deploy is already in progress — a cleanup that ejects a
+release roll costs more than the shadow it clears.
+
 ## What else the record gained
 
 - **`gates`** — the language gate sidecars (`python`, `node`, `pandas`). The chart has been able to

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -142,9 +142,22 @@ portal and left the other with no key at all.
 credential entry, compare it against the source it will fall through to and require the answer
 `EQUAL`:
 
+🚨 **Be precise about where the value travels — this is the part that is easy to state wrongly.**
+`kubectl` is a *client*: both the inline `env:` value (read from the Deployment spec) and the Secret
+data cross the Kubernetes API to **wherever `kubectl` runs**. What the snippet below buys is that
+neither value is ever *printed, logged or persisted* — only a verdict and a length are emitted. That
+is a real and worthwhile property, and it is a different one from "the value stayed in the cluster".
+
+The in-cluster claim is true only of the route this cluster actually allows. It is private, so
+`kubectl` is reachable **only** through `az aks command invoke`, which uploads the script, runs it in
+a pod on the cluster, and returns that pod's *stdout*. Run that way the credential is read
+API-server-side and only the verdict crosses back. Run the same snippet from a laptop and the
+credential lands in that laptop's shell process — same commands, different boundary. Say which one
+you used.
+
 ```sh
-# Runs INSIDE the cluster. Values enter shell variables and never leave the pod:
-# the only thing that crosses the boundary is the verdict and the length.
+# Run through `az aks command invoke -f eq.sh --command "sh eq.sh"`, so the read happens in-cluster
+# and only these verdict lines come back. Nothing here prints a value under any route.
 inline() { kubectl -n "$1" get deploy <deployment> -o go-template='{{range .spec.template.spec.containers}}{{if eq .name "<container>"}}{{range .env}}{{if eq .name "<KEY>"}}{{.value}}{{end}}{{end}}{{end}}{{end}}'; }
 sec()    { kubectl -n "$1" get secret "$2" -o go-template="{{index .data \"$3\"}}" | base64 -d; }
 A=$(inline <ns>); B=$(sec <ns> <synced-secret> <KEY>)


### PR DESCRIPTION
Closes part of #3201 — the documentation half. The cluster act is tracked below and is deliberately not in this PR.

## What this adds

`Doc/Architecture/DeploymentEnvLayers` already names inline `env:` shadows and gives a record the fields to *describe* one (`shadows`, `agreesWithShadowed`). It never said how one is **cleared**, and that omission is exactly what #3201 cost three days and five corrections to work out.

A new section, **"Retiring a shadow takes two steps, and the SECOND one is what changes the pod"**:

- the fixed order — declare the vault home first (changes nothing observable), then `kubectl set env <KEY>-` (changes which value the pod reads, and rolls the Deployment);
- the precondition stated as a **measurement, not a hope**: compare the inline value against the source it falls through to and require `EQUAL`. The comparison runs inside the cluster so only the verdict and the length cross the boundary — no token value is read out, printed or stored, which is the same discipline every comment on #3201 used;
- why `DIFFER` is a stop sign: on `memex` the inline entry stood over a chart Secret holding a *different, also-valid* instance key with more scope, and on `memex-cloud` there was no other copy at all. Deleting the inline entry first would have swapped identity on one portal and removed the credential on the other;
- three generalisations: `envFrom` precedence decides the fall-through; check **every container** (a whole-Deployment `set env` had copied the credential onto both language-gate sidecars, which carry no `envFrom` and whose chart spec renders exactly `MESH_GRPC_URL` + `MESH_GATE_ADDRESS`); and retiring the shadow is **not** the remediation — rotation at the issuer is;
- and that step 2 supersedes an in-flight rollout, so `rollout status` is read first.

## The `check-chart-drift.sh` correction

Its comment asserted that the shadowed key was "never Key Vault-provisioned at all… the vault holds no such entry". Measured 2026-09-08 that is no longer true: `Systemorph/Memex#180` declared it, the deploy landed, and `memex` now has a chart-owned synced Secret carrying the key — **byte-equal to the inline entry**, with the chart's own `memex-portal-secrets` holding the odd one out instead.

Worth noting what did *not* need changing: the checker's **output** was correct throughout. Only the narrative around it aged — twice. The correction says so, because the restraint the comment argues for (report the shadow, refuse to claim provenance or identity from names alone) is precisely what let the finding survive its own explanation being wrong.

## Measured before writing, 2026-09-08T01:03Z

Equality verdicts and lengths only, computed inside the cluster:

| comparison | verdict |
|---|---|
| `memex` inline vs vault-synced (`memex-portal-keyvault`) | **EQUAL** |
| `memex` inline vs chart Secret (`memex-portal-secrets`) | DIFFER |
| `memex-cloud` inline vs vault-synced | **EQUAL** |
| `memex-cloud` inline vs chart Secret | chart Secret has no such key |

So the issue's headline — *"the two differ"* — is no longer true of the Key Vault copy on either portal. That is what makes removing the inline entry a no-op in value terms, and it is stated on the issue.

## Not in this PR

- **The cluster act** (`kubectl set env deployment/memex-portal-deployment PluginCatalog__RegistryToken-` on both namespaces). It rolls the Deployment, and both portals were mid-roll to `3.0.0-ci.8059` while this was written. Held, not skipped.
- **Rotation.** The credential sat in plaintext in a Deployment spec; that disclosure closes at the issuer, not here.

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` → **2 passed, 0 failed** (built first; the edited page is an embedded asset)

No What's New entry: pure-internal (documentation + a script comment), no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
