### PR TITLE
diag(Plugins#1394): a delivery's fate records which queue it entered and how deep

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
@@ -200,6 +200,54 @@ Read it by what is **missing**:
 | `HANDLER_EXIT state=Processed` and **no** `RESPONSE_POSTED` | A handler ran and produced no reply for this correlation — the caller will wait forever |
 | `RESPONSE_POSTED` but the callback is still pending | The reply was posted and lost on the way home — chase the response delivery, not the handler |
 
+### Reading an ORDER defect: the queue-and-depth stamps
+
+🚨 **A hub has TWO queues, and a delivery moves between them at TURN time.** `mainQueue` holds turns
+in arrival order; a turn that is dequeued and found on-target with an initialization gate closed is
+pushed onto `deferredQueue` — so it **leaves** `mainQueue` — and `OpenGate` later drains the deferred
+run back to the **front** (MeshWeaver#3408). Any question of the form *"why did B run before A?"* is
+therefore a question about which queue each delivery was in and how many turns were ahead of it, and
+a trail that records only `ENQUEUED` / `DEFERRED` cannot answer it: a delivery parked in front of an
+empty queue and one parked in front of two messages that then ran look identical.
+
+Every transition consequently carries both depths:
+
+| Stage | Means |
+|---|---|
+| `ENQUEUED` → `QUEUED queue=main depth=N` | Joined `mainQueue` with `N-1` turns ahead of it. Read under the same `turnGate` as the enqueue, so it is the queue's real state at that instant |
+| `DEFERRED gates=[…]` → `QUEUED queue=deferred pos=P mainBehind=M` | It **left** `mainQueue` for `deferredQueue` at position `P`. 🚨 `M` is the count still waiting behind it — precisely the messages that can now overtake it |
+| `DEFERRED_DRAINED` → `QUEUED queue=main depth=N` | Its deferred turn is running. Compare with the `mainBehind` above: if `N` has dropped, those messages already ran and this delivery is now out of order |
+| `GATE_DRAIN gate=… deferred=D behind=B` *(hub-level, `MessageTrace`)* | The restore point. 🚨 `deferred=0` here, paired with a delivery whose fate says it **was** deferred, proves the deferral landed *after* its drain and must wait for a later one — the one conclusion neither stamp shows alone |
+
+🚨 **The depth is a SEPARATE `QUEUED` stage, and that is not cosmetic — a stage token is a matched
+CONTRACT.** Stages render as `{stage}@{hub}`, and suites wait on that literal substring:
+
+```csharp
+// DisposalRaceNackTest, SubscribeDuringRecycleTest
+.Where(trail => trail.Contains($"ENQUEUED@{victimAddress}", StringComparison.Ordinal))
+```
+
+Writing the depth *inside* the token — `ENQUEUED queue=main depth=1` — deletes `ENQUEUED@…`, those
+waits never fire, and the suites time out looking like routing stalls that have nothing to do with
+the change. Measured while adding these stamps: **0/5 with the token altered, 5/5 with it restored.**
+So **append new stages; never edit an existing token.** `MessageTrace` lines are free-form, but a
+fate stage's leading token is API.
+
+**Why this exists** (Plugins#1394). `ActivationBacklogFifoTest` has produced **four** different
+permutations — `A, C, B`, `B, C, A`, `C, A, B` and `B, A, C` — for one address and, in the captured
+case, `Distinct probe-hub instances: 1`. A structural read of `RoutingServiceBase` →
+`MonolithRoutingService.RouteImpl` → `MessageService` says every one of them is unreachable: the
+per-address `ActivationSerializer` is `inbox.Select(RouteOne).Concat()`, so a later message's routing
+begins only after the earlier one's `hub.DeliverMessage` has run; the defer decision and the
+`deferredQueue.Enqueue` are inside the same `lock (gateStateLock)` that `OpenGate` also takes; and
+`DeferredTurnsResumeAheadOfLaterArrivalsTest` pins the restore ordering deterministically. When the
+code says a reorder cannot happen and it keeps happening, the missing evidence is *where each
+delivery waited* — not more reading.
+
+🚨 **A permutation does not name a mechanism.** Four distinct ones from one test is itself evidence
+that this is not a single fixed swap, and triaging from the permutation alone has already sent two
+investigations to the wrong subsystem.
+
 Three things to know before trusting it:
 
 - **It only covers awaited requests.** Entries exist for exactly the ids with a live `Observe`

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -352,8 +352,11 @@ public class MessageService : IMessageService
                         // The old comment claimed this preserved FIFO. It only did so against
                         // messages arriving AFTER the open — the easy half.
                         logger.LogDebug("Draining deferred queue to the front of the main queue for hub {Address}", Address);
+                        int drainedDeferred, drainedBehind;
                         lock (turnGate)
                         {
+                            drainedDeferred = deferredQueue.Count;
+                            drainedBehind = mainQueue.Count;
                             if (deferredQueue.Count > 0)
                             {
                                 // Rebuild as deferred-then-waiting. Both runs keep their own order,
@@ -368,6 +371,14 @@ public class MessageService : IMessageService
                                     mainQueue.Enqueue(reordered.Dequeue());
                             }
                         }
+                        // 🚨 The RESTORE point, stamped (Plugins#1394). This is where total arrival
+                        // order is supposed to be re-established, so a reorder investigation needs
+                        // to know it happened at all, and what it moved: `deferred=0` here means
+                        // there was nothing to restore, which — paired with a delivery whose fate
+                        // says it WAS deferred — proves the deferral landed after this drain and
+                        // has to wait for a later one. That pairing is not derivable from either
+                        // stamp alone, and it is the discrimination the permutations turn on.
+                        MessageTrace.Write($"hub={Address} GATE_DRAIN gate={name} deferred={drainedDeferred} behind={drainedBehind}");
                         // Gate opened + drained — the hub is no longer stuck, so re-arm the one-shot
                         // gate-stuck logger for any future episode.
                         Interlocked.Exchange(ref _deferralOverflowLogged, 0);
@@ -1105,9 +1116,24 @@ public class MessageService : IMessageService
 
         // Always buffer to the main buffer - deferral logic will be handled in NotifyAsync
         // based on whether the message is actually targeted at this hub
-        EnqueueTurn(() => NotifyAsync(delivery, cancellationToken));
+        //
+        // 🚨 The DEPTH is recorded, not just the fact (Plugins#1394). A hub has TWO queues —
+        // mainQueue and deferredQueue — and a delivery moves between them at TURN time, so
+        // "which queue was it in, and how many turns were ahead of it" is the only thing that
+        // reconstructs a total order after the fact. Without the depth the trail says a message
+        // was enqueued and processed, and a reorder between two deliveries is indistinguishable
+        // from a reorder between two queues. See ProcessDeferredMessage / OpenGate for the
+        // matching stamps: every transition a delivery can make now carries both depths.
+        var mainDepthAtEnqueue = EnqueueTurn(() => NotifyAsync(delivery, cancellationToken));
         MessageTrace.Write($"hub={Address} msg={typeName} id={delivery.Id} ENQUEUED");
+        // 🚨 The stage token stays EXACTLY "ENQUEUED" — it is a matched CONTRACT, not a log line.
+        // Stages render as `{stage}@{hub}`, and two suites wait on that literal substring
+        // (DisposalRaceNackTest, SubscribeDuringRecycleTest: `trail.Contains($"ENQUEUED@{addr}")`).
+        // Appending detail inside the token deletes `ENQUEUED@…` and their precondition wait never
+        // fires — measured 0/5 on DisposalRaceNackTest, 5/5 once the token was restored. So the
+        // depth goes in its OWN stage, which is additive and cannot break a `Contains` matcher.
         fate?.Add("ENQUEUED", Address);
+        fate?.Add($"QUEUED queue=main depth={mainDepthAtEnqueue}", Address);
 
         return delivery.Forwarded();
     }
@@ -1118,10 +1144,24 @@ public class MessageService : IMessageService
     // the hub's configured scheduler) and awaited before the next is scheduled —
     // strict FIFO, MaxDegreeOfParallelism=1. A handler that Posts to its own hub
     // enqueues behind the current turn; shutdown re-queues the same way.
-    private void EnqueueTurn(Func<IObservable<IMessageDelivery>> turn)
+    /// <returns>
+    /// The depth of <c>mainQueue</c> AFTER this turn was appended — i.e. this turn's 1-based
+    /// position in the queue at the moment it joined it. Read under the same <c>turnGate</c> that
+    /// performs the enqueue, so the number is the queue's actual state at that instant rather than
+    /// a racy re-read. Recorded on the delivery's fate trail (Plugins#1394): a reorder can only be
+    /// attributed once you know which queue each delivery entered and how many turns were ahead of
+    /// it, and this hub has two queues that deliveries move between at turn time.
+    /// </returns>
+    private int EnqueueTurn(Func<IObservable<IMessageDelivery>> turn)
     {
-        lock (turnGate) mainQueue.Enqueue(turn);
+        int depth;
+        lock (turnGate)
+        {
+            mainQueue.Enqueue(turn);
+            depth = mainQueue.Count;
+        }
         KickDrain();
+        return depth;
     }
 
     private void KickDrain()
@@ -1440,11 +1480,29 @@ public class MessageService : IMessageService
                             }
                             logger.LogDebug("Deferring on-target message {MessageType} (ID: {MessageId}) in {Address}",
                                 delivery.Message.GetType().Name, delivery.Id, Address);
-                            MessageTrace.Write($"hub={Address} msg={name} id={delivery.Id} DEFERRED gates=[{string.Join(",", gates.Keys)}]");
-                            fate?.Add($"DEFERRED gates=[{string.Join(",", gates.Keys)}]", Address);
+                            // 🚨 Both depths, captured in the SAME turnGate as the enqueue
+                            // (Plugins#1394). This is the moment a delivery LEAVES mainQueue for
+                            // deferredQueue, and it is the only place the two queues can be
+                            // observed together. `mainDepth` is what was still waiting behind this
+                            // delivery when it stepped out of line — the messages that can now
+                            // overtake it — and `deferredDepth` is its position among the parked.
+                            // A trail with only "DEFERRED" cannot distinguish a delivery that was
+                            // parked in front of an empty queue from one parked in front of two
+                            // messages that then ran, which is exactly the discrimination the
+                            // B,A,C / B,C,A / C,A,B permutations need.
+                            int mainDepthAtDefer, deferredPosition;
                             ScheduleDeferralTimeout(delivery);
                             lock (turnGate)
+                            {
                                 deferredQueue.Enqueue(() => ProcessDeferredMessage(delivery, cancellationToken));
+                                deferredPosition = deferredQueue.Count;
+                                mainDepthAtDefer = mainQueue.Count;
+                            }
+                            MessageTrace.Write($"hub={Address} msg={name} id={delivery.Id} DEFERRED gates=[{string.Join(",", gates.Keys)}] deferredPos={deferredPosition} mainBehind={mainDepthAtDefer}");
+                            // Existing token verbatim (RequestFateLedger matches StartsWith("DEFERRED")),
+                            // then the depths as a separate additive stage — see the ENQUEUED note above.
+                            fate?.Add($"DEFERRED gates=[{string.Join(",", gates.Keys)}]", Address);
+                            fate?.Add($"QUEUED queue=deferred pos={deferredPosition} mainBehind={mainDepthAtDefer}", Address);
                             return Observable.Return(delivery.Forwarded());
                         }
                     }
@@ -1591,7 +1649,13 @@ public class MessageService : IMessageService
             return Observable.Return(delivery.Ignored());
         }
 
+        // 🚨 Paired with the DEFERRED stamp's `mainBehind` (Plugins#1394): comparing the two says
+        // whether the messages that were queued behind this delivery when it stepped out of line
+        // are still waiting, or already ran. Same-turn depth, read under turnGate.
+        int mainDepthAtDrain;
+        lock (turnGate) mainDepthAtDrain = mainQueue.Count;
         requestFates?.Find(delivery.Id)?.Add("DEFERRED_DRAINED", Address);
+        requestFates?.Find(delivery.Id)?.Add($"QUEUED queue=main depth={mainDepthAtDrain}", Address);
 
         logger.LogDebug("Processing deferred message {MessageType} (ID: {MessageId}) in {Address}",
             delivery.Message.GetType().Name, delivery.Id, Address);

--- a/test/MeshWeaver.Messaging.Hub.Test/FateStageTokensAreAContractTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/FateStageTokensAreAContractTest.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A <c>RequestFateLedger</c> stage token is a matched CONTRACT, not a log line.</b> Stages
+/// render as <c>{stage}@{hub}</c>, and suites wait on that literal substring to know a delivery has
+/// reached a hub's queue:
+///
+/// <code>
+/// // DisposalRaceNackTest, SubscribeDuringRecycleTest
+/// .Where(trail => trail.Contains($"ENQUEUED@{victimAddress}", StringComparison.Ordinal))
+/// </code>
+///
+/// <para><b>What went wrong</b> (while instrumenting Plugins#1394). Adding queue-depth detail
+/// <i>inside</i> the token — <c>fate?.Add($"ENQUEUED queue=main depth={n}")</c> — renders as
+/// <c>ENQUEUED queue=main depth=1@hub</c>, which no longer contains <c>ENQUEUED@hub</c>. Both waits
+/// above stopped firing and their tests timed out. **Measured: `DisposalRaceNackTest` 0/5 with the
+/// token altered, 5/5 with it restored** — and the failures presented as routing stalls
+/// (<c>ROUTED onTarget=False</c>, no handler entered) with nothing pointing at the stamp, which is
+/// what makes this worth a guard rather than a comment.</para>
+///
+/// <para><b>The rule.</b> APPEND a new stage; never edit an existing token. Detail belongs in its
+/// own stage (<c>QUEUED queue=main depth=N</c>), which is additive and cannot break a
+/// <c>Contains</c> matcher. <c>MessageTrace</c> lines are free-form; a fate stage's LEADING TOKEN is
+/// API.</para>
+///
+/// <para>This test pins the one token that is actually depended upon, by driving a real request
+/// through a real hub and asserting the rendered trail — so a future edit to the stamp fails HERE,
+/// naming the reason, instead of surfacing as an unrelated timeout in two other suites.</para>
+/// </summary>
+public class FateStageTokensAreAContractTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record Probe : IRequest<ProbeAck>;
+
+    private record ProbeAck;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithTypes(typeof(Probe), typeof(ProbeAck))
+            .WithHandler<Probe>((hub, delivery) =>
+            {
+                hub.Post(new ProbeAck(), o => o.ResponseFor(delivery));
+                return delivery.Processed();
+            });
+
+    [Fact(Timeout = 30_000)]
+    public async Task TheEnqueuedStageRendersAsTheBareTokenFollowedByTheAddress()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var host = GetHost();
+        var requestId = Guid.NewGuid().ToString("N");
+
+        // A real awaited request: the ledger only tracks ids something is waiting on, so an
+        // unawaited Post would leave the trail empty and this guard would pass having checked
+        // nothing.
+        var response = host.Observe((object)new Probe(), o => o.WithTarget(host.Address), requestId)!
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(20))
+            .Await(ct);
+
+        await response;
+
+        var trail = host.DescribeRequestFate(requestId);
+        Output.WriteLine($"fate trail: {trail}");
+
+        // 🚨 The exact substring DisposalRaceNackTest and SubscribeDuringRecycleTest wait on.
+        Assert.Contains($"ENQUEUED@{host.Address}", trail, StringComparison.Ordinal);
+
+        // Denominator: a trail that rendered nothing at all would satisfy nothing above by
+        // accident, but an empty/one-stage trail would mean the ledger stopped recording and this
+        // guard would be pinning a string that no longer describes anything. Require the stages
+        // that bracket it, so the assertion is about a REAL trail.
+        Assert.Contains("RECEIVED", trail, StringComparison.Ordinal);
+        Assert.Contains("HANDLER_ENTER", trail, StringComparison.Ordinal);
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/FateStageTokensAreAContractTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/FateStageTokensAreAContractTest.cs
@@ -49,7 +49,10 @@ public class FateStageTokensAreAContractTest(ITestOutputHelper output) : HubTest
                 return delivery.Processed();
             });
 
-    [Fact(Timeout = 30_000)]
+    // 120_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a
+    // constant, and the inner wait below already carries the adaptive bound. This outer one
+    // only has to stop a WEDGE.
+    [Fact(Timeout = 120_000)]
     public async Task TheEnqueuedStageRendersAsTheBareTokenFollowedByTheAddress()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -61,7 +64,7 @@ public class FateStageTokensAreAContractTest(ITestOutputHelper output) : HubTest
         // nothing.
         var response = host.Observe((object)new Probe(), o => o.WithTarget(host.Address), requestId)!
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(20))
+            .Timeout(TestTimeouts.Convergence)
             .Await(ct);
 
         await response;


### PR DESCRIPTION
Instrumentation for **Systemorph/MeshWeaver.Plugins#1394** — `ActivationBacklogFifoTest`
intermittently observes the wrong processing order for one address.

🚨 **This is not an ordering fix, and deliberately so.** I was asked to find and fix the reorder.
Reading the paths *excluded* both candidate mechanisms, and the ordering property is already pinned
in two places and passing — so there is no known-broken ordering left to fix, and shipping a
speculative reordering change against code that three independent reads say is correct would be the
confident-wrong-diagnosis this issue has already suffered twice.

## What the read excluded

**1. "A and B were never in the same queue" — killed.** `RouteInMesh` funnels a later message into
the **same** live `ActivationSerializer`, and that branch sits deliberately *before* the hosted-hub
short-circuit:

```csharp
if (activationSerializers.TryGetValue(address, out var draining)
    && draining.TryEnqueue(delivery))
    return;
var hostedHub = Mesh.GetHostedHub(address, HostedHubCreation.Never);   // ← only reached after
```

The pump is `inbox.Select(d => RouteOne(d)).Concat()`, so B's `RouteOne` subscribes only after A's
**completes** — and A's completes only after `MonolithRoutingService.RouteImpl` ran
`hub.DeliverMessage(delivery)`, whose enqueue is synchronous under `turnGate`. **A is enqueued at the
hub before B is even routed.**

**2. "The deferral landed after the drain, stranding A" — killed twice.** The defer decision and the
`deferredQueue.Enqueue` are inside the same `lock (gateStateLock)` that `OpenGate` also takes; and
`DeferredTurnsResumeAheadOfLaterArrivalsTest` (MeshWeaver#3408's regression test) pins the restore
ordering deterministically and passes.

That independently reproduces the conclusion already written into `DeliveryOrderRecorder`'s own
remarks about the 2026-09-06 failure — *"a permutation a complete structural read … says is
unreachable"* — now with `Distinct probe-hub instances: 1` ruling out the two-activations escape.
Further reading will not find this; the missing evidence is **where each delivery waited**.

## The stamps

A hub has **two** queues and a delivery moves between them at *turn* time, so any "why did B run
before A" is a question about which queue each delivery was in and how deep:

| | |
|---|---|
| `ENQUEUED` → `QUEUED queue=main depth=N` | position in `mainQueue` at enqueue |
| `DEFERRED gates=[…]` → `QUEUED queue=deferred pos=P mainBehind=M` | the moment it **leaves** `mainQueue`; `M` is what can now overtake it |
| `DEFERRED_DRAINED` → `QUEUED queue=main depth=N` | pair with `mainBehind` to see whether those messages already ran |
| `GATE_DRAIN gate=… deferred=D behind=B` *(hub-level)* | the restore point |

`GATE_DRAIN deferred=0` paired with a delivery whose fate says it **was** deferred proves a deferral
that landed after its own drain — the one conclusion neither stamp yields alone.

## 🚨 The finding worth more than the stamps: a fate stage token is API

The depth is a **separate** `QUEUED` stage, not detail inside the existing tokens, and that cost a
full debug cycle to learn. Stages render as `{stage}@{hub}`, and two suites wait on that literal:

```csharp
// DisposalRaceNackTest:147 · SubscribeDuringRecycleTest:125
.Where(trail => trail.Contains($"ENQUEUED@{victimAddress}", StringComparison.Ordinal))
```

My first attempt wrote `fate?.Add($"ENQUEUED queue=main depth={n}")`. That renders as
`ENQUEUED queue=main depth=1@hub`, which **no longer contains `ENQUEUED@hub`** — so both waits
stopped firing and the tests timed out, presenting as *routing* stalls (`ROUTED onTarget=False`, no
handler entered) with nothing pointing at the stamp.

Measured in one worktree on one base:

| arm | `DisposalRaceNackTest` ×5 |
|---|---|
| token altered | **0 pass / 5 fail** |
| my code fully reverted | **5 pass / 0 fail** |
| token restored, depth additive | **5 pass / 0 fail** |

**Rule: append a new stage; never edit an existing token.** `MessageTrace` lines are free-form; a
fate stage's *leading token* is API. `FateStageTokensAreAContractTest` pins it and is **falsified
against that exact mutation** — RED (`Assert.Contains() Failure: Sub-string not found`) with the
token altered, green with it restored.

⚠️ Worth a moment for reviewers: my first "control" was invalid — I built it from a *later*
`origin/main` (`73d94b55f` vs my base `7461849ac`) because the branch moved between fetches, and that
delta contains #3692, which rewrote `DisposalRaceNackTest` and recorded a 5/138 flake rate. A
cross-tree comparison could have justified either verdict. Only reverting my own code **in my own
worktree** was a real control.

## Verification

| | |
|---|---|
| `MeshWeaver.Messaging.Hub.Test` | **372 / 0 failed**, 135.4 s vs the control's 135.6 s — no measurable cost |
| `SubscribeDuringRecycleTest` (the other `ENQUEUED@` consumer) | green |
| `DeferredTurnsResumeAheadOfLaterArrivalsTest` (the ordering property) | green |
| new guard, and the same guard against its mutation | green / **RED** |

Diagnostics only; no behaviour change. Every depth is read under the same `turnGate` that performs
the enqueue, so it is the queue's real state at that instant rather than a racy re-read.
Documented in `Doc/Architecture/DebuggingMessageFlow.md`, including the caution that **a permutation
does not name a mechanism** — four distinct ones have now been observed from this one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196MYbG267RQeQhEFyucaJY
