### PR TITLE
feat(hosting-operator): volume capacity is a record property — hosting-pv-resize + audit finding

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -104,6 +104,7 @@ jobs:
           hosting-kv-purge
           hosting-pull-secret
           hosting-pv-purge
+          hosting-pv-resize
           hosting-redirect
           hosting-restore
           hosting-tls
@@ -167,7 +168,7 @@ jobs:
           set +e
           jq -n -f deploy/aks/operator/bin/_audit.jq --slurpfile manifest /dev/null --slurpfile live /dev/null \
             --arg namespace n --arg release r --arg deployment d --arg container c --argjson revision 1 \
-            --arg chart "" --arg auditedAt now --arg skipped "" >/dev/null 2>"$RUNNER_TEMP/audit-jq.err"
+            --arg chart "" --arg auditedAt now --arg skipped "" --argjson persistence '{}' >/dev/null 2>"$RUNNER_TEMP/audit-jq.err"
           jq_rc=$?
           set -e
           if [ "$jq_rc" -eq 3 ]; then
@@ -182,7 +183,7 @@ jobs:
         # through to a REAL az/kubectl on a runner that has one.
         run: |
           set -euo pipefail
-          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl; do
+          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl; do
             git ls-files --error-unmatch "$f" >/dev/null 2>&1 || { echo "::error::${f} is not tracked"; git check-ignore -v "$f" || true; exit 1; }
             [ "$(git ls-files -s "$f" | awk '{print $1}')" = "100755" ] || { echo "::error::${f} is not committed executable (mode 100755)"; exit 1; }
           done

--- a/deploy/aks/README.md
+++ b/deploy/aks/README.md
@@ -635,6 +635,12 @@ Retain` keeps the share + its keys/content if a PVC is accidentally deleted.
 StorageClass; the CSI driver **creates a share per PVC automatically**. Nothing
 else to do — this is what Step 4 applies.
 
+**Growing a share later is NOT a `kubectl patch`.** Capacity is `volumes[].size` on
+the instance's `Hosting/Deployment` record; the hosting operator's
+`hosting-pv-resize` (`operator/bin/`) grows the claim to it as a step of the
+`Provision` / `Reconcile` action — grow-only, read back from the claim's status,
+refusing a class without `allowVolumeExpansion`. Azure Files expands online.
+
 ### Option B — static PV binding to pre-created named shares
 
 If you'd rather pre-create named shares in one account (to size/quota/firewall/

--- a/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
@@ -61,6 +61,14 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["get", "list"]
+  # READ-ONLY, for hosting-pv-resize. The storage class decides whether a claim can grow
+  # (allowVolumeExpansion); the command reads it BEFORE patching, and refuses a class that cannot
+  # expand rather than leaving a request in Pending forever. The patch itself is the
+  # persistentvolumeclaims grant above. Re-apply this file when adopting the feature — a Forbidden
+  # here fails the "Ensure volume capacity" step of every Provision / Reconcile by name.
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/aks/manifests/portal-pvcs.yaml
+++ b/deploy/aks/manifests/portal-pvcs.yaml
@@ -41,8 +41,10 @@ spec:
       storage: 16Gi
 ---
 # /mnt/content — the content collection (Storage__BasePath). Uploaded files, media,
-# per-node-hub content subdirectories. Sized for real user content; expand as needed
-# (allowVolumeExpansion is on in the StorageClass).
+# per-node-hub content subdirectories. Sized for real user content; to expand it later
+# raise `volumes[].size` on the Hosting/Deployment record and run Reconcile — the
+# operator's hosting-pv-resize grows the claim (allowVolumeExpansion is on in the
+# StorageClass). The sizes in this file are what a NEW namespace starts with.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/deploy/aks/operator/bin/_audit.jq
+++ b/deploy/aks/operator/bin/_audit.jq
@@ -5,6 +5,12 @@
 #   $manifest[0]  the helm manifest + hooks as an ARRAY of Kubernetes objects (the truth)
 #   $live[0]      every live object in the namespace, every kind, as ONE array
 #   $namespace $release $deployment $container $revision $chart $auditedAt $skipped
+#   $persistence  the release's user-supplied `persistence` values — the Deployment record's
+#                 volumes[] as HelmValues rendered them (claimName + size per volume). The one
+#                 RECORD-vs-live comparison here: a claim's live capacity below what the record
+#                 declares is drift the manifest cannot show, because on this fleet the portal's
+#                 claims are not helm-managed and a bigger `size` changes nothing until
+#                 hosting-pv-resize applies it.
 #
 # 🚨 NAMES, NEVER VALUES. A ConfigMap value is compared here and never emitted; an env entry's
 # `value` decides whether it is a plain value and is never emitted. The report is written to a node
@@ -38,6 +44,18 @@ def only(a; b): [a[] | select(. as $x | (b | index($x)) == null)] | unique;
 # (`cpu: 4` in a template, `"4"` back from the API). Compare shapes, not spellings.
 def norm: walk(if type == "number" then tostring else . end);
 def compact: tojson | if length > 120 then .[:117] + "…" else . end;
+
+# A Kubernetes quantity as a number of bytes, or null when it is not one. Both unit families
+# occur: the record writes binary units (128Gi), and a provisioner may answer in either.
+def quantity_bytes:
+  (tostring) as $q
+  | if ($q | test("^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E)?$")) | not then null
+    else ($q | capture("^(?<n>[0-9]+(\\.[0-9]+)?)(?<u>[A-Za-z]*)$")) as $m
+      | ($m.n | tonumber) * ({"": 1, "k": 1000, "M": 1000000, "G": 1000000000, "T": 1000000000000,
+                              "P": 1000000000000000, "E": 1000000000000000000,
+                              "Ki": 1024, "Mi": 1048576, "Gi": 1073741824, "Ti": 1099511627776,
+                              "Pi": 1125899906842624, "Ei": 1152921504606846976}[$m.u])
+    end;
 
 # 🚨 lifecycle values are REDACTED to their shape. Every other compared pod-spec field carries
 # placement and sizing (replicas, selectors, quantities, probe numbers) — but a lifecycle hook
@@ -135,11 +153,31 @@ def annotations: (.spec.template.metadata.annotations // {}) | keys;
        | .metadata.name as $n | ((.data // {}) | keys[]) | select(secretish) | "configmap:\($n)/\(.)" ]
    | unique) as $plainSecretEntries
 
+# ── claims below the capacity the record declares ──────────────────────────────────────────────
+# The record's volumes[] arrive as the release's `persistence` values. Every entry with a claimName
+# AND a size is compared against the live claim's status.capacity (what the volume IS, not what
+# was asked for). Below → a finding; absent → a finding (the pod could not have mounted it);
+# unreadable on either side → a finding rather than a silent pass, because "could not compare"
+# must never read as "matches". At or above → nothing: a claim larger than its record is the
+# record's problem to state, and hosting-pv-resize refuses to shrink it.
+| ([ ($persistence // {}) | to_entries[]
+     | .key as $volume | .value as $spec
+     | select(($spec | type) == "object" and (($spec.claimName // "") != "") and (($spec.size // "") != ""))
+     | ($l | map(select(.kind == "PersistentVolumeClaim" and .metadata.name == $spec.claimName)) | .[0]) as $pvc
+     | ($spec.size | quantity_bytes) as $declared
+     | (if $pvc == null then null else ($pvc.status.capacity.storage // $pvc.spec.resources.requests.storage // null) end) as $liveQ
+     | (if $liveQ == null then null else ($liveQ | quantity_bytes) end) as $live
+     | select($pvc == null or $declared == null or $live == null or $live < $declared)
+     | {volume: $volume, claimName: $spec.claimName, declared: ($spec.size | tostring),
+        live: (if $pvc == null then "absent" else ($liveQ // "unknown" | tostring) end)} ]
+   | sort_by(.volume)) as $volumeCapacityBelowRecord
+
 # ── the verdict — derived from the lists, and re-derived by the mesh ───────────────────────────
 | (($envLiveOnly | length) + ($envManifestOnly | length) + ($envFromLiveOnly | length)
    + ($volumesLiveOnly | length) + ($mountsLiveOnly | length) + ($containersLiveOnly | length)
    + ($podAnnotationsLiveOnly | length) + ($podSpecDiffs | length) + $configMapCount
-   + $unmanagedCount + ($unmanagedSecrets | length) + ($plainSecretEntries | length)) as $findingCount
+   + $unmanagedCount + ($unmanagedSecrets | length) + ($plainSecretEntries | length)
+   + ($volumeCapacityBelowRecord | length)) as $findingCount
 | {
     namespace: $namespace,
     release: $release,
@@ -164,6 +202,7 @@ def annotations: (.spec.template.metadata.annotations // {}) | keys;
     unmanagedObjects: $unmanagedObjects,
     unmanagedSecrets: $unmanagedSecrets,
     plainSecretEntries: $plainSecretEntries,
+    volumeCapacityBelowRecord: $volumeCapacityBelowRecord,
     findingCount: $findingCount,
     verdict: (if $findingCount == 0 then "clean" else "drift" end)
   }

--- a/deploy/aks/operator/bin/hosting-audit
+++ b/deploy/aks/operator/bin/hosting-audit
@@ -36,7 +36,13 @@
 #   * Secrets the live pod reads (envFrom, secretKeyRef, secret volumes) that are neither
 #     chart-managed nor CSI-synced;
 #   * entries whose NAME looks like a secret (token|secret|key|password) carried as a PLAIN value —
-#     inline env on the pod, or a key in a chart ConfigMap.
+#     inline env on the pod, or a key in a chart ConfigMap;
+#   * a PersistentVolumeClaim whose live capacity is BELOW the size the Deployment record declares
+#     for it (the record's volumes[] reach helm as the release's `persistence` values). The one
+#     record-vs-live comparison here, because the manifest cannot show it: the portal's claims on
+#     this fleet are not helm-managed, so a bigger `size` on the record changes nothing until
+#     hosting-pv-resize applies it — capacity is a record property, and this is what says when the
+#     cluster has not caught up (measured 2026-09-08: memex-data declared 16Gi, full at 3 MiB free).
 #
 # THE OUTPUT is the human summary plus the machine lines the mesh's Hosting plugin parses:
 #   ::hosting:: audit_verdict=clean|drift   ::hosting:: audit_findings=N   ::hosting:: audit=<base64 JSON>
@@ -89,6 +95,10 @@ status="$(hosting::read helm status "$release" -n "$namespace" -o json 2>"$work/
   || hosting::die "no helm release '${release}' in namespace '${namespace}' ($(tr -d '\n' < "$work/err")). An audit compares the cluster against a release's manifest; with no release there is nothing to compare against, and reporting the namespace as 'unmanaged' would be a confident wrong answer."
 revision="$(printf '%s' "$status" | jq -r '.version // empty')"
 chart="$(printf '%s' "$status" | jq -r '.chart.metadata.version // empty')"
+# The THIRD thing that leaves the release object, and the only part of `config` that does: the
+# record's volumes as HelmValues rendered them (claimName + size per volume — names and sizes, no
+# value of anything). It is what a claim's live capacity is measured against below.
+persistence="$(printf '%s' "$status" | jq -c '.config.persistence // {}')"
 [ -n "$revision" ] || hosting::die "helm status answered for '${release}' but named no revision — refusing to audit against a release the output cannot identify"
 hosting::log "release   ${release} in ${namespace} — revision ${revision}${chart:+, chart ${chart}}"
 
@@ -144,6 +154,7 @@ if ! jq -n \
       --argjson revision "$revision" --arg chart "$chart" \
       --arg auditedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
       --arg skipped "$skipped" \
+      --argjson persistence "$persistence" \
       -f "$AUDIT_JQ" > "$work/report.json" 2>"$work/err"; then
   hosting::die "the audit could not be computed: $(sed -e 's/^jq: error (at <unknown>): //' "$work/err" | tr -d '\n')"
 fi
@@ -172,6 +183,7 @@ jq -r '.podSpecDiffs[] | "  pod spec differs        \(.field): live=\(.live) man
 jq -r '.configMaps[] | select(.missingLive or ((.liveOnlyKeys|length) + (.manifestOnlyKeys|length) + (.differingKeys|length)) > 0)
   | "  ConfigMap \(.name): " + (if .missingLive then "MISSING live" else "live-only keys [\(.liveOnlyKeys|join(" "))] manifest-only keys [\(.manifestOnlyKeys|join(" "))] value-differs [\(.differingKeys|join(" "))]" end)' "$work/report.json"
 jq -r '.unmanagedObjects[] | "  unmanaged \(.kind) (\(.names|length)): \(.names|join(" "))"' "$work/report.json"
+jq -r '.volumeCapacityBelowRecord[] | "  volume below record     \(.volume) (\(.claimName)): live=\(.live) record=\(.declared)"' "$work/report.json"
 say_list "🚨 unmanaged secrets the pod reads" '.unmanagedSecrets'
 say_list "🚨 secret-shaped entries carried as PLAIN values" '.plainSecretEntries'
 say_list "kinds skipped (not served)" '.skippedKinds'

--- a/deploy/aks/operator/bin/hosting-pv-resize
+++ b/deploy/aks/operator/bin/hosting-pv-resize
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# hosting-pv-resize --namespace <ns> --claim <pvc> --size <quantity>
+#
+# Grow ONE PersistentVolumeClaim to the capacity the Deployment record declares for it.
+#
+# 🚨 WHY THIS EXISTS: capacity is a property of the record (`volumes[].size` on Hosting/Deployment),
+# and on this fleet the portal's claims are NOT managed by helm — every `memex-*` claim on memex /
+# memex-cloud was applied by hand once and `helm upgrade` never touches an object it does not own.
+# So a bigger `size` on the record rendered a bigger number into the values file and changed
+# NOTHING on the cluster, and growing a share meant `kubectl patch pvc` from a laptop — exactly the
+# break-glass write the 2026-09-08 rule retires. Measured that day: memex.systemorph.com's /data
+# share (memex-data) was 16Gi with 3 MiB free at 13:51Z while its sibling ran 128Gi. This command
+# is the step the Provision / Reconcile plan runs per declared claim so that editing the record
+# and running the action IS the whole path.
+#
+# 🚨 IT NEVER SHRINKS. Kubernetes refuses a smaller request outright, but the refusal here comes
+# first and names the fix: a record that declares LESS than the claim holds is a wrong record, and
+# the honest move is to correct the record to the measured capacity, not to silently keep going.
+#
+# 🚨 IT NEVER CREATES. A claim that does not exist is the chart's job (`persistence.<name>.create`
+# on a record-driven Provision); resizing "nothing" into a new claim of the wrong class would be a
+# second, unreviewed provisioner. Absent → refusal, naming the claim.
+#
+# The storage class must carry `allowVolumeExpansion: true` (azurefile-memex does — Azure Files
+# expands ONLINE, with no pod restart). A class that does not allow it makes the patch hang in
+# `Pending` forever, so it is checked BEFORE anything is written.
+#
+# IDEMPOTENT: a claim already at (or above — see the shrink rule) the requested capacity is a
+# successful no-op that says so, so the plan step is safe on every run.
+#
+# Output contract (the ::hosting:: lines the mesh reads):
+#   pv_capacity=<quantity>   the claim's capacity after this run, read back from status
+#   pv_resized=0|1           whether a patch was written
+#   pv_resize=filesystem-pending   the volume grew but the filesystem resize waits for a pod
+#                            restart (FileSystemResizePending) — reported, not hidden
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-pv-resize"
+
+namespace="" claim="" size=""
+attempts="${HOSTING_RESIZE_ATTEMPTS:-30}" interval="${HOSTING_RESIZE_INTERVAL:-10}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    --claim)     claim="${2:-}";     shift 2 ;;
+    --size)      size="${2:-}";      shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::need_flag claim "$claim"
+hosting::need_flag size "$size"
+hosting::safe_name namespace "$namespace"
+hosting::safe_name claim "$claim"
+
+# A Kubernetes binary quantity, whole units only. Deliberately narrower than the API allows: a
+# size reaches a JSON patch below, and "128Gi" is the only shape the record has ever carried.
+[[ "$size" =~ ^[1-9][0-9]*(Mi|Gi|Ti)$ ]] \
+  || hosting::die "size '${size}' is not a whole binary quantity (e.g. 128Gi) — refusing"
+
+command -v jq >/dev/null 2>&1 \
+  || hosting::die "jq is not installed in this image — the claim's status is JSON and cannot be read without it"
+
+# Bytes of a quantity, so two spellings compare as numbers. Decimal (k/M/G/T) and binary units
+# both occur: the API answers what the record requested, but a provisioner may round.
+quantity_bytes() {
+  local q="$1" n unit
+  [[ "$q" =~ ^([0-9]+)(Ki|Mi|Gi|Ti|Pi|k|M|G|T|P)?$ ]] || return 1
+  n="${BASH_REMATCH[1]}"; unit="${BASH_REMATCH[2]:-}"
+  case "$unit" in
+    "") echo "$n" ;;
+    Ki) echo $((n * 1024)) ;;
+    Mi) echo $((n * 1024 * 1024)) ;;
+    Gi) echo $((n * 1024 * 1024 * 1024)) ;;
+    Ti) echo $((n * 1024 * 1024 * 1024 * 1024)) ;;
+    Pi) echo $((n * 1024 * 1024 * 1024 * 1024 * 1024)) ;;
+    k)  echo $((n * 1000)) ;;
+    M)  echo $((n * 1000 * 1000)) ;;
+    G)  echo $((n * 1000 * 1000 * 1000)) ;;
+    T)  echo $((n * 1000 * 1000 * 1000 * 1000)) ;;
+    P)  echo $((n * 1000 * 1000 * 1000 * 1000 * 1000)) ;;
+  esac
+}
+
+err="$(mktemp)"
+trap 'rm -f "$err"' EXIT
+
+# ── the claim as it is ─────────────────────────────────────────────────────────────────────────
+pvc="$(hosting::read kubectl -n "$namespace" get pvc "$claim" -o json 2>"$err")" \
+  || hosting::die "no PersistentVolumeClaim '${claim}' in namespace ${namespace} ($(tr -d '\n' < "$err")). This command GROWS a claim; it never creates one — a new claim is rendered by the chart from the record (persistence.<name>.create). Check the record's claimName against 'kubectl -n ${namespace} get pvc'."
+
+phase="$(printf '%s' "$pvc" | jq -r '.status.phase // ""')"
+class="$(printf '%s' "$pvc" | jq -r '.spec.storageClassName // ""')"
+current="$(printf '%s' "$pvc" | jq -r '.status.capacity.storage // ""')"
+requested="$(printf '%s' "$pvc" | jq -r '.spec.resources.requests.storage // ""')"
+
+[ "$phase" = "Bound" ] \
+  || hosting::die "PersistentVolumeClaim ${claim} is '${phase:-<no phase>}', not Bound — only a bound claim has a volume to grow. A Pending claim has nothing behind it yet; a Lost one needs a human first."
+[ -n "$class" ] \
+  || hosting::die "PersistentVolumeClaim ${claim} names no storageClassName — the class is what decides whether a volume can expand, and a claim without one cannot be reasoned about"
+[ -n "$current" ] \
+  || hosting::die "PersistentVolumeClaim ${claim} reports no status.capacity — refusing to compare a request against a capacity the API did not state"
+
+# ── the class must allow expansion, BEFORE anything is written ────────────────────────────────
+expandable="$(hosting::read kubectl get storageclass "$class" -o jsonpath='{.allowVolumeExpansion}' 2>"$err")" \
+  || hosting::die "could not read StorageClass ${class} ($(tr -d '\n' < "$err")) — is the operator's ClusterRole missing 'storageclasses'?"
+[ "$expandable" = "true" ] \
+  || hosting::die "StorageClass ${class} does not allow volume expansion (allowVolumeExpansion='${expandable:-unset}'). A patch would sit in Pending forever; growing ${claim} means moving its data to an expandable class, which is a human's decision."
+
+current_b="$(quantity_bytes "$current")" \
+  || hosting::die "cannot read the claim's capacity '${current}' as a quantity"
+size_b="$(quantity_bytes "$size")"
+
+hosting::log "claim     ${claim} in ${namespace}: ${current} (class ${class}, requested ${requested:-?})"
+hosting::log "record    ${size}"
+
+if [ "$size_b" -lt "$current_b" ]; then
+  hosting::die "the record declares ${size} for ${claim} but the claim already holds ${current} — a volume cannot shrink, and a record that understates its instance's capacity is wrong. Correct the record's size to the measured ${current} (or larger) and re-run."
+fi
+
+if [ "$size_b" -eq "$current_b" ]; then
+  hosting::log "already at ${current} — nothing to do"
+  hosting::say pv_capacity "$current"
+  hosting::say pv_resized 0
+  exit 0
+fi
+
+# ── grow ──────────────────────────────────────────────────────────────────────────────────────
+requested_b="$(quantity_bytes "${requested:-0}" 2>/dev/null || echo 0)"
+if [ "$requested_b" -eq "$size_b" ]; then
+  # The spec already asks for it: a previous run patched and the provisioner is still working, or
+  # was waiting on a pod restart. Do not patch the same value twice; go straight to waiting.
+  hosting::log "spec already requests ${size} — a resize is in flight, waiting for it"
+  resized=0
+else
+  hosting::do kubectl -n "$namespace" patch pvc "$claim" --type merge \
+      -p "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"${size}\"}}}}" \
+    || hosting::die "could not patch PersistentVolumeClaim ${claim} to ${size}"
+  resized=1
+fi
+
+if hosting::dry; then
+  hosting::say pv_capacity "$current"
+  hosting::say pv_resized 0
+  hosting::say pv_resize dry-run
+  exit 0
+fi
+
+# ── read it back: the request is not the outcome, the capacity in status is ───────────────────
+i=0
+while :; do
+  i=$((i + 1))
+  pvc="$(hosting::read kubectl -n "$namespace" get pvc "$claim" -o json 2>"$err")" \
+    || hosting::die "lost the claim while waiting for it to grow ($(tr -d '\n' < "$err"))"
+  now="$(printf '%s' "$pvc" | jq -r '.status.capacity.storage // ""')"
+  now_b="$(quantity_bytes "${now:-0}" 2>/dev/null || echo 0)"
+  if [ "$now_b" -ge "$size_b" ]; then
+    hosting::log "grown     ${claim}: ${current} → ${now} (attempt ${i})"
+    hosting::say pv_capacity "$now"
+    hosting::say pv_resized "$resized"
+    exit 0
+  fi
+  # The volume side is done but the filesystem waits for a pod to mount it (block volumes; never
+  # Azure Files, which is why the fleet's classes expand online). Reported, not treated as done:
+  # the plan's rollout step is what completes it, and the log says so.
+  fs_pending="$(printf '%s' "$pvc" | jq -r '[.status.conditions[]? | select(.type == "FileSystemResizePending" and .status == "True")] | length')"
+  if [ "${fs_pending:-0}" -gt 0 ]; then
+    hosting::log "the volume behind ${claim} grew to ${size}; the FILESYSTEM resize is pending until a pod re-mounts it (FileSystemResizePending) — the rollout that follows completes it"
+    hosting::say pv_capacity "$now"
+    hosting::say pv_resized "$resized"
+    hosting::say pv_resize filesystem-pending
+    exit 0
+  fi
+  [ "$i" -lt "$attempts" ] || break
+  sleep "$interval"
+done
+
+hosting::die "PersistentVolumeClaim ${claim} still reports ${now:-<none>} after ${attempts} attempt(s), requested ${size} and no FileSystemResizePending condition. The provisioner did not act — read 'kubectl -n ${namespace} describe pvc ${claim}' for the controller's event before re-running; the request stays on the claim, so re-running does not patch twice."

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/persistentvolumeclaim.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/persistentvolumeclaim.json
@@ -1,0 +1,33 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": {
+        "name": "memex-data",
+        "namespace": "memex",
+        "annotations": {
+          "helm.sh/resource-policy": "keep"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteMany"
+        ],
+        "storageClassName": "azurefile-memex",
+        "resources": {
+          "requests": {
+            "storage": "16Gi"
+          }
+        }
+      },
+      "status": {
+        "phase": "Bound",
+        "capacity": {
+          "storage": "16Gi"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/manifest.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/manifest.json
@@ -134,6 +134,28 @@
         "namespace": "memex"
       },
       "spec": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": {
+        "name": "memex-data",
+        "namespace": "memex",
+        "annotations": {
+          "helm.sh/resource-policy": "keep"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteMany"
+        ],
+        "storageClassName": "azurefile-memex",
+        "resources": {
+          "requests": {
+            "storage": "16Gi"
+          }
+        }
+      }
     }
   ]
 }

--- a/deploy/aks/operator/test/fixtures/audit/clean/status.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/status.json
@@ -2,7 +2,27 @@
   "name": "memex",
   "namespace": "memex",
   "version": 42,
-  "info": { "status": "deployed" },
-  "chart": { "metadata": { "name": "memex", "version": "1.4.0" } },
-  "config": { "secrets": { "note": "the user-supplied values — the audit must never print these: value-that-must-never-print" } }
+  "info": {
+    "status": "deployed"
+  },
+  "chart": {
+    "metadata": {
+      "name": "memex",
+      "version": "1.4.0"
+    }
+  },
+  "config": {
+    "secrets": {
+      "note": "the user-supplied values \u2014 the audit must never print these: value-that-must-never-print"
+    },
+    "persistence": {
+      "data": {
+        "claimName": "memex-data",
+        "create": true,
+        "mountPath": "/data",
+        "size": "16Gi",
+        "storageClass": "azurefile-memex"
+      }
+    }
+  }
 }

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/persistentvolumeclaim.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/persistentvolumeclaim.json
@@ -1,7 +1,49 @@
 {
   "kind": "List",
   "items": [
-    { "apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": { "name": "memex-data", "namespace": "memex" }, "spec": {} },
-    { "apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": { "name": "memex-content", "namespace": "memex" }, "spec": {} }
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": {
+        "name": "memex-data",
+        "namespace": "memex"
+      },
+      "spec": {
+        "storageClassName": "azurefile-memex",
+        "resources": {
+          "requests": {
+            "storage": "16Gi"
+          }
+        }
+      },
+      "status": {
+        "phase": "Bound",
+        "capacity": {
+          "storage": "16Gi"
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": {
+        "name": "memex-content",
+        "namespace": "memex"
+      },
+      "spec": {
+        "storageClassName": "azurefile-memex",
+        "resources": {
+          "requests": {
+            "storage": "64Gi"
+          }
+        }
+      },
+      "status": {
+        "phase": "Bound",
+        "capacity": {
+          "storage": "64Gi"
+        }
+      }
+    }
   ]
 }

--- a/deploy/aks/operator/test/fixtures/audit/drift/status.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/status.json
@@ -2,7 +2,36 @@
   "name": "memex",
   "namespace": "memex",
   "version": 42,
-  "info": { "status": "deployed" },
-  "chart": { "metadata": { "name": "memex", "version": "1.4.0" } },
-  "config": { "secrets": { "note": "the user-supplied values — the audit must never print these: value-that-must-never-print" } }
+  "info": {
+    "status": "deployed"
+  },
+  "chart": {
+    "metadata": {
+      "name": "memex",
+      "version": "1.4.0"
+    }
+  },
+  "config": {
+    "secrets": {
+      "note": "the user-supplied values \u2014 the audit must never print these: value-that-must-never-print"
+    },
+    "persistence": {
+      "content": {
+        "claimName": "memex-content",
+        "mountPath": "/mnt/content",
+        "size": "64Gi",
+        "storageClass": "azurefile-memex"
+      },
+      "data": {
+        "claimName": "memex-data",
+        "mountPath": "/data",
+        "size": "128Gi",
+        "storageClass": "azurefile-memex"
+      },
+      "postgres": {
+        "size": "128Gi",
+        "storageClass": "managed-csi"
+      }
+    }
+  }
 }

--- a/deploy/aks/operator/test/fixtures/pv-resize/absent/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/absent/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": true
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/already/pvc.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/already/pvc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "128Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "128Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/already/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/already/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": true
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/filesystem-pending/pvc.after.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/filesystem-pending/pvc.after.json
@@ -1,0 +1,31 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "128Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "16Gi"
+    },
+    "conditions": [
+      {
+        "type": "FileSystemResizePending",
+        "status": "True"
+      }
+    ]
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/filesystem-pending/pvc.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/filesystem-pending/pvc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "16Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "16Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/filesystem-pending/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/filesystem-pending/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": true
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/grows/pvc.after.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/grows/pvc.after.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "128Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "128Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/grows/pvc.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/grows/pvc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "16Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "16Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/grows/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/grows/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": true
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/no-expansion/pvc.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/no-expansion/pvc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "16Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "16Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/no-expansion/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/no-expansion/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": false
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/pending/pvc.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/pending/pvc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "16Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Pending",
+    "capacity": {
+      "storage": "16Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/pending/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/pending/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": true
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/stuck/pvc.after.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/stuck/pvc.after.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "128Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "16Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/stuck/pvc.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/stuck/pvc.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolumeClaim",
+  "metadata": {
+    "name": "memex-data",
+    "namespace": "memex"
+  },
+  "spec": {
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "azurefile-memex",
+    "resources": {
+      "requests": {
+        "storage": "16Gi"
+      }
+    }
+  },
+  "status": {
+    "phase": "Bound",
+    "capacity": {
+      "storage": "16Gi"
+    }
+  }
+}

--- a/deploy/aks/operator/test/fixtures/pv-resize/stuck/storageclass.json
+++ b/deploy/aks/operator/test/fixtures/pv-resize/stuck/storageclass.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "storage.k8s.io/v1",
+  "kind": "StorageClass",
+  "metadata": {
+    "name": "azurefile-memex"
+  },
+  "provisioner": "file.csi.azure.com",
+  "allowVolumeExpansion": true
+}

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -79,6 +79,12 @@ refuses "kv-rotate needs --vault"          "missing required flag --vault"      
 refuses "kv-rotate needs --namespace"      "missing required flag --namespace"  hosting-kv-rotate --vault V
 refuses "pv-purge needs --namespace"       "missing required flag --namespace"  hosting-pv-purge
 refuses "pv-purge rejects unknown flags"   "unknown argument"                   hosting-pv-purge --namespace n --nope 1
+refuses "pv-resize needs --namespace"      "missing required flag --namespace"  hosting-pv-resize --claim c --size 1Gi
+refuses "pv-resize needs --claim"          "missing required flag --claim"      hosting-pv-resize --namespace n --size 1Gi
+refuses "pv-resize needs --size"           "missing required flag --size"       hosting-pv-resize --namespace n --claim c
+refuses "pv-resize rejects unknown flags"  "unknown argument"                   hosting-pv-resize --namespace n --claim c --size 1Gi --nope 1
+refuses "pv-resize rejects a non-quantity" "is not a whole binary quantity"     hosting-pv-resize --namespace n --claim c --size 128
+refuses "pv-resize rejects a decimal unit" "is not a whole binary quantity"     hosting-pv-resize --namespace n --claim c --size 128G
 refuses "dns needs a mode"                 "must be 'upsert' or 'delete'"       hosting-dns --zone z --host h
 refuses "redirect needs a mode"            "must be 'suspend' or 'restore'"     hosting-redirect --namespace n
 refuses "deploy needs --release"           "missing required flag --release"    hosting-deploy --namespace n --database d
@@ -165,6 +171,10 @@ refuses_hard "namespace with a shell metacharacter" "is not a plain name" \
   hosting-kv-ensure --vault V --namespace 'n; rm -rf /'
 refuses_hard "pv-purge namespace with a metacharacter" "is not a plain name" \
   hosting-pv-purge --namespace 'n; kubectl delete pv --all'
+refuses_hard "pv-resize claim with a metacharacter"    "is not a plain name" \
+  hosting-pv-resize --namespace n --claim 'c; kubectl delete pvc --all' --size 1Gi
+refuses_hard "pv-resize size with a metacharacter"     "is not a whole binary quantity" \
+  hosting-pv-resize --namespace n --claim c --size '1Gi"}}}; rm -rf /'
 refuses_hard "kv-rotate namespace with a metacharacter" "is not a plain name" \
   hosting-kv-rotate --vault V --namespace 'n; rm -rf /' --synced-secret s
 refuses_hard "kv-rotate prefix with a metacharacter"    "is not a plain name" \
@@ -303,6 +313,88 @@ case "$out" in *"DRY-RUN would run"*) ok "a dry run narrates what it would do" ;
   *) bad "a dry run narrates" "said: ${out}" ;; esac
 
 echo
+echo "── hosting-pv-resize: capacity is a record property ──────────────"
+# The stub answers the command's reads from a per-scenario fixture and RECORDS the writes, so
+# the decisions — never shrink, never patch a class that cannot expand, patch once, read the
+# capacity back — are asserted without a cluster. Whether Azure Files actually grows is proven
+# by the first real run; that it grows ONLINE is the reason the fleet's class is azurefile.
+PV_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/pv-resize" && pwd)"
+PV_FIXTURES="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/fixtures/pv-resize" && pwd)"
+pv_resize() {  # pv_resize <scenario> <size> [env…] — runs against a fresh state dir; sets $_pv_out $_pv_rc $_pv_log
+  local scenario="$1" size="$2"; shift 2
+  _pv_state="$(mktemp -d)"
+  _pv_out="$(env "$@" PATH="$PV_STUBS:$PATH" HOSTING_PV_FIXTURE="$PV_FIXTURES/$scenario" HOSTING_PV_STATE="$_pv_state" \
+    HOSTING_RESIZE_ATTEMPTS=2 HOSTING_RESIZE_INTERVAL=0 \
+    hosting-pv-resize --namespace memex --claim memex-data --size "$size" 2>&1)"; _pv_rc=$?
+  _pv_log="$(cat "$_pv_state/log" 2>/dev/null || true)"
+  rm -rf "$_pv_state"
+}
+
+pv_resize grows 128Gi
+[ "$_pv_rc" -eq 0 ] && ok "a smaller claim is grown to the record's size" \
+  || bad "a smaller claim is grown" "exited ${_pv_rc}: ${_pv_out}"
+case "$_pv_log" in *'patch pvc memex-data --type merge -p {"spec":{"resources":{"requests":{"storage":"128Gi"}}}}'*) ok "the patch carries exactly the requested storage" ;;
+  *) bad "the patch carries the requested storage" "kubectl saw: ${_pv_log}" ;; esac
+[ "$(printf '%s\n' "$_pv_log" | grep -c 'patch pvc')" = "1" ] && ok "…and is written ONCE" \
+  || bad "the patch is written once" "kubectl saw: ${_pv_log}"
+case "$_pv_out" in *"::hosting:: pv_capacity=128Gi"*) ok "the capacity reported is the one READ BACK from status, not the request" ;;
+  *) bad "the capacity is read back" "said: ${_pv_out}" ;; esac
+case "$_pv_out" in *"::hosting:: pv_resized=1"*) ok "…and the run says it resized" ;;
+  *) bad "the run says it resized" "said: ${_pv_out}" ;; esac
+
+pv_resize already 128Gi
+[ "$_pv_rc" -eq 0 ] && ok "a claim already at the record's size is a successful no-op (idempotent plan step)" \
+  || bad "already-at-size is a no-op" "exited ${_pv_rc}: ${_pv_out}"
+case "$_pv_log" in *"patch pvc"*) bad "a no-op writes nothing" "kubectl saw: ${_pv_log}" ;; *) ok "a no-op writes nothing" ;; esac
+case "$_pv_out" in *"::hosting:: pv_resized=0"*) ok "…and says so" ;; *) bad "the no-op says so" "said: ${_pv_out}" ;; esac
+
+# 🚨 The refusals, each BEFORE any write.
+pv_resize already 64Gi
+[ "$_pv_rc" -ne 0 ] && ok "a record SMALLER than the claim is refused — a volume cannot shrink" \
+  || bad "shrink is refused" "exited 0: ${_pv_out}"
+case "$_pv_out" in *"cannot shrink"*"Correct the record"*) ok "…naming the record as the thing to fix" ;;
+  *) bad "the shrink refusal names the fix" "said: ${_pv_out}" ;; esac
+case "$_pv_log" in *"patch pvc"*) bad "a refused shrink writes nothing" "kubectl saw: ${_pv_log}" ;; *) ok "a refused shrink writes nothing" ;; esac
+
+pv_resize no-expansion 128Gi
+[ "$_pv_rc" -ne 0 ] && ok "a class without allowVolumeExpansion is refused" \
+  || bad "non-expandable class is refused" "exited 0: ${_pv_out}"
+case "$_pv_out" in *"does not allow volume expansion"*) ok "…saying which class and why" ;;
+  *) bad "the class refusal says why" "said: ${_pv_out}" ;; esac
+case "$_pv_log" in *"patch pvc"*) bad "a refused class writes nothing" "kubectl saw: ${_pv_log}" ;; *) ok "a refused class writes nothing" ;; esac
+
+pv_resize absent 128Gi
+[ "$_pv_rc" -ne 0 ] && ok "an absent claim is refused — this command never creates one" \
+  || bad "absent claim is refused" "exited 0: ${_pv_out}"
+case "$_pv_out" in *"never creates one"*) ok "…and says creation is the chart's job" ;;
+  *) bad "the absent refusal points at the chart" "said: ${_pv_out}" ;; esac
+
+pv_resize pending 128Gi
+[ "$_pv_rc" -ne 0 ] && ok "an unbound claim is refused — nothing behind it to grow" \
+  || bad "unbound claim is refused" "exited 0: ${_pv_out}"
+
+# The two outcomes of waiting that are not "grown": a filesystem resize the next pod completes
+# (reported, exit 0), and a provisioner that never acted (stuck, exit non-zero — never a pass).
+pv_resize filesystem-pending 128Gi
+[ "$_pv_rc" -eq 0 ] && ok "a FileSystemResizePending claim is reported as pending, not as failed" \
+  || bad "filesystem-pending is reported" "exited ${_pv_rc}: ${_pv_out}"
+case "$_pv_out" in *"::hosting:: pv_resize=filesystem-pending"*) ok "…on its own ::hosting:: line" ;;
+  *) bad "filesystem-pending has a machine line" "said: ${_pv_out}" ;; esac
+
+pv_resize stuck 128Gi
+[ "$_pv_rc" -ne 0 ] && ok "a claim that never grows is a FAILED step, not a timed-out pass" \
+  || bad "a stuck resize fails" "exited 0: ${_pv_out}"
+case "$_pv_out" in *"still reports 16Gi after 2 attempt"*) ok "…naming what it last read and how long it waited" ;;
+  *) bad "the stuck failure names its reading" "said: ${_pv_out}" ;; esac
+
+# A dry run reads for real, narrates the patch and writes nothing.
+pv_resize grows 128Gi HOSTING_DRY_RUN=true
+[ "$_pv_rc" -eq 0 ] && ok "a dry run succeeds" || bad "a dry run succeeds" "exited ${_pv_rc}: ${_pv_out}"
+case "$_pv_log" in *"patch pvc"*) bad "a dry run writes nothing" "kubectl saw: ${_pv_log}" ;; *) ok "a dry run writes nothing" ;; esac
+case "$_pv_out" in *"DRY-RUN would run"*"patch pvc"*) ok "…and narrates the patch it would write" ;;
+  *) bad "a dry run narrates the patch" "said: ${_pv_out}" ;; esac
+
+echo
 echo "── hosting-audit: what lives only on the cluster ─────────────────"
 # The stubs are NOT mocks of helm/kubectl — they answer the audit's read-only calls from fixture
 # files so the DETECTION can be asserted without a cluster. What a fixture cannot prove (that a
@@ -352,7 +444,15 @@ else
   check_report "unmanaged secrets the pod reads"      '.unmanagedSecrets == ["memex-email-secret","memex-extra-secret"]'
   check_report "plain secret-shaped entries, all containers" '.plainSecretEntries | index("env:memex-portal:PluginCatalog__RegistryToken") and index("env:node-gate:GATE_API_KEY") and index("configmap:memex-portal-config/Hosting__ModuleReportSecret")'
   check_report "the audited revision is recorded"     '.helmRevision == 42 and .managedObjectCount == 6'
+  # The record's volumes reach helm as the release's persistence values; a claim below its declared
+  # size is a finding of its own. content matches (64Gi = 64Gi) and postgres names no claim, so
+  # exactly ONE entry — and it carries the two sizes, never a value of anything.
+  check_report "a claim below the record's size is a finding" \
+    '.volumeCapacityBelowRecord == [{"volume":"data","claimName":"memex-data","declared":"128Gi","live":"16Gi"}]'
+  check_report "…counted in the total"                 '.findingCount == (.envLiveOnly|length) + (.envManifestOnly|length) + (.envFromLiveOnly|length) + (.volumesLiveOnly|length) + (.mountsLiveOnly|length) + (.containersLiveOnly|length) + (.podAnnotationsLiveOnly|length) + (.podSpecDiffs|length) + ([.configMaps[] | (.liveOnlyKeys|length) + (.manifestOnlyKeys|length) + (.differingKeys|length) + (if .missingLive then 1 else 0 end)] | add) + ([.unmanagedObjects[].names | length] | add) + (.unmanagedSecrets|length) + (.plainSecretEntries|length) + (.volumeCapacityBelowRecord|length)'
 fi
+case "$out" in *"volume below record     data (memex-data): live=16Gi record=128Gi"*) ok "the human summary names the claim and both sizes" ;;
+  *) bad "the human summary names the claim" "said: ${out}" ;; esac
 # 🚨 The most important assertion of the section: names only. The fixture's secret VALUES must
 # never appear anywhere in the output — the report lands on a node a page renders.
 case "$out" in
@@ -374,6 +474,13 @@ if printf '%s' "$report" | jq -e '.skippedKinds == ["scaledobject"]' >/dev/null 
   ok "an unserved kind is recorded as skipped, not silently absent"
 else
   bad "an unserved kind is recorded as skipped" "report: $(printf '%s' "$report" | jq -c .skippedKinds 2>/dev/null)"
+fi
+# The clean fixture declares data at 16Gi and its chart-rendered claim holds 16Gi: at-size is not
+# a finding, and the category is PRESENT and empty — a reader must never mistake "absent" for "0".
+if printf '%s' "$report" | jq -e '.volumeCapacityBelowRecord == []' >/dev/null 2>&1; then
+  ok "a claim at its declared size is not a finding"
+else
+  bad "a claim at its declared size is not a finding" "report: $(printf '%s' "$report" | jq -c .volumeCapacityBelowRecord 2>/dev/null)"
 fi
 
 # Read-only: a dry run audits for real — same report, same verdict.

--- a/deploy/aks/operator/test/stubs/pv-resize/kubectl
+++ b/deploy/aks/operator/test/stubs/pv-resize/kubectl
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# A stand-in `kubectl` for test/run-tests.sh — answers hosting-pv-resize's read/patch shapes from
+# a fixture directory ($HOSTING_PV_FIXTURE) and records every invocation in $HOSTING_PV_STATE/log.
+# Not a mock of kubectl: what is asserted is the command's DECISIONS — refuse to shrink, refuse a
+# class that cannot expand, patch exactly once, read the capacity BACK — not what kubectl does.
+#
+#   kubectl -n <ns> get pvc <claim> -o json    → $FIXTURE/pvc.json; after a patch, pvc.after.json
+#                                                 when it exists (the provisioner's answer);
+#                                                 no pvc.json → NotFound on stderr, exit 1
+#   kubectl get storageclass <c> -o jsonpath=… → allowVolumeExpansion from $FIXTURE/storageclass.json
+#   kubectl -n <ns> patch pvc <claim> …         → records the patch, marks $STATE/patched
+set -uo pipefail
+fixture="${HOSTING_PV_FIXTURE:?the pv-resize kubectl stub needs HOSTING_PV_FIXTURE}"
+state="${HOSTING_PV_STATE:?the pv-resize kubectl stub needs HOSTING_PV_STATE}"
+printf '%s\n' "kubectl $*" >> "$state/log"
+case "$*" in
+  *" get pvc "*)
+    if [ -f "$state/patched" ] && [ -f "$fixture/pvc.after.json" ]; then cat "$fixture/pvc.after.json"; exit 0; fi
+    if [ -f "$fixture/pvc.json" ]; then cat "$fixture/pvc.json"; exit 0; fi
+    echo 'Error from server (NotFound): persistentvolumeclaims "memex-data" not found' >&2
+    exit 1 ;;
+  *"get storageclass "*)
+    [ -f "$fixture/storageclass.json" ] || { echo 'Error from server (NotFound): storageclasses.storage.k8s.io not found' >&2; exit 1; }
+    jq -r '.allowVolumeExpansion // ""' "$fixture/storageclass.json" ;;
+  *" patch pvc "*)
+    touch "$state/patched"
+    echo "persistentvolumeclaim/memex-data patched" ;;
+  *) echo "kubectl stub (pv-resize): unexpected invocation: $*" >&2; exit 1 ;;
+esac

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -288,7 +288,11 @@ There are **three** sides to chart drift, not two:
 | **M** | the last-deployed release manifest | `helm get manifest <release> -n <ns>` |
 
 Everything above this section is **D vs L**. `hosting-audit` (`deploy/aks/operator/bin`) computes
-**M vs L**. The deletion hazard is in **neither**: it is **D vs M**.
+**M vs L** — plus ONE record-vs-live comparison the manifest cannot carry: a PersistentVolumeClaim
+whose live capacity is below the `size` the Deployment record declares (the record's `volumes[]`
+reach helm as the release's `persistence` values), because on this fleet the portal's claims are
+not helm-managed and a bigger size changes nothing until `hosting-pv-resize` applies it. The
+deletion hazard is in **neither**: it is **D vs M**.
 
 "A `helm upgrade` does not delete cluster-only settings" is the measured rule, and it is right about
 the *mechanism* — helm removes only what it **previously owned**. But a key can be cluster-only

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -220,6 +220,38 @@ Helm's three-way merge removes only what Helm owns), so nothing on that list res
 [Chart Drift — what a deploy actually does](/Doc/Architecture/ChartDriftSemantics) has the
 measurement and the per-class triage.
 
+### Volume capacity is a record property — `volumes[].size`, applied by the operator
+
+🚨 **Never `kubectl patch pvc … storage` on a live portal.** The size of every persistent volume
+is `volumes[].size` on the instance's `Hosting/Deployment` record, and the operator applies it:
+
+| you want | you do | what runs |
+|---|---|---|
+| a bigger share (`/data` full, content growing) | edit `volumes[].size` on the record (`128Gi`), then `{ "requestedAction": "Reconcile", "confirmation": "<id>" }` — or a `Provision`, which carries the same step | `hosting-pv-resize --namespace <ns> --claim <claimName> --size <size>` once per declared claim, ordered FIRST in a Reconcile: a full `/data` blocks the rollout the re-apply then waits on |
+| to know whether the cluster has caught up | `{ "requestedAction": "Audit" }` | the report's `volumeCapacityBelowRecord` — the claim, the declared size and the live capacity |
+
+What the command does, and refuses, is the whole contract (`deploy/aks/operator/bin/hosting-pv-resize`):
+
+- it **grows** one claim to the declared size and reports the capacity it **read back** from the
+  claim's `status`, never the request (`::hosting:: pv_capacity=<quantity>`, `pv_resized=0|1`);
+- it **never shrinks** — a record that declares LESS than the claim holds is a wrong record, and the
+  refusal says to correct the record to the measured capacity;
+- it **never creates** — an absent claim is the chart's job (`persistence.<name>.create` on a
+  record-driven Provision), so the refusal names the claim rather than provisioning one on a guess;
+- it refuses a storage class without `allowVolumeExpansion` BEFORE writing anything (a patch on
+  such a class sits in Pending forever). `azurefile-memex` allows it, and Azure Files expands
+  **online** — no pod restart. A block volume whose filesystem resize waits for a pod re-mount is
+  reported as `::hosting:: pv_resize=filesystem-pending`, and the rollout that follows completes
+  it;
+- a claim already at size is a **successful no-op**, so the step is idempotent from the top.
+
+Why this exists: on this fleet the portal's claims are NOT helm-managed (they were applied by hand
+once from `portal-pvcs.yaml`; `helm upgrade` never touches an object it does not own), so a bigger
+`size` on the record re-rendered a bigger number into the values file and changed nothing on the
+cluster. Measured 2026-09-08 13:51Z: `memex-data` in namespace `memex` was **16Gi with 3 MiB
+free** while memex-cloud's ran 128Gi. The `portal-pvcs.yaml` captures in the config repo are
+descriptive; the record is what the operator applies.
+
 ### The chart must also agree with ITSELF — `check-chart-invariants.sh`
 
 Drift is only half of it. The `memex-cloud` outage above needed no cluster to detect: the chart
@@ -558,6 +590,7 @@ questions as nodes, with no cluster credential on the caller:
 | what did it log | `{ "requestedAction": "Logs", "query": "<regex or \| pipeline>", "sinceMinutes": 60, "limit": 300, "pod": "<optional>" }` | `logQl`, `entryCount`, `truncated` on the run; `Hosting/LogEntry` nodes under `Ops/Logs`, the Deployment page's Logs area |
 | what lives only on the cluster | `{ "requestedAction": "Audit" }` | `Ops/Audit/<id>` |
 | roll it | pin `pinnedImageTag` on the record → `{ "requestedAction": "Reconcile", "confirmation": "<id>" }` | the run's phases; then a `Sample` |
+| grow a full share | set `volumes[].size` on the record → the same `Reconcile` | the run's `Ensure volume capacity: <volume>` phase, `pv_capacity=` read back from the claim — see "Volume capacity is a record property" above |
 
 Both observations read the cluster's monitoring stack (kube-state-metrics via Prometheus, Loki)
 from inside the cluster, where it is credential-free; the roll runs as the in-cluster operator Job.

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -81,7 +81,9 @@ and how to reconcile it in the same session. Do not re-derive that list here —
 1. **Is there an action kind for it?** `set image` + rollout → `Roll`; `rollout restart` →
    `Restart`; `scale --replicas=0` → `Suspend`; `helm upgrade` → `HelmRelease deploy` (today) /
    the record pin + `Roll`; "make the cluster match the record" → `Reconcile`; "what is drifting?"
-   → `Audit`. Use the action. The kubectl line is what the operator runs for you.
+   → `Audit`; `patch pvc … storage` → `volumes[].size` on the record + `Reconcile` (the operator's
+   `hosting-pv-resize`, which never shrinks and reads the capacity back). Use the action. The
+   kubectl line is what the operator runs for you.
 2. **Is it a read the API does not answer yet?** (the three above) Take it read-only, name it as
    break-glass in what you write down, and file the gap against the Hosting package rather than
    leaving the recipe as the procedure.
@@ -90,6 +92,12 @@ and how to reconcile it in the same session. Do not re-derive that list here —
 
 ## Related rules decided the same day
 
+- **Volume capacity is a record property:** `volumes[].size` on the Deployment record is what a
+  claim holds. `Provision` and `Reconcile` grow every declared claim to it through
+  `hosting-pv-resize` (grow-only, read back from the claim's status, refuses a class that cannot
+  expand); `Audit` reports a claim that has fallen below its record. The 16Gi `/data` share that
+  measured FULL on `memex.systemorph.com` at 13:51Z that day is the case —
+  [DeploymentAKS](/Doc/Architecture/DeploymentAKS) → "Volume capacity is a record property".
 - **A platform roll must not need every satellite re-baked first:** `Modules:VersionStrictness`
   (`Exact` / `Family` / `Minimum`, dev = `Minimum`) and "a sealed publication syncs its own sources"
   — [ModuleVersioning](/Doc/Architecture/ModuleVersioning),

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-volume-capacity-is-a-property-of-the-deployment-record.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-volume-capacity-is-a-property-of-the-deployment-record.md
@@ -1,0 +1,42 @@
+---
+Name: Volume capacity is a property of the Deployment record
+Category: Feature
+Description: Growing an instance's data share no longer needs a cluster credential. The size of every persistent volume is a field on the Hosting/Deployment record; the hosting operator's new hosting-pv-resize grows the claim to it (never shrinks, never creates, refuses a class that cannot expand), the Provision and Reconcile actions apply it, and the Audit reports a claim that has fallen below what its record declares.
+Icon: HardDrive
+Order: -20260908
+---
+
+# Volume capacity is a property of the Deployment record
+
+On 2026-09-08 at 13:51Z the `/data` share of `memex.systemorph.com` measured **16 GiB with 3 MiB
+free** — full — while its sibling on `memex.meshweaver.cloud` ran 128 GiB. The size of that share
+was written in three places (the Deployment record, the rendered values file, a hand-applied PVC
+capture) and none of them could change it: on this fleet the portal's claims were applied by hand
+once and are not managed by helm, so a bigger `size` on the record re-rendered a bigger number
+into the values file and left the cluster exactly as it was. Growing the share meant `kubectl
+patch pvc` from a laptop — the break-glass write the same day's rule
+([OperatingFromThePortal](/Doc/Architecture/OperatingFromThePortal)) retires.
+
+**Capacity is now a record property, applied by the operator.** `volumes[].size` on the
+`Hosting/Deployment` record is what the claim holds, and three pieces make that true:
+
+- **`hosting-pv-resize --namespace <ns> --claim <pvc> --size <Gi>`** in the operator image grows
+  ONE claim to the declared size and reads the capacity BACK from the claim's status before it
+  reports. It never shrinks (a record that declares less than the claim holds is a wrong record,
+  and the refusal says to correct it), never creates (a new claim is the chart's job), and refuses
+  a storage class without `allowVolumeExpansion` before writing anything. Azure Files expands
+  online; a block volume whose filesystem resize waits for a pod is reported as pending, on its
+  own `::hosting::` line, rather than treated as done. A claim already at size is a successful
+  no-op, so the step is safe on every run.
+- **`Provision` and `Reconcile` apply it.** Both plans carry one *Ensure volume capacity* step per
+  declared claim, and Reconcile orders it FIRST — a full `/data` blocks the rollout the re-apply
+  then waits on. Editing `size` on the record and running the action you already have is the whole
+  path.
+- **`Audit` reports a claim below its record** as a finding of its own
+  (`volumeCapacityBelowRecord`, with the claim and both sizes) — the one record-versus-live
+  comparison in the audit, because the manifest cannot show it.
+
+The measured numbers are corrected in the same change: `memex`'s data volume is declared at
+128Gi, and `memex-cloud`'s stale 16Gi overlay entry now states the 128Gi its share has held all
+along. The runbook is in [DeploymentAKS](/Doc/Architecture/DeploymentAKS) → "Volume capacity is a
+record property".


### PR DESCRIPTION
## Volume capacity is a record property — `hosting-pv-resize` + the audit's `volumeCapacityBelowRecord`

**Incident (maintainer directives, 2026-09-08):** `memex.systemorph.com`'s `/data` share (`memex-data`, ns `memex`) measured **16 GiB with 3 MiB free at 13:51Z** while `memex-cloud`'s ran 128 GiB with 28 GiB used — and the standing rule that ALL operations go through the memex API (`az`/`kubectl` are break-glass). Three files said 16Gi and none could grow it: on this fleet the portal's claims were applied by hand once and are not helm-managed, so a bigger `volumes[].size` on the Deployment record re-rendered a number into the values file and changed nothing on the cluster.

### The operator half (this PR)

| piece | what |
|---|---|
| `deploy/aks/operator/bin/hosting-pv-resize` | `--namespace <ns> --claim <pvc> --size <Gi>`. Grows ONE claim to the record's size and reads the capacity **back** from `status.capacity` before reporting (`::hosting:: pv_capacity=`, `pv_resized=0\|1`). **Never shrinks** (the refusal names the record as the thing to correct), **never creates** (an absent claim is the chart's job — `persistence.<name>.create`), refuses a storage class without `allowVolumeExpansion` **before** writing, patches once (a spec that already requests the size is waited on, not re-patched), reports `FileSystemResizePending` on its own line instead of treating it as done, and is a successful no-op at size — so the plan step is idempotent from the top. |
| `_audit.jq` / `hosting-audit` | new category `volumeCapacityBelowRecord` — the record's `volumes[]` (as HelmValues rendered them, read back from the release's user-supplied `persistence` values) against each live claim's `status.capacity`. The one record-vs-live comparison in the audit; a claim absent or unreadable is a finding, never a silent pass. Names and sizes only. |
| `test/run-tests.sh` + `test/stubs/pv-resize/kubectl` + `test/fixtures/pv-resize/*` | 9 pv-resize scenarios (grows / at-size / shrink refused / non-expandable class refused / absent refused / unbound refused / filesystem-pending / stuck is RED / dry-run writes nothing), each asserting what kubectl was actually asked; the audit's drift fixture now carries a claim below its record and the clean fixture a chart-rendered claim at size. **129 passed, 0 failed** locally; shellcheck clean. |
| `.github/workflows/hosting-operator.yml` | the plan-claims list learns `hosting-pv-resize`; the jq parse-check learns `--argjson persistence`; the new stub joins the tracked+executable check. |
| `deploy/aks/manifests/hosting-operator/operator-rbac.yaml` | read on `storageclasses` (the command reads the class before patching). **Re-apply on the cluster when adopting** — a Forbidden fails the `Ensure volume capacity` step by name. |
| docs | `DeploymentAKS` → "Volume capacity is a record property" (the runbook and the API-first table row), `OperatingFromThePortal` (`patch pvc … storage` → `volumes[].size` + `Reconcile`), `ChartDriftSemantics`, the AKS README and `portal-pvcs.yaml`; What's New (`Category: Feature`). Doc guard tests green. |

### The other halves

- **MeshWeaver.Plugins#1528** — `Provision` emits one `hosting-pv-resize` per declared claim (after the deploy, before the rollout wait); `Reconcile` gains a `GrowVolumes` remedy ordered FIRST; `LiveOnlyConfigReport` gains the typed category. Hosting 1.13 → 1.14.
- **Memex#253** — `memex-data` 16Gi → 128Gi on the record/overlay; memex-cloud's stale 16Gi overlay corrected to the measured 128Gi.

**Landing order: this PR first** (the operator image publishes from core main; until it carries the command, a Plugins plan that emits it fails inside the Job as `command not found` — which is exactly what the plan-claims gate above exists to keep in step), then Plugins, then Memex.

Pairs-with: none — no public type or member of `src/` is removed; the change is the operator image (bash + jq), a doc tree and an RBAC manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
