### PR TITLE
fix(registry): validate instance keys through the token exchange, not the catalog

### DIFF
--- a/deploy/helm/templates/registry/_registry.tpl
+++ b/deploy/helm/templates/registry/_registry.tpl
@@ -8,7 +8,7 @@ built from two off-the-shelf images and zero registry code of ours:
   * docker_auth    cesanta/docker_auth — the token server. ONE static publisher account (its
                    bcrypt hash is the only credential in values, and a hash is committable) plus an
                    `ext_auth` hook that validates ANY other password as a MeshWeaver instance key
-                   by asking the portal's plugin catalog (`registry.validationUrl`).
+                   by presenting it to the portal's key→token exchange (`registry.validationUrl`).
 
 Both share the one host through ONE Ingress: `/auth` → docker_auth, everything else → distribution.
 Design: Doc/Architecture/ContainerRegistryInMemex → "The registry as a separate service".
@@ -69,7 +69,7 @@ start. The one exception is deliberate and safe: `publisher.passwordBcrypt` is a
       "notificationSecretObject" $notificationSecretObject
       "publisherUsername" ($publisher.username | default "publisher")
       "publisherPasswordBcrypt" $passwordBcrypt
-      "validationUrl" ($r.validationUrl | default "https://memex.meshweaver.cloud/api/plugins?ref=HEAD")
+      "validationUrl" ($r.validationUrl | default "https://memex.meshweaver.cloud/api/instances/token")
       "notificationUrl" $notificationUrl
       "ingressClassName" ($ingress.className | default "nginx")
       "clusterIssuer" ($ingress.clusterIssuer | default "")

--- a/deploy/helm/templates/registry/configmap.yaml
+++ b/deploy/helm/templates/registry/configmap.yaml
@@ -91,7 +91,7 @@ data:
 #      A wrong password for THIS account is `WrongPass` and denies immediately — it never falls
 #      through to the key validator below.
 #   2. `ext_auth` — validate.sh, for EVERY OTHER account name: the password is a MeshWeaver
-#      instance key, validated by asking the portal's plugin catalog with it as a bearer.
+#      instance key, validated by presenting it as a bearer to the portal's key→token exchange.
 #      docker_auth's contract (auth_server/authn/ext_auth.go): "<user> <password>" on stdin,
 #      exit 0 = allow, 1 = deny, 2 = no match (try the next authenticator), 3 = error.
 #
@@ -153,7 +153,10 @@ data:
       exit 1
     fi
     url={{ $r.validationUrl | quote }}
-    status=$(wget -T 10 -qS -O /dev/null --header="Authorization: Bearer $password" "$url" 2>&1 \
+    # POST to the portal's key→token exchange (an empty JSON body is a valid request, ~0.2 s) — NOT
+    # the plugin catalog, which renders in full: measured 14–18 s for a valid key, past the 10 s cap.
+    status=$(wget -T 10 -qS -O /dev/null --post-data='{}' --header='Content-Type: application/json' \
+      --header="Authorization: Bearer $password" "$url" 2>&1 \
       | sed -n 's/^ *HTTP\/[0-9.]* \([0-9][0-9][0-9]\).*/\1/p' | tail -n 1)
     case "$status" in
       200) exit 0 ;;

--- a/deploy/helm/values.registry.example.yaml
+++ b/deploy/helm/values.registry.example.yaml
@@ -29,7 +29,7 @@ registry:
   publisher:
     username: "publisher"
     passwordBcrypt: "$2y$05$lBf8Wat1qrnRJAZaknsvL.4okJYxEJ4OsCOGXVCelcQ8bwIe0Y3B6"
-  validationUrl: "https://memex.meshweaver.cloud/api/plugins?ref=HEAD"
+  validationUrl: "https://memex.meshweaver.cloud/api/instances/token"
   notifications:
     url: "https://memex.meshweaver.cloud/api/registry/events"
   ingress:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -739,9 +739,11 @@ registry:
   publisher:
     username: "publisher"
     passwordBcrypt: ""            # (required) bcrypt HASH — `htpasswd -nB publisher`
-  # Where an instance key is validated: any 200 authenticates, 401/403 denies, anything else is
-  # an error (never a pass). The default is the public portal's plugin catalog.
-  validationUrl: "https://memex.meshweaver.cloud/api/plugins?ref=HEAD"
+  # Where an instance key is validated — a POST with an empty JSON body and the key as a bearer:
+  # any 200 authenticates, 401/403 denies, anything else is an error (never a pass). The default
+  # is the public portal's key→token exchange, which answers in ~0.2 s; the plugin catalog is not
+  # a validator (it renders in full, measured 14–18 s, past the validator's 10 s cap).
+  validationUrl: "https://memex.meshweaver.cloud/api/instances/token"
   notifications:
     url: ""                       # registry events are POSTed here when set
   ingress:

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
@@ -113,8 +113,12 @@ on every pull request: `deploy/helm/values.registry.example.yaml`.
    falls through to the second way.
 2. **Any other account name, with a MeshWeaver instance key as the password.** docker_auth's
    `ext_auth` hook (`validate.sh`, a ConfigMap) presents the password as `Authorization: Bearer`
-   to `registry.validationUrl` — by default the portal's plugin catalog,
-   `https://memex.meshweaver.cloud/api/plugins?ref=HEAD`. `200` authenticates, `401`/`403` denies,
+   in a `POST` with an empty JSON body to `registry.validationUrl` — by default the portal's
+   key→token exchange, `https://memex.meshweaver.cloud/api/instances/token` (the
+   `SyncTokenPayloads` contract; an empty body is a valid request). The plugin catalog is not the
+   validator because it renders in full — measured 2026-09-08 against `memex.meshweaver.cloud`,
+   14–18 s for a valid key against the validator's 10 s cap, while the exchange answers a valid
+   key in 0.2 s and a bad one in 0.1 s. `200` authenticates, `401`/`403` denies,
    and **anything else is exit 3, an ERROR, never a pass** — a DNS failure, a timeout or a 5xx
    refuses the login and is logged by docker_auth as such, so an outage of the validator reads as
    an outage, not as "wrong key". Every authenticated account may `pull` anything.
@@ -145,9 +149,11 @@ validator — and a real `docker login`/`push`/`pull`):
 
 * `docker login` as the publisher with the `$2y$` hash → accepted; `push` → accepted; wrong
   password → refused without reaching the validator.
-* `docker login` as `instance` with the known key → accepted (the stub saw the bearer); `pull` →
-  accepted; `push` → **denied by the ACL**; a bad key → refused; the validator stopped → refused,
-  logged `bad return code from command: 3`; anonymous `pull` → refused.
+* `docker login` as `instance` with the known key → accepted (the stub saw the bearer on a `POST`
+  with `Content-Type: application/json`; the stub answers `405` to a `GET`, so a validator that
+  still fetched would not have logged in); `pull` → accepted; `push` → **denied by the ACL**; a
+  bad key → refused; the validator stopped → refused, logged `bad return code from command: 3`;
+  anonymous `pull` → refused.
 * Every registry event reached the stub carrying the Authorization header from the vault
   (`pull` and `push` actions observed).
 * 🚨 **docker_auth 1.13.0 cannot pair with distribution 3 at all.** distribution 3 keys its

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-fleet-has-its-own-container-registry.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-fleet-has-its-own-container-registry.md
@@ -20,7 +20,8 @@ and a home-grown one would make every bug in it a fleet-wide pull failure.
 
 Who may do what is deliberately simple. One publisher account, used by CI, may push, pull and
 delete. Every other login presents a MeshWeaver instance key as its password; the token server
-asks the portal whether that key is valid, and a valid key may pull anything. A login the portal
+exchanges that key for a portal token — the same exchange an installation already performs, which
+answers in a fraction of a second — and a valid key may pull anything. A login the portal
 cannot vouch for is refused — and if the portal cannot be reached at all, the login is refused and
 logged as an error rather than quietly passed.
 


### PR DESCRIPTION
## The measured defect

On `cr.meshweaver.cloud` (2026-09-08) every real `docker login` with an instance key failed while a bad key was refused "correctly". The registry's `ext_auth` hook (`validate.sh`, rendered from `deploy/helm/templates/registry/configmap.yaml`) validated the key with

```
wget -T 10 … --header="Authorization: Bearer <key>" https://memex.meshweaver.cloud/api/plugins?ref=HEAD
```

That URL is the FULL plugin-catalog render: measured 14–18 s for a valid key (491 KB), so the 10 s cap expired, the script saw no status, exited 3, and docker_auth logged `Ext command error: 3 … no definite answer … (status '')`. A bad key answered 401 in 0.1 s — which is why the failure looked like "valid keys are wrong".

## The fix

Validate through the registry's own key→JWT exchange, `POST https://memex.meshweaver.cloud/api/instances/token` with the key as a bearer and an empty JSON body (`SyncTokenPayloads`, `src/MeshWeaver.PluginCatalog/SyncTokenPayloads.cs`; an empty body is a valid request). Measured: 200 in 0.18 s for a valid instance key, 401 in 0.12 s for a bad one.

- `validate.sh`: `wget --post-data='{}' --header='Content-Type: application/json' …`; the 200 / 401|403 / else-3 mapping is unchanged; a comment states why this URL and not the catalog.
- Default `registry.validationUrl` (values.yaml, values.registry.example.yaml, the `memex.registry` helper's fallback) → `/api/instances/token`.
- `ContainerRegistryInMemex.md` → "The registry as a separate service" and the What's New entry of 2026-09-08 describe the exchange.

## Verified

- Busybox wget in the pinned image (`cesanta/docker_auth:1.14.0@sha256:98e0307e…`, BusyBox 1.37.0) lists `--post-data`, `--header`, `-S`, `-T`.
- `deploy/aks/scripts/check-chart-invariants.sh`: `All 5 values combinations render a self-consistent deployment.` `helm lint` on the registry combination: 0 failed.
- Local docker_auth proof, rendered config + rendered `validate.sh` baked into the pinned image, against a stub validator that answers **405 to GET** and **415 to a non-JSON POST**: valid key → 200 and a token issued; bad key → 401; empty key → 401; publisher right/wrong password → 200/401; stub stopped → exit 3 → HTTP 500, logged `bad return code from command: 3`. The stub saw only `POST /api/instances/token ct='application/json'`.
- `test/MeshWeaver.Documentation.Test` builds `-c Release -warnaserror` (0 warnings, 0 errors); `DocumentationLinkIntegrityTest`, `DocumentationEmbedIntegrityTest`, `WhatsNewEntryIntegrityTest`: 12 passed, fresh `.trx`.

Refs #3697, Systemorph/Memex#248.

Pairs-with: none — chart and docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
