### PR TITLE
Prune the prebuilt-bundle store by reference (recurring) and report data-volume free space

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -251,6 +251,12 @@ public static class MemexConfiguration
             // awaiting-setup early return below on purpose — an instance parked in setup still
             // reclaims its garbage, exactly as the synchronous call did.
             builder.ConfigureServices(services => services.AddModuleGenerationsGc(moduleRoot));
+            // The sibling collector for the CI-published prebuilt-bundle store on the same volume
+            // (2026-09-08: 482 identity directories / 13.4 GiB filled the 16 GiB share). Same
+            // shape — registered here, run after ApplicationStarted behind the bake, on the
+            // file-system IIoPool — then recurring daily. Inert without PreWarm:PrebuiltBundleRoot.
+            // The rule is PrebuiltBundleStore's: prune what nothing references, never by age alone.
+            builder.ConfigureServices(services => services.AddPrebuiltBundleRetention(configuration));
             var persistedActivation = ModuleActivationSidecar.Read(moduleRoot,
                 msg => Console.Error.WriteLine($"[ModuleActivation] {msg}"));
 

--- a/memex/aspire/Memex.Portal.ServiceDefaults/DataVolumeHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/DataVolumeHealthCheck.cs
@@ -1,0 +1,57 @@
+using MeshWeaver.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Memex.Portal.ServiceDefaults;
+
+/// <summary>
+/// The <c>/health</c> check over the data volume's free space (<see cref="DataVolumeFreeSpace"/>):
+/// <c>Degraded</c> — never <c>Unhealthy</c>, pulling the pod frees nothing — when the volume any
+/// configured store root sits on (<c>PreWarm:PrebuiltBundleRoot</c>, <c>Modules:Root</c>, plus
+/// <c>DataVolume:Paths</c>) has less than <c>DataVolume:MinimumFreeBytes</c> free (default 1 GiB),
+/// naming the path, used and total; and <c>Degraded</c> too when a configured path cannot be
+/// measured. <c>Healthy</c> with no path configured. No probe tag: it reads on
+/// <c>ProbeEndpoints.Health</c> alone. The evaluation is the framework's; this host-side check
+/// only reads configuration and hands it the probe.
+/// </summary>
+public sealed class DataVolumeHealthCheck(
+    IConfiguration configuration,
+    Func<string, DataVolumeReading>? probe = null) : IHealthCheck
+{
+    private readonly Func<string, DataVolumeReading> probe = probe ?? DataVolumeFreeSpace.Probe;
+
+    /// <summary>The paths this check watches, from configuration.</summary>
+    public static IEnumerable<string> PathsOf(IConfiguration configuration)
+    {
+        foreach (var key in DataVolumeFreeSpace.PathConfigKeys)
+        {
+            var value = configuration[key];
+            if (!string.IsNullOrWhiteSpace(value))
+                yield return value;
+        }
+        foreach (var child in configuration.GetSection(DataVolumeFreeSpace.PathsConfigKey).GetChildren())
+            if (!string.IsNullOrWhiteSpace(child.Value))
+                yield return child.Value;
+    }
+
+    /// <summary>The verdict, evaluated now.</summary>
+    public DataVolumeVerdict Evaluate() =>
+        DataVolumeFreeSpace.Evaluate(
+            PathsOf(configuration),
+            probe,
+            DataVolumeFreeSpace.MinimumFreeBytesOf(configuration[DataVolumeFreeSpace.MinimumFreeBytesConfigKey]));
+
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var verdict = Evaluate();
+        var data = verdict.Readings.ToDictionary(
+            r => r.Path,
+            r => (object)(r.Fault ?? $"free={r.FreeBytes} used={r.UsedBytes} total={r.TotalBytes} volume={r.Volume}"),
+            StringComparer.Ordinal);
+        return Task.FromResult(verdict.Degraded
+            ? HealthCheckResult.Degraded(verdict.Description, data: data)
+            : HealthCheckResult.Healthy(verdict.Description, data: data));
+    }
+}

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -194,7 +194,13 @@ public static class ServiceDefaults
             // loaded here renders empty, and until now /health said only "Degraded". No probe
             // tag — Degraded on purpose, never a reason to pull the pod — so it reads on
             // ProbeEndpoints.Health alone, with the node types named in the detail.
-            .AddCheck<ContentTypeHealthCheck>(ContentDegradationRegistry.HealthCheckName);
+            .AddCheck<ContentTypeHealthCheck>(ContentDegradationRegistry.HealthCheckName)
+            // How full the data volume is (2026-09-08): the share holding the prebuilt bundles,
+            // the modules, the assembly cache and the DataProtection keys reached 3 MiB free and
+            // every write on it failed far from the cause. Degraded below DataVolume:MinimumFreeBytes
+            // (1 GiB) on the volume of any configured store root — no probe tag, pulling the pod
+            // frees nothing — naming the path, used and total.
+            .AddCheck(DataVolumeFreeSpace.HealthCheckName, new DataVolumeHealthCheck(builder.Configuration));
 
         return builder;
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -714,6 +714,96 @@ username/password secrets, and it bakes **two** trees against **two** known-debt
 bake directory, where the reusable workflow bakes one mount. Both run the identical publish script,
 which is the part that must never drift.
 
+## Retention: the published store is pruned by REFERENCE, never by age alone
+
+> Maintainer directive, 2026-09-08: *"please also set up a recurring process in memex.systemorph.com
+> to clean up these shares from old releases. typically when final release is out, we can remove all
+> -CI"* — *"let's maybe leave last 10 -CI"*.
+
+Every CI build that publishes a bake adds one `<root>/<identity>/` directory to the store, and until
+this pass nothing ever removed one. Measured 2026-09-08 on memex.systemorph.com through the memex
+API: the `/data` share (16384 MiB) had **3 MiB free**; `prebuilt-bundles` held **13398 MiB in 482
+identity directories**, `modules` 2269 MiB, `assembly-cache` 704 MiB. A full share truncates writes
+silently and reports the failure far from the cause — every runtime NodeType recompile landed as
+`Bad IL format`, and CD's bake read-back got `ResourceNotFound` for 39 of 45 files.
+
+### The rule, stated once for two stores
+
+The same predicate governs this store and the container registry's pinned digests
+([Pinned Image Retention](../PinnedImageRetention), #3438):
+
+> **An artifact that anything pins, names, runs or may adopt is kept — regardless of age and
+> regardless of how many newer ones exist. Only an artifact NOTHING references is collected, and an
+> artifact whose references cannot be READ counts as referenced.**
+
+For the registry the references are CI pins; for this store they are the following, each a KEEP,
+ORed together (`PrebuiltBundleStore.Plan`, `MeshWeaver.Hosting`):
+
+| # | an identity directory is kept when… | why that is a reference |
+|---|---|---|
+| 1 | it is the framework identity **this process runs** | its own boot and every install-time adoption read it |
+| 2 | a **clean release marker** `_releases/X.Y.Z` names it | a release line stays adoptable forever and is the rollback target |
+| 3 | a NodeType record's **adoption stamp** (`CompiledFrameworkVersion`, written by `PrebuiltAssemblySeeder` and by every local compile) names it | a record was built under it; a re-seed may ask for it again |
+| 4 | it holds, for some source, the **newest sealed publication on the running major line** | exactly what `Modules:VersionStrictness=Family` adopts ([Module Versioning](../ModuleVersioning)) |
+| 5 | a pre-release marker of an **open line** names it and it is among the newest **N** (`KeepNewestPerSource`, default **10**) such identities for some source, by version | the maintainer's "leave the last 10 -CI"; once the clean `X.Y.Z` marker exists the line is CLOSED and this rule keeps none of its `X.Y.Z-ci.<n>` identities |
+| 6 | **no marker names it** and it is among the newest N for some source **by seal time** | nothing can place an unnamed identity on a line, so recency is the only signal it has — such identities are pruned by recency, not by line |
+| 7 | a source under it is **unsealed and younger than the grace** (`UnsealedGrace`, default 2 h) | the publisher writes bundles first and `_complete` last: a young unsealed directory is a seal in flight. A bounded grace is a reference-like signal; an age cutoff on a *sealed* directory would not be, and there is none |
+| 8 | its seal **cannot be read** | unreadable is never unreferenced (the modules GC's #2509 rule) |
+
+Everything else is collected **oldest first, one identity at a time**, each removal logged with the
+bytes reclaimed. The sentinel of every source is deleted before the directory, so a reader that
+lists mid-removal sees "unsealed" and backs off rather than a sealed listing whose bundles are
+vanishing. The `-ci` **markers** of a removed identity — and of an identity already gone for longer
+than the grace — are removed with it, so `_releases/` does not grow forever; a clean release marker
+is never removed. The release gates read the same directory
+([Release Availability Gates](../ReleaseGates)), so a retired `-ci` version simply reads as
+"published no bake" there, which is the truth once its bundles are gone.
+
+**Fail closed, the way `ModuleSetStore.Prune` does.** A store that cannot be listed, or a release
+marker that cannot be read, aborts the pass with nothing collected — which identity an unreadable
+marker names is unknown, so no identity can be called unreferenced. The NodeType stamps are read
+from the mesh on every pass (system-scoped, mesh-wide — the pre-warmer's own enumeration); an
+enumeration that cannot be taken aborts that pass too. A removal that fails is counted and the
+rest proceeds; a half-removed identity reads as unsealed to every reader and the next pass plans
+it again.
+
+**Scope.** This sweep is **identity-level**. The per-source generation retention that follows a
+pointer swap (`_current`) is the publisher's, at the end of its own run —
+[Sealed Publication Generations](../SealedPublicationGenerations) § Retention — and this pass
+never reaches inside a kept identity.
+
+### Where it runs
+
+`PrebuiltBundleRetentionHostedService`, registered by `ConfigureMemexMesh` beside the modules GC
+(`AddModuleGenerationsGc`) — the two are sibling collectors of the same volume and run the same way:
+registered at boot, never run there; kicked from `ApplicationStarted`, behind `PreWarmCompletion`
+so a listing of thousands of files on a network share never shares a window with the boot compiles;
+blocking filesystem work on the file-system `IIoPool`, never a hub. Then **recurring**, every
+`Interval` (default daily); passes never overlap. Inert without `PreWarm:PrebuiltBundleRoot`.
+
+| key | default | meaning |
+|---|---|---|
+| `PreWarm:PrebuiltBundleRetention:Delete` | `true` | `false` measures and reports only |
+| `PreWarm:PrebuiltBundleRetention:KeepNewestPerSource` | `10` | rules 5 and 6 |
+| `PreWarm:PrebuiltBundleRetention:UnsealedGrace` | `02:00:00` | rule 7 |
+| `PreWarm:PrebuiltBundleRetention:Interval` | `1.00:00:00` | the recurrence |
+
+Every pass appends to the ledger `<root>/_retention/ledger.txt` — one line per pass (kept / would
+collect / collected, with bytes) and one per removed identity and retired marker — and records its
+last result on `PrebuiltBundleRetentionStatus` (a mesh-scoped singleton). There is no on-demand
+operator surface in core: the `assembly-cache-prune` Job is a chart object in the private `Memex`
+repository, not a wire message, and none is invented here; a pass on demand is a pod restart.
+
+### The free-space signal
+
+`/health` now carries **`data_volume_free_space`** (`DataVolumeHealthCheck`,
+`Memex.Portal.ServiceDefaults`, evaluated by `DataVolumeFreeSpace` in `MeshWeaver.Hosting`):
+**Degraded** — never Unhealthy, pulling the pod frees nothing — when the volume any configured
+store root sits on (`PreWarm:PrebuiltBundleRoot`, `Modules:Root`, plus any `DataVolume:Paths`) has
+less than `DataVolume:MinimumFreeBytes` free (default 1 GiB), naming the path, the used and total
+bytes; Degraded too when a configured path cannot be measured; Healthy with nothing configured. The
+retention above is what keeps it green.
+
 ## Node repos run the same lane — as reusable workflows
 
 Every satellite content repo (MeshWeaver.Plugins, MeshWeaver.Education, MeshWeaver.Reinsurance,

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-shared-data-volume-no-longer-fills-up-with-old-builds.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-shared-data-volume-no-longer-fills-up-with-old-builds.md
@@ -1,0 +1,36 @@
+---
+Name: The shared data volume no longer fills up with old builds
+Category: Fix
+Description: Every CI build left its precompiled bundles on the shared data volume forever — 482 sets, 13 GB — until the volume was full and every compile, upload and deployment on it failed with errors that named nothing. A recurring pass now removes the builds nothing references, and /health says how full the volume is before it matters.
+Icon: HardDrive
+Order: -20260908
+---
+
+# The shared data volume no longer fills up with old builds
+
+Each build of the platform publishes the precompiled content bundles a portal adopts at start-up
+instead of compiling. They land on the shared data volume, in one folder per build — and nothing
+ever removed one. On the public instance that had reached 482 folders and 13 GB on a 16 GB volume
+shared with the installed modules, the compile cache and the sign-in keys, leaving 3 MB free. A
+full volume does not say so: writes are cut short silently, so every recompile of a page type
+failed as "Bad IL format", the delivery pipeline could not read back what it had just published,
+and neither message pointed at the disk.
+
+**A recurring pass now keeps what something references and removes the rest.** What counts as a
+reference: the build the running portal is on; every clean release (`3.1.0`, never a `-ci` build)
+— those stay available for good, so a rollback always has its bundles; any build a page type on
+this instance was built from; the newest build a portal on the same release line would adopt; the
+last ten `-ci` builds of a release line that has not shipped yet; and anything that is still being
+published. Once a release ships, the `-ci` builds that led up to it are no longer referenced by
+that rule and are removed, oldest first, each removal recorded with the space it gave back. A
+folder whose state cannot be read is never removed.
+
+The pass runs shortly after each portal start, once the start-up compile has settled, and daily
+after that; a ledger on the volume records what each pass did.
+
+**`/health` now reports the volume's free space.** When the volume holding the bundles or the
+installed modules has less than 1 GB free, the health endpoint reads `Degraded` and names the path,
+how much is used and how much there is — before the next write fails. The portal keeps serving; the
+signal is for whoever watches it.
+
+See [CI Content Bake](/Doc/Architecture/CiContentBake) for the rule and its configuration.

--- a/src/MeshWeaver.Hosting/DataVolumeFreeSpace.cs
+++ b/src/MeshWeaver.Hosting/DataVolumeFreeSpace.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using System.Globalization;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>One data path's free-space reading: the volume it sits on, and what is free of what.</summary>
+/// <param name="Path">The configured data path.</param>
+/// <param name="Volume">The volume (mount) the path resolves to, or null when it could not be read.</param>
+/// <param name="FreeBytes">Bytes available to this process on the volume, or null when unreadable.</param>
+/// <param name="TotalBytes">The volume's size, or null when unreadable.</param>
+/// <param name="Fault">Why the reading failed, or null.</param>
+public sealed record DataVolumeReading(string Path, string? Volume, long? FreeBytes, long? TotalBytes, string? Fault)
+{
+    /// <summary>Bytes in use, when both sides are known.</summary>
+    public long? UsedBytes => FreeBytes is { } free && TotalBytes is { } total ? total - free : null;
+}
+
+/// <summary>What the free-space signal decided.</summary>
+/// <param name="Degraded">True when any volume is below the threshold or could not be measured.</param>
+/// <param name="Description">One line naming each path, its free/used/total, and the threshold.</param>
+/// <param name="Readings">Every reading, one per configured path.</param>
+public sealed record DataVolumeVerdict(bool Degraded, string Description, ImmutableList<DataVolumeReading> Readings);
+
+/// <summary>
+/// The free-space signal for the data volume the shared stores live on — the prebuilt-bundle
+/// store, the modules root, the assembly cache and the DataProtection key ring all share one
+/// Azure Files share on AKS. A FULL share truncates writes silently (memex.systemorph.com,
+/// 2026-09-08: 3 MiB free, every runtime recompile landing as <c>Bad IL format</c>, CD's bake
+/// read-back <c>ResourceNotFound</c> for 39/45 files), and nothing said so until then. Pure over a
+/// probe seam, so the verdict is testable without a real mount; the host's <c>IHealthCheck</c>
+/// reads it — Degraded, never Unhealthy, because pulling the pod would not free a byte.
+/// </summary>
+public static class DataVolumeFreeSpace
+{
+    /// <summary>The health-check name.</summary>
+    public const string HealthCheckName = "data_volume_free_space";
+
+    /// <summary>Config key: the free-bytes threshold below which the volume reads Degraded. Default 1 GiB.</summary>
+    public const string MinimumFreeBytesConfigKey = "DataVolume:MinimumFreeBytes";
+
+    /// <summary>Config section listing ADDITIONAL paths to watch (an array); the store roots below are watched always.</summary>
+    public const string PathsConfigKey = "DataVolume:Paths";
+
+    /// <summary>
+    /// The modules root key — mirrors <c>MeshWeaver.PluginCatalog.ModuleRoot.ConfigKey</c>, which
+    /// this assembly cannot reference (PluginCatalog references Hosting). Pinned equal by
+    /// <c>DataVolumeHealthCheckTest</c>, which sees both.
+    /// </summary>
+    public const string ModulesRootConfigKey = "Modules:Root";
+
+    /// <summary>1 GiB.</summary>
+    public const long DefaultMinimumFreeBytes = 1L << 30;
+
+    /// <summary>The config keys whose values name paths on the data volume.</summary>
+    public static readonly ImmutableList<string> PathConfigKeys =
+        [ShippedPrebuiltBundles.PublishedRootConfigKey, ModulesRootConfigKey];
+
+    /// <summary>Read the threshold from configuration; absent or malformed ⇒ <see cref="DefaultMinimumFreeBytes"/>.</summary>
+    public static long MinimumFreeBytesOf(string? configured) =>
+        long.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytes) && bytes >= 0
+            ? bytes
+            : DefaultMinimumFreeBytes;
+
+    /// <summary>The production probe: <see cref="DriveInfo"/> over the path (statvfs on Unix, so any path on the mount answers).</summary>
+    public static DataVolumeReading Probe(string path)
+    {
+        try
+        {
+            var drive = new DriveInfo(path);
+            return new DataVolumeReading(path, drive.Name, drive.AvailableFreeSpace, drive.TotalSize, null);
+        }
+        catch (Exception ex)
+        {
+            return new DataVolumeReading(path, null, null, null, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The verdict over the given paths. No paths ⇒ Healthy ("no data volume configured"). A path
+    /// that cannot be measured is Degraded: a check that cannot reach its evidence says so rather
+    /// than defaulting to the reassuring answer.
+    /// </summary>
+    public static DataVolumeVerdict Evaluate(
+        IEnumerable<string> paths, Func<string, DataVolumeReading> probe, long minimumFreeBytes)
+    {
+        var readings = paths
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.Ordinal)
+            .Select(probe)
+            .ToImmutableList();
+        if (readings.IsEmpty)
+            return new DataVolumeVerdict(false, "no data volume configured — nothing to measure", readings);
+
+        var degraded = false;
+        var parts = new List<string>();
+        foreach (var reading in readings)
+        {
+            if (reading.Fault is not null || reading.FreeBytes is null || reading.TotalBytes is null)
+            {
+                degraded = true;
+                parts.Add($"{reading.Path}: free space could not be measured ({reading.Fault ?? "no reading"})");
+                continue;
+            }
+            var low = reading.FreeBytes.Value < minimumFreeBytes;
+            degraded |= low;
+            parts.Add(
+                $"{reading.Path} (volume {reading.Volume}): {Mb(reading.FreeBytes.Value)} free of "
+                + $"{Mb(reading.TotalBytes.Value)} ({Mb(reading.UsedBytes!.Value)} used)"
+                + (low ? $" — BELOW the {Mb(minimumFreeBytes)} threshold" : ""));
+        }
+        return new DataVolumeVerdict(degraded, string.Join("; ", parts), readings);
+    }
+
+    private static string Mb(long bytes) =>
+        (bytes / (1024d * 1024d)).ToString("N0", CultureInfo.InvariantCulture) + " MiB";
+}

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
@@ -1,0 +1,641 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Plugin.Packaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>
+/// How much of the CI-published prebuilt-bundle store
+/// (<see cref="ShippedPrebuiltBundles.PublishedRootConfigKey"/>) to keep, and how the sweep runs.
+///
+/// <para><b>Every knob is a KEEP rule, and the rules are ORed</b> — an identity directory survives
+/// if ANY rule protects it. Deleting a publication costs a compile (or, on a
+/// <c>Modules:RequirePrebuilt</c> mesh, a loud refusal); keeping one costs ~30 MB on a 16 GiB share
+/// that ALSO holds the modules, the assembly cache and the DataProtection key ring — and a FULL
+/// share truncates writes silently (memex.systemorph.com, 2026-09-08: 3 MiB free, every runtime
+/// recompile landing as <c>Bad IL format</c>, CD's bake read-back <c>ResourceNotFound</c> for
+/// 39 of 45 files). So the rules keep what something REFERENCES and let nothing else accumulate.</para>
+/// </summary>
+public sealed record PrebuiltBundleRetention
+{
+    /// <summary>The shipped default: deletion armed, ten pre-release identities per source and open line.</summary>
+    public static readonly PrebuiltBundleRetention Default = new();
+
+    /// <summary>
+    /// How many of the newest pre-release (<c>X.Y.Z-ci.&lt;n&gt;</c>) identities to keep per source
+    /// on a line that has no clean release yet — the maintainer's "leave the last 10 -ci"
+    /// (2026-09-08). The same count bounds the unnamed identities (no release marker at all),
+    /// which nothing can place on a line and which are therefore kept by seal time alone.
+    /// </summary>
+    public int KeepNewestPerSource { get; init; } = 10;
+
+    /// <summary>
+    /// How long an UNSEALED source directory (no <see cref="ShippedPrebuiltBundles.CompletionSentinelFileName"/>)
+    /// is presumed to be a seal in flight. The publisher writes the bundles first and the sentinel
+    /// strictly last, so a young unsealed directory is a publication being written; an old one is
+    /// a publish that died. A bounded grace is a reference-like signal — an age cutoff on a SEALED
+    /// directory would not be, and none exists here.
+    /// </summary>
+    public TimeSpan UnsealedGrace { get; init; } = TimeSpan.FromHours(2);
+
+    /// <summary>How often the recurring pass runs after the boot pass.</summary>
+    public TimeSpan Interval { get; init; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Whether the sweep may delete. <b>Default true</b>: the store is a cache of rebuildable
+    /// artifacts, and the share filling up is the outage. Set false to measure and report only.
+    /// </summary>
+    public bool Delete { get; init; } = true;
+}
+
+/// <summary>A platform version string placed on its line: <c>3.1.0-ci.8076</c> → line <c>3.1.0</c>, pre-release.</summary>
+public static class PlatformVersionLine
+{
+    /// <summary>The <c>X.Y.Z</c> line of a version (build metadata and pre-release stripped), or null when it does not start with a numeric core.</summary>
+    public static string? LineOf(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+        var core = version.Trim();
+        var plus = core.IndexOf('+');
+        if (plus >= 0) core = core[..plus];
+        var dash = core.IndexOf('-');
+        if (dash >= 0) core = core[..dash];
+        if (core.Length == 0 || !char.IsAsciiDigit(core[0]))
+            return null;
+        foreach (var c in core)
+            if (!char.IsAsciiDigit(c) && c != '.')
+                return null;
+        return core;
+    }
+
+    /// <summary>True when the version carries a pre-release label (<c>-ci.&lt;n&gt;</c>, historically <c>-rc…</c>).</summary>
+    public static bool IsPrerelease(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+        var v = version.Trim();
+        var plus = v.IndexOf('+');
+        if (plus >= 0) v = v[..plus];
+        return v.Contains('-');
+    }
+}
+
+/// <summary>One source directory under an identity, as the sweep read it.</summary>
+/// <param name="Name">The source segment (<c>plugins</c>, <c>education</c>, …).</param>
+/// <param name="IsSealed">The completion sentinel is present in the publication directory and every bundle it lists is on disk.</param>
+/// <param name="SealUtc">When the sentinel was written, or null when unsealed.</param>
+/// <param name="NewestWriteUtc">The newest write under the source directory (any file).</param>
+/// <param name="ReadFault">Why the seal could not be READ, or null. A source with a read fault PROTECTS its identity.</param>
+public sealed record PrebuiltSourceEntry(
+    string Name, bool IsSealed, DateTimeOffset? SealUtc, DateTimeOffset NewestWriteUtc, string? ReadFault);
+
+/// <summary>One framework-identity directory of the store and everything the rules need to judge it.</summary>
+/// <param name="Identity">The directory name — the framework identity (<c>s…</c> / <c>g…</c>).</param>
+/// <param name="Directory">Full path.</param>
+/// <param name="Sources">Its source directories.</param>
+/// <param name="Bytes">Total bytes under the identity directory.</param>
+/// <param name="NewestWriteUtc">The newest write anywhere under it.</param>
+public sealed record PrebuiltIdentityEntry(
+    string Identity,
+    string Directory,
+    ImmutableList<PrebuiltSourceEntry> Sources,
+    long Bytes,
+    DateTimeOffset NewestWriteUtc)
+{
+    /// <summary>True when any source's seal could not be read.</summary>
+    public bool HasReadFault => Sources.Any(s => s.ReadFault is not null);
+
+    /// <summary>True when any source (or the whole identity) is not sealed.</summary>
+    public bool HasUnsealedSource => Sources.Count == 0 || Sources.Any(s => !s.IsSealed);
+
+    /// <summary>The newest seal across sources, or null when nothing is sealed.</summary>
+    public DateTimeOffset? NewestSealUtc =>
+        Sources.Where(s => s.SealUtc is not null).Select(s => s.SealUtc).Max();
+
+    /// <summary>The instant the collectable ordering sorts on: the newest seal, else the newest write.</summary>
+    public DateTimeOffset OrderingInstant => NewestSealUtc ?? NewestWriteUtc;
+}
+
+/// <summary>One <c>_releases/&lt;version&gt;</c> marker: the file NAME is the platform version, its CONTENT the identity.</summary>
+/// <param name="Version">The platform version (the file name).</param>
+/// <param name="Identity">The framework identity the marker names, or null when it could not be read.</param>
+/// <param name="Path">Full path of the marker file.</param>
+/// <param name="WrittenUtc">The marker's last write.</param>
+/// <param name="ReadFault">Why the marker could not be read, or null. An unreadable marker ABORTS the plan.</param>
+public sealed record ReleaseMarkerEntry(
+    string Version, string? Identity, string Path, DateTimeOffset WrittenUtc, string? ReadFault)
+{
+    /// <summary>The marker's line (<see cref="PlatformVersionLine.LineOf"/>).</summary>
+    public string? Line => PlatformVersionLine.LineOf(Version);
+
+    /// <summary>True for a <c>-ci.&lt;n&gt;</c> (or any other pre-release) marker.</summary>
+    public bool IsPrerelease => PlatformVersionLine.IsPrerelease(Version);
+}
+
+/// <summary>What one scan of the store found.</summary>
+/// <param name="Identities">Every identity directory.</param>
+/// <param name="Markers">Every release marker.</param>
+public sealed record PrebuiltStoreScan(
+    ImmutableList<PrebuiltIdentityEntry> Identities,
+    ImmutableList<ReleaseMarkerEntry> Markers);
+
+/// <summary>What a sweep decided, before any deletion.</summary>
+/// <param name="LiveIdentity">The framework identity this process runs.</param>
+/// <param name="LivePlatformVersion">This process's platform version, or null when unknown.</param>
+/// <param name="Identities">Every identity found.</param>
+/// <param name="Collectable">The identities no rule protects, oldest first.</param>
+/// <param name="Protected">Why each surviving identity survived, keyed by identity.</param>
+/// <param name="CollectableMarkers">The pre-release markers whose identity goes with this plan, or is already gone.</param>
+/// <param name="AbortReason">Why NOTHING may be collected, or null when the plan is sound.</param>
+public sealed record PrebuiltBundleSweepPlan(
+    string LiveIdentity,
+    string? LivePlatformVersion,
+    ImmutableList<PrebuiltIdentityEntry> Identities,
+    ImmutableList<PrebuiltIdentityEntry> Collectable,
+    ImmutableDictionary<string, string> Protected,
+    ImmutableList<ReleaseMarkerEntry> CollectableMarkers,
+    string? AbortReason)
+{
+    /// <summary>Total bytes across every identity.</summary>
+    public long TotalBytes => Identities.Sum(i => i.Bytes);
+
+    /// <summary>Bytes the plan would reclaim.</summary>
+    public long CollectableBytes => Collectable.Sum(i => i.Bytes);
+
+    /// <summary>One line an operator can read.</summary>
+    public string Summary =>
+        $"{Identities.Count} identity directory(ies) / {Mb(TotalBytes)} — live={LiveIdentity}"
+        + $" ({LivePlatformVersion ?? "version unknown"}), collectable={Collectable.Count} / {Mb(CollectableBytes)}"
+        + $", markers to retire={CollectableMarkers.Count}"
+        + (AbortReason is null ? "" : $", ABORTED: {AbortReason}");
+
+    internal static string Mb(long bytes) =>
+        (bytes / (1024d * 1024d)).ToString("N1", CultureInfo.InvariantCulture) + " MB";
+}
+
+/// <summary>The outcome of a sweep: what it planned and what it actually removed.</summary>
+/// <param name="AtUtc">When the sweep ran.</param>
+/// <param name="Plan">The plan, or null when the store could not be scanned.</param>
+/// <param name="Deleted">Whether deletion was armed AND the plan was sound.</param>
+/// <param name="DeletedIdentities">Identity directories actually removed.</param>
+/// <param name="DeletedBytes">Bytes actually reclaimed.</param>
+/// <param name="DeletedMarkers">Release markers actually removed.</param>
+/// <param name="FailedDeletes">Removals that failed (they stay; the next pass re-plans them).</param>
+/// <param name="AbortReason">Why the sweep collected nothing, or null.</param>
+public sealed record PrebuiltBundleSweepResult(
+    DateTimeOffset AtUtc,
+    PrebuiltBundleSweepPlan? Plan,
+    bool Deleted,
+    int DeletedIdentities,
+    long DeletedBytes,
+    int DeletedMarkers,
+    int FailedDeletes,
+    string? AbortReason)
+{
+    /// <summary>One ledger line.</summary>
+    public string LedgerLine =>
+        $"{AtUtc:O} " + (Plan is null
+            ? $"ABORTED before planning: {AbortReason}"
+            : AbortReason is not null
+                ? $"ABORTED: {AbortReason} ({Plan.Summary})"
+                : Deleted
+                    ? $"removed {DeletedIdentities} identity(ies) / {PrebuiltBundleSweepPlan.Mb(DeletedBytes)}, "
+                      + $"{DeletedMarkers} marker(s){(FailedDeletes == 0 ? "" : $", {FailedDeletes} failed")} — {Plan.Summary}"
+                    : $"report only — {Plan.Summary}");
+}
+
+/// <summary>
+/// 🚨 THE PREBUILT-BUNDLE STORE GROWS BY ONE IDENTITY DIRECTORY PER CI BUILD, AND NOTHING USED TO
+/// REMOVE ONE. Measured 2026-09-08 on memex.systemorph.com: 482 identity directories, 13398 MiB, on
+/// a 16384 MiB share with 3 MiB free.
+///
+/// <para><b>The rule: prune what nothing references, never by age alone.</b> Stated once here and
+/// applied to two stores — this one, and the container registry's pinned digests
+/// (<c>Doc/Architecture/PinnedImageRetention</c>, #3438): <i>an artifact that anything pins, names,
+/// runs or may adopt is kept regardless of age and regardless of how many newer ones exist; only
+/// an artifact NOTHING references is collected, and an artifact whose references cannot be READ
+/// counts as referenced.</i></para>
+///
+/// <para><b>What references an identity</b> (each is a KEEP; they are ORed):</para>
+/// <list type="number">
+/// <item>it is the framework identity <b>this process runs</b>;</item>
+/// <item>a <b>clean release marker</b> (<c>_releases/X.Y.Z</c>, no pre-release label) names it —
+/// a release line stays adoptable forever, and it is the rollback target;</item>
+/// <item>a <b>NodeType record's adoption stamp</b> (<c>CompiledFrameworkVersion</c>, written by
+/// <c>PrebuiltAssemblySeeder</c> and by every local compile) names it;</item>
+/// <item>it holds, for some source, the <b>newest sealed publication on the running major line</b> —
+/// exactly what <c>Modules:VersionStrictness=Family</c> adopts at boot;</item>
+/// <item>a pre-release marker of an <b>OPEN line</b> names it (a line with no clean release yet) and
+/// it is among the newest <see cref="PrebuiltBundleRetention.KeepNewestPerSource"/> such identities
+/// for some source, by version — once the clean <c>X.Y.Z</c> marker exists, every
+/// <c>X.Y.Z-ci.&lt;n&gt;</c> identity of that line is unreferenced by this rule (maintainer,
+/// 2026-09-08: <i>"when final release is out, we can remove all -CI … leave last 10"</i>);</item>
+/// <item>no marker names it at all and it is among the newest <see cref="PrebuiltBundleRetention.KeepNewestPerSource"/>
+/// such identities for some source <b>by seal time</b> — nothing can place an unnamed identity on
+/// a line, so recency is the only signal it has;</item>
+/// <item>a source under it is <b>unsealed and younger than <see cref="PrebuiltBundleRetention.UnsealedGrace"/></b>
+/// — a seal in flight;</item>
+/// <item>its seal <b>could not be read</b> — unreadable is never unreferenced.</item>
+/// </list>
+///
+/// <para>Everything else is collected, oldest first, one identity at a time, each removal logged
+/// with the bytes reclaimed. The pre-release markers of a removed identity (and of an identity
+/// already gone for longer than the grace) are removed with it, so <c>_releases/</c> does not grow
+/// forever; a clean release marker is never removed. A release marker that cannot be read, or a
+/// store that cannot be listed, ABORTS the sweep with nothing collected: a partial picture licenses
+/// no deletion. This sweep is IDENTITY-level; the per-source generation retention that follows a
+/// pointer swap is the publisher's (<c>Doc/Architecture/SealedPublicationGenerations</c>).</para>
+/// </summary>
+public static class PrebuiltBundleStore
+{
+    /// <summary>Directory under the root holding the retention ledger. Leading underscore: never an identity.</summary>
+    public const string RetentionDirectoryName = "_retention";
+
+    /// <summary>The append-only ledger of what each pass removed, one line per pass and one per identity.</summary>
+    public const string LedgerFileName = "ledger.txt";
+
+    /// <summary>
+    /// Read the whole store: every identity directory (skipping the <c>_…</c> bookkeeping
+    /// directories) with its sources' seals, and every release marker. Throws when the root or the
+    /// marker directory cannot be listed — the caller aborts on that.
+    /// </summary>
+    public static PrebuiltStoreScan Scan(string root, ILogger? logger = null)
+    {
+        var identities = ImmutableList.CreateBuilder<PrebuiltIdentityEntry>();
+        foreach (var identityDirectory in Directory.EnumerateDirectories(root).OrderBy(d => d, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(identityDirectory);
+            if (string.IsNullOrEmpty(name) || name.StartsWith('_') || name.StartsWith('.'))
+                continue;
+            identities.Add(ReadIdentity(identityDirectory, name, logger));
+        }
+
+        var markers = ImmutableList.CreateBuilder<ReleaseMarkerEntry>();
+        var markerDirectory = Path.Combine(root, SealedPublicationIndex.ReleaseMarkerDirectoryName);
+        if (Directory.Exists(markerDirectory))
+            foreach (var file in Directory.EnumerateFiles(markerDirectory).OrderBy(f => f, StringComparer.Ordinal))
+            {
+                var version = Path.GetFileName(file);
+                var written = new DateTimeOffset(File.GetLastWriteTimeUtc(file), TimeSpan.Zero);
+                try
+                {
+                    var identity = File.ReadAllText(file).Trim();
+                    markers.Add(new ReleaseMarkerEntry(version, identity.Length == 0 ? null : identity, file, written,
+                        identity.Length == 0 ? "the marker is empty" : null));
+                }
+                catch (Exception ex)
+                {
+                    markers.Add(new ReleaseMarkerEntry(version, null, file, written, $"{ex.GetType().Name}: {ex.Message}"));
+                }
+            }
+
+        return new PrebuiltStoreScan(identities.ToImmutable(), markers.ToImmutable());
+    }
+
+    private static PrebuiltIdentityEntry ReadIdentity(string identityDirectory, string identity, ILogger? logger)
+    {
+        var bytes = 0L;
+        var newestWrite = new DateTimeOffset(Directory.GetLastWriteTimeUtc(identityDirectory), TimeSpan.Zero);
+        foreach (var file in Directory.EnumerateFiles(identityDirectory, "*", SearchOption.AllDirectories))
+        {
+            var info = new FileInfo(file);
+            bytes += info.Length;
+            var write = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero);
+            if (write > newestWrite) newestWrite = write;
+        }
+
+        var sources = ImmutableList.CreateBuilder<PrebuiltSourceEntry>();
+        foreach (var sourceDirectory in Directory.EnumerateDirectories(identityDirectory).OrderBy(d => d, StringComparer.Ordinal))
+        {
+            var sourceName = Path.GetFileName(sourceDirectory);
+            var sourceNewest = new DateTimeOffset(Directory.GetLastWriteTimeUtc(sourceDirectory), TimeSpan.Zero);
+            foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+            {
+                var write = new DateTimeOffset(File.GetLastWriteTimeUtc(file), TimeSpan.Zero);
+                if (write > sourceNewest) sourceNewest = write;
+            }
+            // 🚨 Composed under the RESOLVED publication directory (#3461): a pointer may name a
+            // generation subdirectory, and the seal lives there, not beside the pointer.
+            var publication = ShippedPrebuiltBundles.PublicationDirectoryOf(sourceDirectory, logger);
+            var sentinel = Path.Combine(publication, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            if (!File.Exists(sentinel))
+            {
+                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, null));
+                continue;
+            }
+            try
+            {
+                var sealUtc = new DateTimeOffset(File.GetLastWriteTimeUtc(sentinel), TimeSpan.Zero);
+                var torn = File.ReadAllLines(sentinel)
+                    .Select(l => l.Trim())
+                    .Where(l => l.Length > 0)
+                    .Any(name => !File.Exists(Path.Combine(publication, name)));
+                sources.Add(new PrebuiltSourceEntry(sourceName, !torn, torn ? null : sealUtc, sourceNewest, null));
+            }
+            catch (Exception ex)
+            {
+                // 🚨 Every read failure, not just IOException — a denied ACL is every bit as much
+                // "I cannot evaluate this seal" as a locked file. It PROTECTS the identity.
+                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, $"{ex.GetType().Name}: {ex.Message}"));
+            }
+        }
+        return new PrebuiltIdentityEntry(identity, identityDirectory, sources.ToImmutable(), bytes, newestWrite);
+    }
+
+    /// <summary>
+    /// Decide what may be collected. Pure — no filesystem, no clock — so the rules are testable
+    /// exactly as they are enforced.
+    /// </summary>
+    /// <param name="liveIdentity">The framework identity this process runs.</param>
+    /// <param name="livePlatformVersion">This process's platform version (build metadata stripped), or null.</param>
+    /// <param name="scan">What the store holds.</param>
+    /// <param name="stampedIdentities">Every identity a NodeType record's <c>CompiledFrameworkVersion</c> names.</param>
+    /// <param name="retention">The knobs.</param>
+    /// <param name="nowUtc">The instant the grace is measured against.</param>
+    public static PrebuiltBundleSweepPlan Plan(
+        string liveIdentity,
+        string? livePlatformVersion,
+        PrebuiltStoreScan scan,
+        ImmutableHashSet<string> stampedIdentities,
+        PrebuiltBundleRetention retention,
+        DateTimeOffset nowUtc)
+    {
+        var unreadable = scan.Markers.FirstOrDefault(m => m.ReadFault is not null);
+        if (unreadable is not null)
+            return new PrebuiltBundleSweepPlan(liveIdentity, livePlatformVersion, scan.Identities,
+                ImmutableList<PrebuiltIdentityEntry>.Empty, ImmutableDictionary<string, string>.Empty,
+                ImmutableList<ReleaseMarkerEntry>.Empty,
+                $"release marker '{unreadable.Version}' could not be read ({unreadable.ReadFault}) — which "
+                + "identity it references is unknown, so no identity can be called unreferenced");
+
+        var comparer = NuGetVersionComparer.Instance;
+        var readable = scan.Markers.Where(m => m.Identity is not null).ToImmutableList();
+
+        // identity → the newest version naming it (the SAME reading ShippedPrebuiltBundles orders
+        // fallback candidates by: SealedPublicationIndex.ReleasesOf).
+        var newestVersionOf = readable
+            .GroupBy(m => m.Identity!, StringComparer.Ordinal)
+            .ToImmutableDictionary(g => g.Key, g => g.Select(m => m.Version).OrderByDescending(v => v, comparer).First(),
+                StringComparer.Ordinal);
+        var cleanMarkersOf = readable
+            .Where(m => !m.IsPrerelease)
+            .GroupBy(m => m.Identity!, StringComparer.Ordinal)
+            .ToImmutableDictionary(g => g.Key, g => string.Join(", ", g.Select(m => m.Version)), StringComparer.Ordinal);
+        var closedLines = readable.Where(m => !m.IsPrerelease).Select(m => m.Line).Where(l => l is not null)
+            .Select(l => l!).ToImmutableHashSet(StringComparer.Ordinal);
+        var openLines = readable.Where(m => m.IsPrerelease).Select(m => m.Line).Where(l => l is not null && !closedLines.Contains(l))
+            .Select(l => l!).ToImmutableHashSet(StringComparer.Ordinal);
+        var linesOf = readable.Where(m => m.IsPrerelease && m.Line is not null)
+            .GroupBy(m => m.Identity!, StringComparer.Ordinal)
+            .ToImmutableDictionary(g => g.Key, g => g.Select(m => m.Line!).ToImmutableHashSet(StringComparer.Ordinal),
+                StringComparer.Ordinal);
+
+        var reasons = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        void Keep(string identity, string reason)
+        {
+            if (!reasons.ContainsKey(identity))
+                reasons[identity] = reason;
+        }
+
+        var sources = scan.Identities.SelectMany(i => i.Sources.Where(s => s.IsSealed).Select(s => s.Name))
+            .Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(s => s, StringComparer.OrdinalIgnoreCase).ToList();
+        var liveMajor = PrebuiltAdoptionPolicy.MajorOf(livePlatformVersion);
+        var keep = Math.Max(0, retention.KeepNewestPerSource);
+
+        foreach (var identity in scan.Identities)
+        {
+            if (string.Equals(identity.Identity, liveIdentity, StringComparison.Ordinal))
+                Keep(identity.Identity, "the framework identity this process runs");
+            else if (identity.HasReadFault)
+                Keep(identity.Identity,
+                    $"its seal could not be read ({identity.Sources.First(s => s.ReadFault is not null).ReadFault}) — unreadable is never unreferenced");
+            else if (cleanMarkersOf.TryGetValue(identity.Identity, out var releases))
+                Keep(identity.Identity, $"named by release marker {releases}");
+            else if (stampedIdentities.Contains(identity.Identity))
+                Keep(identity.Identity, "a NodeType record's adoption stamp (CompiledFrameworkVersion) names it");
+        }
+
+        foreach (var source in sources)
+        {
+            var sealedHere = scan.Identities
+                .Where(i => i.Sources.Any(s => s.IsSealed && string.Equals(s.Name, source, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            // 4. what Family strictness adopts: the newest sealed publication on the running line.
+            if (liveMajor is { } major)
+            {
+                var family = sealedHere
+                    .Where(i => newestVersionOf.TryGetValue(i.Identity, out var v) && PrebuiltAdoptionPolicy.MajorOf(v) == major)
+                    .OrderByDescending(i => newestVersionOf[i.Identity], comparer)
+                    .FirstOrDefault();
+                if (family is not null)
+                    Keep(family.Identity,
+                        $"the newest sealed '{source}' publication on platform line {major} ({newestVersionOf[family.Identity]}) — what Family strictness adopts");
+            }
+
+            // 5. the newest N pre-release identities of every OPEN line.
+            foreach (var line in openLines.OrderBy(l => l, StringComparer.Ordinal))
+                foreach (var kept in sealedHere
+                             .Where(i => linesOf.TryGetValue(i.Identity, out var lines) && lines.Contains(line))
+                             .OrderByDescending(i => newestVersionOf[i.Identity], comparer)
+                             .Take(keep))
+                    Keep(kept.Identity,
+                        $"among the newest {keep} sealed '{source}' publications of open line {line} ({newestVersionOf[kept.Identity]})");
+
+            // 6. unnamed identities: recency by seal time is the only signal they have.
+            foreach (var kept in sealedHere
+                         .Where(i => !newestVersionOf.ContainsKey(i.Identity))
+                         .OrderByDescending(i => i.Sources.First(s => s.IsSealed && string.Equals(s.Name, source, StringComparison.OrdinalIgnoreCase)).SealUtc)
+                         .Take(keep))
+                Keep(kept.Identity,
+                    $"no release marker names it; among the newest {keep} sealed '{source}' publications by seal time");
+        }
+
+        // 7. a seal in flight.
+        foreach (var identity in scan.Identities)
+            if (identity.HasUnsealedSource && nowUtc - identity.NewestWriteUtc < retention.UnsealedGrace)
+                Keep(identity.Identity,
+                    $"a source is unsealed and its newest write is {(nowUtc - identity.NewestWriteUtc).TotalMinutes:N0} min old — a seal may be in flight (grace {retention.UnsealedGrace})");
+
+        var collectable = scan.Identities
+            .Where(i => !reasons.ContainsKey(i.Identity))
+            .OrderBy(i => i.OrderingInstant)
+            .ToImmutableList();
+        var collectableIdentities = collectable.Select(i => i.Identity).ToImmutableHashSet(StringComparer.Ordinal);
+        var present = scan.Identities.Select(i => i.Identity).ToImmutableHashSet(StringComparer.Ordinal);
+
+        var markers = readable
+            .Where(m => m.IsPrerelease)
+            .Where(m => !string.Equals(m.Identity, liveIdentity, StringComparison.Ordinal))
+            .Where(m => livePlatformVersion is null || !string.Equals(m.Version, livePlatformVersion, StringComparison.Ordinal))
+            .Where(m => collectableIdentities.Contains(m.Identity!)
+                        || (!present.Contains(m.Identity!) && nowUtc - m.WrittenUtc >= retention.UnsealedGrace))
+            .ToImmutableList();
+
+        return new PrebuiltBundleSweepPlan(
+            liveIdentity, livePlatformVersion, scan.Identities, collectable, reasons.ToImmutable(), markers, null);
+    }
+
+    /// <summary>
+    /// Scan, plan, and — when <see cref="PrebuiltBundleRetention.Delete"/> is armed — collect, on
+    /// the I/O pool. The stamps are the caller's (they come from the mesh, which is not a
+    /// filesystem read).
+    /// </summary>
+    public static IObservable<PrebuiltBundleSweepResult> Sweep(
+        string root,
+        string liveIdentity,
+        string? livePlatformVersion,
+        ImmutableHashSet<string> stampedIdentities,
+        PrebuiltBundleRetention retention,
+        IIoPool pool,
+        ILogger? logger = null)
+        => pool.InvokeBlocking(_ =>
+            SweepCore(root, liveIdentity, livePlatformVersion, stampedIdentities, retention, DateTimeOffset.UtcNow, logger));
+
+    /// <summary>The sweep itself, with the clock passed in, so the deleting behaviour is exercised at an exact instant.</summary>
+    public static PrebuiltBundleSweepResult SweepCore(
+        string root,
+        string liveIdentity,
+        string? livePlatformVersion,
+        ImmutableHashSet<string> stampedIdentities,
+        PrebuiltBundleRetention retention,
+        DateTimeOffset nowUtc,
+        ILogger? logger = null,
+        Action<string>? deleteDirectory = null)
+    {
+        PrebuiltStoreScan scan;
+        try
+        {
+            if (!Directory.Exists(root))
+            {
+                var absent = new PrebuiltBundleSweepResult(nowUtc, null, false, 0, 0, 0, 0,
+                    $"the published bundle root '{root}' does not exist");
+                logger?.LogWarning("PrebuiltBundleRetention: {Reason} — nothing collected", absent.AbortReason);
+                return absent;
+            }
+            scan = Scan(root, logger);
+        }
+        catch (Exception ex)
+        {
+            // 🚨 FAIL CLOSED: a partial listing is not a picture of the store, so it licenses nothing.
+            logger?.LogWarning(ex,
+                "PrebuiltBundleRetention: could not read {Root} — NOTHING collected. A store that cannot be "
+                + "enumerated completely can never be pruned safely", root);
+            var failed = new PrebuiltBundleSweepResult(nowUtc, null, false, 0, 0, 0, 0, $"store could not be read: {ex.Message}");
+            AppendLedger(root, failed, logger);
+            return failed;
+        }
+
+        var plan = Plan(liveIdentity, livePlatformVersion, scan, stampedIdentities, retention, nowUtc);
+        if (plan.AbortReason is not null)
+        {
+            logger?.LogWarning("PrebuiltBundleRetention: {Summary}. NOTHING collected", plan.Summary);
+            var aborted = new PrebuiltBundleSweepResult(nowUtc, plan, false, 0, 0, 0, 0, plan.AbortReason);
+            AppendLedger(root, aborted, logger);
+            return aborted;
+        }
+
+        if (!retention.Delete)
+        {
+            logger?.LogInformation(
+                "PrebuiltBundleRetention: {Summary}. DELETING NOTHING — collection is not armed. Would collect: {Collectable}. Kept: {Kept}",
+                plan.Summary,
+                plan.Collectable.Count == 0 ? "(nothing)" : string.Join(", ", plan.Collectable.Select(i => $"{i.Identity} ({PrebuiltBundleSweepPlan.Mb(i.Bytes)})")),
+                Describe(plan.Protected));
+            var report = new PrebuiltBundleSweepResult(nowUtc, plan, false, 0, 0, 0, 0, null);
+            AppendLedger(root, report, logger);
+            return report;
+        }
+
+        var delete = deleteDirectory ?? (dir => Directory.Delete(dir, recursive: true));
+        var deletedIdentities = 0;
+        var deletedBytes = 0L;
+        var failedDeletes = 0;
+        var lines = new List<string>();
+        foreach (var identity in plan.Collectable)
+        {
+            try
+            {
+                // Unseal first: a reader that lists the directory mid-removal then sees "no
+                // sentinel" and backs off, instead of a sealed listing whose bundles are vanishing.
+                foreach (var source in identity.Sources)
+                {
+                    var publication = ShippedPrebuiltBundles.PublicationDirectoryOf(Path.Combine(identity.Directory, source.Name), logger);
+                    var sentinel = Path.Combine(publication, ShippedPrebuiltBundles.CompletionSentinelFileName);
+                    if (File.Exists(sentinel))
+                        File.Delete(sentinel);
+                }
+                delete(identity.Directory);
+                deletedIdentities++;
+                deletedBytes += identity.Bytes;
+                logger?.LogInformation(
+                    "PrebuiltBundleRetention: removed identity {Identity} ({Sources}) — {Bytes} reclaimed; sealed {SealUtc}",
+                    identity.Identity, string.Join(",", identity.Sources.Select(s => s.Name)),
+                    PrebuiltBundleSweepPlan.Mb(identity.Bytes), identity.NewestSealUtc?.ToString("O", CultureInfo.InvariantCulture) ?? "never");
+                lines.Add($"{nowUtc:O}   removed {identity.Identity} {PrebuiltBundleSweepPlan.Mb(identity.Bytes)} sources={string.Join(",", identity.Sources.Select(s => s.Name))}");
+            }
+            catch (Exception ex)
+            {
+                // Surfaced, not swallowed: the directory (or what is left of it) stays, and the next
+                // pass re-plans it — a half-removed identity reads as unsealed to every reader.
+                failedDeletes++;
+                logger?.LogWarning(ex,
+                    "PrebuiltBundleRetention: could not remove {Directory} — it stays, and the next pass considers it again",
+                    identity.Directory);
+            }
+        }
+
+        var deletedMarkers = 0;
+        foreach (var marker in plan.CollectableMarkers)
+        {
+            try
+            {
+                File.Delete(marker.Path);
+                deletedMarkers++;
+                lines.Add($"{nowUtc:O}   retired marker {marker.Version} → {marker.Identity}");
+            }
+            catch (Exception ex)
+            {
+                failedDeletes++;
+                logger?.LogWarning(ex, "PrebuiltBundleRetention: could not remove release marker {Path}", marker.Path);
+            }
+        }
+
+        logger?.LogInformation(
+            "PrebuiltBundleRetention: {Summary}. COLLECTED {Identities} identity(ies) reclaiming {Reclaimed}, retired {Markers} marker(s){Failed}. Kept: {Kept}",
+            plan.Summary, deletedIdentities, PrebuiltBundleSweepPlan.Mb(deletedBytes), deletedMarkers,
+            failedDeletes == 0 ? "" : $" ({failedDeletes} removal(s) failed)",
+            Describe(plan.Protected));
+
+        var result = new PrebuiltBundleSweepResult(nowUtc, plan, true, deletedIdentities, deletedBytes, deletedMarkers, failedDeletes, null);
+        AppendLedger(root, result, logger, lines);
+        return result;
+    }
+
+    private static string Describe(ImmutableDictionary<string, string> reasons) =>
+        reasons.IsEmpty
+            ? "(nothing)"
+            : string.Join(" | ", reasons.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).Select(kvp => $"{kvp.Key} — {kvp.Value}"));
+
+    /// <summary>The ledger path under a root.</summary>
+    public static string LedgerPathOf(string root) => Path.Combine(root, RetentionDirectoryName, LedgerFileName);
+
+    private static void AppendLedger(string root, PrebuiltBundleSweepResult result, ILogger? logger, IReadOnlyList<string>? detail = null)
+    {
+        try
+        {
+            var path = LedgerPathOf(root);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.AppendAllLines(path, (detail ?? []).Prepend(result.LedgerLine));
+        }
+        catch (Exception ex)
+        {
+            // The ledger is a record of the pass, not a precondition of it; a share that cannot take
+            // one more line is exactly the condition the pass exists to relieve.
+            logger?.LogWarning(ex, "PrebuiltBundleRetention: could not append to the ledger under {Root}", root);
+        }
+    }
+}

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetentionHostedService.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetentionHostedService.cs
@@ -1,0 +1,223 @@
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting;
+
+/// <summary>The last outcome of the prebuilt-bundle retention pass on this process — the status row operators read.</summary>
+public sealed class PrebuiltBundleRetentionStatus
+{
+    private PrebuiltBundleSweepResult? last;
+    private string? lastFault;
+
+    /// <summary>The last pass's result, or null when none has run yet.</summary>
+    public PrebuiltBundleSweepResult? Last => Volatile.Read(ref last);
+
+    /// <summary>Why the last pass faulted before producing a result, or null.</summary>
+    public string? LastFault => Volatile.Read(ref lastFault);
+
+    internal void Record(PrebuiltBundleSweepResult result)
+    {
+        Volatile.Write(ref last, result);
+        Volatile.Write(ref lastFault, null);
+    }
+
+    internal void RecordFault(Exception exception) =>
+        Volatile.Write(ref lastFault, $"{exception.GetType().Name}: {exception.Message}");
+}
+
+/// <summary>
+/// The recurring retention pass over the CI-published prebuilt-bundle store: once at boot, behind
+/// the bake, and then every <see cref="PrebuiltBundleRetention.Interval"/>. Inert unless
+/// <see cref="ShippedPrebuiltBundles.PublishedRootConfigKey"/> is configured.
+///
+/// <para><b>Where and why here.</b> Registered beside the modules GC
+/// (<c>ConfigureMemexMesh</c> → <c>AddModuleGenerationsGc</c>): the two are sibling collectors of
+/// the same data volume, and this one runs the same way — registered in <see cref="StartAsync"/>,
+/// never run there; kicked from <c>ApplicationStarted</c>; blocking filesystem work on the
+/// file-system <see cref="IIoPool"/>, never on a hub. It additionally waits for
+/// <see cref="PreWarmCompletion"/> to settle, for the reason the assembly-cache sweep does: a
+/// listing of a few thousand files on a network share has no business sharing a window with the
+/// boot compiles.</para>
+///
+/// <para><b>The reference set is read fresh on every pass.</b> The NodeType records' adoption
+/// stamps come from the mesh (a system-scoped, mesh-wide NodeType enumeration — the pre-warmer's
+/// own reading); an enumeration that cannot be taken aborts THAT pass with nothing collected,
+/// because a reference set that could not be read is incomplete, and incomplete licenses no
+/// deletion.</para>
+///
+/// <para><b>Passes never overlap.</b> The ticks are serialised through <c>Concat</c>; a pass that
+/// outlives the interval simply delays the next one. A faulted pass is logged, recorded on
+/// <see cref="PrebuiltBundleRetentionStatus"/>, and the schedule continues — one bad listing must
+/// not end the recurring process.</para>
+/// </summary>
+public sealed class PrebuiltBundleRetentionHostedService(
+    IServiceProvider services,
+    IHostApplicationLifetime lifetime,
+    PrebuiltBundleRetention retention,
+    PrebuiltBundleRetentionStatus status,
+    ILogger<PrebuiltBundleRetentionHostedService> logger) : IHostedService, IDisposable
+{
+    /// <summary>The budget for the mesh-wide NodeType enumeration that yields the adoption stamps.</summary>
+    private static readonly TimeSpan EnumerationBudget = TimeSpan.FromSeconds(60);
+
+    private IDisposable? startedRegistration;
+    private IDisposable? schedule;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var root = services.GetService<IConfiguration>()?[ShippedPrebuiltBundles.PublishedRootConfigKey];
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            logger.LogDebug(
+                "PrebuiltBundleRetention: no published bundle root configured ({Key}) — nothing to retain or collect",
+                ShippedPrebuiltBundles.PublishedRootConfigKey);
+            return Task.CompletedTask;
+        }
+        logger.LogInformation(
+            "PrebuiltBundleRetention: sweeping {Root} at boot and every {Interval}; keeps the newest {Keep} "
+            + "pre-release identity(ies) per source and open line, {Grace} grace for an unsealed publication, "
+            + "collection {Armed}",
+            root, retention.Interval, retention.KeepNewestPerSource, retention.UnsealedGrace,
+            retention.Delete ? "ARMED" : "NOT armed (report only)");
+        startedRegistration = lifetime.ApplicationStarted.Register(() => KickSchedule(root));
+        return Task.CompletedTask;
+    }
+
+    private void KickSchedule(string root)
+    {
+        var bake = services.GetService<PreWarmCompletion>()?.Settled.Select(_ => Unit.Default)
+                   ?? Observable.Return(Unit.Default);
+        var pool = services.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+        var ticks = bake.Take(1).Concat(Observable.Timer(retention.Interval, retention.Interval).Select(_ => Unit.Default));
+
+        schedule = ticks
+            .Select(_ => RunPass(root, pool)
+                .Do(status.Record)
+                .Select(_ => Unit.Default)
+                .Catch<Unit, Exception>(ex =>
+                {
+                    // Surfaced (log + status), never swallowed — and the schedule survives it: the
+                    // next tick re-reads everything from scratch.
+                    status.RecordFault(ex);
+                    logger.LogWarning(ex,
+                        "PrebuiltBundleRetention: the pass over {Root} faulted — nothing was collected; the next pass plans it again",
+                        root);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat()
+            .Subscribe(
+                _ => { },
+                ex => logger.LogWarning(ex, "PrebuiltBundleRetention: the schedule over {Root} STOPPED", root));
+    }
+
+    private IObservable<PrebuiltBundleSweepResult> RunPass(string root, IIoPool pool) =>
+        StampedIdentities().SelectMany(stamps =>
+            PrebuiltBundleStore.Sweep(
+                root,
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                PrebuiltAdoptionPolicy.RunningPlatformVersion,
+                stamps,
+                retention,
+                pool,
+                logger));
+
+    /// <summary>
+    /// Every framework identity a NodeType record's <c>CompiledFrameworkVersion</c> names — the
+    /// stamp <c>PrebuiltAssemblySeeder</c> writes on adoption (and every local compile writes
+    /// too). Read as System, mesh-wide, exactly as the pre-warmer enumerates the same records.
+    /// Errors propagate: an unreadable reference set aborts the pass.
+    /// </summary>
+    private IObservable<ImmutableHashSet<string>> StampedIdentities()
+    {
+        var mesh = services.GetService<IMessageHub>();
+        var meshService = mesh?.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null || meshService is null)
+            return Observable.Throw<ImmutableHashSet<string>>(new InvalidOperationException(
+                "no mesh hub / IMeshService on this host — the NodeType adoption stamps cannot be read, "
+                + "so the reference set is incomplete"));
+        var access = mesh.ServiceProvider.GetService<AccessService>();
+        return access.RunAsSystem(() => meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
+            .Take(1)
+            .Timeout(EnumerationBudget)
+            .Select(change => change.Items
+                .Select(n => n.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions, logger)?.CompiledFrameworkVersion)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v!)
+                .ToImmutableHashSet(StringComparer.Ordinal)));
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        startedRegistration?.Dispose();
+        startedRegistration = null;
+        schedule?.Dispose();
+        schedule = null;
+    }
+}
+
+/// <summary>Registration for the recurring prebuilt-bundle retention pass.</summary>
+public static class PrebuiltBundleRetentionExtensions
+{
+    /// <summary>Config key disarming DELETION (<c>false</c> ⇒ report only). Default <c>true</c>.</summary>
+    public const string DeleteConfigKey = "PreWarm:PrebuiltBundleRetention:Delete";
+
+    /// <summary>Config key overriding how many newest pre-release identities are kept per source and open line.</summary>
+    public const string KeepNewestPerSourceConfigKey = "PreWarm:PrebuiltBundleRetention:KeepNewestPerSource";
+
+    /// <summary>Config key overriding the grace (a <see cref="TimeSpan"/> string) an unsealed publication is presumed in flight.</summary>
+    public const string UnsealedGraceConfigKey = "PreWarm:PrebuiltBundleRetention:UnsealedGrace";
+
+    /// <summary>Config key overriding the recurrence interval (a <see cref="TimeSpan"/> string).</summary>
+    public const string IntervalConfigKey = "PreWarm:PrebuiltBundleRetention:Interval";
+
+    /// <summary>
+    /// Registers the recurring pass and its status. Safe on any host: without
+    /// <see cref="ShippedPrebuiltBundles.PublishedRootConfigKey"/> the service does nothing.
+    /// </summary>
+    public static IServiceCollection AddPrebuiltBundleRetention(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton(FromConfiguration(configuration));
+        services.AddSingleton<PrebuiltBundleRetentionStatus>();
+        services.AddHostedService<PrebuiltBundleRetentionHostedService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Read the policy from configuration. Every key degrades to its default when absent or
+    /// malformed — a typo in a knob must not silently change what is kept.
+    /// </summary>
+    public static PrebuiltBundleRetention FromConfiguration(IConfiguration configuration)
+    {
+        var retention = PrebuiltBundleRetention.Default;
+        if (bool.TryParse(configuration[DeleteConfigKey], out var delete))
+            retention = retention with { Delete = delete };
+        if (int.TryParse(configuration[KeepNewestPerSourceConfigKey], out var keep) && keep >= 0)
+            retention = retention with { KeepNewestPerSource = keep };
+        if (TimeSpan.TryParse(configuration[UnsealedGraceConfigKey], out var grace) && grace > TimeSpan.Zero)
+            retention = retention with { UnsealedGrace = grace };
+        if (TimeSpan.TryParse(configuration[IntervalConfigKey], out var interval) && interval > TimeSpan.Zero)
+            retention = retention with { Interval = interval };
+        return retention;
+    }
+}

--- a/test/Memex.Portal.Shared.Test/DataVolumeHealthCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/DataVolumeHealthCheckTest.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Memex.Portal.ServiceDefaults;
+using MeshWeaver.Hosting;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The <c>data_volume_free_space</c> health check as the host registers it: the paths come from
+/// the store-root keys, the threshold from <c>DataVolume:MinimumFreeBytes</c>, the probe is a
+/// seam. Degraded — never Unhealthy — names the path, used and total.
+/// </summary>
+public class DataVolumeHealthCheckTest
+{
+    private const long MiB = 1024L * 1024L;
+
+    private static IConfiguration Configuration(params (string Key, string Value)[] entries) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(entries.ToDictionary(e => e.Key, e => (string?)e.Value))
+            .Build();
+
+    [Fact]
+    public async Task AFullShare_ReportsDegraded_NamingPathUsedAndTotal()
+    {
+        var check = new DataVolumeHealthCheck(
+            Configuration((ShippedPrebuiltBundles.PublishedRootConfigKey, "/data/prebuilt-bundles")),
+            path => new DataVolumeReading(path, "/data", 3 * MiB, 16384 * MiB, null));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Contain("/data/prebuilt-bundles");
+        result.Description.Should().Contain("16,381 MiB used");
+        result.Description.Should().Contain("16,384 MiB");
+        result.Data.Keys.Should().Contain("/data/prebuilt-bundles");
+    }
+
+    [Fact]
+    public async Task ARoomyShare_IsHealthy()
+    {
+        var check = new DataVolumeHealthCheck(
+            Configuration(
+                (ShippedPrebuiltBundles.PublishedRootConfigKey, "/data/prebuilt-bundles"),
+                (ModuleRoot.ConfigKey, "/data/modules")),
+            path => new DataVolumeReading(path, "/data", 9000 * MiB, 16384 * MiB, null));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Data.Keys.Should().Contain("/data/modules");
+    }
+
+    [Fact]
+    public async Task NothingConfigured_IsHealthy_NotVacuouslyDegraded()
+    {
+        var check = new DataVolumeHealthCheck(Configuration(), path => throw new System.IO.IOException("never called"));
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Description.Should().Contain("no data volume configured");
+    }
+
+    [Fact]
+    public async Task TheThresholdComesFromConfiguration()
+    {
+        var check = new DataVolumeHealthCheck(
+            Configuration(
+                (ShippedPrebuiltBundles.PublishedRootConfigKey, "/data/prebuilt-bundles"),
+                (DataVolumeFreeSpace.MinimumFreeBytesConfigKey, (2 * MiB).ToString())),
+            path => new DataVolumeReading(path, "/data", 3 * MiB, 16384 * MiB, null));
+
+        (await check.CheckHealthAsync(new HealthCheckContext())).Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public void AdditionalPaths_AreWatchedToo()
+    {
+        var configuration = Configuration(
+            ($"{DataVolumeFreeSpace.PathsConfigKey}:0", "/data/assembly-cache"),
+            ($"{DataVolumeFreeSpace.PathsConfigKey}:1", "/data/dataprotection-keys"));
+
+        DataVolumeHealthCheck.PathsOf(configuration).Should().Equal("/data/assembly-cache", "/data/dataprotection-keys");
+    }
+
+    /// <summary>
+    /// The framework cannot reference PluginCatalog's <see cref="ModuleRoot.ConfigKey"/>, so it
+    /// mirrors the string. This assembly sees both; a drift here would silently stop the check
+    /// watching the modules root.
+    /// </summary>
+    [Fact]
+    public void TheModulesRootKey_IsTheOnePluginCatalogReads()
+    {
+        DataVolumeFreeSpace.ModulesRootConfigKey.Should().Be(ModuleRoot.ConfigKey);
+        DataVolumeFreeSpace.PathConfigKeys.Should().Contain(ModuleRoot.ConfigKey);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/DataVolumeFreeSpaceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/DataVolumeFreeSpaceTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The free-space signal, evaluated over a fake drive probe: Degraded below the threshold naming
+/// path, used and total; Degraded when a configured path cannot be measured; Healthy with nothing
+/// configured. The 2026-09-08 share (16384 MiB, 3 MiB free) is the worked example.
+/// </summary>
+public class DataVolumeFreeSpaceTest
+{
+    private const long MiB = 1024L * 1024L;
+
+    private static DataVolumeReading Full(string path) => new(path, "/data", 3 * MiB, 16384 * MiB, null);
+    private static DataVolumeReading Roomy(string path) => new(path, "/data", 9000 * MiB, 16384 * MiB, null);
+
+    [Fact]
+    public void BelowTheThreshold_IsDegraded_NamingPathUsedAndTotal()
+    {
+        var verdict = DataVolumeFreeSpace.Evaluate(["/data/prebuilt-bundles"], Full, DataVolumeFreeSpace.DefaultMinimumFreeBytes);
+
+        verdict.Degraded.Should().BeTrue();
+        verdict.Description.Should().Contain("/data/prebuilt-bundles");
+        verdict.Description.Should().Contain("3 MiB free");
+        verdict.Description.Should().Contain("16,384 MiB");
+        verdict.Description.Should().Contain("16,381 MiB used");
+        verdict.Description.Should().Contain("BELOW the 1,024 MiB threshold");
+    }
+
+    [Fact]
+    public void AboveTheThreshold_IsHealthy_AndStillReportsTheNumbers()
+    {
+        var verdict = DataVolumeFreeSpace.Evaluate(["/data/prebuilt-bundles", "/data/modules"], Roomy, DataVolumeFreeSpace.DefaultMinimumFreeBytes);
+
+        verdict.Degraded.Should().BeFalse();
+        verdict.Readings.Should().HaveCount(2);
+        verdict.Description.Should().Contain("9,000 MiB free");
+        verdict.Description.Should().NotContain("BELOW");
+    }
+
+    [Fact]
+    public void APathThatCannotBeMeasured_IsDegraded_NeverHealthy()
+    {
+        var verdict = DataVolumeFreeSpace.Evaluate(
+            ["/data/prebuilt-bundles"],
+            path => new DataVolumeReading(path, null, null, null, "IOException: not mounted"),
+            DataVolumeFreeSpace.DefaultMinimumFreeBytes);
+
+        verdict.Degraded.Should().BeTrue();
+        verdict.Description.Should().Contain("could not be measured");
+        verdict.Description.Should().Contain("not mounted");
+    }
+
+    [Fact]
+    public void NoPathConfigured_IsHealthy_AndSaysNothingWasMeasured()
+    {
+        var verdict = DataVolumeFreeSpace.Evaluate([" ", ""], Full, DataVolumeFreeSpace.DefaultMinimumFreeBytes);
+
+        verdict.Degraded.Should().BeFalse();
+        verdict.Readings.Should().BeEmpty();
+        verdict.Description.Should().Contain("no data volume configured");
+    }
+
+    [Fact]
+    public void TheThresholdIsConfigurable_AndAMalformedValueFallsBackToOneGiB()
+    {
+        DataVolumeFreeSpace.MinimumFreeBytesOf("2097152").Should().Be(2 * MiB);
+        DataVolumeFreeSpace.MinimumFreeBytesOf("lots").Should().Be(DataVolumeFreeSpace.DefaultMinimumFreeBytes);
+        DataVolumeFreeSpace.MinimumFreeBytesOf(null).Should().Be(1L << 30);
+
+        // 3 MiB free clears a 2 MiB threshold — the configured value is the one applied.
+        DataVolumeFreeSpace.Evaluate(["/data"], Full, 2 * MiB).Degraded.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheRealProbe_AnswersForAnExistingPath()
+    {
+        var reading = DataVolumeFreeSpace.Probe(Environment.CurrentDirectory);
+
+        reading.Fault.Should().BeNull();
+        reading.TotalBytes!.Value.Should().BeGreaterThan(0);
+        reading.FreeBytes!.Value.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void DuplicatePaths_AreMeasuredOnce()
+    {
+        var probed = 0;
+        DataVolumeFreeSpace.Evaluate(["/data", "/data"], p => { probed++; return Roomy(p); }, MiB)
+            .Readings.Select(r => r.Path).Should().Equal("/data");
+        probed.Should().Be(1);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using MeshWeaver.Hosting;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The prebuilt-bundle retention sweep — the rule "prune what nothing references, never by age
+/// alone" over a temp store tree. One test per KEEP rule proves the rule keeps; the deleting
+/// tests prove the rest goes; and the fail-closed cases (an unreadable seal keeps its identity, an
+/// unreadable release marker aborts the pass) pin the direction a wrong answer must fall in.
+/// </summary>
+public class PrebuiltBundleRetentionTest : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 8, 14, 0, 0, TimeSpan.Zero);
+    private const string Live = "s-live";
+
+    private readonly string root = Path.Combine(Path.GetTempPath(), $"mw-prebuilt-{Guid.NewGuid():N}");
+    private readonly PrebuiltBundleRetention retention = PrebuiltBundleRetention.Default with { KeepNewestPerSource = 2 };
+
+    public PrebuiltBundleRetentionTest() => Directory.CreateDirectory(root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // ---- fixture helpers ----------------------------------------------------------------------
+
+    private string Sealed(string identity, string source, DateTimeOffset sealedAt, int bytes = 1024)
+    {
+        var dir = Path.Combine(root, identity, source);
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "A.zip"), new byte[bytes]);
+        File.SetLastWriteTimeUtc(Path.Combine(dir, "A.zip"), sealedAt.UtcDateTime);
+        var sentinel = Path.Combine(dir, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        File.WriteAllText(sentinel, "A.zip\n");
+        File.SetLastWriteTimeUtc(sentinel, sealedAt.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(dir, sealedAt.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(Path.Combine(root, identity), sealedAt.UtcDateTime);
+        return dir;
+    }
+
+    private string Unsealed(string identity, string source, DateTimeOffset writtenAt)
+    {
+        var dir = Path.Combine(root, identity, source);
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "A.zip"), new byte[64]);
+        File.SetLastWriteTimeUtc(Path.Combine(dir, "A.zip"), writtenAt.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(dir, writtenAt.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(Path.Combine(root, identity), writtenAt.UtcDateTime);
+        return dir;
+    }
+
+    private string Marker(string version, string identity, DateTimeOffset? writtenAt = null)
+    {
+        var dir = Path.Combine(root, SealedPublicationIndex.ReleaseMarkerDirectoryName);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, version);
+        File.WriteAllText(path, identity + "\n");
+        File.SetLastWriteTimeUtc(path, (writtenAt ?? Now - TimeSpan.FromDays(10)).UtcDateTime);
+        return path;
+    }
+
+    private static DateTimeOffset DaysAgo(int days) => Now - TimeSpan.FromDays(days);
+
+    private PrebuiltBundleSweepPlan PlanNow(string? liveVersion = "3.1.0-ci.9000", ImmutableHashSet<string>? stamps = null) =>
+        PrebuiltBundleStore.Plan(Live, liveVersion, PrebuiltBundleStore.Scan(root), stamps ?? [], retention, Now);
+
+    private static string[] Ids(PrebuiltBundleSweepPlan plan) => plan.Collectable.Select(i => i.Identity).OrderBy(i => i, StringComparer.Ordinal).ToArray();
+
+    // ---- the keep rules -----------------------------------------------------------------------
+
+    [Fact]
+    public void TheRunningIdentity_IsKept_HoweverOld()
+    {
+        Sealed(Live, "plugins", DaysAgo(400));
+        Sealed("s-old", "plugins", DaysAgo(400));
+        // Two newer unnamed publications take the whole recency budget, so nothing but rule 1 keeps Live.
+        Sealed("s-u1", "plugins", DaysAgo(2));
+        Sealed("s-u2", "plugins", DaysAgo(3));
+
+        var plan = PlanNow();
+
+        plan.Protected.Keys.Should().Contain(Live);
+        plan.Protected[Live].Should().Contain("this process runs");
+        Ids(plan).Should().Contain("s-old");
+        Ids(plan).Should().NotContain(Live);
+    }
+
+    [Fact]
+    public void AnIdentityNamedByACleanReleaseMarker_IsKept_AndItsCiSiblingsOfThatLineGo()
+    {
+        Marker("3.0.0", "s-release"); Sealed("s-release", "plugins", DaysAgo(300));
+        Marker("3.0.0-ci.10", "s-ci10"); Sealed("s-ci10", "plugins", DaysAgo(320));
+        Marker("3.0.0-ci.20", "s-ci20"); Sealed("s-ci20", "plugins", DaysAgo(310));
+        Marker("3.0.0-ci.30", "s-ci30"); Sealed("s-ci30", "plugins", DaysAgo(305));
+        Sealed(Live, "plugins", DaysAgo(1));
+
+        // The running line is 4.x, so no 3.x identity is what Family adopts here.
+        var plan = PlanNow(liveVersion: "4.0.0-ci.1");
+
+        plan.Protected[ "s-release"].Should().Contain("release marker 3.0.0");
+        // Line 3.0.0 is CLOSED by the clean marker: every -ci identity of it is unreferenced.
+        Ids(plan).Should().Equal("s-ci10", "s-ci20", "s-ci30");
+        // …and their markers retire with them; the clean marker never does.
+        plan.CollectableMarkers.Select(m => m.Version).OrderBy(v => v, StringComparer.Ordinal).Should().Equal("3.0.0-ci.10", "3.0.0-ci.20", "3.0.0-ci.30");
+    }
+
+    [Fact]
+    public void AnOpenLine_KeepsItsNewestNCiIdentities_PerSource_ByVersionNotByText()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        // ci.900 sorts above ci.3758 as TEXT; by version it is the oldest.
+        Marker("3.1.0-ci.900", "s-900"); Sealed("s-900", "plugins", DaysAgo(30));
+        Marker("3.1.0-ci.3758", "s-3758"); Sealed("s-3758", "plugins", DaysAgo(20));
+        Marker("3.1.0-ci.4000", "s-4000"); Sealed("s-4000", "plugins", DaysAgo(10));
+        // A different source on the same line has its own budget.
+        Marker("3.1.0-ci.50", "s-edu50"); Sealed("s-edu50", "education", DaysAgo(40));
+
+        var plan = PlanNow(liveVersion: "4.0.0-ci.1");
+
+        plan.Protected.Keys.Should().Contain("s-3758");
+        plan.Protected.Keys.Should().Contain("s-4000");
+        plan.Protected.Keys.Should().Contain("s-edu50");
+        Ids(plan).Should().Equal("s-900");
+        plan.CollectableMarkers.Select(m => m.Version).OrderBy(v => v, StringComparer.Ordinal).Should().Equal("3.1.0-ci.900");
+    }
+
+    [Fact]
+    public void TheNewestSealedPublicationOnTheRunningLine_IsKept_BecauseFamilyStrictnessAdoptsIt()
+    {
+        // Line 3.0.0 is closed and the budget is spent on line 3.2.0 — only the Family rule keeps s-fam.
+        Marker("3.0.0", "s-rel"); Sealed("s-rel", "plugins", DaysAgo(200));
+        Marker("3.0.0-ci.5", "s-fam"); Sealed("s-fam", "education", DaysAgo(150));
+        Marker("3.2.0-ci.1", "s-a"); Sealed("s-a", "plugins", DaysAgo(3));
+        Marker("3.2.0-ci.2", "s-b"); Sealed("s-b", "plugins", DaysAgo(2));
+        Sealed(Live, "plugins", DaysAgo(1));
+
+        var plan = PlanNow(liveVersion: "3.1.0-ci.9000");
+
+        plan.Protected[ "s-fam"].Should().Contain("Family strictness");
+        Ids(plan).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnIdentityANodeTypeRecordIsStampedWith_IsKept()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-stamped", "plugins", DaysAgo(500));
+        Sealed("s-forgotten", "plugins", DaysAgo(600));
+        // The unnamed recency budget (2) goes to Live and this one, so only the stamp keeps s-stamped.
+        Sealed("s-recent", "plugins", DaysAgo(2));
+
+        var plan = PlanNow(stamps: ["s-stamped"]);
+
+        plan.Protected[ "s-stamped"].Should().Contain("CompiledFrameworkVersion");
+        Ids(plan).Should().Equal("s-forgotten");
+    }
+
+    [Fact]
+    public void UnnamedIdentities_AreKeptByRecencyOnly_TheNewestNPerSourceBySealTime()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-u1", "plugins", DaysAgo(30));
+        Sealed("s-u2", "plugins", DaysAgo(20));
+        Sealed("s-u3", "plugins", DaysAgo(10));
+
+        var plan = PlanNow();
+
+        // Budget 2 by seal time: Live (1 day) and s-u3 (10 days); s-u2 and s-u1 are older and go.
+        plan.Protected[ "s-u3"].Should().Contain("no release marker names it");
+        Ids(plan).Should().Equal("s-u1", "s-u2");
+    }
+
+    [Fact]
+    public void AnUnsealedDirectoryYoungerThanTheGrace_IsASealInFlight_AndKept()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Unsealed("s-inflight", "plugins", Now - TimeSpan.FromMinutes(5));
+        Unsealed("s-dead", "plugins", DaysAgo(3));
+
+        var plan = PlanNow();
+
+        plan.Protected[ "s-inflight"].Should().Contain("in flight");
+        Ids(plan).Should().Equal("s-dead");
+    }
+
+    // ---- fail closed --------------------------------------------------------------------------
+
+    [Fact]
+    public void ASealThatCannotBeRead_KeepsItsIdentity()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        var dir = Sealed("s-unreadable", "plugins", DaysAgo(500));
+        // The seam the scan actually has is File.ReadAllLines throwing: hold the sentinel open with
+        // FileShare.None for the scan's duration (an advisory lock on Unix, a sharing violation on Windows).
+        var sentinel = Path.Combine(dir, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        using var hold = new FileStream(sentinel, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var plan = PlanNow();
+
+        plan.Protected.Keys.Should().Contain("s-unreadable");
+        plan.Protected["s-unreadable"].Should().Contain("could not be read");
+        Ids(plan).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AReleaseMarkerThatCannotBeRead_AbortsTheWholePass()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-old", "plugins", DaysAgo(500));
+        var marker = Marker("3.0.0", "s-old");
+        using var hold = new FileStream(marker, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var plan = PlanNow();
+
+        plan.AbortReason.Should().Contain("3.0.0");
+        Ids(plan).Should().BeEmpty();
+        plan.CollectableMarkers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnEmptyMarker_IsUnreadableToo()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-old", "plugins", DaysAgo(500));
+        File.WriteAllText(Marker("3.0.0", "ignored"), "");
+
+        PlanNow().AbortReason.Should().Contain("empty");
+    }
+
+    // ---- the deleting half --------------------------------------------------------------------
+
+    [Fact]
+    public void SweepCore_RemovesOnlyTheCollectable_OldestFirst_AndRetiresTheirMarkers()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Marker("3.0.0", "s-rel"); Sealed("s-rel", "plugins", DaysAgo(200));
+        Marker("3.0.0-ci.1", "s-c1"); Sealed("s-c1", "plugins", DaysAgo(230), bytes: 4096);
+        Marker("3.0.0-ci.2", "s-c2"); Sealed("s-c2", "plugins", DaysAgo(220), bytes: 2048);
+        Unsealed("s-dead", "plugins", DaysAgo(5));
+        // A -ci marker whose identity is long gone retires as well — _releases must not grow forever.
+        Marker("3.0.0-ci.0", "s-gone");
+        // …but a young dangling marker may precede its bundles (the publisher writes it per run).
+        Marker("3.0.0-ci.3", "s-coming", writtenAt: Now - TimeSpan.FromMinutes(1));
+
+        var removed = new System.Collections.Generic.List<string>();
+        var result = PrebuiltBundleStore.SweepCore(root, Live, "4.0.0-ci.1", [], retention, Now,
+            deleteDirectory: dir => { removed.Add(Path.GetFileName(dir)); Directory.Delete(dir, true); });
+
+        result.Deleted.Should().BeTrue();
+        result.AbortReason.Should().BeNull();
+        removed.Should().Equal("s-c1", "s-c2", "s-dead");
+        result.DeletedIdentities.Should().Be(3);
+        result.DeletedBytes.Should().BeGreaterThan(4096 + 2048);
+        Directory.Exists(Path.Combine(root, Live)).Should().BeTrue();
+        Directory.Exists(Path.Combine(root, "s-rel")).Should().BeTrue();
+        Directory.Exists(Path.Combine(root, "s-c1")).Should().BeFalse();
+
+        var markers = Directory.GetFiles(Path.Combine(root, SealedPublicationIndex.ReleaseMarkerDirectoryName))
+            .Select(Path.GetFileName).OrderBy(n => n).ToArray();
+        markers.Should().Equal("3.0.0", "3.0.0-ci.3");
+        result.DeletedMarkers.Should().Be(3);
+
+        var ledger = File.ReadAllLines(PrebuiltBundleStore.LedgerPathOf(root));
+        ledger[0].Should().Contain("removed 3 identity(ies)");
+        ledger.Should().Contain(l => l.Contains("removed s-c1"));
+        ledger.Should().Contain(l => l.Contains("retired marker 3.0.0-ci.0"));
+    }
+
+    [Fact]
+    public void SweepCore_ReportOnly_RemovesNothing()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-old", "plugins", DaysAgo(500));
+        Sealed("s-recent", "plugins", DaysAgo(2));
+
+        var result = PrebuiltBundleStore.SweepCore(root, Live, "3.1.0-ci.9000", [], retention with { Delete = false }, Now);
+
+        result.Deleted.Should().BeFalse();
+        result.Plan!.Collectable.Select(i => i.Identity).Should().Equal("s-old");
+        Directory.Exists(Path.Combine(root, "s-old")).Should().BeTrue();
+        File.ReadAllText(PrebuiltBundleStore.LedgerPathOf(root)).Should().Contain("report only");
+    }
+
+    [Fact]
+    public void SweepCore_AFailedRemoval_IsCountedAndTheRestProceeds()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-a", "plugins", DaysAgo(500));
+        Sealed("s-b", "plugins", DaysAgo(400));
+        Sealed("s-recent", "plugins", DaysAgo(2));
+
+        var result = PrebuiltBundleStore.SweepCore(root, Live, "3.1.0-ci.9000", [], retention, Now,
+            deleteDirectory: dir =>
+            {
+                if (dir.EndsWith("s-a", StringComparison.Ordinal))
+                    throw new IOException("locked");
+                Directory.Delete(dir, true);
+            });
+
+        result.FailedDeletes.Should().Be(1);
+        result.DeletedIdentities.Should().Be(1);
+        Directory.Exists(Path.Combine(root, "s-b")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SweepCore_AnAbsentRoot_CollectsNothing()
+    {
+        var result = PrebuiltBundleStore.SweepCore(Path.Combine(root, "missing"), Live, null, [], retention, Now);
+        result.Plan.Should().BeNull();
+        result.AbortReason.Should().Contain("does not exist");
+    }
+
+    // ---- version lines ------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("3.1.0-ci.8076", "3.1.0", true)]
+    [InlineData("3.1.0", "3.1.0", false)]
+    [InlineData("3.1.0+abc123", "3.1.0", false)]
+    [InlineData("3.0.0-rc9", "3.0.0", true)]
+    [InlineData("garbage", null, false)]
+    public void PlatformVersionLine_PlacesAVersionOnItsLine(string version, string? line, bool prerelease)
+    {
+        PlatformVersionLine.LineOf(version).Should().Be(line);
+        PlatformVersionLine.IsPrerelease(version).Should().Be(prerelease);
+    }
+
+    [Fact]
+    public void FromConfiguration_DegradesEveryMalformedKnobToItsDefault()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new System.Collections.Generic.Dictionary<string, string?>
+            {
+                [PrebuiltBundleRetentionExtensions.DeleteConfigKey] = "false",
+                [PrebuiltBundleRetentionExtensions.KeepNewestPerSourceConfigKey] = "ten",
+                [PrebuiltBundleRetentionExtensions.IntervalConfigKey] = "06:00:00",
+            })
+            .Build();
+
+        var read = PrebuiltBundleRetentionExtensions.FromConfiguration(configuration);
+
+        read.Delete.Should().BeFalse();
+        read.KeepNewestPerSource.Should().Be(10);
+        read.Interval.Should().Be(TimeSpan.FromHours(6));
+        read.UnsealedGrace.Should().Be(PrebuiltBundleRetention.Default.UnsealedGrace);
+    }
+}


### PR DESCRIPTION
## Summary

Measured 2026-09-08 13:51Z on memex.systemorph.com through the memex API: the `/data` azurefile share (16384 MiB) had **3 MiB free** — `prebuilt-bundles` 13398 MiB in **482 identity directories** (one per CI build ever published, nothing pruned them), `modules` 2269 MiB, `assembly-cache` 704 MiB. A full share truncates writes silently: every runtime NodeType recompile landed as `Bad IL format`, CD's bake read-back got `ResourceNotFound` for 39/45 files. `assembly-cache-prune` touches only the assembly cache.

This adds the sibling collector for the prebuilt-bundle store, recurring inside the portal, plus a free-space health signal.

### The rule — prune what nothing references, never by age alone

Stated once (`PrebuiltBundleStore`, `MeshWeaver.Hosting`) and applied to two stores — this one and the registry digests of #3438 (`Doc/Architecture/PinnedImageRetention`): *an artifact that anything pins, names, runs or may adopt is kept regardless of age and regardless of how many newer ones exist; only an artifact NOTHING references is collected, and an artifact whose references cannot be READ counts as referenced.*

An identity directory is KEPT when any of these holds (ORed):

1. it is the framework identity **this process runs**;
2. a **clean release marker** `_releases/X.Y.Z` names it (a release line stays adoptable forever; the rollback target);
3. a NodeType record's **adoption stamp** (`CompiledFrameworkVersion` — what `PrebuiltAssemblySeeder` writes) names it, read from the mesh on every pass;
4. it holds, per source, the **newest sealed publication on the running major line** — what `Modules:VersionStrictness=Family` (#3727) adopts;
5. a `-ci` marker of an **OPEN line** names it and it is among the newest **10** (`KeepNewestPerSource`) per source by version — once the clean `X.Y.Z` marker exists the line is closed and every `X.Y.Z-ci.<n>` identity of it is unreferenced by this rule (maintainer: *"when final release is out, we can remove all -CI … leave last 10"*);
6. **no marker names it** and it is among the newest 10 per source **by seal time** — nothing can place an unnamed identity on a line, so it is pruned by recency;
7. a source under it is **unsealed and younger than the grace** (2 h) — a seal in flight (bundles first, `_complete` last);
8. its seal **cannot be read**.

Everything else is deleted oldest first, one identity at a time, sentinel first, each removal logged with the bytes reclaimed. The `-ci` markers of a removed identity (and of one already gone for longer than the grace) are retired so `_releases/` does not grow forever; a clean release marker never is. **Fail closed** like `ModuleSetStore.Prune`: an unlistable store, an unreadable release marker, or an unreadable stamp enumeration aborts the pass with nothing collected. Identity-level only — the per-source generation retention after a pointer swap stays the publisher's.

### Where it runs

`PrebuiltBundleRetentionHostedService`, registered by `ConfigureMemexMesh` beside `AddModuleGenerationsGc` (the same place the modules GC runs): kicked from `ApplicationStarted`, behind `PreWarmCompletion`, on the file-system `IIoPool`; then **recurring every `Interval` (default daily)**, passes serialised. Inert without `PreWarm:PrebuiltBundleRoot`. Deletion armed by default (`PreWarm:PrebuiltBundleRetention:Delete=false` reports only). Every pass appends to `<root>/_retention/ledger.txt` and records its result on `PrebuiltBundleRetentionStatus`. No on-demand operator surface exists in core for the assembly-cache prune (it is a chart Job in the private Memex repo), so none is invented here.

### The free-space signal

`/health` gains `data_volume_free_space` (`DataVolumeHealthCheck` in `Memex.Portal.ServiceDefaults`, beside `content-types`; evaluation in `DataVolumeFreeSpace`, `MeshWeaver.Hosting`): **Degraded** — never Unhealthy — when the volume holding `PreWarm:PrebuiltBundleRoot`, `Modules:Root` or any `DataVolume:Paths` has less than `DataVolume:MinimumFreeBytes` (default 1 GiB) free, naming path, used and total; Degraded when a path cannot be measured; Healthy when nothing is configured. No existing free-space check was found in core or Plugins to extend.

### Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)` each: `MeshWeaver.Hosting`, `Memex.Portal.ServiceDefaults`, `Memex.Portal.Shared`, `MeshWeaver.Hosting.Test`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`.
- `PrebuiltBundleRetentionTest` (20) + `DataVolumeFreeSpaceTest` (7): 27 passed, fresh trx. Each keep rule has a test whose recency budget is exhausted so only that rule keeps the identity; fail-closed (locked seal ⇒ kept; locked marker ⇒ pass aborted); in-flight unsealed; the deleting half (oldest first, markers retired, ledger written, a failed removal counted).
- `DataVolumeHealthCheckTest` (6): passed — includes the pin that `DataVolumeFreeSpace.ModulesRootConfigKey == ModuleRoot.ConfigKey`.
- Documentation guards + `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest`: see the CI run.

### Docs

`Doc/Architecture/CiContentBake` § "Retention: the published store is pruned by REFERENCE, never by age alone" (the rule, the config keys, the ledger, the health signal); What's New `Category: Fix`.

Pairs-with: none — this change adds public surface (`PrebuiltBundleStore`, `PrebuiltBundleRetention*`, `PlatformVersionLine`, `DataVolumeFreeSpace`, `DataVolumeHealthCheck`) and removes none; no interface member is added.

Mirror-sync: none — no i18n catalog change (health-check descriptions and ledger lines are operator log text, not viewer UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
