### PR TITLE
fix(MeshNodeStreamCache): release synced-query connections on Dispose — sightings #13/#14 and the teardown chain walked (Plugins#1527)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -961,6 +961,147 @@ reach this suite, and a fix there will not move this rate. Neither will the plat
 that reds Plugins PRs independently: the only failure annotations on `Portal hosts (shard 1)` in run
 `34210183539` are the SIGSEGV verdict and the generic `exit code 1`.
 
+### 2026-09-08: sightings #13 and #14 — two CONSECUTIVE `main` runs, a sixth frame, and the disposal chain walked end to end
+
+Two `Portal hosts (shard 1)` jobs on `main`, started one minute apart, both killed `MeshWeaver.FutuRe.Test`
+with exit 139. Both dumps were read the same way as #11/#12 (`struct.unpack` over the ELF core, the
+`rbp` chain unwound by hand, RVAs resolved against the `.debug` for the build-id read out of the
+crashed process's own `libcoreclr` mapping). The maintainer's standing hypothesis was a use-after-dispose
+in the teardown chain, so this read also carries the audit of that chain — what it found, and why it
+is not what killed these two hosts. Filed as
+[MeshWeaver.Plugins#1527](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1527).
+
+| | **#13** `MeshWeaver.Futu-50673.dmp` | **#14** `MeshWeaver.Futu-50573.dmp` |
+|---|---|---|
+| run / job | [`34222933802`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34222933802) / `102063244677` | [`34222981863`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34222981863) / `102050283390` |
+| head / event | `669b09a9`, `repository_dispatch` (framework released) | `d9e23446`, `push` to **`main`** |
+| `[FATAL ERROR]` | 12:50:37Z | 12:07:55Z |
+| `si_signo` / `si_code` / `si_addr` | 11 / 1 (`SEGV_MAPERR`) / **`0x0`** | 11 / 1 (`SEGV_MAPERR`) / **`0x0`** |
+| `TRAPNO` / `ERR` | 14 / `0x4` | 14 / `0x4` |
+| faulting RVA | `0x5cb171` — **the same RVA as #12** | `0x5eb67a` — **a sixth frame** |
+| frame | `WKS::gc_heap::background_sweep()+0xa61` | `WKS::gc_heap::revisit_written_page(…)+0x1aa` |
+| chain (rbp) | `gc1+0xf6 ← bgc_thread_function+0xdc ← CreateSuspendableThread::$_0::__invoke+0x74 ← CPalThread::ThreadEntry+0x1e9` | `revisit_written_pages+0x4de ← background_mark_phase+0x401 ← gc1+0xf1 ← bgc_thread_function+0xdc ← …ThreadEntry+0x1e9` |
+| thread | dedicated **background-GC** thread, no managed frame | dedicated **background-GC** thread, no managed frame |
+| instruction | `49 8b 07 / 48 83 e0 f8 / 8b 08` — `mov (%r15),%rax ; and $-8,%rax ; mov (%rax),%ecx`, `RAX = 0` | `4c 89 e8 / 48 83 e0 f8 / 8b 08` — `mov %r13,%rax ; and $-8,%rax ; mov (%rax),%ecx`, `R13 = 0` |
+| the word at the source | `[R15]` reads 16 zero bytes | `[R15]` (page-aligned `0x7f59b4ddc000`) reads 32 zero bytes |
+| runtime / build-id | `10.0.11` / `989b56df…` | `10.0.11` / `989b56df…` |
+| `Unwind: exception type` in the job log | none | none |
+
+Same fingerprint, third register (`rax` in #4–#8, `r8`/`rcx` in #9, `r15`→`rax` in #12/#13, `r13` here),
+sixth frame. `revisit_written_page` is the background mark phase re-walking pages the write-watch
+flagged as dirty — it reads the header of whatever object sits at `R15`, and that header is zero.
+
+#### What the trace log says — and #14 died INSIDE a teardown
+
+| | #13 (pid 50673) | #14 (pid 50573) |
+|---|---|---|
+| `DISPOSE_DONE` / of which `teardown clean` | 30 / **30** | 15 / **15** |
+| `DISPOSE_DIRTY_TEARDOWN`, `DISPOSE_QUIESCE_LEAK`, `leakedIoLeaves>0` | **0** | **0** |
+| phase at death | inside `Group_KeyMetrics_ShouldHaveNonZeroData` (`TEST_START`, no `TEST_END`) | **a teardown**: 16 `TEST_START` / 16 `TEST_END`, but 16 `DISPOSE_INVOKED` / 15 `DISPOSE_DONE` — between `DISPOSE_INVOKED` 12:06:51.170 of `AnnualReport_EmbeddedCharts_ShouldRenderViaPathResolution` and a `DISPOSE_IOPOOL_DRAIN_START` that never came |
+| `alc` / `asm` at every checkpoint | **1** / 126–130 | **1** / 106–131 |
+| `FAULT-BUDGET` on this pid | none in the whole shard | none (the shard's two budget lines are pid 2749) |
+| `[FAULT]` records | 6 × `JsonSynchronizationStream … resubscribe failed` at 12:49:25 (12 s earlier) | 2 × `MeshDataSource: Could not lease the NodeType assembly context for FutuRe` at 12:06:51.173/.180 and 2 × `Failed-verdict re-drive: own-stream subscription faulted for FutuRe` at .228 — **3–58 ms after `DISPOSE_INVOKED`** |
+| teardown-straggler capture | 2 first-chance `ObjectDisposedException` — `MeshNodeStreamCache.GetQueryRaw` → `GetWorkspace()` on a disposed Autofac scope, 12:49:31.772/.775, **4 ms after** the previous test's `DISPOSE_DONE` and 5.5 s before death | **none** |
+
+Two facts about the fixture that matter for reading the rest: `FutuReAnalysisTest` declares
+`ShareMeshAcrossTests => true`, but no `DISPOSE_SHARED_SKIP` was ever written — the cluster kill-switch
+had sharing off, so **every `[Fact]` built and disposed its own mesh** (30 full teardowns in 47 s in #13).
+And `alc=1` at every checkpoint — each `INIT_MEM`/`DISPOSE_MEM` line is written after a forced full
+GC — means **no collectible `AssemblyLoadContext` survived any teardown** in either process. It does
+NOT mean none existed: `asm` moves 127 → 129 → 127 → 128 → 130 → 131 → 128 → 130 → 129 … → 133 across
+#13's checkpoints, so contexts (the per-node `DynamicNode_*` / `node-config-script:*` ones) were being
+created inside tests and fully reclaimed by the next checkpoint. Unloads therefore DO happen in this
+process, and what excludes an unload race is the fingerprint, not the count: a freed
+`LoaderAllocator` yields a non-null **unmapped** pointer (`AccessViolation`/SIGABRT, #613) or a #GP on
+a non-canonical one — never a zero word at a page-aligned, still-mapped address read by the collector
+itself — and in #14 the death preceded the `MeshTeardownSignal` every teardown-time unload waits on.
+
+#### The teardown chain, phase by phase — where a later phase can touch what an earlier one released
+
+Walked on the code the crashed runs ran (Plugins `669b09a9`/`d9e23446` on core pin `73d94b55`; the
+disposal-relevant files are unchanged to `main` at the time of writing). The non-shared path of
+`MonolithMeshTestBase.DisposeAsync` (Plugins, `src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs:1364`):
+
+1. **Clients** — `DisposeTestClientsAsync` (`:1285`): each client hub `DisposeAndJoinAsync`, joined
+   sequentially on `DisposalCompleted`. ✔ waits on the signal.
+2. **Hosted services** — reverse start order, `StopAsync` under a `DisposeTimeout` CTS (`:1460`). ✔
+3. **`Mesh.Dispose()`** (`:1488`) → `MessageHub.Dispose` (`src/MeshWeaver.Messaging.Hub/MessageHub.cs:1878`):
+   `hostedHubs.CloseCreation()` + `SignalShuttingDown()` FIRST, then `Post(ShutdownRequest(Quiescing))`.
+   The state machine is `Quiescing → DisposeHostedHubs → ShutDown → Dead`, each phase entered only on
+   the previous phase's own signal (`OnQuiesceComplete`; `hostedHubs.DisposalCompleted`, `:2214`); every
+   hosted hub's `DisposeImpl` (`:2251`) fires its `RegisterForDisposal` callbacks and reactive dispose
+   actions, and `SignalDisposalCompleted` (`:1833`) completes the `ReplaySubject`. ✔ reactive end to end.
+   **This is where `MeshNodeStreamCache.Dispose()` runs** — registered on the cache hub
+   (`src/MeshWeaver.Hosting/MeshNodeStreamCache.cs:616`), so it executes in the mesh's
+   `DisposeHostedHubs` phase, strictly before the mesh signals.
+4. **Wait** — `WaitWithProgressAsync` (`:1693`): `Mesh.DisposalCompleted.ObserveCompletion(…)`, no
+   `.ToTask()`, error arm attached, `ConfigureAwait(false)`. ✔ a subscription, not a timer race.
+5. **`IoPoolRegistry.DrainAll()`** (`:1518`; `src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs:169`):
+   cancel + join of every `IIoPool` leaf. ✔ `leakedIoLeaves=0` in all 45 teardowns across both runs.
+6. **`AsyncDisposeQueue.DrainAsync`** (`:1525`). ✔ `clean=True` throughout.
+7. **`MeshTeardownSignal.SignalCompleted(report)`** (`:1533`) — and only NOW do the hosted hubs' Autofac
+   scopes close: `HostedHubsCollection.CloseScopeWhenDisposed` (`:239`) subscribes each child's
+   `DisposalCompleted.Take(1)` and hands the close to `TeardownOrderedScopeDisposal.CloseWhenDrained`
+   (`src/MeshWeaver.Mesh.Contract/Threading/TeardownOrderedScopeDisposal.cs:41`), which on a disposing
+   mesh defers it to `signal.Completed`. ✔ pinned by `HubScopeClosesAfterTeardownDrainsTest`.
+8. **`base.DisposeAsync()`** (`FileOutput`), then the root `ServiceProvider.Dispose()` (`:1610`,
+   `DisposeServiceProviderOnTeardown` defaults to `true`), then `DISPOSE_MEM` with a forced GC.
+
+Every phase waits on a completion signal, none on a timer, nothing blocks in a `Dispose()`, and no
+`Cancel()` is issued from the teardown thread except the bounded `StopAsync` budget in step 2. The
+collectible-ALC unload (`MeshDataSource.cs:995`, `UnloadNodeAssemblyContexts`) and the lease release
+(`:1017`, `ReleaseNodeTypeLease`) are both gated on `teardownSignal` — which in #14 had not fired when
+the host died (no `DISPOSE_IOPOOL_DRAIN_START`, let alone `DISPOSE_DONE`), and in #13 had fired 5.5 s
+earlier with a forced GC after it that left `alc=1`.
+
+**The one place a later phase touches what an earlier phase released — and it is in core, not in the
+fixture.** `MeshNodeStreamCache.Dispose()` (`:784`) detached the per-path read streams (step 1), the
+update queues (2), the probe cache (3), the in-flight writes (4), the storm-breaker windows (5) and the
+pending self-writes (6) — and never touched `_queries`. Each synced query is
+`Defer(…).SubscribeOn(TaskPoolScheduler.Default).Replay(1).AutoConnect(1)` (`GetQueryRaw`), and
+`AutoConnect` keeps the handle its `Connect()` returns to itself: the cache had no way to release a
+chain even had it tried. A first subscriber's `Connect()` only **queues** the upstream subscribe on
+the pool, and nothing in steps 3–8 joins a pool-queued Rx subscribe (`DisposalCompleted` covers the
+action blocks, `DrainAll` covers `IIoPool` leaves, the queue covers enqueued cleanup). So the item ran
+whenever the pool reached it — in #13, 4 ms after step 8 — and resolved `cacheHub.GetWorkspace()`
+from a scope step 7 had closed. **All 11 disposed-scope stragglers captured in run `34222933802`'s
+shard-1 artifact are that one `Defer`** — FutuRe 2, Blazor.Views 5 (one of them the inner
+`SyncedQueryMeshNodes.BuildReadStreamCore`), ContentCollections.Indexing.Graph 4 — on `.NET TP Worker`
+threads, every one caught by the Defer and forwarded to `OnError`. Fixed in the same change as this
+entry: the connection is registered with the cache (`AutoConnect(1, onConnect)`), released in
+`Dispose()` (a still-queued connect is cancelled before the pool dequeues it; a late registration is
+disposed as it is added), and a query opened after teardown terminates with `ObjectDisposedException`
+instead of parking on a `Replay(1)` nothing will feed. Pinned by
+`test/MeshWeaver.Hosting.Test/QueryConnectionsReleasedOnTeardownTest.cs`, whose control arm proves the
+registry sees the live connection before asserting it was released.
+
+The two `[FAULT]` records in #14's teardown window are the error arms of `RegisterForDisposal`'d
+own-stream subscriptions (`MeshDataSource.cs:1034`, `NodeTypeCompilationHelpers.cs:1036`) reporting the
+own stream ending in error as the hub shuts down — the documented "incoming streams error" contract
+of [HubDisposalModel](../HubDisposalModel), handled by the arm that logged them, not a resolve from a
+disposed scope.
+
+#### Why the audit finding is real and is still not the killer
+
+- It produces a **managed** `ObjectDisposedException`, caught by `Observable.Defer` and forwarded to
+  `OnError`. Nothing on that path writes to an object header, and a managed exception cannot zero
+  one. Its escalation shape, when a subscriber has no error arm, is Rx's `Stubs.Throw` →
+  `AppDomain.UnhandledException` → xUnit's `Catastrophic failure … Failed: 0, exit 1` (Plugins#870,
+  #1390) — **exit 1, not 139**.
+- #14 crashed with **no straggler at all**, and #13's stragglers were 5.5 s and one whole clean
+  teardown before the death.
+- Both faulting threads are the background-GC thread with no managed frame; both `si_addr` are the
+  MethodTable field offset, both source words read zero at their source.
+
+#### #1507 does not reach this suite
+
+Plugins #1507 (`fix/1390-teardown-resolve-guard`, merged 13:13Z) converts 22 Rx call sites in
+`src/MeshWeaver.AI/*` to `TeardownSafeCallback`. `MeshWeaver.FutuRe.Test` references neither
+`MeshWeaver.AI` nor anything that does (checked: its own `.csproj` and
+`MeshWeaver.Hosting.Monolith.TestBase.csproj`), and neither crashed sha contains #1507. `Portal hosts
+(shard 1)` passing on the 13:13 push run `34230683846` is one green sample at a low-single-digit-percent
+rate — the reading the base-rate section above already warns against — not the fix working.
+
 ## Reading the result honestly
 
 The trap in this class of bug is confirmation: the stack shows *a* plausible culprit and it is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-shutdown-no-longer-leaves-a-query-running-behind-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-shutdown-no-longer-leaves-a-query-running-behind-it.md
@@ -1,0 +1,28 @@
+---
+Name: A shutdown no longer leaves a query running behind it
+Category: Fix
+Description: When a portal or a test host shut down, a synced query the node cache had just opened could still start on a background thread after everything it needed was gone. It now stops with the cache, and a query opened after shutdown answers with an error instead of waiting forever.
+Icon: Stop
+Order: -20260908
+---
+
+# A shutdown no longer leaves a query running behind it
+
+The node cache serves every synced query in a process from one shared subscription per query. It
+opens that subscription lazily, on the first reader, and hands the work to a background thread so
+the reader is never blocked. That hand-off is where a small gap sat: the cache's own shutdown
+detached every per-node stream, every pending write and every update queue it owned — but not the
+queries. Their subscriptions belonged to the mechanism that had opened them, and nothing on the
+shutdown path could reach them.
+
+Most of the time that did not matter. But a query opened an instant before shutdown was still
+queued for its background thread when the shutdown completed, and when the thread finally got to
+it, it tried to build the query against a service container that had already been closed. On the
+build servers this appeared as a burst of "already disposed" errors after a test had reported a
+clean teardown — eleven of them in one run, across three unrelated test suites, all from this one
+place.
+
+The cache now keeps hold of each query's subscription and releases them all as part of its own
+shutdown: a query that was already running is unsubscribed, and one that was still queued is
+cancelled before it starts. A query opened after the cache has shut down answers immediately with
+an error naming the cache, rather than waiting on a subscription that will never be served.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -831,6 +831,21 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         }
         _streams.Clear();
 
+        // 1b. Synced-query chains — the read side's OTHER upstream. Disposing the registry
+        //     unsubscribes every connected SyncedQueryMeshNodes (releasing its provider and
+        //     change-feed subscriptions on the cache hub's workspace) and CANCELS every connect
+        //     still queued on the pool scheduler, so no Defer can run against this hub's scope
+        //     after this point; a connect registered later is disposed as it is added. The
+        //     dictionaries are reset so a straggling GetQuery cannot be handed a dead chain —
+        //     it is refused at the disposed-cache guard instead.
+        try { _queryConnections.Dispose(); }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "MeshNodeStreamCache: error releasing synced-query connections");
+        }
+        _queries = System.Collections.Immutable.ImmutableDictionary<object, QueryCacheEntry>.Empty;
+        _optionsWrappedQueries.Clear();
+
         // 2. Per-path update queues: Clear() fires every entry's
         //    post-eviction callback (ConcatSubscription.Dispose +
         //    Subject.OnCompleted) so the serial-update Concat pipelines stop
@@ -2421,6 +2436,33 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private System.Collections.Immutable.ImmutableDictionary<object, QueryCacheEntry> _queries =
         System.Collections.Immutable.ImmutableDictionary<object, QueryCacheEntry>.Empty;
 
+    // 🚨 Every synced-query chain's CONNECTION, so that Dispose() can release them — they were the
+    // one thing this cache started that its teardown could not reach. `AutoConnect(1)` keeps the
+    // handle `Connect()` returns to itself, and the connect it performs is NOT synchronous: the
+    // chain is `Defer(…).SubscribeOn(TaskPoolScheduler.Default)`, so the first subscriber only
+    // QUEUES the upstream subscribe on the pool. Nothing in the teardown joins that queue item —
+    // `DisposalCompleted` covers the action blocks, `IoPoolRegistry.DrainAll` covers IIoPool leaves,
+    // the AsyncDisposeQueue covers enqueued cleanup — so it ran whenever the pool got to it, and
+    // when that was after the cache hub's scope had closed, the Defer resolved
+    // `cacheHub.GetWorkspace()` from a disposed Autofac scope. Measured on Plugins run 34222933802
+    // (2026-09-08): 11 of the 11 disposed-scope stragglers captured across three suites are this one
+    // Defer (`GetQueryRaw` → `GetWorkspace` / `SyncedQueryMeshNodes.BuildReadStreamCore`), the FutuRe
+    // pair landing 4 ms after the mesh had reported `DISPOSE_DONE … teardown clean`.
+    //
+    // A `CompositeDisposable` rather than a bag: once it is disposed, an `Add` disposes the handle
+    // on the spot, which is precisely the connect-after-teardown race — a Connect() that queued its
+    // subscribe an instant before Dispose() ran is cancelled before the pool dequeues it (Rx's
+    // scheduled work item checks its cancellation before invoking). The Defer's own guard below
+    // covers the sliver in which the pool has already started it.
+    private readonly System.Reactive.Disposables.CompositeDisposable _queryConnections = new();
+
+    /// <summary>Test probe: synced-query upstream connections this cache currently holds.</summary>
+    internal int LiveQueryConnections => _queryConnections.Count;
+
+    /// <summary>Test probe: <c>true</c> once <see cref="Dispose"/> has released every synced-query
+    /// connection — from then on a late connect is cancelled the instant it is registered.</summary>
+    internal bool QueryConnectionsReleased => _queryConnections.IsDisposed;
+
     /// <summary>
     /// The identity of a query SET. Order- and duplicate-insensitive, because the synced
     /// collection is the UNION of its queries — two callers that ask for the same set written in
@@ -2466,6 +2508,15 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             throw new ArgumentException("At least one query string is required.", nameof(queries));
 
         var signature = QuerySetSignature(queries);
+
+        // DISPOSED-CACHE GUARD (query side) — the same rule UpdateRaw applies on the write side. A
+        // query opened after teardown has begun must TERMINATE, never park: its connect would be
+        // cancelled by the disposed _queryConnections below, so without this the subscriber would
+        // wait on a Replay(1) that nothing will ever feed (the "burst then silence" shape).
+        if (System.Threading.Volatile.Read(ref _disposed) != 0)
+            return (Observable.Throw<IEnumerable<MeshNode>>(
+                new ObjectDisposedException(nameof(MeshNodeStreamCache))), signature);
+
         while (true)
         {
             var current = _queries;
@@ -2478,8 +2529,19 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // first subscriber's thread (TaskPoolScheduler thanks to
             // SubscribeOn), constructs the SyncedQueryMeshNodes, and the
             // Replay(1) caches its emissions for all later subscribers.
+            // The upstream connection AutoConnect hands back — captured so the fault arm below can
+            // release exactly this chain's connection, and so Dispose() can release them all.
+            IDisposable? connection = null;
             var stream = Observable.Defer(() =>
                 {
+                    // 🚨 This factory runs on the POOL, whenever the pool gets to it — so it is the
+                    // one place that can observe the cache's teardown having happened in between.
+                    // Refuse here rather than resolve `cacheHub.GetWorkspace()` from a scope that
+                    // Dispose() has since closed: that resolve is what every disposed-scope straggler
+                    // in the 2026-09-08 CI captures was (Plugins run 34222933802).
+                    if (System.Threading.Volatile.Read(ref _disposed) != 0)
+                        return Observable.Throw<IEnumerable<MeshNode>>(
+                            new ObjectDisposedException(nameof(MeshNodeStreamCache)));
                     var typeSource = new global::MeshWeaver.Graph.SyncedQueryMeshNodes(
                         cacheHub.GetWorkspace(), id, queries);
                     var updates = typeSource.StreamUpdates();
@@ -2532,7 +2594,16 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // Take(1) / FirstAsync after a runtime AccessAssignment
                 // write sees the STALE cached snapshot. AutoConnect(1)
                 // keeps the upstream connected forever once first subscribed.
-                .AutoConnect(1);
+                //
+                // 🚨 The connection is REGISTERED, not dropped (see _queryConnections): AutoConnect
+                // itself never disposes it, and the connect it triggers is a pool-queued subscribe
+                // that no teardown phase joins. Registering it after the cache's Dispose() disposes
+                // it on the spot — the late-connect race resolved by construction.
+                .AutoConnect(1, c =>
+                {
+                    connection = c;
+                    _queryConnections.Add(c);
+                });
                 // ReplaySubject (backing Replay(1)) already serialises
                 // OnNext/Subscribe internally — no .Synchronize() needed.
                 // Adding it would route every emission through an additional
@@ -2570,7 +2641,14 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // fails against a sibling set's chain, so the poisoned one is replayed forever —
             // #1316 undone) or OVER-EVICT (drop a healthy set that merely shares the id).
             var connected = stream;
-            stream = connected.Do(_ => { }, ex => EvictFaultedQuery(id, signature, stream, ex));
+            stream = connected.Do(_ => { }, ex =>
+            {
+                EvictFaultedQuery(id, signature, stream, ex);
+                // A terminal chain's connection has nothing left to hold — release it so the
+                // registry tracks LIVE connections only (a faulted-then-rebuilt query would
+                // otherwise accumulate one dead handle per fault for the life of the process).
+                ReleaseQueryConnection(connection);
+            });
 
             // Index the new stream under its SIGNATURE and make it the id's latest. Existing
             // signatures are preserved, so a caller still holding the previous declaration keeps
@@ -2635,6 +2713,26 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             + "Replay(1) had latched the terminal error and would have replayed it to every future "
             + "subscriber for the life of the process. The next GetQuery('{QueryId}') for that query set "
             + "opens a fresh upstream instead.", id, signature, id);
+    }
+
+    /// <summary>
+    /// Releases one synced-query chain's upstream connection and drops it from
+    /// <see cref="_queryConnections"/>. <c>Remove</c> disposes a registered handle; a handle the
+    /// registry no longer holds (the registry was disposed first, which already disposed it) is
+    /// disposed again harmlessly — Rx disposables are idempotent.
+    /// </summary>
+    private void ReleaseQueryConnection(IDisposable? connection)
+    {
+        if (connection is null) return;
+        try
+        {
+            if (!_queryConnections.Remove(connection))
+                connection.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "MeshNodeStreamCache: error releasing a synced-query connection");
+        }
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Test/QueryConnectionsReleasedOnTeardownTest.cs
+++ b/test/MeshWeaver.Hosting.Test/QueryConnectionsReleasedOnTeardownTest.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>A teardown releases every synced-query connection the cache opened, and a query opened
+/// after teardown terminates instead of parking.</b>
+///
+/// <para><b>The live defect.</b> <c>MeshNodeStreamCache.GetQueryRaw</c> builds each synced query as
+/// <c>Defer(…).SubscribeOn(TaskPoolScheduler.Default).Replay(1).AutoConnect(1)</c>. The first
+/// subscriber's <c>Connect()</c> only QUEUES the upstream subscribe on the pool, and the handle it
+/// returns stayed inside <c>AutoConnect</c> — so the cache's <c>Dispose()</c>, which detaches every
+/// per-path read stream, every update queue and every in-flight write, could not reach the query
+/// chains at all. Nothing else in the teardown joins a pool-queued Rx subscribe either:
+/// <c>DisposalCompleted</c> covers the action blocks, <c>IoPoolRegistry.DrainAll</c> covers
+/// <c>IIoPool</c> leaves, the <c>AsyncDisposeQueue</c> covers enqueued cleanup. The item therefore
+/// ran whenever the pool reached it, and when that was after the mesh had reported
+/// <c>DISPOSE_DONE … teardown clean</c> and closed its scopes, the Defer resolved
+/// <c>cacheHub.GetWorkspace()</c> from a disposed Autofac scope.</para>
+///
+/// <para><b>Measured</b> on Plugins run 34222933802 (2026-09-08, shard 1): every one of the 11
+/// disposed-scope stragglers captured across <c>MeshWeaver.FutuRe.Test</c>,
+/// <c>MeshWeaver.Blazor.Views.Test</c> and <c>MeshWeaver.ContentCollections.Indexing.Graph.Test</c>
+/// is this Defer — <c>GetQueryRaw</c> → <c>GetWorkspace</c>, or its inner
+/// <c>SyncedQueryMeshNodes.BuildReadStreamCore</c> — on a <c>.NET TP Worker</c>; the FutuRe pair
+/// landed 4 ms after <c>DISPOSE_DONE</c>. Rx's <c>AnonymousSafeObserver</c> rethrows out of a
+/// subscriber with no error arm, so the same straggler on a bare pool thread is the
+/// "Catastrophic failure … Failed: 0, exit 1" shard (Plugins#870, #1390).</para>
+///
+/// <para><b>The contract.</b> The connection is REGISTERED with the cache, the cache's
+/// <c>Dispose()</c> releases the registry — unsubscribing every connected upstream and cancelling
+/// every connect still queued — and a registration arriving after that is disposed on the spot. A
+/// query opened on a disposed cache terminates with <see cref="ObjectDisposedException"/> rather
+/// than waiting on a Replay(1) nothing will feed. The control arm on the live mesh is what makes
+/// the released count mean anything: a cache that never registered a connection would read
+/// zero before AND after.</para>
+/// </summary>
+public class QueryConnectionsReleasedOnTeardownTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    private static string Query => $"nodeType:Markdown namespace:{TestPartition}";
+
+    // 240_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant,
+    // so the property cannot be written here. The value must still DOMINATE it — 216 s at the
+    // CI factor (Convergence 108 s x OuterMargin 2) — or the xunit kill pre-empts the inner
+    // wait and the failure cannot say what it was waiting for.
+    [Fact(Timeout = 240_000)]
+    public async Task MeshDispose_ReleasesEveryConnectedSyncedQuery()
+    {
+        // Resolve BEFORE the teardown — after it the provider is the object being closed.
+        var cache = Cache;
+        var query = cache.GetQuery($"teardown-query-{Guid.NewGuid():N}", Mesh.JsonSerializerOptions, Query);
+
+        await query.FirstAsync().Should().Within(TestTimeouts.Convergence).Emit(
+            "precondition: the synced query connects its upstream and answers on the live mesh");
+        cache.LiveQueryConnections.Should().Be(1,
+            "CONTROL ARM: the first subscriber's Connect() must be registered with the cache — a zero "
+            + "here means the registry sees nothing, and the released count below would be vacuous");
+        cache.QueryConnectionsReleased.Should().BeFalse(
+            "precondition: the registry is live for as long as the cache is");
+
+        Mesh.Dispose();
+        await Mesh.DisposalCompleted.ObserveCompletion(
+            ex => FileOutput.WriteLine($"late disposal fault: {ex}"),
+            TestContext.Current.CancellationToken);
+
+        cache.QueryConnectionsReleased.Should().BeTrue(
+            "the cache's Dispose() runs at the cache hub's ShutDown, strictly inside the mesh's "
+            + "DisposalCompleted — the registry must be released by then, so that any connect still "
+            + "queued on the pool is cancelled BEFORE the drains finish and the scopes close");
+        cache.LiveQueryConnections.Should().Be(0,
+            "the connected upstream must have been unsubscribed with the cache, not left to run its "
+            + "Defer against a scope the teardown has since closed (the GetQueryRaw → GetWorkspace "
+            + "disposed-scope straggler)");
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task AfterMeshDispose_ANewQueryTerminates_AndOpensNoUpstream()
+    {
+        var cache = Cache;
+        var options = Mesh.JsonSerializerOptions;
+
+        Mesh.Dispose();
+        await Mesh.DisposalCompleted.ObserveCompletion(
+            ex => FileOutput.WriteLine($"late disposal fault: {ex}"),
+            TestContext.Current.CancellationToken);
+        cache.QueryConnectionsReleased.Should().BeTrue("precondition: the teardown released the registry");
+
+        var late = cache.GetQuery($"late-query-{Guid.NewGuid():N}", options, Query);
+
+        var terminal = await late.Materialize().FirstAsync().Should().Within(TestTimeouts.Convergence).Emit(
+            "a query opened on a disposed cache must TERMINATE — a subscriber left waiting on a "
+            + "Replay(1) whose connect was cancelled is the burst-then-silence hang");
+        terminal.Kind.Should().Be(NotificationKind.OnError,
+            "the honest answer is a fault naming the cache, never a value from a scope that is gone");
+        terminal.Exception.Should().BeOfType<ObjectDisposedException>();
+        cache.LiveQueryConnections.Should().Be(0,
+            "no upstream may be opened on a disposed cache — a late registration is disposed as it "
+            + "is added, and the refusal above means no chain was built to register at all");
+    }
+}


### PR DESCRIPTION
Tracks [MeshWeaver.Plugins#1527](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1527) — `MeshWeaver.FutuRe.Test` SIGSEGV on two consecutive `main` runs (2026-09-08). Maintainer instruction: *"check again disposal there … normally we access disposed objects after disposal ==> need to control that disposal chain works properly."*

## What the two dumps say (sightings #13 / #14, read from the ELF cores)

Both: `si_signo=11 / si_code=1 (SEGV_MAPERR) / si_addr=0x0`, `TRAPNO=14`, `ERR=0x4`, runtime `10.0.11`, build-id `989b56df…` read out of the crashed process's own `libcoreclr` mapping; both faulting threads are the dedicated background-GC thread, unwound along `rbp`, no managed frame:

| | RVA | frame | instruction | source word |
|---|---|---|---|---|
| #13 run `34222933802` | `0x5cb171` (= #12) | `WKS::gc_heap::background_sweep()+0xa61 ← gc1 ← bgc_thread_function` | `mov (%r15),%rax; and $-8,%rax; mov (%rax),%ecx`, `RAX=0` | `[R15]` reads zero |
| #14 run `34222981863` | `0x5eb67a` (new, 6th frame) | `WKS::gc_heap::revisit_written_page(…)+0x1aa ← revisit_written_pages ← background_mark_phase ← gc1 ← bgc_thread_function` | `mov %r13,%rax; and $-8,%rax; mov (%rax),%ecx`, `R13=0` | `[R15]` (page-aligned) reads zero |

The zero-MethodTable-word family (#1–#12), not a use-after-unload (that yields a non-null unmapped pointer or a #GP on a non-canonical one) and not a managed exception (no `Unwind: exception type` in either job log). #14 died **inside a teardown** (16 `DISPOSE_INVOKED` / 15 `DISPOSE_DONE`, no `DISPOSE_IOPOOL_DRAIN_START`); #13 mid-test, 5.5 s after a clean teardown. All 45 teardowns across both processes reported `teardown clean`, `leakedIoLeaves=0`, no quiesce leak.

## The disposal audit — one real defect, in core, and it is not the killer

`MeshNodeStreamCache.Dispose()` released the per-path read streams, update queues, probe cache, in-flight writes, breaker windows and pending self-writes — and never touched the synced-query chains. Each is `Defer(…).SubscribeOn(TaskPoolScheduler.Default).Replay(1).AutoConnect(1)`: `AutoConnect` keeps the `Connect()` handle to itself, and the first subscriber only **queues** the upstream subscribe on the pool. No teardown phase joins a pool-queued Rx subscribe (`DisposalCompleted` = action blocks; `IoPoolRegistry.DrainAll` = `IIoPool` leaves; `AsyncDisposeQueue` = enqueued cleanup), so it ran whenever the pool reached it and resolved `cacheHub.GetWorkspace()` from a scope the teardown had already closed.

**Measured:** all 11 disposed-scope stragglers in run `34222933802`'s shard-1 artifact — FutuRe 2, Blazor.Views 5, ContentCollections.Indexing.Graph 4 — are that one `Defer` (`GetQueryRaw` → `GetWorkspace`, or its inner `SyncedQueryMeshNodes.BuildReadStreamCore`); the FutuRe pair landed **4 ms after** `DISPOSE_DONE … teardown clean`. Its escalation shape when a subscriber has no error arm is Rx's rethrow → `AppDomain.UnhandledException` → xUnit's *"Catastrophic failure … Failed: 0, exit 1"* (Plugins#870 / #1390) — exit 1, not 139; and #14 crashed with no straggler at all.

### The fix (`src/MeshWeaver.Hosting/MeshNodeStreamCache.cs`)

- Each chain's connection is **registered** with the cache (`AutoConnect(1, onConnect)` into a `CompositeDisposable`).
- `Dispose()` **releases** the registry (step 1b): a connected upstream is unsubscribed, a connect still queued on the pool is cancelled before it is dequeued, and a registration arriving after that is disposed as it is added (the late-connect race, resolved by construction). `_queries` / `_optionsWrappedQueries` are reset so a straggling `GetQuery` is never handed a dead chain.
- A query opened after teardown **terminates** with `ObjectDisposedException` — the guard `UpdateRaw` already applies on the write side — instead of parking on a `Replay(1)` nothing will feed; the `Defer` carries the same guard for the sliver in which the pool has already started it.
- A faulted chain's connection is released with its eviction (`EvictFaultedQuery`), so the registry holds live connections only.

No timeout widened, no retry, no GC setting, no `catch {}`; nothing async added.

### The proof — `test/MeshWeaver.Hosting.Test/QueryConnectionsReleasedOnTeardownTest.cs`

- `MeshDispose_ReleasesEveryConnectedSyncedQuery`: control arm asserts the registry sees the live connection (`LiveQueryConnections == 1`) BEFORE asserting `Mesh.Dispose()` released it.
- `AfterMeshDispose_ANewQueryTerminates_AndOpensNoUpstream`: `OnError` of `ObjectDisposedException`, no upstream opened.
- Local run (Release, fresh `.trx`): `total=2 executed=2 passed=2 failed=0`, 609 ms.
- **Negative control:** with only the `_queryConnections.Dispose()` line removed, the control test fails at the assertion that names the release (`… QueryConnectionsReleased … but found False`), its own control arm still passing. Restored, both pass again.

## Docs

- `DebuggingNativeCrashes.md`: sightings #13/#14 with the fingerprint table, the trace-log readings, the **teardown chain walked phase by phase** (who disposes what, in which order, which completion signal each phase subscribes to) and the one late-touch site above; why #1507 (Plugins, `src/MeshWeaver.AI/*` only) cannot reach `FutuRe.Test`.
- What's New (`Category: Fix`): *A shutdown no longer leaves a query running behind it.*

## Not merged on purpose

Merging is coordinated by the main-thread session today; this PR is left for it to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
