### PR TITLE
fix(#3438): the pin sweep asserts PROTECTION, not only existence

### DIFF
--- a/.github/scripts/check-pinned-digests.py
+++ b/.github/scripts/check-pinned-digests.py
@@ -888,7 +888,7 @@ def run(repos: list[str], registry: str, repo_root: Path) -> int:
     emit(f"      …PROTECTED (deleteEnabled false)    {len(protected)}")
     emit(f"      …UNPROTECTED — purge can delete     {len(unprotected)}")
     emit(f"      …PENDING-LOCK (exempt: moved since  {len(pending_lock)}")
-    emit(f"        the last scheduled lock)")
+    emit("        the last scheduled lock)")
     emit(f"      …protection INDETERMINATE           {len(protection_unknown)}")
     if last_lock is not None:
         emit(f"      last scheduled lock run             {last_lock:%Y-%m-%dT%H:%M:%SZ}"

--- a/.github/scripts/check-pinned-digests.py
+++ b/.github/scripts/check-pinned-digests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""check-pinned-digests.py — does every image digest the fleet PINS still exist in ACR?
+"""check-pinned-digests.py — does every image digest the fleet PINS still exist in ACR, and is it
+PROTECTED from the next purge?
 
 (The name on this first line is load-bearing in the same way compile-check.py's and
 check-workflow-timeouts.py's are: a lane that fetches this file at the platform ref can refuse a
@@ -28,13 +29,43 @@ contradiction and nothing reconciles them.
 
 WHAT THIS SCRIPT IS, AND WHAT IT IS NOT
 ---------------------------------------
-It is the CHEAP half and it is deliberately not the fix: it does not stop the deletion. It converts
-"an entire repository's CI is inexplicably dead, including its nightly" into one named red saying
-which repo, which variable, and which digest is gone. That is worth having whichever retention
-change lands, because it also catches the next variant.
+Its EXISTENCE arm is the cheap half and is deliberately not the fix: it does not stop the deletion.
+It converts "an entire repository's CI is inexplicably dead, including its nightly" into one named
+red saying which repo, which variable, and which digest is gone.
 
 The retention half — locking the pinned manifests so `acr purge` skips them, and collapsing the two
-divergent tasks into one — is written up in Doc/Architecture/PinnedImageRetention.
+divergent tasks into one — is written up in Doc/Architecture/PinnedImageRetention and is implemented
+by lock-pinned-digests.py, running at 01:00 UTC, two hours before the 03:00 purge.
+
+🚨 THE PROTECTION ARM (#3438, added 2026-09-08) — EXISTENCE IS A LAGGING INDICATOR
+---------------------------------------------------------------------------------
+A manifest that is GONE is a past incident: the wedge has already happened and the repository is
+already dead. The leading indicator is one field away and the same `az` call already fetches it:
+
+    a pinned manifest whose `deleteEnabled` is still TRUE is not protected, and `--ago 7d --keep 10`
+    guarantees it dies — the only open question is which night.
+
+So this sweep now reads `changeableAttributes.deleteEnabled` off every pin it resolves and reports
+PROTECTED / UNPROTECTED / PENDING-LOCK. That closes the one hole nothing covered: **the lock job
+could stop protecting and nothing would say so.** A deleted `lock-pinned-digests.yml`, a removed
+`schedule:`, a revoked `metadata/write` grant, a manifest unlocked by hand — every one of those
+leaves a green wall until a satellite's CI dies at `manifest unknown` days later, which is exactly
+the failure mode of the incident this whole file exists for, one level up.
+
+Two structural assertions come with it, and they need NO credential, so they run on every pull
+request inside `--self-test` rather than only at 05:20:
+
+  * `lock-pinned-digests.yml` EXISTS and carries a `schedule:` — the protection is not a comment.
+  * the lock fires BEFORE the purge. Both are read from committed files (the lock workflow's own
+    `cron:`, and the purge task's `schedule` in .github/acr-retention/tasks.json). Moving the lock
+    to 04:00 would make it useless and, until this arm existed, nothing anywhere would have noticed.
+
+PENDING-LOCK, and why it is not a skip. A pin that moved AFTER the last scheduled lock has not yet
+had an opportunity to be protected, so calling it a failure would red on the fleet's ordinary
+working day. It is reported and EXEMPT — and the exemption is COUNTED in the denominator, so a
+sweep that exempted everything cannot read as a sweep that found everything protected. The window
+is narrow where it matters: this sweep runs at 05:20 UTC and the lock at 01:00, so the exempting
+window is 4h20m, not a day.
 
 DESIGN CONSTRAINTS, each one a thing this fleet has already been bitten by
 -------------------------------------------------------------------------
@@ -67,20 +98,23 @@ USAGE
   check-pinned-digests.py --repos Systemorph/A,...   scan exactly these repositories
   check-pinned-digests.py --self-test                prove the extractor fires and stays silent
 
-Exit 0 only when every pin found resolves. Every failure is a `::error` annotation naming the
-repository, the declaration and the digest.
+Exit 0 only when every pin found resolves AND every pin the lock job has had an opportunity to
+protect is locked. Every failure is a `::error` annotation naming the repository, the declaration
+and the digest.
 """
 
 from __future__ import annotations
 
 import argparse
 import base64
+import datetime as dt
 import json
 import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 
 REGISTRY_DEFAULT = "meshweaver"
 REGISTRY_HOST_RE = r"(?P<host>[a-z0-9]+)\.azurecr\.io"
@@ -178,6 +212,23 @@ class Pin:
     resolved_in: str | None = None
     verdict: str = "UNCHECKED"    # RESOLVES | GONE | INDETERMINATE
     detail: str = ""
+    # 🚨 A SECOND, INDEPENDENT VERDICT — never folded into `verdict` above. Existence and
+    # protection are different questions about the same manifest and a pin can pass either while
+    # failing the other; collapsing them into one field is how "it resolves" would come to mean
+    # "it is safe", which is the reading that made #3438 invisible until the manifest was gone.
+    #   PROTECTED     deleteEnabled == false — `acr purge` skips it (neither purge step passes
+    #                 --include-locked; asserted against the committed record on every PR)
+    #   UNPROTECTED   deleteEnabled == true, and the lock job HAS had an opportunity → a failure
+    #   PENDING-LOCK  deleteEnabled == true, but this pin moved after the last scheduled lock run
+    #   INDETERMINATE the registry did not say — never read as protected
+    protection: str = "UNCHECKED"
+    protection_detail: str = ""
+    delete_enabled: bool | None = None
+
+    @property
+    def workflow_file(self) -> str:
+        """The workflow file this pin is declared in — `where` is '<file>:<name>'."""
+        return self.where.split(":", 1)[0]
 
 
 @dataclass
@@ -407,24 +458,290 @@ def registry_control_probe(registry: str) -> None:
     print(f"registry {registry}: reachable, {len(repos)} repositories.")
 
 
-def resolve(registry: str, acr_repo: str, digest: str, cache: dict) -> tuple[bool, str]:
+def resolve(registry: str, acr_repo: str, digest: str, cache: dict) -> tuple[bool, str, bool | None]:
+    """(exists, detail, delete_enabled).
+
+    🚨 `-o json`, not `-o none`. The protection arm needs `changeableAttributes.deleteEnabled` and
+    this is the SAME registry round trip that answers existence — reading it costs nothing and
+    adds no call. `delete_enabled` is None when the manifest is absent, and also when it is present
+    but the attribute could not be read; the caller treats the second as INDETERMINATE, never as
+    protected. "The registry did not say" is not a confirmation.
+    """
     key = (acr_repo, digest)
     if key in cache:
         return cache[key]
-    rc, _, err = az(
-        ["acr", "repository", "show", "--name", registry, "--image", f"{acr_repo}@{digest}", "-o", "none"]
+    rc, out, err = az(
+        ["acr", "repository", "show", "--name", registry, "--image", f"{acr_repo}@{digest}", "-o", "json"]
     )
     if rc == 0:
-        result = (True, "")
+        delete_enabled: bool | None = None
+        try:
+            attrs = (json.loads(out) or {}).get("changeableAttributes") or {}
+            value = attrs.get("deleteEnabled")
+            if isinstance(value, bool):
+                delete_enabled = value
+        except (json.JSONDecodeError, AttributeError):
+            delete_enabled = None
+        result = (True, "", delete_enabled)
     else:
         blob = err.lower()
         if any(marker in blob for marker in ABSENT_MARKERS):
-            result = (False, "absent")
+            result = (False, "absent", None)
         else:
             # Neither present nor provably absent. Surfaced, never smoothed into "gone".
-            result = (False, "INDETERMINATE: " + " ".join(err.split())[:300])
+            result = (False, "INDETERMINATE: " + " ".join(err.split())[:300], None)
     cache[key] = result
     return result
+
+
+# ── The protection schedule: read from committed files, never from a constant here ─────────────
+#
+# 🚨 THE ORDER OF TWO CLOCKS IS THE WHOLE PROTECTION. `acr purge` skips locked manifests; the lock
+# job is what makes a pinned manifest locked. If the lock ever fires AFTER the purge, every pin
+# moved since the previous lock is unprotected for a full day — and nothing anywhere would say so,
+# because both jobs would report success about their own work. So the relation between the two
+# schedules is asserted, from the two places they are actually written down.
+
+LOCK_WORKFLOW = ".github/workflows/lock-pinned-digests.yml"
+RETENTION_RECORD = ".github/acr-retention/tasks.json"
+
+CRON_LINE_RE = re.compile(r"^\s*-\s*cron:\s*(?P<quote>['\"]?)(?P<expr>[^'\"#\r\n]+)(?P=quote)", re.MULTILINE)
+
+
+def _cron_field_matches(spec: str, value: int, low: int, high: int) -> bool:
+    """One crontab field against one value. Supports `*`, lists, ranges and `/steps`."""
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            return False
+        step = 1
+        if "/" in part:
+            part, _, raw_step = part.partition("/")
+            if not raw_step.isdigit() or int(raw_step) == 0:
+                return False
+            step = int(raw_step)
+        if part in ("*", "?"):
+            start, end = low, high
+        elif "-" in part.lstrip("-"):
+            start_s, _, end_s = part.partition("-")
+            if not (start_s.isdigit() and end_s.isdigit()):
+                return False
+            start, end = int(start_s), int(end_s)
+        elif part.isdigit():
+            start = end = int(part)
+            if step != 1:
+                end = high
+        else:
+            return False
+        if start < low or end > high or start > end:
+            return False
+        if start <= value <= end and (value - start) % step == 0:
+            return True
+    return False
+
+
+def cron_matches(expr: str, when: dt.datetime) -> bool:
+    """Does this 5-field crontab expression fire at `when` (UTC, minute resolution)?"""
+    fields = expr.split()
+    if len(fields) != 5:
+        return False
+    minute, hour, dom, month, dow = fields
+    # GitHub/POSIX: when BOTH day-of-month and day-of-week are restricted the match is their union.
+    dom_restricted = dom.strip() not in ("*", "?")
+    dow_restricted = dow.strip() not in ("*", "?")
+    day_ok_dom = _cron_field_matches(dom, when.day, 1, 31)
+    day_ok_dow = _cron_field_matches(dow, when.isoweekday() % 7, 0, 6)
+    if dom_restricted and dow_restricted:
+        day_ok = day_ok_dom or day_ok_dow
+    elif dom_restricted:
+        day_ok = day_ok_dom
+    elif dow_restricted:
+        day_ok = day_ok_dow
+    else:
+        day_ok = True
+    return (
+        _cron_field_matches(minute, when.minute, 0, 59)
+        and _cron_field_matches(hour, when.hour, 0, 23)
+        and _cron_field_matches(month, when.month, 1, 12)
+        and day_ok
+    )
+
+
+def last_cron_occurrence(exprs: list[str], now: dt.datetime, horizon_days: int = 8) -> dt.datetime | None:
+    """The most recent minute at or before `now` at which any of these crons fires.
+
+    Walks back minute by minute rather than solving the expression: the fleet's crons are daily and
+    the horizon is a week, so the loop is ~11k cheap comparisons and there is no clever arithmetic
+    to get subtly wrong. None means "no occurrence within the horizon" — for a job whose whole job
+    is to run before a NIGHTLY purge, that is a defect, not an answer.
+    """
+    cursor = now.replace(second=0, microsecond=0)
+    for _ in range(horizon_days * 24 * 60 + 1):
+        if any(cron_matches(expr, cursor) for expr in exprs):
+            return cursor
+        cursor -= dt.timedelta(minutes=1)
+    return None
+
+
+def read_lock_schedule(repo_root: Path) -> tuple[list[str], str | None]:
+    """The `cron:` expressions the lock workflow declares — from the file, never remembered here."""
+    path = repo_root / LOCK_WORKFLOW
+    if not path.is_file():
+        return [], (
+            f"{LOCK_WORKFLOW} does not exist. That workflow IS the protection: it locks every "
+            "manifest the fleet pins so `acr purge` skips it. Without it every pin ages out."
+        )
+    text = path.read_text(encoding="utf-8", errors="replace")
+    exprs = [m.group("expr").strip() for m in CRON_LINE_RE.finditer(text)]
+    if not exprs:
+        return [], (
+            f"{LOCK_WORKFLOW} declares no `schedule:` cron. A protection that only runs when "
+            "someone remembers to dispatch it is not a protection."
+        )
+    return exprs, None
+
+
+def read_purge_schedules(repo_root: Path) -> tuple[list[tuple[str, str]], str | None]:
+    """(task name, cron) for every ENABLED purge task in the committed retention record."""
+    path = repo_root / RETENTION_RECORD
+    if not path.is_file():
+        return [], f"{RETENTION_RECORD} does not exist, so the purge schedule is unknown."
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [], f"{RETENTION_RECORD} is not JSON: {exc}"
+    tasks = []
+    for task in doc.get("tasks", []):
+        if str(task.get("status", "")).lower() != "enabled":
+            continue          # a Disabled task deletes nothing; only a live clock can beat the lock
+        schedule = task.get("schedule")
+        if schedule:
+            tasks.append((task.get("name", "?"), str(schedule)))
+    if not tasks:
+        return [], (
+            f"{RETENTION_RECORD} records no ENABLED purge task with a schedule. Either the record "
+            "is stale or retention stopped; both are worth a red rather than a silent pass."
+        )
+    return tasks, None
+
+
+def ordering_problems(lock_crons: list[str], purges: list[tuple[str, str]]) -> list[str]:
+    """Pure comparison of two sets of daily clocks — the lock's, and every enabled purge's.
+
+    Separated from the file reads so --self-test can drive it with SABOTAGED schedules and watch it
+    go red. A gate that has only ever been shown to pass has not been shown to be a gate.
+    """
+    problems: list[str] = []
+    # Anchor on a fixed, ordinary UTC day rather than "now": the question is about the relation
+    # between two daily clocks, and it must answer the same on every day this runs.
+    end_of_day = dt.datetime(2026, 1, 7, 23, 59, tzinfo=dt.timezone.utc)   # a Wednesday, mid-month
+    lock_at = last_cron_occurrence(lock_crons, end_of_day, horizon_days=1)
+    if lock_at is None:
+        return [
+            f"{LOCK_WORKFLOW}'s schedule ({', '.join(lock_crons)}) does not fire on an ordinary "
+            "day. The purge runs nightly, so a lock that does not is not protection."
+        ]
+    for name, expr in purges:
+        purge_at = last_cron_occurrence([expr], end_of_day, horizon_days=1)
+        if purge_at is None:
+            problems.append(
+                f"purge task '{name}' has schedule '{expr}', which does not fire on an ordinary "
+                "day — the record cannot be related to the lock's clock."
+            )
+            continue
+        if lock_at >= purge_at:
+            problems.append(
+                f"the lock fires at {lock_at:%H:%M} UTC and purge task '{name}' at "
+                f"{purge_at:%H:%M} UTC — the lock is NOT before the purge. Every pin moved since "
+                "the previous lock run would face that purge unprotected, and both jobs would "
+                "still report success about their own work."
+            )
+    return problems
+
+
+def check_schedule_ordering(repo_root: Path) -> list[str]:
+    """Is the lock still scheduled to fire BEFORE the purge? Offline, credential-free.
+
+    Returns a list of problems; empty means the ordering holds. This runs in --self-test, so a pull
+    request that moves either clock the wrong way reds on that pull request rather than on the night
+    a satellite's pins quietly stop being protected.
+    """
+    lock_crons, lock_error = read_lock_schedule(repo_root)
+    if lock_error:
+        return [lock_error]
+    purges, purge_error = read_purge_schedules(repo_root)
+    if purge_error:
+        return [purge_error]
+    return ordering_problems(lock_crons, purges)
+
+
+def classify_protection(
+    delete_enabled: bool | None,
+    moved_at: dt.datetime | None,
+    last_lock: dt.datetime | None,
+    move_error: str = "",
+) -> tuple[str, str]:
+    """(verdict, detail) for one resolving pin. Pure, so --self-test can drive every branch.
+
+    🚨 The default is never PROTECTED. Only `deleteEnabled is False` — the registry saying the
+    manifest is locked, in its own words — earns that; every other answer, including "the field was
+    not in the response", is INDETERMINATE. That asymmetry is the whole point: the failure this
+    guards against is a protection that quietly stopped, and a protection that cannot be read has
+    not been shown to be working.
+    """
+    if delete_enabled is False:
+        return "PROTECTED", ""
+    if delete_enabled is None:
+        return "INDETERMINATE", (
+            "the manifest exists but the registry did not report "
+            "changeableAttributes.deleteEnabled"
+        )
+    # delete_enabled is True — unlocked. Has the lock job had an opportunity?
+    if last_lock is None:
+        # No schedule to compare against. The missing schedule is its own red (see
+        # check_schedule_ordering); the pin stays UNPROTECTED rather than being exempted by it,
+        # because "the clock is gone" is the worst possible reason to relax a protection check.
+        return "UNPROTECTED", "no lock schedule could be read, so no opportunity can be established"
+    if moved_at is None:
+        return "INDETERMINATE", (
+            "this manifest is UNLOCKED and it could not be established whether the lock job has "
+            f"had an opportunity since the pin moved — {move_error or 'no commit date'}"
+        )
+    if moved_at > last_lock:
+        return "PENDING-LOCK", (
+            f"the declaring workflow last changed {moved_at:%Y-%m-%dT%H:%M:%SZ}, after the last "
+            f"scheduled lock at {last_lock:%Y-%m-%dT%H:%M:%SZ}"
+        )
+    return "UNPROTECTED", (
+        f"the declaring workflow last changed {moved_at:%Y-%m-%dT%H:%M:%SZ}; the lock was scheduled "
+        f"at {last_lock:%Y-%m-%dT%H:%M:%SZ} and did not protect it"
+    )
+
+
+def last_touched(gh_repo: str, path: str) -> tuple[dt.datetime | None, str]:
+    """When the default branch last changed this file. One REST call, Contents: Read.
+
+    🚨 This is a PROXY and it errs in the SAFE direction only. It answers "could this pin have
+    moved since the last lock run", never "did it". A file touched for an unrelated reason exempts
+    its pins from the protection failure — softening, never a false alarm — and the exemption is
+    COUNTED in the denominator so a sweep that exempted the whole fleet cannot read as a clean one.
+    """
+    rc, out, err = gh_api(f"repos/{gh_repo}/commits?path={path}&per_page=1")
+    if rc != 0:
+        return None, err.strip()[:200] or "commits listing failed"
+    try:
+        commits = json.loads(out)
+    except json.JSONDecodeError as exc:
+        return None, f"commits listing is not JSON: {exc}"
+    if not commits:
+        return None, "no commit touches this path"
+    stamp = (((commits[0] or {}).get("commit") or {}).get("committer") or {}).get("date")
+    if not stamp:
+        return None, "commit carries no committer date"
+    try:
+        return dt.datetime.fromisoformat(stamp.replace("Z", "+00:00")), ""
+    except ValueError as exc:
+        return None, f"unparseable commit date {stamp!r}: {exc}"
 
 
 # ── Reporting ──────────────────────────────────────────────────────────────────────────────────
@@ -445,8 +762,15 @@ def emit(text: str) -> None:
             handle.write(text + "\n")
 
 
-def run(repos: list[str], registry: str) -> int:
+def run(repos: list[str], registry: str, repo_root: Path) -> int:
     registry_control_probe(registry)
+
+    # 🚨 FIRST, and with no credential: is the protection still SCHEDULED, and still scheduled
+    # BEFORE the purge? Everything below assumes the lock job ran; this is what makes that an
+    # assertion rather than an assumption.
+    ordering_problems = check_schedule_ordering(repo_root)
+    lock_crons, _ = read_lock_schedule(repo_root)
+    last_lock = last_cron_occurrence(lock_crons, dt.datetime.now(dt.timezone.utc)) if lock_crons else None
 
     scans: list[RepoScan] = []
     for gh_repo in repos:
@@ -472,15 +796,44 @@ def run(repos: list[str], registry: str) -> int:
                 continue
             indeterminate = ""
             for acr_repo in pin.acr_repos:
-                ok, detail = resolve(registry, acr_repo, pin.digest, cache)
+                ok, detail, delete_enabled = resolve(registry, acr_repo, pin.digest, cache)
                 if ok:
                     pin.verdict, pin.resolved_in = "RESOLVES", acr_repo
+                    # Protection is decided in two passes: the registry answer now, and — only for
+                    # the unlocked ones — the pin's own age, below, which costs a REST call each.
+                    if delete_enabled is False:
+                        pin.protection = "PROTECTED"
+                    elif delete_enabled is True:
+                        pin.protection = "UNPROTECTED"
+                    else:
+                        pin.protection, pin.protection_detail = classify_protection(None, None, None)
+                    pin.delete_enabled = delete_enabled
                     break
                 if detail.startswith("INDETERMINATE"):
                     indeterminate = detail
             else:
                 pin.verdict = "INDETERMINATE" if indeterminate else "GONE"
                 pin.detail = indeterminate or "tried: " + ", ".join(pin.acr_repos)
+
+    # PENDING-LOCK: an UNPROTECTED pin the lock job has not yet had a scheduled opportunity to see.
+    # One commits call per (repository, workflow file) that actually holds an unprotected pin — so
+    # a fleet that is fully protected costs nothing extra.
+    touched_cache: dict[tuple[str, str], tuple[dt.datetime | None, str]] = {}
+    for scan in scans:
+        for pin in scan.pins:
+            if pin.protection != "UNPROTECTED":
+                continue
+            moved_at, error = None, ""
+            if last_lock is not None:
+                key = (pin.gh_repo, pin.workflow_file)
+                if key not in touched_cache:
+                    touched_cache[key] = last_touched(
+                        pin.gh_repo, f".github/workflows/{pin.workflow_file}"
+                    )
+                moved_at, error = touched_cache[key]
+            pin.protection, pin.protection_detail = classify_protection(
+                pin.delete_enabled, moved_at, last_lock, error
+            )
 
     all_pins = [pin for scan in scans for pin in scan.pins]
     pinning = [scan for scan in scans if scan.pins]
@@ -492,6 +845,10 @@ def run(repos: list[str], registry: str) -> int:
     resolved = [pin for pin in all_pins if pin.verdict == "RESOLVES"]
     distinct_digests = {pin.digest for pin in all_pins}
     gone_digests = {pin.digest for pin in gone}
+    protected = [pin for pin in resolved if pin.protection == "PROTECTED"]
+    unprotected = [pin for pin in resolved if pin.protection == "UNPROTECTED"]
+    pending_lock = [pin for pin in resolved if pin.protection == "PENDING-LOCK"]
+    protection_unknown = [pin for pin in resolved if pin.protection == "INDETERMINATE"]
 
     # 🚨 THE DENOMINATOR, PRINTED. A bare "0 unresolved" has two causes — every pin is fine, or
     # nothing was extracted — and they are indistinguishable from the verdict alone.
@@ -515,6 +872,19 @@ def run(repos: list[str], registry: str) -> int:
     emit(f"    …INDETERMINATE (registry not reached) {len(indeterminate)}")
     emit(f"    pin-shaped declarations MALFORMED     {len(malformed)}")
     emit("")
+    # 🚨 THE PROTECTION DENOMINATOR — the leading indicator beside the lagging one. Existence says
+    # whether the wedge already happened; protection says whether it is coming. The EXEMPT line is
+    # printed even at zero: it is the one number that could quietly make this whole arm vacuous.
+    emit("    of the declarations that RESOLVE —")
+    emit(f"      …PROTECTED (deleteEnabled false)    {len(protected)}")
+    emit(f"      …UNPROTECTED — purge can delete     {len(unprotected)}")
+    emit(f"      …PENDING-LOCK (exempt: moved since  {len(pending_lock)}")
+    emit(f"        the last scheduled lock)")
+    emit(f"      …protection INDETERMINATE           {len(protection_unknown)}")
+    if last_lock is not None:
+        emit(f"      last scheduled lock run             {last_lock:%Y-%m-%dT%H:%M:%SZ}"
+             f"  ({', '.join(lock_crons)})")
+    emit("")
     for scan in scans:
         if scan.unreadable:
             emit(f"  {scan.gh_repo}: UNREADABLE — {scan.unreadable}")
@@ -526,11 +896,32 @@ def run(repos: list[str], registry: str) -> int:
         for pin in sorted(scan.pins, key=lambda p: (p.verdict, p.where)):
             where = f"{pin.where}"
             target = pin.resolved_in or "/".join(pin.acr_repos) or "(no ACR repo named)"
-            emit(f"      {pin.verdict:14s} {target}@{pin.digest[:19]}…  {where}"
+            state = pin.verdict if pin.verdict != "RESOLVES" else f"RESOLVES/{pin.protection}"
+            emit(f"      {state:26s} {target}@{pin.digest[:19]}…  {where}"
                  + (f"  [{pin.detail}]" if pin.detail else ""))
     emit("")
 
     failed = False
+
+    # 🚨 THE BUCKETS MUST ACCOUNT FOR EVERY RESOLVING PIN. A pin that fell through every branch
+    # would leave the protection block reporting fewer manifests than it examined, with no line
+    # saying so — the "0 at risk over an unstated denominator" shape this whole file refuses.
+    accounted = len(protected) + len(unprotected) + len(pending_lock) + len(protection_unknown)
+    if accounted != len(resolved):
+        print(f"::error::{len(resolved)} pin declaration(s) resolve but only {accounted} carry a "
+              "protection verdict.")
+        print("  The protection buckets must partition the resolving pins. An unaccounted pin is")
+        print("  invisible in the report, which is the failure this arm exists to prevent.")
+        failed = True
+
+    # The protection's own schedule — asserted before anything that depends on it having run.
+    for problem in ordering_problems:
+        print("::error::the pinned-manifest protection is not correctly scheduled.")
+        print(f"  {problem}")
+        print("  `acr purge` skips locked manifests and lock-pinned-digests.yml is what locks them;")
+        print("  the ordering of those two clocks IS the protection. See")
+        print("  Doc/Architecture/PinnedImageRetention.")
+        failed = True
 
     for scan in unreadable:
         print(f"::error::{scan.gh_repo}: its workflows could not be read, so its pins were NOT checked.")
@@ -578,6 +969,46 @@ def run(repos: list[str], registry: str) -> int:
         print("  and then protect the new one — see Doc/Architecture/PinnedImageRetention.")
         failed = True
 
+    # 🚨 THE LEADING INDICATOR. Everything above this point fires after the manifest is already
+    # gone — which is to say, after the repository is already wedged. This fires while the bytes
+    # are still there and the fix is one `az` command.
+    if protection_unknown:
+        print(f"::error::{len(protection_unknown)} pin declaration(s) exist but their protection "
+              "state could not be read, so it is NOT known whether the purge can delete them.")
+    for pin in protection_unknown:
+        print(f"::error::{pin.gh_repo} — {pin.where}: {pin.protection_detail}")
+        print("  Indeterminate is not a confirmation. A manifest whose lock cannot be read has not")
+        print("  been shown to be locked.")
+        failed = True
+
+    if unprotected:
+        unprotected_digests = {pin.digest for pin in unprotected}
+        print(f"::error::{len(unprotected)} pin declaration(s) over {len(unprotected_digests)} "
+              "manifest(s) are pinned and NOT protected from the purge.")
+    for pin in unprotected:
+        print(f"::error::{pin.gh_repo} — {pin.where} pins "
+              f"{pin.resolved_in}@{pin.digest}, which is UNLOCKED (deleteEnabled=true).")
+        if pin.protection_detail:
+            print(f"  {pin.protection_detail}")
+        print("  CONSEQUENCE — `--ago 7d --keep 10` is measured in AGE and in NEWER BUILDS, so an")
+        print("  unlocked pinned manifest is not at some hypothetical risk: it will be deleted, and")
+        print("  the only open question is which night. When it goes, every job that pulls it dies")
+        print("  at `manifest unknown` before it runs anything, INCLUDING that repository's own")
+        print("  nightly (MeshWeaver#3438 — three satellites down at once, Education's baseline")
+        print("  among them).")
+        print("  🚨 This is the LEADING half. `GONE` above is the same defect after the fact.")
+        print("  WHY IT IS UNLOCKED — the nightly lock job derives its set from the fleet's pins")
+        print("  and locks them (lock-pinned-digests.yml, 01:00 UTC). A pin it has had an")
+        print("  opportunity to see and did not protect means that job is not doing its work:")
+        print("  check its last run, and check that the AZURE_CLIENT_ID app still holds")
+        print("  'Container Registry Repository Writer' on the registry.")
+        print("  TO FIX NOW — one idempotent command, then fix the job:")
+        print(f"      az acr repository update --name {registry} \\")
+        print(f"        --image {pin.resolved_in}@{pin.digest} --delete-enabled false")
+        print("  Do NOT raise --ago/--keep instead: that moves the cliff rather than removing it")
+        print("  (Doc/Architecture/PinnedImageRetention).")
+        failed = True
+
     # A sweep that found nothing has not proven the fleet is clean; it has proven the extractor is
     # broken (a workflow syntax the shapes above do not cover, or a token that reads no repository).
     if not all_pins and not unreadable:
@@ -589,7 +1020,8 @@ def run(repos: list[str], registry: str) -> int:
     if failed:
         return 1
     emit(f"All {len(resolved)} pin declaration(s) — {len(distinct_digests)} distinct digest(s) — "
-         f"across {len(pinning)} repository(ies) resolve.")
+         f"across {len(pinning)} repository(ies) resolve; {len(protected)} are locked against the "
+         f"purge and {len(pending_lock)} await the next scheduled lock.")
     return 0
 
 
@@ -625,7 +1057,105 @@ jobs:
 """
 
 
-def self_test() -> int:
+def self_test_schedule(repo_root: Path) -> list[str]:
+    """The protection-schedule arms: the cron evaluator, then the REAL committed schedules.
+
+    🚨 The second half is deliberately not a fixture. The whole point of the ordering assertion is
+    that it is about the two clocks this repository actually ships, and a fixture would agree with
+    itself forever while the shipped ones drifted apart — the vacuity this file's own history is
+    made of (a placeholder digest read as an absence; a release arm asserted against a fixture with
+    nothing to release).
+    """
+    failures: list[str] = []
+
+    def expect(expr: str, when: str, want: bool, why: str) -> None:
+        moment = dt.datetime.fromisoformat(when).replace(tzinfo=dt.timezone.utc)
+        if cron_matches(expr, moment) != want:
+            failures.append(f"cron {expr!r} at {when}: expected {want} — {why}")
+
+    expect("0 1 * * *", "2026-01-07T01:00", True, "a daily 01:00 job fires at 01:00")
+    expect("0 1 * * *", "2026-01-07T01:01", False, "…and not a minute later")
+    expect("0 1 * * *", "2026-01-07T03:00", False, "…and not at the purge's hour")
+    expect("20 5 * * *", "2026-01-07T05:20", True, "this sweep's own schedule")
+    expect("*/15 * * * *", "2026-01-07T04:45", True, "a step field")
+    expect("*/15 * * * *", "2026-01-07T04:50", False, "…which does not fire off-step")
+    expect("0 1 * * 1-5", "2026-01-07T01:00", True, "a weekday range, on a Wednesday")
+    expect("0 1 * * 0", "2026-01-07T01:00", False, "…and not on a Sunday-only cron")
+    expect("0 1 * *", "2026-01-07T01:00", False, "a 4-field expression is not a cron")
+    expect("0 99 * * *", "2026-01-07T01:00", False, "an out-of-range hour matches nothing")
+
+    # last_cron_occurrence walks BACK; it must never answer with a future minute.
+    now = dt.datetime(2026, 1, 7, 2, 30, tzinfo=dt.timezone.utc)
+    last = last_cron_occurrence(["0 1 * * *"], now)
+    if last != dt.datetime(2026, 1, 7, 1, 0, tzinfo=dt.timezone.utc):
+        failures.append(f"last_cron_occurrence returned {last}, expected 2026-01-07T01:00Z")
+    if last_cron_occurrence(["0 0 30 2 *"], now, horizon_days=8) is not None:
+        failures.append("a cron that cannot fire within the horizon must answer None, not a time")
+
+    # …and the real thing: the shipped lock workflow and the shipped purge record.
+    for problem in check_schedule_ordering(repo_root):
+        failures.append(f"the shipped schedules do not hold the ordering: {problem}")
+
+    # 🚨 POSITIVE CONTROL — the assertion must be able to FAIL. Every arm above could pass with the
+    # comparison deleted; these two cannot.
+    lock_crons, error = read_lock_schedule(repo_root)
+    purges, purge_error = read_purge_schedules(repo_root)
+    if error or purge_error:
+        failures.append(f"falsification arm has no input: {error or purge_error}")
+    else:
+        if ordering_problems(["0 23 * * *"], purges) == []:
+            failures.append(
+                "SABOTAGE UNDETECTED: a lock scheduled at 23:00 — after every purge — was accepted"
+            )
+        if ordering_problems(["0 0 30 2 *"], purges) == []:
+            failures.append(
+                "SABOTAGE UNDETECTED: a lock schedule that never fires was accepted"
+            )
+        if ordering_problems(lock_crons, purges) != []:
+            failures.append("the shipped pair was rejected by the very check that accepted it above")
+
+    # A missing lock workflow is a DELETED protection, and must not read as an absent subject.
+    missing_root = Path(__file__).resolve().parent / "__no_such_repo_root__"
+    _, missing_error = read_lock_schedule(missing_root)
+    if not missing_error:
+        failures.append("SABOTAGE UNDETECTED: a missing lock-pinned-digests.yml read as fine")
+
+    # ── The protection classifier, every branch, offline ────────────────────────────────────────
+    # 🚨 This is the arm that cannot be exercised against the live registry without UNLOCKING a
+    # manifest, which is a mutation of production retention state and is not something a test may
+    # do. So the decision is a pure function and it is driven here instead.
+    lock_at = dt.datetime(2026, 9, 8, 1, 0, tzinfo=dt.timezone.utc)
+    before = dt.datetime(2026, 9, 7, 21, 28, tzinfo=dt.timezone.utc)   # Crm's real shape
+    after = dt.datetime(2026, 9, 8, 10, 46, tzinfo=dt.timezone.utc)    # Plugins' real shape
+
+    def expect_class(delete_enabled, moved_at, last, want, why, move_error=""):
+        got, _ = classify_protection(delete_enabled, moved_at, last, move_error)
+        if got != want:
+            failures.append(f"classify_protection({delete_enabled}, {moved_at}) = {got}, "
+                            f"expected {want} — {why}")
+
+    expect_class(False, before, lock_at, "PROTECTED",
+                 "deleteEnabled=false is the registry saying the purge will skip it")
+    expect_class(False, after, lock_at, "PROTECTED",
+                 "a locked manifest is locked whenever the pin moved")
+    expect_class(True, before, lock_at, "UNPROTECTED",
+                 "the lock ran after this pin was written and did not protect it — THE red")
+    expect_class(True, after, lock_at, "PENDING-LOCK",
+                 "the pin moved after the last scheduled lock, so no opportunity has passed")
+    expect_class(True, None, lock_at, "INDETERMINATE",
+                 "unlocked, and no commit date — never silently exempted")
+    expect_class(True, before, None, "UNPROTECTED",
+                 "🚨 a MISSING lock schedule must not exempt an unlocked pin")
+    expect_class(None, before, lock_at, "INDETERMINATE",
+                 "the registry did not report deleteEnabled — not a confirmation")
+    # The one that would make the whole arm vacuous: an unlocked pin reading as protected.
+    if classify_protection(True, before, lock_at)[0] == "PROTECTED":
+        failures.append("SABOTAGE UNDETECTED: an UNLOCKED pinned manifest classified as PROTECTED")
+
+    return failures
+
+
+def self_test(repo_root: Path) -> int:
     pins, malformed = extract("Systemorph/Fixture", "ci.yml", SELF_TEST_YAML)
     found = {(p.where, p.digest, tuple(p.acr_repos)) for p in pins}
     failures: list[str] = []
@@ -682,11 +1212,19 @@ def self_test() -> int:
     if any(not m.value for m in malformed):
         failures.append("FALSE POSITIVE: a key whose value is the nested block beneath it")
 
+    # The protection arms — the cron evaluator, the SHIPPED lock/purge ordering, and the sabotages
+    # that prove the ordering check can go red. No credential, so a pull request that moves either
+    # clock the wrong way is caught on that pull request.
+    schedule_failures = self_test_schedule(repo_root)
+    failures.extend(schedule_failures)
+
     for line in failures:
         print(f"::error::self-test: {line}")
     if failures:
         return 1
-    print(f"self-test: {len(pins)} pin(s) extracted, {len(malformed)} malformed, no false positive.")
+    print(f"self-test: {len(pins)} pin(s) extracted, {len(malformed)} malformed, no false positive; "
+          "the lock is scheduled before every enabled purge and the ordering check goes red when "
+          "it is not.")
     return 0
 
 
@@ -698,10 +1236,17 @@ def main() -> int:
     parser.add_argument("--registry", default=REGISTRY_DEFAULT)
     parser.add_argument("--self-test", action="store_true",
                         help="prove the extractor fires and stays silent; no network")
+    # The lock workflow and the retention record are read from here — both are committed files in
+    # THIS repository, so the default is this script's own repo root and not a guess.
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[2]),
+                        help="root of the MeshWeaver checkout holding the lock workflow and the "
+                             "ACR retention record")
     args = parser.parse_args()
 
+    repo_root = Path(args.repo_root).resolve()
+
     if args.self_test:
-        return self_test()
+        return self_test(repo_root)
     if bool(args.repos) == bool(args.discover):
         parser.error("give exactly one of --repos or --discover")
 
@@ -709,7 +1254,7 @@ def main() -> int:
         r.strip() for r in args.repos.split(",") if r.strip()
     ]
     print(f"scanning {len(repos)} repository(ies): {', '.join(repos)}")
-    return run(repos, args.registry)
+    return run(repos, args.registry, repo_root)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/check-pinned-digests.py
+++ b/.github/scripts/check-pinned-digests.py
@@ -635,8 +635,8 @@ def ordering_problems(lock_crons: list[str], purges: list[tuple[str, str]]) -> l
     # Anchor on a fixed, ordinary UTC day rather than "now": the question is about the relation
     # between two daily clocks, and it must answer the same on every day this runs.
     end_of_day = dt.datetime(2026, 1, 7, 23, 59, tzinfo=dt.timezone.utc)   # a Wednesday, mid-month
-    lock_at = last_cron_occurrence(lock_crons, end_of_day, horizon_days=1)
-    if lock_at is None:
+    any_lock = last_cron_occurrence(lock_crons, end_of_day, horizon_days=1)
+    if any_lock is None:
         return [
             f"{LOCK_WORKFLOW}'s schedule ({', '.join(lock_crons)}) does not fire on an ordinary "
             "day. The purge runs nightly, so a lock that does not is not protection."
@@ -649,12 +649,21 @@ def ordering_problems(lock_crons: list[str], purges: list[tuple[str, str]]) -> l
                 "day — the record cannot be related to the lock's clock."
             )
             continue
-        if lock_at >= purge_at:
+        # 🚨 "SOME lock fires earlier the SAME night", not "the last lock of the day is earlier".
+        # A schedule that fires more than once (`0 1,5 * * *`) satisfies the protection through its
+        # 01:00 run; comparing only the day's last occurrence would red on it for no reason, and a
+        # gate that is usually wrong stops being read. Requiring the same DAY is what keeps the
+        # 04:00 sabotage red — yesterday's 04:00 lock does technically precede today's 03:00 purge,
+        # 23 hours earlier, which is the whole defect rather than a satisfaction of it.
+        lock_before = last_cron_occurrence(
+            lock_crons, purge_at - dt.timedelta(minutes=1), horizon_days=1
+        )
+        if lock_before is None or lock_before.date() != purge_at.date():
             problems.append(
-                f"the lock fires at {lock_at:%H:%M} UTC and purge task '{name}' at "
-                f"{purge_at:%H:%M} UTC — the lock is NOT before the purge. Every pin moved since "
-                "the previous lock run would face that purge unprotected, and both jobs would "
-                "still report success about their own work."
+                f"no lock fires before purge task '{name}' on the same night: the lock schedule is "
+                f"{', '.join(lock_crons)} and the purge runs at {purge_at:%H:%M} UTC. Every pin "
+                "moved since the previous lock run would face that purge unprotected, and both "
+                "jobs would still report success about their own work."
             )
     return problems
 
@@ -1113,6 +1122,13 @@ def self_test_schedule(repo_root: Path) -> list[str]:
             )
         if ordering_problems(lock_crons, purges) != []:
             failures.append("the shipped pair was rejected by the very check that accepted it above")
+        # …and the multi-occurrence case is ACCEPTED, so the gate does not cry wolf on a schedule
+        # that fires twice and satisfies the protection through its earlier run.
+        if ordering_problems(["0 1,23 * * *"], purges) != []:
+            failures.append(
+                "FALSE POSITIVE: a lock firing at 01:00 AND 23:00 was rejected, though its 01:00 "
+                "run precedes every purge"
+            )
 
     # A missing lock workflow is a DELETED protection, and must not read as an absent subject.
     missing_root = Path(__file__).resolve().parent / "__no_such_repo_root__"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2035,7 +2035,18 @@ jobs:
     # placeholder digest is a FAILURE rather than an absence — the `check-platform-pins.py` hole,
     # where a loose `sha256:[0-9a-f]+` reads `sha256:PLACEHOLDER` as "no pin here" and passes — and
     # that a git sha and a `${{ … }}` forward stay silent. An unproven gate is no gate.
-    - name: "Every fleet image pin is extractable — the gate can fail (self-test)"
+    #
+    # 🚨 It also carries the two arms of the PROTECTION half that need no credential, so they run
+    # HERE on every pull request rather than only at 05:20: that lock-pinned-digests.yml still
+    # exists and still carries a `schedule:`, and that its cron fires BEFORE every enabled purge
+    # step recorded in .github/acr-retention/tasks.json. `acr purge` skips locked manifests and that
+    # workflow is what locks them, so the ORDER of those two clocks IS the protection — move the
+    # lock to 04:00 and every pin moved since the previous night faces the purge unprotected, with
+    # both jobs still reporting success about their own work. Two sabotages (a lock at 23:00, a lock
+    # that never fires) are driven through the same comparison and must go red, and the classifier
+    # that decides PROTECTED / UNPROTECTED / PENDING-LOCK is exercised on every branch — including
+    # the one no live run can reach without UNLOCKING a production manifest.
+    - name: "Every fleet image pin is extractable, and the lock still precedes the purge (self-test)"
       run: python3 .github/scripts/check-pinned-digests.py --self-test
 
     # 🚨 …and the OTHER question about the same pins, which existence answers nothing about:

--- a/.github/workflows/pinned-digests.yml
+++ b/.github/workflows/pinned-digests.yml
@@ -10,12 +10,27 @@ name: Pinned image digests
 # below anything a CI log calls out, and the purge itself is not adjacent to the breakage in any log
 # (runners and pods serve from cache long after the delete — Memex#122's lesson, unchanged here).
 #
-# 🚨 THIS IS THE CHEAP HALF, AND DELIBERATELY NOT THE FIX. It does not stop the deletion. It turns
+# 🚨 EXISTENCE IS THE LAGGING HALF, AND IT IS NOT THE FIX. It does not stop the deletion. It turns
 # "an entire repository's CI is inexplicably dead, including its nightly" into one red naming the
-# repository, the declaration and the digest. The retention half — locking pinned manifests so
-# `acr purge` skips them, and collapsing the two divergent purge tasks into one — is designed in
-# src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md and is a live change to
-# shared registry infrastructure, so it is the maintainer's to apply.
+# repository, the declaration and the digest — after the fact. The retention half — locking pinned
+# manifests so `acr purge` skips them, and collapsing the two divergent purge tasks into one — is
+# lock-pinned-digests.yml, and it is live: its first APPLY run on 2026-09-08 locked 8 manifests and
+# left 0 unprotectable.
+#
+# 🚨 SO THIS SWEEP ALSO ASKS THE LEADING QUESTION: is every pinned manifest PROTECTED? A manifest
+# that is GONE is a past incident; a pinned manifest whose `deleteEnabled` is still true is a
+# scheduled one, because `--ago 7d --keep 10` is measured in age and in newer builds and guarantees
+# it dies. The same `az acr repository show` that answers existence carries the attribute, so the
+# leading indicator costs no extra call — and it closes the one hole nothing covered: the lock job
+# could stop protecting (deleted workflow, removed schedule, revoked metadata/write grant, a
+# manifest unlocked by hand) and every wall would stay green until a satellite died days later.
+#
+# Two of its arms need NO credential and therefore run on every pull request inside `--self-test`:
+# that lock-pinned-digests.yml exists with a `schedule:`, and that the lock fires BEFORE the purge
+# (its cron vs. the schedule in .github/acr-retention/tasks.json). Moving the lock past the purge
+# would make it decorative, and nothing anywhere would have noticed.
+#
+# See src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md.
 #
 # 🛡️ THIS WORKFLOW MAY NOT SKIP (AGENTS.md — "a gate NEVER tests its own inputs"). GitHub paints a
 # skipped job with the same grey tick as a passed one, so:
@@ -44,9 +59,13 @@ name: Pinned image digests
 
 on:
   schedule:
-    # 05:20 UTC — AFTER both ACR retention tasks (purge-old-images at 03:00, purge-old-ci-releases
-    # at 04:00) and before the working day, so a pin the night's purge ate is named in a red that is
-    # already waiting rather than discovered by a satellite's CI dying at `manifest unknown`.
+    # 05:20 UTC — AFTER the lock (01:00) and AFTER the purge (03:00), and before the working day.
+    # Both orderings matter and they are why this hour is what it is: a pin the night's purge ate is
+    # named in a red that is already waiting rather than discovered by a satellite's CI dying at
+    # `manifest unknown`, AND the night's lock run has had its turn, so a pin that is STILL
+    # unprotected at this hour means the protection did not do its work — not that it has not
+    # started. The 4h20m between the lock and this sweep is also the whole of the PENDING-LOCK
+    # exemption window; the report counts what it exempts.
     - cron: "20 5 * * *"
   workflow_dispatch:
   push:
@@ -55,6 +74,10 @@ on:
       - '.github/workflows/pinned-digests.yml'
       - '.github/scripts/check-pinned-digests.py'
       - '.github/scripts/check-pin-set-consistency.py'
+      # The protection arm reads both of these, so a change to either must be re-asserted against
+      # the live registry rather than waiting for 05:20.
+      - '.github/workflows/lock-pinned-digests.yml'
+      - '.github/acr-retention/tasks.json'
 
 permissions:
   contents: read
@@ -167,8 +190,10 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       # No `if:`, no `continue-on-error:`. The script fails closed on an unreadable repository, on a
-      # pin-shaped declaration whose value is not a digest, on an indeterminate registry answer, and
-      # on a fleet in which it found no pins at all — that last one because a sweep that extracted
+      # pin-shaped declaration whose value is not a digest, on an indeterminate registry answer, on
+      # a pinned manifest that is UNPROTECTED after the lock has had its turn, on a protection state
+      # the registry would not report, on a lock that is not scheduled before the purge, and on a
+      # fleet in which it found no pins at all — that last one because a sweep that extracted
       # nothing has proven the extractor broken, not the fleet clean.
       - name: Sweep the fleet
         env:

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -143,6 +143,15 @@ locked satisfy this sweep completely while being a half-moved set — see
 [Pin Set Consistency](../PinSetConsistency), whose tag arm runs beside this one in the same workflow,
 under the same credential.
 
+🚨 **And it sees AXIS 1 only** — digests pinned in `.github/workflows`. The lock job protects both
+axes (below), but the independent *assertion* that the protection is still working covers the CI
+digests, not the deployment overlays' tag pins. That is deliberate rather than overlooked: the
+failure being watched for is the **lock job as a whole** silently stopping, and when it does, axis-1
+pins go unprotected in the same breath as axis-2 ones — so axis 1 is a sufficient canary for the
+shared cause. It is **not** sufficient for a fault confined to the axis-2 extractor, which would
+leave overlay-pinned manifests unlocked with every axis-1 pin reading `PROTECTED`. Memex#122's
+victim was pinned on axis 2, so this boundary is worth revisiting if that extractor is ever changed.
+
 ```
     repositories scanned                  8
     …declaring at least one digest pin    6

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -102,15 +102,23 @@ the two places the schedules are actually written down:
 
 * `.github/workflows/lock-pinned-digests.yml` exists and carries a `schedule:` — a protection that
   only runs when someone remembers to dispatch it is not a protection;
-* its `cron` fires **before** every *enabled* purge step's `schedule` in
-  `.github/acr-retention/tasks.json`. A `Disabled` task deletes nothing, so only a live clock counts.
+* some lock occurrence fires **earlier the same night** than every *enabled* purge step's `schedule`
+  in `.github/acr-retention/tasks.json`. A `Disabled` task deletes nothing, so only a live clock
+  counts.
 
-Neither needs a credential, so both live in `--self-test` and run on **every pull request** in
-`dotnet-test.yml`'s workflow-shell lane, rather than only at 05:20. Falsified 2026-09-08 by editing
-the shipped files: moving the lock cron to `0 4 * * *` reds with *"the lock fires at 04:00 UTC and
-purge task 'purge-old-images' at 03:00 UTC"*; deleting the workflow reds with *"that workflow IS the
-protection"*. Two sabotages (a lock at 23:00, a lock schedule that never fires) are driven through
-the same comparison inside the self-test and must both come back non-empty.
+🚨 **"Some occurrence, the same night" — not "the day's last occurrence is earlier".** A schedule
+firing twice (`0 1,23 * * *`) satisfies the protection through its 01:00 run, and rejecting it would
+be a gate that is usually wrong, which is a gate nobody reads. Requiring the same *night* is what
+keeps a lock moved to 04:00 red: yesterday's 04:00 run does technically precede today's 03:00 purge,
+twenty-three hours earlier, and that gap **is** the defect rather than a satisfaction of it.
+
+Neither assertion needs a credential, so both live in `--self-test` and run on **every pull request**
+in `dotnet-test.yml`'s workflow-shell lane, rather than only at 05:20. Falsified 2026-09-08 by
+editing the shipped files: moving the lock cron to `0 4 * * *` reds with *"no lock fires before
+purge task 'purge-old-images' on the same night"*; deleting the workflow reds with *"that workflow IS
+the protection"*. Three cases are driven through the same comparison inside the self-test — a lock at
+23:00 and a lock that never fires must both come back non-empty, and the twice-daily `0 1,23 * * *`
+must come back **empty**, so the false-positive direction is proven too.
 
 ### PENDING-LOCK is an exemption, and it is COUNTED
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -55,20 +55,85 @@ Do not look for an `ImagePullBackOff` or a `manifest unknown` near the purge tim
 not be one. Work from the pin instead: read the digest out of the repository's workflow and ask the
 registry whether it still exists.
 
-## The guard — a dead pin is named before a repository discovers it
+## The guard — a dead pin named before a repository discovers it, an unprotected one before it dies
 
 `.github/scripts/check-pinned-digests.py`, run daily by
-`.github/workflows/pinned-digests.yml` at 05:20 UTC — **after** both retention tasks — and again on
-any push to `main` that touches either file.
+`.github/workflows/pinned-digests.yml` at 05:20 UTC — **after** the 01:00 lock and the 03:00 purge —
+and again on any push to `main` that touches it, the lock workflow, or the retention record.
 
-It does not prevent the deletion. It converts *"an entire repository's CI is inexplicably dead,
-including its nightly"* into one red naming the repository, the declaration and the digest. That is
-worth having whichever retention change lands, because it also catches the next variant.
+Its **existence** arm does not prevent the deletion. It converts *"an entire repository's CI is
+inexplicably dead, including its nightly"* into one red naming the repository, the declaration and
+the digest.
 
-🚨 **It answers EXISTENCE only.** Whether the digests one repository pins name the *same promoted
-build* is a different question with a different answer, and two manifests that both exist satisfy
-this sweep completely while being a half-moved set — see [Pin Set Consistency](../PinSetConsistency),
-whose tag arm runs beside this one in the same workflow, under the same credential.
+🚨 **Existence is a LAGGING indicator, and until 2026-09-08 it was the only one.** A manifest that
+is `GONE` is a past incident — the wedge has already happened and the repository is already dead.
+The leading indicator is one field away and the *same* `az acr repository show` already carries it:
+
+> a pinned manifest whose `deleteEnabled` is still **true** is not protected, and `--ago 7d
+> --keep 10` guarantees it dies. The only open question is which night.
+
+So the sweep reads `changeableAttributes.deleteEnabled` off every pin it resolves — no extra call,
+`-o json` instead of `-o none` — and classifies it:
+
+| Verdict | Meaning | Red? |
+|---|---|---|
+| `PROTECTED` | `deleteEnabled == false` — the purge skips it | no |
+| `UNPROTECTED` | unlocked, and the lock job has had a scheduled opportunity | **yes** |
+| `PENDING-LOCK` | unlocked, but the pin moved *after* the last scheduled lock | no — counted |
+| `INDETERMINATE` | the registry did not report the attribute, or the opportunity could not be established | **yes** |
+
+**The default is never `PROTECTED`.** Only the registry saying `deleteEnabled: false`, in its own
+words, earns it; "the field was not in the response" is INDETERMINATE. That asymmetry is the point —
+the failure being guarded against is a protection that quietly stopped, and a protection that cannot
+be read has not been shown to be working.
+
+**What this closes, and nothing else did.** The lock job asserts its own postcondition *per
+manifest, at lock time* (see below). Nothing asserted that the postcondition still **holds**, from a
+process that does not depend on the lock job having run. So every one of these left a green wall
+until a satellite died days later: `lock-pinned-digests.yml` deleted; its `schedule:` removed; the
+`metadata/write` grant revoked; a manifest unlocked by hand; the cron moved past the purge.
+
+### 🚨 The ordering of two clocks IS the protection, and it is now asserted on every pull request
+
+`acr purge` skips locked manifests; the lock job is what makes a pinned manifest locked. If the lock
+ever fires **after** the purge, every pin moved since the previous lock faces that purge unprotected
+— and *both jobs would still report success about their own work*. So the sweep also asserts, from
+the two places the schedules are actually written down:
+
+* `.github/workflows/lock-pinned-digests.yml` exists and carries a `schedule:` — a protection that
+  only runs when someone remembers to dispatch it is not a protection;
+* its `cron` fires **before** every *enabled* purge step's `schedule` in
+  `.github/acr-retention/tasks.json`. A `Disabled` task deletes nothing, so only a live clock counts.
+
+Neither needs a credential, so both live in `--self-test` and run on **every pull request** in
+`dotnet-test.yml`'s workflow-shell lane, rather than only at 05:20. Falsified 2026-09-08 by editing
+the shipped files: moving the lock cron to `0 4 * * *` reds with *"the lock fires at 04:00 UTC and
+purge task 'purge-old-images' at 03:00 UTC"*; deleting the workflow reds with *"that workflow IS the
+protection"*. Two sabotages (a lock at 23:00, a lock schedule that never fires) are driven through
+the same comparison inside the self-test and must both come back non-empty.
+
+### PENDING-LOCK is an exemption, and it is COUNTED
+
+A pin that moved after the last scheduled lock has not yet had an opportunity to be protected, so
+calling it a failure would red on the fleet's ordinary working day. It is exempt — and the count is
+printed as its own line, because an exemption that can silently grow to cover the whole fleet is how
+this arm would become vacuous.
+
+The proxy is deliberately conservative: *when did the declaring workflow file last change*, one REST
+call per repository, not *when did this digest change*. A file touched for an unrelated reason
+exempts its pins — a **softening**, never a false alarm. And the window where that matters is narrow
+at the hour it runs: the sweep is at 05:20 and the lock at 01:00, so a pin has to have moved inside
+those 4h20m to be exempted at all.
+
+🚨 **A missing lock schedule does NOT exempt anything.** "The clock is gone" is the worst possible
+reason to relax a protection check, so with no schedule to compare against an unlocked pin stays
+`UNPROTECTED` — and the missing schedule is its own red besides.
+
+🚨 **It answers existence and protection, not agreement.** Whether the digests one repository pins
+name the *same promoted build* is a third question, and two manifests that both exist and are both
+locked satisfy this sweep completely while being a half-moved set — see
+[Pin Set Consistency](../PinSetConsistency), whose tag arm runs beside this one in the same workflow,
+under the same credential.
 
 ```
     repositories scanned                  8
@@ -88,6 +153,65 @@ Measured 2026-09-06, mid-release-wave. The three GONE are Education's, and they 
 `mw-plugin-test@sha256:df19f10afc1f…`. Note the gap between **15** and **9**: the fleet moves its
 pins as one set, so most manifests are pinned from several repositories at once, and the two numbers
 must not be collapsed into one — see below.
+
+### The same sweep with the protection arm, measured 2026-09-08T13:5xZ
+
+```
+    …declarations that RESOLVE            15
+    …declarations that are GONE            0
+
+    of the declarations that RESOLVE —
+      …PROTECTED (deleteEnabled false)    11
+      …UNPROTECTED — purge can delete      0
+      …PENDING-LOCK (exempt: moved since   4
+        the last scheduled lock)
+      …protection INDETERMINATE            0
+      last scheduled lock run             2026-09-08T01:00:00Z  (0 1 * * *)
+```
+
+**Zero gone, and every pin the lock has had a turn at is locked.** The four `PENDING-LOCK` are
+MeshWeaver.Plugins' current pair (`mw-plugin-test@7202afd4…`, `memex-portal-ai@05080741…`, over four
+declaration sites), whose `ci.yml` moved at 10:46Z — nine hours after the 01:00 lock run that saw
+the previous pair. Nothing is wrong: tonight's 01:00 lock precedes tomorrow's 03:00 purge, so they
+are protected before anything can delete them.
+
+🚨 **But it makes the shape of the residual exposure legible, and it is worth stating plainly:
+protection is DERIVED on a daily cadence and the purge does not wait for it.** The two live in
+different systems — the lock is a GitHub Actions cron, the purge an ACR timer task — with no
+interlock between them. So a pin that lands in the **01:00–03:00 window** meets that night's purge
+unprotected, and if the lock job does not run at all (a GitHub Actions outage, a failed OIDC login,
+a revoked grant) the purge still runs at 03:00 regardless. Neither is a widened window away from
+being fixed; both are closed only by making the pin move and its lock ONE act, which today means a
+cross-repo dispatch from each satellite and is not built.
+
+**Until it is, the guard's protection arm is what makes the residual exposure visible instead of
+silent** — and a pin that stays unprotected past a lock run is a red naming the repository, the
+declaration, the digest and the one `az` command that fixes it now.
+
+**The independent denominator, measured the same day** (a plain `sha256:` grep over every workflow
+file in all 34 org repositories, deliberately not the shipped extractor):
+
+| | |
+|---|---|
+| repositories in the org | 34 |
+| …with a `.github/workflows` directory | 16 |
+| …declaring ≥ 1 digest pin | 6 (Crm, Education, Manufacturing, Plugins, Reinsurance, SocialMedia) |
+| `sha256:`-shaped tokens found | 31 |
+| …inside COMMENTS (prose about past incidents) | 11 |
+| **pin declaration SITES** | **20** — exactly what the lock job reports |
+| …over how many DISTINCT manifests | 9 |
+| …that exist | 9 |
+| …that are GONE | 0 |
+| …that exist and are LOCKED | 7 |
+| …that exist and are UNLOCKED | 2 (both Plugins', pinned hours earlier) |
+
+Two things that only a hand count shows. **Eleven of thirty-one `sha256:` tokens are comments** —
+several of them narrating *this* incident inside the very files it broke — so any "count the digests"
+instrument that does not exclude them over-reports by more than a third. And **20 sites collapse to
+15 declarations** in the shipped report, because it dedupes on `(declaration name, digest)` and both
+Plugins and Crm write the same `platform-image-digest:` value at two lane calls; 9 distinct
+manifests is the number retention actually has to keep alive, and it is the one the two counts agree
+on.
 
 ### What it is built not to do
 
@@ -232,6 +356,28 @@ would have dragged `memex-portal` from 30 days to `7d --keep 10` with nobody dec
 removed the second *task* — the "which of two lists?" question — while preserving each repository's
 effective window exactly. Both steps share **one 3600 s task budget**; the per-step `timeout` is a
 per-step ceiling, not a second hour.
+
+**Re-verified against the live registry 2026-09-08**, from the task definitions rather than from any
+summary of them — `az acr task show` for both, decoding `step.encodedTaskContent`:
+
+| Task | `status` | `schedule` | Steps |
+|---|---|---|---|
+| `purge-old-images` | **Enabled** | `0 3 * * *` | 5 CI repos at `--ago 7d --keep 10 --untagged`; `memex-portal` at `--ago 30d --untagged` |
+| `purge-old-ci-releases` | **Disabled** | `0 4 * * *` | its old single 30-day step, kept as the record of the Memex#122 reasoning |
+
+So the issue's headline finding — *"the second purge task never learned Memex#122"* — is **settled,
+and the settlement is that there is no longer a second task to teach.** The divergence itself was
+the defect: one repository (`mw-plugin-test`) appeared in the aggressive list and in no other, and
+whether a new repository landed under a 7-day or a 30-day window depended on which of two
+independently-edited filter lists someone happened to open. `lastModifiedAt` on both is
+2026-09-06T21:51Z, ninety seconds apart, which is the edit that collapsed them.
+
+🚨 **The committed record is not the registry, and only one command relates them.**
+`.github/acr-retention/*.yaml` is a *record* — nothing deploys from it — so "the record says
+Disabled" is not evidence the task is. `acr-retention-tasks.sh verify` is what compares the two, and
+it is deliberately not in CI (it needs `registries/tasks/read`, a strictly larger grant than the
+lock job holds, and a step that is permanently red for a missing grant is a step that gets ignored).
+The reading above was taken by hand, read-only.
 
 🚨 **A correction to the reasoning recorded in that task, measured 2026-09-07.** The task's own
 comment justifies the split by saying `memex-portal` "is pinned on the OTHER axis (committed tags in
@@ -413,17 +559,16 @@ protection against a future filter addition rather than against tonight.
 deleted. The job reds on them, by construction, on the same fact the 05:20 guard reds on. Education's
 bump must move all three.
 
-🚨 **Locking is a WRITE, and the read-only sweep's credential cannot do it.**
+### ✅ The WRITE half works — measured on the first apply run, 2026-09-08
+
+**Locking is a WRITE, and the read-only sweep's credential could not do it.**
 `az acr repository update` needs the data action
 `Microsoft.ContainerRegistry/registries/repositories/metadata/write`, which is in
 **`Container Registry Repository Writer`** (and in Contributor/Owner) and in **neither `AcrPull` nor
-`AcrPush`** — measured 2026-09-07: `AcrPush` is `pull/read` + `push/write` and nothing else.
-
-The registry's three service principals hold, between them, only `AcrPull`, `AcrPush` and
-`Container Registry Data Importer and Data Reader` — measured with `--include-inherited`, and that
-third role is `metadata/**read**` only. So on the evidence the lock will be refused until a grant is
-added. **The job's first run is the decisive measurement**, and it reds **once**, naming the exact
-assignment rather than repeating one refusal per manifest:
+`AcrPush`** — measured 2026-09-07: `AcrPush` is `pull/read` + `push/write` and nothing else. The
+registry's three service principals held only `AcrPull`, `AcrPush` and `Container Registry Data
+Importer and Data Reader` (`metadata/**read**` only), so the prediction was that the lock would be
+refused until a grant was added:
 
 ```bash
 az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \
@@ -431,7 +576,29 @@ az role assignment create --assignee <the AZURE_CLIENT_ID app's object id> \
   --scope /subscriptions/<sub>/resourceGroups/meshweaver-shared/providers/Microsoft.ContainerRegistry/registries/meshweaver
 ```
 
-That is a provisioning task, not a workflow defect.
+**That grant landed, and the prediction was confirmed by its removal**: the scheduled run of
+2026-09-08T01:14Z ([34176008757](https://github.com/Systemorph/MeshWeaver/actions/runs/34176008757))
+is the first `apply` run in the job's history to succeed, and it wrote locks:
+
+```
+mode: apply (event: schedule)
+
+    UNION — manifests the fleet pins            REGISTRY
+      distinct manifests wanted        18         manifests in the registry     2813
+      …already protected               10         …currently locked               26
+      …TO LOCK                          8         …locked and pinned by NOTHING   16
+      …that could NOT be protected      0
+
+Protected 18 manifest(s) (8 newly locked this run); 0 released.
+```
+
+Every previous run was report-only or blocked, so **`0 that could NOT be protected` is the first
+measurement of the mechanism end to end** rather than of its plan. The three that #3438 could not
+protect were Education's already-deleted trio; Education's bump moved all three, and they now read
+`memex-portal-ai@47dc1750…`, `memex-migration@24ea2fc6…`, `mw-plugin-test@4cef7b67…`.
+
+🚨 **`…locked and pinned by NOTHING 16` is the standing debt of a lock-only job**, and it grows every
+time a pin moves. The release arm that would clear it stays disabled on purpose — see below.
 
 ### 🚨 The lock asserts its own postcondition — an exit code is not a locked manifest
 
@@ -466,10 +633,9 @@ answer. Both were **falsified** — deleting the read-back turns them red with
 `5 lock(s) were COUNTED although none took`, which is what makes them assertions rather than
 decoration.
 
-This matters more than it looks, because **the write half has never actually run**. Both runs so far
-were report-only or blocked, and the `metadata/write` grant below is (on the role evidence) still
-missing. The first `apply` run is the decisive measurement, and it must not be able to report
-success without having achieved it.
+That read-back is what makes the 2026-09-08 apply run above *evidence*. Before it, the job had never
+written a lock at all; had it still been believing exit codes, `Protected 18 manifest(s)` would have
+been indistinguishable from 18 manifests the purge could still delete.
 
 ### Two questions about the lock job, settled by measurement rather than reasoning
 


### PR DESCRIPTION
Closes part of #3438.

## The gap this closes

`check-pinned-digests.py` answered **existence** only, and existence is a *lagging* indicator:
by the time a pinned manifest reads `GONE`, the repository is already wedged and its own nightly is
dead with it. That is the state #3438 documents.

The leading indicator was one field away, and the *same* `az acr repository show` already carried it:

> a pinned manifest whose `deleteEnabled` is still **true** is not protected, and `--ago 7d --keep 10`
> is measured in age and in newer builds, so it **will** be deleted — the only open question is
> which night.

**So nothing asserted that the protection was still protecting.** The lock job checks its own
postcondition per manifest at lock time (#3563), but from a process that *is* the lock job. Every
one of these left a green wall until a satellite died at `manifest unknown` days later:
`lock-pinned-digests.yml` deleted; its `schedule:` removed; the `metadata/write` grant revoked; a
manifest unlocked by hand; the cron moved past the purge. That is #3438's own failure mode one level
up — silent until the next pull.

## What changed

**1. The sweep classifies protection.** `-o json` instead of `-o none`, no extra call:

| Verdict | Meaning | Red? |
|---|---|---|
| `PROTECTED` | `deleteEnabled == false` — the purge skips it | no |
| `UNPROTECTED` | unlocked, and the lock has had a scheduled opportunity | **yes** |
| `PENDING-LOCK` | unlocked, but the pin moved *after* the last scheduled lock | no — counted |
| `INDETERMINATE` | the registry did not report it, or the opportunity could not be established | **yes** |

The default is never `PROTECTED`. "The field was not in the response" is INDETERMINATE — a
protection that cannot be read has not been shown to be working.

**2. Two structural assertions that need NO credential**, so they run on every pull request inside
`--self-test` rather than only at 05:20:

* `lock-pinned-digests.yml` exists and carries a `schedule:`;
* its cron fires **before** every **enabled** purge step's `schedule` in
  `.github/acr-retention/tasks.json`. `acr purge` skips locked manifests and that workflow is what
  locks them, so **the order of those two clocks IS the protection**. Move the lock to 04:00 and
  every pin moved since the previous night faces the purge unprotected, with both jobs still
  reporting success about their own work.

**3. `PENDING-LOCK` is an exemption and it is COUNTED.** A pin that moved after the last scheduled
lock has had no opportunity to be protected, so failing it would red on the fleet's ordinary working
day. The proxy — when the declaring workflow file last changed — softens, never false-alarms, and
the exempted count is its own reported line, so the arm cannot go vacuous unnoticed. A **missing**
lock schedule exempts nothing: "the clock is gone" is the worst possible reason to relax the check.

## Falsified, not asserted — each watched to go RED

* lock cron moved to `0 4 * * *` → *"the lock fires at 04:00 UTC and purge task 'purge-old-images'
  at 03:00 UTC — the lock is NOT before the purge"*
* `lock-pinned-digests.yml` deleted → *"that workflow IS the protection"*
* two sabotaged schedules (a lock at 23:00; a lock that never fires) driven through the same
  comparison **inside** the self-test, so the ordering check cannot silently stop being one
* the classifier made to answer `PROTECTED` for everything → five arms red, including
  `SABOTAGE UNDETECTED: an UNLOCKED pinned manifest classified as PROTECTED`

The classifier is a pure function precisely so every branch can be driven: the `UNPROTECTED` branch
cannot be reached against the live registry without **unlocking a production manifest**, which a
test may not do.

## Measured — read-only, no purge, no dry run, no registry mutation

**Every pin examined, not only the ones at risk.** Independent hand count (a plain `sha256:` grep
over every workflow file in all 34 org repositories, deliberately *not* the shipped extractor):

| | |
|---|---|
| repositories in the org | 34 |
| …with a `.github/workflows` directory | 16 |
| …declaring ≥ 1 digest pin | **6** (Crm, Education, Manufacturing, Plugins, Reinsurance, SocialMedia) |
| `sha256:`-shaped tokens found | 31 |
| …inside COMMENTS (prose about past incidents) | 11 |
| **pin declaration SITES** | **20** — exactly what the lock job reports |
| …over how many DISTINCT manifests | **9** |
| …that EXIST | 9 |
| …that are GONE | **0** |
| …that exist and are LOCKED | **7** |
| …that exist and are UNLOCKED | **2** — both MeshWeaver.Plugins', pinned at 10:46Z today |

Eleven of thirty-one `sha256:` tokens are **comments** — several narrating *this* incident inside
the very files it broke — so any "count the digests" instrument that does not exclude them
over-reports by more than a third. The two unlocked ones are not a defect: tonight's 01:00 lock
precedes tomorrow's 03:00 purge. They are `PENDING-LOCK`, and the new report says so.

The shipped sweep, run live on this branch, agrees:

```
    …declarations that RESOLVE            15      (20 sites dedupe to 15 (name, digest) pairs)
    …declarations that are GONE            0

    of the declarations that RESOLVE —
      …PROTECTED (deleteEnabled false)    11
      …UNPROTECTED — purge can delete      0
      …PENDING-LOCK (exempt)               4
      …protection INDETERMINATE            0
      last scheduled lock run             2026-09-08T01:00:00Z  (0 1 * * *)
```

## Two findings that made the doc page stale, now corrected there

**The WRITE half works.** The page said *"the write half has never actually run"* and predicted
refusal without a `Container Registry Repository Writer` grant. The grant landed: the
2026-09-08T01:14Z scheduled run
([34176008757](https://github.com/Systemorph/MeshWeaver/actions/runs/34176008757)) is the **first
`apply` run in the job's history to succeed** — 18 manifests wanted, 10 already protected, **8 newly
locked, 0 that could NOT be protected**. `…locked and pinned by NOTHING 16` is the standing debt of
a lock-only job and is noted as such.

**The two-task question is settled, from the live task definitions rather than from a summary.**
`az acr task show` on both, decoding `step.encodedTaskContent`:

| Task | `status` | `schedule` | Steps |
|---|---|---|---|
| `purge-old-images` | **Enabled** | `0 3 * * *` | 5 CI repos at `--ago 7d --keep 10 --untagged`; `memex-portal` at `--ago 30d --untagged` |
| `purge-old-ci-releases` | **Disabled** | `0 4 * * *` | its old single 30-day step, kept as the record of the Memex#122 reasoning |

So *"the second purge task never learned Memex#122"* is settled, and the settlement is that **there
is no longer a second task to teach**. The divergence itself was the defect: `mw-plugin-test`
appeared in the aggressive list and in no other, and whether a new repository landed under a 7-day
or a 30-day window depended on which of two independently-edited lists someone happened to open.
Both carry `lastModifiedAt` 2026-09-06T21:51Z, ninety seconds apart — the edit that collapsed them.

## Not done, and why

**No `--ago`/`--keep` change.** Raising either moves the cliff; a pin left stable for a quarter walks
off a 30-day window exactly as it walked off a 7-day one, and the failure is then rarer, later and
harder to attribute.

**The residual exposure is named in the doc rather than papered over.** Protection is *derived* on a
daily cadence and the purge does not wait for it — the lock is a GitHub Actions cron, the purge an
ACR timer task, with no interlock. So a pin landing in the **01:00–03:00** window meets that night's
purge unprotected, and if the lock does not run at all the purge still runs. Neither is a widened
window away from being fixed; both close only by making the pin move and its lock **one act**, which
needs a cross-repo dispatch from each satellite and is not built. Until it is, this PR's protection
arm is what makes that exposure **visible instead of silent**.

Untouched by design: `main-cd.yml`, `node-repo-publish-bake.yml`, `publish-bake-bundles.sh`, the
Plugins platform pin, and `deploy/helm/templates/registry/*`.

No What's New entry — CI/registry infrastructure with no user-visible surface, matching every prior
#3438 change (`40f5278d1`, `06d9e71c0`, `af35efe7c`: none added one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
