### PR TITLE
test(#3732): pin the witness to the runtime's resolver, and say what #3748 masks

### DIFF
--- a/src/MeshWeaver.Compiler/PlatformShippedAssemblies.cs
+++ b/src/MeshWeaver.Compiler/PlatformShippedAssemblies.cs
@@ -66,6 +66,25 @@ public sealed record PlatformShippedAssembly(string Name, PlatformShipping How, 
 ///     witness that reads only <c>/app</c> answers "not shipped" for every seeded module.</item>
 /// </list>
 ///
+/// <para>🚨 <b>Readings (1) and (3) are the RUNTIME's own two probe locations, in the runtime's own
+/// order</b> — <c>MeshBuilder.ResolveModulePath</c> tries <c>&lt;app&gt;/modules/&lt;name&gt;/&lt;name&gt;.dll</c>
+/// and then <c>&lt;app&gt;/&lt;name&gt;.dll</c>. So "the platform ships this" means here exactly what it
+/// means to the loader that will bind it, and #3735/#3748's image-baseline fallback resolves a
+/// module through that same call. The correspondence is pinned by
+/// <c>PlatformShippedAssembliesTest.TheWitnessProbesTheSamePlacesTheRuntimeResolverDoes</c> rather
+/// than left to coincidence: if the resolver ever grows a third location, that guard goes red here.
+/// Reading (2) has no runtime counterpart by design — it is a compile-time fact about the host, and
+/// a manifest name is in the app closure by construction.</para>
+///
+/// <para>🚨 <b>#3748 recovers from this condition; it does not remove it — and it MASKS the
+/// symptom.</b> When no landed generation of a module loads, the portal now falls back to the
+/// image-shipped copy, so a portal can render correctly while its publication still carries two
+/// builds of one name. Never read "the controls render" as evidence a bundle is clean. Two things
+/// the fallback cannot reach: a riding copy that DOES load shadows the image copy and the fallback
+/// never runs; and <c>PublishedBundleCatalogue</c>'s two-builds conflict still answers
+/// <c>SealedSetInconsistent</c>, which HOLDS the roll for the whole fleet regardless of what any
+/// one process does at boot.</para>
+///
 /// <para><b>It refuses rather than answering nothing.</b> A directory with no surface manifest and
 /// no <c>MeshWeaver.*</c> assembly at its root is not a platform application directory, and
 /// answering "ships nothing" for one would make every caller's strip a no-op that reads exactly

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -55,6 +55,16 @@ tried, the module "contributed nothing", and every skinned control on the portal
 its fallback HTML. The probe was not the gap; the fallback order was, and this section is what
 closes it.
 
+🚨 **This is the CONSUMER half, and it masks the producer's defect rather than removing it.** A
+portal that falls back to the image copy renders correctly while its publication still carries two
+builds of one assembly name, so *"does it render"* is not evidence a bundle is clean. The producer
+half — a module bundle never carrying a `MeshWeaver.*` copy the platform already ships, measured off
+the image rather than declared in a list — is
+[The Platform-Shipped Witness](../PlatformShippedWitness), and it probes the same two locations
+`MeshBuilder.ResolveModulePath` does, on purpose. Two things this fallback cannot reach: a riding
+copy that *does* load shadows the image copy, so the fallback never runs; and the sealed-set
+conflict below still HOLDS the roll for the whole fleet whatever one process does at boot.
+
 ## What the platform roll gates on
 
 The self-updater and the CD post-promote gate select **the newest release on which no installed module is unloadable**. Concretely, per installed package: a build published for the target identity exists (it will be adopted), *or* the landed generation links against the target's surface, *or* neither can be shown — which is reported as *indeterminate*, never as clearance and never as a hold. Declared floors do not enter. A missing content bake does not enter (it is reported as "would compile at boot: …"). The sealed-set consistency check (#3175/#3221) stays: two builds of one platform assembly in one identity is a torn publication, and torn publications are refused whole.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformShippedWitness.md
@@ -76,6 +76,41 @@ seeded module, which is precisely the 27 slots above.
 returns each name with the **provenance and the evidence path** that answered, so a strip decision
 in a pack log names a file rather than an opinion.
 
+### Readings 1 and 3 are the LOADER's own two probe locations
+
+This is not a parallel definition of "the platform ships it" — it is the runtime's.
+`MeshBuilder.ResolveModulePath` answers *where does this deployment's copy of module X live* by
+probing `<app>/modules/<name>/<name>.dll` first and `<app>/<name>.dll` second, which are readings
+(3) and (1) in the resolver's own order. So the packer that strips a riding copy and the loader that
+would otherwise have had to choose between two of them mean the same thing by the same test — and it
+is the very call [#3735/#3748's image-baseline fallback](../ModuleAdoptionPolicy) resolves through.
+
+`PlatformShippedAssembliesTest.TheWitnessProbesTheSamePlacesTheRuntimeResolverDoes` pins the
+correspondence: a resolver that grows a third probe location, or reorders the two, fails there and
+names the reading the witness is missing. Reading (2) has no runtime counterpart by design — it is a
+compile-time fact about the host, and a manifest name is in the app closure by construction.
+
+### 🚨 #3748 recovers from this condition; it does not remove it — and it masks the symptom
+
+The image-baseline fallback (#3735, merged as #3748) makes a portal *survive* the condition: when no
+landed generation of a module loads, it falls back to the copy the image ships, and the module runs.
+That is the right behaviour and it is why memex.systemorph.com's controls render again.
+
+**It does not make shipping two builds correct, and three things follow:**
+
+* **"Does it render" is never the test for this defect.** A portal can render perfectly while its
+  publication still carries two builds of one assembly name. Every assertion here is on the
+  bundle's own bytes — the manifest's declared closure and the archive's entries — which is upstream
+  of the load side entirely.
+* **The fallback only fires when NOTHING loads.** A riding copy that *does* load shadows the image
+  copy, wins the process by arrival order, and the fallback never runs. That is the case the strip
+  prevents, and it is the common one.
+* **The roll is still held.** `PublishedBundleCatalogue`'s two-builds conflict answers
+  `SealedSetInconsistent` for every package binding the name, and `ReleaseAvailability.IsUpdatable`
+  turns that into a HOLD for the whole fleet — independent of what any single process does at boot.
+  #3748 touches neither type. See [Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide) → "The
+  invariant that replaces it".
+
 ### It refuses rather than answering nothing
 
 A directory with no surface manifest and no `MeshWeaver.*` assembly at its root is **not** a platform

--- a/test/MeshWeaver.Graph.Test/PlatformShippedAssembliesTest.cs
+++ b/test/MeshWeaver.Graph.Test/PlatformShippedAssembliesTest.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using MeshWeaver.Compiler;
+using MeshWeaver.Mesh;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -27,6 +28,17 @@ public class PlatformShippedAssembliesTest : IDisposable
         {
             if (Directory.Exists(root))
                 Directory.Delete(root, recursive: true);
+            // The resolver-agreement guard seeds a probe under the TEST HOST's own base directory —
+            // the one directory MeshBuilder.ResolveModulePath treats as "the app" — so it is removed
+            // here rather than left behind for the next run's witness to read as a shipped module.
+            // 🚨 The probe's own folder ONLY. An empty `modules/` beside the app is inert (the
+            // witness enumerates its subdirectories and finds none, the resolver falls through to
+            // the app closure), and deleting it would delete a layout a build may legitimately have
+            // produced — the module-closure lane writes exactly that folder for a real host.
+            var probe = Path.Combine(
+                AppContext.BaseDirectory, PlatformShippedAssemblies.SeededModulesFolder, ProbeName);
+            if (Directory.Exists(probe))
+                Directory.Delete(probe, recursive: true);
         }
         catch
         {
@@ -159,6 +171,60 @@ public class PlatformShippedAssembliesTest : IDisposable
         Assert.Null(shipped);
         Assert.Contains("does not exist", problem!, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// 🚨 <b>THE WITNESS AND THE LOADER PROBE THE SAME TWO PLACES, IN THE SAME ORDER — pinned, not
+    /// assumed.</b> <c>MeshBuilder.ResolveModulePath</c> is the runtime's own answer to "where does
+    /// this deployment's copy of module X live": <c>&lt;app&gt;/modules/&lt;name&gt;/&lt;name&gt;.dll</c>
+    /// first, then <c>&lt;app&gt;/&lt;name&gt;.dll</c>. Those are readings (3) and (1) of the witness,
+    /// which is what makes "the platform ships this" mean the same thing to the packer that strips a
+    /// riding copy and to the loader that would have had to choose between two of them — and it is
+    /// the very call #3735/#3748's image-baseline fallback resolves through.
+    ///
+    /// <para>Without this guard the agreement is a coincidence of two files written days apart. With
+    /// it, a resolver that grows a third probe location — or reorders the two — fails HERE, naming
+    /// the reading the witness is missing, instead of silently letting a bundle carry a copy of
+    /// something the loader would have found on its own.</para>
+    ///
+    /// <para>Run against <see cref="AppContext.BaseDirectory"/>, because that is the one directory
+    /// the resolver treats as "the app" — it reads it from <c>AppContext</c>, not from an argument.
+    /// The probe name is unique to this test so a parallel class cannot collide with it, and the
+    /// seeded folder is removed in <see cref="Dispose"/>.</para>
+    /// </summary>
+    [Fact]
+    public void TheWitnessProbesTheSamePlacesTheRuntimeResolverDoes()
+    {
+        var app = AppContext.BaseDirectory;
+        var entry = ProbeName + ".dll";
+
+        // (1) the app closure — the resolver's LAST resort, and what it returns when nothing is
+        //     seeded. The witness records exactly this path as ApplicationClosure evidence.
+        Assert.Equal(
+            Path.Combine(app, entry),
+            MeshBuilder.ResolveModulePath(entry));
+
+        // (3) the seeded-module lane — the resolver's FIRST choice once the file is there, and the
+        //     path the witness records as SeededModule evidence.
+        var seeded = Path.Combine(app, PlatformShippedAssemblies.SeededModulesFolder, ProbeName);
+        Directory.CreateDirectory(seeded);
+        File.WriteAllText(Path.Combine(seeded, entry), "probe");
+        Assert.Equal(
+            Path.Combine(seeded, entry),
+            MeshBuilder.ResolveModulePath(entry));
+
+        // And the witness reads that very file, at that very path, as the reason the name is shipped.
+        var (shipped, problem) = PlatformShippedAssemblies.Read(app);
+        Assert.Null(problem);
+        Assert.True(shipped!.ContainsKey(ProbeName),
+            "the witness must see what the resolver just resolved — otherwise a bundle would carry a "
+            + "copy of an assembly the loader finds on its own");
+        Assert.Equal(PlatformShipping.SeededModule, shipped[ProbeName].How);
+        Assert.Equal(MeshBuilder.ResolveModulePath(entry), shipped[ProbeName].Evidence);
+    }
+
+    /// <summary>A name no real assembly carries, so the probe cannot collide with a parallel test
+    /// class or with anything the test host genuinely ships.</summary>
+    private const string ProbeName = "MeshWeaver.ResolverAgreementProbe";
 
     [Theory]
     [InlineData("MeshWeaver", true)]


### PR DESCRIPTION
Follow-up to #3751 (which fixed #3732's defect 2). #3748 — the image-baseline fallback (#3735) —
merged 40 minutes later and is the **load** side of the same subject. It is complementary, not
duplicate, and three things follow. All three are handled here; no production behaviour changes.

## 1. It supplies the predicate — and the agreement was a coincidence until now

`MeshBuilder.ResolveModulePath` is the runtime's own answer to *where does this deployment's copy of
module X live*:

```
<moduleRoot>/modules/<name>/<name>.dll   ← the landed tree (not the image)
<app>/modules/<name>/<name>.dll          ← reading (3) of the witness
<app>/<name>.dll                         ← reading (1) of the witness
```

Those last two are exactly readings (3) and (1), **in the resolver's own order** — and
`ResolveModulePath` is the very call #3748's fallback resolves the image copy through. So "the
platform ships this" already meant the same thing to the packer that strips a riding copy and to the
loader that would otherwise have had to choose between two of them. It just was not written down or
checked.

`PlatformShippedAssembliesTest.TheWitnessProbesTheSamePlacesTheRuntimeResolverDoes` pins it:

* asks the resolver for a probe name **before** the seeded file exists → the app-closure shape;
* creates `<app>/modules/<probe>/<probe>.dll` and asks again → the seeded shape.
  The two answers differ, so both branches are demonstrably exercised — that is the guard's own
  positive control, not an assumption;
* then asserts the witness sees that name **and that its recorded evidence path equals what the
  resolver returned**.

A resolver that grows a third probe location, or reorders the two, now fails there naming the
reading the witness is missing — instead of silently letting a bundle carry a copy of something the
loader finds on its own. Reading (2), the surface manifest, has no runtime counterpart by design: it
is a compile-time fact about the host, and a manifest name is in the app closure by construction.

## 2. 🚨 It masks the symptom — "does it render" is not the test

A portal that falls back to the image copy renders correctly **while its publication still carries
two builds of one assembly name**. So a healthy memex.systemorph.com is not evidence any bundle is
clean. Recorded in `PlatformShippedAssemblies`' own remarks and in the doc, because the next
reader's instinct will be to check the portal.

This changes nothing about the existing tests: every assertion in #3751 is on the **bundle's bytes**
— the manifest's declared closure and the archive's entries — which is upstream of the load side
entirely. The condition-reproduced test asserts the ridden bytes *differ* from the host's own copies;
no rendering, no portal, no fallback anywhere in it.

## 3. It does not remove the defect, in two named ways

* **A riding copy that DOES load shadows the image copy, and the fallback never runs.** #3748 fires
  only when *no* landed generation loads. The common case is the riding copy loading fine and
  winning the process by arrival order — which is precisely what the strip prevents.
* **The roll is still held.** `PublishedBundleCatalogue`'s two-builds conflict answers
  `SealedSetInconsistent` and `ReleaseAvailability.IsUpdatable` turns that into a HOLD for the whole
  fleet, independent of what any single process does at boot. #3748 touches neither type (its file
  list is `MemexConfiguration`, `MeshBuilder`, `ModuleInstallCandidate`, `ModuleActivation`,
  `ModuleSet`, `PendingModuleActivations` + docs).

So the producer half stands: a recovery path does not make shipping two builds correct, and the
wasted bytes and the ambiguity remain.

## Files

Zero overlap with #3748's — which is also why #3751 merged clean through the queue after it.

| | |
|---|---|
| `src/MeshWeaver.Compiler/PlatformShippedAssemblies.cs` | remarks: the two readings ARE the resolver's; what #3748 masks |
| `test/MeshWeaver.Graph.Test/PlatformShippedAssembliesTest.cs` | the resolver-agreement guard (+ its cleanup, and why it removes only the probe's own folder) |
| `Doc/Architecture/PlatformShippedWitness` | two sections: the loader correspondence, and #3748's three consequences |
| `Doc/Architecture/ModuleAdoptionPolicy` | the page #3748 wrote now names the producer half, so the two are reachable from each other |

## Verified locally

| | |
|---|---|
| `MeshWeaver.Graph.Test` `-c Release -warnaserror` | `0 Warning(s) 0 Error(s)` |
| `MeshWeaver.Documentation.Test` `-c Release -warnaserror` | `0 Warning(s) 0 Error(s)` |
| `MeshWeaver.Graph.Test` | **1472 passed**, 0 failed (was 1468 + the guard + the 3 from #3751 already on main) |
| `MeshWeaver.Documentation.Test` | **361 passed**, 0 failed |

Pairs-with: none — no public type or member leaves `src/` (remarks, a test, and two doc pages).
Implementers: none — no member added to a public interface or abstract class.
Mirror-sync: none — no i18n catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
