### PR TITLE
Fall back to the image-shipped copy when no landed module generation loads (#3735)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -359,6 +359,16 @@ public static class MemexConfiguration
                     return false;
                 })
                 .ToArray();
+            // 🚨 #3735: and the IMAGE-SHIPPED copy the landed entry displaced, as the LAST step of
+            // the fallback order. The union above substitutes a landed store entry in place of
+            // the same-named Modules:Assemblies entry on the DLL's existence alone; whether it
+            // loads is measured by the link probe inside InstallModules, and until this the
+            // image's copy was simply gone from the list by then — so a refused store generation
+            // SHADOWED the baseline that loads by construction (memex.systemorph.com,
+            // 2026-09-08: MeshWeaver.Blazor.Views, every skinned control on FallbackHtml).
+            // Resolved through MeshBuilder.ResolveModulePath WITHOUT the module root — the image's
+            // own modules/ folder and app closure, never the landed tree — because the baseline is
+            // by definition what the image ships. No pin: the image closure is immutable.
             var resolvedModules = loadableModules
                 .Select(candidate => new ModuleInstallCandidate(candidate.Path)
                 {
@@ -366,6 +376,11 @@ public static class MemexConfiguration
                     PreviousVersion = candidate.Previous?.Version,
                     Previous = candidate.Previous is { } previous
                         ? () => ModuleGenerationPin.PinnedLoadPath(moduleRoot, previous, onWarn: WarnPin)
+                        : null,
+                    ImageBaseline = candidate.Module.BaselineEntry is { } baseline
+                                    && MeshBuilder.ResolveModulePath(baseline) is { } imageCopy
+                                    && File.Exists(imageCopy)
+                        ? imageCopy
                         : null,
                 })
                 .ToArray();

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -31,7 +31,29 @@ Two lanes, two measurements, one fallback:
 
 - **Compiled modules** (`modules/<name>@<gen>/`): `ModulePlatformLink.Check` links the entry assembly's type references against the running platform's surface before any load; the load itself is the second measurement. A refusal names the missing type. This gate exists since core #3552 and is unchanged by the policy — the policy makes it the *only* gate.
 - **NodeType content** (`prebuilt-bundles/<identity>/<source>/`): a baked assembly is adopted only for the exact framework build identity it was baked against (`PrebuiltAssemblySeeder.DeclineReason`, ordinal equality). That is also unchanged — a mismatched bake would be worse than none. What changes is the consequence of *no* bake: **the content compiles in the mesh**, which is the same code path every pull request already proves green. A missing bake is a cost (boot time), not a reason to hold a roll. `Modules:RequirePrebuilt` remains the opt-in strict mode for installations that prefer a named park to a compile.
-- **Fallback**: when the newest generation of a module does not load, the previous generation that did is loaded instead, reported as such, and kept from garbage collection. Only when *no* generation loads is the module absent — and that is the readiness probe's business (the rollout stalls on the pod, the previous pods keep serving), which is the last safety net and the one that has never failed.
+- **Fallback**: when the newest generation of a module does not load, the previous generation that did is loaded instead, reported as such, and kept from garbage collection. When that one does not load either — or the installation holds none — and the **image ships a copy of the same module** (the `Modules:Assemblies` baseline entry the store generation displaced), the image's copy runs, reported as such ([#3735](https://github.com/Systemorph/MeshWeaver/issues/3735)). Only when *nothing* loads is the module absent — and that is the readiness probe's business (the rollout stalls on the pod, the previous pods keep serving), which is the last safety net and the one that has never failed.
+
+**"Loads" includes "installs".** A generation that is refused by the link probe, that faults in
+`Assembly.LoadFrom`, or whose provider attribute throws while its contributions are materialised
+has not loaded in the sense of R1 — it contributes nothing, and a module that contributes nothing
+is *worse* than one that is absent when it has displaced a copy that would have worked. The order
+of the fallback is fixed and every step is **measured by the same probe and load as the one
+before it**: the newest generation → the previous landed generation → the image-shipped copy →
+absent, reported. The one shape the order cannot reach is a generation whose assembly *loaded* and
+whose install then threw: the default load context holds one assembly per simple name, so neither
+the previous generation nor the image copy can be loaded beside it. That shape stays absent and
+reported, and the report names the image copy it could not substitute, so nobody reads the absence
+as "the image had nothing" (the mechanism is on
+[The Module Platform Link Gate](../ModulePlatformLinkGate)).
+
+The rule was measured against on 2026-09-08 (memex.systemorph.com, image `3.0.0-ci.8079`): the
+module set pinned a two-week-old store generation of `MeshWeaver.Blazor.Views`, an assembly the
+image also ships. The boot's link probe refused it correctly — it referenced
+`MeshWeaver.Graph.AnchoredComment`, a type the platform had since removed — but the boot union had
+already substituted the store entry in place of the baseline entry, so the image's copy was never
+tried, the module "contributed nothing", and every skinned control on the portal rendered through
+its fallback HTML. The probe was not the gap; the fallback order was, and this section is what
+closes it.
 
 ## What the platform roll gates on
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -178,8 +178,32 @@ the newest generation of every module that loads, and keeps the one it has until
   up. Only when neither loads is the module incompatible, exactly as before. A generation whose
   assembly *loaded* and whose registration then threw (#2234's shape) is never swapped: two
   assemblies of one simple name cannot coexist in the default load context.
+- **The image-shipped copy is the last step (MeshWeaver#3735).** When the previous generation
+  does not load either — or the entry holds none — and the module is one the IMAGE also ships
+  (a `Modules:Assemblies` baseline entry the landed store entry displaced), the loader tries the
+  image's copy through the same probe and load, and on success registers a `FallbackModule` with
+  `RunsImageBaseline` — stderr line `'<name>' runs the image-shipped baseline (<path>) because
+  v1.3.0 (gen B) cannot load here: …`, status row `runs the image-shipped baseline; v1.3.0 (gen
+  B) landed but does not load here: …`, and `@image` (`FallbackModule.ImageBaselineGeneration`)
+  as its running generation everywhere a generation is recorded. The boot union
+  (`ComputeEffectiveModuleEntries`) carries the displaced baseline entry on the effective module
+  (`EffectiveModule.BaselineEntry`) and the portal resolves it through
+  `MeshBuilder.ResolveModulePath` WITHOUT the module root — the image's own closure, never the
+  landed tree — onto `ModuleInstallCandidate.ImageBaseline`. Until this step existed the
+  substitution happened on the DLL's existence alone, before anything was measured, so a
+  refused store generation SHADOWED the image copy that loads by construction: on
+  memex.systemorph.com (2026-09-08, image `3.0.0-ci.8079`) a two-week-old store generation of
+  `MeshWeaver.Blazor.Views` was refused — `requires 'MeshWeaver.Graph.AnchoredComment
+  (MeshWeaver.Graph)'`, a type the platform had since removed — the entry held no previous
+  generation, the image's copy was never tried, and every skinned control on the portal rendered
+  its fallback HTML. The probe did its job; the fallback order was one step short. An image copy
+  that does not load either leaves the module incompatible, with BOTH reasons on the record; a
+  generation that LOADED and then failed to install is named on stderr as the shape the image
+  copy cannot rescue (one assembly per simple name), never left as an absence that reads like
+  "the image had nothing".
 - **The GC keeps it.** `CollectGarbage` references `PreviousDirectory` exactly like `Directory`,
-  and the running generations the adoption records (below).
+  and the running generations the adoption records (below). The `@image` stand-in matches no
+  directory by construction, so it reclaims nothing on its account.
 - **The set records what runs.** The wave still proposes the head generation; the adoption
   (`ModuleSetStore.RecordAdoption` with `RunningGenerationsOf(set, fallbacks)`) records the
   generation each module actually loaded, `ModuleSetIndex.RunningGenerations` /
@@ -289,6 +313,7 @@ one of these states was previously mis-rendered as "restart required":
 | `Deferred` | landed, but in no proposed module set | the landing wave must complete |
 | **`Quarantined`** | **refused: its bytes need a platform this deployment is not running** | **a platform update — which is itself the restart that loads it** |
 | **`Fallbacks`** (MeshWeaver#3649) | **present and running its PREVIOUS generation; the newest one landed but does not load here** | **none — a build that loads here, or a platform update, takes over by itself** |
+| **`Fallbacks`, `@image`** (MeshWeaver#3735) | **present and running the IMAGE-SHIPPED copy; no landed generation loads here** — the row reads *runs the image-shipped baseline; vX (gen) landed but does not load here: …* | **none — the same; the health check names it, and a restart measures the same bytes and falls back again** |
 
 A quarantined module must never be reported as pending. Its assembly genuinely is not loaded, so
 the pending derivation finds it — and a restart re-runs the same measurement on the same bytes and
@@ -327,7 +352,14 @@ a loadable generation is landed, a generation built for a newer platform is shel
 boot composed as the portal composes it runs the previous one and reports it; both generations
 unloadable stays incompatible; the GC keeps the fallback and reclaims it after an uninstall; the
 adoption records what loaded; the projection onto the mesh's set carries the pointer; the
-activation report names the row and never calls it "restart required".
+activation report names the row and never calls it "restart required". The `#3735` section of the
+same file proves the image-shipped step with the image copy resolved through the REAL baseline
+resolver: the only landed generation is refused and the image copy runs, reported, recorded as
+`@image` on the adoption, `Present` for `Modules:Required`, and named on the activation report;
+a previous generation is tried BEFORE the image copy; an image copy that does not load either
+leaves the module incompatible with both reasons on the record (the negative control on the
+branch); an image entry listed but not shipped claims nothing; and a generation that loaded and
+then threw at install is not replaced by the image copy.
 
 The roll gate's half (MeshWeaver#3651) is `ModulePlatformSurfaceJsonTest` and `ReleaseLinkGateTest`
 in the same project — real modules, a real published root on disk, the running process's own

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleSetConvergence.md
@@ -221,7 +221,10 @@ running"*, not *"this set was read"* — a boot that dies earlier must not close
 it never entered. And since MeshWeaver#3649 the claim says *what* is running: the adoption record
 carries `Generations` — the set's generation for every module that loaded as proposed, the
 **previous** generation for every module the loader fell back on because the set's does not load on
-this platform. `ModuleSetIndex.RunningGenerations` reads it back, `FallbackGenerations` lists the
+this platform — and the stand-in `@image` (`FallbackModule.ImageBaselineGeneration`) for a module
+running the image-shipped copy because no landed generation loads (MeshWeaver#3735; the stand-in
+is not a directory name, so the GC that reads this record reclaims nothing on its account).
+`ModuleSetIndex.RunningGenerations` reads it back, `FallbackGenerations` lists the
 difference, and `ModuleSetStore.Describe` names the modules that run a previous generation, so the
 boot line and the status surfaces say what the mesh runs and not only what it proposed. The
 proposal itself is unchanged — a wave proposes what it landed; whether that loads is measured at

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -157,7 +157,13 @@ saying so on stderr and, once the pipeline is up, as a Warning. The GC reference
 generation like the head one; the mesh-set adoption records the generation that actually loaded;
 the status row reads *"runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load here: …"*, the
 readiness probe stays Healthy, and nothing says "restart required" (a restart falls back again).
-Only when no generation loads is the module incompatible, as before; an uninstall clears both
+**The image-shipped copy is the last step (MeshWeaver#3735):** when no landed generation loads and
+the image ships the module (the `Modules:Assemblies` entry the store entry displaced — carried as
+`EffectiveModule.BaselineEntry`, resolved onto `ModuleInstallCandidate.ImageBaseline`), the image's
+copy runs, recorded as `@image` and worded *"runs the image-shipped baseline; v1.3.0 (gen B) landed
+but does not load here: …"*. Before that step a refused store generation shadowed the image copy
+that loads by construction (memex.systemorph.com, 2026-09-08 — every skinned control on its
+fallback HTML). Only when nothing loads is the module incompatible, as before; an uninstall clears both
 pointers. This is rule R1 of the [Module Adoption Policy](../ModuleAdoptionPolicy): *an
 installation runs the newest generation of every module that loads, and keeps the one it has until
 a newer one does.*

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-module-the-image-ships-runs-again-when-its-installed-version-cannot-load.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-module-the-image-ships-runs-again-when-its-installed-version-cannot-load.md
@@ -1,0 +1,37 @@
+---
+Name: A module the image ships runs again when its installed version cannot load
+Category: Fix
+Description: When a module installed from the store could no longer load on the platform an installation had moved to, the copy of that same module shipped inside the platform image was never tried — the installation ran neither, and everything the module provided disappeared. The image's copy now runs as the last fallback, the health check names it, and the module set records it.
+Icon: Cube
+Order: -20260908
+---
+
+# A module the image ships runs again when its installed version cannot load
+
+Some modules exist twice on an installation: once inside the platform image, as the built-in
+baseline, and once as a newer version installed from the store. The store version wins while it
+works — that is what installing it means — and the platform measures, at every start, whether
+the installed bytes still load on the platform now running.
+
+When that measurement said *no*, the installation was supposed to keep the version it had. For a
+store-only module it does (the previous installed version). But for a module the image also
+ships, the built-in copy was never tried: the installed version had taken the built-in one's
+place on the list before anything was measured, so a refusal left the module absent. That is
+worse than never having installed it. On the public instance the module that renders the standard
+view skins was in exactly this state after a platform update, and every skinned panel showed its
+plain-text fallback instead of the view.
+
+**The fallback now has a third step.** The order is: the newest installed version, then the
+previous installed version, then the copy the image ships — each one measured the same way — and
+only when none of them loads is the module absent. When the image's copy runs, the start-up log
+says so (*runs the image-shipped baseline because v1.3.0 cannot load here: …*), the
+`pending_module_activation` health check names it as running behind rather than as "restart
+required", the installation's module-set record shows `@image` as the running version, and the
+package card reads the same sentence. As soon as a build of the installed version that loads on
+this platform is published, the installation adopts it, exactly as it does for a previous-version
+fallback.
+
+One shape is out of reach and is now named instead of silent: a version whose files loaded and
+whose registration then failed occupies the module's name in the process, so nothing else of that
+name can take over until the next start. The log says which built-in copy it could not use and
+why.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -172,11 +172,17 @@ public record MeshBuilder
     /// same probe and load; when it succeeds the module is installed from it and recorded as a
     /// <see cref="FallbackModule"/> — present, running, and behind — with one
     /// <c>[MeshWeaver.Mesh.FallbackModule]</c> line on stderr naming both generations and why.
-    /// Only when neither loads is the module an <see cref="IncompatibleModule"/>, exactly as
-    /// before. 🚨 A generation whose assembly LOADED and whose registration then threw (#2234's
-    /// shape) is never swapped for the previous one: two assemblies of one simple name cannot
-    /// coexist in the default load context, so the fallback exists only for a newest generation
-    /// that never made it into the process — which is the link probe's case, the whole of #3649.</para>
+    /// When that one does not load either — or the candidate holds none — and the candidate names
+    /// an <see cref="ModuleInstallCandidate.ImageBaseline"/>, the IMAGE-SHIPPED copy of the module
+    /// goes through the same probe and load and is recorded as a <see cref="FallbackModule"/>
+    /// with <see cref="FallbackModule.RunsImageBaseline"/> (#3735). Only when nothing loads is
+    /// the module an <see cref="IncompatibleModule"/>, exactly as before — with the reasons of
+    /// every step it tried on the record. 🚨 A generation whose assembly LOADED and whose
+    /// registration then threw (#2234's shape) is never swapped for the previous one or the image
+    /// copy: two assemblies of one simple name cannot coexist in the default load context, so the
+    /// fallback exists only for a generation that never made it into the process — the link
+    /// probe's case, the whole of #3649 and #3735. That shape is named on stderr when an image
+    /// copy exists, so nobody reads the absent module as "the image had nothing".</para>
     /// </summary>
     /// <param name="modules">The candidates, in install order.</param>
     /// <returns>The builder for method chaining.</returns>
@@ -247,41 +253,92 @@ public record MeshBuilder
             // and the generation that DID load last time was unreferenced and reclaimed by the
             // next GC pass. Rule R1: an installation runs the newest generation that LOADS, and
             // keeps the one it has until a newer one does.
+            //
+            // 🚨 #3735 — and the fallback ORDER has a third step. "Unless the image shipped a
+            // baseline copy" above was never true: the boot union substitutes the landed entry IN
+            // PLACE of the same-named Modules:Assemblies entry before anything is measured, so a
+            // refused store generation SHADOWED the image copy that loads by construction. On
+            // memex.systemorph.com (2026-09-08) a two-week-old store generation of
+            // MeshWeaver.Blazor.Views was refused for a type the platform had since removed, the
+            // image's own copy was never tried, and every skinned control rendered its fallback
+            // HTML — a client-visible outage caused by a module set that "contributed nothing"
+            // over a baseline that would have worked. The order is: newest → the previous landed
+            // generation → the image-shipped copy → absent (reported), and every step is
+            // MEASURED by the same probe and load as the one before it.
+            var reason = newest.Refused!.Error;
             var previous = newest.NeverLoaded ? ResolvePrevious(module) : null;
             if (previous is not null)
             {
                 // The previous generation lives in its own directory, which the surface above
                 // does not carry: a fresh one for the retry, so a sibling module it references is
                 // measured as present rather than as an absent platform assembly.
-                var previousDirectory = Path.GetDirectoryName(Path.GetFullPath(previous));
-                var retry = TryLoad(previous, ModulePlatformSurface.OfRunningProcess([
-                    AppContext.BaseDirectory,
-                    .. probeDirectories,
-                    .. string.IsNullOrEmpty(previousDirectory) ? [] : new[] { previousDirectory },
-                ]));
+                var retry = TryLoad(previous, SurfaceIncluding(probeDirectories, previous));
                 if (retry.Loaded is not null)
                 {
                     pending.Add(retry.Loaded);
-                    var fallback = new FallbackModule(
-                        newest.Refused!.Name, module.Location, previous, newest.Refused.Error)
+                    fallbacks.Add(ReportFallback(new FallbackModule(
+                        newest.Refused.Name, module.Location, previous, reason)
                     {
                         Version = module.Version,
                         PreviousVersion = module.PreviousVersion,
-                    };
-                    // stderr, once per boot: the logging pipeline does not exist yet (see
-                    // ReportIncompatible). The portal re-logs it as a Warning once it does.
-                    Console.Error.WriteLine($"[MeshWeaver.Mesh.FallbackModule] {fallback.Report()}");
-                    fallbacks.Add(fallback);
+                    }));
                     continue;
                 }
 
                 Console.Error.WriteLine(
-                    $"[MeshWeaver.Mesh.FallbackModule] '{newest.Refused!.Name}': the previous "
-                    + $"generation '{previous}' cannot load here either ({retry.Refused!.Error}) — "
-                    + "no generation of this module loads on this platform, so it is absent.");
+                    $"[MeshWeaver.Mesh.FallbackModule] '{newest.Refused.Name}': the previous "
+                    + $"generation '{previous}' cannot load here either ({retry.Refused!.Error}).");
+                reason += $"; the previous generation '{Path.GetFileName(Path.GetDirectoryName(previous))}' "
+                    + $"cannot load here either: {retry.Refused.Error}";
+                // A previous generation that LOADED and then failed to materialise holds the
+                // simple name now; nothing else of that name can enter the process (see
+                // LoadAttempt.NeverLoaded), so the image copy is out of reach exactly like it
+                // would be after the newest one loaded.
+                if (!retry.NeverLoaded)
+                {
+                    ReportBaselineOutOfReach(module, newest.Refused.Name);
+                    incompatible.Add(Report(newest.Refused with { Error = reason }));
+                    continue;
+                }
             }
 
-            incompatible.Add(Report(newest.Refused!));
+            if (newest.NeverLoaded && ResolveImageBaseline(module) is { } baseline)
+            {
+                var image = TryLoad(baseline, SurfaceIncluding(probeDirectories, baseline));
+                if (image.Loaded is not null)
+                {
+                    pending.Add(image.Loaded);
+                    fallbacks.Add(ReportFallback(new FallbackModule(
+                        newest.Refused.Name, module.Location, baseline, reason)
+                    {
+                        Version = module.Version,
+                        RunsImageBaseline = true,
+                    }));
+                    continue;
+                }
+
+                // An image copy that does not load is a build defect of the image itself, which is
+                // a different fault from the store generation's — said separately, and the module
+                // is absent as before.
+                Console.Error.WriteLine(
+                    $"[MeshWeaver.Mesh.FallbackModule] '{newest.Refused.Name}': the image-shipped "
+                    + $"baseline '{baseline}' cannot load here either ({image.Refused!.Error}) — "
+                    + "no generation of this module loads on this platform, so it is absent.");
+                reason += $"; the image-shipped baseline cannot load here either: {image.Refused.Error}";
+            }
+            else if (!newest.NeverLoaded)
+            {
+                ReportBaselineOutOfReach(module, newest.Refused.Name);
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    $"[MeshWeaver.Mesh.FallbackModule] '{newest.Refused.Name}': no previous "
+                    + "generation and no image-shipped baseline loads here — no generation of this "
+                    + "module loads on this platform, so it is absent.");
+            }
+
+            incompatible.Add(Report(newest.Refused with { Error = reason }));
         }
 
         // 🚨 A node's GlobalServiceConfigurations delegate is invoked IMMEDIATELY by
@@ -490,6 +547,65 @@ public record MeshBuilder
                 + $"{exception.Message}) — no fallback is attempted.");
             return null;
         }
+    }
+
+    /// <summary>
+    /// The image-shipped copy of a candidate's module, when the image ships one AND it is on disk
+    /// — the last step of the fallback order (#3735). Null otherwise. A candidate that names a
+    /// baseline which is not there is the listed-but-absent shape the boot already skips loudly
+    /// for baseline entries; here it simply means there is nothing to fall back to.
+    /// </summary>
+    private static string? ResolveImageBaseline(ModuleInstallCandidate module) =>
+        !string.IsNullOrWhiteSpace(module.ImageBaseline) && File.Exists(module.ImageBaseline)
+            ? module.ImageBaseline
+            : null;
+
+    /// <summary>
+    /// The link-probe surface for a fallback attempt: the application closure, every directory
+    /// this batch loads from, and the directory of <paramref name="candidate"/> itself — which the
+    /// batch surface does not carry, so a sibling module the candidate references is measured as
+    /// present rather than as an absent platform assembly.
+    /// </summary>
+    private static ModulePlatformSurface SurfaceIncluding(string[] probeDirectories, string candidate)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(candidate));
+        return ModulePlatformSurface.OfRunningProcess([
+            AppContext.BaseDirectory,
+            .. probeDirectories,
+            .. string.IsNullOrEmpty(directory) ? [] : new[] { directory },
+        ]);
+    }
+
+    /// <summary>
+    /// Writes a fallback to stderr and hands it back for registration — once per boot, because
+    /// the logging pipeline does not exist yet (see <see cref="ReportIncompatible"/>). The portal
+    /// re-logs it as a Warning once it does.
+    /// </summary>
+    private static FallbackModule ReportFallback(FallbackModule fallback)
+    {
+        Console.Error.WriteLine($"[MeshWeaver.Mesh.FallbackModule] {fallback.Report()}");
+        return fallback;
+    }
+
+    /// <summary>
+    /// Says why the image-shipped copy could NOT take over for a module whose generation LOADED
+    /// and then failed to install (#2234's shape): the default load context holds one assembly
+    /// per simple name, so once the store generation is in, the image's copy of the same name
+    /// cannot be loaded beside it. Silent otherwise — a candidate with no image baseline has
+    /// nothing to say here. Not a band-aid on the constraint, a NAME for it: the operator reads
+    /// "the image copy would have worked, and this is why it did not run" instead of an
+    /// incompatible module whose baseline is simply not mentioned.
+    /// </summary>
+    private static void ReportBaselineOutOfReach(ModuleInstallCandidate module, string name)
+    {
+        if (string.IsNullOrWhiteSpace(module.ImageBaseline))
+            return;
+        Console.Error.WriteLine(
+            $"[MeshWeaver.Mesh.FallbackModule] '{name}': the image ships a baseline copy "
+            + $"('{module.ImageBaseline}'), but the landed generation LOADED before it failed to "
+            + "install, and the default load context holds one assembly per simple name — the "
+            + "image copy cannot be loaded beside it, so the module is absent until the next "
+            + "restart measures a generation that does not load at all, or one that installs.");
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs
@@ -38,6 +38,28 @@ public sealed record ModuleInstallCandidate(string Location)
 
     /// <summary>The package version the previous generation was landed at, for the report.</summary>
     public string? PreviousVersion { get; init; }
+
+    /// <summary>
+    /// The entry DLL of the IMAGE-SHIPPED copy of this module — the <c>Modules:Assemblies</c>
+    /// baseline the landed generation displaced — or null when the image ships none (a Store-only
+    /// module). The LAST resort of the fallback order, after <see cref="Previous"/> (#3735).
+    ///
+    /// <para>🚨 <b>Why it exists.</b> The boot union substitutes a landed store entry IN PLACE of
+    /// the same-named baseline entry before anything is measured
+    /// (<c>ModuleActivationBoot.ComputeEffectiveModuleEntries</c>, #2548), so a landed generation
+    /// the link probe then REFUSED left the module absent even though the image carried a copy
+    /// that loads by construction — it is in the application closure. That is strictly worse
+    /// than never having installed the module: the store generation SHADOWED the baseline that
+    /// would have worked. memex.systemorph.com, 2026-09-08: a two-week-old store generation of
+    /// <c>MeshWeaver.Blazor.Views</c> was refused for a type the platform had since removed, the
+    /// image-shipped copy was never tried, and every skinned control on the portal rendered
+    /// through its fallback HTML. Rule R1 says "run the newest thing that LOADS", and the
+    /// image's copy is the oldest thing that always does.</para>
+    ///
+    /// <para>A plain path, not a resolver: the image closure is immutable and needs no pin
+    /// (<see cref="Previous"/> is lazy because a previous generation is COPIED before loading).</para>
+    /// </summary>
+    public string? ImageBaseline { get; init; }
 }
 
 /// <summary>
@@ -71,13 +93,34 @@ public sealed record FallbackModule(string Name, string Entry, string PreviousEn
     /// <summary>The package version of the generation that loaded, when recorded.</summary>
     public string? PreviousVersion { get; init; }
 
+    /// <summary>
+    /// True when what runs is the IMAGE-SHIPPED copy of the module
+    /// (<see cref="ModuleInstallCandidate.ImageBaseline"/>) rather than a previous landed
+    /// generation (#3735): the newest generation could not load here, no previous generation
+    /// loaded either (or none was held), and the image's own copy took over. Then
+    /// <see cref="PreviousEntry"/> is the image path, <see cref="PreviousGeneration"/> is
+    /// <see cref="ImageBaselineGeneration"/>, and <see cref="PreviousVersion"/> is the image's
+    /// notion of the version, which the baseline never records — null.
+    /// </summary>
+    public bool RunsImageBaseline { get; init; }
+
+    /// <summary>
+    /// The stand-in "generation" recorded for a module that runs the image-shipped baseline —
+    /// what <see cref="PreviousGeneration"/> answers, what the module-set adoption writes as the
+    /// running generation, and what every status surface prints. Not a directory name by
+    /// construction (a landed generation is <c>&lt;name&gt;@&lt;id&gt;</c>), so a GC reading it
+    /// as a referenced generation matches nothing and reclaims nothing on its account.
+    /// </summary>
+    public const string ImageBaselineGeneration = "@image";
+
     /// <summary>The generation directory leaf of the newest generation (<c>&lt;name&gt;@&lt;id&gt;</c>)
     /// — the same string the activation record's <c>Directory</c> carries, so a surface can match
     /// this record against the record that landed it.</summary>
     public string Generation => LeafOf(Entry);
 
-    /// <summary>The generation directory leaf of the generation that loaded.</summary>
-    public string PreviousGeneration => LeafOf(PreviousEntry);
+    /// <summary>The generation directory leaf of the generation that loaded — or
+    /// <see cref="ImageBaselineGeneration"/> when the image-shipped copy runs.</summary>
+    public string PreviousGeneration => RunsImageBaseline ? ImageBaselineGeneration : LeafOf(PreviousEntry);
 
     /// <summary>
     /// The boot-log line: which module, which generation it runs, which one it does not, and why.
@@ -85,17 +128,23 @@ public sealed record FallbackModule(string Name, string Entry, string PreviousEn
     /// re-logged as a Warning once the logging pipeline is up.
     /// </summary>
     public string Report() =>
-        $"'{Name}' runs its previous generation {Label(PreviousVersion, PreviousGeneration)} because "
-        + $"{Label(Version, Generation)} cannot load here: {Reason}";
+        RunsImageBaseline
+            ? $"'{Name}' runs the image-shipped baseline ({PreviousEntry}) because "
+              + $"{Label(Version, Generation)} cannot load here: {Reason}"
+            : $"'{Name}' runs its previous generation {Label(PreviousVersion, PreviousGeneration)} because "
+              + $"{Label(Version, Generation)} cannot load here: {Reason}";
 
     /// <summary>
     /// The status-row sentence — "runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load
-    /// here: …" — shared by every surface so an operator and a package card never read two
-    /// different stories about one module.
+    /// here: …", or for the image baseline "runs the image-shipped baseline; v1.3.0 (gen B)
+    /// landed but does not load here: …" — shared by every surface so an operator and a package
+    /// card never read two different stories about one module.
     /// </summary>
     public string Describe() =>
-        $"runs {Label(PreviousVersion, PreviousGeneration)}; {Label(Version, Generation)} landed "
-        + $"but does not load here: {Reason}";
+        (RunsImageBaseline
+            ? "runs the image-shipped baseline"
+            : $"runs {Label(PreviousVersion, PreviousGeneration)}")
+        + $"; {Label(Version, Generation)} landed but does not load here: {Reason}";
 
     private static string Label(string? version, string generation) =>
         string.IsNullOrWhiteSpace(version) ? $"({generation})" : $"v{version} ({generation})";

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -600,7 +600,19 @@ public static class ModuleActivationSidecar
 /// live in the directory ITS entry points at, a baseline module's are resolved by probing, and a
 /// caller that guesses which lane a name belongs to is how the boot gate and the boot loader came
 /// to disagree (#1949).</param>
-public sealed record EffectiveModule(string Entry, ModuleActivationEntry? Landed);
+public sealed record EffectiveModule(string Entry, ModuleActivationEntry? Landed)
+{
+    /// <summary>
+    /// The raw <c>Modules:Assemblies</c> entry this landed module DISPLACED — set only when
+    /// <see cref="Landed"/> is non-null and the image lists the same module (#3735). The boot
+    /// hands it to the loader as the last step of the fallback order
+    /// (<c>ModuleInstallCandidate.ImageBaseline</c>): when the landed generation does not load
+    /// here and no previous generation does either, the image's own copy runs. Null for a
+    /// baseline entry (it IS the image copy) and for a Store-only module (the image ships none).
+    /// Init-only, for binary compatibility with hosts compiled against the two-argument record.
+    /// </summary>
+    public string? BaselineEntry { get; init; }
+}
 
 /// <summary>
 /// The boot-time union of #1664 step 9: appsettings baseline ∪ enabled persisted store installs,
@@ -880,8 +892,14 @@ public static class ModuleActivationBoot
             if (!seen.Add(name))
                 continue; // a baseline that repeats a name is still deduped
 
+            // 🚨 #3735 — the displaced baseline entry TRAVELS with the override. "An unusable one
+            // must not [override]" above is decided on the DLL's existence alone; whether the
+            // landed generation LOADS is measured later, by the link probe in
+            // MeshBuilder.InstallModules — and when it does not, the image's copy is the one
+            // thing that loads by construction. Dropping the entry here is how a refused store
+            // generation came to shadow the working image copy (memex.systemorph.com, 2026-09-08).
             effective.Add(overrides.TryGetValue(name, out var winner)
-                ? new EffectiveModule(winner.Name + ".dll", winner)
+                ? new EffectiveModule(winner.Name + ".dll", winner) { BaselineEntry = entry }
                 : new EffectiveModule(entry, Landed: null));
         }
 

--- a/src/MeshWeaver.PluginCatalog/ModuleSet.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleSet.cs
@@ -755,11 +755,14 @@ public static class ModuleSetStore
                   + $"{proposed.Generations.Count} module(s))"
                   + DescribeFallbacks(index.FallbackGenerations);
 
-    /// <summary>The "; N module(s) run a previous generation: …" suffix, or nothing (#3649).</summary>
+    /// <summary>The "; N module(s) run a previous generation: …" suffix, or nothing (#3649). A
+    /// module running the image-shipped copy (#3735) is listed with
+    /// <see cref="MeshWeaver.Mesh.FallbackModule.ImageBaselineGeneration"/> as its generation.</summary>
     private static string DescribeFallbacks(ImmutableSortedDictionary<string, string> fallbacks) =>
         fallbacks.Count == 0
             ? string.Empty
-            : $"; {fallbacks.Count} module(s) run a PREVIOUS generation because the set's does not "
+            : $"; {fallbacks.Count} module(s) run a PREVIOUS generation (or the image-shipped baseline, "
+              + $"'{MeshWeaver.Mesh.FallbackModule.ImageBaselineGeneration}') because the set's does not "
               + "load on this platform: "
               + string.Join(", ", fallbacks.Select(kv => $"{kv.Key} ({kv.Value})"));
 

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -188,9 +188,11 @@ public sealed record ModuleActivationReport(
               + (HasFloorAdvisories ? "; " + DescribeFloorAdvisories(FloorAdvisories) : string.Empty);
 
     /// <summary>
-    /// One human-readable line naming the modules that run their PREVIOUS generation (#3649) —
-    /// one named row per module, "X runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load
-    /// here: …" — kept apart from every other line because it asks for nothing of the operator:
+    /// One human-readable line naming the modules that run their PREVIOUS generation (#3649) or
+    /// the IMAGE-SHIPPED baseline (#3735) — one named row per module, "X runs v1.2.3 (gen A);
+    /// v1.3.0 (gen B) landed but does not load here: …" / "X runs the image-shipped baseline;
+    /// v1.3.0 (gen B) landed but does not load here: …" — kept apart from every other line
+    /// because it asks for nothing of the operator:
     /// the module works, and the newest generation starts running by itself when a build of it
     /// that loads here ships or the platform moves.
     /// </summary>
@@ -206,9 +208,9 @@ public sealed record ModuleActivationReport(
             .OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
             .Select(f => $"{f.Name} {f.Reason}")
             .ToArray();
-        return $"{rows.Length} module(s) run a PREVIOUS generation because the one the mesh's set "
-            + "activates does not load on this platform — present and working, one version "
-            + "behind; no restart changes that, a build that loads here does: "
+        return $"{rows.Length} module(s) run a PREVIOUS generation or the image-shipped baseline "
+            + "because the one the mesh's set activates does not load on this platform — present "
+            + "and working, behind the set; no restart changes that, a build that loads here does: "
             + string.Join("; ", rows.Take(Math.Max(1, maxNamed)))
             + (rows.Length > maxNamed ? $"; …(+{rows.Length - maxNamed})" : string.Empty);
     }

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
@@ -660,6 +660,262 @@ public class ConfiguredModuleActivationTest
         Assert.Empty(RequiredModuleStatus.ExpectedLater(verdicts));
     }
 
+    // ───────── #3735: when no landed generation loads, the IMAGE-SHIPPED copy runs ─────────
+    //
+    // memex.systemorph.com, 2026-09-08, image 3.0.0-ci.8079: the module set pinned a two-week-old
+    // store generation of MeshWeaver.Blazor.Views — an assembly the image ALSO ships. The link
+    // probe refused it at boot (`requires 'MeshWeaver.Graph.AnchoredComment (MeshWeaver.Graph)'`,
+    // a type the platform had since removed), the entry held no previous generation, and the
+    // image's own copy was never tried: the boot union had substituted the store entry in place
+    // of the baseline entry before anything was measured. Every skinned control on the portal
+    // rendered its FallbackHtml. Rule R1 — "run the newest thing that loads" — has a third step:
+    // newest → previous generation → the image-shipped copy → absent, each one measured.
+
+    /// <summary>
+    /// 🚨 THE repro of #3735. A generation built for a newer platform is the ONLY landed one, and
+    /// the image ships the module. Boot refuses the landed generation, runs the image copy, and
+    /// records a fallback that says so — present, never incompatible.
+    /// </summary>
+    [Fact]
+    public async Task WhenNoLandedGenerationLoads_AndTheImageShipsTheModule_TheImageCopyRuns_AndIsReported()
+    {
+        using var deployment = new Deployment();
+        var imageCopy = deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        Assert.Null(Entry(deployment).PreviousDirectory);
+
+        var (services, _) = Boot(deployment);
+
+        // What runs is the IMAGE's bytes, resolved through the real baseline resolver.
+        var installed = Assert.Single(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+        Assert.Equal(Path.GetFullPath(imageCopy), Path.GetFullPath(installed.Assembly.Location));
+
+        var fallback = Assert.Single(services.GetServices<FallbackModule>());
+        Assert.True(fallback.RunsImageBaseline);
+        Assert.Equal(deployment.Module, fallback.Name);
+        Assert.Equal(b, fallback.Generation);
+        Assert.Equal(FallbackModule.ImageBaselineGeneration, fallback.PreviousGeneration);
+        Assert.Equal("1.3.0", fallback.Version);
+        Assert.Null(fallback.PreviousVersion);
+        Assert.StartsWith(
+            $"'{deployment.Module}' runs the image-shipped baseline ({imageCopy}) because v1.3.0 ({b}) "
+            + "cannot load here:", fallback.Report(), StringComparison.Ordinal);
+        Assert.Contains(FutureType, fallback.Reason, StringComparison.Ordinal);
+
+        // 🚨 Present, not incompatible — the whole point: the refused generation must not SHADOW
+        // the baseline that works.
+        Assert.Empty(services.GetServices<IncompatibleModule>());
+
+        // The boot wrote the marker for the refused head, exactly as a previous-generation
+        // fallback does, so the reconcile re-examines every new build of its version (#3650).
+        var marker = ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module);
+        Assert.NotNull(marker);
+        Assert.Equal(b, marker!.Generation);
+    }
+
+    /// <summary>
+    /// The health check names it: the activation report carries the row with the image stand-in
+    /// as the running generation, the fallback is not "restart required" (a restart measures the
+    /// same bytes and falls back again) and not quarantined (it is running), and the one line
+    /// every surface renders says which module runs the image baseline and why.
+    /// </summary>
+    [Fact]
+    public async Task TheActivationReport_NamesAnImageBaselineFallback_AndNeverCallsItRestartRequired()
+    {
+        using var deployment = new Deployment();
+        deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var (services, _) = Boot(deployment);
+        var fallbacks = services.GetServices<FallbackModule>().ToArray();
+        var loaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { deployment.Module };
+        // The image copy's directory leaf is the module's NAME (modules/<name>/), which is what
+        // LoadedModuleGenerations reads off the loaded assembly — and it is not the set's
+        // generation, so without the loader's record this reads as a pending update.
+        var generations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [deployment.Module] = deployment.Module,
+        };
+
+        var report = new PendingModuleActivations(deployment.Root) { FallbackModules = fallbacks }
+            .Read(loaded, generations);
+
+        Assert.False(report.IsUndetermined, report.UndeterminedReason);
+        var row = Assert.Single(report.Fallbacks);
+        Assert.Equal(deployment.Module, row.Name);
+        Assert.Equal(PackagePath, row.PackagePath);
+        Assert.Equal(FallbackModule.ImageBaselineGeneration, row.PreviousGeneration);
+        Assert.Equal(b, row.Generation);
+        Assert.Equal("1.3.0", row.Version);
+        Assert.StartsWith($"runs the image-shipped baseline; v1.3.0 ({b}) landed but does not load here:",
+            row.Reason, StringComparison.Ordinal);
+        Assert.Contains(FutureType, row.Reason, StringComparison.Ordinal);
+        Assert.False(report.HasPending, "a restart re-measures the same bytes and falls back again");
+        Assert.False(report.IsPendingForPackage(PackagePath));
+        Assert.False(report.HasQuarantined, "it is running");
+        Assert.Contains("image-shipped baseline", report.Describe(), StringComparison.Ordinal);
+        Assert.Contains(deployment.Module, report.Describe(), StringComparison.Ordinal);
+
+        var blind = new PendingModuleActivations(deployment.Root).Read(loaded, generations);
+        Assert.True(blind.HasPending, "without the loader's record the state reads as an ordinary update");
+    }
+
+    /// <summary>
+    /// The set records what runs: the adoption carries the image stand-in as the module's running
+    /// generation, the index reads it back as a fallback, the mesh-set line names it, and the GC —
+    /// which reads the same records — neither trips over the stand-in nor reclaims the head.
+    /// </summary>
+    [Fact]
+    public async Task TheAdoptedSet_RecordsTheImageBaseline_WhenItRuns()
+    {
+        using var deployment = new Deployment();
+        deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        var b = await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var proposed = await deployment.Landing.ProposeModuleSet().Timeout(TestTimeouts.Convergence).Await();
+        Assert.NotNull(proposed);
+        Assert.Equal(b, proposed.Generations[deployment.Module]);
+
+        Boot(deployment);
+
+        var index = ModuleSetStore.Read(deployment.Root);
+        Assert.NotNull(index.Current);
+        Assert.Equal(b, index.Current.Generations[deployment.Module]);
+        Assert.Equal(FallbackModule.ImageBaselineGeneration, index.RunningGenerations[deployment.Module]);
+        Assert.Equal(FallbackModule.ImageBaselineGeneration, Assert.Single(index.FallbackGenerations).Value);
+        Assert.Contains(FallbackModule.ImageBaselineGeneration, ModuleSetStore.Describe(index), StringComparison.Ordinal);
+        Assert.Contains("image-shipped baseline", ModuleSetStore.Describe(index), StringComparison.Ordinal);
+
+        ModuleLandingService.CollectGarbage(deployment.Root, minAge: TimeSpan.Zero, nowUtc: DateTime.UtcNow.AddHours(1));
+        Assert.True(Directory.Exists(deployment.GenerationDirectory(b)), "the head is still the entry's generation");
+    }
+
+    /// <summary>
+    /// A required module running the image copy is <see cref="RequiredModuleState.Present"/>:
+    /// classified off the real loader's output, with the image listing the module — the exact
+    /// combination that used to classify Incompatible and stall a rollout over a module the image
+    /// had a working copy of.
+    /// </summary>
+    [Fact]
+    public async Task ARequiredModuleRunningTheImageBaseline_IsPresent()
+    {
+        using var deployment = new Deployment();
+        deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+        var (services, _) = Boot(deployment);
+
+        var verdicts = RequiredModuleStatus.Classify(
+            requiredEntries: [deployment.ImageEntry],
+            baselineEntries: [deployment.ImageEntry],
+            loadedAssemblyNames: services.GetServices<InstalledModuleAssembly>()
+                .Select(m => m.Assembly.GetName().Name!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase),
+            resolvesFromDeployment: _ => false,
+            activation: ModuleActivationSidecar.Read(deployment.Root),
+            landedDllExists: entry => ModuleActivationBoot.LandedModuleDllExists(deployment.Root, entry),
+            platformGate: _ => null,
+            incompatibleModules: [.. services.GetServices<IncompatibleModule>()]);
+
+        var verdict = Assert.Single(verdicts);
+        Assert.Equal(RequiredModuleState.Present, verdict.State);
+        Assert.Empty(RequiredModuleStatus.Incompatible(verdicts));
+    }
+
+    /// <summary>
+    /// The ORDER: a previous landed generation is tried before the image copy. R1 says "the newest
+    /// thing that loads", and a previous generation is newer than the image's copy by construction
+    /// (it was installed over it).
+    /// </summary>
+    [Fact]
+    public async Task ThePreviousGeneration_IsTriedBeforeTheImageBaseline()
+    {
+        using var deployment = new Deployment();
+        deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        var a = await Land(deployment, ModuleBuiltAgainstThisPlatform(deployment.Module), "1.2.3");
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+
+        var (services, _) = Boot(deployment);
+
+        var fallback = Assert.Single(services.GetServices<FallbackModule>());
+        Assert.False(fallback.RunsImageBaseline);
+        Assert.Equal(a, fallback.PreviousGeneration);
+        var installed = Assert.Single(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+        Assert.Equal(a, Path.GetFileName(Path.GetDirectoryName(installed.Assembly.Location)));
+    }
+
+    /// <summary>
+    /// 🚨 Negative control on the branch: the image copy is MEASURED like every other step, not
+    /// registered because it exists. An image copy that cannot load either leaves the module
+    /// incompatible — named, refused before load, with every step's reason on the record — and
+    /// nothing is installed. Without this a fallback that registered the image copy blindly would
+    /// pass the test above.
+    /// </summary>
+    [Fact]
+    public async Task AnImageCopyThatDoesNotLoadEither_LeavesTheModuleIncompatible_NamingBothReasons()
+    {
+        using var deployment = new Deployment();
+        deployment.ShipInImage(ModuleBuiltAgainstAFuturePlatform(deployment.Module));
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+
+        var (services, _) = Boot(deployment);
+
+        Assert.Empty(services.GetServices<FallbackModule>());
+        var parked = Assert.Single(services.GetServices<IncompatibleModule>());
+        Assert.Equal(deployment.Module, parked.Name);
+        Assert.True(parked.RefusedBeforeLoad);
+        Assert.Contains("image-shipped baseline cannot load here either", parked.Error, StringComparison.Ordinal);
+        Assert.DoesNotContain(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The other negative control: a Store-only module (the image ships nothing) whose only
+    /// generation does not load is absent and reported — today's behaviour, preserved. The image
+    /// entry is listed but NOT shipped, which is the listed-but-absent shape: nothing to fall
+    /// back to, and nothing claimed.
+    /// </summary>
+    [Fact]
+    public async Task WhenTheImageListsTheModuleButDoesNotShipIt_TheModuleStaysIncompatible()
+    {
+        using var deployment = new Deployment();
+        var shipped = deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        File.Delete(shipped);   // listed under Modules:Assemblies, no bytes — the rc5 shape
+        await Shelve(deployment, ModuleBuiltAgainstAFuturePlatform(deployment.Module), "1.3.0");
+
+        var (services, _) = Boot(deployment);
+
+        Assert.Empty(services.GetServices<FallbackModule>());
+        var parked = Assert.Single(services.GetServices<IncompatibleModule>());
+        Assert.True(parked.RefusedBeforeLoad);
+        Assert.DoesNotContain("image-shipped baseline", parked.Error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The shape the fallback CANNOT reach, pinned so nobody reads the absent module as "the
+    /// image had nothing": a generation whose assembly LOADED and whose install then threw
+    /// (#2234) holds its simple name in the default load context, and the image copy of the same
+    /// name cannot be loaded beside it. The module is incompatible — the install exception on the
+    /// record, not a link refusal — and no fallback is claimed. A loader that reported the image
+    /// copy as running here would be lying: the bytes in the process are the broken generation's.
+    /// </summary>
+    [Fact]
+    public async Task AGenerationThatLoadedAndThenFailedToInstall_IsNotReplacedByTheImageCopy()
+    {
+        using var deployment = new Deployment();
+        deployment.ShipInImage(ModuleBuiltAgainstThisPlatform(deployment.Module));
+        await Land(deployment, ModuleThatThrowsAtInstall(deployment.Module), "1.3.0");
+
+        var (services, _) = Boot(deployment);
+
+        Assert.Empty(services.GetServices<FallbackModule>());
+        var broken = Assert.Single(services.GetServices<IncompatibleModule>());
+        Assert.Equal(deployment.Module, broken.Name);
+        Assert.False(broken.RefusedBeforeLoad);
+        Assert.Equal("Void MeshWeaver.Mesh.Gone..ctor()", broken.MissingMember);
+        Assert.DoesNotContain(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+    }
+
     // ───────────────────────────────────────────────────────────── harness
 
     /// <summary>A per-test deployment root with the REAL landing service over it. The module name
@@ -684,11 +940,42 @@ public class ConfiguredModuleActivationTest
 
         public string GenerationDirectory(string generation) => Path.Combine(Root, "modules", generation);
 
+        /// <summary>
+        /// The IMAGE's copy of the module — the <c>modules/&lt;name&gt;/&lt;name&gt;.dll</c>
+        /// publish layout under this process's OWN base directory, which is where
+        /// <c>MeshBuilder.ResolveModulePath</c> (no module root) looks for a baseline entry. Written
+        /// there, not under <see cref="Root"/>, so the boot below resolves it through the REAL
+        /// resolver the portal uses, and the module's unique name keeps tests apart.
+        /// </summary>
+        public string ImageDirectory => Path.Combine(AppContext.BaseDirectory, "modules", Module);
+
+        /// <summary>The raw <c>Modules:Assemblies</c> entry the image would list for this module.</summary>
+        public string ImageEntry => Module + ".dll";
+
+        /// <summary>Whether <see cref="ShipInImage"/> was called — the boot lists the module under
+        /// <c>Modules:Assemblies</c> exactly when it was.</summary>
+        public bool ShipsInImage { get; private set; }
+
+        /// <summary>Makes the image ship <paramref name="bytes"/> as this module, and returns the
+        /// entry DLL path the resolver answers.</summary>
+        public string ShipInImage(byte[] bytes)
+        {
+            Directory.CreateDirectory(ImageDirectory);
+            var dll = Path.Combine(ImageDirectory, ImageEntry);
+            File.WriteAllBytes(dll, bytes);
+            ShipsInImage = true;
+            return dll;
+        }
+
         public void Dispose()
         {
             Landing.Dispose();
             try { Directory.Delete(Root, recursive: true); }
             catch { /* temp cleanup is the OS's problem, never a test failure */ }
+            if (!ShipsInImage)
+                return;
+            try { Directory.Delete(ImageDirectory, recursive: true); }
+            catch { /* same */ }
         }
     }
 
@@ -741,7 +1028,10 @@ public class ConfiguredModuleActivationTest
             onDeferred: null,
             landedDllExists: entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
         var effective = ModuleActivationBoot.ComputeEffectiveModuleEntries(
-            baselineEntries: null,
+            // The image's Modules:Assemblies list — naming the module exactly when the image
+            // ships it (#3735), so the union substitutes the landed entry in the baseline's slot
+            // and carries the displaced entry along, as the portal's does.
+            baselineEntries: deployment.ShipsInImage ? [deployment.ImageEntry] : null,
             onMeshSet,
             ModulePlatformFloor.DeclineReason,
             entry => ModuleActivationBoot.LandedModuleDllExists(root, entry));
@@ -761,6 +1051,14 @@ public class ConfiguredModuleActivationTest
                     Previous = previous is null
                         ? null
                         : () => ModuleGenerationPin.PinnedLoadPath(root, previous, deployment.PinRoot),
+                    // #3735 — the image copy, through the SAME resolver the portal uses for a
+                    // baseline entry (no module root: the image's own closure, never the landed
+                    // tree), so the test cannot agree with itself while the portal diverges.
+                    ImageBaseline = module.BaselineEntry is { } baseline
+                                    && MeshBuilder.ResolveModulePath(baseline) is { } imageCopy
+                                    && File.Exists(imageCopy)
+                        ? imageCopy
+                        : null,
                 };
             })
             .ToArray();
@@ -816,6 +1114,23 @@ public class ConfiguredModuleActivationTest
             public static class CodeViews
             {
                 public static string BuildContent(MeshNode node) => node.Id;
+            }
+            """);
+
+    /// <summary>A module built against THIS platform whose provider attribute THROWS when its
+    /// nodes are materialised — #2234's shape: the assembly loads, the install fails. The
+    /// exception is the literal MissingMethodException wording, so the record extracts the
+    /// member exactly as it did on memex-cloud.</summary>
+    private static byte[] ModuleThatThrowsAtInstall(string moduleName) =>
+        Emit(moduleName, """
+            using System;
+            using System.Collections.Generic;
+            using MeshWeaver.Mesh;
+            [assembly: ThrowingModule]
+            public sealed class ThrowingModuleAttribute : MeshNodeProviderAttribute
+            {
+                public override IEnumerable<MeshNode> Nodes =>
+                    throw new MissingMethodException("Method not found: 'Void MeshWeaver.Mesh.Gone..ctor()'.");
             }
             """);
 


### PR DESCRIPTION
## Summary

**Live production defect, memex.systemorph.com 2026-09-08 (image `3.0.0-ci.8079`):** the module set pinned a two-week-old STORE generation of `MeshWeaver.Blazor.Views` — an assembly the IMAGE also ships. The boot's link probe refused it correctly (`requires 'MeshWeaver.Graph.AnchoredComment (MeshWeaver.Graph)'`, a type the platform has since removed), the entry held no previous generation, and the image's own copy was never tried. The module "contributed nothing", which is worse than absent: it SHADOWED the baseline that loads by construction, and every skinned `StackControl` on the portal rendered through `FallbackHtml` (PartnerRe saw the control's `ToString`).

**Root cause.** `ModuleActivationBoot.ComputeEffectiveModuleEntries` substitutes a landed store entry IN PLACE of the same-named `Modules:Assemblies` baseline entry on the DLL's *existence* alone, before anything is measured — and the displaced baseline entry was dropped right there. Whether the landed generation LOADS is measured later, by the link probe inside `MeshBuilder.InstallModules`; by then the image copy was gone from the list, so a refusal had nothing to fall back to. The #3649 fallback (previous generation) did not help: this entry predates #3649 and holds no `PreviousDirectory`. The link probe was NOT the gap: the generation was landed on 2026-08-25, before #3552 existed, and the type it needs was removed from the platform *afterwards* — no landing-time probe can see a future removal; the boot-time probe refused it as designed, and the message in the log is the probe's own (`FromLinkRefusal`, `RefusedBeforeLoad = true`).

**Fix — rule R1, "run the newest thing that loads", where loads includes installs:** the fallback order is now newest → previous landed generation → **the image-shipped copy** → absent (reported), every step measured by the same probe and load.

- `EffectiveModule.BaselineEntry` (init) carries the displaced baseline entry; the portal (`MemexConfiguration`) resolves it through `MeshBuilder.ResolveModulePath` WITHOUT the module root — the image's own closure, never the landed tree — onto `ModuleInstallCandidate.ImageBaseline` (init; a plain path, no pin — the image closure is immutable).
- `MeshBuilder.InstallModules` tries it after the previous generation; on success registers a `FallbackModule` with `RunsImageBaseline` (init) — `PreviousGeneration` answers `FallbackModule.ImageBaselineGeneration` (`@image`), so the adoption record (`RunningGenerationsOf`), `ModuleSetIndex.FallbackGenerations`, `ModuleSetStore.Describe`, the `#3650` unloadable marker and the GC reference set all work unchanged (`@image` is not a directory name by construction and reclaims nothing).
- The health check (`ModuleActivationReport.Describe`, rendered by the Plugins `PendingModuleActivationHealthCheck`) names it: `X runs the image-shipped baseline; v1.3.0 (gen B) landed but does not load here: …` — present, not pending, not quarantined. `Modules:Required` classifies it `Present`.
- Every failed step's reason lands on the `IncompatibleModule.Error` when nothing loads. A generation that LOADED and then threw at install (#2234's shape) cannot be replaced by the image copy (one assembly per simple name in the default load context) — that constraint is now NAMED on stderr with the baseline path, never left as an absence that reads like "the image had nothing".

## Tests (`ConfiguredModuleActivationTest`, `#3735` section — real landing, real boot composition, real loader, image copy resolved through the REAL baseline resolver)

- the only landed generation is refused, the image ships the module ⇒ the image copy runs, `FallbackModule.RunsImageBaseline`, no `IncompatibleModule`, marker written for the refused head
- the activation report names the row (`@image`, the sentence), not pending, not quarantined; without the loader's record the same state reads as pending (control)
- the adoption records `@image`; `FallbackGenerations` / `Describe` name it; the GC keeps the head
- a required module on the image baseline is `Present`
- a previous landed generation is tried BEFORE the image copy
- **negative control on the branch:** an image copy that does not load either ⇒ incompatible, both reasons on the record, nothing installed
- an image entry listed but not shipped ⇒ incompatible, nothing claimed (today's behaviour preserved)
- a generation that loaded and then threw at install ⇒ not replaced by the image copy, incompatible with the install exception on the record

Local: `Memex.Portal.Shared`, `MeshWeaver.Compiler.Pipeline.Test`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` all `dotnet build -c Release -warnaserror` → `0 Error(s)`; test runs 32/32, 50/50 and the doc guards green with fresh `.trx`.

## Docs

`ModuleAdoptionPolicy` § What "loads" means (install is part of loading; the fallback order; the shape it cannot reach; the 2026-09-08 measurement), `ModulePlatformLinkGate` (the fallback section, the states table, what proves it), `Modules`, `ModuleSetConvergence`. What's New `Category: Fix`.

Not in scope, deliberately: the held newer generation is core #3732 (the crm publication republishing upstream modules), and deleting the stale generation is the operator's stopgap being done separately.

Pairs-with: none — additive only; no public type or member leaves `src/` (new init properties on `ModuleInstallCandidate`, `FallbackModule`, `EffectiveModule`; positional constructors unchanged).
Implementers: none — no member added to a public interface or abstract class.
Mirror-sync: none — no i18n catalog change (boot-log and health-check text is operator-facing diagnostics, not viewer chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
