### PR TITLE
fix(#3664): the module-activation report reads the volume once per CHANGE, never per probe — memex-cloud's startup probe passes again

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-readiness-probe-no-longer-walks-the-module-volume.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-readiness-probe-no-longer-walks-the-module-volume.md
@@ -1,0 +1,21 @@
+---
+Name: A new pod becomes ready again on a large module volume
+Category: Fix
+Description: The module-activation health check now reads the shared module volume once per change instead of on every probe, so a fresh pod on a deployment with hundreds of landed module generations passes its startup probe instead of timing out forever.
+Icon: HeartPulse
+Order: -20260908
+---
+
+# A new pod becomes ready again on a large module volume
+
+Every startup and readiness probe asks the portal whether modules have landed that this process has not
+loaded yet. Until now that question was answered by walking the shared module volume: every landed
+module's record was re-read and every landed assembly's existence re-checked, on every probe. On the
+public instance, with more than seven hundred module generations on a network volume, one answer took
+eight to ten seconds against a five-second probe timeout, so a freshly started pod never became ready
+and no rollout could complete, whatever image it carried.
+
+The volume is now read once per change. Every writer lands its files by renaming into one of three
+directories, so those directories' timestamps say whether anything moved; a probe costs three
+timestamp reads and reuses the last snapshot until they change. What this process has loaded is still
+measured fresh on every call, so a module that loads is reported as loaded without touching the volume.

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -382,6 +382,101 @@ public sealed class PendingModuleActivations(string moduleRoot)
         ModuleActivationStatus.LoadedModuleGenerations());
 
     /// <summary>
+    /// How many times this instance has actually read the activation state off the volume — the
+    /// sidecar, every <c>activation.d/*.json</c>, the set index, and one existence probe per landed
+    /// DLL. A measurement for the tests that pin <see cref="Read()"/>'s cost: it climbs by one per
+    /// CHANGE of the on-disk state, never per call.
+    /// </summary>
+    public int DiskReads => Volatile.Read(ref diskReads);
+
+    private int diskReads;
+
+    // 🚨 #3664 — the report is read on EVERY startup/readiness probe, and every read walked the
+    // volume: ModuleActivationSidecar.Read opens activation.json and each activation.d/*.json,
+    // ModuleSetStore.Read lists and parses sets/*.json, and the projection then asks
+    // File.Exists once per entry in three passes. On memex-cloud's shared Azure Files volume
+    // (714 module generations, 33,383 files) that is 8–10 s per probe against a 5 s probe timeout,
+    // so a fresh pod NEVER passed its startup probe — image-independent, every rollout stalled.
+    //
+    // The state this reads changes only when something LANDS or a wave is PROPOSED, and every
+    // writer in this assembly lands its file by temp-file + rename INTO one of three directories
+    // (modules/, modules/activation.d/, modules/sets/) or creates/deletes a marker there — each of
+    // which moves that directory's last-write time on every filesystem the mesh runs on. So the
+    // disk-derived half of the report is memoised behind a fingerprint of those three
+    // timestamps (three stats per probe), and only the cheap in-process half — which assemblies
+    // THIS process has loaded — is recomputed per call. The snapshot is an immutable record swapped
+    // atomically on an instance field: two concurrent probes may compute it twice, both correctly;
+    // no lock, no timer, nothing to clear.
+    private DiskSnapshot? snapshot;
+
+    /// <summary>The disk-derived inputs of one report, valid while <see cref="Fingerprint"/> stands.</summary>
+    private sealed record DiskSnapshot(
+        DiskFingerprint Fingerprint,
+        ModuleActivationList? Activation,
+        string? Corrupt,
+        Exception? OpenFailure,
+        ModuleSetIndex Sets,
+        ImmutableList<string> SetNotes,
+        Func<ModuleActivationEntry, bool> LandedDllExists);
+
+    /// <summary>
+    /// The last-write times of the three directories every activation writer renames into. PURE
+    /// over the file system; a missing directory reads as <see cref="DateTime.MinValue"/>, so the
+    /// first landing into it changes the fingerprint too.
+    /// </summary>
+    public readonly record struct DiskFingerprint(DateTime Modules, DateTime Entries, DateTime Sets)
+    {
+        public static DiskFingerprint Of(string baseDirectory) => new(
+            LastWrite(Path.Combine(baseDirectory, "modules")),
+            LastWrite(ModuleActivationSidecar.EntriesDirectory(baseDirectory)),
+            LastWrite(ModuleSetStore.SetsDirectory(baseDirectory)));
+
+        private static DateTime LastWrite(string directory) =>
+            Directory.Exists(directory) ? Directory.GetLastWriteTimeUtc(directory) : DateTime.MinValue;
+    }
+
+    private DiskSnapshot ReadDisk()
+    {
+        var fingerprint = DiskFingerprint.Of(ModuleRootPath);
+        var current = snapshot;
+        if (current is not null && current.Fingerprint == fingerprint)
+            return current;
+
+        Interlocked.Increment(ref diskReads);
+        string? corrupt = null;
+        ModuleActivationList? activation = null;
+        Exception? openFailure = null;
+        try
+        {
+            // 🚨 The corruption callback is not optional here. ModuleActivationSidecar.Read
+            // swallows an unparseable file into the EMPTY list, so a surface that ignores the
+            // callback reports a corrupt sidecar as "nothing pending" — cheerfully, forever. That
+            // is the shape this whole cluster of defects has in common.
+            activation = ModuleActivationSidecar.Read(ModuleRootPath, reason => corrupt = reason);
+        }
+        catch (Exception exception)
+        {
+            openFailure = exception;
+        }
+        var setNotes = ImmutableList.CreateBuilder<string>();
+        var sets = openFailure is null && corrupt is null
+            ? ModuleSetStore.Read(ModuleRootPath, setNotes.Add)
+            : ModuleSetIndex.Empty;
+        // One existence probe per landed DLL for the life of this snapshot: the three projection
+        // passes below ask about the same entries, and the answer cannot change while the
+        // fingerprint stands (a landing renames into activation.d, which moves it).
+        var landed = new System.Collections.Concurrent.ConcurrentDictionary<string, bool>(StringComparer.Ordinal);
+        bool LandedDllExists(ModuleActivationEntry entry) =>
+            landed.GetOrAdd(
+                ModuleActivationBoot.LandedDllPath(ModuleRootPath, entry),
+                path => File.Exists(path));
+        var fresh = new DiskSnapshot(
+            fingerprint, activation, corrupt, openFailure, sets, setNotes.ToImmutable(), LandedDllExists);
+        snapshot = fresh;
+        return fresh;
+    }
+
+    /// <summary>
     /// Testable form: the caller supplies what counts as loaded, BY NAME ONLY.
     ///
     /// <para>🚨 Name-only cannot see an UPDATE (#3395) — a module whose activated generation moved
@@ -404,55 +499,20 @@ public sealed class PendingModuleActivations(string moduleRoot)
         IReadOnlySet<string> loadedAssemblyNames,
         IReadOnlyDictionary<string, string> loadedModuleGenerations)
     {
-        string? corrupt = null;
-        ModuleActivationList activation;
-        try
-        {
-            // 🚨 The corruption callback is not optional here. ModuleActivationSidecar.Read
-            // swallows an unparseable file into the EMPTY list, so a surface that ignores the
-            // callback reports a corrupt sidecar as "nothing pending" — cheerfully, forever. That
-            // is the shape this whole cluster of defects has in common.
-            activation = ModuleActivationSidecar.Read(ModuleRootPath, reason => corrupt = reason);
-        }
-        catch (Exception exception)
-        {
+        var disk = ReadDisk();
+        if (disk.OpenFailure is { } exception)
             return new ModuleActivationReport(
                 [], $"the activation sidecar under '{ModuleRootPath}' could not be opened "
                     + $"({exception.GetType().Name}: {exception.Message})");
-        }
-
-        if (corrupt is not null)
-            return new ModuleActivationReport([], corrupt);
-
-        // 🚨 The SAME existence gate boot applies, threaded here for the same reason: this report
-        // PROMISES that a restart activates what it calls pending, and only the gate boot itself
-        // uses can keep that promise. A landed DLL that is gone (#2093) means boot would skip the
-        // entry — reported SEPARATELY rather than dropped: an activated module whose bytes are gone
-        // is a fault an operator must act on, not a quiet nothing. The declared platform floor used
-        // to be the second gate here (a HELD entry — the registry shelf, 2026-08-22); since #3648
-        // boot does not skip on it and neither does this report — it is worded per entry as an
-        // advisory instead.
-        bool LandedDllExists(ModuleActivationEntry entry) =>
-            ModuleActivationBoot.LandedModuleDllExists(ModuleRootPath, entry);
-
-        // 🚨 #3395 — compare against THE MESH'S MODULE SET, which is what a restart of this process
-        // would actually load, not against the raw activation record, which is a moving target no
-        // boot resolves any more. Getting this wrong in either direction breaks the report's one
-        // promise: comparing against the record would call a pod "pending" for a landing whose wave
-        // has not completed (a restart would not load it — a promise no restart can keep, the exact
-        // false prompt the held-entry and missing-bytes rules exist to prevent), and it is what let
-        // a pod 90 minutes behind answer Healthy in the first place.
-        // 🚨 The set store's reports are NOT verdicts, and folding them into UndeterminedReason
-        // would make them into one. `ModuleSetStore.Read` reports a deterministically-RESOLVED
-        // conflict (two replicas proposed one sequence; every reader picks the same set) and a
-        // single unreadable record (skipped, the rest stand) through the same channel — both are
-        // handled conditions with a valid index behind them. Even the one genuinely blind case, a
-        // directory that cannot be listed, answers `Empty`, which projects as the IDENTITY: this
-        // pod then reports exactly what it reported before #3395, which is an answer, not an
-        // absence of one. So the notes go on the mesh-set LINE, where an operator sees them, and
-        // the verdict stays what the activation record supports.
-        var setNotes = new List<string>();
-        var sets = ModuleSetStore.Read(ModuleRootPath, setNotes.Add);
+        if (disk.Corrupt is not null)
+            return new ModuleActivationReport([], disk.Corrupt);
+        var activation = disk.Activation!;
+        // The SAME existence gate boot applies (see ReadDisk): this report PROMISES that a restart
+        // activates what it calls pending, and only the gate boot itself uses can keep that
+        // promise. A landed DLL that is gone (#2093) is reported SEPARATELY rather than dropped.
+        var LandedDllExists = disk.LandedDllExists;
+        var setNotes = disk.SetNotes;
+        var sets = disk.Sets;
 
         var deferred = ImmutableList.CreateBuilder<PendingModuleActivation>();
         var onMeshSet = ModuleActivationBoot.ProjectOntoMeshSet(

--- a/test/Memex.Portal.Shared.Test/PendingModuleActivationsCostTest.cs
+++ b/test/Memex.Portal.Shared.Test/PendingModuleActivationsCostTest.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 #3664 — <see cref="PendingModuleActivations.Read()"/> is the startup/readiness probe's cost.
+/// It used to walk the module volume on every call (the sidecar, every <c>activation.d/*.json</c>,
+/// the set index, one <c>File.Exists</c> per landed DLL in three passes): 8–10 s per probe on
+/// memex-cloud's Azure Files volume against a 5 s probe timeout, so a fresh pod never became
+/// ready and every rollout stalled. These pin the rule that replaces it: the volume is read once
+/// per CHANGE of the on-disk activation state, never per call — and a change is seen.
+/// </summary>
+public class PendingModuleActivationsCostTest : IDisposable
+{
+    private const string ModuleA = "MeshWeaver.Payments.Stripe";
+    private const string ModuleB = "MeshWeaver.Social";
+    private const string ModuleC = "MeshWeaver.Speech";
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-pending-cost-" + Guid.NewGuid().ToString("N"));
+    private readonly ModuleLandingService landing;
+
+    public PendingModuleActivationsCostTest()
+    {
+        Directory.CreateDirectory(root);
+        landing = new ModuleLandingService(baseDirectory: root);
+    }
+
+    public void Dispose()
+    {
+        landing.Dispose();
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Two probes against an unchanged volume cost ONE disk read; the second is served from the snapshot and says the same thing.</summary>
+    [Fact]
+    public async Task AnUnchangedVolume_IsReadOnce_HoweverOftenTheProbeAsks()
+    {
+        await LandWave(ModuleA, ModuleB);
+        var pending = new PendingModuleActivations(root);
+        var nothingLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var first = pending.Read(nothingLoaded);
+        var second = pending.Read(nothingLoaded);
+        var third = pending.Read(nothingLoaded);
+
+        Assert.Equal(1, pending.DiskReads);
+        Assert.Equal(2, first.Pending.Count);
+        Assert.Equal(first.Describe(), second.Describe());
+        Assert.Equal(first.Describe(), third.Describe());
+    }
+
+    /// <summary>A landing (temp-file + rename into activation.d) moves the fingerprint: the next probe re-reads and reports the new module.</summary>
+    [Fact]
+    public async Task ALanding_IsSeenByTheNextProbe()
+    {
+        await LandWave(ModuleA);
+        var pending = new PendingModuleActivations(root);
+        var nothingLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        Assert.Single(pending.Read(nothingLoaded).Pending);
+        Assert.Equal(1, pending.DiskReads);
+
+        await LandWave(ModuleB, ModuleC);
+
+        var after = pending.Read(nothingLoaded);
+        Assert.Equal(2, pending.DiskReads);
+        Assert.Equal(3, after.Pending.Count);
+        Assert.Contains(after.Pending, p => string.Equals(p.Name, ModuleC, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// The in-process half is NOT memoised: the same snapshot, asked with this process's loaded set,
+    /// answers for that set — a module that loaded since the last probe stops being pending without
+    /// a disk read.
+    /// </summary>
+    [Fact]
+    public async Task WhatThisProcessLoaded_IsReadFresh_WithoutTouchingTheVolume()
+    {
+        await LandWave(ModuleA, ModuleB);
+        var pending = new PendingModuleActivations(root);
+        var nothingLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        Assert.Equal(2, pending.Read(nothingLoaded).Pending.Count);
+
+        var loadedA = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ModuleA };
+        var report = pending.Read(loadedA);
+
+        Assert.Equal(1, pending.DiskReads);
+        Assert.Single(report.Pending);
+        Assert.Equal(ModuleB, report.Pending.Single().Name, ignoreCase: true);
+    }
+
+    /// <summary>A missing modules tree is a fingerprint too — the first landing into it is a change, not an identical "nothing".</summary>
+    [Fact]
+    public async Task TheFirstLandingIntoAnEmptyRoot_IsAChange()
+    {
+        var pending = new PendingModuleActivations(root);
+        var nothingLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        Assert.Empty(pending.Read(nothingLoaded).Pending);
+        Assert.Equal(1, pending.DiskReads);
+
+        await LandWave(ModuleA);
+
+        Assert.Single(pending.Read(nothingLoaded).Pending);
+        Assert.Equal(2, pending.DiskReads);
+    }
+
+    private async Task Land(string name) =>
+        await landing.LandModule(name, [(name + ".dll", RealAssemblyBytes)])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+    private static byte[] RealAssemblyBytes =>
+        File.ReadAllBytes(typeof(MeshWeaver.Plugin.Packaging.BundleReader).Assembly.Location);
+
+    private async Task LandWave(params string[] names)
+    {
+        foreach (var name in names)
+            await Land(name);
+        await landing.ProposeModuleSet().Timeout(TestTimeouts.Convergence).Await();
+    }
+}


### PR DESCRIPTION
Fixes #3664.

## What was measured
On memex-cloud every fresh pod — of **two different images** (3.0.0-ci.8059 and 8055) — failed its startup probe 140+ times over 25 min with `context deadline exceeded`: `/health` took **8–10 s** against the probe's 5 s timeout, and the pod's log named the cost: `Health check pending_module_activation … completed after 9990ms`. The volume holds 714 module generations / 33,383 files on Azure Files; `PendingModuleActivations.Read()` walked it on every probe (every `activation.d/*.json`, the set index, `File.Exists` per entry × 3 passes). No rollout could complete on memex-cloud, whatever the image.

## The fix
Every writer in the assembly lands by temp-file + rename **into** `modules/`, `activation.d/` or `sets/` (or creates/deletes a marker there), so those three directories' last-write times say whether anything changed. The disk-derived half of the report is memoised behind that `DiskFingerprint` (three stats per probe) in an immutable snapshot swapped on the singleton's instance field — no lock, no timer, nothing to clear. The in-process half (what THIS process loaded) is still computed fresh per call. `DiskReads` counts real volume reads so the rule is testable.

## Verification
`PendingModuleActivationsCostTest` (4 new): unchanged volume → 1 read for 3 probes; a landing moves the fingerprint and the next probe sees the new module; a module that loaded stops being pending with no disk read; the first landing into an empty root is a change. `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` built `-c Release -warnaserror`; **40/40** across the four suites that read the report; What's New integrity green.

## Follow-up (MeshWeaver.Plugins)
`Program.cs` hand-builds the check's `PendingModuleActivations` (empty quarantine/fallback sets) — it should resolve the `AddPluginCatalog` singleton so quarantined modules stop reading as pending. Separate PR.

Pairs-with: none — public surface only ADDED (`DiskReads`, `DiskFingerprint`), nothing removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)