### PR TITLE
fix(#3680): the installer stops healing a partition the gating reconcile owns

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PartitionAccessOwnership.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PartitionAccessOwnership.md
@@ -1,0 +1,100 @@
+---
+Name: Who Owns a Partition's Access Shape
+Category: Architecture
+Description: Two components write a plugin partition's _Policy and its children's _Access denies — the installer in this repository and the Store's gating reconcile, which is in-mesh source in another one. When both claimed ownership they undid each other on every pass, and the ping-pong failed a CD seal. The rule that settles it, and the survey mistake that produced it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+---
+
+# Who Owns a Partition's Access Shape
+
+**A partition's `_Policy` node and its children's `_Access` deny assignments have exactly ONE
+owner. Where two components both wrote them, neither converged, and the loser was the platform.**
+
+Two components write that shape today:
+
+| Writer | Lives in | Reads | Runs |
+|---|---|---|---|
+| `PackageInstaller.EnsureDeclaredAccess` | this repository, `src/MeshWeaver.PluginCatalog/` | the package **manifest** (`preInstalled`, `price`, `publicSegments`) | once per install, and on the boot repair pass |
+| `PluginGate.SeedGating` | MeshWeaver.Plugins, `Store/Licensing/Source/` — **in-mesh source** | the **root node's** `PluginContent` | on every plugin-root activation, and on every subtree change |
+
+For a **pre-installed** partition the two agree: the installer publishes it fully public, and the
+gating reconcile's pre-installed arm retracts child denies. Nothing fights.
+
+For a **free, non-pre-installed** package that declares no `publicSegments`, they used to disagree
+outright — and both were emphatic about it in their own comments:
+
+> *the installer:* "a free package that a catalog hands out must be readable by everyone, signed in
+> or not."
+
+> *the gating reconcile:* "the cover + declared public segments are the ONLY public surface … there
+> is no open-content tier: a product without a price simply has no self-service way in yet. (The old
+> rule left non-purchasable plugins' content readable — guides, dashboards, even imported personal
+> LinkedIn data were world-visible via the cover grants.)"
+
+## What the disagreement cost
+
+The installer's legacy heal treated the pairing *policy-withholding-public-read + Public/Anonymous
+child denies* as damage left by a pre-#902 installer, retired the denies and reopened the policy.
+That pairing is precisely what the gating reconcile writes, on purpose, every pass. So each pass of
+each component undid the other:
+
+- the installer retires N denies and opens `_Policy`;
+- the gating reconcile re-denies and re-gates, logging
+  `[PluginGating] <plugin>: reconcile is NOT CONVERGING — rewrote …, which this hub already wrote`;
+- the next install repeats it.
+
+Measured on CD run `34190841613` (2026-09-08), package `Chess`: the idempotence re-install retired
+**26** deny assignments, the reconcile immediately rewrote them, and the heal's own `Chess/_Policy`
+write starved behind the contention for 20 s and faulted —
+`MeshNode Unknown at 'Chess/_Policy': TimeoutException`. That failed the package-install idempotence
+gate, so `Plugins: bake + seal` went red and `Register the publication with memex` never ran: a
+complete image set was promoted and verified, and **no installation could adopt it**, because a
+promoted set that is not sealed is held.
+
+**The run 65 minutes earlier, on the same commit, passed while doing the same thing at a smaller
+amplitude — 9 denies retired instead of 26.** Identical content, different count. A steady state
+that differs run to run on unchanged inputs is not a steady state; it is a race, and the count is
+just how far one writer got before the other looked.
+
+Live evidence that this long predates the CD failure: `Chess/_Policy` was measured at **version
+210,801** on 2026-08-25, and `Chess/_Access/Public_Access` at **11,899** on 2026-08-09.
+
+## The rule
+
+**A partition that is not pre-installed belongs to the gating reconcile. The installer does not
+heal it.**
+
+The installer still *creates* a fully-public `_Policy` where none exists — a create cannot loop —
+and still heals the legacy shape on **pre-installed** partitions, which is the case the #902
+incident was actually about ("its 8 pre-installed partitions carried 136 legacy denies, while the
+partitions installed after #902 were correct"). What it no longer does is tear down denies that a
+live component is writing on purpose.
+
+This does not settle *whether* a free plugin should be world-readable. It settles **where that
+question is answered** — in one place, so that the answer can be changed by changing one rule
+rather than by winning a race. If the gating model is wrong, it is wrong in one component.
+
+## The survey mistake, which generalises
+
+The heal's guard was not the pairing alone. It was the pairing plus a claim:
+
+> "Current code cannot produce that (the scoped branch requires `declared.Count > 0`); only a
+> pre-#902 installer could."
+
+That claim was reached by reading this repository's code, and it is true of this repository's code.
+The component that produces the shape is **in-mesh source**: a `.cs` node stored in a mesh package,
+compiled at runtime in the portal. No `dotnet build` here compiles it, no core test executes it, and
+`grep --include='*.cs'` over this repository cannot see it. The survey was complete for the
+compiler's view of one repository and empty of the thing it needed to find.
+
+**When a heal, a migration or a guard is justified by "no current code produces this", the survey
+has to cover the MESH — every node repository's `Source/*.cs`, every NodeType `configuration`
+lambda, every layout area — not one repository's compiler view.** `AGENTS.md` states this for
+deletions of public surface; it applies identically to any premise of the form *nothing writes
+this any more*.
+
+## Related
+
+- [Access Control](/Doc/Architecture/AccessControl) — partition policies, assignments, and the Admin partition.
+- [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation) — why in-mesh source is invisible to CI.
+- [Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract) — what a sealed publication is, and why a promoted-but-unsealed set is held.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PartitionAccessOwnership.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PartitionAccessOwnership.md
@@ -56,8 +56,12 @@ amplitude — 9 denies retired instead of 26.** Identical content, different cou
 that differs run to run on unchanged inputs is not a steady state; it is a race, and the count is
 just how far one writer got before the other looked.
 
-Live evidence that this long predates the CD failure: `Chess/_Policy` was measured at **version
-210,801** on 2026-08-25, and `Chess/_Access/Public_Access` at **11,899** on 2026-08-09.
+`Chess/_Policy` has a longer history of write storms — measured at **version 210,801** on
+2026-08-25 and `Chess/_Access/Public_Access` at **11,899** on 2026-08-09 — but those are **not**
+this defect and should not be cited as it: `PluginGate`'s own comments attribute them to the
+reconcile writing off blind subtree snapshots, which the targeted-read `VerifiedWrite` change then
+fixed. They belong here only as evidence that these particular nodes are a contended surface with
+more than one way to loop, which is the reason to give them exactly one owner.
 
 ## The rule
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-free-plugins-content-no-longer-flips-between-public-and-gated.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-free-plugins-content-no-longer-flips-between-public-and-gated.md
@@ -1,0 +1,44 @@
+---
+Name: A free plugin's content no longer flips between public and gated
+Category: Fix
+Description: Two parts of the platform disagreed about whether a free plugin's content is readable by everyone, and each undid the other on every install and every restart. One of them now owns the answer, so the setting stays where it is put.
+Icon: Checkmark
+Order: -20260908
+---
+
+# A free plugin's content no longer flips between public and gated
+
+A plugin that carries no price had **two parts of the platform writing its access setting, and they
+disagreed**. One published the whole partition as readable by everyone. The other applied the store
+rule — the cover page is public, the content opens when you have access to it — and closed it again.
+Neither gave way, so each install and each restart set the plugin one way and, seconds later, the
+other way put it back.
+
+Nobody chose that behaviour. It was simply whichever ran last.
+
+## What changes
+
+**The store rule now owns the answer for a plugin you install.** Cover page public, content reached
+through your entitlement — one component decides it, and the setting stays put.
+
+**Platform content that ships with your installation is unaffected.** The catalog, the built-in
+apps, the documentation and the other pre-installed partitions are public exactly as before, and the
+repair that restores them if they were ever left unreadable still runs.
+
+**A brief window where a free plugin's content was readable by anyone is gone.** After every restart
+the partition was reopened and then re-closed a few seconds later. In between, content that the
+store rule intends to be gated could be read by anyone, signed in or not. That window no longer
+opens.
+
+**A large amount of pointless write traffic stops.** On one installation this loop had rewritten a
+single plugin's access setting more than 200,000 times. Those writes did nothing except undo each
+other, and they were slow enough to make installing that plugin time out.
+
+## What this does not change
+
+**Nothing you have deliberately set is touched.** A plugin that ships its own access policy keeps
+it, as before. Access you have granted to a person or a group is untouched — this only ever
+concerned the "everyone" and "not signed in" entries the store rule manages for itself.
+
+**Nothing becomes newly unreadable to someone who could already read it.** People with access to a
+plugin's content keep it. What changes is that the intermittent, unintended public window closes.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -897,9 +897,20 @@ public static class PackageInstaller
     /// damage is the pairing: a policy that withholds public read AND Public/Anonymous Viewer denies
     /// on the partition's children, which is the SCOPED shape
     /// (<see cref="EnsureScopedPublicRead"/>) applied with an empty declaration — every child gated,
-    /// nothing left public. Current code cannot produce that (the scoped branch requires
-    /// <c>declared.Count > 0</c>); only a pre-#902 installer could. So the heal triggers on the pair
-    /// and leaves a shipped gated policy — which carries no such denies — completely alone.</para>
+    /// nothing left public. So the heal triggers on the pair and leaves a shipped gated policy —
+    /// which carries no such denies — completely alone.</para>
+    ///
+    /// <para><b>🚨 …but the pair is NOT a reliable fingerprint on its own, so the heal is
+    /// additionally restricted to a PRE-INSTALLED partition.</b> This comment used to argue that
+    /// "current code cannot produce that (the scoped branch requires <c>declared.Count > 0</c>);
+    /// only a pre-#902 installer could" — reasoning that surveyed core's own code paths and
+    /// concluded, correctly for core and wrongly for the mesh, that nothing living writes the
+    /// shape. The Store's gating reconcile writes it on every pass, and it lives in MeshWeaver.
+    /// Plugins as IN-MESH source that compiles at runtime: no core build, no core test and no
+    /// <c>grep --include='*.cs'</c> over this repository can see it. Treating a live component's
+    /// deliberate output as legacy damage cost a CD seal (see the call site). When a heal's guard
+    /// is "no current code produces this", the survey has to cover the MESH, not the compiler's
+    /// view of one repository.</para>
     ///
     /// <para><b>Order matters: denies first, policy last.</b> The denies are what actually hide the
     /// content (an explicit deny beats <c>PublicRead</c>), and the policy node is the marker that
@@ -934,6 +945,45 @@ public static class PackageInstaller
             // A policy that withholds public read. Heal it ONLY together with the legacy denies that
             // identify it as the pre-#902 scoped gate; on their own it is a deliberate shipped
             // policy and stays untouched.
+            //
+            // 🚨 …and ONLY on a PRE-INSTALLED partition. The fingerprint below — a policy that
+            // withholds public read PLUS Public/Anonymous Viewer denies on every child — is NOT
+            // unreachable by current code, which is what this heal used to assume. The Store's
+            // gating reconcile (`PluginGate.SeedGating`, in-mesh source in MeshWeaver.Plugins, so
+            // invisible to `dotnet build` and to any grep over core's *.cs) writes EXACTLY that
+            // shape, deliberately and continuously, for every non-pre-installed plugin whose
+            // manifest declares no publicSegments — its stated model is "the cover + declared
+            // public segments are the ONLY public surface … there is no open-content tier".
+            //
+            // So on such a partition the heal is not a migration, it is one half of a ping-pong:
+            // core retires the denies and opens the policy, the gating reconcile re-denies and
+            // re-gates, and neither ever sticks. Measured on CD run 34190841613 (2026-09-08):
+            // Chess's idempotence re-install retired 26 denies, `PluginGating` logged
+            // "reconcile is NOT CONVERGING — rewrote 26 …", and the heal's own `Chess/_Policy`
+            // write starved behind the contention for 20s and faulted
+            // ("MeshNode Unknown at 'Chess/_Policy': TimeoutException") — which failed the
+            // package-install idempotence gate and left the promoted image set UNSEALED. The
+            // same fight, at a smaller amplitude, is visible in the run that passed 65 minutes
+            // earlier (9 denies retired instead of 26): identical content, different count, which
+            // is the tell that the steady state was decided by a race rather than by either rule.
+            //
+            // The #902 incident this heal exists for was about the platform BASELINE — "its 8
+            // pre-installed partitions carried 136 legacy denies while memex/systemorph —
+            // installed after #902 — were correct" — and a pre-installed partition is the one
+            // case where the two components AGREE: SeedGating's pre-installed arm retracts the
+            // very denies this sweep retires, so nothing fights and the heal sticks. Restricting
+            // it there keeps the incident's fix intact and takes core out of a contest it cannot
+            // win. A non-pre-installed partition's access model belongs to the gating reconcile;
+            // if that model is wrong, it is wrong in ONE place, which is the point.
+            if (!manifest.PreInstalled)
+            {
+                logger?.LogDebug(
+                    "[PackageInstaller] {Partition} withholds public read and is not pre-installed "
+                    + "— leaving its policy to the gating reconcile that owns it (no legacy heal)",
+                    partition);
+                return Observable.Return(Unit.Default);
+            }
+
             return ContradictingDenies(hub, partition, logger).SelectMany(stale =>
             {
                 if (stale.Count == 0)


### PR DESCRIPTION
Fixes the seal failure in #3680 (CD run [34190841613](https://github.com/Systemorph/MeshWeaver/actions/runs/34190841613), commit `4fedf454`).

## Which delivery broke

**Neither of the two the issue names — the third one.** `preflight`, every image job, `promote`, `verify-images` and `notify-platform-update` were all **green**: a complete image set was published and promoted, and the release event did reach the control instance. The red was `Plugins: bake + seal … / Bake + publish NodeType assemblies to portal storage`, and `Register the publication with memex` was **skipped**.

So the set is **promoted but not SEALED** — the images exist, the event went out, and no install can adopt them (`heldReason: no sealed content bake …`). Not the budget cap: the failing job executed 37 steps, and September spend is ≈ $2,482 of $3,000.

## Root cause

The bake itself was fine — `compile: 89/89 NodeType(s) compiled`. The `--seed` gate failed on package-install **idempotence**:

```
[FAIL] Chess (34 node(s), 3 type(s))
    idempotence: re-install failed: InvalidOperationException: Install of 'Chess/_Policy'
    failed: Inner UpdateNode faulted: MeshNode Unknown at 'Chess/_Policy':
    TimeoutException: The operation has timed out.
GATE FAILED — idempotence: Chess — 1 new failure(s), 0 stale allow entr(ies).
```

**Two components own a partition's `_Policy` and its children's `_Access` denies, and each undoes the other.**

| Writer | Lives in | Reads | Runs |
|---|---|---|---|
| `PackageInstaller.EnsureDeclaredAccess` | this repo | the package **manifest** | per install + boot repair |
| `PluginGate.SeedGating` | MeshWeaver.Plugins — **in-mesh source** | the **root node's** `PluginContent` | every root activation + every subtree change |

For a free, non-pre-installed package with no `publicSegments` (Chess: `preInstalled` absent, `publicSegments: []`, `price: 0`) they state opposite rules in their own comments — core: *"a free package that a catalog hands out must be readable by everyone"*; the gating reconcile: *"there is no open-content tier … (The old rule left non-purchasable plugins' content readable — guides, dashboards, even imported personal LinkedIn data were world-visible)"*.

So on the idempotence re-install core retired **26** denies and reopened the policy, `PluginGating` immediately logged `Chess: reconcile is NOT CONVERGING — rewrote …, which this hub already wrote`, and the heal's own `Chess/_Policy` write starved behind the contention for 20 s and faulted. That is the write in the error message.

**The control confirms it.** Run [34186868747](https://github.com/Systemorph/MeshWeaver/actions/runs/34186868747), 65 minutes earlier on the **same commit**, *sealed* — while doing the same thing at a smaller amplitude: `retiring 9` instead of `retiring 26`, and no `NOT CONVERGING`. Identical content, different count. A steady state that differs run to run on unchanged inputs is a race, and the count is just how far one writer got before the other looked.

(`Chess/_Policy` has been measured at version **210,801** before, on 2026-08-25 — but that is **not** this defect: `PluginGate`'s own comments attribute it to the reconcile writing off blind subtree snapshots, since fixed. It is cited here only as evidence that these nodes are a contended surface with more than one way to loop.)

## The survey mistake

The heal's guard was the fingerprint **plus a claim**:

> "Current code cannot produce that (the scoped branch requires `declared.Count > 0`); only a pre-#902 installer could."

True of this repository's code. The producer is **in-mesh source** — a `.cs` node compiled at runtime in the portal: no `dotnet build` here compiles it, no core test executes it, no `grep --include='*.cs'` over this repo can see it. AGENTS.md states this blind spot for *deletions* of public surface; it applies identically to any premise of the form *nothing writes this any more*.

## The change

The legacy heal (deny sweep + policy rewrite) now runs **only on a pre-installed partition** — the case the #902 incident was actually about ("its 8 pre-installed partitions carried 136 legacy denies, while the partitions installed after #902 were correct"), and the one case where the two components **agree**: `SeedGating`'s pre-installed arm retracts the very denies this sweep retires, so nothing fights and the heal sticks.

- The **create-only** path is untouched — a create cannot loop, so a partition with no policy still gets one.
- A shipped gated policy still survives untouched.
- This does **not** decide whether a free plugin should be world-readable. It decides **where that question is answered**: in one component, so the answer can be changed by changing one rule instead of by winning a race.

## Behaviour change, stated plainly

A free, non-pre-installed plugin's partition previously oscillated: reopened by every install and every boot repair, re-gated by the reconcile seconds later. It is now consistently gated by the Store model, and the brief post-boot window in which its content was readable by anyone closes. Nothing that was deliberately set is touched, and nobody who could already read a plugin's content loses access.

## 🚨 Cross-repo: break shape 7, which no gate sees

This changes BEHAVIOUR behind an unchanged signature (#3276's shape). It removes no public type or member and adds no interface member, so no `Pairs-with:` / `Implementers:` line applies — and no gate will catch it either.

`MeshWeaver.Plugins`' `src/MeshWeaver.PluginCatalog.Test/DeclaredAccessInstallTest.cs` has `LegacyScopedGate_OnAFullyPublicPackage_IsHealed`, which asserts the heal fires on a **free** package (`FreePlug`). That test encodes the same false premise and must move to a pre-installed package. It builds against `MW_PLATFORM_REF` (a pinned core commit), so merging this reds nothing immediately — it would red at the next pin bump. **A follow-up PR in MeshWeaver.Plugins updates that test and adds a case pinning that a free plugin's gating is NOT healed; it must land before the pin crosses this commit.**

## Verification

- `dotnet build src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj -c Release -warnaserror` → `Build succeeded. 0 Warning(s) 0 Error(s)`, 9 projects, 15.2 s.
- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → clean; new doc confirmed embedded in the built `MeshWeaver.Documentation.dll`.
- `DocumentationLinkIntegrityTest` → `Passed! Failed: 0, Passed: 1`.

## Also in this PR

- `Doc/Architecture/PartitionAccessOwnership` — who owns a partition's access shape, the measured ping-pong, and the survey rule.
- A What's New entry (`Category: Fix`) for the user-visible half.

## Deliberately not in this PR

The **recycle race** is a separate defect and is reported on #3510, whose central open question this run answers: `[PackageInstaller] recycling root Chess …` names the disposer as the installer's own retyped-root recycle (`SettleRetypedRoot`), contradicting #3499's stated hypothesis that it was *"not the installer's retyped-root recycle"*. Fixing that alone would **not** have fixed this red — the heal-vs-gating ping-pong is independent of it.
