### PR TITLE
Publish: one process per phase per target instead of one az launch per file (184 → 6 launches)

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -42,7 +42,12 @@
 #
 # AUTH: `az login` must already have happened (the CD jobs use OIDC). Data-plane access uses
 # --auth-mode login with --backup-intent, which requires the identity to hold the
-# "Storage File Data Privileged Contributor" role on the target storage accounts.
+# "Storage File Data Privileged Contributor" role on the target storage accounts. The bulk
+# phases — every upload of a publication, and every read-back before the seal — run through
+# publish-bake-files.py beside this file, ONE process per phase per target on the Azure SDK with
+# the SAME CLI identity (AzureCliCredential + token_intent=backup); see THE BULK PHASES below.
+# The remaining `az` calls are the handful of per-target decisions (does the sentinel exist, what
+# does the marker say) and the rarely-taken paths (unseal, release marker, architecture backfill).
 #
 # <release-version> is the PLATFORM VERSION this publication belongs to (main-cd passes the
 # promoted `memex-portal-ai:<version>`; node repos pass nothing — they do not define a platform
@@ -129,13 +134,17 @@ fi
 # PRESENCE means "every bundle of this publication landed", because it is uploaded strictly LAST.
 # Its content lists the bundle set, so the reader can detect a listed-but-missing bundle too.
 #
-# 🚨 The local copy lives in a temp DIRECTORY under its REAL name, and the upload below targets
-# the destination DIRECTORY (not "$dest/$SENTINEL"): `az storage file upload` silently treats an
-# EXTENSIONLESS --path as a directory and appends the source basename — so uploading a mktemp
-# file to "$dest/_complete" actually attempts "$dest/_complete/tmp.XXXX" and fails
-# `ParentNotFound` every time, while every ".zip" beside it lands fine. Verified live against the
-# portals' Azure Files share 2026-08-17; with the naive shape the seal step can never succeed and
-# every publication stays torn (unreadable to portals) forever.
+# 🚨 The local copy lives in a temp DIRECTORY under its REAL name. That used to be forced by the
+# CLI: `az storage file upload` silently treats an EXTENSIONLESS --path as a directory and appends
+# the source basename — so uploading a mktemp file to "$dest/_complete" actually attempts
+# "$dest/_complete/tmp.XXXX" and fails `ParentNotFound` every time, while every ".zip" beside it
+# lands fine. Verified live against the portals' Azure Files share 2026-08-17; with the naive
+# shape the seal step can never succeed and every publication stays torn (unreadable to portals)
+# forever. The publication's files and the sentinel now go through the SDK helper, which
+# addresses the exact path and has no such rule — but the two `az` uploads that remain (the
+# release marker and the architecture backfill) still pass the DIRECTORY as --path for this
+# reason, and the real-name convention is kept for all of them so no reader has to know which
+# uploader a file took.
 SENTINEL="_complete"
 
 # ══════════════════════ THE PUBLICATION LAYOUT SELECTOR (MeshWeaver#3461) ══════════════════════
@@ -239,8 +248,9 @@ printf '%s\n' "${SOURCE_SHA:-unknown}" > "$SOURCE_MARKER_LOCAL"
 # attribute a sealed source to the repository whose green builds it receives, so its sync sources
 # advance only to the commit sealed for its own identity (SealedPublicationIndex / SealedSyncGate
 # in core). A local run records nothing rather than a guess; the gate attributes such a seal by
-# commit instead. Listed and uploaded BEFORE architecture.txt, which stays the LAST upload before
-# the postcondition — the overlap harness hooks its second publisher onto that file.
+# commit instead. Planned BEFORE architecture.txt, which stays the LAST entry of the upload plan
+# — the overlap harness runs the plan with a pool of 1 and hooks its second publisher onto that
+# file.
 #
 # 🚨 It is the CONTENT repository, NEVER $GITHUB_REPOSITORY (MeshWeaver#3583). The two differ in
 # exactly the case the marker exists for: core CD's `plugins-bake` bakes MeshWeaver.Plugins content
@@ -387,10 +397,11 @@ fi
 # `plugins` prefix in ONE change set because it is the only one with two producers.
 # Doc/Architecture/SealedPublicationGenerations carries the table and the ordered phases.
 #
-# Cost: one `az storage file show` per published file per target, at seal time — measured against
-# the ~43-file publication these lanes produce, ~1s each. That is the price of the assertion and it
-# is deliberately paid in full: verifying a SAMPLE would be a guard that passes on the files nobody
-# overwrote.
+# Cost: every published file is read back per target, at seal time — deliberately paid in full:
+# verifying a SAMPLE would be a guard that passes on the files nobody overwrote. What changed on
+# 2026-09-08 is HOW it is paid — see THE BULK PHASES just below. It used to be one `az storage
+# file show` process per file (~1–3 s each, 46 per target, on top of 46 upload processes), which
+# made this step 5–10 minutes of a bake whose compile is ~7; it is now one process per phase.
 sha256_of() { # <file> — hex digest, portable across the CI runner and a developer's macOS
   if command -v sha256sum > /dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -399,53 +410,109 @@ sha256_of() { # <file> — hex digest, portable across the CI runner and a devel
   fi
 }
 
-# 🚨 THE RENDERING IS MEASURED, NOT ASSUMED, and getting it wrong is silent. knack's `format_tsv`
-# treats a TOP-LEVEL list as ROWS: `--query "[a, b]" -o tsv` prints a's value and b's value on TWO
-# LINES, not as two columns — so `awk '{print $2}'` would read EMPTY for every file, every owner
-# would compare unequal to $PUBLICATION, `ours` would be 0 on every publish and the postcondition
-# would refuse EVERY publication in the fleet as "superseded". Hence a list-of-ONE-ROW: `[[a, b]]`
-# renders one tab-separated line. The `|| '-'` guards exist because a null field renders as the
-# LITERAL STRING 'None', not as empty. Both measured against azure-cli 2.90.0's own jmespath +
-# knack formatter, and re-asserted with the real jmespath engine by test-publish-bake-overlap.py.
-STAMP_QUERY="[[metadata.digest || '-', metadata.publication || '-']]"
+# ═══════════════════════════════ THE BULK PHASES (2026-09-08) ═══════════════════════════════
+#
+# Maintainer directive, after asking why the bake queue runs so slowly: "how many are there? this
+# must be one bulk query ==> optimize this to one bulk query". Measured: a 46-file publication was
+# 46 `az storage file upload` launches and 46 `az storage file show` launches PER TARGET — 184 CLI
+# processes for two targets, 1–3 s each, so this step took 5–10 minutes of a bake whose compile is
+# ~7 minutes. Each launch paid the CLI's start-up, a fresh token lookup and a new connection for
+# ONE request.
+#
+# publish-bake-files.py (beside this file, fetched at the same platform-ref) now does each phase
+# in ONE process per target on the Azure SDK: `upload` pushes every file of the plan through a
+# bounded thread pool with the two metadata stamps, and `verify` lists the destination ONCE and
+# reads every manifest file's properties in the same process over one connection pool, printing
+# one TSV row per file that the accounting below consumes. 🚨 The listing cannot carry the stamps
+# — Azure Files' List Directories and Files returns names and sizes, never metadata — so the
+# per-file property read inside one process IS the bulk read; the helper prints the elapsed time
+# so the cost stays measured. Every verdict, bucket and refusal below is UNCHANGED: only the input
+# source of the sweep moved.
+#
+# 🚨 THE SDK IS INSTALLED HERE, PINNED, AND NOT BY THE WORKFLOW. Satellites fetch this script at
+# `platform-ref` but run the lane at their `uses:` pin, and the two move independently (the
+# EXT_MODULES_DIR refusal above is that exact skew) — a workflow-side install would leave a
+# satellite whose ref is newer than its pin running a script whose dependency nobody installed.
+# The venv lands under $RUNNER_TEMP (the runner's own scratch, cleaned per job) and the install
+# is followed by `sdk-check`, which asserts the installed versions ARE the pins and constructs the
+# clients — the positive signal, so a broken install is RED here and never a later "unreadable".
+# PUBLISH_BAKE_PYTHON names a python that ALREADY carries exactly these pins (the overlap harness
+# passes its own, so twenty publications do not build twenty venvs); sdk-check holds it to the
+# same pins. There is no fallback to the per-file CLI path: that is the defect this replaces.
+HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/publish-bake-files.py"
+if [ ! -f "$HELPER" ]; then
+  echo "::error::$HELPER is missing beside publish-bake-bundles.sh — the two are fetched together at platform-ref; a checkout that carries one without the other cannot publish."
+  exit 1
+fi
+SDK_PINS=("azure-storage-file-share==12.26.0" "azure-identity==1.25.3")
+if [ -n "${PUBLISH_BAKE_PYTHON:-}" ]; then
+  PYTHON="$PUBLISH_BAKE_PYTHON"
+else
+  VENV="${RUNNER_TEMP:-$SENTINEL_LOCAL_DIR}/publish-bake-venv"
+  python3 -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --disable-pip-version-check "${SDK_PINS[@]}"
+  PYTHON="$VENV/bin/python"
+fi
+"$PYTHON" "$HELPER" sdk-check --pins "${SDK_PINS[*]}"
+# The pool width for both phases. 12 is plenty for ~46 small files and well under the share's
+# per-client request limits; the harness sets 1 so the plan order is the upload order.
+PUBLISH_BAKE_UPLOAD_WORKERS="${PUBLISH_BAKE_UPLOAD_WORKERS:-12}"
 
-# The ONE read-back, in one place. Both the per-file verification sweep and the sentinel check the
-# convergence verdict makes parse the SAME rendering, so a query change cannot leave one of them
-# reading a shape the other no longer produces. Answers through globals rather than stdout: an
-# `::error::` written inside a command substitution would be CAPTURED instead of reaching the log.
+# The ONE parse of a read-back row, in one place. Both the per-file verification sweep and the
+# sentinel check the convergence verdict makes parse the SAME rendering, so a helper change cannot
+# leave one of them reading a shape the other no longer produces. Answers through globals rather
+# than stdout: an `::error::` written inside a command substitution would be CAPTURED instead of
+# reaching the log.
 #
-#   rc 0  STAMP_DIGEST / STAMP_OWNER hold the values ('' where az rendered '-')
-#   rc 1  unreadable — a transient fault, an expired credential, or the file is simply not there
-#   rc 2  the CLI's rendering changed; STAMP_RAW/STAMP_FIELDS say what came back
+# A row is `<path> <state> <digest> <publication> <length>`, tab-separated, and the field count is
+# ASSERTED rather than trusted — the helper's `-` for an absent value is what lets an empty digest
+# be told from a missing column. If that rendering ever changes this is a loud refusal on the next
+# publish instead of a fleet-wide false verdict (the first draft of the CLI-based read used a
+# `--query` shape that rendered two LINES instead of two columns, which would have refused every
+# publication in the fleet as "superseded").
 #
-# 🚨 `< /dev/null` because the sweep below runs this INSIDE a `while read` loop fed by the
-# manifest: a command that consumed stdin would swallow the remaining lines and the loop would end
-# early, having verified a PREFIX of the publication while reporting no foreign bytes at all.
+#   rc 0  STAMP_DIGEST / STAMP_OWNER hold the values ('' where the helper rendered '-')
+#   rc 1  unreadable — the helper could not read the file (state error/absent), or no row at all
+#   rc 2  the rendering changed; STAMP_RAW/STAMP_FIELDS say what came back
 STAMP_DIGEST=""
 STAMP_OWNER=""
 STAMP_RAW=""
 STAMP_FIELDS=0
-read_stamp() { # <account> <share> <path>
-  local account="$1" share="$2" path="$3" props fields
-  STAMP_DIGEST=""; STAMP_OWNER=""; STAMP_RAW=""; STAMP_FIELDS=0
-  if ! props=$(az storage file show --account-name "$account" --share-name "$share" \
-      --path "$path" --auth-mode login --backup-intent \
-      --query "$STAMP_QUERY" -o tsv --only-show-errors < /dev/null); then
+STAMP_STATE=""
+read_stamp_row() { # <row>
+  local props="$1" fields
+  STAMP_DIGEST=""; STAMP_OWNER=""; STAMP_RAW="$props"; STAMP_FIELDS=0; STAMP_STATE=""
+  if [ -z "$props" ]; then
     return 1
   fi
-  STAMP_RAW="$props"
   fields=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print NF }')
   STAMP_FIELDS="${fields:-0}"
-  # The field count is ASSERTED rather than trusted: if that rendering ever changes, this is a loud
-  # refusal on the next publish instead of a fleet-wide false verdict.
-  if [ "$STAMP_FIELDS" -ne 2 ]; then
+  if [ "$STAMP_FIELDS" -ne 5 ]; then
     return 2
   fi
-  STAMP_DIGEST=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $1 }')
-  STAMP_OWNER=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
+  STAMP_STATE=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $2 }')
+  case "$STAMP_STATE" in
+    ok) ;;
+    absent|error) return 1 ;;
+    *) return 2 ;;
+  esac
+  STAMP_DIGEST=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $3 }')
+  STAMP_OWNER=$(printf '%s' "$props" | awk -F'\t' 'NR == 1 { print $4 }')
   if [ "$STAMP_DIGEST" = "-" ]; then STAMP_DIGEST=""; fi
   if [ "$STAMP_OWNER" = "-" ]; then STAMP_OWNER=""; fi
   return 0
+}
+# ONE file, read now — used by the convergence verdict for the sentinel, AFTER the sweep, so a
+# sibling that sealed while the sweep ran is seen. `< /dev/null` is discipline kept from when this
+# ran inside the manifest loop: a command that consumed stdin there would have ended the loop
+# early, having verified a PREFIX of the publication.
+read_stamp() { # <account> <share> <path>
+  local account="$1" share="$2" path="$3" props
+  if ! props=$("$PYTHON" "$HELPER" stamp --account "$account" --share "$share" --path "$path" < /dev/null); then
+    STAMP_DIGEST=""; STAMP_OWNER=""; STAMP_RAW=""; STAMP_FIELDS=0; STAMP_STATE=""
+    return 1
+  fi
+  read_stamp_row "$props"
 }
 
 # 🚨 THE POINTER RESOLUTION, AND IT MIRRORS THE READER'S EXACTLY — same rules, same fallbacks, same
@@ -571,20 +638,42 @@ $1
 }
 echo "publication $PUBLICATION: $MANIFEST_COUNT file(s) to publish and verify per target (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s), $MARKER_COUNT marker/index file(s)$([ "$HAS_SURFACE" = "true" ] && echo ", surface published" || echo ", NO platform surface"))"
 
-# Uploads ONE file of the publication, stamped with the two metadata values the postcondition
-# reads back. The digest is LOOKED UP from the manifest rather than recomputed: a file uploaded
-# that the manifest does not describe would be published and never verified, so that is fatal
-# rather than a fresh digest.
-upload_published_file() { # <account> <share> <dest> <path-under-dest> <local-file> [<upload-path>]
-  local account="$1" share="$2" dest="$3" rel="$4" src="$5" upload_path="${6:-$3/$4}" digest
+# The upload PLAN: "<path-under-dest><TAB><local-file><TAB><sha256>", one line per file, in the
+# order the files used to be uploaded one by one — bundles, modules, modules/_index, the markers,
+# architecture.txt last. Built ONCE like the manifest (the local bytes are the same for every
+# target) and handed to the helper, which uploads it in one process. The digest is LOOKED UP from
+# the manifest rather than recomputed: a file planned that the manifest does not describe would be
+# published and never verified, so that is fatal rather than a fresh digest.
+PLAN="$SENTINEL_LOCAL_DIR/plan"
+: > "$PLAN"
+plan_add() { # <path-under-dest> <local-file>
+  local rel="$1" src="$2" digest
   digest=$(awk -F'\t' -v k="$rel" '$1 == k { print $2; found = 1 } END { exit !found }' "$MANIFEST") || {
     echo "::error::'$rel' is being uploaded but the publication manifest does not describe it — it would be published and never verified. This is a bug in this script, not in the bake."
     exit 1
   }
-  az storage file upload --account-name "$account" --share-name "$share" \
-    --path "$upload_path" --source "$src" \
-    --metadata "digest=$digest" "publication=$PUBLICATION" \
-    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  printf '%s\t%s\t%s\n' "$rel" "$src" "$digest" >> "$PLAN"
+}
+for zip in "${BUNDLES[@]}"; do plan_add "$(basename "$zip")" "$zip"; done
+for m in ${MODULES[@]+"${MODULES[@]}"}; do plan_add "$MODULES_DIR_NAME/$(basename "$m")" "$m"; done
+plan_add "$MODULES_DIR_NAME/$MODULES_INDEX" "$MODULES_INDEX_LOCAL"
+plan_add "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL"
+if [ "$HAS_SURFACE" = "true" ]; then plan_add "$SURFACE_FILE" "$SURFACE_LOCAL"; fi
+plan_add "$REPO_MARKER" "$REPO_MARKER_LOCAL"
+plan_add "$ARCH_MARKER" "$ARCH_MARKER_LOCAL"
+PLAN_COUNT=$(grep -c '[^[:space:]]' "$PLAN" || true)
+if [ "${PLAN_COUNT:-0}" -ne "$MANIFEST_COUNT" ]; then
+  echo "::error::the upload plan holds $PLAN_COUNT file(s) but the manifest describes $MANIFEST_COUNT — the two are built from the same lists, so this is a bug in this script. Refusing: a file in one and not the other is either unpublished or unverified."
+  exit 1
+fi
+
+# Uploads a whole plan — every file stamped with the two metadata values the postcondition reads
+# back — in ONE helper process per target. Fatal on any failure: the helper cancels what is
+# pending, names the file on stderr, and the directory stays sentinel-less.
+upload_plan() { # <account> <share> <dest> <plan-file>
+  local account="$1" share="$2" dest="$3" plan="$4"
+  "$PYTHON" "$HELPER" upload --account "$account" --share "$share" --dest "$dest" \
+    --plan "$plan" --publication "$PUBLICATION" --workers "$PUBLISH_BAKE_UPLOAD_WORKERS" < /dev/null
 }
 
 # Removes a seal that is known to cover a MIX. Called only from the mixed verdict below, and it
@@ -716,24 +805,41 @@ converged_on_equivalent() { # <account> <share> <dest> <foreign-markers> <neutra
 # core lane deleted the satellite's seal.
 verify_publication() { # <account> <share> <dest>
   local account="$1" share="$2" dest="$3" rel expected actual owner rc ours=0 neutral=0
-  local foreign_markers=0 neutral_markers=0 foreign_owners=""
+  local foreign_markers=0 neutral_markers=0 foreign_owners="" table row rows
   local -a foreign=() unreadable=() overlapped=()
+  # THE ONE READ-BACK per target: the helper lists the directory once and reads every manifest
+  # file's stamps in one process, one row per file. A sweep that cannot run at all (a listing that
+  # fails, a credential that expired) leaves the verdict undecidable and is refused like an
+  # unreadable file — never read as "nothing foreign".
+  table="$SENTINEL_LOCAL_DIR/verify-$(printf '%s' "$account-$share-$dest" | tr -c 'A-Za-z0-9._-' '_')"
+  if ! "$PYTHON" "$HELPER" verify --account "$account" --share "$share" --dest "$dest" \
+      --manifest "$MANIFEST" --workers "$PUBLISH_BAKE_UPLOAD_WORKERS" < /dev/null > "$table"; then
+    echo "::error title=Refusing to seal — the publication could not be read back::$account/$share/$dest: the read-back sweep itself failed (see the helper's ::error:: above), so whether this directory holds one publication or two cannot be established. Refusing rather than assuming — that assumption is what would seal a mix."
+    return 1
+  fi
+  rows=$(grep -c '[^[:space:]]' "$table" || true)
+  if [ "${rows:-0}" -ne "$MANIFEST_COUNT" ]; then
+    echo "::error title=Refusing to seal — the verification did not cover the publication::$account/$share/$dest: the read-back answered ${rows:-0} row(s) for a manifest of $MANIFEST_COUNT file(s). A sweep that reports on fewer files than it was asked about has NOT shown this publication to be free of another publisher's bytes. Refusing."
+    return 1
+  fi
   while IFS=$'\t' read -r rel expected; do
     [ -n "$rel" ] || continue
-    # 🚨 FAIL CLOSED. `|| echo ""` on the read would turn a transient fault, an expired credential
-    # or a CLI shape change into "no digest recorded" — the one answer that is indistinguishable
-    # from "another publisher wrote this", and the errors below would then name the wrong cause.
-    # An unreadable file is refused as loudly as a foreign one; it is simply refused by name. The
-    # accounting assertion after the loop is the belt to `read_stamp`'s `< /dev/null` brace.
+    # 🚨 FAIL CLOSED. A transient fault, an expired credential or a helper shape change must never
+    # read as "no digest recorded" — the one answer that is indistinguishable from "another
+    # publisher wrote this", and the errors below would then name the wrong cause. An unreadable
+    # file is refused as loudly as a foreign one; it is simply refused by name. Nothing inside this
+    # loop runs a command that could consume its stdin, and the accounting assertion after it is
+    # the belt to that.
     rc=0
-    read_stamp "$account" "$share" "$dest/$rel" || rc=$?
+    row=$(awk -F'\t' -v k="$dest/$rel" '$1 == k { print; exit }' "$table")
+    read_stamp_row "$row" || rc=$?
     if [ "$rc" -eq 1 ]; then
-      unreadable+=("$rel")
+      unreadable+=("$rel (${STAMP_STATE:-no row in the read-back table})")
       continue
     fi
     if [ "$rc" -ne 0 ]; then
-      echo "::error::az answered '$STAMP_RAW' for $dest/$rel — one tab-separated row of TWO fields was expected from --query \"$STAMP_QUERY\" -o tsv. The CLI's rendering has changed; this verification cannot be trusted until the parse is updated to match."
-      unreadable+=("$rel (unexpected --query rendering: $STAMP_FIELDS field(s))")
+      echo "::error::the read-back answered '$STAMP_RAW' for $dest/$rel — one tab-separated row of FIVE fields (path, state, digest, publication, length) with state ok/absent/error was expected from publish-bake-files.py verify. The rendering has changed; this verification cannot be trusted until the parse is updated to match."
+      unreadable+=("$rel (unexpected read-back rendering: $STAMP_FIELDS field(s), state '${STAMP_STATE:-}')")
       continue
     fi
     actual="$STAMP_DIGEST"
@@ -778,7 +884,8 @@ verify_publication() { # <account> <share> <dest>
   # cannot fail by inspection — which is precisely why it is checked: the loop is fed by a
   # redirect, so anything inside it that consumed stdin would end it EARLY, and a verification that
   # covered the first few files would then report "no foreign bytes" and SEAL. A guard that can
-  # quietly check less than it claims is the vacuity every gate here is written to avoid.
+  # quietly check less than it claims is the vacuity every gate here is written to avoid. (The
+  # row-count assertion above is the same check on the helper's side of the table.)
   local accounted=$((ours + neutral + ${#foreign[@]} + ${#unreadable[@]}))
   if [ "$accounted" -ne "$MANIFEST_COUNT" ]; then
     echo "::error title=Refusing to seal — the verification did not cover the publication::$account/$share/$dest: $accounted of $MANIFEST_COUNT file(s) were accounted for ($ours ours, $neutral byte-identical, ${#foreign[@]} foreign, ${#unreadable[@]} unreadable). The read-back loop ended early, so this publication has NOT been shown to be free of another publisher's bytes. Refusing."
@@ -889,7 +996,6 @@ publish_release_marker() { # <account> <share> <base>
 
 publish_one_target() { # <account> <share> <dest-dir> <resealing>
   local account="$1" share="$2" dest="$3" resealing="$4"
-  ensure_directory "$account" "$share" "$dest"
   # Republishing OVER a sealed directory: UNSEAL first. Readers must never seed a mid-replace
   # mix of old and new bundles under a stale sentinel — deleting the sentinel returns the
   # directory to the not-yet-complete state readers skip, and the re-seal below closes it again.
@@ -898,36 +1004,14 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
       --path "$dest/$SENTINEL" --auth-mode login --backup-intent --only-show-errors > /dev/null
     echo "unsealed: $account/$share/$dest ($SENTINEL removed — content changed, republishing)"
   fi
-  local zip
-  for zip in "${BUNDLES[@]}"; do
-    upload_published_file "$account" "$share" "$dest" "$(basename "$zip")" "$zip"
-    echo "published: $account/$share/$dest/$(basename "$zip")"
-  done
-  # The module set: every bundle, then its index — both strictly before the sentinel.
-  ensure_directory "$account" "$share" "$dest/$MODULES_DIR_NAME"
-  local m
-  for m in ${MODULES[@]+"${MODULES[@]}"}; do
-    upload_published_file "$account" "$share" "$dest" \
-      "$MODULES_DIR_NAME/$(basename "$m")" "$m"
-    echo "published module: $account/$share/$dest/$MODULES_DIR_NAME/$(basename "$m")"
-  done
-  upload_published_file "$account" "$share" "$dest" \
-    "$MODULES_DIR_NAME/$MODULES_INDEX" "$MODULES_INDEX_LOCAL" "$dest/$MODULES_DIR_NAME"
-  echo "module set: $account/$share/$dest/$MODULES_DIR_NAME/$MODULES_INDEX (${#MODULES[@]} bundle(s))"
-  # 🚨 Both marker uploads pass the DIRECTORY as --path on purpose — the CLI appends the source
-  # basename. An extensionless "$dest/$SENTINEL" --path would be silently re-interpreted as a
-  # DIRECTORY and fail ParentNotFound (see the SENTINEL_LOCAL comment above).
-  upload_published_file "$account" "$share" "$dest" "$SOURCE_MARKER" "$SOURCE_MARKER_LOCAL" "$dest"
-  # The platform surface (#3651) — before repository.txt and architecture.txt, which stay the last
-  # uploads before the postcondition (the overlap harness hooks its second publisher onto them).
-  # A ".json" --path is a FILE to the CLI, so the full path is passed; the directory trick the
-  # extensionless markers need does not apply here.
-  if [ "$HAS_SURFACE" = "true" ]; then
-    upload_published_file "$account" "$share" "$dest" "$SURFACE_FILE" "$SURFACE_LOCAL"
-    echo "published surface: $account/$share/$dest/$SURFACE_FILE"
-  fi
-  upload_published_file "$account" "$share" "$dest" "$REPO_MARKER" "$REPO_MARKER_LOCAL" "$dest"
-  upload_published_file "$account" "$share" "$dest" "$ARCH_MARKER" "$ARCH_MARKER_LOCAL" "$dest"
+  # THE WHOLE PUBLICATION IN ONE PROCESS: every bundle, every module, modules/_index, the markers
+  # and the platform surface — the plan built above, in the order they used to go one by one
+  # (architecture.txt last; the overlap harness hooks its second publisher onto that order with a
+  # pool of 1). The helper creates $dest and $dest/modules first. Every one of these files is
+  # strictly BEFORE the sentinel, which is a separate call after the postcondition; the reader
+  # contract needs no other ordering. `set -e` stops here on a failed upload, exactly as before.
+  upload_plan "$account" "$share" "$dest" "$PLAN"
+  echo "module set: $account/$share/$dest/$MODULES_DIR_NAME/$MODULES_INDEX (${#MODULES[@]} bundle(s)); platform surface: $HAS_SURFACE"
   # 🚨 THE POSTCONDITION, between the last content upload and the seal (MeshWeaver#3461). Every
   # file above is read back and must still carry THIS run's digest; a foreign publisher that
   # overwrote any of them makes this refuse, and the directory stays sentinel-less rather than
@@ -948,11 +1032,11 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
     exit 1
   fi
   # LAST write — the atomic completeness marker. Anything that dies before this line leaves the
-  # directory sentinel-less: unreadable to portals, re-published wholesale by the next run.
-  az storage file upload --account-name "$account" --share-name "$share" \
-    --path "$dest" --source "$SENTINEL_LOCAL" \
-    --metadata "digest=$(sha256_of "$SENTINEL_LOCAL")" "publication=$PUBLICATION" \
-    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  # directory sentinel-less: unreadable to portals, re-published wholesale by the next run. A
+  # one-line plan through the same uploader, stamped like every other file (the convergence
+  # verdict reads the sentinel's digest and token on the next overlapping run).
+  printf '%s\t%s\t%s\n' "$SENTINEL" "$SENTINEL_LOCAL" "$(sha256_of "$SENTINEL_LOCAL")" > "$SENTINEL_LOCAL_DIR/seal-plan"
+  upload_plan "$account" "$share" "$dest" "$SENTINEL_LOCAL_DIR/seal-plan"
   echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s), source ${SOURCE_SHA:-unknown}, platform surface: $HAS_SURFACE)"
 }
 
@@ -1139,7 +1223,7 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
       # be carried out. Stamping is safe precisely because the refusal below is sound: only the
       # amd64 lane has ever published, and this IS that lane.
       #
-      # 🚨 Deliberately NOT `upload_published_file`: this writes onto a publication that is NOT
+      # 🚨 Deliberately NOT the stamped uploader (`upload_plan`): this writes onto a publication that is NOT
       # this run's, so stamping it with this run's `publication` token would be a lie — a later
       # verification would read one of somebody else's files as ours. It is safe to leave
       # unstamped because it only ever runs on a directory that IS sealed (`complete = true`), and

--- a/.github/scripts/publish-bake-files.py
+++ b/.github/scripts/publish-bake-files.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""The bulk share I/O behind publish-bake-bundles.sh — ONE process per phase per target.
+
+WHY THIS EXISTS
+---------------
+publish-bake-bundles.sh used to publish a ~46-file publication with one `az storage file upload`
+process per file and then verify it with one `az storage file show` process per file, per target.
+Measured 2026-09-08: 184 CLI launches for two targets at 1–3 s each, so "Publish bundles to every
+portal target" took 5–10 minutes of a bake whose compile is ~7 minutes. The maintainer's directive
+was one bulk operation per target, and this file is that: bash stays the orchestrator and owns
+every verdict; this helper owns the share I/O and runs it inside one process with one
+authenticated client, one HTTP connection pool and a bounded thread pool.
+
+THE TWO PHASES
+--------------
+`upload`   reads a PLAN (`<path-under-dest>\\t<local-file>\\t<sha256>` per line), ensures every
+           parent directory exists, then uploads every file with the two metadata values the
+           postcondition reads back — `digest` (the sha256 from the plan) and `publication` (the
+           run's token) — through a thread pool of `--workers` threads. Any failure is fatal:
+           pending uploads are cancelled, the failure is named on stderr as `::error::`, exit 1.
+           The directory stays sentinel-less, which is the state every reader already skips.
+
+`verify`   reads the MANIFEST (`<path-under-dest>\\t<sha256>` per line), LISTS the destination
+           directory and each subdirectory the manifest names ONCE, and then reads the properties
+           of every listed manifest file — in the same process, over the same connection pool.
+           🚨 The listing cannot carry the stamps: Azure Files' `List Directories and Files` returns
+           names and sizes only, never metadata, so the per-file `get_file_properties` inside ONE
+           process IS the bulk read. What the listing buys is the absent files (no 404 round trip
+           per missing file) and the denominator ("N listed, M of them in this publication"). The
+           elapsed time is printed so the cost stays measured rather than assumed.
+
+           One TSV row per manifest line, in manifest order, on stdout:
+
+               <path>  <state>  <digest>  <publication>  <length>
+
+           state    ok       the file was read; digest/publication are its metadata, '-' if absent
+                    absent   the listing does not contain it (nothing was read)
+                    error    reading its properties FAILED — a `::error::` on stderr names why.
+                             This is NOT "no digest": the two must never be the same value, or a
+                             transient fault would read as a foreign publisher.
+           digest / publication are '-' when the metadata key is missing or empty — never the
+           empty string, never 'None' — so the bash parse can assert exactly five fields on every
+           row and treat '-' as absent, exactly as it did with the CLI's `|| '-'` guards.
+
+`stamp`    the same row for ONE path (`--path`), used by the convergence verdict to read the
+           sentinel AFTER the sweep — the ordering is what lets it see a sibling that sealed in the
+           meantime.
+
+`sdk-check` imports the pinned SDK, constructs the clients this file uses (no network), asserts
+           the installed versions are the ones the caller pinned, and prints them. It is the
+           positive signal after the install and the one case the overlap harness runs against the
+           REAL backend.
+
+AUTH
+----
+The share is reached with the SAME identity the script's `az login` established: `AzureCliCredential`
+asks the CLI for a storage token once per process (the pipeline caches it), and every request
+carries `x-ms-file-request-intent: backup` — the SDK's `token_intent="backup"`, which is what the
+CLI's `--backup-intent` sets. The identity therefore needs exactly the role it needed before:
+Storage File Data Privileged Contributor on the target account.
+
+THE FAKE BACKEND
+----------------
+`PUBLISH_BAKE_FAKE_SHARE_BACKEND=<path/to/module.py>` replaces the Azure backend with the module's
+`make_backend(account, share)` — the overlap harness (test-publish-bake-overlap.py) uses it to run
+the REAL script against a filesystem share and to interleave a second publisher mid-upload. It is
+announced on stderr whenever it is in use, so a production log could never carry it silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable, Protocol
+
+ABSENT = "-"
+DEFAULT_WORKERS = 12
+SENTINEL = "_complete"
+
+
+def log(msg: str) -> None:
+    """Progress and errors go to stderr: stdout is the TSV the caller parses."""
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+# ───────────────────────────── the backend contract ─────────────────────────────
+class ShareBackend(Protocol):
+    def ensure_directory(self, path: str) -> None: ...
+    def upload(self, path: str, local: Path, metadata: dict[str, str]) -> None: ...
+    def list_files(self, directory: str) -> dict[str, int | None]:
+        """name → size for every FILE directly under `directory`; {} when it does not exist."""
+        ...
+    def get_properties(self, path: str) -> tuple[dict[str, str], int | None]:
+        """(metadata, length) of one file. Raises when it cannot be read."""
+        ...
+
+
+class AzureFilesBackend:
+    """The real share. Imports lazily so the fake backend needs no SDK."""
+
+    def __init__(self, account: str, share: str):
+        from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+        from azure.identity import AzureCliCredential
+        from azure.storage.fileshare import ShareClient
+
+        self._exists_error = ResourceExistsError
+        self._not_found = ResourceNotFoundError
+        # The fleet's accounts are public-cloud accounts; the suffix is the CLI's default too.
+        self.share = ShareClient(
+            f"https://{account}.file.core.windows.net", share,
+            credential=AzureCliCredential(), token_intent="backup",
+        )
+
+    def ensure_directory(self, path: str) -> None:
+        d = self.share.get_directory_client(path)
+        if d.exists():
+            return
+        try:
+            d.create_directory()
+        except self._exists_error:
+            # Not a swallowed fault: the postcondition of this call is "the directory exists", and a
+            # concurrent publisher creating the same level a moment earlier has established it.
+            return
+
+    def upload(self, path: str, local: Path, metadata: dict[str, str]) -> None:
+        size = local.stat().st_size
+        with open(local, "rb") as fh:
+            self.share.get_file_client(path).upload_file(fh, length=size, metadata=metadata)
+
+    def list_files(self, directory: str) -> dict[str, int | None]:
+        d = self.share.get_directory_client(directory)
+        try:
+            items = list(d.list_directories_and_files())
+        except self._not_found:
+            # A directory that is not there holds no files: every manifest entry under it is
+            # reported `absent`, which refuses the seal by name. Any OTHER failure propagates.
+            return {}
+        return {item["name"]: item.get("size") for item in items if not item["is_directory"]}
+
+    def get_properties(self, path: str) -> tuple[dict[str, str], int | None]:
+        props = self.share.get_file_client(path).get_file_properties()
+        return dict(props.metadata or {}), props.size
+
+
+def make_backend(account: str, share: str) -> ShareBackend:
+    fake = os.environ.get("PUBLISH_BAKE_FAKE_SHARE_BACKEND")
+    if fake:
+        spec = importlib.util.spec_from_file_location("publish_bake_fake_backend", fake)
+        if spec is None or spec.loader is None:
+            raise SystemExit(f"::error::PUBLISH_BAKE_FAKE_SHARE_BACKEND={fake!r} is not a loadable module")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        log(f"backend: FAKE share ({fake}) — this is a harness run, not Azure Files")
+        return module.make_backend(account, share)
+    return AzureFilesBackend(account, share)
+
+
+# ───────────────────────────── inputs ─────────────────────────────
+def read_table(path: Path, columns: int, what: str) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for n, line in enumerate(path.read_text().splitlines(), 1):
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        if len(fields) != columns:
+            raise SystemExit(f"::error::{what} line {n} has {len(fields)} tab-separated field(s), "
+                             f"{columns} expected: {line!r}")
+        rows.append(fields)
+    if not rows:
+        # A plan or manifest with nothing in it would upload or verify nothing and exit 0 — the
+        # vacuity every gate here refuses to render as green.
+        raise SystemExit(f"::error::{what} at {path} is EMPTY — nothing to do is a failure here, "
+                         f"never a success")
+    return rows
+
+
+def joined(dest: str, rel: str) -> str:
+    return f"{dest}/{rel}" if dest else rel
+
+
+def parent_directories(dest: str, rels: Iterable[str]) -> list[str]:
+    """Every directory level any planned file needs, shallowest first, each once."""
+    levels: list[str] = []
+    for rel in rels:
+        full = joined(dest, rel)
+        parts = full.split("/")[:-1]
+        for i in range(1, len(parts) + 1):
+            level = "/".join(parts[:i])
+            if level not in levels:
+                levels.append(level)
+    levels.sort(key=lambda p: p.count("/"))
+    return levels
+
+
+def workers_arg(value: int) -> int:
+    if value < 1:
+        raise SystemExit(f"::error::--workers must be at least 1, got {value}")
+    return value
+
+
+# ───────────────────────────── upload ─────────────────────────────
+def cmd_upload(args: argparse.Namespace) -> int:
+    plan = read_table(Path(args.plan), 3, "the upload plan")
+    for rel, local, digest in plan:
+        if not Path(local).is_file():
+            raise SystemExit(f"::error::the upload plan names {local} for {rel}, and it is not a file")
+        if not digest:
+            raise SystemExit(f"::error::the upload plan carries no digest for {rel} — it would be "
+                             f"published and never verifiable")
+    backend = make_backend(args.account, args.share)
+    for level in parent_directories(args.dest, (rel for rel, _, _ in plan)):
+        backend.ensure_directory(level)
+
+    started = time.monotonic()
+    total_bytes = 0
+    failures: list[str] = []
+
+    def one(rel: str, local: str, digest: str) -> tuple[str, int]:
+        backend.upload(joined(args.dest, rel), Path(local),
+                       {"digest": digest, "publication": args.publication})
+        return rel, Path(local).stat().st_size
+
+    # 🚨 `max_workers=1` makes the plan order the upload order; the overlap harness relies on that
+    # to interleave a second publisher at a named file. The reader contract needs no order among
+    # these files at all — only that `_complete` (a separate call, after verification) is LAST.
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(one, rel, local, digest): rel for rel, local, digest in plan}
+        for future in as_completed(futures):
+            rel = futures[future]
+            try:
+                _, size = future.result()
+            except Exception as exc:  # noqa: BLE001 — named on stderr and fatal, never swallowed
+                failures.append(rel)
+                log(f"::error::upload of {joined(args.dest, rel)} to {args.account}/{args.share} "
+                    f"FAILED: {type(exc).__name__}: {exc}")
+                pool.shutdown(wait=True, cancel_futures=True)
+                break
+            total_bytes += size
+            log(f"published: {args.account}/{args.share}/{joined(args.dest, rel)}")
+    elapsed = time.monotonic() - started
+    if failures:
+        log(f"::error::{len(failures)} upload(s) failed after {elapsed:.1f}s; the remaining "
+            f"{len(plan) - len(failures)} were completed or cancelled. Nothing is sealed.")
+        return 1
+    log(f"uploaded {len(plan)} file(s), {total_bytes} bytes, to {args.account}/{args.share}/"
+        f"{args.dest} in {elapsed:.1f}s ({args.workers} worker(s), one process)")
+    return 0
+
+
+# ───────────────────────────── verify / stamp ─────────────────────────────
+def row(path: str, state: str, metadata: dict[str, str] | None, length: int | None) -> str:
+    md = metadata or {}
+    digest = md.get("digest") or ABSENT
+    publication = md.get("publication") or ABSENT
+    size = str(length) if length is not None else ABSENT
+    return "\t".join((path, state, digest, publication, size))
+
+
+def read_one(backend: ShareBackend, path: str) -> str:
+    try:
+        metadata, length = backend.get_properties(path)
+    except Exception as exc:  # noqa: BLE001 — reported as `error`, which refuses the seal by name
+        log(f"::error::could not read the properties of {path}: {type(exc).__name__}: {exc}")
+        return row(path, "error", None, None)
+    return row(path, "ok", metadata, length)
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    manifest = read_table(Path(args.manifest), 2, "the publication manifest")
+    backend = make_backend(args.account, args.share)
+    started = time.monotonic()
+
+    # ONE listing per directory the manifest names (the destination itself and, today, modules/).
+    directories: list[str] = []
+    for rel, _ in manifest:
+        d = "/".join(rel.split("/")[:-1])
+        if d not in directories:
+            directories.append(d)
+    listed: dict[str, dict[str, int | None]] = {}
+    for d in directories:
+        try:
+            listed[d] = backend.list_files(joined(args.dest, d))
+        except Exception as exc:  # noqa: BLE001
+            log(f"::error::could not list {args.account}/{args.share}/{joined(args.dest, d)}: "
+                f"{type(exc).__name__}: {exc} — nothing under it can be verified")
+            return 1
+    listed_count = sum(len(files) for files in listed.values())
+
+    present: list[str] = []
+    results: dict[str, str] = {}
+    for rel, _ in manifest:
+        d, _, name = rel.rpartition("/")
+        if name in listed.get(d, {}):
+            present.append(rel)
+        else:
+            results[rel] = row(joined(args.dest, rel), "absent", None, None)
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(read_one, backend, joined(args.dest, rel)): rel for rel in present}
+        for future in as_completed(futures):
+            results[futures[future]] = future.result()
+
+    manifest_names = {rel for rel, _ in manifest}
+    extra = sorted(
+        f"{d}/{name}" if d else name
+        for d, files in listed.items() for name in files
+        if (f"{d}/{name}" if d else name) not in manifest_names and name != SENTINEL
+    )
+    for rel, _ in manifest:
+        sys.stdout.write(results[rel] + "\n")
+    sys.stdout.flush()
+    elapsed = time.monotonic() - started
+    states = {"ok": 0, "absent": 0, "error": 0}
+    for text in results.values():
+        states[text.split("\t")[1]] += 1
+    log(f"verified {len(manifest)} file(s) under {args.account}/{args.share}/{args.dest} in "
+        f"{elapsed:.1f}s: {states['ok']} read, {states['absent']} absent, {states['error']} "
+        f"unreadable ({listed_count} listed in {len(directories)} listing call(s), "
+        f"{args.workers} worker(s), one process)")
+    if extra:
+        log(f"note: {len(extra)} listed file(s) under {args.dest} are not in this publication and "
+            f"were not read: {' '.join(extra)}")
+    # Rows carry the verdict per file; the exit code says only whether the sweep itself ran.
+    return 0
+
+
+def cmd_stamp(args: argparse.Namespace) -> int:
+    backend = make_backend(args.account, args.share)
+    sys.stdout.write(read_one(backend, args.path) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+# ───────────────────────────── sdk-check ─────────────────────────────
+def cmd_sdk_check(args: argparse.Namespace) -> int:
+    import importlib.metadata as md
+
+    pins = [p for p in (args.pins or "").split() if p]
+    if not pins:
+        raise SystemExit("::error::sdk-check needs --pins 'name==version …' — an unpinned check "
+                         "proves nothing about what production runs")
+    for pin in pins:
+        name, sep, version = pin.partition("==")
+        if not sep or not version:
+            raise SystemExit(f"::error::pin {pin!r} is not of the form name==version")
+        installed = md.version(name)
+        if installed != version:
+            raise SystemExit(f"::error::{name} is {installed}, the pin says {version} — this helper "
+                             f"must run against the versions it was verified with")
+    from azure.core.credentials import AccessToken
+    from azure.storage.fileshare import ShareClient, ShareDirectoryClient, ShareFileClient
+
+    class _NoNetworkCredential:
+        def get_token(self, *scopes, **kwargs):  # pragma: no cover — never called
+            return AccessToken("unused", 0)
+
+    share = ShareClient("https://sdkcheck.file.core.windows.net", "sdkcheck",
+                        credential=_NoNetworkCredential(), token_intent="backup")
+    file = share.get_file_client("dir/file.zip")
+    directory = share.get_directory_client("dir")
+    for obj, attrs in ((file, ("upload_file", "get_file_properties")),
+                       (directory, ("exists", "create_directory", "list_directories_and_files"))):
+        for a in attrs:
+            if not callable(getattr(obj, a, None)):
+                raise SystemExit(f"::error::{type(obj).__name__}.{a} is missing — the SDK surface "
+                                 f"this helper uses has moved")
+    assert isinstance(file, ShareFileClient) and isinstance(directory, ShareDirectoryClient)
+    log("sdk-check: " + " ".join(f"{p.split('==')[0]}=={md.version(p.split('==')[0])}" for p in pins)
+        + " — clients construct with token_intent=backup; no network was touched")
+    return 0
+
+
+# ───────────────────────────── main ─────────────────────────────
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="bulk share I/O for publish-bake-bundles.sh")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    def target(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--account", required=True)
+        p.add_argument("--share", required=True)
+
+    up = sub.add_parser("upload", help="upload every file of a plan, stamped, in one process")
+    target(up)
+    up.add_argument("--dest", required=True, help="directory under the share the plan is relative to")
+    up.add_argument("--plan", required=True, help="<path-under-dest>\\t<local-file>\\t<sha256> per line")
+    up.add_argument("--publication", required=True, help="this run's publication token")
+    up.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    up.set_defaults(fn=cmd_upload)
+
+    ve = sub.add_parser("verify", help="list once, read every manifest file's stamps, print TSV rows")
+    target(ve)
+    ve.add_argument("--dest", required=True)
+    ve.add_argument("--manifest", required=True, help="<path-under-dest>\\t<sha256> per line")
+    ve.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    ve.set_defaults(fn=cmd_verify)
+
+    st = sub.add_parser("stamp", help="one TSV row for one file")
+    target(st)
+    st.add_argument("--path", required=True, help="full path under the share")
+    st.set_defaults(fn=cmd_stamp)
+
+    sc = sub.add_parser("sdk-check", help="the pinned SDK imports and its clients construct")
+    sc.add_argument("--pins", required=True, help="'name==version …' as installed")
+    sc.set_defaults(fn=cmd_sdk_check)
+
+    args = ap.parse_args(argv)
+    if hasattr(args, "workers"):
+        args.workers = workers_arg(args.workers)
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-publish-bake-overlap.py
+++ b/.github/scripts/test-publish-bake-overlap.py
@@ -36,22 +36,35 @@ HOW IT STAYS HONEST
   the stub cannot drift apart silently: change the script's query and this harness goes red until
   the stub is taught the new one.
 
+TWO I/O EDGES, TWO STUBS
+------------------------
+Since 2026-09-08 the script publishes and reads back through `publish-bake-files.py` — ONE process
+per phase per target on the Azure SDK, replacing 46 + 46 CLI launches per target — and keeps `az`
+only for the per-target decisions (does the sentinel exist, what does a marker say) and the rare
+paths (unseal, release marker, architecture backfill). So the harness substitutes BOTH edges over
+ONE filesystem share: the stub `az` on PATH, and a fake share backend the helper loads from
+`PUBLISH_BAKE_FAKE_SHARE_BACKEND`. They read and write the same files and the same per-file
+metadata, so a file the helper uploads is the file the stub's `exists`/`download` answers about.
+The second-publisher hooks moved to the fake backend's `upload`, and the harness runs the upload
+pool ONE wide so the plan order is the upload order and "hook onto architecture.txt" means what it
+always meant; one control case runs the default pool width so the parallel path is exercised too.
+
 WHAT THIS HARNESS CANNOT PROVE
 ------------------------------
-The stub is not Azure Files. It reproduces the parts the script depends on — an extensionless
-`--path` naming a directory, per-file metadata, the sentinel written last — and nothing else. In
-particular the exact JSON shape of the real `az storage file show` is taken from the CLI's own
-transformer (`transform_file_show_result` puts the file's metadata at the TOP level), and asserted
-only there. What the harness CAN prove about the real CLI it does: the fidelity case runs the read-
-back query through the real `jmespath` engine azure-cli evaluates `--query` with, and asserts the
-shape knack then renders as ONE tab-separated row. That case exists because the first draft of this
-change used a flat `[a, b]` — which knack prints as TWO LINES, so `$2` would have read empty for
-every file and the postcondition would have refused every publication in the fleet. The stub said
-nothing, because the stub was written to match the draft.
+The fake is not Azure Files. It reproduces the parts the script depends on — per-file metadata,
+directories, the sentinel written last — and nothing else. Two things are asserted against the REAL
+pieces instead: `sdk-check` imports the PINNED SDK the script installs and constructs the clients
+the helper uses (no network), so an SDK surface move is red here and not in a production publish;
+and the helper's TSV rendering — five fields, `-` for an absent stamp, `absent`/`error` never
+disguised as "no digest" — is pinned by running the helper itself against the fake, because that
+rendering is what the bash parse asserts a field count on. The lesson behind that case is older
+than the helper: the first draft of the CLI-based read used a `--query` shape that knack rendered as
+two LINES instead of two columns, so `$2` would have read empty for every file and the
+postcondition would have refused every publication in the fleet — and the stub of the day said
+nothing, because it was written to match the draft.
 
-Beyond that the script fails CLOSED on an unreadable, empty or unexpectedly-shaped answer, so a CLI
-change is a RED publish rather than a silent one — the only protection available against a shape
-this harness cannot run.
+Beyond that the script fails CLOSED on an unreadable, empty or unexpectedly-shaped answer, so a
+rendering change is a RED publish rather than a silent one.
 """
 
 from __future__ import annotations
@@ -60,23 +73,17 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
-
-try:
-    import jmespath
-except ImportError:  # pragma: no cover — the CI step installs it; locally `pip install jmespath`
-    print("::error::test-publish-bake-overlap.py needs jmespath (the engine azure-cli evaluates "
-          "--query with) to assert how the publish script's read-back query renders. Refusing "
-          "rather than skipping that case: it is the one thing this harness's stub cannot prove "
-          "about the real CLI.")
-    raise SystemExit(1) from None
 
 HERE = Path(__file__).resolve().parent
 DEFAULT_SCRIPT = HERE / "publish-bake-bundles.sh"
+HELPER = HERE / "publish-bake-files.py"
 
 IDENTITY = "s0123456789abcdef0123456789abcdef"
 SOURCE = "plugins"
@@ -87,15 +94,6 @@ DEST = f"prebuilt-bundles/{IDENTITY}/{SOURCE}"
 SENTINEL = "_complete"
 # Must match ShippedPrebuiltBundles.PublicationPointerFileName and the POINTER in the script.
 POINTER = "_current"
-
-# 🚨 THE ONE `file show` QUERY, and its exact shape is load-bearing. knack's `format_tsv` renders a
-# TOP-LEVEL list as ROWS, so `--query "[a, b]" -o tsv` prints TWO LINES rather than two columns; a
-# script parsing `$2` would then read EMPTY for every file, count `ours` as zero on every publish,
-# and refuse every publication in the fleet as "superseded". A list-of-ONE-ROW renders one
-# tab-separated line. And a null field renders as the LITERAL 'None', which is why both fields
-# carry a `|| '-'` guard. Measured against azure-cli 2.90.0's own jmespath + knack formatter; the
-# fidelity case below re-asserts it with the real jmespath engine on every run.
-SHOW_QUERY = "[[metadata.digest || '-', metadata.publication || '-']]"
 
 BUNDLES = ["Chess.zip", "Edu.zip", "Store.zip"]
 MODULES = ["MeshWeaver.AI.module.nupkg", "MeshWeaver.Maps.module.nupkg"]
@@ -159,25 +157,6 @@ def meta_path(p):
 def emit(v):
     sys.stdout.write(v + "\n")
 
-def run_hook(when, rel):
-    on = os.environ.get("MOCK_AZ_HOOK_ON")
-    if not on or on != rel:
-        return
-    if os.environ.get("MOCK_AZ_HOOK_WHEN", "before") != when:
-        return
-    once = os.environ.get("MOCK_AZ_HOOK_ONCE")
-    if once:
-        marker = Path(once)
-        if marker.exists():
-            return
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text("fired")
-    cmd = os.environ["MOCK_AZ_HOOK_CMD"]
-    env = dict(os.environ)
-    for k in ("MOCK_AZ_HOOK_ON", "MOCK_AZ_HOOK_CMD", "MOCK_AZ_HOOK_ONCE", "MOCK_AZ_HOOK_WHEN"):
-        env.pop(k, None)
-    subprocess.run(["bash", "-c", cmd], env=env, check=False)
-
 if group == "storage" and verb == "":
     die("no verb: " + raw)
 
@@ -205,38 +184,27 @@ if action == "exists":
     emit("true" if (share_root() / path).is_file() else "false"); sys.exit(0)
 
 if action == "upload":
+    # Only the architecture BACKFILL still uploads through the CLI (unstamped, onto a sealed
+    # incumbent); the publication itself goes through the helper and the fake backend below.
     src = Path(flag("--source"))
     dest_dir = share_root() / path
     # 🚨 The real CLI silently treats an EXTENSIONLESS --path as a DIRECTORY and appends the
-    # source basename; the script relies on that for _complete, modules/_index and the two
-    # markers. Model it by the same rule the script documents: an existing directory wins.
+    # source basename; the script relies on that for the markers it still uploads this way.
+    # Model it by the same rule the script documents: an existing directory wins.
     if dest_dir.is_dir():
         target = dest_dir / src.name
     else:
         target = share_root() / path
     rel = str(target.relative_to(share_root()))
-    run_hook("before", rel)
-    n = int(os.environ.get("MOCK_AZ_UPLOADS_SO_FAR_FILE_COUNT", "0"))
-    counter = os.environ.get("MOCK_AZ_UPLOAD_COUNTER")
-    if counter:
-        c = Path(counter)
-        n = (int(c.read_text()) if c.exists() else 0) + 1
-        c.write_text(str(n))
-        cap = os.environ.get("MOCK_AZ_FAIL_UPLOADS_AFTER")
-        if cap and n > int(cap):
-            sys.stderr.write("stub-az: simulated upload failure (#%d)\n" % n)
-            sys.exit(1)
+    if opts.get("--metadata"):
+        die("a stamped upload through the CLI — the publication's files go through "
+            "publish-bake-files.py now; this stub models only the unstamped backfill: " + raw)
     if not target.parent.is_dir():
         sys.stderr.write("stub-az: ParentNotFound for %s\n" % target); sys.exit(1)
     target.write_bytes(src.read_bytes())
-    md = {}
-    for kv in opts.get("--metadata", []):
-        k, _, v = kv.partition("=")
-        md[k] = v
     mp = meta_path(rel)
-    mp.parent.mkdir(parents=True, exist_ok=True)
-    mp.write_text(json.dumps(md))
-    run_hook("after", rel)
+    if mp.exists():
+        mp.unlink()
     sys.exit(0)
 
 if action == "download":
@@ -257,37 +225,117 @@ if action == "delete":
         mp.unlink()
     sys.exit(0)
 
-if action == "show":
-    SHOW_QUERY = os.environ["MOCK_AZ_SHOW_QUERY"]
+if action == "list":
+    # The ONE listing the script takes through the CLI: the diagnostic on a read-back refusal
+    # (MeshWeaver#3461, #3731) — "what the directory holds now", from inside the job's credential.
     q = opts.get("--query", [None])[0]
-    if q != SHOW_QUERY or not out_tsv:
-        die("this stub models exactly one `file show` query, %r with -o tsv — the script asked "
-            "for %r. Teach the stub the new query (and re-measure how knack renders it) rather "
-            "than loosening it." % (SHOW_QUERY, q))
-    # Reproduces the ONE way the read-back loop can end early: a command inside a `while read`
-    # loop that consumes the loop's stdin. Without the script's `< /dev/null` (and the accounting
-    # assertion behind it), the verification would cover a PREFIX of the publication and seal.
-    if os.environ.get("MOCK_AZ_EAT_STDIN") == "1":
-        try:
-            sys.stdin.read()
-        except Exception:
-            pass
-    fails = os.environ.get("MOCK_AZ_SHOW_FAILS")
-    if fails and path.endswith(fails):
-        sys.stderr.write("stub-az: simulated read failure for %s\n" % path); sys.exit(1)
-    f = share_root() / path
-    if not f.is_file():
+    if q != "[].{name:name, bytes:properties.contentLength}" or not out_tsv:
+        die("only the refusal diagnostic's listing query is modelled for file list: " + raw)
+    d = share_root() / path
+    if not d.is_dir():
         sys.stderr.write("stub-az: ResourceNotFound %s\n" % path); sys.exit(1)
-    mp = meta_path(path)
-    md = json.loads(mp.read_text()) if mp.exists() else {}
-    # 🚨 The rendering the REAL cli produces, measured against azure-cli 2.90.0's own jmespath +
-    # knack.output.format_tsv: `[[a || '-', b || '-']]` is ONE tab-separated row, and an absent
-    # value is '-'. A flat `[a, b]` would print two LINES instead, which is the shape the script
-    # must never go back to — see the fidelity assertion in run_cases.
-    emit("%s\t%s" % (md.get("digest") or "-", md.get("publication") or "-"))
+    for p in sorted(d.iterdir()):
+        if p.is_file():
+            emit("%s\t%d" % (p.name, p.stat().st_size))
     sys.exit(0)
 
+# `show` is deliberately NOT modelled: the per-file read-back is the launch storm this harness's
+# subject retired (46 processes per target). A script that reaches for it again dies here.
 die("unmodelled file action %r" % action)
+'''
+
+
+# ────────────────────────────── the fake share backend ──────────────────────────────
+# Loaded by publish-bake-files.py from PUBLISH_BAKE_FAKE_SHARE_BACKEND, over the SAME filesystem
+# share and the SAME `.meta` sidecars the stub `az` reads and writes. Every second-publisher hook
+# lives here now, on `upload`, because that is where the publication's bytes land.
+FAKE_BACKEND = r'''
+import json, os, subprocess, sys, threading
+from pathlib import Path
+
+ROOT = Path(os.environ["MOCK_AZ_ROOT"])
+_LOCK = threading.Lock()
+
+
+def _run_hook(when, rel):
+    on = os.environ.get("MOCK_AZ_HOOK_ON")
+    if not on or on != rel:
+        return
+    if os.environ.get("MOCK_AZ_HOOK_WHEN", "before") != when:
+        return
+    once = os.environ.get("MOCK_AZ_HOOK_ONCE")
+    if once:
+        marker = Path(once)
+        if marker.exists():
+            return
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("fired")
+    cmd = os.environ["MOCK_AZ_HOOK_CMD"]
+    env = dict(os.environ)
+    for k in ("MOCK_AZ_HOOK_ON", "MOCK_AZ_HOOK_CMD", "MOCK_AZ_HOOK_ONCE", "MOCK_AZ_HOOK_WHEN"):
+        env.pop(k, None)
+    subprocess.run(["bash", "-c", cmd], env=env, check=False)
+
+
+class FakeShare:
+    def __init__(self, account, share):
+        self.root = ROOT / account / share
+        self.meta = ROOT / ".meta" / account / share
+
+    def _meta(self, path):
+        return self.meta / (path + ".json")
+
+    def ensure_directory(self, path):
+        (self.root / path).mkdir(parents=True, exist_ok=True)
+
+    def upload(self, path, local, metadata):
+        _run_hook("before", path)
+        counter = os.environ.get("MOCK_AZ_UPLOAD_COUNTER")
+        if counter:
+            with _LOCK:
+                c = Path(counter)
+                n = (int(c.read_text()) if c.exists() else 0) + 1
+                c.write_text(str(n))
+            cap = os.environ.get("MOCK_AZ_FAIL_UPLOADS_AFTER")
+            if cap and n > int(cap):
+                raise RuntimeError("simulated upload failure (#%d)" % n)
+        target = self.root / path
+        if not target.parent.is_dir():
+            raise FileNotFoundError("ParentNotFound for %s" % target)
+        target.write_bytes(Path(local).read_bytes())
+        mp = self._meta(path)
+        mp.parent.mkdir(parents=True, exist_ok=True)
+        mp.write_text(json.dumps(dict(metadata)))
+        _run_hook("after", path)
+
+    def list_files(self, directory):
+        d = self.root / directory
+        if not d.is_dir():
+            return {}
+        return {p.name: p.stat().st_size for p in d.iterdir() if p.is_file()}
+
+    def get_properties(self, path):
+        # Reproduces the ONE way a read-back loop could end early: a command inside a `while read`
+        # loop that consumes the loop's stdin. The helper runs OUTSIDE that loop now, and this
+        # keeps the case honest if anyone ever moves it back in.
+        if os.environ.get("MOCK_AZ_EAT_STDIN") == "1":
+            try:
+                sys.stdin.read()
+            except Exception:
+                pass
+        fails = os.environ.get("MOCK_AZ_SHOW_FAILS")
+        if fails and path.endswith(fails):
+            raise RuntimeError("simulated read failure for %s" % path)
+        f = self.root / path
+        if not f.is_file():
+            raise FileNotFoundError("ResourceNotFound %s" % path)
+        mp = self._meta(path)
+        md = json.loads(mp.read_text()) if mp.exists() else {}
+        return md, f.stat().st_size
+
+
+def make_backend(account, share):
+    return FakeShare(account, share)
 '''
 
 
@@ -409,22 +457,43 @@ class Harness:
         az = self.bin / "az"
         az.write_text(STUB_AZ)
         az.chmod(0o755)
+        self.backend = workdir / "fake_share_backend.py"
+        self.backend.write_text(FAKE_BACKEND)
+
+    def base_env(self) -> dict[str, str]:
+        return {
+            "MOCK_AZ_ROOT": str(self.shelf_root),
+            "PUBLISH_BAKE_FAKE_SHARE_BACKEND": str(self.backend),
+            # The harness's own interpreter carries the pinned SDK (CI installs it into the same
+            # venv this file runs from), so the script does not build a venv per publication —
+            # and sdk-check still holds it to the pins on every run.
+            "PUBLISH_BAKE_PYTHON": sys.executable,
+            # ONE upload at a time, so the plan order is the upload order and a hook "before
+            # Store.zip" / "after architecture.txt" means what it always meant. The parallel
+            # control case below unsets this.
+            "PUBLISH_BAKE_UPLOAD_WORKERS": "1",
+            "BAKE_PUBLISH_TARGETS": TARGET,
+            "GITHUB_RUN_ATTEMPT": "1",
+        }
 
     def publish(self, bake: Bake, publisher: str, run_id: str, env_extra: dict | None = None):
         env = dict(os.environ)
         env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
-        env["MOCK_AZ_ROOT"] = str(self.shelf_root)
-        env["MOCK_AZ_SHOW_QUERY"] = SHOW_QUERY
-        env["BAKE_PUBLISH_TARGETS"] = TARGET
+        env.update(self.base_env())
         env["GITHUB_REPOSITORY"] = publisher
         env["GITHUB_RUN_ID"] = run_id
-        env["GITHUB_RUN_ATTEMPT"] = "1"
         env.pop("EXT_MODULES_DIR", None)
         env.pop("GITHUB_STEP_SUMMARY", None)
+        env.pop("RUNNER_TEMP", None)
         for k in ("MOCK_AZ_HOOK_ON", "MOCK_AZ_HOOK_CMD", "MOCK_AZ_HOOK_ONCE", "MOCK_AZ_HOOK_WHEN",
-                  "MOCK_AZ_FAIL_UPLOADS_AFTER", "MOCK_AZ_UPLOAD_COUNTER", "MOCK_AZ_SHOW_FAILS"):
+                  "MOCK_AZ_FAIL_UPLOADS_AFTER", "MOCK_AZ_UPLOAD_COUNTER", "MOCK_AZ_SHOW_FAILS",
+                  "MOCK_AZ_EAT_STDIN"):
             env.pop(k, None)
-        env.update({k: str(v) for k, v in (env_extra or {}).items()})
+        for k, v in (env_extra or {}).items():
+            if v is None:
+                env.pop(k, None)
+            else:
+                env[k] = str(v)
         return subprocess.run(
             ["bash", str(self.script), str(bake.dir), SOURCE, bake.source_sha],
             capture_output=True, text=True, env=env,
@@ -432,16 +501,13 @@ class Harness:
 
     def publish_command(self, bake: Bake, publisher: str, run_id: str,
                         env_extra: dict | None = None) -> str:
-        """The same publication, as a shell command a stub hook can run mid-upload."""
-        assigns = {
-            "PATH": f"{self.bin}:$PATH",
-            "MOCK_AZ_ROOT": str(self.shelf_root),
-            "MOCK_AZ_SHOW_QUERY": SHOW_QUERY,
-            "BAKE_PUBLISH_TARGETS": TARGET,
+        """The same publication, as a shell command a backend hook can run mid-upload."""
+        assigns = {"PATH": f"{self.bin}:$PATH"}
+        assigns.update(self.base_env())
+        assigns.update({
             "GITHUB_REPOSITORY": publisher,
             "GITHUB_RUN_ID": run_id,
-            "GITHUB_RUN_ATTEMPT": "1",
-        }
+        })
         assigns.update({k: str(v) for k, v in (env_extra or {}).items()})
         prefix = " ".join(f'{k}="{v}"' for k, v in assigns.items())
         return (f'{prefix} bash "{self.script}" "{bake.dir}" {SOURCE} {bake.source_sha}'
@@ -477,42 +543,111 @@ def denominator(shelf: Shelf) -> str:
 
 
 # ────────────────────────────── the cases ──────────────────────────────
-def check_query_fidelity(script: Path) -> None:
-    """The one thing the stub cannot prove: how the REAL cli renders this script's read-back query.
+def script_code_lines(script: Path) -> str:
+    """The script minus its comments — the launch storm is named in a comment as history."""
+    return "\n".join(l for l in script.read_text().splitlines() if not l.lstrip().startswith("#"))
 
-    knack.output.format_tsv does `result if isinstance(result, list) else [result]` and then dumps
-    each element as a ROW. So a flat two-element list is two LINES, and only a list-of-one-list is
-    one row of two tab-separated columns. Asserted here with the engine azure-cli itself uses.
+
+def check_helper_shape(script: Path, h: "Harness") -> None:
+    """Pin the two things the fake cannot stand in for: the helper's rendering, and the real SDK.
+
+    The bash parse asserts a FIELD COUNT on every row and reads `-` as "no stamp"; a rendering
+    change on the helper's side is therefore a fleet-wide false verdict unless it is pinned here.
+    And the fake backend never imports the SDK, so `sdk-check` — the same call the script makes
+    after its pinned install — is run against the real one: a moved client surface goes red in
+    this harness instead of in a production publish.
     """
-    print("\nquery fidelity (the stub cannot prove this; the real jmespath engine can):")
-    text = script.read_text()
-    check("the script asks for exactly the query this harness models",
-          SHOW_QUERY in text, f"{SHOW_QUERY!r}")
+    print("\nthe bulk helper (the fake cannot prove these; the helper and the real SDK can):")
+    code = script_code_lines(script)
+    check("the script publishes and reads back through publish-bake-files.py",
+          "publish-bake-files.py" in code and code.count('"$PYTHON" "$HELPER"') >= 4,
+          "upload, verify, stamp and sdk-check are all routed through the helper")
+    check("the script no longer launches a CLI process per file",
+          "az storage file show" not in code and "--metadata" not in code,
+          "no `az storage file show`, no stamped `az storage file upload` outside comments")
+    pins = re.search(r'SDK_PINS=\((.*?)\)', code)
+    check("the script pins the SDK it installs", bool(pins) and "==" in (pins.group(1) if pins else ""),
+          pins.group(1) if pins else "no SDK_PINS=( … ) in the script")
+    if pins:
+        pin_list = " ".join(p.strip('"') for p in pins.group(1).split())
+        r = subprocess.run([sys.executable, str(HELPER), "sdk-check", "--pins", pin_list],
+                           capture_output=True, text=True)
+        check("sdk-check passes against the REAL, pinned SDK (clients construct, no network)",
+              r.returncode == 0 and "token_intent=backup" in r.stderr,
+              f"rc={r.returncode}: {(r.stderr or r.stdout).strip().splitlines()[-1:] }")
 
-    rows = jmespath.compile(SHOW_QUERY).search(
-        {"name": "a.zip", "metadata": {"digest": "abc", "publication": "Systemorph-MW-1-1"}})
-    check("the query yields ONE row of TWO columns, not two rows",
-          isinstance(rows, list) and len(rows) == 1
-          and isinstance(rows[0], list) and len(rows[0]) == 2,
-          f"jmespath -> {rows!r}; knack would render {chr(9).join(rows[0])!r} on one line"
-          if isinstance(rows, list) and rows and isinstance(rows[0], list) else f"jmespath -> {rows!r}")
-
-    # A null field renders as the literal string 'None' unless it is guarded, and 'None' is not
-    # empty — so the script's fail-closed "no digest recorded" branch would never fire.
-    for label, doc in (("no metadata key", {"name": "a.zip"}),
-                       ("empty metadata", {"name": "a.zip", "metadata": {}}),
-                       ("null metadata", {"name": "a.zip", "metadata": None})):
-        got = jmespath.compile(SHOW_QUERY).search(doc)
-        check(f"an absent value is rendered '-' rather than a null ({label})",
-              got == [["-", "-"]], f"jmespath -> {got!r}")
+    # The rendering, pinned by running the helper against the fake: four states of one shelf.
+    h.reset()
+    shelf = h.shelf_root / ACCOUNT / SHARE / DEST
+    meta = h.shelf_root / ".meta" / ACCOUNT / SHARE / DEST
+    (shelf / "modules").mkdir(parents=True)
+    meta.mkdir(parents=True)
+    (shelf / "stamped.zip").write_bytes(b"12345")
+    (meta / "stamped.zip.json").write_text(json.dumps({"digest": "d1", "publication": "P-1-1"}))
+    (shelf / "unstamped.zip").write_bytes(b"")
+    (meta / "unstamped.zip.json").write_text(json.dumps({}))
+    (shelf / "modules" / "half.nupkg").write_bytes(b"xy")
+    (meta / "modules").mkdir()
+    (meta / "modules" / "half.nupkg.json").write_text(json.dumps({"digest": "", "publication": "P-2-1"}))
+    (shelf / "stray.zip").write_bytes(b"not in the manifest")
+    manifest = h.work / "shape-manifest"
+    manifest.write_text("stamped.zip\td1\nunstamped.zip\td2\nmodules/half.nupkg\td3\n"
+                        "missing.zip\td4\nbroken.zip\td5\n")
+    (shelf / "broken.zip").write_bytes(b"?")
+    env = dict(os.environ, **h.base_env(), MOCK_AZ_SHOW_FAILS="broken.zip")
+    r = subprocess.run([sys.executable, str(HELPER), "verify", "--account", ACCOUNT, "--share", SHARE,
+                        "--dest", DEST, "--manifest", str(manifest)],
+                       capture_output=True, text=True, env=env)
+    rows = [l.split("\t") for l in r.stdout.splitlines() if l]
+    check("verify answers ONE row per manifest line, in manifest order, and exits 0",
+          r.returncode == 0 and [row[0] for row in rows] == [
+              f"{DEST}/stamped.zip", f"{DEST}/unstamped.zip", f"{DEST}/modules/half.nupkg",
+              f"{DEST}/missing.zip", f"{DEST}/broken.zip"],
+          f"rc={r.returncode}, rows={[row[0] for row in rows]}")
+    check("every row has exactly FIVE tab-separated fields",
+          bool(rows) and all(len(row) == 5 for row in rows),
+          f"field counts {[len(row) for row in rows]}")
+    by_name = {row[0].rsplit("/", 1)[-1]: row for row in rows}
+    check("a stamped file reads ok with both stamps and its length",
+          by_name.get("stamped.zip") == [f"{DEST}/stamped.zip", "ok", "d1", "P-1-1", "5"],
+          repr(by_name.get("stamped.zip")))
+    check("an absent stamp renders '-' — never empty, never 'None'",
+          by_name.get("unstamped.zip", [None] * 5)[1:4] == ["ok", "-", "-"]
+          and by_name.get("half.nupkg", [None] * 5)[1:4] == ["ok", "-", "P-2-1"],
+          f"{by_name.get('unstamped.zip')!r} / {by_name.get('half.nupkg')!r}")
+    check("a file the listing does not contain is 'absent', not 'no digest'",
+          by_name.get("missing.zip") == [f"{DEST}/missing.zip", "absent", "-", "-", "-"],
+          repr(by_name.get("missing.zip")))
+    check("a file whose read FAILS is 'error', named on stderr, and the sweep still completes",
+          by_name.get("broken.zip") == [f"{DEST}/broken.zip", "error", "-", "-", "-"]
+          and "::error::" in r.stderr and "broken.zip" in r.stderr,
+          repr(by_name.get("broken.zip")))
+    check("the sweep names its cost and its denominator",
+          re.search(r"verified 5 file\(s\) under .* in [0-9.]+s: 3 read, 1 absent, 1 unreadable "
+                    r"\(5 listed in 2 listing call\(s\)", r.stderr) is not None,
+          next((l for l in r.stderr.splitlines() if l.startswith("verified ")), "<no 'verified' line>"))
+    check("a file on the shelf that is not in the publication is noted, not read",
+          "stray.zip" in r.stderr and not any(row[0].endswith("stray.zip") for row in rows))
+    r = subprocess.run([sys.executable, str(HELPER), "stamp", "--account", ACCOUNT, "--share", SHARE,
+                        "--path", f"{DEST}/stamped.zip"], capture_output=True, text=True, env=env)
+    check("stamp answers the same row shape for one file",
+          r.returncode == 0 and r.stdout.strip().split("\t") == [f"{DEST}/stamped.zip", "ok", "d1", "P-1-1", "5"],
+          repr(r.stdout.strip()))
+    # An EMPTY manifest must not verify nothing and exit 0.
+    empty = h.work / "empty-manifest"
+    empty.write_text("\n")
+    r = subprocess.run([sys.executable, str(HELPER), "verify", "--account", ACCOUNT, "--share", SHARE,
+                        "--dest", DEST, "--manifest", str(empty)], capture_output=True, text=True, env=env)
+    check("an empty manifest is refused, never verified into a green",
+          r.returncode != 0 and "EMPTY" in r.stderr, f"rc={r.returncode}")
 
 
 def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
-    # The pre-fix script reads nothing back, so it has no query to be faithful about. Every OTHER
-    # run asserts it — including `--script` pointed at a copy of the current one.
-    if not expect_defect:
-        check_query_fidelity(script)
     h = Harness(script, work)
+    # The pre-fix script has no helper to be faithful about. Every OTHER run asserts it —
+    # including `--script` pointed at a copy of the current one.
+    if not expect_defect:
+        check_helper_shape(script, h)
     core = Bake(work, "core-cd", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     sat = Bake(work, "satellite", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 
@@ -528,7 +663,29 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
           len(s.files()) > 0 and set(s.bakes_present()) - {"<marker>"} == {"core-cd"},
           denominator(s))
 
+    if not expect_defect:
+        check("…and it was one upload process and one read-back process, not one per file",
+              r.stderr.count("uploaded ") == 2 and r.stderr.count("verified ") == 1
+              and f"uploaded {EXPECTED_FILES} file(s)" in r.stderr and "one process" in r.stderr,
+              "one `uploaded N file(s)` line for the publication, one for the sentinel, one sweep")
+
+    # ── CONTROL 1b: the same publication with the DEFAULT pool width (the production shape). ───
+    # Every other case runs the pool one wide so the hooks are deterministic; this one exercises
+    # the parallel path the fleet actually runs, on a fresh shelf with nothing to interleave.
+    h.reset()
+    started = time.monotonic()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1002", {"PUBLISH_BAKE_UPLOAD_WORKERS": None})
+    s = h.shelf()
+    if not expect_defect:
+        check("a settled publication with the default (parallel) pool seals and verifies every file",
+              r.returncode == 0 and s.sealed() and len(s.files()) == EXPECTED_FILES
+              and f"{EXPECTED_FILES}/{EXPECTED_FILES} file(s) hold this run's bytes" in r.stdout
+              and "12 worker(s)" in r.stderr,
+              f"rc={r.returncode}, {denominator(s)}, {time.monotonic() - started:.1f}s")
+
     # ── CONTROL 2: a second publication of DIFFERENT content reseals cleanly. ──────────────────
+    h.reset()
+    r = h.publish(core, "Systemorph/MeshWeaver", "1001")
     r = h.publish(sat, "Systemorph/MeshWeaver.Plugins", "2001")
     s = h.shelf()
     check("a republication of new content reseals",
@@ -961,6 +1118,13 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
               and "could not be read back" in r.stdout, f"rc={r.returncode}, {denominator(s)}")
         check("an undecidable verdict does NOT remove a sentinel",
               f"removed {DEST}/{SENTINEL}" not in r.stdout)
+        # #3731: the refusal lists what the directory actually holds, from inside the job. The
+        # listing is a CLI call after the bulk sweep, so it is a second witness with a second
+        # client — asserted so the diagnostic cannot rot into its own "the listing itself failed".
+        check("the refusal lists what the directory holds (#3731), and the listing succeeded",
+              f"what {TARGET}/{DEST} holds now" in r.stdout
+              and f"{BUNDLES[0]}\t" in r.stdout and "the listing itself failed" not in r.stdout,
+              "the diagnostic group names the refused file with its byte count")
 
     # ── UNSTAMPED: a publisher that writes no digest is not one of ours. ───────────────────────
     print("\nan incumbent written by a publisher that stamps no digest:")
@@ -997,7 +1161,8 @@ def run_cases(script: Path, work: Path, expect_defect: bool) -> None:
               "expected/verified are both printed")
 
     # ── The read-back loop is fed by a redirect. A command inside it that ate stdin would end it
-    # ── early, and a verification covering a PREFIX would report no foreign bytes and SEAL.
+    # ── early, and a verification covering a PREFIX would report no foreign bytes and SEAL. The
+    # ── helper runs OUTSIDE that loop now; this keeps the case honest if it is ever moved back.
     print("\nthe read-back loop cannot be truncated by something eating its stdin:")
     h.reset()
     r = h.publish(core, "Systemorph/MeshWeaver", "1701", {"MOCK_AZ_EAT_STDIN": "1"})

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1926,6 +1926,11 @@ jobs:
     # jmespath is PINNED, and the pin is the fidelity claim: it is the engine the azure-cli
     # itself evaluates `--query` with, so "this query throws on a null field" is reproduced here
     # rather than asserted about. A venv keeps it off the runner's externally-managed python.
+    #
+    # The two Azure SDK pins are the SAME pins publish-bake-bundles.sh installs for its bulk
+    # helper (SDK_PINS in that script — the overlap harness reads them from there and holds this
+    # venv to them through `sdk-check`), so the harness constructs the real clients the helper
+    # uses and a moved SDK surface goes red here rather than in a production publish.
     - name: Assert the tools this gate needs
       run: |
         set -euo pipefail
@@ -1933,7 +1938,8 @@ jobs:
         shellcheck --version | head -2
         python3 -m venv "$RUNNER_TEMP/wfshell"
         "$RUNNER_TEMP/wfshell/bin/pip" install --quiet --disable-pip-version-check \
-          'jmespath==1.0.1' 'PyYAML==6.0.2'
+          'jmespath==1.0.1' 'PyYAML==6.0.2' \
+          'azure-storage-file-share==12.26.0' 'azure-identity==1.25.3'
         echo "$RUNNER_TEMP/wfshell/bin" >> "$GITHUB_PATH"
 
     # 🚨 Run the self-test FIRST, and let it fail the job. An unproven gate is no gate: every

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -397,13 +397,23 @@ was ever visible instead of silently shipping a mixed set.
   job — the postcondition covering it is unchanged. What the flip buys immediately is that the
   *publication* survives an overlap intact and pointed-to instead of being lost. The reds go when the
   flat copy does (phase 5), or when the publication moves to digest-addressed artifacts.
+- **What the postcondition costs in TIME, and the 2026-09-08 change to it.** The sweep used to be
+  one `az storage file show` process per file on top of one `az storage file upload` process per
+  file — **184 CLI launches for two targets**, 5–10 minutes of every bake. It is now one process per
+  phase per target on the Azure SDK (`publish-bake-files.py`), with the verdict logic untouched;
+  the table and the measurement are in
+  [Sealed Publication Reads](../SealedPublicationReads) → "What the postcondition costs". This
+  changes the *duration* of the in-place window (the interval between the last verification read
+  and the seal, and the interval a sibling can overwrite inside), not its existence — the layout
+  above is still what closes it.
 - The reds the postcondition produces are the correct number and must not be loosened away — see
   [Sealed Publication Reads](../SealedPublicationReads) → "What is NOT closed".
 
 ## Verification
 
-- `.github/scripts/test-publish-bake-overlap.py` — **67 assertions**, executing the REAL publish
-  script against a stub share and reading every verdict off the BYTES. The writer half is covered by
+- `.github/scripts/test-publish-bake-overlap.py` — **82 assertions**, executing the REAL publish
+  script against a stub share (the stub `az` for the per-target decisions, a fake share backend for
+  the bulk helper's uploads and read-back) and reading every verdict off the BYTES. The writer half is covered by
   five generation cases: one publisher writes and seals under its own token and the pointer names it;
   **two interleaved publishers each seal their OWN generation, neither directory holds a byte of the
   other, both are complete, and `_current` names exactly one of them**; "already published" is

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -218,6 +218,46 @@ asymmetry: whoever stamps *last* re-reads its own marker and seals happily over 
 The loser detects the winner; the winner detects nothing. No arrangement of a single marker fixes
 that, because a marker records who wrote last, not whose bytes are on the shelf.
 
+### What the postcondition costs — one process per phase, not one per file
+
+Every file is read back, never a sample — a sample is a guard that passes on the files nobody
+overwrote. What changed on 2026-09-08 is how that is paid. Until then the script published with one
+`az storage file upload` **process per file** and verified with one `az storage file show` process
+per file: for the ~46-file publication the lanes produce that was **184 CLI launches for two
+targets**, each paying the CLI's start-up, a token lookup and a fresh connection for one request, at
+1–3 s apiece — so "Publish bundles to every portal target" took **5–10 minutes** of a bake whose
+compile is ~7. The maintainer's directive, after asking why the bake queue ran so slowly: *"how many
+are there? this must be one bulk query"*.
+
+It is now `publish-bake-files.py` beside the script, **one process per phase per target** on the
+Azure SDK with the same CLI identity (`AzureCliCredential` + `token_intent=backup`, the SDK's form of
+`--auth-mode login --backup-intent`):
+
+| phase | before | after |
+|---|---|---|
+| upload | 46 processes per target, sequential | 1 process: parent directories ensured, then every file through a 12-wide thread pool, stamped `digest` + `publication` |
+| read-back | 46 processes per target, sequential | 1 process: the destination and `modules/` **listed once**, then every manifest file's properties over one connection pool, one TSV row per file |
+| seal | 1 process | 1 process (a one-line plan through the same uploader) |
+| per target | ~93 launches | 3 launches + a handful of `az` decisions (sentinel present? marker content?) |
+
+🚨 **The listing cannot carry the stamps.** Azure Files' *List Directories and Files* returns names
+and sizes, never metadata, so the per-file `get_file_properties` inside one process **is** the bulk
+read; the helper prints `verified N file(s) … in S s (L listed in K listing call(s))` so the cost
+stays measured rather than assumed. The verdict logic did not move: bash still sorts every row into
+*ours* / *neutral* / *foreign* / *unreadable*, asserts the denominator, and refuses exactly as above
+— only the **input source** of the sweep changed. A row is five tab-separated fields (path, state,
+digest, publication, length) with `-` for an absent stamp and `absent` / `error` as states in their
+own right, so a transient fault can never read as "no digest recorded"; the parse asserts the field
+count and refuses on any other shape. The SDK is installed **by the script**, pinned, followed by
+`sdk-check` as the positive signal — a satellite fetches the script at `platform-ref` and runs the
+lane at its `uses:` pin, and the two move independently, so a workflow-side install would leave the
+newer script without its dependency.
+
+Measured locally against the overlap harness's fake share: the whole suite — about twenty-five full
+publications (upload, read-back, seal, plus `sdk-check` each, the generation-layout cases writing
+two directories apiece) — in 25 s wall; under a second per publication, where the CLI shape spent
+minutes per target.
+
 ### Superseded is not always a failure — the convergence verdict
 
 🚨 **The postcondition and the sealed-skip answer the same question and used to disagree,
@@ -383,7 +423,13 @@ the pin is removed:
 - `.github/scripts/test-publish-bake-overlap.py` — runs the REAL `publish-bake-bundles.sh` **twice,
   interleaved**, against a stub share, and reads the verdict off the BYTES rather than off the
   script's own log: each fixture bundle names the bake that produced it, so "the sealed directory
-  holds two bakes" is a fact about the shelf. **47 assertions over eleven cases** — three controls
+  holds two bakes" is a fact about the shelf. Both I/O edges are substituted over ONE filesystem
+  share — the stub `az` on PATH for the per-target decisions, and a fake share backend the bulk
+  helper loads from `PUBLISH_BAKE_FAKE_SHARE_BACKEND` for the uploads and the read-back — with the
+  upload pool one wide so the second-publisher hooks fire at a named file; one control runs the
+  default (parallel) pool. The helper's row rendering is pinned by running the helper itself, and
+  `sdk-check` runs against the REAL pinned SDK. **82 assertions** (the generation-layout cases
+  included — see [Sealed Publication Generations](../SealedPublicationGenerations)) — three controls
   that must PASS (settled publish, republish of new content, already-published skip), the other lane
   in flight, the other lane completing inside a gap, a full supersession, an unreadable read-back, an
   unstamped incumbent, two concurrent runs of ONE repo, and the three convergence arms (a sibling

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-bake-publication-no-longer-spends-minutes-per-target.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-bake-publication-no-longer-spends-minutes-per-target.md
@@ -1,0 +1,33 @@
+---
+Name: Bake publication no longer spends minutes per target
+Category: Fix
+Description: Publishing a CI content bake to the portals' shared storage launched one command-line process per file to upload and another per file to verify — 184 launches for two targets, 5–10 minutes of every bake. Each phase is now one process per target, every file still verified; the publication step takes seconds.
+Icon: Timer
+Order: -20260908
+---
+
+# Bake publication no longer spends minutes per target
+
+Every merge to `main` bakes the platform's shipped content inside the image that ships it and
+publishes the result — about 46 files — to the storage every portal mounts, so a booting pod adopts
+the compiled bundles instead of compiling them itself. Before writing the seal that makes a
+publication visible, the publisher reads every file back and checks that the bytes on the shelf are
+the ones it uploaded, because two publishers can land on one directory at once and a seal over a
+mix is silent and wrong.
+
+The upload and that read-back were each done with one command-line process **per file**, per
+target. For two targets that was 184 process launches, each paying the tool's start-up, a token
+lookup and a new connection for a single request — 5 to 10 minutes of a bake whose actual compile
+takes about 7. The maintainer's question, on seeing the bake queue crawl: *"how many are there? this
+must be one bulk query"*.
+
+**Each phase is now one process per target.** The upload pushes every file through a bounded pool
+with the same two stamps as before; the read-back lists the destination once and reads every file's
+stamps over one connection in the same process, printing one row per file that the existing
+accounting consumes. Nothing about the verdict changed: every file is still verified (never a
+sample), both stamps of every file are still read, an unreadable file still refuses the seal, a mixed
+directory still has its foreign seal removed, and the seal is still written strictly last. Measured
+on the publisher's own test harness, about twenty-five full publications now complete in 25 seconds.
+
+See [Sealed Publication Reads](/Doc/Architecture/SealedPublicationReads) → "What the postcondition
+costs" for the before/after table.


### PR DESCRIPTION
## Why

Maintainer directive (2026-09-08), after asking why the bake queue runs so slowly: *"how many are there? this must be one bulk query ==> optimize this to one bulk query"*.

Measured: `publish-bake-bundles.sh` uploaded a 46-file publication with one `az storage file upload` process per file and verified it with one `az storage file show` process per file, per target — **184 CLI launches for two targets** at 1–3 s each, so "Publish bundles to every portal target" took **5–10 minutes** of a bake whose compile is ~7 minutes. Each launch paid the CLI's start-up, a token lookup and a fresh connection for one request.

## What

`.github/scripts/publish-bake-files.py` (beside the script, fetched at the same `platform-ref`) — **one process per phase per target** on the Azure SDK with the same CLI identity (`AzureCliCredential` + `token_intent="backup"`, the SDK's form of `--auth-mode login --backup-intent`):

| phase | before (per target) | after (per target) |
|---|---|---|
| upload | 46 `az storage file upload` processes | 1 process: parent dirs ensured, every file through a 12-wide pool, stamped `digest` + `publication` |
| read-back | 46 `az storage file show` processes | 1 process: destination + `modules/` **listed once**, every manifest file's properties over one connection pool, one 5-field TSV row per file |
| seal | 1 process | 1 process (one-line plan, same uploader) |
| **total** | **~93 launches** | **3 launches** + the handful of `az` per-target decisions (sentinel exists? marker content?) |

The listing cannot carry the stamps (Azure Files' *List Directories and Files* returns names and sizes, never metadata), so the per-file `get_file_properties` inside one process **is** the bulk read; the helper prints `verified N file(s) … in S s (L listed in K listing call(s))` so the cost stays measured.

**Unchanged, by construction:** every file verified (never a sample); both stamps of every file read; the ours/neutral/foreign/unreadable accounting and the denominator assertion in bash; the convergence verdict (#3717) reading `_complete` *after* the sweep; the sentinel written strictly last and only after the whole set verified; an unreadable file refuses the seal; a mixed directory removes the foreign seal; #3731's directory listing where the refusal fires; `< /dev/null` on every helper call; `::error::` refusal lines. Only the sweep's **input source** moved. The row parse asserts exactly five fields with `-` for an absent stamp and `absent`/`error` as states in their own right, so a transient fault can never read as "no digest recorded".

The SDK is installed **by the script** (pinned `azure-storage-file-share==12.26.0`, `azure-identity==1.25.3`, venv under `$RUNNER_TEMP`) followed by `sdk-check` as the positive signal — a satellite fetches the script at `platform-ref` and runs the lane at its `uses:` pin, and the two move independently, so a workflow-side install would leave the newer script without its dependency. `PUBLISH_BAKE_PYTHON` lets a caller supply a python already carrying exactly those pins (the harness does; `sdk-check` holds it to them).

Rebased onto #3724/#3717/#3731: `publish_one_target` is called per directory (generation dir, then flat copy) and the helper works per `dest`, so the pointer-file layout, the `flat` default and the prefix layout the four Azure-direct readers address are untouched; `move_pointer` and the architecture backfill keep their unstamped `az` uploads.

## Tests

- `test-publish-bake-overlap.py` substitutes **both** I/O edges over one filesystem share — the stub `az` on PATH plus a fake share backend the helper loads from `PUBLISH_BAKE_FAKE_SHARE_BACKEND` — with the upload pool one wide so the second-publisher hooks fire at a named file; a new control runs the default (parallel) pool. It pins the helper's row rendering by running the helper itself, runs `sdk-check` against the **real** pinned SDK (the CI venv now carries the same pins), asserts one upload + one read-back process per publication, teaches the stub `az storage file list` so #3731's diagnostic is exercised rather than falling into its "listing itself failed" arm, and keeps every existing case (overlaps, supersession, convergence, generation layout). **82 assertions, 0 failed; 25 s wall for the whole suite (17:49:27Z → 17:49:52Z; ~25 full publications, each upload + read-back + seal + sdk-check) — under a second per publication where the CLI shape spent minutes per target.**
- `check-workflow-shell.py` (shellcheck at CI severity over `.github/scripts/*.sh`): clean. `check-workflow-timeouts.py`: clean.
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` on a fresh `-c Release -warnaserror` build: 2/2.

## Docs

- `SealedPublicationReads.md` → new section "What the postcondition costs — one process per phase, not one per file" (the table above and the measurement).
- `SealedPublicationGenerations.md` → "Where this stands" bullet on the time cost; verification bullet updated.
- What's New: `2026-09-08-bake-publication-no-longer-spends-minutes-per-target.md` (`Category: Fix`).

Pairs-with: none — CI script only (no `src/` public surface touched; the helper is fetched with the script at `platform-ref`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
