### PR TITLE
feat(self-update): clean releases by default; continuous builds opt in by version pattern

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -43,10 +43,21 @@ and the version mechanics in
 | **Docker** | **multi-arch** (`linux-x64;linux-arm64` → OCI image-index) → ACR | ACR retag + GHCR mirror, by digest |
 | **Bake / seal** | ✅ platform content + Plugins modules, sealed per framework identity | ✅ inherited — `_releases/<clean>` copies the identity marker |
 | **NuGet** | ❌ never | ❌ **retired** (last publish `3.0.0-rc13`) |
-| **Rollout** | CD rolls memex/memex-cloud + all Continuous installs self-update | Stable installs self-update on their next check |
+| **Rollout** | CD rolls memex/memex-cloud; an install self-updates onto it ONLY when its `Admin/UpdatePolicy` is `Continuous` **with a pattern** that admits the tag (`3.0.0-ci*`) | every install on the default (`Stable`, clean releases only) self-updates on its next check |
 
 So: **merge to main = build + bake + seal + deploy; tag = promote.** There is no rc line: the
 continuous builds ARE the pre-releases, and `PlatformVersion` always names the next clean release.
+
+🚨 **Self-update takes clean releases by default** (maintainer, 2026-09-08: *"by default we will not
+upgrade as long as no version without `-ci…` is labelled"*). A `-ci.<n>` build is rolled onto only
+under `Continuous` + a `pattern` on `Admin/UpdatePolicy` — a glob over the tag, `3.0.1-ci*` — and
+`Continuous` with no pattern IS `Stable` (the poller warns once, naming the pattern to set). A
+pattern admits exactly the line it names: `3.0.0-ci*` never selects `3.0.1`, so following a line
+ends by itself when the next release is tagged. **Fleet today: `memex` and `memex-cloud` carry
+`Continuous` + `3.0.0-ci*`; change it the day `3.0.1` is tagged.** The `-latest` pointers (`3-latest`,
+`3.0-latest`, `3.0.1-latest`) are a fresh install's STARTING image and never a self-update
+candidate. Full rule: [ReleaseProcess.md](../../../src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md)
+→ "Which build an install takes".
 
 ## Preconditions for a release (gates the lane enforces — check them before tagging)
 
@@ -120,7 +131,9 @@ gh api "repos/Systemorph/MeshWeaver/actions/runs?branch=main&per_page=3" \
 # 2. Merge the PR. main-cd.yml then fires automatically on the green test run:
 #    builds multi-arch portal-ai + migration + mw-plugin-test, promotes <version>;<sha>;main to ACR,
 #    bakes + seals the platform content and the Plugins modules, and rolls memex/memex-cloud.
-# 3. Every OTHER Continuous install self-updates from ACR on the next publication EVENT (no action).
+# 3. Every OTHER install whose Admin/UpdatePolicy is Continuous + a pattern admitting the tag
+#    (3.0.0-ci*) self-updates from ACR on the next publication EVENT (no action). Stable installs
+#    (the default) wait for the clean release.
 ```
 
 ## 🚨 A merged fix can look SHIPPED while producing no image — verify the IMAGE, never the tick
@@ -210,10 +223,11 @@ promoted, a set whose bake is not sealed, and a release with no notes page.
 Two mechanisms, both live:
 - **Push (CD):** `main-cd.yml`'s `deploy` matrix rolls `memex` and `memex-cloud` directly.
 - **Pull (self-update):** `SelfUpdateHostedService` runs on EVERY install. It reads
-  `Admin/UpdatePolicy` (default **Continuous**), lists ACR tags, walks them newest-first and takes
-  the first one whose set is SEALED for its identity (`VersionSelect.PickTargets` +
-  `ReleaseAvailability`), then patches its own Deployment in-pod. `Stable` considers only clean
-  tags — i.e. what `release.yml` promoted.
+  `Admin/UpdatePolicy` (default **Stable** — clean tags only, i.e. what `release.yml` promoted),
+  lists ACR tags, walks the eligible ones newest-first and takes the first one whose set is SEALED
+  for its identity (`VersionSelect.SelectCandidates` + `ReleaseAvailability`), then patches its own
+  Deployment in-pod. `Continuous` + `pattern` (e.g. `3.0.0-ci*`) makes that line's `-ci.<n>` builds
+  eligible; `Continuous` without a pattern is `Stable`.
 
 Confirm a roll-out:
 ```bash

--- a/memex/Memex.Portal.Shared/SelfUpdate/PlatformModuleUpdatePolicy.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/PlatformModuleUpdatePolicy.cs
@@ -14,10 +14,13 @@ namespace Memex.Portal.Shared.SelfUpdate;
 /// node that already governs the image roll. There is deliberately NO module-specific knob:
 ///
 /// <list type="bullet">
-///   <item><b>Continuous</b> (the platform default, and the value an ABSENT node reads as) —
-///     unattended module landing is allowed: store-installed modules track their registry the same
-///     way the platform tracks its image.</item>
-///   <item><b>Stable</b> / <b>None</b> — declined: a deployment that pins its image takes updates
+///   <item><b>Continuous</b> — unattended module landing is allowed: store-installed modules track
+///     their registry the same way the platform tracks its image. The record's version PATTERN
+///     governs the platform IMAGE only (<see cref="UpdateChannelPattern"/>): modules carry their
+///     own versions, so a <c>Continuous</c> record without a pattern still lands modules
+///     unattended while its platform stays on clean releases.</item>
+///   <item><b>Stable</b> (the platform default since 2026-09-08) / <b>None</b> (what an ABSENT
+///     node reads as, #3542) — declined: a deployment that pins its image takes updates
 ///     deliberately, and its modules must not run ahead of that choice. The catalog card's manual
 ///     Update (and any explicit install) still lands the module — the gate covers only the
 ///     background reconcile.</item>
@@ -35,7 +38,8 @@ public sealed class PlatformModuleUpdatePolicy(IMessageHub hub, ILogger<Platform
     {
         var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
         if (storage is null)
-            // No storage = no persisted policy = the platform default (Continuous): allowed.
+            // No storage = no persisted policy = nothing an operator could have pinned: allowed
+            // (a host without storage has no image roll to run ahead of either).
             return Observable.Return<string?>(null);
 
         return storage.Read(UpdatePolicyNodeType.NodePath, hub.JsonSerializerOptions)

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -65,6 +65,11 @@ public class SelfUpdateHostedService : IHostedService
     /// </summary>
     private int _policyEstablished;
 
+    /// <summary>Whether the "Continuous without a pattern is Stable" advisory has been logged —
+    /// once per process, so a record written before the pattern existed is named on the first check
+    /// and not on every one.</summary>
+    private int _channelAdvisoryLogged;
+
     public SelfUpdateHostedService(
         IMessageHub hub,
         IAcrTagLister acr,
@@ -154,7 +159,10 @@ public class SelfUpdateHostedService : IHostedService
                 BuildCompletionTicks().Do(_ => Interlocked.Increment(ref _buildEventsSeen)),
                 SafetyNetTicks(),
                 ModuleSetProposedTicks(),
-                policy.DistinctUntilChanged(content => content.Policy).Skip(1)
+                // The pattern is part of the channel (Continuous + `3.0.1-ci*`), so editing it is a
+                // policy change and re-drives a check exactly like flipping the enum.
+                policy.DistinctUntilChanged(content => (content.Policy, UpdateChannelPattern.Normalize(content.Pattern)))
+                    .Skip(1)
                     .Select(_ => SelfUpdateTrigger.PolicyChange)))
             // 🚨 Read the CURRENT policy at decision time — never WithLatestFrom. That operator only
             // pairs once its secondary has produced, and the startup trigger fires synchronously on
@@ -445,7 +453,8 @@ public class SelfUpdateHostedService : IHostedService
     {
         var accessService = _hub.ServiceProvider.GetService<AccessService>();
         return Observable
-            .Defer(() => UpdatePolicyNodeType.EnsureExists(_hub, accessService, _options.DefaultPolicy, _logger))
+            .Defer(() => UpdatePolicyNodeType.EnsureExists(
+                _hub, accessService, _options.DefaultPolicy, _logger, _options.DefaultPattern))
             .RetryWhen(ResubscribeAfterRetryInterval("policy-node seeding"))
             .Take(1)
             .SelectMany(_ => Observable
@@ -615,6 +624,16 @@ public class SelfUpdateHostedService : IHostedService
         if (policy.Policy == UpdatePolicyKind.None)
             return Observable.Return(SelfUpdateVerdict.UpdatesDisabled());
 
+        // 🚨 The CHANNEL, resolved once per check (maintainer, 2026-09-08): a continuous build is
+        // eligible only when the record's version pattern admits it, so `Continuous` with no
+        // pattern IS `Stable`. That is a real change for a record written before the pattern
+        // existed, so it is said — once per process, at Warning, naming the record and the pattern
+        // to set — rather than applied silently; SelectCandidates below applies the same
+        // resolution, so the log and the decision cannot disagree.
+        var channel = VersionSelect.ResolveChannel(policy.Policy, policy.Pattern);
+        if (channel.Advisory is { } advisory && Interlocked.Exchange(ref _channelAdvisoryLogged, 1) == 0)
+            _logger?.LogWarning("[SelfUpdate] {Advisory}", advisory);
+
         return ListTags()
             // 🚨 The BEST ROLLABLE release, not merely the newest one. A target is only rollable if a
             // sealed content bake exists for the identity that exact image resolves to, and picking
@@ -637,7 +656,8 @@ public class SelfUpdateHostedService : IHostedService
             // backwards if need be. Both AKS portals sat in that state on 2026-09-07 printing the
             // up-to-date sentence, and an operator had to move them by hand.
             .Select(tags => VersionSelect.SelectCandidates(
-                tags, ShippedReleaseSeed.InstalledPlatformVersion, policy.Policy, policy.RequireCiGreen))
+                tags, ShippedReleaseSeed.InstalledPlatformVersion, policy.Policy, policy.RequireCiGreen,
+                policy.Pattern))
             .SelectMany(selection => selection.Candidates.Length == 0
                 // 🚨 "We asked and the answer was no" — the OTHER formerly-silent exit, and the one
                 // that made a stalled install unfalsifiable from outside. This is the normal, happy

--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -65,6 +65,24 @@ public record UpdatePolicyContent
     }
 
     /// <summary>
+    /// 🚨 The version PATTERN that admits continuous builds — a glob over the registry tag, e.g.
+    /// <c>3.0.1-ci*</c> (<see cref="UpdateChannelPattern"/>). Read only under
+    /// <see cref="UpdatePolicyKind.Continuous"/>: a pre-release tag is eligible ONLY when this
+    /// admits it, and <c>Continuous</c> with no pattern is <c>Stable</c> (clean releases only) —
+    /// the poller says so once at Warning, naming this field. Under <c>Stable</c> a pattern, when
+    /// set, narrows the clean releases considered (e.g. <c>3.0.*</c> keeps an install on one line).
+    /// Null or blank = no pattern.
+    ///
+    /// <para>The fleet's own setting while no clean release above <c>3.0.0</c> exists is
+    /// <c>3.0.0-ci*</c>; it stops matching the day <c>3.0.1</c> is tagged, which is the intended
+    /// way for "follow the line" to end. See <c>Doc/Architecture/ReleaseProcess</c> §1.</para>
+    /// </summary>
+    [Description("Version pattern for continuous builds, e.g. 3.0.1-ci*")]
+    [Translation("de", "Versionsmuster für Continuous-Builds, z. B. 3.0.1-ci*")]
+    [JsonPropertyName("pattern")]
+    public string? Pattern { get; init; }
+
+    /// <summary>
     /// When <c>true</c> (default) the install only rolls to builds that PASSED CI ("green").
     /// The continuous-delivery pipeline already publishes an image ONLY when "MeshWeaver Build and
     /// Test" succeeds, so the verified channel contains green builds exclusively; this flag is the
@@ -257,10 +275,12 @@ public static class UpdatePolicyNodeType
     /// default policy. Existence is read via <c>GetQuery</c> (empty-on-absent) — NEVER a point
     /// <c>GetMeshNodeStream(path)</c> probe of the maybe-absent node (which NotFound-resubscribe-storms
     /// on a fresh DB). Emits the node path when it exists. An existing node is left untouched (its
-    /// admin-chosen policy is preserved).
+    /// admin-chosen policy is preserved). <paramref name="defaultPattern"/> is seeded beside the
+    /// policy (<see cref="UpdatePolicyContent.Pattern"/>); null seeds none.
     /// </summary>
     public static IObservable<string> EnsureExists(
-        IMessageHub hub, AccessService? accessService, UpdatePolicyKind defaultPolicy, ILogger? logger = null)
+        IMessageHub hub, AccessService? accessService, UpdatePolicyKind defaultPolicy, ILogger? logger = null,
+        string? defaultPattern = null)
     {
         var meshService = hub.ServiceProvider.GetService<IMeshService>();
         if (meshService is null)
@@ -272,7 +292,11 @@ public static class UpdatePolicyNodeType
             NodeType = NodeType,
             Name = "Update Policy",
             State = MeshNodeState.Active,
-            Content = new UpdatePolicyContent { Policy = defaultPolicy },
+            Content = new UpdatePolicyContent
+            {
+                Policy = defaultPolicy,
+                Pattern = UpdateChannelPattern.Normalize(defaultPattern),
+            },
         };
 
         // 🚨 RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` (#1444/#1790):
@@ -292,7 +316,8 @@ public static class UpdatePolicyNodeType
                     if (existing is not null)
                         return Observable.Return(NodePath);
                     logger?.LogInformation(
-                        "[SelfUpdate] seeding {Path} = {Policy}.", NodePath, defaultPolicy);
+                        "[SelfUpdate] seeding {Path} = {Policy} (pattern: {Pattern}).",
+                        NodePath, defaultPolicy, UpdateChannelPattern.Normalize(defaultPattern) ?? "none");
                     return meshService.CreateNode(BuildNode())
                         .Select(_ => NodePath)
                         // Idempotent: a concurrent first-writer (other replica) won the create race.

--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -81,6 +81,17 @@ public static class VersionSelect
     private static readonly Regex PlatformVersionTag =
         new(@"^\d+\.\d+\.\d+([-+].*)?$", RegexOptions.Compiled);
 
+    // 🚨 The MOVING image pointers (2026-09-08): CD re-points `<major>-latest`, `<major.minor>-latest`
+    // and `<major.minor.patch>-latest` at every publication of that line, so an install STARTS from
+    // one and self-updates from there. The three-part one — `3.0.1-latest` — has the dotted shape
+    // above and NuGet-parses as a pre-release of 3.0.1, so without this filter it would be listed as a
+    // release, ranked in the promotion band, and could be selected by a pattern such as `3.0.1*`.
+    // A pointer is not a version: it names different bytes tomorrow, and rolling a Deployment onto
+    // it makes "what does this install run" unanswerable. Never a candidate, under any policy or
+    // pattern. `3-latest` / `3.0-latest` already fail the dotted shape; this names the rule for all.
+    private static readonly Regex MovingPointer =
+        new(@"-latest$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     /// <summary>The CD run number <paramref name="version"/> was published by — see
     /// <see cref="PlatformReleaseOrder.BuildOrdinal"/>, which owns it. Kept here as the name this
     /// file's own documentation and tests refer to, never as a second implementation.</summary>
@@ -91,14 +102,66 @@ public static class VersionSelect
     /// <see cref="UpdatePolicyKind.Continuous"/> considers every parseable tag (incl. build-numbered
     /// pre-releases); <see cref="UpdatePolicyKind.Stable"/> considers only clean releases
     /// (<c>!IsPrerelease</c>); <see cref="UpdatePolicyKind.None"/> always returns <c>null</c>.
+    /// A <paramref name="pattern"/>, when given, narrows either to the tags it admits.
     /// Returns the ORIGINAL tag string (so the image patch uses the exact registry tag).
     ///
     /// <para>Literally the head of <see cref="PickTargets"/> — one filter, one ordering, no second
     /// copy of "which release is best" to drift from the first.</para>
     /// </summary>
     public static string? PickTarget(
-        IEnumerable<string> tags, UpdatePolicyKind policy, bool requireCiGreen = true) =>
-        PickTargets(tags, policy, requireCiGreen).FirstOrDefault();
+        IEnumerable<string> tags, UpdatePolicyKind policy, bool requireCiGreen = true, string? pattern = null) =>
+        PickTargets(tags, policy, requireCiGreen, pattern).FirstOrDefault();
+
+    /// <summary>
+    /// What ONE policy record means for the image roll: which <see cref="UpdatePolicyKind"/> is
+    /// actually applied, under which pattern, and — when that differs from what the record SAYS —
+    /// the sentence an operator needs to read.
+    /// </summary>
+    /// <param name="Policy">The policy applied.</param>
+    /// <param name="Pattern">The normalized version pattern applied, or null.</param>
+    /// <param name="Advisory">Non-null exactly when the record declares <c>Continuous</c> without a
+    /// pattern: the channel is then <c>Stable</c>, and this names the record and the pattern to set.
+    /// Logged ONCE per process by the poller; never a hold, never a fault.</param>
+    public readonly record struct UpdateChannel(UpdatePolicyKind Policy, string? Pattern, string? Advisory);
+
+    /// <summary>
+    /// 🚨 <b>The channel rule (maintainer, 2026-09-08), stated once.</b> <i>"By default we will not
+    /// upgrade as long as no version without <c>-ci…</c> is labelled ⇒ we want to have a clean label
+    /// <c>3.0.1</c> to upgrade. If we want to get the <c>-ci…</c> we have to specify the pattern
+    /// <c>3.0.1-ci*</c>."</i>
+    ///
+    /// <list type="bullet">
+    /// <item><see cref="UpdatePolicyKind.None"/> — nothing; the pattern is ignored.</item>
+    /// <item><see cref="UpdatePolicyKind.Stable"/> — clean releases only; a pattern narrows them.</item>
+    /// <item><see cref="UpdatePolicyKind.Continuous"/> WITH a pattern — the tags the pattern admits,
+    /// continuous builds included, newest run first.</item>
+    /// <item><see cref="UpdatePolicyKind.Continuous"/> WITHOUT a pattern — <b>is <c>Stable</c></b>:
+    /// no pre-release is ever eligible on its own. The record is not rewritten (an operator's
+    /// choice is theirs to edit), the advisory names what to set, and the poller logs it once.</item>
+    /// </list>
+    ///
+    /// <para>Pure. <see cref="SelectCandidates"/> applies this itself, so the decision can never be
+    /// taken on an unresolved channel; <see cref="PickTargets"/> deliberately does NOT — it is the
+    /// LISTING every reader of a registry or a published root uses ("which publications exist, in
+    /// what order"), and the availability service enumerates publications through it under
+    /// <c>Continuous</c> regardless of what this install would apply.</para>
+    /// </summary>
+    public static UpdateChannel ResolveChannel(UpdatePolicyKind policy, string? pattern)
+    {
+        var normalized = UpdateChannelPattern.Normalize(pattern);
+        return policy switch
+        {
+            UpdatePolicyKind.None => new(UpdatePolicyKind.None, null, null),
+            UpdatePolicyKind.Continuous when normalized is null => new(
+                UpdatePolicyKind.Stable, null,
+                $"{UpdatePolicyNodeType.NodePath} declares policy Continuous with no version pattern, "
+                + "so it follows CLEAN releases only (the same as Stable): a continuous build is "
+                + "eligible only when a pattern admits it. To follow the current line's continuous "
+                + "builds set `pattern` on the record, e.g. \"3.0.0-ci*\" — it stops matching the "
+                + "day the next clean release is tagged, which is when following the line should end."),
+            _ => new(policy, normalized, null),
+        };
+    }
 
     /// <summary>
     /// Every eligible tag under <paramref name="policy"/>, NEWEST FIRST — where "newest" is the
@@ -123,9 +186,16 @@ public static class VersionSelect
     /// never which of them is newer than what runs. <see cref="SelectCandidates"/> makes that call —
     /// forward-only, except on the one path where the installed tag has been proven WITHDRAWN and
     /// rolling backwards is the only way out.</para>
+    ///
+    /// <para>🚨 A <paramref name="pattern"/> NARROWS, on top of the policy: <c>Stable</c> +
+    /// <c>3.0.*</c> lists one line's clean releases, <c>Continuous</c> + <c>3.0.1-ci*</c> lists that
+    /// line's continuous builds and nothing else — <c>3.0.2-ci.1</c> and the clean <c>3.0.1</c>
+    /// alike are out, because the glob says so. Whether an absent pattern turns <c>Continuous</c>
+    /// into <c>Stable</c> is <see cref="ResolveChannel"/>'s decision, taken by
+    /// <see cref="SelectCandidates"/>; this listing answers only for the arguments it is given.</para>
     /// </summary>
     public static IReadOnlyList<string> PickTargets(
-        IEnumerable<string> tags, UpdatePolicyKind policy, bool requireCiGreen = true)
+        IEnumerable<string> tags, UpdatePolicyKind policy, bool requireCiGreen = true, string? pattern = null)
     {
         if (policy == UpdatePolicyKind.None)
             return [];
@@ -134,6 +204,9 @@ public static class VersionSelect
 
         if (policy == UpdatePolicyKind.Stable)
             parsed = parsed.Where(x => !x.ver.IsPrerelease);
+
+        if (UpdateChannelPattern.Normalize(pattern) is { } glob)
+            parsed = parsed.Where(x => UpdateChannelPattern.Matches(glob, x.tag));
 
         // CI-green gate: the verified channel (continuous delivery, which builds+pushes ONLY when the
         // test workflow is green) never carries the `edge` pre-release label. An unverified "edge"
@@ -162,12 +235,14 @@ public static class VersionSelect
         ];
     }
 
-    /// <summary>The structural filter every reader of a tag listing applies: drop the per-RID images
-    /// and the git-sha / <c>main</c> pointers, keep what parses as a platform version.</summary>
+    /// <summary>The structural filter every reader of a tag listing applies: drop the per-RID images,
+    /// the git-sha / <c>main</c> pointers and the moving <c>-latest</c> pointers, keep what parses
+    /// as a platform version.</summary>
     private static IEnumerable<(string tag, NuGetVersion ver, long? ordinal)> Parse(
         IEnumerable<string> tags) =>
         tags
             .Where(t => !RuntimeIdentifierSuffix.IsMatch(t))   // exclude per-RID image tags; keep the manifest list
+            .Where(t => !MovingPointer.IsMatch(t))             // exclude `3-latest` / `3.0-latest` / `3.0.1-latest` (see MovingPointer)
             .Where(t => PlatformVersionTag.IsMatch(t))         // exclude bare git-sha / `main` tags (see PlatformVersionTag)
             .Select(t => (tag: t, ver: NuGetVersion.TryParse(t, out var v) ? v : null))
             .Where(x => x.ver is not null)
@@ -231,14 +306,22 @@ public static class VersionSelect
     /// ON the continuous line stays on it: the clean release is NOT a Continuous target, even though
     /// <see cref="IsNewer"/> correctly reports it as newer. Those are different questions and both
     /// answers are wanted — see <see cref="OnTheContinuousLine"/>.</para>
+    ///
+    /// <para>🚨 <b>And a continuous build is eligible only when the record's <paramref name="pattern"/>
+    /// admits it</b> (maintainer, 2026-09-08): the channel is <see cref="ResolveChannel"/>'d FIRST,
+    /// so <c>Continuous</c> with no pattern decides exactly as <c>Stable</c> does — clean releases
+    /// only, until <c>3.0.1</c> exists — and <c>3.0.0-ci*</c> can never select <c>3.0.1</c>.</para>
     /// </summary>
     public static RollCandidates SelectCandidates(
         IReadOnlyList<string> tags,
         string installedVersion,
         UpdatePolicyKind policy,
-        bool requireCiGreen = true)
+        bool requireCiGreen = true,
+        string? pattern = null)
     {
-        var eligible = PickTargets(tags, policy, requireCiGreen);
+        var channel = ResolveChannel(policy, pattern);
+        policy = channel.Policy;
+        var eligible = PickTargets(tags, policy, requireCiGreen, channel.Pattern);
         var installed = CheckInstalledTag(tags, installedVersion);
         var staysOnTheCiLine = OnTheContinuousLine(installedVersion, policy);
 

--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -205,8 +205,9 @@ public static class VersionSelect
         if (policy == UpdatePolicyKind.Stable)
             parsed = parsed.Where(x => !x.ver.IsPrerelease);
 
-        if (UpdateChannelPattern.Normalize(pattern) is { } glob)
-            parsed = parsed.Where(x => UpdateChannelPattern.Matches(glob, x.tag));
+        // Compiled once per listing, not once per tag (Copilot review on #3723).
+        if (UpdateChannelPattern.Compile(pattern) is { } glob)
+            parsed = parsed.Where(x => glob.IsMatch(x.tag));
 
         // CI-green gate: the verified channel (continuous delivery, which builds+pushes ONLY when the
         // test workflow is green) never carries the `edge` pre-release label. An unverified "edge"

--- a/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
@@ -36,25 +36,25 @@ public static class UpdatePolicySettingsTab
     internal static UiControl BuildContent(LayoutAreaHost host, StackControl stack)
     {
         stack = stack.WithView(Controls.H2(host.Localize("ui.platformUpdates")).WithStyle("margin: 0 0 8px 0;"));
-        stack = stack.WithView(Controls.Markdown(
-            "The platform self-updates per the strategy below. **Continuous** rolls to the newest build " +
-            "(including build-numbered continuous builds); **Stable** rolls only to clean releases; " +
-            "**None** disables auto-update. **Only update to CI-verified (green) builds** (default on) " +
-            "keeps the install on builds that passed CI — turn it off to also accept unverified edge builds. " +
-            "On Kubernetes the portal patches its own deployment; elsewhere the latest version is surfaced " +
-            "for a manual update."));
+        stack = stack.WithView(Controls.Markdown(host.Localize("ui.mdUpdatePolicyIntro")));
 
         // Running version (the installed platform version baked into the binary).
         stack = stack.WithView(Controls.Markdown(
             $"**Running version:** `{ShippedReleaseSeed.InstalledPlatformVersion}`"));
 
         // Policy editor — bound DIRECTLY to Admin/UpdatePolicy. EnsureExists (create-on-absent, as
-        // System) before binding so the editor binds to an existing node.
-        stack = stack.WithView((h, _) => UpdatePolicyNodeType
-            .EnsureExists(h.Hub, h.Hub.ServiceProvider.GetService<AccessService>(), UpdatePolicyKind.Continuous)
-            .Select(_ => (UiControl?)MeshNodeContentEditorControl.ForType(
-                UpdatePolicyNodeType.NodePath, typeof(UpdatePolicyContent)))
-            .StartWith((UiControl?)Controls.Markdown(host.Localize("ui.mdLoadingUpdatePolicy"))));
+        // System) before binding so the editor binds to an existing node. The seed is the SAME
+        // default the poller seeds (SelfUpdateOptions.DefaultPolicy — Stable), never a second one.
+        stack = stack.WithView((h, _) =>
+        {
+            var options = h.Hub.ServiceProvider.GetService<SelfUpdateOptions>() ?? new SelfUpdateOptions();
+            return UpdatePolicyNodeType
+                .EnsureExists(h.Hub, h.Hub.ServiceProvider.GetService<AccessService>(), options.DefaultPolicy,
+                    defaultPattern: options.DefaultPattern)
+                .Select(_ => (UiControl?)MeshNodeContentEditorControl.ForType(
+                    UpdatePolicyNodeType.NodePath, typeof(UpdatePolicyContent)))
+                .StartWith((UiControl?)Controls.Markdown(host.Localize("ui.mdLoadingUpdatePolicy")));
+        });
 
         // Live status: the latest available tag, when last checked, and — when the combo gate has
         // verified that tag against THIS instance's module set (mw-combo-verify) — its verdict. A

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -13,7 +13,7 @@ This is **one of two deploy routes** for MeshWeaver. Use it for the shared porta
 
 A **code update** is three steps: build the images, point the Deployments at the new tag, restart. It is **not** `tools/deploy.sh` and **not** `aspire deploy` — those are the Container Apps route.
 
-> **Steady state is self-update, not this runbook.** Once an environment runs, it rolls *itself* to new images per `Admin/UpdatePolicy` (default Continuous) — the portal patches its own Deployment from inside the pod. This manual runbook is the **bootstrap / break-glass** path (first install, or to force a specific tag). See [ReleaseStrategy.md](/Doc/Architecture/ReleaseStrategy), which also covers the one-time RBAC + workload-identity (AcrPull) setup the in-pod updater needs.
+> **Steady state is self-update, not this runbook.** Once an environment runs, it rolls *itself* to new images per `Admin/UpdatePolicy` (default Stable — clean releases; `Continuous` + a `pattern` such as `3.0.0-ci*` follows a line's continuous builds) — the portal patches its own Deployment from inside the pod. This manual runbook is the **bootstrap / break-glass** path (first install, or to force a specific tag). See [ReleaseStrategy.md](/Doc/Architecture/ReleaseStrategy), which also covers the one-time RBAC + workload-identity (AcrPull) setup the in-pod updater needs.
 
 ## 1. Build + push the images
 
@@ -265,8 +265,8 @@ Operational facts about the in-pod updater (learned the hard way — each cost a
   judges it newer, and **patches the Deployment off your image**. Manual rolls therefore only stick with
   CI-built `ci.<N>` tags — ship code via a merged PR, or pause the updater first.
 - **Pause switch** = the `Admin/UpdatePolicy` node: patch `content.policy` to `None`
-  (`Continuous`/`Stable`/`None`). BUT a **freshly booted pod races the policy read**: `CreatePolicySource`
-  emits the configured default (`Continuous`) via `StartWith` *before* the node's live value arrives, and
+  (`Continuous`+`pattern`/`Stable`/`None`). BUT a **freshly booted pod races the policy read**: `CreatePolicySource`
+  emits the configured default (`Stable` since 2026-09-08) via `StartWith` *before* the node's live value arrives, and
   the poll timer fires immediately (`StartWith(-1L)`). The live `None` then switches the poller off, but a
   check may already have fired. `None` alone therefore does not reliably protect a roll that restarts the
   pod.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -716,8 +716,11 @@ was built against" for the producer half.
 
 The policy gate is the deployment's **existing update policy — `Admin/UpdatePolicy`**, the same
 single surface that governs the platform image roll; there is no module-specific knob.
-**Continuous — the platform default, and what an absent policy reads as — lands unattended;
-Stable and None decline the UPGRADE** (the catalog's manual Update still works there): a
+**Continuous lands unattended; Stable — the platform default since 2026-09-08 — and None
+(what an absent policy reads as, #3542) decline the UPGRADE** (the catalog's manual Update still
+works there). The record's version `pattern` governs the platform IMAGE only — modules carry their
+own versions — so a `Continuous` record without a pattern still lands modules while its platform
+stays on clean releases. A
 deployment that pins its image takes updates deliberately, and its modules do not run ahead of
 that choice. A **first landing** is deliberately policy-exempt: it completes an install the
 operator's own surfaces already sanctioned, and gating it would ship a package whose binary half

--- a/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md
@@ -134,8 +134,11 @@ environment, in this order:
    (the **same** value for every env). This authenticates the tag-list call; the chart wires the
    workload-identity annotation/label + `AZURE_CLIENT_ID` from it.
 4. **Set `Admin/UpdatePolicy` for the env.** Settings → Updates (platform admin) writes the
-   `Admin/UpdatePolicy` node. Recommended: **Continuous for dev/test** (always rolls to the newest
-   build-numbered image), **Stable for prod** (rolls only to the newest clean release). See
+   `Admin/UpdatePolicy` node. The seeded default is **Stable** (rolls only to the newest clean
+   release). For **dev/test** set **Continuous with a pattern** — `3.0.0-ci*` today — so the
+   install follows that line's build-numbered images; `Continuous` without a pattern is Stable. A
+   new install can seed that from the chart: `SelfUpdate__DefaultPolicy=Continuous` +
+   `SelfUpdate__DefaultPattern=3.0.0-ci*`. See
    [Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy).
 5. **Add the env's Azure Files share to the CI bake targets** — otherwise no published bundle ever
    reaches the new portal and its pods Roslyn-compile every shipped NodeType at boot. Append its

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -160,8 +160,9 @@ runtime"* as *"a floor can say anything"*.
 
 Two consequences of the same ordering, both load-bearing:
 
-- **A Stable install takes the clean release and nothing before it.** `Stable` selects
-  `!IsPrerelease`; the only clean tags are the promoted ones.
+- **An install takes the clean release and nothing before it — by default.** `Stable` selects
+  `!IsPrerelease`; the only clean tags are the promoted ones. Continuous builds are taken only
+  under a version PATTERN (next subsection).
 - **The number must move the day a release is tagged.** `3.0.0-ci.7950` sorts *below* `3.0.0`, so a
   continuous build stamped with an already-released number would stop every Continuous install from
   rolling forward. `release.yml` opens the pull request that moves the line to `3.1.0` itself; rc6
@@ -174,6 +175,63 @@ Two consequences of the same ordering, both load-bearing:
 seconds-since-midnight build number made a morning build sort below the previous evening's. See
 [Self-Update Target Selection](/Doc/Architecture/SelfUpdateTargetSelection) for the two different
 keys the *ordering* and the *is-this-newer* questions use.
+
+### Which build an install takes — clean releases by default, continuous builds by pattern
+
+> Maintainer, 2026-09-08: *"by default we will not upgrade as long as no version without `-ci…` is
+> labelled ⇒ we want to have a clean label `3.0.1` to upgrade. If we want to get the `-ci…` we have
+> to specify the pattern `3.0.1-ci*` or something. At the moment it is `3.0.0-ci*` as we have not
+> released anything else."*
+
+The version scheme has two shapes, and **self-update reads them as two channels with one default**:
+
+| `Admin/UpdatePolicy` | `pattern` | what the install rolls to |
+|---|---|---|
+| `Stable` — **the default** | *(none)* | the newest clean `X.Y.Z`, and nothing before it |
+| `Stable` | `3.0.*` | the newest clean release of that line only |
+| `Continuous` | `3.0.1-ci*` | the newest sealed `3.0.1-ci.<n>` — by run number, so `ci.7845 < ci.8059` numerically and a retired `rc` label never outranks a later run |
+| `Continuous` | *(none)* | **the same as `Stable`** — a pre-release is eligible only when a pattern admits it; the poller says so once at Warning, naming the record and the pattern to set |
+| `None` | *(ignored)* | nothing |
+
+Three rules that follow, each pinned by `VersionSelectTest`:
+
+- 🚨 **A pattern is a glob over the registry tag and admits exactly what it names.** `3.0.1-ci*`
+  matches `3.0.1-ci.30` and NOT `3.0.2-ci.1` — and not the clean `3.0.1` either. So `3.0.0-ci*` can
+  **never** select `3.0.1`: following one line's continuous builds *ends* by the pattern matching
+  nothing new, and that is the intended way for it to end. `*` matches any run of characters, `?`
+  one; the whole tag must match; case does not matter.
+- **The order under a pattern is still the lineage** (`PlatformReleaseOrder.BuildOrdinal` — the CD
+  run number), never the version string: `ci < rc < release` holds where a wide pattern admits all
+  three, and two builds of one line compare by `<n>`.
+- 🚨 **The moving image pointers are never candidates.** CD re-points `<major>-latest`,
+  `<major.minor>-latest` and `<major.minor.patch>-latest` at every publication of the line
+  (`3-latest`, `3.0-latest`, `3.0.1-latest`) so that a fresh install *starts* from a pointer and
+  self-updates from there. They name different bytes tomorrow; `VersionSelect` drops them before
+  any policy or pattern is applied, and a pattern that would match one textually still selects
+  nothing.
+
+**How we do semver, in one line:** `<major>.<minor>.<patch>[-ci.<n>]` — the *family* is the major
+line (`3`), a *release* is a clean label on it, a *continuous build* is a release-in-progress
+distinguished only by its run number. A clean label is the only thing the default channel moves on,
+which is why it is what "releasing" means here.
+
+🚨 **The fleet's setting while no clean release above `3.0.0` exists: `policy: Continuous`,
+`pattern: 3.0.0-ci*`** on `memex` and `memex-cloud` — they follow the line's sealed sets. **Change
+it the day `3.0.1` is tagged**: either remove the pattern (the install then waits for clean
+releases — the default) or move it to `3.0.1-ci*` to keep following the next line's builds. A
+record that still reads `3.0.0-ci*` after the tag is not broken, it is finished: it selects nothing
+new, which the Updates tab shows as "no newer release".
+
+The record an operator writes (Settings → Updates edits the same fields):
+
+```json
+{ "$type": "UpdatePolicyContent", "policy": "Stable" }                                   // clean only — the default
+{ "$type": "UpdatePolicyContent", "policy": "Continuous", "pattern": "3.0.1-ci*" }      // follow one line's builds
+```
+
+`SelfUpdate__DefaultPolicy` / `SelfUpdate__DefaultPattern` seed a NEW install's record (a dev/test
+host that should track the line sets `Continuous` + `3.0.0-ci*`); an existing record is edited on
+the record, never by configuration.
 
 > 🚨 **There is no rc line and there will be none** (maintainer, 2026-09-05; restated and settled
 > 2026-09-07). `3.0.0-rc1` … `3.0.0-rc13` were tagged and rebuilt on tagging, which made each

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
@@ -1,7 +1,7 @@
 ---
 NodeType: Markdown
 Name: "Release & Self-Update Strategy"
-Abstract: "The end-to-end production model: the merge preconditions (build green with warnings-as-errors, tests green, reviewed, comments resolved), the version scheme (current-build vs official), CI producing ALL images to ACR tagged by version, and policy-driven SELF-UPDATE — each install (AKS, local k3s, MAUI) rolls itself to the newest image per Admin/UpdatePolicy (Stable | Continuous | None, default Continuous)."
+Abstract: "The end-to-end production model: the merge preconditions (build green with warnings-as-errors, tests green, reviewed, comments resolved), the version scheme (current-build vs official), CI producing ALL images to ACR tagged by version, and policy-driven SELF-UPDATE — each install (AKS, local k3s, MAUI) rolls itself to the newest image per Admin/UpdatePolicy (Stable | Continuous + pattern | None, default Stable — clean releases only)."
 Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#0e7490'/><path d='M12 5a7 7 0 1 0 6.3 4' fill='none' stroke='white' stroke-width='1.8' stroke-linecap='round'/><path d='M18.5 4.5v3.2h-3.2' fill='none' stroke='white' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/></svg>"
 Authors:
   - "Roland Buergi"
@@ -23,7 +23,7 @@ The production model in one picture:
 PR ──[merge preconditions]──▶ main ──[CI: build ALL images, tag by version]──▶ ACR
                                                                                  │
                                   each install polls ACR per Admin/UpdatePolicy ◀┘
-                                  Continuous → newest build · Stable → newest release · None → manual
+                                  Stable (default) → newest clean release · Continuous + pattern → newest build the pattern admits · None → manual
                                                  │
                   AKS / local k3s: patch own deployment   MAUI: notify + relaunch
 ```
@@ -125,14 +125,19 @@ Two properties of the continuous leg matter to a reader of tags:
 
 ## 4. The update policy — `Admin/UpdatePolicy`
 
-A single mesh node, edited by platform admins under **Settings → Updates** (a dropdown bound straight
-to the node). Default **Continuous**.
+A single mesh node, edited by platform admins under **Settings → Updates** (a dropdown and a
+pattern field bound straight to the node). Default **Stable** — clean releases only (maintainer,
+2026-09-08: *"by default we will not upgrade as long as no version without `-ci…` is labelled"*).
 
-| Policy | Behaviour |
-|---|---|
-| **Continuous** (default) | Roll to the **latest-published** tag on ACR, **including** build-numbered continuous builds — latest by CD run number, not by version string ([why](/Doc/Architecture/SelfUpdateTargetSelection)). As soon as a new build number lands, the install picks it up. |
-| **Stable** | Roll only to the newest **clean release** (no build number). |
-| **None** | Never auto-update. Apply updates manually (operator, or the admin tab's *Apply available update now*). |
+| Policy | `pattern` | Behaviour |
+|---|---|---|
+| **Stable** (default) | *(optional; narrows to a line, e.g. `3.0.*`)* | Roll only to the newest **clean release** (no build number). |
+| **Continuous** | **required**, e.g. `3.0.1-ci*` | Roll to the newest sealed continuous build the pattern admits — latest by CD run number, not by version string ([why](/Doc/Architecture/SelfUpdateTargetSelection)). `3.0.0-ci*` never selects `3.0.1`: following a line ends when its release is tagged. **Without a pattern this is Stable**, and the poller says so once at Warning. |
+| **None** | *(ignored)* | Never auto-update. Apply updates manually (operator, or the admin tab's *Apply available update now*). |
+
+Fleet today (no clean release above `3.0.0` yet): `memex` and `memex-cloud` carry `Continuous` +
+`3.0.0-ci*`, to be changed the day `3.0.1` is tagged. The record shapes and the semver rule are in
+[Release Process & Versioning](/Doc/Architecture/ReleaseProcess) → "Which build an install takes".
 
 The poller (`SelfUpdateHostedService`) reads this node live: changing the policy re-drives it
 immediately. It checks ACR a few times a day, records the latest tag it sees on the node
@@ -212,7 +217,8 @@ in-cluster Deployment PATCH works without this; it only authenticates the tag-li
 - **Watch a continuous roll (AKS):** merge to `main` → a new `…-ci.<n>` tag lands on ACR → within the
   poll window a `Continuous` install patches `memex-portal-deployment` + `memex-migration-deployment`
   (`kubectl rollout status`).
-- **Pin an environment:** set the policy to `None` (or `Stable` for releases-only).
+- **Pin an environment:** set the policy to `None`. `Stable` (the default) is releases-only; a
+  `Continuous` install follows only the line its `pattern` names.
 - **Manual apply:** Settings → Updates → *Apply available update now* (installs that can self-patch).
 
 The decision logic (which tag each policy picks; "is newer") is unit-pinned in
@@ -231,8 +237,8 @@ not `kubectl set image` by hand. The manual [AKS runbook](/Doc/Architecture/Depl
 
 | Step | Action | What ships | Who rolls to it |
 |---|---|---|---|
-| **a** | **Merge to `main`** (preconditions §1 green) | `main-cd.yml` builds the **multi-arch** image set (amd64 + arm64), tags it `3.0.0-ci.<run#>` (+ short SHA + moving `main`), pushes to **ACR**, bakes and seals | **Continuous** installs (dev/test) |
-| **b** | **Push the annotated tag `v3.0.0`** on a promoted, sealed commit | `release.yml` retags that set `3.0.0` in ACR, mirrors it to GHCR, records `_releases/3.0.0`, publishes the GitHub Release | **Stable** installs (prod) |
+| **a** | **Merge to `main`** (preconditions §1 green) | `main-cd.yml` builds the **multi-arch** image set (amd64 + arm64), tags it `3.0.0-ci.<run#>` (+ short SHA + moving `main`), pushes to **ACR**, bakes and seals | **Continuous** installs whose `pattern` admits the tag (dev/test; the fleet's `3.0.0-ci*` today) |
+| **b** | **Push the annotated tag `v3.0.0`** on a promoted, sealed commit | `release.yml` retags that set `3.0.0` in ACR, mirrors it to GHCR, records `_releases/3.0.0`, publishes the GitHub Release | **Stable** installs — the default (prod) |
 | **c** | **Merge the bump** the lane opened (`PlatformVersion` → `3.1.0`) | continuous builds become `3.1.0-ci.<n>` | opens the next development line |
 
 ```bash

--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
@@ -119,6 +119,20 @@ the release is sitting there looking newer.
 The RECOVERY path (§3) deliberately drops the line rule: an install that cannot start a pod at all
 takes the best image that EXISTS, and the verdict says `RECOVERY` so the departure is visible.
 
+### 🚦 …and only the builds its PATTERN admits (2026-09-08)
+
+**Maintainer decision, 2026-09-08.** The default channel is the clean release: *"by default we will
+not upgrade as long as no version without `-ci…` is labelled."* A continuous build is eligible only
+when the policy record's `pattern` — a glob over the tag, `3.0.1-ci*` — admits it, so
+`SelectCandidates` resolves the CHANNEL first (`VersionSelect.ResolveChannel`): `Continuous` with a
+pattern lists that pattern's tags, `Continuous` without one **is `Stable`** and the poller logs the
+advisory once. The order under a pattern is unchanged — still `BuildOrdinal`, still the promotion
+band last — and the three `-latest` pointers CD moves are dropped by the structural filter before any
+policy is applied. `PickTargets` keeps its LISTING semantics for the availability service, which
+enumerates publications under `Continuous` regardless of what an install would apply. Rule, record
+shapes and the fleet's current `3.0.0-ci*`:
+[Release Process & Versioning](/Doc/Architecture/ReleaseProcess) → "Which build an install takes".
+
 ## 3. "I am current" is not "my tag no longer exists"
 
 The second defect is the same code being unable to tell two opposite states apart.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-an-install-updates-to-clean-releases-by-default.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-an-install-updates-to-clean-releases-by-default.md
@@ -1,0 +1,38 @@
+---
+Name: An install updates to clean releases by default
+Category: Feature
+Description: Self-update now waits for a clean release such as 3.0.1 unless you tell it which continuous builds to follow. Settings → Updates gains a version pattern — set it to 3.0.0-ci* to keep tracking the current line's builds; leave it empty to move only on releases.
+Icon: ArrowSync
+Order: -20260908
+---
+
+# An install updates to clean releases by default
+
+Until now an installation on the **Continuous** update strategy rolled itself onto every
+build-numbered image the pipeline published — `3.0.0-ci.8059`, then `ci.8079`, and so on. That is
+what a development portal wants and what a production one does not: a production install should
+move when a release is *labelled*, not every time a build passes.
+
+## What changed
+
+- **The default strategy is now Stable.** A new installation takes the newest clean release
+  (`3.0.1`) and nothing before it. Nothing about an existing record is rewritten.
+- **Continuous builds are opt-in, by pattern.** Settings → Updates has a new **version pattern**
+  field. `Continuous` together with `3.0.0-ci*` follows exactly that line's builds — newest run first
+  — and stops matching the day `3.0.1` is tagged, which is the intended way for "follow the line" to
+  end. `3.0.1-ci*` then follows the next one.
+- **Continuous without a pattern behaves like Stable.** If your record already reads `Continuous`
+  and you want it to keep tracking builds, set the pattern; the update log says so once, naming the
+  record and the pattern to set.
+- **`None` is unchanged** — no automatic update at all.
+
+## Why a pattern rather than a switch
+
+A pattern says *which* builds you accept, not merely *that* you accept builds. It cannot cross a
+release boundary you did not write down (`3.0.0-ci*` never selects `3.0.1` or `3.0.1-ci.4`), so a
+portal that was meant to follow one line during its development does not silently continue onto
+the next. The order of the builds a pattern admits is still the pipeline's own publication order.
+
+The moving image pointers the pipeline now maintains — `3-latest`, `3.0-latest`, `3.0.1-latest` —
+are the image a fresh installation *starts* from; self-update never treats them as a version to roll
+to.

--- a/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
@@ -208,9 +208,26 @@ public record SelfUpdateOptions
     /// </summary>
     public bool AllowUnverifiedRoll { get; init; }
 
-    /// <summary>The policy seeded onto <c>Admin/UpdatePolicy</c> when it doesn't exist yet, and the
-    /// fallback used before the policy node's first live emission.</summary>
-    public UpdatePolicyKind DefaultPolicy { get; init; } = UpdatePolicyKind.Continuous;
+    /// <summary>
+    /// The policy seeded onto <c>Admin/UpdatePolicy</c> when it doesn't exist yet.
+    ///
+    /// <para>🚨 <see cref="UpdatePolicyKind.Stable"/> — clean releases only (maintainer,
+    /// 2026-09-08: <i>"by default we will not upgrade as long as no version without <c>-ci…</c> is
+    /// labelled"</i>). A host that wants a fresh install to follow continuous builds seeds
+    /// <see cref="UpdatePolicyKind.Continuous"/> together with a <see cref="DefaultPattern"/>;
+    /// <c>Continuous</c> alone is still clean-only (see <see cref="UpdateChannelPattern"/>).</para>
+    /// </summary>
+    public UpdatePolicyKind DefaultPolicy { get; init; } = UpdatePolicyKind.Stable;
+
+    /// <summary>
+    /// The version pattern seeded beside <see cref="DefaultPolicy"/> when the node is created —
+    /// <c>null</c> (the default) seeds none. Only meaningful with
+    /// <see cref="UpdatePolicyKind.Continuous"/>: a dev/test host that should stay on the current
+    /// line's continuous builds sets e.g. <c>SelfUpdate__DefaultPattern=3.0.0-ci*</c>. An EXISTING
+    /// record is never touched by this value — the pattern is edited on the record itself
+    /// (Settings → Updates).
+    /// </summary>
+    public string? DefaultPattern { get; init; }
 
     /// <summary>The full image reference for a portal version tag.</summary>
     public string PortalImage(string tag) => $"{Registry}/{PortalRepository}:{tag}";

--- a/src/MeshWeaver.Hosting/SelfUpdate/UpdateChannelPattern.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/UpdateChannelPattern.cs
@@ -42,13 +42,18 @@ public static class UpdateChannelPattern
     /// pattern admits NOTHING — the caller decides what "no pattern" means (for the update policy:
     /// clean releases only), never this matcher, so an absent pattern can never widen a channel.
     /// </summary>
-    public static bool Matches(string? pattern, string tag)
-    {
-        var normalized = Normalize(pattern);
-        if (normalized is null || string.IsNullOrEmpty(tag))
-            return false;
-        return Regex.IsMatch(tag, ToRegex(normalized), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    }
+    public static bool Matches(string? pattern, string tag) =>
+        Compile(pattern) is { } regex && !string.IsNullOrEmpty(tag) && regex.IsMatch(tag);
+
+    /// <summary>
+    /// The matcher for <paramref name="pattern"/>, compiled ONCE — a listing walks hundreds of tags
+    /// (memex-cloud measured 1268), so the caller filtering a listing holds this and tests each tag
+    /// against it rather than re-translating the glob per tag. Null for no pattern.
+    /// </summary>
+    public static Regex? Compile(string? pattern) =>
+        Normalize(pattern) is { } normalized
+            ? new Regex(ToRegex(normalized), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)
+            : null;
 
     /// <summary>The anchored regular expression <paramref name="glob"/> denotes — exposed so a
     /// test can pin the translation rather than infer it from matches.</summary>

--- a/src/MeshWeaver.Hosting/SelfUpdate/UpdateChannelPattern.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/UpdateChannelPattern.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+
+namespace MeshWeaver.Hosting.SelfUpdate;
+
+/// <summary>
+/// The VERSION PATTERN an <c>Admin/UpdatePolicy</c> record uses to opt into continuous builds —
+/// a glob over the registry tag, e.g. <c>3.0.1-ci*</c>.
+///
+/// <para>🚨 <b>Why a pattern at all (maintainer, 2026-09-08).</b> <i>"By default we will not
+/// upgrade as long as no version without <c>-ci…</c> is labelled ⇒ we want a clean label
+/// <c>3.0.1</c> to upgrade. If we want to get the <c>-ci…</c> we have to specify the pattern
+/// <c>3.0.1-ci*</c>."</i> A pre-release tag is therefore never eligible on its own: it is eligible
+/// only when a pattern on the policy record ADMITS it. The pattern is deliberately a glob and not a
+/// SemVer range — an operator writes the line they want to follow the way it appears in the
+/// registry, and <c>3.0.0-ci*</c> can never admit <c>3.0.1</c> or <c>3.0.1-ci.4</c>, which is the
+/// whole point: following one line's continuous builds is a decision that ends when the next
+/// clean release is cut, and it ends by the pattern no longer matching anything new.</para>
+///
+/// <para>The pattern only says WHICH tags are candidates. Their ORDER is still the
+/// sealed-publication lineage (<c>PlatformReleaseOrder</c>): among <c>3.0.1-ci.7845</c> and
+/// <c>3.0.1-ci.8059</c> the run number decides, so <c>ci.7845 &lt; ci.8059</c> numerically and a
+/// retired <c>rc</c> label never outranks a later run.</para>
+///
+/// <para>Pure. <c>*</c> matches any run of characters, <c>?</c> exactly one, everything else
+/// literally; the whole tag must match; case-insensitive because registries are.</para>
+/// </summary>
+public static class UpdateChannelPattern
+{
+    /// <summary>
+    /// <paramref name="pattern"/> with surrounding whitespace removed, or <c>null</c> when it is
+    /// null, empty or whitespace — the ONE notion of "no pattern", so a record whose field reads
+    /// <c>" "</c> is not silently a different policy from one whose field is absent.
+    /// </summary>
+    public static string? Normalize(string? pattern)
+    {
+        var trimmed = pattern?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="tag"/> is admitted by <paramref name="pattern"/>. A null/blank
+    /// pattern admits NOTHING — the caller decides what "no pattern" means (for the update policy:
+    /// clean releases only), never this matcher, so an absent pattern can never widen a channel.
+    /// </summary>
+    public static bool Matches(string? pattern, string tag)
+    {
+        var normalized = Normalize(pattern);
+        if (normalized is null || string.IsNullOrEmpty(tag))
+            return false;
+        return Regex.IsMatch(tag, ToRegex(normalized), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    /// <summary>The anchored regular expression <paramref name="glob"/> denotes — exposed so a
+    /// test can pin the translation rather than infer it from matches.</summary>
+    public static string ToRegex(string glob) =>
+        "^" + Regex.Escape(glob).Replace(@"\*", ".*").Replace(@"\?", ".") + "$";
+}

--- a/src/MeshWeaver.Hosting/SelfUpdate/UpdatePolicyKind.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/UpdatePolicyKind.cs
@@ -5,15 +5,29 @@ namespace MeshWeaver.Hosting.SelfUpdate;
 // REGISTRATION stays in the portal, so existing Admin/UpdatePolicy nodes keep deserializing
 // whether or not the module is listed.
 
-/// <summary>The platform auto-update strategy — the single value on <c>Admin/UpdatePolicy</c>.</summary>
+/// <summary>
+/// The platform auto-update strategy — the single value on <c>Admin/UpdatePolicy</c>.
+///
+/// <para>🚨 <b>The default is <see cref="Stable"/> — clean releases only (maintainer, 2026-09-08):</b>
+/// <i>"by default we will not upgrade as long as no version without <c>-ci…</c> is labelled ⇒ we
+/// want to have a clean label <c>3.0.1</c> to upgrade."</i> A continuous build (<c>X.Y.Z-ci.&lt;n&gt;</c>)
+/// is taken only under <see cref="Continuous"/> AND only when the record's version pattern admits
+/// it (<see cref="UpdateChannelPattern"/>, e.g. <c>3.0.1-ci*</c>); <see cref="Continuous"/> with no
+/// pattern behaves as <see cref="Stable"/> and says so once at Warning, naming the pattern to set.</para>
+///
+/// <para>🚨 The enum ORDER is binary contract: the hub serializer drops whichever member is zero on
+/// write (<c>WhenWritingDefault</c>), which is why <c>UpdatePolicyContent.DeclaredPolicy</c> is
+/// nullable rather than this enum being reordered to put the default first. Do not reorder.</para>
+/// </summary>
 public enum UpdatePolicyKind
 {
-    /// <summary>Always roll to the newest image on ACR, INCLUDING build-numbered continuous builds
-    /// (e.g. <c>3.0.0-ci.51</c>). This is the platform default.</summary>
+    /// <summary>Follow the continuous builds the policy record's version PATTERN admits (e.g.
+    /// <c>3.0.1-ci*</c> ⇒ every sealed <c>3.0.1-ci.&lt;n&gt;</c>, newest run first). Without a pattern
+    /// this is <see cref="Stable"/>: no pre-release is ever eligible on its own.</summary>
     Continuous,
 
-    /// <summary>Roll only to the newest CLEAN release (no build number, e.g. <c>3.0.0</c>); ignore
-    /// continuous build-numbered images.</summary>
+    /// <summary>Roll only to the newest CLEAN release (no pre-release label, e.g. <c>3.0.1</c>);
+    /// ignore every continuous build. <b>This is the platform default.</b></summary>
     Stable,
 
     /// <summary>Never auto-update. Updates are applied manually (operator / admin action).</summary>

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -660,6 +660,7 @@
   "ui.mdLoadingPrivacy": "_Datenschutzerklärung wird geladen…_",
   "ui.mdLoadingRepoSettings": "_Repository-Einstellungen werden geladen…_",
   "ui.mdLoadingUpdatePolicy": "_Update-Richtlinie wird geladen…_",
+  "ui.mdUpdatePolicyIntro": "Die Plattform aktualisiert sich selbst gemäss der Strategie unten. **Stable** (Standard) wechselt nur auf saubere Releases wie `3.0.1`. **Continuous** wechselt auf die Continuous-Builds, die das **Versionsmuster** zulässt — zum Beispiel `3.0.1-ci*` — und verhält sich ohne Muster wie Stable. **None** schaltet die automatische Aktualisierung aus. **Nur auf CI-geprüfte (grüne) Builds aktualisieren** (standardmässig an) hält die Installation auf Builds, die CI bestanden haben — ausschalten, um auch ungeprüfte Edge-Builds zu akzeptieren. Auf Kubernetes patcht das Portal sein eigenes Deployment; sonst wird die neueste Version für ein manuelles Update angezeigt.",
   "ui.mdNoCommits": "_Keine Commits._",
   "ui.mdNoDocumentData": "_Keine Dokumentdaten._",
   "ui.mdNoFileChanges": "_Keine Dateiänderungen._",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -660,6 +660,7 @@
   "ui.mdLoadingPrivacy": "_Loading privacy statement…_",
   "ui.mdLoadingRepoSettings": "_Loading repository settings…_",
   "ui.mdLoadingUpdatePolicy": "_Loading update policy…_",
+  "ui.mdUpdatePolicyIntro": "The platform self-updates per the strategy below. **Stable** (the default) rolls only to clean releases such as `3.0.1`. **Continuous** rolls to the continuous builds the **version pattern** admits — for example `3.0.1-ci*` — and without a pattern it behaves like Stable. **None** disables auto-update. **Only update to CI-verified (green) builds** (default on) keeps the install on builds that passed CI — turn it off to also accept unverified edge builds. On Kubernetes the portal patches its own deployment; elsewhere the latest version is surfaced for a manual update.",
   "ui.mdNoCommits": "_No commits._",
   "ui.mdNoDocumentData": "_No document data._",
   "ui.mdNoFileChanges": "_No file changes._",

--- a/test/Memex.Portal.Shared.Test/ComboGateRollTest.cs
+++ b/test/Memex.Portal.Shared.Test/ComboGateRollTest.cs
@@ -381,6 +381,7 @@ public class ComboGateRollTest(ITestOutputHelper output) : MonolithMeshTestBase(
         RetryInterval = TimeSpan.FromMilliseconds(500),
         EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
         DefaultPolicy = UpdatePolicyKind.Continuous,
+        DefaultPattern = "*-ci*",
     };
 
     /// <summary>Fake registry (the documented IO seam): one build newer than anything installed.</summary>
@@ -575,7 +576,8 @@ public class ComboGateRollTest(ITestOutputHelper output) : MonolithMeshTestBase(
     private Task Seed(bool held = false)
     {
         var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
-        var content = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous };
+        // 2026-09-08: the candidate is a ci build, eligible only under a pattern that admits it.
+        var content = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, Pattern = "*-ci*" };
         if (held)
             content = content with
             {

--- a/test/Memex.Portal.Shared.Test/OciTagListerTest.cs
+++ b/test/Memex.Portal.Shared.Test/OciTagListerTest.cs
@@ -164,6 +164,7 @@ public class OciTagListerTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             RetryInterval = TimeSpan.FromMilliseconds(500),
             EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
             DefaultPolicy = UpdatePolicyKind.Continuous,
+            DefaultPattern = "*-ci*",
         };
         var service = new SeamedSelfUpdateService(
             Mesh, new AcrMustNotBeCalled(), updater, options,
@@ -338,7 +339,8 @@ public class OciTagListerTest(ITestOutputHelper output) : MonolithMeshTestBase(o
             NodeType = UpdatePolicyNodeType.NodeType,
             Name = "Update Policy",
             State = MeshNodeState.Active,
-            Content = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous },
+            // 2026-09-08: the newest tag is a ci build, eligible only under a pattern that admits it.
+            Content = new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, Pattern = "*-ci*" },
         };
         return Observable.Create<MeshNode>(observer =>
             {

--- a/test/Memex.Portal.Shared.Test/SelfUpdatePendingRestartTest.cs
+++ b/test/Memex.Portal.Shared.Test/SelfUpdatePendingRestartTest.cs
@@ -268,6 +268,7 @@ public class SelfUpdatePendingRestartTest(ITestOutputHelper output) : MonolithMe
         RetryInterval = TimeSpan.FromMilliseconds(500),
         EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
         DefaultPolicy = UpdatePolicyKind.Continuous,
+        DefaultPattern = "*-ci*",
     };
 
     private async Task<UpdatePolicyContent> RunOneCheck(
@@ -302,7 +303,12 @@ public class SelfUpdatePendingRestartTest(ITestOutputHelper output) : MonolithMe
             NodeType = UpdatePolicyNodeType.NodeType,
             Name = "Update Policy",
             State = MeshNodeState.Active,
-            Content = new UpdatePolicyContent { Policy = policy },
+            // 2026-09-08: a continuous build is eligible only when a pattern admits it.
+            Content = new UpdatePolicyContent
+            {
+                Policy = policy,
+                Pattern = policy == UpdatePolicyKind.Continuous ? "*-ci*" : null,
+            },
         };
         return Observable.Create<MeshNode>(observer =>
             {

--- a/test/Memex.Portal.Shared.Test/SelfUpdateStrandRecoveryTest.cs
+++ b/test/Memex.Portal.Shared.Test/SelfUpdateStrandRecoveryTest.cs
@@ -244,6 +244,7 @@ public class SelfUpdateStrandRecoveryTest(ITestOutputHelper output) : MonolithMe
         RetryInterval = TimeSpan.FromMilliseconds(500),
         EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
         DefaultPolicy = policy,
+        DefaultPattern = policy == UpdatePolicyKind.Continuous ? "*-ci*" : null,
     };
 
     /// <summary>
@@ -286,7 +287,13 @@ public class SelfUpdateStrandRecoveryTest(ITestOutputHelper output) : MonolithMe
             NodeType = UpdatePolicyNodeType.NodeType,
             Name = "Update Policy",
             State = MeshNodeState.Active,
-            Content = new UpdatePolicyContent { Policy = policy },
+            // 2026-09-08: a continuous build is eligible only when a pattern admits it — a
+            // Continuous seed without one is Stable and would roll to no ci tag at all.
+            Content = new UpdatePolicyContent
+            {
+                Policy = policy,
+                Pattern = policy == UpdatePolicyKind.Continuous ? "*-ci*" : null,
+            },
         };
         // System scope opened/closed SYNCHRONOUSLY around the subscribe — impersonation is an
         // AsyncLocal, so Observable.Using would restore it on the wrong thread.

--- a/test/Memex.Portal.Shared.Test/UpdatePolicyMcpPatchTest.cs
+++ b/test/Memex.Portal.Shared.Test/UpdatePolicyMcpPatchTest.cs
@@ -25,8 +25,8 @@ namespace Memex.Portal.Shared.Test;
 /// (<c>"Patched: Admin/UpdatePolicy"</c>, no version-transition suffix) while the durable node
 /// stayed on its old <see cref="UpdatePolicyContent.Policy"/> — the operator's auto-update
 /// kill-switch never took effect. Reproduces the exact operator sequence against a REAL mesh:
-/// seed the node at the PLATFORM DEFAULT policy (<see cref="UpdatePolicyKind.Continuous"/> —
-/// also the enum's own default value, so it is OMITTED from JSON under this hub's
+/// seed the node at <see cref="UpdatePolicyKind.Continuous"/> (the platform default until
+/// 2026-09-08, and still the enum's own default value, so it is OMITTED from JSON under this hub's
 /// <c>DefaultIgnoreCondition = WhenWritingDefault</c>), then run the exact MCP <c>patch</c> call
 /// an operator would issue to freeze auto-update, while the self-update poller concurrently
 /// writes its own bookkeeping fields (<c>checkedAt</c> / <c>latestAvailableTag</c>) on the SAME
@@ -183,8 +183,8 @@ public class UpdatePolicyMcpPatchTest(ITestOutputHelper output) : MonolithMeshTe
             NodeType = UpdatePolicyNodeType.NodeType,
             Name = "Update Policy",
             State = MeshNodeState.Active,
-            // The default overload seeds at the PLATFORM default AND the enum's own default
-            // (Continuous = 0) — deliberately, so it is omitted from JSON under
+            // The default overload seeds at the enum's own default (Continuous = 0; the platform
+            // default is Stable since 2026-09-08) — deliberately, so it is omitted from JSON under
             // DefaultIgnoreCondition = WhenWritingDefault, exactly like the real
             // Admin/UpdatePolicy node on a fresh install.
             Content = new UpdatePolicyContent { Policy = policy },

--- a/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
+++ b/test/Memex.Portal.Shared.Test/VersionSelectTest.cs
@@ -75,6 +75,181 @@ public class VersionSelectTest
     public void UpdatePolicyContent_DefaultsToRequireCiGreen()
         => Assert.True(new UpdatePolicyContent().RequireCiGreen, "green-only must be the safe default");
 
+    // ───────── 2026-09-08: clean releases by default; continuous builds by PATTERN only ─────────
+    //
+    // Maintainer: "by default we will not upgrade as long as no version without -ci... is labelled.
+    // ==> we want to have a clean label 3.0.1 to upgrade. if we want to get the -ci... we have to
+    // specify the pattern 3.0.1-ci* or something. at the moment it is 3.0.0-ci* as we have not
+    // released anything else."
+
+    /// <summary>The registry after 3.0.1 is tagged and the next line has started: the clean
+    /// release, its own ci builds, and the next line's first ci build. Run numbers are MONOTONIC
+    /// across lines, as the pipeline produces them (#3542) — `3.0.1-ci.8112` was published after
+    /// `3.0.0-ci.8059`, whatever the labels say.</summary>
+    private static readonly string[] LineRegistry =
+    [
+        "3.0.0", "3.0.0-ci.8059", "3.0.1-ci.8112", "3.0.1-ci.8130", "3.0.1", "3.0.2-ci.8140",
+        "3-latest", "3.0-latest", "3.0.1-latest",
+    ];
+
+    /// <summary>🚨 The seeded default is Stable — clean releases only — and it is the ONE default.</summary>
+    [Fact]
+    public void TheDefaultPolicy_IsCleanReleasesOnly()
+    {
+        Assert.Equal(UpdatePolicyKind.Stable, new SelfUpdateOptions().DefaultPolicy);
+        Assert.Null(new SelfUpdateOptions().DefaultPattern);
+    }
+
+    /// <summary>Clean-only ignores <c>3.0.1-ci.12</c> and picks <c>3.0.1</c> — an install that has
+    /// never opted into a pattern sees the release and nothing before it.</summary>
+    [Fact]
+    public void CleanOnly_IgnoresTheCiBuilds_AndPicksTheRelease()
+    {
+        var selection = VersionSelect.SelectCandidates(LineRegistry, "3.0.0", UpdatePolicyKind.Stable);
+        Assert.Equal(["3.0.1"], selection.Candidates);
+    }
+
+    /// <summary>🚨 The rule itself: <c>Continuous</c> WITHOUT a pattern decides exactly as
+    /// <c>Stable</c> — no pre-release is eligible on its own — and says so.</summary>
+    [Fact]
+    public void ContinuousWithoutAPattern_IsStable_AndSaysSo()
+    {
+        var channel = VersionSelect.ResolveChannel(UpdatePolicyKind.Continuous, null);
+        Assert.Equal(UpdatePolicyKind.Stable, channel.Policy);
+        Assert.Null(channel.Pattern);
+        Assert.NotNull(channel.Advisory);
+        Assert.Contains(UpdatePolicyNodeType.NodePath, channel.Advisory, StringComparison.Ordinal);
+        Assert.Contains("pattern", channel.Advisory, StringComparison.Ordinal);
+        Assert.Contains("3.0.0-ci*", channel.Advisory, StringComparison.Ordinal);
+
+        // A blank pattern is no pattern — " " must not be a third policy.
+        Assert.Equal(UpdatePolicyKind.Stable, VersionSelect.ResolveChannel(UpdatePolicyKind.Continuous, "  ").Policy);
+
+        var selection = VersionSelect.SelectCandidates(
+            LineRegistry, "3.0.0", UpdatePolicyKind.Continuous, pattern: null);
+        Assert.Equal(["3.0.1"], selection.Candidates);
+
+        // The other two policies carry no advisory: they mean what they say.
+        Assert.Null(VersionSelect.ResolveChannel(UpdatePolicyKind.Stable, null).Advisory);
+        Assert.Null(VersionSelect.ResolveChannel(UpdatePolicyKind.None, null).Advisory);
+        Assert.Null(VersionSelect.ResolveChannel(UpdatePolicyKind.Continuous, "3.0.1-ci*").Advisory);
+        Assert.Equal(UpdatePolicyKind.None, VersionSelect.ResolveChannel(UpdatePolicyKind.None, "3.0.1-ci*").Policy);
+    }
+
+    /// <summary>Pattern <c>3.0.1-ci*</c> picks the highest ci of 3.0.1 — by run number, so
+    /// <c>ci.8130</c> over <c>ci.8112</c> — and NOT <c>3.0.2-ci.8140</c>, and not the clean
+    /// <c>3.0.1</c> either: the glob names the line's continuous builds and nothing else.</summary>
+    [Fact]
+    public void APattern_AdmitsExactlyTheLineItNames()
+    {
+        var selection = VersionSelect.SelectCandidates(
+            LineRegistry, "3.0.0-ci.8059", UpdatePolicyKind.Continuous, pattern: "3.0.1-ci*");
+        Assert.Equal(["3.0.1-ci.8130", "3.0.1-ci.8112"], selection.Candidates);
+        Assert.Equal("3.0.1-ci.8130",
+            VersionSelect.PickTarget(LineRegistry, UpdatePolicyKind.Continuous, pattern: "3.0.1-ci*"));
+    }
+
+    /// <summary>🚨 The fleet's own setting today: <c>3.0.0-ci*</c> never picks <c>3.0.1</c> (nor
+    /// <c>3.0.1-ci.*</c>). Following one line's continuous builds ENDS by the pattern matching
+    /// nothing new — which is why the docs say to change it the day 3.0.1 is tagged.</summary>
+    [Fact]
+    public void TheCurrentFleetPattern_NeverCrossesToTheNextRelease()
+    {
+        Assert.Equal(["3.0.0-ci.8059"],
+            VersionSelect.PickTargets(LineRegistry, UpdatePolicyKind.Continuous, pattern: "3.0.0-ci*"));
+
+        var settled = VersionSelect.SelectCandidates(
+            LineRegistry, "3.0.0-ci.8059", UpdatePolicyKind.Continuous, pattern: "3.0.0-ci*");
+        Assert.Empty(settled.Candidates);
+        Assert.False(settled.IsRecovery);
+    }
+
+    /// <summary>Ordering under a pattern is still the lineage: <c>ci.7845 &lt; ci.8059</c> numerically,
+    /// a retired <c>rc</c> label never outranks a later run, and the clean release ranks above its
+    /// own pre-releases wherever both are admitted (a pattern wide enough to admit both).</summary>
+    [Fact]
+    public void UnderAPattern_TheOrderIsStillTheLineage()
+    {
+        string[] registry = ["3.0.0-ci.7845", "3.0.0-rc9.ci.7824", "3.0.0-ci.8059", "3.0.0"];
+
+        Assert.Equal(["3.0.0-ci.8059", "3.0.0-ci.7845"],
+            VersionSelect.PickTargets(registry, UpdatePolicyKind.Continuous, pattern: "3.0.0-ci*"));
+        // `3.0.0*` admits the rc tag and the release too: run number first, promotion last.
+        Assert.Equal(["3.0.0-ci.8059", "3.0.0-ci.7845", "3.0.0-rc9.ci.7824", "3.0.0"],
+            VersionSelect.PickTargets(registry, UpdatePolicyKind.Continuous, pattern: "3.0.0*"));
+        Assert.True(VersionSelect.IsNewer("3.0.0-ci.8059", "3.0.0-ci.7845"));
+        Assert.True(VersionSelect.IsNewer("3.0.0", "3.0.0-ci.8059"));
+    }
+
+    /// <summary>A pattern narrows <c>Stable</c> too — <c>3.0.*</c> keeps an install on one line's
+    /// clean releases while the next line's release exists.</summary>
+    [Fact]
+    public void APattern_NarrowsStable_ToOneLine()
+    {
+        string[] registry = ["3.0.1", "3.1.0", "3.1.0-ci.9000", "3.0.2"];
+        Assert.Equal(["3.0.2", "3.0.1"],
+            VersionSelect.PickTargets(registry, UpdatePolicyKind.Stable, pattern: "3.0.*"));
+    }
+
+    /// <summary>🚨 The moving image pointers (<c>3-latest</c>, <c>3.0-latest</c>, <c>3.0.1-latest</c>)
+    /// are POINTERS, not versions: never a candidate, under any policy or pattern — even a pattern
+    /// that would match them textually.</summary>
+    [Fact]
+    public void MovingPointers_AreNeverCandidates()
+    {
+        string[] registry = ["3-latest", "3.0-latest", "3.0.1-latest", "latest", "3.0.1"];
+        Assert.Equal(["3.0.1"], VersionSelect.PickTargets(registry, UpdatePolicyKind.Stable));
+        Assert.Equal(["3.0.1"], VersionSelect.PickTargets(registry, UpdatePolicyKind.Continuous));
+        Assert.Empty(VersionSelect.PickTargets(registry, UpdatePolicyKind.Continuous, pattern: "*-latest"));
+        Assert.Empty(VersionSelect.PickTargets(registry, UpdatePolicyKind.Continuous, pattern: "3-latest"));
+    }
+
+    /// <summary>The glob itself: <c>*</c> any run, <c>?</c> one character, everything else literal,
+    /// whole-tag, case-insensitive; a blank pattern admits nothing (the CALLER decides what "no
+    /// pattern" means, never the matcher).</summary>
+    [Theory]
+    [InlineData("3.0.1-ci*", "3.0.1-ci.12", true)]
+    [InlineData("3.0.1-ci*", "3.0.1-CI.12", true)]
+    [InlineData("3.0.1-ci*", "3.0.1", false)]
+    [InlineData("3.0.1-ci*", "3.0.10-ci.1", false)]
+    [InlineData("3.0.?-ci*", "3.0.7-ci.1", true)]
+    [InlineData("3.0.?-ci*", "3.0.10-ci.1", false)]
+    [InlineData("3.0.*", "3.0.1", true)]
+    [InlineData("3.0.*", "3.1.0", false)]
+    [InlineData("", "3.0.1", false)]
+    [InlineData(null, "3.0.1", false)]
+    [InlineData("   ", "3.0.1", false)]
+    public void UpdateChannelPattern_IsAWholeTagGlob(string? pattern, string tag, bool expected)
+        => Assert.Equal(expected, UpdateChannelPattern.Matches(pattern, tag));
+
+    [Fact]
+    public void UpdateChannelPattern_EscapesEverythingButTheWildcards()
+    {
+        Assert.Equal(@"^3\.0\.1-ci.*$", UpdateChannelPattern.ToRegex("3.0.1-ci*"));
+        Assert.Null(UpdateChannelPattern.Normalize("  "));
+        Assert.Equal("3.0.1-ci*", UpdateChannelPattern.Normalize(" 3.0.1-ci* "));
+    }
+
+    /// <summary>The pattern round-trips on the record as <c>pattern</c>, and its absence stays
+    /// absent (the serializer drops nulls, and null is the one "no pattern").</summary>
+    [Fact]
+    public void UpdatePolicyContent_PatternRoundTrips_AsPattern()
+    {
+        var element = JsonSerializer.SerializeToElement(
+            new UpdatePolicyContent { Policy = UpdatePolicyKind.Continuous, Pattern = "3.0.0-ci*" }, Web);
+        Assert.Equal("3.0.0-ci*", element.GetProperty("pattern").GetString());
+        var parsed = UpdatePolicyNodeType.ParseContent(element, Web);
+        Assert.Equal("3.0.0-ci*", parsed.Pattern);
+        Assert.Equal(UpdatePolicyKind.Continuous, parsed.Policy);
+
+        // These Web options write nulls out (the hub's own options drop them); either way the
+        // read is "no pattern", which is the one fact the record must not lose.
+        var bare = JsonSerializer.SerializeToElement(
+            new UpdatePolicyContent { Policy = UpdatePolicyKind.Stable }, Web);
+        Assert.True(!bare.TryGetProperty("pattern", out var p) || p.ValueKind == JsonValueKind.Null);
+        Assert.Null(UpdatePolicyNodeType.ParseContent(bare, Web).Pattern);
+    }
+
     [Theory]
     [InlineData("3.1.0-ci.55", "3.0.0-ci.51", true)]  // later run on a higher base wins
     [InlineData("3.0.0-ci.51", "3.0.0-ci.40", true)]  // monotonic ci number
@@ -287,22 +462,31 @@ public class VersionSelectTest
         Assert.Equal("3.0.0-ci.7989", VersionSelect.PickTarget(registry, UpdatePolicyKind.Continuous));
 
         // 2. 🚨 Nothing newer ON the line ⇒ nothing to take. The release must NOT be the answer, and
-        //    it is exactly here that SemVer would have said it was.
+        //    it is exactly here that SemVer would have said it was. (2026-09-08: "on the line" now
+        //    needs the pattern that admits the line — see case 5.)
         var settled = VersionSelect.SelectCandidates(
-            registry, "3.0.0-ci.7989", UpdatePolicyKind.Continuous);
+            registry, "3.0.0-ci.7989", UpdatePolicyKind.Continuous, pattern: "3.0.0-ci*");
         Assert.Empty(settled.Candidates);
         Assert.False(settled.IsRecovery);
 
         // 3. A newer ci build ⇒ take it, and the release is not even a fallback the gate walk could
         //    drop through to.
         var rolling = VersionSelect.SelectCandidates(
-            registry, "3.0.0-ci.7977", UpdatePolicyKind.Continuous);
+            registry, "3.0.0-ci.7977", UpdatePolicyKind.Continuous, pattern: "3.0.0-ci*");
         Assert.Equal(["3.0.0-ci.7989"], rolling.Candidates);
 
-        // 4. An install NOT on the line is not held off it: it rejoins at the next line's ci builds.
+        // 4. An install NOT on the line is not held off it: it rejoins at the next line's ci builds
+        //    — provided its pattern admits them.
         var offTheLine = VersionSelect.SelectCandidates(
-            ["3.0.0", "3.1.0-ci.8100"], "3.0.0", UpdatePolicyKind.Continuous);
+            ["3.0.0", "3.1.0-ci.8100"], "3.0.0", UpdatePolicyKind.Continuous, pattern: "*-ci*");
         Assert.Equal(["3.1.0-ci.8100"], offTheLine.Candidates);
+
+        // 5. 🚨 2026-09-08: the SAME record with NO pattern is Stable — and Stable DOES take the
+        //    release above its pre-releases. The ci-line rule protects an install that opted into
+        //    the line; one that never wrote a pattern is waiting for exactly this clean label.
+        var noPattern = VersionSelect.SelectCandidates(
+            registry, "3.0.0-ci.7989", UpdatePolicyKind.Continuous);
+        Assert.Equal(["3.0.0"], noPattern.Candidates);
     }
 
     /// <summary>
@@ -391,7 +575,7 @@ public class VersionSelectTest
         string[] registry = ["3.0.0-ci.7000", "3.0.0-ci.7100"];
 
         var selection = VersionSelect.SelectCandidates(
-            registry, "3.1.0-ci.7841", UpdatePolicyKind.Continuous);
+            registry, "3.1.0-ci.7841", UpdatePolicyKind.Continuous, pattern: "*-ci*");
 
         Assert.True(selection.IsRecovery,
             "nothing is newer than a withdrawn tag, so 'nothing newer' cannot be the answer");
@@ -413,7 +597,8 @@ public class VersionSelectTest
         var selection = VersionSelect.SelectCandidates(
             ["3.0.0-ci.7955", "3.0.0-ci.7962", "3.0.0-ci.7977"],
             "3.1.0-ci.7841",
-            UpdatePolicyKind.Continuous);
+            UpdatePolicyKind.Continuous,
+            pattern: "*-ci*");
 
         Assert.False(selection.IsRecovery);
         Assert.Equal("3.0.0-ci.7977", selection.Candidates[0]);
@@ -454,7 +639,7 @@ public class VersionSelectTest
     public void SomethingNewer_IsAnOrdinaryUpdate_EvenWhenTheInstalledTagIsGone()
     {
         var selection = VersionSelect.SelectCandidates(
-            ["3.0.0-ci.7977"], "3.1.0-ci.7000", UpdatePolicyKind.Continuous);
+            ["3.0.0-ci.7977"], "3.1.0-ci.7000", UpdatePolicyKind.Continuous, pattern: "*-ci*");
 
         Assert.Equal(["3.0.0-ci.7977"], selection.Candidates);
         Assert.False(selection.IsRecovery);


### PR DESCRIPTION
## Self-update takes clean releases by default; continuous builds are opt-in by version pattern

Maintainer directive, 2026-09-08 (verbatim): *"by default we will not upgrade as long as no version
without -ci... is labelled. ==> we want to have a clean label 3.0.1 to upgrade. if we want to get the
-ci... we have to specify the pattern 3.0.1-ci* or something. at the moment it is 3.0.0-ci* as we have
not released anything else. see you update docs accordingly including release skill and any note on
how we do semver"*.

### What changes

- **`SelfUpdateOptions.DefaultPolicy` is `Stable`** (was `Continuous`): a new install's `Admin/UpdatePolicy`
  is seeded clean-releases-only. New `SelfUpdateOptions.DefaultPattern` (null) seeds a pattern beside it
  for hosts that should track a line (`SelfUpdate__DefaultPolicy=Continuous` + `SelfUpdate__DefaultPattern=3.0.0-ci*`).
  An existing record is never rewritten.
- **`UpdatePolicyContent.Pattern`** (`pattern` on the wire, editable on Settings → Updates, en+de): a glob
  over the registry tag. `UpdateChannelPattern` (MeshWeaver.Hosting) is the pure matcher — `*`, `?`,
  whole-tag, case-insensitive; a blank pattern admits nothing.
- **`VersionSelect.ResolveChannel(policy, pattern)`** — the rule stated once: `None` → nothing; `Stable`
  → clean only (a pattern narrows); `Continuous` + pattern → the tags the pattern admits; **`Continuous`
  without a pattern → `Stable`**, with an advisory the poller logs ONCE per process at Warning naming
  `Admin/UpdatePolicy` and the pattern to set. `SelectCandidates` resolves the channel itself, so the
  decision can never run on an unresolved one. `PickTargets` keeps its LISTING semantics (the
  availability service enumerates publications through it under `Continuous`).
- Ordering under a pattern is unchanged — still the sealed-publication lineage (`ci.7845 < ci.8059`
  numerically, a retired `rc` never outranks a later run, the promotion band last).
- **The moving image pointers (`3-latest`, `3.0-latest`, `3.0.1-latest`, core #3715) are never
  candidates**: `3.0.1-latest` has the dotted shape and NuGet-parses as a pre-release, so `VersionSelect`
  now drops `-latest` structurally, before any policy or pattern.
- Editing the pattern is a policy change: the poller's `PolicyChange` trigger keys on `(Policy, Pattern)`.
- The Updates tab's intro text moves from a hard-coded English literal to `ui.mdUpdatePolicyIntro` (en+de).

### Record shapes an operator writes

```json
{ "$type": "UpdatePolicyContent", "policy": "Stable" }                                   // clean only — the default
{ "$type": "UpdatePolicyContent", "policy": "Continuous", "pattern": "3.0.1-ci*" }      // follow one line's builds
```

**Fleet today:** `memex` and `memex-cloud` are to carry `Continuous` + `3.0.0-ci*` (no clean release above
3.0.0 exists); the pattern stops matching the day `3.0.1` is tagged — remove it or move it to `3.0.1-ci*`.
Measured 2026-09-08: memex.systemorph.com's record reads `policy: None`; nothing here changes it.

### Tests (`VersionSelectTest`, pure)

- `TheDefaultPolicy_IsCleanReleasesOnly`, `CleanOnly_IgnoresTheCiBuilds_AndPicksTheRelease`
  (`3.0.1-ci.*` ignored, `3.0.1` picked), `ContinuousWithoutAPattern_IsStable_AndSaysSo`,
  `APattern_AdmitsExactlyTheLineItNames` (`3.0.1-ci*` → highest ci of 3.0.1, never `3.0.2-ci.*`),
  `TheCurrentFleetPattern_NeverCrossesToTheNextRelease` (`3.0.0-ci*` never picks `3.0.1`),
  `UnderAPattern_TheOrderIsStillTheLineage` (ci < rc < release), `APattern_NarrowsStable_ToOneLine`,
  `MovingPointers_AreNeverCandidates`, the glob truth table, the JSON round trip.
- The four existing `SelectCandidates` tests that exercised `Continuous` on ci tags now pass the pattern
  they implicitly assumed (`*-ci*`), and `ContinuousFollowsTheCiLine…` gains case 5: the same record with
  NO pattern takes the clean release. Poller tests (`SelfUpdateStrandRecoveryTest`, `SelfUpdatePendingRestartTest`,
  `ComboGateRollTest`, `OciTagListerTest`) seed `Pattern = "*-ci*"` beside `Continuous` for the same reason.
- Run locally, Release: the 17 self-update/policy classes (195 tests), `LocalizationTest` (58),
  `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest`.

### Docs (committed)

`ReleaseProcess.md` §1 → new "Which build an install takes — clean releases by default, continuous builds
by pattern" (the table, the three rules, the semver line, the fleet's current `3.0.0-ci*` and when it changes,
the record shapes); `ReleaseStrategy.md` §4 table + abstract + picture + §7/§8; `SelfUpdateTargetSelection.md`
new "…and only the builds its PATTERN admits"; `.claude/skills/release/SKILL.md` (channels table, the
"All portals update" paragraph, the continuous-release recipe); `Modules.md`, `OnboardingNewEnvironment.md`,
`DeploymentAKS.md` where they said "default Continuous". What's New: `2026-09-08-an-install-updates-to-clean-releases-by-default.md`.

### Hand-over

Mirror-sync: npm run sync:i18n -- --ref <merged core sha> in MeshWeaver.Plugins/clients/react — tracked on Systemorph/MeshWeaver.Plugins#1520 (core adds ui.mdUpdatePolicyIntro).
- The fleet records (`memex`, `memex-cloud`) are set through Settings → Updates / MCP `patch`, a deploy
  decision for the operator, not this PR.

Pairs-with: none — no public type or member leaves; `EnsureExists` gains an optional trailing parameter.
