### PR TITLE
fix(#3542): one total order for platform builds — the release markers were ranked by label too

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs
@@ -219,19 +219,16 @@ public static class VersionSelect
         return
         [
             .. parsed
-                // 🚨 THE ORDER, and the whole of #3542. Lineage first: a continuous build is ranked by
-                // the run number that published it, so a mislabelled line can never outrank a later
-                // sealed set. Promotion tags (a clean release, which has no run number of its own)
-                // follow, ordered among themselves by SemVer — which is the only key they share, and
-                // the correct one for a deliberate human act. Keeping them in a separate band is what
-                // makes this a TOTAL order: mixing the two keys pairwise is not transitive (a slip tag
-                // A beats a release C beats a sealed tag B beats A), and an intransitive comparer hands
-                // a sort an arbitrary answer.
-                .OrderByDescending(x => x.ordinal.HasValue)
-                .ThenByDescending(x => x.ordinal ?? 0L)
-                // The SAME SemVer implementation the shared comparison uses, so the band ordering and
-                // PlatformReleaseOrder.Compare can never disagree about two promotion tags.
-                .ThenByDescending(x => x.tag, NuGetVersionComparer.Instance)
+                // 🚨 THE ORDER, and the whole of #3542 — and it is NOT defined here. Lineage first:
+                // a continuous build is ranked by the run number that published it, so a mislabelled
+                // line can never outrank a later sealed set; promotion tags (a clean release, which
+                // has no run number of its own) follow, ordered among themselves by SemVer. That
+                // banding is what makes it a TOTAL order, and it is shared with every other caller
+                // that ranks platform builds — the release-marker index, the bundle sweep and the
+                // retention plan all read the same `_releases/<version>` names this reads tags. A
+                // second private copy of "which build is newest" is how #3542 came back at another
+                // call site while this one was already fixed.
+                .OrderByDescending(x => x.tag, PlatformReleaseOrder.Newest)
                 .Select(x => x.tag),
         ];
     }
@@ -239,7 +236,7 @@ public static class VersionSelect
     /// <summary>The structural filter every reader of a tag listing applies: drop the per-RID images,
     /// the git-sha / <c>main</c> pointers and the moving <c>-latest</c> pointers, keep what parses
     /// as a platform version.</summary>
-    private static IEnumerable<(string tag, NuGetVersion ver, long? ordinal)> Parse(
+    private static IEnumerable<(string tag, NuGetVersion ver)> Parse(
         IEnumerable<string> tags) =>
         tags
             .Where(t => !RuntimeIdentifierSuffix.IsMatch(t))   // exclude per-RID image tags; keep the manifest list
@@ -247,7 +244,7 @@ public static class VersionSelect
             .Where(t => PlatformVersionTag.IsMatch(t))         // exclude bare git-sha / `main` tags (see PlatformVersionTag)
             .Select(t => (tag: t, ver: NuGetVersion.TryParse(t, out var v) ? v : null))
             .Where(x => x.ver is not null)
-            .Select(x => (x.tag, ver: x.ver!, ordinal: PlatformReleaseOrder.BuildOrdinal(x.tag)));
+            .Select(x => (x.tag, ver: x.ver!));
 
     /// <summary>An UNVERIFIED edge/pre-merge build — identified by an <c>edge</c> SemVer pre-release
     /// label (e.g. <c>3.0.0-edge.51</c>). Verified CD builds use <c>-ci.&lt;n&gt;</c> or a clean release,

--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
@@ -7,7 +7,12 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # Self-Update Target Selection
 
-> 🚨 **Rule change, 2026-09-07 (maintainer) — see [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy).** The floor table below stops mattering: `ModulePlatformFloor.DeclineReason` becomes advisory at every runtime decision point, and "declared floors are not going away, so do not design as if they were" is superseded — they stay as pack-time authoring lint only. The mechanism described below is what runs until [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) lands; this page is rewritten by that change.
+> ✅ **Settled, 2026-09-08.** [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) landed:
+> `ModulePlatformFloor.DeclineReason` is **advisory** at every runtime decision point (see
+> [Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy), rule R2 — whether a module loads
+> is MEASURED by the link probe, never declared by a version string), and it remains a pack-time
+> authoring lint. §4 below is rewritten accordingly. The floors themselves moved off the retired rc
+> line the day before (MeshWeaver.Plugins#1447 — 42 packages, plus a gate that refuses a new one).
 
 **A version string is a LABEL a human maintains. The CD run number is the ORDER a machine
 produced. The self-updater must rank candidates by the second, because the first can be wrong —
@@ -168,84 +173,106 @@ reached only once the newer set is empty.
 - A strand with nothing eligible to recover to reports `SelfUpdateOutcome.InstalledTagWithdrawn` at
   Warning, naming the operator's move. Nothing in the process can fix that one.
 
-## 4. The same wrong assumption has a SECOND call site
+## 4. Fixing the selector moved the trap — FOUR readers rank platform builds
 
-`ModulePlatformFloor.DeclineReason` decides whether a module bundle may land: it declines when
-`NuGetVersionComparer.Instance.Compare(runningVersion, minMeshVersion) < 0`. That is pure SemVer, and
-SemVer §11.4 compares pre-release identifiers as text — so `"ci"` < `"rc"`, and a floor of
-`3.0.0-rc8` is unsatisfiable by **every** `3.0.0-ci.N`. Measured 2026-09-07 against the real comparer
-(`Compare(running, floor) < 0` ⇒ DECLINED):
+The selector was fixed on 2026-09-07. On 2026-09-08 the same wrong assumption reappeared one layer
+down, in code written that day: the **release markers**. `publish-bake-bundles.sh` writes
+`_releases/<platform-version>` on every run — one file per publication, its NAME the exact version
+string that publication was labelled with, its CONTENT the framework identity — and three new
+readers ranked those names by SemVer.
 
-| running \ floor | `3.0.0-rc4` | `3.0.0-rc8` | `3.0.0-rc9` | `3.0.0` |
-|---|---|---|---|---|
-| `3.0.0-ci.1` | DECLINED | DECLINED | DECLINED | DECLINED |
-| `3.0.0-ci.7989` | DECLINED | DECLINED | DECLINED | DECLINED |
-| `3.0.0-ci.999999999` | DECLINED | DECLINED | DECLINED | DECLINED |
-| `3.0.0` | ok | ok | ok | ok |
-| `3.1.0-ci.1` | ok | ok | ok | ok |
+| Reader | What it ranks | What a mislabelled or retired label does to it |
+|---|---|---|
+| `VersionSelect.PickTargets` | registry tags | rolled both AKS portals onto a withdrawn `3.1.0` build (§1) |
+| `SealedPublicationIndex.ReleasesOf` | markers → identity → its newest version | places an identity on a stale platform LINE |
+| `ShippedPrebuiltBundles.FallbackPublishedBundlesOf` | which sealed publication a tolerant adoption takes | adopts a three-day-old bake over the newest sealed one |
+| `PrebuiltBundleStore.Plan` (retention) | which publications survive the sweep | **protects the stale publication and deletes the newest** |
 
-Note the last column: a **clean `3.0.0` floor is refused too**, because a pre-release ranks below its
-own release. So it is not only the ~20 packages carrying retired `rc4`..`rc9` floors — a package
-declaring the current line's clean version is equally un-landable while the fleet runs `3.0.0-ci.N`.
-On both AKS portals at 08:20Z the observed line was:
+The markers carry exactly the strings the tags did, so the same two members lose to nothing:
+`3.1.0-ci.7841` (the withdrawn slip) and `3.0.0-rc9.ci.7824` (the retired line, where SemVer §11.4
+compares the identifiers `ci` and `rc9` as **text**) both outrank the later, sealed `3.0.0-ci.8130`
+for ever. The last row is the one that costs bytes rather than a listing: retention decides what to
+**delete**, so a label that sorts above a later run does not merely mis-rank — it keeps the stale
+publication and collects the one the running platform actually adopts.
 
-```
-HOLDING 3.0.0-ci.7989 — AI: the module requires platform 3.0.0-rc8 or newer
-                         but this deployment runs 3.0.0-ci.7989
-```
+### The order is defined once — `PlatformReleaseOrder.Newest`
 
-### 🚨 …but "newer than" and "satisfies the floor of" are NOT the same predicate
+Three keys, lexicographically, each a total order on its own:
 
-The tempting conclusion is "make the floor use this page's comparison". **That is measured to be
-wrong, and the counter-example is one line up in this very design.** For an updater, `3.0.0` MUST
-outrank `3.0.0-ci.7977` — otherwise a Stable install running a continuous build can never take the
-clean release it is waiting for, which is the regression §2 exists to avoid. For a floor, the same
-two strings must give the OPPOSITE answer: a `3.0.0` floor must be *satisfied* by `3.0.0-ci.7977`.
+1. **the band** — a version carrying a `BuildOrdinal` outranks one that does not (a build the machine
+   published outranks a string nobody can place);
+2. **the run number**, within the lineage band — the line in front of it is ignored, which is
+   precisely what makes a mislabelled line lose;
+3. **SemVer**, as the tie-break inside the lineage band and as the whole of the order in the
+   promotion band, where the version string is the only key the members share.
 
-Same two strings, opposite required answers. So the shareable part is the **key**
-(`PlatformReleaseOrder.BuildOrdinal` — the lineage), not the **predicate**. Forcing one predicate to
-serve both would fix the floor by breaking the update path.
+🚨 **It is a comparer and `Compare` is deliberately not.** Pairwise, the three members form a CYCLE:
+the slip `3.1.0-ci.7841` beats the promotion `3.0.0` (SemVer), the promotion beats the sealed
+`3.0.0-ci.8130` (SemVer, a release outranks its pre-releases), and the sealed tag beats the slip
+(run number). A sort handed a cycle answers arbitrarily — which is how a "fixed" ordering keeps
+picking the wrong build. Banding removes it, and `PlatformReleaseOrderTest` runs the cycle through
+every input permutation so a stable-sort accident cannot hide a regression.
 
-The overlap that *does* exist is the **same-line** case, and there the two must agree exactly: two
-builds of one line compare by build number, numerically. Once the declared floors name a
-`3.0.0-ci.<n>` (MeshWeaver.Plugins#1447) that is the whole of the shared surface, and
-`VersionSelectTest.SameLineBuildsCompareNumerically_TheOneCaseTheFloorAlsoAsks` pins this side of it.
+### 🚨 …and why the FLOOR is still not this predicate
 
-🚨 **Declared floors are not going away, so do not design as if they were.** The measured link probe
-(core #3552) reads `ModulePlatformFloor.DeclineReason(minMeshVersion) ?? LinkHoldReason()` — the probe
-short-circuits *behind* the declared floor and never runs unless the declared floor already passes.
-The declared floor still gates first.
+The tempting conclusion is "make the declared `minMeshVersion` floor use this comparison too".
+**That is measured to be wrong, and the counter-example is one section up.** For an updater, `3.0.0`
+MUST outrank `3.0.0-ci.7977` — otherwise a Stable install running a continuous build can never take
+the clean release it is waiting for (§2). For a floor, the same two strings must give the OPPOSITE
+answer: a `3.0.0` floor must be *satisfied* by `3.0.0-ci.7977`. Same two strings, opposite required
+answers, so the shareable part is the **key** (`BuildOrdinal`), never the **predicate**.
 
-That is why `PlatformReleaseOrder` lives in `MeshWeaver.Plugin.Packaging`, beside
-`NuGetVersionComparer` and in the lowest assembly both `MeshWeaver.PluginCatalog` (which owns
-`ModulePlatformFloor`) and `Memex.Portal.Shared` (which owns `VersionSelect`) already reference
-directly — the key is in reach of whoever writes the floor's own predicate, and neither call site
-carries a private idea of lineage. `PlatformReleaseOrderTest` pins the boundary so the floor decision
-is taken knowingly rather than by reusing the update one.
+The floor's own answer was settled elsewhere, and by two changes on consecutive days rather than by
+a comparator:
+
+- **The data moved.** MeshWeaver.Plugins#1447 (2026-09-07) took 42 packages off the retired rc line —
+  they now declare `3.0.0-ci.7845`, the first build of the ci line, which every existing platform
+  satisfies — and added `check-module-floors.py`, which refuses a new floor naming an rc. Both sides
+  of every floor comparison are now on one convention, where SemVer is right by construction.
+- **The decision moved.** [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648) (2026-09-08)
+  made the declared floor **advisory** at every runtime decision point: whether a module loads is
+  measured by the type-level link probe, never declared by a version string
+  ([Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy), rule R2). It survives as a
+  pack-time authoring lint and as a sentence on the status surfaces.
+
+So `PlatformReleaseOrder` lives in `MeshWeaver.Plugin.Packaging`, beside `NuGetVersionComparer` and in
+the lowest assembly `MeshWeaver.Hosting`, `MeshWeaver.PluginCatalog` and `Memex.Portal.Shared` all
+reference directly. `PlatformReleaseOrderTest.ThePreReleaseLabelIsTextToSemVer_WhichIsWhyTheFloorNeedsItsOwnPredicate`
+pins the boundary so the floor decision is taken knowingly rather than by reusing the update one.
 
 ## 5. What this does NOT fix
 
 - **The withdrawn tags themselves.** Ordering makes them lose; it does not remove them. Measured
-  2026-09-07 (`az acr repository show-tags -n meshweaver --repository memex-portal-ai`): **1268 tags —
-  798 `staging-*`, 48 `3.0.0-ci.*`, ZERO `3.1.0-*`, ZERO `rc*`.** The slip tags and the whole retired
-  rc line are already untagged from all three repositories (manifests kept, reachable via
-  `staging-*`), so the 2026-09-07 trap has no tag left to fire on. A future slip needs the same
-  maintainer action — the selector's job is to make the slip harmless while its tags are still there.
-- **The policy record losing its own policy** under its bookkeeping writes (issue #3542, proposal 3).
+  2026-09-08 (`az acr repository show-tags -n meshweaver --repository memex-portal-ai`): **1403 tags,
+  of which 97 survive the structural filters — every one of them `3.0.0-ci.<n>`, ZERO `3.1.0-*`,
+  ZERO `rc*`, so ZERO outrank the newest sealed set (`3.0.0-ci.8130`) under either comparator.** That
+  zero is the product of a hand deletion (issue #3542, proposal 4), not of the ordering: the slip
+  tags and the whole retired rc line were untagged by an operator on 2026-09-07. A future slip needs
+  the same action — the ordering's job is to make the slip HARMLESS while its tags are still there.
+  🚨 The `_releases/` markers are the same set of labels and are **not** covered by that deletion;
+  retention removes a pre-release marker only when the identity it names is collected.
+- **The policy record losing its own policy** under its bookkeeping writes (issue #3542, proposal 3 —
+  settled by #3619 for the clobber, still open for the `[MergeGuard]` refusals).
 - **"Installed" is what the pod RUNS.** This reads `ShippedReleaseSeed.InstalledPlatformVersion` —
   the injected `MESHWEAVER_PLATFORM_VERSION`, never the record's `LatestAvailableTag`, which after a
   manual roll-back kept naming a version no pod ran.
 
 ## Where it lives
 
-- `src/MeshWeaver.Plugin.Packaging/PlatformReleaseOrder.cs` — the lineage key (`BuildOrdinal`) and the
-  update predicate (`Compare` / `IsNewer`), in the lowest assembly both call sites reach.
-- `memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs` — the tag-shape filters, the policy, the
-  total order a heterogeneous listing needs, `CheckInstalledTag` and `SelectCandidates`. Pure; no hub,
-  no registry, no Rx.
+- `src/MeshWeaver.Plugin.Packaging/PlatformReleaseOrder.cs` — the lineage key (`BuildOrdinal`), the
+  pairwise update predicate (`Compare` / `IsNewer`) and the total order every ranking caller shares
+  (`Newest`), in the lowest assembly all of them reach.
+- `memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs` — the tag-shape filters, the policy,
+  `CheckInstalledTag` and `SelectCandidates`. Pure; no hub, no registry, no Rx.
 - `memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs` — `RunOnce` / `NothingToRoll`.
-- `test/MeshWeaver.Graph.Test/PlatformReleaseOrderTest.cs` — the lineage key, the incident, and the
-  measured floor boundary.
+- `src/MeshWeaver.Hosting/SealedPublicationIndex.cs` — identity → its newest published version.
+- `src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs` — which sealed publication a tolerant adoption
+  takes (`Modules:VersionStrictness`, [Module Versioning](/Doc/Architecture/ModuleVersioning)).
+- `src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs` — the sweep plan, i.e. what is deleted.
+- `test/MeshWeaver.Graph.Test/PlatformReleaseOrderTest.cs` — the lineage key, the incident, the total
+  order and its transitivity, and the measured floor boundary.
+- `test/MeshWeaver.Hosting.Test/SealedPublicationLineageTest.cs` — the markers: the index and the
+  sweep, each in both directions.
 - `test/Memex.Portal.Shared.Test/VersionSelectTest.cs` — the ordering and the three-valued check.
 - `test/Memex.Portal.Shared.Test/SelfUpdateStrandRecoveryTest.cs` — the poller, against a real mesh.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-mislabelled-build-can-no-longer-outrank-a-newer-one-anywhere.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-mislabelled-build-can-no-longer-outrank-a-newer-one-anywhere.md
@@ -1,0 +1,44 @@
+---
+Name: A mislabelled build can no longer outrank a newer one, anywhere
+Category: Fix
+Description: A build published under the wrong version label used to look newer than every build that came after it — forever. That was fixed for the self-updater; three more places still ranked platform builds by their label, including the pass that decides which precompiled bundles to delete. All four now rank by the build that published them.
+Icon: ArrowSortDownLines
+Order: -20260908
+---
+
+# A mislabelled build can no longer outrank a newer one, anywhere
+
+A platform build carries two things: a **version label** a person maintains by hand, and the
+**build number** of the delivery run that published it. Only the second one is produced by the
+machine, and only the second one always increases.
+
+On 2026-09-05 the label was briefly wrong — ten builds went out labelled `3.1.0` on a line that was
+still `3.0.0`, and were withdrawn. Ranked by the label those ten outrank every later build for good,
+so on 2026-09-07 two portals updated themselves onto one of them, three days behind, and then
+reported "nothing newer" on every check for the rest of the day. Nothing is ever newer than the
+highest label. Removing the bad labels did not help either: the ranking simply moved to the next
+oddly-labelled build, an older one from a retired naming scheme.
+
+**The self-updater was taught to rank by the build number instead.** What this change adds is the
+rest of the story: three more places ranked platform builds by their label, and they read the same
+labels one layer down — the marker files the delivery pipeline writes beside the precompiled
+content bundles, one per publication, each named after the version that publication carried.
+
+- Which platform line a set of precompiled bundles belongs to.
+- Which set of bundles an installation adopts when it has been rolled onto a newer platform than the
+  one those bundles were built for.
+- **Which sets the clean-up pass keeps, and which it deletes.** This is the one that mattered most:
+  ranked by the label, the withdrawn build's bundles were the ones protected, and the newest ones —
+  the sets the running portal actually uses — were the ones removed.
+
+All four now share a single ranking: a build the delivery pipeline published wins on its build
+number, whatever line it is labelled with; a shipped release, which has no build number of its own
+because it is a re-tag of a build that does, is ranked among the other releases by version. Nothing
+in this ranking can be moved by editing a label.
+
+Nothing changes for an installation on a correctly labelled line, which is every installation today
+— the ranking is identical when the labels agree with the build numbers. It changes what happens the
+next time they do not.
+
+See [Self-Update Target Selection](/Doc/Architecture/SelfUpdateTargetSelection) for the incident, the
+ranking and the one question it deliberately does not answer.

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
@@ -371,7 +371,11 @@ public static class PrebuiltBundleStore
                 $"release marker '{unreadable.Version}' could not be read ({unreadable.ReadFault}) — which "
                 + "identity it references is unknown, so no identity can be called unreferenced");
 
-        var comparer = NuGetVersionComparer.Instance;
+        // 🚨 The SEALED-PUBLICATION LINEAGE, never the version LABEL (#3542). Retention decides what
+        // to DELETE, so a label that sorts above a later run does not merely mis-rank a listing here:
+        // it protects the stale publication and collects the newest one. `3.0.0-rc9.ci.7824` and the
+        // withdrawn `3.1.0-ci.7841` both outrank `3.0.0-ci.8130` under SemVer.
+        var comparer = PlatformReleaseOrder.Newest;
         var readable = scan.Markers.Where(m => m.Identity is not null).ToImmutableList();
 
         // identity → the newest version naming it (the SAME reading ShippedPrebuiltBundles orders

--- a/src/MeshWeaver.Hosting/SealedPublicationIndex.cs
+++ b/src/MeshWeaver.Hosting/SealedPublicationIndex.cs
@@ -58,8 +58,16 @@ public static class SealedPublicationIndex
 
     /// <summary>
     /// The REVERSE of the release markers: framework identity → the newest platform version
-    /// published under it (SemVer order via <see cref="Plugin.Packaging.NuGetVersionComparer"/>,
-    /// so <c>ci.900</c> never sorts above <c>ci.3758</c>). This is how a bundle sealed for another
+    /// published under it — <b>newest by SEALED-PUBLICATION LINEAGE</b>
+    /// (<see cref="Plugin.Packaging.PlatformReleaseOrder.Newest"/>), the same total order the
+    /// self-updater ranks registry tags with. 🚨 Not SemVer: a marker's file NAME is the version
+    /// LABEL that publication carried, and a label can be wrong or retired — <c>3.1.0-ci.7841</c>
+    /// (the withdrawn 2026-09-05 slip) and <c>3.0.0-rc9.ci.7824</c> (the retired rc line, where
+    /// SemVer §11.4 puts the text <c>rc9</c> above <c>ci</c>) both sort ABOVE the later, sealed
+    /// <c>3.0.0-ci.8130</c>, so a SemVer reading would place an identity on a stale line and hand
+    /// <see cref="ShippedPrebuiltBundles"/> a three-day-old publication as "newest" (#3542). The run
+    /// number the marker's own name carries is the only key the machine produced. This is how a
+    /// bundle sealed for another
     /// identity is placed on a platform LINE: its manifest names the identity, the marker names
     /// the version, and <see cref="PrebuiltAdoptionPolicy"/> compares lines. An identity no
     /// marker names is absent — the policy then declines it under <c>Family</c> strictness, as a
@@ -83,7 +91,7 @@ public static class SealedPublicationIndex
                 if (string.IsNullOrEmpty(identity) || string.IsNullOrEmpty(version))
                     continue;
                 if (!byIdentity.TryGetValue(identity, out var known)
-                    || Plugin.Packaging.NuGetVersionComparer.Instance.Compare(version, known) > 0)
+                    || Plugin.Packaging.PlatformReleaseOrder.Newest.Compare(version, known) > 0)
                     byIdentity[identity] = version;
             }
         }

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -303,7 +303,10 @@ public static class ShippedPrebuiltBundles
             .Where(kv => PrebuiltAdoptionPolicy
                 .Decide(context.Strictness, new PrebuiltAdoptionPolicy.Candidate(kv.Key, kv.Value, null), context.Live)
                 .Adopts)
-            .OrderByDescending(kv => kv.Value, Plugin.Packaging.NuGetVersionComparer.Instance)
+            // 🚨 Newest by SEALED-PUBLICATION LINEAGE, never by the version LABEL the marker is named
+            // with (#3542) — the shared total order, so this sweep and the self-updater can never
+            // disagree about which publication is the newest one.
+            .OrderByDescending(kv => kv.Value, Plugin.Packaging.PlatformReleaseOrder.Newest)
             .ToList();
         var taken = new HashSet<string>(sealedHere, StringComparer.OrdinalIgnoreCase);
         var bundles = new List<string>();

--- a/src/MeshWeaver.Plugin.Packaging/PlatformReleaseOrder.cs
+++ b/src/MeshWeaver.Plugin.Packaging/PlatformReleaseOrder.cs
@@ -37,9 +37,9 @@ namespace MeshWeaver.Plugin.Packaging;
 /// <para>🚨 <b><see cref="Compare"/> is PAIRWISE and is deliberately NOT an
 /// <see cref="IComparer{T}"/>.</b> Over a mixed set the relation is not transitive — a slip tag beats
 /// a promotion beats a sealed tag beats the slip tag — and an intransitive comparer hands a sort an
-/// arbitrary answer. A caller that must ORDER a heterogeneous set bands by
-/// <see cref="BuildOrdinal"/><c>.HasValue</c> first and only then compares within a band;
-/// <c>VersionSelect.PickTargets</c> is the reference implementation.</para>
+/// arbitrary answer. A caller that must ORDER a heterogeneous set uses <see cref="Newest"/>, which
+/// bands by <see cref="BuildOrdinal"/><c>.HasValue</c> first and only then compares within a band.
+/// </para>
 /// </summary>
 public static class PlatformReleaseOrder
 {
@@ -119,6 +119,56 @@ public static class PlatformReleaseOrder
     /// on a comparison nobody could make.
     /// </summary>
     public static bool IsNewer(string? candidate, string? current) => Compare(candidate, current) > 0;
+
+    /// <summary>
+    /// 🚨 <b>The ONE total order over a set of platform versions — ASCENDING, so "newest first" is
+    /// <c>OrderByDescending(x, PlatformReleaseOrder.Newest)</c>.</b> Every caller that has to RANK
+    /// platform builds against each other uses this and nothing else (#3542).
+    ///
+    /// <para><b>Why it is not <see cref="Compare"/>.</b> Compare answers a PAIRWISE question and
+    /// falls back to SemVer whenever one side carries no run number — correct for two versions, and
+    /// intransitive over a SET: the slip tag <c>3.1.0-ci.7841</c> beats the promotion <c>3.0.0</c>
+    /// (SemVer), the promotion beats the sealed <c>3.0.0-ci.8130</c> (SemVer), and the sealed tag
+    /// beats the slip tag (run number). A sort handed a cycle produces an arbitrary answer, which is
+    /// how a "fixed" ordering silently keeps picking the wrong build.</para>
+    ///
+    /// <para><b>The order, and why it is total.</b> Three keys, lexicographically, each a total
+    /// order on its own:</para>
+    /// <list type="number">
+    /// <item><b>the band</b> — a version carrying a <see cref="BuildOrdinal"/> outranks one that does
+    /// not. A build the machine published outranks a string nobody can place;</item>
+    /// <item><b>the run number</b>, within the lineage band. The version LINE in front of it is
+    /// ignored, which is precisely what makes a mislabelled line lose;</item>
+    /// <item><b>SemVer</b> (<see cref="NuGetVersionComparer"/>) — the tie-break inside the lineage
+    /// band, and the whole of the order in the promotion band, where the version string is the only
+    /// key the members share and a deliberately cut release makes it a trustworthy one.</item>
+    /// </list>
+    ///
+    /// <para>🚨 <b>This is an ORDER, never a THRESHOLD.</b> "Is the platform at least X" — a declared
+    /// <c>minMeshVersion</c> floor — is a different predicate over the same key and must not be
+    /// answered with this comparer: for an updater the clean <c>3.0.0</c> must outrank
+    /// <c>3.0.0-ci.7977</c> (or a Stable install can never reach the release it waits for), while a
+    /// <c>3.0.0</c> FLOOR must be SATISFIED by <c>3.0.0-ci.7977</c>. Same two strings, opposite
+    /// required answers. See <c>Doc/Architecture/SelfUpdateTargetSelection</c> §4.</para>
+    /// </summary>
+    public static IComparer<string> Newest { get; } = new TotalOrder();
+
+    private sealed class TotalOrder : IComparer<string>
+    {
+        public int Compare(string? left, string? right)
+        {
+            var leftOrdinal = BuildOrdinal(left);
+            var rightOrdinal = BuildOrdinal(right);
+
+            if (leftOrdinal.HasValue != rightOrdinal.HasValue)
+                return leftOrdinal.HasValue ? 1 : -1;
+
+            if (leftOrdinal is { } l && rightOrdinal is { } r && l != r)
+                return l.CompareTo(r);
+
+            return Math.Sign(NuGetVersionComparer.Instance.Compare(left, right));
+        }
+    }
 
     /// <summary>
     /// A platform version is a NUMERIC dotted core (1–4 components, matching what a .NET assembly

--- a/test/MeshWeaver.Graph.Test/PlatformReleaseOrderTest.cs
+++ b/test/MeshWeaver.Graph.Test/PlatformReleaseOrderTest.cs
@@ -149,4 +149,76 @@ public class PlatformReleaseOrderTest
         Assert.Equal(0, PlatformReleaseOrder.Compare("3.0.0-ci.51", "3.0.0-ci.51+build.638123456789"));
         Assert.True(PlatformReleaseOrder.IsNewer("3.0.0-ci.52", "3.0.0-ci.51+build.638123456789"));
     }
+
+    // ───────── the total order every RANKING caller shares ─────────
+
+    /// <summary>
+    /// 🚨 <b><see cref="PlatformReleaseOrder.Newest"/> over the incident's own set.</b> Four
+    /// callers rank platform builds — the self-updater's tag listing, the release-marker index, the
+    /// bundle-adoption sweep and the retention plan — and every one of them reads a version string
+    /// a publication was LABELLED with. Ordered descending, the two mislabelled members must both
+    /// sink below the later sealed runs, and the promotion (no run number of its own) sits in the
+    /// band behind them.
+    /// </summary>
+    [Fact]
+    public void TheTotalOrder_RanksTheRunNumberFirst_AndTheLabelNever()
+    {
+        string[] published =
+        [
+            "3.0.0",              // a promotion — no run number of its own
+            "3.1.0-ci.7841",      // the withdrawn 2026-09-05 slip line
+            "3.0.0-ci.8130",      // the newest sealed set
+            "3.0.0-rc9.ci.7824",  // the retired rc line, 2026-09-04
+            "3.0.0-ci.8059",
+        ];
+
+        Assert.Equal(
+            ["3.0.0-ci.8130", "3.0.0-ci.8059", "3.1.0-ci.7841", "3.0.0-rc9.ci.7824", "3.0.0"],
+            published.OrderByDescending(v => v, PlatformReleaseOrder.Newest));
+    }
+
+    /// <summary>
+    /// 🚨 <b>Why the ordering is not <see cref="PlatformReleaseOrder.Compare"/>.</b> Pairwise, the
+    /// three members form a CYCLE — slip beats promotion beats sealed beats slip — and a sort handed
+    /// a cycle answers arbitrarily, which is how a "fixed" ordering keeps picking the wrong build.
+    /// Banding by <see cref="PlatformReleaseOrder.BuildOrdinal"/> is what removes it, and this test
+    /// exercises the cycle in every input order so a stable-sort accident cannot hide a regression.
+    /// </summary>
+    [Fact]
+    public void TheTotalOrder_IsTransitive_WhereThePairwiseComparisonIsNot()
+    {
+        // The cycle, measured on the pairwise predicate.
+        Assert.True(PlatformReleaseOrder.IsNewer("3.1.0-ci.7841", "3.0.0"));
+        Assert.True(PlatformReleaseOrder.IsNewer("3.0.0", "3.0.0-ci.8130"));
+        Assert.True(PlatformReleaseOrder.IsNewer("3.0.0-ci.8130", "3.1.0-ci.7841"));
+
+        // The order over the same three is one answer, whatever order they arrive in.
+        string[] cycle = ["3.1.0-ci.7841", "3.0.0", "3.0.0-ci.8130"];
+        foreach (var permutation in Permutations(cycle))
+            Assert.Equal(
+                ["3.0.0-ci.8130", "3.1.0-ci.7841", "3.0.0"],
+                permutation.OrderByDescending(v => v, PlatformReleaseOrder.Newest));
+    }
+
+    /// <summary>
+    /// The one key a promotion band shares is the version string, and a deliberately cut release
+    /// makes it a trustworthy one — so promotions order among themselves by SemVer, and an
+    /// uncomparable string (an unstamped build's <c>unknown</c>) sinks to the bottom rather than
+    /// throwing or being read as newest.
+    /// </summary>
+    [Fact]
+    public void TheTotalOrder_OrdersPromotionsBySemVer_AndSinksWhatItCannotRead()
+    {
+        Assert.Equal(
+            ["3.0.1", "3.0.0", "3.0.0-rc8", "unknown"],
+            new[] { "3.0.0-rc8", "unknown", "3.0.1", "3.0.0" }
+                .OrderByDescending(v => v, PlatformReleaseOrder.Newest));
+    }
+
+    private static IEnumerable<string[]> Permutations(string[] items) =>
+        items.Length <= 1
+            ? [items]
+            : items.SelectMany(
+                (head, i) => Permutations([.. items.Take(i), .. items.Skip(i + 1)])
+                    .Select(rest => (string[])[head, .. rest]));
 }

--- a/test/MeshWeaver.Hosting.Test/SealedPublicationLineageTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SealedPublicationLineageTest.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Linq;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>#3542 at its SECOND call site — the release markers, ordered by the version LABEL.</b>
+///
+/// <para>The self-updater was taught on 2026-09-07 to rank registry tags by the CD run number
+/// rather than by SemVer, because a version LINE is a label a human maintains and a label can be
+/// wrong: <c>3.1.0-ci.7832…7841</c> (the withdrawn 2026-09-05 slip) and <c>3.0.0-rc9.ci.7824</c>
+/// (the retired rc line, where SemVer §11.4 compares the pre-release identifiers as TEXT so
+/// <c>"ci"</c> &lt; <c>"rc9"</c>) both outrank the later, sealed <c>3.0.0-ci.8130</c> for ever.</para>
+///
+/// <para>The store reads the SAME labels one layer down: <c>_releases/&lt;platform-version&gt;</c>,
+/// one marker per publication, named by exactly the string the tag carried. Three readers ranked
+/// them by SemVer — <see cref="SealedPublicationIndex.ReleasesOf"/> (identity → its newest
+/// version), <c>ShippedPrebuiltBundles.FallbackPublishedBundlesOf</c> (which sealed publication a
+/// tolerant adoption takes) and <see cref="PrebuiltBundleStore.Plan"/> (which publications
+/// survive the sweep) — so a mislabelled marker did not merely mis-rank a listing: it placed an
+/// identity on a stale line, handed a three-day-old publication over as "newest", and PROTECTED
+/// that publication from collection while the newest one was swept.</para>
+///
+/// <para>Every arm below is written against the incident's own data, and each asserts BOTH
+/// directions: the mislabelled/retired marker loses, and a legitimately newer publication still
+/// wins.</para>
+/// </summary>
+public class SealedPublicationLineageTest : IDisposable
+{
+    private const string Identity = "s0000000000000000000000000000one1";
+    private const string OtherIdentity = "s0000000000000000000000000000two2";
+
+    private readonly string root = Path.Combine(Path.GetTempPath(), "sealed-lineage-" + Guid.NewGuid().ToString("N"));
+
+    private void Marker(string version, string identity)
+    {
+        var dir = Path.Combine(root, SealedPublicationIndex.ReleaseMarkerDirectoryName);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, version), identity + "\n");
+    }
+
+    // ───────── SealedPublicationIndex.ReleasesOf ─────────
+
+    /// <summary>
+    /// The withdrawn slip line. <c>3.1.0-ci.7841</c> is a 2026-09-05 build; <c>3.0.0-ci.8130</c> is
+    /// later and sealed. By SemVer the slip wins for ever, so the identity would be reported as a
+    /// 3.1.0 publication and every downstream reader would rank it first.
+    /// </summary>
+    [Fact]
+    public void AMislabelledLine_IsNotTheIdentitysNewestPublication()
+    {
+        Marker("3.1.0-ci.7841", Identity);
+        Marker("3.0.0-ci.8130", Identity);
+
+        SealedPublicationIndex.ReleasesOf(root)[Identity].Should().Be("3.0.0-ci.8130",
+            "run 8130 published after run 7841, whatever line each was labelled with");
+    }
+
+    /// <summary>
+    /// The trap one layer down, and the reason deleting the 3.1.0 tags did not fix the incident:
+    /// with them gone the selector simply moved to the next mislabelled marker.
+    /// </summary>
+    [Fact]
+    public void ARetiredPrereleaseLabel_IsNotTheIdentitysNewestPublication()
+    {
+        Marker("3.0.0-rc9.ci.7824", Identity);
+        Marker("3.0.0-ci.8130", Identity);
+
+        SealedPublicationIndex.ReleasesOf(root)[Identity].Should().Be("3.0.0-ci.8130",
+            "SemVer puts the text 'rc9' above 'ci', but run 8130 published three days after run 7824");
+    }
+
+    /// <summary>
+    /// 🚨 The other direction, which the fix must not break: a genuinely later run still wins, and
+    /// the marker order is independent of the order the directory happens to enumerate in.
+    /// </summary>
+    [Fact]
+    public void ALaterRunStillWins_WhicheverOrderTheMarkersAreWritten()
+    {
+        Marker("3.0.0-ci.8130", Identity);
+        Marker("3.0.0-ci.8059", Identity);
+        Marker("3.0.0-ci.7845", Identity);
+        SealedPublicationIndex.ReleasesOf(root)[Identity].Should().Be("3.0.0-ci.8130");
+
+        Marker("3.0.0-ci.7845", OtherIdentity);
+        Marker("3.0.0-ci.8200", OtherIdentity);
+        SealedPublicationIndex.ReleasesOf(root)[OtherIdentity].Should().Be("3.0.0-ci.8200");
+    }
+
+    /// <summary>
+    /// A PROMOTION carries no run number of its own (<c>release.yml</c> retags one already-sealed
+    /// continuous set), so it is ranked behind every lineage-bearing marker and among the
+    /// promotions by SemVer. Its identity is the same bytes the sibling ci marker names, so nothing
+    /// is lost by it — and an identity named ONLY by promotions is still placed on its line.
+    /// </summary>
+    [Fact]
+    public void APromotionIsRankedBehindTheLineageItWasCutFrom_ButStillPlacesAnIdentity()
+    {
+        Marker("3.0.0", Identity);
+        Marker("3.0.0-ci.8130", Identity);
+        SealedPublicationIndex.ReleasesOf(root)[Identity].Should().Be("3.0.0-ci.8130",
+            "the clean release is a retag of a sealed continuous set — the run number is the publication");
+
+        Marker("3.0.0", OtherIdentity);
+        Marker("3.0.1", OtherIdentity);
+        SealedPublicationIndex.ReleasesOf(root)[OtherIdentity].Should().Be("3.0.1",
+            "among promotions the version string is the only key they share, and it is a trustworthy one");
+    }
+
+    // ───────── PrebuiltBundleRetention: the ordering decides what is DELETED ─────────
+
+    /// <summary>
+    /// 🚨 <b>The sweep is where a mis-ranking costs bytes rather than a listing.</b> With room for
+    /// ONE publication per source, retention keeps the newest sealed one of the live line and
+    /// collects the rest. Ranked by SemVer the retired <c>3.0.0-rc9.ci.7824</c> is "the newest" —
+    /// so it would be protected and the later, sealed <c>3.0.0-ci.8130</c> publication, the one the
+    /// running platform actually adopts, would be DELETED.
+    /// </summary>
+    [Fact]
+    public void TheSweepKeepsTheNewestRun_NotTheHighestLabel()
+    {
+        var plan = Sweep(
+            new ReleaseMarkerEntry("3.0.0-rc9.ci.7824", Identity, "/m/3.0.0-rc9.ci.7824", At(1), null),
+            new ReleaseMarkerEntry("3.0.0-ci.8130", OtherIdentity, "/m/3.0.0-ci.8130", At(2), null));
+
+        plan.AbortReason.Should().BeNull();
+        plan.Protected.Should().ContainKey(OtherIdentity,
+            "run 8130 is the newest sealed 'plugins' publication — the one the running platform adopts");
+        // …and the retired rc9 publication, which only outranks it as a LABEL (SemVer §11.4
+        // compares 'rc9' and 'ci' as text), is the one collected.
+        plan.Collectable.Select(i => i.Identity).Should().Equal(Identity);
+    }
+
+    /// <summary>The other direction: a genuinely newer publication is the one kept.</summary>
+    [Fact]
+    public void TheSweepStillKeepsAGenuinelyNewerPublication()
+    {
+        var plan = Sweep(
+            new ReleaseMarkerEntry("3.0.0-ci.8200", Identity, "/m/3.0.0-ci.8200", At(1), null),
+            new ReleaseMarkerEntry("3.0.0-ci.8130", OtherIdentity, "/m/3.0.0-ci.8130", At(2), null));
+
+        plan.AbortReason.Should().BeNull();
+        plan.Protected.Should().ContainKey(Identity, "run 8200 published after run 8130");
+        plan.Collectable.Select(i => i.Identity).Should().Equal(OtherIdentity);
+    }
+
+    /// <summary>Two sealed 'plugins' publications, room for exactly one — so the ORDER decides which
+    /// survives and which is deleted. The live identity is neither of them.</summary>
+    private static PrebuiltBundleSweepPlan Sweep(params ReleaseMarkerEntry[] markers) =>
+        PrebuiltBundleStore.Plan(
+            liveIdentity: "s00000000000000000000000000live1",
+            livePlatformVersion: "3.0.0-ci.8130",
+            scan: new PrebuiltStoreScan(
+                [.. markers.Select(m => SealedIdentity(m.Identity!, "plugins", m.WrittenUtc))],
+                [.. markers]),
+            stampedIdentities: [],
+            retention: new PrebuiltBundleRetention { KeepNewestPerSource = 1 },
+            nowUtc: At(10));
+
+    private static DateTimeOffset At(int hours) =>
+        new DateTimeOffset(2026, 9, 8, 0, 0, 0, TimeSpan.Zero).AddHours(hours);
+
+    private static PrebuiltIdentityEntry SealedIdentity(string identity, string source, DateTimeOffset sealedAt) =>
+        new(identity, "/store/" + identity,
+            [new PrebuiltSourceEntry(source, true, sealedAt, sealedAt, null)],
+            Bytes: 1024, NewestWriteUtc: sealedAt);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+    }
+}


### PR DESCRIPTION
## One total order for platform builds — fixing the selector moved the trap, it did not remove it

`#3551` (2026-09-07) taught the self-updater to rank registry tags by the CD run number rather than
by SemVer, because a version LINE is a label a human maintains and a label can be wrong. `#3727`
(2026-09-08) landed **three more readers that rank platform builds by the version string**, over the
same labels one layer down.

### The denominator, measured

**Registry tags** — `az acr repository show-tags -n meshweaver --repository memex-portal-ai`,
2026-09-08: **1403 tags → 97 survive the structural filters** (per-RID images, `-latest` pointers,
git-sha tags and `edge` dropped). Every one of them is `3.0.0-ci.<n>`; **zero `3.1.0-*`, zero
`rc*`, so zero outrank the newest sealed set (`3.0.0-ci.8130`) under either comparator.** 🚨 That
zero is the product of a HAND DELETION (this issue's proposal 4, done by an operator on 2026-09-07),
not of the ordering — which is exactly why "one bad tag" is the wrong reading. The property that
made the slip permanent is a standing one, and it had already recurred elsewhere.

**Release markers** — `publish-bake-bundles.sh` writes `_releases/<platform-version>` on every run,
one file per publication, its NAME the exact string that publication's tag carried. The retired
`3.0.0-rc*.ci.*` line and the withdrawn `3.1.0-ci.783x` sets both published bakes, so both wrote
markers, and retention removes a pre-release marker only when the identity it names is collected —
the tag deletion did not touch them. 🚨 **I could not enumerate the share to count them** (this
credential has no Storage File/Blob Data role; `az storage file list --auth-mode login
--backup-intent` is refused). That is "could not find out", not "none", and it is not the basis of
anything below.

### The three readers, and what a label does to each

| Reader | What it ranks | What a mislabelled or retired label does |
|---|---|---|
| `VersionSelect.PickTargets` | registry tags | rolled both AKS portals onto a withdrawn `3.1.0` build (already fixed) |
| `SealedPublicationIndex.ReleasesOf` | markers → identity → its newest version | places an identity on a stale platform LINE |
| `ShippedPrebuiltBundles.FallbackPublishedBundlesOf` | which sealed publication a tolerant adoption takes | adopts a three-day-old bake over the newest sealed one |
| `PrebuiltBundleStore.Plan` (retention) | which publications survive the sweep | **protects the stale publication and DELETES the newest** |

`3.1.0-ci.7841` (the withdrawn 2026-09-05 slip) and `3.0.0-rc9.ci.7824` (the retired line — SemVer
§11.4 compares the identifiers `ci` and `rc9` as **text**) outrank the later, sealed `3.0.0-ci.8130`
at all of them. The last row is the one that costs bytes rather than a listing: retention decides
what to **delete**, so the label does not merely mis-rank — it keeps the stale publication and
collects the one the running platform actually adopts.

### The ordering, stated

**Rank by sealed-publication lineage, and where a candidate carries none, by the version string it
does carry — banded, never mixed pairwise.** `PlatformReleaseOrder.Newest`, an `IComparer<string>`,
is the ONE definition, and `VersionSelect.PickTargets`' inline banding becomes a call to it so there
is no second copy to drift from the first. Three keys, lexicographically, each a total order:

1. **the band** — a version carrying a `BuildOrdinal` outranks one that does not;
2. **the run number**, within the lineage band — the line in front of it is ignored, which is what
   makes a mislabelled line lose;
3. **SemVer**, as the tie-break inside the band and as the whole of the promotion band, where the
   version string is the only key the members share.

🚨 **It is a comparer where `Compare` cannot be.** Pairwise the three members form a CYCLE: the slip
`3.1.0-ci.7841` beats the promotion `3.0.0` (SemVer), the promotion beats the sealed `3.0.0-ci.8130`
(a release outranks its pre-releases), and the sealed tag beats the slip (run number). A sort handed
a cycle answers arbitrarily — which is how a "fixed" ordering keeps picking the wrong build.
`PlatformReleaseOrderTest` runs that cycle through **every input permutation** so a stable-sort
accident cannot hide a regression.

**Nothing here is a denylist, a special case or a widened comparison.** A tag cannot be made to win
by editing its label, because the label is not the key.

### Selectability of a withdrawn or unsealed candidate — unchanged, and already the right shape

`SelectCandidates` keeps its three-valued `InstalledTagResolution` (`Resolved` / `Withdrawn` /
`Indeterminate`), the availability walk still takes the first candidate with a **sealed** bake, and
`ReleasesOf` still reports an identity no marker names as ABSENT — which `Family` strictness declines
as "a line it cannot establish", never as "fine". A failed read is still not a negative.

### 🚨 The declared `minMeshVersion` FLOOR is deliberately NOT changed

A floor is a **threshold**, not an order, and it needs the OPPOSITE answer for the same two strings:
for the updater `3.0.0` must outrank `3.0.0-ci.7977` (or a Stable install can never reach the release
it waits for), while a `3.0.0` FLOOR must be *satisfied* by `3.0.0-ci.7977`. So the shareable part is
the key (`BuildOrdinal`), never the predicate. Its own question was settled twice over, on
consecutive days, and both are recorded on the doc page:

- **Systemorph/MeshWeaver.Plugins#1447** (2026-09-07) took 42 packages off the retired rc line —
  they declare `3.0.0-ci.7845` now — and added `check-module-floors.py`, which refuses a new rc
  floor. Both sides of every floor comparison are on one convention, where SemVer is right by
  construction. (Measured: a stale local Plugins checkout still shows 41 rc floors; `origin/main`
  does not.)
- **#3648** (2026-09-08) made the floor advisory at every runtime decision point — loadability is
  measured by the link probe, never declared.

### Evidence, both directions

**Falsified.** With the two `src/` comparer lines reverted to `NuGetVersionComparer` and everything
else identical: **4 of the 6 new arms FAIL** — `AMislabelledLine_…`, `ARetiredPrereleaseLabel_…`,
`APromotionIsRankedBehindTheLineageItWasCutFrom_…`, `TheSweepKeepsTheNewestRun_NotTheHighestLabel` —
and the **2 positive controls PASS** (`ALaterRunStillWins_…`, `TheSweepStillKeepsAGenuinelyNewer…`).
With the fix: **6/6**.

Green locally, `-c Release -warnaserror` one project per invocation, `0 Error(s)` each:
`MeshWeaver.Hosting`, `Memex.Portal.Shared`, `MeshWeaver.Plugin.Packaging`, and the four test
projects. Filtered runs: **Hosting.Test 46/46**, **Graph.Test 27/27**, **Memex.Portal.Shared.Test
`VersionSelectTest` 64/64** (the "a legitimately newer set still wins" direction, including
`AMislabelledLine_NeverOutranksALaterSealedSet` and
`ContinuousFollowsTheCiLine_AndDoesNotJumpToTheRelease`), **Documentation.Test 358/358**.
`check-record-signatures` ✓ (7 changed C# files, no binary break), `check-type-forwards` ✓.

### Work product conserved

[`Doc/Architecture/SelfUpdateTargetSelection`](src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md)
— §4 rewritten (the four readers, the total order, why it is a comparer and `Compare` is not, and why
the floor is still not this predicate), §5 carries the re-measured tag denominator plus the marker
caveat, its stale "#3648 has not landed yet" banner is settled, and "Where it lives" now names the
Hosting readers. Plus a What's New entry (`Category: Fix`).

### Still open on #3542 after this

The `~1300 [MergeGuard] Admin/UpdatePolicy: refused stale/reordered cross-hub write` events in the
issue body. That is a write being REFUSED, not a write destroying state (#3619 fixed that half), and
nothing here touches it.

Pairs-with: none — no public type or member is removed; `PlatformReleaseOrder.Newest` is additive and
`VersionSelect.Parse` is private.
Implementers: none — no interface or abstract member is added.
Mirror-sync: none — no i18n catalog key is added, changed or re-worded.

Refs #3542, #3551, #3727, #3648, Systemorph/MeshWeaver.Plugins#1447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
