### PR TITLE
Publish: a supersession by this bake's own content is not a failure

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -342,6 +342,55 @@ sha256_of() { # <file> — hex digest, portable across the CI runner and a devel
   fi
 }
 
+# 🚨 THE RENDERING IS MEASURED, NOT ASSUMED, and getting it wrong is silent. knack's `format_tsv`
+# treats a TOP-LEVEL list as ROWS: `--query "[a, b]" -o tsv` prints a's value and b's value on TWO
+# LINES, not as two columns — so `awk '{print $2}'` would read EMPTY for every file, every owner
+# would compare unequal to $PUBLICATION, `ours` would be 0 on every publish and the postcondition
+# would refuse EVERY publication in the fleet as "superseded". Hence a list-of-ONE-ROW: `[[a, b]]`
+# renders one tab-separated line. The `|| '-'` guards exist because a null field renders as the
+# LITERAL STRING 'None', not as empty. Both measured against azure-cli 2.90.0's own jmespath +
+# knack formatter, and re-asserted with the real jmespath engine by test-publish-bake-overlap.py.
+STAMP_QUERY="[[metadata.digest || '-', metadata.publication || '-']]"
+
+# The ONE read-back, in one place. Both the per-file verification sweep and the sentinel check the
+# convergence verdict makes parse the SAME rendering, so a query change cannot leave one of them
+# reading a shape the other no longer produces. Answers through globals rather than stdout: an
+# `::error::` written inside a command substitution would be CAPTURED instead of reaching the log.
+#
+#   rc 0  STAMP_DIGEST / STAMP_OWNER hold the values ('' where az rendered '-')
+#   rc 1  unreadable — a transient fault, an expired credential, or the file is simply not there
+#   rc 2  the CLI's rendering changed; STAMP_RAW/STAMP_FIELDS say what came back
+#
+# 🚨 `< /dev/null` because the sweep below runs this INSIDE a `while read` loop fed by the
+# manifest: a command that consumed stdin would swallow the remaining lines and the loop would end
+# early, having verified a PREFIX of the publication while reporting no foreign bytes at all.
+STAMP_DIGEST=""
+STAMP_OWNER=""
+STAMP_RAW=""
+STAMP_FIELDS=0
+read_stamp() { # <account> <share> <path>
+  local account="$1" share="$2" path="$3" props fields
+  STAMP_DIGEST=""; STAMP_OWNER=""; STAMP_RAW=""; STAMP_FIELDS=0
+  if ! props=$(az storage file show --account-name "$account" --share-name "$share" \
+      --path "$path" --auth-mode login --backup-intent \
+      --query "$STAMP_QUERY" -o tsv --only-show-errors < /dev/null); then
+    return 1
+  fi
+  STAMP_RAW="$props"
+  fields=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print NF }')
+  STAMP_FIELDS="${fields:-0}"
+  # The field count is ASSERTED rather than trusted: if that rendering ever changes, this is a loud
+  # refusal on the next publish instead of a fleet-wide false verdict.
+  if [ "$STAMP_FIELDS" -ne 2 ]; then
+    return 2
+  fi
+  STAMP_DIGEST=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $1 }')
+  STAMP_OWNER=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
+  if [ "$STAMP_DIGEST" = "-" ]; then STAMP_DIGEST=""; fi
+  if [ "$STAMP_OWNER" = "-" ]; then STAMP_OWNER=""; fi
+  return 0
+}
+
 # The publication token: unique to THIS invocation, and readable as the run that made it. Metadata
 # values are ASCII, and `-o tsv` splits on tabs, so it is restricted to [A-Za-z0-9._-] — a value
 # carrying a tab or a space would silently split into two fields and compare equal to a truncation.
@@ -380,6 +429,30 @@ if [ "${MANIFEST_COUNT:-0}" -lt 1 ]; then
 fi
 MARKER_COUNT=4
 if [ "$HAS_SURFACE" = "true" ]; then MARKER_COUNT=5; fi
+# The NON-PAYLOAD half of the manifest: the markers, the module index and the platform surface —
+# everything that describes WHAT was baked rather than the compiled bytes. Two bakes of the same
+# content produce byte-identical files here and DIFFERENT bundle zips (the compile is not
+# reproducible byte-for-byte), so this split is what lets the convergence verdict below tell "a
+# second publication of MY content beat me to it" from "somebody published something else".
+# One name per line, so the membership test cannot match a substring.
+MARKER_RELS="$SOURCE_MARKER
+$REPO_MARKER
+$ARCH_MARKER
+$MODULES_DIR_NAME/$MODULES_INDEX"
+if [ "$HAS_SURFACE" = "true" ]; then
+  MARKER_RELS="$MARKER_RELS
+$SURFACE_FILE"
+fi
+is_marker() { # <path-under-dest>
+  case "
+$MARKER_RELS
+" in
+    *"
+$1
+"*) return 0 ;;
+  esac
+  return 1
+}
 echo "publication $PUBLICATION: $MANIFEST_COUNT file(s) to publish and verify per target (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s), $MARKER_COUNT marker/index file(s)$([ "$HAS_SURFACE" = "true" ] && echo ", surface published" || echo ", NO platform surface"))"
 
 # Uploads ONE file of the publication, stamped with the two metadata values the postcondition
@@ -426,6 +499,80 @@ unseal_mixed_publication() { # <account> <share> <dest>
   return 1
 }
 
+# ══════════════ THE CONVERGENCE VERDICT — the one supersession that is not a failure ══════════════
+#
+# 🚨 The postcondition below and the sealed-skip in `publish_to_target` are answering the SAME
+# question — "is the publication this run was asked to make on the shelf?" — and until this
+# function existed they disagreed, because the skip keys on CONTENT × FRAMEWORK while the
+# postcondition can only ask "are these MY bytes". A run that finds the shelf unsealed, uploads,
+# and is then overwritten by a sibling publishing the SAME content therefore went RED for a
+# publication that is present, whole and correct.
+#
+# Measured on the incident that made this loud: core CD runs 34205409381 and 34206854855 both
+# published `plugins` at source cfac152ef023bc8e16203511aa60b50f581d3161 for identity
+# s057b1e7785fba6c6ba079e9d84a0c00d on 2026-09-08. Each won one of the two targets and each went
+# red on the other, with the same verdict — `40 of 45 file(s) were overwritten … the remaining 5
+# are byte-identical`. The 40 are bundle zips and module packages (the compile is not reproducible
+# byte-for-byte); the 5 are source-commit.txt, repository.txt, architecture.txt, modules/_index and
+# platform-surface.json — byte-identical BECAUSE it is the same content. Both targets ended sealed
+# with exactly the right bytes, and both CD runs failed. That is a false red, not a caught defect.
+#
+# So a supersession converges only on POSITIVE, byte-level proof of all three:
+#
+#   1. every non-payload file is byte-identical to ours (foreign markers 0, and the neutral markers
+#      count reaches MARKER_COUNT — the denominator, so it cannot pass having checked nothing);
+#   2. every foreign file names ONE publication, and that publication is stamped (an unstamped file
+#      can never satisfy this: '<unstamped>' is not a legal token);
+#   3. `_complete` is on the shelf, its digest is the sha256 of OUR listing (so the sealed bundle
+#      SET is ours, name for name) and it was sealed by that same publication (so the seal belongs
+#      to the bytes, not to some earlier publication a third writer left behind).
+#
+# Anything less is the superseded RED, unchanged, with the reason named. 🚨 This never touches the
+# MIX verdict (ours > 0), never seals, never deletes, and never reports a publication that is not
+# there: it reports that SOMEONE ELSE made the exact one this run was asked for. The residual it
+# does NOT cover is a sibling that has not sealed yet when this run's sweep ends — 20 seconds, in
+# the incident above. Shrinking that further is a bound, not a fix; the fix is the generation
+# layout (Doc/Architecture/SealedPublicationGenerations), where the two runs never share a
+# directory and neither has to lose.
+CONVERGENCE_REASON=""
+converged_on_equivalent() { # <account> <share> <dest> <foreign-markers> <neutral-markers> <foreign-owners>
+  local account="$1" share="$2" dest="$3" fmark="$4" nmark="$5" owners="$6"
+  local distinct count owner expected rc=0
+  CONVERGENCE_REASON=""
+  if [ "$fmark" -ne 0 ] || [ "$nmark" -ne "$MARKER_COUNT" ]; then
+    CONVERGENCE_REASON="the shelf describes DIFFERENT content: $fmark of the $MARKER_COUNT marker/index file(s) differ from this bake's and only $nmark were byte-identical. source-commit.txt, modules/_index and platform-surface.json are byte-identical between two bakes of the same content, so a difference here means the publication on the shelf is not the one this run was asked to make."
+    return 1
+  fi
+  distinct=$(printf '%s\n' $owners | sed '/^[[:space:]]*$/d' | sort -u)
+  count=$(printf '%s\n' "$distinct" | grep -c '[^[:space:]]' || true)
+  if [ "${count:-0}" -ne 1 ]; then
+    CONVERGENCE_REASON="the foreign bytes name ${count:-0} publication(s) ($(printf '%s' "$distinct" | tr '\n' ' ')) — convergence needs exactly one, whole and identifiable."
+    return 1
+  fi
+  owner="$distinct"
+  case "$owner" in
+    *"<"*|*">"*)
+      CONVERGENCE_REASON="the foreign bytes carry no publication stamp, so nothing can establish that they are one publication rather than several."
+      return 1 ;;
+  esac
+  expected=$(sha256_of "$SENTINEL_LOCAL")
+  read_stamp "$account" "$share" "$dest/$SENTINEL" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    CONVERGENCE_REASON="publication '$owner' has not sealed $dest/$SENTINEL yet (or it could not be read) — an unsealed directory is not a publication, and this run must not report one that does not exist."
+    return 1
+  fi
+  if [ "$STAMP_DIGEST" != "$expected" ]; then
+    CONVERGENCE_REASON="$dest/$SENTINEL lists a different bundle set (it holds ${STAMP_DIGEST:-<no digest>}, this bake's listing hashes to $expected) — the sealed publication is not this bake's set, name for name."
+    return 1
+  fi
+  if [ "$STAMP_OWNER" != "$owner" ]; then
+    CONVERGENCE_REASON="$dest/$SENTINEL was sealed by '${STAMP_OWNER:-<unstamped>}' but the bytes under it were written by '$owner' — the seal does not belong to the publication on the shelf."
+    return 1
+  fi
+  echo "::warning title=Superseded by an equivalent publication — this content IS published::$account/$share/$dest was published by '$owner' while this run was in flight, and it is byte-for-byte the publication this run was asked to make: all $MARKER_COUNT marker/index file(s) are identical (same source ${SOURCE_SHA:-unknown}, same module set, same platform surface), the sealed listing is this bake's bundle set, and '$owner' sealed it. Only the compiled bundle bytes differ, which two bakes of one commit always do. Nothing of this run reached this target and nothing needed to (MeshWeaver#3461)."
+  return 0
+}
+
 # THE POSTCONDITION. Runs immediately before the seal. Every file is sorted into three buckets,
 # and the buckets are what decide the verdict:
 #
@@ -452,61 +599,51 @@ unseal_mixed_publication() { # <account> <share> <dest>
 # the satellite's publication whole on the shelf, `architecture.txt` alone made OURS = 1 and the
 # core lane deleted the satellite's seal.
 verify_publication() { # <account> <share> <dest>
-  local account="$1" share="$2" dest="$3" rel expected actual owner props fields ours=0 neutral=0
+  local account="$1" share="$2" dest="$3" rel expected actual owner rc ours=0 neutral=0
+  local foreign_markers=0 neutral_markers=0 foreign_owners=""
   local -a foreign=() unreadable=() overlapped=()
   while IFS=$'\t' read -r rel expected; do
     [ -n "$rel" ] || continue
     # 🚨 FAIL CLOSED. `|| echo ""` on the read would turn a transient fault, an expired credential
     # or a CLI shape change into "no digest recorded" — the one answer that is indistinguishable
     # from "another publisher wrote this", and the errors below would then name the wrong cause.
-    # An unreadable file is refused as loudly as a foreign one; it is simply refused by name.
-    # `< /dev/null` because this runs INSIDE a `while read` loop fed by the manifest: a command
-    # that consumed stdin would swallow the remaining lines, and the loop would end early having
-    # verified a PREFIX of the publication while reporting no foreign bytes at all. The accounting
-    # assertion after the loop is the belt to that brace.
-    if ! props=$(az storage file show --account-name "$account" --share-name "$share" \
-        --path "$dest/$rel" --auth-mode login --backup-intent \
-        --query "[[metadata.digest || '-', metadata.publication || '-']]" -o tsv --only-show-errors \
-        < /dev/null); then
+    # An unreadable file is refused as loudly as a foreign one; it is simply refused by name. The
+    # accounting assertion after the loop is the belt to `read_stamp`'s `< /dev/null` brace.
+    rc=0
+    read_stamp "$account" "$share" "$dest/$rel" || rc=$?
+    if [ "$rc" -eq 1 ]; then
       unreadable+=("$rel")
       continue
     fi
-    # 🚨 THE RENDERING IS MEASURED, NOT ASSUMED, and getting it wrong is silent. knack's
-    # `format_tsv` treats a TOP-LEVEL list as ROWS: `--query "[a, b]" -o tsv` prints a's value and
-    # b's value on TWO LINES, not as two columns — so `awk '{print $2}'` would read EMPTY for every
-    # file, every `owner` would compare unequal to $PUBLICATION, `ours` would be 0 on every publish
-    # and this postcondition would refuse EVERY publication in the fleet as "superseded". Hence a
-    # list-of-ONE-ROW: `[[a, b]]` renders one tab-separated line. The `|| '-'` guards exist because
-    # a null field renders as the LITERAL STRING 'None', not as empty. Both measured against
-    # azure-cli 2.90.0's own jmespath + knack formatter.
-    #
-    # The field count is ASSERTED rather than trusted: if that rendering ever changes, this is a
-    # loud refusal on the next publish instead of a fleet-wide false verdict.
-    fields=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print NF }')
-    if [ "${fields:-0}" -ne 2 ]; then
-      echo "::error::az answered '$props' for $dest/$rel — one tab-separated row of TWO fields was expected from --query \"[[metadata.digest || '-', metadata.publication || '-']]\" -o tsv. The CLI's rendering has changed; this verification cannot be trusted until the parse is updated to match."
-      unreadable+=("$rel (unexpected --query rendering: $fields field(s))")
+    if [ "$rc" -ne 0 ]; then
+      echo "::error::az answered '$STAMP_RAW' for $dest/$rel — one tab-separated row of TWO fields was expected from --query \"$STAMP_QUERY\" -o tsv. The CLI's rendering has changed; this verification cannot be trusted until the parse is updated to match."
+      unreadable+=("$rel (unexpected --query rendering: $STAMP_FIELDS field(s))")
       continue
     fi
-    actual=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $1 }')
-    owner=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
-    if [ "$actual" = "-" ]; then actual=""; fi
-    if [ "$owner" = "-" ]; then owner=""; fi
+    actual="$STAMP_DIGEST"
+    owner="$STAMP_OWNER"
     if [ -z "$actual" ]; then
       # Present, but carrying no digest at all: written by a publisher that predates this stamp
       # (a repo still pinned to an older copy of this script) or by something else entirely.
       # Either way its bytes cannot be established, and the seal must not claim them.
       foreign+=("$rel (no digest recorded — written by a publisher that does not stamp one)")
+      # '<' and '>' can never occur in a publication token, so an unstamped file can never be
+      # counted towards "one foreign publication wrote all of this" below. Fail-closed by shape.
+      foreign_owners="$foreign_owners <unstamped>"
+      if is_marker "$rel"; then foreign_markers=$((foreign_markers + 1)); fi
       continue
     fi
     if [ "$actual" != "$expected" ]; then
       foreign+=("$rel (we uploaded $expected, the shelf holds $actual, written by publication '${owner:-<unstamped>}')")
+      foreign_owners="$foreign_owners ${owner:-<unstamped>}"
+      if is_marker "$rel"; then foreign_markers=$((foreign_markers + 1)); fi
       continue
     fi
     if [ "$owner" = "$PUBLICATION" ]; then
       ours=$((ours + 1))
     else
       neutral=$((neutral + 1))
+      if is_marker "$rel"; then neutral_markers=$((neutral_markers + 1)); fi
       overlapped+=("$rel ← '${owner:-<unstamped>}'")
     fi
   done < "$MANIFEST"
@@ -548,7 +685,15 @@ verify_publication() { # <account> <share> <dest>
 
   local entry
   if [ "$ours" -eq 0 ]; then
+    # 🚨 BEFORE the refusal, and it is the only path that can turn a supersession green: the shelf
+    # may hold the publication this run was asked to make, sealed by a sibling that raced it. That
+    # is PROVED on the bytes or not concluded at all — see converged_on_equivalent.
+    if converged_on_equivalent "$account" "$share" "$dest" \
+        "$foreign_markers" "$neutral_markers" "$foreign_owners"; then
+      return 2
+    fi
     echo "::error title=Refusing to seal — this run's publication was entirely superseded::$account/$share/$dest holds nothing that distinguishes this run: ${#foreign[@]} of $MANIFEST_COUNT file(s) were overwritten by another publication while this one was in flight, and the remaining $neutral are byte-identical in both (MeshWeaver#3461). That publication is whole, and is left exactly as it is — sealing OUR sentinel over it would claim a bundle set that is not there. Nothing of this run reached this target."
+    echo "::error::this is NOT the same publication as the one this run baked: $CONVERGENCE_REASON"
     for entry in "${foreign[@]}"; do echo "::error::superseded: $entry"; done
     echo "::error::$OVERLAP_WRITERS"
     return 1
@@ -653,7 +798,18 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   # file above is read back and must still carry THIS run's digest; a foreign publisher that
   # overwrote any of them makes this refuse, and the directory stays sentinel-less rather than
   # sealed over a mix. See the long note beside verify_publication.
-  if ! verify_publication "$account" "$share" "$dest"; then
+  #
+  # rc 2 is the CONVERGENCE verdict: a sibling published this exact content and sealed it while
+  # this run was in flight. The target is satisfied and MUST NOT be sealed again — writing our own
+  # sentinel over their files would stamp their publication with this run's token and make the
+  # next carry-forward read two publications where there is one.
+  local verdict=0
+  verify_publication "$account" "$share" "$dest" || verdict=$?
+  if [ "$verdict" -eq 2 ]; then
+    echo converged >> "$OUTCOMES"
+    return 0
+  fi
+  if [ "$verdict" -ne 0 ]; then
     exit 1
   fi
   # LAST write — the atomic completeness marker. Anything that dies before this line leaves the
@@ -663,6 +819,10 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
     --metadata "digest=$(sha256_of "$SENTINEL_LOCAL")" "publication=$PUBLICATION" \
     --auth-mode login --backup-intent --only-show-errors > /dev/null
   echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s), source ${SOURCE_SHA:-unknown}, platform surface: $HAS_SURFACE)"
+  # 🚨 Recorded HERE, beside the seal, and not at the call sites: since the convergence verdict
+  # returns 0 without sealing, a caller counting "publish_one_target returned" as "published"
+  # would report a publication this run did not make.
+  echo published >> "$OUTCOMES"
 }
 
 # 🚨 PER-TARGET ISOLATION (Plugins #2682, 2026-08-30). Each target is published in its OWN subshell:
@@ -794,7 +954,6 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
       echo "sealed publication under $DEST carries no $MODULES_DIR_NAME/$MODULES_INDEX (exists=$module_set) — it predates module sealing; republishing WITH the module set."
       echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
       publish_one_target "$ACCOUNT" "$SHARE" "$DEST" true
-      echo published >> "$OUTCOMES"
       return 0
     fi
     if [ -n "${SOURCE_SHA:-}" ] && [ "$published_sha" = "$SOURCE_SHA" ]; then
@@ -812,7 +971,6 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
   fi
   echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
   publish_one_target "$ACCOUNT" "$SHARE" "$DEST" "$resealing"
-  echo published >> "$OUTCOMES"
 }
 
 FAILED=()
@@ -826,9 +984,14 @@ for target in $BAKE_PUBLISH_TARGETS; do
 done
 PUBLISHED=$(awk '/^published$/ { c++ } END { print c + 0 }' "$OUTCOMES")
 MARKERS=$(awk '/^marker$/ { c++ } END { print c + 0 }' "$OUTCOMES")
+# Targets a sibling publication of THIS content had already sealed by the time this run's
+# postcondition ran (MeshWeaver#3461). Counted separately from `published` so the summary never
+# claims a seal this run did not write — and printed on every run, including zero, so the number
+# is a denominator rather than an occasional line.
+CONVERGED=$(awk '/^converged$/ { c++ } END { print c + 0 }' "$OUTCOMES")
 if [ "${#FAILED[@]}" -gt 0 ]; then
   echo "::error::bake publication FAILED on ${#FAILED[@]} of $(printf '%s\n' $BAKE_PUBLISH_TARGETS | wc -l | tr -d ' ') target(s): ${FAILED[*]} — identity=$IDENTITY source=$SOURCE. Every OTHER target above was published and sealed; these were not. A target that no longer exists (a torn-down instance's share) belongs OUT of BAKE_PUBLISH_TARGETS — remove it, never route around it."
   exit 1
 fi
 
-echo "bake published: identity=$IDENTITY arch=$BAKE_ARCHITECTURE source=$SOURCE source-sha=${SOURCE_SHA:-unknown} bundles=${#BUNDLES[@]} surface=$HAS_SURFACE targets-published=$PUBLISHED release=${RELEASE_VERSION:-none} release-markers=$MARKERS"
+echo "bake published: identity=$IDENTITY arch=$BAKE_ARCHITECTURE source=$SOURCE source-sha=${SOURCE_SHA:-unknown} bundles=${#BUNDLES[@]} surface=$HAS_SURFACE targets-published=$PUBLISHED targets-converged=$CONVERGED release=${RELEASE_VERSION:-none} release-markers=$MARKERS"

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -293,21 +293,35 @@ die("unmodelled file action %r" % action)
 class Bake:
     """One producer's bake directory — every byte in it names the bake that made it."""
 
-    def __init__(self, root: Path, name: str, source_sha: str, surface: bool = True):
+    def __init__(self, root: Path, name: str, source_sha: str, surface: bool = True,
+                 surface_shared: bool = False, extra_bundles: tuple[str, ...] = ()):
         self.name = name
         self.source_sha = source_sha
+        self.bundles = list(BUNDLES) + list(extra_bundles)
         self.dir = root / f"bake-{name}"
         (self.dir / "modules").mkdir(parents=True, exist_ok=True)
         (self.dir / "framework-mvid.txt").write_text(IDENTITY + "\n")
-        for b in BUNDLES:
+        for b in self.bundles:
             (self.dir / b).write_text(f"{b} produced by bake {name} at {source_sha}\n")
         for m in MODULES:
             (self.dir / "modules" / m).write_text(f"{m} produced by bake {name} at {source_sha}\n")
         if surface:
-            # The real document is JSON; the harness reads bytes, not shape, so the fixture line
-            # names its producer like every other file — a mix is then a fact about the shelf.
-            (self.dir / SURFACE).write_text(
-                f"{SURFACE} produced by bake {name} at {source_sha}\n")
+            if surface_shared:
+                # 🚨 THE REAL DOCUMENT IS A PROPERTY OF THE PLATFORM IMAGE, NOT OF THE BAKE RUN, so
+                # two bakes taken with one image write it byte-identically — measured on the
+                # 2026-09-08 incident, where source-commit.txt, repository.txt, architecture.txt,
+                # modules/_index AND platform-surface.json were all byte-identical between the two
+                # racing publications and only the compiled zips differed. A fixture that made it
+                # differ per bake could never reproduce a convergence, and the case below would
+                # pass having tested the wrong thing. It carries no "produced by bake" phrase, so
+                # the shelf reader counts it as a marker rather than as a second bake's bytes.
+                (self.dir / SURFACE).write_text(
+                    f"{SURFACE} for the platform image behind {IDENTITY}\n")
+            else:
+                # The harness reads bytes, not shape, so the fixture line names its producer like
+                # every other file — a mix is then a fact about the shelf.
+                (self.dir / SURFACE).write_text(
+                    f"{SURFACE} produced by bake {name} at {source_sha}\n")
 
 
 class Shelf:
@@ -319,6 +333,11 @@ class Shelf:
 
     def sealed(self) -> bool:
         return (self.dest / SENTINEL).is_file()
+
+    def stamp(self, rel: str) -> dict:
+        """The metadata the publisher wrote on one file — `digest` and `publication`."""
+        mp = self.root / ".meta" / ACCOUNT / SHARE / DEST / (rel + ".json")
+        return json.loads(mp.read_text()) if mp.is_file() else {}
 
     def files(self) -> dict[str, str]:
         """path-under-dest → content, for every published file (the sentinel excluded)."""
@@ -641,6 +660,106 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
         check("the superseded publisher goes RED rather than claiming it published",
               r.returncode != 0 and "entirely superseded" in r.stdout,
               f"rc={r.returncode}")
+        check("…and says the shelf describes DIFFERENT content, so it did not converge",
+              "describes DIFFERENT content" in r.stdout,
+              "a different source sha is what separates this from the convergence case below")
+
+    # ── CONVERGENCE: superseded by a publication of THE SAME CONTENT. #3461, 2026-09-08 ───────
+    #
+    # The shape that actually bit, and the one the postcondition used to call a failure. Core CD
+    # runs 34205409381 and 34206854855 both published `plugins` at source cfac152ef… for identity
+    # s057b1e77…; each won one of the two storage targets and each went RED on the other, with the
+    # same verdict — "40 of 45 file(s) were overwritten … the remaining 5 are byte-identical".
+    # The 40 are bundle zips and module packages (the compile is not reproducible byte-for-byte);
+    # the 5 are the markers, the module index and the platform surface, byte-identical BECAUSE it
+    # is the same content. Both targets ended sealed with exactly the right bytes, and both CD runs
+    # failed — a false red that produced no sealed set and blocked the platform pin behind it.
+    #
+    # The publication key the sealed-skip uses is CONTENT × FRAMEWORK, so a sibling that published
+    # this content and sealed it has made the publication this run was asked for. Reporting that is
+    # the same statement the skip makes a minute earlier; refusing was the two ends of one script
+    # disagreeing.
+    print("\nconvergence — a sibling publishes THE SAME CONTENT and seals it while we are in flight:")
+    same_sha = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    mine = Bake(work, "run-a", same_sha, surface_shared=True)
+    sibling = Bake(work, "run-b", same_sha, surface_shared=True)
+    h.reset()
+    inner = h.publish_command(sibling, "Systemorph/MeshWeaver", "1902")
+    r = h.publish(mine, "Systemorph/MeshWeaver", "1901", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/architecture.txt",
+        "MOCK_AZ_HOOK_WHEN": "after",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-converged",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    theirs_only = set(s.bakes_present()) - {"<marker>"} == {"run-b"}
+    check("the fixture really did leave the sibling's publication whole (not vacuous)",
+          theirs_only and len(s.files()) == EXPECTED_FILES and s.sealed(), denominator(s))
+    check("…and this run really did publish first, so it had bytes to lose (not vacuous)",
+          f"publication Systemorph-MeshWeaver-1901-1: {EXPECTED_FILES} file(s)" in r.stdout
+          and f"→ {TARGET}: {DEST}" in r.stdout,
+          "it uploaded a full publication before the sibling overwrote it")
+    if expect_defect:
+        check("PRE-FIX: the superseded run seals its own sentinel over their bytes",
+              s.sealed() and r.returncode == 0, f"rc={r.returncode}, {denominator(s)}")
+    else:
+        check("a run superseded by an equivalent publication SUCCEEDS",
+              r.returncode == 0 and "Superseded by an equivalent publication" in r.stdout,
+              f"rc={r.returncode}")
+        check("…naming the publication that made it",
+              "Systemorph-MeshWeaver-1902-1" in r.stdout)
+        check("…and counting it apart from a seal this run did not write",
+              "targets-published=0 targets-converged=1" in r.stdout,
+              "the summary never claims a publication it did not make")
+        check("the sibling's seal is left exactly as it is",
+              s.stamp(SENTINEL).get("publication") == "Systemorph-MeshWeaver-1902-1",
+              f"_complete is stamped {s.stamp(SENTINEL).get('publication')!r}")
+        check("nothing of this run's is on the shelf under their seal",
+              theirs_only, denominator(s))
+
+    # The SAME fixture, one variable apart: the sibling never seals. Convergence is a positive
+    # proof that the publication EXISTS, so an unsealed directory must stay RED — a run reporting
+    # a publication that is not there is the silent-nothing outcome, whoever would have made it.
+    print("\n…but an unsealed sibling is not a publication:")
+    h.reset()
+    counter = work / "counter-unsealed"
+    inner = h.publish_command(sibling, "Systemorph/MeshWeaver", "1912",
+                              {"MOCK_AZ_UPLOAD_COUNTER": counter,
+                               "MOCK_AZ_FAIL_UPLOADS_AFTER": EXPECTED_FILES})
+    r = h.publish(mine, "Systemorph/MeshWeaver", "1911", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/architecture.txt",
+        "MOCK_AZ_HOOK_WHEN": "after",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-unsealed",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    check("the fixture really did overwrite everything without sealing (not vacuous)",
+          set(s.bakes_present()) - {"<marker>"} == {"run-b"} and not s.sealed(), denominator(s))
+    if not expect_defect:
+        check("an unsealed sibling does NOT converge — the run stays red",
+              r.returncode != 0 and "entirely superseded" in r.stdout
+              and "has not sealed" in r.stdout, f"rc={r.returncode}")
+
+    # And one variable the other way: the sibling seals the same CONTENT but a different bundle
+    # SET. `source-commit.txt` cannot see that, so the sealed listing's digest is what does — the
+    # reason the check reads `_complete` rather than trusting the content marker alone.
+    print("\n…and an equivalent-looking sibling with a DIFFERENT bundle set is refused:")
+    h.reset()
+    bigger = Bake(work, "run-c", same_sha, surface_shared=True, extra_bundles=("Extra.zip",))
+    inner = h.publish_command(bigger, "Systemorph/MeshWeaver", "1922")
+    r = h.publish(mine, "Systemorph/MeshWeaver", "1921", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/architecture.txt",
+        "MOCK_AZ_HOOK_WHEN": "after",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-widerset",
+        "MOCK_AZ_HOOK_CMD": inner,
+    })
+    s = h.shelf()
+    check("the fixture really did seal a WIDER set (not vacuous)",
+          s.sealed() and len(s.files()) == EXPECTED_FILES + 1, denominator(s))
+    if not expect_defect:
+        check("a sibling sealing a different bundle set does NOT converge",
+              r.returncode != 0 and "entirely superseded" in r.stdout
+              and "lists a different bundle set" in r.stdout, f"rc={r.returncode}")
 
     # ── FAIL CLOSED: a file that cannot be read back is refused, not assumed unchanged. ────────
     print("\nfail-closed (an unreadable answer is not a permissive one):")

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -259,6 +259,20 @@ that says "the window is closed" at phase 4 is describing the pointer-following 
   [#3461](https://github.com/Systemorph/MeshWeaver/issues/3461). Until the writer flips, **the window
   is shrunk, not closed**: the publisher's postcondition still carries the whole load, and the
   interval between its last verification read and the seal is still live.
+- 🚨 **What the postcondition costs while this is open, measured 2026-09-08.** Of 30 core-CD runs,
+  9 executed the bake job; of the 9 publications (either lane) that had a same-identity run
+  overlapping them in time, **2 failed** — 22%, and both were the two halves of ONE mutual
+  supersession: core CD runs `34205409381` and `34206854855` publishing the same content
+  (`cfac152ef…`) for the same identity, each winning one storage target and reddening on the other.
+  Both shares ended sealed with the right bytes and both CD runs failed, so the run produced no
+  sealed set and the platform pin did not move. **All 9 overlaps were same-lane; zero cross-lane** —
+  the same finding as 2026-09-06, on a different day.
+
+  The [convergence verdict](../SealedPublicationReads) removes the half of that which is a false
+  red — a supersession by a publication *proved* to be this bake's own content, sealed. It takes 2
+  to 1 on that incident. The **residual is a sibling that has not sealed yet when this run's sweep
+  ends** (21 seconds, measured), and that is not shrinkable by any amount of checking: it is what
+  phases 2–5 exist for.
 - **The next change is phase 2, and it is one PR in this repository** — the selector, the writer
   behind it, the two Azure-direct readers, and the harness cases. It changes nothing anywhere until a
   caller opts in, which is the property that lets it land at all.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -200,8 +200,8 @@ buckets, and the buckets are the verdict:
 
 - **foreign = 0** → seal. The directory is byte-for-byte this publication.
 - **ours = 0, foreign > 0** → *superseded*. Nothing distinguishing survived; the shelf is another
-  publication, whole. **Leave its seal alone** and go red — a run reporting "published" having
-  shipped nothing is the silent-nothing outcome this script exists to prevent.
+  publication, whole. **Leave its seal alone.** Whether that is red depends on WHOSE publication it
+  is — see "Superseded is not always a failure" below.
 - **ours > 0, foreign > 0** → a **mix**. Refuse, and delete any sentinel over it, because a
   publisher can finish and seal inside a gap in our uploads: refusing to write *our* sentinel is not
   enough when the one already there covers a directory we have since partly overwritten.
@@ -217,6 +217,52 @@ before unsealing, re-read it before sealing" is check-then-act on one mutable ce
 asymmetry: whoever stamps *last* re-reads its own marker and seals happily over the other's bytes.
 The loser detects the winner; the winner detects nothing. No arrangement of a single marker fixes
 that, because a marker records who wrote last, not whose bytes are on the shelf.
+
+### Superseded is not always a failure — the convergence verdict
+
+🚨 **The postcondition and the sealed-skip answer the same question and used to disagree,
+and the disagreement is what made core CD fail.** The skip at the top of `publish_to_target` says a
+sealed directory is already-published when the framework identity *and* the source commit match —
+the publication key is **content × framework**, and a different run's bytes for the same key are
+explicitly acceptable. The postcondition can only ask *"are these MY bytes"*. So a run that finds the
+shelf unsealed, uploads, and is then overwritten by a sibling publishing the **same content** was
+told it had shipped nothing, when in fact the publication it was asked to make was on the shelf,
+whole and sealed.
+
+**Measured — 2026-09-08, the incident that made it loud.** Core CD runs `34205409381` and
+`34206854855` both published `plugins` at source `cfac152ef023bc8e16203511aa60b50f581d3161` for
+identity `s057b1e7785fba6c6ba079e9d84a0c00d`. `BAKE_PUBLISH_TARGETS` holds two shares; each run won
+one and each went red on the other, with the same verdict: *40 of 45 file(s) were overwritten … the
+remaining 5 are byte-identical*. The **40** are bundle zips and module packages — the compile is not
+reproducible byte-for-byte. The **5** are `source-commit.txt`, `repository.txt`, `architecture.txt`,
+`modules/_index` and `platform-surface.json`, byte-identical *because it is the same content*. Both
+shares ended sealed with exactly the right bytes; both CD runs failed; the run produced no sealed set
+and the platform pin behind it did not move.
+
+So `ours = 0, foreign > 0` now converges instead of failing, on **positive byte-level proof of all
+three** — nothing inferred, nothing waited for:
+
+1. every **non-payload** file is byte-identical to this bake's (foreign markers `0`, *and* the
+   neutral-marker count reaches `MARKER_COUNT` — the denominator, so it cannot pass having checked
+   nothing);
+2. every foreign file names **one** publication, and that publication is stamped — an unstamped file
+   can never satisfy it, because `<unstamped>` is not a legal token;
+3. `_complete` is on the shelf, its digest is the SHA-256 of **this bake's own listing** (so the
+   sealed bundle *set* is ours, name for name — a same-content sibling with a wider set is refused)
+   and it carries that same publication token (so the seal belongs to the bytes under it, not to an
+   earlier publication a third writer left behind).
+
+Anything less is the superseded **red**, unchanged, with the reason printed beside it. Convergence
+never touches the **mix** verdict, never seals, never deletes, and never reports a publication that
+is not there — it reports that *somebody else made the exact one this run was asked for*, names
+them, and counts it as `targets-converged` rather than `targets-published` so no summary claims a
+seal this run did not write.
+
+🚨 **What it does not cover, stated so nobody re-derives it:** a sibling that has **not sealed
+yet** when this run's sweep ends. In the incident that was 21 seconds on one target and −0.24
+seconds on the other — so of those two reds, one converges and one does not. Closing that gap by
+looking again later would be a retry, and by looking more slowly would be a bound; the fix is the
+generation layout, where the two runs never share a directory and neither has to lose.
 
 The same two stamps close the carry-forward (below): `carry-forward-bundles.sh` verifies each
 bundle it downloads against the digest the publication records, and refuses when the carried set
@@ -253,6 +299,15 @@ Stated plainly, because a page that only lists what works is how the next sessio
   not have before, and it is the correct number: the alternative is four sealed mixes a day, which
   is what the fleet actually had. Whoever is holding the loser's re-run should not "fix" it by
   loosening the check.
+- **How often it bites, with the denominator it needs — measured 2026-09-08.** 30 core-CD runs
+  examined; 3 had not reached the bake job, 16 were cancelled before it and 2 decided not to
+  publish, leaving **9 core-CD bake jobs that actually executed**. Counting every publication of
+  either lane that had a same-identity run overlapping it in time — 4 core-CD plus 5 satellite
+  `publish-bake` — the corrected rate is **2 failures / 9 overlapping publications (22%)**, and both
+  failures are the two halves of the single mutual supersession above. 🚨 **All 9 overlaps were
+  same-lane; zero were cross-lane**, which reproduces the 2026-09-06 finding on a different day and
+  is the second independent measurement saying that "one owner per prefix" addresses none of this.
+  The convergence verdict takes that 2 to 1; the layout takes it to 0.
 - **The window itself remains.** In this layout it cannot be removed — in-place replacement means
   unsealed time, and the alternative is a layout migration every reader must land first (the portal
   boot seeder, the gate's Azure-direct path, and every pinned satellite workflow copy).
@@ -277,12 +332,17 @@ the pin is removed:
 - `.github/scripts/test-publish-bake-overlap.py` — runs the REAL `publish-bake-bundles.sh` **twice,
   interleaved**, against a stub share, and reads the verdict off the BYTES rather than off the
   script's own log: each fixture bundle names the bake that produced it, so "the sealed directory
-  holds two bakes" is a fact about the shelf. Twenty-one assertions over eight cases — three
-  controls that must PASS (settled publish, republish of new content, already-published skip), the
-  other lane in flight, the other lane completing inside a gap, a full supersession, an unreadable
-  read-back, an unstamped incumbent, and two concurrent runs of ONE repo. `--expect-defect` runs
-  the same cases against the pre-fix script and asserts the opposite; on `main` before the fix,
-  every overlap case sealed a mix.
+  holds two bakes" is a fact about the shelf. **47 assertions over eleven cases** — three controls
+  that must PASS (settled publish, republish of new content, already-published skip), the other lane
+  in flight, the other lane completing inside a gap, a full supersession, an unreadable read-back, an
+  unstamped incumbent, two concurrent runs of ONE repo, and the three convergence arms (a sibling
+  publishing the SAME content and sealing it → success; the same sibling **not** sealing → still red;
+  the same sibling sealing a **different bundle set** → still red). The convergence fixture pins
+  `platform-surface.json` to the platform rather than to the bake, because that is what the incident
+  measured — a fixture that made it differ per bake could not reproduce a convergence and the case
+  would pass having tested the wrong thing. `--expect-defect` runs the same cases against the pre-fix
+  script and asserts the opposite; run against `main`'s script with the ordinary arms, 5 of the 47
+  fail, which is the negative control for the convergence verdict.
 - `carry-forward-bundles.sh --self-test` — eleven cases, now executed by CI for the first time
   (this script runs only inside a node repo's publish lane, so the first execution of an edit used
   to be a production publish). It covers the shrink refusals it has always owed plus the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-platform-update-no-longer-stalls-when-two-builds-publish-the-same-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-platform-update-no-longer-stalls-when-two-builds-publish-the-same-content.md
@@ -1,0 +1,47 @@
+---
+Name: A platform update no longer stalls when two builds publish the same content
+Category: Fix
+Description: Two delivery runs that published the identical content at the same moment both declared failure, so neither produced a sealed set and the platform update behind them did not roll. A run whose content is proved to be on the shelf already, sealed, now reports that instead of failing.
+Icon: Cube
+Order: -20260908
+---
+
+# A platform update no longer stalls when two builds publish the same content
+
+Everything a portal runs at boot without recompiling it — the plugin bundles, the module set, the
+description of the platform they were built against — is *published* by the delivery pipeline into
+one directory per platform identity, and finished with a single completeness marker written last.
+The marker is what makes "published" mean "all of it is here".
+
+Two delivery runs can be in flight at once, and when the platform's public surface has not changed
+between them they resolve the **same identity** and publish the **same content** — the ordinary case,
+because that identity only changes when the surface does. They then write the same directory. Each
+run checks, immediately before writing its marker, that every file it uploaded still holds its own
+bytes; a run that finds somebody else's bytes refuses to write the marker, which is what stops a
+directory holding half of one build and half of another from ever being declared complete.
+
+That check could not tell two situations apart, and one of them is not a failure at all: **another
+run publishing something else**, and **another run publishing exactly what this one was asked to
+publish**. Two builds of one commit produce byte-identical descriptions and *non*-identical
+compiled bundles — compilation is not reproducible byte-for-byte — so the second case looks, file by
+file, like the first.
+
+On 2026-09-08 two delivery runs published the same content to two storage targets. Each won one
+target and each reported failure on the other. Both targets ended up sealed with exactly the right
+bytes, both runs went red, neither produced a sealed set, and the platform update waiting behind
+them did not roll — for a publication that was, in fact, correct and complete.
+
+**A run that is entirely overtaken now checks whether the publication it was asked to make is
+actually there.** It reports success only on proof: every file describing *what* was baked is
+byte-identical to its own, all the overtaking bytes come from one named publication, and the
+completeness marker on the shelf lists this build's own bundle set and was written by that same
+publication. Anything short of that is still a failure, with the reason printed — an unsealed
+directory, a different source commit, a different bundle set and an unstamped file each keep the run
+red. Two builds that genuinely publish *different* content still both refuse, and a directory
+holding a mixture is still never declared complete.
+
+The underlying race — two runs replacing one directory in place — is not removed by this, only its
+false alarm. Removing it means giving each publication its own directory and moving a pointer last;
+see [Sealed Publication Generations](/Doc/Architecture/SealedPublicationGenerations) for that design
+and [Sealed Publication Reads](/Doc/Architecture/SealedPublicationReads) for how a publication is
+written and read today.


### PR DESCRIPTION
Two commits, both `Refs #3461`: the **false red that is failing core CD today**, and the **writer
half of the generation layout** that removes the race itself.

---

## 1 — A supersession by this bake's own content is not a failure

**Measured, 2026-09-08.** Core CD runs `34205409381` and `34206854855` both published `plugins` at
source `cfac152ef023bc8e16203511aa60b50f581d3161` for identity `s057b1e7785fba6c6ba079e9d84a0c00d`.
`BAKE_PUBLISH_TARGETS` holds two shares; **each run won one and each went red on the other**, with
the same verdict — *40 of 45 file(s) were overwritten … the remaining 5 are byte-identical*. Both
shares ended sealed with exactly the right bytes; both CD runs failed; neither produced a sealed set;
the platform pin behind them did not move.

The 40 are bundle zips and module packages — the compile is not reproducible byte for byte. The 5 are
`source-commit.txt`, `repository.txt`, `architecture.txt`, `modules/_index` and
`platform-surface.json`, byte-identical *because it is the same content*.

**The defect.** The two ends of `publish-bake-bundles.sh` answered the same question and disagreed.
The sealed-skip keys on **content × framework** and says a *different run's bytes for the same key*
are already-published. `verify_publication` can only ask *"are these MY bytes"*, so it called the
same state a failure.

**The change.** `ours = 0, foreign > 0` now **converges** instead of failing, on positive byte-level
proof of all three — nothing inferred, nothing waited for:

1. every **non-payload** file byte-identical to this bake's (foreign markers `0` **and** the
   neutral-marker count asserted against `MARKER_COUNT`, so it cannot pass having checked nothing);
2. every foreign file naming **one** publication, and that publication **stamped** (`<unstamped>` is
   not a legal token, so an unstamped file can never satisfy it);
3. `_complete` on the shelf, its digest the SHA-256 of **this bake's own listing**, sealed by **that
   same** publication.

Anything less is the superseded **red**, unchanged, with the reason printed. It never touches the
**mix** verdict, never seals, never deletes, and reports `targets-converged` separately from
`targets-published`.

## 2 — The writer learns the generation layout, behind a per-caller selector

Phase 2 of `Doc/Architecture/SealedPublicationGenerations`. Each publication is written under its own
run-unique token, sealed there, and a one-line `_current` pointer says which one applies — so two
publishers never write the same bytes and a mix becomes **unrepresentable** rather than merely
detectable.

🚨 **The obvious design was measured and rejected.** Staging plus an atomic directory rename is **not
available on this store through this client**. Read off azure-cli 2.90.0: `az storage file` has copy
· hard-link · metadata · symbolic-link · delete · delete-batch · download · download-batch · exists ·
generate-sas · list · resize · show · update · upload · upload-batch · url and **no `rename`**;
`az storage directory` has create · delete · exists · list · show — **no `rename`**, and its delete is
documented *"Delete the specified **empty** directory"*. Neither group has a `lease` command, so a
lease per identity is not reachable either. Even in REST, `Rename Directory` cannot **replace** an
existing directory, so the swap is rename-away plus rename-in — two operations with a gap in which
the live path does not exist. **The smallest write this store offers is one small file, and that is
what the pointer is.**

- Selector `publication-layout` on `node-repo-publish-bake.yml`, default `flat`, carried in as
  `BAKE_PUBLICATION_LAYOUT`. An unrecognised value is **refused**, never read as flat. **Nothing
  anywhere writes a generation until a caller opts in.**
- `bake-scope.sh` and `carry-forward-bundles.sh` resolve the pointer in the SAME commit, by the
  reader's rules, so the writer and the two Azure-direct readers cannot disagree about what is live.
- **One deliberate deviation**, documented in place: the pointer moves **before** the flat
  compatibility copy. "Last" is about the *generation*; the flat copy is a different audience and the
  one part another publisher can still be writing. Ordering it after the pointer means an overlap on
  the flat copy costs the *compatibility copy* instead of a publication that is already whole.
- **Retention is not implemented**, and that is a precondition on flipping, not a follow-up: the
  sweep deletes from the production share and must land as its own reviewed change. Nothing here
  deletes anything it did not create.

## The denominator

Of 30 core-CD runs examined, 3 had not reached the bake job, 16 were cancelled before it and 2
decided not to publish — **9 executed it**. Counting every publication of *either* lane that had a
same-identity run overlapping it in time (4 core-CD + 5 satellite `publish-bake`): **2 failures / 9
overlapping publications = 22%**, both being the two halves of the one incident above. 🚨 **All 9
overlaps were same-lane; zero cross-lane** — the same finding as 2026-09-06 on a different day, and
the second independent measurement saying "one owner per prefix" addresses none of this.

## What is still open, plainly

- The convergence verdict does **not** cover a sibling that has not sealed yet when this run's sweep
  ends — 21 seconds on one target of the incident, −0.24 on the other, so of those two reds one
  converges and one does not. More checking cannot close it; disjoint directories can.
- Flipping a prefix to `generation` needs **every producer of it** past this commit (`plugins` has
  two: core CD and the satellite), and even then the **flat compatibility copy still races** — the
  reds go when that copy goes, or when the publication becomes digest-addressed.
- `Doc/Architecture/SealedPublicationGenerations` now records what an **OCI registry** does and does
  not close: content-addressed blobs make a mix unrepresentable, but a **tag** is a mutable
  last-writer-wins reference and moves the defect unless the seal names **digests** — every bundle
  recorded by digest, each publication also given an immutable identity-qualified tag, and the sealed
  set a list of `(package, digest)` pairs. Plus the two invariants that migration must carry across:
  the **framework identity must stay in the reference** (a path like `plugins/<source>/<pkg>:<ver>`
  carries none, and two surfaces' bakes would then collide on one reference), and the `_releases`
  marker must survive.

**The refusal is not weakened anywhere.** A mix is still never sealed, and a sentinel covering one is
still removed.

## Verification (nothing here triggered a CD run)

- `test-publish-bake-overlap.py` — **67 assertions**, executing the REAL script, reading every
  verdict off the bytes on a stub share. Three convergence arms and five generation arms, including
  **two interleaved publishers each sealing their OWN generation with neither directory holding a
  byte of the other, both complete, and `_current` naming exactly one**.
  🚨 **Negative control: 16 of the 67 fail against `main`'s script.**
- `bake-scope.sh --self-test` — 22 cases. The pointer case is discriminating by construction: the
  flat copy and the generation record **different** baselines, so the verdict says which was read.
- `carry-forward-bundles.sh --self-test` — 12 cases, incl. a **decoy** bundle planted at the prefix
  under the same name and different bytes.
- `bash -n` × 3 clean · `shellcheck -S warning` × 3 clean · `check-workflow-shell.py`,
  `check-workflow-yaml-keys.py`, `check-workflow-timeouts.py`, `check-pr-secret-preflight.py` clean ·
  `DocumentationLinkIntegrityTest` passed ·
  `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → 0 Warning(s), 0 Error(s).

Refs #3461
