### PR TITLE
fix(operator): hosting::do narrates on stderr — a piped manifest reaches kubectl clean

### DIFF
--- a/deploy/aks/operator/bin/_common.sh
+++ b/deploy/aks/operator/bin/_common.sh
@@ -67,11 +67,20 @@ hosting::dry() { [ "${HOSTING_DRY_RUN:-false}" = "true" ]; }
 
 # Run a command, or narrate it when rehearsing. Use for every MUTATION.
 hosting::do() {
+  # 🚨 The narration goes to STDERR, never stdout. `hosting::do` wraps MUTATIONS, and a mutation can
+  # sit in a pipe whose consumer reads the command's output as data — hosting-deploy's
+  #   hosting::do kubectl create namespace … --dry-run=client -o yaml | kubectl apply -f -
+  # is one. Measured 2026-09-08 on memex (Deployments/memex-reconcile-20260908-ci8118): the
+  # `  + kubectl create namespace …` line went down the pipe as line 1 of the manifest, `apiVersion:
+  # v1` became line 2, and kubectl answered "yaml: line 2: mapping values are not allowed in this
+  # context" — the Reconcile stopped at step 1/3 before helm ran, and every Provision would have
+  # stopped at the same line. The job log (what the mesh's OperatorOutput parser reads) carries both
+  # streams, so nothing an operator reads changes; only the data channel is clean.
   if hosting::dry; then
-    printf '  DRY-RUN would run: %s\n' "$*"
+    printf '  DRY-RUN would run: %s\n' "$*" >&2
     return 0
   fi
-  printf '  + %s\n' "$*"
+  printf '  + %s\n' "$*" >&2
   "$@"
 }
 

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -60,6 +60,24 @@ emits() {
   case "$out" in *"$line"*) ok "$what" ;; *) bad "$what" "no '${line}' in: ${out}" ;; esac
 }
 
+# ── hosting::do keeps the DATA channel clean ────────────────────────────────────────────────────
+# A wrapped mutation can feed a pipe (hosting-deploy: `hosting::do kubectl create namespace …
+# -o yaml | kubectl apply -f -`). Its narration must therefore never share stdout with the
+# command's output. Measured 2026-09-08 on memex: the narration became line 1 of the manifest and
+# kubectl refused it ("yaml: line 2: mapping values are not allowed in this context"), stopping the
+# Reconcile at step 1/3 — and a Provision at the same line. Asserted BYTE-FOR-BYTE, not "contains":
+# a leading narration line would still contain the manifest.
+_manifest=$'apiVersion: v1\nkind: Namespace'
+_piped="$(bash -c 'source "$1"; hosting::do printf "%s\n" "$2"' _ "$BIN/_common.sh" "$_manifest" 2>/dev/null)"
+if [ "$_piped" = "$_manifest" ]; then ok "hosting::do narrates on stderr — a piped consumer gets only the command's stdout"
+else bad "hosting::do narrates on stderr — a piped consumer gets only the command's stdout" "stdout carried: ${_piped}"; fi
+_dry="$(HOSTING_DRY_RUN=true bash -c 'source "$1"; hosting::do printf "%s\n" "$2"' _ "$BIN/_common.sh" "$_manifest" 2>/dev/null)"
+if [ -z "$_dry" ]; then ok "hosting::do under DRY-RUN writes nothing to stdout either"
+else bad "hosting::do under DRY-RUN writes nothing to stdout either" "stdout carried: ${_dry}"; fi
+_narrated="$(bash -c 'source "$1"; hosting::do true' _ "$BIN/_common.sh" 2>&1 >/dev/null)"
+case "$_narrated" in *"+ true"*) ok "hosting::do still narrates the command (on stderr)" ;;
+  *) bad "hosting::do still narrates the command (on stderr)" "stderr was: ${_narrated}" ;; esac
+
 # Assert a command did NOT stop at a specific guard. It may still fail for want of az/kubectl —
 # what matters is that the named refusal is not the reason, i.e. execution got past that guard.
 not_refused_by_guard() {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-record-driven-deploy-no-longer-stops-before-helm.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-a-record-driven-deploy-no-longer-stops-before-helm.md
@@ -1,0 +1,37 @@
+---
+Name: A record-driven deploy no longer stops before Helm
+Category: Fix
+Description: A Reconcile or Provision run by the hosting operator stopped at its first step — "could not ensure namespace" — because the operator's own narration was handed to kubectl as part of the namespace manifest. The narration now goes where a log line belongs, and the manifest reaches kubectl clean.
+Icon: Wrench
+Order: -20260908
+---
+
+Rolling an instance from its `Deployments/<name>` record — a `Reconcile`, and the `Provision` of a
+new instance — starts with the operator making sure the namespace exists. On 2026-09-08 that step
+failed on the first record-driven roll of memex:
+
+```
+hosting-deploy: ERROR: could not ensure namespace memex
+error parsing STDIN: yaml: line 2: mapping values are not allowed in this context
+```
+
+## What was happening
+
+The operator narrates every mutation it runs (`  + kubectl create namespace …`) so the run's log
+tells you what it did. That narration was written to the same stream as the command's output — and
+this particular command's output is a YAML manifest that is piped straight into `kubectl apply`.
+kubectl therefore received the narration as line 1 of the manifest and refused line 2.
+
+A `Restart` was unaffected (its steps pipe nothing), which is why a restart could roll the pods
+earlier the same day while a reconcile of the same instance could not.
+
+## What it does now
+
+Narration is written to the log's error stream, so the data a wrapped command produces is exactly
+what the next command receives. The operator's test suite now asserts this byte-for-byte: a
+manifest piped through the wrapper comes out identical, a dry run writes nothing to the data
+channel, and the narration is still there — on the stream a log reader sees.
+
+The operator image carrying this fix has to be named on each instance's record
+(`operator.image`); until it is, a `Reconcile` or `Provision` on that instance stops at the same
+line.


### PR DESCRIPTION
## `hosting::do` narrates on stderr — a piped manifest reaches kubectl clean

**Measured 2026-09-08, memex.systemorph.com**, the first record-driven roll (`Deployments/memex-reconcile-20260908-ci8118`, Reconcile onto `3.0.0-ci.8118`), step 1/3 "Re-apply the record":

```
hosting-deploy: ERROR: could not ensure namespace memex
error: error parsing STDIN: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
```

`hosting-deploy` pipes `hosting::do kubectl create namespace … --dry-run=client -o yaml` into `kubectl apply -f -`. `hosting::do` printed its `  + kubectl create namespace …` narration on **stdout**, so the consumer received the narration as line 1 of the manifest and `apiVersion: v1` as line 2. A `Restart` (no pipe in its steps) rolled the same instance fine minutes earlier; every `Provision` runs the same ensure-namespace step and would stop at the same line — which is why Pearl's first Provision was held.

**Fix:** the wrapper's narration goes to stderr in both branches (real run and DRY-RUN). The job log the mesh's `OperatorOutput` parser reads carries both streams, so nothing an operator reads changes; only the data channel is clean.

**Test (falsifying):** three byte-exact cases in `deploy/aks/operator/test/run-tests.sh` — a manifest piped through `hosting::do` comes out identical; dry-run writes nothing to stdout; the narration is still there on stderr. Against the previous wrapper: `129 passed, 3 failed`. With the fix: `132 passed, 0 failed`. `shellcheck -S warning` clean on both files.

**Delivery:** after merge the `publish` job pushes `meshweaver.azurecr.io/hosting-operator:<short sha>`; each instance's record must name it under `operator.image` (memex still names `5e80ee3`) — I do that on the memex record next, then re-file the Reconcile. Doc: What's New (Fix).
