### PR TITLE
diag(#3461): the read-back refusal lists what the directory actually holds

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -675,6 +675,24 @@ verify_publication() { # <account> <share> <dest>
     echo "::error title=Refusing to seal — the publication could not be read back::$account/$share/$dest: ${#unreadable[@]} of $MANIFEST_COUNT file(s) could not be read after being uploaded, so whether this directory holds one publication or two cannot be established. Refusing rather than assuming — that assumption is what would seal a mix."
     local entry
     for entry in "${unreadable[@]}"; do echo "::error::could not read back after uploading it: $entry"; done
+    # 🚨 WHAT THE DIRECTORY ACTUALLY HOLDS, listed from inside the job. Measured 2026-09-08 on
+    # identity s96c0dfb0…: 39 of 45 files were ResourceNotFound on read-back although every upload
+    # had returned SUCCESS under `set -e`, on one share only, with NO concurrent writer (verified:
+    # nothing in this script deletes anything but the sentinel, carry-forward only downloads, and
+    # no other run was publishing in the window). That leaves "the CLI reported success without
+    # storing" and "a transient on that share", which the per-file 404s cannot separate — and
+    # NOBODY'S LAPTOP CAN ASK: both investigating identities were refused on the share, while this
+    # job's identity can read it. So the listing is taken HERE, where the credential exists.
+    #
+    # Read-only, after the refusal, and deliberately non-fatal: it must never convert a decided
+    # refusal into a different exit path. `|| true` is the one place in this file that idiom is
+    # right — a diagnostic that fails is still a refusal, and the return below is unchanged.
+    echo "::group::what $account/$share/$dest holds now (diagnostic only — the refusal above stands)"
+    az storage file list --account-name "$account" --share-name "$share" \
+      --path "$dest" --auth-mode login --backup-intent \
+      --query "[].{name:name, bytes:properties.contentLength}" -o tsv --only-show-errors \
+      < /dev/null || echo "the listing itself failed — that is itself the finding: this identity could not read the directory it had just written"
+    echo "::endgroup::"
     return 1
   fi
 


### PR DESCRIPTION
**DRAFT on purpose** — held so it cannot evict the CD run currently protected on `86d8d50db`. Un-draft the moment that run concludes, or immediately if it refuses the same way (the next run then diagnoses it).

## The measurement this answers

CD run 34221941579 refused to seal identity `s96c0dfb0…` on one of two targets:

```
prebuilt-bundles/s96c0dfb0…/plugins: 39 of 45 file(s) could not be read after being uploaded
ERROR: Operation returned an invalid status 'The specified resource does not exist.'
ErrorCode:ResourceNotFound        (×39)
```

**Every upload returned SUCCESS.** This script runs under `set -euo pipefail`, so a failing upload would have ended that target's subshell rather than reaching the read-back. Six of forty-five survived, spread across the write order.

## What was ruled out, rather than assumed

| candidate | why not |
|---|---|
| a quota wall | a share at quota fails the **write** loudly, and `set -e` would have stopped it there |
| this script deleting | it removes nothing but the sentinel (the unseal on reseal) |
| `carry-forward-bundles.sh` | only **downloads** from a source identity; never deletes or moves on a target |
| a concurrent publisher | no Plugins or satellite run was publishing 12:30–13:13Z; the only other core run on that sha was the 12:40 reconcile, which decided "nothing to publish" |

That leaves the storage side — the CLI reporting success without storing, or a transient on that share — and **the per-file 404s cannot separate the two.**

## Why the diagnostic goes in the job

🚨 **Nobody investigating could ask.** Both identities that tried to look were refused on the share (`Storage Blob Data Contributor` required), while this job's own identity had just written to it. So the question is asked where the credential exists: a **read-only listing** after the refusal, naming what the directory holds and each file's size.

- **Non-fatal by design.** `|| true` is right in this one place — a diagnostic that fails is still a refusal. A failed listing prints its own finding, because *"this identity could not read the directory it had just written"* is itself the answer.
- **No behaviour change.** The verdict, its precedence over foreign and neutral bytes, and the `return 1` are untouched. This adds evidence, not a decision.

## What I deliberately did NOT do

- **No stderr capture on `read_stamp`** — I started it, then found az's error was already reaching the log; I had grepped the wrong region.
- **No exit check on the uploads** — `set -e` already covers a failing upload, so a check would catch nothing that is happening here. Adding code against an unestablished cause is what this issue is trying to stop.

Verified: `test-publish-bake-overlap.py` **47 passed / 0 failed**.

Refs #3461.
