### PR TITLE
fix(modules): the module-set reader opens only the deciding records — memex-cloud's stuck rollout (10-s health check over 687 set records)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -99,6 +99,20 @@ without coordinating: **the ordinally smallest `Id` wins**, and the conflict is 
 lost — a proposal is derived from the activation record, never from the previous proposal, so the
 next wave's sequence N+2 carries everything both replicas landed.
 
+**The reader decides from the NAMES and opens only what the decision needs.** Every record's name
+carries its sequence and set id (`<sequence:D9>-<id16>.proposed|adopted.json`), so one directory
+listing determines the newest proposal and the newest adopted set; `ModuleSetStore.Read` then opens
+the proposal files of those two sequences and the one adoption record — nothing else. 🚨 Measured
+on memex-cloud, 2026-09-08: 687 records had accumulated under `modules/sets` (the GC that prunes
+them had been fail-closing — see [GC must see the set](#gc-must-see-the-set)), the previous reader
+opened every one on every call, and on Azure Files that took 10 s — inside
+`pending_module_activation`, the health check the startup probe asks every 10 s with a 5 s
+timeout. No new pod could pass the probe; the 8059 rollout sat for hours on two ageing replicas and
+KEDA could add nothing. A record no decision depends on is neither read nor reported: a corrupt
+superseded record is `Prune`'s to remove, not the reader's to announce on every probe, and the
+conflict notice names only the sequences that were actually decided on (the historical
+"proposed by more than one replica" lines that used to repeat on every boot are gone).
+
 ## Boot — converge, don't serve your own
 
 `MemexConfiguration.ConfigureMemexMesh`, in order:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-portal-on-a-large-module-volume-can-roll-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-portal-on-a-large-module-volume-can-roll-again.md
@@ -1,0 +1,27 @@
+---
+Name: A portal on a large module volume can roll again
+Category: Fix
+Description: Reading which module set the mesh runs no longer opens every historical set record on the shared volume. On a portal whose volume had accumulated hundreds of superseded records, that read took ten seconds inside the health check the startup probe asks every ten seconds with a five-second limit, so no new pod could ever become ready and a rollout stayed stuck for hours.
+Icon: Checkmark
+Order: -20260908
+---
+
+# A portal on a large module volume can roll again
+
+On 2026-09-08 memex.meshweaver.cloud could not complete a rollout, and could not add a pod when
+load rose: every new pod failed its startup probe, while the two old pods kept serving. The
+migration had completed, the image was fine, and the same image was healthy on memex.systemorph.com.
+
+The difference was the shared module volume. Under `modules/sets` the portal keeps one small record
+per module-set proposal and adoption, and memex-cloud's volume had accumulated 687 of them, beside
+843 superseded module generations that a separate fault had kept the garbage collector from
+removing. The reader that answers "which set does the mesh run" opened every one of those records
+on every call — ten seconds on Azure Files — and a health check asks it on every startup probe,
+which allows five.
+
+The reader now decides from the record names, which carry the sequence and the set id, and opens
+only the records the decision needs: the newest proposal, the newest adopted proposal and its one
+adoption record. A record no decision depends on is neither read nor reported, so a duplicate
+proposal from months ago is no longer announced on every probe either; the conflict notice names
+only the sequences that were actually decided on. The result is the same index as before, from a
+handful of reads instead of hundreds.

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -226,12 +226,18 @@ public sealed class ModuleLandingService : IDisposable
         // the 2026-08-27 outage from the other side. Both retained sets count (the one the mesh is
         // on and the one it has proposed), and a set directory that cannot be read counts as a read
         // fault for the same fail-closed reason the entries do.
+        // 🚨 #3675: a record that could not be READ is a fault; a sequence that two replicas
+        // proposed is a NOTICE — decided deterministically, nothing lost. The store used to deliver
+        // both through one callback, so a single duplicate pair on the volume made this pass fail
+        // closed forever (memex-cloud, 2026-09-08: 100 such sequences, 687 records, 843 generation
+        // directories, never one reclaimed). Only the fault channel counts here.
         var setIndex = ModuleSetStore.Read(baseDirectory,
-            msg =>
+            onCorrupt: msg =>
             {
                 readFaults++;
                 logger?.LogError("{Message}", msg);
-            });
+            },
+            onNotice: msg => logger?.LogInformation("Modules GC: {Message}", msg));
         foreach (var generation in ModuleSetStore.ReferencedGenerations(setIndex))
             referenced.Add(generation);
         // Superseded set records are housekeeping like the rest of this pass — and only ever below
@@ -277,10 +283,10 @@ public sealed class ModuleLandingService : IDisposable
             {
                 if (!reportedUnreliable)
                     logger?.LogWarning(
-                        "Modules GC: {Faults} activation entry file(s) could not be read, so the "
-                        + "reference set is incomplete — SKIPPING every generation delete this pass "
-                        + "(unreadable is never unreferenced, #2509). A later pass re-reads and "
-                        + "sweeps.", readFaults);
+                        "Modules GC: {Faults} activation entry or set record file(s) could not be "
+                        + "read, so the reference set is incomplete — SKIPPING every generation "
+                        + "delete this pass (unreadable is never unreferenced, #2509). A later pass "
+                        + "re-reads and sweeps.", readFaults);
                 reportedUnreliable = true;
                 continue;
             }

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -220,6 +221,17 @@ public static class ModuleSetStore
     /// transient SMB fault must not take a portal down or silently collapse the mesh's module set
     /// to "none". A proposal that is skipped simply leaves an older one current, which is a set
     /// that was correct a moment ago.</para>
+    /// <para>🚨 <b>It decides from the NAMES and reads only what the decision needs.</b> Every record
+    /// this store writes is named <c>&lt;sequence:D9&gt;-&lt;id16&gt;.proposed|adopted.json</c>
+    /// (<see cref="PathOf"/>), so the newest proposal and the newest adopted set are determined
+    /// from one directory listing; only the proposal files of those two sequences and the one
+    /// adoption record are opened. Measured on memex-cloud (2026-09-08): 687 records under
+    /// <c>modules/sets</c> on Azure Files, and the previous read — every file, every call — took
+    /// 10 s per call, inside a health check probed every 10 s with a 5 s timeout: no new pod could
+    /// pass its startup probe, so a rollout stuck for hours on two ageing replicas. A record that
+    /// no decision depends on is neither read nor reported — a corrupt superseded record is
+    /// <see cref="Prune"/>'s to remove, not this reader's to announce on every probe; the
+    /// conflict report likewise names only the sequences that were actually decided on.</para>
     /// </summary>
     /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
     /// <param name="onCorrupt">The loud channel — one call per record that could not be read.</param>
@@ -243,74 +255,170 @@ public static class ModuleSetStore
             return ModuleSetIndex.Empty;
         }
 
-        var proposals = new List<ModuleSet>();
-        var adopted = new Dictionary<string, ModuleSetAdoption>(StringComparer.Ordinal);
+        // ── 1. Index by NAME — one listing, no file opened ──
+        // proposals: sequence → the proposal files written for it (one per proposing replica);
+        // adoptions: "{sequence}:{id16}" → the adoption file. A name this store never wrote is
+        // read as before (it cannot be placed on the index without its content).
+        var proposalFiles = new Dictionary<long, List<string>>();
+        var adoptionFiles = new Dictionary<string, string>(StringComparer.Ordinal);
+        var unnamedProposals = new List<string>();
+        var unnamedAdoptions = new List<string>();
         foreach (var file in files)
         {
-            if (file.EndsWith(ProposedSuffix, StringComparison.Ordinal))
+            var leaf = Path.GetFileName(file);
+            if (leaf.EndsWith(ProposedSuffix, StringComparison.Ordinal))
             {
-                if (TryRead<ModuleSet>(file, onCorrupt) is { } set && set.Generations is not null)
-                    // 🚨 The comparer does NOT survive the JSON round-trip — a deserialized
-                    // ImmutableSortedDictionary carries the DEFAULT ordinal one. Module identity is
-                    // case-insensitive everywhere else (the activation record, the loaded-assembly
-                    // set, MeshBuilder's probe), and a set that alone compared case-sensitively
-                    // would silently defer a module whose entry differs only in case — the same
-                    // name reading as two.
-                    proposals.Add(set with
-                    {
-                        Generations = set.Generations
-                            .WithComparers(StringComparer.OrdinalIgnoreCase),
-                    });
+                if (TryParseRecordName(leaf, ProposedSuffix, out var sequence, out _))
+                    (proposalFiles.TryGetValue(sequence, out var list) ? list : proposalFiles[sequence] = []).Add(file);
+                else
+                    unnamedProposals.Add(file);
             }
-            else if (file.EndsWith(AdoptedSuffix, StringComparison.Ordinal)
-                     && TryRead<ModuleSetAdoption>(file, onCorrupt) is { } adoption)
+            else if (leaf.EndsWith(AdoptedSuffix, StringComparison.Ordinal))
             {
-                // Create-if-absent means one record per set, so a second file for the same key
-                // is the same bytes; first read wins and nothing is lost.
-                adopted.TryAdd(Key(adoption.Sequence, adoption.Id), adoption with
-                {
-                    Generations = adoption.Generations?.WithComparers(StringComparer.OrdinalIgnoreCase),
-                });
+                if (TryParseRecordName(leaf, AdoptedSuffix, out var sequence, out var shortId))
+                    adoptionFiles.TryAdd(ShortKey(sequence, shortId), file);
+                else
+                    unnamedAdoptions.Add(file);
             }
         }
 
-        if (proposals.Count == 0)
+        // ── 2. Read the few records the decision needs ──
+        var proposals = new Dictionary<long, List<ModuleSet>>();
+        var read = new HashSet<long>();
+        void ReadProposalsAt(long sequence)
+        {
+            if (!read.Add(sequence) || !proposalFiles.TryGetValue(sequence, out var atSequence))
+                return;
+            foreach (var file in atSequence)
+                if (TryRead<ModuleSet>(file, onCorrupt) is { } set && set.Generations is not null)
+                    Add(proposals, sequence, WithCaseInsensitiveGenerations(set));
+        }
+        // A hand-placed or foreign-named record keeps the old contract: read, then indexed by content.
+        foreach (var file in unnamedProposals)
+            if (TryRead<ModuleSet>(file, onCorrupt) is { } set && set.Generations is not null)
+            {
+                Add(proposals, set.Sequence, WithCaseInsensitiveGenerations(set));
+                read.Add(set.Sequence);
+            }
+        var unnamedAdopted = new Dictionary<string, ModuleSetAdoption>(StringComparer.Ordinal);
+        foreach (var file in unnamedAdoptions)
+            if (TryRead<ModuleSetAdoption>(file, onCorrupt) is { } foreign)
+                unnamedAdopted.TryAdd(Key(foreign.Sequence, foreign.Id), foreign with
+                {
+                    Generations = foreign.Generations?.WithComparers(StringComparer.OrdinalIgnoreCase),
+                });
+
+        // The newest proposal: the highest sequence whose records can be read. A sequence whose
+        // every file is corrupt is reported (it was opened) and the next one down decides — exactly
+        // what reading everything answered, minus the records nothing depended on.
+        ModuleSet? newest = null;
+        foreach (var sequence in proposalFiles.Keys.Concat(proposals.Keys).Distinct().OrderByDescending(s => s))
+        {
+            ReadProposalsAt(sequence);
+            if (WinnerAt(proposals, sequence) is { } winner)
+            {
+                newest = winner;
+                break;
+            }
+        }
+        if (newest is null)
             return ModuleSetIndex.Empty;
 
-        // 🚨 Deterministic conflict resolution. Two replicas can complete a wave at the same
-        // moment and each write sequence N+1; both files survive (nothing is ever renamed over).
-        // Every reader must then pick the SAME one without talking to anyone, so the tie-break is
-        // the ordinally smallest content id. The loser is not lost: the proposal is derived from
-        // the activation record, so the next wave's sequence N+2 carries everything both landed.
-        var bySequence = proposals
-            .GroupBy(p => p.Sequence)
-            .ToDictionary(
-                g => g.Key,
-                g => g.OrderBy(p => p.Id, StringComparer.Ordinal).First());
+        // The current set: the highest sequence that has BOTH a proposal and an adoption record
+        // for the same id. The name index answers which sequences qualify; only their records are
+        // read, highest first, until one reads consistently (a corrupt adoption falls through to the
+        // next adopted sequence, as it always did).
+        ModuleSet? current = null;
+        ModuleSetAdoption? adoption = null;
+        var adoptedSequences = proposalFiles
+            .Where(kv => kv.Value.Any(file =>
+                TryParseRecordName(Path.GetFileName(file), ProposedSuffix, out _, out var shortId)
+                && adoptionFiles.ContainsKey(ShortKey(kv.Key, shortId))))
+            .Select(kv => kv.Key)
+            .Concat(unnamedAdopted.Values.Select(a => a.Sequence))
+            .Distinct()
+            .OrderByDescending(s => s);
+        foreach (var sequence in adoptedSequences)
+        {
+            ReadProposalsAt(sequence);
+            if (WinnerAt(proposals, sequence) is not { } winner)
+                continue;
+            var candidate = unnamedAdopted.GetValueOrDefault(Key(winner.Sequence, winner.Id));
+            if (candidate is null
+                && adoptionFiles.TryGetValue(ShortKey(winner.Sequence, ShortId(winner.Id)), out var adoptionFile)
+                && TryRead<ModuleSetAdoption>(adoptionFile, onCorrupt) is { } readAdoption
+                && string.Equals(readAdoption.Id, winner.Id, StringComparison.Ordinal))
+                candidate = readAdoption with
+                {
+                    Generations = readAdoption.Generations?.WithComparers(StringComparer.OrdinalIgnoreCase),
+                };
+            if (candidate is null)
+                continue;
+            current = winner;
+            adoption = candidate;
+            break;
+        }
+
+        // 🚨 Deterministic conflict resolution, reported for the sequences this read decided on.
+        // Two replicas can complete a wave at the same moment and each write sequence N+1; both
+        // files survive (nothing is ever renamed over). Every reader picks the SAME one without
+        // talking to anyone — the ordinally smallest content id — and the loser is not lost: the
+        // proposal is derived from the activation record, so the next wave carries everything both
+        // landed. A conflict on a sequence nothing decides on any more is history, not a finding.
         var conflicts = proposals
-            .GroupBy(p => p.Sequence)
-            .Where(g => g.Select(p => p.Id).Distinct(StringComparer.Ordinal).Count() > 1)
-            .Select(g => g.Key)
+            .Where(kv => kv.Value.Select(p => p.Id).Distinct(StringComparer.Ordinal).Count() > 1)
+            .Select(kv => kv.Key)
             .OrderBy(x => x)
             .ToImmutableList();
         foreach (var sequence in conflicts)
             onCorrupt?.Invoke(
                 $"Module set sequence {sequence} was proposed by more than one replica — the "
-                + $"ordinally smallest id wins ('{bySequence[sequence].Id}'), and the next landing "
+                + $"ordinally smallest id wins ('{WinnerAt(proposals, sequence)!.Id}'), and the next landing "
                 + "wave folds every landing back in. No module is lost; the mesh runs one set.");
 
-        var newest = bySequence.Values.OrderByDescending(p => p.Sequence).First();
-        var current = bySequence.Values
-            .Where(p => adopted.ContainsKey(Key(p.Sequence, p.Id)))
-            .OrderByDescending(p => p.Sequence)
-            .FirstOrDefault();
         // #3649 — what the adopting replica RAN. An adoption written before the field existed
         // carries no generations, and then the set's own are the best anyone recorded.
-        var running = current is null
+        var running = current is null || adoption is null
             ? ImmutableSortedDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase)
-            : adopted[Key(current.Sequence, current.Id)].Generations ?? current.Generations;
+            : adoption.Generations ?? current.Generations;
         return new ModuleSetIndex(newest, current, conflicts) { RunningGenerations = running };
     }
+
+    /// <summary>Parses a record name this store wrote — <c>&lt;sequence:D9&gt;-&lt;id16&gt;&lt;suffix&gt;</c>.</summary>
+    private static bool TryParseRecordName(string leaf, string suffix, out long sequence, out string shortId)
+    {
+        sequence = 0;
+        shortId = string.Empty;
+        if (!leaf.EndsWith(suffix, StringComparison.Ordinal))
+            return false;
+        var stem = leaf[..^suffix.Length];
+        var dash = stem.IndexOf('-');
+        if (dash <= 0 || dash == stem.Length - 1)
+            return false;
+        if (!long.TryParse(stem[..dash], NumberStyles.None, CultureInfo.InvariantCulture, out sequence))
+            return false;
+        shortId = stem[(dash + 1)..];
+        return true;
+    }
+
+    private static string ShortKey(long sequence, string shortId) => $"{sequence}:{shortId}";
+
+    private static void Add(Dictionary<long, List<ModuleSet>> proposals, long sequence, ModuleSet set)
+        => (proposals.TryGetValue(sequence, out var list) ? list : proposals[sequence] = []).Add(set);
+
+    /// <summary>The proposal that wins <paramref name="sequence"/>: the ordinally smallest id.</summary>
+    private static ModuleSet? WinnerAt(Dictionary<long, List<ModuleSet>> proposals, long sequence)
+        => proposals.TryGetValue(sequence, out var at) && at.Count > 0
+            ? at.OrderBy(p => p.Id, StringComparer.Ordinal).First()
+            : null;
+
+    // 🚨 The comparer does NOT survive the JSON round-trip — a deserialized ImmutableSortedDictionary
+    // carries the DEFAULT ordinal one. Module identity is case-insensitive everywhere else (the
+    // activation record, the loaded-assembly set, MeshBuilder's probe), and a set that alone
+    // compared case-sensitively would silently defer a module whose entry differs only in case —
+    // the same name reading as two.
+    private static ModuleSet WithCaseInsensitiveGenerations(ModuleSet set)
+        => set with { Generations = set.Generations.WithComparers(StringComparer.OrdinalIgnoreCase) };
 
     /// <summary>
     /// Proposes the set the deployment's activation record currently describes — the coordination

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -234,8 +234,31 @@ public static class ModuleSetStore
     /// conflict report likewise names only the sequences that were actually decided on.</para>
     /// </summary>
     /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
-    /// <param name="onCorrupt">The loud channel — one call per record that could not be read.</param>
-    public static ModuleSetIndex Read(string baseDirectory, Action<string>? onCorrupt = null)
+    /// <param name="onCorrupt">The loud channel — one call per record that could not be read. This
+    /// overload also routes the duplicate-proposal NOTICE here, which is what every caller saw
+    /// before #3675; a caller that must tell the two apart passes <c>onNotice</c> on the
+    /// three-argument overload.</param>
+    public static ModuleSetIndex Read(string baseDirectory, Action<string>? onCorrupt = null) =>
+        Read(baseDirectory, onCorrupt, onNotice: onCorrupt);
+
+    /// <summary>
+    /// <see cref="Read(string, Action{string})"/> with the NOTICE channel separate from the FAULT
+    /// channel (#3675). "Sequence N was proposed by more than one replica" is a decided outcome —
+    /// the ordinally smallest id wins, every reader picks the same one, nothing is lost — and not a
+    /// record that could not be read. Delivering it through <paramref name="onCorrupt"/> made the
+    /// modules GC count it as a read fault and fail closed on EVERY pass for as long as one such pair
+    /// existed on the volume: measured on memex-cloud 2026-09-08 — 100 duplicate sequences, 687 set
+    /// records and 843 generation directories that no pass ever reclaimed, and a <c>/health</c>
+    /// probe reading all 687 records in 9–10 s on Azure Files (over its 5 s timeout), which is what
+    /// kept every new pod from passing its startup probe.
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
+    /// <param name="onCorrupt">The loud channel — one call per record (or the directory) that could
+    /// not be read. A caller that fails closed on incomplete knowledge counts THESE.</param>
+    /// <param name="onNotice">The informational channel — one call per sequence that more than one
+    /// replica proposed, naming the winner. Never a reason to distrust the index.</param>
+    public static ModuleSetIndex Read(
+        string baseDirectory, Action<string>? onCorrupt, Action<string>? onNotice)
     {
         var directory = SetsDirectory(baseDirectory);
         string[] files;
@@ -371,7 +394,7 @@ public static class ModuleSetStore
             .OrderBy(x => x)
             .ToImmutableList();
         foreach (var sequence in conflicts)
-            onCorrupt?.Invoke(
+            onNotice?.Invoke(
                 $"Module set sequence {sequence} was proposed by more than one replica — the "
                 + $"ordinally smallest id wins ('{WinnerAt(proposals, sequence)!.Id}'), and the next landing "
                 + "wave folds every landing back in. No module is lost; the mesh runs one set.");
@@ -530,7 +553,7 @@ public static class ModuleSetStore
     /// while a wave's landings wait to be proposed, so that generation is unreferenced by the
     /// entries alone — and GC would reclaim the very bytes every replica is running.</para>
     /// </summary>
-    /// <param name="index">The set index, as <see cref="Read"/> answered it.</param>
+    /// <param name="index">The set index, as <see cref="Read(string, Action{string})"/> answered it.</param>
     public static IReadOnlySet<string> ReferencedGenerations(ModuleSetIndex? index)
     {
         var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -572,7 +595,7 @@ public static class ModuleSetStore
     /// <summary>
     /// Removes set records the mesh has moved past — everything below <paramref name="keepFrom"/>.
     /// One tiny file per record, but a deployment that lands weekly for a year accumulates
-    /// hundreds, and <see cref="Read"/> is on the BOOT path.
+    /// hundreds, and <see cref="Read(string, Action{string})"/> is on the BOOT path.
     ///
     /// <para>🚨 A record below the CURRENT set references generations nothing the mesh runs
     /// resolves against — and a process still on one of them loaded from its own pinned copy

--- a/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
@@ -228,6 +228,92 @@ public class ModuleSetConvergenceTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 #3675: a sequence two replicas proposed is a decided outcome, not a record that could not
+    /// be read. The three-argument <see cref="ModuleSetStore.Read(string, Action{string}, Action{string})"/>
+    /// keeps the two apart — the notice never reaches the fault channel — while the two-argument
+    /// overload still surfaces it to every caller that read it there before (the health report's
+    /// notes, the boot log), so nothing that used to be said falls silent.
+    /// </summary>
+    [Fact]
+    public async Task ADuplicateProposal_IsANotice_NeverAFault()
+    {
+        await LandWave(ModuleA);
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+
+        var faults = new List<string>();
+        var notices = new List<string>();
+        var index = ModuleSetStore.Read(root, faults.Add, notices.Add);
+
+        Assert.Empty(faults);
+        Assert.Contains(notices, m => m.Contains("proposed by more than one replica"));
+        Assert.Equal([rival.Sequence], index.ConflictingSequences);
+
+        // Compatibility: the two-argument overload still says it, where every caller heard it.
+        var reported = new List<string>();
+        ModuleSetStore.Read(root, reported.Add);
+        Assert.Contains(reported, m => m.Contains("proposed by more than one replica"));
+
+        // And a record that genuinely cannot be read IS a fault, on the three-argument overload too.
+        // At the NEWEST sequence, so it is a record the reader has to open (#3676 opens only the
+        // deciding records; an unreadable one below them is not consulted and not a fault).
+        var garbage = Path.Combine(ModuleSetStore.SetsDirectory(root), $"{rival.Sequence + 1:D9}-garbage000000000.proposed.json");
+        File.WriteAllText(garbage, "{ not json");
+        faults.Clear();
+        ModuleSetStore.Read(root, faults.Add, notices.Add);
+        Assert.Contains(faults, m => m.Contains("garbage000000000"));
+    }
+
+    /// <summary>
+    /// 🚨 #3675, the consequence that mattered: the GC used to count the duplicate-proposal notice as
+    /// a read fault and fail closed on EVERY pass for as long as one such pair existed — on
+    /// memex-cloud, 100 duplicate sequences kept 687 set records and 843 generation directories
+    /// alive that no pass ever reclaimed, and reading that pile is what put the /health probe over
+    /// its timeout. With a duplicate pair on the volume the sweep must still prune the records
+    /// below the current set and still reclaim an orphan generation — and a record that really
+    /// cannot be read must still stop it (#2509 is untouched).
+    /// </summary>
+    [Fact]
+    public async Task GarbageCollection_StillSweepsWithADuplicateProposalOnTheVolume()
+    {
+        await LandWave(ModuleA);
+        BootReplica();                                   // sequence 1 adopted — the mesh is on it
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+        BootReplica();                                   // the winner at sequence 2 is adopted
+        var current = ModuleSetStore.Read(root).Current!.Sequence;
+        Assert.Equal(rival.Sequence, current);
+
+        var orphan = Path.Combine(root, "modules", "MeshWeaver.Orphan@deadbeef");
+        Directory.CreateDirectory(orphan);
+        File.WriteAllText(Path.Combine(orphan, "MeshWeaver.Orphan.dll"), "not a module");
+        var below = SetRecordsBelow(current);
+        Assert.NotEmpty(below);
+
+        ModuleLandingService.CollectGarbage(root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+
+        Assert.False(Directory.Exists(orphan), "an unreferenced generation survived a pass that had nothing unreadable to fail closed on");
+        Assert.Empty(SetRecordsBelow(current));
+        Assert.Equal(2, ProposalIds(current).Count);   // the duplicate pair itself is never the one removed
+
+        // #2509 still holds: one record that cannot be read, and the pass reclaims nothing.
+        Directory.CreateDirectory(orphan);
+        File.WriteAllText(Path.Combine(orphan, "MeshWeaver.Orphan.dll"), "not a module");
+        File.WriteAllText(Path.Combine(ModuleSetStore.SetsDirectory(root), $"{current + 1:D9}-garbage000000000.proposed.json"), "{ not json");
+        ModuleLandingService.CollectGarbage(root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+        Assert.True(Directory.Exists(orphan), "a pass with an unreadable set record must not reclaim anything");
+    }
+
+    private IReadOnlyList<string> SetRecordsBelow(long sequence) =>
+        [.. Directory.EnumerateFiles(ModuleSetStore.SetsDirectory(root), "*.json")
+            .Select(f => Path.GetFileName(f))
+            .Where(f => long.TryParse(f[..f.IndexOf('-')], out var seq) && seq < sequence)];
+
+    /// <summary>
     /// 🚨 The generations the mesh's set PINS are referenced even when the activation entries have
     /// moved past them — otherwise the convergence would re-open the 2026-08-27 outage from the
     /// other side, with GC reclaiming the very bytes every replica is executing.

--- a/test/Memex.Portal.Shared.Test/ModuleSetStoreReadsOnlyDecidingRecordsTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetStoreReadsOnlyDecidingRecordsTest.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// <see cref="ModuleSetStore.Read"/> decides from the record NAMES and opens only the records the
+/// decision needs. Measured on memex-cloud, 2026-09-08: 687 set records under <c>modules/sets</c>
+/// on Azure Files, every one read on every call, 10 s per call — inside a health check that the
+/// startup probe asks every 10 s with a 5 s timeout. No new pod could pass the probe, so the 8059
+/// rollout sat for hours on two ageing replicas and KEDA could add nothing.
+///
+/// <para>Each test here plants records that the OLD reader would have opened and the new one must
+/// not: a corrupt superseded proposal is the falsifier — reading it reports it, and the assertion
+/// is that nothing is reported. The records are written in the store's own on-disk shape
+/// (<c>&lt;sequence:D9&gt;-&lt;id16&gt;.proposed.json</c>, web-cased JSON) so the reader is measured
+/// against the format it will meet on a volume, not against a mock.</para>
+/// </summary>
+public sealed class ModuleSetStoreReadsOnlyDecidingRecordsTest : IDisposable
+{
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-setstore-read-" + Guid.NewGuid().ToString("N"));
+
+    public ModuleSetStoreReadsOnlyDecidingRecordsTest()
+    {
+        Directory.CreateDirectory(ModuleSetStore.SetsDirectory(root));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    private static ModuleSet Set(long sequence, string idSeed, string generation = "g")
+        => new(
+            sequence,
+            Id: Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(idSeed))),
+            Generations: ImmutableSortedDictionary<string, string>.Empty
+                .WithComparers(StringComparer.OrdinalIgnoreCase)
+                .Add("MeshWeaver.Speech", generation + sequence.ToString("D4")),
+            ProposedAtUtc: new DateTime(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc).AddSeconds(sequence),
+            ProposedBy: "replica-" + idSeed);
+
+    /// <summary>Writes a proposal exactly where and how the store writes one.</summary>
+    private string WriteProposal(ModuleSet set, string? fileNameOverride = null)
+    {
+        var name = fileNameOverride ?? (set.Sequence.ToString("D9") + "-" + set.Id[..16] + ".proposed.json");
+        var path = Path.Combine(ModuleSetStore.SetsDirectory(root), name);
+        File.WriteAllText(path, JsonSerializer.Serialize(set, Web));
+        return path;
+    }
+
+    private static void Corrupt(string path) => File.WriteAllText(path, "{");
+
+    [Fact]
+    public void ACorruptSupersededRecordIsNeverOpened_SoItIsNeverReported()
+    {
+        // 300 sequences, one proposal each; the one before the newest is the adopted (current) set.
+        var files = new Dictionary<long, string>();
+        for (var sequence = 1L; sequence <= 300; sequence++)
+            files[sequence] = WriteProposal(Set(sequence, "seed-" + sequence));
+        var adopted = Set(299, "seed-299");
+        ModuleSetStore.RecordAdoption(root, adopted, adopted.Generations, "replica-x");
+
+        // Every record no decision depends on is made unreadable. The old reader opened all of
+        // them and reported each; this reader must not touch a single one.
+        foreach (var (sequence, path) in files)
+            if (sequence < 299)
+                Corrupt(path);
+
+        var reported = new List<string>();
+        var index = ModuleSetStore.Read(root, reported.Add);
+
+        Assert.Empty(reported);
+        Assert.Equal(300, index.Proposed!.Sequence);
+        Assert.Equal(299, index.Current!.Sequence);
+        Assert.Equal(adopted.Id, index.Current.Id);
+        Assert.Equal("g0299", index.RunningGenerations["meshweaver.speech"]);
+        Assert.True(index.ConvergencePending);
+    }
+
+    [Fact]
+    public void ConflictsAreReportedOnlyForTheSequencesDecidedOn()
+    {
+        // Two replicas proposed sequence 100 (history) and two proposed sequence 300 (the newest).
+        WriteProposal(Set(100, "a-100"));
+        WriteProposal(Set(100, "b-100"));
+        for (var sequence = 101L; sequence < 300; sequence++)
+            WriteProposal(Set(sequence, "seed-" + sequence));
+        var alpha = Set(300, "a-300");
+        var beta = Set(300, "b-300");
+        WriteProposal(alpha);
+        WriteProposal(beta);
+
+        var reported = new List<string>();
+        var index = ModuleSetStore.Read(root, reported.Add);
+
+        Assert.Equal([300L], index.ConflictingSequences);
+        var winner = string.CompareOrdinal(alpha.Id, beta.Id) < 0 ? alpha : beta;
+        Assert.Equal(winner.Id, index.Proposed!.Id);
+        var notice = Assert.Single(reported);
+        Assert.Contains("sequence 300", notice);
+        Assert.DoesNotContain("sequence 100", notice);
+    }
+
+    [Fact]
+    public void ANewestSequenceThatCannotBeRead_FallsToTheNextReadableOne_AndReportsExactlyThat()
+    {
+        for (var sequence = 1L; sequence <= 299; sequence++)
+            WriteProposal(Set(sequence, "seed-" + sequence));
+        var broken = WriteProposal(Set(300, "seed-300"));
+        Corrupt(broken);
+
+        var reported = new List<string>();
+        var index = ModuleSetStore.Read(root, reported.Add);
+
+        Assert.Equal(299, index.Proposed!.Sequence);
+        var fault = Assert.Single(reported);
+        Assert.Contains(Path.GetFileName(broken), fault);
+    }
+
+    [Fact]
+    public void ACorruptAdoptionFallsThroughToTheNextAdoptedSequence()
+    {
+        for (var sequence = 1L; sequence <= 300; sequence++)
+            WriteProposal(Set(sequence, "seed-" + sequence));
+        var older = Set(250, "seed-250");
+        var newer = Set(299, "seed-299");
+        ModuleSetStore.RecordAdoption(root, older, older.Generations, "replica-x");
+        ModuleSetStore.RecordAdoption(root, newer, newer.Generations, "replica-y");
+        var newerAdoption = Directory
+            .EnumerateFiles(ModuleSetStore.SetsDirectory(root), "000000299-*.adopted.json")
+            .Single();
+        Corrupt(newerAdoption);
+
+        var reported = new List<string>();
+        var index = ModuleSetStore.Read(root, reported.Add);
+
+        Assert.Equal(300, index.Proposed!.Sequence);
+        Assert.Equal(250, index.Current!.Sequence);
+        Assert.Equal("g0250", index.RunningGenerations["MeshWeaver.Speech"]);
+        var fault = Assert.Single(reported);
+        Assert.Contains(Path.GetFileName(newerAdoption), fault);
+    }
+
+    [Fact]
+    public void ARecordUnderAForeignName_IsStillRead()
+    {
+        for (var sequence = 1L; sequence <= 10; sequence++)
+            WriteProposal(Set(sequence, "seed-" + sequence));
+        // Not a name this store ever writes — placed by hand, it still counts, by its content.
+        WriteProposal(Set(400, "hand-placed"), fileNameOverride: "hand-placed.proposed.json");
+
+        var index = ModuleSetStore.Read(root);
+
+        Assert.Equal(400, index.Proposed!.Sequence);
+    }
+
+    [Fact]
+    public void AnEmptyStore_ReadsAsEmpty()
+    {
+        Assert.Same(ModuleSetIndex.Empty, ModuleSetStore.Read(root));
+    }
+}


### PR DESCRIPTION
## The incident this fixes (memex-cloud, 2026-09-08 00:23Z → )

The 8059 rollout on memex.meshweaver.cloud never completed: the new pod failed its **startup probe** (`/health`, `timeoutSeconds: 5`) for hours, and so did every other new pod — the 8055 replicas KEDA tried to add included. The migration had completed (`Version: 55` in 2:43), the image was fine, and the same image was Ready on memex.systemorph.com. Measured in the pods:

| | memex-cloud | memex |
|---|---|---|
| `Health check pending_module_activation … completed after` | **9.3–10.4 s**, every call | 0.7–1.2 s |
| `modules/sets` records | **687** | 38 |
| `find /data/modules -type f` | 42,720 (843 generation dirs, 22 per module) | 3,172 |
| `cat modules/sets/*` | **10 s** (Azure Files) | — |

`PendingModuleActivations.Read()` runs on every probe and calls `ModuleSetStore.Read`, which opened **every** `modules/sets/*.json` on every call. The pile exists because the GC that prunes set records and superseded generations has been fail-closing on the reader's own "proposed by more than one replica" notices (education-34's finding, the follow-up PR on top of this one). Two serving pods from 22:20Z carried the portal; nothing could replace or join them.

## The change

`ModuleSetStore.Read` decides from the record **names** — every record this store writes is `<sequence:D9>-<id16>.proposed|adopted.json` (`PathOf`) — and opens only what the decision needs: the proposal files of the newest sequence, the proposal files of the newest *adopted* sequence, and that one adoption record (walking down on a corrupt record, exactly as reading everything answered). Same `ModuleSetIndex` — `Proposed`, `Current`, `ConflictingSequences`, `RunningGenerations` — from a handful of reads instead of hundreds; the signature is unchanged. A record no decision depends on is neither read nor reported: a corrupt superseded record is `Prune`'s to remove, and the conflict notice names only the sequences actually decided on (the historical "sequence 319/322/…/339 was proposed by more than one replica" lines that repeated on every boot stop). A record under a name this store never wrote is still read, by content.

Doc: the reading rule and the measurement on `Doc/Architecture/ModuleSetConvergence`. What's New (Fix): `2026-09-08-a-portal-on-a-large-module-volume-can-roll-again`.

## Verification

- `ModuleSetStoreReadsOnlyDecidingRecordsTest` (6): 300 sequences with the 298 superseded proposals **corrupted on disk** — the reader reports nothing and answers newest 300 / current 299 with the adoption's running generations; conflicts reported only for the decided sequence (a duplicate pair at 100 is silent, the pair at 300 is not); a newest sequence that cannot be read falls to the next readable one and reports exactly that file; a corrupt adoption falls through to the next adopted sequence; a hand-placed record under a foreign name is still read; an empty store reads as `Empty`.
- **Control:** the same test class against `main`'s reader — 2 of 6 fail (the corrupt-superseded and the conflicts-only cases), the other 4 pin unchanged semantics on both.
- Regression: `ModuleSetConvergenceTest`, `ConfiguredModuleActivationTest`, `PlatformUpdateKeepsThePluginThenTakesTheRebuildTest` — `ModuleSetConvergenceTest` 10/10, `Compiler.Pipeline.Test` set-store consumers 25/25, the whole `Memex.Portal.Shared.Test` 1073/1073 (2 m 5 s); `DocumentationLinkIntegrityTest` + What's New shape 2/2; every project built `-c Release -warnaserror`.

Pairs-with: none — no public type or member removed; the only public signature touched (`Read`) is unchanged.
Implementers: none — no interface member added.
