### PR TITLE
docs(skill): /new-deployment is the record-driven Provision through memex

### DIFF
--- a/.claude/skills/new-deployment/SKILL.md
+++ b/.claude/skills/new-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-deployment
-description: Ramp up a NEW MeshWeaver portal deployment (its own domain, database, sign-in, plugins) on the shared AKS cluster, and register it so it is tracked. Use when standing up a new customer/internal portal, adding a namespace to the cluster, or auditing whether an existing deployment is wired correctly (self-update, plugins, TLS, update policy). Covers the order that matters (federated identity BEFORE deploy, DNS BEFORE TLS), the silent-failure traps (federated-credential subject mismatch, un-templated chart keys, non-idempotent portal-patch, CSI envFrom order), and where the deployment inventory lives — the PRIVATE Systemorph/Memex repo, never the public MeshWeaver repo.
+description: "Bring up a NEW MeshWeaver instance the ONLY sanctioned way: a Hosting/Deployment record in the private Systemorph/Memex repo, provisioned by the control instance's Hosting plugin (a Provision InstanceAction on memex.systemorph.com) — never kubectl, never deploy.sh, never the ACR image: images come from the fleet's own registry cr.meshweaver.cloud. Use when standing up a customer/internal portal, when a Provision refuses or fails, or when auditing whether an instance is wired the way its record says. Covers the human-done prerequisites (Entra app, registry instance key, db-connection secret, a tag present in cr), what the operator's Provision plan does in what order, the refusals that are ANSWERS not errors, and the traps that read as success."
 user-invocable: true
 allowed-tools:
   - Bash
@@ -9,145 +9,150 @@ allowed-tools:
   - Grep
 ---
 
-> The cluster name, resource group and namespace list are deployment identities and live in
-> the PRIVATE `Systemorph/Memex` repo — `deployments/aks/envs.json` (cluster + environments)
-> and `docs/deployments.md`. Export them once per session rather than hard-coding them here:
->
-> ```bash
-> eval "$(gh api repos/Systemorph/Memex/contents/deployments/aks/envs.json --jq '.content' | base64 -d \
->   | jq -r '"AKS_RG=\(.cluster.resourceGroup) AKS_CLUSTER=\(.cluster.name) NAMESPACES=\"\([.environments[].ns]|join(" "))\""')"
-> ```
->
-> Verified to set all three (`memex-aks-rg` / `memexaks-cluster` / the three namespaces) on
-> 2026-08-19. Reading it from the source of truth also means a new environment shows up here
-> automatically instead of this file going quietly stale.
+# /new-deployment — a new instance is a record, provisioned by memex
 
-# /new-deployment — stand up a new portal deployment
+A deployment is **one Hosting/Deployment record** — `mesh/Deployments/<id>.json` in the PRIVATE
+`Systemorph/Memex` repo — that the **control instance** (`memex.systemorph.com`, record `memex`,
+`operator.enabled: true`) turns into a namespace, a database, DNS, a Helm release and a certificate
+when a global admin files a **Provision** action against it. Everything else — cluster, ingress,
+Postgres server, Key Vault, the registry, observability — already exists and is shared.
 
-A deployment is **one namespace** on the shared AKS cluster with its own domain, database and
-sign-in. Everything else — cluster, ingress, Postgres server, Key Vault, ACR, observability — already
-exists and is shared.
+> 🔒 **The inventory is private.** Hosts, namespaces and database names live in `Systemorph/Memex`
+> (`mesh/Deployments/*.json`, `docs/inventory.md`, the Deployments tab). The public MeshWeaver repo
+> carries the *mechanism* (chart, operator scripts, the Hosting plugin's sources) and must never
+> carry *who runs what*.
 
-> 🔒 **The inventory is private.** Customer domains, namespaces and database names go in
-> [`Systemorph/Memex`](https://github.com/Systemorph/Memex) → `docs/deployments.md` and its
-> **Deployments** tab. The public MeshWeaver repo carries the *mechanism* (chart, scripts, generic
-> docs) and must never carry *who runs what*. Deployment records were deleted from the public repo on
-> 2026-08-06 for this reason — don't recreate them there.
+🚨 **The maintained runbook is `docs/new-deployment.md` in `Systemorph/Memex`.** It is authoritative
+wherever it and this page disagree; this page is the map, not a copy of the commands.
 
-## Ground truth first
+## Where the work happens — and where it does not
 
-Never write a runbook step from memory — read the live cluster:
-
-```bash
-# What exists, and what each namespace actually runs
-az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command \
-  "for ns in $NAMESPACES; do echo -n \"\$ns|\"; \
-   kubectl -n \$ns get deploy memex-portal-deployment -o jsonpath='{.spec.template.spec.containers[0].image}'; \
-   echo -n '|'; kubectl -n \$ns get ingress -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host} {end}{end}'; echo; done" \
-  --query logs -o tsv
-```
-
-The cluster is **private** — every `kubectl` goes through `az aks command invoke`. There is no direct
-kubeconfig path without the P2S VPN.
-
-## The order that matters
-
-Two orderings are not negotiable, and both fail *silently* when you get them wrong:
-
-1. **Federated workload identity BEFORE the first deploy.** Subject must be exactly
-   `system:serviceaccount:<env>:memex-portal-sa`. A mismatch does **not** error — the in-pod
-   Deployment patch still works, only ACR *tag discovery* is blocked, so the deployment simply never
-   self-updates and looks fine.
-2. **DNS BEFORE TLS.** cert-manager uses an HTTP-01 challenge; without a publicly resolving A-record
-   it fails and retries with backoff that gets slow enough to look like a hang.
-
-## The steps
-
-🚨 **The maintained runbook is `docs/new-deployment.md` in `Systemorph/Memex`** (private) — it is
-authoritative wherever it and anything here disagree, and the table below is a map of the steps,
-NOT a copy of them. Do not restate its commands here: two copies of a procedure drift, and the one
-in the public repo is the one nobody updates. Generic mechanism (public):
-[OnboardingNewEnvironment.md](../../../src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md).
-Shared-platform bring-up (public sample): [deploy/aks/README.md](../../../deploy/aks/README.md).
-
-| # | Step | Gets it wrong how |
+| | who | how |
 |---|---|---|
-| 1 | Namespace → `portalNamespaces` in `deploy/aks/infra/main.bicep`, re-run infra deploy | subject mismatch → never self-updates |
-| 2 | `az postgres flexible-server db create -d <env>` on `memexaks-pg` | migrating? **reuse the source master key** or every `enc:` provider key is undecryptable |
-| 3 | DNS A-record → the **shared** ingress IP | pointing at a per-env IP that doesn't exist |
-| 4 | Entra app (multi-tenant) + Key Vault secrets `<env>-*` | invitation-only is the gate, not the audience |
-| 5 | Env-folder scaffold + `deploy.sh` — **in the PRIVATE ops repo**, not `deploy/aks/envs/<env>/` (folders moved out 2026-08-08/09, `a69959165`); `deploy/aks/envs/example/` here is only the shape to copy | see traps below |
-| 6 | **Plugins** → `/plugins` skill | new deployment starts with none |
-| 7 | `tls.sh` | needs step 3 resolving publicly |
-| 8 | Register the GitHub Environment on `Systemorph/Memex` | otherwise it's untracked |
-| 9 | `Admin/UpdatePolicy`: Continuous internal, **Stable** for a customer | |
+| the record | a human, by PR | `mesh/Deployments/<id>.json` (GitSynced to both portals; a mesh-side edit is written back as a PR by `DeploymentGitSync`) |
+| secrets an instance cannot mint for itself | a human, once | Key Vault `Systemorph`, names `<keyVaultSecretPrefix><Section>-<Key>` |
+| namespace, database, identity, DNS, pull secret, release, TLS | **the operator**, from the Provision plan | a `Hosting/InstanceAction` node on the control instance |
+| the cluster | nobody by hand | `kubectl` is not part of this procedure; a step that needs it is a defect in the lane, file it |
 
-`values.<env>.yaml` and `secretproviderclass.yaml` are **git-ignored** — they carry hosts, database
-names, Entra ids and KV references. Managed out-of-band on disk. That is deliberate.
+## 1. What a human does first
 
-## 🚨 Silent-failure traps
+Every one of these is a **prerequisite the Provision REFUSES without**, so do them before filing it.
+`<prefix>` is the record's `keyVaultSecretPrefix`.
 
-Every one of these presents as "it deployed fine" while something is broken.
+1. **The sign-in app** (multi-tenant; invitation-only is the gate, not the audience):
+   `az ad app create --display-name "<Name> Portal (<host>)" --sign-in-audience AzureADMultipleOrgs --web-redirect-uris https://<host>/signin-microsoft`,
+   then `az ad sp create --id <appId>`, then the client secret into the vault as
+   `<prefix>Authentication-Microsoft-ClientSecret`. The appId goes on the record as
+   `signIn.microsoftClientId`. 🚨 `az … credential reset` PRINTS the secret on stderr:
+   `--query password -o tsv > "$S/x" 2>/dev/null`, then `az keyvault secret set --file "$S/x"`,
+   then `rm`. Never `cat` a stderr capture from a minting verb.
+2. **The registry instance key** — ONE key, two jobs (plugin catalog AND image pull):
+   `POST https://memex.meshweaver.cloud/api/instances/register` with
+   `{"bootstrapKey":"","instanceId":"<id>","displayName":"…","homeUrl":"https://<host>"}` (open
+   registration = the `free` plan; an admin raises it under Admin ▸ Instance grants). Pipe
+   `.instanceKey` straight into the vault as `<prefix>PluginCatalog-RegistryToken`.
+   `hosting-kv-ensure` lists this object as REQUIRED and refuses the whole Provision without it —
+   "minting a random value here would produce an instance that boots, registers nothing, and shows
+   an empty Store with no error".
+3. **The database connection string** — `<prefix>db-connection`
+   (`InstanceSpec.DatabaseSecretName`), composed from the shared admin password in vault object
+   `memex-postgres-password`: `Host=memexaks-pg.postgres.database.azure.com;Port=5432;Username=memexadmin;Password=…;Database=<db>;SslMode=Require;Trust Server Certificate=true`.
+   **FQDN, never an IP** — Azure moves the backing instance and DNS follows it. Mapped on the
+   record's `keyVaultSecrets.secrets` as `ConnectionStrings__memex`.
+4. **An image tag that EXISTS in `cr.meshweaver.cloud`.** `imageRepository:
+   cr.meshweaver.cloud/memex-portal-ai`, `pinnedImageTag: <tag>` — a first install with no pin is
+   REFUSED by `hosting-deploy` ("Pin an image tag on the Deployment record for the first install").
+   If the tag is not in cr yet (CD pushes to ACR), copy it there as the registry's `publisher` account:
+   `crane copy meshweaver.azurecr.io/memex-portal-ai:<tag> cr.meshweaver.cloud/memex-portal-ai:<tag>`
+   and the same for `memex-migration` (the migration image is DERIVED by replacing
+   `memex-portal-ai` → `memex-migration`; both must be present).
+5. **The record itself**, by PR, with (a sibling record is the worked example): `imagePullSecret:
+   registry-pull`; `volumes[]` for `data`/`content`/`attachments`/`users` with `claimName`,
+   `mountPath`, `size`, `storageClass: azurefile-memex`, `accessMode: ReadWriteMany` and
+   **`create: true`** — the chart creates the claims; without `create` a new instance gets
+   emptyDir and every restart wipes it; `keyVaultSecrets` naming the
+   three vault objects above plus `<prefix>Ai-KeyProtection-MasterKey` (GENERATED by
+   `hosting-kv-ensure`, never regenerated — it seals every stored `enc:` provider key);
+   `pluginRepos[0] = { name: "Plugins", url: "https://memex.meshweaver.cloud" }` (the name is the
+   REGISTRY's name, never the instance's — a bare `preInstall` id is qualified against it and the
+   catalog FAILS CLOSED on a mismatch); `preInstall: ["Essentials"]`; `updatePolicy: Stable` for a
+   customer; `extraPortalConfig` with `Hosting__Deployment: <id>` and `Hosting__ReportTo:
+   https://memex.systemorph.com`.
+   Gates that read it: `check-record-renders-overlay.py` (record ↔ `values.<release>.public.yaml`,
+   `extraPortalConfig` one way, `keyVaultSecrets` both ways), `check-image-pins.py` (resolves every
+   pin — `cr.meshweaver.cloud` pins need `MW_REGISTRY_KEY`), `config-key-coverage`.
 
-- **The chart configMap only emits keys it templates.** `deploy/helm/templates/memex-portal/config.yaml`
-  has a fixed key list; anything else in your overlay is **dropped without a warning**. Symptom: the
-  Microsoft button never renders, or the plugin catalog reads "not configured", with the values file
-  looking correct. **If you add a config key, add it to the template.** Verify what actually landed:
-  ```bash
-  helm template t deploy/helm -f <your-values>.yaml | grep -A0 '<YourKey>' || echo "DROPPED"
-  ```
-- **`kubectl set env` is not a deployment.** Config applied by hand lives only on the live
-  Deployment; the next `helm upgrade` reverts it and nothing in git says it existed. If you find
-  yourself patching env vars to make something work, the fix is a chart key, not a patch.
-- **`portal-patch.json` is not idempotent and replaces volumes BY INDEX.** Re-applying can fail on a
-  duplicate volume add, and because the patch is atomic that rejects the *whole* patch — silently
-  dropping the CSI `envFrom`. Adding or reordering a chart volume misaligns every environment.
-- **The Key Vault (CSI) secret must be LAST in `envFrom`.** The chart's `memex-portal-secrets` has an
-  *empty* client secret; the CSI-synced one has the real value; later `envFrom` wins. Symptom:
-  `AADSTS7000218`.
-- **Never emit `""` for an int/bool key.** `Anthropic__Order: ""` fails `Int32` binding → DI throws →
-  the post-onboarding landing page dies.
-- **HTTP 200 proves nothing.** The Blazor shell returns 200 for an error page or a paywall redirect.
-  Verify rendered content, in a loop.
-- **KEDA overrides `kubectl scale`.** `minReplicaCount: 2` silently restores replicas, so the
-  documented scale-to-zero heal never runs. `kubectl get scaledobject -n <env>` first.
+## 2. What the operator does — the Provision plan, in order
 
-## Verifying a fresh deployment
+Composed by `InstanceActionPlan.ProvisionSteps` (MeshWeaver.Plugins, in-mesh — it compiles in the
+portal, no CI type-checks it), run by `deploy/aks/operator/bin/run.sh` in a Job in `memex-ops`,
+fail-fast, the failing STEP named on the node:
 
-A cold deployment recompiles **every** dynamic NodeType. Expect a window of *"No response received …
-`SubscribeRequest`"*. That is cold-compile, not a bad image.
+1. `az postgres flexible-server db create` — control plane, workload identity. (Memex#132 —
+   `PGPASSWORD` has no secret channel — blocks Backup/Suspend/Teardown/Restore, **not** this.)
+2. `hosting-kv-ensure` — generates the master key, REQUIRES the registry token.
+3. `hosting-federate` — federated credential, subject **exactly**
+   `system:serviceaccount:<ns>:memex-portal-sa`; a mismatch does not error, it silently stops
+   self-update tag discovery.
+4. `hosting-dns upsert` — the A record at the shared ingress IP. DNS BEFORE TLS: HTTP-01 needs it.
+5. `hosting-pull-secret` — ensures the namespace, turns the vault's registry token into the
+   `kubernetes.io/dockerconfigjson` Secret named by `imagePullSecret`, reads it back, never prints
+   the key.
+6. `hosting-deploy --image <imageRepository>:<pinnedImageTag>` with values **rendered from the
+   record** (`HelmValues`) — the chart is BAKED INTO THE OPERATOR IMAGE, so the control record's
+   `operator.image` (`meshweaver.azurecr.io/hosting-operator:<short sha>`, published on every push
+   to MeshWeaver main) decides which chart deploys. A stale operator image deploys a stale chart.
+7. rollout wait → 8. `hosting-tls` (waits for the Secret to carry a key pair) → 9.
+   `hosting-verify` → 10. `hosting-verify-catalog` (the expected mounts and packages, so an empty
+   Store cannot read as healthy).
 
-- **Do not cycle pods while it warms** — that restarts the work from cold.
-- A pod sitting `0/1` during a bake is the readiness gate doing its job.
-- A *steady* ~50% error ratio across many minutes is one failing replica, not warm-up. Warm-up
-  converges toward 100%.
+## 3. Filing it
 
-```bash
-NEW=$(kubectl -n <env> get pods -l app.kubernetes.io/component=memex-portal \
-  --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}')
-kubectl -n <env> logs "$NEW" | grep "DynamicTypePreWarmer: warm-up complete"
+On the control instance (MCP server for memex.systemorph.com), create under `Deployments/`:
+
+```json
+{ "id": "<id>-provision", "namespace": "Deployments", "nodeType": "Hosting/InstanceAction",
+  "name": "Provision <id>", "content": { "$type": "InstanceActionContent",
+  "deployment": "Deployments/<id>", "requestedAction": "Provision",
+  "confirmation": "<id>", "dryRun": true, "reason": "…" } }
 ```
 
-## Register it
+**Dry run first** — Authorize → Read record → Plan → "Dry run — nothing changed" prints the composed
+step list on the node's `log`; a refusal here (`state: Refused`, `error` naming the field) is the
+ANSWER, not an error to retry. Then the real one (`dryRun: false`). Read `state`/`phase`/`message`
+and the `log` on the node; a failed step names itself and the plan is idempotent from the top, so
+fix the cause and file again.
 
-```bash
-gh api -X PUT repos/Systemorph/Memex/environments/<env>
-jq -n '{ref:"main", environment:"<env>", task:"deploy", auto_merge:false, required_contexts:[],
-        production_environment:true, description:"<purpose>",
-        payload:{namespace:"<env>", cluster:"'"$AKS_CLUSTER"'", database:"<env>",
-                 image:"meshweaver.azurecr.io/memex-portal-ai:<tag>"}}' \
-  | gh api -X POST repos/Systemorph/Memex/deployments --input -
-# then a status carrying the live URL
-```
+## 4. After it answers
 
-`required_contexts` must be a real JSON array — `-F required_contexts='[]'` is rejected with a 422,
-which is why the body goes through `jq` and `--input -`.
+- **A cold instance recompiles every dynamic NodeType.** The startup budget on the record
+  (`startupProbe.budgetSeconds`, 3 h on the siblings) exists for this; a pod `0/1` during the bake
+  is the gate doing its job. Do not cycle pods while it warms.
+- Register the GitHub Environment and a deployments entry on `Systemorph/Memex`, add the
+  `docs/inventory.md` row, set `Admin/UpdatePolicy` (**Stable** for a customer). A deployment nobody
+  recorded is a deployment nobody will remember to patch.
 
-Then add the row to `docs/deployments.md` in that repo. A deployment nobody recorded is a deployment
-nobody will remember to patch.
+## 🚨 Traps that read as success
+
+- **HTTP 200 proves nothing.** The Blazor shell answers 200 for an error page or a paywall redirect;
+  `hosting-verify` checks rendered content — so should you.
+- **Nobody can sign in** is a perfectly healthy instance: every `Authentication__*__ClientId`
+  empty and dev login off means it boots, passes probes, serves, and has nothing to authenticate
+  against. Step 1 is not optional.
+- **The chart ConfigMap emits only the keys it templates**; a record `extraPortalConfig` key the
+  chart has no line for reaches NO container, with no error. `config-key-coverage` is the guard.
+- **`kubectl set env` is not a deployment.** Helm's three-way merge never removes an inline entry it
+  did not own; the record's `inlineEnv` exists to make such drift visible, not to bless it.
+- **Never emit `""` for an int/bool key** — it fails binding, DI throws, the landing page dies.
+- **A refused Provision with `hosting-kv-ensure` naming a missing vault object** wants the object
+  ISSUED (step 1.2), never a random value.
+- **`az` prints minted secrets on stderr** — see step 1.1; a leaked value is rotated in the same
+  turn.
 
 ## Related
 
-- `/plugins` — wire the deployment to the plugin registry
-- `/release` — how images get built and rolled
-- `/delete-user` · `/storm` · `/debug` — operating a live deployment
+- `/plugins` — the registry the instance consumes packages from
+- `/release` — how images get built; a tag missing from cr is copied there by hand (step 1.4)
+- `/deployment` · `/delete-user` · `/storm` · `/debug` — operating a live instance
+- Design: [ContainerRegistryInMemex.md](../../../src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md)
+  (the registry as a separate service) · Memex#132 (the operator's PGPASSWORD gap)


### PR DESCRIPTION
## What

`/new-deployment` is rewritten around the only sanctioned path for a new instance: a `Hosting/Deployment` record in `Systemorph/Memex`, provisioned by a **Provision** `InstanceAction` on the control instance, with images pulled from the fleet's own registry `cr.meshweaver.cloud`. The previous text (bicep, `kubectl` via `az aks command invoke`, `deploy.sh`, `tls.sh`, an operator-disk values file, ACR images) is gone.

The skill now maps: what a human provisions first (sign-in app, registry instance key, `db-connection` secret, a tag present in cr, the record and the gates that read it), the operator's Provision plan step by step, how to file a dry run and the real action, and the refusals and traps that read as success. No history, no dated narrative — present-tense procedure only. The Memex runbook it points at (`docs/new-deployment.md`) is being rewritten in the same spirit on that repo.

## Verification

- `MeshWeaver.Documentation.Test` built `-c Release -warnaserror`: 0 warnings, 0 errors.
- Full project 351/351; after the last edit the skill guards re-run: `SkillFrontMatterGuard`, `MigrationWorkloadModelGuard`, `GuidanceBridgeRatchetGuard`, `DocumentationLinkIntegrityTest` — 11/11, fresh `.trx`.

No What's New entry: the skill is agent-facing, not a portal-visible change.

Pairs-with: none — documentation only, no `src/` change.

Refs #3353 · Systemorph/Memex#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
