### PR TITLE
release: the line pointers <major>-latest, <major.minor>-latest, <major.minor.patch>-latest

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1540,6 +1540,28 @@ jobs:
             echo "- memex-migration \`$V_MIGRATION\`, \`$SHA\`, \`main\`"
             echo "- mw-plugin-test \`$V_PLUGIN\`, \`$SHA\`, \`main\`, \`latest\` (ACR + GHCR)"
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: "Phase D — the line pointers: <major>-latest, <major.minor>-latest, <major.minor.patch>-latest (ACR + GHCR)"
+        run: |
+          set -euo pipefail
+          # The three MOVING POINTERS of a line, from a version like 3.0.0-ci.8059 (or a clean
+          # 3.0.0): `3-latest` (the major), `3.0-latest` (major.minor) and `3.0.0-latest`
+          # (the patch line the ci builds belong to). Each moves along ITS line only — 3.1.0-ci
+          # never touches 3.0.0-latest, and a 4.x seal is a new set of pointers — so a package
+          # of major N that starts on `N-latest` can never be handed an image of another major.
+          # Written here, AFTER the arming PUT, so a fresh install that resolves a pointer sees a
+          # set whose migration and portal both exist (maintainer, 2026-09-08: "platform will be
+          # anyway self-updating => should point to latest image to start"; "1, 2 or 3 digits").
+          line_tags() { local v="${1%%-*}"; local maj="${v%%.*}"; local min="${v%.*}"; printf '%s-latest %s-latest %s-latest' "$maj" "$min" "$v"; }
+          NS=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          for pair in "memex-migration:$V_MIGRATION" "memex-portal-ai:$V_PORTAL"; do
+            repo="${pair%%:*}"; ver="${pair#*:}"
+            args=(); gargs=()
+            for t in $(line_tags "$ver"); do args+=(--tag "${{ env.ACR }}/$repo:$t"); gargs+=(--tag "ghcr.io/$NS/$repo:$t"); done
+            echo "→ $repo: $(line_tags "$ver")  (ACR, then GHCR — the adapter's default registry)"
+            docker buildx imagetools create "${args[@]}" "${{ env.ACR }}/$repo:$STAGING"
+            docker buildx imagetools create "${gargs[@]}" --tag "ghcr.io/$NS/$repo:$ver" "${{ env.ACR }}/$repo:$STAGING"
+          done
+          echo "- line pointers moved: memex-migration + memex-portal-ai → $(line_tags "$V_PORTAL") (ACR + GHCR)" >> "$GITHUB_STEP_SUMMARY"
 
   # ────────── BAKE THE PLATFORM'S OWN CONTENT *IN THE SHIPPED IMAGE*, THEN PUBLISH ──────────
   # #1660 WS3 delivery, corrected by #1725. The portals adopt a prebuilt NodeType bundle only when

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,12 @@ jobs:
           done
           echo "→ memex-portal-ai: $VERSION  (arming Stable self-updaters)"
           docker buildx imagetools create --tag "$ACR/memex-portal-ai:$VERSION" "$ACR/memex-portal-ai:$SHORT"
+          # The line pointers move with an official release too — same rule as CD's Phase D.
+          line_tags() { local v="${1%%-*}"; local maj="${v%%.*}"; local min="${v%.*}"; printf '%s-latest %s-latest %s-latest' "$maj" "$min" "$v"; }
+          for repo in memex-migration memex-portal-ai; do
+            args=(); for t in $(line_tags "$VERSION"); do args+=(--tag "$ACR/$repo:$t"); done
+            docker buildx imagetools create "${args[@]}" "$ACR/$repo:$SHORT"
+          done
           {
             echo "### Released \`$VERSION\` = \`$SHORT\` (continuous ${{ steps.set.outputs.ci_version }})"
             echo "- memex-portal-ai, memex-migration, mw-plugin-test retagged \`$VERSION\` in ACR"
@@ -294,13 +300,17 @@ jobs:
         run: |
           set -euo pipefail
           NS=$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
+          line_tags() { local v="${1%%-*}"; local maj="${v%%.*}"; local min="${v%.*}"; printf '%s-latest %s-latest %s-latest' "$maj" "$min" "$v"; }
           for repo in memex-migration mw-plugin-test memex-portal-ai; do
+            extra=()
+            case "$repo" in memex-migration|memex-portal-ai) for t in $(line_tags "$VERSION"); do extra+=(--tag "ghcr.io/$NS/$repo:$t"); done;; esac
             docker buildx imagetools create \
               --tag "ghcr.io/$NS/$repo:$VERSION" \
               --tag "ghcr.io/$NS/$repo:latest" \
+              "${extra[@]}" \
               "$ACR/$repo:$SHORT"
           done
-          echo "- mirrored to ghcr.io/$NS/{memex-portal-ai,memex-migration,mw-plugin-test}:$VERSION (+ latest)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- mirrored to ghcr.io/$NS/{memex-portal-ai,memex-migration,mw-plugin-test}:$VERSION (+ latest; portal + migration also $(line_tags "$VERSION"))" >> "$GITHUB_STEP_SUMMARY"
 
       - name: "Publish the GitHub Release from the committed notes"
         env:

--- a/memex/aspire/Memex.Aspire.Hosting/MemexOptions.cs
+++ b/memex/aspire/Memex.Aspire.Hosting/MemexOptions.cs
@@ -27,8 +27,25 @@ public sealed record MemexOptions
     /// <summary>Container registry + namespace holding the Memex images. Default GHCR / Systemorph.</summary>
     public string ImageRegistry { get; init; } = "ghcr.io/systemorph";
 
-    /// <summary>Image tag applied to all Memex images (portal, migration). Default <c>latest</c>.</summary>
-    public string ImageTag { get; init; } = "latest";
+    /// <summary>
+    /// Image tag applied to all Memex images (portal, migration). Default: the MAJOR-LINE POINTER of
+    /// this adapter's own version — <c>3-latest</c> for a 3.x adapter, <c>4-latest</c> for 4.x —
+    /// which CD moves to every sealed set of that major (across minors) and never to another major.
+    /// The registry also carries <c>&lt;major.minor&gt;-latest</c> and
+    /// <c>&lt;major.minor.patch&gt;-latest</c> for a narrower line, and every exact version; pick
+    /// one with <see cref="WithImage"/>. The portal starts on the pointer and its own self-updater
+    /// takes over from there, so the package version and the image version are independent.
+    /// </summary>
+    public string ImageTag { get; init; } = DefaultImageTag;
+
+    /// <summary>
+    /// <c>&lt;major&gt;-latest</c> for the major of the assembly this record ships in. Derived,
+    /// not typed, so a 4.x adapter cannot be published still naming <c>3-latest</c>. The assembly
+    /// version is stamped by the platform's Directory.Build.props; the <c>latest</c> fallback exists
+    /// only for an unstamped local build, never for a published package.
+    /// </summary>
+    public static string DefaultImageTag { get; } =
+        typeof(MemexOptions).Assembly.GetName().Version is { Major: > 0 } v ? $"{v.Major}-latest" : "latest";
 
     /// <summary>
     /// Use the <c>memex-portal-ai</c> image (co-hosted Claude Code + GitHub Copilot CLIs baked in)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -231,6 +231,34 @@ the *compiled attributes* is what makes a promotion possible at all:
 
 ---
 
+### The moving pointers: `<major>-latest`, `<major.minor>-latest`, `<major.minor.patch>-latest`
+
+**Maintainer, 2026-09-08:** *"platform will be anyway self-updating ⇒ should point to latest image
+to start"*, *"let's offer all variants ⇒ we fix 1 digit, 2 digits, or even 3 digits"*, and for the
+adapter's default *"3 latest and 4 latest — I am for the latter"*.
+
+Every sealed set moves three pointers on `memex-portal-ai` and `memex-migration`, in ACR and in
+GHCR, derived from the set's version (`3.0.0-ci.8059` → `3.0.0`):
+
+| pointer | moves to | never touched by |
+|---|---|---|
+| `3-latest` | every sealed set of major 3, across minors | any 4.x seal |
+| `3.0-latest` | every sealed set of 3.0.x | 3.1.0-ci |
+| `3.0.0-latest` | every sealed set of the 3.0.0 line (the `3.0.0-ci.*` builds) | 3.0.1 |
+
+CD writes them in **Phase D, after the arming PUT** (`memex-portal-ai:<version>`, CD's last write
+before this), so a fresh install that resolves a pointer never sees a set whose migration exists
+and whose portal does not. `release.yml` moves the same three when it promotes a sealed set to a
+clean version. The self-updater ignores them — it selects on `^\d+\.\d+\.\d+` tags — so a
+pointer is only ever a **first-start** address.
+
+**The rule this makes clear:** a package of major N names `N-latest` and is otherwise independent
+of the image. `MeshWeaver.Aspire.Hosting.Memex` defaults `ImageTag` to `<its own major>-latest`,
+derived from its assembly version rather than typed, so a 4.x adapter cannot ship still naming
+`3-latest`; a consumer that wants a narrower line passes `WithImage(tag: "3.0-latest")` or an
+exact version. The package version moves only when the adapter's surface does — 3.0.x for fixes,
+3.1.0 when the API grows — never per image.
+
 ## 3. Commands
 
 ```bash


### PR DESCRIPTION
## What

Every sealed set now moves three **line pointers** on `memex-portal-ai` and `memex-migration`, in ACR
and GHCR, derived from the set's version (`3.0.0-ci.8059` → `3.0.0`):

| pointer | moves to | never touched by |
|---|---|---|
| `3-latest` | every sealed set of major 3, across minors | any 4.x seal |
| `3.0-latest` | every sealed set of 3.0.x | 3.1.0-ci |
| `3.0.0-latest` | every sealed set of the 3.0.0 line | 3.0.1 |

Maintainer, 2026-09-08: *"platform will be anyway self-updating ⇒ should point to latest image to
start"*, *"offer all variants ⇒ 1, 2 or 3 digits"*, default *"3 latest / 4 latest — I am for the latter"*.

- CD writes them in a new **Phase D, after the arming PUT** (CD's last write before this), so a fresh
  install resolving a pointer never sees a set whose migration exists and whose portal does not.
- `release.yml` moves the same three when it promotes a sealed set.
- `MeshWeaver.Aspire.Hosting.Memex` defaults `ImageTag` to `<its own major>-latest`, **derived from the
  assembly version**, so a 4.x adapter cannot ship naming `3-latest`; `WithImage(tag:)` narrows.
- The self-updater selects on `^\d+\.\d+\.\d+` tags and ignores pointers: a pointer is a first-start address only.
- Rule recorded in `ReleaseProcess` §2.

Gates: `check-workflow-shell` 0 live, `check-workflow-timeouts` 0, `check-workflow-yaml-keys` 0. The
`line_tags` helper verified on `3.0.0-ci.8059`, `3.1.0-ci.42`, `3.0.0`, `4.2.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
