### PR TITLE
fix(#3732): the platform-shipped witness MEASURES the image, so a riding sibling is never a second build

### DIFF
--- a/.github/scripts/module-build-key.py
+++ b/.github/scripts/module-build-key.py
@@ -77,7 +77,13 @@ from pathlib import Path
 # instead of deriving an MVID from a compiler DLL built per matrix job (#3308). Bundles packed
 # under recipe 2 state an identity no consumer can match, so they must be REPACKED rather than
 # reused — which is exactly what changing this constant forces.
-RECIPE_VERSION = "3"
+# 4: the pack now MEASURES what the platform ships (`--platform-app`, the pinned image's extracted
+# /app: its app closure, its surface manifest and its seeded modules/<Name>/ lane) and DROPS every
+# MeshWeaver.* sibling that host already has, instead of trusting the repo's declared
+# src/platform-shipped.txt (#3732). Bundles packed under recipe 3 carry those duplicates — 14 of
+# MeshWeaver.Plugins' 37 carried 27 of them, measured 2026-09-08 — and a duplicate is exactly what
+# makes one assembly name reach a process at two builds, so they must be REPACKED, never reused.
+RECIPE_VERSION = "4"
 
 # Repo-level files that change what EVERY project compiles or tests. Presence and content both
 # count; a file the repo does not have hashes as null so adding it later changes the key.

--- a/.github/scripts/module-owned-platform.sh
+++ b/.github/scripts/module-owned-platform.sh
@@ -31,8 +31,8 @@
 #     source, so there is no /app to read); it SAYS which witness answered, on stderr, every time.
 #
 # When both are available the IMAGE decides and the declared list is compared to it, with any
-# disagreement printed on stderr naming the exact lines to add or drop. The list then decides
-# nothing and can be deleted; leaving it stale costs a warning, never a wrong bundle.
+# disagreement printed on stderr as a `DRIFT` line naming the exact entry to add or drop. The list
+# then decides nothing and can be deleted; leaving it stale costs a log line, never a wrong bundle.
 #
 # An absent platform-shipped.txt means "nothing is image-shipped" — the state of every node repo
 # before the storage carve-out — and is deliberately not an error: the list DECLARES exclusions.
@@ -81,17 +81,21 @@ if [ -n "$app" ]; then
   shipped="$(printf '%s\n%s\n%s\n' "$root_dlls" "$manifest_names" "$seeded" | grep -v '^$' | sort -u)"
   echo "module-owned-platform: MEASURED against $app — $(printf '%s\n' "$shipped" | grep -c '[^[:space:]]' || true) MeshWeaver.* assembl(y|ies) shipped by that host" >&2
   # The declared list decides nothing now; say where it disagrees so it can be corrected or deleted.
+  # 🚨 PLAIN stderr, never `::warning::`. This script runs THREE times per matrix entry — 111 times
+  # on MeshWeaver.Plugins' 37 — and a drift line is diagnostic about a file that decides nothing, so
+  # annotating it would bury the annotations that do decide something under two hundred that do not.
+  # The refusals above stay `::error::`: those stop the pack.
   if [ -n "$declared" ]; then
     while IFS= read -r name; do
       [ -n "$name" ] || continue
       grep -qxF "$name" <<<"$shipped" \
-        || echo "::warning::src/platform-shipped.txt names '$name' as image-shipped, but $app does not ship it — the line is stale and, before this measurement existed, kept that assembly OUT of every bundle that needs it." >&2
+        || echo "module-owned-platform: DRIFT — src/platform-shipped.txt names '$name' as image-shipped, but $app does not ship it. The line is stale; before this measurement existed it kept that assembly OUT of every bundle that needs it." >&2
     done <<<"$declared"
     while IFS= read -r name; do
       [ -n "$name" ] || continue
       [ -d "$src/$name" ] || continue
       grep -qxF "$name" <<<"$declared" \
-        || echo "::warning::$app ships '$name' and src/platform-shipped.txt does not name it — before this measurement existed, every bundle referencing it carried a second build of it." >&2
+        || echo "module-owned-platform: DRIFT — $app ships '$name' and src/platform-shipped.txt does not name it. Before this measurement existed, every bundle referencing it carried a second build of it." >&2
     done <<<"$shipped"
   fi
 else

--- a/.github/scripts/module-owned-platform.sh
+++ b/.github/scripts/module-owned-platform.sh
@@ -1,24 +1,104 @@
 #!/usr/bin/env bash
 # The MODULE-OWNED MeshWeaver.* assemblies of a node repo: every MeshWeaver.* project DIRECTORY in
-# its src/ EXCEPT the ones its src/platform-shipped.txt names — projects that live there but ship
-# in the portal IMAGE (the storage backends and transports that moved out of the platform with the
-# hosts). A module bundle may carry the former (they exist nowhere in /app) and must never carry the
-# latter (a same-identity duplicate beside the app's copy). Printed semicolon-separated, the shape
-# `meshweaver-plugin-build module-pack --own-platform` takes; the bundle inspection in
-# node-repo-module-pack.yml calls this same script so the two cannot disagree.
+# its src/ that the PLATFORM does not ship. A module bundle may carry the former (they exist nowhere
+# in the host) and must never carry the latter (a same-identity duplicate beside the host's own
+# copy). Printed semicolon-separated, the shape `meshweaver-plugin-build module-pack
+# --own-platform` takes; the bundle inspection in node-repo-module-pack.yml calls this same script
+# so the two cannot disagree.
 #
-#   module-owned-platform.sh <node-repo>/src
+#   module-owned-platform.sh <node-repo>/src [<platform-app-dir>]
+#
+# 🚨 WHICH WITNESS ANSWERS, AND WHY IT MATTERS (MeshWeaver#3732).
+#
+#   * WITH <platform-app-dir> — a portal image's extracted /app — the answer is MEASURED off what
+#     that host ACTUALLY ships, three ways, because the image ships assemblies three ways:
+#       1. <app>/<Name>.dll                        the application closure
+#       2. <app>/meshweaver-surface.manifest       the host's own record of its compile references
+#       3. <app>/modules/<Name>/<Name>.dll         the seeded-module lane (MeshModulesPublish's
+#                                                  CLOSURE lane, which MeshBuilder.ResolveModulePath
+#                                                  probes FIRST)
+#     🚨 A `MeshModuleClosure` row touches NEITHER (1) NOR (2) — the portal hosts' csproj comments
+#     say so in as many words — so a witness reading only /app answers "not shipped" for every
+#     seeded module. That is how MeshWeaver.Markdown.Collaboration came to ride 14 of the 37
+#     MeshWeaver.Plugins bundles while the image seeds it too (Plugins#1515).
+#
+#   * WITHOUT one, the fallback is the repo's DECLARED list, src/platform-shipped.txt. It is a
+#     declaration, not a measurement, and it has been wrong in both directions inside one week:
+#     #3335 found five names in /app that it did not list (a duplicate in every bundle referencing
+#     one) and corrected it BY HAND; the same file previously listed MeshWeaver.Maps after the
+#     image stopped shipping it, so that name reached a mesh from nowhere at all. The fallback
+#     exists only for the lane that pins no platform image (core's own CD builds the platform from
+#     source, so there is no /app to read); it SAYS which witness answered, on stderr, every time.
+#
+# When both are available the IMAGE decides and the declared list is compared to it, with any
+# disagreement printed on stderr naming the exact lines to add or drop. The list then decides
+# nothing and can be deleted; leaving it stale costs a warning, never a wrong bundle.
 #
 # An absent platform-shipped.txt means "nothing is image-shipped" — the state of every node repo
 # before the storage carve-out — and is deliberately not an error: the list DECLARES exclusions.
 # An EMPTY result (a repo whose every MeshWeaver.* project is image-shipped, or one with none) is
 # valid too, and prints an empty line rather than failing.
 set -euo pipefail
-src="${1:?usage: module-owned-platform.sh <node-repo>/src}"
-shipped=""
+src="${1:?usage: module-owned-platform.sh <node-repo>/src [<platform-app-dir>]}"
+app="${2:-}"
+
+declared=""
 if [ -f "$src/platform-shipped.txt" ]; then
-  shipped="$(grep -v '^[[:space:]]*#' "$src/platform-shipped.txt" | sed 's/[[:space:]]*$//' | grep -v '^$' || true)"
+  declared="$(grep -v '^[[:space:]]*#' "$src/platform-shipped.txt" | sed 's/[[:space:]]*$//' | grep -v '^$' || true)"
 fi
+
+shipped=""
+if [ -n "$app" ]; then
+  [ -d "$app" ] || { echo "::error::module-owned-platform.sh: platform app directory '$app' does not exist. A witness that cannot read the host would fall back to a declared list while looking like a measurement — refusing instead (MeshWeaver#3732)." >&2; exit 2; }
+  # 1. the application closure. The name test mirrors PlatformShippedAssemblies.IsPlatformAssemblyName
+  #    exactly — `MeshWeaver` or `MeshWeaver.<something>`, never `MeshWeaverish`.
+  root_dlls="$(find "$app" -maxdepth 1 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) \
+    | sed 's#.*/##; s#\.dll$##' | sort -u)"
+  # 2. the host's own surface manifest (<name>=<sha256> per line)
+  manifest_names=""
+  if [ -f "$app/meshweaver-surface.manifest" ]; then
+    manifest_names="$(sed -n 's/^\(MeshWeaver\(\.[^=]*\)\{0,1\}\)=.*$/\1/p' "$app/meshweaver-surface.manifest" | sort -u)"
+  fi
+  # 3. the seeded-module lane — ONLY modules/<Name>/<Name>.dll, the file ResolveModulePath probes;
+  #    the rest of a seeded folder is that module's own private closure, on nobody else's path.
+  seeded=""
+  if [ -d "$app/modules" ]; then
+    while IFS= read -r dir; do
+      name="$(basename "$dir")"
+      case "$name" in MeshWeaver.?*|MeshWeaver) ;; *) continue ;; esac
+      [ -f "$dir/$name.dll" ] || continue
+      seeded="$seeded$name
+"
+    done < <(find "$app/modules" -mindepth 1 -maxdepth 1 -type d | sort)
+  fi
+  # 🚨 An empty reading is a WRONG DIRECTORY, never an answer. A portal /app carries 200+
+  # MeshWeaver.* assemblies and the tester image 88; "this host ships none" would silently turn
+  # every exclusion below into a ride while logging like a clean measurement.
+  if [ -z "$root_dlls" ] && [ -z "$manifest_names" ]; then
+    echo "::error::module-owned-platform.sh: '$app' carries no meshweaver-surface.manifest and no MeshWeaver.*.dll at its root, so it is not a platform application directory. Pass a portal image's extracted /app." >&2
+    exit 2
+  fi
+  shipped="$(printf '%s\n%s\n%s\n' "$root_dlls" "$manifest_names" "$seeded" | grep -v '^$' | sort -u)"
+  echo "module-owned-platform: MEASURED against $app — $(printf '%s\n' "$shipped" | grep -c '[^[:space:]]' || true) MeshWeaver.* assembl(y|ies) shipped by that host" >&2
+  # The declared list decides nothing now; say where it disagrees so it can be corrected or deleted.
+  if [ -n "$declared" ]; then
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      grep -qxF "$name" <<<"$shipped" \
+        || echo "::warning::src/platform-shipped.txt names '$name' as image-shipped, but $app does not ship it — the line is stale and, before this measurement existed, kept that assembly OUT of every bundle that needs it." >&2
+    done <<<"$declared"
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      [ -d "$src/$name" ] || continue
+      grep -qxF "$name" <<<"$declared" \
+        || echo "::warning::$app ships '$name' and src/platform-shipped.txt does not name it — before this measurement existed, every bundle referencing it carried a second build of it." >&2
+    done <<<"$shipped"
+  fi
+else
+  shipped="$declared"
+  echo "module-owned-platform: no platform app directory given — the split rests on the DECLARED src/platform-shipped.txt ($(printf '%s\n' "$declared" | grep -c '[^[:space:]]' || true) name(s)), which is not a measurement. Pass the pinned image's extracted /app to measure it (MeshWeaver#3732)." >&2
+fi
+
 own=()
 while IFS= read -r dir; do
   name="$(basename "$dir")"

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -42,8 +42,10 @@ gate exists.
     `gen-manifests.py` hashes a mixed package's own `src/` project into its `moduleVersion` too.
     What remains is narrower and still fatal: the version covers the module's OWN project, while
     the CONTAINER pack path copies every MODULE-OWNED `MeshWeaver.*` sibling INTO the bundle
-    (`module-owned-platform.sh`: in this repo's `src/`, absent from `src/platform-shipped.txt`,
-    therefore nowhere in the image's `/app`). Measured on MeshWeaver.Plugins 2026-09-01:
+    (`module-owned-platform.sh`: in this repo's `src/`, and MEASURED as absent from the pinned
+    platform host — its app closure, its surface manifest and its seeded `modules/<Name>/` lane;
+    MeshWeaver#3732 replaced the declared `src/platform-shipped.txt` reading with that measurement).
+    Measured on MeshWeaver.Plugins 2026-09-01:
     `MeshWeaver.Blazor` rides in SEVEN published bundles and not one of their `manifest.lock`s
     hashes a byte of it. So version equality still does not imply byte equality, and "the registry
     already serves this version" is still NOT evidence the published bundle matches HEAD.

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1532,6 +1532,14 @@ jobs:
         run: |
           set -euo pipefail
           src="$RUNNER_TEMP/platform-refs"
+          # 🚨 TWO ANSWERS, DELIBERATELY DIFFERENT (MeshWeaver#3732):
+          #   refs = the COMPILE reference set, which supersede may prune;
+          #   app  = the RAW image copy, which is what the host SHIPS and therefore the only sound
+          #          input to the platform-shipped witness. Superseding drops an assembly from the
+          #          compile set precisely BECAUSE the image still carries it, so a witness reading
+          #          the pruned copy would answer "not shipped" for a name that is right there in
+          #          /app — and every bundle referencing it would go back to carrying a duplicate.
+          echo "app=$src" >> "$GITHUB_OUTPUT"
           # Empty ⇒ the reference set is the image's /app unchanged, and REFS keeps the exact value
           # it had before this step existed. Byte-identical to before the input existed.
           if [ -z "${SUPERSEDED// /}" ]; then
@@ -1618,6 +1626,11 @@ jobs:
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
           REFS: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.refs || '' }}
+          # 🚨 The RAW image copy, never the superseded-pruned reference set: this decides what
+          # the host SHIPS, not what the module compiles against (MeshWeaver#3732). Empty when the
+          # caller pins no image — then the platform came from source and there is no /app to
+          # measure, which the witness says out loud instead of pretending it measured.
+          PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
           # The closure arguments are written HERE and read by the pack step, so the compiler that
@@ -1689,8 +1702,10 @@ jobs:
               echo "compiler: CONTAINER — consumed from the ONE global workspace build (no docker, no registry, no compile in this job)"
               # MODULE-OWNED in-tree siblings (from THIS module's closure manifest, never a glob of
               # the shared output) MUST ride; image-shipped ones must NOT (same-identity duplicate
-              # beside /app's copy — the #143 family). Same script as packer + inspection.
-              own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")"
+              # beside /app's copy — the #143 family). Same script as packer + inspection, and with
+              # the image in hand it MEASURES what that host ships instead of reading the repo's
+              # declared src/platform-shipped.txt (MeshWeaver#3732).
+              own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
               while IFS= read -r name; do
                 { [ -n "$name" ] && [ "$name" != "$MODULE" ]; } || continue
                 dir="$ws/$name"
@@ -1708,7 +1723,7 @@ jobs:
                   printf '%s\n%s\n' --with "$name.dll" >> "$packargs"
                   echo "closure: $name.dll RIDES — module-owned (its source is in this repo's src/, so it is nowhere in the image's /app)"
                 else
-                  echo "closure: $name.dll does NOT ride — the image ships it (src/platform-shipped.txt); bundling it would land a same-identity duplicate beside /app's copy"
+                  echo "closure: $name.dll does NOT ride — the platform ships it (${PLATFORM_APP:+measured off $PLATFORM_APP}${PLATFORM_APP:-declared by src/platform-shipped.txt}); bundling it would land a same-identity duplicate beside the host's own copy"
                 fi
               done < "$closure_file"
               # The PRIVATE CLOSURE rides: module-libs.txt is the builder-written provenance —
@@ -1835,6 +1850,11 @@ jobs:
           # its /app, which the sdk build passes as `-p:MeshWeaverRefs=$REFS` and the container
           # build compiles inside; when none is, it is empty and the platform came from source.
           REFS: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.refs || '' }}
+          # 🚨 The RAW image copy — what the host SHIPS, which is a different question from what
+          # the module COMPILES against and must not be answered off the superseded-pruned set
+          # (MeshWeaver#3732). It reaches the packer as --platform-app and the classification
+          # script as its second argument, so one measurement decides both.
+          PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
           # 🚨 The closure flags come from the COMPILER THAT RAN, written to a file by the step
@@ -1933,7 +1953,8 @@ jobs:
             --package-version "$VERSION" \
             --min-mesh-version "$FLOOR" \
             "${identity[@]}" \
-            --own-platform "$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")" \
+            --own-platform "$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})" \
+            ${PLATFORM_APP:+--platform-app "$PLATFORM_APP"} \
             --out "$RUNNER_TEMP/bundles"
 
       # A bundle that PACKED is not yet a bundle that LANDS: assert the closure and the manifest a
@@ -1952,6 +1973,9 @@ jobs:
           FLOOR: ${{ steps.identity.outputs.floor }}
           COMPILER: ${{ steps.build.outputs.compiler }}
           PACKDIR: ${{ steps.build.outputs.packdir }}
+          # The SAME witness the pack used, so this jq cannot disagree with it about what
+          # "platform" means (MeshWeaver#3732).
+          PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
           bundle="$RUNNER_TEMP/bundles/MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg"
@@ -1980,11 +2004,14 @@ jobs:
           # repo's src/, so they exist nowhere in /app — Import's DataSetReader family) are the
           # deliberate exception: for them, NOT riding is the fault. The jq mirrors the pack's
           # --own-platform set exactly, so the two cannot disagree about what "platform" means.
-          # …EXCEPT the projects the repo lists in src/platform-shipped.txt: they live in its src/
-          # yet ship in the portal IMAGE (the storage backends and transports that moved out of the
-          # platform with the hosts), so a bundle carrying one would land a same-identity duplicate
-          # beside the app's copy. ONE script computes the set for the pack AND for this check.
-          own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")"
+          # …EXCEPT the projects the PLATFORM ships: they live in this repo's src/ yet also reach a
+          # portal through the image (the storage backends and transports that moved out with the
+          # hosts, and the modules the image seeds under /app/modules/<Name>/), so a bundle carrying
+          # one would land a same-identity duplicate beside the host's copy. ONE script computes the
+          # set for the pack AND for this check — and with $PLATFORM_APP it MEASURES that set off
+          # the pinned image rather than reading the repo's declared src/platform-shipped.txt, which
+          # went stale in both directions inside one week (MeshWeaver#3732, #3335).
+          own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
           jq -e --arg m "$MODULE" --arg own "$own" \
             '($own | split(";")) as $owned
              | [.module.assemblies[]

--- a/src/MeshWeaver.Compiler/PlatformShippedAssemblies.cs
+++ b/src/MeshWeaver.Compiler/PlatformShippedAssemblies.cs
@@ -1,0 +1,180 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>How a platform host ships one <c>MeshWeaver.*</c> assembly.</summary>
+public enum PlatformShipping
+{
+    /// <summary>The file sits in the host's application directory itself — the app closure, loaded
+    /// into the default ALC at start and never overridable. A second copy landing beside a module
+    /// is dead weight at best: the loader keeps the one it saw first, and the loser reads as
+    /// "landed but not yet loaded".</summary>
+    ApplicationClosure,
+
+    /// <summary>The host's own <c>meshweaver-surface.manifest</c> names it — the platform's written
+    /// record of what it COMPILED against, which is the app closure by construction.</summary>
+    SurfaceManifest,
+
+    /// <summary>The image seeds it under <c>&lt;app&gt;/modules/&lt;Name&gt;/&lt;Name&gt;.dll</c> —
+    /// the closure lane of <c>MeshModulesPublish.targets</c>, which is where
+    /// <c>MeshBuilder.ResolveModulePath</c> probes FIRST. A landed bundle of that same module
+    /// legitimately supersedes this copy; a bundle merely CARRYING it as a riding sibling does
+    /// not, and produces two builds of one assembly name in one process.</summary>
+    SeededModule,
+}
+
+/// <summary>One assembly a platform host ships, with the evidence that says so.</summary>
+/// <param name="Name">The assembly's simple name.</param>
+/// <param name="How">Which of the three witnesses answered.</param>
+/// <param name="Evidence">The path (or manifest line) the answer was read from — printed by every
+/// caller, so a strip decision names the file it rests on rather than an opinion.</param>
+public sealed record PlatformShippedAssembly(string Name, PlatformShipping How, string Evidence);
+
+/// <summary>
+/// 🚨 <b>THE PLATFORM-SHIPPED WITNESS — what a platform host ACTUALLY SHIPS, measured off that
+/// host's own application directory, never read from a list.</b>
+///
+/// <para><b>Why a list cannot do this job (MeshWeaver#3732).</b> A module bundle may carry the
+/// <c>MeshWeaver.*</c> assemblies that exist nowhere in the host, and must never carry one the host
+/// already has: <c>MeshWeaver.*</c> assemblies bind by a strictly synchronised
+/// <c>AssemblyVersion</c>, so two copies under one simple name are ONE assembly identity and the
+/// loader keeps whichever it saw first. Until now that split was decided by a hand-maintained file
+/// in each node repo (<c>src/platform-shipped.txt</c>), and a declaration goes stale silently in
+/// both directions the moment a project moves in or out of the image:</para>
+/// <list type="bullet">
+///   <item>MeshWeaver.Plugins#1023 removed <c>MeshWeaver.AI</c> from the list when the engine left
+///     <c>/app</c>; MeshWeaver.Plugins#1515 put four modules back under <c>Modules:Assemblies</c>
+///     and the list did not move — so 14 of 37 bundles ship a copy of an assembly the image seeds.</item>
+///   <item>#3335 found FIVE names in <c>/app</c> that the list did not name, each a duplicate in
+///     every bundle that referenced it, and corrected the file BY HAND after a manual
+///     re-measurement — which is the same measurement this type makes automatically.</item>
+///   <item>The opposite error costs a <c>ReflectionTypeLoadException</c>: a name listed as
+///     image-shipped that the image no longer ships reaches a mesh from nowhere at all
+///     (<c>MeshWeaver.Maps</c>, #3335).</item>
+/// </list>
+///
+/// <para><b>Three witnesses, because the image ships assemblies three ways</b> — and reading only
+/// the first is exactly how <c>MeshWeaver.Markdown.Collaboration</c> came to ride 14 bundles while
+/// the image also seeds it:</para>
+/// <list type="number">
+///   <item><see cref="PlatformShipping.ApplicationClosure"/> — <c>&lt;app&gt;/&lt;Name&gt;.dll</c>.</item>
+///   <item><see cref="PlatformShipping.SurfaceManifest"/> — a name in
+///     <see cref="FrameworkBuildIdentity.SurfaceManifestFileName"/>.</item>
+///   <item><see cref="PlatformShipping.SeededModule"/> —
+///     <c>&lt;app&gt;/modules/&lt;Name&gt;/&lt;Name&gt;.dll</c>. 🚨 A <c>MeshModuleClosure</c> row
+///     touches NEITHER of the first two (the hosts' csproj comments say so in as many words), so a
+///     witness that reads only <c>/app</c> answers "not shipped" for every seeded module.</item>
+/// </list>
+///
+/// <para><b>It refuses rather than answering nothing.</b> A directory with no surface manifest and
+/// no <c>MeshWeaver.*</c> assembly at its root is not a platform application directory, and
+/// answering "ships nothing" for one would make every caller's strip a no-op that reads exactly
+/// like a clean measurement. Pure file reads, so it is unit-testable with no image on disk.</para>
+/// </summary>
+public static class PlatformShippedAssemblies
+{
+    /// <summary>The folder a host lays seeded modules out under, beside the app
+    /// (<c>memex/MeshModulesPublish.targets</c>; <c>MeshBuilder.ResolveModulePath</c> probes it
+    /// before the app directory).</summary>
+    public const string SeededModulesFolder = "modules";
+
+    /// <summary>
+    /// The names that bind by a strictly synchronised <c>AssemblyVersion</c> and therefore collapse
+    /// to ONE identity in a loaded process. The same predicate
+    /// <c>MeshWeaver.Plugin.Build.DepsClosure</c>, <c>PrivateClosure</c> and
+    /// <c>PublishedBundleCatalogue</c> apply, kept here so "what the platform side owns" has one
+    /// spelling. A third-party diamond rides by design, versions independently, and is deliberately
+    /// NOT judged.
+    /// </summary>
+    public static bool IsPlatformAssemblyName(string? name) =>
+        !string.IsNullOrEmpty(name)
+        && (name.StartsWith("MeshWeaver.", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(name, "MeshWeaver", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Reads what the platform host at <paramref name="appDirectory"/> ships.
+    /// </summary>
+    /// <param name="appDirectory">The host's application directory — a portal image's <c>/app</c>,
+    /// extracted or mounted.</param>
+    /// <returns>The shipped assemblies by simple name (ordinal-ignore-case), or <c>null</c> with a
+    /// <c>Problem</c> naming why this directory cannot answer.</returns>
+    public static (ImmutableDictionary<string, PlatformShippedAssembly>? Shipped, string? Problem)
+        Read(string appDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(appDirectory))
+            return (null, "no platform application directory was given");
+        var app = Path.GetFullPath(appDirectory);
+        if (!Directory.Exists(app))
+            return (null, $"'{app}' does not exist or is not a directory");
+
+        var shipped = ImmutableDictionary.CreateBuilder<string, PlatformShippedAssembly>(
+            StringComparer.OrdinalIgnoreCase);
+        var rootAssemblies = 0;
+        try
+        {
+            // 1. The application closure.
+            foreach (var file in Directory.EnumerateFiles(app, "*.dll", SearchOption.TopDirectoryOnly))
+            {
+                var name = Path.GetFileNameWithoutExtension(file);
+                if (!IsPlatformAssemblyName(name))
+                    continue;
+                rootAssemblies++;
+                shipped[name] = new PlatformShippedAssembly(
+                    name, PlatformShipping.ApplicationClosure, file);
+            }
+
+            // 2. The host's own surface manifest — its record of what it compiled against.
+            var manifestPath = Path.Combine(app, FrameworkBuildIdentity.SurfaceManifestFileName);
+            var manifestPairs = 0;
+            if (File.Exists(manifestPath))
+            {
+                var pairs = FrameworkBuildIdentity.ParseSurfaceManifest(File.ReadAllText(manifestPath));
+                manifestPairs = pairs.Count;
+                foreach (var name in pairs.Keys)
+                {
+                    if (!IsPlatformAssemblyName(name) || shipped.ContainsKey(name))
+                        continue;
+                    shipped[name] = new PlatformShippedAssembly(
+                        name, PlatformShipping.SurfaceManifest, manifestPath);
+                }
+            }
+
+            // 3. The seeded-module lane. ONLY <dir>/<dir name>.dll: that is the file
+            //    ResolveModulePath probes, and the other files in a seeded folder are that module's
+            //    own private closure, on no probing path of any other module.
+            var modulesRoot = Path.Combine(app, SeededModulesFolder);
+            if (Directory.Exists(modulesRoot))
+            {
+                foreach (var directory in Directory.EnumerateDirectories(modulesRoot))
+                {
+                    var name = Path.GetFileName(directory);
+                    if (!IsPlatformAssemblyName(name) || shipped.ContainsKey(name))
+                        continue;
+                    var dll = Path.Combine(directory, name + ".dll");
+                    if (File.Exists(dll))
+                        shipped[name] = new PlatformShippedAssembly(
+                            name, PlatformShipping.SeededModule, dll);
+                }
+            }
+
+            // 🚨 A witness that read nothing must say so. "This host ships no MeshWeaver assembly"
+            // is not a fact any real platform directory produces — a portal /app carries 200+ and
+            // the tester's 88 — so an empty reading means the caller pointed at the wrong place,
+            // and returning it as an answer would make every strip a silent no-op that logs like a
+            // clean measurement.
+            if (rootAssemblies == 0 && manifestPairs == 0)
+                return (null,
+                    $"'{app}' carries no {FrameworkBuildIdentity.SurfaceManifestFileName} and no "
+                    + "MeshWeaver.* assembly at its root, so it is not a platform application "
+                    + "directory. Pass a portal image's extracted /app (the directory holding the "
+                    + "surface manifest beside its assemblies) — an empty reading here would strip "
+                    + "nothing while looking exactly like a clean measurement.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return (null, $"'{app}' could not be read ({ex.GetType().Name}: {ex.Message})");
+        }
+
+        return (shipped.ToImmutable(), null);
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/CarvingProjectsOutOfCore.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CarvingProjectsOutOfCore.md
@@ -213,8 +213,12 @@ When you move a project, in the same change set:
    only to ship the bits, which are the easiest to mistake for a real dependency (a
    warnings-as-errors build of the consumer will tell you: if it still compiles clean, there was no
    code dependency);
-3. if the moved project still ships in the image, add it to `src/platform-shipped.txt` in plugins,
-   or its bundles will carry a second copy beside `/app`'s;
+3. if the moved project still ships in the image, the pack lane now MEASURES that off the pinned
+   image rather than taking your word for it, so no list entry is required — but the measurement is
+   only as current as the image the lane pins, and it is not armed at all in a lane that pins no
+   image, so state the move in the change set anyway. (`src/platform-shipped.txt` remains as a
+   declaration the lane compares against and warns about; it decides nothing. See
+   [The Platform-Shipped Witness](../PlatformShippedWitness).)
 4. add it to the plugins host build list in `ci.yml` — it is explicit, not a glob, exactly so a
    moved project cannot silently stop being built;
 5. move its tests, and **split any test that spans the boundary** rather than moving it whole —

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -74,6 +74,16 @@ not (Plugins#1268 removed it from `/app`) and no required package brings it. The
 [Module Closure Accounting](../ModuleClosureAccounting) was written after: *"Could not load file or
 assembly …"*, a red trunk in a repo that changed nothing, for eleven hours.
 
+🚨 **That third argument is CONDITIONAL on the image, and the image moved.** Plugins#1515 seeds
+`MeshWeaver.Markdown.Collaboration` (and `MeshWeaver.AI`, `MeshWeaver.Blazor.Chat`,
+`MeshWeaver.Mcp`) into the portal image under `/app/modules/<Name>/`, so *today* the image DOES
+supply it and the ride is both unnecessary and harmful. The rule is therefore not "declared modules
+ride" but "a sibling rides **iff** the platform host does not ship it" — the same predicate, now
+measured rather than assumed. Since MeshWeaver#3732 the packer answers it off the pinned image
+itself: see [The Platform-Shipped Witness](../PlatformShippedWitness). The decision below stands
+unchanged for every sibling the image genuinely does not carry, which is what the argument was
+always about.
+
 ### 4. The host case and the module case are not the same defect
 
 `ShippedByHostProblem` refuses host-vs-module because the two provenances use **incompatible id

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
@@ -127,9 +127,13 @@ true, and the half it misses is live.**
 `DepsClosure.Derive` does stop at `MeshWeaver.*`, and that is what the `sdk` pack path uses
 (`--deps-closure`). The **container** path — now the default for nearly every entry — does not use
 it. It reads the module's closure manifest and, for every `MeshWeaver.*` sibling in it, asks
-`module-owned-platform.sh` one question: *is this project's source in this repo's `src/` and
-absent from `src/platform-shipped.txt`?* If yes, the sibling **is copied into the bundle** and
+`module-owned-platform.sh` one question: *is this project's source in this repo's `src/` and does
+the platform host not already ship it?* If yes, the sibling **is copied into the bundle** and
 passed as `--with <Name>.dll`, and the job log says so:
+
+🚨 That second half used to read *"and absent from `src/platform-shipped.txt`"* — a hand-maintained
+list, which drifted in both directions and put 27 duplicate copies into 14 of 37 bundles. It is now
+MEASURED off the pinned image; see [The Platform-Shipped Witness](../PlatformShippedWitness).
 
 ```
 closure: MeshWeaver.Blazor.dll RIDES — module-owned (its source is in this repo's src/,

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformImageClosure.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformImageClosure.md
@@ -273,6 +273,12 @@ adds the gate.
   "do NOT re-add"; they are present in both `ci.7755` and `ci.7794`. That is the same
   declaration-versus-bytes gap this page is about, one layer over, and it interacts with the
   in-flight optional-Blazor work — so it is filed as #3335 rather than folded in here.
+  🚨 **The pack lane no longer rests on that declaration** (#3732): it measures what the image ships
+  — app root, surface manifest, **and** the `modules/<Name>/` seeds the first bullet above
+  deliberately exempts from *this* gate — and drops any `MeshWeaver.*` sibling the host already has
+  from a bundle's closure. The two readings differ on purpose: a seed is not a second producer for
+  the COMPILE contract, but it very much is one for a bundle that carries a riding copy of it. See
+  [The Platform-Shipped Witness](../PlatformShippedWitness).
 - **Runtime binding.** `/app` is a runtime directory and the runtime binds by simple name, ignoring
   version — which is why the portal runs perfectly with a reference set that will not resolve. This
   gate asserts the COMPILE contract, which is the one the fleet consumes.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
@@ -132,6 +132,30 @@ collapse to one identity. Judging it would hold every bundle in the fleet for a 
 claimed. See [Module Closure Accounting](../ModuleClosureAccounting) for why "the image has it" is
 never on its own a reason to leave a *package* assembly out.
 
+## What stops riding, and why that is safe
+
+The measurement removes `MeshWeaver.AI` from 13 bundles and
+`MeshWeaver.Markdown.Collaboration` from 14. Those rides were **insurance for the standalone
+install** — [Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide) §3: with the sibling excluded,
+a bundle installed on its own would land without an assembly nothing supplies, and throw
+`ReflectionTypeLoadException` on first touch.
+
+That argument was always conditional on the image, and the image moved. Plugins#1515 seeds **and
+activates** both assemblies in every portal host, so the copy is there before any dependent module
+loads — and because `MeshWeaver.*` collapses to one identity, an already-loaded copy is what a later
+`Assembly.LoadFrom` binds to. The ride is therefore redundant *and* harmful today, which is exactly
+what the measurement says.
+
+🚨 **The failure this trades against is a host that SEEDS an assembly under `modules/<Name>/` but
+never activates it** — a seed nobody asks for is, in Plugins#1515's own words, *"not a third
+category; it is nothing"*. `Modules:Assemblies` is deployment configuration, not part of the image,
+so two deployments of one image can differ here. If that shape ever appears, the symptom is a
+`ReflectionTypeLoadException` naming the seeded assembly, and the fix is to activate it — not to
+re-add the ride, which would put the two-builds condition back.
+
+The self-correcting property is the point: the day the image stops shipping one of these, the
+measurement says so and the ride returns on the next pack, with nobody editing a list.
+
 ## Which repositories this changes
 
 `src/platform-shipped.txt` exists in exactly **one** repository of the fleet — `MeshWeaver.Plugins`,

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
@@ -1,0 +1,164 @@
+---
+Name: The Platform-Shipped Witness
+Category: Architecture
+Description: What a module bundle may carry beside its entry is decided by MEASURING what the platform host actually ships — its app closure, its surface manifest and its seeded modules/ lane — never by a declared name list. The three witnesses, why a list drifts in both directions, and where the measurement still cannot reach.
+Icon: /static/NodeTypeIcons/code.svg
+---
+
+# The Platform-Shipped Witness
+
+A module bundle carries its entry assembly plus a private closure. Which `MeshWeaver.*` siblings may
+ride that closure has exactly one correct answer, and it is a property of the **platform host the
+bundle is packed against**, not of the repository the module lives in:
+
+> A `MeshWeaver.*` sibling rides a bundle **if and only if** the platform host does not already
+> ship it.
+
+Both directions of that rule are load-bearing, and each has cost a fleet-wide incident:
+
+* **Carrying one the host has.** `MeshWeaver.*` assemblies bind by a strictly synchronised
+  `AssemblyVersion`, so two copies under one simple name are **one assembly identity**: the loader
+  keeps whichever it saw first and the loser's bytes are never in memory. Every NodeType whose
+  dependency record named the other build is declined at adoption — *"dependency record mismatch —
+  built against mvid:A, live is mvid:B"* — and the health check reports the loser as
+  `pending_module_activation` **Degraded**, *"landed but not yet loaded"*.
+* **Omitting one the host does not have.** The bundle lands without an assembly nothing else
+  supplies, and the first code path that touches it throws `ReflectionTypeLoadException` — hours
+  after the install, in a repository that changed nothing.
+
+## What used to decide it, and why it drifted
+
+Until [#3732](../ModuleBuildArchitecture) the split came from a hand-maintained file in each node
+repository, `src/platform-shipped.txt`: every `MeshWeaver.*` project directory in `src/` **except**
+the names that file lists. `.github/scripts/module-owned-platform.sh` computed the complement, and
+the same set reached three consumers — the container build's closure copy, the packer's
+`--own-platform`, and the bundle inspection's assertion.
+
+A declaration is not a measurement, and this one went stale in **both** directions inside one week:
+
+| when | what moved | what the list did | what it cost |
+|---|---|---|---|
+| Plugins#1023 | `MeshWeaver.AI` left the image | the line was correctly removed | — |
+| MeshWeaver#3335 | five assemblies were in `/app` and unlisted | corrected **by hand** after a manual re-measurement | every bundle referencing one carried a duplicate |
+| MeshWeaver#3335 | `MeshWeaver.Maps` had left the image | the line lingered | a name that reached a mesh **from nowhere at all** |
+| Plugins#1515 | four modules returned under `Modules:Assemblies` | the list did not move | see the measurement below |
+
+Measured on `MeshWeaver.Plugins` `main`, 2026-09-08 — every packed module's transitive in-repo
+`ProjectReference` closure, minus `src/platform-shipped.txt`, against the seeded-module rows in both
+portal hosts' csproj:
+
+| | |
+|---|---|
+| module bundles the repository packs | **37** |
+| bundles riding at least one `MeshWeaver.*` sibling | **18** (34 riding slots) |
+| bundles riding a sibling **the image also ships** | **14** (27 slots) |
+| the names | `MeshWeaver.Markdown.Collaboration` (14 bundles), `MeshWeaver.AI` (13) |
+
+Every one of those 27 slots is a second build of an assembly a portal already has, and none of them
+was visible to the witness that was supposed to prevent exactly that.
+
+## The three witnesses
+
+The reason the list could not simply be corrected once more is that **an image ships an assembly
+three ways**, and the previous reading knew about one of them.
+
+| # | Where | What puts it there |
+|---|---|---|
+| 1 | `<app>/<Name>.dll` | the application closure — a `ProjectReference` from a portal host |
+| 2 | `<app>/meshweaver-surface.manifest` | the host's own record of its `MeshWeaver.*` **compile references** (`MeshWeaverSurfaceManifest.targets`) |
+| 3 | `<app>/modules/<Name>/<Name>.dll` | the **seeded-module** lane — `@(MeshModuleClosure)` in `memex/MeshModulesPublish.targets`, which `MeshBuilder.ResolveModulePath` probes *before* the app directory |
+
+🚨 **A `MeshModuleClosure` row touches neither (1) nor (2)** — the portal hosts' own csproj comments
+say so in as many words. So a witness that read `/app` alone answered *"not shipped"* for every
+seeded module, which is precisely the 27 slots above.
+
+`PlatformShippedAssemblies.Read(appDirectory)` (in `MeshWeaver.Compiler`) reads all three and
+returns each name with the **provenance and the evidence path** that answered, so a strip decision
+in a pack log names a file rather than an opinion.
+
+### It refuses rather than answering nothing
+
+A directory with no surface manifest and no `MeshWeaver.*` assembly at its root is **not** a platform
+application directory, and the reader returns a problem for it. Answering *"this host ships nothing"*
+would turn every caller's strip into a silent no-op that logs exactly like a clean measurement — the
+gate-that-cannot-fail shape [CI](../ReadingCiSignals) forbids. A portal `/app` carries 200+
+`MeshWeaver.*` assemblies and the tester image 88; zero is a wrong directory, never an answer.
+
+## Where the measurement is applied
+
+Two places, deliberately, and they answer different questions.
+
+**The classification** — `module-owned-platform.sh <src> [<platform-app>]` — decides what the deps
+walk treats as module-owned, which matters beyond the `MeshWeaver.*` names themselves: walking into
+a platform-shipped project also drags that project's private package dependencies into the bundle.
+With an app directory it measures; without one it falls back to the declared list and **says so on
+stderr**, because the fallback lane is structurally different (see the blind spot below), not because
+the input happened to be missing. When both are available the image decides and the list decides
+nothing — the disagreement is printed as a warning naming the exact lines to add or drop, so the
+file converges and can eventually be deleted.
+
+**The enforcement** — `module-pack --platform-app <dir>` — is a second, independent reading over the
+bundle's actual file list. Everything upstream composes the closure from *declarations* (`--with`
+from the lane's classification, `--deps-closure` from a graph walk seeded by `--own-platform`), and
+those are shell-string sets matched with `grep -qF`; this one is a typed measurement taken at the
+moment the bytes are written. Every `MeshWeaver.*` file in the closure is measured against the host
+and **dropped** when the host already has it, with one printed line each naming the evidence.
+
+🚨 **On a lane where the classification is also measured, the drop count should be ZERO — and that
+makes it a control, not decoration.** Both readings answer the same question from the same image, so
+a non-zero `platform-shipped: … dropped` line in a pack log means the two disagree, and the
+disagreement is worth reading. It also means a caller that drives `module-pack` directly — a new
+lane, a hand invocation, a satellite that has not adopted the shared workflow — gets the protection
+without having to know about the classification at all. What it deliberately does NOT do is refuse:
+shipping a correct bundle with a loud line beats reddening a delivery lane over a disagreement whose
+resolution is already in hand.
+
+The lane passes the **raw** image copy (`$RUNNER_TEMP/platform-refs`), never the
+supersede-pruned reference set: `superseded-image-assemblies` drops an assembly from the *compile*
+set precisely **because** the image still carries it, so measuring the pruned copy would answer
+"not shipped" for a name that is right there in `/app`.
+
+### What the witness does NOT judge
+
+**The entry assembly.** A module the image seeds under `modules/<Name>/` is *meant* to be superseded
+by a landed bundle of itself — a usable persisted entry overrides the same-named baseline in place —
+so dropping the entry would delete the module from its own bundle. The host-versus-entry case is a
+different defect with a different remedy, and it already has a gate:
+`BakeHost.ShippedByHostProblem` refuses a module composed with `--module` that the platform host
+also carries, at the bake, where both provenances are in one hand.
+
+**Third-party assemblies.** A diamond rides by design and versions independently; it does not
+collapse to one identity. Judging it would hold every bundle in the fleet for a property nobody
+claimed. See [Module Closure Accounting](../ModuleClosureAccounting) for why "the image has it" is
+never on its own a reason to leave a *package* assembly out.
+
+## Which repositories this changes
+
+`src/platform-shipped.txt` exists in exactly **one** repository of the fleet — `MeshWeaver.Plugins`,
+where it names 17 assemblies. In the other five node repos it is absent, which the script reads (and
+still reads) as *"the platform ships nothing"*: every `MeshWeaver.*` project in their `src/` is
+classified module-owned and rides. That is right today only because those repos own few such
+projects (`MeshWeaver.SocialMedia` has 2; the rest have none) — it was never a measurement, and it
+becomes one for all six with no per-repo file to write.
+
+## The blind spot, named
+
+**A lane that pins no platform image has nothing to measure.** Core's own CD packs the four bundles
+its bake composes with `platform-ref` (a source build), not `platform-image-digest`, so there is no
+`/app` in that job at all and the classification falls back to the declared list. That fallback is
+stated on stderr on every run rather than passing silently, and the enforcement step is simply not
+armed there.
+
+That is a real gap and not a trapdoor: it is one structurally different lane, named in the log, not
+an `if:` that asks whether an input happens to be present. Closing it means giving that job the
+promoted portal image the same run already resolves.
+
+## Related
+
+* [Module Build Architecture](../ModuleBuildArchitecture) — the one build shape every repo follows
+* [Module Closure Accounting](../ModuleClosureAccounting) — what a bundle must carry, and the
+  same-identity trap
+* [Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide) — why a sibling that is *another
+  package's* declared module still rides, and the one-name-one-build invariant that replaced
+  exclusivity
+* [Module Versioning](../ModuleVersioning) — what you author and what the build derives

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
@@ -94,8 +94,10 @@ a platform-shipped project also drags that project's private package dependencie
 With an app directory it measures; without one it falls back to the declared list and **says so on
 stderr**, because the fallback lane is structurally different (see the blind spot below), not because
 the input happened to be missing. When both are available the image decides and the list decides
-nothing — the disagreement is printed as a warning naming the exact lines to add or drop, so the
-file converges and can eventually be deleted.
+nothing — the disagreement is printed on stderr as a `DRIFT` line naming the exact entry to add or
+drop, so the file converges and can eventually be deleted. Plain stderr, not `::warning::`: the
+script runs three times per matrix entry (111 times on Plugins' 37), and annotating a diagnostic
+about a file that decides nothing would bury the annotations that do decide something.
 
 **The enforcement** — `module-pack --platform-app <dir>` — is a second, independent reading over the
 bundle's actual file list. Everything upstream composes the closure from *declarations* (`--with`

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -270,8 +270,11 @@ container build that succeeded proves every assembly the module binds is one the
 already carries. The bundle inspection then asserts exactly that claim, refusing any non-`MeshWeaver.*`
 assembly in a container-built bundle. The in-root `ProjectReference`s the builder compiled from source
 are a separate question, answered the same way for both paths: **module-owned** ones ride (`--with`),
-**image-shipped** ones (`src/platform-shipped.txt`) must not, and one script computes that set for the
-packer, the lane and the inspection alike.
+**platform-shipped** ones must not, and one script computes that set for the packer, the lane and the
+inspection alike. Which names are platform-shipped is MEASURED off the pinned image — its app
+closure, its surface manifest and its seeded `modules/<Name>/` lane — not read from a declared list;
+the packer then drops any that slipped through anyway. See
+[The Platform-Shipped Witness](../PlatformShippedWitness).
 
 🚨 **Two preconditions gate any entry declaring `container`.** The pinned image must carry the
 `build-project` verb at all; and the builder must stamp `<AssemblyVersion>`. It runs no MSBuild

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-controls-no-longer-render-as-plain-text-when-a-module-ships-a-duplicate-view-assembly.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-controls-no-longer-render-as-plain-text-when-a-module-ships-a-duplicate-view-assembly.md
@@ -1,0 +1,37 @@
+---
+Name: Controls no longer render as plain text when a module ships a duplicate of a portal assembly
+Category: Fix
+Description: A module package could carry its own copy of an assembly the portal already ships. The portal then held two builds of one name, kept whichever it loaded first, and the views in the other copy never activated — so pages rendered their controls as raw text. Packages now carry only what the portal does not already have.
+Icon: Sparkle
+Order: -20260908
+---
+
+# Controls no longer render as plain text when a module ships a duplicate of a portal assembly
+
+Some pages came up with their controls rendered as plain text instead of as buttons, cards and
+stacks — the raw shape of the control, printed out, where the styled view should have been. The
+portal's own health page said what had happened, in a line that read like housekeeping: *one module
+is landed but not yet loaded*.
+
+Both statements had the same cause. A plugin package ships its code as a bundle, and a bundle
+carries the package's own assembly plus anything it needs that the portal does not already have. The
+rule that decided "does the portal already have this?" was a list, written and maintained by hand in
+each plugin repository — and a list goes out of date the moment something moves. When it did, a
+package began shipping a second copy of an assembly the portal ships too.
+
+The portal cannot use both. Two copies of one assembly name are one identity to it: it keeps the
+first one it loads and the second is simply never there. When the copy that lost held the views —
+the components that draw a control on screen — the portal has the control but nothing to draw it
+with, so it falls back to printing the control instead. Nothing errors, nothing is missing from any
+log; a page just renders wrong.
+
+The rule is no longer a list. When a package is built, the build now looks at the portal it is being
+built for and **measures** what that portal actually ships — the assemblies alongside it, the record
+it publishes of what it was compiled against, and the modules it carries in its own module folder —
+and drops anything the portal already has from the package. Nothing the portal does not have is
+dropped, so a package that genuinely needs to bring an assembly still brings it.
+
+Measured across the plugin catalog when this was found: 14 of 37 packages were carrying 27 such
+duplicate copies. They are gone from the next build of each package, and the check that holds a
+portal back from updating onto an inconsistent set of packages — which is what caught this — now has
+nothing to hold.

--- a/src/MeshWeaver.Plugin.Build/DepsClosure.cs
+++ b/src/MeshWeaver.Plugin.Build/DepsClosure.cs
@@ -168,9 +168,11 @@ public static class DepsClosure
             universe);
     }
 
+    // ONE spelling of "the platform side owns this name", shared with the platform-shipped witness
+    // and with PublishedBundleCatalogue's sealed-set reading (#3732) — the three used to carry
+    // three copies of the same three lines.
     private static bool IsPlatform(string name) =>
-        name.StartsWith("MeshWeaver.", StringComparison.OrdinalIgnoreCase)
-        || string.Equals(name, "MeshWeaver", StringComparison.OrdinalIgnoreCase);
+        MeshWeaver.Compiler.PlatformShippedAssemblies.IsPlatformAssemblyName(name);
 
     /// <summary>Transitive reachability over the dependency edges, from <paramref name="roots"/>
     /// inclusive — STOPPING at MeshWeaver.* nodes (collected separately, never walked: their

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using MeshWeaver.Compiler;
 using MeshWeaver.Plugin.Packaging;
 
 namespace MeshWeaver.Plugin.Build;
@@ -69,6 +70,16 @@ public static class ModulePackCommand
         Console.Error.WriteLine($"error: {what} '{value}' is invalid — {constraint}");
         return true;
     }
+
+    /// <summary>Which of the platform-shipped witness's three readings answered, in words a pack
+    /// log can be read by. The evidence path travels beside it, so a drop names a file.</summary>
+    private static string Describe(PlatformShipping how) => how switch
+    {
+        PlatformShipping.ApplicationClosure => "in its app closure",
+        PlatformShipping.SurfaceManifest => "named by its surface manifest",
+        PlatformShipping.SeededModule => "seeded under modules/<Name>/",
+        _ => how.ToString(),
+    };
 
     /// <summary>
     /// Reads <c>content.includeSource</c> off the package's ROOT node (<c>index.json</c>) — the
@@ -163,6 +174,19 @@ public static class ModulePackCommand
                                               bundles them instead of stopping: they are nowhere
                                               in /app, so a stop would ship a module that faults
                                               on its first sibling (Import's DataSetReader family)
+                  --platform-app <dir>        the PLATFORM HOST's application directory (a portal
+                                              image's extracted /app). Every MeshWeaver.* file the
+                                              closure would carry is measured against what that
+                                              host ACTUALLY ships — its app closure, its
+                                              meshweaver-surface.manifest, and its seeded
+                                              modules/<Name>/ lane — and a copy the host already
+                                              has is DROPPED, one line each naming the evidence.
+                                              🚨 This is the witness, not --own-platform: a name
+                                              list drifts silently the moment a project moves in or
+                                              out of the image, which is how 14 of 37 bundles came
+                                              to carry a second build of an assembly the image
+                                              seeds (#3732). A directory that is not a platform app
+                                              is refused, never read as "ships nothing"
                   --deps-closure              derive the module's PRIVATE dependency closure from
                                               <name>.deps.json beside the entry DLL and bundle it:
                                               assemblies reachable from the module's own package
@@ -191,6 +215,7 @@ public static class ModulePackCommand
         string? statedFrameworkMvid = null;
         var extras = new List<string>();
         var ownPlatform = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? platformApp = null;
         var depsClosure = false;
         var outputDirectory = Environment.CurrentDirectory;
 
@@ -225,6 +250,9 @@ public static class ModulePackCommand
                 case "--own-platform" when i + 1 < args.Length:
                     ownPlatform.UnionWith(args[++i]
                         .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+                    break;
+                case "--platform-app" when i + 1 < args.Length:
+                    platformApp = args[++i];
                     break;
                 case "--deps-closure":
                     depsClosure = true;
@@ -477,6 +505,71 @@ public static class ModulePackCommand
             }
             if (!closure.Contains(extra, StringComparer.OrdinalIgnoreCase))
                 closure.Add(extra);
+        }
+
+        // ───────── THE PLATFORM-SHIPPED WITNESS — measured, never a list (#3732) ─────────
+        // 🚨 Everything above composes the closure from DECLARATIONS: --with names what the lane's
+        // classification said may ride, --deps-closure walks a graph whose platform/module split
+        // comes from --own-platform, and BOTH ultimately rest on a node repo's hand-maintained
+        // src/platform-shipped.txt. A declaration goes stale silently, in both directions, the
+        // moment a project moves in or out of the image — and it did: measured on
+        // MeshWeaver.Plugins main 2026-09-08, 14 of 37 module bundles carry 27 copies of
+        // MeshWeaver.AI / MeshWeaver.Markdown.Collaboration, both of which the portal image SEEDS
+        // under /app/modules/<Name>/ (Plugins#1515). MeshWeaver.* binds by a strictly synchronised
+        // AssemblyVersion, so two copies under one simple name are ONE identity: the loader keeps
+        // whichever it saw first, every NodeType whose dependency record named the other build is
+        // DECLINED at adoption, and the loser reads on the health check as "landed but not yet
+        // loaded" — which on memex.systemorph.com meant MeshWeaver.Blazor.Views never activated and
+        // every skinned StackControl rendered through FallbackHtml.
+        //
+        // So the bytes get a SECOND, INDEPENDENT reading — a typed measurement of the host they
+        // were compiled against, taken over the actual file list at the moment it is written. On a
+        // lane whose classification is also measured the two agree and this drops NOTHING, which is
+        // what makes the count a control: a non-zero drop line means the two readings disagree and
+        // is worth reading. A caller driving module-pack directly gets the protection without
+        // knowing the classification exists.
+        // Not a refusal, deliberately: shipping a correct bundle with a loud line beats reddening a
+        // delivery lane over a disagreement whose resolution is already in hand. Every drop is
+        // printed with the evidence it rests on, so the log says which witness answered.
+        if (platformApp is not null)
+        {
+            var (platformShipped, witnessProblem) = PlatformShippedAssemblies.Read(platformApp);
+            if (platformShipped is null)
+            {
+                Console.Error.WriteLine(
+                    $"error: --platform-app '{platformApp}' cannot answer what the platform ships — "
+                    + witnessProblem
+                    + ". A witness that reads nothing strips nothing while logging exactly like a "
+                    + "clean measurement, so the pack stops instead.");
+                return 2;
+            }
+            var dropped = new List<string>();
+            foreach (var file in closure.ToList())
+            {
+                var simple = Path.GetFileNameWithoutExtension(file);
+                // The ENTRY is never judged here. A module the image seeds under modules/<Name>/ is
+                // MEANT to be superseded by a landed bundle of itself (ModuleActivation's
+                // usable-persisted-entry override), and a module the image carries in its app
+                // closure is the two-producer FATAL that BakeHost.ShippedByHostProblem refuses at
+                // the bake, where both provenances are in one hand. This step is about the copies
+                // that RIDE, which no gate looked at at all.
+                if (string.Equals(simple, moduleName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!PlatformShippedAssemblies.IsPlatformAssemblyName(simple))
+                    continue;
+                if (!platformShipped.TryGetValue(simple, out var evidence))
+                    continue;
+                closure.Remove(file);
+                dropped.Add(file);
+                Console.WriteLine(
+                    $"platform-shipped: dropped {file} — the platform host ships {simple} "
+                    + $"({Describe(evidence.How)}: {evidence.Evidence}); a second copy beside the "
+                    + "module is one assembly identity with two builds");
+            }
+            Console.WriteLine(
+                $"platform-shipped: measured against {Path.GetFullPath(platformApp)} — "
+                + $"{platformShipped.Count} MeshWeaver.* assembl(y|ies) shipped by that host, "
+                + $"{dropped.Count} dropped from this bundle's closure");
         }
 
         var manifest = new PluginManifest(

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -522,4 +522,214 @@ public class ModulePackCommandTest : IDisposable
         Assert.False(Directory.Exists(Path.Combine(root, "out-missing")),
             "a refused invocation must not have written anything");
     }
+
+    // ─────── #3732: the platform-shipped witness, measured off the host, applied to the RIDES ───────
+
+    /// <summary>Bytes of the copy the PLATFORM ships — deliberately different from the copy the
+    /// module output holds, because that difference IS the condition under test.</summary>
+    private const string PlatformBuild = "BUILD-A (the copy the platform ships)";
+
+    /// <summary>Bytes of the copy the module output holds — the ride.</summary>
+    private const string ModuleBuild = "BUILD-B (the copy that would ride the bundle)";
+
+    /// <summary>
+    /// A platform host directory shaped like a portal image's <c>/app</c>: an app closure carrying
+    /// <c>MeshWeaver.Blazor.Views</c>, a surface manifest, and a SEEDED module under
+    /// <c>modules/&lt;Name&gt;/</c> — the three ways an image ships an assembly.
+    /// </summary>
+    private string PlatformApp()
+    {
+        var app = Path.Combine(root, "app");
+        Directory.CreateDirectory(app);
+        File.WriteAllText(Path.Combine(app, "MeshWeaver.Blazor.Views.dll"), PlatformBuild);
+        File.WriteAllText(Path.Combine(app, "MeshWeaver.Graph.dll"), PlatformBuild);
+        File.WriteAllLines(Path.Combine(app, "meshweaver-surface.manifest"),
+        [
+            "MeshWeaver.Blazor.Views=0000000000000000000000000000000000000000000000000000000000000000",
+            "MeshWeaver.Graph=1111111111111111111111111111111111111111111111111111111111111111",
+        ]);
+        var seeded = Path.Combine(app, "modules", "MeshWeaver.Markdown.Collaboration");
+        Directory.CreateDirectory(seeded);
+        File.WriteAllText(
+            Path.Combine(seeded, "MeshWeaver.Markdown.Collaboration.dll"), PlatformBuild);
+        return app;
+    }
+
+    /// <summary>The module output as the lane hands it to the packer: the entry, two MeshWeaver.*
+    /// siblings the host also has (at a DIFFERENT build), and one it does not.</summary>
+    private void ModuleOutputWithRides()
+    {
+        var closure = Path.Combine(root, "closure");
+        File.WriteAllText(
+            Path.Combine(closure, "MeshWeaver.Markdown.Collaboration.dll"), ModuleBuild);
+        File.WriteAllText(Path.Combine(closure, "MeshWeaver.Markdown.Collaboration.pdb"), ModuleBuild);
+        File.WriteAllText(Path.Combine(closure, "MeshWeaver.Blazor.Views.dll"), ModuleBuild);
+        // The name the platform genuinely does NOT ship — the anti-vacuity control.
+        File.WriteAllText(Path.Combine(closure, "MeshWeaver.Maps.dll"), ModuleBuild);
+    }
+
+    private int PackWidget(string outDir, string? platformApp)
+    {
+        var args = new List<string>
+        {
+            Path.Combine(root, "closure"),
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.9.0",
+            "--framework-mvid", Identity,
+            "--with", "MeshWeaver.Markdown.Collaboration.dll",
+            "--with", "MeshWeaver.Markdown.Collaboration.pdb",
+            "--with", "MeshWeaver.Blazor.Views.dll",
+            "--with", "MeshWeaver.Maps.dll",
+            "--out", outDir,
+        };
+        if (platformApp is not null)
+        {
+            args.Add("--platform-app");
+            args.Add(platformApp);
+        }
+        return ModulePackCommand.Run([.. args]);
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE CONDITION, REPRODUCED (#3732).</b> Without the witness the bundle carries a SECOND
+    /// BUILD of two assemblies the platform host already has — one from its app closure
+    /// (<c>MeshWeaver.Blazor.Views</c>, which no package declares as a module at all: it arrives
+    /// only because a module-owned sibling references it) and one from its seeded
+    /// <c>modules/&lt;Name&gt;/</c> lane (<c>MeshWeaver.Markdown.Collaboration</c>).
+    ///
+    /// <para>Both bind by a strictly synchronised <c>AssemblyVersion</c>, so the two copies are ONE
+    /// identity: the loader keeps whichever it saw first and the loser is never in memory. On
+    /// memex.systemorph.com that loser was <c>MeshWeaver.Blazor.Views</c> — both pods reported
+    /// <c>pending_module_activation</c> Degraded ("landed but not yet loaded"), and every skinned
+    /// <c>StackControl</c> rendered through <c>FallbackHtml</c>.</para>
+    ///
+    /// <para>This is the state of the lane BEFORE the fix, asserted rather than described — without
+    /// it the test below could pass because the packer drops everything, or because the fixture
+    /// never carried the rides at all.</para>
+    /// </summary>
+    [Fact]
+    public void WithoutTheWitness_TheBundleCarriesASecondBuildOfWhatThePlatformShips()
+    {
+        var app = PlatformApp();
+        ModuleOutputWithRides();
+
+        var outDir = Path.Combine(root, "out-unwitnessed");
+        Assert.Equal(0, PackWidget(outDir, platformApp: null));
+
+        var (manifest, files) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.9.0.module.nupkg")));
+
+        Assert.Contains("MeshWeaver.Blazor.Views.dll", manifest!.Module!.Assemblies!);
+        Assert.Contains("MeshWeaver.Markdown.Collaboration.dll", manifest.Module.Assemblies!);
+
+        // …and they are a DIFFERENT BUILD from the host's own copies, which is what makes one
+        // assembly name reach a process at two builds rather than merely costing bytes.
+        var ridden = files.Single(f => f.FileName == "MeshWeaver.Blazor.Views.dll");
+        Assert.Equal(ModuleBuild, Encoding.UTF8.GetString(ridden.Bytes));
+        Assert.Equal(PlatformBuild,
+            File.ReadAllText(Path.Combine(app, "MeshWeaver.Blazor.Views.dll")));
+        Assert.NotEqual(
+            File.ReadAllText(Path.Combine(app, "modules", "MeshWeaver.Markdown.Collaboration",
+                "MeshWeaver.Markdown.Collaboration.dll")),
+            Encoding.UTF8.GetString(
+                files.Single(f => f.FileName == "MeshWeaver.Markdown.Collaboration.dll").Bytes));
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE FIX (#3732).</b> With the host in hand, every <c>MeshWeaver.*</c> file the closure
+    /// would carry is measured against what that host ACTUALLY ships and dropped when it already
+    /// has it — from the manifest AND from the archive, symbols included — whichever of the three
+    /// witnesses answered.
+    ///
+    /// <para><b>And the anti-vacuity control is in the same assertion:</b>
+    /// <c>MeshWeaver.Maps</c> is a <c>MeshWeaver.*</c> sibling the host does NOT ship, so it must
+    /// STILL ride. A packer that simply dropped every platform-named file would pass the first half
+    /// and fail here — and would reintroduce the opposite defect, a name that reaches a mesh from
+    /// nowhere at all (#3335's <c>MeshWeaver.Maps</c> line, exactly).</para>
+    /// </summary>
+    [Fact]
+    public void WithTheWitness_ThePlatformsOwnCopiesAreDropped_AndOnlyThose()
+    {
+        var app = PlatformApp();
+        ModuleOutputWithRides();
+
+        var outDir = Path.Combine(root, "out-witnessed");
+        Assert.Equal(0, PackWidget(outDir, app));
+
+        var (manifest, files) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.9.0.module.nupkg")));
+
+        // Dropped: the app-closure copy, the seeded-module copy, and the symbols that came with it.
+        Assert.DoesNotContain("MeshWeaver.Blazor.Views.dll", manifest!.Module!.Assemblies!);
+        Assert.DoesNotContain("MeshWeaver.Markdown.Collaboration.dll", manifest.Module.Assemblies!);
+        Assert.DoesNotContain("MeshWeaver.Markdown.Collaboration.pdb", manifest.Module.Assemblies!);
+        Assert.DoesNotContain(files, f => f.FileName.StartsWith(
+            "MeshWeaver.Blazor.Views", StringComparison.Ordinal));
+        Assert.DoesNotContain(files, f => f.FileName.StartsWith(
+            "MeshWeaver.Markdown.Collaboration", StringComparison.Ordinal));
+
+        // Kept: the entry, and the sibling the platform does not ship.
+        Assert.Contains("Widget.dll", manifest.Module.Assemblies!);
+        Assert.Contains("MeshWeaver.Maps.dll", manifest.Module.Assemblies!);
+        Assert.Contains(files, f => f.FileName == "MeshWeaver.Maps.dll");
+        Assert.Contains(files, f => f.FileName == "Widget.dll");
+    }
+
+    /// <summary>
+    /// 🚨 The ENTRY is never judged by this step, and that boundary is deliberate. A module the
+    /// image seeds under <c>modules/&lt;Name&gt;/</c> is MEANT to be superseded by a landed bundle
+    /// of itself (a usable persisted entry overrides the same-named baseline in place), so dropping
+    /// the entry would delete the module from its own bundle. The host-vs-entry two-producer case
+    /// is <c>BakeHost.ShippedByHostProblem</c>'s, at the bake, where both provenances are in one
+    /// hand.
+    /// </summary>
+    [Fact]
+    public void TheEntryAssemblyIsNeverDropped_EvenWhenTheImageSeedsThatVeryModule()
+    {
+        var app = PlatformApp();
+        var closure = Path.Combine(root, "closure2");
+        Directory.CreateDirectory(closure);
+        File.WriteAllText(
+            Path.Combine(closure, "MeshWeaver.Markdown.Collaboration.dll"), ModuleBuild);
+
+        var outDir = Path.Combine(root, "out-entry");
+        var exit = ModulePackCommand.Run(
+        [
+            closure,
+            "--module-name", "MeshWeaver.Markdown.Collaboration",
+            "--plugin", "Essentials",
+            "--package-version", "2.0.0",
+            "--framework-mvid", Identity,
+            "--platform-app", app,
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(0, exit);
+        var (manifest, files) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.Essentials.2.0.0.module.nupkg")));
+        Assert.Contains("MeshWeaver.Markdown.Collaboration.dll", manifest!.Module!.Assemblies!);
+        Assert.Contains(files, f => f.FileName == "MeshWeaver.Markdown.Collaboration.dll");
+    }
+
+    /// <summary>
+    /// 🚨 A witness that reads nothing must REFUSE, never answer "the platform ships nothing" — that
+    /// answer strips nothing while logging exactly like a clean measurement, which is the
+    /// gate-that-cannot-fail shape CI forbids.
+    /// </summary>
+    [Fact]
+    public void APlatformAppThatIsNotOne_IsRefused_AndWritesNothing()
+    {
+        ModuleOutputWithRides();
+        var notAnApp = Path.Combine(root, "not-an-app");
+        Directory.CreateDirectory(notAnApp);
+        File.WriteAllText(Path.Combine(notAnApp, "readme.txt"), "no assemblies, no manifest");
+
+        var outDir = Path.Combine(root, "out-bad-witness");
+        var exit = PackWidget(outDir, notAnApp);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(outDir),
+            "a refused invocation must not have written a bundle");
+    }
 }

--- a/test/MeshWeaver.Graph.Test/PlatformShippedAssembliesTest.cs
+++ b/test/MeshWeaver.Graph.Test/PlatformShippedAssembliesTest.cs
@@ -1,0 +1,172 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Compiler;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The PLATFORM-SHIPPED WITNESS (#3732): what a platform host actually ships, measured off that
+/// host's application directory. Three readings, because the image ships assemblies three ways —
+/// and a witness that reads only the first answers "not shipped" for every seeded module, which is
+/// how <c>MeshWeaver.Markdown.Collaboration</c> came to ride 14 of MeshWeaver.Plugins' 37 bundles
+/// while the portal image seeds it too.
+/// </summary>
+public class PlatformShippedAssembliesTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-platform-witness-" + Guid.NewGuid().ToString("N"));
+
+    private string App => Path.Combine(root, "app");
+
+    public PlatformShippedAssembliesTest() => Directory.CreateDirectory(App);
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+        catch
+        {
+            // Leaked temp dirs are the OS's to reap; cleanup must not mask a failure.
+        }
+    }
+
+    private void AppAssembly(string name) =>
+        File.WriteAllText(Path.Combine(App, name + ".dll"), name);
+
+    private void SurfaceManifest(params string[] names) =>
+        File.WriteAllLines(
+            Path.Combine(App, "meshweaver-surface.manifest"),
+            names.Select(n => $"{n}=0000000000000000000000000000000000000000000000000000000000000000"));
+
+    private void SeededModule(string name)
+    {
+        var directory = Path.Combine(App, PlatformShippedAssemblies.SeededModulesFolder, name);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, name + ".dll"), name);
+    }
+
+    /// <summary>
+    /// All three witnesses answer, and each says WHICH one did — the evidence a strip decision is
+    /// printed with, so a dropped file names the path it rests on rather than an opinion.
+    /// </summary>
+    [Fact]
+    public void TheThreeWaysAnImageShipsAnAssembly_AreAllRead_WithTheirEvidence()
+    {
+        AppAssembly("MeshWeaver.Blazor.Views");           // (1) the app closure
+        SurfaceManifest("MeshWeaver.Graph", "MeshWeaver.Layout");  // (2) the host's own record
+        SeededModule("MeshWeaver.Markdown.Collaboration"); // (3) MeshModuleClosure's lane
+
+        var (shipped, problem) = PlatformShippedAssemblies.Read(App);
+
+        Assert.Null(problem);
+        Assert.Equal(
+            ["MeshWeaver.Blazor.Views", "MeshWeaver.Graph", "MeshWeaver.Layout",
+             "MeshWeaver.Markdown.Collaboration"],
+            shipped!.Keys.OrderBy(k => k, StringComparer.Ordinal));
+        Assert.Equal(PlatformShipping.ApplicationClosure, shipped["MeshWeaver.Blazor.Views"].How);
+        Assert.Equal(PlatformShipping.SurfaceManifest, shipped["MeshWeaver.Layout"].How);
+        Assert.Equal(PlatformShipping.SeededModule, shipped["MeshWeaver.Markdown.Collaboration"].How);
+        Assert.EndsWith(
+            Path.Combine("modules", "MeshWeaver.Markdown.Collaboration",
+                "MeshWeaver.Markdown.Collaboration.dll"),
+            shipped["MeshWeaver.Markdown.Collaboration"].Evidence, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 THE READING THAT WAS MISSING, isolated. A <c>MeshModuleClosure</c> row puts the assembly
+    /// under <c>modules/&lt;Name&gt;/</c> and touches NEITHER the app root NOR the surface manifest —
+    /// the portal hosts' csproj comments say exactly that — so a witness that read only <c>/app</c>
+    /// answered "not shipped" for MeshWeaver.AI and MeshWeaver.Markdown.Collaboration, the two names
+    /// that account for all 27 duplicate slots measured on MeshWeaver.Plugins main 2026-09-08.
+    /// </summary>
+    [Fact]
+    public void ASeededModule_IsShipped_EvenThoughTheAppRootAndTheManifestBothOmitIt()
+    {
+        AppAssembly("MeshWeaver.Graph");
+        SurfaceManifest("MeshWeaver.Graph");
+        SeededModule("MeshWeaver.AI");
+
+        var (shipped, problem) = PlatformShippedAssemblies.Read(App);
+
+        Assert.Null(problem);
+        Assert.False(File.Exists(Path.Combine(App, "MeshWeaver.AI.dll")),
+            "the fixture must not put it in the app root, or this would pass for the wrong reason");
+        Assert.True(shipped!.ContainsKey("MeshWeaver.AI"));
+        Assert.Equal(PlatformShipping.SeededModule, shipped["MeshWeaver.AI"].How);
+    }
+
+    /// <summary>A seeded folder holds that module's OWN private closure; those files are on no
+    /// other module's probing path, so only <c>&lt;Name&gt;/&lt;Name&gt;.dll</c> counts. Reading the
+    /// whole folder would forbid a legitimate ride and cost the ReflectionTypeLoadException the
+    /// closure rule exists to prevent.</summary>
+    [Fact]
+    public void ASeededModulesPrivateClosure_IsNotItselfShipped()
+    {
+        AppAssembly("MeshWeaver.Graph");
+        SeededModule("MeshWeaver.AI");
+        File.WriteAllText(
+            Path.Combine(App, PlatformShippedAssemblies.SeededModulesFolder, "MeshWeaver.AI",
+                "MeshWeaver.Maps.dll"),
+            "a private ride of the seeded module, on nobody else's probing path");
+
+        var (shipped, _) = PlatformShippedAssemblies.Read(App);
+
+        Assert.True(shipped!.ContainsKey("MeshWeaver.AI"));
+        Assert.False(shipped.ContainsKey("MeshWeaver.Maps"));
+    }
+
+    /// <summary>Third-party assemblies version independently and ride by design — judging them
+    /// would hold every bundle in the fleet for a property nobody claimed.</summary>
+    [Fact]
+    public void OnlyMeshWeaverNamesAreJudged()
+    {
+        AppAssembly("MeshWeaver.Graph");
+        File.WriteAllText(Path.Combine(App, "Azure.Identity.dll"), "third party");
+        File.WriteAllText(Path.Combine(App, "MeshWeaverish.dll"), "not a platform name");
+
+        var (shipped, _) = PlatformShippedAssemblies.Read(App);
+
+        Assert.Equal(["MeshWeaver.Graph"], shipped!.Keys);
+    }
+
+    /// <summary>
+    /// 🚨 THE NEGATIVE CONTROL, and the reason this returns a problem instead of an empty set.
+    /// "This host ships nothing" is not a fact any real platform directory produces — a portal /app
+    /// carries 200+ MeshWeaver.* assemblies and the tester image 88. Answering it would make every
+    /// caller's strip a silent no-op that logs exactly like a clean measurement, which is the
+    /// gate-that-cannot-fail shape.
+    /// </summary>
+    [Fact]
+    public void ADirectoryThatIsNotAPlatformApp_IsRefused_NotReadAsShippingNothing()
+    {
+        File.WriteAllText(Path.Combine(App, "readme.txt"), "not an app directory");
+
+        var (shipped, problem) = PlatformShippedAssemblies.Read(App);
+
+        Assert.Null(shipped);
+        Assert.Contains("not a platform application directory", problem!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AMissingDirectory_IsRefused()
+    {
+        var (shipped, problem) = PlatformShippedAssemblies.Read(Path.Combine(root, "nope"));
+
+        Assert.Null(shipped);
+        Assert.Contains("does not exist", problem!, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("MeshWeaver", true)]
+    [InlineData("MeshWeaver.AI", true)]
+    [InlineData("meshweaver.ai", true)]
+    [InlineData("MeshWeaverish", false)]
+    [InlineData("Azure.Identity", false)]
+    [InlineData("", false)]
+    public void ThePlatformNamePredicate_IsTheOneSpelling(string name, bool expected) =>
+        Assert.Equal(expected, PlatformShippedAssemblies.IsPlatformAssemblyName(name));
+}


### PR DESCRIPTION
Closes #3732 (defect **2** only — see "Which defect" below).

## The chain, and where it is cut

A module bundle carries its entry plus a private closure. Which `MeshWeaver.*` siblings may **ride**
that closure was decided by a hand-maintained list — `src/platform-shipped.txt`, one per node repo.
A declaration is not a measurement, and it drifted in both directions inside one week (#3335
corrected five names *by hand* after re-measuring `/app`; the same file kept a `MeshWeaver.Maps`
line after the image stopped shipping it, so that name reached a mesh from nowhere at all).

`MeshWeaver.*` binds by a strictly synchronised `AssemblyVersion`, so two copies under one simple
name are **one identity**: the loader keeps whichever it saw first, every NodeType whose dependency
record named the other build is declined at adoption, and the loser reads as *landed but not yet
loaded*. On memex.systemorph.com the loser was `MeshWeaver.Blazor.Views` — both pods Degraded on
`pending_module_activation`, and every skinned `StackControl` rendered through `FallbackHtml`.

## The denominator

Measured on `MeshWeaver.Plugins` `main`, 2026-09-08 — every packed module's transitive in-repo
`ProjectReference` closure minus `src/platform-shipped.txt`, against the `@(MeshModuleClosure)` rows
in both portal hosts' csproj:

| | |
|---|---|
| module bundles the repo packs | **37** |
| bundles riding ≥1 `MeshWeaver.*` sibling | **18** (34 riding slots) |
| bundles riding a sibling **the image also ships** | **14** (27 slots) |
| the names | `MeshWeaver.Markdown.Collaboration` (14 bundles), `MeshWeaver.AI` (13) |

So it is not one instance: 27 duplicate copies across 14 of 37 bundles, none of them visible to the
witness that existed to prevent exactly that. (Cross-check: the walk reproduces #3221's independent
2026-09-03 measurement — 14 riding `Markdown.Collaboration`, 4 riding `Maps`.)

`src/platform-shipped.txt` exists in **1 of the 6** node repos. In the other five its absence reads
as *"the platform ships nothing"* — never a measurement either.

## Which defect this fixes, and which it does not

**Fixed — defect 2: siblings the platform image ships are not stripped by the platform-shipped
witness.** The witness now decides from what the image *actually ships*, three ways, because an
image ships an assembly three ways — and the previous reading knew about one:

| # | where | what puts it there |
|---|---|---|
| 1 | `<app>/<Name>.dll` | the application closure |
| 2 | `<app>/meshweaver-surface.manifest` | the host's own record of its compile references |
| 3 | `<app>/modules/<Name>/<Name>.dll` | the seeded-module lane, `@(MeshModuleClosure)` |

🚨 **A `MeshModuleClosure` row touches neither (1) nor (2)** — the portal hosts' own csproj comments
say so in as many words. That is precisely why all 27 slots were invisible: a witness reading `/app`
alone answers *"not shipped"* for every seeded module.

**Not fixed — defect 1: a downstream publication republishes its upstream's modules.** `crm` copying
`plugins`' sealed bundles into its own publication happens in `node-repo-publish-bake.yml` (line
`cp "$b" "$SEAL/…module.nupkg"`), which this session was told not to touch — another session owns
that lane. It is a separable defect and the issue says so.

## What the witness reads now

* **`PlatformShippedAssemblies.Read`** (`MeshWeaver.Compiler`) — the three readings, each name
  carrying the **provenance and evidence path** that answered. It **refuses** a directory that is
  not a platform application directory rather than answering "ships nothing": that answer strips
  nothing while logging exactly like a clean measurement.
* **`module-owned-platform.sh <src> [<platform-app>]`** — measures when given the image; says on
  stderr which witness answered when not. With both available the **image decides** and the declared
  list is *compared* to it, every disagreement printed as a warning naming the line to add or drop.
  The list then decides nothing and can eventually be deleted.
* **`module-pack --platform-app <dir>`** — a second, independent reading over the bundle's actual
  file list: every `MeshWeaver.*` file the host already has is dropped, one line each. On a lane
  whose classification is also measured this drops **zero**, which makes the count a *control*: a
  non-zero line means the two readings disagree.
* The lane passes the **raw** image copy (`$RUNNER_TEMP/platform-refs`), never the superseded-pruned
  reference set — supersede drops an assembly from the *compile* set precisely **because** the image
  still carries it.
* `RECIPE_VERSION` 3 → 4: the lane packs different bytes for the same source, so recipe-3 bundles
  must be **repacked**, never reused from the ledger. (`platformDigest` was already a key input, so
  a new image re-keys on its own.)

The **entry** assembly is deliberately not judged here: a module the image seeds under
`modules/<Name>/` is *meant* to be superseded by a landed bundle of itself, and the host-vs-entry
case already has `BakeHost.ShippedByHostProblem` at the bake.

## Evidence, both directions

`test/MeshWeaver.Graph.Test`:

* **The condition reproduced** — `WithoutTheWitness_TheBundleCarriesASecondBuildOfWhatThePlatformShips`:
  the bundle carries `MeshWeaver.Blazor.Views` (app closure) and `MeshWeaver.Markdown.Collaboration`
  (seeded module), and asserts the ridden bytes **differ** from the host's own copies — which is what
  makes it two builds rather than merely wasted bytes.
* **The fix** — `WithTheWitness_ThePlatformsOwnCopiesAreDropped_AndOnlyThose`: both gone from the
  manifest *and* the archive, symbols included.
* **The anti-vacuity control, in the same assertion** — `MeshWeaver.Maps`, a `MeshWeaver.*` sibling
  the host does **not** ship, still rides. A packer that dropped every platform-named file would
  pass the first half and fail here, and would reintroduce #3335's opposite defect.
* **The boundary** — `TheEntryAssemblyIsNeverDropped_EvenWhenTheImageSeedsThatVeryModule`.
* **The refusals** — a directory that is not a platform app, and a missing one.
* **Falsification control (run, not asserted in prose):** deleting the seeded-module reading alone
  turns **4** of these red, including the fix test, which then reports the bundle still carrying
  `MeshWeaver.Markdown.Collaboration`.

## Verified locally

| | |
|---|---|
| `MeshWeaver.Compiler` `-c Release -warnaserror` | `0 Warning(s) 0 Error(s)` |
| `MeshWeaver.Plugin.Build` `-c Release -warnaserror` | `0 Warning(s) 0 Error(s)` |
| `MeshWeaver.Graph.Test` `-c Release -warnaserror` | `0 Warning(s) 0 Error(s)` |
| `MeshWeaver.Graph.Test` | **1468 passed**, 0 failed |
| `MeshWeaver.Documentation.Test` | **351 passed**, 0 failed |
| `module-build-key.py --self-test` | 36 cases green |
| `check-workflow-timeouts.py` | 80 jobs, 0 violations |
| `check-pr-secret-preflight.py` | 2 reachable, 2 asserted, 0 violations |
| `module-owned-platform.sh` smoke + both refusals | exercised against a synthetic `/app` |

## The remaining gap, named rather than hidden

A lane that pins **no** platform image has nothing to measure — core's own CD packs the bake's four
bundles against a source-built platform, so there is no `/app` in that job. The classification falls
back to the declared list there **and says so on stderr every run**, and the enforcement step is
simply not armed. That is one structurally different lane named in the log, not an `if:` that asks
whether an input happens to be set. Closing it means handing that job the promoted portal image the
same run already resolves.

## Conserved

`Doc/Architecture/PlatformShippedWitness` — the three witnesses, the drift table, both harm
directions, where the measurement is applied and where it cannot reach. Cross-linked from
`ModuleOwnedSiblingsRide` (whose §3 argument rested on an image state that has since moved),
`ModuleVersioning`, `PluginPackaging`, `PlatformImageClosure` and `CarvingProjectsOutOfCore`.
Plus a `Category: Fix` What's New entry for the user-visible symptom.

Pairs-with: none — this PR removes no public type or member from `src/` (it adds one type and one
private-predicate delegation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
