### PR TITLE
feat(#3353): every installation but the mirror pulls its platform images from the mirror

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -60,7 +60,7 @@ jobs:
           set -euo pipefail
           tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
           if [ "$tracked" -lt 20 ]; then
-            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 20 (17 commands + run.sh + _common.sh + _audit.jq)."
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 21 (18 commands + run.sh + _common.sh + _audit.jq)."
             echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
             git check-ignore -v deploy/aks/operator/bin/run.sh || true
             exit 1
@@ -102,6 +102,7 @@ jobs:
           hosting-federate
           hosting-kv-ensure
           hosting-kv-purge
+          hosting-pull-secret
           hosting-pv-purge
           hosting-redirect
           hosting-restore
@@ -174,6 +175,19 @@ jobs:
           fi
           echo "_audit.jq parses (exit ${jq_rc} on empty inputs is its own refusal, as designed)"
 
+      - name: The test stubs are TRACKED and executable
+        # The same .gitignore trap as bin/ above, one directory over: the pull-secret behaviour
+        # tests run against stubs under test/stubs/pull-secret/, and a stub git refused to track
+        # makes those tests fail on a fresh checkout as "command not found" — or, worse, fall
+        # through to a REAL az/kubectl on a runner that has one.
+        run: |
+          set -euo pipefail
+          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl; do
+            git ls-files --error-unmatch "$f" >/dev/null 2>&1 || { echo "::error::${f} is not tracked"; git check-ignore -v "$f" || true; exit 1; }
+            [ "$(git ls-files -s "$f" | awk '{print $1}')" = "100755" ] || { echo "::error::${f} is not committed executable (mode 100755)"; exit 1; }
+          done
+          echo "pull-secret stubs tracked and executable"
+
       - name: Behaviour tests
         run: deploy/aks/operator/test/run-tests.sh
 
@@ -229,3 +243,90 @@ jobs:
         run: |
           docker run --rm -v "$PWD/deploy/aks/operator/test:/opt/hosting/test:ro" \
             --entrypoint /bin/bash hosting-operator:ci -c 'cd /opt/hosting && bash test/run-tests.sh'
+
+  # ═══════════════════════════════════════════════════════════════════════════════════════════
+  # PUBLISH — on a push to main only. Never on a pull request (nothing from a PR reaches ACR),
+  # never with continue-on-error, never behind "is the secret set" (AGENTS.md → a gate never
+  # tests its own inputs): the preflight below asserts every external input and fails RED naming
+  # what to provision, and this job runs unconditionally after it.
+  #
+  # 🚨 WHY THIS JOB EXISTS. `meshweaver.azurecr.io/hosting-operator` was last built by hand on
+  # 2026-08-22 and NOTHING republished it: the two jobs above build the image on every push and
+  # then throw it away, so every fix to a hosting-* script since then — the audit, kv-rotate, the
+  # chart baked into the image — shipped to the repository and never to the Jobs that run them.
+  # The mesh names the image by tag (Hosting__Operator__Image); a tag nobody moves is a fleet
+  # running the operator as it was the day someone last remembered to `docker push`.
+  #
+  # Two tags per build: `<short sha>` (immutable — what a deployment record pins) and `main`
+  # (moving — what a Provision that has not pinned yet uses). Multi-arch is deliberately NOT
+  # built here: the Jobs run on the cluster's amd64 node pools, and the Dockerfile's TARGETARCH
+  # handles a laptop build.
+  # ═══════════════════════════════════════════════════════════════════════════════════════════
+  publish-preflight:
+    name: Publish preflight (every external input, or a red naming it)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Every external input, or a red build naming what to provision
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          missing=()
+          [ -n "$AZURE_CLIENT_ID" ]       || missing+=("secrets.AZURE_CLIENT_ID           OIDC app registration for azure/login (the same one main-cd.yml uses)")
+          [ -n "$AZURE_TENANT_ID" ]       || missing+=("secrets.AZURE_TENANT_ID           the Systemorph AAD tenant")
+          [ -n "$AZURE_SUBSCRIPTION_ID" ] || missing+=("secrets.AZURE_SUBSCRIPTION_ID     the subscription holding ACR meshweaver")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::the operator image cannot be published — provision the following under Settings → Secrets → Actions, then re-run:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+          echo "All external inputs are present."
+
+  publish:
+    name: Publish operator image to ACR
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [publish-preflight, scripts, image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # id-token: write is required for OIDC federated login to Azure (no stored client secret) —
+    # the federated credential on the app registration is scoped to this repo's main branch,
+    # which is the only ref this job runs on.
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      ACR: meshweaver.azurecr.io
+    steps:
+      - uses: actions/checkout@v7
+      - name: Ensure Azure CLI
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: ACR login
+        # The bounded transport retry main-cd.yml uses (#2827) — the bare one-liner has died on
+        # `context deadline exceeded` from a single runner while sibling jobs logged in fine.
+        run: bash .github/scripts/acr-login.sh
+      - name: Build and push hosting-operator:<sha> and :main
+        run: |
+          set -euo pipefail
+          short="${GITHUB_SHA::7}"
+          docker build -f deploy/aks/operator/Dockerfile \
+            -t "$ACR/hosting-operator:$short" -t "$ACR/hosting-operator:main" deploy/
+          docker push "$ACR/hosting-operator:$short"
+          docker push "$ACR/hosting-operator:main"
+      - name: Verify the tags exist in the registry (never the green tick)
+        run: |
+          set -euo pipefail
+          short="${GITHUB_SHA::7}"
+          # Read the pushed manifests BACK; a push that "succeeded" against a stale login has
+          # produced a green step and no image before (#2827's family).
+          az acr manifest show-metadata --registry meshweaver --name "hosting-operator:$short" --query digest -o tsv
+          az acr manifest show-metadata --registry meshweaver --name "hosting-operator:main" --query digest -o tsv
+          echo "published $ACR/hosting-operator:$short (+ :main)"

--- a/deploy/aks/manifests/hosting-operator/README.md
+++ b/deploy/aks/manifests/hosting-operator/README.md
@@ -47,3 +47,40 @@ config:
 
 🚨 **Only on the control instance.** `Hosting:Operator:Enabled` on a tenant portal would give that
 tenant's pod the ability to start a job that can delete any namespace on the cluster.
+
+## The image is published on every push to `main`
+
+`meshweaver.azurecr.io/hosting-operator:<short sha>` (immutable — what a deployment record pins)
+and `:main` (moving) are built and pushed by `.github/workflows/hosting-operator.yml`'s `publish`
+job, on `push` to `main` only, behind a preflight that fails red naming a missing OIDC secret.
+Until MeshWeaver#3353 the image was built by hand (last on 2026-08-22) and nothing republished it,
+so every script fix shipped to the repository and never to a Job.
+
+## `hosting-pull-secret` — the platform images come from the mirror
+
+Every installation **except** the one serving the read-through mirror (`cr.meshweaver.cloud`,
+[A Container Registry in Memex](../../../src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md))
+pulls `memex-portal-ai` and `memex-migration` from that mirror instead of ACR, and lists tags there
+when it self-updates. Its pods therefore need a pull credential for the mirror host — and the
+credential is the instance's **own plugin-registry key**, the vault object `hosting-kv-ensure`
+lists as REQUIRED. Nothing new is minted.
+
+```
+hosting-pull-secret --namespace <ns> --registry cr.meshweaver.cloud \
+                    --vault <vault> --secret <prefix>PluginCatalog-RegistryToken \
+                    [--name registry-pull] [--username instance]
+```
+
+In order, each step idempotent: **ensures the namespace exists** (the plan runs this *before*
+`hosting-deploy` on Provision, and first on Roll and Reconcile, so the namespace may not exist
+yet); reads the key from Key Vault; creates-or-updates a `kubernetes.io/dockerconfigjson` Secret
+named `--name` for `--registry`; **reads it back** and refuses a Secret of another type or one
+naming another registry. It reports `::hosting:: pull_secret=<name>` — the value the deployment
+record's `portal.imagePullSecret` must equal — and `pull_secret_registry=<host>`, which
+`selfUpdate.registry` must equal. 🚨 **It never prints the key**: not in a command echo (the key
+travels on stdin, never argv), not on failure, not in a fact; `test/run-tests.sh` asserts it.
+
+The chart's half: `portal.imagePullSecret` renders `imagePullSecrets` on the portal Deployment
+**and** the migration Job; `selfUpdate.registry` renders `SelfUpdate__Registry`, which makes the
+self-updater list tags over the OCI Distribution API with the same key. Neither is set on the
+mirror instance itself — it cannot serve the image that boots it.

--- a/deploy/aks/operator/bin/hosting-pull-secret
+++ b/deploy/aks/operator/bin/hosting-pull-secret
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# hosting-pull-secret --namespace <ns> --registry <host> --vault <vault> --secret <vault object> [--name registry-pull] [--username instance]
+#
+# Give an instance's namespace the credential its pods pull the PLATFORM IMAGES with when those
+# images come from the read-through mirror (cr.meshweaver.cloud, MeshWeaver#3353) instead of ACR.
+# The credential IS the instance's own plugin-registry key — the vault object hosting-kv-ensure
+# lists as REQUIRED (<prefix>PluginCatalog-RegistryToken) — so nothing new is minted and nothing
+# new has to be rotated: the mirror authenticates the same key the Store presents.
+#
+# What it does, in order, and each step is idempotent so the plan can run it on every Provision,
+# Roll and Reconcile:
+#   1. ensures the NAMESPACE exists — this runs BEFORE hosting-deploy in the plan, so the namespace
+#      may not exist yet; the same create --dry-run | apply idiom hosting-deploy uses.
+#   2. reads the key from Key Vault (never printed — see below).
+#   3. creates-or-updates a kubernetes.io/dockerconfigjson Secret named --name in the namespace,
+#      for --registry, user --username — the Secret `portal.imagePullSecret` names in the chart.
+#   4. reads the Secret BACK and verifies its type and registry before reporting it.
+#
+# 🚨 IT NEVER PRINTS THE KEY. Not in a `+ command` echo (the kubectl invocation that carries it is
+# deliberately NOT routed through hosting::do, and the key travels on stdin, never argv), not on
+# failure, not in a ::hosting:: fact, not in a `set -x` (not enabled). The 2026-08-30 exposure this
+# fleet already paid for came from a CHECK that selected `.value`; every read below compares by
+# name, type and registry host. test/run-tests.sh asserts the absence of `mwi_` in the output.
+#
+# 🚨 A pull secret the kubelet cannot use is a pod in ImagePullBackOff with nothing naming this
+# step, so the read-back is not optional: a Secret of the wrong type, or one whose config names a
+# different registry, is a refusal here rather than a silent ImagePullBackOff later.
+
+# shellcheck source=_common.sh
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-pull-secret"
+
+namespace="" registry="" vault="" secret="" name="registry-pull" username="instance"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    --registry)  registry="${2:-}";  shift 2 ;;
+    --vault)     vault="${2:-}";     shift 2 ;;
+    --secret)    secret="${2:-}";    shift 2 ;;
+    --name)      name="${2:-}";      shift 2 ;;
+    --username)  username="${2:-}";  shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::need_flag registry "$registry"
+hosting::need_flag vault "$vault"
+hosting::need_flag secret "$secret"
+hosting::need_flag name "$name"
+hosting::need_flag username "$username"
+hosting::safe_name namespace "$namespace"
+hosting::safe_host registry "$registry"
+hosting::safe_name vault "$vault"
+hosting::safe_name secret "$secret"
+hosting::safe_name name "$name"
+hosting::safe_name username "$username"
+
+hosting::log "pull secret ${name} in ${namespace} for ${registry} (user ${username}), key from vault ${vault} object ${secret}"
+
+# ── 1. the namespace ──────────────────────────────────────────────────────────────────────────
+# Before hosting-deploy in every plan, so the namespace may not exist yet. Idempotent: an existing
+# namespace applies unchanged. The same idiom hosting-deploy uses, so the two agree on the shape.
+hosting::step "Ensure namespace ${namespace}"
+hosting::do kubectl create namespace "$namespace" --dry-run=client -o yaml \
+  | { hosting::dry && cat >/dev/null || kubectl apply -f - ; } \
+  || hosting::die "could not ensure namespace ${namespace}"
+
+# ── 2. the key ────────────────────────────────────────────────────────────────────────────────
+hosting::step "Read the instance key from Key Vault"
+if hosting::dry; then
+  hosting::log "(dry run) would read ${secret} from vault ${vault} — the value is never shown"
+  hosting::log "(dry run) would apply Secret ${namespace}/${name} (kubernetes.io/dockerconfigjson) for ${registry}"
+  hosting::say pull_secret "$name"
+  hosting::say pull_secret_registry "$registry"
+  hosting::say pull_secret_verify "dry-run"
+  exit 0
+fi
+
+key="$(az keyvault secret show --vault-name "$vault" --name "$secret" --query value -o tsv 2>/dev/null)" \
+  || hosting::die "could not read ${secret} from vault ${vault}. This is the instance's plugin-registry key — hosting-kv-ensure lists it as REQUIRED, so an absent object means the instance has not been issued one yet."
+[ -n "$key" ] || hosting::die "vault ${vault} object ${secret} is EMPTY — a pull secret carrying no credential is an ImagePullBackOff with nothing naming this step."
+# The key goes into a JSON string below. An InstanceKeys.Generate key is mwi_ + URL-safe base64,
+# so anything that would need escaping is not a key this operator issued — refuse rather than
+# quote, because a mis-quoted credential fails at the kubelet with no message naming the cause.
+if [[ "$key" =~ [\"\\[:space:]] ]]; then
+  unset key
+  hosting::die "vault ${vault} object ${secret} is not a plain token (it contains a quote, backslash or whitespace) — refusing to write it into a docker config"
+fi
+
+# ── 3. the Secret ─────────────────────────────────────────────────────────────────────────────
+# 🚨 The key travels on STDIN and lives in a mode-600 temporary for the duration of one kubectl
+# call — never on a command line (argv is readable by every process in the pod, and hosting::do
+# would echo it). `kubectl create secret generic --type=kubernetes.io/dockerconfigjson
+# --from-file=.dockerconfigjson=…` is the documented way to build the Secret without --docker-password.
+hosting::step "Apply the pull secret"
+auth="$(printf '%s:%s' "$username" "$key" | base64 | tr -d '\n')"
+umask 077
+config="$(mktemp)"
+trap 'rm -f "$config"' EXIT
+printf '{"auths":{"%s":{"username":"%s","password":"%s","auth":"%s"}}}' \
+  "$registry" "$username" "$key" "$auth" > "$config"
+unset key auth
+hosting::log "  + kubectl -n ${namespace} create secret generic ${name} --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=<temp> --dry-run=client -o yaml | kubectl apply -f -"
+kubectl -n "$namespace" create secret generic "$name" \
+    --type=kubernetes.io/dockerconfigjson \
+    --from-file=.dockerconfigjson="$config" \
+    --dry-run=client -o yaml \
+  | kubectl apply -f - >/dev/null \
+  || hosting::die "could not apply Secret ${namespace}/${name}"
+rm -f "$config"
+
+# ── 4. read it back ───────────────────────────────────────────────────────────────────────────
+# Type and registry, by name — never the value. A Secret of another type is one the kubelet will
+# not use as a pull credential; a config naming another registry is a credential for the wrong
+# host. Both are ImagePullBackOff later with nothing pointing here, so both refuse now.
+hosting::step "Verify the pull secret"
+type="$(kubectl -n "$namespace" get secret "$name" -o 'jsonpath={.type}' 2>/dev/null)" \
+  || hosting::die "Secret ${namespace}/${name} could not be read back after apply"
+[ "$type" = "kubernetes.io/dockerconfigjson" ] \
+  || hosting::die "Secret ${namespace}/${name} is of type '${type}', not kubernetes.io/dockerconfigjson — the kubelet will not use it as a pull credential. A Secret of that name already existed with another type; delete it and re-request the action."
+if ! kubectl -n "$namespace" get secret "$name" -o 'jsonpath={.data.\.dockerconfigjson}' 2>/dev/null \
+    | base64 -d 2>/dev/null | grep -q "\"${registry}\""; then
+  hosting::die "Secret ${namespace}/${name} does not name registry ${registry} in its docker config"
+fi
+hosting::log "verified ${namespace}/${name}: kubernetes.io/dockerconfigjson for ${registry}"
+
+# The facts the mesh records. The NAME is what the deployment record's portal.imagePullSecret must
+# equal; the registry is what selfUpdate.registry must equal. Never the value.
+hosting::say pull_secret "$name"
+hosting::say pull_secret_registry "$registry"
+hosting::say pull_secret_verify "true"

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -84,6 +84,11 @@ refuses "redirect needs a mode"            "must be 'suspend' or 'restore'"     
 refuses "deploy needs --release"           "missing required flag --release"    hosting-deploy --namespace n --database d
 refuses "verify needs --host"              "missing required flag --host"       hosting-verify
 refuses "unknown flags are not ignored"    "unknown argument"                   hosting-verify --host h --nope 1
+refuses "pull-secret needs --namespace"    "missing required flag --namespace"  hosting-pull-secret --registry r.example.test --vault V --secret S
+refuses "pull-secret needs --registry"     "missing required flag --registry"   hosting-pull-secret --namespace n --vault V --secret S
+refuses "pull-secret needs --vault"        "missing required flag --vault"      hosting-pull-secret --namespace n --registry r.example.test --secret S
+refuses "pull-secret needs --secret"       "missing required flag --secret"     hosting-pull-secret --namespace n --registry r.example.test --vault V
+refuses "pull-secret rejects unknown flags" "unknown argument"                  hosting-pull-secret --namespace n --registry r.example.test --vault V --secret S --nope 1
 
 echo
 echo "── the refusals that stand in front of something destructive ─────"
@@ -170,6 +175,82 @@ refuses_hard "host with a space"                    "is not a hostname" \
   hosting-verify --host 'a.example.com b'
 refuses_hard "store-uri host with a semicolon"      "is not a plain name" \
   env HOSTING_DRY_RUN=true hosting-backup --database 'd;id' --server s --store-uri https://x/y/z --object o
+refuses_hard "pull-secret namespace with a metacharacter" "is not a plain name" \
+  hosting-pull-secret --namespace 'n; rm -rf /' --registry cr.meshweaver.cloud --vault V --secret S
+refuses_hard "pull-secret registry with a space"     "is not a hostname" \
+  hosting-pull-secret --namespace n --registry 'cr.meshweaver.cloud x' --vault V --secret S
+refuses_hard "pull-secret name with a backtick"      "is not a plain name" \
+  hosting-pull-secret --namespace n --registry cr.meshweaver.cloud --vault V --secret S --name 'p`whoami`'
+
+echo
+echo "── hosting-pull-secret: the namespace first, the key never ──────"
+# The plan runs this BEFORE hosting-deploy (Provision) and as the FIRST step of Roll / Reconcile
+# (MeshWeaver.Plugins#1514), so the namespace may not exist yet and the command must ensure it —
+# idempotently — before it applies anything into it. The stubs record every invocation in order
+# and keep the applied manifest, so the read-backs the script verifies with come from what it
+# actually applied: a script that applied nothing cannot pass its own verification.
+PS_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/pull-secret" && pwd)"
+_ps_dir="$(mktemp -d)"; _ps_log="$_ps_dir/calls.log"; : > "$_ps_log"
+_ps_out="$(env PATH="$PS_STUBS:$PATH" HOSTING_PULL_SECRET_STUB_LOG="$_ps_log" HOSTING_PULL_SECRET_STUB_DIR="$_ps_dir" \
+  hosting-pull-secret --namespace acme --registry cr.meshweaver.cloud --vault Systemorph --secret acme-PluginCatalog-RegistryToken --name registry-pull 2>&1)"; _ps_rc=$?
+[ "$_ps_rc" -eq 0 ] && ok "pull-secret succeeds against the stubbed estate" || bad "pull-secret succeeds against the stubbed estate" "exited ${_ps_rc}: ${_ps_out}"
+# 🚨 THE property: the key never leaves the process. The stub answers a sentinel `mwi_` key; its
+# presence anywhere in the output — a `+ command` echo, a fact, an error — is the leak.
+case "$_ps_out" in
+  *mwi_*) bad "pull-secret never prints the key" "a 'mwi_' token appeared in its output: ${_ps_out}" ;;
+  *)      ok  "pull-secret never prints the key" ;;
+esac
+# …and the key never travels on a kubectl COMMAND LINE either (argv is readable by every process
+# in the pod). The stub logs every invocation verbatim; only an apply's STDIN may carry it.
+if grep -v '^  <stdin>' "$_ps_log" | grep -q 'mwi_'; then
+  bad "pull-secret never puts the key on a command line" "$(grep -v '^  <stdin>' "$_ps_log" | grep mwi_)"
+else
+  ok "pull-secret never puts the key on a command line"
+fi
+# Ordering: the namespace is ensured (create --dry-run | apply) BEFORE the Secret is applied.
+_ns_line="$(grep -n 'kubectl create namespace acme --dry-run=client' "$_ps_log" | head -1 | cut -d: -f1)"
+_sec_line="$(grep -n 'kubectl -n acme create secret generic registry-pull' "$_ps_log" | head -1 | cut -d: -f1)"
+if [ -n "$_ns_line" ] && [ -n "$_sec_line" ] && [ "$_ns_line" -lt "$_sec_line" ]; then
+  ok "pull-secret ensures the namespace before it applies the Secret"
+else
+  bad "pull-secret ensures the namespace before it applies the Secret" "namespace at line '${_ns_line}', secret at '${_sec_line}' in: $(cat "$_ps_log")"
+fi
+grep -q 'kubectl apply -f -' "$_ps_log" && ok "the namespace manifest is APPLIED, not only rendered" \
+  || bad "the namespace manifest is APPLIED" "no 'kubectl apply -f -' in: $(cat "$_ps_log")"
+# Content: the applied Secret is a dockerconfigjson for the registry, with the default username.
+if [ -f "$_ps_dir/applied-secret.yaml" ] \
+   && grep -q '^type: kubernetes.io/dockerconfigjson' "$_ps_dir/applied-secret.yaml" \
+   && sed -n 's/^  .dockerconfigjson: //p' "$_ps_dir/applied-secret.yaml" | base64 -d | grep -q '"cr.meshweaver.cloud":{"username":"instance"'; then
+  ok "the applied Secret is a dockerconfigjson for the registry, user 'instance'"
+else
+  bad "the applied Secret is a dockerconfigjson for the registry" "applied: $(cat "$_ps_dir/applied-secret.yaml" 2>/dev/null)"
+fi
+case "$_ps_out" in *"::hosting:: pull_secret=registry-pull"*) ok "pull-secret reports the Secret NAME the record must carry" ;;
+  *) bad "pull-secret reports the Secret name" "said: ${_ps_out}" ;; esac
+case "$_ps_out" in *"::hosting:: pull_secret_verify=true"*) ok "pull-secret reports verified=true only after reading the Secret back" ;;
+  *) bad "pull-secret reports verified=true" "said: ${_ps_out}" ;; esac
+rm -rf "$_ps_dir"
+
+# The refusals a stubbed estate can reach: an absent vault object, and a pre-existing Secret of
+# another type (which the kubelet would silently not use).
+_ps_dir="$(mktemp -d)"; _ps_log="$_ps_dir/calls.log"; : > "$_ps_log"
+refuses "pull-secret refuses when the vault object is absent" "could not read" \
+  env PATH="$PS_STUBS:$PATH" HOSTING_PULL_SECRET_STUB_LOG="$_ps_log" HOSTING_PULL_SECRET_STUB_DIR="$_ps_dir" HOSTING_PULL_SECRET_STUB_AZ_FAIL=1 \
+  hosting-pull-secret --namespace acme --registry cr.meshweaver.cloud --vault Systemorph --secret acme-PluginCatalog-RegistryToken
+refuses "pull-secret refuses a Secret of another type" "not kubernetes.io/dockerconfigjson" \
+  env PATH="$PS_STUBS:$PATH" HOSTING_PULL_SECRET_STUB_LOG="$_ps_log" HOSTING_PULL_SECRET_STUB_DIR="$_ps_dir" HOSTING_PULL_SECRET_STUB_WRONG_TYPE=1 \
+  hosting-pull-secret --namespace acme --registry cr.meshweaver.cloud --vault Systemorph --secret acme-PluginCatalog-RegistryToken
+refuses "pull-secret refuses a key that is not a plain token" "is not a plain token" \
+  env PATH="$PS_STUBS:$PATH" HOSTING_PULL_SECRET_STUB_LOG="$_ps_log" HOSTING_PULL_SECRET_STUB_DIR="$_ps_dir" HOSTING_PULL_SECRET_STUB_KEY='mwi_has a space' \
+  hosting-pull-secret --namespace acme --registry cr.meshweaver.cloud --vault Systemorph --secret acme-PluginCatalog-RegistryToken
+rm -rf "$_ps_dir"
+# A dry run reads nothing, applies nothing, and still reports the name — never verified=true.
+_ps_out="$(env HOSTING_DRY_RUN=true hosting-pull-secret --namespace acme --registry cr.meshweaver.cloud --vault Systemorph --secret S 2>&1)"; _ps_rc=$?
+[ "$_ps_rc" -eq 0 ] && ok "a dry-run pull-secret needs no az and no cluster" || bad "a dry-run pull-secret needs no az and no cluster" "exited ${_ps_rc}: ${_ps_out}"
+case "$_ps_out" in *"pull_secret_verify=true"*) bad "a dry-run pull-secret never claims verified" "it did: ${_ps_out}" ;;
+  *"::hosting:: pull_secret_verify=dry-run"*) ok "a dry-run pull-secret never claims verified" ;;
+  *) bad "a dry-run pull-secret reports its verify state" "said: ${_ps_out}" ;; esac
+unset _ps_out _ps_rc _ps_dir _ps_log _ns_line _sec_line
 
 echo
 echo "── the ::hosting:: contract the mesh parses ──────────────────────"

--- a/deploy/aks/operator/test/stubs/pull-secret/az
+++ b/deploy/aks/operator/test/stubs/pull-secret/az
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# A stand-in `az` for hosting-pull-secret's behaviour tests — answers the ONE read the command
+# makes (`az keyvault secret show --vault-name V --name N --query value -o tsv`) with a fake
+# instance key, and records the invocation. Not a mock of az: what is under test is that the
+# script READS the key without ever printing it, so the stub's key is a sentinel (`mwi_` prefix,
+# the scheme InstanceKeys.Generate uses) the test greps the output for.
+#
+#   HOSTING_PULL_SECRET_STUB_LOG   every invocation is appended here, one line each
+#   HOSTING_PULL_SECRET_STUB_KEY   the key to answer with (default: a plain mwi_ token)
+#   HOSTING_PULL_SECRET_STUB_AZ_FAIL=1   the read fails (the object does not exist)
+set -uo pipefail
+printf 'az %s\n' "$*" >> "${HOSTING_PULL_SECRET_STUB_LOG:?the az stub needs HOSTING_PULL_SECRET_STUB_LOG}"
+if [ "${1:-}" = "keyvault" ] && [ "${2:-}" = "secret" ] && [ "${3:-}" = "show" ]; then
+  if [ "${HOSTING_PULL_SECRET_STUB_AZ_FAIL:-0}" = "1" ]; then
+    echo "ERROR: (SecretNotFound) A secret with (name/id) x was not found in this key vault." >&2
+    exit 3
+  fi
+  printf '%s\n' "${HOSTING_PULL_SECRET_STUB_KEY-mwi_stub-key-that-must-never-print-0123456789}"
+  exit 0
+fi
+echo "az stub: unexpected invocation: $*" >&2
+exit 1

--- a/deploy/aks/operator/test/stubs/pull-secret/kubectl
+++ b/deploy/aks/operator/test/stubs/pull-secret/kubectl
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# A stand-in `kubectl` for hosting-pull-secret's behaviour tests. It records every invocation —
+# and, for an `apply -f -`, the manifest it received on stdin — so the test can assert the ORDER
+# (the namespace is ensured before the Secret is applied) and the CONTENT (the registry and the
+# username are in the applied config; the key is never in the script's OUTPUT). The read-backs the
+# script verifies with are answered from what was applied, so a script that applied nothing cannot
+# pass its own verification.
+#
+#   HOSTING_PULL_SECRET_STUB_LOG        every invocation, one line each; an apply's stdin follows it
+#   HOSTING_PULL_SECRET_STUB_DIR        where the applied Secret manifest is kept between calls
+#   HOSTING_PULL_SECRET_STUB_WRONG_TYPE=1   the read-back reports an Opaque Secret (a pre-existing
+#                                           object of another type — the refusal under test)
+set -uo pipefail
+log="${HOSTING_PULL_SECRET_STUB_LOG:?the kubectl stub needs HOSTING_PULL_SECRET_STUB_LOG}"
+dir="${HOSTING_PULL_SECRET_STUB_DIR:?the kubectl stub needs HOSTING_PULL_SECRET_STUB_DIR}"
+printf 'kubectl %s\n' "$*" >> "$log"
+
+# Strip a leading `-n <ns>` so the verb is positional whichever way the script spells it.
+ns=""
+if [ "${1:-}" = "-n" ]; then ns="${2:-}"; shift 2; fi
+
+case "${1:-}" in
+  create)
+    case "${2:-}" in
+      namespace)
+        # `create namespace X --dry-run=client -o yaml` → a manifest on stdout, as kubectl does.
+        printf 'apiVersion: v1\nkind: Namespace\nmetadata:\n  name: %s\n' "${3:-}" ;;
+      secret)
+        # `create secret generic NAME --type=… --from-file=.dockerconfigjson=PATH --dry-run=client -o yaml`
+        name="${3:-}"; file=""; type=""
+        for arg in "$@"; do
+          case "$arg" in
+            --from-file=.dockerconfigjson=*) file="${arg#--from-file=.dockerconfigjson=}" ;;
+            --type=*) type="${arg#--type=}" ;;
+          esac
+        done
+        [ -f "$file" ] || { echo "kubectl stub: --from-file path does not exist" >&2; exit 1; }
+        printf 'apiVersion: v1\nkind: Secret\ntype: %s\nmetadata:\n  name: %s\n  namespace: %s\ndata:\n  .dockerconfigjson: %s\n' \
+          "$type" "$name" "$ns" "$(base64 < "$file" | tr -d '\n')" ;;
+      *) echo "kubectl stub: unexpected create $2" >&2; exit 1 ;;
+    esac ;;
+  apply)
+    # Record what was applied; keep a Secret manifest for the read-backs.
+    manifest="$(cat)"
+    printf '  <stdin> %s\n' "$(printf '%s' "$manifest" | tr '\n' ' ')" >> "$log"
+    if printf '%s' "$manifest" | grep -q '^kind: Secret'; then
+      printf '%s\n' "$manifest" > "$dir/applied-secret.yaml"
+    fi
+    echo "applied" ;;
+  get)
+    # `get secret NAME -o jsonpath={.type}` / `jsonpath={.data.\.dockerconfigjson}`
+    [ "${2:-}" = "secret" ] || { echo "kubectl stub: unexpected get $2" >&2; exit 1; }
+    [ -f "$dir/applied-secret.yaml" ] || { echo "Error from server (NotFound): secrets \"${3:-}\" not found" >&2; exit 1; }
+    path=""
+    for arg in "$@"; do case "$arg" in jsonpath=*) path="${arg#jsonpath=}" ;; esac; done
+    case "$path" in
+      '{.type}')
+        if [ "${HOSTING_PULL_SECRET_STUB_WRONG_TYPE:-0}" = "1" ]; then printf 'Opaque'; else
+          sed -n 's/^type: //p' "$dir/applied-secret.yaml" | tr -d '\n'; fi ;;
+      '{.data.\.dockerconfigjson}')
+        sed -n 's/^  .dockerconfigjson: //p' "$dir/applied-secret.yaml" | tr -d '\n' ;;
+      *) echo "kubectl stub: unexpected jsonpath $path" >&2; exit 1 ;;
+    esac ;;
+  *) echo "kubectl stub: unexpected invocation: $*" >&2; exit 1 ;;
+esac

--- a/deploy/aks/scripts/check-chart-invariants.py
+++ b/deploy/aks/scripts/check-chart-invariants.py
@@ -99,7 +99,7 @@ if floor > 1:
     }
     modes = {
         (d.get("metadata") or {}).get("name"): (d.get("spec") or {}).get("accessModes") or []
-        for d in load_all(pvc_path)
+        for d in load_all(pvc_path) + by_kind("PersistentVolumeClaim")
         if d.get("kind") == "PersistentVolumeClaim"
     }
     for claim in sorted(claims):
@@ -246,6 +246,14 @@ NEVER_BLANK_CONFIG = {
         "read as an Int32 — empty fails the binder. Emit \"0\", never \"\".",
     "AzureAIS__Order":
         "read as an Int32 — empty fails the binder. Emit \"0\", never \"\".",
+    "ContainerImages__CacheMaxBytes":
+        "binds to a long (ContainerImageOptions.CacheMaxBytes, the read-through cache's byte "
+        "budget). Absent leaves the image default (20 GiB); an empty string fails the binder at "
+        "startup. Rendered only when containerImages.cacheMaxBytes is set.",
+    "SelfUpdate__Registry":
+        "binds to SelfUpdateOptions.Registry, whose default is the upstream ACR and whose value "
+        "names the host of EVERY image the self-updater rolls to. Blank is not inert here — it is "
+        "a roll to '/memex-portal-ai:<tag>'. Rendered only when selfUpdate.registry is set.",
 }
 
 for key, why in NEVER_BLANK_CONFIG.items():
@@ -305,6 +313,86 @@ elif _probe_paths["readinessProbe"] == _probe_paths["startupProbe"]:
         "the survivors inherit its traffic: the 2026-07-21 death spiral. The startup probe already "
         "holds readiness on the heavy path until the mesh is up; after that readiness must be cheap.",
     )
+
+# ---------------------------------------------------------------------------
+# 11. The platform-image pull secret is on BOTH pods that pull a platform image, or on neither.
+#
+# MeshWeaver#3353: an installation that pulls from the mirror instead of ACR needs a
+# kubernetes.io/dockerconfigjson credential on every pod that pulls memex-portal-ai or
+# memex-migration. The chart renders `portal.imagePullSecret` onto the portal Deployment AND the
+# migration Job; a template edit that dropped it from one would leave a Job in ImagePullBackOff
+# while the portal rolls — and helm upgrade waits on that Job, so the deploy hangs on the one
+# object nobody looks at. The two pod specs are asserted against each other, per render.
+# ---------------------------------------------------------------------------
+checks += 1
+# The Job is named per release revision (memex-migration-<n>), so it is found by its component
+# label, and its ABSENCE is a finding: the chart always renders one, so a render without it is not
+# the shape this check understands, and "no Job to compare" must never read as "they agree".
+migration = next(
+    (d for d in by_kind("Job")
+     if ((d.get("metadata") or {}).get("labels") or {}).get("app.kubernetes.io/component") == "memex-migration"),
+    None)
+if migration is None:
+    finding(
+        "the render contains no Job labelled app.kubernetes.io/component=memex-migration",
+        "the chart always renders the migration Job (memex-migration/job.yaml), and invariant 11 "
+        "compares its pod spec against the portal's — with no Job there is nothing to compare, "
+        "which must not read as agreement.",
+    )
+else:
+    _portal_pull = {s.get("name") for s in (pod.get("imagePullSecrets") or [])}
+    _mig_pod = (((migration.get("spec") or {}).get("template") or {}).get("spec")) or {}
+    _mig_pull = {s.get("name") for s in (_mig_pod.get("imagePullSecrets") or [])}
+    if _portal_pull != _mig_pull:
+        finding(
+            f"imagePullSecrets differ between the portal Deployment ({sorted(_portal_pull) or 'none'}) "
+            f"and the migration Job ({sorted(_mig_pull) or 'none'})",
+            "both pull a platform image from the same registry (portal.imagePullSecret). The one "
+            "without the credential is stuck in ImagePullBackOff while the other rolls — for the "
+            "Job, that is a helm upgrade that never completes.",
+        )
+
+# ---------------------------------------------------------------------------
+# 12. A chart-created PersistentVolumeClaim is sized, classed, kept, and actually mounted.
+#
+# MeshWeaver#3353: templates/memex-portal/pvc.yaml renders a claim for each persistence.<name>
+# with `create: true`. Its `required` calls refuse a missing size or class at render time, so a
+# rendered claim carrying neither can only mean the template lost them; `helm.sh/resource-policy:
+# keep` is what stands between a helm uninstall and the data; and a claim the portal pod does not
+# mount is storage nobody uses — the values entry that created it named a claimName the volumes
+# block did not, i.e. the two halves of one entry disagree.
+# ---------------------------------------------------------------------------
+checks += 1
+_mounted_claims = {
+    v["persistentVolumeClaim"]["claimName"]
+    for v in (pod.get("volumes") or [])
+    if isinstance(v.get("persistentVolumeClaim"), dict)
+    and v["persistentVolumeClaim"].get("claimName")
+}
+for _pvc in by_kind("PersistentVolumeClaim"):
+    _pvc_name = (_pvc.get("metadata") or {}).get("name")
+    _pvc_spec = _pvc.get("spec") or {}
+    _size = ((_pvc_spec.get("resources") or {}).get("requests") or {}).get("storage")
+    _keep = ((_pvc.get("metadata") or {}).get("annotations") or {}).get("helm.sh/resource-policy")
+    if not _size or not _pvc_spec.get("storageClassName"):
+        finding(
+            f"chart-created PVC '{_pvc_name}' has no size or no storageClassName",
+            "pvc.yaml marks both `required`; a rendered claim without them means the template "
+            "changed shape. A claim of default size on the default class is a claim on the wrong tier.",
+        )
+    if _keep != "keep":
+        finding(
+            f"chart-created PVC '{_pvc_name}' is not annotated helm.sh/resource-policy: keep",
+            "without it a helm uninstall — or `create` flipped back to false — deletes the claim and "
+            "its data as a side effect of a release going away. Deleting data is an operator's "
+            "explicit act.",
+        )
+    if _pvc_name not in _mounted_claims:
+        finding(
+            f"chart-created PVC '{_pvc_name}' is not mounted by the portal pod",
+            "the persistence entry that created it names a claimName the volumes block does not use "
+            "— the two halves of one entry disagree, and the storage is provisioned for nobody.",
+        )
 
 MIN_CHECKS = 5
 if checks < MIN_CHECKS:

--- a/deploy/aks/scripts/check-chart-invariants.sh
+++ b/deploy/aks/scripts/check-chart-invariants.sh
@@ -86,6 +86,11 @@ COMBOS=(
   "self-host (neutral chart defaults)|deploy/helm/values.yaml"
   "AKS overlay (the layer every AKS install shares)|deploy/helm/values.yaml:deploy/aks/values.aks.yaml"
   "memex-local (Colima k3s)|deploy/helm/values.yaml:deploy/homebrew/share/values.local.defaults.yaml"
+  # A record-driven Provision of a MIRROR-CONSUMING instance (MeshWeaver#3353): the only combination
+  # that switches on the pull secret, SelfUpdate__Registry and the chart-created PVCs. A fixture, not
+  # an environment — without it those template branches render on nothing in this repo and a
+  # regression in any of them is invisible until a real Provision fails.
+  "mirror consumer (record-driven provision fixture)|deploy/helm/values.yaml:deploy/aks/scripts/testdata/values.mirror-consumer.yaml"
 )
 
 WORK="$(mktemp -d)"

--- a/deploy/aks/scripts/testdata/values.mirror-consumer.yaml
+++ b/deploy/aks/scripts/testdata/values.mirror-consumer.yaml
@@ -1,0 +1,34 @@
+# The values a RECORD-DRIVEN PROVISION of a mirror-consuming instance renders (MeshWeaver#3353) —
+# layered on deploy/helm/values.yaml by check-chart-invariants.sh as its fourth combination.
+#
+# 🚨 A FIXTURE, not a deployment. No real environment is described here; its job is to switch on
+# every template branch the default chart leaves dark — the pull secret on both platform pods, the
+# mirror registry key, the chart-created PersistentVolumeClaims — so the render gate can assert
+# them. Without it those branches render on no combination in this repo and a regression in any
+# of them is invisible until a real Provision fails in a namespace nobody can see.
+#
+# The three things a consumer sets, and nothing else (the mirror INSTANCE sets containerImages,
+# which is exercised by the values it lives on — memex-cloud — and is asserted here only in the
+# sense that a consumer renders NO ContainerImages__ key):
+selfUpdate:
+  registry: "mirror.example.test"
+portal:
+  imagePullSecret: "registry-pull"
+persistence:
+  data:
+    claimName: "memex-data"
+    create: true
+    size: "16Gi"
+    storageClass: "azurefile-memex"
+    accessMode: "ReadWriteMany"
+  content:
+    claimName: "memex-content"
+    create: true
+    size: "128Gi"
+    storageClass: "azurefile-memex"
+    mountPath: "/mnt/content"
+  # An entry WITHOUT `create` keeps today's behaviour: the claim is mounted, never rendered.
+  users:
+    claimName: "memex-users"
+    size: "32Gi"
+    storageClass: "azurefile-memex"

--- a/deploy/helm/templates/memex-migration/job.yaml
+++ b/deploy/helm/templates/memex-migration/job.yaml
@@ -52,6 +52,13 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
     spec:
       restartPolicy: "Never"
+{{- /* The same pull credential the portal Deployment carries (portal.imagePullSecret): the
+       migration image is the OTHER platform image, pulled from the same registry. Rendered only
+       when set. MeshWeaver#3353. */}}
+{{- if (.Values.portal).imagePullSecret }}
+      imagePullSecrets:
+        - name: "{{ .Values.portal.imagePullSecret }}"
+{{- end }}
       initContainers:
         # Postgres and the migration can start concurrently on a fresh install; gate on Postgres
         # TCP readiness so the migration doesn't fail-fast before the DB accepts connections.

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -415,6 +415,34 @@ data:
   # #2494's safety net. Same typed-key rule as the line above: a real default, never "" — this
   # binds to a TimeSpan and an empty string aborts the host in the configuration binder.
   SelfUpdate__SafetyNetCheckInterval: "{{ .Values.config.memex_portal.SelfUpdate__SafetyNetCheckInterval | default "01:00:00" }}"
+  # The registry this installation pulls its platform images from and lists them on
+  # (MeshWeaver#3353). Rendered ONLY when selfUpdate.registry is set: SelfUpdateOptions.Registry
+  # has a real default (the upstream ACR) and every image the updater rolls to is named on it, so
+  # an empty string here would make the poller roll to "/memex-portal-ai:<tag>" — the opposite of
+  # inert. Absent ⇒ the image default; a host ⇒ the OCI mirror, listed with the instance key.
+  {{- if (.Values.selfUpdate).registry }}
+  SelfUpdate__Registry: "{{ .Values.selfUpdate.registry }}"
+  {{- end }}
+  # ---- Container image mirror (MeshWeaver#3353, src/MeshWeaver.ContainerImages) --------------
+  # The /v2 pull surface THIS installation serves. Rendered only when containerImages.upstream is
+  # set — an absent block reaches no container and the mirror stays OFF (every /v2 route 404s).
+  # 🚨 ContainerImages__Password is NOT here: a secret arrives through the Key Vault CSI mapping
+  # (keyVaultSecrets.secrets → key: ContainerImages__Password), never through a ConfigMap.
+  {{- if (.Values.containerImages).upstream }}
+  ContainerImages__Upstream: "{{ .Values.containerImages.upstream }}"
+  ContainerImages__Username: "{{ .Values.containerImages.username | default "" }}"
+  ContainerImages__ImageRoot: "{{ .Values.containerImages.imageRoot | default "" }}"
+  ContainerImages__CacheDirectory: "{{ .Values.containerImages.cacheDirectory | default "" }}"
+  {{- /* Binds to a long: rendered only when set, never "" (invariant 9 in check-chart-invariants). */}}
+  {{- if .Values.containerImages.cacheMaxBytes }}
+  ContainerImages__CacheMaxBytes: "{{ .Values.containerImages.cacheMaxBytes }}"
+  {{- end }}
+  {{- /* The allowlist, index by index, the same shape as PluginCatalog__Registries__<i>. An empty
+         list renders no key, which the mirror reads as "serve nothing" — never as "serve all". */}}
+  {{- range $i, $r := .Values.containerImages.repositories }}
+  ContainerImages__Repositories__{{ $i }}: "{{ $r }}"
+  {{- end }}
+  {{- end }}
   # ---- Deployment inventory (Doc/Architecture/DeploymentInventory) ---------------------------
   # Every instance reports what it runs — platform build, commit, framework identity, update policy
   # and every module's pinned coordinate — to the control instance's Hosting/Modules inbox, once

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -48,6 +48,17 @@ spec:
       # The in-pod self-updater patches this deployment via the Kubernetes API using this SA's
       # projected token (RBAC in rbac.yaml). See Doc/Architecture/ReleaseStrategy.
       serviceAccountName: "memex-portal-sa"
+{{- /* The pull credential for the platform images when they come from the MIRROR rather than ACR
+       (MeshWeaver#3353). A Secret NAME, rendered only when set: absent ⇒ no imagePullSecrets, and
+       the kubelet's AcrPull keeps pulling from ACR exactly as before. The self-updater's PATCH
+       changes containers[].image only — a strategic merge leaves this list in place — so a pull
+       secret set once here survives every automatic roll. The same block is on the migration
+       Job's pod spec: both pods pull a platform image, and one without the secret is a Job stuck
+       in ImagePullBackOff while the portal rolls. */}}
+{{- if (.Values.portal).imagePullSecret }}
+      imagePullSecrets:
+        - name: "{{ .Values.portal.imagePullSecret }}"
+{{- end }}
       # Graceful drain budget: the host's ShutdownTimeout is 90s (Memex.Portal.Distributed
       # Program.cs) and the preStop below waits for this pod's SESSIONS to end — the k8s default
       # of 30s SIGKILLed the portal mid-drain on every rollout (circuits and the Orleans silo torn

--- a/deploy/helm/templates/memex-portal/pvc.yaml
+++ b/deploy/helm/templates/memex-portal/pvc.yaml
@@ -1,0 +1,49 @@
+{{- /*
+The portal's PersistentVolumeClaims — rendered ONLY for a `persistence.<name>` entry that says
+`create: true` (MeshWeaver#3353).
+
+🚨 WHY OPT-IN, AND WHY THE DEFAULT IS ABSENT. Until now the chart rendered NO PVC at all:
+`persistence.<name>.claimName` names a claim SOMETHING ELSE created, and on memex / memex-cloud
+that something was a laptop applying deploy/aks/manifests/portal-pvcs.yaml once. Those objects are
+unmanaged by helm, so a chart that started rendering `memex-data` on those namespaces would fail
+the next upgrade on "resource already exists" — `create` therefore MUST default to absent/false,
+and the existing environments never set it. The case it exists for is a record-driven Provision of
+a NEW instance by the Hosting operator: with no claim rendered, a new namespace got emptyDir (no
+claimName → the Memex#134 data-loss shape) or pods stuck Pending on a claim that did not exist.
+
+`size` and `storageClass` are REQUIRED when `create` is true and fail the render NAMING THE ENTRY:
+a claim of some default size on the cluster's default class is a claim on the wrong tier that
+looks fine until the volume is full or ReadWriteOnce pins the second replica. `accessMode`
+defaults to ReadWriteMany because every claim the portal mounts is shared state across replicas
+(check-chart-invariants #3 asserts it when the replica floor is above one).
+
+`helm.sh/resource-policy: keep`: an uninstall — or a `create` flipped back to false — leaves the
+claim and its data in place. Deleting data is an operator's explicit act, never a side effect of
+a release going away.
+
+An entry with no claimName is never rendered (`postgres` in values.aks.yaml is sizing information
+for the StatefulSet, not a portal claim).
+*/ -}}
+{{- range $name, $spec := .Values.persistence }}
+{{- if and $spec $spec.create $spec.claimName }}
+---
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: "{{ $spec.claimName }}"
+  labels:
+    app.kubernetes.io/name: "{{ $.Chart.Name }}"
+    app.kubernetes.io/component: "memex-portal"
+    app.kubernetes.io/instance: "{{ $.Release.Name }}"
+    meshweaver.io/volume: "{{ $name }}"
+  annotations:
+    helm.sh/resource-policy: "keep"
+spec:
+  accessModes:
+    - "{{ $spec.accessMode | default "ReadWriteMany" }}"
+  storageClassName: "{{ required (printf "persistence.%s.storageClass is required when persistence.%s.create is true — a claim on the cluster's default class is a claim on the wrong tier (the portal's shared volumes need a ReadWriteMany class such as azurefile-memex)" $name $name) $spec.storageClass }}"
+  resources:
+    requests:
+      storage: "{{ required (printf "persistence.%s.size is required when persistence.%s.create is true — the chart will not guess a volume size" $name $name) $spec.size }}"
+{{- end }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -16,6 +16,28 @@ persistDataVolume: false
 # a `helm uninstall` can never take the data with it. Previously these mounts were bolted on by
 # per-env kubectl JSON patches AFTER helm — any unpatched `helm upgrade` silently reverted /data to
 # emptyDir, wiping the caches on every restart.
+# 🚨 The chart renders NO PersistentVolumeClaim unless an entry says `create: true`. Every claim
+# named above on memex / memex-cloud was applied BY HAND from deploy/aks/manifests/portal-pvcs.yaml
+# and is unmanaged by helm — so `create` MUST stay absent/false on those environments: a chart
+# that started rendering `memex-data` there would fail the next upgrade on "resource already
+# exists". A record-driven Provision of a NEW instance (MeshWeaver#3353, the Hosting operator) is
+# the case `create: true` exists for: without it a new namespace gets emptyDir (no claimName → the
+# Memex#134 data-loss shape) or pods stuck Pending on a claim nothing created.
+#
+# With `create: true` the chart renders one PersistentVolumeClaim per entry (templates/memex-portal/
+# pvc.yaml), named `claimName`, with `size` and `storageClass` REQUIRED (a missing one fails the
+# render naming the entry — never a claim of chart-default size on the wrong class), `accessMode`
+# defaulting to ReadWriteMany (every portal claim is shared across replicas), and annotated
+# `helm.sh/resource-policy: keep`, so an uninstall never takes the data with it. `mountPath` keeps
+# its meaning from above; an entry with no claimName is never rendered.
+#
+#   content:
+#     claimName: "memex-content"
+#     create: true
+#     size: "128Gi"
+#     storageClass: "azurefile-memex"
+#     accessMode: "ReadWriteMany"
+#     mountPath: "/mnt/content"
 persistence:
   data:
     claimName: ""
@@ -29,6 +51,57 @@ persistence:
 # leave empty for local/self-host (the in-cluster patch still works; ACR polling just won't auth).
 selfUpdate:
   azureClientId: ""
+  # 🚨 WHERE THIS INSTALLATION PULLS ITS PLATFORM IMAGES FROM, AND LISTS THEM (MeshWeaver#3353).
+  # Empty (the default) keeps SelfUpdate__Registry at the image's own default — the upstream Azure
+  # Container Registry, listed through ACR's API with the workload identity above. A registry
+  # login-server host here — `memex.meshweaver.cloud`, the read-through mirror another
+  # installation serves at /v2 — makes the self-updater list tags through the OCI Distribution API
+  # instead, authenticated with THIS installation's plugin-registry instance key (the mirror host
+  # must equal a pluginCatalog registry's host; no second secret), and roll to images named on
+  # that host. Every installation EXCEPT the one serving the mirror sets this — the mirror instance
+  # cannot serve the image that boots it (Doc/Architecture/ContainerRegistryInMemex).
+  #
+  # 🚨 PAIRED with portal.imagePullSecret below: the images the updater rolls to are named on this
+  # host, so the kubelet needs a credential for it. AcrPull on the node identity covers ACR only.
+  registry: ""
+# ---- Container image mirror (the /v2 pull surface THIS installation serves) -----------------
+# The read-through OCI mirror (src/MeshWeaver.ContainerImages, MeshWeaver#3353): this installation
+# proxies container images from an upstream registry with ONE credential it holds, while every
+# caller — a satellite's CI, another installation's self-updater — authenticates with the plugin-
+# registry instance key it already carries. ONLY the mirror instance (memex.meshweaver.cloud)
+# sets this block; every other installation is a CONSUMER and sets selfUpdate.registry +
+# portal.imagePullSecret instead.
+#
+# Rendered ONLY when `upstream` is set, and then key by key into the portal ConfigMap as
+# ContainerImages__Upstream / __Username / __ImageRoot / __CacheDirectory / __CacheMaxBytes and
+# ContainerImages__Repositories__<i>. Absent block ⇒ no key rendered ⇒ the mirror is OFF and every
+# /v2 route answers 404 (never a partial service). 🚨 `ContainerImages__Password` is a SECRET and
+# is NOT rendered from values: it arrives through the Key Vault CSI mapping like every other
+# credential —
+#   keyVaultSecrets.secrets:
+#     - vaultSecret: <prefix>ContainerImages-Password
+#       key: ContainerImages__Password
+# The mirror is off unless Upstream, Username AND Password are all present.
+containerImages:
+  # The upstream registry login server, e.g. meshweaver.azurecr.io. Empty ⇒ the block is inert.
+  upstream: ""
+  # The upstream pull credential's username (an ACR token name). Its password comes from Key Vault.
+  username: ""
+  # 🚨 The ALLOWLIST of repositories this mirror serves. EMPTY MEANS NONE — without it one upstream
+  # credential becomes an open read proxy for the whole registry.
+  repositories: []
+  #   - memex-portal-ai
+  #   - memex-migration
+  #   - mw-plugin-test
+  # Where every served manifest is recorded as a ContainerImage node (the node must exist).
+  # Empty ⇒ recording is off; the mirror still proxies.
+  imageRoot: ""
+  # The digest-keyed read-through cache. Empty ⇒ off, the mirror proxies every pull. On a
+  # multi-replica installation this must be a SHARED (ReadWriteMany) mount, e.g. under /data.
+  cacheDirectory: ""
+  # The cache's byte budget (an integer). Empty ⇒ the image default (20 GiB). Rendered only when
+  # set: it binds to a long, and a blank string fails the binder at startup.
+  cacheMaxBytes: ""
 # ---- Plugin catalog ---------------------------------------------------------
 # Plugins are folders of mesh nodes in (usually private) git repos. ONE install acts as the
 # REGISTRY: it alone holds the git credential, reads the repos listed in `sources`, and re-serves
@@ -433,6 +506,13 @@ ollama:
 # swaps whatever else on the machine is already running them at its next restart.
 portal:
   image: "ghcr.io/systemorph/memex-portal-ai:latest"
+  # The NAME of a kubernetes.io/dockerconfigjson Secret in this namespace, rendered as
+  # `imagePullSecrets` on the portal Deployment's pod spec AND the migration Job's — the two pods
+  # that pull the platform images. Empty (the default) renders nothing, and the AKS kubelet's
+  # AcrPull keeps working exactly as today. Set it on an installation whose selfUpdate.registry
+  # is the mirror: the operator's `hosting-pull-secret` creates the Secret from the instance key in
+  # Key Vault (deploy/aks/manifests/hosting-operator/README.md). MeshWeaver#3353.
+  imagePullSecret: ""
   # How long a rolled-out pod may keep serving the sessions it already has. The container's preStop
   # drains the ingress (15s) and then waits on /drain until its last Blazor circuit closes, so this
   # is the ceiling on "how long may someone keep working on the OLD build after a roll" — not a

--- a/memex/Memex.Portal.Shared/SelfUpdate/OciTagLister.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/OciTagLister.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.SelfUpdate;
+
+/// <summary>
+/// Lists a repository's tags on an <b>OCI Distribution</b> registry — the read-through mirror
+/// another installation serves at <c>{portal}/v2</c> (#3353,
+/// <c>Doc/Architecture/ContainerRegistryInMemex</c>) — for a self-updater whose
+/// <see cref="SelfUpdateOptions.Registry"/> is NOT an Azure Container Registry.
+///
+/// <para><b>The credential is the one this installation already holds.</b> The mirror authenticates
+/// a caller with its plugin-registry instance key, and a consuming installation already carries
+/// exactly that key for the registry it installs modules from
+/// (<c>PluginCatalog:Registries:N:Token</c> / legacy <c>PluginCatalog:RegistryToken</c>, or the
+/// stored auto-registration credential). So the credential is RESOLVED, never configured a second
+/// time: the plugin registry whose host equals the container registry host is the one whose token
+/// is presented, through the same <see cref="RegistryTokenResolver"/> the Store uses. No new
+/// secret, nothing to rotate twice.</para>
+///
+/// <para><b>The wire conversation</b> is the standard one an OCI client has, and the one the
+/// mirror's own tests walk: <c>GET /v2/{repo}/tags/list</c> → <c>401</c> with
+/// <c>WWW-Authenticate: Bearer realm="…",service="…"</c> → <c>GET {realm}?service=…&amp;scope=…</c>
+/// with <c>Basic base64(user:key)</c> → the bearer the realm answers, on every later request.
+/// The listing is PAGINATED (<c>?n=</c>, continued by a relative <c>Link</c> header) and every
+/// page is followed: ACR sorts tags lexically and pages at 100, so a lister that stopped after
+/// the first page would see the OLDEST hundred builds and print "nothing newer" forever.</para>
+///
+/// <para><b>Failure is an error, never an empty list.</b> A refused credential, an unreachable
+/// host or a malformed answer FAULT the observable and the poller records the fault — an empty
+/// listing would be read as "nothing to roll to", which is the one silent state #2553 exists to
+/// forbid. Compare <c>UnavailableUpdateMechanics.NoRegistry</c>, which answers empty by design
+/// because it stands for "no registry configured at all".</para>
+///
+/// <para>Reactive at the surface, one async IO leaf inside <see cref="IIoPool"/> — the same shape
+/// as <see cref="RegistryTokenResolver"/>'s exchange and the ACR lister's call site in the poller.
+/// Selected by the poller from <see cref="SelfUpdateOptions.RegistryIsAzureContainerRegistry"/>;
+/// the ACR path is untouched.</para>
+/// </summary>
+public sealed class OciTagLister(
+    IMessageHub hub,
+    SelfUpdateOptions options,
+    ILogger<OciTagLister>? logger = null)
+{
+    /// <summary>The page size asked for. The registry may answer fewer; every page is followed.</summary>
+    public const int PageSize = 500;
+
+    /// <summary>The named HttpClient a host may configure; the shared fallback is used otherwise.</summary>
+    public const string HttpClientName = "MeshWeaver.SelfUpdate.Oci";
+
+    // Shared fallback when no IHttpClientFactory is registered — HttpClient is designed to be
+    // long-lived and shared; a per-call `new HttpClient()` leaks sockets. Immutable shared
+    // resource, not a cache, so it does not fall under the no-static-state rule (the same
+    // arrangement RegistryTokenResolver makes).
+    private static readonly HttpClient SharedHttp = new();
+
+    private static readonly Regex ChallengeParameter = new(
+        "(?<key>[a-zA-Z]+)=\"(?<value>[^\"]*)\"", RegexOptions.Compiled);
+
+    private static readonly Regex LinkTarget = new("<(?<url>[^>]+)>", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Every tag on <paramref name="repository"/> at <see cref="SelfUpdateOptions.Registry"/>.
+    /// Cold; emits once; FAULTS on any answer that is not a complete listing.
+    /// </summary>
+    public IObservable<IReadOnlyList<string>> ListTags(string repository)
+    {
+        var registry = (options.Registry ?? string.Empty).Trim().TrimEnd('/');
+        if (registry.Length == 0)
+            return Observable.Throw<IReadOnlyList<string>>(new InvalidOperationException(
+                "SelfUpdate:Registry is empty — there is no registry to list tags on."));
+
+        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        var http = hub.ServiceProvider.GetService<IHttpClientFactory>()?.CreateClient(HttpClientName)
+                   ?? SharedHttp;
+
+        return ResolveCredential(registry)
+            .SelectMany(key => pool.Invoke(ct => ListAsync(http, registry, repository, key, ct)));
+    }
+
+    /// <summary>
+    /// The plugin-registry credential for the registry whose host IS the container registry —
+    /// the reuse this lister exists for. Faults, naming the host, when no configured plugin
+    /// registry lives there or when the resolved credential is empty: a mirror listing without a
+    /// credential could only ever be a 401, so the misconfiguration is said once here instead of
+    /// on every check as a refused handshake.
+    /// </summary>
+    private IObservable<string> ResolveCredential(string registry)
+    {
+        var catalog = hub.ServiceProvider.GetService<PluginCatalogOptions>() ?? new PluginCatalogOptions();
+        var registries = RegistryTokenResolver.WithLegacyTokens(catalog, catalog.EffectiveRegistries);
+        var match = registries.FirstOrDefault(r => HostOf(r.Url) is { } host
+            && string.Equals(host, registry, StringComparison.OrdinalIgnoreCase));
+        if (match is null)
+            return Observable.Throw<string>(new InvalidOperationException(
+                $"SelfUpdate:Registry is '{registry}', an OCI registry the self-updater authenticates "
+                + "with this installation's plugin-registry instance key — but no plugin registry "
+                + "(PluginCatalog:Registries / PluginCatalog:RegistryUrl) is configured on that host, "
+                + "so there is no key to present. The mirror an installation pulls images from is the "
+                + "installation it installs modules from; configure both on the same host, or set "
+                + "SelfUpdate:Registry back to the upstream Azure Container Registry."));
+
+        var resolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
+        var credential = resolver is null
+            ? Observable.Return(match.Token?.Trim() ?? string.Empty)
+            : resolver.ResolveToken(match);
+
+        return credential.Select(token => token.Length > 0
+            ? token
+            : throw new InvalidOperationException(
+                $"No instance key could be resolved for the plugin registry at {match.Url}, so the "
+                + $"container registry {registry} cannot be listed. The key arrives as "
+                + "PluginCatalog:Registries:N:Token (or the legacy PluginCatalog:RegistryToken), or "
+                + "through auto-registration with PluginCatalog:BootstrapKey."));
+    }
+
+    private static string? HostOf(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return null;
+        if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri))
+            return null;
+        return uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}";
+    }
+
+    /// <summary>
+    /// The async IO leaf — the whole conversation with the registry, run inside the pool slot.
+    /// Async by the same rule that makes <c>AcrTagLister.ListTagsAsync</c> async: this is the ONE
+    /// place the network is touched, and its sole caller is <see cref="IIoPool.Invoke{T}"/>.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> ListAsync(
+        HttpClient http, string registry, string repository, string key, CancellationToken ct)
+    {
+        var baseUri = new Uri($"https://{registry}/");
+        Uri? next = new Uri(baseUri, $"/v2/{repository}/tags/list?n={PageSize}");
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var tags = new List<string>();
+        string? bearer = null;
+        var pages = 0;
+
+        while (next is not null)
+        {
+            // 🚨 A continuation that points back at a page already read is a registry looping,
+            // and following it would be an unbounded poll. Refuse rather than "cap".
+            if (!visited.Add(next.AbsoluteUri))
+                throw new InvalidOperationException(
+                    $"{registry} named {next.AbsoluteUri} as the next tags page twice — the listing loops.");
+
+            using var response = await SendAsync(http, next, bearer, ct).ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.Unauthorized && bearer is null)
+            {
+                bearer = await ExchangeAsync(http, baseUri, response, repository, key, ct).ConfigureAwait(false);
+                using var retried = await SendAsync(http, next, bearer, ct).ConfigureAwait(false);
+                next = await ReadPageAsync(retried, registry, repository, baseUri, tags, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                next = await ReadPageAsync(response, registry, repository, baseUri, tags, ct).ConfigureAwait(false);
+            }
+            pages++;
+        }
+
+        logger?.LogDebug("[SelfUpdate] {Count} tag(s) on {Registry}/{Repo} over {Pages} page(s).",
+            tags.Count, registry, repository, pages);
+        return tags;
+    }
+
+    private static async Task<HttpResponseMessage> SendAsync(
+        HttpClient http, Uri uri, string? bearer, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        if (bearer is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        return await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The bearer exchange the challenge names: <c>Basic base64(user:key)</c> at the realm, with
+    /// the service and a pull scope for the repository, answered as <c>token</c> or
+    /// <c>access_token</c>. A realm that refuses the key is reported as exactly that.
+    /// </summary>
+    private async Task<string> ExchangeAsync(
+        HttpClient http, Uri baseUri, HttpResponseMessage challenge, string repository, string key,
+        CancellationToken ct)
+    {
+        var header = challenge.Headers.WwwAuthenticate
+            .FirstOrDefault(h => h.Scheme.Equals("Bearer", StringComparison.OrdinalIgnoreCase));
+        if (header is null)
+            throw new InvalidOperationException(
+                $"{baseUri.Host} answered 401 without a Bearer challenge — not an OCI registry, or the "
+                + "route is not the mirror's.");
+
+        var parameters = ChallengeParameter.Matches(header.Parameter ?? string.Empty)
+            .ToDictionary(m => m.Groups["key"].Value, m => m.Groups["value"].Value,
+                StringComparer.OrdinalIgnoreCase);
+        if (!parameters.TryGetValue("realm", out var realm) || realm.Length == 0)
+            throw new InvalidOperationException(
+                $"{baseUri.Host}'s Bearer challenge names no realm: {header.Parameter}");
+
+        var query = new List<string>();
+        if (parameters.TryGetValue("service", out var service) && service.Length > 0)
+            query.Add("service=" + Uri.EscapeDataString(service));
+        query.Add("scope=" + Uri.EscapeDataString(
+            parameters.TryGetValue("scope", out var scope) && scope.Length > 0
+                ? scope
+                : $"repository:{repository}:pull"));
+        // A relative realm resolves against the registry; an absolute one is taken as given.
+        var realmBase = Uri.TryCreate(realm, UriKind.Absolute, out var absoluteRealm)
+            ? absoluteRealm
+            : new Uri(baseUri, realm);
+        var realmUri = new Uri(
+            realmBase.AbsoluteUri + (realmBase.Query.Length > 0 ? "&" : "?") + string.Join('&', query));
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, realmUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{options.RegistryUsername}:{key}")));
+        using var response = await http.SendAsync(request, ct).ConfigureAwait(false);
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            throw new InvalidOperationException(
+                $"{realmUri.Host} refused this installation's instance key at its token endpoint "
+                + $"({(int)response.StatusCode}). The key presented is the plugin-registry credential "
+                + "for that host; if it was rotated, the pods must restart onto the new synced Secret.");
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException(
+                $"{realmUri.Host} answered {(int)response.StatusCode} at its token endpoint.",
+                null, response.StatusCode);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+        var token = doc.RootElement.TryGetProperty("token", out var t) && t.ValueKind == JsonValueKind.String
+            ? t.GetString()
+            : doc.RootElement.TryGetProperty("access_token", out var a) && a.ValueKind == JsonValueKind.String
+                ? a.GetString()
+                : null;
+        return string.IsNullOrEmpty(token)
+            ? throw new InvalidOperationException($"{realmUri.Host}'s token endpoint answered no token.")
+            : token;
+    }
+
+    /// <summary>Reads one page into <paramref name="tags"/>; returns the next page's URI, or null on the last.</summary>
+    private static async Task<Uri?> ReadPageAsync(
+        HttpResponseMessage response, string registry, string repository, Uri baseUri,
+        List<string> tags, CancellationToken ct)
+    {
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+            throw new InvalidOperationException(
+                $"{registry} refused the bearer it had just issued for {repository} — the credential "
+                + "was revoked between the exchange and the listing.");
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            throw new InvalidOperationException(
+                $"{registry} has no repository {repository} — or does not serve it: the mirror's "
+                + "ContainerImages:Repositories allowlist must name it.");
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException(
+                $"{registry} answered {(int)response.StatusCode} listing {repository}.",
+                null, response.StatusCode);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        if (!doc.RootElement.TryGetProperty("tags", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException(
+                $"{registry} answered a tags/list body for {repository} with no \"tags\" array.");
+        foreach (var t in arr.EnumerateArray())
+            if (t.ValueKind == JsonValueKind.String && t.GetString() is { Length: > 0 } s)
+                tags.Add(s);
+
+        if (!response.Headers.TryGetValues("Link", out var links))
+            return null;
+        foreach (var link in links)
+        {
+            if (!link.Contains("rel=\"next\"", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var match = LinkTarget.Match(link);
+            if (!match.Success)
+                continue;
+            return new Uri(baseUri, match.Groups["url"].Value);
+        }
+        return null;
+    }
+}

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateConfiguration.cs
@@ -70,6 +70,14 @@ public static class SelfUpdateConfiguration
                 // lost the module could not update anything, including re-installing the module.
                 services.TryAddSingleton<IAcrTagLister, UnavailableUpdateMechanics.NoRegistry>();
                 services.TryAddSingleton<IDeploymentUpdater, UnavailableUpdateMechanics.DetectOnly>();
+                // The OCI Distribution lister for an install whose SelfUpdate:Registry is NOT an
+                // Azure Container Registry — the read-through mirror another installation serves
+                // (#3353). Registered by the PLATFORM, not the AKS module: it needs no Azure SDK
+                // and no Kubernetes, only the plugin-registry credential this install already
+                // holds, and the poller selects it by registry host at check time. The
+                // IAcrTagLister above (module-supplied or the NoRegistry fallback) stays exactly
+                // what it was for an ACR host.
+                services.AddSingleton<OciTagLister>();
                 services.AddHostedService<SelfUpdateHostedService>();
             }
             return services;

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -40,6 +40,7 @@ public class SelfUpdateHostedService : IHostedService
 {
     private readonly IMessageHub _hub;
     private readonly IAcrTagLister _acr;
+    private readonly OciTagLister? _oci;
     private readonly IDeploymentUpdater _updater;
     private readonly SelfUpdateOptions _options;
     private readonly ILogger<SelfUpdateHostedService>? _logger;
@@ -70,10 +71,12 @@ public class SelfUpdateHostedService : IHostedService
         IDeploymentUpdater updater,
         SelfUpdateOptions options,
         ILogger<SelfUpdateHostedService>? logger = null,
-        IoPoolRegistry? registry = null)
+        IoPoolRegistry? registry = null,
+        OciTagLister? oci = null)
     {
         _hub = hub;
         _acr = acr;
+        _oci = oci;
         _updater = updater;
         _options = options;
         _logger = logger;
@@ -86,11 +89,12 @@ public class SelfUpdateHostedService : IHostedService
     {
         _logger?.LogInformation(
             "[SelfUpdate] starting (event-driven, with a {SafetyNet} safety net); version={Version}, "
-            + "registry={Registry}/{Repo}, canPatch={CanPatch}, retryInterval={Interval}.",
+            + "registry={Registry}/{Repo} listed as {RegistryKind}, canPatch={CanPatch}, retryInterval={Interval}.",
             _options.SafetyNetCheckInterval > TimeSpan.Zero
                 ? _options.SafetyNetCheckInterval.ToString()
                 : "disabled",
             ShippedReleaseSeed.InstalledPlatformVersion, _options.Registry, _options.PortalRepository,
+            UsesOciListing ? "an OCI Distribution registry (the mirror, instance-key auth)" : "an Azure Container Registry",
             _updater.CanPatch, _options.RetryInterval);
 
         // 🚨 EVENT-DRIVEN WITH A SAFETY NET, and the event source is deliberately OUTSIDE the
@@ -572,6 +576,26 @@ public class SelfUpdateHostedService : IHostedService
             return Observable.Timer(delay);
         });
 
+    /// <summary>
+    /// Whether tags are listed through the OCI Distribution API rather than ACR's own: true for
+    /// any <see cref="SelfUpdateOptions.Registry"/> that is not an <c>*.azurecr.io</c> host AND
+    /// an <see cref="OciTagLister"/> was supplied. Without one (a host constructed without the
+    /// platform registration) the ACR seam is used as before, so nothing that worked stops.
+    /// </summary>
+    private bool UsesOciListing => _oci is not null && !_options.RegistryIsAzureContainerRegistry;
+
+    /// <summary>
+    /// The tag listing, from whichever registry kind <see cref="SelfUpdateOptions.Registry"/>
+    /// names (#3353). The ACR path is BYTE-IDENTICAL to what it was: the module-supplied
+    /// <see cref="IAcrTagLister"/> inside the Http pool. A non-ACR host — the read-through mirror
+    /// another installation serves — is listed by <see cref="OciTagLister"/>, which authenticates
+    /// with this install's own plugin-registry instance key and follows every page.
+    /// </summary>
+    private IObservable<IReadOnlyList<string>> ListTags() =>
+        UsesOciListing
+            ? _oci!.ListTags(_options.PortalRepository)
+            : _http.Invoke(ct => _acr.ListTagsAsync(_options.PortalRepository, ct));
+
     /// <summary>One evaluation: list tags → pick target per policy → gate target &gt; current →
     /// record availability → (if armed) patch the workloads.
     ///
@@ -591,7 +615,7 @@ public class SelfUpdateHostedService : IHostedService
         if (policy.Policy == UpdatePolicyKind.None)
             return Observable.Return(SelfUpdateVerdict.UpdatesDisabled());
 
-        return _http.Invoke(ct => _acr.ListTagsAsync(_options.PortalRepository, ct))
+        return ListTags()
             // 🚨 The BEST ROLLABLE release, not merely the newest one. A target is only rollable if a
             // sealed content bake exists for the identity that exact image resolves to, and picking
             // the newest tag and stopping means one unbaked release freezes the instance FOREVER:

--- a/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
@@ -264,6 +264,28 @@ public static class ContainerImageEndpoints
             statusCode: StatusCodes.Status401Unauthorized);
     }
 
+    /// <summary>
+    /// The caller's query string, forwarded on the <c>tags/list</c> route ONLY.
+    ///
+    /// <para><c>tags/list</c> is the one pull route the Distribution API paginates: a registry
+    /// answers the first page and names the next in a RELATIVE <c>Link</c> header
+    /// (<c>&lt;/v2/{name}/tags/list?n=100&amp;last=…&gt;; rel="next"</c>), and ACR pages at 100 tags
+    /// sorted lexically — so a mirror that dropped <c>?n=</c>/<c>?last=</c> answered every request
+    /// with the OLDEST hundred tags and could never be walked past them. The self-updater lists
+    /// tags through this route (#3353); against a repository with 500 builds it would have found
+    /// nothing newer than what it runs, forever, and printed the up-to-date sentence. The
+    /// <c>Link</c> header is forwarded by <see cref="UpstreamPassthroughResult"/> and, being
+    /// relative, resolves against the mirror's own host.</para>
+    ///
+    /// <para>A manifest or blob route never carries a query the upstream would honour, so nothing
+    /// is forwarded there: a query is not part of a content address and must not reach a cache
+    /// key or an allowlist check by the back door.</para>
+    /// </summary>
+    private static string TagsQuery(HttpContext http, RegistryRoute route) =>
+        route.Kind == "tags" && http.Request.QueryString.HasValue
+            ? http.Request.QueryString.Value ?? string.Empty
+            : string.Empty;
+
     private static async Task<IResult> Serve(HttpContext http, CancellationToken ct)
     {
         var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
@@ -338,8 +360,8 @@ public static class ContainerImageEndpoints
         try
         {
             upstream = await client.OpenAsync(
-                isHead ? HttpMethod.Head : HttpMethod.Get, route.Repository, "/v2/" + rest,
-                range, ct);
+                isHead ? HttpMethod.Head : HttpMethod.Get, route.Repository,
+                "/v2/" + rest + TagsQuery(http, route), range, ct);
         }
         catch (UpstreamUnreachableException ex)
         {

--- a/src/MeshWeaver.ContainerImages/README.md
+++ b/src/MeshWeaver.ContainerImages/README.md
@@ -24,8 +24,10 @@ registry, and consumers present a registry token.
 | `/v2/{name}/tags/list` | `GET` `HEAD` | |
 
 **Pull only.** No push, no upload, no delete — those keep going to the upstream, so this can be
-switched off without a migration. Also NOT implemented: `/v2/_catalog`, the referrers API,
-`tags/list` pagination, and serving a `Range` from the cache.
+switched off without a migration. Also NOT implemented: `/v2/_catalog`, the referrers API, and
+serving a `Range` from the cache. `tags/list` pagination IS forwarded (`?n=`/`?last=` up, the
+relative `Link` continuation back) — a self-updating installation lists its releases through this
+route, and ACR pages at 100 tags in lexical order.
 
 ## The read-through cache
 

--- a/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
+++ b/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
@@ -67,11 +67,14 @@ public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IR
     }
 
     /// <summary>Headers an OCI client depends on. <c>Docker-Content-Digest</c> is how a client
-    /// verifies it got the bytes it asked for, and dropping it silently breaks digest pinning.</summary>
+    /// verifies it got the bytes it asked for, and dropping it silently breaks digest pinning.
+    /// <c>Link</c> is the <c>tags/list</c> continuation (a RELATIVE URL, so it resolves against
+    /// the mirror) — without it a paginated listing ends after its first page and reads as
+    /// complete.</summary>
     private static readonly string[] ForwardedHeaders =
     [
         "Docker-Content-Digest", "Content-Type", "Content-Length",
-        "Accept-Ranges", "Content-Range", "ETag", "Docker-Distribution-Api-Version",
+        "Accept-Ranges", "Content-Range", "ETag", "Docker-Distribution-Api-Version", "Link",
     ];
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
@@ -33,7 +33,51 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 > **Not built:** no push or upload, no `/v2/_catalog`, no referrers API, no delete, no
 > pin-protected retention, and no **/app assembly** closure — see "What v1 records" below for
 > exactly where that line falls, and "The pull surface, exactly" for the endpoint-by-endpoint list.
-> The boot image comes from the upstream, permanently. Container images live in Azure Container
+> The boot image comes from the upstream, permanently.
+>
+> **CONSUMED (2026-09-08, maintainer directive):** every installation EXCEPT the one serving the
+> mirror pulls its platform images from the mirror — when it is created AND when it self-updates.
+> The consumption order is fixed by the bootstrap constraint below: **the mirror instance
+> (`memex.meshweaver.cloud`, serving the mirror at `cr.meshweaver.cloud`) stays on ACR, permanently;
+> every other instance moves.** What this increment adds, per repo:
+>
+> * **Chart** (`deploy/helm`, this repo): `selfUpdate.registry` → `SelfUpdate__Registry`
+>   (rendered only when set — blank would be a roll to `/memex-portal-ai:<tag>`, not inert);
+>   `portal.imagePullSecret` → `imagePullSecrets` on the portal Deployment AND the migration Job
+>   (invariant 11 of `check-chart-invariants` holds the two equal); `containerImages:` →
+>   `ContainerImages__Upstream/__Username/__ImageRoot/__CacheDirectory/__CacheMaxBytes` and
+>   `ContainerImages__Repositories__<i>`, rendered only when `upstream` is set, `Password` arriving
+>   through the Key Vault CSI mapping like every other secret; and `persistence.<name>.create: true`
+>   rendering the PersistentVolumeClaim itself (`size` and `storageClass` required, kept on
+>   uninstall) so a record-driven Provision has storage — `create` defaults to absent because the
+>   existing environments' claims are unmanaged by helm.
+> * **Self-update** (`Memex.Portal.Shared`, this repo): a `Registry` that is not `*.azurecr.io`
+>   is listed by `OciTagLister` through `/v2/{repo}/tags/list` — the standard bearer handshake,
+>   `Basic user:key` at the realm the challenge names, every page followed by the relative
+>   `Link` — with the installation's own plugin-registry instance key (resolved through
+>   `RegistryTokenResolver`; the plugin registry whose host equals the container registry host is
+>   the one whose key is presented — no second secret). A refused credential is an ERROR, never an
+>   empty listing. The ACR path is byte-identical. 🚨 The mirror had to learn to forward the
+>   `tags/list` query string and the `Link` header for this: ACR pages at 100 tags in lexical
+>   order, so a mirror that dropped `?last=` served the OLDEST hundred to every caller and a lister
+>   through it would have printed "nothing newer" forever.
+> * **Operator** (`deploy/aks/operator`, this repo): `hosting-pull-secret` turns the instance key
+>   in Key Vault into the namespace's `kubernetes.io/dockerconfigjson` Secret — ensuring the
+>   namespace first (it runs before `hosting-deploy` on Provision, first on Roll/Reconcile), reading
+>   the Secret back before reporting, never printing the key. The image is now PUBLISHED on every
+>   push to `main` (`hosting-operator:<short sha>` + `:main`); it had been built by hand on
+>   2026-08-22 and republished by nothing since.
+> * **Plugins** (MeshWeaver.Plugins#1514, in parallel): the portal host wires the mirror
+>   (`IContainerImageAuthenticator` bound to the instance-key authenticator), the Hosting
+>   deployment record grows the consumer fields and renders exactly the values above, and the
+>   Provision/Roll/Reconcile plans emit `hosting-pull-secret`. 🚨 The migration Job the
+>   self-updater MINTS (`KubernetesDeploymentUpdater.RunMigrationAsync`) must carry the same
+>   `imagePullSecrets` as the portal pod — it builds its pod spec from scratch, and a Job without
+>   the credential is ImagePullBackOff on a mirror-consuming instance while the portal rolls.
+>
+> **Still not measured: pull latency through the mirror against ACR directly** — the paragraph at
+> the end of this page stands. The directive moves the consumers anyway; the measurement is now
+> something every consuming instance produces for free, and should be read. Container images live in Azure Container
 > Registry (`meshweaver.azurecr.io`), named by `ACR:` in `main-cd.yml` and referenced by eight
 > workflows. This page exists so the decision is a decision rather than a recurring conversation.
 
@@ -196,7 +240,10 @@ half-working:
   catalog would be a second, drifting answer to the same question.
 * **the referrers API** (`/v2/<name>/referrers/<digest>`) — signatures and attestations. Nothing in
   the fleet consumes it through the mirror yet.
-* **pagination on `tags/list`** (`?n=`/`?last=`) — the query string is not forwarded.
+* ~~**pagination on `tags/list`**~~ — the query string IS forwarded on the tags route, and the
+  relative `Link` continuation is passed back, since the self-updater lists through the mirror
+  (2026-09-08). A manifest or blob route still carries no query: a query is not part of a
+  content address and must not reach a cache key by the back door.
 * **serving a `Range` FROM the cache.** A range request bypasses the cache entirely: a partial body
   cannot be verified against the whole body's digest, and an unverified entry is worse than none.
   It is proxied, and resumable, but not accelerated.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-an-installation-pulls-its-platform-images-from-the-mirror.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-an-installation-pulls-its-platform-images-from-the-mirror.md
@@ -1,0 +1,38 @@
+---
+Name: An installation pulls its platform images from the mirror
+Category: Feature
+Description: Every installation except the one serving the container-image mirror can now pull its portal and migration images from that mirror instead of the upstream registry — when it is first created and every time it updates itself — using the plugin-registry key it already holds. The chart declares it in three values, the self-updater lists releases through the mirror, the operator creates the pull credential, and the operator image is published on every merge.
+Icon: Cube
+Order: -20260908
+---
+
+# An installation pulls its platform images from the mirror
+
+The platform's container images — the portal and its database migration — used to be pulled from
+the upstream Azure Container Registry by every installation, which meant every installation held
+an upstream registry credential beside the plugin-registry key it already had. The read-through
+mirror one installation serves at `/v2` removes that second credential: a caller authenticates
+with its instance key, and the mirror holds the one upstream credential for everyone.
+
+This release makes the mirror the source of platform images for **every installation except the
+one serving it** — that instance cannot serve the image that boots it, so it stays on the
+upstream permanently ([A Container Registry in Memex](/Doc/Architecture/ContainerRegistryInMemex)).
+
+**In the chart**, three values describe a consumer: `selfUpdate.registry` names the mirror host,
+`portal.imagePullSecret` names the pull credential its pods use for it — rendered on the portal
+Deployment *and* the migration Job, so a roll can never leave the Job unable to pull — and the
+mirror instance's own configuration lives under `containerImages`, rendered key by key and off
+unless set. A chart can now also **create an installation's persistent volumes** (`persistence.<name>.create: true`,
+with size and storage class required and the claims kept on uninstall), so a newly provisioned
+installation starts with real storage rather than an empty directory that vanishes on restart.
+
+**In the self-updater**, a registry that is not an Azure Container Registry is listed through the
+OCI Distribution API with the installation's plugin-registry key — the same handshake any registry
+client speaks, every page of a paginated listing followed, and a refused credential reported as an
+error rather than mistaken for "nothing newer". An installation on the upstream registry behaves
+exactly as before.
+
+**In the operator**, `hosting-pull-secret` turns the instance key in Key Vault into the pull
+credential its namespace needs — creating the namespace first, since it runs before the release
+is deployed — and never prints the key. The operator image itself is now published on every
+merge, so a fix to a lifecycle script reaches the Jobs that run it instead of only the repository.

--- a/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
@@ -10,8 +10,39 @@ public record SelfUpdateOptions
     /// <summary>Configuration section this binds from (e.g. <c>SelfUpdate__RetryInterval</c>).</summary>
     public const string SectionName = "SelfUpdate";
 
-    /// <summary>The container registry login server the running install pulls from and polls.</summary>
+    /// <summary>
+    /// The container registry login server the running install pulls from and polls.
+    ///
+    /// <para>Two kinds of host are understood, told apart by <see cref="RegistryIsAzureContainerRegistry"/>:
+    /// an Azure Container Registry (<c>*.azurecr.io</c>, the default — tags are listed through
+    /// ACR's own <c>/acr/v1/{repo}/_tags</c> with Workload Identity), and ANY OTHER host, which is
+    /// read as an OCI Distribution registry — in this fleet the read-through mirror another
+    /// installation serves at <c>{portal}/v2</c> (#3353, <c>Doc/Architecture/ContainerRegistryInMemex</c>),
+    /// authenticated with this installation's own plugin-registry instance key. The chart renders
+    /// it from <c>selfUpdate.registry</c>; the images the updater rolls to
+    /// (<see cref="PortalImage"/>, <see cref="MigrationImage"/>) are named on this host, so a
+    /// mirror-consuming installation must ALSO carry the pull secret the chart's
+    /// <c>portal.imagePullSecret</c> declares, or the roll names an image its kubelet cannot pull.</para>
+    /// </summary>
     public string Registry { get; init; } = "meshweaver.azurecr.io";
+
+    /// <summary>
+    /// The username presented to a non-ACR registry's token endpoint (<c>Basic user:key</c>). The
+    /// mirror authenticates the KEY and discards the username by design (<c>RegistryCredential</c>),
+    /// so this is a placeholder there; another OCI registry may care.
+    /// </summary>
+    public string RegistryUsername { get; init; } = "instance";
+
+    /// <summary>
+    /// Whether <see cref="Registry"/> is an Azure Container Registry host — the discriminator
+    /// between the ACR tag lister (proprietary API, Workload Identity) and the OCI Distribution
+    /// lister (<c>/v2/{repo}/tags/list</c>, bearer handshake, instance key). Pure: a suffix test
+    /// on the host, case-insensitive, so <c>meshweaver.azurecr.io</c> and <c>MESHWEAVER.AZURECR.IO</c>
+    /// answer alike and <c>memex.meshweaver.cloud</c> does not.
+    /// </summary>
+    public bool RegistryIsAzureContainerRegistry =>
+        (Registry ?? string.Empty).Trim().TrimEnd('/')
+            .EndsWith(".azurecr.io", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Repository whose tags are the platform version source of truth (portal + migration
     /// share the same version, built together).</summary>

--- a/test/Memex.Portal.Shared.Test/OciTagListerTest.cs
+++ b/test/Memex.Portal.Shared.Test/OciTagListerTest.cs
@@ -1,0 +1,352 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The self-updater listing tags on the read-through MIRROR instead of ACR (#3353): the bearer
+/// handshake the mirror speaks, walked end to end against an in-process registry; the
+/// credential being this installation's own plugin-registry instance key and nothing new; every
+/// page of a paginated listing being followed; and a refused or misconfigured credential being an
+/// ERROR — never an empty list, which the poller would read as "nothing to roll to".
+///
+/// <para>The fake substitutes the NETWORK, not a MeshWeaver interface: it holds the protocol's
+/// invariants (a 401 without a bearer, a 401 on a wrong key, a relative <c>Link</c> continuation)
+/// rather than replaying recorded answers. The hub, the token resolver and the poller's decision
+/// path are real.</para>
+/// </summary>
+public class OciTagListerTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string MirrorHost = "mirror.example.test";
+    private const string MirrorUrl = "https://" + MirrorHost;
+    private const string InstanceKey = "mwi_this-installations-own-plugin-registry-key";
+    private const string Repository = "memex-portal-ai";
+
+    /// <summary>Strictly newer than anything this test host can run as, so the roll it drives is
+    /// the ordinary forward roll (the same shape ComboGateRollTest uses) — and the highest CD build
+    /// number in the fixture, because lineage orders by <c>ci.N</c>, not by the SemVer prefix.</summary>
+    private const string NewestTag = "9999.0.0-ci.3";
+
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    private readonly FakeMirror mirror = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddUpdatePolicyType()
+            .ConfigureServices(s => s
+                .AddSingleton<IHttpClientFactory>(new FakeMirrorClientFactory(mirror))
+                // The resolver the Store uses — real, so "the same credential" is measured on the
+                // same code path rather than assumed.
+                .AddSingleton<RegistryTokenResolver>()
+                // The plugin registry this installation installs modules from IS the mirror host,
+                // and the key it holds for it is the credential the lister must present.
+                .AddSingleton(new PluginCatalogOptions
+                {
+                    Registries =
+                    [
+                        new PluginRegistryReference { Name = "Plugins", Url = MirrorUrl, Token = InstanceKey },
+                    ],
+                }));
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private OciTagLister Lister(string registry = MirrorHost) => new(
+        Mesh,
+        new SelfUpdateOptions { Registry = registry },
+        Mesh.ServiceProvider.GetService<ILogger<OciTagLister>>());
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The handshake, the credential, the pages
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact(Timeout = 120_000)]
+    public async Task ListsEveryPage_ThroughTheBearerHandshake_WithThePluginRegistryKey()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var tags = await Lister().ListTags(Repository).FirstAsync().Timeout(Budget).Await(ct);
+
+        tags.Should().Equal(FakeMirror.Tags,
+            "the listing is paginated and every page must be followed — ACR pages at 100 in lexical "
+            + "order, so a lister that stops after the first page sees the OLDEST builds only");
+        mirror.PresentedSecret.Should().Be(InstanceKey,
+            "the credential is the plugin-registry instance key this installation already holds, "
+            + "presented as Basic user:key at the realm the challenge names — no second secret");
+        mirror.TokenRequests.Should().Be(1, "one exchange serves every page of one listing");
+        mirror.PagesServed.Should().BeGreaterThan(1, "the fixture pages so that pagination is observable");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ARefusedKey_FaultsTheListing_NeverAnEmptyList()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        mirror.RefuseKey = true;
+
+        var fault = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Lister().ListTags(Repository).FirstAsync().Timeout(Budget).Await(ct));
+
+        fault.Message.Should().Contain("refused",
+            "an empty listing would read as 'nothing to roll to' — the one silent state #2553 forbids");
+        fault.Message.Should().Contain(MirrorHost);
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task NoPluginRegistryOnThatHost_FaultsNamingTheHost()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var fault = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Lister("other.example.test").ListTags(Repository).FirstAsync().Timeout(Budget).Await(ct));
+
+        fault.Message.Should().Contain("other.example.test");
+        fault.Message.Should().Contain("PluginCatalog",
+            "the fix is a configuration change, and the message has to say which one");
+        mirror.Requests.Should().Be(0, "a listing with no credential could only ever be a 401");
+    }
+
+    [Fact]
+    public void AnAzureContainerRegistryHost_KeepsTheAcrLister()
+    {
+        new SelfUpdateOptions().RegistryIsAzureContainerRegistry.Should().BeTrue("the default is ACR");
+        new SelfUpdateOptions { Registry = "MESHWEAVER.AZURECR.IO" }.RegistryIsAzureContainerRegistry
+            .Should().BeTrue("host names are case-insensitive");
+        new SelfUpdateOptions { Registry = "memex.meshweaver.cloud" }.RegistryIsAzureContainerRegistry
+            .Should().BeFalse("the mirror is an OCI Distribution registry, listed through /v2");
+        new SelfUpdateOptions { Registry = "memex.meshweaver.cloud/" }.RegistryIsAzureContainerRegistry
+            .Should().BeFalse();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The poller's selection: a mirror install never talks to ACR
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 The integration claim. With <c>SelfUpdate:Registry</c> naming the mirror, ONE check
+    /// lists through the mirror, finds the newer release and rolls to it — and the ACR seam is
+    /// never touched (it throws if it is). The roll names the image on the mirror host, which is
+    /// what makes the pull secret on the pod spec matter.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task AMirrorInstall_RollsFromTheMirrorListing_AndNeverCallsAcr()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await Seed();
+        var updater = new RecordingUpdater();
+        var options = new SelfUpdateOptions
+        {
+            Registry = MirrorHost,
+            RetryInterval = TimeSpan.FromMilliseconds(500),
+            EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
+            DefaultPolicy = UpdatePolicyKind.Continuous,
+        };
+        var service = new SeamedSelfUpdateService(
+            Mesh, new AcrMustNotBeCalled(), updater, options,
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(),
+            new AlwaysAvailable(Mesh, new ConfigurationBuilder().Build()),
+            new OciTagLister(Mesh, options, Mesh.ServiceProvider.GetService<ILogger<OciTagLister>>()));
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await service.Evaluations.FirstAsync().Timeout(Budget).Await(ct);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        updater.Tags.Should().Contain(NewestTag,
+            "the newest release on the mirror is what a mirror-consuming install rolls to");
+        updater.Images.Should().Contain($"{MirrorHost}/{Repository}:{NewestTag}",
+            "the image the updater rolls to is named on the mirror host — that is the pull the pod's pull secret exists for");
+        mirror.PresentedSecret.Should().Be(InstanceKey);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The fake mirror
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// The mirror's pull surface for <c>tags/list</c>, as its own tests pin it: a bare 401 with a
+    /// Bearer challenge until a bearer is presented, <c>/v2/token</c> answering the caller's OWN key
+    /// back for <c>Basic user:key</c>, and a listing paginated with a relative <c>Link</c>.
+    /// </summary>
+    private sealed class FakeMirror : HttpMessageHandler
+    {
+        public static readonly string[] Tags = ["3.0.0-ci.1", "3.0.0-ci.2", NewestTag, "latest"];
+
+        /// <summary>Two per page, whatever <c>?n=</c> asks, so pagination is always exercised.</summary>
+        private const int PageSize = 2;
+
+        public bool RefuseKey;
+        public int Requests;
+        public int TokenRequests;
+        public int PagesServed;
+        public string? PresentedSecret;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref Requests);
+            var uri = request.RequestUri!;
+            if (!string.Equals(uri.Host, MirrorHost, StringComparison.Ordinal))
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            if (uri.AbsolutePath == "/v2/token")
+            {
+                Interlocked.Increment(ref TokenRequests);
+                var header = request.Headers.Authorization;
+                string? secret = null;
+                if (header is { Scheme: "Basic", Parameter: { } basic })
+                {
+                    var pair = Encoding.UTF8.GetString(Convert.FromBase64String(basic));
+                    secret = pair[(pair.IndexOf(':') + 1)..];
+                }
+                PresentedSecret = secret;
+                if (RefuseKey || secret != InstanceKey)
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+                // The mirror mints nothing: the bearer IS the caller's key.
+                return Task.FromResult(Json($$"""{"token":"{{InstanceKey}}"}"""));
+            }
+
+            if (request.Headers.Authorization is not { Scheme: "Bearer" } auth || auth.Parameter != InstanceKey)
+                return Task.FromResult(Challenge());
+
+            if (uri.AbsolutePath == $"/v2/{Repository}/tags/list")
+            {
+                Interlocked.Increment(ref PagesServed);
+                var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+                var last = query["last"];
+                var remaining = last is null ? Tags : Tags.SkipWhile(t => t != last).Skip(1).ToArray();
+                var page = remaining.Take(PageSize).ToArray();
+                var response = Json(
+                    $$"""{"name":"{{Repository}}","tags":[{{string.Join(",", page.Select(t => $"\"{t}\""))}}]}""");
+                if (page.Length < remaining.Length)
+                    response.Headers.TryAddWithoutValidation(
+                        "Link", $"</v2/{Repository}/tags/list?n={PageSize}&last={page[^1]}>; rel=\"next\"");
+                return Task.FromResult(response);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Challenge()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("Bearer",
+                $"realm=\"{MirrorUrl}/v2/token\",service=\"{MirrorHost}\""));
+            return response;
+        }
+
+        private static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private sealed class FakeMirrorClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The poller harness (the seams SelfUpdateStrandRecoveryTest documents)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>The ACR seam of a mirror install: reaching it IS the failure.</summary>
+    private sealed class AcrMustNotBeCalled : IAcrTagLister
+    {
+        public Task<IReadOnlyList<string>> ListTagsAsync(string repository, CancellationToken ct) =>
+            throw new InvalidOperationException(
+                "the ACR lister was called on an install whose SelfUpdate:Registry is the mirror");
+    }
+
+    private sealed class RecordingUpdater : IDeploymentUpdater
+    {
+        private ImmutableList<string> tags = ImmutableList<string>.Empty;
+        private ImmutableList<string> images = ImmutableList<string>.Empty;
+
+        public ImmutableList<string> Tags => tags;
+        public ImmutableList<string> Images => images;
+        public bool CanPatch => true;
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+            Task.FromResult<DateTimeOffset?>(null);
+
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct)
+        {
+            ImmutableInterlocked.Update(ref tags, current => current.Add(versionTag));
+            ImmutableInterlocked.Update(ref images, current => current.Add(
+                new SelfUpdateOptions { Registry = MirrorHost }.PortalImage(versionTag)));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class AlwaysAvailable(IMessageHub hub, IConfiguration configuration)
+        : ReleaseAvailabilityService(hub, configuration)
+    {
+        public override IObservable<UpdatabilityVerdict> IsUpdatable(string? targetVersion) =>
+            Observable.Return(UpdatabilityVerdict.NotEnforced("this test host consumes no CI bakes"));
+    }
+
+    private sealed class SeamedSelfUpdateService(
+        IMessageHub hub,
+        IAcrTagLister acr,
+        IDeploymentUpdater updater,
+        SelfUpdateOptions options,
+        ILogger<SelfUpdateHostedService>? logger,
+        ReleaseAvailabilityService gate,
+        OciTagLister oci)
+        : SelfUpdateHostedService(hub, acr, updater, options, logger, oci: oci)
+    {
+        public IObservable<Unit> Evaluations => ChecksReported;
+
+        protected override ReleaseAvailabilityService? ResolveAvailabilityGate() => gate;
+
+        protected override ComboVerificationGate? ResolveComboGate() => null;
+    }
+
+    private Task Seed()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var node = new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+        {
+            NodeType = UpdatePolicyNodeType.NodeType,
+            Name = "Update Policy",
+            State = MeshNodeState.Active,
+            Content = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous },
+        };
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return (IDisposable)meshService.CreateNode(node).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+    }
+}

--- a/test/MeshWeaver.ContainerImages.Test/FakeUpstreamRegistry.cs
+++ b/test/MeshWeaver.ContainerImages.Test/FakeUpstreamRegistry.cs
@@ -146,7 +146,7 @@ internal sealed class FakeUpstreamRegistry : HttpMessageHandler
                 || path == $"/v2/{repository}/manifests/{ManifestDigest}")
                 return Task.FromResult(Manifest(request));
             if (path == $"/v2/{repository}/tags/list")
-                return Task.FromResult(Json($$"""{"name":"{{repository}}","tags":["ci.7794","latest"]}"""));
+                return Task.FromResult(TagsList(repository, uri.Query));
             // 🚨 Only the digests this registry actually HOLDS. A fixture that answered every
             // sha256 path with the same bytes could not tell "does not exist" apart from
             // "exists" — which is one of the four outcomes under test.
@@ -227,6 +227,35 @@ internal sealed class FakeUpstreamRegistry : HttpMessageHandler
         };
         response.Content.Headers.ContentLength = LayerBytes.Length;
         response.Headers.AcceptRanges.Add("bytes");
+        return response;
+    }
+
+    /// <summary>The tags this registry holds, in the lexical order a registry lists them.</summary>
+    public static readonly string[] Tags = ["ci.7794", "latest"];
+
+    /// <summary>
+    /// <c>tags/list</c>, paginated the way ACR paginates it: with <c>?n=</c> the answer is at most
+    /// <c>n</c> tags after <c>?last=</c>, and a page that is not the last names the next one in a
+    /// RELATIVE <c>Link</c> header. Without <c>n</c> every tag is returned in one answer.
+    ///
+    /// <para>🚨 A fixture that ignored the query would make "the mirror forwards the query string"
+    /// unobservable: every page would carry every tag and a mirror that dropped <c>?last=</c> would
+    /// pass, while against ACR it serves the oldest hundred tags to every caller forever.</para>
+    /// </summary>
+    private static HttpResponseMessage TagsList(string repository, string query)
+    {
+        var parameters = System.Web.HttpUtility.ParseQueryString(query);
+        var n = int.TryParse(parameters["n"], out var parsed) ? parsed : Tags.Length;
+        var last = parameters["last"];
+        var remaining = last is null
+            ? Tags
+            : Tags.SkipWhile(t => t != last).Skip(1).ToArray();
+        var page = remaining.Take(n).ToArray();
+        var response = Json(
+            $$"""{"name":"{{repository}}","tags":[{{string.Join(",", page.Select(t => $"\"{t}\""))}}]}""");
+        if (page.Length < remaining.Length)
+            response.Headers.TryAddWithoutValidation(
+                "Link", $"</v2/{repository}/tags/list?n={n}&last={page[^1]}>; rel=\"next\"");
         return response;
     }
 

--- a/test/MeshWeaver.ContainerImages.Test/PullSurfaceTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/PullSurfaceTest.cs
@@ -231,6 +231,43 @@ public class PullSurfaceTest
         Assert.Contains("ci.7794", await response.Content.ReadAsStringAsync());
     }
 
+    /// <summary>
+    /// 🚨 <c>tags/list</c> is the one pull route the Distribution API PAGINATES, and the page is
+    /// chosen by the query string. ACR pages at 100 tags in lexical order, so a mirror that dropped
+    /// <c>?n=</c>/<c>?last=</c> answered every caller with the OLDEST hundred and could never be
+    /// walked past them — the self-updater listing 500 builds through it would never see the newest
+    /// and print the up-to-date sentence forever (#3353). The query goes up, the relative
+    /// <c>Link</c> continuation comes back, and following it against the MIRROR reaches the rest.
+    /// </summary>
+    [Fact]
+    public async Task TagsListIsPaginated_ThroughTheMirror()
+    {
+        var upstream = new FakeUpstreamRegistry();
+        using var app = await BuildMirror(upstream);
+        var client = Authenticated(app);
+
+        var first = await client.GetAsync($"/v2/{FakeUpstreamRegistry.Repository}/tags/list?n=1");
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        var firstBody = await first.Content.ReadAsStringAsync();
+        Assert.Contains(FakeUpstreamRegistry.Tags[0], firstBody);
+        Assert.DoesNotContain(FakeUpstreamRegistry.Tags[1], firstBody);
+        Assert.True(first.Headers.TryGetValues("Link", out var links),
+            "the first of two pages must name the second in a Link header, or a caller reads one page as the whole listing");
+        var next = links.Single();
+        var match = System.Text.RegularExpressions.Regex.Match(next, "<([^>]+)>");
+        Assert.True(match.Success, next);
+
+        // Relative, so it resolves against the mirror — never against the upstream host.
+        var second = await client.GetAsync(match.Groups[1].Value);
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        var secondBody = await second.Content.ReadAsStringAsync();
+        Assert.Contains(FakeUpstreamRegistry.Tags[1], secondBody);
+        Assert.DoesNotContain(FakeUpstreamRegistry.Tags[0], secondBody);
+        Assert.False(second.Headers.Contains("Link"), "the last page names no successor");
+    }
+
     [Fact]
     public async Task ABlobIsServedWhole_AndByteForByte()
     {


### PR DESCRIPTION
Core half of #3353's consumption directive (maintainer, 2026-09-08): **every installation EXCEPT the one serving the read-through mirror pulls its platform images from that mirror instead of ACR** — when it is created and when it self-updates. The Plugins counterpart (portal-host wiring of the mirror, the Hosting deployment-record fields that render exactly the values below, the plan steps that emit `hosting-pull-secret`) is Systemorph/MeshWeaver.Plugins#1514, opened in parallel.

## The config contract (what the record renders)

| values key | rendered | default |
|---|---|---|
| `selfUpdate.registry` | `SelfUpdate__Registry` — only when set (blank would be a roll to `/memex-portal-ai:<tag>`, not inert) | absent → image default (ACR) |
| `portal.imagePullSecret` | `imagePullSecrets: [{name}]` on the portal Deployment **and** the migration Job | absent → nothing rendered, AcrPull as today |
| `containerImages.{upstream,username,imageRoot,cacheDirectory,cacheMaxBytes,repositories[]}` | `ContainerImages__Upstream/__Username/__ImageRoot/__CacheDirectory/__CacheMaxBytes`, `ContainerImages__Repositories__<i>` — whole block only when `upstream` is set; `CacheMaxBytes` only when set (binds to a long) | absent → no key → mirror OFF |
| `ContainerImages__Password` | **not from values** — a `keyVaultSecrets.secrets` mapping (`key: ContainerImages__Password`) like every other secret | |
| `persistence.<name>.create: true` (+ `claimName`, `size` *required*, `storageClass` *required*, `accessMode` default `ReadWriteMany`) | one `PersistentVolumeClaim`, `helm.sh/resource-policy: keep`, labelled like the chart's objects | `create` absent → no PVC (existing envs' claims are unmanaged by helm) |

Chart gate: a fourth `check-chart-invariants` combination (`deploy/aks/scripts/testdata/values.mirror-consumer.yaml`) switches on every new branch; invariant 11 holds the two pod specs' `imagePullSecrets` equal (and fails on a render without the migration Job), invariant 12 asserts a chart-created claim is sized, classed, kept and mounted; `ContainerImages__CacheMaxBytes` / `SelfUpdate__Registry` joined the never-blank list. Both new invariants were shown to FAIL on a broken chart copy before this was pushed.

## Self-update over the OCI Distribution API

`SelfUpdateOptions.RegistryIsAzureContainerRegistry` (a `*.azurecr.io` suffix test) selects the lister in the poller. A non-ACR host is listed by the new `OciTagLister` (`Memex.Portal.Shared`): `GET /v2/{repo}/tags/list?n=500` → `401` + `WWW-Authenticate: Bearer realm=…` → `GET {realm}?service=…&scope=repository:{repo}:pull` with `Basic instance:<key>` → bearer on every page, every relative `Link` continuation followed. The key is the installation's **own plugin-registry instance key**: the plugin registry whose host equals `SelfUpdate:Registry` is resolved through `RegistryTokenResolver` (so whatever the Store presents — the configured token, or the exchanged sync token — is what the mirror sees). No second secret. A refused credential, an unknown repository or a host with no plugin registry configured **fault** the check — never an empty listing (the #2553 silent state). ACR listing is byte-identical.

🚨 The mirror had to learn two things for this: it now forwards the `tags/list` **query string** and the **`Link`** header. ACR pages at 100 tags in lexical order, so a mirror that dropped `?last=` answered every caller with the OLDEST hundred and a lister through it would have printed "no newer release" forever. Asserted by `TagsListIsPaginated_ThroughTheMirror` against a paging fake upstream.

Verified on the Plugins side (read, not changed here): `KubernetesDeploymentUpdater.PatchToVersionAsync` is a strategic merge of `containers[].image` only, so a pull secret on the pod spec survives every roll; `PortalImage`/`MigrationImage` derive from `Registry`. ⚠️ The migration **Job the updater mints** (`RunMigrationAsync`) builds its pod spec from scratch with no `imagePullSecrets` — on a mirror-consuming install that Job is ImagePullBackOff while the portal rolls. Named in the design page's status block for the Plugins half.

## Operator

`deploy/aks/operator/bin/hosting-pull-secret --namespace <ns> --registry <host> --vault <vault> --secret <vault object> [--name registry-pull] [--username instance]`: ensures the namespace (it runs BEFORE `hosting-deploy` on Provision, first on Roll/Reconcile — the Plugins plan's exact command line), reads the key from Key Vault, applies a `kubernetes.io/dockerconfigjson` Secret (key on stdin, never argv, never echoed), reads it back and refuses another type or another registry, reports `::hosting:: pull_secret=<name>` / `pull_secret_registry=<host>` / `pull_secret_verify=true|dry-run`. 19 behaviour assertions with az/kubectl stubs — including that no `mwi_` token ever reaches the output or a command line, and that the namespace apply precedes the Secret apply.

`hosting-operator.yml` gains `publish-preflight` + `publish` on `push` to `main` only: OIDC login, `.github/scripts/acr-login.sh`, build from `deploy/`, push `hosting-operator:<short sha>` and `:main`, then read both manifests BACK. No `continue-on-error`, no secret-shaped `if:`; every job has a literal `timeout-minutes` ≤ 45 (`check-workflow-timeouts.py`: 0 violations; `check-pr-secret-preflight.py`: 0 violations). `hosting-pull-secret` is added to the plan-command list.

## Docs

`ContainerRegistryInMemex.md` status block (consumption order: the mirror instance stays on ACR permanently, every other instance moves; what each repo adds), the operator README, `MeshWeaver.ContainerImages/README.md`, and a What's New entry (`Category: Feature`).

## Verification

`dotnet build -c Release -warnaserror`, one project each, all `0 Error(s)`: `MeshWeaver.ContainerImages.Test`, `Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`. Tests with fresh `.trx`: `PullSurfaceTest` 20/20, `OciTagListerTest` 5/5 (incl. the poller rolling from the mirror listing with an ACR seam that throws if touched), doc guards (`DocumentationLinkIntegrityTest`, `PlatformBakeLaneGuard`, What's New) 14/14. `check-chart-invariants.sh` 4/4 combinations, `check-values-are-read.sh` 119/119 keys, `helm lint` clean, operator `run-tests.sh` 93/93, shellcheck clean on the new script and stubs.

Pairs-with: none — no public type or member is removed; additions only (`OciTagLister`, `SelfUpdateOptions.RegistryUsername` / `RegistryIsAzureContainerRegistry`, an optional trailing ctor parameter on `SelfUpdateHostedService`). The Plugins counterpart #1514 consumes the chart contract above and is being opened in parallel.

Closes nothing on its own — #3353 stays open for the Plugins half and the Memex records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HizVHRYAjYJM8UTi4TBVCt
