### PR TITLE
#3589: a run that did not converge no longer licences the next skip — retired source finally leaves the mesh

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ImportMarkerRecordsConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ImportMarkerRecordsConvergence.md
@@ -1,0 +1,169 @@
+---
+Name: The Import Marker Records Convergence
+Category: Architecture
+Description: A static-repo import short-circuits on a content-addressed marker that the next run reads INSTEAD of the partition. So the marker is a claim about the partition, not about the source — and a run that kept nodes back, or could not prune at all, must not make it. What went wrong when it did, why the ownership test alone could not repair it, and why an absent verdict reads as UNKNOWN.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12l2 2 4-4"/><path d="M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9"/><path d="M16 3h5v5"/><path d="M21 3l-7 7"/></svg>
+---
+
+# The Import Marker Records Convergence
+
+A [static-repo import](/Doc/Architecture/StaticRepoImport) is idempotent through a **content-addressed
+marker**. The importer hashes every node the source ships into a fingerprint, and writes an activity
+at `{Partition}/_Activity/import-{fingerprint}`. A `Succeeded` one short-circuits the next run:
+
+```
+marker at import-{fingerprint} is Succeeded
+   ⇒ "Skipped", 0 nodes, WITHOUT READING THE PARTITION
+```
+
+That is a large saving and it is the right shape. But note what the id is derived from and what the
+skip concludes from it:
+
+> The id is a hash of the **source**. What the next run reads out of it is *"the partition holds
+> exactly content F"* — and it reads that **instead of** the partition.
+
+**So the marker is a claim about the PARTITION.** Only a run that made the claim true may write it.
+
+## What happened when it didn't
+
+Measured end to end on `memex.systemorph.com`, 2026-09-07/08.
+
+`MeshWeaver.Crm` deleted four files on 09-06. The 09-07 10:15Z import ran, computed the prune set
+correctly, and found every one of them — and then kept them all:
+
+```
+↩ Kept Crm/Mail (added on the server — commit to sync it back).
+↩ Kept Crm/Migration (added on the server — commit to sync it back).
+↩ Kept Crm/Source/Mail (added on the server — commit to sync it back).
+↩ Kept Crm/Source/MailTests (added on the server — commit to sync it back).
+↩ Kept Crm/Source/MailView (added on the server — commit to sync it back).
+Imported 23 node(s), kept 5 local change(s), pruned 0, synced 0 content file(s).
+```
+
+Two distinct defects produced that state, and only the first is about the prune.
+
+### 1. Ownership — fixed by the predicate, and it was not enough
+
+`ImportConflictPolicy.PreservesFromPruneOf` protects a node **changed on the server since the last
+sync**. The horizon (`LastSyncedAt`) is deliberately *held* while anything is preserved (#675/#677),
+so it falls further and further behind — and a previous import's OWN writes then sit after it and
+read as "newer on the server" for ever. Judged by timestamp alone, the importer was preserving its
+own output from itself. `ImportConflictPolicy.IsHumanEdit` is the ownership test:
+
+```csharp
+public static bool IsHumanEdit(MeshNode? target) =>
+    target?.LastModifiedBy is { Length: > 0 } author
+    && !string.Equals(author, WellKnownUsers.System, StringComparison.Ordinal);
+```
+
+The measurement bears the predicate out exactly. Of the six retired nodes found across the portal's
+fourteen synced partitions, **not one carried a real user id**: three (`Crm/Source/Mail`,
+`MailTests`, `MailView`) had *no author field at all* — version 1, never touched by a person — and
+the rest read `system-security`. Every one is the import's to retire; none is authored content.
+
+🚨 **But fixing the rule cannot retire what is already there**, and that is the whole reason this
+page exists. The 10:15Z run stamped `import-0ff4e895224bfde0` **Succeeded**. Every later trigger
+reads that marker and answers `Skipped` before the prune phase — where `IsHumanEdit` lives — is ever
+reached. A portal rolled onto the corrected predicate would have skipped those three files for ever.
+
+### 2. The marker — the reason the residue is permanent
+
+The 23:11Z sync did exactly that, and the `Skipped` outcome then propagated one level further:
+
+| field | value at 23:11Z | meaning |
+|---|---|---|
+| `lastSyncOutcome` | `Skipped` | the marker matched; the partition was never read |
+| `lastSyncCommitSha` | `76cdb553b` (branch head) | **advanced** |
+| `lastSyncedAt` | `2026-08-30T17:06Z` | frozen 8 days back |
+
+`Skipped` reports `Preserved = 0` — **a zero nothing measured** — and
+`GitHubSyncService.MayAdvanceBaseline` reads `Preserved == 0` as "the mesh is in sync with the repo
+at this commit" and advances the seen commit. `GitHubWebhookProcessor.SkipReason` then answers
+*"already at this commit"* for every later green build. The partition is now declared converged to a
+commit whose tree it demonstrably does not match, and nothing will look again until the repository
+produces new content.
+
+That is why `Edu/Course` had been deleted upstream for **53 days** and was still Active — still being
+recompiled every boot, parked at `compilationStatus: Error` with `Matched Code nodes (0)`, and
+therefore still polluting the pre-production NodeType sweep.
+
+The two facts are the same fact recorded twice and disagreeing: the run that **refused to advance
+the baseline** (`Preserved = 5`) still wrote **the marker that let the next run advance it**. The
+marker wins, because it is read first and it is read instead of the partition.
+
+## The rule
+
+> **A run that did not converge does not licence the next skip.** The marker records what the run
+> LEFT UNDONE, and the skip requires it to be nothing.
+
+`StaticRepoImportResult.Converged` is the one predicate — four ways a run leaves the partition
+unequal to the content its marker names:
+
+```csharp
+public bool Converged =>
+    Preserved == 0            // kept a live node back: from an overwrite, or from the prune
+    && Failed == 0            // some node did not land (#2229 item C)
+    && !PruneRefused          // the prune could not run at all (#3614)
+    && !string.Equals(Outcome, "Failed", StringComparison.OrdinalIgnoreCase);
+```
+
+`ImportMarkerVerdict` carries `preserved` and `pruneRefused` beside the outcome it already recorded,
+and `MarkerConverged` is what the skip arm consults before it trusts the claim.
+
+🚨 **`PruneRefused` is the clause a count cannot see.** After a
+[refused prune](/Doc/Architecture/PruneRequiresACompleteListing) both `preserved` and `pruned` are
+zero, and *"looked and found nothing"* is indistinguishable from *"could not look"* — only the second
+means the retired files are still there.
+
+## An absent verdict is UNKNOWN, never zero
+
+Every marker written before 2026-09-08 carries an outcome and no `preserved` field. Reading that
+absence as zero would be the same fail-open the fix is about — and it would also leave every
+partition **already** in this state stranded, because the residue can only be retired by a run that
+reaches the prune.
+
+So `MarkerConverged` answers `false` for an absent verdict, and that branch is what repairs the
+fleet: each affected partition pays **one** re-import, which at an unchanged fingerprint matches
+every entry of the per-node manifest, writes nothing, recompiles nothing, and then stamps a real
+verdict. After that the skip is exactly as cheap as it was.
+
+This is deliberately not "stop trusting the marker". A change that re-imported on every trigger would
+trade this defect for #3146 — 19 complete passes in three hours on `memex-cloud`, ≈425 identical
+failures and a NodeType compile each — which is the more expensive mistake. A **converged** run's
+marker is still a licence to skip, and `AConvergedImport_StillShortCircuits` is the falsifier that
+holds the fix to it.
+
+## The opposite danger
+
+🚨 **Propagating a deletion too eagerly destroys authored content, and that is worse than the bug.**
+The protection this fix narrows is real: a node a person created on the portal between syncs is a
+local addition to be committed back, not a stale extra to mirror away (#604). Nothing here weakens
+it — `IsHumanEdit` is the *only* thing that separates the two, the two integration tests carry an
+authored node through every pass, and the assertion that matters is that the re-import the fix newly
+causes is not the pass that finally deletes it.
+
+The corresponding fail-open would be a node whose author the mesh does not know: an unauthored node
+absent from the source reads as the import's. That is the right reading for this fleet — every
+retired node measured had no author precisely *because* an import wrote it — but it is a statement
+about who writes nodes, not a law of nature, so it is stated here rather than left implicit.
+
+## What this does not cover
+
+- **The overwrite direction on a skip.** A `Skipped` still does not verify that each node the source
+  ships matches the repo byte for byte; that is what the fingerprint legitimately claims, and the
+  content sentinel plus the per-node manifest cover the rest.
+- **`MayAdvanceBaseline` is deliberately unchanged.** It answers a different question — where the
+  next git diff starts — and #3614 reasoned the `PruneRefused` case there on its own terms. It still
+  reads `Preserved == 0`; what changed is that a `Skipped` now only reaches it after a converged run
+  said so.
+- **Retiring a NodeType is still not the same as retiring its sources.** See
+  [Retiring a NodeType](/Doc/Architecture/RetiringANodeType) for the instances a pruned definition
+  strands.
+
+## Related
+
+- [The Prune Requires a Complete Listing](/Doc/Architecture/PruneRequiresACompleteListing) — the two reads the prune's inference rests on
+- [Static Repo Import](/Doc/Architecture/StaticRepoImport) — the pipeline, and the marker's place in it
+- [Retiring a NodeType](/Doc/Architecture/RetiringANodeType) — what a retirement has to remove beyond the source files
+- [GitHub Sync](/Doc/Architecture/GitHubSync) — the route that fetches, imports and records the baseline
+- [Sealed Publication Reads](/Doc/Architecture/SealedPublicationReads) — the reconciling import, which bypasses the same short-circuit on measured evidence

--- a/src/MeshWeaver.Documentation/Data/Architecture/ImportMarkerRecordsConvergence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ImportMarkerRecordsConvergence.md
@@ -64,7 +64,22 @@ the rest read `system-security`. Every one is the import's to retire; none is au
 🚨 **But fixing the rule cannot retire what is already there**, and that is the whole reason this
 page exists. The 10:15Z run stamped `import-0ff4e895224bfde0` **Succeeded**. Every later trigger
 reads that marker and answers `Skipped` before the prune phase — where `IsHumanEdit` lives — is ever
-reached. A portal rolled onto the corrected predicate would have skipped those three files for ever.
+reached, and the webhook does not even get that far: `GitHubWebhookProcessor.SkipReason` answers
+*"already at this commit"* because the `Skipped` outcome had advanced the pointer.
+
+**One route does reach the importer, and its coverage is exactly the measure of the gap.**
+`SealedPublicationSyncReconciler` (core#3727) re-imports with the content-skip bypassed
+(`ImportConflictPolicy.Reconcile`) — but only when all three of: the repository has a publication
+**sealed for this instance's framework identity**, the config sits **at** that sealed commit, and at
+least one NodeType under the Space was **declined on its source fingerprint** in that sweep. That is
+the *bundle-refusal* case, which `Crm` is; it is a symptom-driven trigger, not the mechanism.
+
+**`Edu/Course` is the case it does not reach, and it has had 53 days of boots to prove it.** Deleted
+upstream on 2026-07-17, its partition reads `lastSyncOutcome: Skipped`, nothing about it declines a
+bundle, and it is still Active — recompiled every boot at `compilationStatus: Error` with
+`Matched Code nodes (0)`. No seal fires for it, so nothing reaches the prune, so the ownership test
+never runs. **A partition converges only when something makes the importer read it, and until now
+the only things that did were a new repository commit or a declined bundle.**
 
 ### 2. The marker — the reason the residue is permanent
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PruneRequiresACompleteListing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PruneRequiresACompleteListing.md
@@ -134,9 +134,13 @@ and an empty candidate set stay silent — they are not failures.
 - **The export side.** `Push` reconstructs the commit tree from `HeadInfo.ExistingBlobs`, which is
   the *same* read. A truncated tree there would drop files from the repository rather than from the
   mesh. The flag now travels on `HeadInfo` so the guard can be added; it has not been.
-- **A partition whose orphans are already live.** The guards stop the class of defect from being
-  created; they do not retire nodes a previous route already wrote. A partition in that state needs
-  a forced re-import once its listing reads in full.
+- **~~A partition whose orphans are already live.~~** *(Closed 2026-09-08.)* The guards on this page
+  stop the class of defect being created; they cannot retire what is already there, because the run
+  that left the orphans stamped a green content-addressed marker and every later trigger answers
+  `Skipped` before the prune is reached. That is a second defect on the same path, and it is fixed
+  in [The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence): the
+  marker now records whether its run CONVERGED, an absent verdict reads as UNKNOWN, and a partition
+  in this state retires its orphans on the one re-import that buys. No forced re-import is needed.
 - **The satellite-path question.** Whether `path:{p} scope:descendants` returns a partition's
   `Source/*` satellite rows on a Postgres backend is a separate strand, in a different repository's
   query layer. In the in-memory adapter `Source`/`Test` are *not* satellite paths, so a monolith test
@@ -148,3 +152,4 @@ and an empty candidate set stay silent — they are not failures.
 - [GitHub Sync](/Doc/Architecture/GitHubSync) — the route that fetches, parses and imports a repo
 - [Partition Sync Guide](/Doc/Architecture/PartitionSyncGuide) — the `PartitionSyncMode` the prune reads
 - [CQRS and Content Access](/Doc/Architecture/CqrsAndContentAccess) — why a query never decides a single node's content
+- [The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence) — the other half of #3589: why a refused prune must not licence the next skip

--- a/src/MeshWeaver.Documentation/Data/Architecture/RetiringANodeType.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RetiringANodeType.md
@@ -27,37 +27,59 @@ anyway — pinned at `compilationStatus: "Error"` by a failure nobody authored.
 | Artifact | Where | Removed by |
 |---|---|---|
 | `{Type}/Source/*.cs`, `{Type}/Test/*.cs` | the package / node repo | the import's prune |
-| `{Type}.json` — the `NodeTypeDefinition` | the package / node repo | the import's prune — **except see below** |
+| `{Type}.json` — the `NodeTypeDefinition` | the package / node repo | the import's prune — **see below: this was broken until 2026-09-08** |
 | Instances (`nodeType:{Type}`) | anywhere on the mesh, incl. user partitions | nothing automatic |
 | `{Type}/Release/**` | mesh-minted | nothing — `IsMeshMintedRelease` spares it by design |
 
 Only the first row is reliable. The rest need a decision.
 
-## 🚨 The prune cannot reach the definition — but reaches its sources
+## 🚨 The prune used to reach the sources and not the definition — FIXED 2026-09-08
+
+**This section describes a defect that is repaired. It is kept because the shape it left behind is
+still findable on any mesh that has not re-imported since.**
 
 The importer's prune is guarded by a **sync baseline**. `ImportConflictPolicy.PreservesFromPruneOf`
 (`src/MeshWeaver.Graph/StaticRepoImporter.cs`) keeps any node the repo no longer carries when it was
-changed on the server since the last sync:
+changed on the server since the last sync — and until 2026-09-08 that was the whole rule:
 
 ```csharp
+// BEFORE — timestamp only
 public bool PreservesFromPruneOf(MeshNode? target) =>
     (PreserveServerNewer || PreserveServerAdditions) && !Force && Since is { } since
     && target is not null && target.LastModified > since;
 ```
 
-That guard exists for a good reason — a node someone *added* on the server is a local addition to be
+The guard exists for a good reason — a node someone *added* on the server is a local addition to be
 committed back, not a stale extra (see [Static Repo Import](/Doc/Architecture/StaticRepoImport)). But
-it reads `LastModified`, and `LastModified` does not distinguish an author from the framework:
+`LastModified` does not distinguish an author from the framework:
 
 - **A NodeType definition is written by the framework on every compile.** `compilationStatus`,
   `lastCompileStartedAt`, `lastCompileSucceededAt`, `latestReleasePath`, `latestAssemblyMvid`,
   `compiledSources`, `requestedReleaseAt` all live on the definition's content and are stamped by
   `system-security`. Its `LastModified` therefore sits *after* any sync baseline.
-- **Its `Source`/`Test` Code nodes are written only by real edits.** Nothing framework-generated
-  touches them, so their `LastModified` stays where the last human edit left it — *before* the
-  baseline.
+- **Its `Source`/`Test` Code nodes were assumed to be written only by real edits** — so their
+  `LastModified` would stay where the last human edit left it, *before* the baseline.
 
-So on the import that drops the type, the prune deletes the sources and keeps the definition:
+That second assumption is false, which is why the asymmetry was never the whole story: an IMPORT
+writes those Code nodes too, and the horizon is held while anything is preserved, so the importer
+ended up preserving its own output from itself. Measured on `memex.systemorph.com` 2026-09-08, three
+`Crm/Source/Mail*` nodes deleted upstream on 09-06 were kept on exactly this rule.
+
+**The rule now asks WHO wrote it** (`ImportConflictPolicy.IsHumanEdit`): only a write carrying a real
+user id is a server edit. A definition stamped `system-security` by the compile pipeline is
+therefore pruned along with its sources — the asymmetry below is gone — and a node a *person* edited
+is preserved exactly as before. 🚨 Pruning the definition is intended, and it still strands live
+instances: `NodeTypeInstanceProbe` raises the ⚠, which is why step 1 of the runbook below has always
+been "establish the instance count is zero".
+
+🚨 **And a partition already in this state does not repair itself just because the rule changed** —
+the run that preserved those nodes stamped a green content-addressed marker, so every later trigger
+answered `Skipped` before the prune was reached. That half is
+[The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence).
+
+### What it looked like
+
+On the import that dropped the type, the prune deleted the sources and kept the definition:
 
 ```
 ↩ Kept Edu/Course (added on the server — commit to sync it back).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-file-the-repository-deleted-now-leaves-the-mesh.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-file-the-repository-deleted-now-leaves-the-mesh.md
@@ -1,0 +1,46 @@
+---
+Name: A file the repository deleted now leaves the mesh
+Category: Fix
+Description: A source file retired upstream could stay in its partition for ever — still compiled, still occupying a NodeType, still refusing every bundle on the source fingerprint. The import's content-addressed marker now records whether the run CONVERGED, and a run that kept nodes back no longer licences the next one to skip reading the partition.
+Icon: Broom
+Order: -20260908
+---
+
+# A file the repository deleted now leaves the mesh
+
+On `memex.systemorph.com`, three `Crm/Source/Mail*` code nodes deleted from `MeshWeaver.Crm` on
+2026-09-06 were still in the partition — and still compiled into every Crm type — two days later.
+`Edu/Course` had been deleted upstream for **53 days**. Six retired nodes across two of the portal's
+fourteen synced partitions; two of them parked at `compilationStatus: Error`, recompiled on every
+boot and reported by the pre-production NodeType sweep. Because the source-fingerprint gate hashes
+the *live* source set, every `Crm` bundle stayed refused for as long as the three files did.
+
+The import had actually found them. Its own log says so:
+
+```
+↩ Kept Crm/Source/Mail (added on the server — commit to sync it back).
+Imported 23 node(s), kept 5 local change(s), pruned 0, synced 0 content file(s).
+```
+
+Two things had to be true for that to become permanent, and both are now fixed.
+
+**Only a person's write counts as a server edit.** The prune keeps a node changed on the server since
+the last sync — but the sync horizon is deliberately held while anything is preserved, so a previous
+import's *own* writes sat after it and read as "newer on the server" for ever. Every one of the six
+retired nodes was import-written (`system-security`, or no author at all); not one carried a real
+user id. `ImportConflictPolicy.IsHumanEdit` is what separates them, and a node a *person* edited is
+still preserved exactly as before.
+
+**And a run that kept nodes back no longer licences the next skip.** This is what made the residue
+permanent rather than merely slow. The import short-circuits on a content-addressed marker that the
+next run reads *instead of* the partition — so the marker is a claim about the partition, and the run
+that kept five nodes back stamped it green anyway. The next sync then answered `Skipped`, reported
+`Preserved = 0` — a zero nothing measured — and advanced the partition's seen commit to the branch
+head, after which every later build answered "already at this commit". The marker now records what
+its run left undone (`preserved`, `pruneRefused`); a marker that does not say "converged" — including
+every marker written before today, which says nothing — is re-examined once, which is what retires
+what is already there. A converged run's marker still short-circuits, at exactly the cost it always
+did.
+
+The design is in
+[The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence).

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -122,6 +122,44 @@ public sealed record StaticRepoImportResult(string Partition, string Fingerprint
     /// </summary>
     public ImmutableList<RefusedContentSync> RefusedContent { get; init; } =
         ImmutableList<RefusedContentSync>.Empty;
+
+    /// <summary>
+    /// 🚨 <b>Issue #3589.</b> True when this run could NOT ask the prune's question at all: the
+    /// source listing came back incomplete (a TRUNCATED GitHub tree — HTTP 200, partial body), so
+    /// "absent from the source" stopped being evidence of a deletion and
+    /// <see cref="StaticRepoImporter.ComputePrunableNodes"/> returned empty before every other guard
+    /// (#3614). Distinct from <c>PrunedPaths.Count == 0</c>, which cannot say WHY it is zero — the
+    /// unfalsifiable silence the issue was reported on.
+    /// </summary>
+    public bool PruneRefused { get; init; }
+
+    /// <summary>
+    /// 🚨 <b>Issue #3589 — the ONE question the content-addressed import marker answers.</b> True
+    /// when this run left the partition EQUAL to the source content it hashed.
+    ///
+    /// <para>The marker at <c>{Partition}/_Activity/import-{fingerprint}</c> is a claim about the
+    /// PARTITION ("this partition holds exactly content F"), and the next run reads it INSTEAD OF
+    /// the partition. So only a run that made that claim true may stamp it green. Four ways a run
+    /// leaves it false: it kept a live node back from an overwrite or from the prune
+    /// (<see cref="Preserved"/>), some node did not land (<see cref="Failed"/>), the whole import
+    /// failed (<see cref="Outcome"/>), or the prune could not run (<see cref="PruneRefused"/>).</para>
+    ///
+    /// <para><b>Measured on memex.systemorph.com, 2026-09-07/08.</b> The Crm import at 10:15Z
+    /// correctly found five prune candidates the repository had deleted and preserved all five
+    /// (<c>"Imported 23 node(s), kept 5 local change(s), pruned 0"</c>) — then stamped
+    /// <c>import-0ff4e895224bfde0</c> <see cref="ActivityStatus.Succeeded"/> anyway. At 23:11Z the
+    /// next sync read that marker, answered <c>Skipped</c> WITHOUT reading the partition, reported
+    /// <c>Preserved = 0</c> — a zero it never measured — and
+    /// <c>GitHubSyncService.MayAdvanceBaseline</c> read that zero as "the mesh is in sync" and
+    /// advanced <c>LastSyncCommitSha</c> to the branch head. The partition was then permanently
+    /// declared converged to a commit whose tree it demonstrably did not match, three retired
+    /// <c>Crm/Source/Mail*</c> files still compiled into every Crm type.</para>
+    /// </summary>
+    public bool Converged =>
+        Preserved == 0
+        && Failed == 0
+        && !PruneRefused
+        && !string.Equals(Outcome, "Failed", StringComparison.OrdinalIgnoreCase);
 }
 
 /// <summary>
@@ -809,7 +847,7 @@ public static class StaticRepoImporter
                 // skip arm below decides whether to re-run from it, and a decision that parses a log
                 // line is one re-wording away from silently re-importing forever again.
                 MeshNode BookkeepingNode(
-                    string id, string name, ActivityStatus status, string? outcome = null,
+                    string id, string name, ActivityStatus status, ImportMarkerVerdict? verdict = null,
                     params LogMessage[] messages) =>
                     new(id, activityNamespace)
                     {
@@ -823,10 +861,9 @@ public static class StaticRepoImporter
                             HubPath = source.Partition,
                             Status = status,
                             End = status == ActivityStatus.Running ? null : DateTime.UtcNow,
-                            ReturnValue = outcome is null
+                            ReturnValue = verdict is null
                                 ? null
-                                : System.Text.Json.JsonSerializer.SerializeToElement(
-                                    new ImportMarkerVerdict(outcome)),
+                                : System.Text.Json.JsonSerializer.SerializeToElement(verdict),
                             Messages = ImmutableList.CreateRange(messages),
                         }
                     };
@@ -859,11 +896,12 @@ public static class StaticRepoImporter
                 // node that may not exist yet (the early-failure path) AND on one left forked by a prior
                 // half-write. The human-readable log lives on the attempt; the lock carries the verdict
                 // plus a pointer to the attempt that produced it.
-                IObservable<int> StampLock(ActivityStatus status, string summary, string? lockOutcome = null) =>
+                IObservable<int> StampLock(
+                    ActivityStatus status, string summary, ImportMarkerVerdict? verdict = null) =>
                     // A scoped run never touches the content-addressed marker — see isScopedRun.
                     isScopedRun
                     ? Observable.Return(0)
-                    : Upsert(hub, BookkeepingNode(activityId, lockName, status, lockOutcome,
+                    : Upsert(hub, BookkeepingNode(activityId, lockName, status, verdict,
                             new LogMessage(summary, status is ActivityStatus.Succeeded
                                 ? Microsoft.Extensions.Logging.LogLevel.Information
                                 : status is ActivityStatus.Warning
@@ -950,7 +988,17 @@ public static class StaticRepoImporter
                         //    (Run guards its own faults into a "Failed" RESULT rather than an exception,
                         //    so this arm — not the Catch below — is what a failed run reaches.)
                         .SelectMany(result => StampLock(
-                                lockOutcome: result.Outcome,
+                                // 🚨 #3589 — the marker records WHAT THE RUN LEFT UNDONE, not only
+                                // its outcome word. `Preserved` and `PruneRefused` are the two ways
+                                // an "Imported" run leaves the partition unequal to the content the
+                                // marker id names, and the skip arm reads them before it trusts the
+                                // claim. Written for every run so an absent value can keep its one
+                                // honest meaning: UNKNOWN.
+                                verdict: new ImportMarkerVerdict(result.Outcome)
+                                {
+                                    Preserved = result.Preserved,
+                                    PruneRefused = result.PruneRefused,
+                                },
                                 status: result.Outcome switch
                                 {
                                     "ImportedWithErrors" => ActivityStatus.Warning,
@@ -1045,6 +1093,43 @@ public static class StaticRepoImporter
                     logger?.LogInformation(
                         "[StaticRepoImport] {Partition}: reconciling re-import at unchanged fingerprint "
                         + "{Fingerprint} — the live partition was measured to disagree with it.",
+                        source.Partition, fingerprint);
+                    return Reimport();
+                }
+
+                // 🚨 issue #3589 — A SUCCEEDED MARKER IS A CLAIM ABOUT THE **PARTITION**, AND ONLY A
+                // RUN THAT CONVERGED MAY MAKE IT.
+                //
+                // The id is content-addressed on the SOURCE, but what the next run reads out of it is
+                // "this partition holds exactly content F" — and it reads that INSTEAD of the
+                // partition. A run that kept live nodes back (from an overwrite or from the prune)
+                // did not make that true; nor did one whose prune could not run at all (#3614). Both
+                // stamped Succeeded anyway, so the very next trigger answered "Skipped" — and
+                // GitHubSyncService then read Skipped's `Preserved = 0`, a zero nothing measured, as
+                // "the mesh is in sync" and advanced LastSyncCommitSha to the branch head. The
+                // partition is then declared converged to a commit whose tree it does not match, and
+                // no later import ever looks again.
+                //
+                // Measured end to end on memex.systemorph.com: the 2026-09-07 10:15Z Crm import found
+                // all five nodes the repo had deleted, preserved all five ("kept 5 local change(s),
+                // pruned 0"), stamped import-0ff4e895224bfde0 Succeeded, and at 23:11Z the next sync
+                // skipped and advanced the commit pointer. Three retired Crm/Source/Mail* files were
+                // still compiled into every Crm type two days after the commit that deleted them, and
+                // every Crm bundle stayed refused on its source fingerprint (#2813).
+                //
+                // 🚨 An ABSENT verdict is UNKNOWN, never zero — the marker predates this field, so
+                // nothing recorded whether that run converged. Reading it as "converged" is exactly
+                // the fail-open zero this fixes, and it is also what would leave every partition
+                // ALREADY in this state stranded for ever: the residue is retired by the ONE
+                // re-import an unknown verdict buys. That re-import is cheap and self-limiting — at
+                // an unchanged fingerprint the per-node manifest matches, so it writes nothing and
+                // recompiles nothing — and it ends the moment a converged run stamps a real verdict.
+                if (!MarkerConverged(existingLog))
+                {
+                    logger?.LogInformation(
+                        "[StaticRepoImport] {Partition}: the marker at {Fingerprint} says imported, but "
+                        + "the run that wrote it did NOT converge (or recorded no verdict) — re-importing "
+                        + "rather than skipping on a claim nothing checked.",
                         source.Partition, fingerprint);
                     return Reimport();
                 }
@@ -1899,6 +1984,11 @@ public static class StaticRepoImporter
                                 // has to string-match a log line to learn that a Space's assets are
                                 // stale is one re-wording away from not learning it at all.
                                 RefusedContent = refusedContent,
+                                // 🚨 #3589 — carried so the MARKER can record it. "pruned 0" cannot
+                                // separate "looked and found nothing" from "could not look", and the
+                                // second is not convergence: a run that could not ask the prune's
+                                // question must not licence the next one to skip asking it too.
+                                PruneRefused = !sourceListingIsComplete,
                             };
                         });
                         }));
@@ -2813,7 +2903,32 @@ public static class StaticRepoImporter
         // fired and the loop this fixes stayed exactly as it was, with every test green except the
         // one that measured the second pass.
         [property: System.Text.Json.Serialization.JsonPropertyName("outcome")]
-        string Outcome);
+        string Outcome)
+    {
+        /// <summary>
+        /// 🚨 <b>Issue #3589 — how many live nodes the run KEPT BACK</b>
+        /// (<see cref="StaticRepoImportResult.Preserved"/>): kept-not-overwritten plus
+        /// kept-not-pruned. Zero is the marker's licence to skip; anything else says the run left
+        /// the partition unequal to the content this marker's id names.
+        ///
+        /// <para>🚨 NULLABLE ON PURPOSE. <c>null</c> means the marker was written before this field
+        /// existed (2026-09-08) and nothing recorded whether that run converged — <b>UNKNOWN, never
+        /// zero</b>. That distinction is the whole fix: reading an absent field as zero is the
+        /// fail-open that let a run which had just preserved five deleted files hand the next run a
+        /// green light.</para>
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("preserved")]
+        public int? Preserved { get; init; }
+
+        /// <summary>
+        /// 🚨 <b>Issue #3589 / #3614.</b> True when the run could not ask the prune's question —
+        /// the source listing came back incomplete, so nothing was removed and nothing could be.
+        /// A run that pruned nothing BECAUSE IT COULD NOT LOOK has not converged either, and must
+        /// not licence a skip that would make the refusal permanent at this fingerprint.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("pruneRefused")]
+        public bool PruneRefused { get; init; }
+    }
 
     /// <summary>
     /// ONE source node's contribution to the upsert phase's tally: the counters, the path it wrote or
@@ -2863,6 +2978,49 @@ public static class StaticRepoImporter
         catch (System.Text.Json.JsonException)
         {
             return null;
+        }
+    }
+
+    /// <summary>
+    /// 🚨 <b>Issue #3589 — did the run that wrote this marker CONVERGE the partition to the content
+    /// the marker's id names?</b> Only then is the marker a licence to answer <c>Skipped</c> without
+    /// reading the partition.
+    ///
+    /// <para>Reads the two facts the run recorded: <see cref="ImportMarkerVerdict.Preserved"/> (live
+    /// nodes it kept back — from an overwrite or from the prune) and
+    /// <see cref="ImportMarkerVerdict.PruneRefused"/> (the prune could not run at all). Converged
+    /// means kept nothing back and the prune was able to look.</para>
+    ///
+    /// <para>🚨 <b>ABSENT ⇒ FALSE, and that is the point.</b> A marker with no <c>preserved</c>
+    /// field predates 2026-09-08: nothing recorded whether that run converged, so the honest answer
+    /// is UNKNOWN and the safe reading of UNKNOWN is "look again". Every partition already carrying
+    /// the residue this fixes is in exactly that state, and this is the branch that retires it —
+    /// one re-import, which at an unchanged fingerprint writes nothing (the per-node manifest
+    /// matches) and then stamps a real verdict, after which the skip is free again.</para>
+    ///
+    /// <para>Pure and total: an unreadable, non-object or non-numeric verdict answers <c>false</c>,
+    /// never throws.</para>
+    /// </summary>
+    /// <param name="log">The marker's activity log.</param>
+    /// <returns><c>true</c> only when the run recorded that it converged.</returns>
+    private static bool MarkerConverged(ActivityLog log)
+    {
+        if (log.ReturnValue is not { } value)
+            return false;
+        try
+        {
+            if (value.ValueKind != System.Text.Json.JsonValueKind.Object
+                || !value.TryGetProperty("preserved", out var preserved)
+                || preserved.ValueKind != System.Text.Json.JsonValueKind.Number
+                || !preserved.TryGetInt32(out var keptBack))
+                return false;
+            var pruneRefused = value.TryGetProperty("pruneRefused", out var refused)
+                               && refused.ValueKind == System.Text.Json.JsonValueKind.True;
+            return keptBack == 0 && !pruneRefused;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return false;
         }
     }
 

--- a/test/MeshWeaver.Graph.Test/RetiredSourceLeavesTheMeshTest.cs
+++ b/test/MeshWeaver.Graph.Test/RetiredSourceLeavesTheMeshTest.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #3589 — a file the repository RETIRED stayed in the mesh, compiled, for ever.</b>
+///
+/// <para><b>Measured on memex.systemorph.com, 2026-09-07/08.</b> Three <c>Crm/Source/Mail*</c> code
+/// nodes deleted from <c>MeshWeaver.Crm</c> on 09-06 were still in the partition — and still compiled
+/// into every Crm type — two days later, and <c>Edu/Course</c> had been deleted upstream for
+/// <b>53 days</b>. Six retired nodes across two of the portal's fourteen synced partitions; two of
+/// them parked at <c>compilationStatus: Error</c> and still being recompiled every boot. Because the
+/// #2813 gate hashes the LIVE source set, every Crm bundle was refused on its fingerprint for as long
+/// as the three files stayed.</para>
+///
+/// <para><b>The two halves of the mechanism, and what pins each.</b></para>
+///
+/// <para><b>1. Ownership.</b> The prune's protection (<see cref="ImportConflictPolicy.PreservesFromPruneOf"/>)
+/// asks "was this node changed on the server since the last sync?". The horizon is HELD while
+/// anything is preserved, so a previous import's OWN writes sit after it and read as "newer on the
+/// server" for ever. The 10:15Z Crm import found all five nodes the repo had deleted and kept all
+/// five: <c>"Imported 23 node(s), kept 5 local change(s), pruned 0"</c>.
+/// <see cref="ImportConflictPolicy.IsHumanEdit"/> (core#3727) is the ownership test —
+/// <see cref="ARetiredFileLeavesTheMesh_AnAuthoredOneStays"/> is that test end to end, against a
+/// live mesh rather than a constructed <c>MeshNode</c>.</para>
+///
+/// <para><b>2. The marker.</b> Fixing the rule is not enough to retire what is already there, and
+/// that is what this file exists for. The run that kept those five back stamped its content-addressed
+/// marker <c>Succeeded</c> anyway; the next trigger read the marker, answered <c>Skipped</c> WITHOUT
+/// READING THE PARTITION, and reported <c>Preserved = 0</c> — a zero nothing measured — which
+/// <c>GitHubSyncService.MayAdvanceBaseline</c> took for "the mesh is in sync" and used to advance
+/// <c>LastSyncCommitSha</c> to the branch head. The partition was then declared converged to a commit
+/// whose tree it did not match, and the prune phase — where every other guard lives — was never
+/// reached again. A marker now records what its run LEFT UNDONE, and a run that kept anything back
+/// does not licence the next skip.</para>
+///
+/// <para>🚨 The danger here is the OPPOSITE of the bug: a deletion propagated too eagerly destroys
+/// authored content. Both tests below therefore carry an authored node through every pass and assert
+/// it survives — including the re-import the fix newly causes.</para>
+/// </summary>
+public class RetiredSourceLeavesTheMeshTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The person whose edit must survive every prune — the control on the opposite danger.</summary>
+    private static readonly AccessContext Author = new()
+    {
+        ObjectId = "alice",
+        Name = "Alice",
+        Email = "alice@acme.com",
+    };
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    /// <summary>A source that ships exactly the nodes it is given — the repo tree, in memory.</summary>
+    private sealed class RepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; init; } = [];
+        public MeshNode? Root { get; init; }
+
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+        public IReadOnlyList<StaticContentSync> EnumerateInlineContentSyncs() => [];
+    }
+
+    private static MeshNode Space(string partition) =>
+        new(partition) { Name = partition, NodeType = "Space", State = MeshNodeState.Active };
+
+    private static MeshNode Page(string partition, string id) =>
+        new(id, partition)
+        {
+            Name = id,
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+            Content = new MarkdownContent { Content = $"# {id}" },
+        };
+
+    private static string NewPartition() => "Rt" + Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// Two-way, with a horizon set BEFORE anything in the test was written — so every live node
+    /// reads as "changed on the server since the last sync" and only
+    /// <see cref="ImportConflictPolicy.IsHumanEdit"/> can separate them. That is the live Crm
+    /// configuration: the horizon is held while anything is preserved, so it falls ever further
+    /// behind the writes the import itself makes.
+    /// </summary>
+    private static ImportConflictPolicy TwoWaySince(DateTimeOffset horizon) =>
+        new(PreserveServerNewer: true, Since: horizon);
+
+    /// <summary>Creates a node AS A PERSON — the identity is captured on the calling thread, so the
+    /// scope has to be open across the call that builds the write, not across the subscribe.</summary>
+    private async Task CreateAsAuthor(MeshNode node)
+    {
+        IObservable<MeshNode> write;
+        using (Access.SwitchAccessContext(Author))
+            write = MeshService.CreateNode(node);
+        await write.FirstAsync().Timeout(60.Seconds());
+    }
+
+    /// <summary>The partition's immediate children, read through the query index. Bounded retry on
+    /// the CONDITION (never a delay): the read model trails the writes the import has already
+    /// confirmed through <c>PrunedPaths</c>.</summary>
+    private IObservable<IReadOnlyCollection<string>> ChildrenWhen(
+        string partition, Func<IReadOnlyCollection<string>, bool> settled) =>
+        Observable.Interval(100.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => MeshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{partition} scope:children"))
+                .Take(1))
+            .Select(c => (IReadOnlyCollection<string>)c.Items
+                .Select(n => n.Path)
+                .Where(p => !string.IsNullOrEmpty(p))
+                .ToArray())
+            .Where(settled)
+            .FirstAsync();
+
+    /// <summary>
+    /// 🚨 <b>THE OWNERSHIP TEST, end to end.</b> The repository retires two nodes at once: one the
+    /// IMPORT wrote (the <c>Crm/Source/Mail*</c> shape — system identity, or no author at all) and
+    /// one a PERSON authored on the portal. Both are absent from the source; both are newer than the
+    /// sync horizon. Only authorship separates them, and it must: the import's own writes are the
+    /// import's to retire, a person's are not.
+    ///
+    /// <para>Then the falsifier for the second half of the fix: once that pass CONVERGED — nothing
+    /// kept back — the marker is a licence to skip again, and the next pass must take it. A change
+    /// that simply stopped trusting the marker would fix #3589 by re-importing every partition on
+    /// every boot for ever, which is the far more expensive mistake (#3146: 19 full passes in three
+    /// hours on memex-cloud).</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ARetiredFileLeavesTheMesh_AnAuthoredOneStays()
+    {
+        var partition = NewPartition();
+        var horizon = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var kept = $"{partition}/Kept";
+        var retired = $"{partition}/Retired";
+        var authored = $"{partition}/Authored";
+
+        // Pass 1 — the repository ships both files; the import writes both, as the import.
+        var first = await StaticRepoImporter
+            .ImportSource(Mesh, new RepoSource(partition)
+            {
+                Root = Space(partition),
+                Nodes = [Page(partition, "Kept"), Page(partition, "Retired")],
+            })
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"pass 1 = {first.Outcome} ({first.Count} node(s))");
+        first.Outcome.Should().Be("Imported");
+
+        // A person adds a node of their own, on the portal, that the repository has never carried.
+        await CreateAsAuthor(Page(partition, "Authored"));
+
+        // Pass 2 — the repository has DELETED Retired. Two prune candidates now: the node the import
+        // wrote, and the node the person wrote. Both are newer than the horizon.
+        var afterRetirement = new RepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Kept")],
+        };
+        var second = await StaticRepoImporter
+            .ImportSource(Mesh, afterRetirement, policy: TwoWaySince(horizon))
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine(
+            $"pass 2 = {second.Outcome}, preserved {second.Preserved}, pruned [{string.Join(", ", second.PrunedPaths)}]");
+
+        second.PrunedPaths.Should().Contain(retired,
+            "the repository deleted this file and the IMPORT is what wrote it — an import's own "
+            + "writes are not a server edit, and judging them by timestamp alone is why three "
+            + "Crm/Source/Mail* files stayed compiled for two days after the commit that removed them");
+        second.PrunedPaths.Should().NotContain(authored,
+            "a person authored this one; a deletion propagated too eagerly destroys authored content, "
+            + "which is the failure this fix must not trade for the one it repairs");
+        second.Preserved.Should().Be(1,
+            "exactly one node was kept back — the authored one — and the count is what the marker "
+            + "and the sync baseline both read");
+
+        var settled = await ChildrenWhen(partition,
+                children => !children.Contains(retired, StringComparer.OrdinalIgnoreCase))
+            .Timeout(120.Seconds());
+        settled.Should().Contain(authored,
+            "the authored node is still in the mesh after the prune that removed the retired one");
+        settled.Should().Contain(kept, "and so is the file the repository still ships");
+
+        // Pass 3 — the SAME source again. Pass 2 kept a node back, so it did NOT converge to the
+        // content its marker names, and its marker must not licence a skip. Pre-fix this answered
+        // "Skipped" — the exact state memex.systemorph.com was frozen in.
+        var third = await StaticRepoImporter
+            .ImportSource(Mesh, afterRetirement, policy: TwoWaySince(horizon))
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"pass 3 = {third.Outcome}, preserved {third.Preserved}");
+
+        third.Outcome.Should().NotBe("Skipped",
+            "the run that wrote this marker kept a node back, so the partition does not hold the "
+            + "content the marker's id names. Answering Skipped here reports a success on evidence "
+            + "the run never gathered, and it is what made the residue permanent: GitHubSyncService "
+            + "reads Skipped's unmeasured Preserved = 0 as 'in sync' and advances LastSyncCommitSha "
+            + "to the branch head, after which no import ever looks again");
+
+        var afterThird = await ChildrenWhen(partition, children => children.Contains(authored))
+            .Timeout(120.Seconds());
+        afterThird.Should().Contain(authored,
+            "🚨 and the re-import this fix newly causes must not be the thing that finally deletes "
+            + "the authored node — the ownership test governs every pass, not just the first");
+        afterThird.Should().NotContain(retired, "the retired file does not come back");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The falsifier.</b> A pass that CONVERGED — pruned what the repository dropped and kept
+    /// nothing back — still stamps a marker the next pass may trust, and the next pass must answer
+    /// <c>Skipped</c>. Without this, "stop trusting the marker" would pass the test above while
+    /// re-importing every partition on every boot for ever.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AConvergedImport_StillShortCircuits()
+    {
+        var partition = NewPartition();
+        var horizon = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var retired = $"{partition}/Retired";
+
+        await StaticRepoImporter
+            .ImportSource(Mesh, new RepoSource(partition)
+            {
+                Root = Space(partition),
+                Nodes = [Page(partition, "Kept"), Page(partition, "Retired")],
+            })
+            .FirstAsync().Timeout(240.Seconds());
+
+        var afterRetirement = new RepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Kept")],
+        };
+
+        var converging = await StaticRepoImporter
+            .ImportSource(Mesh, afterRetirement, policy: TwoWaySince(horizon))
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine(
+            $"converging = {converging.Outcome}, preserved {converging.Preserved}, "
+            + $"pruned [{string.Join(", ", converging.PrunedPaths)}]");
+
+        converging.PrunedPaths.Should().Contain(retired);
+        converging.Preserved.Should().Be(0, "nothing was kept back — this pass converged the partition");
+
+        var again = await StaticRepoImporter
+            .ImportSource(Mesh, afterRetirement, policy: TwoWaySince(horizon))
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"again = {again.Outcome}");
+
+        again.Outcome.Should().Be("Skipped",
+            "a converged run's marker is a claim the partition satisfies, so the short-circuit stays "
+            + "exactly as cheap as it was. A fix that re-imported here would trade #3589 for #3146");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/StaticRepoImporterIncompleteListingTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaticRepoImporterIncompleteListingTest.cs
@@ -131,4 +131,56 @@ public class StaticRepoImporterIncompleteListingTest
         public bool Versioned => false;
         public IReadOnlyList<MeshNode> EnumerateSourceNodes() => [];
     }
+
+    // ── The other half of #3589: DID THE RUN CONVERGE? ───────────────────────────────────────────
+    //
+    // The refusal above is the prune's premise. This is what the run has to RECORD about itself, and
+    // it is the half that decides whether the next run ever reaches the prune at all. The
+    // content-addressed marker at {Partition}/_Activity/import-{fingerprint} is read INSTEAD of the
+    // partition, so a run that left the partition unequal to the content that id names must not
+    // stamp it as a licence to skip. Four ways to leave it unequal — each one pinned below.
+
+    private static StaticRepoImportResult Result(
+        string outcome = "Imported", int preserved = 0, int failed = 0, bool pruneRefused = false) =>
+        new(Partition, "fp", outcome, Count: 1, Preserved: preserved)
+        {
+            Failed = failed,
+            PruneRefused = pruneRefused,
+        };
+
+    [Fact]
+    public void ACleanImport_Converged()
+        => Result().Converged.Should().BeTrue(
+            "nothing was kept back, nothing failed, and the prune was able to look — the partition "
+            + "now holds exactly the content the marker's id names, which is the only state that "
+            + "licenses the next run to skip reading it");
+
+    [Fact]
+    public void AnImportThatKeptNodesBack_DidNotConverge()
+        => Result(preserved: 5).Converged.Should().BeFalse(
+            "measured on memex.systemorph.com: the 2026-09-07 10:15Z Crm import kept back all five "
+            + "nodes the repository had deleted (\"kept 5 local change(s), pruned 0\") and stamped "
+            + "its marker Succeeded anyway. At 23:11Z the next sync read that marker, answered "
+            + "Skipped without reading the partition, and its unmeasured Preserved = 0 advanced "
+            + "LastSyncCommitSha to the branch head");
+
+    [Fact]
+    public void AnImportWhoseNodesDidNotAllLand_DidNotConverge()
+        => Result(outcome: "ImportedWithErrors", failed: 2).Converged.Should().BeFalse(
+            "a node that did not land is a node the partition does not hold — the same claim, and "
+            + "the same reason the sync baseline is held (#2229 item C)");
+
+    [Fact]
+    public void AnImportWhosePruneWasRefused_DidNotConverge()
+        => Result(pruneRefused: true).Converged.Should().BeFalse(
+            "🚨 the case the count alone cannot see: preserved is 0 and pruned is 0, but the prune "
+            + "never ran — the source listing came back truncated. \"Looked and found nothing\" and "
+            + "\"could not look\" read identically in every log, and only the second means the "
+            + "retired files are still there");
+
+    [Fact]
+    public void AFailedImport_DidNotConverge()
+        => Result(outcome: "Failed").Converged.Should().BeFalse(
+            "the whole import failed; it carries no per-file tally to read, so the outcome literal "
+            + "is still the signal for that one");
 }


### PR DESCRIPTION
## A run that did not converge no longer licences the next skip — so a retired file finally leaves the mesh

Fixes #3589.

### The denominator, measured on both live portals today (read-only)

| portal | retired nodes | partitions | of | sweep |
|---|---|---|---|---|
| memex.systemorph.com | **6** | **2** | 14 synced | partition root + `{partition}/Source`, per partition, against the repo tree at each config's own `lastSyncCommitSha` |
| memex.meshweaver.cloud | **0** | **0** | 67 synced | `namespace:{P} scope:descendants nodeType:Code`, filtered to `/Source/` |

🚨 **Both zeros are non-vacuous, and the memex one has a positive control.** The same instrument returned **4** candidates against each partition's *recorded* sha and **0** against each repo's current `main` — the four are present on `MeshWeaver.Plugins@main` right now, i.e. artifacts of a stale pointer, not retirements. No mesh query truncated; all six `git/trees?recursive=1` reads returned `truncated: false`; all 67 `_GitSync` nodes and all repos read successfully.

**Every one of the six is import-owned.** Three (`Crm/Source/Mail`, `MailTests`, `MailView`) carry **no author field at all** — version 1, never touched by a person; `Crm/Mail`, `Crm/Migration` and `Edu/Course` read `system-security`. **Not one carries a real user id.** `Edu/Course` was deleted upstream on **2026-07-17 — 53 days ago**. Two of the six sit at `compilationStatus: Error` and were recompiled again today, so #3589 also pollutes the pre-production NodeType sweep.

Scope limit, stated: the systemorph sweep covered two levels (partition root and `{partition}/Source`), not nested `{NodeType}/Source` subtrees — 6 is a lower bound there. The memex sweep covered the nested level.

### The mechanism, from the portal's own activity log

The 2026-09-07 10:15Z Crm import **found every retired node** and kept them all:

```
↩ Kept Crm/Mail (added on the server — commit to sync it back).
↩ Kept Crm/Migration …   ↩ Kept Crm/Source/Mail …   ↩ Kept Crm/Source/MailTests …   ↩ Kept Crm/Source/MailView …
Imported 23 node(s), kept 5 local change(s), pruned 0, synced 0 content file(s).
```

`Preserved = 5` correctly **held** the sync baseline. But the same run stamped its content-addressed marker `import-0ff4e895224bfde0` **`Succeeded`** — and at 23:11Z the next sync read that marker, answered `Skipped` **without reading the partition**, reported `Preserved = 0` *(a zero nothing measured)*, and `MayAdvanceBaseline` took that zero for "in sync" and advanced `lastSyncCommitSha` to the branch head. The live config still shows it: `lastSyncCommitSha=76cdb553b` (a 09-07 commit) beside `lastSyncedAt=2026-08-30T17:06Z` and `lastSyncOutcome=Skipped`.

> **The run that refused to advance the baseline wrote the marker that let the next run advance it.** Both record the same fact — *did this import converge?* — and they disagreed. The marker wins, because it is read first and it is read **instead of** the partition.

### Why core#3727 was necessary and not sufficient

`ImportConflictPolicy.IsHumanEdit` is exactly the ownership test, and the measurement bears it out — every retired node is import-written. **But it lives in the prune phase, and the prune phase is not reached**: the marker short-circuits first, and the webhook does not even get that far (`SkipReason` → *"already at this commit"*, because the `Skipped` outcome advanced the pointer).

🚨 **One route does reach the importer, and I initially overstated the gap by ignoring it.** `SealedPublicationSyncReconciler` (#3727) re-imports with the content-skip bypassed — but only when the repository has a publication **sealed for this instance's identity**, the config sits **at** that sealed commit, **and** a NodeType under the Space was **declined on its source fingerprint** in that sweep. That is the *bundle-refusal* case, which `Crm` is; it is a symptom-driven trigger, not the mechanism.

**`Edu/Course` is the case it does not reach, and it has had 53 days of boots to prove it** — deleted upstream 2026-07-17, partition reads `Skipped`, declines no bundle, still Active at `compilationStatus: Error` with `Matched Code nodes (0)`. No seal fires, nothing reaches the prune, the ownership test never runs. Until this PR, a partition converged only when a **new repository commit** or a **declined bundle** forced the importer to read it.

### The fix

- **`StaticRepoImportResult.Converged`** — one predicate for the one question. Four ways a run leaves the partition unequal to the content its marker names: `Preserved > 0`, `Failed > 0`, outcome `Failed`, or **`PruneRefused`** (new init property — the #3614 case a count cannot see, where `preserved 0 / pruned 0` means *could not look*, not *looked and found nothing*).
- **`ImportMarkerVerdict` records `preserved` + `pruneRefused`** beside the outcome it already carried, on every run.
- **The skip arm requires it.** `MarkerConverged(existingLog)` is consulted before the marker is trusted; a non-converged marker re-imports instead of answering `Skipped`.
- 🚨 **An absent verdict is UNKNOWN, never zero.** Every marker written before today says nothing about convergence, and reading that as "converged" would be the same fail-open — *and* would leave every partition already in this state stranded, because the residue can only be retired by a run that reaches the prune. That branch is what repairs the fleet: one re-import per affected partition, which at an unchanged fingerprint matches every per-node manifest entry, **writes nothing and recompiles nothing**, then stamps a real verdict. The skip is free again from then on.

`MayAdvanceBaseline` is deliberately **unchanged** — it answers a different question (where the next git diff starts), #3614 reasoned its `PruneRefused` case on its own terms, and a `Skipped` now only reaches it after a converged run said so.

### 🚨 The opposite danger — authored content

Propagating a deletion too eagerly destroys authored content, which is worse than the bug. Nothing here weakens the #604 protection: `IsHumanEdit` is the only thing separating the two, both integration tests carry a **person-authored** node through every pass, and the assertion that matters is that **the re-import this fix newly causes is not the pass that finally deletes it**.

### Falsification — four runs, and run 2 is the discriminator

| run | marker guard | `IsHumanEdit` | result |
|---|---|---|---|
| 1 · as shipped | live | live | **2 passed** |
| 2 · marker guard neutered | dead | live | **1 failed** — `pass 3 = Skipped, preserved 0` (the exact live shape) · the converged-still-skips falsifier stayed **green** |
| 3 · ownership neutered | live | dead | **2 failed** — `pass 2 = Imported, preserved 3, pruned []` (the exact live "kept N, pruned 0" shape) |
| 4 · restored | live | live | **2 passed** |

Run 2 matters: the pin reddens while `AConvergedImport_StillShortCircuits` stays green, so the pin is not merely re-stating the falsifier — and that falsifier is what stops this becoming #3146 (19 full passes in 3 h on memex-cloud). A **converged** run's marker still short-circuits at exactly the cost it always did.

### Verified locally

`-c Release -warnaserror`, one project per invocation, `0 Error(s)` each: `MeshWeaver.Graph`, `MeshWeaver.GitSync`, `Memex.Portal.Shared`, `MeshWeaver.Graph.Test`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Documentation.Test`.
Tests: **Graph.Test import surface 78/78** (`~Import|~StaticRepo|~RetiredSource`), **Graph.Test full suite green**, `TruncatedRepoListingIsNotADeletionTest` 1/1, `DocumentationLinkIntegrityTest` 1/1 (the new page verified present in the built `MeshWeaver.Documentation.dll` — not a `--no-build` false pass). `check-record-signatures` clean (both new members are `init` properties, not primary-constructor parameters).

### Docs

- **New:** `Doc/Architecture/ImportMarkerRecordsConvergence` — the marker is a claim about the partition; the measurement; why an absent verdict is UNKNOWN; the opposite danger.
- **Corrected:** `RetiringANodeType` quoted the pre-#3727 timestamp-only `PreservesFromPruneOf` and asserted "the prune cannot reach the definition" — a definition stamped `system-security` is now pruned with its sources. `PruneRequiresACompleteListing`'s "a partition whose orphans are already live … needs a forced re-import" is closed.
- What's New (Fix).

### One thing the sweep raised and then falsified

The memex sweep also showed 20 partitions whose repo carries `Source` files the mesh does not (DataModeling 0/171, Manufacturing 0/37). I nearly filed that as a second defect; two reads killed it. `Manufacturing` and `DataModeling` are both `nodeType: Store/Plugin` with `installPaths` — a plugin's payload is **installed**, not mirrored into the hosting portal's partition, so 0-of-N is the designed shape there, and `lastSyncOutcome: Imported` over a near-empty partition is correct rather than a green label over a failure. No issue filed; the withdrawal is recorded on #3589 so the number is not left standing as a bug count.

What does stand as measured: 63 of 67 configs read `Skipped`, 29 with a horizon more than a week behind the attempt (Publish 32.9 d, Edu 32.2 d) — the state this PR is about.

Pairs-with: none — no public type or member is removed; `PruneRefused` and `Converged` are additive (`Converged` is a computed property, `PruneRefused` an init property, neither a primary-constructor parameter).
Implementers: none — no member added to a public interface or abstract class.
Mirror-sync: none — no localization catalog key is added or re-worded (the one new string is a server-side `LogInformation`, not user-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
