### PR TITLE
test: the owner-disposing NACK is asserted on a CAUSE, not on a six-second clock

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownVerdictsAreCausal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownVerdictsAreCausal.md
@@ -56,8 +56,31 @@ that was answered; and it is below the 8 s disposal stall budget, so a stall ver
 what produced the answer. The bad one, unstated: it also raced **the owner's entire teardown**,
 which the paragraphs above say is unbounded.
 
-It flaked in MeshWeaver.Plugins CI — run 34195323935, shard 2, 2026-09-08. The evidence is
-entirely **negative**, and that is the tell:
+### The rate, and why the asymmetry is the finding
+
+| repo / suite | failures | executions examined | window | rate |
+|---|---|---|---|---|
+| MeshWeaver.Plugins, `src/MeshWeaver.Hosting.Monolith.Test` slice #2 | **5** | **138** | 2026-09-07T15:19Z → 2026-09-08T07:12Z | **3.6% — 1 in 28** |
+| MeshWeaver (core), `test/MeshWeaver.Graph.Test` twin | **0** | **796** runs | 2026-09-05T15:24Z → 2026-09-08T07:23Z | 0% |
+
+Same test body — they are twins, held in step by Plugins' `TeardownTwinParityTest` — and the same
+framework. What differs is the size of the mesh being torn down, and therefore how long the owner's
+teardown takes. A flat 6 s is comfortable in core's fixture and marginal in the portal's, which is
+exactly what "asserting a bound the framework does not provide" looks like from the outside: it
+tracks mesh size, not correctness.
+
+Two measurement notes worth keeping, because both would have understated it:
+
+* **Filter on JOB conclusion, not run conclusion.** Two of the five failures sit in runs whose *run*
+  conclusion is `cancelled` — the test failed, then a newer push cancelled the run. Filtering on run
+  conclusion finds 3 of 5.
+* **One of the five was on `main`** (run `34176831015`, 2026-09-08T01:45Z). This reddens the trunk,
+  not only pull requests.
+
+### The failing run in detail
+
+Run 34195323935, `Portal hosts (shard 2)`, 2026-09-08. The evidence is entirely **negative**, and
+that is the tell:
 
 | signal | present? | what its absence rules out |
 |---|---|---|

--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownVerdictsAreCausal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownVerdictsAreCausal.md
@@ -1,0 +1,173 @@
+---
+Name: Teardown Verdicts Are Causal, Not Timed
+Description: "A verdict minted in a hub's ShutDown phase arrives when that hub's teardown reaches ShutDown — and the framework deliberately puts no duration bound on getting there. Any assertion that budgets such a verdict in seconds is asserting a guarantee the framework does not make, and it flakes."
+---
+
+# A teardown verdict arrives on a CAUSE, not on a clock
+
+Some of this system's most important answers are minted during a hub's **teardown**, not during its
+working life. The owner-disposing patch NACK is the canonical one: when a per-node hub goes down
+owing an answer for an in-flight `PatchDataRequest`, a `RegisterForDisposal` registrant mints
+`MeshNodeErrorCode.OwnerDisposing` and hands it to the waiting caller
+(`DataExtensions.RegisterOwnerDisposingNack`, #2778).
+
+**That registrant runs in the ShutDown phase — the LAST phase of the hub's teardown.** Everything
+in front of it must finish first: Quiescing, then the whole `DisposeHostedHubs` join over the hub's
+own subtree.
+
+The rule this page exists to state is:
+
+> **Nothing bounds how long that takes, on purpose. So nothing downstream may budget it in
+> seconds — not production code, and above all not a test.**
+
+## Why there is no bound, and why that is right
+
+`HostedHubsCollection.DisposeHubsReactive` used to cap the hosted-hub join at a flat
+`Timeout(5s)`. #1317 removed it, and the reasoning is worth restating because it is exactly the
+reasoning that applies one layer up:
+
+- Every leg of that join answers **from its own terminal state** — each child is a `MessageHub`
+  whose disposal signals `DisposalCompleted` as its last act. The answer is guaranteed to come; it
+  is not guaranteed to come inside any particular number.
+- Nesting made the cap fire with nothing wedged at all: a child's disposal is its own quiesce
+  budget plus its own subtree join, so a busy two-level tree exceeds a flat 5 s while every
+  individual step stays inside its own budget.
+- On expiry the collection signalled done *anyway*, and the owner tore down the DI container while
+  children were still resolving out of it — the cap was **manufacturing** the leak it was meant to
+  contain.
+
+What replaced it is a **stall detector**, not a deadline (`MessageHub`'s disposal watchdog, #1701).
+It is re-armed by `SubtreeDisposalProgress` on every `RunLevel` transition anywhere in the subtree.
+So a large teardown that keeps making progress **never trips it, however long it takes** — which is
+the correct behaviour and is precisely why "the teardown is taking a while" produces no report.
+
+Read those two facts together and the consequence is unavoidable: **a healthy teardown has no
+upper bound in time, and no signal that says how long it took.**
+
+## The failure this produced (measured)
+
+`NackReachesTheWaiterDuringTeardownTest` is the regression test for #2778. It parks the owner's
+merge turn, posts a patch, fences on the caller being armed in `LatePatchResponseRegistry`,
+disposes the **mesh**, and then asserted that the armed watch was consumed **within 6 seconds**.
+
+That bound was chosen for two good reasons and one bad one. The good reasons: it is far below
+`LateResponseWatchBound` (30 s), so an entry that merely *expired* could not be mistaken for one
+that was answered; and it is below the 8 s disposal stall budget, so a stall verdict could not be
+what produced the answer. The bad one, unstated: it also raced **the owner's entire teardown**,
+which the paragraphs above say is unbounded.
+
+It flaked in MeshWeaver.Plugins CI — run 34195323935, shard 2, 2026-09-08. The evidence is
+entirely **negative**, and that is the tell:
+
+| signal | present? | what its absence rules out |
+|---|---|---|
+| `LATE_NACK_REENQUEUE` (Warning) | no | the caller's watch never received any verdict, early or late |
+| `[PatchAck] … reached no route` (Warning) | no | the owner never minted a verdict and lost it on both routes |
+| `[LateWatch] VERDICT_EXPIRED` (Warning) | no | no verdict arrived after the 30 s window either |
+| `Message delivery failed … cannot route` (Warning) | no | routing never refused the patch or its answer |
+| `[QUIESCE-WAIT]` / `[QUIESCE-CUT]` | no | no hub re-armed its quiesce budget on an owed reply |
+| `DISPOSAL DEADLOCK DETECTED` / `[DISPOSE-WEDGE]` | no | the stall detector never fired: the teardown kept moving |
+| `MEM_WATCHDOG` on its normal 5 s cadence | **yes** | the process itself was healthy and not starved |
+
+The one warning in the window was `[QUIESCE-TIMEOUT] cache/…: 0 callback(s) still pending after 2s
+— Pending: <none>`, which `OnQuiesceComplete` documents as the *benign* shape: the poll said
+not-drained and the dictionary was empty by the time the verdict was rendered.
+
+Nothing had gone wrong. **The owner had simply not reached its ShutDown phase yet.** The test
+asserted a timing guarantee that does not exist, and the failure it produced was a bare
+`System.TimeoutException` naming a line number — no state, no armed ids, no run level. Six
+CI-artifact greps were needed to establish "nothing happened", which is why this had recurred
+without ever being diagnosed.
+
+## The shape that is correct
+
+Assert the **cause**, then read the state. The ordering inside `MessageHub.HandleShutdownCore` is
+fixed and is what makes this exact rather than lucky:
+
+```
+ShutDown phase:
+    CancelCallbacks()
+    DisposeImpl()          ← disposables.Dispose() runs the RegisterForDisposal registrants
+                             — this IS where the NACK is minted and dispatched
+    messageService.Dispose()
+    RunLevel = Dead        ← set BEFORE the signal, deliberately (see its comment)
+    SignalDisposalCompleted()
+```
+
+So `RunLevel == Dead` (equivalently, `DisposalCompleted` having fired) is **the exact instant at
+which "the owner has had its chance to answer" becomes true**. Waiting for that and then reading
+the registry is a decision, not a race:
+
+```csharp
+// Wait for the CAUSE …
+await Observable.Interval(50.Milliseconds()).StartWith(0L)
+    .Where(_ => owner.RunLevel == MessageHubRunLevel.Dead)
+    .FirstAsync().Timeout(ownerDownBound).Await(ct);
+
+// … then the assertion is instantaneous and unconditional.
+registry.ArmedRequestIds.Should().NotContain(armedId, "…the #2778 defect…");
+registry.ExpiredVerdicts.Should().Be(0, "CONSUMED, not lapsed");
+```
+
+Three things get strictly better:
+
+1. **It still catches the defect — sooner.** Falsified by restoring the pre-#2778 shape (dropping
+   the `ILatePatchVerdictSink` dispatch so only the run-level-guarded parent post remains): the
+   test fails in **2 s** instead of 6, and the message reads *"Did not expect collection
+   {"gKQ_…"} to contain "gKQ_…" because the owner minted an OwnerDisposing NACK …"* instead of
+   `TimeoutException`. The owner reaches `Dead` just as fast when it is broken; it is the *watch*
+   that is still armed.
+2. **"Consumed" stops being inferred from a stopwatch.** The 6 s bound was standing in for
+   "it did not merely expire". `LatePatchResponseRegistry.ExpiredVerdicts` counts that case
+   directly — #3197 made an expired verdict a *reported fact* rather than silence — so the
+   distinction is now **observed**, and it stays true however long the teardown took.
+3. **The remaining bound guards a PRECONDITION and says so.** If it trips, the failure is "the
+   owner never finished disposing", which is a different defect with a different investigation —
+   and the test's stall-verdict assertion (`verdicts.Entries.Should().BeEmpty()`) names it. It must
+   stay below `LateResponseWatchBound`, because a question asked after the entry has lapsed cannot
+   be answered either way; deriving it (`LateResponseWatchBound - 10.Seconds()`) keeps that true
+   without a second literal, per [Bounds must be ordered](../BoundsMustBeOrdered).
+
+### A second defect the same change removes
+
+The old assertion polled `registry.ArmedCount == 0` — a **whole-registry** count. But dispatching
+the NACK runs the caller's `LATE_NACK_REENQUEUE` arm, which posts a fresh `PatchDataRequest` and
+**arms a second watch** microseconds later. `ArmedCount` therefore goes `1 → 0 → 1 → 0`, and the
+zero the test was looking for exists for less than a millisecond. It passed only because the
+re-attempt is refused quickly during a teardown — i.e. the assertion was reading a transient it had
+no right to observe. `ArmedRequestIds` exists for exactly this (its own remarks say so): name the
+correlation the verdict has to land on, and a second, unrelated arm cannot falsify it.
+
+## The rule, generalized
+
+**If an answer is produced by a `RegisterForDisposal` registrant, a `ShuttingDown` handler, or
+anything else in a hub's teardown, then its latency is the teardown's latency — which is
+deliberately unbounded and deliberately unreported.**
+
+- Do not budget it. A duration assertion over it is measuring the teardown, not the answer.
+- Wait for the terminal fact instead: `RunLevel == Dead`, or `DisposalCompleted`. Both are
+  guaranteed to arrive or to be reported by the stall detector.
+- 🚨 When you wait on `DisposalCompleted` directly, remember that awaiting an observable resumes
+  the continuation **on the signalling thread** — here, inside `SignalDisposalCompleted()`, inside
+  the hub's ShutDown `try`/`catch`. An assertion that throws there is swallowed and logged as
+  "Error during shutdown of hub". Polling `RunLevel` off a timer, as above, avoids that entirely.
+- In production this same fact has a caller-visible consequence, which is not a bug but is worth
+  knowing: a write whose owner is torn down inside a large teardown wave waits for that teardown,
+  and if it exceeds `LateResponseWatchBound` the caller is told `OwnerUnreachable` for a verdict
+  that was minted. `VERDICT_EXPIRED` exists so that case is distinguishable from silence.
+
+## Related
+
+- [Bounds must be ordered](../BoundsMustBeOrdered) — the sibling rule: an inner bound just under an
+  outer one destroys the outer one's diagnosis. This page is the case where the inner bound was over
+  something with **no** outer bound at all.
+- [Write verdict totality](../WriteVerdictTotality) — every in-flight patch gets exactly one
+  terminal; this page is about *when* the teardown-phase one can arrive.
+- [Disposal stall verdicts](../DisposalStallVerdicts) — why the watchdog is a stall detector and
+  what it does and does not report.
+- [Hub disposal model](../HubDisposalModel) · [Teardown layers](../TeardownLayers) — the phase
+  ordering this page depends on.
+- [Refused replies during teardown](../RefusedRepliesDuringTeardown) — the routing-side seam
+  (`IUndeliverableReplySink`) that catches a verdict the transport cannot forward.
+- [Writing tests](../WritingTests) — wait on the condition, never on a delay. A teardown-phase
+  verdict is one more condition that must be waited on causally.

--- a/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
+++ b/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
@@ -214,13 +214,29 @@ public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
             // <para>The bound below is a liveness guard on that PRECONDITION, named as such: it
             // must leave the watch admissible (below <see cref="LatePatchResponseRegistry.LateResponseWatchBound"/>),
             // because a question asked after the entry has expired cannot be answered either way.
-            // If it ever trips, the failure says "the owner never finished disposing", which is a
-            // different defect with a different investigation — and the stall-verdict assertion
-            // below names it.</para>
+            // Derived from that constant rather than restated as a second literal
+            // (Doc/Architecture/BoundsMustBeOrdered), and it sits ABOVE the 8 s disposal stall
+            // budget on purpose: if the teardown genuinely wedges, the stall detector reaches its
+            // verdict FIRST and names the hub and the turn, and this reports that verdict instead
+            // of hiding it behind an anonymous timeout — which is what the old 6 s bound did, by
+            // firing two seconds before the detector could speak.</para>
+            //
+            // <para>🚨 It therefore FALLS BACK rather than throwing: a bare
+            // <c>TimeoutException</c> from a `.Timeout(...)` names a line number and nothing else,
+            // and that is precisely the failure this whole change exists to stop producing.</para>
             var ownerDownBound = LatePatchResponseRegistry.LateResponseWatchBound - 10.Seconds();
-            await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            var ownerIsDown = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
                 .Where(_ => owner.RunLevel == MessageHubRunLevel.Dead)
-                .FirstAsync().Timeout(ownerDownBound).Await(ct);
+                .Select(_ => true)
+                .FirstAsync()
+                .Timeout(ownerDownBound, Observable.Return(false))
+                .Await(ct);
+            ownerIsDown.Should().BeTrue(
+                $"the owner's verdict cannot be judged until the owner has finished disposing, and "
+                + $"{owner.Address} is still at RunLevel={owner.RunLevel} after "
+                + $"{ownerDownBound.TotalSeconds:F0}s. That is a WEDGED TEARDOWN, a different defect "
+                + $"from the one this test is about. Disposal stall verdicts seen so far: "
+                + (verdicts.Entries.IsEmpty ? "<none>" : string.Join(" | ", verdicts.Entries)));
             Output.WriteLine($"[owner] {owner.Address} is Dead — its disposal registrants have run");
 
             registry.ArmedRequestIds.Should().NotContain(armedId,

--- a/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
+++ b/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
@@ -75,8 +75,24 @@ namespace MeshWeaver.Graph.Test;
 /// lost those two seconds (run 33847949620). That force-teardown no longer exists: a hub whose turn
 /// is parked stays honestly pending and reports the turn (<c>DisposalStallWatchdogTest</c>). So the
 /// parked turn here is what accepted work is supposed to be — it observes the owner's
-/// <c>IsShuttingDown</c> and finishes its job — and the assertion bound is now well inside the
-/// 8 s stall budget, which is also what proves no watchdog took part.</para>
+/// <c>IsShuttingDown</c> and finishes its job.</para>
+///
+/// <para><b>🚨 Why the assertion waits for the owner to be Dead instead of budgeting the
+/// verdict.</b> The successor to that 10 s bound was a flat 6 s from <c>Mesh.Dispose()</c>, and it
+/// repeated the same error one layer up: it raced the OWNER'S WHOLE TEARDOWN, which the framework
+/// deliberately does not bound. Measured in MeshWeaver.Plugins CI (run 34195323935, 2026-09-08):
+/// the test timed out with not one framework warning in the window — no
+/// <c>LATE_NACK_REENQUEUE</c>, no "reached no route", no <c>VERDICT_EXPIRED</c>, no
+/// <c>QUIESCE-WAIT</c>, no <c>DISPOSE-WEDGE</c>, and the memory watchdog ticking on schedule.
+/// Nothing had gone wrong; the owner had simply not reached its ShutDown phase yet, and nothing
+/// promised it would. <c>DisposeHubsReactive</c> dropped its flat <c>Timeout(5s)</c> in #1317
+/// because "a join must not out-run the answers it is joining", and the stall detector that
+/// replaced it re-arms on any progress — so a large teardown that keeps moving has no duration
+/// bound at all. The assertion is now CAUSAL: <c>RunLevel == Dead</c> is set strictly after
+/// <c>DisposeImpl()</c> has run the disposal registrants, so it is the exact instant at which
+/// "the owner has had its chance to answer" becomes true. With the #2778 defect present the owner
+/// reaches Dead just as fast with the watch still armed, so the test fails SOONER than the 6 s
+/// version did, and for the right reason. See Doc/Architecture/TeardownVerdictsAreCausal.</para>
 /// </summary>
 public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
@@ -153,7 +169,15 @@ public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
             await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
                 .Where(_ => registry.ArmedCount > 0)
                 .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
-            Output.WriteLine($"[fence] caller is armed on the late watch (ArmedCount={registry.ArmedCount})");
+            // 🚨 The watch this test is about is THIS ONE, named. `ArmedCount` is the whole
+            // registry, and the framework legitimately arms a SECOND entry microseconds after the
+            // first is consumed: dispatching the NACK runs the caller's LATE_NACK_REENQUEUE, which
+            // posts a fresh PatchDataRequest and arms a watch for it. So "the count is back to
+            // zero" is not the fact this test wants and cannot even be relied on to occur — it
+            // held only because that re-attempt is refused quickly. `ArmedRequestIds` exists for
+            // exactly this (see its remarks); the id is the correlation the NACK has to land on.
+            var armedId = registry.ArmedRequestIds.Single();
+            Output.WriteLine($"[fence] caller is armed on the late watch (request={armedId})");
 
             // 🚨 The scenario. Dispose the MESH, not the node hub: the owner's disposal action then
             // runs with its parent already past DisposeHostedHubs — the exact window in which the
@@ -161,23 +185,60 @@ public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
             Mesh.Dispose();
             Output.WriteLine("[dispose] mesh disposal invoked — parent is past DisposeHostedHubs");
 
-            // 🚨 The assertion: the armed watch is CONSUMED. Dispatch removes the entry, so
-            // ArmedCount returning to zero is the observable fact "the owner's verdict reached the
-            // waiter". The bound is deliberately far below LateResponseWatchBound (30 s), because
-            // an entry that merely EXPIRES would also end at zero — waiting that long is
-            // indistinguishable from the defect, so a generous bound would pass on it. It is ALSO
-            // below the 8 s disposal stall budget: the verdict has to come from the ordinary
-            // teardown, never from a stall verdict on a parked hub.
-            await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
-                .Where(_ => registry.ArmedCount == 0)
-                .FirstAsync().Timeout(6.Seconds()).Await(ct);
+            // 🚨 Wait for the OWNER to be terminally down — the causal precondition — and only
+            // then assert. This is NOT a duration budget for the verdict, and that distinction is
+            // the whole point.
+            //
+            // <para>The NACK is a ShutDown-phase disposal registrant, and the ordering inside
+            // <c>HandleShutdownCore</c> is fixed: <c>DisposeImpl()</c> runs
+            // <c>disposables.Dispose()</c> — which IS the registrant that mints and dispatches this
+            // verdict — strictly before <c>RunLevel = Dead</c> and <c>SignalDisposalCompleted()</c>.
+            // So <c>Dead</c> is the exact instant at which "the owner has had its chance to answer"
+            // becomes true. Reading the registry there is a decision, not a race: with the #2778
+            // defect present the owner reaches Dead just as fast and the entry is STILL armed, so
+            // this fails at the first instant rather than six seconds later.</para>
+            //
+            // <para>🚨 It replaces a flat 6 s race against the whole teardown, which is what made
+            // this test flaky in MeshWeaver.Plugins CI (run 34195323935, 2026-09-08): the failure
+            // carried a bare TimeoutException and NOT ONE framework warning — no
+            // LATE_NACK_REENQUEUE, no `reached no route`, no VERDICT_EXPIRED, no QUIESCE-WAIT, no
+            // DISPOSE-WEDGE — i.e. the owner simply had not reached ShutDown yet. Nothing promises
+            // it will. <c>DisposeHubsReactive</c> deliberately dropped its flat <c>Timeout(5s)</c>
+            // in #1317 precisely because "a join must not out-run the answers it is joining", and
+            // the disposal watchdog that replaced it is a STALL detector re-armed on any progress —
+            // so a big teardown that keeps moving is unbounded BY DESIGN. Asserting a 6 s bound on
+            // it was asserting a guarantee the framework does not make, and it is the same flat-cap
+            // mistake #1317 removed one layer down. See Doc/Architecture/TeardownVerdictsAreCausal.
+            // </para>
+            //
+            // <para>The bound below is a liveness guard on that PRECONDITION, named as such: it
+            // must leave the watch admissible (below <see cref="LatePatchResponseRegistry.LateResponseWatchBound"/>),
+            // because a question asked after the entry has expired cannot be answered either way.
+            // If it ever trips, the failure says "the owner never finished disposing", which is a
+            // different defect with a different investigation — and the stall-verdict assertion
+            // below names it.</para>
+            var ownerDownBound = LatePatchResponseRegistry.LateResponseWatchBound - 10.Seconds();
+            await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .Where(_ => owner.RunLevel == MessageHubRunLevel.Dead)
+                .FirstAsync().Timeout(ownerDownBound).Await(ct);
+            Output.WriteLine($"[owner] {owner.Address} is Dead — its disposal registrants have run");
 
-            registry.ArmedCount.Should().Be(0,
+            registry.ArmedRequestIds.Should().NotContain(armedId,
                 "the owner minted an OwnerDisposing NACK for this patch, and a caller was armed and "
                 + "waiting for it; the verdict must reach that watch even though the parent is past "
-                + "DisposeHostedHubs. Leaving the watch armed is the #2778 defect — the caller then "
-                + "hears nothing and burns the whole 31 s verdict budget for an answer that had "
-                + "already been minted");
+                + "DisposeHostedHubs. The owner is now terminally Dead, so its ShutDown-phase "
+                + "registrant has already run — a watch still armed here is the #2778 defect, and "
+                + "the caller then hears nothing and burns the whole 31 s verdict budget for an "
+                + "answer that had already been minted");
+
+            // 🚨 CONSUMED, not merely gone. This is what the old 6 s bound was standing in for:
+            // an entry that EXPIRES also stops being armed, so "not armed" alone would pass on the
+            // defect. The registry counts that case itself (#3197 made an expired verdict a
+            // reported fact rather than silence), so the distinction is now OBSERVED instead of
+            // inferred from a stopwatch — and the observation holds however long the teardown took.
+            registry.ExpiredVerdicts.Should().Be(0,
+                "the watch must have been CONSUMED by the owner's dispatch, not have lapsed past "
+                + "LateResponseWatchBound and been reported as a verdict that arrived too late");
 
             // Diagnostics only — under a full mesh teardown the caller's own subscription is going
             // down too, so whether its callback still runs is not this test's subject (see the


### PR DESCRIPTION
## The flake

`NackReachesTheWaiterDuringTeardownTest.OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller`
failed on MeshWeaver.Plugins#1459 (run `34195323935`, `Portal hosts (shard 2)`, 2026-09-08) with a
bare `System.TimeoutException` and nothing else.

### Denominator (measured, both repos)

| repo / suite | failures | executions examined | window | rate |
|---|---|---|---|---|
| **MeshWeaver.Plugins** `src/MeshWeaver.Hosting.Monolith.Test` slice #2 | **5** | **138** | 2026-09-07T15:19Z → 2026-09-08T07:12Z | **3.6% — 1 in 28** |
| **MeshWeaver** (core) `test/MeshWeaver.Graph.Test` twin | **0** | **796** runs | 2026-09-05T15:24Z → 2026-09-08T07:23Z | 0% |

The Plugins sweep listed 200 runs (191 completed, 9 excluded as still running), pulled jobs for all
191 with `filter=all`, and downloaded 612 of 649 `Portal hosts (shard N)` logs; the slice holding
this test ran on `Portal hosts (shard 2)` in 138 of 138 executions. 37 logs 404'd (all `cancelled`
jobs), which bounds the rate at 3.4%–3.6%. **Two of the five failures sit in runs whose *run*
conclusion is `cancelled`** — the test failed, then a newer push cancelled the run — so filtering on
run conclusion instead of job conclusion finds only 3 of 5.

**One of the five was on Plugins `main`** (run `34176831015`, 2026-09-08T01:45Z), so this reddens the
trunk, not just PRs. All five are byte-identical in shape: `TimeoutException` at line 165, 6–7 s,
preceded by `[fence] … ArmedCount=1` → `[dispose] …` → the benign `[QUIESCE-TIMEOUT] cache/…
Pending: <none>` and nothing else.

The asymmetry is the finding: **0/796 in core, 5/138 in Plugins.** Same test body (they are twins),
same framework — a much bigger mesh, so a much longer owner teardown, against the same flat 6 s.

## Root cause

The assertion budgeted **6 seconds from `Mesh.Dispose()`** for the armed late watch to be consumed.
That bound races **the owner hub's whole teardown**, which the framework deliberately does not bound:

* `HostedHubsCollection.DisposeHubsReactive` dropped its flat `Timeout(5s)` in #1317 — *"a join must
  not out-run the answers it is joining"* — and the cap was shown to manufacture the very leak it
  was meant to contain.
* What replaced it is a **stall detector** re-armed by `SubtreeDisposalProgress` on every `RunLevel`
  transition in the subtree (#1701), so a big teardown that keeps moving never trips it, however
  long it takes, and emits no report.

The NACK is a `RegisterForDisposal` registrant, i.e. it runs in the **last** phase of that teardown.
So its latency *is* the teardown's latency.

The CI evidence is entirely negative, which is the tell — nothing went wrong, the owner just had not
reached ShutDown yet:

| signal in the failing window | present? |
|---|---|
| `LATE_NACK_REENQUEUE` (Warning) | no |
| `[PatchAck] … reached no route` (Warning) | no |
| `[LateWatch] VERDICT_EXPIRED` (Warning) | no |
| `Message delivery failed … cannot route` (Warning) | no |
| `[QUIESCE-WAIT]` / `[QUIESCE-CUT]` | no |
| `DISPOSAL DEADLOCK DETECTED` / `[DISPOSE-WEDGE]` | no |
| `MEM_WATCHDOG` on its normal 5 s cadence | **yes** — the process was healthy |

The only warning was `[QUIESCE-TIMEOUT] cache/…: 0 callback(s) still pending after 2s — Pending:
<none>`, which `OnQuiesceComplete` documents as the benign "drained during the hand-off" shape.

## The fix

Assert the **cause**, then read the state. `HandleShutdownCore` runs `DisposeImpl()` — which *is*
`disposables.Dispose()`, the registrant that mints and dispatches this verdict — strictly before
`RunLevel = Dead` and `SignalDisposalCompleted()`. So `Dead` is the exact instant at which "the owner
has had its chance to answer" becomes true, and reading the registry there is a decision, not a race.

Two further corrections in the same change:

1. **`ArmedCount == 0` was the wrong subject.** Dispatching the NACK runs the caller's
   `LATE_NACK_REENQUEUE` arm, which posts a fresh `PatchDataRequest` and **arms a second watch**
   microseconds later — the count goes `1 → 0 → 1 → 0` and the zero it polled for exists for under a
   millisecond. It passed only because the re-attempt is refused quickly during a teardown. It now
   names the correlation via `ArmedRequestIds`, which exists for exactly this.
2. **"Consumed, not expired" is now observed rather than inferred.** That was the stated reason for
   the tight bound. `LatePatchResponseRegistry.ExpiredVerdicts` counts the case directly (#3197), so
   the distinction holds however long the teardown took.

The remaining wait guards the *precondition* and says so, and is derived from `LateResponseWatchBound`
rather than restated (`Doc/Architecture/BoundsMustBeOrdered`).

## Evidence it works

**Falsified against broken framework code.** Restoring the pre-#2778 shape in
`DataExtensions.RegisterOwnerDisposingNack` (dropping the `ILatePatchVerdictSink` dispatch so only the
run-level-guarded parent post remains):

* revised test **FAILS in 2 s** (the old one took 6 s) with
  `Did not expect collection {"gKQ_zeVOiUKFsIMUbodj8A"} to contain "gKQ_zeVOiUKFsIMUbodj8A" because
  the owner minted an OwnerDisposing NACK for this patch …` — it now **names the defect** instead of
  `TimeoutException`.

Framework restored (`git diff` clean):

* `dotnet build test/MeshWeaver.Graph.Test -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
* the test passes (`Passed! Failed: 0, Passed: 1`)
* the whole teardown/NACK family passes: `Passed! Failed: 0, Passed: 16` (`NackReachesTheWaiter…`,
  `OwnerDisposalNackTest`, `LateNackReenqueueTest`, `UpsertAnswersWhenTheOwnerGoesAway…`,
  `RefusedReplyReachesTheWaiter…`, `LateVerdictAdmissibility…`, `UndeliverableReplyShapes…`)
* `DocumentationLinkIntegrityTest` → `Passed! Failed: 0, Passed: 1`

## Work product

`Doc/Architecture/TeardownVerdictsAreCausal` — the general rule (an answer minted by a
`RegisterForDisposal` registrant, a `ShuttingDown` handler, or anything else in a hub's teardown has
the teardown's latency, which is deliberately unbounded *and* unreported), the phase ordering that
makes `Dead` exact, the negative-evidence table, and the signalling-thread hazard in awaiting
`DisposalCompleted` directly.

## 🚨 Twin

`MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/NackReachesTheWaiterDuringTeardownTest.cs`
carries the same body below the `namespace` line, and Plugins' `TeardownTwinParityTest` compares them
**at `MW_PLATFORM_REF`**. It reddens on the **pin bump**, not here — the Plugins copy must carry this
change in the same PR that moves the pin past this commit.

Pairs-with: none — no public type or member is removed; the diff is one test file plus a new doc page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
