### PR TITLE
fix(#3656): a module generation is its content address, and a decided duplicate is retired

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -99,6 +99,18 @@ without coordinating: **the ordinally smallest `Id` wins**, and the conflict is 
 lost — a proposal is derived from the activation record, never from the previous proposal, so the
 next wave's sequence N+2 carries everything both replicas landed.
 
+**…and a conflict is DECIDED once, not re-decided on every boot (#3656).** The winner is a pure
+function of the records, so the loser has no further job the moment anything has read the pair: it
+cannot be adopted (`Read` matches an adoption against the WINNER's id), it is not in the GC's
+reference set, and the landings behind it ride the next wave whether it survives or not. What it
+did do while it survived was make the conflict re-detectable forever — `Prune` only reaches BELOW
+the current set, so a duplicate at the newest sequence outlived every pass, and every pod's sweep
+re-read it and re-reported the same decided conflict on every boot. The modules GC now retires the
+loser (`ModuleSetStore.PruneDuplicateProposals`, gated on the same fail-closed read-fault counter
+as every other removal), reporting it once, where it is decided. A record whose id cannot be READ
+makes the winner unknown, so nothing at that sequence is retired — the one thing this must never do
+is delete the record the mesh resolves to.
+
 **The reader decides from the NAMES and opens only what the decision needs.** Every record's name
 carries its sequence and set id (`<sequence:D9>-<id16>.proposed|adopted.json`), so one directory
 listing determines the newest proposal and the newest adopted set; `ModuleSetStore.Read` then opens
@@ -112,6 +124,52 @@ KEDA could add nothing. A record no decision depends on is neither read nor repo
 superseded record is `Prune`'s to remove, not the reader's to announce on every probe, and the
 conflict notice names only the sequences that were actually decided on (the historical
 "proposed by more than one replica" lines that used to repeat on every boot are gone).
+
+## The generation is the content address (#3656)
+
+A module's generation directory leaf is `<name>@<16 hex of SHA-256 over the bytes the landing
+writes>` — every file's module-relative path, its length and its bytes, ordinal-sorted by path.
+Two landings of the same bundle therefore resolve to the **same directory**, and the second one
+adopts what is there instead of writing a second copy.
+
+**Why this belongs to convergence and not merely to storage.** The leaf used to be
+`<name>@<8 random hex>`, and that is what turned a harmless simultaneity into a permanent
+divergence. Every replica reconciles the same feed at boot and on every `ModulePublished`
+broadcast, so two replicas deciding to land one published bundle at the same moment is the normal
+shape, not a rarity. With a random leaf each wrote the *identical bytes* under a *different* name;
+`GenerationsOf` reads the DIRECTORY off the activation record, so the set each derived named a
+different generation for that module, and both were proposed at sequence N+1 with different ids —
+a conflict about nothing. The cost compounded three ways:
+
+- the loser's generation directory was left behind as garbage;
+- the loser's `.proposed.json` sat at the mesh's newest sequence, re-read and re-reported by every
+  pod's sweep on every boot;
+- the two sets named different directories for identical bytes, so replicas on either side pinned
+  different generations and the NodeType stamp ping-ponged — the #3395 symptom, re-created by the
+  fix's own plumbing.
+
+Measured on `memex-cloud`, 2026-09-08: **100 duplicate sequences, 687 set records, 843 generation
+directories**.
+
+With the content address the two landings are one landing: same leaf, same activation entry, same
+derived set, and the second replica's `Propose` is the no-op it should always have been — no
+conflicting record is ever written. A **genuine** conflict (two replicas landing different content)
+still derives two sets and is still reported; the report is now about something that actually
+differs.
+
+Two consequences worth stating, because both look surprising until the rule is in view:
+
+- **A bundle republished with identical assemblies is not a new generation.** Its version and
+  framework identity move on the activation entry; the directory does not, because the bytes did
+  not. What runs is what runs.
+- **An existing directory is the right answer, never a collision.** The landing probes for it, and
+  catches the rename that loses the race to another replica; it then refreshes the directory's
+  timestamp, which is what puts a generation nothing referenced a moment ago back inside the
+  [#2303 grace window](/Doc/Architecture/Modules) before the activation entry references it.
+  Sixteen hex characters, not the eight the random leaf used: a content address that COLLIDED
+  would make a landing adopt somebody else's bytes, where a random one merely failed the rename.
+  It also means no legacy `<name>@<8 hex>` directory can ever be mistaken for a content-addressed
+  one — the lengths differ.
 
 ## Boot — converge, don't serve your own
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-two-replicas-installing-one-module-no-longer-store-it-twice.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-two-replicas-installing-one-module-no-longer-store-it-twice.md
@@ -1,0 +1,43 @@
+---
+Name: Two replicas installing one module no longer store it twice
+Category: Fix
+Description: When several replicas of an installation adopted the same published module at the same moment, each wrote the identical bytes into its own folder — so they disagreed about which module set the installation runs, left the extra copies behind, and reported a conflict about nothing on every restart. A module folder is now named after its contents, so the same bytes are stored once and the replicas agree.
+Icon: Cube
+Order: -20260908
+---
+
+# Two replicas installing one module no longer store it twice
+
+An installation that runs several replicas has them all watch the same plugin registry, so when a
+module is published they all adopt it — usually within the same second. Each replica downloaded the
+module and wrote it into a folder named with a fresh random id. The bytes were identical; the
+folder names were not.
+
+That difference propagated. The installation records *one* module set — the exact folder of every
+module it runs, so every replica runs the same thing — and each replica derived that set from the
+folder *it* had just written. Two replicas therefore proposed two different sets for the same
+moment in the same installation. One was picked (deterministically, so nobody disagreed about
+which), nothing was lost, and the other replica's copy stayed on the volume forever. The rejected
+proposal stayed too, and every replica that started afterwards re-read it and reported the same
+already-settled conflict again — an error line on every start, about a state that was correct.
+
+On the public instance this had accumulated to 100 such conflicts, 687 bookkeeping records and 843
+module folders that nothing could clear.
+
+**A module folder is now named after its contents.** Two replicas adopting the same published
+module compute the same name, so the second one finds the module already there and adopts it
+instead of storing a second copy. They derive the same module set, the second proposal is simply
+"nothing changed", and no conflict is recorded — because there is no disagreement to record. Two
+replicas that genuinely adopt *different* modules still produce two sets, and that conflict is still
+reported: it now means something.
+
+A conflict that does occur is also settled once. The rejected proposal is retired by the same
+housekeeping pass that clears superseded records, so it is reported where it is decided rather than
+on every start of every replica from then on. Nothing is lost by retiring it: the next update wave
+derives the set from what is actually installed, never from the previous proposal.
+
+One consequence is worth knowing: if a module is republished with a new version number but
+byte-identical contents, its folder does not change — the new version is recorded, and what runs is
+what already ran, because the bytes are the same.
+
+See [Module Set Convergence](/Doc/Architecture/ModuleSetConvergence) for the mechanism.

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -2,6 +2,8 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Security.Cryptography;
+using System.Text;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Logging;
@@ -253,6 +255,16 @@ public sealed class ModuleLandingService : IDisposable
                     "Modules GC: removed {Count} superseded module set record(s) below sequence "
                     + "{Sequence}", prunedSets, onSet.Sequence);
         }
+        // 🚨 #3656: and the LOSER of a decided duplicate, at ANY sequence — Prune above only
+        // reaches below the current set, so a duplicate at the newest sequence survived every
+        // pass and every pod re-read it and re-reported the same decided conflict on every boot,
+        // forever. Retiring it says the conflict once, where it is decided, and leaves the one
+        // record the mesh actually resolves to. Gated on the same fail-closed counter as the
+        // pruning above: with anything unreadable on the volume this pass removes nothing.
+        if (readFaults == 0)
+            ModuleSetStore.PruneDuplicateProposals(baseDirectory,
+                onRetired: msg => logger?.LogInformation("Modules GC: {Message}", msg),
+                onWarn: msg => logger?.LogWarning("Modules GC: {Message}", msg));
         // 🚨 #2509: with any entry file unreadable, `referenced` is INCOMPLETE — an ACTIVE
         // generation would read as an orphan. Generation deletes are skipped wholesale this pass.
         var referencesReliable = readFaults == 0;
@@ -692,6 +704,27 @@ public sealed class ModuleLandingService : IDisposable
             return verdict.MayLoad ? null : verdict.Report();
         }
 
+        // 🚨 THE GENERATION IS CONTENT-ADDRESSED (#3656) — `name@<16 hex of SHA-256 over the bytes
+        // this landing writes>`, never a random id. The leaf used to be `name@<8 random hex>`, and
+        // that is what turned a HARMLESS simultaneity into a permanent divergence. Every replica
+        // reconciles the same feed at boot and on every ModulePublished broadcast, so two replicas
+        // deciding to land the SAME bundle at the same moment is the normal shape, not a rarity —
+        // and each wrote the identical bytes into a DIFFERENT directory. The set each then derived
+        // from the activation record (ModuleSetStore.GenerationsOf reads the DIRECTORY) therefore
+        // named a different generation for that module, so both proposed the same sequence with
+        // different ids: the conflict ModuleSetIndex resolves deterministically, the loser's bytes
+        // left behind as an orphan, and the loser's `.proposed.json` sitting at the mesh's newest
+        // sequence until some later wave superseded it — re-read and re-reported by every pod's
+        // sweep in the meantime, on every boot, forever. Measured on memex-cloud 2026-09-08: 100
+        // duplicate sequences, 687 set records, 843 generation directories.
+        //
+        // Addressing the directory by its CONTENT makes those two landings ONE landing: same leaf,
+        // same activation entry, same derived set — and the second replica's Propose is the no-op
+        // it should always have been, so no conflicting record is ever written. A GENUINE conflict
+        // (two replicas landing different content) still derives two sets and is still reported;
+        // that report is now about something that actually differs.
+        var generation = $"{name}@{GenerationIdOf(assemblies, staticAssets)}";
+
         // 🚨 #3649 — THE PREVIOUS GENERATION IS KEPT, never overwritten. The entry this landing
         // displaces becomes the new entry's fallback: boot loads the head generation, and when
         // that one cannot load on the running platform it loads this one instead and says so.
@@ -709,8 +742,14 @@ public sealed class ModuleLandingService : IDisposable
             && !string.IsNullOrWhiteSpace(e.Directory));
         var previous = displaced is null ? null : PreviousToKeep(displaced);
 
-        ModuleActivationEntry PreviousToKeep(ModuleActivationEntry current)
+        ModuleActivationEntry? PreviousToKeep(ModuleActivationEntry current)
         {
+            // A re-land of the IDENTICAL bytes resolves to the generation the entry ALREADY names,
+            // because the leaf is the content address. Nothing is displaced, so nothing becomes a
+            // fallback: the entry keeps the fallback it had. Recording itself would be a fallback
+            // that is no fallback (PreviousGeneration reads it back as none anyway).
+            if (string.Equals(current.Directory, generation, StringComparison.OrdinalIgnoreCase))
+                return ModuleActivationBoot.PreviousGeneration(current);
             var older = ModuleActivationBoot.PreviousGeneration(current);
             if (older is null || !ModuleActivationBoot.LandedModuleDllExists(baseDirectory, older))
                 return current;
@@ -738,7 +777,6 @@ public sealed class ModuleLandingService : IDisposable
         // garbage-collected by the post-start GC pass (ModuleGenerationsGcHostedService →
         // CollectGarbage), skip-on-locked, once no entry references them.
         var modulesRoot = Path.Combine(baseDirectory, "modules");
-        var generation = $"{name}@{Guid.NewGuid():N}"[..(name.Length + 9)];
         var target = Path.Combine(modulesRoot, generation);
         var staging = Path.Combine(modulesRoot, $".staging-{name}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(staging);
@@ -756,7 +794,30 @@ public sealed class ModuleLandingService : IDisposable
                 Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
                 File.WriteAllBytes(destination, bytes);
             }
-            Directory.Move(staging, target);
+            // 🚨 An EXISTING target is the right answer, never a collision (#3656): the leaf is the
+            // content address, so a directory already carrying this name already carries these
+            // bytes. Another replica landing the same bundle concurrently, or an earlier landing
+            // this deployment's entry has since moved off — either way the landing ADOPTS it
+            // instead of writing a second copy under a second name, which is the whole point of
+            // addressing it by content. Probed first and caught as well: the other replica's
+            // rename can land between the probe and ours.
+            var alreadyLanded = Directory.Exists(target);
+            if (!alreadyLanded)
+            {
+                try
+                {
+                    Directory.Move(staging, target);
+                }
+                catch (IOException) when (Directory.Exists(target))
+                {
+                    alreadyLanded = true;
+                }
+            }
+            if (alreadyLanded)
+            {
+                Directory.Delete(staging, recursive: true);
+                AdoptLandedGeneration(target, name, generation);
+            }
         }
         catch
         {
@@ -820,6 +881,75 @@ public sealed class ModuleLandingService : IDisposable
                 name, generation, assemblies.Count, held, previous?.Directory ?? "(none)");
 
         return new ModuleLandingOutcome(Held: held is not null, HoldReason: held);
+    }
+
+    /// <summary>
+    /// The CONTENT ADDRESS of one landing (#3656): 16 lowercase hex characters of SHA-256 over
+    /// every file the landing would write — each file's module-relative path, its byte length and
+    /// its bytes, ordinal-sorted by path, so the answer depends on the content alone and never on
+    /// the order the caller happened to hand the files over in.
+    ///
+    /// <para>This is what makes two replicas landing one bundle land ONE generation. The
+    /// generation leaf was a random id until #3656, and two replicas that both decided to land the
+    /// same module — the normal shape of a reconcile wave, since every replica reconciles the same
+    /// feed — therefore wrote identical bytes under two names, derived two different module sets
+    /// from the activation record and proposed both at the same sequence. See the block comment in
+    /// <c>LandCore</c> for the production measurement.</para>
+    ///
+    /// <para>Sixteen characters (64 bits), deliberately not the eight the random leaf used: a
+    /// content address that COLLIDES would make a landing adopt somebody else's bytes, where a
+    /// random one merely failed the rename. It also means no legacy <c>name@&lt;8 hex&gt;</c>
+    /// directory can ever be mistaken for a content-addressed one — the lengths differ.</para>
+    /// </summary>
+    /// <param name="assemblies">The assemblies the landing writes, as file name → bytes.</param>
+    /// <param name="staticAssets">The static web assets it writes, as module-relative path →
+    /// bytes; null or empty when the module ships none.</param>
+    internal static string GenerationIdOf(
+        IReadOnlyList<(string FileName, byte[] Bytes)> assemblies,
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? staticAssets)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        foreach (var (path, bytes) in (assemblies ?? [])
+                     .Select(a => (Path: a.FileName.Replace('\\', '/'), a.Bytes))
+                     .Concat((staticAssets ?? [])
+                         .Select(a => (Path: a.RelativePath.Replace('\\', '/'), a.Bytes)))
+                     .OrderBy(x => x.Path, StringComparer.Ordinal))
+        {
+            // The length goes in as well as the bytes, so no concatenation of two files can hash
+            // like a different split of the same stream.
+            hash.AppendData(Encoding.UTF8.GetBytes($"{path}\n{bytes?.Length ?? 0}\n"));
+            if (bytes is { Length: > 0 })
+                hash.AppendData(bytes);
+        }
+        return Convert.ToHexStringLower(hash.GetHashAndReset())[..16];
+    }
+
+    /// <summary>
+    /// Takes over a generation directory that was ALREADY on the volume when this landing resolved
+    /// its content address — the concurrent-replica case (#3656). The bytes are identical by
+    /// construction, so there is nothing to write; what the landing must do is put the directory
+    /// back inside the #2303 grace window, because a directory nothing referenced a moment ago is
+    /// exactly the directory a GC pass on another replica may be about to reclaim — and the
+    /// activation entry written immediately after this is about to reference it.
+    /// </summary>
+    private void AdoptLandedGeneration(string target, string name, string generation)
+    {
+        try
+        {
+            Directory.SetLastWriteTimeUtc(target, DateTime.UtcNow);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Surfaced, never swallowed: the landing itself is complete and correct — the entry
+            // below references bytes that are on disk. What is lost is the grace window, so a GC
+            // pass that had already read this directory as unreferenced could still reclaim it,
+            // and the next reconcile would re-land it. Loud enough to see it happen twice.
+            logger?.LogWarning(ex,
+                "Module '{Name}': generation {Generation} was already landed by another replica, "
+                + "but its timestamp could not be refreshed ({Cause}) — a concurrent GC pass may "
+                + "still reclaim it as unreferenced, and the next reconcile re-lands it.",
+                name, generation, ex.Message);
+        }
     }
 
     private void RemoveCore(string name)

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -634,6 +634,113 @@ public static class ModuleSetStore
         return removed;
     }
 
+    /// <summary>
+    /// Retires the LOSERS of a duplicate that has been DECIDED (#3656) — at every sequence more
+    /// than one replica proposed, every proposal record except the one every reader resolves to
+    /// (the ordinally smallest <see cref="ModuleSet.Id"/>, exactly as
+    /// <see cref="Read(string, Action{string}, Action{string})"/> resolves it), plus any adoption
+    /// record written against a loser.
+    ///
+    /// <para>🚨 <b>Why the loser is housekeeping and not evidence.</b> A duplicate is decided the
+    /// first time anything reads it: every reader picks the same winner without coordinating, and
+    /// nothing is lost, because the next proposal is derived from the ACTIVATION RECORD and never
+    /// from the previous proposal — so the loser's landings ride the following wave whether its
+    /// record survives or not. What the record does do while it survives is make the conflict
+    /// re-detectable: the two files sit at the mesh's newest sequence until some later wave
+    /// supersedes them (<see cref="Prune"/> only reaches BELOW the current set), so every pod's
+    /// sweep re-reads them and re-reports the same decided conflict on every boot, forever. That
+    /// is issue #3656. Retiring the loser reports the conflict ONCE — when it is decided — instead
+    /// of once per sweep per pod, and leaves one record at the sequence, which is what a decided
+    /// conflict actually is.</para>
+    ///
+    /// <para>🚨 <b>Fail closed on a record it cannot read.</b> A record whose id is unknown makes
+    /// the WINNER unknown, so nothing at that sequence is retired until it can be read — the
+    /// #2509 rule, for the same reason: the one thing this must never do is delete the record the
+    /// mesh resolves to.</para>
+    /// </summary>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under.</param>
+    /// <param name="onRetired">One call per retired record, naming the sequence, the winner and
+    /// the loser — the once-per-conflict report that replaces the once-per-sweep one.</param>
+    /// <param name="onWarn">The loud channel for a record that could not be read or removed.</param>
+    /// <returns>How many records were removed.</returns>
+    public static int PruneDuplicateProposals(
+        string baseDirectory, Action<string>? onRetired = null, Action<string>? onWarn = null)
+    {
+        var directory = SetsDirectory(baseDirectory);
+        if (!Directory.Exists(directory))
+            return 0;
+        string[] files;
+        try
+        {
+            files = [.. Directory.EnumerateFiles(directory, "*" + ProposedSuffix)];
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            onWarn?.Invoke(
+                $"Module set records under '{directory}' could not be listed ({ex.GetType().Name}: "
+                + $"{ex.Message}) — no decided duplicate was retired this pass.");
+            return 0;
+        }
+
+        var bySequence = new Dictionary<long, List<string>>();
+        foreach (var file in files)
+            if (TryParseRecordName(Path.GetFileName(file), ProposedSuffix, out var sequence, out _))
+                (bySequence.TryGetValue(sequence, out var list) ? list : bySequence[sequence] = [])
+                    .Add(file);
+
+        var removed = 0;
+        foreach (var (sequence, atSequence) in bySequence.Where(kv => kv.Value.Count > 1))
+        {
+            var records = atSequence
+                .Select(file => (File: file, Set: TryRead<ModuleSet>(file, onWarn)))
+                .ToArray();
+            if (Array.Exists(records, r => r.Set is null))
+                continue;   // unknown id ⇒ unknown winner ⇒ nothing is retired here
+            var winner = records.OrderBy(r => r.Set!.Id, StringComparer.Ordinal).First();
+            foreach (var (file, set) in records)
+            {
+                if (string.Equals(set!.Id, winner.Set!.Id, StringComparison.Ordinal))
+                    continue;
+                if (!TryDelete(file, onWarn))
+                    continue;
+                removed++;
+                // The loser's adoption record, if any replica wrote one before the winner's file
+                // existed. Read() already ignores it (an adoption counts only against the winner's
+                // id); leaving it behind would leave the conflict half-visible.
+                if (TryDelete(PathOf(baseDirectory, sequence, set.Id, AdoptedSuffix), onWarn: null))
+                    removed++;
+                onRetired?.Invoke(
+                    $"Module set sequence {sequence} was proposed by more than one replica and is "
+                    + $"decided — the ordinally smallest id wins ('{winner.Set.Id}'), and the "
+                    + $"superseded proposal '{set.Id}' has been retired. No module is lost: the "
+                    + "next proposal is derived from the activation record, so every landing rides "
+                    + "the following wave.");
+            }
+        }
+        return removed;
+    }
+
+    /// <summary>Deletes one record; an absent file is success, and a refusal is reported to
+    /// <paramref name="onWarn"/> and left for a later pass.</summary>
+    private static bool TryDelete(string path, Action<string>? onWarn)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return false;
+            File.Delete(path);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            onWarn?.Invoke(
+                $"Module set record '{Path.GetFileName(path)}' could not be removed "
+                + $"({ex.GetType().Name}: {ex.Message}) — a later pass collects it; nothing "
+                + "resolves against it.");
+            return false;
+        }
+    }
+
     /// <summary>One human-readable line naming which set the mesh is on and whether a replica is
     /// serving it yet — shared by every surface so two of them can never report different sets.</summary>
     /// <param name="index">The set index.</param>

--- a/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleSetConvergenceTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
@@ -228,6 +229,157 @@ public class ModuleSetConvergenceTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 <b>THE repro of #3656.</b> Two replicas that both decide to land the SAME published
+    /// bundle — the normal shape of a reconcile wave, because every replica reconciles the same
+    /// feed at boot and on every <c>ModulePublished</c> broadcast — must land ONE generation and
+    /// derive ONE set. The second one's proposal is then the no-op it should always have been, and
+    /// no conflicting record is ever written.
+    ///
+    /// <para>Before the fix the generation leaf was <c>name@&lt;8 random hex&gt;</c>, so the two
+    /// identical landings wrote the identical bytes into two DIFFERENT directories; the set each
+    /// derived from the activation record named a different generation for that module, both were
+    /// proposed at the same sequence, and the loser's record then sat at the mesh's newest sequence
+    /// being re-read and re-reported by every pod's sweep on every boot — forever, because
+    /// <see cref="ModuleSetStore.Prune"/> only reaches BELOW the current set. Measured on
+    /// memex-cloud 2026-09-08: 100 duplicate sequences, 687 set records, 843 generation
+    /// directories.</para>
+    ///
+    /// <para><see cref="TwoReplicasLandingDifferentBuilds_StillDeriveTwoGenerations"/> is the
+    /// control that keeps every assertion here honest: the single-generation and no-conflict claims
+    /// FAIL there, so neither can pass by nothing ever landing.</para>
+    /// </summary>
+    [Fact]
+    public async Task TwoReplicasLandingOneBundle_LandOneGenerationAndProposeOneSet()
+    {
+        var build = await Land(ModuleA);            // replica 1's wave lands the published bundle
+        var afterFirst = await ProposeWave();
+        Assert.NotNull(afterFirst);
+
+        // Replica 2 read the same feed and decided to land the same bundle: identical bytes.
+        await LandBuild(ModuleA, build);
+        var afterSecond = await ProposeWave();
+
+        Assert.Null(afterSecond);                    // the set did not move — there was nothing new
+        Assert.Equal(
+            Path.GetFileName(Assert.Single(GenerationDirectories(ModuleA))),
+            ModuleSetStore.Read(root).Proposed!.Generations[ModuleA]);
+        var index = ModuleSetStore.Read(root);
+        Assert.Empty(index.ConflictingSequences);
+        Assert.Equal(afterFirst!.Id, index.Proposed!.Id);
+        Assert.Equal(afterFirst.Sequence, index.Proposed.Sequence);
+        // …and the entry did not record a fallback to ITSELF: nothing was displaced.
+        Assert.Null(ModuleActivationSidecar.Read(root).Entries
+            .Single(e => e.Name == ModuleA).PreviousDirectory);
+    }
+
+    /// <summary>
+    /// The control for <see cref="TwoReplicasLandingOneBundle_LandOneGenerationAndProposeOneSet"/>
+    /// — and the half of #3656 that must NOT change. Two replicas landing DIFFERENT content is a
+    /// genuine divergence: two generations, two sets, and the conflict the design exists to resolve
+    /// and report. Without this, "one generation, no conflict" would pass on a harness where
+    /// nothing ever lands twice.
+    /// </summary>
+    [Fact]
+    public async Task TwoReplicasLandingDifferentBuilds_StillDeriveTwoGenerations()
+    {
+        await Land(ModuleA);
+        var first = await ProposeWave();
+        Assert.NotNull(first);
+
+        await Land(ModuleA);                         // a DIFFERENT build of the same module
+        var second = await ProposeWave();
+
+        Assert.NotNull(second);
+        Assert.NotEqual(first!.Id, second!.Id);
+        Assert.Equal(2, GenerationDirectories(ModuleA).Count);
+        Assert.NotEqual(
+            first.Generations[ModuleA], ModuleSetStore.Read(root).Proposed!.Generations[ModuleA]);
+    }
+
+    /// <summary>
+    /// 🚨 The other half of #3656: a duplicate that HAS been produced must be reported once and
+    /// then retired, never re-read and re-reported by every pod's sweep on every boot. The loser is
+    /// housekeeping the moment the conflict is decided — every reader resolves to the same winner,
+    /// and the next proposal is derived from the ACTIVATION RECORD, so the loser's landings ride the
+    /// following wave whether its record survives or not.
+    ///
+    /// <para>The first read is the POSITIVE CONTROL: it proves the notice can fire on this volume,
+    /// so the silence after the sweep is the retirement and not an assertion that could never have
+    /// been made. The winner is asserted UNCHANGED across the retirement — the one thing this must
+    /// never do is remove the record the mesh resolves to.</para>
+    /// </summary>
+    [Fact]
+    public async Task ADecidedDuplicate_IsRetiredSoNoLaterSweepCanReReportIt()
+    {
+        await LandWave(ModuleA);
+        BootReplica();                                     // sequence 1 is adopted
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+        BootReplica();
+
+        // Positive control: with both records on the volume the conflict IS reported.
+        var before = new List<string>();
+        var winner = ModuleSetStore.Read(root, onCorrupt: null, before.Add).Proposed!;
+        Assert.Contains(before, m => m.Contains("proposed by more than one replica"));
+        Assert.Equal(2, ProposalIds(rival.Sequence).Count);
+
+        var retired = new List<string>();
+        var removed = ModuleSetStore.PruneDuplicateProposals(root, retired.Add);
+
+        Assert.Equal(1, removed);
+        Assert.Contains(retired, m => m.Contains("decided") && m.Contains(winner.Id));
+        // One record left, the SAME winner, and nothing left for a later sweep to re-report.
+        var after = new List<string>();
+        var index = ModuleSetStore.Read(root, onCorrupt: null, after.Add);
+        Assert.Empty(after);
+        Assert.Empty(index.ConflictingSequences);
+        Assert.Equal(winner.Id, index.Proposed!.Id);
+        Assert.Equal([winner.Id], ProposalIds(rival.Sequence));
+    }
+
+    /// <summary>
+    /// 🚨 Fail closed, the #2509 rule: a proposal record whose id cannot be READ makes the winner
+    /// unknown, so nothing at that sequence is retired. The one thing this pass must never do is
+    /// delete the record the mesh resolves to.
+    /// </summary>
+    [Fact]
+    public async Task ADuplicateWithAnUnreadableRecord_RetiresNothing()
+    {
+        await LandWave(ModuleA);
+        var landed = ModuleActivationSidecar.Read(root);
+        await Land(ModuleB);
+        var rival = ModuleSetStore.Propose(root, ModuleActivationSidecar.Read(root), "replica-2")!;
+        WriteRivalProposalAtSameSequence(rival.Sequence, landed);
+        Assert.Equal(2, ProposalIds(rival.Sequence).Count);
+
+        // A THIRD record at the same sequence that cannot be read at all.
+        File.WriteAllText(
+            Path.Combine(ModuleSetStore.SetsDirectory(root),
+                $"{rival.Sequence:D9}-garbage000000000.proposed.json"),
+            "{ not json");
+
+        var warnings = new List<string>();
+        Assert.Equal(0, ModuleSetStore.PruneDuplicateProposals(root, onWarn: warnings.Add));
+
+        Assert.Contains(warnings, m => m.Contains("garbage000000000"));
+        Assert.Equal(3, ProposalFileCount(rival.Sequence));
+    }
+
+    /// <summary>Every generation directory on the volume for one module.</summary>
+    private IReadOnlyList<string> GenerationDirectories(string name) =>
+        [.. Directory.EnumerateDirectories(Path.Combine(root, "modules"),
+            name + "@*", SearchOption.TopDirectoryOnly)];
+
+    /// <summary>How many proposal records sit at one sequence — counted from the NAMES, so a
+    /// record that cannot be parsed still counts.</summary>
+    private int ProposalFileCount(long sequence) =>
+        Directory.EnumerateFiles(ModuleSetStore.SetsDirectory(root), "*.proposed.json")
+            .Count(f => Path.GetFileName(f)
+                .StartsWith(sequence.ToString("D9") + "-", StringComparison.Ordinal));
+
+    /// <summary>
     /// 🚨 #3675: a sequence two replicas proposed is a decided outcome, not a record that could not
     /// be read. The three-argument <see cref="ModuleSetStore.Read(string, Action{string}, Action{string})"/>
     /// keeps the two apart — the notice never reaches the fault channel — while the two-argument
@@ -298,7 +450,10 @@ public class ModuleSetConvergenceTest : IDisposable
 
         Assert.False(Directory.Exists(orphan), "an unreferenced generation survived a pass that had nothing unreadable to fail closed on");
         Assert.Empty(SetRecordsBelow(current));
-        Assert.Equal(2, ProposalIds(current).Count);   // the duplicate pair itself is never the one removed
+        // 🚨 #3656: the duplicate pair is DECIDED, so the same pass retires the loser — one record
+        // is left at the sequence and it is the winner every reader resolves to. Before #3656 both
+        // survived, and every pod's next sweep re-read and re-reported the same decided conflict.
+        Assert.Equal([ModuleSetStore.Read(root).Proposed!.Id], ProposalIds(current));
 
         // #2509 still holds: one record that cannot be read, and the pass reclaims nothing.
         Directory.CreateDirectory(orphan);
@@ -428,8 +583,35 @@ public class ModuleSetConvergenceTest : IDisposable
 
     // ───────────────────────────────────────────────────────────── harness
 
-    /// <summary>Lands one module through the REAL landing service — a fresh generation plus the
-    /// activation entry, exactly as an auto-update or an install does.</summary>
+    /// <summary>Lands a NEW BUILD of one module through the REAL landing service — a fresh
+    /// generation plus the activation entry, exactly as an auto-update or an install does. Returns
+    /// the build number, so a test can hand the SAME build to <see cref="LandBuild"/> and model the
+    /// second replica landing the bundle the first one just landed.</summary>
+    /// <remarks>
+    /// 🚨 Every call lands DIFFERENT bytes, and that is load-bearing since #3656. The generation
+    /// leaf is now the CONTENT ADDRESS of the landing, so re-landing identical bytes resolves to
+    /// the generation that is already there — correctly, and deliberately. A helper that landed one
+    /// fixed byte array over and over would therefore model a RE-LAND, not an update, and every
+    /// "the wave moved the mesh's set" assertion below would silently be asserting the opposite of
+    /// what it says. Before #3656 the random leaf hid the difference: identical bytes still minted
+    /// a new generation, which is precisely the defect (two replicas landing one bundle produced
+    /// two generations, two sets and a permanent conflict record).
+    /// </remarks>
+    private async Task<int> Land(string name)
+    {
+        var build = ++landings;
+        await LandBuild(name, build);
+        return build;
+    }
+
+    /// <summary>The number of builds this test has landed — the content differentiator.</summary>
+    private int landings;
+
+    /// <summary>
+    /// Lands ONE identified build of a module. The build number rides in a static asset, so two
+    /// calls with the same number write byte-identical bundles — what two replicas adopting one
+    /// published bundle actually do — and two calls with different numbers write different ones.
+    /// </summary>
     /// <remarks>
     /// 🚨 REAL assembly bytes, not a three-byte MZ stand-in. Since #3538 the landing MEASURES the
     /// module's link requirements against this platform's surface, so bytes that are not a managed
@@ -437,8 +619,12 @@ public class ModuleSetConvergenceTest : IDisposable
     /// Any assembly whose references this process carries works; the packaging assembly is the
     /// same one <c>ServedModuleBytesTest</c> uses for the same reason.
     /// </remarks>
-    private async Task Land(string name) =>
-        await landing.LandModule(name, [(name + ".dll", RealAssemblyBytes)])
+    private async Task LandBuild(string name, int build) =>
+        await landing.LandModule(
+                name,
+                [(name + ".dll", RealAssemblyBytes)],
+                version: $"1.0.{build}",
+                staticAssets: [("wwwroot/build.txt", Encoding.UTF8.GetBytes($"build {build}"))])
             .Timeout(TestTimeouts.Convergence).Await();
 
     /// <summary>A real, loadable managed assembly's bytes — see <see cref="Land"/>.</summary>

--- a/test/MeshWeaver.Compiler.Pipeline.Test/PlatformUpdateKeepsThePluginThenTakesTheRebuildTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/PlatformUpdateKeepsThePluginThenTakesTheRebuildTest.cs
@@ -156,11 +156,22 @@ public class PlatformUpdateKeepsThePluginThenTakesTheRebuildTest : IDisposable
     // ───────────────────────────────────────────────────────────── harness
 
     /// <summary>Lands one version of the plugin through the REAL landing service.</summary>
+    /// <remarks>
+    /// 🚨 A rebuild carries DIFFERENT BYTES, and since #3656 that is what makes it a different
+    /// generation: the generation directory leaf is the CONTENT ADDRESS of the landing, so two
+    /// bundles whose assemblies are byte-identical resolve to one generation no matter what their
+    /// manifests say the version is — correctly, because identical bytes are identical bytes. The
+    /// version and the framework identity therefore ride a marker asset here, exactly as a real
+    /// rebuild would differ. Landing one fixed byte array under two version strings would model a
+    /// re-land, not the rebuild this test is about.
+    /// </remarks>
     private async Task Land(string version, string frameworkMvid, string minMeshVersion) =>
         await landing.LandModule(
                 Plugin, [(Plugin + ".dll", RealAssemblyBytes)],
                 frameworkMvid: frameworkMvid, packagePath: PackagePath, version: version,
-                minMeshVersion: minMeshVersion)
+                minMeshVersion: minMeshVersion,
+                staticAssets: [("wwwroot/build.txt",
+                    System.Text.Encoding.UTF8.GetBytes($"{version} {frameworkMvid}"))])
             .Timeout(TestTimeouts.Convergence).Await();
 
     /// <summary>


### PR DESCRIPTION
Closes #3656.

## The root cause

The issue reads as a logging problem — a resolved conflict reported at `Error`, once per pod per boot. The severity half landed as #3677. This is the other half, and it is not about reporting: **the duplicates were being manufactured by the landing path, and a duplicate once produced could never be retired.**

### Why duplicate proposals exist

`ModuleLandingService.LandCore` named a module's generation directory `name@<8 random hex>`.

Every replica reconciles the same registry feed at boot **and** on every `ModulePublished` broadcast, so two replicas both deciding to land the *same* published bundle at the same moment is the normal shape of a wave, not a rarity. With a random leaf each wrote the **identical bytes** under a **different** name. `ModuleSetStore.GenerationsOf` derives the set from the activation record's `Directory`, so the set each replica derived named a different generation for that module — two different sets at one sequence, i.e. exactly the conflict `ModuleSetIndex` resolves. So a *harmless* simultaneity produced, by construction:

* an orphaned generation directory (identical bytes, second copy);
* a `.proposed.json` loser sitting at the mesh's newest sequence;
* two sets naming different directories for identical bytes — the #3395 ping-pong, re-created by the fix's own plumbing.

Measured on memex-cloud 2026-09-08: **100 duplicate sequences, 687 set records, 843 generation directories**.

### Why it kept being re-reported

`ModuleSetStore.Prune` only reaches records **below** the current set. A duplicate at the *newest* sequence therefore outlived every pass — and in steady state no further wave proposes, so it stayed newest indefinitely while every pod's sweep re-read it and re-derived the same decided conflict.

## The fix

**1. The generation is the content address.** `name@<16 hex of SHA-256 over every file the landing writes — path, length, bytes, ordinal-sorted>`. The two landings become one landing: same leaf, same activation entry, same derived set, and the second replica's `Propose` is the no-op it should always have been, so **no conflicting record is ever written**. A genuine conflict (two replicas landing *different* content) still derives two sets and is still reported — that report now means something.

An existing target is the right answer, never a collision: the landing probes for it and also catches the rename that loses the race, then refreshes the directory's mtime so the #2303 grace window covers it before the activation entry references it. 16 hex chars rather than 8 — a content address that *collided* would make a landing adopt somebody else's bytes, where a random one merely failed the rename; it also means no legacy `name@<8 hex>` directory can be mistaken for a content-addressed one.

**2. A decided duplicate is retired.** `ModuleSetStore.PruneDuplicateProposals` removes every proposal record at a duplicated sequence except the winner every reader resolves to (plus any adoption written against a loser), reporting it **once, where it is decided**. Nothing is lost: a proposal is derived from the activation record, never from the previous proposal, so the loser's landings ride the next wave whether its record survives or not. Fail-closed — a record whose id cannot be READ makes the winner unknown, so nothing at that sequence is retired — and gated on the same read-fault counter as every other removal in the GC pass.

No log level was changed and no line was filtered.

## Guards, and evidence each can fail

Falsification run: each fix reverted in place, tests rebuilt and re-run, then restored.

| Guard | Falsification | Result |
|---|---|---|
| `TwoReplicasLandingOneBundle_LandOneGenerationAndProposeOneSet` | restore `name@<8 random hex>` | **RED** |
| `ADecidedDuplicate_IsRetiredSoNoLaterSweepCanReReportIt` | `PruneDuplicateProposals` returns 0 without deleting | **RED** |
| `ADuplicateWithAnUnreadableRecord_RetiresNothing` | same | **RED** (it asserts the fail-closed path was *exercised* — the warning names the unreadable record — not merely that nothing happened) |
| `GarbageCollection_StillSweepsWithADuplicateProposalOnTheVolume` (existing, updated) | same | **RED** |
| `TwoReplicasLandingDifferentBuilds_StillDeriveTwoGenerations` | both | **GREEN under both** — this is the *control*: it proves "one generation, no conflict" cannot pass by nothing ever landing |

`ADecidedDuplicate_…` carries its own positive control inline: the first `Read` asserts the notice **does** fire on that volume, so the silence after the sweep is the retirement rather than an assertion that could never have been made — and the winner id is asserted **unchanged** across the retirement.

## A fiction in two existing harnesses

`ModuleSetConvergenceTest.Land` and `PlatformUpdateKeepsThePluginThenTakesTheRebuildTest.Land` landed one fixed byte array under two different version strings and relied on the random leaf to produce "a new generation". That is precisely the fiction that hid this defect: it could not distinguish *a new generation because the bytes are new* from *a new generation because the name is random*. Both now land different bytes for a different build, which is what a rebuild actually is.

## Behaviour worth knowing

A bundle republished with byte-identical assemblies is **not** a new generation. Its version and framework identity move on the activation entry; the directory does not, because the bytes did not. What runs is what already ran.

## Verification

Local, Release, `-warnaserror`, one project per invocation:

* `src/MeshWeaver.PluginCatalog` — 0 Warning(s), 0 Error(s)
* `test/Memex.Portal.Shared.Test` — **1083 passed, 0 failed**
* `test/MeshWeaver.Compiler.Pipeline.Test` — **712 passed, 0 failed**
* `test/MeshWeaver.Documentation.Test` — **350 passed, 0 failed** (`DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`)

## Cross-repo

No public type or member is removed; `PruneDuplicateProposals` is an addition to a static class, so neither the pair gate nor the interface-additions gate applies. The behaviour change is shape 7 (behaviour behind an unchanged signature) — a dependent that asserted "landing the same bytes twice yields two generations" would see the change; nothing in `MeshWeaver.Plugins` references `ModuleLandingService`'s generation naming (it goes through `LandModule`/`ShelveModule`, whose signatures and semantics are unchanged).

## Docs

[Module Set Convergence](/Doc/Architecture/ModuleSetConvergence) gains **The generation is the content address (#3656)** and the "…and a conflict is DECIDED once" clause. What's New: *Two replicas installing one module no longer store it twice* (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
