### PR TITLE
Publish: the writer learns the generation layout, behind a per-caller selector

### DIFF
--- a/.github/scripts/bake-scope.sh
+++ b/.github/scripts/bake-scope.sh
@@ -72,23 +72,27 @@ if [ "${1:-}" = "--self-test" ]; then
   mkdir -p "$ST_TMP/bin"
   cat > "$ST_TMP/bin/az" <<'AZ'
 #!/usr/bin/env bash
+group="$2"          # file | directory
 verb=""
 for a in "$@"; do case "$a" in exists|download) verb="$a"; break;; esac; done
-account=""; share=""; path=""; dest=""
+account=""; share=""; path=""; dest=""; name=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --account-name) account="$2"; shift 2;;
     --share-name)   share="$2";   shift 2;;
     --path)         path="$2";    shift 2;;
     --dest)         dest="$2";    shift 2;;
+    --name)         name="$2";    shift 2;;
     *) shift;;
   esac
 done
 file="$MOCK_AZ_ROOT/$account/$share/$path"
-case "$verb" in
-  exists)   { [ -f "$file" ] && echo true; } || echo false;;
-  download) [ -f "$file" ] || exit 1; mkdir -p "$(dirname "$dest")"; cp "$file" "$dest";;
-  *) exit 1;;
+dir="$MOCK_AZ_ROOT/$account/$share/$name"
+case "$group/$verb" in
+  directory/exists) { [ -d "$dir" ] && echo true; } || echo false;;
+  file/exists)      { [ -f "$file" ] && echo true; } || echo false;;
+  file/download)    [ -f "$file" ] || exit 1; mkdir -p "$(dirname "$dest")"; cp "$file" "$dest";;
+  *) echo "stub-az: unmodelled '$group $verb' — teach the stub rather than letting the script fall back" >&2; exit 64;;
 esac
 AZ
   chmod +x "$ST_TMP/bin/az"
@@ -127,6 +131,19 @@ AZ
     mkdir -p "$dir"
     printf '%s\n' "$sha" > "$dir/source-commit.txt"
     printf '%s\n' "$@" > "$dir/_complete"
+  }
+
+  # A publication under a GENERATION directory, with the pointer naming it (MeshWeaver#3461).
+  seal_generation() {  # <account/share[/base]> <generation> <source-sha> <bundle…>
+    local target="$1" gen="$2" sha="$3"; shift 3
+    local account="${target%%/*}" rest="${target#*/}"
+    local share="${rest%%/*}" base=""
+    case "$rest" in */*) base="${rest#*/}";; esac
+    local prefix="$ST_TMP/remote/$account/$share/${base:+$base/}prebuilt-bundles/ID1/plugins"
+    mkdir -p "$prefix/$gen"
+    printf '%s\n' "$sha" > "$prefix/$gen/source-commit.txt"
+    printf '%s\n' "$@" > "$prefix/$gen/_complete"
+    printf '%s\n' "$gen" > "$prefix/_current"
   }
 
   run_case() {  # <event> <targets> [<head-sha>]
@@ -205,6 +222,30 @@ AZ
   write_selector 0 '{"runAll": false, "mount": [], "affected": [], "skipped": ["Store","Edu"], "support": []}'
   expect "a diff that reaches no module at all (docs/, e2e/, .claude/)" none "$(run_case push acct/share)"
 
+  # ── THE POINTER. The flat copy and the generation deliberately record DIFFERENT baselines, so
+  # ── the verdict says which one was read: a diverged baseline forces `full`, an ancestor one
+  # ── narrows. A resolver that ignored the pointer would read the flat copy and answer `full`.
+  echo "the publication pointer (MeshWeaver#3461) — read the generation, not the prefix:"
+  rm -rf "$ST_TMP/state"; write_selector 0 "$OK_JSON"
+  seal gen/share "$OTHER_SHA" Store.zip Edu.zip Chess.zip
+  seal_generation gen/share Systemorph-MeshWeaver-42-1 "$BASE_SHA" Store.zip Edu.zip Chess.zip
+  OUT=$(run_case push gen/share)
+  expect "the baseline comes from the generation _current names, not the flat copy beside it" \
+    narrowed "$OUT"
+  expect_line "…and it is that generation's recorded commit" baseline "$BASE_SHA" "$OUT"
+  # The control, one variable apart: the same fixture with a pointer nothing backs must fall back
+  # to the flat copy — and say so, so a silent fallback cannot be mistaken for a resolution.
+  rm -rf "$ST_TMP/state"
+  printf '%s\n' "Systemorph-MeshWeaver-9999-1" > "$ST_TMP/remote/gen/share/prebuilt-bundles/ID1/plugins/_current"
+  OUT=$(run_case push gen/share)
+  expect "a pointer naming a generation that is not there falls back to the flat copy" full "$OUT"
+  if printf '%s\n' "$OUT" | grep -q "is not on the share"; then
+    printf '  OK   %s\n' "…and names the dangling pointer rather than falling back in silence"
+  else
+    printf '  FAIL %s\n' "the dangling-pointer fallback said nothing"
+    FAILED=$((FAILED + 1))
+  fi
+
   echo "narrowed:"
   rm -rf "$ST_TMP/state"; write_selector 0 "$OK_JSON"
   OUT=$(run_case push acct/share)
@@ -226,7 +267,7 @@ AZ
     exit 1
   fi
   echo ""
-  echo "bake-scope self-test: 12 full-bake fallbacks, 2 verified nothing-to-do verdicts, 4 narrowed assertions — all green."
+  echo "bake-scope self-test: 12 full-bake fallbacks, 2 verified nothing-to-do verdicts, 4 pointer-resolution assertions, 4 narrowed assertions — all green."
   exit 0
 fi
 
@@ -240,6 +281,57 @@ fi
 
 SENTINEL="_complete"
 SOURCE_MARKER="source-commit.txt"
+
+# ══════════════ THE PUBLICATION POINTER (MeshWeaver#3461) ══════════════
+#
+# A source directory MAY hold `_current`: one line naming the SUBDIRECTORY that holds the
+# publication which currently applies. Absent, it IS its own publication directory — the flat
+# layout, and the only one anything has written until a caller opts in to `publication-layout:
+# generation`.
+#
+# 🚨 THE RULES ARE THE READER'S, EXACTLY (ShippedPrebuiltBundles.PublicationDirectoryOf, and the
+# resolver in publish-bake-bundles.sh). This file, bake-scope.sh and publish-bake-bundles.sh are
+# fetched at ONE `platform-ref`, so no pin can carry half of them — but they must also AGREE, or
+# this lane would read what portals do not serve. Absent, blank, unreadable, not a single path
+# segment, or naming a directory that is not there ⇒ the source directory. A pointer is a NAME: it
+# must never be able to address bytes outside its own source directory.
+POINTER="_current"
+RESOLVED_DIR=""
+resolve_publication_dir() { # <account> <share> <source-dir>
+  _rp_account="$1"; _rp_share="$2"; _rp_source="$3"
+  RESOLVED_DIR="$_rp_source"
+  _rp_exists=$(az storage file exists --account-name "$_rp_account" --share-name "$_rp_share" \
+    --path "$_rp_source/$POINTER" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo "unknown")
+  [ "$_rp_exists" = "true" ] || return 0
+  _rp_local="$(mktemp)"
+  if ! az storage file download --account-name "$_rp_account" --share-name "$_rp_share" \
+      --path "$_rp_source/$POINTER" --dest "$_rp_local" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
+    rm -f "$_rp_local"
+    return 0
+  fi
+  _rp_named=$(sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$_rp_local" | grep -m1 '[^[:space:]]' || true)
+  rm -f "$_rp_local"
+  [ -n "$_rp_named" ] || return 0
+  case "$_rp_named" in
+    # A rooted name always contains a '/', so `*/*` already covers it — shellcheck SC2222 is
+    # right that a separate `/*` arm can never match anything this one does not.
+    .|..|*/*|*\\*)
+      echo "::warning::$_rp_source/$POINTER names '$_rp_named', which is not a single directory name — reading $_rp_source as its own publication directory."
+      return 0 ;;
+  esac
+  _rp_exists=$(az storage directory exists --account-name "$_rp_account" --share-name "$_rp_share" \
+    --name "$_rp_source/$_rp_named" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo "unknown")
+  if [ "$_rp_exists" != "true" ]; then
+    echo "::warning::$_rp_source/$POINTER names generation '$_rp_named', which is not on the share (exists=$_rp_exists) — reading $_rp_source as its own publication directory."
+    return 0
+  fi
+  RESOLVED_DIR="$_rp_source/$_rp_named"
+  return 0
+}
+
 mkdir -p "$STATE_DIR"
 
 SCOPE="full"
@@ -310,7 +402,13 @@ for target in $BAKE_PUBLISH_TARGETS; do
   if [ -z "$account" ] || [ -z "$share" ] || [ "$account" = "$target" ]; then
     full "malformed BAKE_PUBLISH_TARGETS entry '$target' — cannot read its publication, so the bake cannot be narrowed. (publish-bake-bundles.sh fails on this too.)"
   fi
-  dest="${base:+$base/}prebuilt-bundles/$IDENTITY/$SOURCE"
+  prefix="${base:+$base/}prebuilt-bundles/$IDENTITY/$SOURCE"
+  # The publication that currently applies — the generation the pointer names, or the prefix itself
+  # when there is none. Reading the prefix under the generation layout would take the baseline off
+  # the flat COMPATIBILITY copy while portals served the generation, and a narrowed bake would then
+  # diff against a publication nobody serves.
+  resolve_publication_dir "$account" "$share" "$prefix"
+  dest="$RESOLVED_DIR"
 
   complete=$(az storage file exists --account-name "$account" --share-name "$share" \
     --path "$dest/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \

--- a/.github/scripts/carry-forward-bundles.sh
+++ b/.github/scripts/carry-forward-bundles.sh
@@ -48,17 +48,23 @@ if [ "${1:-}" = "--self-test" ]; then
   # apart silently. Metadata lives in a sidecar named after the file.
   cat > "$ST/bin/az" <<'AZ'
 #!/usr/bin/env bash
+group="$2"          # file | directory
 action="$3"
-account=""; share=""; path=""; dest=""; query=""
+account=""; share=""; path=""; dest=""; query=""; name=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --account-name) account="$2"; shift 2;; --share-name) share="$2"; shift 2;;
-    --path) path="$2"; shift 2;; --dest) dest="$2"; shift 2;;
+    --path) path="$2"; shift 2;; --dest) dest="$2"; shift 2;; --name) name="$2"; shift 2;;
     --query) query="$2"; shift 2;; *) shift;;
   esac
 done
 file="$MOCK_AZ_ROOT/$account/$share/$path"
+if [ "$group/$action" = "directory/exists" ]; then
+  { [ -d "$MOCK_AZ_ROOT/$account/$share/$name" ] && echo true; } || echo false; exit 0
+fi
 case "$action" in
+  exists)
+    { [ -f "$file" ] && echo true; } || echo false ;;
   download)
     [ -f "$file" ] || exit 1
     mkdir -p "$(dirname "$dest")"; cp "$file" "$dest" ;;
@@ -76,7 +82,11 @@ case "$action" in
 esac
 AZ
   chmod +x "$ST/bin/az"; PATH="$ST/bin:$PATH"; export MOCK_AZ_ROOT="$ST/remote"
-  REMOTE="$ST/remote/acct/share/prebuilt-bundles/ID1/plugins"
+  PREFIX="$ST/remote/acct/share/prebuilt-bundles/ID1/plugins"
+  # Where a fixture's publication lives. The flat layout writes it AT the prefix; the generation
+  # layout writes it under a token the `_current` pointer names, and this script must follow that
+  # pointer or it would carry bundles forward from the compatibility copy instead.
+  REMOTE="$PREFIX"
   FAILED=0
   PASSED=0
   ok()   { printf '  OK   %s\n' "$1"; PASSED=$((PASSED + 1)); }
@@ -90,12 +100,23 @@ AZ
 
   setup() {  # <listing lines…> — the sealed publication holds a bundle for each, all from ONE run
     rm -rf "$ST/bake" "$ST/remote" "$ST/listing"
+    REMOTE="$PREFIX"
     mkdir -p "$ST/bake" "$REMOTE"
     for b in "$@"; do echo "published $b" > "$REMOTE/$b"; stamp "$b" "Systemorph-MeshWeaver-1-1"; done
     printf '%s\n' "$@" > "$ST/listing"
   }
+  setup_generation() {  # <generation> <listing…> — the publication lives under a pointed-to token
+    local gen="$1"; shift
+    rm -rf "$ST/bake" "$ST/remote" "$ST/listing"
+    REMOTE="$PREFIX/$gen"
+    mkdir -p "$ST/bake" "$REMOTE"
+    for b in "$@"; do echo "published $b" > "$REMOTE/$b"; stamp "$b" "Systemorph-MeshWeaver-7-1"; done
+    printf '%s\n' "$gen" > "$PREFIX/_current"
+    printf '%s\n' "$@" > "$ST/listing"
+  }
   setup_unstamped() {  # a publication sealed before the stamp existed
     rm -rf "$ST/bake" "$ST/remote" "$ST/listing"
+    REMOTE="$PREFIX"
     mkdir -p "$ST/bake" "$REMOTE"
     for b in "$@"; do echo "published $b" > "$REMOTE/$b"; done
     printf '%s\n' "$@" > "$ST/listing"
@@ -147,6 +168,20 @@ AZ
   rm -rf "$ST/bake"; setup Store.zip; rm -rf "$ST/bake"
   OUT=$(run); RC=$?
   [ "$RC" -ne 0 ] && ok "a missing bake directory is refused" || bad "missing bake dir should be fatal"
+
+  echo "the publication pointer (MeshWeaver#3461) — carry forward from the generation, not the prefix:"
+  setup_generation Systemorph-MeshWeaver-7-1 Store.zip Edu.zip
+  # A DECOY at the prefix under the same name and different bytes: if this script read the prefix
+  # it would carry the decoy forward and the digest check would say so. Only following the pointer
+  # gets the publication's own bytes.
+  echo "decoy Store.zip" > "$PREFIX/Store.zip"
+  rebuilt Edu.zip
+  OUT=$(run); RC=$?
+  if [ "$RC" -eq 0 ] && [ "$(cat "$ST/bake/Store.zip")" = "published Store.zip" ]; then
+    ok "the carried bundle comes from the generation _current names, not the decoy at the prefix"
+  else
+    bad "pointer resolution (rc=$RC): $(printf '%s' "$OUT" | tail -3)"
+  fi
 
   echo "refusals (the carried set must come from ONE publication — MeshWeaver#3461):"
   setup Store.zip Edu.zip Chess.zip
@@ -233,7 +268,69 @@ REST="${TARGET#*/}"
 SHARE="${REST%%/*}"
 BASE=""
 case "$REST" in */*) BASE="${REST#*/}";; esac
-SRC_DIR="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
+
+# ══════════════ THE PUBLICATION POINTER (MeshWeaver#3461) ══════════════
+#
+# A source directory MAY hold `_current`: one line naming the SUBDIRECTORY that holds the
+# publication which currently applies. Absent, it IS its own publication directory — the flat
+# layout, and the only one anything has written until a caller opts in to `publication-layout:
+# generation`.
+#
+# 🚨 THE RULES ARE THE READER'S, EXACTLY (ShippedPrebuiltBundles.PublicationDirectoryOf, and the
+# resolver in publish-bake-bundles.sh). This file, bake-scope.sh and publish-bake-bundles.sh are
+# fetched at ONE `platform-ref`, so no pin can carry half of them — but they must also AGREE, or
+# this lane would read what portals do not serve. Absent, blank, unreadable, not a single path
+# segment, or naming a directory that is not there ⇒ the source directory. A pointer is a NAME: it
+# must never be able to address bytes outside its own source directory.
+POINTER="_current"
+RESOLVED_DIR=""
+resolve_publication_dir() { # <account> <share> <source-dir>
+  _rp_account="$1"; _rp_share="$2"; _rp_source="$3"
+  RESOLVED_DIR="$_rp_source"
+  _rp_exists=$(az storage file exists --account-name "$_rp_account" --share-name "$_rp_share" \
+    --path "$_rp_source/$POINTER" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo "unknown")
+  [ "$_rp_exists" = "true" ] || return 0
+  _rp_local="$(mktemp)"
+  if ! az storage file download --account-name "$_rp_account" --share-name "$_rp_share" \
+      --path "$_rp_source/$POINTER" --dest "$_rp_local" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
+    rm -f "$_rp_local"
+    return 0
+  fi
+  _rp_named=$(sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$_rp_local" | grep -m1 '[^[:space:]]' || true)
+  rm -f "$_rp_local"
+  [ -n "$_rp_named" ] || return 0
+  case "$_rp_named" in
+    # A rooted name always contains a '/', so `*/*` already covers it — shellcheck SC2222 is
+    # right that a separate `/*` arm can never match anything this one does not.
+    .|..|*/*|*\\*)
+      echo "::warning::$_rp_source/$POINTER names '$_rp_named', which is not a single directory name — reading $_rp_source as its own publication directory."
+      return 0 ;;
+  esac
+  _rp_exists=$(az storage directory exists --account-name "$_rp_account" --share-name "$_rp_share" \
+    --name "$_rp_source/$_rp_named" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo "unknown")
+  if [ "$_rp_exists" != "true" ]; then
+    echo "::warning::$_rp_source/$POINTER names generation '$_rp_named', which is not on the share (exists=$_rp_exists) — reading $_rp_source as its own publication directory."
+    return 0
+  fi
+  RESOLVED_DIR="$_rp_source/$_rp_named"
+  return 0
+}
+
+SRC_PREFIX="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
+# The generation the listing came from — resolved by the reader's rules, exactly as bake-scope.sh
+# resolved it to take that listing.
+#
+# 🚨 THE POINTER CAN MOVE BETWEEN THE TWO READS, and that is already covered rather than newly
+# opened: every carried bundle is verified against the digest the publication records and the
+# carried set must name ONE `publication`, so a publication replaced between the listing and the
+# downloads is REFUSED by name — the shell analogue of the reader's If-Match. Resolving here rather
+# than being handed the directory keeps this script correct when its caller is pinned to a workflow
+# copy that does not know about generations.
+resolve_publication_dir "$ACCOUNT" "$SHARE" "$SRC_PREFIX"
+SRC_DIR="$RESOLVED_DIR"
 
 # 🚨 THE CARRY-FORWARD IS AN N+1 READ OF A DIRECTORY THAT CAN BE REPLACED UNDERNEATH IT
 # (MeshWeaver#3461). The listing came from the sealed publication `bake-scope.sh` read; each

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -142,7 +142,8 @@ SENTINEL="_complete"
 #
 #   flat        the historical layout: <identity>/<source>/ IS the publication, replaced IN PLACE.
 #   generation  each publication gets its OWN directory <identity>/<source>/<publication token>/,
-#               and a one-line `_current` pointer — moved LAST — says which one applies.
+#               and a one-line `_current` pointer — moved as soon as that directory is SEALED, and
+#               before the flat compatibility copy — says which one applies.
 #
 # 🚨 IT DEFAULTS TO `flat` AND MUST STAY THAT WAY until every producer of a prefix can write
 # generations. A NEW writer and an OLD writer on one prefix is the half-migration to avoid: the new
@@ -360,7 +361,8 @@ fi
 # 🚨 THAT LAYOUT IS DESIGNED AND ITS READER HALF IS LANDED — do not re-derive it either:
 # Doc/Architecture/SealedPublicationGenerations. Each publication goes into its OWN directory named
 # by $PUBLICATION (already unique per run, already a legal bare name), and a one-line `_current`
-# pointer is moved LAST; disjoint directories mean two publishers cannot interleave at all, so a mix
+# pointer is moved once that directory is sealed and never before it; disjoint directories mean two
+# publishers cannot interleave at all, so a mix
 # stops being detectable and becomes unrepresentable. Every READER now resolves that pointer and
 # falls back to this flat layout when there is none (ShippedPrebuiltBundles.PublicationDirectoryOf),
 # so the reader side is already deployed and inert.
@@ -995,7 +997,7 @@ publish_publication() { # <account> <share> <dest> <live-was-sealed>
     return 0
   fi
   generation="$dest/$PUBLICATION"
-  echo "generation layout: $account/$share/$dest — publishing into $PUBLICATION/ (a path no other publisher writes), then the flat compatibility copy, then $POINTER."
+  echo "generation layout: $account/$share/$dest — publishing into $PUBLICATION/ (a path no other publisher writes), then $POINTER, then the flat compatibility copy (which is the part that still races)."
   publish_one_target "$account" "$share" "$generation" false
   # The flat copy's own sealed state, read fresh: `resealing` above describes the LIVE publication,
   # which under this layout may be a generation directory and says nothing about the flat copy.

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -137,6 +137,61 @@ fi
 # portals' Azure Files share 2026-08-17; with the naive shape the seal step can never succeed and
 # every publication stays torn (unreadable to portals) forever.
 SENTINEL="_complete"
+
+# ══════════════════════ THE PUBLICATION LAYOUT SELECTOR (MeshWeaver#3461) ══════════════════════
+#
+#   flat        the historical layout: <identity>/<source>/ IS the publication, replaced IN PLACE.
+#   generation  each publication gets its OWN directory <identity>/<source>/<publication token>/,
+#               and a one-line `_current` pointer — moved LAST — says which one applies.
+#
+# 🚨 IT DEFAULTS TO `flat` AND MUST STAY THAT WAY until every producer of a prefix can write
+# generations. A NEW writer and an OLD writer on one prefix is the half-migration to avoid: the new
+# one moves the pointer, the old one replaces the flat copy in place and never touches it, so a
+# pointer-following reader keeps serving its generation and never sees the old writer's NEWER
+# publication. A stale serve, silent, with nothing red anywhere. `plugins` is the only prefix with
+# two producers (core CD's `plugins-bake` and the MeshWeaver.Plugins satellite's own `publish-bake`),
+# and core CD pins nothing — it checks the platform out at its own gate sha — so a writer that was on
+# by default would flip that prefix the day it merged, against a satellite hundreds of commits
+# behind. Hence a per-caller selector, and hence the flip is a separate one-line change per producer.
+#
+# 🚨 WHY A POINTER AND NOT AN ATOMIC DIRECTORY RENAME, measured rather than assumed. The obvious
+# design — stage the publication, then rename it over the live one — is NOT AVAILABLE on this store
+# through this client. Measured against azure-cli 2.90.0 (the version the read-back query above was
+# measured against): `az storage file` offers copy / hard-link / metadata / symbolic-link / delete /
+# delete-batch / download / download-batch / exists / generate-sas / list / resize / show / update /
+# upload / upload-batch / url — and NO `rename`; `az storage directory` offers create / delete /
+# exists / list / show — no `rename`, and its `delete` is documented "Delete the specified EMPTY
+# directory". There is no `lease` command under either group either, so a lease per identity is not
+# reachable from this lane. Even in the REST API, where `Rename Directory` exists (2021-04-10), a
+# rename cannot REPLACE an existing directory — the swap would be rename-away plus rename-in, two
+# operations with a gap in which the live path does not exist at all. So the smallest write this
+# store actually offers is one small FILE, and that is what the pointer is.
+#
+# 🚨 The pointer write is not atomic either (`az storage file upload` is create-then-put-range, so a
+# reader can catch it empty or short) — but it CANNOT PRODUCE A MIX. Every unusable pointer resolves
+# to the source directory: absent, blank, unreadable, not a single path segment, or naming a
+# directory that is not there. So the worst case degrades to the generation that applied a moment
+# ago, never to a set no publisher produced. That is the whole trade, and it is why this is a
+# different thing from a shorter version of the same window.
+#
+# Doc/Architecture/SealedPublicationGenerations carries the phases, the reader contract and what
+# each phase does and does not close. 🚨 In particular: phase 4 (flipping a prefix) does NOT close
+# the window for the flat compatibility copy below — that copy is still unsealed, rewritten and
+# re-sealed in place, so it still races, and only dropping it (phase 5, once no pinned reader needs
+# it) removes the window rather than moving it.
+PUBLICATION_LAYOUT="${BAKE_PUBLICATION_LAYOUT:-flat}"
+case "$PUBLICATION_LAYOUT" in
+  flat|generation) ;;
+  *)
+    echo "::error::BAKE_PUBLICATION_LAYOUT='$PUBLICATION_LAYOUT' is not a known publication layout (flat|generation). It decides where a publication is written and which directory every reader resolves, so an unrecognised value must never be published under."
+    exit 1 ;;
+esac
+
+# The publication POINTER (must match ShippedPrebuiltBundles.PublicationPointerFileName): one line
+# naming the SUBDIRECTORY of a source directory that holds the publication which currently applies.
+# Leading underscore so it can never collide with a publication token.
+POINTER="_current"
+
 SENTINEL_LOCAL_DIR=$(mktemp -d)
 trap 'rm -rf "$SENTINEL_LOCAL_DIR"' EXIT
 SENTINEL_LOCAL="$SENTINEL_LOCAL_DIR/$SENTINEL"
@@ -388,6 +443,65 @@ read_stamp() { # <account> <share> <path>
   STAMP_OWNER=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
   if [ "$STAMP_DIGEST" = "-" ]; then STAMP_DIGEST=""; fi
   if [ "$STAMP_OWNER" = "-" ]; then STAMP_OWNER=""; fi
+  return 0
+}
+
+# 🚨 THE POINTER RESOLUTION, AND IT MIRRORS THE READER'S EXACTLY — same rules, same fallbacks, same
+# order (`ShippedPrebuiltBundles.PublicationDirectoryOf`). If the writer and the readers disagreed
+# about which directory is live, the writer would decide "already published" from one publication
+# while portals served another, which is the silent stale serve this whole layout exists to prevent.
+#
+# It NEVER fails; it falls back. Absent, blank, unreadable, not a single path segment, or naming a
+# directory that is not there ⇒ the source directory itself, which IS the flat layout. That is what
+# makes the migration possible at all: resolution is opt-in BY THE WRITER, never by the reader.
+#
+# 🚨 A pointer is a NAME. Anything carrying a separator, a root, or a `.`/`..` segment is refused
+# outright — a publication pointer must never be able to address bytes outside its own source
+# directory. Refused loudly, because it means a publisher wrote something this lane will not follow.
+#
+# Answers through a global for the same reason read_stamp does: a `::warning::` written inside a
+# command substitution would be captured instead of reaching the log.
+RESOLVED_DIR=""
+resolve_publication_dir() { # <account> <share> <source-dir>
+  local account="$1" share="$2" source_dir="$3" exists named local_pointer
+  RESOLVED_DIR="$source_dir"
+  exists=$(az storage file exists --account-name "$account" --share-name "$share" \
+    --path "$source_dir/$POINTER" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo "unknown")
+  if [ "$exists" != "true" ]; then
+    # `unknown` lands here too, deliberately: an unreadable pointer means "the previous generation
+    # still applies", which in the flat layout IS the source directory. There is no answer this can
+    # give that reaches bytes no publisher produced.
+    return 0
+  fi
+  local_pointer="$SENTINEL_LOCAL_DIR/remote-$POINTER"
+  rm -f "$local_pointer"
+  if ! az storage file download --account-name "$account" --share-name "$share" \
+      --path "$source_dir/$POINTER" --dest "$local_pointer" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
+    echo "::notice::$source_dir/$POINTER exists but could not be read — reading $source_dir as its own publication directory. A pointer being replaced reads this way, and the next read resolves it."
+    return 0
+  fi
+  named=$(sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' "$local_pointer" | grep -m1 '[^[:space:]]' || true)
+  rm -f "$local_pointer"
+  if [ -z "$named" ]; then
+    return 0
+  fi
+  case "$named" in
+    # A rooted name always contains a '/', so `*/*` already covers it — shellcheck SC2222 is
+    # right that a separate `/*` arm can never match anything this one does not.
+    .|..|*/*|*\\*)
+      echo "::warning::$source_dir/$POINTER names '$named', which is not a single directory name — a publication pointer may only address a subdirectory of its own source directory. Reading $source_dir as its own publication directory instead."
+      return 0 ;;
+  esac
+  exists=$(az storage directory exists --account-name "$account" --share-name "$share" \
+    --name "$source_dir/$named" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo "unknown")
+  if [ "$exists" != "true" ]; then
+    echo "::warning::$source_dir/$POINTER names generation '$named', which is not on the share (exists=$exists) — reading $source_dir as its own publication directory instead. A generation the pointer names must outlive the pointer."
+    return 0
+  fi
+  RESOLVED_DIR="$source_dir/$named"
   return 0
 }
 
@@ -806,8 +920,9 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   local verdict=0
   verify_publication "$account" "$share" "$dest" || verdict=$?
   if [ "$verdict" -eq 2 ]; then
-    echo converged >> "$OUTCOMES"
-    return 0
+    # 3, not 0: the caller does the accounting, and it must be able to tell a seal this run wrote
+    # from a publication somebody else made. Returning 0 here would count a convergence as a seal.
+    return 3
   fi
   if [ "$verdict" -ne 0 ]; then
     exit 1
@@ -819,10 +934,81 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
     --metadata "digest=$(sha256_of "$SENTINEL_LOCAL")" "publication=$PUBLICATION" \
     --auth-mode login --backup-intent --only-show-errors > /dev/null
   echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s), source ${SOURCE_SHA:-unknown}, platform surface: $HAS_SURFACE)"
-  # 🚨 Recorded HERE, beside the seal, and not at the call sites: since the convergence verdict
-  # returns 0 without sealing, a caller counting "publish_one_target returned" as "published"
-  # would report a publication this run did not make.
+}
+
+# Moves the pointer that says which generation applies. The LAST write of a generation publication,
+# and the only one a reader has to see for the new publication to become live.
+#
+# 🚨 Deliberately OUTSIDE the verified manifest, and it is the one file that must be. Everything in
+# the manifest is read back and asserted to be this run's bytes immediately before its directory is
+# sealed; the pointer is written AFTER that, precisely because it is what CHANGES once the set is
+# proven whole. Stamping it would claim it was covered by a postcondition that, by construction, ran
+# before it existed.
+move_pointer() { # <account> <share> <dest>
+  local account="$1" share="$2" dest="$3"
+  printf '%s\n' "$PUBLICATION" > "$SENTINEL_LOCAL_DIR/$POINTER"
+  # Same directory-as---path shape the sentinel needs: an extensionless --path is re-interpreted as
+  # a DIRECTORY by the CLI, which then appends the source basename.
+  az storage file upload --account-name "$account" --share-name "$share" \
+    --path "$dest" --source "$SENTINEL_LOCAL_DIR/$POINTER" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  echo "pointer: $account/$share/$dest/$POINTER -> $PUBLICATION (this publication is now the live one)"
+}
+
+# ONE publication, in whichever layout this caller selected. Everything above this function writes
+# ONE directory; this is the only place that knows there can be two.
+#
+# At `generation` the order is load-bearing and is the whole safety argument:
+#
+#   1. the generation directory — a fresh path named by this run's publication token, so NO other
+#      publisher can be writing it. The #3496 postcondition still runs there and still refuses, but
+#      it now asserts something that cannot fail for the reason it was written for.
+#   2. the pointer — so a reader either sees the previous generation (intact, sealed, still on the
+#      shelf) or this one, and never a directory being filled in. A refusal at 1 fails the target
+#      before this, so a run that could not prove its publication never becomes the live one.
+#   3. the flat compatibility copy, for readers that predate pointer resolution. 🚨 THIS COPY IS
+#      STILL REPLACED IN PLACE AND STILL RACES — the postcondition is the only thing covering it,
+#      exactly as today. Flipping a prefix does NOT close that window; only dropping the flat copy
+#      does, once no pinned reader needs it.
+#
+# 🚨 THE POINTER MOVES BEFORE THE FLAT COPY, and the design page says "last" — this is the one
+# deliberate deviation, so here is the reasoning. "Last" is about the GENERATION: a reader must never
+# be pointed at a directory that is still being filled in, and moving the pointer after the seal
+# satisfies that exactly. The flat copy is a different audience — readers that cannot follow a
+# pointer at all — and it is the one part of a generation publication that another publisher can
+# still be writing. Ordering it after the pointer means an overlap on the flat copy costs the
+# compatibility copy (which the postcondition refuses to seal as a mix, as today, and the run goes
+# red) instead of costing the publication itself. Ordering it before would let a race on the OLD
+# layout withhold a publication that is already whole, sealed and disjoint on the NEW one — which
+# would make flipping a prefix deliver nothing until the flat copy is dropped.
+#
+# 🚨 RETENTION IS NOT HERE, and that is a precondition on flipping a prefix rather than an omission
+# to fix later. Generations accumulate (~45 small files each) until a sweep removes the ones nothing
+# names, and that sweep DELETES from the production share — it must land as its own reviewed change,
+# with its own harness, and it cannot be written before there is anything to sweep. Nothing in this
+# function deletes anything it did not create.
+publish_publication() { # <account> <share> <dest> <live-was-sealed>
+  local account="$1" share="$2" dest="$3" resealing="$4" rc=0 flat_resealing generation
+  if [ "$PUBLICATION_LAYOUT" = "flat" ]; then
+    publish_one_target "$account" "$share" "$dest" "$resealing" || rc=$?
+    if [ "$rc" -eq 3 ]; then echo converged >> "$OUTCOMES"; else echo published >> "$OUTCOMES"; fi
+    return 0
+  fi
+  generation="$dest/$PUBLICATION"
+  echo "generation layout: $account/$share/$dest — publishing into $PUBLICATION/ (a path no other publisher writes), then the flat compatibility copy, then $POINTER."
+  publish_one_target "$account" "$share" "$generation" false
+  # The flat copy's own sealed state, read fresh: `resealing` above describes the LIVE publication,
+  # which under this layout may be a generation directory and says nothing about the flat copy.
+  flat_resealing=$(az storage file exists --account-name "$account" --share-name "$share" \
+    --path "$dest/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
+    --only-show-errors 2>/dev/null || echo false)
+  if [ "$flat_resealing" != "true" ]; then flat_resealing=false; fi
+  move_pointer "$account" "$share" "$dest"
+  # Recorded before the compatibility copy: the publication IS live at this point, for every reader
+  # that follows the pointer. A refusal below leaves that true and still fails the target.
   echo published >> "$OUTCOMES"
+  publish_one_target "$account" "$share" "$dest" "$flat_resealing" || rc=$?
+  return 0
 }
 
 # 🚨 PER-TARGET ISOLATION (Plugins #2682, 2026-08-30). Each target is published in its OWN subshell:
@@ -856,6 +1042,19 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
     echo marker >> "$OUTCOMES"
   fi
   DEST="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
+  # 🚨 WHICH DIRECTORY IS ALREADY PUBLISHED, resolved by the SAME rules the portal readers use
+  # (MeshWeaver#3461). Every question below — which architecture published, is it sealed, from which
+  # source commit, does it carry a module set — is a question about the LIVE publication, and under
+  # the generation layout that is a subdirectory the pointer names, not the prefix itself. Asking
+  # the prefix would answer from the flat compatibility copy while portals served the generation:
+  # the writer and the readers would disagree about what is published, which is the silent stale
+  # serve this layout exists to prevent. In the flat layout there is no pointer, LIVE == DEST, and
+  # every read below is byte-identical to what it has always been.
+  resolve_publication_dir "$ACCOUNT" "$SHARE" "$DEST"
+  LIVE="$RESOLVED_DIR"
+  if [ "$LIVE" != "$DEST" ]; then
+    echo "::notice::$ACCOUNT/$SHARE: $DEST/$POINTER names '${LIVE##*/}' — reading the live publication from there."
+  fi
   # "Rebuild only when we need to" applies to the publish too (#1660 WS3), but the key is
   # CONTENT × FRAMEWORK: a sealed directory is already-published only when the framework
   # identity (the directory) AND the source commit (the marker) both match. A framework-only
@@ -881,33 +1080,33 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
   # recorded", which is the one answer that lets the publish proceed. A guard whose error path is
   # indistinguishable from its permissive path is not a guard.
   arch_exists=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
-    --path "$DEST/$ARCH_MARKER" --auth-mode login --backup-intent --query exists -o tsv \
+    --path "$LIVE/$ARCH_MARKER" --auth-mode login --backup-intent --query exists -o tsv \
     --only-show-errors 2>/dev/null || echo "unknown")
   if [ "$arch_exists" != "true" ] && [ "$arch_exists" != "false" ]; then
-    echo "::error::could not determine whether $ACCOUNT/$SHARE holds $DEST/$ARCH_MARKER (az returned no usable answer). Refusing rather than assuming the marker is absent — that assumption is what would let one architecture overwrite another's publication."
+    echo "::error::could not determine whether $ACCOUNT/$SHARE holds $LIVE/$ARCH_MARKER (az returned no usable answer). Refusing rather than assuming the marker is absent — that assumption is what would let one architecture overwrite another's publication."
     exit 1
   fi
   published_arch=""
   if [ "$arch_exists" = "true" ]; then
     if ! az storage file download --account-name "$ACCOUNT" --share-name "$SHARE" \
-        --path "$DEST/$ARCH_MARKER" --dest "$SENTINEL_LOCAL_DIR/remote-$ARCH_MARKER" \
+        --path "$LIVE/$ARCH_MARKER" --dest "$SENTINEL_LOCAL_DIR/remote-$ARCH_MARKER" \
         --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
-      echo "::error::$DEST/$ARCH_MARKER EXISTS under $ACCOUNT/$SHARE but could not be read. Refusing: an unreadable marker is not an absent one."
+      echo "::error::$LIVE/$ARCH_MARKER EXISTS under $ACCOUNT/$SHARE but could not be read. Refusing: an unreadable marker is not an absent one."
       exit 1
     fi
     published_arch="$(tr -d '[:space:]' < "$SENTINEL_LOCAL_DIR/remote-$ARCH_MARKER")"
     rm -f "$SENTINEL_LOCAL_DIR/remote-$ARCH_MARKER"
     if [ -z "$published_arch" ]; then
-      echo "::error::$DEST/$ARCH_MARKER under $ACCOUNT/$SHARE is present but EMPTY — the incumbent's architecture cannot be established, so this publication cannot be proven safe. Refusing."
+      echo "::error::$LIVE/$ARCH_MARKER under $ACCOUNT/$SHARE is present but EMPTY — the incumbent's architecture cannot be established, so this publication cannot be proven safe. Refusing."
       exit 1
     fi
   fi
   if [ -n "$published_arch" ] && [ "$published_arch" != "$BAKE_ARCHITECTURE" ]; then
-    echo "::error::$ACCOUNT/$SHARE holds a publication under $DEST built for '$published_arch', but this bake is '$BAKE_ARCHITECTURE'. One framework identity cannot hold two architectures: the reference assemblies differ, so pods resolving this identity would adopt bytes they did not build against (TypeLoadException inside a collectible ALC at activation). This means the identity is architecture-INDEPENDENT — a g<sha> commit stamp rather than an s<hash> surface hash — so the two lanes need distinct identities before both can publish. Refusing rather than overwriting '$published_arch'."
+    echo "::error::$ACCOUNT/$SHARE holds a publication under $LIVE built for '$published_arch', but this bake is '$BAKE_ARCHITECTURE'. One framework identity cannot hold two architectures: the reference assemblies differ, so pods resolving this identity would adopt bytes they did not build against (TypeLoadException inside a collectible ALC at activation). This means the identity is architecture-INDEPENDENT — a g<sha> commit stamp rather than an s<hash> surface hash — so the two lanes need distinct identities before both can publish. Refusing rather than overwriting '$published_arch'."
     exit 1
   fi
   complete=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
-    --path "$DEST/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
+    --path "$LIVE/$SENTINEL" --auth-mode login --backup-intent --query exists -o tsv \
     --only-show-errors 2>/dev/null || echo false)
   # An incumbent with NO architecture marker predates this recording, and the only lane that has
   # ever published is amd64 — so it is treated as linux-x64.
@@ -928,19 +1127,19 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
       # `verify_publication` can be looking at this file while it is written. If this run goes on
       # to republish, `publish_one_target` overwrites it stamped a moment later.
       az storage file upload --account-name "$ACCOUNT" --share-name "$SHARE" \
-        --path "$DEST" --source "$ARCH_MARKER_LOCAL" \
+        --path "$LIVE" --source "$ARCH_MARKER_LOCAL" \
         --auth-mode login --backup-intent --only-show-errors > /dev/null
-      echo "::notice::stamped $DEST/$ARCH_MARKER = $BAKE_ARCHITECTURE on a pre-existing publication (it predates architecture recording). Another architecture can now establish whether it may publish under this identity."
+      echo "::notice::stamped $LIVE/$ARCH_MARKER = $BAKE_ARCHITECTURE on a pre-existing publication (it predates architecture recording). Another architecture can now establish whether it may publish under this identity."
       published_arch="$BAKE_ARCHITECTURE"
     else
-      echo "::error::$ACCOUNT/$SHARE holds a COMPLETE publication under $DEST with no $ARCH_MARKER — it predates architecture recording, so it can only be the linux-x64 lane. This bake is '$BAKE_ARCHITECTURE' and would overwrite it. The next linux-x64 publication to this target stamps the marker automatically (even when it skips the bundles); retry after it has run."
+      echo "::error::$ACCOUNT/$SHARE holds a COMPLETE publication under $LIVE with no $ARCH_MARKER — it predates architecture recording, so it can only be the linux-x64 lane. This bake is '$BAKE_ARCHITECTURE' and would overwrite it. The next linux-x64 publication to this target stamps the marker automatically (even when it skips the bundles); retry after it has run."
       exit 1
     fi
   fi
   resealing=false
   if [ "$complete" = "true" ]; then
     published_sha=$(az storage file download --account-name "$ACCOUNT" --share-name "$SHARE" \
-      --path "$DEST/$SOURCE_MARKER" --dest "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" \
+      --path "$LIVE/$SOURCE_MARKER" --dest "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" \
       --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1 \
       && tr -d '[:space:]' < "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" || echo "")
     # A publication sealed before module sealing existed has no modules/_index. Under the current
@@ -948,29 +1147,29 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
     # republished even when the content is unchanged. This is what converges the fleet (#2698):
     # the next bake of each source re-seals it WITH its module set, and nothing is done by hand.
     module_set=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
-      --path "$DEST/$MODULES_DIR_NAME/$MODULES_INDEX" --auth-mode login --backup-intent --query exists -o tsv \
+      --path "$LIVE/$MODULES_DIR_NAME/$MODULES_INDEX" --auth-mode login --backup-intent --query exists -o tsv \
       --only-show-errors 2>/dev/null || echo unknown)
     if [ "$module_set" != "true" ]; then
-      echo "sealed publication under $DEST carries no $MODULES_DIR_NAME/$MODULES_INDEX (exists=$module_set) — it predates module sealing; republishing WITH the module set."
+      echo "sealed publication under $LIVE carries no $MODULES_DIR_NAME/$MODULES_INDEX (exists=$module_set) — it predates module sealing; republishing WITH the module set."
       echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
-      publish_one_target "$ACCOUNT" "$SHARE" "$DEST" true
+      publish_publication "$ACCOUNT" "$SHARE" "$DEST" true
       return 0
     fi
     if [ -n "${SOURCE_SHA:-}" ] && [ "$published_sha" = "$SOURCE_SHA" ]; then
-      echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication of THIS content under $DEST (sentinel present, source $published_sha) — already published; skipping."
+      echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication of THIS content under $LIVE (sentinel present, source $published_sha) — already published; skipping."
       return 0
     fi
     if [ -z "${SOURCE_SHA:-}" ]; then
       # No content identity given (framework-repo producer): the framework identity IS the
       # content key, so a sealed directory is already this publication.
-      echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $DEST ($SENTINEL present) — surface unchanged, bake already published; skipping."
+      echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $LIVE ($SENTINEL present) — surface unchanged, bake already published; skipping."
       return 0
     fi
     resealing=true
-    echo "sealed publication under $DEST is from source '${published_sha:-<unrecorded>}' but this bake is from '$SOURCE_SHA' — republishing."
+    echo "sealed publication under $LIVE is from source '${published_sha:-<unrecorded>}' but this bake is from '$SOURCE_SHA' — republishing."
   fi
   echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
-  publish_one_target "$ACCOUNT" "$SHARE" "$DEST" "$resealing"
+  publish_publication "$ACCOUNT" "$SHARE" "$DEST" "$resealing"
 }
 
 FAILED=()

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -826,6 +826,40 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
         check("the pointer is NOT stamped — it is written after the postcondition, by construction",
               s.stamp(POINTER) == {}, f"stamp={s.stamp(POINTER)!r}")
 
+    # 🚨 THE ORDER, OBSERVED RATHER THAN READ OFF THE CODE. The pointer moves once the generation is
+    # sealed and BEFORE the flat compatibility copy — deliberately, so that an overlap on the flat
+    # copy (which still races) costs that copy rather than a publication which is already whole and
+    # disjoint. Nothing in the finished state records the order, so this hooks the flat copy's first
+    # upload and asks whether the pointer is already there. Without it the ordering lived only in a
+    # comment, and a comment is what drifted: the announcement line described the opposite order for
+    # one review cycle.
+    print("\ngeneration layout — the pointer moves BEFORE the flat compatibility copy:")
+    h.reset()
+    witness = work / "pointer-at-flat-copy"
+    r = h.publish(core, "Systemorph/MeshWeaver", "3501", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/{BUNDLES[0]}",
+        "MOCK_AZ_HOOK_WHEN": "before",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-order",
+        "MOCK_AZ_HOOK_CMD":
+            f'if [ -f "{h.shelf_root}/{ACCOUNT}/{SHARE}/{DEST}/{POINTER}" ]; '
+            f'then echo present > "{witness}"; else echo absent > "{witness}"; fi',
+        **gen,
+    })
+    s = h.shelf()
+    check("the hook really did fire on the flat copy's first upload (not vacuous)",
+          witness.is_file(), f"witness={witness.read_text().strip() if witness.is_file() else '<none>'}")
+    if not expect_defect:
+        check("the pointer is already live when the flat compatibility copy starts being written",
+              witness.is_file() and witness.read_text().strip() == "present"
+              and r.returncode == 0 and s.pointer() == "Systemorph-MeshWeaver-3501-1",
+              f"rc={r.returncode}, at the flat copy's first upload {POINTER} was "
+              f"{witness.read_text().strip() if witness.is_file() else '<unobserved>'}")
+        check("…and the announcement says that order, so an incident log matches the code",
+              r.stdout.index(f"then {POINTER}") < r.stdout.index("then the flat compatibility copy")
+              if (f"then {POINTER}" in r.stdout and "then the flat compatibility copy" in r.stdout)
+              else False,
+              "the generation-layout line names the pointer before the flat copy")
+
     # ── THE HEADLINE: interleave two publishers and neither directory can hold the other's bytes.
     print("\ngeneration layout — two publishers interleaved on one prefix:")
     h.reset()

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -85,6 +85,8 @@ SHARE = "memex-data"
 TARGET = f"{ACCOUNT}/{SHARE}"
 DEST = f"prebuilt-bundles/{IDENTITY}/{SOURCE}"
 SENTINEL = "_complete"
+# Must match ShippedPrebuiltBundles.PublicationPointerFileName and the POINTER in the script.
+POINTER = "_current"
 
 # 🚨 THE ONE `file show` QUERY, and its exact shape is load-bearing. knack's `format_tsv` renders a
 # TOP-LEVEL list as ROWS, so `--query "[a, b]" -o tsv` prints TWO LINES rather than two columns; a
@@ -334,19 +336,47 @@ class Shelf:
     def sealed(self) -> bool:
         return (self.dest / SENTINEL).is_file()
 
+    def under(self, sub: str) -> "Shelf":
+        """The same share, read at a SUBDIRECTORY of the source dir — i.e. one generation."""
+        s = Shelf(self.root)
+        s.dest = self.dest / sub
+        return s
+
+    def generations(self) -> list[str]:
+        """Every publication directory under the source dir (the pointer and markers excluded)."""
+        if not self.dest.is_dir():
+            return []
+        return sorted(d.name for d in self.dest.iterdir()
+                      if d.is_dir() and d.name != "modules")
+
+    def pointer(self) -> str:
+        f = self.dest / POINTER
+        return f.read_text().strip() if f.is_file() else ""
+
     def stamp(self, rel: str) -> dict:
         """The metadata the publisher wrote on one file — `digest` and `publication`."""
         mp = self.root / ".meta" / ACCOUNT / SHARE / DEST / (rel + ".json")
         return json.loads(mp.read_text()) if mp.is_file() else {}
 
     def files(self) -> dict[str, str]:
-        """path-under-dest → content, for every published file (the sentinel excluded)."""
+        """path-under-dest -> content, for every published file of THIS publication.
+
+        The sentinel and the pointer are excluded (neither is published content), and so is
+        anything under a GENERATION directory: a generation is its own publication, read through
+        `under()`. Without that exclusion a flat-copy assertion would silently count the
+        generations' files too and pass on a number that means nothing.
+        """
         out: dict[str, str] = {}
         if not self.dest.is_dir():
             return out
+        skip = set(self.generations())
         for p in sorted(self.dest.rglob("*")):
-            if p.is_file() and p.name != SENTINEL:
-                out[str(p.relative_to(self.dest))] = p.read_text()
+            if not p.is_file() or p.name in (SENTINEL, POINTER):
+                continue
+            rel = p.relative_to(self.dest)
+            if rel.parts[0] in skip:
+                continue
+            out[str(rel)] = p.read_text()
         return out
 
     def bakes_present(self) -> dict[str, int]:
@@ -760,6 +790,128 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
         check("a sibling sealing a different bundle set does NOT converge",
               r.returncode != 0 and "entirely superseded" in r.stdout
               and "lists a different bundle set" in r.stdout, f"rc={r.returncode}")
+
+    # ── THE GENERATION LAYOUT: two interleaved publishers cannot write one directory. #3461 ───
+    #
+    # Phase 2 of Doc/Architecture/SealedPublicationGenerations. The postcondition above turns an
+    # overlap from a silent mix into a loud refusal; it is a postcondition, not mutual exclusion,
+    # and it leaves the interval between its last read and the seal. This layout removes the shared
+    # directory instead: each publication is written under its own run-unique token, so there is
+    # nothing to interleave, and a one-line `_current` pointer says which one applies.
+    #
+    # 🚨 The selector defaults to `flat`, and the three CONTROL cases at the top of this file are
+    # the regression suite for that: they run the same script with no BAKE_PUBLICATION_LAYOUT set
+    # and must keep passing byte for byte. These cases opt in explicitly.
+    gen = {"BAKE_PUBLICATION_LAYOUT": "generation"}
+
+    print("\ngeneration layout — one publisher, on an empty prefix:")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "3001", gen)
+    s = h.shelf()
+    tok_a = "Systemorph-MeshWeaver-3001-1"
+    ga = s.under(tok_a)
+    if expect_defect:
+        check("PRE-FIX: the layout selector does not exist, so nothing is written under a token",
+              s.generations() == [], f"generations={s.generations()}")
+    else:
+        check("the publication is written into its own generation directory, and sealed there",
+              r.returncode == 0 and ga.sealed() and len(ga.files()) == EXPECTED_FILES,
+              f"rc={r.returncode}, generation {tok_a}: {denominator(ga)}")
+        check("the pointer names it",
+              s.pointer() == tok_a, f"_current={s.pointer()!r}")
+        check("the flat compatibility copy is written too, for readers that cannot follow a pointer",
+              s.sealed() and len(s.files()) == EXPECTED_FILES
+              and set(s.bakes_present()) - {"<marker>"} == {"core-cd"},
+              denominator(s))
+        check("the pointer is NOT stamped — it is written after the postcondition, by construction",
+              s.stamp(POINTER) == {}, f"stamp={s.stamp(POINTER)!r}")
+
+    # ── THE HEADLINE: interleave two publishers and neither directory can hold the other's bytes.
+    print("\ngeneration layout — two publishers interleaved on one prefix:")
+    h.reset()
+    inner = h.publish_command(sat, "Systemorph/MeshWeaver.Plugins", "3102", gen)
+    r = h.publish(core, "Systemorph/MeshWeaver", "3101", {
+        "MOCK_AZ_HOOK_ON": f"{DEST}/Systemorph-MeshWeaver-3101-1/{BUNDLES[1]}",
+        "MOCK_AZ_HOOK_WHEN": "before",
+        "MOCK_AZ_HOOK_ONCE": work / "fired-gen-overlap",
+        "MOCK_AZ_HOOK_CMD": inner,
+        **gen,
+    })
+    s = h.shelf()
+    tok_core, tok_sat = "Systemorph-MeshWeaver-3101-1", "Systemorph-MeshWeaver.Plugins-3102-1"
+    gc, gs = s.under(tok_core), s.under(tok_sat)
+    check("the fixture really did interleave them (both generations exist — not vacuous)",
+          sorted(s.generations()) == sorted([tok_core, tok_sat]),
+          f"generations={s.generations()}")
+    if not expect_defect:
+        check("each publisher sealed its OWN generation",
+              gc.sealed() and gs.sealed(),
+              f"{tok_core}: {denominator(gc)} | {tok_sat}: {denominator(gs)}")
+        check("neither generation holds a byte of the other — a mix is UNREPRESENTABLE",
+              set(gc.bakes_present()) - {"<marker>"} == {"core-cd"}
+              and set(gs.bakes_present()) - {"<marker>"} == {"satellite"},
+              f"{tok_core} by bake {gc.bakes_present()}, {tok_sat} by bake {gs.bakes_present()}")
+        check("both generations are COMPLETE, so whichever the pointer names is whole",
+              len(gc.files()) == EXPECTED_FILES and len(gs.files()) == EXPECTED_FILES,
+              f"{len(gc.files())} and {len(gs.files())} of {EXPECTED_FILES}")
+        check("the pointer names exactly ONE of them, and it is one that exists",
+              s.pointer() in (tok_core, tok_sat), f"_current={s.pointer()!r}")
+        # The flat compatibility copy is the part that still races — the postcondition covers it
+        # exactly as today, and the run that loses it goes red. Asserted so nobody reads phase 4 as
+        # "the window is closed": it is closed for pointer-following readers only.
+        check("the flat copy still races, and is never sealed over a mix",
+              not s.sealed_mix(),
+              f"flat: {denominator(s)} — the compatibility copy is the phase-5 remainder")
+        check("…and the generation the pointer names is served whole regardless of what the flat copy holds",
+              s.under(s.pointer()).sealed()
+              and len(s.under(s.pointer()).files()) == EXPECTED_FILES,
+              f"_current={s.pointer()!r}: {denominator(s.under(s.pointer()))}")
+
+    # ── The writer must decide "already published" from the POINTED-TO directory, not the prefix.
+    # Getting this wrong is the silent one: the writer would read the flat compatibility copy while
+    # portals served the generation, and republish (or skip) against a publication nobody serves.
+    print("\ngeneration layout — 'already published' is read from the generation the pointer names:")
+    h.reset()
+    r = h.publish(sat, "Systemorph/MeshWeaver.Plugins", "3201", gen)
+    r = h.publish(sat, "Systemorph/MeshWeaver.Plugins", "3202", gen)
+    s = h.shelf()
+    check("the fixture really did publish once (not vacuous)",
+          s.pointer() == "Systemorph-MeshWeaver.Plugins-3201-1", f"_current={s.pointer()!r}")
+    if not expect_defect:
+        check("the same content is skipped — resolved through the pointer, not off the prefix",
+              r.returncode == 0 and "already published; skipping" in r.stdout
+              and "Systemorph-MeshWeaver.Plugins-3201-1" in r.stdout,
+              f"rc={r.returncode}, generations={s.generations()}")
+        check("…and nothing new was written",
+              s.generations() == ["Systemorph-MeshWeaver.Plugins-3201-1"],
+              f"generations={s.generations()}")
+
+    # ── A pointer this writer will not follow must degrade to the flat layout, exactly as the
+    # reader does. The escape shapes are the ones that must never be followed at all.
+    print("\ngeneration layout — an unusable pointer degrades to the prefix, never to bytes outside it:")
+    for label, value in (("an escaping pointer", "../../etc"),
+                         ("a rooted pointer", "/etc"),
+                         ("a dot pointer", ".."),
+                         ("a blank pointer", "   "),
+                         ("a dangling pointer", "Systemorph-MeshWeaver-9999-1")):
+        h.reset()
+        h.publish(core, "Systemorph/MeshWeaver", "3301")          # a flat publication to fall back to
+        (h.shelf().dest / POINTER).write_text(value + "\n")
+        r = h.publish(core, "Systemorph/MeshWeaver", "3302")
+        if not expect_defect:
+            check(f"{label} reads the prefix as its own publication",
+                  r.returncode == 0 and "already published; skipping" in r.stdout,
+                  f"rc={r.returncode}, pointer={value!r}")
+
+    # ── An unknown layout is refused, not silently treated as flat: the value decides where a
+    # publication is written and which directory every reader resolves.
+    print("\ngeneration layout — an unrecognised selector is refused:")
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "3401", {"BAKE_PUBLICATION_LAYOUT": "generations"})
+    if not expect_defect:
+        check("a typo'd layout fails loudly and publishes nothing",
+              r.returncode != 0 and "is not a known publication layout" in r.stdout
+              and not h.shelf().sealed(), f"rc={r.returncode}")
 
     # ── FAIL CLOSED: a file that cannot be read back is refused, not assumed unchanged. ────────
     print("\nfail-closed (an unreadable answer is not a permissive one):")

--- a/.github/workflow-shell.allow
+++ b/.github/workflow-shell.allow
@@ -14,7 +14,7 @@
 #
 # Format:  <check> <path> <hash>       (the gate prints the exact line to paste)
 
-# publish-bake-bundles.sh: the ABSENCE of $DEST/$SOURCE_MARKER is a NORMAL, expected state — a
+# publish-bake-bundles.sh: the ABSENCE of $LIVE/$SOURCE_MARKER is a NORMAL, expected state — a
 # publication sealed before source-marker recording existed simply has no such file, and this
 # script's whole job at that point is to notice that and republish. So `az storage file download`
 # failing here is the ordinary path, not an incident, and it runs once per module per publish (~40
@@ -23,4 +23,7 @@
 # authoritative: the next two lines test it against $SOURCE_SHA and fall through to republishing
 # when it does not match, so a genuine credential failure degrades to "publish again", never to
 # "already published; skipping".
-swallow .github/scripts/publish-bake-bundles.sh 67fc06cddcb7
+# (Re-keyed 2026-09-08: the read now resolves the publication pointer first, so it addresses
+# $LIVE — the generation that currently applies — rather than the prefix. Same call, same
+# diagnosis; only the line changed. MeshWeaver#3461.)
+swallow .github/scripts/publish-bake-bundles.sh 465523efa176

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -250,6 +250,41 @@ on:
         required: false
         type: string
         default: 'plugin-gate.allow'
+      publication-layout:
+        description: >-
+          Where a publication is written under
+          `<base>/prebuilt-bundles/<framework-identity>/<bake-source>/` (MeshWeaver#3461).
+
+          `flat` (the default, and today's behaviour everywhere): that directory IS the
+          publication, replaced IN PLACE — unseal, upload over the live files, re-seal. Two
+          publishers interleaved on one prefix can therefore leave a sentinel over bytes from two
+          bakes; the publisher's byte-level postcondition refuses to seal that, which makes an
+          overlap a loud red rather than a silent mix, but it is a postcondition and not mutual
+          exclusion.
+
+          `generation`: each publication is written into its OWN directory named by the publisher's
+          run-unique token, sealed there, and a one-line `_current` pointer — written after the
+          seal — says which one applies. Two publishers never write the same bytes, so a mix
+          becomes unrepresentable rather than merely detectable. The flat copy is still written
+          for readers that predate pointer resolution, and THAT copy still races: flipping a
+          prefix closes the window for pointer-following readers only.
+
+          🚨 DO NOT FLIP A PREFIX UNTIL EVERY PRODUCER OF IT CAN WRITE GENERATIONS. A new writer
+          and an old writer on one prefix is the half-migration to avoid: the new one moves the
+          pointer, the old one replaces the flat copy in place and never touches it, so a
+          pointer-following reader keeps serving its generation and never sees the old writer's
+          NEWER publication — a stale serve with nothing red anywhere. `plugins` is the only
+          prefix with two producers (core CD's `plugins-bake` and this repo's own `publish-bake`),
+          so it flips in ONE change set; every other prefix flips in its own repository's PR.
+
+          🚨 Retention is not implemented: generations accumulate until a sweep lands. That sweep
+          deletes from the production share, so it is its own reviewed change — and it is a
+          precondition on flipping, not a follow-up.
+
+          Full reference: Doc/Architecture/SealedPublicationGenerations.
+        required: false
+        type: string
+        default: 'flat'
       platform-ref:
         description: >-
           Ref of Systemorph/MeshWeaver to take the canonical publish script from. Default main;
@@ -1209,6 +1244,9 @@ jobs:
           # it was written for. Same expression as the checkout's `repository:` on purpose: one
           # answer to "whose content is this", used by both.
           BAKE_CONTENT_REPOSITORY: ${{ inputs.content-repository || github.repository }}
+          # flat (the default) or generation — see the `publication-layout` input. At `flat` the
+          # script behaves byte-identically to before this input existed.
+          BAKE_PUBLICATION_LAYOUT: ${{ inputs.publication-layout }}
         # Contract: layout <base>/prebuilt-bundles/<framework-identity>/<source>/<bundle>.zip,
         # every bundle first, the `_complete` sentinel strictly LAST; an already-sealed identity
         # with the same source sha skips (the surface identity is breaking-change-keyed, so

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -74,6 +74,29 @@ A source directory with **no** `_current` **is** its own publication directory. 
 today's behaviour, it stays legal for as long as any reader needs it, and it is what makes the
 migration below possible at all. Resolution is opt-in **by the writer**, never by the reader.
 
+### Why a pointer and not an atomic directory rename — measured, 2026-09-08
+
+The obvious design is to stage the publication and then **rename it over** the live one. It is not
+available on this store through this client, and that is a measurement rather than a recollection.
+
+Read off `azure-cli 2.90.0` — the same version the publisher's read-back query was measured
+against:
+
+| group | commands |
+|---|---|
+| `az storage file` | copy · hard-link · metadata · symbolic-link · delete · delete-batch · download · download-batch · exists · generate-sas · list · resize · show · update · upload · upload-batch · url |
+| `az storage directory` | create · delete · exists · list · show |
+
+There is **no `rename`** in either, `directory delete` is documented *"Delete the specified **empty**
+directory"*, and there is no `lease` command under either group — so a lease per identity is not
+reachable from this lane either. And even in the REST API, where `Rename Directory` has existed
+since API version 2021-04-10, a rename cannot **replace** an existing directory: the swap would be
+rename-away plus rename-in, two operations with a gap in which the live path does not exist at all.
+
+🚨 **So the smallest write this store actually offers is one small FILE, and that is what the
+pointer is.** A design that assumed an atomic directory rename would have reintroduced a
+partial-visibility window wearing a better story.
+
 ### What is still a window, stated honestly
 
 The pointer is one small file, and writing it is not atomic on every backend: `az storage file
@@ -190,7 +213,7 @@ Nothing writes a pointer yet, so this changes nothing observable — which is wh
 suite that *builds the generation layout by hand* and asserts the readers serve it, including the
 arm that catches the compose-under-the-source-directory mistake.
 
-### Phase 2 — the writer LEARNS the layout, selected per caller, defaulting to flat *(open — the next PR)*
+### Phase 2 — the writer LEARNS the layout, selected per caller, defaulting to flat *(landed)*
 
 `publish-bake-bundles.sh` gains generation publishing behind an explicit selector: a
 `publication-layout` input on `node-repo-publish-bake.yml`, carried into the script as an environment
@@ -220,7 +243,33 @@ upload before the postcondition, and the overlap harness hooks its second publis
 marker written after it silently stops the harness detecting overlaps while every case still reads
 green. (`repository.txt` was added under this rule and says so in place.)
 
-### Phase 3 — every producer's pin reaches phase 2 *(open)*
+#### What actually shipped, and the one deliberate deviation
+
+- The selector is `publication-layout` on `node-repo-publish-bake.yml`, defaulting to `flat`,
+  carried into the script as `BAKE_PUBLICATION_LAYOUT`. An unrecognised value is **refused**, never
+  silently read as flat: the value decides where a publication is written and which directory every
+  reader resolves.
+- `bake-scope.sh` and `carry-forward-bundles.sh` resolve the pointer in the SAME commit, by the same
+  rules, so the writer and the two Azure-direct readers cannot disagree about which publication is
+  live. `carry-forward-bundles.sh` resolves it **itself** rather than being handed the directory —
+  its caller may be pinned to a workflow copy that knows nothing about generations, and the
+  one-publication postcondition it already carries is what pins it to a single generation if the
+  pointer moves between the listing and the downloads.
+- 🚨 **The pointer moves BEFORE the flat compatibility copy, not after it.** "Last" in this page is
+  about the *generation*: a reader must never be pointed at a directory still being filled in, and
+  moving the pointer straight after the seal satisfies that exactly. The flat copy is a different
+  audience — readers that cannot follow a pointer at all — and it is the one part of a generation
+  publication another publisher can still be writing. Ordering it after the pointer means an overlap
+  on the flat copy costs the *compatibility copy* (refused, as today, and the run goes red) instead
+  of costing a publication that is already whole, sealed and disjoint. Ordering it before would let
+  a race on the OLD layout withhold a publication that is correct on the NEW one — which would make
+  flipping a prefix deliver nothing at all until the flat copy is dropped.
+- 🚨 **Retention is NOT implemented, and that is a precondition on flipping rather than a follow-up.**
+  Generations accumulate at ~45 small files each until a sweep removes the ones nothing names, and
+  that sweep DELETES from the production share — it must land as its own reviewed change, with its
+  own harness. Nothing the writer does today deletes anything it did not create.
+
+### Phase 3 — every producer's pin reaches phase 2 *(open — the next step)*
 
 Only now is the condition both satisfiable and meaningful: a producer past phase 2 *can* write
 generations and is still writing flat. Core CD needs no pin move. The four satellites move theirs the
@@ -251,11 +300,65 @@ pre-phase-1 images is unsealed, rewritten and re-sealed exactly as today, and ca
 a mix. The #3496 postcondition is what covers it, and it covers it only as a postcondition. A report
 that says "the window is closed" at phase 4 is describing the pointer-following readers only.
 
+## If the publication moves to an OCI registry
+
+The fleet now has its own registry (`cr.meshweaver.cloud`) and a program to push plugin bundles into
+it as OCI artifacts. It is worth writing down exactly what that does and does not close, because
+"content-addressed" is easy to read as "the race is gone".
+
+**What it closes by construction.** Blobs and manifests are addressed by the digest of their own
+bytes. Two publications pushing byte-identical content collide **benignly** — same digest, a no-op —
+and two publications pushing different content get *different* blobs, which cannot overwrite each
+other. A blob is immutable once pushed; there is no partial overwrite to interleave. So the **mix**
+— a set holding some of each publisher's bytes — becomes unrepresentable at the byte level, which is
+the same property the generation directory buys, obtained more cheaply.
+
+🚨 **What it does NOT close: a tag is a mutable, last-writer-wins pointer.** If the publication is
+addressed by tag, the defect simply moves from a directory prefix to a tag, and the migration
+inherits it. Three conditions close it, and they are the rule already in force for images via
+`MW_IMAGE_DIGEST`:
+
+1. **Every bundle is pushed and recorded by DIGEST**, never by tag alone.
+2. **Each publication also gets an immutable, identity-qualified tag** — so a publication can be
+   named without that name being reassignable to different bytes later.
+3. **The sealed set is a list of `(package, digest)` pairs**, so a mixed set cannot be written at
+   all: the set names exact bytes, and a publisher that did not assemble those bytes cannot produce
+   that list.
+
+🚨 **Content addressing does NOT make two bakes of one commit converge.** The bundle compile is not
+byte-reproducible — measured 2026-09-08, 40 of 45 files differed between two bakes of the same
+source commit — so two publications of one commit produce different blobs and therefore different
+manifest digests. OCI does not merge them; what it does is make each one a complete, immutable,
+self-consistent object, so the only contention left is which one the reference names. That is a
+last-writer-wins between two *correct* sets, which is a different and far weaker thing than a mix.
+
+🚨 **Two invariants the migration must carry across, or it reopens something worse than it closed:**
+
+- **The framework identity must stay in the reference.** Today the directory is keyed
+  `prebuilt-bundles/<framework-identity>/<source>/`, and that is not decoration: a bundle is only
+  adoptable by a portal that resolved the *same* identity, which is why the publisher refuses when an
+  incumbent's `architecture.txt` disagrees. A repository path of the shape
+  `plugins/<source>/<package>:<version>` carries no identity, so two platform surfaces' bakes would
+  collide on one reference and a portal would adopt bytes built against a surface it does not have —
+  `dependency record mismatch — built against mvid:…`, this issue's original symptom by another road.
+- **The release marker must survive.** `prebuilt-bundles/_releases/<version>` → `<identity>` is the
+  only way anything outside the image learns a release's framework identity, and two release gates
+  HOLD on its absence.
+
+**And the refusal must not be weakened, in either world.** On the share it reads "never seal a
+sentinel over another publication's bundles". In OCI terms it is the same sentence one level up:
+**never publish a reference to a set you did not assemble.** That refusal is the only reason this
+was ever visible instead of silently shipping a mixed set.
+
 ## Where this stands
 
 - **Phase 1 is landed** (`a4109d422`) — the readers resolve the pointer, and the fallback is the
   previous behaviour exactly.
-- **Phases 2–5 are open**, tracked on
+- **Phase 2 is landed** — the writer can publish generations, behind `publication-layout`, which
+  defaults to `flat`. Nothing anywhere writes a generation until a caller opts in, and the three
+  control cases in `test-publish-bake-overlap.py` are the regression suite proving the default path
+  is byte-identical to what it was.
+- **Phases 3–5 are open**, tracked on
   [#3461](https://github.com/Systemorph/MeshWeaver/issues/3461). Until the writer flips, **the window
   is shrunk, not closed**: the publisher's postcondition still carries the whole load, and the
   interval between its last verification read and the seal is still live.
@@ -273,14 +376,37 @@ that says "the window is closed" at phase 4 is describing the pointer-following 
   to 1 on that incident. The **residual is a sibling that has not sealed yet when this run's sweep
   ends** (21 seconds, measured), and that is not shrinkable by any amount of checking: it is what
   phases 2–5 exist for.
-- **The next change is phase 2, and it is one PR in this repository** — the selector, the writer
-  behind it, the two Azure-direct readers, and the harness cases. It changes nothing anywhere until a
-  caller opts in, which is the property that lets it land at all.
+- **The next change is phase 3** — each producer's `platform-ref` reaches the writer commit. Only
+  then is flipping a prefix both possible and meaningful. `plugins` flips in ONE change set because
+  it is the only prefix with two producers; the rest flip one repository at a time.
+- 🚨 **Flipping `plugins` does not by itself stop the publish reds.** The flat compatibility copy is
+  still replaced in place and still races, so an overlap still costs that copy and still fails the
+  job — the postcondition covering it is unchanged. What the flip buys immediately is that the
+  *publication* survives an overlap intact and pointed-to instead of being lost. The reds go when the
+  flat copy does (phase 5), or when the publication moves to digest-addressed artifacts.
 - The reds the postcondition produces are the correct number and must not be loosened away — see
   [Sealed Publication Reads](../SealedPublicationReads) → "What is NOT closed".
 
 ## Verification
 
+- `.github/scripts/test-publish-bake-overlap.py` — **67 assertions**, executing the REAL publish
+  script against a stub share and reading every verdict off the BYTES. The writer half is covered by
+  five generation cases: one publisher writes and seals under its own token and the pointer names it;
+  **two interleaved publishers each seal their OWN generation, neither directory holds a byte of the
+  other, both are complete, and `_current` names exactly one of them**; "already published" is
+  resolved *through* the pointer rather than off the prefix; every unusable pointer shape (escaping,
+  rooted, `..`, blank, dangling) degrades to the prefix; and an unrecognised selector is refused. The
+  three flat controls are unchanged and are the regression suite for the default.
+  🚨 **Negative control:** run against the pre-change script, **16 of the 67 fail**.
+- `bake-scope.sh --self-test` — four pointer-resolution assertions, and the positive one is
+  discriminating by construction: the flat copy and the generation record *different* baselines (a
+  diverged commit versus an ancestor), so the verdict itself says which was read. A resolver that
+  ignored the pointer answers `full`; one that follows it answers `narrowed` with the generation's
+  commit. The dangling-pointer control asserts the fallback SAYS so, so silence cannot pass for
+  resolution.
+- `carry-forward-bundles.sh --self-test` — a decoy bundle is planted at the prefix under the same
+  name and different bytes, so carrying the publication's own bytes forward is only possible by
+  following the pointer.
 - `test/Memex.Portal.Shared.Test/PublicationGenerationTest.cs` — builds the generation layout on
   disk and asserts what is served. The fixtures make the flat copy and the generation differ in
   **bytes under the same file names**, so "which publication was read" is a fact off the archive

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -250,11 +250,22 @@ green. (`repository.txt` was added under this rule and says so in place.)
   silently read as flat: the value decides where a publication is written and which directory every
   reader resolves.
 - `bake-scope.sh` and `carry-forward-bundles.sh` resolve the pointer in the SAME commit, by the same
-  rules, so the writer and the two Azure-direct readers cannot disagree about which publication is
-  live. `carry-forward-bundles.sh` resolves it **itself** rather than being handed the directory —
-  its caller may be pinned to a workflow copy that knows nothing about generations, and the
-  one-publication postcondition it already carries is what pins it to a single generation if the
+  rules, so the writer and the two readers of the publish lane cannot disagree about which
+  publication is live. `carry-forward-bundles.sh` resolves it **itself** rather than being handed the
+  directory — its caller may be pinned to a workflow copy that knows nothing about generations, and
+  the one-publication postcondition it already carries is what pins it to a single generation if the
   pointer moves between the listing and the downloads.
+- 🚨 **TWO Azure-direct readers still read the PREFIX, and they are part of phase 3's precondition,
+  not of this change.** `compose-sealed-modules.sh` (the module-set index and each module, on the
+  OIDC fallback path) and `node-repo-gate.yml`'s inline `download-batch` both compose their paths
+  under `prebuilt-bundles/<identity>/<source>/` directly. This is harmless while nothing writes a
+  generation, and it stays harmless at phase 4 in the ordinary case — the flat compatibility copy is
+  written by the same run, from the same bytes, so reading it gives the same content the pointer
+  names. It stops being harmless in exactly two places, and both are worth knowing before flipping:
+  a run whose flat copy is REFUSED (the compatibility copy still races) leaves those two readers on
+  the previous publication while pointer-following readers have moved on; and at phase 5, when the
+  flat copy is dropped, they break outright. **Route them through the same resolution before any
+  prefix flips.** Neither is a reader the portal image carries, so neither was covered by phase 1.
 - 🚨 **The pointer moves BEFORE the flat compatibility copy, not after it.** "Last" in this page is
   about the *generation*: a reader must never be pointed at a directory still being filled in, and
   moving the pointer straight after the seal satisfies that exactly. The flat copy is a different
@@ -376,8 +387,10 @@ was ever visible instead of silently shipping a mixed set.
   to 1 on that incident. The **residual is a sibling that has not sealed yet when this run's sweep
   ends** (21 seconds, measured), and that is not shrinkable by any amount of checking: it is what
   phases 2–5 exist for.
-- **The next change is phase 3** — each producer's `platform-ref` reaches the writer commit. Only
-  then is flipping a prefix both possible and meaningful. `plugins` flips in ONE change set because
+- **The next change is phase 3** — each producer's `platform-ref` reaches the writer commit, **and
+  the two remaining Azure-direct readers (`compose-sealed-modules.sh`, `node-repo-gate.yml`'s
+  `download-batch`) are routed through the same pointer resolution.** Only then is flipping a prefix
+  both possible and meaningful. `plugins` flips in ONE change set because
   it is the only prefix with two producers; the rest flip one repository at a time.
 - 🚨 **Flipping `plugins` does not by itself stop the publish reds.** The flat compatibility copy is
   still replaced in place and still races, so an overlap still costs that copy and still fails the

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -316,6 +316,14 @@ Stated plainly, because a page that only lists what works is how the next sessio
 - **The window itself remains.** In this layout it cannot be removed — in-place replacement means
   unsealed time, and the alternative is a layout migration every reader must land first (the portal
   boot seeder, the gate's Azure-direct path, and every pinned satellite workflow copy).
+- 🚨 **Two Azure-direct readers still address the PREFIX rather than the publication.**
+  `compose-sealed-modules.sh` and `node-repo-gate.yml`'s inline `download-batch` compose their paths
+  under `prebuilt-bundles/<identity>/<source>/` directly, so they read the flat copy whatever the
+  pointer says. Inert while nothing writes a generation, and correct at phase 4 in the ordinary case
+  — but a run whose flat copy is refused leaves them on the previous publication, and phase 5 breaks
+  them outright. They are named as phase 3's precondition on
+  [Sealed Publication Generations](../SealedPublicationGenerations); the publish lane's own two
+  readers (`bake-scope.sh`, `carry-forward-bundles.sh`) already resolve it.
 - **The Azure-direct read path carries no generation.** `az storage file download-batch` against the
   share has no server to ask, so `--storage-target` consumers still do unpinned N+1 reads. The lanes
   all pass `--registry-url`; the storage path is the OIDC fallback.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -280,16 +280,21 @@ Stated plainly, because a page that only lists what works is how the next sessio
   a generation directory plus an atomic pointer swap removes republication in place entirely, and
   is the shape the read side already pins.
 
-  **That layout is now designed and its reader half is landed**:
+  **That layout is now designed, and BOTH its reader half and its writer half are landed**:
   [Sealed Publication Generations](../SealedPublicationGenerations) carries the directory shape, the
   resolution rules, the retention rule, and — the part that decides the order — why a *new* writer
   and an *old* writer on one prefix is the half-migration to avoid: the pointer-following reader
   would keep serving its generation and never see the flat writer's newer publication, a stale serve
-  with nothing red anywhere. Phase 1 (every reader tolerates a pointer) is in; the writer is not, so
-  **everything on this page still describes what is live**. The ORDER that gets there was re-measured
-  on 2026-09-07 and corrected on that page: `plugins` is the only prefix with two producers, core CD
-  pins nothing (so an unconditional writer would flip it the day it merged), and the writer therefore
-  lands behind a per-caller layout selector defaulting to flat.
+  with nothing red anywhere. The writer is behind a per-caller `publication-layout` selector that
+  **defaults to `flat`**, so nothing anywhere writes a generation until a caller opts in and
+  **everything on this page still describes what is live**. What remains is each producer's pin
+  reaching the writer, then flipping — `plugins` in ONE change set, because it is the only prefix
+  with two producers.
+
+  🚨 That page also records what an **OCI registry** does and does not close, since the fleet is
+  moving plugin bundles into one: content-addressed blobs make a mix unrepresentable, but a **tag**
+  is a mutable last-writer-wins reference and simply moves the defect unless the seal names
+  **digests** — the rule already in force for images via `MW_IMAGE_DIGEST`.
 - **A refused publication leaves the prefix unsealed**, which every consumer skips — correct, and
   it means an overlap now costs a red lane and a re-run rather than a portal that renders nothing.
   It is not free: the identity serves nothing until either publisher runs again.


### PR DESCRIPTION
Phase 2 of `Doc/Architecture/SealedPublicationGenerations`. The second half of #3717 — it was pushed
four minutes after the merge queue took that PR, so it landed on the branch and not on `main`.

**It changes nothing anywhere until a caller opts in.** The selector defaults to `flat`, and the three
flat control cases in the overlap harness are the regression suite proving the default path is
byte-identical to what it was.

## Why

The #3496 postcondition turns an overlap from a silent mix into a loud refusal. It is a
**postcondition, not mutual exclusion**, and it leaves the interval between its last verification read
and the seal. This removes the shared directory instead: each publication is written under its own
run-unique token, sealed there, and a one-line `_current` pointer says which one applies. Two
publishers never write the same bytes, so **a mix becomes unrepresentable rather than merely
detectable**.

## 🚨 The obvious design was measured and rejected

Staging the publication and renaming it over the live one is **not available on this store through
this client**. Read off azure-cli 2.90.0 — the version the read-back query was measured against:

| group | commands |
|---|---|
| `az storage file` | copy · hard-link · metadata · symbolic-link · delete · delete-batch · download · download-batch · exists · generate-sas · list · resize · show · update · upload · upload-batch · url |
| `az storage directory` | create · delete · exists · list · show |

**No `rename` in either**, `directory delete` is documented *"Delete the specified **empty**
directory"*, and neither group has a `lease` command — so a lease per identity is not reachable from
this lane either. Even in REST, `Rename Directory` (2021-04-10) cannot **replace** an existing
directory: the swap is rename-away plus rename-in, two operations with a gap in which the live path
does not exist at all.

**So the smallest write this store offers is one small FILE, and that is what the pointer is.** A
rename design would have reintroduced a partial-visibility window wearing a better story.

## What is in it

- `publication-layout` on `node-repo-publish-bake.yml`, default `flat`, carried in as
  `BAKE_PUBLICATION_LAYOUT`. An unrecognised value is **refused**, never silently read as flat.
- `bake-scope.sh` and `carry-forward-bundles.sh` resolve the pointer **in the same commit**, by the
  reader's rules (`ShippedPrebuiltBundles.PublicationDirectoryOf`), so the writer and the two
  Azure-direct readers cannot disagree about which publication is live. `carry-forward` resolves it
  itself rather than being handed the directory — its caller may be pinned to a workflow copy that
  knows nothing about generations, and its one-publication postcondition is what pins it to a single
  generation if the pointer moves mid-read.
- **One deliberate deviation from the design page, documented in place:** the pointer moves **before**
  the flat compatibility copy, not after it. "Last" is about the *generation* — a reader must never be
  pointed at a directory still being filled in — and the flat copy is a different audience and the one
  part another publisher can still be writing. Ordering it after the pointer means an overlap on the
  flat copy costs the *compatibility copy* (refused as today; the run goes red) instead of costing a
  publication that is already whole, sealed and disjoint.
- 🚨 **Retention is NOT implemented, and that is a precondition on flipping rather than a follow-up.**
  Generations accumulate at ~45 small files each until a sweep removes the ones nothing names, and
  that sweep DELETES from the production share, so it must land as its own reviewed change with its
  own harness. **Nothing here deletes anything it did not create.**
- The doc also records what an **OCI registry** does and does not close, for the migration that is
  about to touch these files: content-addressed blobs make a mix unrepresentable, but a **tag** is a
  mutable last-writer-wins reference and moves the defect unless the seal names **digests** — every
  bundle recorded by digest, each publication also given an immutable identity-qualified tag, and the
  sealed set a list of `(package, digest)` pairs (the rule already in force for images via
  `MW_IMAGE_DIGEST`). Plus the two invariants that migration must carry across: the **framework
  identity must stay in the reference**, and the `_releases` marker must survive.

## What this does NOT do

- **Nothing writes a generation yet.** Phase 3 is each producer's `platform-ref` reaching this commit;
  phase 4 is flipping per prefix — `plugins` in ONE change set, because it is the only prefix with two
  producers (core CD's `plugins-bake` and the satellite's own `publish-bake`), and a new writer beside
  an old one on one prefix is the half-migration that serves stale silently.
- 🚨 **Flipping does not by itself stop the publish reds.** The flat compatibility copy is still
  replaced in place and still races. What the flip buys immediately is that the *publication* survives
  an overlap intact and pointed-to instead of being lost. The reds go when the flat copy goes
  (phase 5), or when the publication becomes digest-addressed.
- **The refusal is not weakened anywhere.** A mix is still never sealed, and a sentinel covering one
  is still removed.

## Verification (nothing here triggered a CD run)

- `test-publish-bake-overlap.py` — **67 assertions**, executing the REAL script against a stub share
  and reading every verdict off the BYTES. Five generation cases: one publisher seals under its own
  token and the pointer names it; **two interleaved publishers each seal their OWN generation, neither
  directory holds a byte of the other, both are complete, and `_current` names exactly one of them**;
  "already published" resolves *through* the pointer, not off the prefix; every unusable pointer shape
  (escaping, rooted, `..`, blank, dangling) degrades to the prefix; an unrecognised selector is
  refused. 🚨 **Negative control: 16 of the 67 fail against the pre-change script.**
- `bake-scope.sh --self-test` — the pointer case is **discriminating by construction**: the flat copy
  and the generation record *different* baselines (a diverged commit vs. an ancestor), so the verdict
  itself says which was read — a resolver that ignored the pointer answers `full`, one that follows it
  answers `narrowed` with the generation's commit. The dangling-pointer control asserts the fallback
  SAYS so, so silence cannot pass for resolution.
- `carry-forward-bundles.sh --self-test` — a **decoy** bundle is planted at the prefix under the same
  name and different bytes, so carrying the publication's own bytes forward is only possible by
  following the pointer.
- `bash -n` × 3 clean · `shellcheck -S warning` × 3 clean · `check-workflow-shell.py`,
  `check-workflow-yaml-keys.py`, `check-workflow-timeouts.py`, `check-pr-secret-preflight.py` clean ·
  `DocumentationLinkIntegrityTest` passed ·
  `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → 0 Warning(s), 0 Error(s).

Refs #3461
