### PR TITLE
fix(Layout): a node's default area must not be decided by hash order

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-node-opens-on-its-own-overview-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-node-opens-on-its-own-overview-again.md
@@ -1,0 +1,38 @@
+---
+Name: A node opens on its own Overview again
+Category: Fix
+Description: Opening a node without naming an area could land on a different type's area — and show "Area not found" on a node whose own page was perfectly fine. Which area you got depended on the set of areas installed on the mesh, so installing a plugin could change it. A node now opens on its Overview.
+Icon: DocumentBulletList
+Order: -20260908
+---
+
+Opening a node without naming an area — `/YourSpace/` rather than `/YourSpace/Overview` — is
+supposed to show that node's own landing page. On some meshes it showed **"Area not found"**
+instead, naming an area that belongs to a different node type entirely, while
+`/YourSpace/Overview` rendered the complete page.
+
+Nothing was wrong with the node. The portal was choosing the wrong area to open.
+
+## What was happening
+
+When a node type does not state which area is its default, the portal picked one. The rule it used
+came down to "whichever area comes first" — over a dictionary, so the winner was decided by how the
+area *names* hash, not by anything anyone configured.
+
+That has an uncomfortable consequence: the answer depends on the **whole set** of areas present on
+the mesh. Install a plugin that contributes one more area and the set changes, so the choice can
+change too — on every node type, silently, with nothing in the logs to say the landing page moved.
+Measured on a real mesh: a `Space` resolved its default to an area no layout on that hub even
+registers.
+
+## What it does now
+
+A node whose layout states a default still uses it — nothing changes there, and almost every node
+type in the platform states `Overview`.
+
+When no default is stated, the portal now looks for `Overview` and opens that. Only if a layout
+genuinely has no Overview — a single-area app view, say — does it fall back to the first area it
+finds, so those keep working exactly as before.
+
+The upshot: which page a node opens on is now a property of that node type, not of which plugins
+happen to be installed alongside it.

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -1689,9 +1689,36 @@ public record LayoutAreaHost : IDisposable
     internal IEnumerable<LayoutAreaDefinition> GetLayoutAreaDefinitions()
         => LayoutDefinition.AreaDefinitions.Values.Where(l => l.IsVisible());
 
+    /// <summary>The area a node falls back to when nothing declares a default. See <see cref="ResolveDefaultArea"/>.</summary>
+    public const string ConventionalDefaultArea = "Overview";
+
     /// <summary>
-    /// Resolves the default area name from LayoutDefinition.DefaultArea,
-    /// or falls back to the first visible area definition.
+    /// Resolves the default area name from <c>LayoutDefinition.DefaultArea</c>, else the
+    /// conventional <see cref="ConventionalDefaultArea"/>, else the first visible area definition.
+    ///
+    /// <para>🚨 <b>The middle step exists because the last one is decided by HASH ORDER, and that
+    /// is not a decision anybody makes.</b> <c>AreaDefinitions</c> is an
+    /// <c>ImmutableDictionary</c>, whose <c>.Values</c> enumerate in hash-trie order, and
+    /// <c>Order</c> is null on almost every area definition — so <c>OrderBy(l =&gt; l.Order ?? 0)</c>
+    /// ties on 0 for all of them and the survivor is whichever KEY happened to hash first. That
+    /// makes the default a property of the whole area-name SET: installing a plugin that adds one
+    /// more area re-rolls it, on every node type, with nothing logged. Every layout in the tree
+    /// that states a default states
+    /// <c>Overview</c> (<c>MeshNodeLayoutAreas</c>, <c>MarkdownLayoutAreas</c>,
+    /// <c>CodeLayoutAreas</c>, <c>NodeTypeLayoutAreas</c>, <c>ActivityLayoutAreas</c>,
+    /// <c>CommentLayoutAreas</c>, …), so when a hub's composed definition carries no default the
+    /// intended answer is Overview — and picking it explicitly is what stops a newly-installed
+    /// plugin from silently becoming the landing page of every node on the mesh.</para>
+    ///
+    /// <para>Measured on memex 2026-09-08: <c>/PartnerRe/</c> (a <c>Space</c>) resolved its default
+    /// to <c>Workspace</c> — an area no layout on that hub registers — and rendered
+    /// "Area not found", while <c>/PartnerRe/Overview</c> rendered the full page. Nothing anywhere
+    /// calls <c>WithDefaultArea("Workspace")</c>; the composed definition simply had no default and
+    /// the order fallback picked a foreign area. A node whose own Overview renders perfectly must
+    /// not land on another type's area because of registration order.</para>
+    ///
+    /// <para>The order fallback is KEPT as the last resort: a layout that genuinely registers no
+    /// Overview (a single-area app view) still resolves to its only area rather than to nothing.</para>
     /// </summary>
     private string ResolveDefaultArea()
     {
@@ -1699,9 +1726,18 @@ public record LayoutAreaHost : IDisposable
         if (!string.IsNullOrEmpty(LayoutDefinition.DefaultArea))
             return LayoutDefinition.DefaultArea;
 
-        // Fall back to the first visible area definition
-        var firstArea = LayoutDefinition.AreaDefinitions.Values
+        var visible = LayoutDefinition.AreaDefinitions.Values
             .Where(l => l.IsVisible())
+            .ToArray();
+
+        // The convention, before order gets a vote.
+        var conventional = visible.FirstOrDefault(
+            l => string.Equals(l.Area, ConventionalDefaultArea, StringComparison.Ordinal));
+        if (conventional is not null)
+            return conventional.Area;
+
+        // Last resort: the first visible area definition.
+        var firstArea = visible
             .OrderBy(l => l.Order ?? 0)
             .FirstOrDefault();
 

--- a/test/MeshWeaver.Layout.Test/LayoutTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutTest.cs
@@ -1497,3 +1497,70 @@ public class CodeEditorDataBindingTest(ITestOutputHelper output) : HubTestBase(o
             "UpdatePointer with empty pointer should update the value at DataContext");
     }
 }
+
+/// <summary>
+/// 🚨 A hub whose composed layout declares NO default area must not land on whichever module
+/// registered first.
+///
+/// <para><c>LayoutAreaHost.ResolveDefaultArea</c> used to fall straight through to
+/// <c>OrderBy(l =&gt; l.Order ?? 0).FirstOrDefault()</c> over <c>AreaDefinitions</c> — an
+/// <c>ImmutableDictionary</c>. <c>Order</c> is null on almost every area definition, so every entry
+/// ties on 0 and the survivor is whichever KEY HASHED FIRST. The default is therefore a property of
+/// the whole area-name SET: installing a plugin that adds one more area silently re-rolls it.
+/// Measured here — over the ten-area set below the un-fixed resolver answers <c>"Details"</c>.</para>
+///
+/// <para>Measured on memex 2026-09-08: <c>/PartnerRe/</c> (a <c>Space</c>) resolved its default to
+/// <c>Workspace</c>, an area no layout on that hub registers, and rendered "Area not found" — while
+/// <c>/PartnerRe/Overview</c> rendered the complete page. Nothing anywhere calls
+/// <c>WithDefaultArea("Workspace")</c>; the composed definition simply carried no default.</para>
+///
+/// <para>The foreign area is registered FIRST here on purpose: under the old rule it wins, so this
+/// test fails without the fix rather than passing for the wrong reason.</para>
+/// </summary>
+public class DefaultAreaConventionTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string ForeignView = "Workspace";
+    private const string OverviewView = "Overview";
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
+            // NO WithDefaultArea — this is the case the fallback decides.
+            .AddLayout(layout =>
+                layout
+                    // The real hub's shape: a Space carries a dozen areas from several modules.
+                    // ImmutableDictionary enumerates by HASH, so which one comes first is a
+                    // property of the whole key SET — installing one more plugin re-rolls it.
+                    .WithView(ForeignView, Controls.Html("another type's area"))
+                    .WithView("Details", Controls.Html("details"))
+                    .WithView("Catalog", Controls.Html("catalog"))
+                    .WithView("Chat", Controls.Html("chat"))
+                    .WithView("Data", Controls.Html("data"))
+                    .WithView("Files", Controls.Html("files"))
+                    .WithView("Edit", Controls.Html("edit"))
+                    .WithView("Threads", Controls.Html("threads"))
+                    .WithView("Search", Controls.Html("search"))
+                    .WithView(OverviewView, Controls.Html("the node's own overview"))
+            );
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    [HubFact]
+    public async Task NoDeclaredDefault_ResolvesToOverview_NotTheFirstRegisteredArea()
+    {
+        var workspace = GetClient().GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(),
+            new LayoutAreaReference(null));
+
+        var control = await stream.GetControlStream(string.Empty)
+            .Should().Within(10.Seconds()).Match(x => x != null);
+
+        var namedArea = control.Should().BeOfType<NamedAreaControl>().Which;
+        namedArea.Area.Should().Be(OverviewView,
+            "a hub that declares no default must land on its own Overview — hash order over the "
+            + "area-name set is not a decision, and letting it decide is how a Space came to "
+            + "resolve its landing page to another type's area");
+    }
+}


### PR DESCRIPTION
## The symptom

`https://memex.systemorph.com/PartnerRe/` rendered

```
NamedAreaControl { Id = , Style = , … Area = Workspace, … SpinnerType = Ring }
```

and the hub itself said why:

> **Area not found** — No renderer is registered for area `Workspace` on hub `PartnerRe`.
> Available named areas: `$Content`, `Overview`, `Details`, `Catalog`, `Edit`, …

`PartnerRe` is a `Space`. **`/PartnerRe/Overview` rendered the complete page** — title, logo,
description, body, menus. Nothing was wrong with the node; the portal opened the wrong area.

## Root cause

`LayoutAreaHost.ResolveDefaultArea()` fell through to

```csharp
AreaDefinitions.Values.Where(l => l.IsVisible()).OrderBy(l => l.Order ?? 0).FirstOrDefault()
```

`AreaDefinitions` is an **`ImmutableDictionary`**, so `.Values` enumerates in hash-trie order, and
`Order` is null on almost every area definition — every entry ties on `0` and the survivor is
whichever **key hashed first**.

So the default area is a property of the whole area-name **set**. Install a plugin that contributes
one more area and the set changes, so the landing page of *every node type* can change — silently,
with nothing logged. Nothing anywhere calls `WithDefaultArea("Workspace")`; the composed definition
simply carried no default and the fallback picked a foreign area.

## The change

One step inserted between the declared default and the order fallback: the convention every layout
in the tree already states. `MeshNodeLayoutAreas`, `MarkdownLayoutAreas`, `CodeLayoutAreas`,
`NodeTypeLayoutAreas`, `ActivityLayoutAreas` and `CommentLayoutAreas` all say `Overview`, so a hub
whose composed definition states nothing lands on its own Overview.

The order fallback is **kept** as the last resort — a layout that genuinely registers no Overview (a
single-area app view) still resolves to its only area rather than to nothing.

## The test is a control, not a restatement

Over a realistic ten-area set the **un-fixed** resolver answers `"Details"`, so
`DefaultAreaConventionTest` fails without this change. I verified that by disabling the new branch
and re-running:

```
AssertionException : Expected value to be "Overview" …, but found "Details".
Failed!  - Failed: 1, Passed: 0
```

Worth saying explicitly: an earlier two-area version of the same test **passed either way** and
proved nothing — with two keys, `Overview` happened to hash first. That is why the fixture uses a
realistic set.

- `DefaultAreaTest` (the existing declared-default tests): still green.
- Full `MeshWeaver.Layout.Test`: **455/455**.

## Scope

This fixes the *landing page* defect. It does not address the separate, still-open production
issues found while diagnosing: the `Collaboration` double-seal that blocks every roll
(*"the set is inconsistent and nothing rolls"*), the `[PluginGating]` non-converging write loops,
and `Store/Install` content staying an untyped `JsonElement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
