### PR TITLE
ci: one live run per PR ref on the four core workflows that had no concurrency group

### DIFF
--- a/.github/workflows/chart-gate.yml
+++ b/.github/workflows/chart-gate.yml
@@ -49,6 +49,12 @@ on:
 permissions:
   contents: read
 
+# One live run per ref: a newer push to the same PR branch cancels the run it supersedes; main and
+# the merge queue never cancel (each main push is its own group, keyed on the commit).
+concurrency:
+  group: chart-gate-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   invariants:
     name: Chart invariants

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -72,6 +72,12 @@ on:
       - ".github/workflows/clients.yml"
       - "src/MeshWeaver.Mesh.Contract/Protos/**"
 
+# One live run per ref: a newer push to the same PR branch cancels the run it supersedes; main and
+# the merge queue never cancel (each main push is its own group, keyed on the commit).
+concurrency:
+  group: clients-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   python-sdk:
     name: "meshweaver (Python test)"

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -48,6 +48,12 @@ permissions:
 env:
   TAP_REPO: Systemorph/homebrew-memex
 
+# One live run per ref: a newer push to the same PR branch cancels the run it supersedes; main and
+# the merge queue never cancel (each main push is its own group, keyed on the commit).
+concurrency:
+  group: homebrew-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   install:
     name: brew install + test (macOS)

--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -27,6 +27,12 @@ on:
 permissions:
   contents: read
 
+# One live run per ref: a newer push to the same PR branch cancels the run it supersedes; main and
+# the merge queue never cancel (each main push is its own group, keyed on the commit).
+concurrency:
+  group: hosting-operator-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   scripts:
     name: Operator scripts (shellcheck + behaviour)


### PR DESCRIPTION
Measured 2026-09-08 while checking why superseded runs were not self-cancelling fleet-wide: `chart-gate.yml`, `clients.yml`, `hosting-operator.yml` and `homebrew.yml` are the four PR-triggered core workflows with no `concurrency:` block, so a push to a PR branch left the previous run burning a runner to completion. Every other PR workflow in the fleet already cancels superseded runs per ref.

Same group shape as `dotnet-test.yml`: a `main` push (and a merge-queue ref) is keyed on its own commit and is never cancelled; every other ref cancels in progress.

Pairs-with: none — CI wiring only, no public surface.
