### PR TITLE
ci(nuget): publish and unlist by Trusted Publishing — no stored NuGet secret

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -66,7 +66,7 @@ name: Publish the surviving NuGet packages
 # is no `continue-on-error` and no `if: secrets.X != ''`. Every job carries a literal timeout ≤ 45.
 #
 # 🚨 nuget.org has no App-token equivalent — an API key is the only credential it accepts — so
-# `secrets.NUGET_PAT` stays, exactly as unlist-orphaned-packages.yml uses it. The App token replaces
+# nuget.org is reached by Trusted Publishing (GitHub OIDC via NuGet/login — no stored NuGet secret), exactly as unlist-orphaned-packages.yml does. The App token replaces
 # the stored GitHub PAT, which is the one this repository could actually stop storing.
 
 on:
@@ -97,23 +97,37 @@ jobs:
     name: Publish inputs are provisioned
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write       # the OIDC exchange below
+      contents: read
     steps:
-      - name: Every secret this lane consumes exists
+      - name: Every input this lane consumes exists
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_PAT }}
+          NUGET_TRUSTED_USER: ${{ vars.NUGET_TRUSTED_USER }}
         run: |
           set -euo pipefail
           # Only what this lane actually consumes. The App credential that would read
           # MeshWeaver.Plugins for the template belongs here the day the template's step does —
           # asserting an input nothing uses teaches a reader the wrong thing about what runs.
+          #
+          # 🔐 nuget.org is reached by TRUSTED PUBLISHING (GitHub OIDC → NuGet/login → a short-lived
+          # key), not a stored key: the policy on nuget.org names this repository and THIS workflow
+          # file, and `vars.NUGET_TRUSTED_USER` is the nuget.org account that owns that policy.
+          # There is nothing to rotate and nothing to leak. The exchange is PERFORMED below, so a
+          # policy that does not match this file fails here, named, rather than at the push.
           missing=()
-          [ -n "${NUGET_API_KEY:-}" ] || missing+=("secrets.NUGET_PAT — the nuget.org API key with push rights for the MeshWeaver prefix (Settings → Secrets → Actions)")
+          [ -n "${NUGET_TRUSTED_USER:-}" ] || missing+=("vars.NUGET_TRUSTED_USER — the nuget.org account (user or organisation) that owns the Trusted Publishing policy for publish-packages.yml (Settings → Secrets and variables → Actions → Variables)")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::the surviving packages cannot be published — provision:"
             for m in "${missing[@]}"; do echo "  • $m"; done
             exit 1
           fi
           echo "every publish input is present"
+
+      - name: The Trusted Publishing policy matches this workflow (OIDC exchange)
+        uses: NuGet/login@v1.2.0
+        with:
+          user: ${{ vars.NUGET_TRUSTED_USER }}
 
       - name: A dispatch must name the version
         if: github.event_name == 'workflow_dispatch' && inputs.version == ''
@@ -126,6 +140,9 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      id-token: write       # NuGet/login — the short-lived push key
+      contents: read
     steps:
       - name: Checkout MeshWeaver (the platform, and the Aspire adapter)
         uses: actions/checkout@v7
@@ -191,10 +208,17 @@ jobs:
           [ "$count" -eq 1 ] || { echo "::error::expected exactly 1 package, found $count — a project has regained packability; see Directory.Build.props"; exit 1; }
           echo "1 package at $V"
 
+      - name: Log in to nuget.org (Trusted Publishing — a short-lived key, nothing stored)
+        if: ${{ !inputs.dry-run }}
+        id: nuget_login
+        uses: NuGet/login@v1.2.0
+        with:
+          user: ${{ vars.NUGET_TRUSTED_USER }}
+
       - name: Push to nuget.org
         if: ${{ !inputs.dry-run }}
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_PAT }}
+          NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
         run: |
           set -euo pipefail
           dotnet nuget push "$RUNNER_TEMP/nupkgs/*.nupkg" \

--- a/.github/workflows/unlist-orphaned-packages.yml
+++ b/.github/workflows/unlist-orphaned-packages.yml
@@ -41,6 +41,9 @@ jobs:
     name: Report or unlist orphaned packages
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      id-token: write       # NuGet/login — the short-lived unlist key, only when applying
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6
@@ -72,14 +75,31 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # 🔐 Trusted Publishing: nuget.org exchanges this run's GitHub OIDC token for a short-lived
+      # key, under the policy that names this repository and THIS workflow file (a policy per
+      # file — publish-packages.yml has its own). No stored NuGet secret anywhere.
+      - name: The policy owner is named
+        if: inputs.apply && inputs.confirm == 'UNLIST'
+        env:
+          NUGET_TRUSTED_USER: ${{ vars.NUGET_TRUSTED_USER }}
+        run: |
+          set -euo pipefail
+          [ -n "${NUGET_TRUSTED_USER:-}" ] || { echo "::error::vars.NUGET_TRUSTED_USER is not set — the nuget.org account that owns the Trusted Publishing policy for unlist-orphaned-packages.yml. A step that cannot run must fail RED, never pass quietly."; exit 1; }
+      - name: Log in to nuget.org (Trusted Publishing)
+        if: inputs.apply && inputs.confirm == 'UNLIST'
+        id: nuget_login
+        uses: NuGet/login@v1.2.0
+        with:
+          user: ${{ vars.NUGET_TRUSTED_USER }}
+
       - name: Unlist them
         if: inputs.apply && inputs.confirm == 'UNLIST'
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_PAT }}
+          NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
         run: |
           set -euo pipefail
           if [ -z "${NUGET_API_KEY:-}" ]; then
-            echo "::error::secrets.NUGET_PAT is not provisioned — the unlist cannot run. A step that cannot run must fail RED, never pass quietly."
+            echo "::error::the Trusted Publishing exchange returned no key — the unlist cannot run. A step that cannot run must fail RED, never pass quietly."
             exit 1
           fi
           keep_args=""

--- a/src/MeshWeaver.Documentation/Data/Architecture/NuGetPackageRetirement.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NuGetPackageRetirement.md
@@ -309,7 +309,7 @@ step below is a web action by the current owner, so this section is the checklis
 | `MeshWeaver.MemexTemplate` and every retired id — fully unlisted, ownership unchanged | still `rbuergi`'s; an owner can re-list any version |
 | `verified: false` on the survivor | the **`MeshWeaver.*` ID prefix is not reserved** — anyone can publish a new `MeshWeaver.X` |
 | nuget.org profile `Systemorph` exists | the organisation account to transfer to is there |
-| `publish-packages.yml` pushes with `secrets.NUGET_PAT` | the key is the owner's, not the organisation's |
+| `publish-packages.yml` and `unlist-orphaned-packages.yml` authenticate by **Trusted Publishing** — GitHub OIDC exchanged by `NuGet/login` for a short-lived key, under a nuget.org policy per workflow file — with the policy owner in `vars.NUGET_TRUSTED_USER` | no stored NuGet secret; the policy today is the owner's, not the organisation's |
 
 The transfer, in the order that keeps publishing working throughout:
 
@@ -319,9 +319,11 @@ The transfer, in the order that keeps publishing working throughout:
    `Systemorph`; the organisation accepts the invitation.
 2. **Reserve the `MeshWeaver.*` ID prefix for `Systemorph`** (nuget.org's ID-prefix reservation
    request). Until then the `verified` badge stays off and the prefix is open.
-3. **Rotate `secrets.NUGET_PAT`** to an API key minted under the `Systemorph` organisation, scoped
-   to push `MeshWeaver.*`. The lane's preflight names that secret and goes red naming it if absent,
-   so a missing rotation is loud, not silent.
+3. **Move the Trusted Publishing policies to the organisation** — one per workflow file
+   (`publish-packages.yml`, `unlist-orphaned-packages.yml`; repository `Systemorph/MeshWeaver`;
+   environment blank, since neither job declares one) — and set `vars.NUGET_TRUSTED_USER` to
+   `Systemorph`. The publish preflight *performs* the exchange, so a policy that does not match goes
+   red there, named. Then delete `secrets.NUGET_PAT`: nothing reads it any more.
 4. **Remove `rbuergi` as owner** only after step 3 has published once from the organisation's key.
 
 ---


### PR DESCRIPTION
## What

Both NuGet lanes pushed/unlisted with `secrets.NUGET_PAT`, a personal 365-day key. They now use
nuget.org **Trusted Publishing**: the run's GitHub OIDC token is exchanged by `NuGet/login@v1.2.0`
for a short-lived key under a policy that names this repository and the workflow **file** (one policy
per file — `publish-packages.yml`, `unlist-orphaned-packages.yml`; environment blank, since neither
job declares one). Nothing is stored, nothing rotates — the same shape as `azure/login` OIDC in every
other lane here.

- The policy owner is `vars.NUGET_TRUSTED_USER` (a nuget.org user or organisation), asserted
  red-not-skip.
- The publish **preflight performs the exchange**, so a policy that doesn't match the file fails
  there, named, rather than at the push.
- The unlist lane logs in only when it actually applies.
- The retirement doc's ownership checklist: "rotate the key" becomes "move the policies to
  Systemorph, set the variable, delete `NUGET_PAT`".

## To provision

```
gh variable set NUGET_TRUSTED_USER --repo Systemorph/MeshWeaver --body <nuget.org account owning the policy>
```

Gates: `check-workflow-shell` 0 live, `check-workflow-timeouts` 0, `check-workflow-yaml-keys` 0,
`check-pr-secret-preflight` 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
