### PR TITLE
fix(#3659): the install-completeness sweep counts the population the installer writes

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/InstallCompleteness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstallCompleteness.md
@@ -107,10 +107,63 @@ answers because four different things can go wrong and only one outcome is fine.
 
 **Declared side.** `PackageManifest.InstalledFiles` — the per-file hash map CI generates as
 `manifest.lock` and the installer stamps onto the record — mapped through
-`PackageInstaller.NodePathForFile`, the same file→node mapping the incremental update path uses.
-Non-node files (`README.md`, the manifest sidecar, `content/**` assets) map to `null` and are
-excluded: a content asset is not a node, and counting one would make every healthy install read as
-incomplete.
+`PackageInstaller.NodePathForFile`, the installer's OWN file→node rule.
+
+🚨 **That rule has TWO halves, and counting only the first is #3659.** A file is not a node
+candidate when it is a non-node file **by design** (`README.md` at the repo root, the
+`manifest.lock` sidecar, a `content/**` asset) **or** when **no registered parser claims its
+extension** — which is how a package's ordinary carry-along files are skipped by the install
+without a word. Until #3659 the declared side asked only the first question while
+`ParseCanonical` asked both, so the two disagreed about the very population this page compares:
+
+```text
+Chess ships 37 files.  manifest.lock and content/og-card.png excluded  →  35 "declared nodes"
+                       Chess/gui/rn/chess.tsx  →  no parser claims .tsx  →  never written
+sweep, every pod, every boot:  Chess → 1 of 35 declared node(s) are ABSENT: [Chess/gui/rn/chess]
+```
+
+Measured over `MeshWeaver.Plugins`' package folders on 2026-09-08: 617 `.cs`, 275 `.json` and 248
+`.md` files a parser claims, against 200+ it does not — `.ts`, `.tsx`, `.py`, `.png`, `.mjs`,
+`.js`, `.html`, `.gitignore`, `.mp4`, `.jpg`, and four files with no extension at all. Every one of
+those was a permanent phantom ABSENT: reported at **Error**, indefinitely, spelled exactly like the
+genuinely lost source node this whole page exists to find — and driving `SkipOrHeal` to run a FULL
+reinstall of the package on every catalog visit that could never make the count reach zero.
+
+`NodePathForFile` now takes the parser registry the install itself uses, and `ParseCanonical` is
+expressed in terms of it, so there is ONE predicate rather than two implementations of half of one.
+The registry is a required argument, deliberately: which extensions are claimed is DI-dependent (a
+module contributes parsers), so a hard-coded list would be a fourth copy of a rule that drifts the
+moment one is added.
+
+**The residual, stated because it is reachable.** The declared side holds PATHS, not bytes, so it
+can ask only the extension half. A file whose extension IS claimed can still fail to become a node
+on its CONTENT — a `.json` object carrying no `$type`/`id`/`nodeType`, a file no parser can read —
+and such a file is still counted. Measured on the same day over every package folder in
+`MeshWeaver.Plugins`: that set is **empty** (every `.json` inside a package carries a node key; the
+non-node ones all live under `app/` and `e2e/`, which are not packages). Closing it properly means
+recording what the install actually wrote rather than re-deriving it, which is a different change.
+
+### The verdict states its own population
+
+🚨 **A count over the wrong population reads exactly like a correct one.** Nothing in the old
+output said which set had been counted, which is why a phantom ABSENT and a real one were
+indistinguishable for as long as the sweep existed. Every verdict now carries and prints:
+
+| Field | Says |
+|---|---|
+| `DeclaredFiles` | how many FILES the record's map holds — the population that was read |
+| `NonNodeFiles` | how many of them are not node candidates, and why (README/manifest/content asset, or an extension no parser claims) |
+| `Declared` | the DISTINCT node paths the rest map to |
+
+`Population` renders the three as one clause on every line that reports a verdict. The three are
+printed rather than two and a subtraction because `DeclaredFiles − NonNodeFiles` legitimately
+exceeds `Declared` when two files fold onto one node (the `X.json` → `X/index.json` layout move),
+and a reader has to be able to see that rather than infer it.
+
+A record whose files are ALL carry-along assets now reads `Undeclared` — *"all N file(s) the record
+declares are non-node files … so this package declares no node to compare against"* — never
+`Complete` (which would be the zero-found-zero-expected pass this page rejects) and never
+`Incomplete` (which is what it answered before).
 
 **Observed side.** ONE batched `IStorageAdapter.ReadMany` over exactly the declared paths.
 
@@ -188,6 +241,11 @@ Stated so nobody reads a green sweep as more than it is.
   deliberately theirs.
 - **A record with no file map.** `Undeclared`, and it says so — but it cannot name what is missing,
   because nothing declared it.
+- **A declared file whose CONTENT is not a node** — a well-formed `.json` with no
+  `$type`/`id`/`nodeType`, or a file no parser can read. The extension gate cannot see it (the
+  declared side holds paths, not bytes) so it is still counted. Empty over every package folder in
+  `MeshWeaver.Plugins` as of 2026-09-08; stated because it is reachable, not because it is
+  occupied.
 - **A partial storage failure.** `ReadMany` reports absence by omission, so a silent partial loss
   reads as `Incomplete` rather than `NotObserved`. That errs toward reinstalling, which is
   idempotent — the safe direction.

--- a/src/MeshWeaver.Documentation/Data/Architecture/InstallCompleteness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstallCompleteness.md
@@ -117,9 +117,11 @@ without a word. Until #3659 the declared side asked only the first question whil
 `ParseCanonical` asked both, so the two disagreed about the very population this page compares:
 
 ```text
-Chess ships 37 files.  manifest.lock and content/og-card.png excluded  →  35 "declared nodes"
-                       Chess/gui/rn/chess.tsx  →  no parser claims .tsx  →  never written
+Chess ships 37 files; gen-manifests leaves manifest.lock out of the map  →  36 declared files
+   content/og-card.png excluded (a content asset)                        →  35 "declared nodes"
+   Chess/gui/rn/chess.tsx  →  no parser claims .tsx  →  no install ever writes it
 sweep, every pod, every boot:  Chess → 1 of 35 declared node(s) are ABSENT: [Chess/gui/rn/chess]
+                    after the fix:  36 file(s) declared, 2 not node files → 34 compared, Complete
 ```
 
 Measured over `MeshWeaver.Plugins`' package folders on 2026-09-08: 617 `.cs`, 275 `.json` and 248

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-install-check-no-longer-reports-a-packages-images-as-missing-pages.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-install-check-no-longer-reports-a-packages-images-as-missing-pages.md
@@ -1,0 +1,43 @@
+---
+Name: The install check no longer reports a package's assets as missing pages
+Category: Fix
+Description: The check that verifies an installed package is whole counted every file the package ships — images, app source, licence files — as a page the install owed you, and reported the ones that are not pages as missing on every restart. It now counts exactly what an install writes, and every line says which population it counted.
+Icon: ClipboardCheckmark
+Order: -20260908
+---
+
+# The install check no longer reports a package's assets as missing pages
+
+Since last week every start checks each installed package against what its install record says it
+should hold, and reports anything absent. That check was counting the wrong things.
+
+A package ships more than pages. Alongside the Markdown, the code and the typed content that become
+nodes, it carries images, app source, licence files, configuration — files the install correctly
+never turns into anything. The check did not know that: it counted **every** file the package
+declares. So `Chess`, which ships one React Native view under `gui/`, was reported as *"1 of 35
+declared node(s) are ABSENT: [Chess/gui/rn/chess]"* — at error level, on every replica, on every
+restart, for a file no install has ever written. Worse, the same verdict made the catalog run a
+full reinstall of the package each time it was visited, which could never make the count reach
+zero.
+
+The two sides now ask the same question. Whether a file becomes a page is the installer's rule, and
+the check uses that rule rather than a second copy of half of it. A package whose files are *all*
+assets now reports "declares no page to compare against" instead of reporting every one of them
+missing.
+
+**And every line says what it counted.** A count taken over the wrong set of things reads exactly
+like a correct one, which is why nothing gave this away for a week. Each verdict now carries and
+prints its population — how many files the record declares, how many of those are not pages and
+why, and how many distinct pages were compared:
+
+```text
+Chess → 'Chess': every declared node is present.
+Counted over: 37 file(s) declared, 3 of them not node files
+(README/manifest/content assets, or an extension no parser claims) → 34 distinct node path(s) compared.
+```
+
+A genuinely missing page is still reported exactly as before — the change narrows what is counted,
+not what counts as missing.
+
+See [Install Completeness](/Doc/Architecture/InstallCompleteness) for the contract and the five
+verdicts.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-install-check-no-longer-reports-a-packages-images-as-missing-pages.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-install-check-no-longer-reports-a-packages-images-as-missing-pages.md
@@ -32,7 +32,7 @@ why, and how many distinct pages were compared:
 
 ```text
 Chess → 'Chess': every declared node is present.
-Counted over: 37 file(s) declared, 3 of them not node files
+Counted over: 36 file(s) declared, 2 of them not node files
 (README/manifest/content assets, or an extension no parser claims) → 34 distinct node path(s) compared.
 ```
 

--- a/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Parsers/FileFormatParserRegistry.cs
@@ -73,6 +73,34 @@ public class FileFormatParserRegistry
     }
 
     /// <summary>
+    /// Whether ANY registered parser claims <paramref name="extension"/> — the content-free half
+    /// of "is this file a node", and the only half a caller holding a PATH but no bytes can ask.
+    ///
+    /// <para>🚨 <b>Why this is a public question (#3659).</b> Two places decide whether a package
+    /// file becomes a mesh node: the installer, which parses (this registry), and the
+    /// install-completeness sweep, which only has the record's path→hash map. Until this existed
+    /// the sweep asked a DIFFERENT question — the by-design exclusions alone — so every file whose
+    /// extension no parser claims (<c>.tsx</c>, <c>.png</c>, <c>.py</c>, an extension-less
+    /// <c>LICENSE</c>) counted as a node the install owed the mesh and was reported ABSENT at
+    /// Error on every boot, forever. Measured on <c>MeshWeaver.Plugins</c>' package folders,
+    /// 2026-09-08: 617 <c>.cs</c>, 275 <c>.json</c> and 248 <c>.md</c> files a parser claims,
+    /// against 200+ (<c>.ts</c>, <c>.tsx</c>, <c>.py</c>, <c>.png</c>, <c>.mjs</c>, <c>.js</c>,
+    /// <c>.html</c>, <c>.gitignore</c>, <c>.mp4</c>, <c>.jpg</c>, four extension-less) it does
+    /// not.</para>
+    ///
+    /// <para>It answers about the EXTENSION only. A file whose extension is claimed can still fail
+    /// to become a node on its CONTENT — a <c>.json</c> object carrying no <c>$type</c>/<c>id</c>/
+    /// <c>nodeType</c>, a file no parser can read — and no path-only caller can see that. Callers
+    /// that hold the bytes must still use <see cref="TryParse"/>.</para>
+    /// </summary>
+    /// <param name="extension">File extension including the dot (e.g. <c>".md"</c>); null, empty
+    /// or unclaimed all answer false.</param>
+    public bool ClaimsExtension(string? extension) =>
+        !string.IsNullOrEmpty(extension)
+        && _parsersByExtension.TryGetValue(extension, out var list)
+        && list.Count > 0;
+
+    /// <summary>
     /// Gets all parsers for the given file extension in priority order.
     /// </summary>
     /// <param name="extension">File extension including the dot (e.g., ".md").</param>

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -10,6 +10,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
+using MeshWeaver.Hosting.Persistence.Parsers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -1048,7 +1049,12 @@ public static class CatalogLayoutAreas
                     //                    Warning that completeness was not checked, and why.
                     return InstallCompleteness
                         .Observe(persistence, hub.JsonSerializerOptions, pkg.Id,
-                            PackageInstaller.TargetPartitionOf(pkg.Id, record), record)
+                            PackageInstaller.TargetPartitionOf(pkg.Id, record), record,
+                            // The INSTALL's own parser registry — the declared population must be
+                            // the files this install would write, never a superset (#3659).
+                            new FileFormatParserRegistry(
+                                hub.JsonSerializerOptions,
+                                hub.ServiceProvider.GetServices<IFileFormatParser>()))
                         .SelectMany(verdict => SkipOrHeal(verdict, pkg, logger, Full, WithModule));
                 }
 
@@ -1085,19 +1091,20 @@ public static class CatalogLayoutAreas
         {
             logger?.LogError(
                 "Package {Id} records module {ModuleVersion} as installed, but {Missing} of "
-                + "{Declared} declared node(s) are ABSENT from the mesh: [{Paths}]. The content "
-                + "hash cannot see this — it describes the SOURCE, not what landed — so the install "
-                + "is being REPAIRED rather than skipped (MeshWeaver#3485).",
+                + "{Declared} declared node(s) are ABSENT from the mesh: [{Paths}]. Counted over: "
+                + "{Population}. The content hash cannot see this — it describes the SOURCE, not "
+                + "what landed — so the install is being REPAIRED rather than skipped "
+                + "(MeshWeaver#3485).",
                 pkg.Id, pkg.ModuleVersion, verdict.Missing.Count, verdict.Declared,
-                string.Join(", ", verdict.Missing.Take(20)));
+                string.Join(", ", verdict.Missing.Take(20)), verdict.Population);
             return full();
         }
 
         if (verdict.Kind is InstallCompletenessKind.Complete)
             logger?.LogInformation(
                 "Package {Id} content is up to date (module {ModuleVersion}, {Present}/{Declared} "
-                + "declared node(s) present); nothing to sync.",
-                pkg.Id, pkg.ModuleVersion, verdict.Present, verdict.Declared);
+                + "declared node(s) present; counted over: {Population}); nothing to sync.",
+                pkg.Id, pkg.ModuleVersion, verdict.Present, verdict.Declared, verdict.Population);
         else
             logger?.LogWarning(
                 "Package {Id} content is up to date by module hash ({ModuleVersion}) but its "
@@ -1150,14 +1157,19 @@ public static class CatalogLayoutAreas
                     throw new InvalidOperationException(
                         $"Package '{pkg.Id}' changed shared Source/Test files; full install required.");
 
+                // The install's OWN parser registry — the file→node rule is DI-dependent (#3659),
+                // so a file whose extension no parser claims is not a node here either and must
+                // neither be fetched as one nor pruned as one.
+                var parsers = new FileFormatParserRegistry(
+                    hub.JsonSerializerOptions, hub.ServiceProvider.GetServices<IFileFormatParser>());
                 var changedNodePaths = delta.AddedOrChangedFiles
-                    .Select(PackageInstaller.NodePathForFile)
+                    .Select(f => PackageInstaller.NodePathForFile(f, parsers))
                     .Where(p => p is not null).Select(p => p!)
                     .ToHashSet(StringComparer.Ordinal);
                 // Removed FILES prune their nodes — unless the node is still fed by a changed file
                 // (the `X.json` → `X/index.json` layout move maps both to node X).
                 var removedNodePaths = delta.RemovedFiles
-                    .Select(PackageInstaller.NodePathForFile)
+                    .Select(f => PackageInstaller.NodePathForFile(f, parsers))
                     .Where(p => p is not null && !changedNodePaths.Contains(p))
                     .Select(p => p!)
                     .ToHashSet(StringComparer.Ordinal);

--- a/src/MeshWeaver.PluginCatalog/InstallCompleteness.cs
+++ b/src/MeshWeaver.PluginCatalog/InstallCompleteness.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 
@@ -37,26 +38,53 @@ public static class InstallCompleteness
 {
     /// <summary>
     /// The node paths an install record DECLARES must be present, derived from the per-file hash map
-    /// the installer stamped on it (<see cref="PackageManifest.InstalledFiles"/>) through the same
-    /// file→node mapping the incremental update path uses
-    /// (<see cref="PackageInstaller.NodePathForFile"/>).
+    /// the installer stamped on it (<see cref="PackageManifest.InstalledFiles"/>) through
+    /// <see cref="PackageInstaller.NodePathForFile(string, FileFormatParserRegistry)"/> — the
+    /// installer's OWN file→node rule, not a second implementation of part of it.
     ///
-    /// <para>Non-node files — <c>README.md</c>, the <c>manifest.lock</c> sidecar, <c>content/**</c>
-    /// assets — map to <c>null</c> and are excluded: a content asset is not a node and its absence
-    /// is a different question.</para>
+    /// <para>🚨 <b>The population is the whole point, and getting it wrong is #3659.</b> This used
+    /// to apply only the by-design exclusions (<c>README.md</c>, the <c>manifest.lock</c> sidecar,
+    /// <c>content/**</c>) while the installer ALSO skipped every file whose extension no registered
+    /// parser claims. So a package's ordinary carry-along files counted as nodes the install owed
+    /// the mesh: <c>Chess</c> ships <c>Chess/gui/rn/chess.tsx</c>, nothing ever wrote it, and the
+    /// sweep reported <c>Chess/gui/rn/chess</c> ABSENT at Error on every pod boot — indefinitely,
+    /// and spelled exactly like the genuinely lost source node the sweep exists to find. A count
+    /// over the wrong population reads exactly like a correct one, which is why
+    /// <see cref="InstallCompletenessVerdict.DeclaredFiles"/> and
+    /// <see cref="InstallCompletenessVerdict.NonNodeFiles"/> now travel with every verdict and are
+    /// printed: a wrong population is visible rather than silent.</para>
     /// </summary>
     /// <param name="record">The install record's manifest, as stamped by the installer.</param>
+    /// <param name="parsers">The parser registry the INSTALL would use. Required — the claimed
+    /// extensions are DI-dependent, so a hard-coded list here would be exactly the second
+    /// implementation this parameter exists to remove.</param>
     /// <returns>The declared node paths, ordinal-sorted and distinct; empty when nothing is declared.</returns>
-    public static ImmutableSortedSet<string> DeclaredNodePaths(PackageManifest? record)
+    public static ImmutableSortedSet<string> DeclaredNodePaths(
+        PackageManifest? record, FileFormatParserRegistry parsers)
     {
+        ArgumentNullException.ThrowIfNull(parsers);
         if (record?.InstalledFiles is not { Count: > 0 } files)
             return ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal);
         return files.Keys
-            .Select(PackageInstaller.NodePathForFile)
+            .Select(f => PackageInstaller.NodePathForFile(f, parsers))
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Select(p => p!)
             .ToImmutableSortedSet(StringComparer.Ordinal);
     }
+
+    /// <summary>
+    /// <see cref="DeclaredNodePaths(PackageManifest, FileFormatParserRegistry)"/> against the
+    /// BUILT-IN parser set alone.
+    ///
+    /// <para>🚨 A caller with a hub must pass that hub's registry: which extensions become nodes is
+    /// DI-dependent, and this overload cannot see a module's contributed parser. It exists so the
+    /// public surface of this change is purely ADDITIVE — removing a public member reds a plugin
+    /// repo's trunk on pull requests that did not make the change (#2689) — and every caller inside
+    /// the install and completeness paths passes a real registry.</para>
+    /// </summary>
+    /// <param name="record">The install record's manifest, as stamped by the installer.</param>
+    public static ImmutableSortedSet<string> DeclaredNodePaths(PackageManifest? record) =>
+        DeclaredNodePaths(record, PackageInstaller.BuiltInParsers);
 
     /// <summary>
     /// The verdict, computed purely — no mesh, no hub, so the falsification tests can drive every
@@ -74,22 +102,39 @@ public static class InstallCompleteness
         string packageId,
         string partition,
         PackageManifest? record,
-        IReadOnlySet<string>? present)
+        IReadOnlySet<string>? present,
+        FileFormatParserRegistry parsers)
     {
+        ArgumentNullException.ThrowIfNull(parsers);
         if (record is null)
             return new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.Undeclared, 0, 0,
                 ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
                 "no install record exists, so nothing declares what this partition should hold");
 
-        var declared = DeclaredNodePaths(record);
+        var declared = DeclaredNodePaths(record, parsers);
+        // 🚨 The POPULATION, carried on every verdict (#3659): how many files the record holds and
+        // how many of them are not node candidates at all. Without these two the count of "declared
+        // nodes" is a bare number that reads identically whether it was taken over the right set or
+        // the wrong one — which is exactly how a `.tsx` asset was reported as a missing node on
+        // every boot for as long as the sweep existed.
+        var declaredFiles = record.InstalledFiles?.Count ?? 0;
+        var nonNodeFiles = declaredFiles - (record.InstalledFiles?.Keys
+            .Count(f => PackageInstaller.NodePathForFile(f, parsers) is not null) ?? 0);
+        InstallCompletenessVerdict WithPopulation(InstallCompletenessVerdict verdict) =>
+            verdict with { DeclaredFiles = declaredFiles, NonNodeFiles = nonNodeFiles };
         if (declared.Count == 0)
-            return new InstallCompletenessVerdict(
+            return WithPopulation(new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.Undeclared, 0, 0,
                 ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
-                "the install record carries no file map (installedFiles), so what it should hold is "
-                + "not declared anywhere — it was installed before the file map was stamped, or by "
-                + "a lane that does not stamp one. The next real install writes one.");
+                declaredFiles == 0
+                    ? "the install record carries no file map (installedFiles), so what it should "
+                      + "hold is not declared anywhere — it was installed before the file map was "
+                      + "stamped, or by a lane that does not stamp one. The next real install "
+                      + "writes one."
+                    : $"all {declaredFiles} file(s) the record declares are non-node files (a "
+                      + "README, the manifest sidecar, a content/** asset, or an extension no "
+                      + "parser claims), so this package declares no node to compare against"));
 
         // 🚨 A file map that does not map ONTO this partition cannot be compared against it, and
         // guessing a rebase would manufacture a shortfall out of a naming difference. Say so
@@ -98,24 +143,24 @@ public static class InstallCompleteness
             .Where(p => !IsUnder(p, partition))
             .ToImmutableSortedSet(StringComparer.Ordinal);
         if (offPartition.Count > 0)
-            return new InstallCompletenessVerdict(
+            return WithPopulation(new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.Undeclared, declared.Count, 0,
                 offPartition,
                 $"{offPartition.Count} of {declared.Count} declared file(s) map outside the target "
                 + $"partition '{partition}' (e.g. '{offPartition[0]}'), so the record cannot be "
-                + "compared against it");
+                + "compared against it"));
 
         if (present is null)
-            return new InstallCompletenessVerdict(
+            return WithPopulation(new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.NotObserved, declared.Count, 0,
                 ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
-                "the mesh could not be read, so completeness was NOT checked — this is not a pass");
+                "the mesh could not be read, so completeness was NOT checked — this is not a pass"));
 
         var missing = declared
             .Where(p => !present.Contains(p))
             .ToImmutableSortedSet(StringComparer.Ordinal);
         var found = declared.Count - missing.Count;
-        return missing.Count == 0
+        return WithPopulation(missing.Count == 0
             ? new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.Complete, declared.Count, found,
                 ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
@@ -123,8 +168,26 @@ public static class InstallCompleteness
             : new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.Incomplete, declared.Count, found,
                 missing,
-                $"{missing.Count} of {declared.Count} declared node(s) are ABSENT from the mesh");
+                $"{missing.Count} of {declared.Count} declared node(s) are ABSENT from the mesh"));
     }
+
+    /// <summary>
+    /// <see cref="Compare(string, string, PackageManifest, IReadOnlySet{string}, FileFormatParserRegistry)"/>
+    /// against the BUILT-IN parser set alone — see the remarks on
+    /// <see cref="DeclaredNodePaths(PackageManifest)"/> for why this overload exists and when it is
+    /// the wrong one to call.
+    /// </summary>
+    /// <param name="packageId">The package the record belongs to.</param>
+    /// <param name="partition">The partition the package installed into.</param>
+    /// <param name="record">The install record's manifest, or null when no record exists.</param>
+    /// <param name="present">The node paths OBSERVED in the mesh; null means the read did not
+    /// happen.</param>
+    public static InstallCompletenessVerdict Compare(
+        string packageId,
+        string partition,
+        PackageManifest? record,
+        IReadOnlySet<string>? present) =>
+        Compare(packageId, partition, record, present, PackageInstaller.BuiltInParsers);
 
     /// <summary>
     /// The reactive half: read back exactly the paths the record declares and compare.
@@ -146,33 +209,59 @@ public static class InstallCompleteness
         JsonSerializerOptions options,
         string packageId,
         string partition,
-        PackageManifest? record)
+        PackageManifest? record,
+        FileFormatParserRegistry parsers)
     {
-        var declared = DeclaredNodePaths(record);
+        ArgumentNullException.ThrowIfNull(parsers);
+        var declared = DeclaredNodePaths(record, parsers);
+        var files = record?.InstalledFiles?.Count ?? 0;
+        var nonNode = files - (record?.InstalledFiles?.Keys
+            .Count(f => PackageInstaller.NodePathForFile(f, parsers) is not null) ?? 0);
         if (persistence is null)
             return Observable.Return(new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.NotObserved, declared.Count, 0,
                 ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
-                "this host registers no storage adapter, so the mesh was NOT read"));
+                "this host registers no storage adapter, so the mesh was NOT read")
+            { DeclaredFiles = files, NonNodeFiles = nonNode });
         // Nothing declared ⇒ nothing to read. Compare against an EMPTY observation rather than a
         // null one: the verdict is Undeclared either way, and reading the mesh to learn that would
         // be a round-trip that cannot change the answer.
         if (declared.Count == 0)
             return Observable.Return(
-                Compare(packageId, partition, record, ImmutableHashSet<string>.Empty));
+                Compare(packageId, partition, record, ImmutableHashSet<string>.Empty, parsers));
 
         return persistence.ReadMany(declared, options)
             .Select(n => n.Path)
             .ToList()
             .Select(paths => Compare(packageId, partition, record,
-                paths.ToImmutableHashSet(StringComparer.Ordinal)))
+                paths.ToImmutableHashSet(StringComparer.Ordinal), parsers))
             .Catch<InstallCompletenessVerdict, Exception>(ex => Observable.Return(
                 new InstallCompletenessVerdict(
                     packageId, partition, InstallCompletenessKind.NotObserved, declared.Count, 0,
                     ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
                     $"reading the mesh failed, so completeness was NOT checked — this is not a "
-                    + $"pass. Cause: {ex.Message}")));
+                    + $"pass. Cause: {ex.Message}")
+                { DeclaredFiles = files, NonNodeFiles = nonNode }));
     }
+
+    /// <summary>
+    /// <see cref="Observe(IStorageAdapter, JsonSerializerOptions, string, string, PackageManifest, FileFormatParserRegistry)"/>
+    /// against the BUILT-IN parser set alone — see the remarks on
+    /// <see cref="DeclaredNodePaths(PackageManifest)"/> for why this overload exists and when it is
+    /// the wrong one to call.
+    /// </summary>
+    /// <param name="persistence">The storage adapter; <c>null</c> yields <c>NotObserved</c>.</param>
+    /// <param name="options">Serializer options for the read.</param>
+    /// <param name="packageId">The package id.</param>
+    /// <param name="partition">The package's target partition.</param>
+    /// <param name="record">The install record's manifest.</param>
+    public static IObservable<InstallCompletenessVerdict> Observe(
+        IStorageAdapter? persistence,
+        JsonSerializerOptions options,
+        string packageId,
+        string partition,
+        PackageManifest? record) =>
+        Observe(persistence, options, packageId, partition, record, PackageInstaller.BuiltInParsers);
 
     /// <summary>
     /// The OTHER half of the same question, and the one the record-driven arm cannot ask: a
@@ -412,9 +501,37 @@ public sealed record InstallCompletenessVerdict(
     /// <summary>🚨 True ONLY for <see cref="InstallCompletenessKind.Complete"/>. "Not checked" is not "clean".</summary>
     public bool IsComplete => Kind is InstallCompletenessKind.Complete;
 
+    /// <summary>
+    /// How many FILES the install record declares — the population <see cref="Declared"/> was taken
+    /// over. 🚨 Carried and printed because a count over the WRONG population reads exactly like a
+    /// correct one (#3659): the sweep counted every carry-along asset as a node the install owed
+    /// the mesh and reported it absent on every boot, and nothing in the output said which set had
+    /// been counted. Zero on a record with no file map, and on a verdict built by a caller
+    /// compiled before this field existed — an init-only property, not a positional parameter, so
+    /// such a caller keeps binding.
+    /// </summary>
+    public int DeclaredFiles { get; init; }
+
+    /// <summary>
+    /// How many of <see cref="DeclaredFiles"/> are NOT node candidates — a README, the
+    /// <c>manifest.lock</c> sidecar, a <c>content/**</c> asset, or a file whose extension no
+    /// registered parser claims. <see cref="Declared"/> is the DISTINCT node paths the rest map to,
+    /// so <c>DeclaredFiles - NonNodeFiles</c> exceeds it exactly when two files fold onto one node
+    /// (the <c>X.json</c> → <c>X/index.json</c> layout move) — which is why all three are printed
+    /// rather than two and a subtraction.
+    /// </summary>
+    public int NonNodeFiles { get; init; }
+
+    /// <summary>What this verdict counted, and over what — one clause, on every line that reports
+    /// a verdict, so a wrong population is visible instead of silent.</summary>
+    public string Population =>
+        $"{DeclaredFiles} file(s) declared, {NonNodeFiles} of them not node files "
+        + $"(README/manifest/content assets, or an extension no parser claims) → {Declared} "
+        + "distinct node path(s) compared";
+
     /// <inheritdoc />
     public override string ToString() =>
-        $"{PackageId} [{Kind}] {Present}/{Declared} present"
+        $"{PackageId} [{Kind}] {Present}/{Declared} present ({Population})"
         + (Missing.Count == 0 ? "" : $" — missing: {string.Join(", ", Missing.Take(10))}"
                                      + (Missing.Count > 10 ? $" (+{Missing.Count - 10} more)" : ""));
 }

--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -244,12 +245,19 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
             .Concat([PackageInstaller.InstalledPartition])
             .ToImmutableHashSet(StringComparer.Ordinal);
 
+        // 🚨 The INSTALL's own parser registry (#3659). The declared population is "the files the
+        // installer would have written as nodes", and which extensions those are is DI-dependent —
+        // a module contributes parsers. Deriving it from half the rule is what made every
+        // carry-along asset (a `.tsx` view, a `.png`, an extension-less LICENSE) count as a node
+        // the install owed the mesh and be reported ABSENT at Error on every boot, forever.
+        var parsers = new FileFormatParserRegistry(
+            hub.JsonSerializerOptions, hub.ServiceProvider.GetServices<IFileFormatParser>());
         var perRecord = records.Count == 0
             ? Observable.Empty<InstallCompletenessVerdict>()
             : records
                 .Select(record => InstallCompleteness.Observe(
                     persistence, hub.JsonSerializerOptions,
-                    record.PackageId, record.Partition, record.Manifest))
+                    record.PackageId, record.Partition, record.Manifest, parsers))
                 .ToObservable()
                 .Concat();
 
@@ -263,12 +271,13 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                 foreach (var verdict in verdicts.Where(v => v.Kind is InstallCompletenessKind.Incomplete))
                     logger?.LogError(
                         "[InstallCompleteness] {Package} → '{Partition}': {Missing} of {Declared} "
-                        + "declared node(s) are ABSENT. Missing: [{Paths}]. The install record says "
-                        + "this package is up to date; the mesh disagrees. Reinstalling it now "
-                        + "repairs it — the up-to-date gate no longer skips an incomplete install "
-                        + "(MeshWeaver#3485).",
+                        + "declared node(s) are ABSENT. Missing: [{Paths}]. Counted over: "
+                        + "{Population}. The install record says this package is up to date; the "
+                        + "mesh disagrees. Reinstalling it now repairs it — the up-to-date gate no "
+                        + "longer skips an incomplete install (MeshWeaver#3485).",
                         verdict.PackageId, verdict.Partition, verdict.Missing.Count,
-                        verdict.Declared, string.Join(", ", verdict.Missing.Take(20)));
+                        verdict.Declared, string.Join(", ", verdict.Missing.Take(20)),
+                        verdict.Population);
 
                 foreach (var verdict in verdicts.Where(v => v.Kind is InstallCompletenessKind.RootWithoutRecord))
                     logger?.LogError(
@@ -284,8 +293,10 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                                  or InstallCompletenessKind.Undeclared))
                     logger?.LogWarning(
                         "[InstallCompleteness] {Package} → '{Partition}': NOT VERIFIED ({Kind}) — "
-                        + "{Because}. This is not a clean bill of health; it is an absence of one.",
-                        verdict.PackageId, verdict.Partition, verdict.Kind, verdict.Because);
+                        + "{Because}. Counted over: {Population}. This is not a clean bill of "
+                        + "health; it is an absence of one.",
+                        verdict.PackageId, verdict.Partition, verdict.Kind, verdict.Because,
+                        verdict.Population);
 
                 var summary = InstallCompleteness.Summarize(verdicts);
                 logger?.LogInformation(

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -3086,8 +3086,11 @@ public static class PackageInstaller
 
                 var currentNodePaths = nodes.Select(n => n.Path)
                     .ToImmutableHashSet(StringComparer.Ordinal);
+                // The install's OWN parser registry — the file→node rule is DI-dependent (#3659).
+                var parsers = new FileFormatParserRegistry(
+                    options, hub.ServiceProvider.GetServices<IFileFormatParser>());
                 var removedNodePaths = moduleManifest.DiffFrom(previousFiles).RemovedFiles
-                    .Select(NodePathForFile)
+                    .Select(f => NodePathForFile(f, parsers))
                     .Where(p => p is not null && !currentNodePaths.Contains(p))
                     .Select(p => p!)
                     .ToImmutableHashSet(StringComparer.Ordinal);
@@ -3414,12 +3417,20 @@ public static class PackageInstaller
             .Where(n => n is not null).Select(n => n!)
             .ToArray();
 
+        // 🚨 The line states the POPULATION, not just the shortfall (#3659). "3 of 200 skipped"
+        // read very differently once 150 of the 200 were never node candidates — and the sweep on
+        // the other side counted a DIFFERENT 200, which is the defect this whole change is about.
+        // Both denominators are printed so a wrong one is visible rather than silent.
+        var candidates = files.Count(f => NodePathForFile(f.RelativePath, parsers) is not null);
         if (unparsed.Count > 0)
             logger?.LogWarning(
-                "Package '{Package}': {Skipped} of {Candidates} candidate files had no parser and "
-                + "were skipped; {Installed} nodes installed. First skipped: {Sample}.",
-                packageId, unparsed.Count, files.Count(f => !IsNotANodeFile(f.RelativePath)),
-                nodes.Length, string.Join(", ", unparsed.Take(5)));
+                "Package '{Package}': {Skipped} of {Candidates} node candidate file(s) could not "
+                + "be read and were skipped; {Installed} node(s) installed. Population: {Files} "
+                + "file(s) in the package, {NonNode} of them not node files (README, the manifest "
+                + "sidecar, content/** assets, or an extension no parser claims). First skipped: "
+                + "{Sample}.",
+                packageId, unparsed.Count, candidates, nodes.Length, files.Count,
+                files.Count - candidates, string.Join(", ", unparsed.Take(5)));
 
         return nodes;
     }
@@ -3451,13 +3462,23 @@ public static class PackageInstaller
         FileFormatParserRegistry parsers, PackageFile file, ILogger? logger,
         JsonSerializerOptions? options = null, List<string>? unparsed = null)
     {
-        if (IsNotANodeFile(file.RelativePath))
+        // 🚨 ONE predicate, shared with the install-completeness sweep (#3659). A file is a node
+        // CANDIDATE when it is not a by-design non-node file AND some registered parser claims its
+        // extension. Anything else is not a skip and is not counted as one — and, decisively, the
+        // sweep now counts the SAME population instead of a larger one derived by a second
+        // implementation of half this rule.
+        if (NodePathForFile(file.RelativePath, parsers) is null)
             return null;
         var ext = System.IO.Path.GetExtension(file.RelativePath);
         var parsed = parsers.TryParse(ext, file.RelativePath, file.Content, file.RelativePath);
         if (parsed is null)
         {
-            logger?.LogWarning("No parser for node-repo file {Path}; skipped.", file.RelativePath);
+            // A CLAIMED extension whose CONTENT could not be read — the #1767 population, and the
+            // only one of the two that means damage. "No parser for X" used to say this as well,
+            // so a real loss and an ordinary carry-along asset read identically.
+            logger?.LogWarning(
+                "Node-repo file {Path} has a parser for '{Extension}' but could not be read as a "
+                + "node; skipped.", file.RelativePath, ext);
             unparsed?.Add(file.RelativePath);
             return null;
         }
@@ -3644,16 +3665,66 @@ public static class PackageInstaller
         || ModuleManifest.IsManifestPath(relativePath);
 
     /// <summary>
-    /// The canonical node path a node-repo file maps to, or null for the non-node files a package
-    /// ships (README, the manifest sidecar, <c>content/**</c> assets). Used to derive prune targets
-    /// from a manifest diff's removed files — a removed content asset must never delete its owning
-    /// node.
+    /// The BUILT-IN parser set — <c>.md</c>, <c>.cs</c>, <c>.json</c> — as a registry, for the
+    /// convenience overload below. <c>static readonly</c> is the sanctioned shape here: a
+    /// <see cref="FileFormatParserRegistry"/> builds its lookup once in its constructor and is
+    /// never written at runtime, so this is an immutable constant lookup, not process-wide state.
     /// </summary>
-    public static string? NodePathForFile(string relativePath)
+    internal static readonly FileFormatParserRegistry BuiltInParsers =
+        new(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+    /// <summary>
+    /// <see cref="NodePathForFile(string, FileFormatParserRegistry)"/> against the BUILT-IN parser
+    /// set alone (<c>.md</c>, <c>.cs</c>, <c>.json</c>).
+    ///
+    /// <para>🚨 <b>A caller that has a hub must pass that hub's registry instead.</b> Which
+    /// extensions become nodes is DI-dependent — a module contributes parsers — and this overload
+    /// cannot see them, so on a host with a contributed parser it answers "not a node" for a file
+    /// that IS one. It exists because it is public API a dependent repo already calls
+    /// (<c>MeshWeaver.Plugins</c>' <c>ModuleManifestTest</c>), and removing it would red that
+    /// repo's build at its next platform-pin move while its adaptation cannot compile until that
+    /// same pin moves. Every caller INSIDE the install and completeness paths passes a real
+    /// registry; this overload is a compiling convenience, never the rule.</para>
+    /// </summary>
+    /// <param name="relativePath">The file's repo-relative path.</param>
+    public static string? NodePathForFile(string relativePath) =>
+        NodePathForFile(relativePath, BuiltInParsers);
+
+    /// <summary>
+    /// The canonical node path a node-repo file maps to, or null when the file is not a node
+    /// candidate at all.
+    ///
+    /// <para>🚨 <b>TWO reasons for null, and #3659 is what happened when only the first was
+    /// asked.</b> A file is not a node candidate when it is a non-node file BY DESIGN
+    /// (<see cref="IsNotANodeFile"/> — the README, the manifest sidecar, a <c>content/**</c>
+    /// asset) <b>or</b> when NO REGISTERED PARSER CLAIMS ITS EXTENSION, which is how a package's
+    /// ordinary carry-along files (<c>.tsx</c>, <c>.png</c>, <c>.py</c>, an extension-less
+    /// <c>LICENSE</c>) are silently skipped by the install. Until #3659 this method asked only the
+    /// first question while <c>ParseCanonical</c> asked both, so the two disagreed about the very
+    /// population the install-completeness sweep counts: <c>Chess</c> ships
+    /// <c>Chess/gui/rn/chess.tsx</c>, which no install ever writes, and the sweep reported
+    /// <c>Chess/gui/rn/chess</c> ABSENT at Error on every pod boot forever — and drove a FULL
+    /// reinstall of the package that could never make the count reach zero.</para>
+    ///
+    /// <para>🚨 It answers about the PATH. A file whose extension IS claimed can still fail to
+    /// become a node on its CONTENT (a <c>.json</c> object carrying no
+    /// <c>$type</c>/<c>id</c>/<c>nodeType</c>; a file no parser can read). Only a caller holding
+    /// the bytes can see that, which is why <c>ParseCanonical</c> still runs
+    /// <see cref="FileFormatParserRegistry.TryParse"/> after this and reports the difference under
+    /// its own name. Measured 2026-09-08 over every package folder in
+    /// <c>MeshWeaver.Plugins</c>: that residual is EMPTY — every <c>.json</c> inside a package
+    /// carries a node key — so the extension question covers the whole live population; the
+    /// residual is stated because it is reachable, not because it is occupied.</para>
+    /// </summary>
+    /// <param name="relativePath">The file's repo-relative path.</param>
+    /// <param name="parsers">The parser registry the INSTALL would use — required, because the
+    /// claimed extensions are DI-dependent (a module contributes parsers) and a hard-coded list
+    /// here would be a fourth copy of a rule that drifts the moment one is added.</param>
+    public static string? NodePathForFile(string relativePath, FileFormatParserRegistry parsers)
     {
-        if (string.Equals(relativePath, "README.md", StringComparison.OrdinalIgnoreCase)
-            || ModuleManifest.IsManifestPath(relativePath)
-            || ContentAssetMapper.IsContentPath(relativePath))
+        ArgumentNullException.ThrowIfNull(parsers);
+        if (IsNotANodeFile(relativePath)
+            || !parsers.ClaimsExtension(System.IO.Path.GetExtension(relativePath)))
             return null;
         var (id, ns) = NodeFileMapper.FromRelativePath(relativePath);
         return string.IsNullOrEmpty(ns) ? id : $"{ns}/{id}";

--- a/test/Memex.Portal.Shared.Test/InstallCompletenessTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstallCompletenessTest.cs
@@ -9,6 +9,7 @@ using MeshWeaver.Fixture;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -64,6 +65,16 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
           }
         }
         """;
+
+    /// <summary>
+    /// The parser registry the INSTALL would use — the file→node rule's second half since #3659.
+    /// Built exactly as <c>InstallNodeRepo</c> builds it (hub serializer options + the
+    /// DI-contributed parsers), so these arms cannot agree with themselves while the installer
+    /// answers differently.
+    /// </summary>
+    private FileFormatParserRegistry Parsers() => new(
+        Mesh.JsonSerializerOptions,
+        Mesh.ServiceProvider.GetServices<IFileFormatParser>());
 
     private static PackageManifest Candidate() => new()
     {
@@ -125,7 +136,7 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
         record!.ModuleVersion.Should().Be(ModuleHash,
             "the record's module hash is what the up-to-date gate compares — the whole premise is "
             + "that it stays EQUAL across the deletion, so the gate sees 'nothing to sync'");
-        InstallCompleteness.DeclaredNodePaths(record).Should().Contain(GuidePath,
+        InstallCompleteness.DeclaredNodePaths(record, Parsers()).Should().Contain(GuidePath,
             "the record must DECLARE the node for its absence to be detectable at all — a record "
             + "with no file map is the 'Undeclared' verdict, not a shortfall");
 
@@ -266,6 +277,7 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
     [Fact]
     public void NotCheckedIsNeverClean()
     {
+        var parsers = Parsers();
         var declared = new PackageManifest
         {
             Id = Package,
@@ -274,30 +286,31 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
                 .Add($"{Package}/Guide.md", "bbb"),
         };
 
-        InstallCompleteness.Compare(Package, Package, null, ImmutableHashSet<string>.Empty)
+        InstallCompleteness.Compare(Package, Package, null, ImmutableHashSet<string>.Empty, parsers)
             .Kind.Should().Be(InstallCompletenessKind.Undeclared,
                 "no record at all means nothing declares what should be here");
 
         InstallCompleteness
-            .Compare(Package, Package, new PackageManifest { Id = Package }, ImmutableHashSet<string>.Empty)
+            .Compare(Package, Package, new PackageManifest { Id = Package }, ImmutableHashSet<string>.Empty, parsers)
             .IsComplete.Should().BeFalse(
                 "a record with no file map cannot be compared against anything — reporting that as "
                 + "complete is the 'zero found, zero expected, green' family");
 
-        InstallCompleteness.Compare(Package, Package, declared, null)
+        InstallCompleteness.Compare(Package, Package, declared, null, parsers)
             .Kind.Should().Be(InstallCompletenessKind.NotObserved,
                 "a mesh that could not be read was NOT checked; a failed read must never be spelled "
                 + "the same way as a real negative");
 
-        InstallCompleteness.Compare(Package, Package, declared, null)
+        InstallCompleteness.Compare(Package, Package, declared, null, parsers)
             .IsComplete.Should().BeFalse("and it is not a pass");
 
         InstallCompleteness
-            .Compare(Package, Package, declared, ImmutableHashSet.Create(StringComparer.Ordinal, GuidePath))
+            .Compare(Package, Package, declared, ImmutableHashSet.Create(StringComparer.Ordinal, GuidePath), parsers)
             .IsComplete.Should().BeTrue("the one case that IS a pass: every declared node observed");
 
         var short_ = InstallCompleteness.Compare(
-            Package, Package, declared, ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal));
+            Package, Package, declared, ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal),
+            parsers);
         short_.Kind.Should().Be(InstallCompletenessKind.Incomplete);
         short_.Missing.Should().ContainSingle().Which.Should().Be(GuidePath);
     }
@@ -319,7 +332,7 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
         };
 
         var verdict = InstallCompleteness.Compare(
-            Package, "SomewhereElse", record, ImmutableHashSet<string>.Empty);
+            Package, "SomewhereElse", record, ImmutableHashSet<string>.Empty, Parsers());
 
         verdict.Kind.Should().Be(InstallCompletenessKind.Undeclared,
             "a file map that maps outside the target partition cannot answer whether that partition "
@@ -343,11 +356,172 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
                 .Add("README.md", "fff"),
         };
 
-        InstallCompleteness.DeclaredNodePaths(record).Should().ContainSingle().Which.Should().Be(
+        InstallCompleteness.DeclaredNodePaths(record, Parsers()).Should().ContainSingle().Which.Should().Be(
             GuidePath,
             "the manifest sidecar, content/** assets and the README are files, not nodes — counting "
             + "them would make every healthy install read as incomplete, and a check that is always "
             + "red is a check nobody reads");
+    }
+
+    // ── #3659: the DENOMINATOR — the declared population must be the installer's own ───────────
+
+    /// <summary>
+    /// 🚨 <b>THE repro of #3659, end to end.</b> A package ships files a parser claims (<c>.json</c>,
+    /// <c>.md</c>) and files no parser claims (<c>.tsx</c>, <c>.png</c>, an extension-less
+    /// <c>LICENSE</c>) — the ordinary shape of a real node repo. The install writes the first kind
+    /// and silently skips the second. The sweep must count the SAME population.
+    ///
+    /// <para>Before the fix the declared side applied only the by-design exclusions (README at the
+    /// repo root, the manifest sidecar, <c>content/**</c>) and counted every other file as a node
+    /// the install owed the mesh, so this package read as <c>Incomplete</c> with three phantom
+    /// paths ABSENT — at Error, on every pod boot, forever, and driving a full reinstall of the
+    /// package that could never make the count reach zero. <c>Chess/gui/rn/chess.tsx</c> is the
+    /// live instance.</para>
+    ///
+    /// <para><b>The assertion that keeps this honest</b> is the second half: after deleting a node
+    /// that IS a declared one, the same sweep must go <c>Incomplete</c> naming exactly it. Without
+    /// that, "Complete" here could be bought by a gate that excludes everything.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task FilesNoParserClaims_AreNotDeclaredNodes_AndARealAbsenceStillIs()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var logger = Mesh.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger<InstallCompletenessTest>();
+
+        await CatalogLayoutAreas
+            .InstallOrUpdate(Mesh, new FixedSource(CarryAlongFiles()), "HEAD", CarryAlongCandidate(), logger)
+            .Should().Within(180.Seconds())
+            .Emit("the install has to land before its completeness can be measured");
+
+        (await WaitForNode($"{CarryAlong}/Guide", present: true)).Should().BeTrue(
+            "the package's Guide node is what the second half of this test deletes — if the "
+            + "install never wrote it, both halves would pass for the wrong reason");
+
+        var record = await ReadRecord(CarryAlong);
+        record.Should().NotBeNull("the installer stamps an install record");
+        record!.InstalledFiles.Should().HaveCount(8,
+            "the record declares every file the package ships — that is the population the sweep "
+            + "counts over, and stating it is the point of this test");
+
+        var declared = InstallCompleteness.DeclaredNodePaths(record, Parsers());
+        declared.Should().Equal(
+            [CarryAlong, $"{CarryAlong}/Guide", $"{CarryAlong}/README"],
+            "only the files a registered parser claims become nodes — the installer skips the "
+            + "rest, so counting them is counting a population no install ever writes");
+        declared.Should().NotContain($"{CarryAlong}/gui/rn/widget",
+            "a .tsx view is a carry-along asset; this is Chess/gui/rn/chess, the reported phantom");
+        declared.Should().NotContain($"{CarryAlong}/logo", "nor is a .png");
+        declared.Should().NotContain($"{CarryAlong}/LICENSE", "nor is an extension-less file");
+
+        var verdict = await WaitForVerdict(record, InstallCompletenessKind.Complete, CarryAlong);
+        verdict.DeclaredFiles.Should().Be(8, "the record's file map is the population read");
+        verdict.NonNodeFiles.Should().Be(5,
+            "README.md at the REPO root is not in this map; the five are the manifest sidecar, "
+            + "the content/** asset, the .tsx, the .png and the extension-less LICENSE");
+        verdict.Declared.Should().Be(3, "leaving index.json, Guide.md and README.md");
+        verdict.Population.Should().Contain("8 file(s) declared").And.Contain("3 distinct node path(s)",
+            "a count over the wrong population reads exactly like a correct one unless the line "
+            + "says which population it was taken over");
+        verdict.ToString().Should().Contain("8 file(s) declared",
+            "and every surface that prints a verdict carries it");
+
+        // ── The control: the gate must not have blinded the sweep to a REAL loss.
+        await meshService.DeleteNode($"{CarryAlong}/Guide")
+            .Should().Within(60.Seconds())
+            .Emit("the deletion is the control's precondition");
+        (await WaitForNode($"{CarryAlong}/Guide", present: false)).Should().BeTrue(
+            "the node has to be gone before its absence can be the thing measured");
+
+        var afterLoss = await WaitForVerdict(record, InstallCompletenessKind.Incomplete, CarryAlong);
+        afterLoss.Missing.Should().ContainSingle().Which.Should().Be($"{CarryAlong}/Guide",
+            "a declared node that is genuinely absent is still a shortfall — the fix narrows the "
+            + "population, it does not narrow what a shortfall means");
+    }
+
+    /// <summary>
+    /// 🚨 The one-argument <c>NodePathForFile</c> is public API a DEPENDENT repo already calls —
+    /// <c>MeshWeaver.Plugins</c>' <c>ModuleManifestTest.NodePathMappingSkipsNonNodeFiles</c>, six
+    /// assertions. Removing it when #3659 gave the rule a second half would have reddened that
+    /// repo's build at its next platform-pin move while its adaptation could not compile until that
+    /// same pin moved, so it stays as a convenience over the BUILT-IN parser set. Its contract is
+    /// pinned HERE, in the repo that owns the method, because this is where a change can break it —
+    /// a cross-repo caller cannot defend itself.
+    ///
+    /// <para>The loop is the guard that matters: on this host the convenience overload and the
+    /// hub's own registry must give the SAME answer for every shape, so the overload is a
+    /// convenience and never a second rule.</para>
+    /// </summary>
+    [Fact]
+    public void TheBuiltInOverload_AgreesWithTheHubsRegistry_AndWithTheDependentsAssertions()
+    {
+        string?[] shapes =
+        [
+            "Widget/Thing.json", "Widget/index.json", "Widget/Thing/Source/Thing.cs",
+            "Widget/manifest.lock", "README.md", "Widget/Poster/content/poster.png",
+            "Widget/gui/rn/widget.tsx", "Widget/logo.png", "Widget/LICENSE",
+        ];
+
+        // The dependent's six assertions, verbatim.
+        PackageInstaller.NodePathForFile("Widget/Thing.json").Should().Be("Widget/Thing");
+        PackageInstaller.NodePathForFile("Widget/index.json").Should().Be("Widget");
+        PackageInstaller.NodePathForFile("Widget/Thing/Source/Thing.cs")
+            .Should().Be("Widget/Thing/Source/Thing");
+        PackageInstaller.NodePathForFile("Widget/manifest.lock").Should().BeNull();
+        PackageInstaller.NodePathForFile("README.md").Should().BeNull();
+        PackageInstaller.NodePathForFile("Widget/Poster/content/poster.png").Should().BeNull(
+            "a removed content asset must never prune its owning node");
+
+        // …and #3659's own half: a carry-along asset is not a node candidate either.
+        PackageInstaller.NodePathForFile("Widget/gui/rn/widget.tsx").Should().BeNull(
+            "no registered parser claims .tsx, so no install ever writes it — this is the "
+            + "Chess/gui/rn/chess phantom");
+        PackageInstaller.NodePathForFile("Widget/logo.png").Should().BeNull("nor .png");
+        PackageInstaller.NodePathForFile("Widget/LICENSE").Should().BeNull(
+            "nor a file with no extension at all");
+
+        var parsers = Parsers();
+        foreach (var shape in shapes)
+            PackageInstaller.NodePathForFile(shape!, parsers).Should()
+                .Be(PackageInstaller.NodePathForFile(shape!),
+                    "the convenience overload must not be a SECOND rule — where this host's "
+                    + "registry and the built-in set disagree, the install and the sweep would "
+                    + "again be counting different populations");
+    }
+
+    /// <summary>
+    /// The pure arm of the same rule, so the population statement can be read without a mesh: a
+    /// record whose files are ALL carry-along assets declares no node at all, and says so as
+    /// <see cref="InstallCompletenessKind.Undeclared"/> — never <c>Complete</c>, which would be
+    /// "zero found, zero expected, green" (AGENTS.md), and never <c>Incomplete</c>, which is what
+    /// it answered before #3659.
+    /// </summary>
+    [Fact]
+    public void ARecordOfNothingButCarryAlongFiles_DeclaresNoNode_AndSaysSo()
+    {
+        var record = new PackageManifest
+        {
+            Id = Package,
+            TargetPartition = Package,
+            InstalledFiles = ImmutableSortedDictionary<string, string>.Empty
+                .Add($"{Package}/gui/rn/widget.tsx", "aaa")
+                .Add($"{Package}/logo.png", "bbb")
+                .Add($"{Package}/LICENSE", "ccc"),
+        };
+
+        var verdict = InstallCompleteness.Compare(
+            Package, Package, record,
+            ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal), Parsers());
+
+        verdict.Kind.Should().Be(InstallCompletenessKind.Undeclared,
+            "no file in this record is a node candidate, so nothing declares what the partition "
+            + "should hold — before #3659 all three were counted and reported ABSENT on every boot");
+        verdict.IsComplete.Should().BeFalse("'not declared' is not a clean bill of health either");
+        verdict.DeclaredFiles.Should().Be(3);
+        verdict.NonNodeFiles.Should().Be(3);
+        verdict.Because.Should().Contain("non-node files",
+            "the reason has to name WHY there is nothing to compare, or the operator cannot tell "
+            + "this apart from a record that was never stamped");
     }
 
     /// <summary>
@@ -439,21 +613,78 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
             .Timeout(120.Seconds())
             .Await();
 
-    private async Task<PackageManifest?> ReadRecord()
+    private Task<PackageManifest?> ReadRecord() => ReadRecord(Package);
+
+    private async Task<PackageManifest?> ReadRecord(string packageId)
     {
         var persistence = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
         var node = await persistence
-            .Read($"{PackageInstaller.InstalledPartition}/{Package}", Mesh.JsonSerializerOptions)
+            .Read($"{PackageInstaller.InstalledPartition}/{packageId}", Mesh.JsonSerializerOptions)
             .Take(1)
             .Timeout(60.Seconds())
             .Await();
         return node?.ContentAs<PackageManifest>(Mesh.JsonSerializerOptions);
     }
 
+    // ── #3659 fixture: a package carrying the files a real node repo carries ────────────────────
+
+    private const string CarryAlong = "CarryAlongPkg";
+    private const string CarryAlongHash = "fedcba9876543210";
+
+    private static PackageManifest CarryAlongCandidate() => new()
+    {
+        Id = CarryAlong,
+        Name = CarryAlong,
+        Kind = PackageKind.NodeRepo,
+        TargetPartition = CarryAlong,
+        SourceFolder = CarryAlong,
+        Version = "1.0.0",
+        ModuleVersion = CarryAlongHash,
+    };
+
+    private static IReadOnlyList<PackageFile> CarryAlongFiles() =>
+    [
+        new PackageFile($"{CarryAlong}/{ModuleManifest.FileName}", $$"""
+            {
+              "module": "{{CarryAlong}}",
+              "moduleVersion": "{{CarryAlongHash}}",
+              "version": "1.0.0",
+              "files": {
+                "{{CarryAlong}}/{{ModuleManifest.FileName}}": "000",
+                "{{CarryAlong}}/index.json": "aaa",
+                "{{CarryAlong}}/Guide.md": "bbb",
+                "{{CarryAlong}}/README.md": "ccc",
+                "{{CarryAlong}}/gui/rn/widget.tsx": "ddd",
+                "{{CarryAlong}}/logo.png": "eee",
+                "{{CarryAlong}}/LICENSE": "fff",
+                "{{CarryAlong}}/content/og.png": "ggg"
+              }
+            }
+            """),
+        new PackageFile($"{CarryAlong}/index.json", $$"""
+            {
+              "id": "{{CarryAlong}}",
+              "path": "{{CarryAlong}}",
+              "nodeType": "Space",
+              "name": "Carry-along package",
+              "state": "Active"
+            }
+            """),
+        new PackageFile($"{CarryAlong}/Guide.md", "# Guide\n\nA node, and the control's subject."),
+        new PackageFile($"{CarryAlong}/README.md", "# Carry-along\n\nA node: the root-only README "
+            + "exclusion does not match a package-folder README."),
+        // The three the installer silently skips — a React Native view, an image, a licence file.
+        new PackageFile($"{CarryAlong}/gui/rn/widget.tsx", "export const Widget = () => null;"),
+        new PackageFile($"{CarryAlong}/logo.png", "not really a png, and no parser claims .png"),
+        new PackageFile($"{CarryAlong}/LICENSE", "MIT"),
+        // …and one that is a non-node BY DESIGN, which was already excluded before #3659.
+        new PackageFile($"{CarryAlong}/content/og.png", "a content asset"),
+    ];
+
     private IObservable<InstallCompletenessVerdict> Observe(PackageManifest record) =>
         InstallCompleteness.Observe(
             Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>(),
-            Mesh.JsonSerializerOptions, Package, Package, record);
+            Mesh.JsonSerializerOptions, Package, Package, record, Parsers());
 
     /// <summary>
     /// Waits for the verdict to REACH <paramref name="kind"/> rather than sampling once: the delete
@@ -461,10 +692,16 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
     /// observation and this is a condition, never a clock (AGENTS.md — never Task.Delay to wait for
     /// propagation).
     /// </summary>
-    private async Task<InstallCompletenessVerdict> WaitForVerdict(
+    private Task<InstallCompletenessVerdict> WaitForVerdict(
         PackageManifest record, InstallCompletenessKind kind) =>
+        WaitForVerdict(record, kind, Package);
+
+    private async Task<InstallCompletenessVerdict> WaitForVerdict(
+        PackageManifest record, InstallCompletenessKind kind, string packageId) =>
         await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
-            .SelectMany(_ => Observe(record))
+            .SelectMany(_ => InstallCompleteness.Observe(
+                Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>(),
+                Mesh.JsonSerializerOptions, packageId, packageId, record, Parsers()))
             .Where(v => v.Kind == kind)
             .FirstAsync()
             .Timeout(120.Seconds())

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -524,13 +524,18 @@ public static class PluginGateRunner
             .Select(f => f.RelativePath[..f.RelativePath.IndexOf("/Source/", StringComparison.Ordinal)])
             .ToImmutableHashSet(StringComparer.Ordinal);
 
+        // The installer's own registry shape (#3659): the file→node rule now also asks whether any
+        // parser claims the extension, so this discovery must hold one. JSON options are supplied
+        // because .json is exactly what this loop discovers — a registry built without them
+        // registers no JSON parser and would discover nothing.
+        var parsers = new FileFormatParserRegistry(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var types = new List<NodeTypeUnderTest>();
         foreach (var file in files)
         {
             if (!file.RelativePath.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
                 continue;
             // The installer's own rule — null means "this file is not a node at all".
-            if (PackageInstaller.NodePathForFile(file.RelativePath) is not { Length: > 0 } path)
+            if (PackageInstaller.NodePathForFile(file.RelativePath, parsers) is not { Length: > 0 } path)
                 continue;
             string? configuration;
             try

--- a/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
+++ b/tools/MeshWeaver.PluginTester/TreeNodeLoader.cs
@@ -15,7 +15,7 @@ namespace MeshWeaver.PluginTester;
 /// import: the same files the installer would write, materialised in a list.
 ///
 /// <para><b>The path rule is not re-implemented.</b> Which files are nodes, and what path each one
-/// takes, comes from <see cref="PackageInstaller.NodePathForFile"/> — the installer's own public
+/// takes, comes from <see cref="PackageInstaller.NodePathForFile(string, FileFormatParserRegistry)"/> — the installer's own public
 /// mapping (<c>NodeFileMapper.FromRelativePath</c> plus the README / <c>manifest.lock</c> /
 /// <c>content/**</c> exclusions). A private copy of that rule here is exactly how a build-process
 /// bake would start resolving sources under paths the runtime never uses, and the failure would be
@@ -95,8 +95,12 @@ public static class TreeNodeLoader
         ArgumentNullException.ThrowIfNull(snapshot);
         ArgumentNullException.ThrowIfNull(packages);
 
-        // No serializer options: the JSON parser is replaced by the explicit typed reader below.
-        var parsers = new FileFormatParserRegistry();
+        // 🚨 JSON options ARE supplied (#3659), although MaterialiseJson below still does the
+        // typed read: since the file→node rule asks whether any parser claims the extension, a
+        // registry with no JSON parser would answer "not a node" for every `.json` in the tree and
+        // this loader would discover nothing at all. The JSON parser is registered so the rule can
+        // be asked; it is never the one that reads the file.
+        var parsers = new FileFormatParserRegistry(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var result = ImmutableArray.CreateBuilder<TreeNode>();
 
         foreach (var package in packages.OrderBy(p => p.Id, StringComparer.Ordinal))
@@ -109,7 +113,7 @@ public static class TreeNodeLoader
                 // The installer's own rule: null = this file is not a node (README, manifest.lock,
                 // content/** asset). NodeRepo packages keep the FULL repo-relative path — the
                 // package folder IS the partition — so no rebasing happens here either.
-                if (PackageInstaller.NodePathForFile(file.Path) is not { Length: > 0 } nodePath)
+                if (PackageInstaller.NodePathForFile(file.Path, parsers) is not { Length: > 0 } nodePath)
                     continue;
 
                 var node = Materialise(parsers, file, nodePath, out var reason);


### PR DESCRIPTION
Closes #3659.

Pairs-with: none — the public surface of this change is purely ADDITIVE. Every previous signature (`PackageInstaller.NodePathForFile(string)`, `InstallCompleteness.DeclaredNodePaths(record)`, `Compare(4)`, `Observe(5)`) is kept as a forwarder, so nothing outside this repo has to change. `MeshWeaver.Plugins` does call `NodePathForFile(string)` — six times, in `src/MeshWeaver.PluginCatalog.Test/ModuleManifestTest.cs` — which is exactly why they are kept rather than replaced.

## The root cause

**Two places decide whether a package file becomes a mesh node, and they asked different questions.**

| | by-design non-node (`README.md` at repo root, `manifest.lock`, `content/**`) | extension no registered parser claims |
|---|---|---|
| write side — `ParseCanonical` | excluded | **excluded** |
| declared side — `NodePathForFile` → `DeclaredNodePaths` | excluded | **counted** |

So every carry-along file a package ships counted as a node the install owed the mesh:

```text
Chess ships 37 files.  manifest.lock and content/og-card.png excluded  →  35 "declared nodes"
                       Chess/gui/rn/chess.tsx  →  no parser claims .tsx  →  never written
every pod, every boot:  Chess → 1 of 35 declared node(s) are ABSENT: [Chess/gui/rn/chess]
```

At **Error**, indefinitely, spelled exactly like the genuinely lost source node the sweep exists to find — and driving `SkipOrHeal` to run a **full reinstall** of the package on every catalog visit that could never make the count reach zero.

Measured over `MeshWeaver.Plugins`' package folders, 2026-09-08: 617 `.cs`, 275 `.json` and 248 `.md` files a parser claims, against **200+ it does not** — `.ts`, `.tsx`, `.py`, `.png`, `.mjs`, `.js`, `.html`, `.gitignore`, `.mp4`, `.jpg`, and four files with no extension at all.

## The fix

**One predicate.** `FileFormatParserRegistry` gains `ClaimsExtension`; `NodePathForFile` takes the registry the install itself uses; `ParseCanonical` is expressed in terms of `NodePathForFile`. The registry is a **required** argument, not a defaulted one — which extensions are claimed is DI-dependent (a module contributes parsers), so a hard-coded list would be a fourth copy of a rule that drifts the moment one is added.

The install's own aggregate line also stops conflating the two: *"no parser for X"* used to cover both an ordinary asset and a file that genuinely could not be read, so a real loss and a `.png` printed the same. They are now separate messages with separate denominators.

## The denominator, made visible

🚨 **A count over the wrong population reads exactly like a correct one.** Nothing in the output said which set had been counted — which is why this survived a week of Error lines. Every verdict now carries and prints:

| Field | Says |
|---|---|
| `DeclaredFiles` | how many FILES the record's map holds — the population read |
| `NonNodeFiles` | how many are not node candidates, and why |
| `Declared` | the DISTINCT node paths the rest map to |

rendered as one `Population` clause on the install gate's line, the boot sweep's line and `ToString()`:

```text
Counted over: 37 file(s) declared, 3 of them not node files
(README/manifest/content assets, or an extension no parser claims) → 34 distinct node path(s) compared.
```

Three numbers rather than two and a subtraction: `DeclaredFiles − NonNodeFiles` legitimately exceeds `Declared` when two files fold onto one node (the `X.json` → `X/index.json` layout move), and a reader must be able to see that rather than infer it. A record of nothing but carry-along files now reads `Undeclared` **naming why** — never `Complete` (the zero-found-zero-expected pass) and never `Incomplete` (what it answered before).

## Guards, and evidence each can fail

Falsification run: `NodePathForFile` reverted to the pre-#3659 predicate, rebuilt, re-run, restored.

| Guard | Result under falsification |
|---|---|
| `FilesNoParserClaims_AreNotDeclaredNodes_AndARealAbsenceStillIs` | **RED** — declared set gains `CarryAlongPkg/LICENSE`, `/gui/rn/widget`, `/logo` |
| `ARecordOfNothingButCarryAlongFiles_DeclaresNoNode_AndSaysSo` | **RED** |
| `TheBuiltInOverload_AgreesWithTheHubsRegistry_AndWithTheDependentsAssertions` | green both ways — it pins the *dependent's* contract, not the new behaviour |

The first guard is an end-to-end install through the real `CatalogLayoutAreas.InstallOrUpdate` over a package carrying a `.tsx`, a `.png`, an extension-less `LICENSE`, a `content/**` asset, a `.md`, a package README and an `index.json`.

🚨 **It carries its own positive control, because the risk here is an absence assertion.** "These paths are not declared" would pass vacuously for a gate that excludes everything. So the second half deletes a node that **is** declared and requires the same sweep to go `Incomplete` naming exactly it. The fix narrows the population; it does not narrow what a shortfall means.

## The added overload broke a dependent, locally

`NodePathForFile` gaining an overload made `TreeNodeLoader`'s `<see cref="PackageInstaller.NodePathForFile"/>` ambiguous — **CS0419 under `-warnaserror`**, the break shape AGENTS.md names as invisible to every surface gate (it bit `MeshWeaver.SocialMedia` on 2026-09-04). Caught in the local Release build and qualified. `MeshWeaver.Plugins` carries no bare cref to any of the four members — checked over `origin/main`.

## What this does NOT fix

- **The content-level residual.** The declared side holds paths, not bytes, so it can only ask the extension half. A `.json` whose object carries no `$type`/`id`/`nodeType`, or a file no parser can read, is still counted. Measured over every package folder in `MeshWeaver.Plugins` on 2026-09-08: that set is **empty** — every `.json` inside a package carries a node key; the non-node ones all live under `app/` and `e2e/`, which are not packages. Stated in the doc because it is reachable, not because it is occupied. Closing it means recording what the install actually wrote instead of re-deriving it, which is a separate change with its own drift surface (the incremental lane would have to maintain the set).
- **`Store/README`, which the issue lists as the other phantom — it is not one.** Measured on the live mesh: `get_versions Store/README` returns **one version, 2026-08-10**, while the node is absent today. It was written and later removed. `Chess/README` — the identical shape — is present and was written 2026-08-24, so the README mapping is not leaking. It is a genuine loss, correctly reported, and this PR keeps reporting it. Why a reinstall did not heal it is a separate question I could not settle from outside the portal: `SkipOrHeal` on `Incomplete` calls the FULL install and `DecideAndWrite` writes whenever `current is null`, so it *should* heal; the boot sweep itself only reports.

## Verification

Local, Release, `-warnaserror`, one project per invocation:

* `src/MeshWeaver.Hosting`, `src/MeshWeaver.PluginCatalog`, `tools/MeshWeaver.PluginTester` — 0 Warning(s), 0 Error(s)
* `test/Memex.Portal.Shared.Test` — **1082 passed, 0 failed**
* `test/MeshWeaver.PluginTester.Test` — **361 passed, 0 failed** (incl. `GateDiscoveryEqualsBakeDiscoveryTest`, which pins gate discovery equal to bake discovery)
* `test/MeshWeaver.Documentation.Test` — **350 passed, 0 failed** (`DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`)

## Docs

[Install Completeness](/Doc/Architecture/InstallCompleteness) gains the two-halves rule with the `Chess` measurement, the residual, and *The verdict states its own population*. What's New: *The install check no longer reports a package's assets as missing pages* (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
