### PR TITLE
fix(dispose): every rooted Rx connection in src/ is owned and released with its owner — the #3737 shape as the one spelling, ratcheted

### DIFF
--- a/.claude/skills/async/SKILL.md
+++ b/.claude/skills/async/SKILL.md
@@ -277,6 +277,22 @@ EventCalendar bug. Application code that writes MUST carry a real user identity 
 > AccessContext is gone** and wrap the write in `SwitchAccessContext`/`ImpersonateAsSystem`. If you
 > don't, it fails closed, you swallow it, and something upstream retries it into a storm.
 
+## Rooted connections: a `Connect()` handle belongs to an OWNER
+
+**A bare `.AutoConnect(1)` or a dropped `.Connect()` in `src/` is a defect, and
+`RootedRxConnectionRatchetGuard` reds it with no allow-list escape.** The handle `Connect()`
+returns is the only way to close the upstream; `AutoConnect` keeps it inside the operator, so the
+owner's `Dispose()` cannot reach it — and a `Defer(…).SubscribeOn(TaskPool)` chain's connect is a
+*queued* subscribe that no teardown phase joins, so it runs after the scope has closed (11
+disposed-scope stragglers in Plugins run 34222933802, every one this shape). Spell it
+`.Replay(1).AutoConnectOwnedBy(hub | compositeDisposableField, nameof(Owner))` or
+`.Publish().ConnectOwnedBy(owner)` (`MeshWeaver.Messaging.OwnedConnectionExtensions`): released
+with the owner, a queued connect cancelled, a late subscriber refused with
+`ObjectDisposedException`. `RefCount()` is subscriber-owned and is instead INVENTORIED with a
+reason in `test/RootedRxConnectionSites.allow`. Full reference:
+[HubDisposalModel.md](../../../src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md)
+→ "Rooted Rx connections".
+
 ## Cold observables: Subscribe is mandatory
 
 Writes are **cold** — the side effect runs on `Subscribe`, not on call. A composed write you never

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -3470,7 +3470,15 @@ internal static class NodeTypeCompilationHelpers
                     return Observable.Return<string?>(null);
                 }))
             .Replay(1)
-            .AutoConnect(1);
+            // 🚨 OWNED by the NodeType hub, not a bare AutoConnect(1). The compile pipeline below
+            // subscribes on the pool (SubscribeOn), so the FIRST subscriber — the one whose
+            // Connect() runs this create against hub.ServiceProvider — can land after the hub has
+            // torn down; a bare connect would then resolve the mesh service from a closed scope,
+            // swallow the ObjectDisposedException in the Catch above and run Roslyn for a hub that
+            // no longer exists. The hub's ShutDown releases the connection instead, and a
+            // subscriber arriving after that terminates — the compile subscription's error arm
+            // logs it as the faulted compile it is.
+            .AutoConnectOwnedBy(hub, $"{nameof(RunCompile)}({hubPath})");
 
         // Flip the parent NodeType to Compiling, stamping the ACTUAL activity path (or
         // null when the create didn't land). The stamp follows the create — it is never

--- a/src/MeshWeaver.ContentCollections/ContentService.cs
+++ b/src/MeshWeaver.ContentCollections/ContentService.cs
@@ -270,7 +270,14 @@ public class ContentService : IContentService
                     return Observable.Return<ContentCollection?>(null);
                 })
                 .Replay(1)
-                .AutoConnect(1));
+                // 🚨 OWNED by the hub, not a bare AutoConnect(1): the promise resolves a provider
+                // factory and a ContentCollection off this hub's scope, and its first subscriber
+                // may be a layout render that lands on the pool after the hub has torn down. The
+                // hub's ShutDown releases the connection (an in-flight creation is unsubscribed, a
+                // still-queued one is cancelled), and a GetCollection after that terminates with
+                // ObjectDisposedException instead of resolving from a closed scope or replaying a
+                // collection the hub has already disposed.
+                .AutoConnectOwnedBy(hub, nameof(ContentService)));
     }
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -320,6 +320,76 @@ an observable.
 
 ---
 
+## Rooted Rx connections: what a `Dispose()` must release, and the one spelling for it
+
+Every multicast chain an object builds — `Replay(1)`, `Publish()`, `PublishLast()` — has a
+**connection**: the upstream subscription `Connect()` opens. Whoever holds the handle
+`Connect()` returns is the only party that can close it. Two spellings hold it *nowhere an
+owner can reach*, and both were live in core until 2026-09-08:
+
+- **`.AutoConnect(1)`** keeps the handle *inside the operator*. The owner's `Dispose()`
+  detaches everything it can name and never touches the chain.
+- **`.Connect()` whose result is dropped** (or stored in a field nobody disposes) is the
+  same thing without the operator.
+
+That would be a leak. What makes it a **use-after-dispose** is that the connect is frequently
+*not synchronous*: a chain shaped `Defer(…).SubscribeOn(TaskPoolScheduler)` only *queues* its
+upstream subscribe on the first subscriber's thread, and **nothing in the teardown joins a
+pool-queued Rx subscribe** — `DisposalCompleted` covers the action blocks,
+`IoPoolRegistry.DrainAll()` covers `IIoPool` leaves, the `AsyncDisposeQueue` covers enqueued
+cleanup. The item ran whenever the pool reached it. Measured on MeshWeaver.Plugins run
+`34222933802` (2026-09-08): all 11 disposed-scope stragglers captured across three suites
+were `MeshNodeStreamCache.GetQueryRaw`'s `Defer` resolving `cacheHub.GetWorkspace()` from an
+Autofac scope the mesh had already closed, the FutuRe pair 4 ms after `DISPOSE_DONE`
+([the chain walk](/Doc/Architecture/DebuggingNativeCrashes)).
+
+**The rule.** A connection is owned by the object whose services the chain resolves, and
+that object's `Dispose()` releases it. The one spelling is
+`MeshWeaver.Messaging.OwnedConnectionExtensions`:
+
+```csharp
+// A lazily-connected shared chain (a promise cache, a synced query, a per-name collection):
+var stream = Observable.Defer(() => BuildAgainst(hub.GetWorkspace()))
+    .SubscribeOn(TaskPoolScheduler.Default)
+    .Replay(1)
+    .AutoConnectOwnedBy(hub, nameof(MyService));          // or (compositeDisposableField, name)
+
+// An eager feed that must keep filling with no subscribers (a directory index, a counter):
+applied.ConnectOwnedBy(hub);                              // or ConnectOwnedBy(compositeDisposableField)
+```
+
+What the helper guarantees, and what a bare `AutoConnect(1)` cannot:
+
+| | bare `AutoConnect(1)` / dropped `Connect()` | `AutoConnectOwnedBy` / `ConnectOwnedBy` |
+|---|---|---|
+| The owner's `Dispose()` | cannot reach the upstream | unsubscribes it (`hub.RegisterForDisposal` → ShutDown phase, strictly before any scope closes) |
+| A connect still **queued** on the pool | runs later, against whatever is left | is **cancelled** before the pool dequeues it — the registration lands in a disposed `CompositeDisposable`, whose `Add` disposes on the spot |
+| A subscriber arriving **after** the release | gets the replay buffer, then silence forever ("burst then dead silence") | is **refused** with `ObjectDisposedException(ownerName)` — terminates, attributable |
+| A chain that **terminates** (a settled promise) | — | drops its handle, so the owner tracks *live* connections only and a faulted-then-rebuilt promise never accumulates dead handles |
+
+**Choosing the owner.** A hub-scoped service registers with its hub; a DI singleton owns a
+`CompositeDisposable` field it disposes in its own `Dispose()` (the container disposes
+singletons); an object that already has a disposal registry (`MeshNodeStreamCache`'s
+`_queryConnections`) uses that. Never a static.
+
+**`RefCount()` is different, deliberately.** A ref-counted chain's connection belongs to its
+*subscribers* — it releases with the last of them — so there is no handle for an owner to
+hold. What must be owned there is each *subscription*, through the ordinary
+`RegisterForDisposal` rule (`MeshNodeTypeSource` registers its own; `VirtualDataSource`
+registers with its stream). Every `RefCount()` site in `src/` is inventoried with the reason
+its subscriptions are owned.
+
+**Enforced** by `RootedRxConnectionRatchetGuard` (`test/MeshWeaver.Documentation.Test`):
+a bare `.AutoConnect(` / `.Connect()` anywhere in `src/` is red with no allow-list escape
+(the rooted budget is zero); a `.RefCount(` site must carry a reasoned line in
+`test/RootedRxConnectionSites.allow`, and that inventory only grows together with the
+guard's budget constant. Pinned end to end by `OwnedConnectionTest` (Messaging.Hub.Test —
+a connect queued on a `TestScheduler` is cancelled by the owner's release, with a control
+arm proving it was registered) and, at a converted site,
+`ContentCollectionConnectionOwnedByHubTest` and `QueryConnectionsReleasedOnTeardownTest`.
+
+---
+
 ## Teardown-safe writes: `Post` drops, incoming streams error
 
 Disposal is reactive and bounded, but it is not instantaneous — and **background

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-shutdown-releases-every-shared-subscription-it-owns.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-shutdown-releases-every-shared-subscription-it-owns.md
@@ -1,0 +1,26 @@
+---
+Name: A shutdown releases every shared subscription it owns
+Category: Fix
+Description: Several services shared one background subscription among many readers and had no way to stop it when they shut down, so it could keep running — or start late — against a container that was already gone. Each now hands its subscription to its owner, which releases it on shutdown; a reader arriving after that gets an error naming the owner instead of waiting forever.
+Icon: Stop
+Order: -20260908
+---
+
+# A shutdown releases every shared subscription it owns
+
+A number of services share one background subscription among every caller that asks for the same
+thing — the compile pipeline's activity record, a content collection's initial load, a repository's
+canonical name, the user directory index, the in-flight activity and routing counters, and the
+node cache's synced queries. Sharing is right: the work runs once and every reader sees the same
+result. What was missing was an owner. The mechanism that opened the shared subscription kept its
+handle to itself, so when the service shut down nothing could close it, and when the subscription
+was still queued for a background thread at that moment, it started *after* the shutdown and tried
+to build itself against services that no longer existed. On the build servers that surfaced as a
+burst of "already disposed" errors after a test had reported a clean teardown.
+
+Every such subscription now belongs to the service that opened it and is released as part of that
+service's own shutdown: one that is running is unsubscribed, one that is still queued is cancelled
+before it starts, and one that has already finished its work no longer counts as open. A caller who
+asks after the shutdown is answered immediately with an error naming the service, rather than being
+handed a stale result and then left waiting for updates that will never come. A guard in the test
+suite keeps every future shared subscription on the same rule.

--- a/src/MeshWeaver.GitSync/GitHubRepoIdentityResolver.cs
+++ b/src/MeshWeaver.GitSync/GitHubRepoIdentityResolver.cs
@@ -1,6 +1,8 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.GitSync;
@@ -44,7 +46,7 @@ public sealed class GitHubRepoIdentityResolver(
     GitHubCredentialService credentials,
     GitHubAppTokenService? appTokens = null,
     TimeProvider? timeProvider = null,
-    ILogger<GitHubRepoIdentityResolver>? logger = null)
+    ILogger<GitHubRepoIdentityResolver>? logger = null) : IDisposable
 {
     /// <summary>
     /// How long a resolved identity is trusted before it is looked up again. Long enough that a
@@ -60,14 +62,21 @@ public sealed class GitHubRepoIdentityResolver(
     private readonly TimeProvider clock = timeProvider ?? TimeProvider.System;
     private readonly PromiseCache<string, Resolution> cache = new(StringComparer.OrdinalIgnoreCase);
 
+    // Every in-flight lookup's upstream connection, released with this singleton (the container
+    // disposes it). A lookup is a one-shot, so a handle normally leaves the registry the moment
+    // its GitHub round-trip settles; what this owns is the one that has NOT settled when the host
+    // goes down — its credential read and pool leaf are unsubscribed rather than left to complete
+    // against a disposed container, and a Resolve() after that is refused rather than parked.
+    private readonly CompositeDisposable lookups = new();
+
     /// <summary>
     /// How many GitHub lookups this resolver has actually performed. Diagnostics only — a test uses
     /// it to prove the cache serves repeat callers without a second call, and that an EXPIRED entry
     /// costs a fresh one.
     /// </summary>
-    public int LookupCount => lookups;
+    public int LookupCount => lookupCount;
 
-    private int lookups;
+    private int lookupCount;
 
     /// <summary>
     /// The canonical identity of <paramref name="repositoryUrl"/>, or <see langword="null"/> when it
@@ -104,10 +113,11 @@ public sealed class GitHubRepoIdentityResolver(
     }
 
     /// <summary>One real GitHub lookup, stamped with the time it settled and shared by every
-    /// concurrent caller (<c>Replay(1).AutoConnect(1)</c> — the promise runs once).</summary>
+    /// concurrent caller (<c>Replay(1)</c> connected once, owned by this resolver — the promise
+    /// runs once and dies with the resolver).</summary>
     private IObservable<Resolution> Lookup(string repositoryUrl, string? userId) =>
         ResolveToken(userId)
-            .Do(_ => Interlocked.Increment(ref lookups))
+            .Do(_ => Interlocked.Increment(ref lookupCount))
             .SelectMany(token => repoClient.GetCanonicalRepository(repositoryUrl, token))
             .Select(id => id is { IsComplete: true } ? id : null)
             .Catch((Exception ex) =>
@@ -125,7 +135,10 @@ public sealed class GitHubRepoIdentityResolver(
             })
             .Select(id => new Resolution(clock.GetUtcNow(), id))
             .Replay(1)
-            .AutoConnect(1);
+            .AutoConnectOwnedBy(lookups, nameof(GitHubRepoIdentityResolver));
+
+    /// <summary>Releases every lookup still in flight; a <see cref="Resolve"/> after this is refused.</summary>
+    public void Dispose() => lookups.Dispose();
 
     /// <summary>
     /// Parses a stored repository url to its <c>owner/repo</c> identity, or null when it cannot be

--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/UserIdentityCache.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/UserIdentityCache.cs
@@ -178,8 +178,11 @@ public sealed class UserIdentityCache : IDisposable
 
     private readonly ConcurrentDictionary<string, MeshNode> _byEmail =
         new(StringComparer.OrdinalIgnoreCase);
-    private readonly IDisposable _subscription;
-    private readonly IDisposable _faultWatch;
+    // The directory query's connection and its fault watcher. Registered with the hub (released in
+    // its ShutDown phase, strictly before any scope closes — the index cannot fill from a dead
+    // container) AND disposed by this singleton's own Dispose(), whichever the container reaches
+    // first; both are idempotent.
+    private readonly CompositeDisposable _connections = new();
     private readonly JsonSerializerOptions _jsonOptions;
     private readonly ILogger<UserIdentityCache> _logger;
 
@@ -297,7 +300,8 @@ public sealed class UserIdentityCache : IDisposable
             })
             .Publish();
         IndexChanged = applied;
-        _faultWatch = applied.Subscribe(
+        hub.RegisterForDisposal(_connections);
+        _connections.Add(applied.Subscribe(
             _ => { },
             ex =>
             {
@@ -307,11 +311,12 @@ public sealed class UserIdentityCache : IDisposable
                 Volatile.Write(ref _subscriptionFailure,
                     $"user index subscription failed: {ex.GetType().Name}: {ex.Message}");
                 _logger.LogWarning(ex, "UserIdentityCache subscription failed");
-            });
+            }));
         // Connect LAST: the fault watcher is already attached, and Publish's subject replays its
         // terminal notification to late subscribers, so a waiter that arrives after a failure is
-        // told the index is dead instead of waiting on it forever.
-        _subscription = applied.Connect();
+        // told the index is dead instead of waiting on it forever. The connection is OWNED
+        // (ConnectOwnedBy) — released with _connections, never left to the chain itself.
+        applied.ConnectOwnedBy(_connections);
     }
 
     private void Apply(QueryResultChange<MeshNode> change)
@@ -456,9 +461,5 @@ public sealed class UserIdentityCache : IDisposable
         UserIdentityLookup.UntilDetermined(IndexChanged, () => Lookup(email));
 
     /// <summary>Disposes the underlying query subscription, stopping further cache updates.</summary>
-    public void Dispose()
-    {
-        _subscription.Dispose();
-        _faultWatch.Dispose();
-    }
+    public void Dispose() => _connections.Dispose();
 }

--- a/src/MeshWeaver.Hosting.Orleans/RoutingQuiescence.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingQuiescence.cs
@@ -49,7 +49,9 @@ public sealed class RoutingQuiescence : IDisposable
     private readonly Subject<int> deltas = new();
     private readonly EventLoopScheduler scheduler = new();
     private readonly IConnectableObservable<int> counts;
-    private readonly IDisposable connection;
+    // Owns the counts connection: released in Dispose(), through the one sanctioned spelling for a
+    // rooted connection (ConnectOwnedBy) so the ratchet can see it is owned.
+    private readonly CompositeDisposable connections = new();
     private int disposed;
 
     // 🚨 What is in flight, not just HOW MANY. The count alone made the shutdown residual
@@ -75,7 +77,7 @@ public sealed class RoutingQuiescence : IDisposable
             .Scan(0, (running, delta) => running + delta)
             .StartWith(0)
             .Replay(1);
-        connection = counts.Connect();
+        counts.ConnectOwnedBy(connections);
     }
 
     /// <summary>
@@ -153,7 +155,7 @@ public sealed class RoutingQuiescence : IDisposable
     {
         if (Interlocked.Exchange(ref disposed, 1) != 0)
             return;
-        connection.Dispose();
+        connections.Dispose();
         scheduler.Dispose();
     }
 }

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -2453,7 +2453,9 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // on the spot, which is precisely the connect-after-teardown race — a Connect() that queued its
     // subscribe an instant before Dispose() ran is cancelled before the pool dequeues it (Rx's
     // scheduled work item checks its cancellation before invoking). The Defer's own guard below
-    // covers the sliver in which the pool has already started it.
+    // covers the sliver in which the pool has already started it. The registration itself is
+    // `OwnedConnectionExtensions.AutoConnectOwnedBy` — the one spelling for a rooted connection,
+    // ratcheted by RootedRxConnectionRatchetGuard.
     private readonly System.Reactive.Disposables.CompositeDisposable _queryConnections = new();
 
     /// <summary>Test probe: synced-query upstream connections this cache currently holds.</summary>
@@ -2529,9 +2531,6 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // first subscriber's thread (TaskPoolScheduler thanks to
             // SubscribeOn), constructs the SyncedQueryMeshNodes, and the
             // Replay(1) caches its emissions for all later subscribers.
-            // The upstream connection AutoConnect hands back — captured so the fault arm below can
-            // release exactly this chain's connection, and so Dispose() can release them all.
-            IDisposable? connection = null;
             var stream = Observable.Defer(() =>
                 {
                     // 🚨 This factory runs on the POOL, whenever the pool gets to it — so it is the
@@ -2595,15 +2594,14 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // write sees the STALE cached snapshot. AutoConnect(1)
                 // keeps the upstream connected forever once first subscribed.
                 //
-                // 🚨 The connection is REGISTERED, not dropped (see _queryConnections): AutoConnect
+                // 🚨 The connection is OWNED, not dropped (see _queryConnections): AutoConnect
                 // itself never disposes it, and the connect it triggers is a pool-queued subscribe
-                // that no teardown phase joins. Registering it after the cache's Dispose() disposes
-                // it on the spot — the late-connect race resolved by construction.
-                .AutoConnect(1, c =>
-                {
-                    connection = c;
-                    _queryConnections.Add(c);
-                });
+                // that no teardown phase joins. AutoConnectOwnedBy registers the handle with the
+                // cache's registry, drops it again when the chain terminates (a faulted-then-
+                // rebuilt query never accumulates dead handles), disposes it on the spot when it
+                // arrives after the cache's Dispose() — the late-connect race resolved by
+                // construction — and refuses a subscriber that arrives after the release.
+                .AutoConnectOwnedBy(_queryConnections, nameof(MeshNodeStreamCache));
                 // ReplaySubject (backing Replay(1)) already serialises
                 // OnNext/Subscribe internally — no .Synchronize() needed.
                 // Adding it would route every emission through an additional
@@ -2641,14 +2639,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // fails against a sibling set's chain, so the poisoned one is replayed forever —
             // #1316 undone) or OVER-EVICT (drop a healthy set that merely shares the id).
             var connected = stream;
-            stream = connected.Do(_ => { }, ex =>
-            {
-                EvictFaultedQuery(id, signature, stream, ex);
-                // A terminal chain's connection has nothing left to hold — release it so the
-                // registry tracks LIVE connections only (a faulted-then-rebuilt query would
-                // otherwise accumulate one dead handle per fault for the life of the process).
-                ReleaseQueryConnection(connection);
-            });
+            // (The faulted chain's CONNECTION needs no release here: AutoConnectOwnedBy drops a
+            // terminated chain's handle from _queryConnections itself, so the registry tracks
+            // LIVE connections only.)
+            stream = connected.Do(_ => { }, ex => EvictFaultedQuery(id, signature, stream, ex));
 
             // Index the new stream under its SIGNATURE and make it the id's latest. Existing
             // signatures are preserved, so a caller still holding the previous declaration keeps
@@ -2713,26 +2707,6 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             + "Replay(1) had latched the terminal error and would have replayed it to every future "
             + "subscriber for the life of the process. The next GetQuery('{QueryId}') for that query set "
             + "opens a fresh upstream instead.", id, signature, id);
-    }
-
-    /// <summary>
-    /// Releases one synced-query chain's upstream connection and drops it from
-    /// <see cref="_queryConnections"/>. <c>Remove</c> disposes a registered handle; a handle the
-    /// registry no longer holds (the registry was disposed first, which already disposed it) is
-    /// disposed again harmlessly — Rx disposables are idempotent.
-    /// </summary>
-    private void ReleaseQueryConnection(IDisposable? connection)
-    {
-        if (connection is null) return;
-        try
-        {
-            if (!_queryConnections.Remove(connection))
-                connection.Dispose();
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "MeshNodeStreamCache: error releasing a synced-query connection");
-        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
@@ -6,6 +6,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Subjects;
+using MeshWeaver.Messaging;
 
 namespace MeshWeaver.Mesh;
 
@@ -62,7 +63,9 @@ public sealed class ActivityTracker : IDisposable
     private readonly Subject<int> deltas = new();
     private readonly EventLoopScheduler scheduler = new();
     private readonly IConnectableObservable<int> counts;
-    private readonly IDisposable connection;
+    // Owns the counts connection: released in Dispose(), through the one sanctioned spelling for a
+    // rooted connection (ConnectOwnedBy) so the ratchet can see it is owned.
+    private readonly CompositeDisposable connections = new();
     // The live runs, keyed by ticket, so a quiesce can look at EACH one's progress rather than at
     // an anonymous count. Instance field on the mesh-scoped singleton — never static.
     private readonly ConcurrentDictionary<long, ActivityRunHandle> runs = new();
@@ -78,7 +81,7 @@ public sealed class ActivityTracker : IDisposable
             .Scan(0, (running, delta) => running + delta)
             .StartWith(0)
             .Replay(1);
-        connection = counts.Connect();
+        counts.ConnectOwnedBy(connections);
     }
 
     /// <summary>
@@ -259,7 +262,7 @@ public sealed class ActivityTracker : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
-        connection.Dispose();
+        connections.Dispose();
         deltas.Dispose();
         scheduler.Dispose();
     }

--- a/src/MeshWeaver.Messaging.Hub/OwnedConnectionExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/OwnedConnectionExtensions.cs
@@ -1,0 +1,165 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// The ONE spelling for connecting a multicast chain (<c>Replay(…)</c>, <c>Publish()</c>,
+/// <c>PublishLast()</c>) whose upstream must die with a specific owner: the connection handle is
+/// REGISTERED with the owner the instant <c>Connect()</c> runs, the owner's disposal releases it,
+/// and a subscriber arriving after that release is refused with <see cref="ObjectDisposedException"/>
+/// instead of being parked on a replay that nothing will ever feed.
+///
+/// <para><b>The defect this replaces.</b> A bare <c>.AutoConnect(1)</c> keeps the handle its
+/// <c>Connect()</c> returns to itself; a bare <c>.Connect()</c> whose result is dropped keeps it
+/// nowhere. Either way the owner's <c>Dispose()</c> cannot reach the upstream, and the connect is
+/// frequently NOT synchronous: a chain shaped <c>Defer(…).SubscribeOn(TaskPoolScheduler)</c> only
+/// QUEUES its upstream subscribe on the first subscriber's thread, and no teardown phase joins a
+/// pool-queued Rx subscribe (<c>DisposalCompleted</c> covers the action blocks,
+/// <c>IoPoolRegistry.DrainAll</c> covers <c>IIoPool</c> leaves, the <c>AsyncDisposeQueue</c> covers
+/// enqueued cleanup). The item then ran whenever the pool reached it — measured on
+/// MeshWeaver.Plugins run 34222933802 (2026-09-08) as 11 <c>ObjectDisposedException</c> stragglers
+/// across three suites, every one a <c>Defer</c> resolving a workspace from an Autofac scope the
+/// mesh had already closed. See <c>Doc/Architecture/HubDisposalModel</c> → "Rooted Rx connections".</para>
+///
+/// <para><b>What registration buys, by construction.</b> The owner is a
+/// <see cref="CompositeDisposable"/> (or a hub, which holds one): once it is disposed an
+/// <c>Add</c> disposes the handle on the spot, so a <c>Connect()</c> that queued its subscribe an
+/// instant before the owner's <c>Dispose()</c> is cancelled before the pool dequeues it — Rx's
+/// scheduled work item checks its cancellation before invoking. A connection whose upstream has
+/// TERMINATED (a one-shot promise that resolved or faulted) is dropped from the owner as it
+/// terminates, so the owner tracks LIVE connections only and a faulted-then-rebuilt promise never
+/// accumulates dead handles for the life of the process.</para>
+///
+/// <para><b>Choosing the owner.</b> The object whose services the chain resolves: a hub-scoped
+/// service registers with its hub (<see cref="IMessageHub.RegisterForDisposal(IDisposable)"/>, which
+/// runs the release in the hub's ShutDown phase — strictly before the mesh's <c>DisposalCompleted</c>
+/// and therefore before any scope closes); a DI singleton owns a <see cref="CompositeDisposable"/>
+/// field it disposes in its own <see cref="IDisposable.Dispose"/>. Never a static.</para>
+///
+/// <para><b>Not for <c>RefCount()</c>.</b> A ref-counted chain's connection is owned by its
+/// SUBSCRIBERS — it releases with the last of them — so there is no handle for an owner to hold;
+/// what must be owned there is each subscription, which is the ordinary
+/// <see cref="IMessageHub.RegisterForDisposal(IDisposable)"/> rule. The ratchet
+/// (<c>RootedRxConnectionRatchetGuard</c>) lists every <c>RefCount()</c> site with the reason its
+/// subscribers are owned.</para>
+/// </summary>
+public static class OwnedConnectionExtensions
+{
+    /// <summary>
+    /// <c>AutoConnect(minObservers)</c> whose connection is owned by <paramref name="owner"/>: the
+    /// handle is added to it on connect, released by its disposal, and dropped when the upstream
+    /// terminates. A subscription made after the owner is disposed terminates with
+    /// <see cref="ObjectDisposedException"/> naming <paramref name="ownerName"/>.
+    /// </summary>
+    /// <typeparam name="T">Element type.</typeparam>
+    /// <param name="source">The connectable chain — <c>….Replay(1)</c>, <c>….Publish()</c>.</param>
+    /// <param name="owner">The registry the owner disposes with itself.</param>
+    /// <param name="ownerName">Names the owner in the refusal, e.g. <c>nameof(ContentService)</c>.</param>
+    /// <param name="minObservers">Subscribers required before the connect fires (Rx's <c>AutoConnect</c> argument).</param>
+    /// <returns>The shared observable — the one to hand out and cache.</returns>
+    public static IObservable<T> AutoConnectOwnedBy<T>(
+        this IConnectableObservable<T> source,
+        CompositeDisposable owner,
+        string ownerName,
+        int minObservers = 1)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerName);
+
+        var shared = source.AutoConnect(minObservers, connection => Register(source, owner, connection));
+
+        // 🚨 Refuse, never park. After the release the replay subject still hands a late subscriber
+        // whatever it buffered and then goes silent — the "burst then dead silence" wedge. A
+        // refusal names the owner and terminates.
+        return Observable.Defer(() => owner.IsDisposed
+            ? Observable.Throw<T>(Disposed(ownerName))
+            : shared);
+    }
+
+    /// <summary>
+    /// <c>AutoConnect(minObservers)</c> whose connection is owned by <paramref name="hub"/>: released
+    /// in the hub's ShutDown phase (<see cref="IMessageHub.RegisterForDisposal(IDisposable)"/>). On a
+    /// hub that is already past that phase the registration is disposed as it is added, so every
+    /// subscription is refused from the start.
+    /// </summary>
+    /// <typeparam name="T">Element type.</typeparam>
+    /// <param name="source">The connectable chain.</param>
+    /// <param name="hub">The hub whose services the chain resolves.</param>
+    /// <param name="ownerName">Names the owner in the refusal.</param>
+    /// <param name="minObservers">Subscribers required before the connect fires.</param>
+    /// <returns>The shared observable.</returns>
+    public static IObservable<T> AutoConnectOwnedBy<T>(
+        this IConnectableObservable<T> source,
+        IMessageHub hub,
+        string ownerName,
+        int minObservers = 1)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        var owner = new CompositeDisposable();
+        hub.RegisterForDisposal(owner);
+        return source.AutoConnectOwnedBy(owner, ownerName, minObservers);
+    }
+
+    /// <summary>
+    /// Connects NOW and hands the connection to <paramref name="owner"/>. For a feed the owner keeps
+    /// filling regardless of subscribers (a directory index, an in-flight counter) — the
+    /// <c>Publish()</c> + <c>Connect()</c> shape, where a <c>RefCount()</c> dropping to zero would
+    /// tear the upstream down. Read through the connectable itself; the owner's disposal is what
+    /// ends the feed.
+    /// </summary>
+    /// <typeparam name="T">Element type.</typeparam>
+    /// <param name="source">The connectable chain.</param>
+    /// <param name="owner">The registry the owner disposes with itself.</param>
+    /// <returns>The owned handle — disposing it early releases this connection alone.</returns>
+    public static IDisposable ConnectOwnedBy<T>(this IConnectableObservable<T> source, CompositeDisposable owner)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(owner);
+        return Register(source, owner, source.Connect());
+    }
+
+    /// <summary>
+    /// Connects NOW and hands the connection to <paramref name="hub"/>, which releases it in its
+    /// ShutDown phase.
+    /// </summary>
+    /// <typeparam name="T">Element type.</typeparam>
+    /// <param name="source">The connectable chain.</param>
+    /// <param name="hub">The hub whose services the chain resolves.</param>
+    /// <returns>The owned handle.</returns>
+    public static IDisposable ConnectOwnedBy<T>(this IConnectableObservable<T> source, IMessageHub hub)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        var owner = new CompositeDisposable();
+        hub.RegisterForDisposal(owner);
+        return source.ConnectOwnedBy(owner);
+    }
+
+    /// <summary>
+    /// One owned handle: the connection plus a bookkeeping observer on the connectable that drops
+    /// the handle from the owner once the upstream terminates. Added to the owner FIRST — an owner
+    /// already disposed then disposes it on the spot (the late-connect race), and an upstream that
+    /// has already terminated (a settled replay) removes it in the same call rather than leaving a
+    /// dead handle behind.
+    /// </summary>
+    private static IDisposable Register<T>(IConnectableObservable<T> source, CompositeDisposable owner, IDisposable connection)
+    {
+        var handle = new CompositeDisposable(2) { connection };
+        owner.Add(handle);
+        // `Remove` disposes what it removes, so a terminated chain's connection is released with
+        // its bookkeeping in one step; on an owner disposed meanwhile it is a no-op (already done).
+        handle.Add(source.Subscribe(
+            _ => { },
+            _ => owner.Remove(handle),
+            () => owner.Remove(handle)));
+        return handle;
+    }
+
+    private static ObjectDisposedException Disposed(string ownerName) => new(
+        ownerName,
+        $"{ownerName} has released the shared connection this subscription would ride: the owner "
+        + "is disposed, its upstream is unsubscribed, and a subscriber arriving now would otherwise "
+        + "wait on a replay nothing will feed.");
+}

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionConnectionOwnedByHubTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionConnectionOwnedByHubTest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// 🚨 <b>A content collection's creation promise is owned by the hub, and a request after the hub's
+/// teardown is refused instead of served from a replay.</b>
+///
+/// <para><b>The site.</b> <c>ContentService.InitializeCollection</c> caches each collection as
+/// <c>CreateCollection(config)…Replay(1)</c> connected on its first subscriber. With a bare
+/// <c>AutoConnect(1)</c> the connection belonged to the chain: the hub's teardown disposed the
+/// collection (see <c>ContentCollectionDiesWithItsHubTest</c>) but could not reach the promise, so a
+/// creation still in flight ran its provider factory against the closed scope, and a
+/// <c>GetCollection</c> after the teardown REPLAYED the disposed collection to its caller as if it
+/// were live. It is now <c>AutoConnectOwnedBy(hub, nameof(ContentService))</c>.</para>
+///
+/// <para><b>Negative control</b> (run by hand when this test was written): restoring the bare
+/// <c>.AutoConnect(1)</c> at the site fails the last assertion — the late <c>GetCollection</c> emits
+/// the disposed collection (<c>OnNext</c>) instead of terminating with
+/// <see cref="ObjectDisposedException"/>. The control arm proves the collection resolved on the live
+/// hub first, so the refusal is measured against a promise that had genuinely been connected.</para>
+/// </summary>
+public class ContentCollectionConnectionOwnedByHubTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private readonly string path = Path.Combine(
+        AppContext.BaseDirectory, "Files", "OwnedByHub", Guid.NewGuid().ToString("N"));
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddContentCollections()
+            .AddFileSystemContentCollection("owned", _ => path);
+
+    [Fact(Timeout = 60_000)]
+    public async Task AfterTheHubsTeardown_GetCollectionIsRefused_NotServedFromTheReplay()
+    {
+        Directory.CreateDirectory(path);
+        var host = GetHost();
+        var service = host.ServiceProvider.GetRequiredService<IContentService>();
+
+        var collection = await service
+            .GetCollection("owned")
+            .Where(c => c is not null)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        collection!.IsDisposed.Should().BeFalse(
+            "CONTROL ARM: the creation promise connected and resolved a live collection on the live hub");
+
+        host.Dispose();
+        await host.DisposalCompleted.ObserveCompletion(
+            ex => Output.WriteLine($"late disposal fault: {ex}"),
+            TestContext.Current.CancellationToken);
+        collection.IsDisposed.Should().BeTrue("precondition: the hub disposed the collection it created");
+
+        var terminal = await service
+            .GetCollection("owned")
+            .Materialize()
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+
+        terminal.Kind.Should().Be(NotificationKind.OnError,
+            "a GetCollection after the hub's teardown must TERMINATE: a bare AutoConnect(1) replays the "
+            + "collection the hub has since disposed, handing the caller a dead watcher and a dead stream");
+        terminal.Exception.Should().BeOfType<ObjectDisposedException>()
+            .Which.ObjectName.Should().Be(nameof(ContentService),
+                "the refusal names the owner whose teardown released the promise");
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/RootedRxConnectionRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/RootedRxConnectionRatchetGuard.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance ratchet for the rooted-Rx-connection defect class: a multicast chain
+/// (<c>Replay(…)</c>, <c>Publish()</c>) whose <c>Connect()</c> handle nobody owns.
+///
+/// <para><b>The defect.</b> A bare <c>.AutoConnect(1)</c> keeps the handle its <c>Connect()</c>
+/// returns to itself; a bare <c>.Connect()</c> whose result is dropped keeps it nowhere. The owner's
+/// <c>Dispose()</c> therefore cannot reach the upstream — and the connect is often NOT synchronous:
+/// <c>Defer(…).SubscribeOn(TaskPoolScheduler)</c> only QUEUES the upstream subscribe, and no teardown
+/// phase joins a pool-queued Rx subscribe (<c>DisposalCompleted</c> covers the action blocks,
+/// <c>IoPoolRegistry.DrainAll</c> covers <c>IIoPool</c> leaves, the <c>AsyncDisposeQueue</c> covers
+/// enqueued cleanup). It ran whenever the pool reached it: MeshWeaver.Plugins run 34222933802
+/// (2026-09-08, shard 1) captured 11 <c>ObjectDisposedException</c> stragglers across three suites,
+/// every one <c>MeshNodeStreamCache.GetQueryRaw</c>'s Defer resolving <c>GetWorkspace()</c> from an
+/// Autofac scope the mesh had already closed, the FutuRe pair 4 ms after <c>DISPOSE_DONE</c>. Core
+/// #3737 fixed that one site; this guard keeps every other one fixed.</para>
+///
+/// <para><b>The fix at a site</b> is <c>MeshWeaver.Messaging.OwnedConnectionExtensions</c>:
+/// <c>.Replay(1).AutoConnectOwnedBy(owner, nameof(Owner))</c> for a lazily-connected shared chain,
+/// <c>.Publish().ConnectOwnedBy(owner)</c> for an eager feed — where <c>owner</c> is the hub whose
+/// services the chain resolves (<c>RegisterForDisposal</c>, released in its ShutDown phase) or a
+/// <see cref="System.Reactive.Disposables.CompositeDisposable"/> a singleton disposes with itself.
+/// The helper registers the handle on connect, drops it when the chain terminates, disposes a
+/// registration that arrives after the owner's disposal on the spot, and refuses a subscriber
+/// arriving after the release with <see cref="ObjectDisposedException"/> rather than parking it on a
+/// replay nothing will feed.</para>
+///
+/// <para><b>Why <c>RefCount()</c> is listed rather than rejected.</b> A ref-counted chain's
+/// connection is owned by its SUBSCRIBERS — it releases with the last of them — so there is no
+/// handle for an owner to hold; what must be owned is each subscription, which is the ordinary
+/// <c>RegisterForDisposal</c> rule and is not visible at the <c>RefCount()</c> call site. Every such
+/// site is therefore inventoried with the reason its subscriptions are owned, and the inventory may
+/// only shrink unless a new line and a raised <see cref="RefCountBudget"/> land in the same change.</para>
+///
+/// <para><b>Why the ROOTED budget is zero from day one.</b> Every bare rooted site in <c>src/</c>
+/// was converted in the change that added this guard (seven sites; see the allow file's header), so
+/// the list starts empty for that form and may only ever be empty: adding a line is not a fix.</para>
+/// </summary>
+public class RootedRxConnectionRatchetGuard(ITestOutputHelper output)
+{
+    private const string AllowFileName = "RootedRxConnectionSites.allow";
+
+    /// <summary>The one file that may spell <c>AutoConnect(</c> / <c>Connect()</c>: the helper itself.</summary>
+    private const string HelperFile = "src/MeshWeaver.Messaging.Hub/OwnedConnectionExtensions.cs";
+
+    /// <summary>Bare <c>.AutoConnect(</c> / <c>.Connect()</c> sites permitted in <c>src/</c>: none.</summary>
+    private const int RootedBudget = 0;
+
+    /// <summary>
+    /// <c>.RefCount(</c> sites inventoried with a reason. Six on 2026-09-08. May only go down unless a
+    /// new reasoned line and this constant move together.
+    /// </summary>
+    private const int RefCountBudget = 6;
+
+    private static readonly string[] ScannedRoots = ["src"];
+
+    /// <summary>
+    /// The rooted forms. <c>.AutoConnect(</c> does not match <c>.AutoConnectOwnedBy(</c> (the next
+    /// character is <c>O</c>, not <c>(</c>); <c>.Connect()</c> — empty parens — does not match
+    /// <c>.ConnectOwnedBy(</c>.
+    /// </summary>
+    private static readonly Regex Rooted = new(@"\.AutoConnect\s*\(|\.Connect\s*\(\s*\)", RegexOptions.Compiled);
+
+    private static readonly Regex RefCount = new(@"\.RefCount\s*\(", RegexOptions.Compiled);
+
+    private enum Form { Rooted, RefCount }
+
+    private sealed record Site(string File, int Line, string Symbol, Form Form, string Text);
+
+    private sealed record Allowance(string File, string Symbol, string Reason);
+
+    [Fact]
+    public void EveryRootedRxConnectionInSrc_IsOwnedOrInventoried()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var allowed = ReadAllowFile(Path.Combine(root, "test", AllowFileName));
+        var sites = Scan(root);
+
+        var failures = new List<string>();
+        var byKey = allowed.ToDictionary(a => Key(a.File, a.Symbol), a => a, StringComparer.Ordinal);
+        var used = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var site in sites.OrderBy(s => s.File, StringComparer.Ordinal).ThenBy(s => s.Line))
+        {
+            var key = Key(site.File, site.Symbol);
+            if (!byKey.ContainsKey(key))
+            {
+                failures.Add(site.Form == Form.Rooted
+                    ? $"  ROOTED     {site.File}:{site.Line} in `{site.Symbol}` — `{site.Text.Trim()}`. The connection "
+                      + "handle is held by the chain, not by an owner, so no Dispose() can release it. "
+                      + "Use `.AutoConnectOwnedBy(hub | CompositeDisposable, nameof(Owner))` or "
+                      + "`.ConnectOwnedBy(owner)` from MeshWeaver.Messaging.OwnedConnectionExtensions. "
+                      + "Do NOT add a line to " + AllowFileName + "."
+                    : $"  REFCOUNT   {site.File}:{site.Line} in `{site.Symbol}` — `{site.Text.Trim()}`. A "
+                      + "ref-counted chain's connection is owned by its subscribers; add a line to "
+                      + AllowFileName + " stating who owns those subscriptions (RegisterForDisposal, a "
+                      + "hub-scoped consumer, a completing one-shot) AND raise RefCountBudget in the "
+                      + "same change — or convert to an owned connection.");
+                continue;
+            }
+            used.Add(key);
+        }
+
+        // Budgets — counted over the allow file's LIVE entries, by the form the tree shows for them.
+        var rootedAllowed = sites.Where(s => s.Form == Form.Rooted && byKey.ContainsKey(Key(s.File, s.Symbol)))
+            .Select(s => Key(s.File, s.Symbol)).Distinct(StringComparer.Ordinal).Count();
+        if (rootedAllowed > RootedBudget)
+            failures.Add(
+                $"  BUDGET     {rootedAllowed} bare rooted site(s) are allow-listed; the budget is {RootedBudget}. "
+                + "A bare AutoConnect( / Connect() is never inventoried — convert it.");
+
+        var refCountAllowed = sites.Where(s => s.Form == Form.RefCount && byKey.ContainsKey(Key(s.File, s.Symbol)))
+            .Select(s => Key(s.File, s.Symbol)).Distinct(StringComparer.Ordinal).Count();
+        if (refCountAllowed > RefCountBudget)
+            failures.Add(
+                $"  BUDGET     {refCountAllowed} RefCount site(s) are allow-listed; the budget is {RefCountBudget}. "
+                + "Raise RefCountBudget in the same change that adds the reasoned line, so the growth is a "
+                + "reviewed decision rather than a drift.");
+
+        foreach (var stale in byKey.Keys.Where(k => !used.Contains(k)).OrderBy(k => k, StringComparer.Ordinal))
+            failures.Add(
+                $"  STALE      {stale} is allow-listed but no such site exists — the site moved, was "
+                + "renamed, or was converted. Delete the line (and lower RefCountBudget if it was one).");
+
+        foreach (var a in allowed.Where(a => string.IsNullOrWhiteSpace(a.Reason)))
+            failures.Add($"  NO REASON  {Key(a.File, a.Symbol)} — every inventoried site carries a one-line reason.");
+
+        Assert.True(failures.Count == 0,
+            "A multicast chain's connection must be OWNED by the object whose services it resolves, so "
+            + "that the owner's Dispose() releases it; a bare AutoConnect(1) / Connect() keeps the handle "
+            + "where no teardown can reach it, and a pool-queued connect then runs against a closed scope "
+            + "(11 disposed-scope stragglers in one Plugins run, 34222933802 — all this shape).\n"
+            + string.Join("\n", failures));
+    }
+
+    /// <summary>
+    /// Non-vacuity, part 1 — the CLASSIFIER, on synthetic source: the bare forms are flagged, the
+    /// helper spellings are not, prose is not, and the symbol attribution reaches the member that
+    /// encloses the call rather than a nearer local or parameter.
+    /// </summary>
+    [Fact]
+    public void TheClassifierTellsABareConnectionFromAnOwnedOne()
+    {
+        const string bare = """
+            namespace N;
+            public sealed class Owner
+            {
+                private readonly IObservable<int> shared;
+                public Owner(IObservable<int> source, ILogger? logger = null)
+                {
+                    shared = source.Replay(1).AutoConnect(1);
+                }
+                public IObservable<int> Feed() => source.Publish().Connect();
+                public IObservable<int> Counted => source.Replay(1).RefCount();
+            }
+            """;
+        var sites = Sites("x.cs", bare);
+        Assert.Equal(3, sites.Count);
+        Assert.Equal(("Owner", Form.Rooted), (sites[0].Symbol, sites[0].Form));
+        Assert.Equal(("Feed", Form.Rooted), (sites[1].Symbol, sites[1].Form));
+        Assert.Equal(("Counted", Form.RefCount), (sites[2].Symbol, sites[2].Form));
+
+        const string owned = """
+            public sealed class Owner
+            {
+                private readonly IObservable<int> shared = source.Replay(1).AutoConnectOwnedBy(hub, nameof(Owner));
+                public Owner() { source.Publish().ConnectOwnedBy(hub); }
+            }
+            """;
+        Assert.Empty(Sites("y.cs", owned));
+
+        // Prose quoting the shape is not a call site — this file and the allow file both do it.
+        const string prose = """
+            public sealed class Owner
+            {
+                // a bare .AutoConnect(1) or .Connect() is the defect; "x.RefCount()" too
+                public void M() { }
+            }
+            """;
+        Assert.Empty(Sites("z.cs", prose));
+
+        // Expression-bodied member spanning lines: the member is the declaration, not a call inside it.
+        const string expressionBodied = """
+            public sealed class Resolver
+            {
+                private sealed record Resolution(DateTimeOffset At, string? Id);
+                private IObservable<Resolution> Lookup(string url, string? user) =>
+                    ResolveToken(user)
+                        .SelectMany(token => client.Get(url, token))
+                        .Replay(1)
+                        .AutoConnect(1);
+            }
+            """;
+        var expr = Sites("r.cs", expressionBodied);
+        Assert.Single(expr);
+        Assert.Equal("Lookup", expr[0].Symbol);
+    }
+
+    /// <summary>
+    /// Non-vacuity, part 2 — the WALK. The rooted inventory is empty by design, so the only evidence
+    /// the tree is still being read is that the scan sees the helper's call sites (the converted
+    /// rooted connections) and the inventoried RefCount sites.
+    /// </summary>
+    [Fact]
+    public void TheScannerStillSeesTheConvertedSitesAndTheInventory()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var helperCalls = 0;
+        foreach (var file in SourceScan.SourceFiles(root, ScannedRoots))
+        {
+            if (SourceScan.Relative(root, file) == HelperFile) continue;
+            var code = SourceScan.MaskCommentsAndStrings(File.ReadAllText(file));
+            helperCalls += HelperCalls.Matches(code).Count;
+        }
+
+        Assert.True(helperCalls >= 7,
+            $"The scan found {helperCalls} AutoConnectOwnedBy/ConnectOwnedBy call sites in src/ (expected at least "
+            + "7 — the sites converted on 2026-09-08). Either the helper was renamed, or SourceScan is not "
+            + "reading the production tree, in which case the empty rooted inventory is proving nothing.");
+
+        var sites = Scan(root);
+        Assert.True(sites.Count(s => s.Form == Form.RefCount) >= 1,
+            "The scan found no RefCount site at all — the pattern no longer matches this codebase or the "
+            + "tree was not read; the inventory above is then vacuous.");
+
+        foreach (var site in sites.OrderBy(s => s.File, StringComparer.Ordinal).ThenBy(s => s.Line))
+            output.WriteLine($"{site.Form,-8} {site.File}:{site.Line}  {site.Symbol}");
+    }
+
+    private static readonly Regex HelperCalls = new(@"\.(?:AutoConnectOwnedBy|ConnectOwnedBy)\s*\(", RegexOptions.Compiled);
+
+    private static string Key(string file, string symbol) => file + "\t" + symbol;
+
+    private static List<Site> Scan(string root)
+    {
+        var result = new List<Site>();
+        foreach (var file in SourceScan.SourceFiles(root, ScannedRoots))
+        {
+            var relative = SourceScan.Relative(root, file);
+            if (relative == HelperFile) continue;
+            string text;
+            try { text = File.ReadAllText(file); }
+            catch (IOException) { continue; } // a file a concurrent build is writing is not evidence
+            result.AddRange(Sites(relative, text));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Every connection site in <paramref name="text"/>, attributed to its enclosing member.
+    /// Comments and string literals are masked first, so prose quoting the shape is not counted.
+    /// </summary>
+    private static List<Site> Sites(string file, string text)
+    {
+        var result = new List<Site>();
+        if (!text.Contains("Connect", StringComparison.Ordinal) && !text.Contains("RefCount", StringComparison.Ordinal))
+            return result;
+
+        var code = SourceScan.MaskCommentsAndStrings(text);
+        var lines = code.Split('\n');
+        var depths = DepthAtLineStart(code);
+
+        foreach (var (regex, form) in new[] { (Rooted, Form.Rooted), (RefCount, Form.RefCount) })
+        {
+            foreach (Match match in regex.Matches(code))
+            {
+                var line = code.AsSpan(0, match.Index).Count('\n');
+                result.Add(new Site(file, line + 1, EnclosingMember(lines, depths, line), form, lines[line]));
+            }
+        }
+
+        return result.OrderBy(s => s.Line).ToList();
+    }
+
+    /// <summary>Brace depth at the START of each line of masked code.</summary>
+    private static int[] DepthAtLineStart(string code)
+    {
+        var lines = code.Split('\n');
+        var depths = new int[lines.Length];
+        var depth = 0;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            depths[i] = depth;
+            foreach (var c in lines[i])
+                depth += c == '{' ? 1 : c == '}' ? -1 : 0;
+        }
+
+        return depths;
+    }
+
+    private static readonly Regex TypeDeclaration = new(
+        @"\b(?:class|record|struct|interface)\s+[A-Za-z_]\w*", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A member declaration: optional attributes, modifiers, then either at least one modifier or at
+    /// least one type token before the NAME, followed by a parameter list, an expression body, a
+    /// block, an initializer or a terminator. A call (<c>ResolveToken(user)</c>) has neither a
+    /// modifier nor a type token and does not match; a local (<c>var x = …</c>) is excluded by the
+    /// <c>var</c> lookahead and by depth.
+    /// </summary>
+    private static readonly Regex MemberDeclaration = new(
+        @"^\s*(?:\[[^\]]*\]\s*)*"
+        + @"(?<mods>(?:(?:public|private|protected|internal|static|override|virtual|abstract|sealed|async|partial|new|readonly|extern|unsafe|required|volatile|const)\s+)*)"
+        + @"(?<types>(?:(?!(?:var|return|throw|yield|await|else|using|case|default|new)\b)[A-Za-z_][\w.]*(?:<[^;(){}=]*>)?(?:\[[\],]*\])*\??\s+)*)"
+        + @"(?<name>[A-Za-z_]\w*)\s*(?:<[^>]*>)?\s*(?:\(|=>|\{|=(?!=)|;|$)",
+        RegexOptions.Compiled);
+
+    private static readonly HashSet<string> Keywords = new(StringComparer.Ordinal)
+    {
+        "if", "while", "for", "foreach", "switch", "using", "lock", "catch", "return", "new", "throw",
+        "yield", "await", "case", "do", "try", "else", "get", "set", "init", "add", "remove", "is", "as",
+        "in", "out", "ref", "params", "this", "base", "typeof", "nameof", "default", "sizeof", "checked",
+        "unchecked", "fixed", "goto", "break", "continue", "when", "where", "select", "from", "var",
+        "namespace", "class", "record", "struct", "interface", "enum", "delegate", "event",
+    };
+
+    /// <summary>
+    /// The member enclosing <paramref name="hitLine"/>: the nearest preceding type declaration that
+    /// ENCLOSES the hit fixes the member depth (one deeper than the type's line), and the nearest
+    /// declaration-shaped line at that depth — the hit's own line included, for one-line members —
+    /// names the member. Parameter and expression-body continuations (a previous line ending in
+    /// <c>,</c>, <c>(</c> or <c>=&gt;</c>) are skipped, as are lines that begin with an operator.
+    /// </summary>
+    private static string EnclosingMember(string[] lines, int[] depths, int hitLine)
+    {
+        var typeLine = -1;
+        for (var t = hitLine; t >= 0; t--)
+        {
+            if (depths[t] >= depths[hitLine] && !(t == hitLine)) continue;
+            if (!TypeDeclaration.IsMatch(lines[t])) continue;
+            if (Encloses(lines, depths, t, hitLine)) { typeLine = t; break; }
+        }
+
+        if (typeLine < 0) return "<no enclosing type>";
+        var memberDepth = depths[typeLine] + 1;
+
+        for (var k = hitLine; k > typeLine; k--)
+        {
+            if (depths[k] != memberDepth) continue;
+            var line = lines[k];
+            var trimmed = line.TrimStart();
+            if (trimmed.Length == 0 || trimmed[0] is '.' or '?' or ':' or '=' or ')' or '}' or '{') continue;
+            if (IsContinuation(lines, k)) continue;
+            var m = MemberDeclaration.Match(line);
+            if (!m.Success) continue;
+            var name = m.Groups["name"].Value;
+            if (Keywords.Contains(name)) continue;
+            if (m.Groups["mods"].Value.Length == 0 && m.Groups["types"].Value.Length == 0) continue;
+            if (m.Groups["types"].Value.Split(' ', StringSplitOptions.RemoveEmptyEntries).Any(Keywords.Contains)) continue;
+            return name;
+        }
+
+        return "<no enclosing member>";
+    }
+
+    /// <summary>
+    /// Whether the type declared on <paramref name="typeLine"/> encloses <paramref name="hitLine"/>.
+    /// The type's HEADER — a positional record's parameter list, a base list, constraints — sits at
+    /// the type's own depth and runs to the line carrying the body's opening brace; only after that
+    /// must every line stay deeper than the type. A one-line <c>record X(…);</c> has no body, so it
+    /// encloses nothing.
+    /// </summary>
+    private static bool Encloses(string[] lines, int[] depths, int typeLine, int hitLine)
+    {
+        if (typeLine >= hitLine || depths[hitLine] <= depths[typeLine]) return false;
+
+        var bodyStart = -1;
+        for (var k = typeLine; k < hitLine; k++)
+        {
+            if (k + 1 < depths.Length && depths[k + 1] > depths[typeLine]) { bodyStart = k; break; }
+            if (lines[k].Contains(';')) return false; // a header that ends in `;` declares a body-less type
+        }
+
+        if (bodyStart < 0) return false;
+        for (var k = bodyStart + 1; k < hitLine; k++)
+            if (depths[k] <= depths[typeLine] && lines[k].Trim().Length > 0) return false;
+
+        return true;
+    }
+
+    private static bool IsContinuation(string[] lines, int k)
+    {
+        for (var p = k - 1; p >= 0; p--)
+        {
+            var prev = lines[p].TrimEnd();
+            if (prev.Length == 0) continue;
+            return prev.EndsWith(',') || prev.EndsWith('(') || prev.EndsWith("=>", StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    /// <summary><c>path&lt;TAB&gt;symbol&lt;TAB&gt;reason</c>, one per line; <c>#</c> starts a comment.</summary>
+    private static List<Allowance> ReadAllowFile(string path)
+    {
+        Assert.True(File.Exists(path),
+            $"{AllowFileName} is missing — without it this guard cannot tell an inventoried RefCount site "
+            + "from a new one. Restore it from git rather than regenerating it.");
+
+        return File.ReadAllLines(path)
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0 && !l.StartsWith('#'))
+            .Select(l => l.Split('\t', StringSplitOptions.TrimEntries))
+            .Select(parts =>
+            {
+                Assert.True(parts.Length >= 3,
+                    $"{AllowFileName}: `{string.Join("\\t", parts)}` — every line is <path><TAB><member><TAB><reason>.");
+                return new Allowance(parts[0], parts[1], string.Join(" ", parts.Skip(2)));
+            })
+            .ToList();
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/MeshWeaver.Messaging.Hub.Test.csproj
+++ b/test/MeshWeaver.Messaging.Hub.Test/MeshWeaver.Messaging.Hub.Test.csproj
@@ -3,6 +3,7 @@
     <ProjectGuid>{99c0d432-37b8-4c2c-92a5-1b0d980b7480}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Reactive.Testing" />
     <ProjectReference Include="..\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
   </ItemGroup>
 </Project>

--- a/test/MeshWeaver.Messaging.Hub.Test/OwnedConnectionTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/OwnedConnectionTest.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A multicast chain's connection belongs to its owner, and the owner's disposal releases it —
+/// including a connect that is still QUEUED.</b>
+///
+/// <para><b>The live defect.</b> <c>Defer(…).SubscribeOn(TaskPoolScheduler).Replay(1).AutoConnect(1)</c>:
+/// the first subscriber's <c>Connect()</c> only queues the upstream subscribe on the pool, and the
+/// handle <c>Connect()</c> returns stays inside <c>AutoConnect</c>. Nothing in a teardown joins a
+/// pool-queued Rx subscribe, so the item ran whenever the pool reached it — after the owner's scope
+/// had closed, resolving services from a disposed container. Measured on MeshWeaver.Plugins run
+/// 34222933802 (2026-09-08): 11 disposed-scope stragglers across three suites, all this shape
+/// (core #3737 fixed the one site; <c>OwnedConnectionExtensions</c> is the shape for every site).</para>
+///
+/// <para><b>The contract, each arm with its control.</b> A connect still queued when the owner is
+/// released never runs (the control arm proves the connection WAS registered — a helper that
+/// registered nothing would read zero before and after); a live upstream is unsubscribed with the
+/// owner; a subscriber arriving after the release is refused, naming the owner; a chain that
+/// terminates drops its handle so the owner tracks live connections only; and a hub-owned
+/// connection is released in the hub's ShutDown phase.</para>
+///
+/// <para><b>Negative control</b> (run once, by hand, when this test was written): replacing the
+/// helper's body with a bare <c>source.AutoConnect(minObservers)</c> fails
+/// <see cref="AConnectStillQueuedWhenTheOwnerIsReleased_NeverRuns"/> at the control arm
+/// (<c>owner.Count</c> reads 0, not 1) and, with the control removed, at the assertion that the
+/// factory never ran — the queued connect goes ahead against the disposed owner.</para>
+/// </summary>
+public class OwnedConnectionTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    [Fact]
+    public void AConnectStillQueuedWhenTheOwnerIsReleased_NeverRuns()
+    {
+        var scheduler = new TestScheduler();
+        var owner = new CompositeDisposable();
+        var factoryRuns = 0;
+
+        // The #3737 shape, verbatim: the factory is the Defer that resolved a workspace from a
+        // disposed scope, SubscribeOn is the pool hand-off, Replay(1) the shared buffer.
+        var shared = Observable
+            .Defer(() =>
+            {
+                factoryRuns++;
+                return Observable.Return(42);
+            })
+            .SubscribeOn(scheduler)
+            .Replay(1)
+            .AutoConnectOwnedBy(owner, "test-owner");
+
+        var received = new List<Notification<int>>();
+        using var subscription = shared.Materialize().Subscribe(received.Add);
+
+        factoryRuns.Should().Be(0, "precondition: SubscribeOn queued the connect; the pool has not run it");
+        owner.Count.Should().Be(1,
+            "CONTROL ARM: the first subscriber's Connect() must be registered with the owner the instant "
+            + "it runs — a zero here means the helper registered nothing, and the assertion below would be "
+            + "vacuous");
+
+        owner.Dispose();
+        scheduler.Start(); // the pool gets to the queued item — AFTER the owner is gone
+
+        factoryRuns.Should().Be(0,
+            "the queued connect must be CANCELLED by the owner's release, never run against a disposed "
+            + "owner — this is the GetQueryRaw → GetWorkspace disposed-scope straggler");
+        received.Should().BeEmpty("a cancelled connect feeds nothing to the subscriber that queued it");
+    }
+
+    [Fact]
+    public void ALiveConnection_IsReleasedWithItsOwner()
+    {
+        var upstream = new Subject<int>();
+        var owner = new CompositeDisposable();
+        var shared = upstream.Replay(1).AutoConnectOwnedBy(owner, "test-owner");
+
+        using var subscription = shared.Subscribe(_ => { });
+        upstream.HasObservers.Should().BeTrue("CONTROL ARM: the first subscriber connected the upstream");
+        owner.Count.Should().Be(1, "CONTROL ARM: the connection is registered");
+
+        owner.Dispose();
+
+        upstream.HasObservers.Should().BeFalse(
+            "the owner's disposal unsubscribes the upstream — the connection is no longer rooted by the chain");
+    }
+
+    [Fact]
+    public void ASubscriptionAfterTheRelease_IsRefusedNamingTheOwner()
+    {
+        var upstream = new Subject<int>();
+        var owner = new CompositeDisposable();
+        var shared = upstream.Replay(1).AutoConnectOwnedBy(owner, "test-owner");
+
+        using (shared.Subscribe(_ => { }))
+            upstream.OnNext(7);
+        owner.Dispose();
+
+        // The refusal is emitted synchronously on subscribe (a Defer that throws), so a plain
+        // Subscribe captures it — no blocking bridge, nothing to wait on.
+        Notification<int>? terminal = null;
+        using (shared.Materialize().Take(1).Subscribe(n => terminal = n))
+        {
+        }
+
+        terminal.Should().NotBeNull("the refusal is synchronous — a subscriber is told at once, never parked");
+        terminal!.Kind.Should().Be(NotificationKind.OnError,
+            "a subscriber arriving after the release must TERMINATE — a bare Replay(1) would hand it the "
+            + "buffered 7 and then go silent forever, the burst-then-silence hang");
+        terminal.Exception.Should().BeOfType<ObjectDisposedException>()
+            .Which.ObjectName.Should().Be("test-owner", "the refusal names the owner so the straggler is attributable");
+        upstream.HasObservers.Should().BeFalse("a refused subscription opens no upstream");
+    }
+
+    [Fact]
+    public void ATerminatedChain_DropsItsHandleFromTheOwner_AndStillReplays()
+    {
+        var upstream = new Subject<int>();
+        var owner = new CompositeDisposable();
+        var shared = upstream.Replay(1).AutoConnectOwnedBy(owner, "test-owner");
+
+        using var subscription = shared.Subscribe(_ => { });
+        owner.Count.Should().Be(1, "CONTROL ARM: registered while live");
+
+        upstream.OnNext(1);
+        upstream.OnCompleted();
+
+        owner.Count.Should().Be(0,
+            "a terminated chain's connection holds nothing — it leaves the owner so a faulted-then-rebuilt "
+            + "promise cannot accumulate one dead handle per attempt for the life of the process");
+
+        var late = new List<Notification<int>>();
+        shared.Materialize().Subscribe(late.Add);
+        late.Should().HaveCount(2, "the owner is NOT disposed, so the settled promise still replays to a late subscriber");
+        late[0].Value.Should().Be(1);
+        late[1].Kind.Should().Be(NotificationKind.OnCompleted);
+    }
+
+    [Fact]
+    public void AFaultedChain_DropsItsHandleFromTheOwner()
+    {
+        var upstream = new Subject<int>();
+        var owner = new CompositeDisposable();
+        var shared = upstream.Replay(1).AutoConnectOwnedBy(owner, "test-owner");
+
+        using var subscription = shared.Subscribe(_ => { }, _ => { });
+        owner.Count.Should().Be(1, "CONTROL ARM: registered while live");
+
+        upstream.OnError(new InvalidOperationException("upstream fault"));
+
+        owner.Count.Should().Be(0, "a faulted chain's connection is released with its eviction");
+    }
+
+    [Fact]
+    public void ConnectOwnedBy_ConnectsNow_AndReleasesWithTheOwner()
+    {
+        var upstream = new Subject<int>();
+        var owner = new CompositeDisposable();
+        var published = upstream.Publish();
+
+        upstream.HasObservers.Should().BeFalse("precondition: nothing is connected before ConnectOwnedBy");
+        published.ConnectOwnedBy(owner);
+        upstream.HasObservers.Should().BeTrue("CONTROL ARM: ConnectOwnedBy connects eagerly — a feed fills without subscribers");
+        owner.Count.Should().Be(1);
+
+        owner.Dispose();
+        upstream.HasObservers.Should().BeFalse("the owner's disposal ends the feed");
+    }
+
+    [Fact]
+    public void AConnectionRegisteredOnADisposedOwner_IsReleasedOnTheSpot()
+    {
+        var upstream = new Subject<int>();
+        var owner = new CompositeDisposable();
+        owner.Dispose();
+
+        // The sliver the Defer guard cannot see: a Connect() that ran between the guard's read and
+        // the owner's disposal. CompositeDisposable's contract — Add on a disposed composite
+        // disposes the item — is what closes it; ConnectOwnedBy exercises that path directly.
+        upstream.Publish().ConnectOwnedBy(owner);
+
+        upstream.HasObservers.Should().BeFalse(
+            "a registration arriving after the owner's disposal is disposed as it is added — the "
+            + "late-connect race resolved by construction");
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task AHubOwnedConnection_IsReleasedInTheHubsShutDown()
+    {
+        var host = GetHost();
+        var hub = host.GetHostedHub(new Address("owned-connection", "1"), c => c);
+
+        var upstream = new Subject<int>();
+        var shared = upstream.Replay(1).AutoConnectOwnedBy(hub, "hosted-owner");
+        using var subscription = shared.Subscribe(_ => { }, _ => { });
+        upstream.HasObservers.Should().BeTrue("CONTROL ARM: connected on the live hub");
+
+        hub.Dispose();
+        await hub.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(TimeSpan.FromSeconds(120));
+
+        upstream.HasObservers.Should().BeFalse(
+            "RegisterForDisposal runs the release in the hub's ShutDown phase — strictly inside its "
+            + "DisposalCompleted, before any scope closes");
+
+        Notification<int>? terminal = null;
+        using (shared.Materialize().Take(1).Subscribe(n => terminal = n))
+        {
+        }
+
+        terminal.Should().NotBeNull("the refusal is synchronous");
+        terminal!.Kind.Should().Be(NotificationKind.OnError, "a subscriber after the hub's teardown is refused");
+        terminal.Exception.Should().BeOfType<ObjectDisposedException>().Which.ObjectName.Should().Be("hosted-owner");
+    }
+}

--- a/test/RootedRxConnectionSites.allow
+++ b/test/RootedRxConnectionSites.allow
@@ -1,0 +1,29 @@
+# RootedRxConnectionSites.allow — the rooted-Rx-connection ratchet (RootedRxConnectionRatchetGuard).
+#
+# A multicast chain's CONNECTION must be owned by the object whose services it resolves, so that
+# the owner's Dispose() releases it. The one sanctioned spelling is
+# `OwnedConnectionExtensions.AutoConnectOwnedBy(owner, name)` / `ConnectOwnedBy(owner)`
+# (src/MeshWeaver.Messaging.Hub/OwnedConnectionExtensions.cs). A bare `.AutoConnect(` or a bare
+# `.Connect()` in src/ keeps the handle where no teardown can reach it, and when the connect is a
+# pool-queued subscribe (`Defer(…).SubscribeOn(TaskPoolScheduler)`) it runs whenever the pool gets
+# to it — after the owner's scope has closed, resolving from a disposed container (11 stragglers
+# in one Plugins run, 34222933802, every one this shape; see Doc/Architecture/HubDisposalModel →
+# "Rooted Rx connections").
+#
+# 🚨 The ROOTED budget is ZERO and stays zero: no bare `.AutoConnect(` / `.Connect()` may be listed
+# here. Convert the site to the helper; do not add a line.
+#
+# `.RefCount()` sites ARE listed, each with the reason its SUBSCRIPTIONS are owned: a ref-counted
+# chain releases its upstream with its last subscriber, so there is no handle for the owner to hold
+# — what must be owned is each subscription, through the ordinary hub.RegisterForDisposal rule. A
+# new RefCount site needs a reasoned line here AND a raised RefCountBudget in the guard, in the
+# same change; a line whose site is gone is a failure, not a tidy-up.
+#
+# format: <repo-relative path><TAB><enclosing member><TAB><reason>   — '#' starts a comment.
+
+src/MeshWeaver.Data/VirtualDataSource.cs	StreamUpdates	RefCount, subscriber-owned: the data source's own subscription is stream.RegisterForDisposal'd in SetupDataSourceStream, the chain disconnects with the last subscriber, and EvictCachedStream drops a faulted one (#3155).
+src/MeshWeaver.Graph/Configuration/PartitionRegistry.cs	GetPartition	RefCount, subscriber-owned: script-execution callers hold and dispose their own subscriptions; the mesh service is resolved at CALL time, so a call after the hub's teardown throws at the resolve rather than inside a live chain.
+src/MeshWeaver.Graph/DeckSlidesCache.cs	GetOrderedSlides	RefCount, subscriber-owned: slide renders dispose with their layout-area hubs, the entry disconnects the instant the deck is left (deliberately NO RefCount(TimeSpan) — that timer rooted a disposed mesh, MeshHubDisposalLeakTest), and the PromiseCache evicts a faulted entry.
+src/MeshWeaver.Graph/MeshNodeTypeSource.cs	MeshNodeTypeSource	RefCount, subscriber-owned: the constructor's enrichment-capture subscription is hub.RegisterForDisposal'd and OwnNodeCache's is hub-scoped, so the routing own-node stream disconnects at the hub's ShutDown with the last of them.
+src/MeshWeaver.Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs	RoutingProxyAdapter	RefCount, subscriber-owned one-shot: the Defer'd probe completes, so the connection lives only while a read is in flight; a probe after the caller hub's teardown resolves the providers from the dead scope INSIDE the Defer and terminates with ObjectDisposedException.
+src/MeshWeaver.Hosting/Persistence/PersistenceService.cs	PersistenceService	RefCount, subscriber-owned one-shot: Defer + Take(1) + Timeout per provider, so the probe completes and each read's subscription is the reader's own; no scope is resolved inside the chain.


### PR DESCRIPTION
## The dispose chain, made structurally correct for every rooted Rx connection in `src/`

Follows #3737 (`fix(MeshNodeStreamCache): release synced-query connections on Dispose`), which fixed ONE
site of a defect class. This makes the fix the only spelling and ratchets the class to zero.

**The defect class.** A multicast chain (`Replay(1)`, `Publish()`) whose `Connect()` handle nobody owns:
`.AutoConnect(1)` keeps it inside the operator, a dropped `.Connect()` keeps it nowhere. The owner's
`Dispose()` cannot reach the upstream — and the connect is frequently NOT synchronous:
`Defer(…).SubscribeOn(TaskPoolScheduler)` only queues the upstream subscribe, and no teardown phase joins a
pool-queued Rx subscribe (`DisposalCompleted` covers action blocks, `IoPoolRegistry.DrainAll` covers
`IIoPool` leaves, `AsyncDisposeQueue` covers enqueued cleanup). It ran whenever the pool reached it, against
a closed scope: 11 `ObjectDisposedException` stragglers in Plugins run 34222933802, all one `Defer`.

**The shape (one helper, `MeshWeaver.Messaging.OwnedConnectionExtensions`).**
`.Replay(1).AutoConnectOwnedBy(hub | CompositeDisposable, nameof(Owner))` / `.Publish().ConnectOwnedBy(owner)`:
the handle is registered with the owner on connect; the owner's disposal unsubscribes a live upstream and
**cancels a still-queued connect** (a registration landing in a disposed `CompositeDisposable` is disposed on
the spot); a chain that terminates drops its handle (the owner tracks LIVE connections only); a subscriber
arriving after the release is refused with `ObjectDisposedException(ownerName)` instead of being parked on a
replay nothing will feed.

### Per-site table (sweep: `git grep -n -E "AutoConnect\(|\.Connect\(\)|RefCount\(" -- src`, code hits only)

| Site | Owner | Verdict before | What changed |
|---|---|---|---|
| `Hosting/MeshNodeStreamCache.cs` `GetQueryRaw` | cache (`_queryConnections`) | fixed inline by #3737 | migrated to `AutoConnectOwnedBy(_queryConnections, …)`; the hand-written `ReleaseQueryConnection` fault-arm release is now the helper's terminal release. #3737's `QueryConnectionsReleasedOnTeardownTest` still passes (2/2) |
| `ContentCollections/ContentService.cs` `InitializeCollection` | hub-scoped (`AddScoped<IContentService>`) | **FAILS** — bare `AutoConnect(1)` on a promise whose first subscriber can be a pool-landed render; after teardown `GetCollection` REPLAYED the disposed collection | `AutoConnectOwnedBy(hub, nameof(ContentService))`; new `ContentCollectionConnectionOwnedByHubTest` |
| `Compiler.Pipeline/NodeTypeCompilationHelpers.cs` `RunCompile` | NodeType hub | **FAILS** — the compile pipeline subscribes on the pool (`SubscribeOn`), so the first subscriber's connect could run the activity `CreateNode` off a closed scope, `Catch` swallowed it as `null`, and Roslyn ran for a dead hub | `AutoConnectOwnedBy(hub, $"RunCompile({hubPath})")`; a late subscribe now faults into the compile subscription's existing error arm |
| `GitSync/GitHubRepoIdentityResolver.cs` `Lookup` | DI singleton, no hub | **FAILS** — promise in a `PromiseCache`, bare `AutoConnect(1)`; a lookup in flight at host stop completed against the disposed container | class is now `IDisposable` with a `CompositeDisposable lookups`; `AutoConnectOwnedBy(lookups, …)` |
| `Hosting.AspNetCore/Portal/UserIdentityCache.cs` ctor | DI singleton + mesh hub | partial — `Publish()+Connect()` handle WAS stored and disposed in `Dispose()`, but only at container disposal, i.e. AFTER the mesh's scopes closed | `hub.RegisterForDisposal(_connections)` + `ConnectOwnedBy(_connections)`: released in the hub's ShutDown, and by `Dispose()` (idempotent) |
| `Mesh.Contract/ActivityTracker.cs` ctor | self (DI singleton) | OK — handle stored, disposed in `Dispose()`, upstream is its own Subject+EventLoopScheduler | `ConnectOwnedBy(connections)` so the guard sees ownership; behaviour unchanged |
| `Hosting.Orleans/RoutingQuiescence.cs` ctor | self (DI singleton) | OK — same as ActivityTracker | same |
| `Data/VirtualDataSource.cs` `StreamUpdates` | — | `RefCount()`: subscriber-owned, subscription `stream.RegisterForDisposal`'d | inventoried with reason |
| `Graph/Configuration/PartitionRegistry.cs` `GetPartition` | — | `RefCount()`: subscriber-owned; mesh service resolved at CALL time | inventoried |
| `Graph/DeckSlidesCache.cs` `GetOrderedSlides` | — | `RefCount()`: subscriber-owned; deliberately no disconnect delay | inventoried |
| `Graph/MeshNodeTypeSource.cs` ctor | — | `RefCount()`: own subscription `hub.RegisterForDisposal`'d | inventoried |
| `Hosting/Persistence/PartitionStorage/RoutingProxyAdapter.cs` ctor | — | `RefCount()`: completing one-shot probe, `Defer`'d | inventoried |
| `Hosting/Persistence/PersistenceService.cs` ctor | — | `RefCount()`: completing one-shot probe | inventoried |

`Mesh.Contract/Threading/PromiseCache.cs` only mentions `AutoConnect` in prose (its `Do`, not a `Subscribe`, is
exactly so it never connects a chain). `tools/MeshWeaver.PluginTester/Cascade.cs` (`PublishLast().AutoConnect()`)
is a run harness whose `Finally` completes the queue — outside `src/`, not touched.

### The guard — `RootedRxConnectionRatchetGuard` (Documentation.Test) + `test/RootedRxConnectionSites.allow`

Scans `src/` (comments/strings masked) for `.AutoConnect(` / `.Connect()` / `.RefCount(`, attributes each hit to
its enclosing member, and requires a `path<TAB>member<TAB>reason` line. The **rooted budget is zero** — a bare
`AutoConnect(`/`Connect()` is red with no allow-list escape (convert to the helper). `RefCount()` sites are
inventoried with the reason their subscriptions are owned; growing that list also needs `RefCountBudget` raised,
so it is a reviewed decision. A stale line is a failure. Two non-vacuity tests: the classifier on synthetic
source (bare vs owned vs prose vs expression-bodied member attribution), and the walk (≥ 7 helper call sites
in `src/`, ≥ 1 RefCount site).

### Verification (all Release `-warnaserror`, one project per invocation, `0 Error(s)` read for each)

Built: Messaging.Hub, Mesh.Contract, ContentCollections, Compiler.Pipeline, Hosting, GitSync, Hosting.Orleans,
Hosting.AspNetCore, Messaging.Hub.Test, ContentCollections.Test, Hosting.Test, Documentation.Test — and every
built DLL checked to carry the new symbols (no up-to-date no-op).

- `OwnedConnectionTest` (Messaging.Hub.Test) 8/8: a connect queued on a `TestScheduler` is **cancelled** by the
  owner's release (control arm: the registration count reads 1 first); live connection released; late subscriber
  refused naming the owner; terminated/faulted chain drops its handle; eager `ConnectOwnedBy`; registration on a
  disposed owner disposed on the spot; hub-owned connection released in ShutDown.
- `ContentCollectionConnectionOwnedByHubTest` + `ContentCollectionDiesWithItsHubTest` 2/2.
- `QueryConnectionsReleasedOnTeardownTest` (#3737's, on the migrated site) 2/2.
- Guard 3/3 + `DocumentationLinkIntegrityTest`; full runs of Documentation.Test, ContentCollections.Test,
  Messaging.Hub.Test green.
- **Negative controls, run and restored (md5 identical before/after):** ContentService back to bare
  `AutoConnect(1)` → the site test fails at `Expected value to be OnError … but found OnNext` (the disposed
  collection replayed); the helper reduced to `source.AutoConnect(minObservers)` → 6 of 8 helper tests fail at
  their control arms (`Expected 1 … found 0`) and release assertions.

### Docs
`HubDisposalModel.md` → new section "Rooted Rx connections: what a `Dispose()` must release, and the one
spelling for it"; `/async` skill rule; What's New `Category: Fix`.

Was stacked on #3737's head; #3737 merged (9567a2e5) while this was in progress and the branch is rebased onto
`origin/main`. Pairs-with: none — no public type or member is removed
(`GitHubRepoIdentityResolver` GAINS `IDisposable`; every other public surface is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
