### PR TITLE
docs(bake): #3663's two open halves get their tracking issues (#3703, #3704)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SourceSetEstablishment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SourceSetEstablishment.md
@@ -110,8 +110,10 @@ simultaneous memex-cloud stall did not involve this gate at all.
 > `ShippedPrebuiltBundles: bundle Doc.zip: adopted 4/4 prebuilt assembly(ies)` at 00:31:08 — ten
 > seconds before the sweep enumerated `204 of 209 … need building — 5 already on the share` and set
 > about recompiling them. Adoption seeding and the sweep's own store probe disagreeing on a cold
-> boot is what put those four types on the compile path at all; it is a separate seam and it is not
-> fixed here.
+> boot is what put those four types on the compile path at all; it is a separate seam, it is **not
+> fixed here**, and it is tracked as **issue #3703** — which carries both log lines, the control that
+> makes it a disagreement rather than a cold-store fact (a boot with `77 already current` sees 189
+> baked; this boot, with `78 adopted now`, saw 5), and the measurement that would name the mechanism.
 
 ### Why it lasted three hours, and why that is the dangerous part
 
@@ -160,7 +162,9 @@ signal available to the reader, and a chunk gap wider than it silently truncates
 suspect boot ran its discovery 14 seconds after a 35-second burst of bundle seeding onto the shared
 volume, which is exactly the kind of contention that widens a gap.
 
-**That is a hypothesis, and it has not been measured.** What would settle it: instrument `RunQuery`
+**That is a hypothesis, and it has not been measured. It is tracked as issue #3704**, which carries
+this section's content plus the ruling-out below, so the next reader starts from the instrument
+rather than rebuilding it. What would settle it: instrument `RunQuery`
 to record, per query, the number of change events folded and the largest inter-chunk gap, then
 compare a short pass against a complete one on the same portal. A pass whose largest gap approaches
 `QueryQuietWindow` names the completion rule; one whose gaps are all small says the shortfall is


### PR DESCRIPTION
Follow-up to #3698 (merged). `Doc/Architecture/SourceSetEstablishment` named two open questions and gave neither a number — which is exactly the shape that gets forgotten once the symptom stops. Both are now filed, and the page points at them so the chain is followable from the durable artifact and not only from the issue tracker.

- **#3703** — the adoption / store-probe disagreement (`Doc.zip: adopted 4/4` at 00:31:08, `5 already on the share` at 00:31:18). This is what put those four types on the compile path at all, i.e. what made the short pass reachable.
- **#3704** — the unexplained short discovery pass (1145 Code nodes vs 1236/1237/1241 on the same portal). Carries the candidate (`RunQuery`'s 1-second quiet window; `QueryResultChange<T>` has no terminal marker), the discriminating measurement, and an explicit ruling-out of widening the window with its three reasons — because that will look like the obvious fix within a week.

Two prose edits, no behaviour. `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` 2/2; `MeshWeaver.Documentation.Test` built `-c Release -warnaserror`, `0 Warning(s) 0 Error(s)`.

Pairs-with: none — documentation only, no public type or member removed.
Implementers: none — no interface member added.
Mirror-sync: none — no localization catalog key added or reworded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
