### PR TITLE
fix(#3675): a duplicate module-set proposal is a notice, and the modules GC counts only faults

### DIFF
--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -226,12 +226,18 @@ public sealed class ModuleLandingService : IDisposable
         // the 2026-08-27 outage from the other side. Both retained sets count (the one the mesh is
         // on and the one it has proposed), and a set directory that cannot be read counts as a read
         // fault for the same fail-closed reason the entries do.
+        // 🚨 #3675: a record that could not be READ is a fault; a sequence that two replicas
+        // proposed is a NOTICE — decided deterministically, nothing lost. The store used to deliver
+        // both through one callback, so a single duplicate pair on the volume made this pass fail
+        // closed forever (memex-cloud, 2026-09-08: 100 such sequences, 687 records, 843 generation
+        // directories, never one reclaimed). Only the fault channel counts here.
         var setIndex = ModuleSetStore.Read(baseDirectory,
-            msg =>
+            onCorrupt: msg =>
             {
                 readFaults++;
                 logger?.LogError("{Message}", msg);
-            });
+            },
+            onNotice: msg => logger?.LogInformation("Modules GC: {Message}", msg));
         foreach (var generation in ModuleSetStore.ReferencedGenerations(setIndex))
             referenced.Add(generation);
         // Superseded set records are housekeeping like the rest of this pass — and only ever below
@@ -277,10 +283,10 @@ public sealed class ModuleLandingService : IDisposable
             {
                 if (!reportedUnreliable)
                     logger?.LogWarning(
-                        "Modules GC: {Faults} activation entry file(s) could not be read, so the "
-                        + "reference set is incomplete — SKIPPING every generation delete this pass "
-                        + "(unreadable is never unreferenced, #2509). A later pass re-reads and "
-                        + "sweeps.", readFaults);
+                        "Modules GC: {Faults} activation entry or set record file(s) could not be "
+                        + "read, so the reference set is incomplete — SKIPPING every generation "
+                        + "delete this pass (unreadable is never unreferenced, #2509). A later pass "
+                        + "re-reads and sweeps.", readFaults);
                 reportedUnreliable = true;
                 continue;
             }

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -234,8 +234,31 @@ public static class ModuleSetStore
     /// conflict report likewise names only the sequences that were actually decided on.</para>
     /// </summary>
     /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
-    /// <param name="onCorrupt">The loud channel — one call per record that could not be read.</param>
-    public static ModuleSetIndex Read(string baseDirectory, Action<string>? onCorrupt = null)
+    /// <param name="onCorrupt">The loud channel — one call per record that could not be read. This
+    /// overload also routes the duplicate-proposal NOTICE here, which is what every caller saw
+    /// before #3675; a caller that must tell the two apart passes <c>onNotice</c> on the
+    /// three-argument overload.</param>
+    public static ModuleSetIndex Read(string baseDirectory, Action<string>? onCorrupt = null) =>
+        Read(baseDirectory, onCorrupt, onNotice: onCorrupt);
+
+    /// <summary>
+    /// <see cref="Read(string, Action{string})"/> with the NOTICE channel separate from the FAULT
+    /// channel (#3675). "Sequence N was proposed by more than one replica" is a decided outcome —
+    /// the ordinally smallest id wins, every reader picks the same one, nothing is lost — and not a
+    /// record that could not be read. Delivering it through <paramref name="onCorrupt"/> made the
+    /// modules GC count it as a read fault and fail closed on EVERY pass for as long as one such pair
+    /// existed on the volume: measured on memex-cloud 2026-09-08 — 100 duplicate sequences, 687 set
+    /// records and 843 generation directories that no pass ever reclaimed, and a <c>/health</c>
+    /// probe reading all 687 records in 9–10 s on Azure Files (over its 5 s timeout), which is what
+    /// kept every new pod from passing its startup probe.
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
+    /// <param name="onCorrupt">The loud channel — one call per record (or the directory) that could
+    /// not be read. A caller that fails closed on incomplete knowledge counts THESE.</param>
+    /// <param name="onNotice">The informational channel — one call per sequence that more than one
+    /// replica proposed, naming the winner. Never a reason to distrust the index.</param>
+    public static ModuleSetIndex Read(
+        string baseDirectory, Action<string>? onCorrupt, Action<string>? onNotice)
     {
         var directory = SetsDirectory(baseDirectory);
         string[] files;
@@ -371,7 +394,7 @@ public static class ModuleSetStore
             .OrderBy(x => x)
             .ToImmutableList();
         foreach (var sequence in conflicts)
-            onCorrupt?.Invoke(
+            onNotice?.Invoke(
                 $"Module set sequence {sequence} was proposed by more than one replica — the "
                 + $"ordinally smallest id wins ('{WinnerAt(proposals, sequence)!.Id}'), and the next landing "
                 + "wave folds every landing back in. No module is lost; the mesh runs one set.");
@@ -530,7 +553,7 @@ public static class ModuleSetStore
     /// while a wave's landings wait to be proposed, so that generation is unreferenced by the
     /// entries alone — and GC would reclaim the very bytes every replica is running.</para>
     /// </summary>
-    /// <param name="index">The set index, as <see cref="Read"/> answered it.</param>
+    /// <param name="index">The set index, as <see cref="Read(string, Action{string})"/> answered it.</param>
     public static IReadOnlySet<string> ReferencedGenerations(ModuleSetIndex? index)
     {
         var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -572,7 +595,7 @@ public static class ModuleSetStore
     /// <summary>
     /// Removes set records the mesh has moved past — everything below <paramref name="keepFrom"/>.
     /// One tiny file per record, but a deployment that lands weekly for a year accumulates
-    /// hundreds, and <see cref="Read"/> is on the BOOT path.
+    /// hundreds, and <see cref="Read(string, Action{string})"/> is on the BOOT path.
     ///
     /// <para>🚨 A record below the CURRENT set references generations nothing the mesh runs
     /// resolves against — and a process still on one of them loaded from its own pinned copy

--- a/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
@@ -228,6 +228,92 @@ public class ModuleSetConvergenceTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 #3675: a sequence two replicas proposed is a decided outcome, not a record that could not
+    /// be read. The three-argument <see cref="ModuleSetStore.Read(string, Action{string}, Action{string})"/>
+    /// keeps the two apart — the notice never reaches the fault channel — while the two-argument
+    /// overload still surfaces it to every caller that read it there before (the health report's
+    /// notes, the boot log), so nothing that used to be said falls silent.
+    /// </summary>
+    [Fact]
+    public async Task ADuplicateProposal_IsANotice_NeverAFault()
+    {
+        await LandWave(ModuleA);
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+
+        var faults = new List<string>();
+        var notices = new List<string>();
+        var index = ModuleSetStore.Read(root, faults.Add, notices.Add);
+
+        Assert.Empty(faults);
+        Assert.Contains(notices, m => m.Contains("proposed by more than one replica"));
+        Assert.Equal([rival.Sequence], index.ConflictingSequences);
+
+        // Compatibility: the two-argument overload still says it, where every caller heard it.
+        var reported = new List<string>();
+        ModuleSetStore.Read(root, reported.Add);
+        Assert.Contains(reported, m => m.Contains("proposed by more than one replica"));
+
+        // And a record that genuinely cannot be read IS a fault, on the three-argument overload too.
+        // At the NEWEST sequence, so it is a record the reader has to open (#3676 opens only the
+        // deciding records; an unreadable one below them is not consulted and not a fault).
+        var garbage = Path.Combine(ModuleSetStore.SetsDirectory(root), $"{rival.Sequence + 1:D9}-garbage000000000.proposed.json");
+        File.WriteAllText(garbage, "{ not json");
+        faults.Clear();
+        ModuleSetStore.Read(root, faults.Add, notices.Add);
+        Assert.Contains(faults, m => m.Contains("garbage000000000"));
+    }
+
+    /// <summary>
+    /// 🚨 #3675, the consequence that mattered: the GC used to count the duplicate-proposal notice as
+    /// a read fault and fail closed on EVERY pass for as long as one such pair existed — on
+    /// memex-cloud, 100 duplicate sequences kept 687 set records and 843 generation directories
+    /// alive that no pass ever reclaimed, and reading that pile is what put the /health probe over
+    /// its timeout. With a duplicate pair on the volume the sweep must still prune the records
+    /// below the current set and still reclaim an orphan generation — and a record that really
+    /// cannot be read must still stop it (#2509 is untouched).
+    /// </summary>
+    [Fact]
+    public async Task GarbageCollection_StillSweepsWithADuplicateProposalOnTheVolume()
+    {
+        await LandWave(ModuleA);
+        BootReplica();                                   // sequence 1 adopted — the mesh is on it
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+        BootReplica();                                   // the winner at sequence 2 is adopted
+        var current = ModuleSetStore.Read(root).Current!.Sequence;
+        Assert.Equal(rival.Sequence, current);
+
+        var orphan = Path.Combine(root, "modules", "MeshWeaver.Orphan@deadbeef");
+        Directory.CreateDirectory(orphan);
+        File.WriteAllText(Path.Combine(orphan, "MeshWeaver.Orphan.dll"), "not a module");
+        var below = SetRecordsBelow(current);
+        Assert.NotEmpty(below);
+
+        ModuleLandingService.CollectGarbage(root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+
+        Assert.False(Directory.Exists(orphan), "an unreferenced generation survived a pass that had nothing unreadable to fail closed on");
+        Assert.Empty(SetRecordsBelow(current));
+        Assert.Equal(2, ProposalIds(current).Count);   // the duplicate pair itself is never the one removed
+
+        // #2509 still holds: one record that cannot be read, and the pass reclaims nothing.
+        Directory.CreateDirectory(orphan);
+        File.WriteAllText(Path.Combine(orphan, "MeshWeaver.Orphan.dll"), "not a module");
+        File.WriteAllText(Path.Combine(ModuleSetStore.SetsDirectory(root), $"{current + 1:D9}-garbage000000000.proposed.json"), "{ not json");
+        ModuleLandingService.CollectGarbage(root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+        Assert.True(Directory.Exists(orphan), "a pass with an unreadable set record must not reclaim anything");
+    }
+
+    private IReadOnlyList<string> SetRecordsBelow(long sequence) =>
+        [.. Directory.EnumerateFiles(ModuleSetStore.SetsDirectory(root), "*.json")
+            .Select(f => Path.GetFileName(f))
+            .Where(f => long.TryParse(f[..f.IndexOf('-')], out var seq) && seq < sequence)];
+
+    /// <summary>
     /// 🚨 The generations the mesh's set PINS are referenced even when the activation entries have
     /// moved past them — otherwise the convergence would re-open the 2026-08-27 outage from the
     /// other side, with GC reclaiming the very bytes every replica is executing.


### PR DESCRIPTION
Stacked on #3676 (retarget to `main` once it lands). Closes #3675.

**Measured on memex-cloud (2026-09-08 ~03:30Z, pod qk5gf, 8055):** 843 generation directories (22 per module), 687 set records (100 duplicate sequences), 43 activation entries — every file parses. The GC's once-per-boot pass logged `16 activation entry file(s) could not be read … SKIPPING every generation delete`; the 16 were `ModuleSetStore.Read`'s *"sequence N was proposed by more than one replica — the ordinally smallest id wins … No module is lost"* notices, delivered through the same `onCorrupt` the GC counts as a read fault. So the GC failed closed on every boot, `Prune` (gated on the same counter) never ran, the pairs that trigger the notice were never removed, and reading the pile put `/health`'s set read at 9–10 s over the probe's 5 s — no new memex-cloud pod has passed its startup probe since 00:23Z (#3676 takes the probe path).

- `ModuleSetStore.Read(baseDirectory, onCorrupt, onNotice)`: the duplicate-proposal notice goes to `onNotice`; the two-argument overload forwards `onNotice: onCorrupt`, so `PendingModuleActivations` and `MemexConfiguration` keep every note they show today. Binary-compatible (the old signature stays a real overload).
- `CollectGarbage` counts only `onCorrupt` toward the fail-closed reference set, logs notices at Information, and its warning names "activation entry or set record file(s)".
- Tests (`ModuleSetConvergenceTest`): a duplicate proposal is reported on the notice channel and never on the fault channel, the two-argument overload still says it, an unreadable deciding record is still a fault; with a duplicate pair on the volume the GC still prunes the records below the current set and reclaims an orphan generation, and still reclaims nothing when a deciding record cannot be read (#2509 untouched).

Local, `-c Release -warnaserror`: convergence + store + pending-activation + floor classes green; `ConfiguredModuleActivationTest` + `PlatformUpdateKeepsThePluginThenTakesTheRebuildTest` 25/25.

The production volume itself still needs one pass to catch up: once this and #3676 run there, the next boot prunes 685 records and ~800 generations at SMB speed, off the readiness path. Doing the record prune by hand first is the maintainer's call (proposed on #3675, not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)