### PR TITLE
docs: the retired BlazorMonaco tree measured gone, on the artifact and on the wire (#3617)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -99,7 +99,7 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
 - 🚨 **Dropping a `<script>` removes the LOAD, not the ASSET.** Measured on both portals
   2026-09-07, after MeshWeaver.Plugins#1393 stopped `App.razor` loading BlazorMonaco's `min/vs`
   tree, a plain `GET` of
-  `/_content/BlazorMonaco/lib/monaco-editor/min/vs/editor.api-CalNCsUg.js` still answers
+  `/_content/BlazorMonaco/lib/monaco-editor/min/vs/editor.api-CalNCsUg.js` still answered
   **200 with 3,669,759 bytes**: the package is still referenced for its `jsInterop.js`, so
   `MapStaticAssets` still publishes every file it ships, and .NET's fingerprint **import map**
   re-advertises 240 of them in the anonymously served app shell — an 81 KB
@@ -115,7 +115,8 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
   the premise the deletion rests on: the interop file only DECLARES the AMD path
   (`var require = { paths: { vs: … } }`) and never resolves it. Measured either side of the filter —
   `MeshWeaver.Blazor`'s manifest carries 122 BlazorMonaco assets on `main` and 1 after; a minimal
-  app publishes 366 files under `_content/BlazorMonaco` without it and 3 with it. Read the general rule
+  app publishes 366 files under `_content/BlazorMonaco` without it and 3 with it — and then measured
+  again on the shipped image and on the wire, 2026-09-08, below. Read the general rule
   the other way round too: **a bundle a page stops loading does not leave the origin**, so an
   inventory taken from `App.razor` is not an inventory of what is served.
 
@@ -132,13 +133,13 @@ The full report of this scan — coverage, attack classes exercised, the delta a
 
 | rule | level | run | instances | disposition |
 |---|---|---|---|---|
-| Vulnerable JS Library [10003] — DOMPurify 3.2.7 inside BlazorMonaco's Monaco bundle | Medium | authenticated | 1 | **Fixed and DELIVERED, re-scan still owed**: MeshWeaver#3378 — the portal builds its own Monaco with DOMPurify 3.4.14 (MeshWeaver.Plugins#1393, `tools/monaco-editor`), guarded by `MonacoBundleGuard`. Delivery measured 2026-09-07 on the served bytes, not on the merge: `GET /_content/MeshWeaver.Blazor/lib/monaco-editor/monaco.js` answers 200 / 4,483,269 bytes / `sha256:8e991296e5e49dca83a02afa00a0eca20128a5c530b9996ce00830e6b039e846` on **both** memex.meshweaver.cloud and memex.systemorph.com — byte-identical to the committed bundle on MeshWeaver.Plugins `main` — carrying `/*! @license DOMPurify 3.4.14` (`versions.json`: monaco-editor 0.56.0, dompurify 3.4.14). Corroborated by an anonymous re-scan on 2026-09-07 that provably reached the bundle (10003 PASS over 1330 URLs, 10096 on `monaco.js`); the issue still closes on the AUTHENTICATED re-scan. Residue CLOSED by MeshWeaver#3617 (MeshWeaver.Plugins#1482): the retired `min/vs` tree is no longer published — see *What the scanner cannot see*. |
+| Vulnerable JS Library [10003] — DOMPurify 3.2.7 inside BlazorMonaco's Monaco bundle | Medium | authenticated | 1 | **Fixed and DELIVERED, re-scan still owed**: MeshWeaver#3378 — the portal builds its own Monaco with DOMPurify 3.4.14 (MeshWeaver.Plugins#1393, `tools/monaco-editor`), guarded by `MonacoBundleGuard`. Delivery measured 2026-09-07 on the served bytes, not on the merge: `GET /_content/MeshWeaver.Blazor/lib/monaco-editor/monaco.js` answers 200 / 4,483,269 bytes / `sha256:8e991296e5e49dca83a02afa00a0eca20128a5c530b9996ce00830e6b039e846` on **both** memex.meshweaver.cloud and memex.systemorph.com — byte-identical to the committed bundle on MeshWeaver.Plugins `main` — carrying `/*! @license DOMPurify 3.4.14` (`versions.json`: monaco-editor 0.56.0, dompurify 3.4.14). Corroborated by an anonymous re-scan on 2026-09-07 that provably reached the bundle (10003 PASS over 1330 URLs, 10096 on `monaco.js`); the issue still closes on the AUTHENTICATED re-scan. Residue CLOSED by MeshWeaver#3617 (MeshWeaver.Plugins#1482): the retired `min/vs` tree is no longer published, measured 2026-09-08 on the shipped image (366 files under `_content/BlazorMonaco` → 3; 726 retired endpoints → 0) and on the wire (the flagged `editor.api-CalNCsUg.js` answers **404** on a portal running ≥ `ci.8079`) — see *What the scanner cannot see*. That removes the URL the alert instanced, and with it the only DOMPurify 3.2.7 the origin served; it does NOT by itself settle rule 10003, which is a verdict over every library the signed-in portal loads. |
 | Backup File Disclosure [10095] | Medium | public | 21 | **False positive, measured**: every instance is `/static/NodeTypeIcons/Copy (n) of <icon>.svg`, and that route synthesises an icon for ANY name — a nonsense name answers 200 with a 547-byte SVG of its own, while `bot.svg.bak` is 404 — so no file is disclosed; the rule keys on "a variant of the URL also answers 200". Carried: the fallback icon is the feature. |
 | Proxy Disclosure [40025] | Medium | public | systemic | **False positive, measured**: `TRACE` and `OPTIONS` answer 405 (`allow: GET, POST`) with no `Server`/`Via` header; the "Unknown proxy" is ZAP's inference from the refusal. Carried. |
 | CSP: Failure to Define Directive with No Fallback [10055] | Medium | both | 15 / 10 | **Carried by design** — see the row below; `form-action 'self' https:` is declared on every response measured (`/`, `/login`), so the missing directive the rule names is to be re-read on the next scan. |
 | CSP: script-src unsafe-inline · script-src unsafe-eval · style-src unsafe-inline · Wildcard Directive [10055] | Medium | both | 3 each / 2 each | **Carried by design**: the policy is set and explained in `MemexPortalComposition.cs` (MeshWeaver.Plugins; enforced since #1988 after a Report-Only run over the live pages with zero violations) — `'unsafe-inline'`/`'unsafe-eval'`, `blob:`/`data:` and `https:`/`wss:` are what the Blazor Server circuit, the editor and embedded https content need; per-response nonces and dropping `'unsafe-inline'` are a separate hardening pass. Follow-up: the bundled Monaco (MeshWeaver.Plugins#1393) carries no `eval`/`new Function`, so `'unsafe-eval'` — kept for the editor — can be re-measured. |
 | Cross-Origin-Resource-Policy header missing [90004] · Cross-Origin-Embedder-Policy header missing | Low | both | systemic / 7 | **Accepted**: the portal embeds cross-origin resources by design (sign-in assets from the Microsoft CDNs, fonts, user-embedded media); `COEP: require-corp` would break them, and `CORP: same-site` on the portal's own assets is the intended scope. |
-| Dangerous JS Functions [10110] — `eval(` | Low | both | 1 | **Fixed by MeshWeaver.Plugins#1393**: the `eval(` is in BlazorMonaco's AMD `loader.js`, which the page no longer loads; the bundled Monaco has no `eval` and no `new Function`. Confirmed on the rolled portal — `PASS: Dangerous JS Functions [10110]` in the 2026-09-07 anonymous baseline, the same run that reached `monaco.js`. The `eval(`-bearing file itself stayed published until MeshWeaver#3617 (MeshWeaver.Plugins#1482) dropped the tree from the build output. |
+| Dangerous JS Functions [10110] — `eval(` | Low | both | 1 | **Fixed by MeshWeaver.Plugins#1393**: the `eval(` is in BlazorMonaco's AMD `loader.js`, which the page no longer loads; the bundled Monaco has no `eval` and no `new Function`. Confirmed on the rolled portal — `PASS: Dangerous JS Functions [10110]` in the 2026-09-07 anonymous baseline, the same run that reached `monaco.js`. The `eval(`-bearing file itself stayed published until MeshWeaver#3617 (MeshWeaver.Plugins#1482) dropped the tree from the build output: `GET …/min/vs/loader.js` answered 200 · 39,848 B on `ci.8059` and **404** on `ci.8079`, measured 2026-09-08. |
 | Timestamp Disclosure — Unix [10096] | Low | authenticated | 3 | **False positive**: 1732584193, 1518500249, 1859775393 are 0x67452301, 0x5A827999, 0x6ED9EBA1 — SHA-1 round constants in Monaco's hashing code, not timestamps. The same constants sit in the new bundle and will be flagged again. |
 | Re-examine Cache-control Directives [10015] · Non-Storable Content [10049] · Suspicious Comments [10027] · Modern Web Application [10109] | Informational | authenticated | 5 / 11 / 15 / 5 | informational — no action |
 
@@ -167,6 +168,66 @@ bundle. Retire.js read that file and passed it.
 baseline (it is the run that reaches libraries only a signed-in page loads), and it needs a human
 sign-in. What the anonymous run settles is this one rule against this one bundle; what it cannot
 settle is any library the signed-in portal loads and the anonymous shell does not.
+
+#### 2026-09-08 — the retired BlazorMonaco tree measured gone, on the artifact and on the wire
+
+MeshWeaver.Plugins#1482 merged 2026-09-07T23:14:40Z. The first portal image built after it is
+`meshweaver.azurecr.io/memex-portal-ai:3.0.0-ci.8079` (built 2026-09-08T05:55:35Z); the last one
+built before it is `…:3.0.0-ci.8059` (2026-09-07T23:06:50Z — eight minutes short of the merge, so it
+cannot carry the filter). That morning the fleet was mid-roll and running one of each, which is what
+made the *before* column still measurable:
+
+| | `ci.8059` → memex.systemorph.com | `ci.8079` → memex.meshweaver.cloud |
+|---|---|---|
+| files under `/app/wwwroot/_content/BlazorMonaco/` **in the image** | **366** | **3** — `jsInterop.js`, `.br`, `.gz` |
+| endpoints in the shipped `Memex.Portal.Distributed.staticwebassets.endpoints.json` | 1,419 | 693 |
+| …naming BlazorMonaco | 732 | 6 |
+| …under `lib/monaco-editor/` | **726** | **0** |
+| `GET /_content/BlazorMonaco/jsInterop.js` | 200 · 41,627 B | 200 · 41,627 B |
+| `GET …/min/vs/loader.js` | 200 · 39,848 B | **404** |
+| `GET …/min/vs/editor.api-CalNCsUg.js` | 200 · 3,669,759 B | **404** |
+| `GET …/min/vs/editor/editor.main.css` | 200 · 308,989 B | **404** |
+| anonymous app shell `/` | 96,125 B | 43,826 B |
+| its `<script type="importmap">` | 81,371 B | 29,027 B |
+| import map `imports` keys — total / BlazorMonaco / retired | 181 / 121 / **120** | 61 / 1 / **0** |
+| import map `integrity` keys — total / BlazorMonaco / retired | 363 / 242 / **240** | 123 / 2 / **0** |
+
+The package ships **122** static web asset files, of which exactly one sits outside the retired tree
+(`jsInterop.js`) and exactly one is not JavaScript (`min/vs/editor/editor.main.css`). So the four
+`GET` rows are the whole denominator rather than a sample: they probe the kept file, the two the
+scanner named, and the only asset the JavaScript-only import map could never have accounted for.
+
+**Nothing lost.** On `ci.8079` every URL the shell's Monaco bootstrap can resolve answers 200:
+`monaco.js` (4,483,269 B, carrying `@license DOMPurify 3.4.14`), `monaco.css`, `versions.json` and
+all five workers `getWorkerUrl` names (`editor`, `json`, `css`, `html`, `ts`) — all under
+`_content/MeshWeaver.Blazor/`, none under BlazorMonaco. `jsInterop.js` is byte-identical across the
+two sets. 🚨 **That is an asset-level check, not a rendered editor.** No test in either repository
+executes the editor's JavaScript: `MonacoBundleGuard` asserts file contents, and the bUnit suites
+render the component tree without a browser. A dead editor caused by a missing static asset would be
+caught by neither, and the last time one was verified end to end was the manual headless check on
+MeshWeaver.Plugins#1393.
+
+Three method notes, each of which was needed to reach that verdict:
+
+- **The import map is a remote probe of the publish manifest.** What `MapStaticAssets` publishes is
+  normally readable only from inside the image, but .NET writes its fingerprint import map into the
+  **anonymous** app shell — so counting `<script type="importmap">` keys per package inventories the
+  origin with one unauthenticated `GET`, no session and no image pull. The "240 URLs" recorded above
+  on 2026-09-07 is exactly the `integrity` section's retired-tree key count, and it now reads 0.
+- **A 404 alone does not distinguish a removal from a block.** A routing rule, a WAF or a CDN would
+  answer 404 just the same while the endpoint stayed in the manifest and the import map went on
+  advertising it. The import map falling to zero — with the image's own endpoints manifest agreeing —
+  is what makes this a publish-time removal rather than a suppressed response.
+- **A mid-roll fleet is a free control, and it expires.** The *before* column exists only because
+  memex.systemorph.com had not yet taken `ci.8079`. Measure both sides while the laggard is still
+  behind; once it rolls, the pre-fix state is reconstructible only by pulling an old image.
+
+One residual, named here so it is not rediscovered as a finding: `Systemorph/Memex` still holds
+`Memex.Portal.Shared/App.razor` loading `…/min/vs/loader.js` (last touched 2026-08-13). That tree is
+a **frozen copy that ships to nobody** — the running portal is built by MeshWeaver.Plugins from
+`src/Memex.Portal.Distributed`, and that repository's `Portal copies are frozen` gate holds the copy
+in place deliberately (`docs/portal-source-copies.md`). It is not an exposure; it would become one
+only if that copy were ever revived as a build.
 
 ## See also
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -208,9 +208,12 @@ scanner named, and the only asset the JavaScript-only import map could never hav
 all five workers `getWorkerUrl` names (`editor`, `json`, `css`, `html`, `ts`) — all under
 `_content/MeshWeaver.Blazor/`, none under BlazorMonaco. `jsInterop.js` is byte-identical across the
 two sets. 🚨 **That is an asset-level check, not a rendered editor.** No test in either repository
-executes the editor's JavaScript: `MonacoBundleGuard` asserts file contents, and the bUnit suites
-render the component tree without a browser. A dead editor caused by a missing static asset would be
-caught by neither, and the last time one was verified end to end was the manual headless check on
+executes this shell's editor JavaScript — measured, not assumed: `MonacoBundleGuard` and
+`MonacoEditorContainerSizingGuard` both read files and match regexes, the remaining Monaco-touching
+suites render the component tree without a browser, and the fleet's only Playwright project
+(`clients/portal-next/e2e`) drives the separate Next.js client, which serves no
+`_content/BlazorMonaco` at all. A dead editor caused by a missing static asset would be caught by
+none of them; the last end-to-end verification on record is the manual headless check reported on
 MeshWeaver.Plugins#1393.
 
 Three method notes, each of which was needed to reach that verdict:

--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -116,9 +116,12 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
   (`var require = { paths: { vs: … } }`) and never resolves it. Measured either side of the filter —
   `MeshWeaver.Blazor`'s manifest carries 122 BlazorMonaco assets on `main` and 1 after; a minimal
   app publishes 366 files under `_content/BlazorMonaco` without it and 3 with it — and then measured
-  again on the shipped image and on the wire, 2026-09-08, below. Read the general rule
-  the other way round too: **a bundle a page stops loading does not leave the origin**, so an
-  inventory taken from `App.razor` is not an inventory of what is served.
+  again on the shipped image and on the wire, 2026-09-08, below. 🚨 **That verification stops at the
+  asset boundary**: it proves the retired files are neither published nor served and that every file
+  the editor loads still answers 200, but nothing in either repository drives the editor's JavaScript,
+  so a dead editor is not something a green build or that measurement would have caught. Read the
+  general rule the other way round too: **a bundle a page stops loading does not leave the origin**,
+  so an inventory taken from `App.razor` is not an inventory of what is served.
 
 ## Findings by release
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -171,11 +171,17 @@ settle is any library the signed-in portal loads and the anonymous shell does no
 
 #### 2026-09-08 — the retired BlazorMonaco tree measured gone, on the artifact and on the wire
 
-MeshWeaver.Plugins#1482 merged 2026-09-07T23:14:40Z. The first portal image built after it is
-`meshweaver.azurecr.io/memex-portal-ai:3.0.0-ci.8079` (built 2026-09-08T05:55:35Z); the last one
-built before it is `…:3.0.0-ci.8059` (2026-09-07T23:06:50Z — eight minutes short of the merge, so it
-cannot carry the filter). That morning the fleet was mid-roll and running one of each, which is what
-made the *before* column still measurable:
+MeshWeaver.Plugins#1482 merged 2026-09-07T23:14:40Z. That morning the fleet was mid-roll and running
+one portal image on each side of that merge, which is what made the *before* column still
+measurable: `memex-cloud` had taken `meshweaver.azurecr.io/memex-portal-ai:3.0.0-ci.8079` (built
+2026-09-08T05:55:35Z, well after the merge), while `memex` was still on `…:3.0.0-ci.8059`, built
+2026-09-07T23:06:50Z — eight minutes short of the merge, so it cannot carry the filter.
+
+🚨 Neither image is *adjacent* to the merge, and the tag numbers do not say so: `ci.8058` finished
+one second after it from a build that started before, and `ci.8064` (2026-09-08T00:04:16Z) is the
+earliest whose build could have carried it. **Tag order is not build order** — read `createdTime`
+off the registry (`az acr repository show-tags --orderby time_desc --detail`) rather than sorting
+the numbers.
 
 | | `ci.8059` → memex.systemorph.com | `ci.8079` → memex.meshweaver.cloud |
 |---|---|---|

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-portal-no-longer-serves-a-retired-editor-bundle.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-portal-no-longer-serves-a-retired-editor-bundle.md
@@ -1,0 +1,41 @@
+---
+Name: The portal no longer serves a retired editor bundle
+Category: Fix
+Description: The portal went on publishing an old, unused code-editor bundle — 366 files, including a 3.6 MB script carrying a sanitiser with published security advisories — long after it stopped loading any of them. They are gone from what the portal ships, and the page every visitor downloads first is now half the size.
+Icon: ShieldCheckmark
+Order: -20260908
+---
+
+# The portal no longer serves a retired editor bundle
+
+The portal's code editor used to come from a prebuilt bundle inside one of its packages. That bundle
+was retired earlier: the portal now builds its own editor with an up-to-date HTML sanitiser, and no
+page has loaded the old one since.
+
+**Retiring the bundle stopped it being loaded. It did not stop it being served.** The package is
+still needed for one small file that connects the editor to the rest of the portal, and a package
+publishes everything it ships or nothing — so all 366 of the old bundle's files stayed on the
+portal, downloadable by anyone who knew the address. Among them was the 3.6 MB script carrying the
+sanitiser version the security scan had flagged, and the loader whose use of `eval` the same scan
+names.
+
+Nothing loaded them, so this was never a live vulnerability: making a visitor's browser fetch that
+file would already require the ability to run scripts on the page, which is the thing an attacker
+does not have. It was inventory — a file with known advisories, published under the portal's own
+name, waiting to be found by the next scanner, crawler or third-party asset inventory that looked.
+
+**The portal now publishes exactly the one file it actually needs.** Measured on the two portal
+builds either side of the change: 366 files under the package's address became 3 (the one file plus
+its two compressed forms), and the 726 published addresses under the retired tree became none. The
+old addresses now answer *not found*.
+
+Two things visitors get for free. The page every visitor downloads first carries a list of the
+portal's script addresses, and it shrank from 96 KB to 44 KB — the list itself from 81 KB to 29 KB,
+because 240 of its entries named files nothing had used for days. And the portal image is smaller by
+everything the old bundle weighed.
+
+The editor is unaffected: it was already being built and served separately, and every file it loads
+was verified present on the new build.
+
+See [OWASP ZAP Scan — Every Release](/Doc/Architecture/SecurityScanning) for the measurement and the
+method behind it.


### PR DESCRIPTION
## The verification half of #3617, on the shipped artifact rather than a local build

MeshWeaver.Plugins#1482 landed the MSBuild `StaticWebAsset` filter and merged
2026-09-07T23:14:40Z. `Doc/Architecture/SecurityScanning` carried its evidence as *build-time*
numbers only (a manifest count, a minimal-app publish). This records the measurement on the
**portal image the fleet actually runs** and on the **served bytes** — which is what the issue's own
closing criterion asked for.

### The control was free, and it was about to expire

On the morning of 2026-09-08 the fleet was mid-roll and running one image on each side of the merge
(2026-09-07T23:14:40Z), so the *before* column is a live measurement rather than a reconstruction:

| | `ci.8059` → memex.systemorph.com | `ci.8079` → memex.meshweaver.cloud |
|---|---|---|
| image built | 2026-09-07T23:06:50Z — **8 min before the merge**, so it cannot carry the filter | 2026-09-08T05:55:35Z, well after it |
| files under `/app/wwwroot/_content/BlazorMonaco/` in the image | **366** | **3** (`jsInterop.js`, `.br`, `.gz`) |
| endpoints in the shipped `…staticwebassets.endpoints.json` | 1,419 | 693 |
| …under `lib/monaco-editor/` | **726** | **0** |
| `GET …/min/vs/editor.api-CalNCsUg.js` | 200 · 3,669,759 B | **404** |
| `GET …/min/vs/loader.js` | 200 · 39,848 B | **404** |
| `GET …/min/vs/editor/editor.main.css` | 200 · 308,989 B | **404** |
| `GET /_content/BlazorMonaco/jsInterop.js` | 200 · 41,627 B | 200 · 41,627 B |
| anonymous app shell `/` | 96,125 B | 43,826 B |
| its `<script type="importmap">` | 81,371 B | 29,027 B |
| import map `imports` keys — total / BlazorMonaco / retired | 181 / 121 / **120** | 61 / 1 / **0** |
| import map `integrity` keys — total / BlazorMonaco / retired | 363 / 242 / **240** | 123 / 2 / **0** |

🚨 Neither image is *adjacent* to the merge, and the tag numbers do not say so — `ci.8058` finished
one second after it from a build that started before, and `ci.8064` (00:04:16Z) is the earliest whose
build could have carried it. **Tag order is not build order**; read `createdTime` off the registry.
(The first draft of this PR claimed 8079 was the first image after the merge and 8059 the last before
it. Both were unmeasured superlatives; the second commit corrects them. The measurement itself is
unaffected.)

The package ships **122** static web asset files, exactly one outside the retired tree
(`jsInterop.js`) and exactly one not JavaScript (`editor.main.css`) — so those four `GET` rows are
the whole denominator, not a sample. The `240` this page recorded on 2026-09-07 is precisely the
`integrity` section's retired-tree key count; it now reads 0.

### Three method notes, each of which was needed to reach the verdict

- **The import map is a remote probe of the publish manifest.** What `MapStaticAssets` published is
  normally readable only from inside the image — but .NET writes its fingerprint import map into the
  *anonymous* app shell, so counting its keys per package inventories the origin with one
  unauthenticated `GET`.
- **A 404 alone cannot distinguish a removal from a block.** A routing rule, WAF or CDN answers 404
  identically while the endpoint stays in the manifest and the import map keeps advertising it. The
  import map falling to zero, with the image's own endpoints manifest agreeing, is what makes this a
  publish-time removal.
- **A mid-roll fleet is a free control that expires.** Once memex.systemorph.com takes `ci.8079` the
  pre-fix state is only reachable by pulling an old image.

### What this deliberately does NOT claim

- 🚨 **The "nothing broke" check is asset-level, not a rendered editor.** On `ci.8079` every URL the
  shell's Monaco bootstrap can resolve answers 200 — `monaco.js` (4,483,269 B,
  `@license DOMPurify 3.4.14`), `monaco.css`, `versions.json` and all five workers `getWorkerUrl`
  names — and `jsInterop.js` is byte-identical across the two sets. But **no test in either
  repository executes the editor's JavaScript**: `MonacoBundleGuard` asserts file contents and the
  bUnit suites render without a browser, so neither would catch a dead editor caused by a missing
  static asset. That is stated in the page rather than implied away.
- **This does not settle rule 10003** (#3378). It removes the URL the alert instanced and the only
  DOMPurify 3.2.7 the origin served; the rule is a verdict over *every* library the signed-in portal
  loads, and that still needs the authenticated baseline a human must run.

One residual is named so it is not rediscovered as a finding: `Systemorph/Memex` still holds
`Memex.Portal.Shared/App.razor` loading `…/min/vs/loader.js`, last touched 2026-08-13. That tree is a
**frozen copy that ships to nobody** (`docs/portal-source-copies.md`, guarded by that repo's
`Portal copies are frozen` job) — not an exposure, but it would become one if ever revived as a build.

### Verification

- `dotnet build src/MeshWeaver.Documentation/MeshWeaver.Documentation.csproj -c Release -warnaserror` → `0 Warning(s) / 0 Error(s)`
- `dotnet build test/MeshWeaver.Documentation.Test/… -c Release -warnaserror` → `0 Warning(s) / 0 Error(s)`
- `dotnet test test/MeshWeaver.Documentation.Test --no-build` → **350 passed, 0 failed** (includes `DocumentationLinkIntegrityTest` and `WhatsNewEntryIntegrityTest`)

Docs only — no `src/` code changes, no public surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
