### PR TITLE
fix(#3650): the boot that falls back writes the marker the reconcile re-examines

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -422,6 +422,24 @@ public static class MemexConfiguration
                         ModuleSetStore.RunningGenerationsOf(adoptedSet, sp.GetServices<FallbackModule>()),
                         adoptedBy: Environment.MachineName,
                         onWarn: msg => Console.Error.WriteLine($"[ModuleSet] {msg}"))));
+            // 🚨 #3650 — the boot that falls back WRITES THE MARKER the update reconcile reads:
+            // for every store entry the loader was handed (the union above, so its Directory is
+            // the generation actually tried), the FallbackModule / IncompatibleModule records say
+            // whether that generation loaded here, and the verdict lands on that module's own
+            // sidecar marker (activation.d/<Name>.unloadable). Without it the reconcile's
+            // fallback branch (ModuleUpdateDecision, an entry in fallback re-examining every new
+            // build of its version) could never fire — #3665 records what RUNS on the module set's
+            // adoption, once per set, which survives a platform roll unchanged; this is re-measured
+            // by every boot. Unconditional, unlike the adoption: a deployment with no proposed set
+            // yet still measures its heads.
+            var triedEntries = loadableModules
+                .Select(candidate => candidate.Module.Landed)
+                .Where(landed => landed is not null)
+                .Select(landed => landed!)
+                .ToArray();
+            if (triedEntries.Length > 0)
+                builder.ConfigureServices(services =>
+                    services.AddModuleLoadabilityRecord(moduleRoot, triedEntries));
             // Restart-as-activation: this boot IS the restart the sidecar was waiting for —
             // consume the pending flag so the step-10 signal reads current. Best-effort: on a
             // read-only app filesystem the flag simply stays set (cosmetic), and boot proceeds.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -657,12 +657,23 @@ unrelated publication. An install that cannot restart itself reports `RestartUna
 Updates tab, naming the operator's move.
 
 **A fallback is re-examined.** When the newest landed generation could not be loaded and the previous
-one runs ([the keep-the-old fallback](/Doc/Architecture/ModuleSetConvergence), #3649), the entry
-carries the refused build's identity (`ModuleActivationEntry.UnloadableFrameworkMvid`). The
-same-version branch of the decision then asks the one question such a deployment has: does the
-registry serve a *different* build of this version than the one that would not load? It **lands**
-when it does — a build for this platform appeared — and answers `SkipUnloadable` (never "already
-landed") when the registry still serves the build that was refused.
+one runs ([the keep-the-old fallback](/Doc/Architecture/ModuleSetConvergence), #3649), **the boot that
+falls back writes the marker the reconcile re-examines**: for every store entry the loader was handed,
+`ModuleLoadabilityRecorder` reads the `FallbackModule` / `IncompatibleModule` records back onto the
+generation the loader tried and writes that module's marker file — `activation.d/<Name>.unloadable`,
+the head's generation, its framework identity and the refusal — or deletes it when the head loaded. A
+create and a delete, never a read-modify-write of the entry a landing on another replica may be
+replacing (#2090). `ModuleActivationSidecar.Read` attaches the identity to the entry
+(`ModuleActivationEntry.UnloadableFrameworkMvid`, never stored in the entry file) only while the entry
+still heads the generation the marker measured, so a landing that moves the head on retires a stale
+marker without touching it. It is the boot's measurement rather than the module set's adoption record
+(`ModuleSetIndex.FallbackGenerations`) on purpose: that record is written once per set by the first
+replica to adopt it and survives a platform roll unchanged, so it can report a fallback the running
+image no longer takes; every boot rewrites the marker. The same-version branch of the decision then
+asks the one question such a deployment has: does the registry serve a *different* build of this
+version than the one that would not load? It **lands** when it does — a build for this platform
+appeared — and answers `SkipUnloadable` (never "already landed") when the registry still serves the
+build that was refused.
 
 #### "Already landed" means this content against this FRAMEWORK
 

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -99,10 +99,10 @@ public sealed record ModuleActivationEntry
     public string? Version { get; init; }
 
     /// <summary>
-    /// 🚨 The framework identity of the NEWEST landed generation when boot could not load it and
-    /// fell back to the previous one (#3649 supplies that fallback: <c>PreviousDirectory</c> and
-    /// its siblings, the boot's link probe deciding). Null when the newest generation loads, or
-    /// was never probed — the ordinary state.
+    /// 🚨 The framework identity of the HEAD generation (<see cref="Directory"/>) when the boot
+    /// MEASURED it unloadable on this platform — the link probe refused it, or the load threw —
+    /// and fell back to the previous one (#3649) or parked the module. Null when the head loads,
+    /// or was never measured: the ordinary state.
     ///
     /// <para>This is the one fact the update reconcile needs to honour rule R3 of
     /// <c>Doc/Architecture/ModuleAdoptionPolicy</c> (#3650): an entry in fallback is
@@ -110,10 +110,22 @@ public sealed record ModuleActivationEntry
     /// DIFFERENT identity than this one is a build for this platform that appeared — it lands.
     /// Without it the same-version branch of <see cref="ModuleUpdateDecision"/> could only compare
     /// against <see cref="FrameworkMvid"/>, and a deployment running its previous generation would
-    /// answer "already landed" for exactly the build that would have got it off the fallback.
-    /// Written by the boot that falls back, cleared by the boot that loads the newest generation;
-    /// the reconcile never writes it.</para>
+    /// answer "already landed" for exactly the build that would have got it off the fallback.</para>
+    ///
+    /// <para>🚨 <b>Derived at read time from the sidecar's MARKER file, never stored in the entry
+    /// file</b> (<see cref="ModuleActivationSidecar.UnloadableMarkerPath"/>,
+    /// <c>activation.d/&lt;Name&gt;.unloadable</c>). The boot that measures the head writes the
+    /// marker (unloadable) or deletes it (loaded) — a create and a delete, never a read-modify-write
+    /// of the entry a landing on another replica may be replacing at that moment (#2090). The marker
+    /// names the generation it measured, and <see cref="ModuleActivationSidecar.Read"/> attaches it
+    /// here ONLY while <see cref="Directory"/> is still that generation: a landing that moves the
+    /// head on makes a stale marker inert without touching it, and the next boot re-measures. It is
+    /// deliberately the boot's measurement and not the module set's adoption record
+    /// (<c>ModuleSetIndex.FallbackGenerations</c>): that record is written once per set by the
+    /// first replica to adopt it and survives a platform roll unchanged, so it can report a fallback
+    /// the image now running no longer takes; every boot rewrites this.</para>
     /// </summary>
+    [JsonIgnore]
     public string? UnloadableFrameworkMvid { get; init; }
 
     /// <summary>False = uninstalled (the record is kept for history/idempotence; the folder is
@@ -258,11 +270,117 @@ public static class ModuleActivationSidecar
 
         return new ModuleActivationList
         {
-            Entries = [.. order.Select(name => byName[name])],
+            // #3650 — the boot's measurement of each head generation rides along, from the
+            // per-module marker file, only while the head is still the generation it measured.
+            Entries = [.. order.Select(name => WithUnloadableMarker(baseDirectory, byName[name]))],
             // The marker is authoritative; the legacy flag is honoured once, for a deployment
             // upgrading with the flag still set. Boot clears both.
             PendingRestart = File.Exists(PendingRestartMarkerPath(baseDirectory)) || legacy.PendingRestart,
         };
+    }
+
+    // ── the unloadable-head marker (#3650) ──────────────────────────────────
+
+    /// <summary>The per-module marker's file suffix inside <see cref="EntriesDirectoryName"/> —
+    /// deliberately NOT <c>.json</c>, so <see cref="Read"/>'s entry enumeration never parses a
+    /// marker as an entry and the bulk <see cref="Write"/> never sweeps one.</summary>
+    public const string UnloadableMarkerSuffix = ".unloadable";
+
+    /// <summary>The marker file recording that a module's head generation was measured unloadable
+    /// on this platform: <c>modules/activation.d/&lt;Name&gt;.unloadable</c>.</summary>
+    public static string UnloadableMarkerPath(string baseDirectory, string moduleName) =>
+        Path.Combine(EntriesDirectory(baseDirectory), moduleName + UnloadableMarkerSuffix);
+
+    /// <summary>
+    /// What the boot measured about one module's head generation (#3650): the generation it
+    /// tried, the framework identity that generation was recorded with, why it did not load, and
+    /// when. The generation is what keeps the marker honest across a landing — a marker for a
+    /// generation the entry no longer heads is inert.
+    /// </summary>
+    /// <param name="Generation">The generation directory leaf the boot measured (<c>&lt;name&gt;@&lt;id&gt;</c>).</param>
+    /// <param name="FrameworkMvid">That generation's recorded framework identity, or null when unrecorded.</param>
+    /// <param name="Reason">Why it did not load — the link probe's report or the load exception.</param>
+    /// <param name="MeasuredAt">When the boot measured it.</param>
+    public sealed record UnloadableGeneration(
+        string Generation, string? FrameworkMvid, string? Reason, DateTimeOffset MeasuredAt);
+
+    /// <summary>
+    /// Records that <paramref name="generation"/> of <paramref name="moduleName"/> was measured
+    /// unloadable on this platform — an atomic replace of that module's own marker file, which
+    /// only boots write and which no landing ever reads or modifies. Idempotent.
+    /// </summary>
+    public static void SetUnloadable(
+        string baseDirectory, string moduleName, string generation, string? frameworkMvid, string? reason)
+    {
+        ValidateModuleName(moduleName);
+        if (string.IsNullOrWhiteSpace(generation))
+            throw new ArgumentException("the measured generation is required", nameof(generation));
+        WriteAtomic(UnloadableMarkerPath(baseDirectory, moduleName), JsonSerializer.Serialize(
+            new UnloadableGeneration(generation, frameworkMvid, reason, DateTimeOffset.UtcNow), Json));
+    }
+
+    /// <summary>Removes the module's marker — the boot loaded its head generation, or the module
+    /// was uninstalled. A delete, tolerant of an absent file and of a volume that is momentarily
+    /// read-only: the marker is a measurement, and activation never depends on it.</summary>
+    public static void ClearUnloadable(string baseDirectory, string moduleName)
+    {
+        ValidateModuleName(moduleName);
+        try
+        {
+            File.Delete(UnloadableMarkerPath(baseDirectory, moduleName));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Another replica clearing the same marker, or a read-only volume; the next boot
+            // measures again.
+        }
+    }
+
+    /// <summary>
+    /// The module's marker as written, or null when there is none — or when it cannot be read or
+    /// parsed. Silent on purpose: the marker is a hint the boot rewrites, and a read that opens
+    /// into another replica's atomic replace (#2189's shape) must cost nothing but that one
+    /// reading, never a false "corrupt sidecar".
+    /// </summary>
+    public static UnloadableGeneration? ReadUnloadable(string baseDirectory, string moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName))
+            return null;
+        try
+        {
+            var text = TryReadAllText(UnloadableMarkerPath(baseDirectory, moduleName));
+            return text is null ? null : JsonSerializer.Deserialize<UnloadableGeneration>(text, Json);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Attaches the marker's identity to <paramref name="entry"/> when — and only when —
+    /// the marker measured the generation the entry currently heads.</summary>
+    private static ModuleActivationEntry WithUnloadableMarker(string baseDirectory, ModuleActivationEntry entry)
+    {
+        if (string.IsNullOrWhiteSpace(entry.Directory))
+            return entry;
+        var marker = ReadUnloadable(baseDirectory, entry.Name);
+        if (marker is null
+            || !string.Equals(marker.Generation, entry.Directory, StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(marker.FrameworkMvid))
+            return entry;
+        return entry with { UnloadableFrameworkMvid = marker.FrameworkMvid };
+    }
+
+    /// <summary>The same rule <see cref="WriteEntry"/> applies: the name BECOMES a path.</summary>
+    private static void ValidateModuleName(string? moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName)
+            || moduleName is "." or ".."
+            || moduleName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || moduleName.Contains('/') || moduleName.Contains('\\'))
+            throw new ArgumentException(
+                $"'{moduleName}' is not a valid module name — a marker is a file named after its module.",
+                nameof(moduleName));
     }
 
     /// <summary>
@@ -840,6 +958,129 @@ public static class ModuleActivationBoot
             PreviousVersion = null,
             PreviousFrameworkMvid = null,
         };
+    }
+
+    // ── what the boot measured, written where the reconcile reads it (#3650) ─────────────
+
+    /// <summary>
+    /// The boot's verdict on one module's head generation: what the loader was handed
+    /// (<paramref name="Generation"/>, the entry's <see cref="ModuleActivationEntry.Directory"/>
+    /// as projected onto the mesh's set) and whether it loaded.
+    /// </summary>
+    /// <param name="Name">The module's simple name.</param>
+    /// <param name="Generation">The generation the loader tried.</param>
+    /// <param name="FrameworkMvid">That generation's recorded framework identity, or null.</param>
+    /// <param name="Unloadable">True when the loader could not load it — it fell back to the
+    /// previous generation (<see cref="FallbackModule"/>) or parked the module
+    /// (<see cref="IncompatibleModule"/>).</param>
+    /// <param name="Reason">Why, when unloadable.</param>
+    public sealed record MeasuredLoadability(
+        string Name, string Generation, string? FrameworkMvid, bool Unloadable, string? Reason);
+
+    /// <summary>
+    /// Reads the loader's records back onto the entries it was handed (#3650): for every enabled
+    /// store entry in <paramref name="tried"/> — the union AFTER
+    /// <see cref="ProjectOntoMeshSet"/>, i.e. with <see cref="ModuleActivationEntry.Directory"/>
+    /// naming the generation the loader actually tried — a <see cref="FallbackModule"/> or an
+    /// <see cref="IncompatibleModule"/> whose generation IS that directory says the head did not
+    /// load; the absence of both says it did. A record naming another generation of the same
+    /// module says nothing about this one. Pure.
+    /// </summary>
+    public static ImmutableList<MeasuredLoadability> MeasureLoadability(
+        IEnumerable<ModuleActivationEntry> tried,
+        IEnumerable<FallbackModule> fallbacks,
+        IEnumerable<IncompatibleModule> incompatible)
+    {
+        ArgumentNullException.ThrowIfNull(tried);
+        var fellBack = fallbacks.ToArray();
+        var parked = incompatible.ToArray();
+        var verdicts = ImmutableList.CreateBuilder<MeasuredLoadability>();
+        foreach (var entry in tried)
+        {
+            if (entry is not { Enabled: true } || string.IsNullOrWhiteSpace(entry.Name)
+                || string.IsNullOrWhiteSpace(entry.Directory))
+                continue;
+            var fallback = fellBack.FirstOrDefault(f =>
+                string.Equals(f.Name, entry.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(f.Generation, entry.Directory, StringComparison.Ordinal));
+            var refused = fallback is null
+                ? parked.FirstOrDefault(m =>
+                    string.Equals(m.Name, entry.Name, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(GenerationOf(m.Entry), entry.Directory, StringComparison.Ordinal))
+                : null;
+            verdicts.Add(new MeasuredLoadability(
+                entry.Name, entry.Directory!, entry.FrameworkMvid,
+                Unloadable: fallback is not null || refused is not null,
+                Reason: fallback?.Reason ?? refused?.Error));
+        }
+        return verdicts.ToImmutable();
+    }
+
+    /// <summary>
+    /// Writes the boot's measurement where the reconcile reads it: the marker
+    /// (<see cref="ModuleActivationSidecar.SetUnloadable"/>) for every head generation that did
+    /// not load, cleared (<see cref="ModuleActivationSidecar.ClearUnloadable"/>) for every one
+    /// that did — touching only markers whose content CHANGES, so a steady state costs no writes
+    /// and two replicas booting together write the same bytes or nothing. Best-effort per module:
+    /// a marker that cannot be written is reported through <paramref name="onReport"/> and the
+    /// next boot tries again; nothing here can fail a boot.
+    /// </summary>
+    /// <returns>The transitions this boot made — a marker written or cleared — for the log.</returns>
+    public static ImmutableList<MeasuredLoadability> RecordMeasuredLoadability(
+        string baseDirectory,
+        IEnumerable<ModuleActivationEntry> tried,
+        IEnumerable<FallbackModule> fallbacks,
+        IEnumerable<IncompatibleModule> incompatible,
+        Action<string>? onReport = null)
+    {
+        var transitions = ImmutableList.CreateBuilder<MeasuredLoadability>();
+        foreach (var verdict in MeasureLoadability(tried, fallbacks, incompatible))
+        {
+            var current = ModuleActivationSidecar.ReadUnloadable(baseDirectory, verdict.Name);
+            try
+            {
+                if (verdict.Unloadable)
+                {
+                    if (current is not null
+                        && string.Equals(current.Generation, verdict.Generation, StringComparison.Ordinal)
+                        && string.Equals(current.FrameworkMvid, verdict.FrameworkMvid, StringComparison.Ordinal))
+                        continue;
+                    ModuleActivationSidecar.SetUnloadable(
+                        baseDirectory, verdict.Name, verdict.Generation, verdict.FrameworkMvid, verdict.Reason);
+                    onReport?.Invoke(
+                        $"module '{verdict.Name}': generation '{verdict.Generation}' (framework "
+                        + $"{verdict.FrameworkMvid ?? "(unrecorded)"}) measured UNLOADABLE here — recorded, "
+                        + "so the update reconcile re-examines every new build of its version: "
+                        + verdict.Reason);
+                }
+                else
+                {
+                    if (current is null)
+                        continue;
+                    ModuleActivationSidecar.ClearUnloadable(baseDirectory, verdict.Name);
+                    onReport?.Invoke(
+                        $"module '{verdict.Name}': generation '{verdict.Generation}' loaded — the "
+                        + $"unloadable marker (for '{current.Generation}') is cleared.");
+                }
+                transitions.Add(verdict);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                onReport?.Invoke(
+                    $"module '{verdict.Name}': could not record its measured loadability "
+                    + $"({ex.GetType().Name}: {ex.Message}) — the next boot measures again; until then the "
+                    + "update reconcile compares identities without knowing the head did not load.");
+            }
+        }
+        return transitions.ToImmutable();
+    }
+
+    /// <summary>The generation directory leaf of a loader's entry path — the same derivation
+    /// <see cref="FallbackModule.Generation"/> uses, so the two agree by construction.</summary>
+    private static string GenerationOf(string entry)
+    {
+        var directory = Path.GetDirectoryName(entry);
+        return string.IsNullOrEmpty(directory) ? entry : Path.GetFileName(directory);
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -843,6 +843,9 @@ public sealed class ModuleLandingService : IDisposable
                 PreviousFrameworkMvid = null,
             });
         ModuleActivationSidecar.SetPendingRestart(baseDirectory, true);
+        // An uninstalled module has no head to have measured (#3650); a marker left behind would
+        // be inert (its generation is gone) but is one more thing to explain.
+        ModuleActivationSidecar.ClearUnloadable(baseDirectory, name);
 
         // Best-effort immediate delete: on a shared volume the files of a LOADED module refuse
         // deletion (SMB keeps them open) — that is fine, the cleared pointers above make the

--- a/src/MeshWeaver.PluginCatalog/ModuleLoadabilityRecorder.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLoadabilityRecorder.cs
@@ -1,0 +1,88 @@
+using System.Collections.Immutable;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The boot that falls back writes the marker the reconcile re-examines (#3650): once the loader
+/// has run, this reads the <see cref="FallbackModule"/> and <see cref="IncompatibleModule"/>
+/// records it registered and writes each measured head generation's verdict onto that module's
+/// sidecar marker (<see cref="ModuleActivationBoot.RecordMeasuredLoadability"/>) — unloadable
+/// ⇒ marker written, loaded ⇒ marker cleared.
+///
+/// <para><b>Why here, and why a hosted service.</b> The loader's records exist only after
+/// <c>MeshBuilder.InstallModules</c> ran and the container is built, which is after the point in
+/// boot that knows which entries the loader was handed — the same seam
+/// <c>ModuleSetAdoptionService</c> sits in, for the same reason. The entries travel in from
+/// <c>ConfigureMemexMesh</c> (the union AFTER the mesh-set projection: their <c>Directory</c> is
+/// what the loader tried), so nothing is re-derived here; the records come off the container at
+/// start. Runs inline in <see cref="StartAsync"/>: a handful of tiny per-module files beside the
+/// entries, and the write is what makes the next reconcile honest, so it is not deferred.</para>
+///
+/// <para>Deliberately NOT gated on the bake (<c>MeshPublicationGate</c>) like the adoption write:
+/// the adoption claims "this replica serves this set", which a refused bake falsifies; the marker
+/// claims "these bytes do not load on this platform build", which the bake's verdict cannot
+/// change. Best-effort: a marker that cannot be written is logged and the next boot measures
+/// again.</para>
+/// </summary>
+public sealed class ModuleLoadabilityRecorder(
+    string baseDirectory,
+    IReadOnlyList<ModuleActivationEntry> tried,
+    IServiceProvider services,
+    ILogger<ModuleLoadabilityRecorder>? logger = null) : IHostedService
+{
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var transitions = ModuleActivationBoot.RecordMeasuredLoadability(
+                baseDirectory,
+                tried,
+                services.GetServices<FallbackModule>(),
+                services.GetServices<IncompatibleModule>(),
+                message => logger?.LogInformation("[ModuleLoadability] {Message}", message));
+            if (transitions.Count > 0)
+                logger?.LogInformation(
+                    "[ModuleLoadability] {Count} module marker(s) changed this boot: {Unloadable} now "
+                    + "recorded unloadable, {Loaded} cleared.",
+                    transitions.Count, transitions.Count(t => t.Unloadable), transitions.Count(t => !t.Unloadable));
+        }
+        catch (Exception ex)
+        {
+            // Nothing here may fail a boot: the marker is what makes the next reconcile precise,
+            // and a reconcile without it compares identities as it always did.
+            logger?.LogWarning(ex,
+                "[ModuleLoadability] could not record the boot's module measurements; the next boot "
+                + "measures again.");
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>Registration for <see cref="ModuleLoadabilityRecorder"/>.</summary>
+public static class ModuleLoadabilityRecorderRegistration
+{
+    /// <summary>
+    /// Registers the recorder for the entries the loader is about to be handed — call it beside
+    /// <c>AddModuleSetAdoption</c>, with the union AFTER the mesh-set projection, so the
+    /// generations it measures are the ones the loader tried.
+    /// </summary>
+    /// <param name="services">The mesh's service collection.</param>
+    /// <param name="baseDirectory">The module root the sidecar lives under.</param>
+    /// <param name="tried">The store entries handed to the loader, as projected.</param>
+    public static IServiceCollection AddModuleLoadabilityRecord(
+        this IServiceCollection services, string baseDirectory, IReadOnlyList<ModuleActivationEntry> tried)
+    {
+        ArgumentNullException.ThrowIfNull(tried);
+        var snapshot = tried.ToImmutableList();
+        return services.AddSingleton<IHostedService>(sp => new ModuleLoadabilityRecorder(
+            baseDirectory, snapshot, sp, sp.GetService<ILogger<ModuleLoadabilityRecorder>>()));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ModuleUnloadableMarkerTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleUnloadableMarkerTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using System.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The unloadable-head marker (#3650) — the sidecar half, pinned pure over a temp directory: the
+/// boot's measurement is a per-module marker FILE beside the entries, attached to the entry at
+/// read time only while the entry still heads the generation it measured, never stored in the
+/// entry file, and written only on a transition. The whole chain through the real loader is
+/// <c>ConfiguredModuleActivationTest</c> (MeshWeaver.Compiler.Pipeline.Test); this file is the
+/// contract each half of that chain relies on.
+/// </summary>
+public sealed class ModuleUnloadableMarkerTest : IDisposable
+{
+    private const string Module = "MeshWeaver.Test.Marker";
+    private const string Head = Module + "@head0000";
+    private const string Previous = Module + "@prev0000";
+    private const string HeadMvid = "s1111111111111111111111111111111a";
+
+    private readonly string root = Path.Combine(Path.GetTempPath(), "mw-marker-" + Guid.NewGuid().ToString("N"));
+
+    public ModuleUnloadableMarkerTest() => Directory.CreateDirectory(root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch (IOException) { /* temp cleanup is the OS's problem */ }
+    }
+
+    private void WriteHead(string? frameworkMvid = HeadMvid) =>
+        ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry
+        {
+            Name = Module, Directory = Head, Version = "1.0.0", FrameworkMvid = frameworkMvid,
+            PreviousDirectory = Previous, PreviousVersion = "1.0.0", PreviousFrameworkMvid = "s0",
+        });
+
+    private ModuleActivationEntry ReadEntry() =>
+        ModuleActivationSidecar.Read(root).Entries.Single(e => e.Name == Module);
+
+    /// <summary>The marker for the head reads back onto the entry; one for another generation is
+    /// inert — a landing that moved the head on needs no write to retire it.</summary>
+    [Fact]
+    public void AMarker_AttachesOnlyWhileTheEntryHeadsTheGenerationItMeasured()
+    {
+        WriteHead();
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+
+        ModuleActivationSidecar.SetUnloadable(root, Module, Head, HeadMvid, "missing type");
+        Assert.Equal(HeadMvid, ReadEntry().UnloadableFrameworkMvid);
+
+        ModuleActivationSidecar.SetUnloadable(root, Module, Module + "@stale000", HeadMvid, "missing type");
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+        Assert.NotNull(ModuleActivationSidecar.ReadUnloadable(root, Module));
+    }
+
+    /// <summary>🚨 The identity is derived, never persisted: an entry written WITH the field reads
+    /// back without it unless the marker file says so, and a marker without an identity attaches
+    /// nothing (an unknown identity cannot be compared).</summary>
+    [Fact]
+    public void TheEntryFile_NeverCarriesTheMarker()
+    {
+        ModuleActivationSidecar.WriteEntry(root, new ModuleActivationEntry
+        {
+            Name = Module, Directory = Head, FrameworkMvid = HeadMvid, UnloadableFrameworkMvid = HeadMvid,
+        });
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+        Assert.DoesNotContain("nloadable", File.ReadAllText(ModuleActivationSidecar.EntryPath(root, Module)),
+            StringComparison.Ordinal);
+
+        ModuleActivationSidecar.SetUnloadable(root, Module, Head, frameworkMvid: null, "missing type");
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+    }
+
+    /// <summary>A marker is not an entry: the enumeration of entry files never sees it, so a
+    /// deployment with markers reads exactly its modules.</summary>
+    [Fact]
+    public void AMarker_IsNeverReadAsAnEntry()
+    {
+        WriteHead();
+        ModuleActivationSidecar.SetUnloadable(root, Module, Head, HeadMvid, "missing type");
+        var corrupt = 0;
+
+        var list = ModuleActivationSidecar.Read(root, _ => corrupt++);
+
+        Assert.Single(list.Entries);
+        Assert.Equal(0, corrupt);
+    }
+
+    [Fact]
+    public void ClearUnloadable_RemovesIt_AndTolerates_Absence()
+    {
+        WriteHead();
+        ModuleActivationSidecar.SetUnloadable(root, Module, Head, HeadMvid, "missing type");
+        ModuleActivationSidecar.ClearUnloadable(root, Module);
+        ModuleActivationSidecar.ClearUnloadable(root, Module);
+
+        Assert.Null(ModuleActivationSidecar.ReadUnloadable(root, Module));
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+    }
+
+    /// <summary>The measurement: a fallback or a refusal naming the TRIED generation says
+    /// unloadable; a record naming another generation of the same module says nothing.</summary>
+    [Fact]
+    public void MeasureLoadability_ReadsTheLoadersRecordsOntoTheTriedGeneration()
+    {
+        var tried = new ModuleActivationEntry { Name = Module, Directory = Head, FrameworkMvid = HeadMvid };
+        var fellBack = new FallbackModule(Module, $"/pin/{Head}/{Module}.dll", $"/pin/{Previous}/{Module}.dll", "no type");
+        var parked = new IncompatibleModule($"/pin/{Head}/{Module}.dll", Module, "no type either", null);
+        var elsewhere = new FallbackModule(Module, $"/pin/{Module}@other000/{Module}.dll", $"/pin/{Previous}/{Module}.dll", "no type");
+
+        var viaFallback = Assert.Single(ModuleActivationBoot.MeasureLoadability([tried], [fellBack], []));
+        Assert.True(viaFallback.Unloadable);
+        Assert.Equal("no type", viaFallback.Reason);
+        Assert.Equal(HeadMvid, viaFallback.FrameworkMvid);
+
+        var viaRefusal = Assert.Single(ModuleActivationBoot.MeasureLoadability([tried], [], [parked]));
+        Assert.True(viaRefusal.Unloadable);
+        Assert.Equal("no type either", viaRefusal.Reason);
+
+        var loaded = Assert.Single(ModuleActivationBoot.MeasureLoadability([tried], [elsewhere], []));
+        Assert.False(loaded.Unloadable);
+
+        // A disabled entry and one without a generation are not measured at all.
+        Assert.Empty(ModuleActivationBoot.MeasureLoadability(
+            [tried with { Enabled = false }, tried with { Directory = null }], [fellBack], [parked]));
+    }
+
+    /// <summary>Only transitions write: the same measurement twice costs nothing, a changed one
+    /// rewrites, a loaded head clears — and each transition is reported once.</summary>
+    [Fact]
+    public void RecordMeasuredLoadability_WritesOnTransitionsOnly()
+    {
+        WriteHead();
+        var tried = new[] { ReadEntry() };
+        var fellBack = new FallbackModule(Module, $"/pin/{Head}/{Module}.dll", $"/pin/{Previous}/{Module}.dll", "no type");
+        var reports = 0;
+
+        var first = ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [fellBack], [], _ => reports++);
+        Assert.Single(first);
+        Assert.Equal(HeadMvid, ReadEntry().UnloadableFrameworkMvid);
+
+        var again = ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [fellBack], [], _ => reports++);
+        Assert.Empty(again);
+
+        var cleared = ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [], [], _ => reports++);
+        Assert.Single(cleared);
+        Assert.False(cleared[0].Unloadable);
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+
+        Assert.Empty(ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [], [], _ => reports++));
+        Assert.Equal(2, reports);
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
@@ -304,6 +304,114 @@ public class ConfiguredModuleActivationTest
     }
 
     /// <summary>
+    /// 🚨 <b>#3650, the whole chain.</b> #3665 keeps the previous generation running but writes
+    /// nothing the update reconcile reads, so a deployment in fallback answered "already landed"
+    /// for exactly the build that would have got it off its previous generation. This walks the
+    /// seam end to end, through the REAL landing, the REAL boot composition and the REAL decision:
+    /// a build for a newer platform is shelved over a loadable one ⇒ the boot refuses it, runs the
+    /// previous generation, and WRITES THE MARKER (the head's generation and identity) ⇒ the entry
+    /// reads back in fallback ⇒ an index entry with the SAME version and a DIFFERENT identity than
+    /// the refused build is <c>Land</c>, the refused build itself is <c>SkipUnloadable</c> ⇒ a
+    /// build that loads lands (the marker for the old head is inert at once, without a write) ⇒
+    /// the boot loads it and CLEARS the marker ⇒ the same served identity is <c>SkipUpToDate</c>.
+    /// </summary>
+    [Fact]
+    public async Task TheBootThatFallsBack_WritesTheMarkerTheReconcileReExamines_AndTheBootThatLoads_ClearsIt()
+    {
+        const string Loadable = "s1111111111111111111111111111111a";
+        const string Future = "s2222222222222222222222222222222b";
+        const string Rebuilt = "s3333333333333333333333333333333c";
+        const string Version = "1.4.0";
+        using var deployment = new Deployment();
+        string? Gate(string? floor) => ModulePlatformFloor.DeclineReason(floor, "3.2.0");
+        bool Present(ModuleActivationEntry e) => ModuleActivationBoot.LandedModuleDllExists(deployment.Root, e);
+        ModuleUpdateVerdict Decide(string served) => ModuleUpdateDecision.Decide(
+            Version, bundleMinMeshVersion: null, Gate, Entry(deployment), policyDecline: null, Present, served);
+        // 🚨 ONE assembly for both loadable generations. This process boots the deployment three
+        // times, and its load context can hold ONE assembly per simple name: a second, different
+        // build of the same name is refused with "Assembly with same name is already loaded" — a
+        // constraint of the test process (every real boot is a fresh one), not of the loader. The
+        // identity the reconcile compares is the string the REGISTRY advertises, recorded on the
+        // entry at landing (Loadable / Rebuilt below), not the bytes' MVID — so the same bytes
+        // landed under a different advertised identity walk the chain faithfully.
+        var loadable = ModuleBuiltAgainstThisPlatform(deployment.Module);
+
+        // ── 1. A loadable generation runs; nothing is marked ───────────────────────────────────
+        var a = await Land(deployment, loadable, Version, Loadable);
+        Boot(deployment);
+        Assert.Null(Entry(deployment).UnloadableFrameworkMvid);
+        Assert.False(File.Exists(ModuleActivationSidecar.UnloadableMarkerPath(deployment.Root, deployment.Module)));
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, Decide(Loadable).Action);
+
+        // ── 2. The same version, rebuilt for a NEWER platform, is shelved over it ──────────────
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), Version, Future);
+        var (services, _) = Boot(deployment);
+        var fallback = Assert.Single(services.GetServices<FallbackModule>());
+        Assert.Equal(b, fallback.Generation);
+        Assert.Equal(a, fallback.PreviousGeneration);
+
+        // The boot WROTE the marker: the head's generation and identity, and why.
+        var marker = ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module);
+        Assert.NotNull(marker);
+        Assert.Equal(b, marker!.Generation);
+        Assert.Equal(Future, marker.FrameworkMvid);
+        Assert.Contains(FutureType, marker.Reason, StringComparison.Ordinal);
+
+        // …and the entry reads back IN FALLBACK — which is what the decision consumes.
+        var inFallback = Entry(deployment);
+        Assert.Equal(b, inFallback.Directory);
+        Assert.Equal(Future, inFallback.UnloadableFrameworkMvid);
+
+        // ── 3. The decision: a different build of this version lands; the refused one does not ─
+        var lands = Decide(Rebuilt);
+        Assert.Equal(ModuleUpdateAction.Land, lands.Action);
+        Assert.Contains(Future, lands.Reason);
+        Assert.Contains(Rebuilt, lands.Reason);
+        var stays = Decide(Future);
+        Assert.Equal(ModuleUpdateAction.SkipUnloadable, stays.Action);
+        Assert.DoesNotContain("already landed", stays.Reason);
+
+        // ── 4. The build for this platform lands (what the reconcile now does) ─────────────────
+        var c = await Land(deployment, loadable, Version, Rebuilt);
+        Assert.NotEqual(b, c);
+        // Before any boot the old marker still exists — and is INERT: it measured b, the head is c.
+        Assert.NotNull(ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module));
+        Assert.Null(Entry(deployment).UnloadableFrameworkMvid);
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, Decide(Rebuilt).Action);
+
+        // ── 5. The boot loads the new head and CLEARS the marker ───────────────────────────────
+        var (afterwards, _) = Boot(deployment);
+        Assert.Empty(afterwards.GetServices<FallbackModule>());
+        Assert.Empty(afterwards.GetServices<IncompatibleModule>());
+        Assert.Null(ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module));
+        Assert.Null(Entry(deployment).UnloadableFrameworkMvid);
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, Decide(Rebuilt).Action);
+        // The ordinary identity rule is back in charge: yet another build still lands.
+        Assert.Equal(ModuleUpdateAction.Land, Decide(Loadable).Action);
+    }
+
+    /// <summary>
+    /// When NO generation loads, the head is unloadable too — and the marker says so, so a build
+    /// for this platform still lands the moment one ships (the module is parked, not forgotten).
+    /// </summary>
+    [Fact]
+    public async Task WhenNoGenerationLoadsHere_TheHeadIsStillMarkedUnloadable()
+    {
+        const string Future = "s4444444444444444444444444444444d";
+        using var deployment = new Deployment();
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var head = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0", Future);
+
+        var (services, _) = Boot(deployment);
+
+        Assert.Single(services.GetServices<IncompatibleModule>());
+        var marker = ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module);
+        Assert.NotNull(marker);
+        Assert.Equal(head, marker!.Generation);
+        Assert.Equal(Future, Entry(deployment).UnloadableFrameworkMvid);
+    }
+
+    /// <summary>
     /// The other half of "as today": when NO generation loads here, the module is incompatible
     /// exactly as it was before #3649 — named, refused before load, contributing nothing.
     /// </summary>
@@ -589,12 +697,14 @@ public class ConfiguredModuleActivationTest
             .Single(e => string.Equals(e.Name, deployment.Module, StringComparison.Ordinal));
 
     /// <summary>Lands a generation on the ADOPT path (refuses what cannot load) and returns its
-    /// generation directory leaf.</summary>
-    private static async Task<string> Land(Deployment deployment, byte[] bytes, string version)
+    /// generation directory leaf. <paramref name="frameworkMvid"/> is the identity the registry
+    /// would advertise for these bytes — what the update reconcile compares (#3650).</summary>
+    private static async Task<string> Land(
+        Deployment deployment, byte[] bytes, string version, string? frameworkMvid = null)
     {
         await deployment.Landing.LandModule(
                 deployment.Module, [(deployment.Module + ".dll", bytes)],
-                packagePath: PackagePath, version: version)
+                frameworkMvid: frameworkMvid, packagePath: PackagePath, version: version)
             .Timeout(TestTimeouts.Convergence).Await();
         return Entry(deployment).Directory!;
     }
@@ -602,11 +712,12 @@ public class ConfiguredModuleActivationTest
     /// <summary>Lands a generation on the SHELF path (holds what cannot load) and returns its
     /// generation directory leaf. Asserts it was held — every shelved generation here is one
     /// built for a newer platform.</summary>
-    private static async Task<string> Shelve(Deployment deployment, byte[] bytes, string version)
+    private static async Task<string> Shelve(
+        Deployment deployment, byte[] bytes, string version, string? frameworkMvid = null)
     {
         var outcome = await deployment.Landing.ShelveModule(
                 deployment.Module, [(deployment.Module + ".dll", bytes)],
-                packagePath: PackagePath, version: version)
+                frameworkMvid: frameworkMvid, packagePath: PackagePath, version: version)
             .Timeout(TestTimeouts.Convergence).Await();
         Assert.True(outcome.Held, "the shelved generation was expected to be unloadable here");
         return Entry(deployment).Directory!;
@@ -663,6 +774,14 @@ public class ConfiguredModuleActivationTest
             ModuleSetStore.RecordAdoption(root, adopted,
                 ModuleSetStore.RunningGenerationsOf(adopted, provider.GetServices<FallbackModule>()),
                 adoptedBy: "replica");
+        // #3650 — the boot that falls back writes the marker the reconcile re-examines: the same
+        // call ModuleLoadabilityRecorder makes on the portal, off the same records, for the same
+        // entries the loader was handed.
+        ModuleActivationBoot.RecordMeasuredLoadability(
+            root,
+            effective.Select(module => module.Landed!),
+            provider.GetServices<FallbackModule>(),
+            provider.GetServices<IncompatibleModule>());
         return (provider, sets);
     }
 


### PR DESCRIPTION
Follow-up to #3667 (merged into this base at 63d9a3b). **The seam:** #3665 keeps the previous generation running — `ModuleActivationEntry.PreviousDirectory/PreviousVersion/PreviousFrameworkMvid`, `MeshBuilder.InstallModules` retrying with the previous generation and registering a `FallbackModule`, the module set's `RunningGenerations`/`FallbackGenerations` — but **writes nothing `ModuleUpdateDecision` reads**, so the `Land`-on-a-new-build branch #3667 added (an entry in fallback re-examining every new build of its version, policy rule R3) could never fire. This PR closes that seam.

## What changed

- **The boot that falls back writes the marker.** `ModuleLoadabilityRecorder` (PluginCatalog, hosted service) is registered by `ConfigureMemexMesh` beside the module-set adoption, for the store entries the loader was handed — the union *after* `ProjectOntoMeshSet`, so each entry's `Directory` is the generation actually tried. At start it reads the loader's `FallbackModule` / `IncompatibleModule` records back onto those generations (`ModuleActivationBoot.MeasureLoadability`, pure) and applies the verdict (`RecordMeasuredLoadability`): a head that did not load gets its module's marker file `activation.d/<Name>.unloadable` (generation, framework identity, refusal, time); a head that loaded has it deleted. Only transitions write, so a steady state costs nothing and replicas booting together write identical bytes or nothing. Not gated on the bake like the adoption: "these bytes do not load on this platform build" is true whatever the bake decides.
- **The reconcile reads it — and only while it is true.** `ModuleActivationSidecar.Read` attaches the marker's identity to the entry (`UnloadableFrameworkMvid`, now `[JsonIgnore]` — never part of the entry file) only while the entry still heads the generation the marker measured. A landing that moves the head on therefore retires a stale marker with **no write** (the sidecar rule of #2090: a create and a delete, never a read-modify-write of the entry a landing on another replica may be replacing). Uninstall clears it. `.unloadable`, not `.json`, so the entry enumeration never parses a marker as an entry and the bulk `Write` never sweeps one.
- **Why a marker and not `ModuleSetIndex.FallbackGenerations`.** `RecordAdoption` is create-if-absent per set: the adoption record freezes the *first* adopter's measurement and survives a platform roll unchanged, so after a roll onto an image where the head now loads it would still report the fallback — and the reconcile would keep calling a loadable head unloadable. The marker is re-measured by every boot. One source of truth for *this* question — the boot's measurement — kept where the decision reads it.

## The chain test

`ConfiguredModuleActivationTest.TheBootThatFallsBack_WritesTheMarkerTheReconcileReExamines_AndTheBootThatLoads_ClearsIt` (MeshWeaver.Compiler.Pipeline.Test), through the real landing, the real boot composition (its `Boot` harness now records the measurement exactly as the portal does) and the real decision:

1. a loadable generation (identity A) runs — no marker, served A ⇒ `SkipUpToDate`;
2. the **same version** built for a newer platform (identity B) is shelved over it ⇒ the boot refuses it, runs the previous one, **writes the marker** (generation, B, the missing type) ⇒ the entry reads back with `UnloadableFrameworkMvid == B`;
3. served C ⇒ **`Land`** (reason names B and C); served B ⇒ `SkipUnloadable` (never "already landed");
4. the build for this platform (C) lands ⇒ the old marker is **inert at once** (`UnloadableFrameworkMvid` null, served C ⇒ `SkipUpToDate`) without any write;
5. the boot loads C ⇒ no fallback, **marker cleared** ⇒ served C ⇒ `SkipUpToDate`, served A ⇒ `Land` (the ordinary identity rule again).

Plus `WhenNoGenerationLoadsHere_TheHeadIsStillMarkedUnloadable`, and `ModuleUnloadableMarkerTest` (Memex.Portal.Shared.Test) for the sidecar contract.

## Tests
All local, Debug, after `dotnet build`; the Release `-warnaserror` builds of `Memex.Portal.Shared`, `Memex.Portal.Shared.Test` and `MeshWeaver.Compiler.Pipeline.Test` are clean.

| project | filter | result |
|---|---|---|
| `MeshWeaver.Compiler.Pipeline.Test` | `ConfiguredModuleActivationTest` (incl. the two new cases) + `PlatformUpdateKeepsThePluginThenTakesTheRebuildTest` | **25 passed, 0 failed, 0 skipped** |
| `Memex.Portal.Shared.Test` | `ModuleUnloadableMarkerTest` (new ×6) + the ten classes #3667 reported (`ModuleUpdateIdentityTest`, `SelfUpdateVerdictTest`, `SelfUpdatePendingRestartTest`, `RegistryUpdateReconcilerTest`, `ModulePublishShelfTest`, `RegistryReconcileDeferralTest`, `SelfUpdateStrandRecoveryTest`, `ComboGateRollTest`, `SelfUpdateMigratesBeforeItRollsTest`, `ModuleFloorAdvisoryTest`) | **114 passed, 0 failed, 0 skipped** |
| `MeshWeaver.Documentation.Test` | `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest` | **2 passed, 0 failed** |

## Copilot on #3667
No review, line comment or issue comment was posted on #3667 (merged a minute after opening); nothing to address.

Implementers: none — no interface changed.

Pairs-with: none — additive.

Mirror-sync: none — no i18n key changed.

Stacked on #3661 (`fix/3648-module-floors-advisory`) — retarget to `main` after #3661 merges.

Closes #3650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
