### PR TITLE
docs: the live half of semantic search — a lexical gate must not veto a cosine ranking

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/QueryProviderParity.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/QueryProviderParity.md
@@ -185,6 +185,40 @@ also carries a `createdBy`; for any node type whose content does not, the same s
 empty. Fixing it is a MeshWeaver.Plugins change (widen `PropertyMap`), not a core one, and the
 corpus is the checklist.
 
+### The free-text divergence, and why it is not closable by widening a map
+
+Everything above is about **selectors**. The bare-text half of a query diverged too, and that one
+cannot be fixed by teaching one executor another column name — the two are answering genuinely
+different questions:
+
+| | `QueryEvaluator.GetFuzzyScore` (A) | Postgres (B) |
+|---|---|---|
+| free text | EVERY term must be a case-insensitive **substring** of the node's searchable text | **cosine distance** to the query's embedding, hybridised with a lexical tier |
+| a semantic neighbour sharing no literal token | no match | ranked in |
+| adding a word to the query | can only ever **narrow** | re-ranks |
+
+Before MeshWeaver.Plugins#1493 both were lexical and agreed. #1493 gave the unpinned fan-out a
+vector branch — and *that is what created the divergence*, because A is not dev-only: it is the
+live-query relevance gate on **every** backend. SQL ranked a row in; A, asked about the same row,
+said no; the change notification was dropped and the live query never re-read.
+
+🚨 **The direction is the dangerous one.** A stops the result set from ever updating, silently, on
+the exact queries the vector index was added to serve — and no test of the Initial read can see it.
+
+**A cannot be made to agree**, because it has no embeddings in memory and no business calling an
+embedding provider from a change-feed filter. So the resolution is not parity of *answers* but
+parity of *scope*: for a query that takes the semantic route, A is asked only the **structured**
+half (`parsed with { TextSearch = null }`) — the half both executors resolve identically — and the
+free-text half is dropped rather than answered wrongly. One predicate,
+`PostgreSqlPartitionedMeshQuery.TakesSemanticRoute`, is read by both the routing site and the gate,
+so the two cannot drift; a host with no embedding provider keeps the lexical contract on both sides.
+
+This is the general shape whenever B gains a capability A structurally lacks: **narrow what the
+weaker executor is asked, never let it veto on a question it cannot answer.** Erring toward an
+extra re-query is bounded; erring toward a veto drops rows and looks like an empty mesh.
+
+See [Vector Search](/Doc/Architecture/VectorSearch) for the routing and the no-provider fallback.
+
 ## A third resolver exists
 
 `MeshSearchView.razor.cs` (MeshWeaver.Plugins) carries its own private

--- a/src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md
@@ -102,6 +102,12 @@ routing site and the relevance gate, so they cannot drift apart again:
   the host's capability rather than on the outcome of a single embed call, stays widened. That is
   deliberately the safe direction — an extra re-query, never a dropped row.
 
+This is not a new idiom. `SqliteVectorMeshQuery` — the SQLite-local vector provider — has always
+filtered its cosine-ranked candidates with `parsed with { TextSearch = null }`, the identical
+expression, for the identical reason: once a vector ranks the rows, the evaluator's job is the
+structured half and nothing else. The Postgres fan-out's live gate was simply the one place the
+pattern had not reached.
+
 Pinned by `SemanticRelevanceGateParityTests` in MeshWeaver.Plugins, which carries the no-provider
 control and a `nodeType:` control — without the second, a gate that had been widened to "always
 relevant" would score identically on the first.

--- a/src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/VectorSearch.md
@@ -68,6 +68,45 @@ When the parsed query has a non-empty `TextSearch` **and** an `IEmbeddingProvide
 
 🚨 **Until MeshWeaver.Plugins#1493 (2026-09-08) the unpinned route was lexical only.** `GenerateTextSearchClause` demanded every whitespace-separated term as an ILIKE substring of name/path/description/node_type, AND-ed, so a natural-language query returned nothing mesh-wide while the same words pinned to one partition found their documents — measured on both production portals on 2026-09-07 (`asynchronous calls observable subscribe never await task namespace:Doc scope:descendants` → 3 hits; the same words unpinned → 0; the hit count shrank with every added word). The 80k stored embeddings were consulted exactly when a caller already knew where to look. A host with no embedding provider, and the Snowflake fan-out, keep the lexical contract — the table below describes a Postgres host with a provider.
 
+### 🚨 The live half: a semantic query must not be gated by a lexical matcher
+
+Ranking the *first* read semantically is only half of it. A `Query` is live — it re-reads when a
+change notification looks like it could alter the result set — and that relevance decision is taken
+by the **other** executor of the query language, in memory: `PostgreSqlPartitionedMeshQuery`'s
+`IsRelevant` asks core's `QueryEvaluator.Matches` whether a newly written node could enter.
+
+`QueryEvaluator.GetFuzzyScore` requires **every** term to be a case-insensitive substring of the
+node's searchable text. That is precisely the predicate the vector index replaced. So for one day
+after #1493 the two executors disagreed in the direction that drops rows: SQL ranked a semantic
+neighbour in, the in-memory gate answered `false` for the same node, the notification was dropped,
+and the live query never re-read. **A search that works on first paint and then silently stops
+updating is the same "returns nothing" symptom, deferred** — and it is invisible to any test that
+only measures the Initial read.
+
+The rule is now one predicate, `TakesSemanticRoute(parsed, semanticCapable)`, read by **both** the
+routing site and the relevance gate, so they cannot drift apart again:
+
+- **Semantic query** → the gate evaluates the **structured half only** (`parsed with { TextSearch =
+  null }`). `nodeType:`, `namespace:` and every `content.` selector are resolved identically by both
+  executors, so the gate stays narrow enough not to re-query on every write
+  (Systemorph/MeshWeaver#2194) — but the free-text half is **dropped rather than answered wrongly**.
+  Dropping it can only cost an extra re-query, which the serialised re-query path already bounds;
+  answering it lexically drops rows.
+- **No embedding provider, or a satellite table** (`nodeType:Thread` → `threads`, which carries no
+  embedding column) → nothing changes: the SQL is lexical there too, so `Matches` is the right
+  question and is asked unchanged. The capability is read as *is an `IEmbeddingProvider`
+  registered* — the same `GetService` signal described under the fallback below, which is why
+  `NullEmbeddingProvider` must never be registered as a default.
+- **A registered provider that returns `null` for one query** (a transient failure) is the one
+  asymmetric case: the SQL falls back to lexical for that query while the gate, which decides on
+  the host's capability rather than on the outcome of a single embed call, stays widened. That is
+  deliberately the safe direction — an extra re-query, never a dropped row.
+
+Pinned by `SemanticRelevanceGateParityTests` in MeshWeaver.Plugins, which carries the no-provider
+control and a `nodeType:` control — without the second, a gate that had been widened to "always
+relevant" would score identically on the first.
+
+
 **Routing examples:**
 
 | Query | TextSearch | Vector path? |


### PR DESCRIPTION
Docs-only. The core pages that describe a contract whose fix lands in
Systemorph/MeshWeaver.Plugins#1532.

## What happened

MeshWeaver.Plugins#1493 was *"unpinned free-text search never consults the vector index"*. #1495
fixed it by giving the cross-schema fan-out a vector branch — and in doing so created a divergence
in the **live** path, because the change-feed relevance gate asks the **other** executor of the
query language, which lives here:

`QueryEvaluator.GetFuzzyScore` requires **every** term to be a case-insensitive substring of the
node's searchable text — precisely the predicate the vector index replaced. SQL ranks a semantic
neighbour in; the in-memory gate answers `false` for the same node; the notification is dropped and
the live query never re-reads. **A search that works on first paint and then silently stops updating
is the same "returns nothing" symptom, deferred**, and no test of the Initial read can see it.

## Why this is a parity page, not a footnote

`QueryProviderParity.md` already documents the two executors and the selector drift between them.
This is the same failure mode on the free-text half — but it is **not closable by widening a map**,
which is what every case already on that page has in common. A has no embeddings in memory and no
business calling an embedding provider from a change-feed filter, so the two are answering
genuinely different questions and one of them cannot be taught the other's answer.

The resolution is therefore **parity of scope, not of answers**: ask the weaker executor only the
structured half, and never let it veto on a question it cannot answer. Erring toward an extra
re-query is bounded; erring toward a veto drops rows and looks like an empty mesh. That generalises
to any future case where B gains a capability A structurally lacks, which is why it is written up
rather than left in a commit message.

## Changes

- **`VectorSearch.md`** — a new *"The live half"* subsection under Routing: the divergence, the one
  shared predicate both the routing site and the gate now read, the no-provider behaviour (unchanged,
  and *announced* by the existing `EmbeddingCapabilityReporter` rather than silent), and the one
  asymmetric case (a registered provider that transiently returns `null`).
- **`QueryProviderParity.md`** — a new *"The free-text divergence"* subsection under
  *What is still divergent*, with the A-vs-B table and the scope-not-answers rule.

`Architecture.md` is deliberately **untouched** — both pages already exist and are already listed,
so this change cannot hit the #3699 conflict.

## Verification

`DocumentationLinkIntegrityTest` + `NoConflictMarkersGuard`: **2 passed / 0 failed**, re-run after
the final edit. Built `-c Release -warnaserror`: `0 Warning(s), 0 Error(s)`.

Pairs-with: none — documentation only; no public surface added, removed or changed.
