### PR TITLE
Log which view packs declined a control that renders as escaped HTML

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -68,10 +68,36 @@ line.
 
 Two load-bearing rules for pack authors:
 
-1. **Register before `AddBlazor()`.** View maps are first-match-wins and the core registry's
-   default mapping is currently terminal (its fallback never declines), so a pack registered after
-   the core mapping is silently dead. The portal's composition does this correctly today; treat it
-   as a contract until the planned explicit-priority fix lands.
+1. **Decline what you do not know — return `null`, never throw and never a fallback.** View maps
+   are first-match-wins in registration order, and the escaped-HTML last resort lives OUTSIDE that
+   list (`WithFallbackView`, set once by the host), so order is no longer load-bearing: a map that
+   declines lets every later pack be consulted, and only after all of them declined does the
+   fallback render. A map that answers for a control it does not own — or throws, which the old
+   terminal arm did — silently replaces every pack registered after it.
+
+   **Reading the fallback warning.** That last resort is the one place a control silently turns
+   into text (`StackControl { Id = , Style = … }` on screen), so `LayoutClientConfiguration` logs
+   it once per control type per hub, at Warning, on the channel
+   `MeshWeaver.Layout.Client.ViewDispatch`:
+
+   ```
+   no view map accepted StackControl ($type StackControl, skins [LayoutStackSkin]) in area Workspace
+   on hub mesh/memex: 3 map(s) registered [MeshWeaver.Blazor.Views:AddDefaultViews, …] — falling
+   back to the last-resort view (escaped HTML in the Blazor portal)
+   ```
+
+   Read it from the tail. `0 map(s) registered — no view pack applied its HubConfigurations to this
+   hub` means the packs never reached the hub the page renders on (the hub address says which one
+   was asked — the Blazor renderer resolves `ILayoutClient` from the per-circuit `portal/<id>` hub,
+   whose container is a child scope of the mesh hub's, so an address of `mesh/…` here says the
+   root hub's configuration answered). A list of owners means the packs DID register and each one
+   declined: the owners are recorded at `WithView` time as `Assembly:Method` (`ViewMapOwners`), so a
+   pack missing from the list never registered, and a pack present in it declined this control —
+   check its skin arm. A control or skin printed as `LayoutStackSkin@MeshWeaver.Layout[…]` names an
+   assembly or load context other than the framework's: the same-named-type trap, where every
+   pattern match on the real type declines the copy. The Blazor portal pairs the line with an
+   Information entry from `DispatchView` (`Rendering Area … through the escaped-HTML fallback`) and
+   a `view_packs` health check that reports the same owner list for the root hub.
 2. **Never ship copies of contract assemblies.** The pack compiles against the host's
    `MeshWeaver.Layout` / `MeshWeaver.Blazor` and binds to them at load time. A same-named type from
    a second copy is the platform's documented trap-door class — values silently read as absent.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-control-that-renders-as-text-now-says-which-view-packs-declined-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-control-that-renders-as-text-now-says-which-view-packs-declined-it.md
@@ -1,0 +1,37 @@
+---
+Name: A control that renders as text now says which view packs declined it
+Category: Fix
+Description: When a page shows a control as raw text instead of the real thing, the portal now logs one line naming the control, its skins, the area, the hub, and every view pack that was asked and said no — or that no view pack registered at all. Until now that path was silent.
+Icon: Bug
+Order: -20260908
+---
+
+# A control that renders as text now says which view packs declined it
+
+Occasionally a page shows a control as its own description — a line of text beginning
+`StackControl { Id = , Style = … }` where a layout should be. That is the portal's last resort: no
+registered view pack accepted the control, so it rendered the control's text, escaped. It is
+harmless, and it is also completely silent — nothing on that path said which packs were asked, or
+whether any pack had registered on that hub at all, so an operator reading the logs had nothing to
+start from.
+
+**Now it logs once per control type per hub**, at Warning, on the `MeshWeaver.Layout.Client.ViewDispatch`
+channel:
+
+```
+no view map accepted StackControl ($type StackControl, skins [LayoutStackSkin]) in area Workspace
+on hub mesh/memex: 3 map(s) registered [MeshWeaver.Blazor.Views:AddDefaultViews,
+MeshWeaver.Blazor.EntityViews:AddEntityViews, …] — falling back to the last-resort view
+(escaped HTML in the Blazor portal)
+```
+
+The line separates the two causes that look identical on screen. `0 map(s) registered — no view
+pack applied its HubConfigurations to this hub` means the view packs never reached the hub the page
+renders on; a list of owners means they did, and every one of them declined this control — and the
+skins and the control's assembly are printed, so a skin no pack knows, or a same-named type loaded
+from a second assembly, reads off the line directly.
+
+A page with fifty controls of one kind logs one line, not fifty; a different kind on the same hub
+logs again. Nothing changes on screen.
+
+See [UI Extensibility](/Doc/Architecture/UiExtensibility) for how to read the line.

--- a/src/MeshWeaver.Layout/Client/LayoutClientConfiguration.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Immutable;
+using System.Runtime.Loader;
 using System.Text.Json;
 using MeshWeaver.Data;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using MeshWeaver.Domain;
 using MeshWeaver.Messaging;
 
@@ -14,7 +16,35 @@ namespace MeshWeaver.Layout.Client;
 /// <param name="Hub">The message hub this configuration is associated with.</param>
 public record LayoutClientConfiguration(IMessageHub Hub)
 {
+    /// <summary>
+    /// The log category of the one Warning this configuration emits: a control for which EVERY
+    /// registered view map declined, so the renderer fell through to the host's last-resort view
+    /// (the escaped-HTML fallback in the Blazor portal) or to nothing. Filter Loki on this category
+    /// to answer "why did that control render as text".
+    /// </summary>
+    public const string ViewDispatchLogCategory = "MeshWeaver.Layout.Client.ViewDispatch";
+
+    /// <summary>
+    /// Upper bound on the (hub, control type) keys remembered for rate-bounding the fallback
+    /// warning. A page with fifty controls of one type logs once per type per hub; when the set
+    /// fills it starts over rather than going silent, so a new type is never suppressed for good.
+    /// </summary>
+    private const int FallbackWarningBound = 256;
+
     private readonly ITypeRegistry typeRegistry = Hub.ServiceProvider.GetRequiredService<ITypeRegistry>();
+
+    // Resolved lazily on the first fallback, never per dispatch — most renders never take the
+    // fallback and must not pay for a logger they never use. An instance field, so it travels with
+    // the `with` copies made during configuration and is created at most a handful of times.
+    private ILogger? viewDispatchLogger;
+
+    private ILogger? ViewDispatchLogger =>
+        viewDispatchLogger ??= Hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(ViewDispatchLogCategory);
+
+    // The rate-bound: (hub, control type) keys already warned about. An INSTANCE set on this
+    // configuration — never static, which would bleed across meshes and tests — updated through
+    // ImmutableInterlocked so concurrent renders on one hub neither lose a key nor double-log.
+    private ImmutableHashSet<string> warnedFallbacks = ImmutableHashSet<string>.Empty;
 
     /// <summary>
     /// A delegate that maps a view-model instance, its synchronization stream, and an area name to a <see cref="ViewDescriptor"/>.
@@ -33,7 +63,7 @@ public record LayoutClientConfiguration(IMessageHub Hub)
     /// Ordered list of delegates that extend the portal's hub configuration.
     /// Applied in order during portal hub setup.
     /// </summary>
-    public ImmutableList<Func<MessageHubConfiguration, MessageHubConfiguration>> PortalConfiguration { get; init; } 
+    public ImmutableList<Func<MessageHubConfiguration, MessageHubConfiguration>> PortalConfiguration { get; init; }
         = [];
 
     /// <summary>
@@ -46,6 +76,16 @@ public record LayoutClientConfiguration(IMessageHub Hub)
         => this with { PortalConfiguration = PortalConfiguration.Add(config) };
 
     internal ImmutableList<ViewMap> ViewMaps { get; init; } = ImmutableList<ViewMap>.Empty;
+
+    /// <summary>
+    /// Who registered each entry of <see cref="ViewMaps"/>, in registration order — one string per
+    /// map, shaped <c>Assembly:Method</c> (for example <c>MeshWeaver.Blazor.Views:AddDefaultViews</c>)
+    /// or <c>Assembly:ViewModel→View</c> for the typed <see cref="WithView{TViewModel,TView}"/> form.
+    /// Recorded at <c>WithView</c> time so the fallback warning and a host's health check can name
+    /// the packs that were consulted and declined, and — when the list is empty — say that no view
+    /// pack applied its hub configuration to this hub at all.
+    /// </summary>
+    public ImmutableList<string> ViewMapOwners { get; private init; } = ImmutableList<string>.Empty;
 
     /// <summary>
     /// The LAST-resort view map, consulted only after every registered map declined. Kept OUTSIDE
@@ -66,12 +106,29 @@ public record LayoutClientConfiguration(IMessageHub Hub)
 
 
     /// <summary>
-    /// Returns a copy with <paramref name="viewMap"/> appended to the view-mapping chain.
+    /// Returns a copy with <paramref name="viewMap"/> appended to the view-mapping chain. The owner
+    /// recorded in <see cref="ViewMapOwners"/> is derived from the delegate's declaring assembly and
+    /// method (a compiler-generated lambda is attributed to the method that declares it).
     /// </summary>
     /// <param name="viewMap">The view map delegate to add.</param>
     /// <returns>A new instance with the updated view map list.</returns>
     public LayoutClientConfiguration WithView(ViewMap viewMap)
-        => this with { ViewMaps = ViewMaps.Add(viewMap) };
+        => WithView(viewMap, DescribeOwner(viewMap));
+
+    /// <summary>
+    /// Returns a copy with <paramref name="viewMap"/> appended to the view-mapping chain, attributed
+    /// to <paramref name="owner"/> in <see cref="ViewMapOwners"/>. Use this form when the delegate's
+    /// own identity would not name the pack a reader recognises.
+    /// </summary>
+    /// <param name="viewMap">The view map delegate to add.</param>
+    /// <param name="owner">The name recorded for this map, conventionally <c>Assembly:Method</c>.</param>
+    /// <returns>A new instance with the updated view map list.</returns>
+    public LayoutClientConfiguration WithView(ViewMap viewMap, string owner)
+    {
+        ArgumentNullException.ThrowIfNull(viewMap);
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        return this with { ViewMaps = ViewMaps.Add(viewMap), ViewMapOwners = ViewMapOwners.Add(owner) };
+    }
 
     /// <summary>
     /// Registers a Blazor view of type <typeparamref name="TView"/> for view-model instances of type <typeparamref name="TViewModel"/>
@@ -83,21 +140,124 @@ public record LayoutClientConfiguration(IMessageHub Hub)
     public LayoutClientConfiguration WithView<TViewModel, TView>()
     {
         typeRegistry.WithType<TViewModel>();
-        return WithView((i, s, a) => 
-            i is not TViewModel vm ? null : StandardView<TViewModel, TView>(vm, s, a));
+        return WithView(
+            (i, s, a) => i is not TViewModel vm ? null : StandardView<TViewModel, TView>(vm, s, a),
+            $"{typeof(TView).Assembly.GetName().Name}:{typeof(TViewModel).Name}→{typeof(TView).Name}");
     }
 
     /// <summary>
     /// Tries each registered view map in order and returns the first non-null <see cref="ViewDescriptor"/> for the given instance;
     /// when every map declines, the host's <see cref="FallbackViewMap"/> (if any) produces the last-resort descriptor.
+    /// That fall-through is the ONE place a control silently turns into escaped text, so it is logged
+    /// once per (hub, control type) at Warning on <see cref="ViewDispatchLogCategory"/>, naming the
+    /// control, its <c>$type</c> discriminator, its skins, the area, the hub, and every map that
+    /// declined by owner (<see cref="ViewMapOwners"/>).
     /// </summary>
     /// <param name="instance">The view-model instance to resolve a view for.</param>
     /// <param name="stream">The synchronization stream for the area, or null.</param>
     /// <param name="area">The area name.</param>
     /// <returns>The first matching <see cref="ViewDescriptor"/>, the fallback's descriptor, or null.</returns>
-    public ViewDescriptor? GetViewDescriptor(object instance, ISynchronizationStream<JsonElement>? stream, string area) =>
-        ViewMaps.Select(m => m.Invoke(instance, stream, area)).FirstOrDefault(d => d is not null)
-        ?? FallbackViewMap?.Invoke(instance, stream, area);
+    public ViewDescriptor? GetViewDescriptor(object instance, ISynchronizationStream<JsonElement>? stream, string area)
+    {
+        var descriptor = ViewMaps.Select(m => m.Invoke(instance, stream, area)).FirstOrDefault(d => d is not null);
+        if (descriptor is not null)
+            return descriptor;
+
+        var fallback = FallbackViewMap?.Invoke(instance, stream, area);
+        WarnNoViewMapAccepted(instance, area, fallback is not null);
+        return fallback;
+    }
+
+    private void WarnNoViewMapAccepted(object? instance, string area, bool fallbackUsed)
+    {
+        var logger = ViewDispatchLogger;
+        if (logger is null || !logger.IsEnabled(LogLevel.Warning))
+            return;
+
+        var type = instance?.GetType();
+        var key = $"{Hub.Address}|{type?.FullName ?? "null"}";
+        // Update returns false when the transformer handed the set back unchanged — i.e. the key
+        // was already there — so exactly one caller per key sees true and logs.
+        var firstForKey = ImmutableInterlocked.Update(
+            ref warnedFallbacks,
+            static (set, k) => set.Contains(k)
+                ? set
+                : set.Count >= FallbackWarningBound ? ImmutableHashSet.Create(k) : set.Add(k),
+            key);
+        if (!firstForKey)
+            return;
+
+        var owners = ViewMapOwners;
+        var registered = owners.Count == 0
+            ? "0 map(s) registered — no view pack applied its HubConfigurations to this hub"
+            : $"{owners.Count} map(s) registered [{string.Join(", ", owners)}]";
+        var outcome = fallbackUsed
+            ? "falling back to the last-resort view (escaped HTML in the Blazor portal)"
+            : "no fallback view map is set, so the area renders nothing";
+
+        logger.LogWarning(
+            "no view map accepted {ControlType} ($type {Discriminator}, skins [{Skins}]) in area {Area} on hub {HubAddress}: {Registered} — {Outcome}",
+            DescribeType(type, typeof(UiControl).Assembly),
+            type is null ? "null" : typeRegistry.GetCollectionName(type) ?? "(not registered)",
+            instance is UiControl control
+                ? string.Join(", ", SkinsOf(control).Select(skin => DescribeType(skin.GetType(), typeof(Skin).Assembly)))
+                : string.Empty,
+            area,
+            Hub.Address,
+            registered,
+            outcome);
+    }
+
+    /// <summary>
+    /// The skins a map would see: <see cref="UiControl.Skins"/>, plus a container's own <c>Skin</c>
+    /// property — <c>ContainerControl&lt;TControl,TSkin&gt;</c> keeps it there and only merges it into
+    /// <c>Skins</c> when preparing for render, so a control read before that step would otherwise
+    /// report <c>skins []</c> while its text shows <c>Skin = LayoutStackSkin</c>. Deduplicated by
+    /// value, so a prepared control lists each skin once.
+    /// </summary>
+    private static IEnumerable<Skin> SkinsOf(UiControl control)
+    {
+        var ownSkin = control.GetType().GetProperty(nameof(Skin))?.GetValue(control) as Skin;
+        return ownSkin is null ? control.Skins : control.Skins.Append(ownSkin).Distinct();
+    }
+
+    /// <summary>
+    /// A type's short name, annotated with its assembly (and load context when not the default)
+    /// whenever it does NOT come from <paramref name="expectedAssembly"/>. A control or skin that
+    /// LOOKS like a framework one but reads as <c>StackControl@MeshWeaver.Layout[…]</c> is the
+    /// same-named-type-from-another-assembly trap — every pattern match on the real type declines it.
+    /// </summary>
+    private static string DescribeType(Type? type, System.Reflection.Assembly expectedAssembly)
+    {
+        if (type is null)
+            return "null";
+        if (type.Assembly == expectedAssembly)
+            return type.Name;
+        var loadContext = AssemblyLoadContext.GetLoadContext(type.Assembly);
+        var contextSuffix = loadContext is null || loadContext == AssemblyLoadContext.Default
+            ? string.Empty
+            : $"[{loadContext.Name}]";
+        return $"{type.Name}@{type.Assembly.GetName().Name}{contextSuffix}";
+    }
+
+    /// <summary>
+    /// <c>Assembly:Method</c> for a delegate. A lambda compiles to <c>&lt;Enclosing&gt;b__N_M</c> on a
+    /// closure class; the enclosing method's name is the one a reader recognises, so it is unwrapped.
+    /// </summary>
+    private static string DescribeOwner(ViewMap viewMap)
+    {
+        ArgumentNullException.ThrowIfNull(viewMap);
+        var method = viewMap.Method;
+        var assembly = (method.DeclaringType?.Assembly ?? method.Module.Assembly).GetName().Name ?? "?";
+        var name = method.Name;
+        if (name.StartsWith('<'))
+        {
+            var close = name.IndexOf('>');
+            if (close > 1)
+                name = name[1..close];
+        }
+        return $"{assembly}:{name}";
+    }
 
     /// <summary>Parameter key used to pass the view-model instance into a Blazor component's parameter dictionary.</summary>
     public const string ViewModel = nameof(ViewModel);

--- a/test/MeshWeaver.Layout.Test/ViewDispatchFallbackWarningTest.cs
+++ b/test/MeshWeaver.Layout.Test/ViewDispatchFallbackWarningTest.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// The fallback warning of <see cref="LayoutClientConfiguration.GetViewDescriptor"/>: when every
+/// registered view map declines a control, ONE Warning on
+/// <see cref="LayoutClientConfiguration.ViewDispatchLogCategory"/> names the control, its
+/// <c>$type</c>, its skins, the area, the hub and every map that declined by owner.
+///
+/// <para><b>Why.</b> On memex (2026-09-08) the PartnerRe Workspace area rendered as the TEXT of a
+/// <c>StackControl</c> — every map had declined and the escaped-HTML fallback took it — and nothing
+/// on that path logged above Debug. A control that turns into text has to say which packs were
+/// asked, so the reader can tell "no pack registered on this hub" from "the pack registered and
+/// declined this skin".</para>
+///
+/// <para>Rate-bound per (hub, control type): a page with fifty stacks logs once, and a SECOND type
+/// on the same hub logs again — the positive control that proves the single line is a bound, not a
+/// dead logger.</para>
+/// </summary>
+public class ViewDispatchFallbackWarningTest : HubTestBase
+{
+    private readonly ConcurrentQueue<(string Category, LogLevel Level, string Message)> logRecords = new();
+
+    /// <inheritdoc />
+    public ViewDispatchFallbackWarningTest(ITestOutputHelper output) : base(output)
+    {
+        Services.AddLogging(logging =>
+            logging.Services.AddSingleton<ILoggerProvider>(new QueueLoggerProvider(logRecords)));
+    }
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    private static readonly string TestAssembly = typeof(ViewDispatchFallbackWarningTest).Assembly.GetName().Name!;
+
+    /// <summary>A map that declines everything — the shape of a pack that does not know the control.</summary>
+    private static ViewDescriptor? DeclineEverything(object instance, ISynchronizationStream<JsonElement>? stream, string area)
+        => null;
+
+    private sealed class ProbeView;
+
+    private IReadOnlyList<string> FallbackWarnings() =>
+        logRecords
+            .Where(r => r.Category == LayoutClientConfiguration.ViewDispatchLogCategory && r.Level == LogLevel.Warning)
+            .Select(r => r.Message)
+            .ToList();
+
+    [Fact]
+    public void ZeroMaps_LogsTheZeroMapLine_OncePerControlType()
+    {
+        var client = GetClient();
+        var configuration = new LayoutClientConfiguration(client);
+        configuration.ViewMapOwners.Should().BeEmpty();
+
+        // Controls.Stack carries a LayoutStackSkin by construction — in its own Skin property, which
+        // PrepareForRender merges into Skins before the control leaves the server. The line must
+        // name it from EITHER place, so the first call is the unprepared shape and the third the
+        // prepared one (skin in both) — and neither lists it twice.
+        var descriptor = configuration.GetViewDescriptor(Controls.Stack, null, "Workspace");
+        configuration.GetViewDescriptor(Controls.Stack, null, "Workspace");
+        configuration.GetViewDescriptor(Controls.Stack.AddSkin(new LayoutStackSkin()).WithStyle("max-width:980px"), null, "Other");
+
+        descriptor.Should().BeNull("there is no map and no fallback");
+        var warnings = FallbackWarnings();
+        warnings.Should().HaveCount(1, "the same control type on the same hub is logged once");
+        warnings[0].Should().Contain("no view map accepted StackControl ($type StackControl, skins [LayoutStackSkin]) in area Workspace on hub " + client.Address);
+        warnings[0].Should().Contain("0 map(s) registered — no view pack applied its HubConfigurations to this hub");
+        warnings[0].Should().Contain("no fallback view map is set, so the area renders nothing");
+
+        // Positive control for the bound: a DIFFERENT type on the same hub logs again.
+        configuration.GetViewDescriptor(Controls.Label("x"), null, "Workspace");
+        FallbackWarnings().Should().HaveCount(2);
+        FallbackWarnings()[1].Should().Contain("no view map accepted LabelControl ($type LabelControl, skins [])");
+
+        // The prepared shape — skin in Skins AND in the Skin property — on a fresh configuration
+        // (a fresh rate-bound) lists the skin exactly once.
+        var prepared = new LayoutClientConfiguration(client);
+        prepared.GetViewDescriptor(Controls.Stack.AddSkin(new LayoutStackSkin()), null, "Workspace");
+        FallbackWarnings().Last().Should().Contain("skins [LayoutStackSkin])");
+    }
+
+    [Fact]
+    public void DecliningMaps_LogTheirOwners_InRegistrationOrder()
+    {
+        var client = GetClient();
+        var configuration = new LayoutClientConfiguration(client)
+            .WithView(DeclineEverything)
+            .WithView((_, _, _) => null)
+            .WithView<LabelControl, ProbeView>();
+
+        configuration.ViewMapOwners.Should().Equal(
+            $"{TestAssembly}:{nameof(DeclineEverything)}",
+            // A lambda is attributed to the method that declares it, not to its <…>b__N_M closure name.
+            $"{TestAssembly}:{nameof(DecliningMaps_LogTheirOwners_InRegistrationOrder)}",
+            $"{TestAssembly}:LabelControl→ProbeView");
+
+        // Anti-vacuity: the typed map DOES answer for its own control, with no warning.
+        configuration.GetViewDescriptor(Controls.Label("x"), null, "Workspace")!.Type.Should().Be(typeof(ProbeView));
+        FallbackWarnings().Should().BeEmpty();
+
+        configuration.GetViewDescriptor(Controls.Stack, null, "Workspace").Should().BeNull();
+
+        var warnings = FallbackWarnings();
+        warnings.Should().HaveCount(1);
+        warnings[0].Should().Contain(
+            $"3 map(s) registered [{TestAssembly}:{nameof(DeclineEverything)}, "
+            + $"{TestAssembly}:{nameof(DecliningMaps_LogTheirOwners_InRegistrationOrder)}, "
+            + $"{TestAssembly}:LabelControl→ProbeView]");
+    }
+
+    [Fact]
+    public void WithFallback_ReturnsTheFallbackDescriptor_AndSaysSo()
+    {
+        var client = GetClient();
+        var configuration = new LayoutClientConfiguration(client)
+            .WithView(DeclineEverything)
+            .WithFallbackView((_, _, _) => new ViewDescriptor(typeof(ProbeView), new Dictionary<string, object?>()));
+
+        var descriptor = configuration.GetViewDescriptor(Controls.Stack, null, "Workspace");
+
+        descriptor!.Type.Should().Be(typeof(ProbeView));
+        var warnings = FallbackWarnings();
+        warnings.Should().HaveCount(1);
+        warnings[0].Should().Contain("falling back to the last-resort view (escaped HTML in the Blazor portal)");
+    }
+
+    /// <summary>
+    /// The owners survive the real path: <c>AddViews</c> on the hub configuration, aggregated by the
+    /// <see cref="ILayoutClient"/> the renderer resolves — the same object the host's health check reads.
+    /// </summary>
+    [Fact]
+    public void TheLayoutClientsConfiguration_CarriesTheOwners_RegisteredThroughAddViews()
+    {
+        // GetClient(cfg) REPLACES ConfigureClient rather than extending it, so chain it explicitly.
+        var client = GetClient(c => ConfigureClient(c).AddViews(layout => layout.WithView(DeclineEverything)));
+
+        var configuration = client.ServiceProvider.GetRequiredService<ILayoutClient>().Configuration;
+
+        configuration.ViewMapOwners.Should().Equal($"{TestAssembly}:{nameof(DeclineEverything)}");
+        configuration.GetViewDescriptor(Controls.Stack, null, "Workspace").Should().BeNull();
+        FallbackWarnings().Should().ContainSingle()
+            .Which.Should().Contain($"1 map(s) registered [{TestAssembly}:{nameof(DeclineEverything)}]");
+    }
+
+    /// <summary>Captures every record, with its category, into the owning test's instance queue.</summary>
+    private sealed class QueueLoggerProvider(ConcurrentQueue<(string, LogLevel, string)> sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new QueueLogger(categoryName, sink);
+        public void Dispose() { }
+
+        private sealed class QueueLogger(string category, ConcurrentQueue<(string, LogLevel, string)> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => sink.Enqueue((category, logLevel, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
## Why

On memex.systemorph.com today the PartnerRe node's Workspace area renders as the TEXT of its
control — `StackControl { Id = , Style = max-width:980px;…, Skin = LayoutStackSkin {…} }` — i.e.
every registered view map declined a `StackControl` carrying a `LayoutStackSkin`, and the Blazor
client rendered it through `BlazorViewRegistry.FallbackHtml`. Nothing on that path logs above
Debug: `LayoutClientConfiguration.GetViewDescriptor` is silent, `DispatchView` logs at Debug, and
`ViewsExtensions.MapSkinnedView` declines silently. Maintainer's directive: *"check loki what
happens on the way. why is the view not rendered? instrument and then measure."*

This is the core half: the instrumentation at the ONE place a control turns into text. The Plugins
half (pack-side Information line, `DispatchView` promotion on the fallback, `view_packs` health
check) follows and needs the two additive members below.

## What

`LayoutClientConfiguration` (`src/MeshWeaver.Layout/Client/LayoutClientConfiguration.cs`):

- When every map declined, ONE Warning on channel **`MeshWeaver.Layout.Client.ViewDispatch`**,
  resolved lazily from `Hub.ServiceProvider`'s `ILoggerFactory` (never per dispatch):

  ```
  no view map accepted StackControl ($type StackControl, skins [LayoutStackSkin]) in area Workspace on hub mesh/…: 3 map(s) registered [MeshWeaver.Blazor.Views:AddDefaultViews, …] — falling back to the last-resort view (escaped HTML in the Blazor portal)
  ```

  With zero maps the middle reads `0 map(s) registered — no view pack applied its HubConfigurations
  to this hub`; with no fallback slot the tail reads `no fallback view map is set, so the area
  renders nothing`. The `$type` is the hub's type-registry name; a control or skin from an assembly
  other than the framework's is printed `Name@Assembly[LoadContext]` — the same-named-type trap
  reads straight off the line. A container's own `Skin` property is included (it is merged into
  `Skins` only by `PrepareForRender`).
- Rate-bound per (hub, control type) on an instance `ImmutableHashSet` (bounded at 256, restarts
  when full — never permanently silent; no static state).
- **`ViewMapOwners`** (read-only `ImmutableList<string>`): who registered each map, recorded at
  `WithView` time as `Assembly:Method` (a lambda is attributed to the method that declares it) or
  `Assembly:ViewModel→View` for the typed form. New overload **`WithView(ViewMap, string owner)`**
  for a pack that wants to name itself; `WithView(ViewMap)` keeps its signature (an added optional
  parameter would be a binary break for a pack DLL compiled against the old core).

Doc: `UiExtensibility.md` — rule 1 of the pack-author rules was stale (it still described the
terminal fallback arm); it now states the decline contract and has a "Reading the fallback
warning" paragraph. What's New: `Category: Fix`.

Tests (`test/MeshWeaver.Layout.Test/ViewDispatchFallbackWarningTest.cs`, 4 tests, green on a fresh
Release build): zero maps logs the zero-map line once per type per hub (a second type logs again —
the positive control for the bound); declining maps log their owners in registration order
(static method, lambda, typed form); the fallback slot returns its descriptor and the line says so;
the owners survive the real `AddViews` → `ILayoutClient` path.

## Code-path finding (for the measurement)

- `MeshBuilder.InstallAssemblies` folds a module's `HubConfigurations` (e.g.
  `ViewsViewPackModuleAttribute` → `AddDefaultViews()`) into the **root mesh hub** configuration
  via `ConfigureHub`. `AddDefaultViews` → `AddViews` stores a view-configuration function in that
  hub config; `LayoutClient` (singleton registered by `AddLayoutClient` on the root hub) aggregates
  them on first resolve.
- The per-circuit `portal/<circuitId>` hub (`src/MeshWeaver.Hosting.AspNetCore/Portal/PortalApplication.cs`,
  ctor) is built from `DefaultPortalConfig` + `LayoutClientConfiguration.PortalConfiguration` +
  `PortalConfigurationRegistry.Current`. **It does NOT receive module `HubConfigurations` and
  registers no `ILayoutClient` of its own.** Its container is an Autofac child scope of the root's
  (`ServiceProviderExtensions.SetupModules`), so `DispatchView`'s
  `Hub.ServiceProvider.GetRequiredService<ILayoutClient>()` resolves the ROOT hub's singleton —
  i.e. the maps consulted are the root hub's. Consequence: the `on hub …` address in the new
  warning is expected to read `mesh/…`, not `portal/…`; if it reads `portal/…` some contribution
  built a second layout client on the circuit hub, and THAT is the finding.
- So the two hypotheses the line separates on memex are: (a) `0 map(s) registered` — the
  `[ModuleLoad] MeshWeaver.Blazor.Views ← /app/…` line notwithstanding, the attribute's
  `HubConfigurations` never reached the root hub config (attribute type identity / quarantine);
  (b) `MeshWeaver.Blazor.Views:AddDefaultViews` IS listed and declined — then the skin reads
  `LayoutStackSkin@…[…]` (a second copy of `MeshWeaver.Layout`) or the control is not the
  framework's `StackControl`; the Plugins-side Debug line names the exact skin type per decline.

## What to grep in Loki once this reaches memex

- Warning, logger `MeshWeaver.Layout.Client.ViewDispatch`, text `no view map accepted` — one line
  per (hub, control type). Read the tail first: `0 map(s) registered` vs the owner list.
- After the Plugins half: Information `DefaultViews registered on hub` (logger
  `MeshWeaver.Blazor.Views.ViewsExtensions`) and Information `through the escaped-HTML fallback`
  (`DispatchView`); `/health` → `view_packs`.

Pairs-with: none — additive (no public type or member removed; `ViewMapOwners`, `WithView(ViewMap, string)` and `ViewDispatchLogCategory` are new)
Implementers: none — no member added to a public interface or abstract class
Mirror-sync: none — no catalog change; the new text is operator-facing log output, not UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
