### PR TITLE
fix(#2543): a response continuation no longer runs on the responding hub's action block

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
@@ -391,6 +391,55 @@ hop. The first draft of that test asserted the opposite and failed. **So a creat
 block for 24.9 s is doing something this path does not normally do**, and "the create pipeline is
 expensive" is not the answer.
 
+## 🚨 CORRECTION (2026-09-08): half of the paragraph above is wrong, and the fix is one line
+
+Everything above about the *request turn* holds. Two inferences drawn from it do not, and both were
+falsified by measurement rather than by re-reading the code.
+
+**Correction 1 — `Executing(T, N ms)` does NOT measure time on the block.** The mechanism is stated
+correctly earlier in this page (`currentlyExecutingMessageType` is cleared in the handler
+observable's `.Finally`) and then read the wrong way round. `.Finally` fires when the handler's
+**observable completes** — i.e. when the whole detached chain finishes — not when the pump is
+released. So the field measures the handler's in-flight LIFETIME, including every pooled hop the
+chain has already left the block for. Demonstrated: with a create parked in its validator, that
+counter read `Executing(CreateNodeResponse, 36001ms)` and tracked the observer's sampling window
+exactly. **Therefore #2543's `Executing(CreateNodeRequest, 24888ms)` never established that the
+block was held for 24.9 s** — the `buffer=45` beside it is the part that was real. The
+`drainsInFlight` table above inherits this error and reads `> 0` as "a thread is inside the
+handler"; it is "a chain is still in flight", which is not the same claim.
+
+**Correction 2 — the create pipeline DID hold the block, via its continuation.** The request turn
+is genuinely free (`HANDLER_EXIT state=Processed` at +1 ms, confirmed on the fate trail). But the
+detached chain does a partition bootstrap, whose nested response comes back to the SAME hub as a NEW
+turn — and the rest of the pipeline, validators included, ran inline inside that response's turn.
+The earlier reading of an idle hub was taken at a single instant before that turn began, and in
+isolation the path differs; under load the test caught it at 0–1 ms and the assertion read it as
+noise.
+
+**How it was settled — behaviourally, because the snapshot fields cannot decide it.** With a create
+parked, post an INDEPENDENT node create to the same hub:
+
+| | result |
+|---|---|
+| probe alone, nothing parked (**positive control**) | completes promptly |
+| same probe, while a create is parked | never runs — `Queue(buffer=1,…)` for the whole budget |
+
+The control is what makes the second row mean "the pump is held" rather than "this probe never
+completes anyway".
+
+**The fix, and it is not in the node-CRUD path at all.** A response subject is signalled from inside
+the turn that handled the response, and Rx runs a continuation on the thread that signalled it — so
+*every* `hub.Observe(x).SelectMany(…)` chain in the framework ran its remainder on that hub's action
+block, inside that turn. `MessageHub.ContinueOffBlockRestoringUserContext` now hops the continuation
+off the block (`ObserveOn`) before restoring the caller's identity — the hop must precede the
+identity restore, or the chain resumes unauthenticated. Create, delete, move and copy are fixed by
+the same line because they all await nested node ops the same way.
+
+`NodeCrudDoesNotOccupyTheExecutionBlockTest` carries the three tests: the probe, its positive
+control, and `TwoCreates_AreInFlightSimultaneously`, which parks two creates at once and requires
+both validators to be entered before either is released. With the hop removed the first and third
+fail and the control still passes; that pairing is the evidence, not the green.
+
 Two shapes remain, and the `drainsInFlight` table above picks between them:
 
 - **A blocking construct in the composition prologue.** Exactly one exists on the path:

--- a/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
@@ -204,12 +204,244 @@ those two instants is larger than the entire margin. See
 5. Signature counts (`STALE-CALLBACK`, `ADVANCE_WITHOUT_HANDOFF`) are **amplitude, not identity** —
    they are present in passing runs too. The fate trail discriminates; the counts do not.
 
+## 🚨 2026-09-08 — the capture this page reasons from was read through a BROKEN INSTRUMENT
+
+Everything above that says *"the hub stops draining"* rests on one dump, quoted twice on this page
+and throughout [#2543](https://github.com/Systemorph/MeshWeaver/issues/2543):
+
+```
+Reader: Hub portal/nodeops-… RunLevel=Started Queue(buffer=45,deferred=0,exec=0)
+  Executing(CreateNodeRequest, 24888ms)
+```
+
+**`exec=0` measured nothing.** `MessageService.GetQueueSnapshot` returned a **hard-coded literal
+`0`** in that position — a leftover from the TPL-Dataflow pump that the turn loop replaced — so it
+was true of every snapshot ever taken, on every hub, in every state. It is the field a reader
+naturally takes as *"no drain is running"*, i.e. as the very evidence that the pump has stopped, and
+it never said that about anything. Replaced by a live `Interlocked` count in
+[#3593](https://github.com/Systemorph/MeshWeaver/issues/3593) (`4e440f630`, **2026-09-07T15:05Z** —
+about an hour after the last comment on #2543, so **no reading in that entire thread used the fixed
+instrument**). The same commit renamed `deliveryActionCompleted`, whose printed name asserted the
+negation of its datum, to `draining`. Full taxonomy:
+[Reading a Disposal Stall Verdict](../DisposalStallVerdicts).
+
+🚨 **And there are TWO diagnostics here, not one — which is why the dumps were never found.**
+Measured over the 61 bake jobs (see the denominator below): the `Hub <address> RunLevel=… exec=…`
+form is `GetPendingRequestDiagnostics`, written on a **disposal stall**, and it fires **0 times in
+1,512,136 log lines**. `exec=` therefore appears **nowhere** in a live bake — searching for it finds
+nothing and reads as "no dumps exist". What a bake actually emits is
+`BuildTimeoutMessage`'s clause, embedded in every hub `TimeoutException` and beginning
+**`This hub:`** (lower-case *h*) — **34 occurrences in 20 of 61 jobs.** Its old-vocabulary field is
+`deliveryActionCompleted`, not `exec`; #3593 renamed both. Grep for `This hub: RunLevel=`, never for
+`Hub .* Queue\(buffer=`.
+
+### 🚨 The 34 dumps describe the WRONG HUB — and the message says so itself
+
+Every one of the 34 is the **requester** talking about itself, and all 34 are byte-identically idle:
+
+```
+This hub: RunLevel=Started Queue(buffer=0,deferred=0,openGates=0,drainsInFlight=0,draining=False).
+This hub was idle while waiting, so it processed everything delivered to it and the silence is
+upstream of here. Cause is UNKNOWN between: the target never received the request (routing), the
+target received it and is wedged …, or the target answered and the reply was lost.
+This message cannot distinguish them; the target's own RunLevel and queue can.
+```
+
+`buffer=0, deferred=0, openGates=0, drainsInFlight=0, draining=False` in **34 of 34**; `Executing(`
+absent in **34 of 34** (the clause is appended only when a handler is on the block). 32 of the 34 are
+`CreateOrUpdateNodeRequest → portal/nodeops-…`.
+
+**The last sentence names the measurement and nothing takes it.** `portal/nodeops`' own `RunLevel`
+and queue have not been observed since the single 2026-08-28 capture — not because the state is hard
+to read, but because no diagnostic in the system prints the TARGET's. That is the gap
+`[STALE-CALLBACK] … TARGET …` closes.
+
+### What survives, and what was never established
+
+`Executing(T, N ms)` **is** a real measurement and always was: `MessageService.RunHandler` sets
+`currentlyExecutingMessageType` immediately before `HandleMessageAsync` and clears it in that
+observable's `.Finally`. So the dump does say a `CreateNodeRequest` handler had been on the block for
+24.9 s with 45 turns behind it — and since `MessageService.DrainLoop` advances **only** when a turn's
+observable terminates (`Terminal()` is the sole thing that re-schedules the drain; no timer, no
+watchdog, nothing else restarts it), those 45 were going nowhere until it did.
+
+What was never established is **which of the two roots** that is, because they are the same picture
+until `drainsInFlight` is read beside it:
+
+| `drainsInFlight` | `Executing(T, N ms)` | Reading |
+|---|---|---|
+| **> 0** | set | A **thread is inside the handler** and has been for N ms. The turn is BLOCKED, not slow — look for a synchronous wait taken on the block. |
+| **0** | set | **No thread is in the handler**, yet the turn's observable has not terminated. The handler returned something that never completes; the terminal is owed by an async leaf. |
+| 0 | absent, `draining=True`, `buffer>0` | The drain was **scheduled and never ran** — a scheduling stall in the target, not a handler at all. |
+| 0 | absent, `buffer` small | The target is **IDLE**. The silence is not queueing; look at the reply leg. |
+
+Those are four different defects. Rows 1 and 2 are the two candidates named below, and until
+2026-09-07 nothing in the fleet could tell them apart.
+
+### The instrument now emits itself — no dump to capture
+
+The reason the 08-28 dump *"has not been reproduced since"* is that nothing emits it on a live mesh:
+the hub reader dump is written on a **disposal stall**, and a mesh saturating mid-bake never reaches
+one. Meanwhile `[STALE-CALLBACK]` fires every 5 s and 300+ times in a failing bake — and described
+the wrong hub. Every field on it (`{Address}`, the pending list, the pool counters) belongs to the
+hub that is **waiting**, and a waiting hub is idle by construction, so the line reported truthfully
+and uselessly that the reporter had nothing to do. The hub whose state decides the verdict is the
+TARGET named inside the detail (`…@portal/nodeops-…`), and it was never described.
+
+It is now. `MessageHub.ScanStaleCallbacks` resolves each distinct target to a local hub — a pure
+read, `HostedHubCreation.Never`, because a diagnostic must never construct a hub — and appends its
+turn-loop state:
+
+```
+[STALE-CALLBACK] Hosting/Admin: 1 callback(s) pending > 30000ms: …=CreateOrUpdateNodeRequest@portal/nodeops-…(31018ms)
+  [pool threads=12 pendingWork=0 completed=88401]
+  TARGET portal/nodeops-… RunLevel=Started Queue(buffer=45,deferred=0,drainsInFlight=1,openGates=0,draining=True) Executing(CreateNodeRequest, 24888ms)
+```
+
+Deliberately the COMPACT snapshot (`GetTurnLoopSnapshot`), not `GetPendingRequestDiagnostics`: the
+target's own callback list runs to kilobytes and multiplying that by 300 lines is how a hub once
+emitted a ~100 KB line that broke the TRX parsers. Capped at three distinct targets per line. The
+target's own scanner tick prints its callbacks.
+
+### The denominator, 2026-09-07T00:00Z → 2026-09-08T18:45Z
+
+Every `Plugins: bake + seal … / Bake + publish NodeType assemblies to portal storage` job in core's
+`Continuous Delivery (main)` (workflow `303778518`): 182 runs created, 80 non-cancelled, **61 bake
+jobs**, **61/61 logs fetched, 0 unfetchable**, 0 re-attempts. Durations 8m23s / 24m30s / 33m41s
+(min / median / max).
+
+| | count | of 61 |
+|---|---:|---:|
+| `success` | 50 | 82 % |
+| `failure` | 11 | 18 % |
+| carrying `GATE FAILED` | **6** | **9.8 %** |
+| `ADVANCE_WITHOUT_HANDOFF` present | 61 | **100 %** |
+| `STALE-CALLBACK` present | 59 | 97 % |
+| `OwnerUnreachable` present | 25 | 41 % |
+| `PATCH_ECHO_SEEN` present | 16 | 26 % |
+| `Executing(` present | **0** | **0 %** |
+
+🚨 **Only 6 of the 11 failures are this defect.** The other 5 are a concurrent-publish collision on
+the prebuilt-bundles PVC (*"the shelf holds a different sha"*, *"could not read back after uploading
+it"*) — a different bug that a `failure` conclusion alone does not separate. **Counting red bake
+jobs overstates this issue by ~2×**; count `GATE FAILED`.
+
+And the weak form is **universal, not diagnostic**: `ADVANCE_WITHOUT_HANDOFF` is present in 61 of 61
+jobs including all 50 green ones. Signature counts are amplitude; presence discriminates nothing.
+
+**One cohort worth re-measuring before anything else.** Splitting the 61 on `3893dc486`
+(*"arm the patch flush bound BEFORE the flush is built"*, merged 2026-09-08T06:55Z — the #3510 fix
+whose reasoning is recorded at the end of this page):
+
+| cohort | n | `OwnerUnreachable` jobs | `PATCH_ECHO_SEEN` jobs | `GATE FAILED` |
+|---|---:|---:|---:|---:|
+| before `3893dc486` | 45 | 25 (56 %) | 16 (36 %) | 6 |
+| **after** | **16** | **0** | **0** | **0** |
+
+The last `OwnerUnreachable` and the last `PATCH_ECHO_SEEN` in the whole window are the **same log
+line**, 2026-09-08T07:45:53Z; the first post-fix bake started 08:35:34Z. 🚨 **Confounded, and not to
+be banked**: all 16 post-fix jobs are short (≤ 23m31s), and prevalence tracks duration — the
+duration-matched pre-fix rate is 4/13 (31 %) and 2/13 (15 %), so n=16 clean is suggestive, not
+decisive. Re-measure once a long post-fix bake exists. This is the *write-verdict* half; it says
+nothing about queue latency on `nodeops`.
+
+**Where it does NOT reproduce.** In core outside the bake, over 32 jobs / 426 k lines
+(`Doc content compiles and runs` ×16, `Run tests (shard 0)` ×16): `STALE-CALLBACK`,
+`OwnerUnreachable` and `PATCH_ECHO_SEEN` are **0**; only `ADVANCE_WITHOUT_HANDOFF` appears, twice.
+🚨 The issue's claim that this reproduces in PR gates is about `test-repos / Compile + render node
+repos` and `Gate shard`, which are `node-repo-gate.yml` jobs — **core never calls that workflow**;
+they exist only in the satellites. That half is still unmeasured.
+
+🚨 **Scope — this covers the SATURATION shape, not the release-wave park.** The 2026-09-07 reading
+below measured **zero** `[STALE-CALLBACK]` lines during its eight-minute park, so an instrument
+riding on that line says nothing about it (#3510 closed that one separately). What it covers is the
+shape this page's first half measures: bimodal queue latency with a wall of stale callbacks, where
+by construction the line fires and the target is exactly the hub in question.
+
+**Calibration, so the reading is not itself a guess.** `NodeCrudTurnStateIsMeasuredTest` parks a real
+`CreateNodeRequest` inside the node-CRUD execution hub's turn (an `INodeValidator` that blocks —
+the same harness [The /api/content 503](../ContentRoute503) uses to establish that a validator runs
+*inside* that turn) and asserts the hub then reports `drainsInFlight` non-zero with
+`Executing(CreateNodeRequest, …)`; a negative control asserts an idle hub reports neither. That pair
+is what stops the field quietly becoming a constant again — which is the whole defect above, and
+the reason a field that cannot fail is not a measurement.
+
 ## Open — what the next measurement must be
 
-**Which rule holds `nodeops`' action block?** The 25 s `Executing(CreateNodeRequest, …)` capture is
-from 2026-08-28 and has not been reproduced since; today's job logs carry no hub-reader dump. Until
-that is measured, the saturation's *cause* is named but not identified. Two candidate shapes, both
-consistent with the actor loop awaiting the full rule chain:
+**Which rule holds `nodeops`' action block?** Not a rule at all: the fold has been walked and
+**no rule after the create handler can hold it**. `Executing(T, ms)` is set inside
+`MessageService.RunHandler`, so the window it measures is `HandleMessageAsync` — the rule fold —
+and nothing before it. (Worth knowing on its own: `AccessControlPipeline`'s permission fold is a
+DELIVERY-PIPELINE step, not a rule, so it runs while `Executing` reads *idle*. It is the obvious
+"IO per delivery" suspect and the field would never have shown it.)
+
+Inside the fold, the eight `WithNodeOperationHandlers` handlers are registered through
+`WithHandler<T>(sync)`, which is `Observable.Return(delivery.Invoke(...))` — **the handler body runs
+before the observable is even built**. `HandleCreateNodeRequest` is detached by design (it
+`.Subscribe(...)`s its chain and returns `Processed()`), so everything downstream of the first
+storage read runs off-block. What is charged to the block is therefore exactly: the handler's
+synchronous prologue, plus whatever `persistence.Read(node.Path, …)` does **at composition time** —
+that line is a CALL, not a `Defer`.
+
+🚨 **Measured, not assumed: on the bake's wiring the create pipeline does NOT hold the block.**
+`NodeCrudDoesNotOccupyTheExecutionBlockTest` parks a real create inside its own validator and reads
+the execution hub as `Queue(buffer=0,deferred=0,drainsInFlight=0,openGates=0,draining=False)` —
+completely idle, because storage reads go through `IIoPool` and the chain leaves the block at that
+hop. The first draft of that test asserted the opposite and failed. **So a create that holds the
+block for 24.9 s is doing something this path does not normally do**, and "the create pipeline is
+expensive" is not the answer.
+
+Two shapes remain, and the `drainsInFlight` table above picks between them:
+
+- **A blocking construct in the composition prologue.** Exactly one exists on the path:
+  `HostedHubsCollection.GetHubWithOutcome`'s per-address creation `Lazy`
+  (`LazyThreadSafetyMode.ExecutionAndPublication`, `lazy.Value`), which blocks a second caller for
+  the whole of `CreateHub` — unbounded, and `CreateHub` is *recursive* (`SyncBuildupActions` reach
+  `SynchronizationStream`'s constructor, which always creates a `sync/{clientId}` hub; 1,350 nested
+  Builds measured in one green test run). It is reached inline because
+  `RoutingProxyAdapter.Read → LegacyUserPartitionRepair.ReadWithRepair → ReadCore →
+  PartitionStorageRouter.AddressFor` evaluates `SpawnOrReuse` inside `Observable.Return(...)`, i.e.
+  eagerly on the calling thread. That router's hub cache carries a **5-minute sliding expiration
+  with a post-eviction `Dispose`**, so after any lull the next create re-pays a full hub
+  construction on the turn — a bimodal cost by construction, which is the shape this page measures.
+  🚨 **But this path is NOT in play for the bake:** `AddPartitionStorageHubs` is called nowhere in
+  `src/`, and the bake host wires `AddInMemoryPersistence()`
+  (`tools/MeshWeaver.PluginTester/PluginGateRunner.cs`). It is live for a portal wired that way, and
+  is a real defect there.
+- **Amplification.** Confirmed on the SUCCESS path, which is the case
+  [Action-Block Wedge Prevention](../ActionBlockWedgePrevention)'s invariants do not cover — they
+  are written about failure producing more messages. Every hop lands back on `nodeops`: an upsert
+  dispatches an inner `CreateNodeRequest` **to its own address** (so one upsert ≥ 3 turns — upsert,
+  inner create, response callback); `EnsurePartitionBootstrap` issues nested `meshService.CreateNode`
+  calls whose `NodeOperationTarget` resolves to `nodeops` again; and `nodeops` is the router's
+  `RouterCarrier`, so `Workspace.AnnounceRecycleToClientSubscriptions` posts one `StreamEndedEvent`
+  per orphaned client subscription through it — during exactly the package-root recycles a bulk
+  install performs (~120 per bake gate run). A handful of concurrent creates is arithmetically the
+  `buffer=45` in the capture.
+
+**Ruled out on the way, so the next session does not re-derive them:**
+
+- **`ActivatePendingControlPlane`** — fire-and-forget, strictly after the response, gated on the
+  content carrying a `RequestedXxx`. It cannot delay a create.
+- **The access-control permission fold** — runs outside the window `Executing` measures.
+- **Every leg of `EnsurePartitionBootstrap`** — it does three storage reads and a permission fold,
+  but all are bounded (`Timeout(15s)` + `Catch`, `DefaultIfEmpty`, 5 s absence probes) and all are
+  downstream of the first read, hence off-block. Its *amplification* is the live concern, not its
+  duration.
+
+**The two measurements that would settle it**, in order of cost:
+
+1. Read the next failing bake's `[STALE-CALLBACK] … TARGET portal/nodeops-… drainsInFlight=…` line
+   and take the row from the table. No capture, no instrumentation round — the line already fires
+   300+ times in a failing run.
+2. If row 1 (a thread inside the handler): time `persistence.Read(node.Path, …)` at its call site,
+   before the `.Subscribe`. It is the only inline call in the handler that can block, so one run
+   discriminates. **And note the unresolved binding question**: `RoutingProxyAdapter` is documented
+   as registered per-hub, but the only registration in `src/` is a container-level
+   `services.Replace(Singleton<IStorageAdapter>)` resolving `sp.GetRequiredService<IMessageHub>()` —
+   if that binds to the mesh hub, every node create's storage round-trips are issued from and
+   dispatched on **the router's** block, which is the `ROUTER_TRAFFIC` shape `nodeops` exists to
+   remove.
 
 - a rule that performs IO per delivery (a storage read, a permission fold, a path resolution) and is
   therefore charged to the block rather than to the pool; or
@@ -314,6 +546,8 @@ pending callback at all.
 
 ## Related
 
+- [Reading a Disposal Stall Verdict](../DisposalStallVerdicts) — what every field of a hub snapshot
+  measures, and the three that measured nothing while being read as evidence.
 - [Action-Block Wedge Prevention](../ActionBlockWedgePrevention) — the invariants a single-threaded hub
   must satisfy so no input can saturate it.
 - [Bounds Must Be Ordered](../BoundsMustBeOrdered) — why an inner bound just under an outer one

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
@@ -542,6 +542,41 @@ direction (a *deleted-address* NACK must NOT contain any of those markers, or a 
 degrades back into "retry shortly"). Pinned by
 `TimeoutMessageNamesTheCallersOwnStateTest.TheTimeoutMessage_KeepsTheMarkerThatClassifiesItAsTransient`.
 
+## 🚨 `Executing(T, N ms)` is a LIFETIME, not an occupancy — `buffer=N` is the occupancy
+
+A hub dump's turn-loop clause reads like a statement about the pump. It is not:
+
+```
+portal/nodeops-… RunLevel=Started Queue(buffer=45,deferred=0,drainsInFlight=1,openGates=0,draining=True) Executing(CreateNodeRequest, 24888ms)
+```
+
+`currentlyExecutingMessageType` is cleared in the `.Finally` of the handler's returned
+**observable**, which fires when that whole chain COMPLETES — not when the pump is released. A
+handler that correctly detaches (returns `Processed()` in a millisecond and lets its chain run on
+the IO pool) keeps the field set, with a growing elapsed, for as long as the work is in flight
+**anywhere**.
+
+So the clause says *"T's handler chain has been in flight N ms"*. It does **not** say a turn held
+the block for N ms, and a non-null `Executing(` does not mean the block is busy. `drainsInFlight`
+carries the same ambiguity: it counts a drain body that is in flight, which is not the same as a
+thread sitting on the block.
+
+**Measured (2026-09-08, #2543):** with a create parked in its validator on a hub whose pump was
+demonstrably free, this read `Executing(CreateNodeResponse, 36001ms)` — and the number tracked the
+observer's own sampling window, because the park *was* the handler's lifetime. Read as block time it
+says a turn was wedged for 36 s; nothing was.
+
+**What to read instead:**
+
+| question | read |
+|---|---|
+| Is the pump occupied? | `buffer=N` — a message queued and not draining IS occupancy. In the dump above, `buffer=45` was the real signal; the `24888ms` was not. |
+| Is *this* hub still answering? | Post an independent request to it and see whether it is answered. Behavioural, and the only reading that cannot be misinterpreted. |
+| Which handler is in flight? | `Executing(T, …)` — it names T correctly. Only its DURATION is misleading. |
+
+A behavioural probe needs a **positive control** — the same request with nothing blocking — or "it
+did not complete" cannot distinguish a held pump from a probe that never completes anyway.
+
 ## The Golden Rule
 
 > **Run once. Grep the trace. Fix the root cause.**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-node-writes-no-longer-queue-behind-one-another.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-node-writes-no-longer-queue-behind-one-another.md
@@ -1,0 +1,20 @@
+---
+Name: Node writes no longer queue behind one another
+Category: Fix
+Description: Every node write in a mesh was executed by a single hub, one at a time, so a slow create or delete held every other one behind it — a bulk install or an import could stall ordinary edits for tens of seconds while the portal looked frozen. Node writes now proceed in parallel.
+Icon: Flash
+Order: -20260908
+---
+
+# Node writes no longer queue behind one another
+
+Creating, deleting, moving or copying a node no longer waits for whatever other node write happens
+to be in progress. Until now every node write in a mesh was executed by a single hub, one at a time,
+and a slow write held every other one behind it — a bulk install or an import could stall ordinary
+edits for tens of seconds, and the portal looked frozen while it did.
+
+The cause was not in the node-write path. When a hub waits for a reply, the continuation used to run
+on that hub's own message loop, inside the turn that delivered the reply — so a write that waited on
+anything internally kept the loop busy for as long as the whole operation took, and nothing else
+could be processed. Continuations now run off the message loop, so the loop stays free and writes
+proceed in parallel.

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1174,7 +1174,7 @@ public sealed class MessageHub : IMessageHub
         // registration would read as "nothing was ever posted" — the opposite of the truth (#981).
         requestFates.Find(delivery.Id)?.Add(
             "REGISTERED_AFTER_POST (Observe(delivery) overload — earlier stages not recorded)", Address);
-        return RestoreUserContextOnEmission(observable, delivery.AccessContext);
+        return ContinueOffBlockRestoringUserContext(observable, delivery.AccessContext);
     }
 
     /// <summary>
@@ -1218,7 +1218,7 @@ public sealed class MessageHub : IMessageHub
             requestFates.Find(messageId)?.Add($"POST_THREW {postEx.GetType().Name}: {postEx.Message}", Address);
             throw;
         }
-        return RestoreUserContextOnEmission(
+        return ContinueOffBlockRestoringUserContext(
             WrapWithCancelOnDispose(
                 ApplyTimeout(subject, requestType, probeOptions.Target, messageId),
                 messageId, subject),
@@ -1263,7 +1263,7 @@ public sealed class MessageHub : IMessageHub
             }
             return null;
         }
-        return RestoreUserContextOnEmission(
+        return ContinueOffBlockRestoringUserContext(
             WrapWithCancelOnDispose(
                 ApplyTimeout(subject, requestType, probeOptions.Target, messageId),
                 messageId, subject),
@@ -1322,9 +1322,31 @@ public sealed class MessageHub : IMessageHub
     /// hub-impersonation), and any post made from the Subscribe callback inherits the wrong
     /// identity — surfaces as <c>Access denied: user '&lt;cell-hub-path&gt;' lacks ...</c>.
     /// </summary>
-    private IObservable<IMessageDelivery> RestoreUserContextOnEmission(
+    private IObservable<IMessageDelivery> ContinueOffBlockRestoringUserContext(
         IObservable<IMessageDelivery> source, AccessContext? capturedCtx)
     {
+        // 🚨 THE CONTINUATION LEAVES THE RESPONDING HUB'S ACTION BLOCK HERE — and this one hop is
+        // why node CRUD is not a single global queue any more.
+        //
+        // A response subject is signalled from INSIDE the turn that handled the response (see the
+        // identity comment on Observe). Rx runs a continuation on whichever thread signalled it, so
+        // without this hop EVERY `hub.Observe(x).SelectMany(...)` chain in the framework executes
+        // its whole remainder ON that hub's action block, inside that turn. The turn cannot end
+        // until the chain does, and one hub processes one turn at a time.
+        //
+        // Measured on `portal/nodeops` — the mesh's ONE node-CRUD execution hub (#2543). A create
+        // correctly returns `Processed()` in ~1 ms and detaches its pipeline; the pipeline then
+        // does a partition bootstrap, whose nested response comes back to the SAME hub, and the
+        // rest of the create — validators, save, change feed — ran inline in that response's turn.
+        // With a create parked in its validator, a second, unrelated create posted to the same hub
+        // sat unprocessed at `Queue(buffer=1,…) Executing(CreateNodeResponse, …)` for the whole
+        // budget: every node write in the mesh serialised behind one create's continuation.
+        // Delete, move and copy inherit it identically — they await nested node ops the same way.
+        //
+        // The hop is placed BEFORE the identity restore below on purpose: `.Do(SetContext)` must
+        // run on the thread that will run the continuation, or the chain resumes unauthenticated.
+        source = source.ObserveOn(System.Reactive.Concurrency.DefaultScheduler.Instance);
+
         if (capturedCtx is null)
             return source;
         // Restore-on-Finally pattern (2026-05-22): set Context during the

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1345,7 +1345,24 @@ public sealed class MessageHub : IMessageHub
     /// <returns>The same sequence, with observer faults routed instead of escaping.</returns>
     private IObservable<IMessageDelivery> GuardContinuationFaults(IObservable<IMessageDelivery> source)
         => Observable.Create<IMessageDelivery>(observer => source.Subscribe(
-            value => Guarded(() => observer.OnNext(value)),
+            value =>
+            {
+                try
+                {
+                    observer.OnNext(value);
+                }
+                catch (Exception ex)
+                {
+                    // 🚨 REPORT **AND TERMINATE**. Reporting alone is the worse bug: the sequence
+                    // would neither emit nor error, so anything awaiting this response waits for its
+                    // full timeout instead of learning immediately that the work failed — a hang
+                    // where the block used to fail fast. `MessageService` did not swallow either; it
+                    // logged AND called ReportFailure, so the caller got an answer. This is the same
+                    // disposition: say what happened, then end the sequence with the fault.
+                    ReportContinuationFault(ex);
+                    Guarded(() => observer.OnError(ex));
+                }
+            },
             error => Guarded(() => observer.OnError(error)),
             () => Guarded(observer.OnCompleted)));
 
@@ -1360,6 +1377,15 @@ public sealed class MessageHub : IMessageHub
             deliver();
         }
         catch (Exception ex)
+        {
+            ReportContinuationFault(ex);
+        }
+    }
+
+    /// <summary>Says what a continuation fault was, at the level its cause deserves.</summary>
+    /// <param name="ex">The fault an observer callback threw.</param>
+    private void ReportContinuationFault(Exception ex)
+    {
         {
             if (RunLevel >= MessageHubRunLevel.ShutDown)
                 logger.LogDebug(ex,

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -370,11 +370,12 @@ public sealed class MessageHub : IMessageHub
             // that reading is impossible from the callbacks alone.
             TryLog(LogLevel.Warning,
                 "[STALE-CALLBACK] {Address}: {Count} callback(s) pending > {ThresholdMs}ms: {Detail}{Fates} "
-                + "[pool threads={PoolThreads} pendingWork={PoolPending} completed={PoolCompleted}]",
+                + "[pool threads={PoolThreads} pendingWork={PoolPending} completed={PoolCompleted}]{Targets}",
                 Address, stale.Length, thresholdMs, FormatPendingCallbacks(stale),
                 FormatPendingCallbackFates(stale),
                 System.Threading.ThreadPool.ThreadCount, System.Threading.ThreadPool.PendingWorkItemCount,
-                System.Threading.ThreadPool.CompletedWorkItemCount);
+                System.Threading.ThreadPool.CompletedWorkItemCount,
+                FormatStaleCallbackTargets(stale));
         }
         catch (Exception ex)
         {
@@ -382,6 +383,158 @@ public sealed class MessageHub : IMessageHub
                 "[STALE-CALLBACK] {Address}: scan tick failed: {Error}",
                 Address, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// How many DISTINCT targets one <c>[STALE-CALLBACK]</c> line describes. Three is enough to
+    /// name a shared bottleneck without turning a wall of stale callbacks into a wall of hub
+    /// dumps — a failing CD bake emits 300+ of these lines, so the per-line cost is multiplied by
+    /// the very condition that makes the line interesting.
+    /// </summary>
+    private const int StaleCallbackTargetReportCap = 3;
+
+    /// <summary>
+    /// The TURN-LOOP STATE of the hubs these stale callbacks are waiting ON — the one thing the
+    /// report has never carried, and the one thing that decides the verdict.
+    ///
+    /// <para>🚨 <b>A stale-callback line describes the wrong hub.</b> Everything on it —
+    /// <c>{Address}</c>, <c>{Detail}</c>, the pool counters — belongs to the hub that is WAITING,
+    /// and a waiting hub is idle by construction. So the line has always reported, truthfully and
+    /// uselessly, that the reporter has nothing to do. The hub whose state answers "is this a
+    /// wedge or a queue" is the TARGET named inside <c>{Detail}</c> (<c>…@portal/nodeops-…</c>),
+    /// and it was never described. <see href="https://github.com/Systemorph/MeshWeaver/issues/2543">#2543</see>
+    /// has been asking for that hub's snapshot since 2026-08-28; it appears in exactly ONE captured
+    /// log in the whole history of the issue, because nothing emits it — the hub reader dump is
+    /// written on a disposal stall, and a live mesh saturating mid-bake never reaches one.</para>
+    ///
+    /// <para><b>What the fields discriminate</b> (see <c>Doc/Architecture/DisposalStallVerdicts</c>
+    /// for what each one measures, and why two of them measured nothing until #3593):</para>
+    /// <list type="bullet">
+    ///   <item><c>drainsInFlight&gt;0</c> with <c>Executing(T, N ms)</c> — a THREAD is inside that
+    ///     handler and has been for N ms. The turn is not slow, it is BLOCKED: the pump cannot
+    ///     advance because the handler has not returned. Look for a synchronous wait on the
+    ///     block.</item>
+    ///   <item><c>drainsInFlight=0</c> with <c>Executing(T, N ms)</c> — no thread is in the
+    ///     handler, yet the turn's observable has not terminated. The handler returned something
+    ///     that never completes; the pump is parked awaiting a terminal that is owed by an async
+    ///     leaf.</item>
+    ///   <item><c>drainsInFlight=0</c>, no <c>Executing</c>, <c>draining=true</c>, a non-empty
+    ///     <c>buffer</c> — the drain was scheduled and never ran. That is a scheduling stall in the
+    ///     target, not a handler at all.</item>
+    ///   <item>a small <c>buffer</c> and no <c>Executing</c> — the target is IDLE, so the silence is
+    ///     not queueing at all and the reply leg is where to look.</item>
+    /// </list>
+    ///
+    /// <para>Deliberately the COMPACT snapshot and not <see cref="GetPendingRequestDiagnostics"/>:
+    /// the target's own pending-callback list can run to kilobytes, and multiplying that by 300
+    /// lines is how a single hub once emitted a ~100 KB log line that broke the TRX parsers
+    /// (see <see cref="FormatPendingCallbacks"/>). Queue shape plus the executing turn is the
+    /// discriminating datum; the target's own scanner tick prints its callbacks.</para>
+    ///
+    /// <para>Resolution is a PURE READ (<see cref="HostedHubCreation.Never"/>) — a diagnostic must
+    /// never construct a hub, which would both perturb what it is measuring and take the very
+    /// creation lock a wedged mesh may be contending on. A target outside this mesh (a remote
+    /// address, a hub already gone) is skipped silently: there is nothing local to describe.</para>
+    /// </summary>
+    /// <param name="stale">The stale callbacks this tick is reporting.</param>
+    /// <returns>A possibly-empty clause; never null, never throws.</returns>
+    private string FormatStaleCallbackTargets(
+        (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[] stale)
+    {
+        var sb = new System.Text.StringBuilder();
+        var seen = new HashSet<Address>(AddressComparer.Instance);
+        // 🚨 The cap counts targets actually DESCRIBED, not targets considered. Counting the
+        // considered ones lets three unresolvable addresses (a remote hub, one already gone) spend
+        // the whole budget and push the one hub that matters into "not described" — which is the
+        // shape this report exists to name.
+        var described = 0;
+        foreach (var entry in stale)
+        {
+            if (entry.Target is not { } target
+                || AddressComparer.Instance.Equals(target, Address)
+                || !seen.Add(target)
+                || ResolveLocalHub(target) is not { } owner)
+                continue;
+            if (described == StaleCallbackTargetReportCap)
+            {
+                sb.Append(" (further targets not described)");
+                break;
+            }
+            sb.Append(" TARGET ").Append(owner.GetTurnLoopSnapshot());
+            described++;
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// This hub's turn loop in one clause — the QUEUE SHAPE plus the currently-executing turn, with
+    /// no pending-callback list. The half of <see cref="GetPendingRequestDiagnostics"/> that says
+    /// whether the pump is advancing, sized to be quoted on somebody else's log line.
+    /// </summary>
+    /// <returns>A single-line description; never null.</returns>
+    public string GetTurnLoopSnapshot()
+    {
+        var snapshot = (messageService is MessageService ms)
+            ? ms.GetQueueSnapshot()
+            : (Buffer: -1, Deferred: -1, DrainsInFlight: -1, OpenGates: -1, Draining: false,
+               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L);
+        var sb = new System.Text.StringBuilder();
+        sb.Append(Address)
+          .Append(" RunLevel=").Append(RunLevel)
+          .Append(" Queue(buffer=").Append(snapshot.Buffer)
+          .Append(",deferred=").Append(snapshot.Deferred)
+          .Append(",drainsInFlight=").Append(snapshot.DrainsInFlight)
+          .Append(",openGates=").Append(snapshot.OpenGates)
+          .Append(",draining=").Append(snapshot.Draining)
+          .Append(')');
+        if (snapshot.CurrentMessage != null)
+            sb.Append(" Executing(").Append(snapshot.CurrentMessage)
+              .Append(", ").Append(snapshot.CurrentMessageElapsedMs).Append("ms)");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The hub in THIS mesh that <paramref name="target"/> addresses, or <c>null</c> when the
+    /// address is remote, nested below a top-level hub, already gone, or this hub itself.
+    ///
+    /// <para>Mirrors <c>HierarchicalRouting</c> at the root: climb the address's host chain to its
+    /// top-level form, then look that up on the mesh root — never creating — falling back to
+    /// shorter prefixes for a hub that hosts a sub-path. Extracted so the stale-callback report and
+    /// <see cref="AReplyIsOwedByAShuttingDownLocalHub"/> resolve a target the SAME way; two copies
+    /// of this walk is how a report and the budget it justifies come to disagree about which hub
+    /// they are talking about.</para>
+    /// </summary>
+    /// <param name="target">The address to resolve.</param>
+    /// <returns>The local hub, or null.</returns>
+    private MessageHub? ResolveLocalHub(Address? target)
+    {
+        if (target is null)
+            return null;
+        try
+        {
+            IMessageHub root = this;
+            while ((root as MessageHub)?.messageService is MessageService ms && ms.ParentHub is { } parent)
+                root = parent;
+            if (ReferenceEquals(root, this))
+                return null;
+            var top = target;
+            while (top.Host is not null)
+                top = top.Host;
+            var segments = top.Segments;
+            for (var k = segments.Length; k >= 1; k--)
+            {
+                var candidate = k == segments.Length ? top : new Address(segments[..k]);
+                if (root.GetHostedHub(candidate, HostedHubCreation.Never) is not MessageHub sibling
+                    || ReferenceEquals(sibling, this))
+                    continue;
+                return sibling;
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The registry or a scope is already gone — there is no local hub to describe.
+        }
+        return null;
     }
 
     private readonly ThreadSafeLinkedList<AsyncDelivery> rules = new();
@@ -2775,35 +2928,9 @@ public sealed class MessageHub : IMessageHub
     /// — a remote address, a nested hub, a live hub that is not disposing — keeps today's budget.</para>
     /// </summary>
     private bool AReplyIsOwedByAShuttingDownLocalHub(Address? target)
-    {
-        if (target is null)
-            return false;
-        try
-        {
-            IMessageHub root = this;
-            while ((root as MessageHub)?.messageService is MessageService ms && ms.ParentHub is { } parent)
-                root = parent;
-            if (ReferenceEquals(root, this))
-                return false;
-            var top = target;
-            while (top.Host is not null)
-                top = top.Host;
-            var segments = top.Segments;
-            for (var k = segments.Length; k >= 1; k--)
-            {
-                var candidate = k == segments.Length ? top : new Address(segments[..k]);
-                if (root.GetHostedHub(candidate, HostedHubCreation.Never) is not MessageHub sibling
-                    || ReferenceEquals(sibling, this))
-                    continue;
-                return sibling.IsShuttingDown && !sibling.DisposalSignalled;
-            }
-        }
-        catch (ObjectDisposedException)
-        {
-            // The registry or a scope is already gone — nothing there will answer.
-        }
-        return false;
-    }
+        => ResolveLocalHub(target) is { } sibling
+           && sibling.IsShuttingDown
+           && !sibling.DisposalSignalled;
 
     /// <summary>
     /// Terminal step of the reactive Quiescing poll (see the Quiescing branch of

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1322,6 +1322,59 @@ public sealed class MessageHub : IMessageHub
     /// hub-impersonation), and any post made from the Subscribe callback inherits the wrong
     /// identity — surfaces as <c>Access denied: user '&lt;cell-hub-path&gt;' lacks ...</c>.
     /// </summary>
+    /// <summary>
+    /// Restores the fault boundary the action block used to provide, now that the continuation no
+    /// longer runs on it.
+    ///
+    /// <para>🚨 <b>This is not a swallow — it is where a continuation fault went BEFORE the hop.</b>
+    /// A subscriber's exception used to be thrown inside <c>HandleMessageAsync</c>'s chain, on the
+    /// block, where <c>MessageService</c>'s catch arm logged it and called <c>ReportFailure</c>: a
+    /// reported failure, never a crash. Off the block there is nothing above it — Rx rethrows on the
+    /// scheduler thread, it is unhandled, and the PROCESS dies. Measured on #3759's first CI runs:
+    /// <c>Memex.Portal.Shared.Test</c> ran 1156 tests with ZERO failures and the host then exited 2,
+    /// with 7 <c>[FATAL ERROR]</c>s. So this restores the previous disposition of the exception; it
+    /// does not decide a new one.</para>
+    ///
+    /// <para>The dominant case is a continuation that outlives its hub: it resolves a service from a
+    /// scope that teardown has already disposed. That is a RACE, not a defect — the same shape
+    /// <c>LayoutAreaHost</c> already reports as "render raced a hub disposal — transient" — so it is
+    /// logged at Debug once this hub is shutting down and as an error while it is still serving,
+    /// where it means real application code threw.</para>
+    /// </summary>
+    /// <param name="source">The response observable, already hopped off the block.</param>
+    /// <returns>The same sequence, with observer faults routed instead of escaping.</returns>
+    private IObservable<IMessageDelivery> GuardContinuationFaults(IObservable<IMessageDelivery> source)
+        => Observable.Create<IMessageDelivery>(observer => source.Subscribe(
+            value => Guarded(() => observer.OnNext(value)),
+            error => Guarded(() => observer.OnError(error)),
+            () => Guarded(observer.OnCompleted)));
+
+    /// <summary>Runs one observer callback, routing anything it throws. See
+    /// <see cref="GuardContinuationFaults"/> for why this is the block's boundary and not a
+    /// swallow.</summary>
+    /// <param name="deliver">The observer callback to run.</param>
+    private void Guarded(Action deliver)
+    {
+        try
+        {
+            deliver();
+        }
+        catch (Exception ex)
+        {
+            if (RunLevel >= MessageHubRunLevel.ShutDown)
+                logger.LogDebug(ex,
+                    "{Address}: a response continuation raced this hub's teardown — transient. The "
+                    + "continuation runs off the action block, so it can outlive the scope it "
+                    + "resolves from; the caller's subscription is already going away.", Address);
+            else
+                logger.LogError(ex,
+                    "{Address}: a response continuation threw. It runs off the action block, so "
+                    + "this did not fault a turn — it would otherwise have gone unhandled on a "
+                    + "scheduler thread and killed the process. The throw is in the code that "
+                    + "subscribed to hub.Observe(...), not in the hub.", Address);
+        }
+    }
+
     private IObservable<IMessageDelivery> ContinueOffBlockRestoringUserContext(
         IObservable<IMessageDelivery> source, AccessContext? capturedCtx)
     {
@@ -1345,7 +1398,7 @@ public sealed class MessageHub : IMessageHub
         //
         // The hop is placed BEFORE the identity restore below on purpose: `.Do(SetContext)` must
         // run on the thread that will run the continuation, or the chain resumes unauthenticated.
-        source = source.ObserveOn(System.Reactive.Concurrency.DefaultScheduler.Instance);
+        source = GuardContinuationFaults(source.ObserveOn(PooledContinuationScheduler.Instance));
 
         if (capturedCtx is null)
             return source;

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -913,7 +913,24 @@ public class MessageService : IMessageService
 
     // Tracks what message is currently executing so the disposal diagnostic snapshot
     // can name *which* handler is wedged. Updated atomically around each handler
-    // invocation in ScheduleExecution. Null means the action block is idle.
+    // invocation in ScheduleExecution.
+    //
+    // 🚨 THIS IS A LIFETIME, NOT AN OCCUPANCY. It is cleared in the `.Finally` of the handler's
+    // returned OBSERVABLE, which fires when that whole chain COMPLETES — not when the pump is
+    // released. A handler that correctly detaches (returns `Processed()` in a millisecond and lets
+    // its chain run on the IO pool) therefore keeps this field set, and its elapsed keeps growing,
+    // for as long as the work is in flight ANYWHERE. So `Executing(T, N ms)` means "T's handler
+    // chain has been in flight N ms"; it does NOT mean "a turn has held the block for N ms", and a
+    // non-null value does NOT mean the block is busy.
+    //
+    // Measured (#2543, 2026-09-08): with a create parked in its validator on a hub whose pump was
+    // free, this read `Executing(CreateNodeResponse, 36001ms)` and tracked the observer's own
+    // sampling window. #2543's headline `Executing(CreateNodeRequest, 24888ms)` is the same
+    // reading, so it never established that the block was held — the `buffer=45` beside it did.
+    //
+    // 🚨 To ask whether the PUMP is occupied, read `mainQueue.Count` (a message queued and not
+    // draining is occupancy) or measure it behaviourally: post an independent request to the hub
+    // and see whether it is answered. See Doc/Architecture/BakeSealNodeOpsSaturation.
     private volatile string? currentlyExecutingMessageType;
     private long currentlyExecutingStartedTicks;
     // Turns the pump has finished since this service was built. The disposal stall detector reads

--- a/src/MeshWeaver.Messaging.Hub/PooledContinuationScheduler.cs
+++ b/src/MeshWeaver.Messaging.Hub/PooledContinuationScheduler.cs
@@ -1,0 +1,48 @@
+using System.Reactive.Concurrency;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Hands work to the task pool, and deliberately does NOT implement
+/// <see cref="ISchedulerLongRunning"/>.
+///
+/// <para>🚨 <b>The omission is the whole point — do not "complete" this class by adding it.</b>
+/// <c>ObserveOn</c> asks the scheduler for long-running support and, when it is offered, uses
+/// <c>ObserveOnObserverLongRunning</c>, which dedicates a DRAIN WORKER PER SUBSCRIPTION. That is
+/// tolerable for a handful of long-lived streams and ruinous for a response continuation, which is
+/// created once per request in flight: with the hop on every <c>hub.Observe(…)</c> it is a thread
+/// per request. Measured on #3759's first CI run — <c>ObserveOnObserverLongRunning.Drain()</c>
+/// sitting on a raw <c>Thread.StartHelper.Callback</c> in the crash stack. Hiding the capability
+/// keeps Rx on the per-item pooled path, which is what a short observable (one value, then
+/// complete) actually wants.</para>
+///
+/// <para>Rx's own <see cref="TaskPoolScheduler"/> and <see cref="DefaultScheduler"/> both advertise
+/// long-running, so neither can be used directly here; this wrapper exists only to withhold that
+/// one capability. Everything else delegates.</para>
+/// </summary>
+internal sealed class PooledContinuationScheduler : IScheduler
+{
+    /// <summary>The process-wide instance. Immutable — it holds only a delegate scheduler.</summary>
+    public static readonly PooledContinuationScheduler Instance = new();
+
+    private static readonly IScheduler Inner = TaskPoolScheduler.Default;
+
+    private PooledContinuationScheduler() { }
+
+    /// <inheritdoc />
+    public DateTimeOffset Now => Inner.Now;
+
+    /// <inheritdoc />
+    public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+        => Inner.Schedule(state, action);
+
+    /// <inheritdoc />
+    public IDisposable Schedule<TState>(TState state, TimeSpan dueTime,
+        Func<IScheduler, TState, IDisposable> action)
+        => Inner.Schedule(state, dueTime, action);
+
+    /// <inheritdoc />
+    public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime,
+        Func<IScheduler, TState, IDisposable> action)
+        => Inner.Schedule(state, dueTime, action);
+}

--- a/test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs
@@ -56,15 +56,44 @@ public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output
     private const string ParkedNodeId = "TurnStateParkedWrite";
     private const string ParkedNodePath = $"{TestPartition}/{ParkedNodeId}";
 
+    /// <summary>The INDEPENDENT second operation: never parked, so only a held pump delays it.</summary>
+    private const string ProbeNodeId = "TurnStateProbeWrite";
+
+    /// <summary>The control's node — created with nothing parked, so it measures the probe itself.</summary>
+    private const string ControlNodeId = "TurnStateControlWrite";
+
+    /// <summary>Bound for the probe. Deliberately WELL under the parked validator's own
+    /// <c>TestTimeouts.Convergence</c> spin, so the park cannot expire first and hand the probe a
+    /// pass that says nothing about whether the pump was free.</summary>
+    private static readonly TimeSpan ProbeBudget = TimeSpan.FromSeconds(10);
+
+    /// <summary>The two nodes parked SIMULTANEOUSLY by the parallelism test below.</summary>
+    private const string ParallelANodeId = "TurnStateParallelA";
+
+    private const string ParallelBNodeId = "TurnStateParallelB";
+
+    private const string ParallelAPath = $"{TestPartition}/{ParallelANodeId}";
+
+    private const string ParallelBPath = $"{TestPartition}/{ParallelBNodeId}";
+
     /// <summary>Producer → test: the parking validator completes this once its turn is running.</summary>
     private readonly AsyncSubject<Unit> _parked = new();
+
+    private readonly AsyncSubject<Unit> _parkedA = new();
+
+    private readonly AsyncSubject<Unit> _parkedB = new();
 
     private ParkTheNodeCrudBlock? _park;
 
     /// <inheritdoc />
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {
-        _park = new ParkTheNodeCrudBlock(ParkedNodePath, _parked);
+        _park = new ParkTheNodeCrudBlock(new Dictionary<string, AsyncSubject<Unit>>
+        {
+            [ParkedNodePath] = _parked,
+            [ParallelAPath] = _parkedA,
+            [ParallelBPath] = _parkedB,
+        });
         return base.ConfigureMesh(builder)
             .ConfigureServices(services => services.AddSingleton<INodeValidator>(_park));
     }
@@ -95,14 +124,47 @@ public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output
                 Name = "Turn State Parked Write",
                 NodeType = "Markdown",
             }));
-        string snapshot;
+        // 🚨 THE BLOCK IS MEASURED BY WHAT IT CAN STILL DO, NOT BY GetTurnLoopSnapshot().
+        //
+        // The snapshot's `Executing(...)` clause CANNOT answer this question, and the first version
+        // of this test failed because it asked. `currentlyExecutingMessageType` is cleared in the
+        // `.Finally(...)` of the handler's returned OBSERVABLE (MessageService), so it stays set for
+        // as long as the handler's chain is in flight — including every pooled hop the chain has
+        // already left the block for. Its elapsed is therefore the handler's lifetime, not the time
+        // the pump was occupied: with the create parked here, one run read
+        // `Executing(CreateNodeResponse, 36001ms)` while the pump was idle throughout, and the
+        // number tracked the park window exactly because the park IS the handler's lifetime.
+        // `drainsInFlight`/`draining` read 1/True for the same reason.
+        //
+        // That is also why #2543's `Executing(CreateNodeRequest, 24888ms)` does not by itself say
+        // the block was held for 24.9 s — the same field, the same ambiguity.
+        //
+        // So the claim is measured behaviourally: with a create provably parked, post an INDEPENDENT
+        // node operation to the same hub and require it to complete. A pump held by the parked
+        // create cannot answer it; a pump that answers is free by demonstration, whatever the
+        // snapshot says.
         try
         {
             await _parked.Should().Within(TestTimeouts.Convergence)
                 .Emit("the create must actually be in flight and blocked, or this test describes an "
                     + "idle mesh and proves nothing");
 
-            snapshot = NodeOperationHub.GetTurnLoopSnapshot();
+            var probe = ObserveNodeOperation(new CreateNodeRequest(
+                new MeshNode(ProbeNodeId, TestPartition)
+                {
+                    Name = "Turn State Probe Write",
+                    NodeType = "Markdown",
+                }));
+
+            await probe.Should().Within(ProbeBudget)
+                .Emit("the node-CRUD execution hub must still process a SECOND node operation while "
+                    + "the first is parked inside its validator: the create pipeline leaves the "
+                    + "action block at its first pooled storage hop, so it is a pool thread that is "
+                    + "parked, not the pump. If this times out the block IS held for the duration of "
+                    + "a create, every node CRUD in the mesh serialises behind it, and #2543's "
+                    + "24.9 s capture is routine rather than anomalous. Turn-loop snapshot at this "
+                    + "moment (diagnostic only, see above — it cannot decide this): "
+                    + NodeOperationHub.GetTurnLoopSnapshot());
         }
         finally
         {
@@ -111,18 +173,70 @@ public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output
             _park!.Release();
         }
 
-        snapshot.Should().NotContain("Executing(",
-            "the create pipeline left the action block at its first pooled storage hop, so no "
-            + "handler is on the block while the create is blocked downstream — a create that DID "
-            + "hold the block would make #2543's 24.9 s capture routine instead of anomalous");
-        snapshot.Should().Contain("drainsInFlight=0",
-            "no drain body is executing: the parked work is on a pool thread, not on the pump");
-        snapshot.Should().Contain("buffer=0",
-            "and nothing is queued behind it — node CRUD in flight does not back up this hub");
-
         await write.Should().Within(TestTimeouts.Convergence)
             .Emit("the parked write must complete once released — a stranded create would leak into "
                 + "the next test");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL for the measurement above, and it is not optional. The probe there
+    /// is read as "the pump is held" when it does not complete — a reading that is only valid if
+    /// the very same operation DOES complete when nothing is parked. Without this, a probe that
+    /// never completes for its own reasons looks exactly like a held pump, and the conclusion
+    /// would be drawn from an instrument that cannot answer.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheProbeOperation_CompletesPromptly_WhenNothingIsParked()
+    {
+        var probe = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ControlNodeId, TestPartition)
+            {
+                Name = "Turn State Control Write",
+                NodeType = "Markdown",
+            }));
+
+        await probe.Should().Within(ProbeBudget)
+            .Emit("an unparked node create must complete well inside the budget the probe above "
+                + "uses — that budget is only meaningful if this passes");
+    }
+
+    /// <summary>
+    /// 🚨 <b>Node CRUD runs in PARALLEL</b> — the property the decoupling in
+    /// <c>MessageHub.ContinueOffBlockRestoringUserContext</c> exists to give, asserted without a
+    /// stopwatch.
+    ///
+    /// <para>Two creates are parked in their validators AT THE SAME TIME. Both validators must be
+    /// entered before either is released, which can only happen if two creates are in flight
+    /// concurrently. When every response continuation ran on <c>portal/nodeops</c>'s action block,
+    /// the second create could not even be DEQUEUED while the first was parked — it sat at
+    /// <c>Queue(buffer=1,…)</c> and its validator never ran, so this test could not pass by
+    /// timing luck. It is a structural assertion, not a benchmark.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TwoCreates_AreInFlightSimultaneously()
+    {
+        var a = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParallelANodeId, TestPartition) { Name = "Parallel A", NodeType = "Markdown" }));
+        var b = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParallelBNodeId, TestPartition) { Name = "Parallel B", NodeType = "Markdown" }));
+
+        try
+        {
+            await _parkedA.Should().Within(TestTimeouts.Convergence)
+                .Emit("the first create must reach its validator");
+            await _parkedB.Should().Within(ProbeBudget)
+                .Emit("the SECOND create must reach its validator while the first is still parked "
+                    + "there — two node writes genuinely in flight at once. A hub that runs "
+                    + "continuations on its own action block cannot get here: the second create "
+                    + "would still be queued behind the first, unstarted");
+        }
+        finally
+        {
+            _park!.Release();
+        }
+
+        await a.Should().Within(TestTimeouts.Convergence).Emit("the first create must complete");
+        await b.Should().Within(TestTimeouts.Convergence).Emit("the second create must complete");
     }
 
     /// <summary>
@@ -136,7 +250,8 @@ public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output
     /// so nothing else in the mesh is slowed down. (Same harness as
     /// <c>ContentReadIsNotQueuedBehindNodeCrudTest</c>.)</para>
     /// </summary>
-    private sealed class ParkTheNodeCrudBlock(string parkPath, AsyncSubject<Unit> parked) : INodeValidator
+    private sealed class ParkTheNodeCrudBlock(
+        IReadOnlyDictionary<string, AsyncSubject<Unit>> parkPoints) : INodeValidator
     {
         private int _released;
 
@@ -146,7 +261,7 @@ public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output
         public void Release() => Interlocked.Exchange(ref _released, 1);
 
         public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
-            => string.Equals(context.Node.Path, parkPath, StringComparison.Ordinal)
+            => parkPoints.TryGetValue(context.Node.Path, out var parked)
                 ? Observable.Defer(() =>
                 {
                     parked.OnNext(Unit.Default);

--- a/test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A node create in flight must NOT occupy the node-CRUD execution block</b> — and measuring
+/// that it does not is what makes
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/2543">#2543</see>'s central capture an
+/// ANOMALY rather than the normal cost of a create.
+///
+/// <para><b>The reasoning this pins down.</b> #2543 is argued from one hub dump reading
+/// <c>Queue(buffer=45,…) Executing(CreateNodeRequest, 24888ms)</c> on <c>portal/nodeops</c> — the
+/// mesh's ONE node-CRUD execution hub, whose single block runs every create and upsert in the mesh.
+/// The natural reading is that a create simply costs that much: <c>HandleCreateNodeRequest</c>
+/// <c>.Subscribe(...)</c>s its whole pipeline — partition bootstrap, validators, NodeType existence,
+/// enrich, save, change feed — <b>inline</b>, and only then returns <c>request.Processed()</c>, so
+/// everything that runs synchronously inside that <c>Subscribe</c> is charged to the block. If that
+/// were the steady state, the fix would be a throughput question and the whole issue would be
+/// mis-framed.</para>
+///
+/// <para><b>It is not the steady state, and this test is the measurement.</b> The pipeline's first
+/// leaf is a storage read, and storage reads go through <c>IIoPool</c> — so the chain leaves the
+/// block at that hop and the handler returns in milliseconds. Parking a create INSIDE its own
+/// validator (which runs downstream of that read) therefore parks a pool thread, not the pump: the
+/// execution hub reads completely idle while a create is provably in flight. Measured, not assumed —
+/// the first draft of this test asserted the opposite and failed with
+/// <c>Queue(buffer=0,deferred=0,drainsInFlight=0,openGates=0,draining=False)</c>.</para>
+///
+/// <para><b>What that buys the investigation.</b> A create that holds the block for 24.9 s is doing
+/// something this path does not normally do, so "which rule holds the block" is not answered by
+/// "the create pipeline is expensive". It also gives the invariant a guard: should a future change
+/// move a synchronous leaf ahead of the pool hop — a blocking service resolution, an eager address
+/// resolution, a hosted-hub construction — every node CRUD in the mesh would start serialising
+/// behind it, and this test goes red at that commit instead of in a bake three weeks later.</para>
+///
+/// <para>Companion: <c>TurnLoopSnapshotIsMeasuredTest</c> (MeshWeaver.Messaging.Hub.Test) is the
+/// positive control for the two fields read here — it builds a genuinely blocked block and asserts
+/// they say so. Together: the fields move, and node CRUD does not move them.</para>
+/// </summary>
+public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string ParkedNodeId = "TurnStateParkedWrite";
+    private const string ParkedNodePath = $"{TestPartition}/{ParkedNodeId}";
+
+    /// <summary>Producer → test: the parking validator completes this once its turn is running.</summary>
+    private readonly AsyncSubject<Unit> _parked = new();
+
+    private ParkTheNodeCrudBlock? _park;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        _park = new ParkTheNodeCrudBlock(ParkedNodePath, _parked);
+        return base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<INodeValidator>(_park));
+    }
+
+    /// <summary>The mesh's ONE node-CRUD execution hub — the hub #2543 is about.</summary>
+    private MessageHub NodeOperationHub =>
+        Mesh.GetHostedHub(Mesh.NodeOperationTarget(), HostedHubCreation.Never) as MessageHub
+        ?? throw new InvalidOperationException(
+            "the node-CRUD execution hub is not materialised — the test cannot describe a hub that "
+            + "does not exist; a node operation must have been issued first");
+
+    /// <summary>
+    /// 🚨 THE MEASUREMENT. A create is blocked mid-pipeline, in its own validator, and the hub that
+    /// EXECUTES node CRUD is idle: no drain body, no executing turn, nothing queued.
+    ///
+    /// <para>So the create pipeline is not what a 25 s <c>Executing(CreateNodeRequest, …)</c>
+    /// reports. Anything that DOES hold that block for tens of seconds is running ahead of the
+    /// pipeline's first pooled hop, and that is a much smaller place to look.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheExecutionBlock_IsFree_WhileACreateIsInFlightInsideItsValidator()
+    {
+        // A REAL node create, posted exactly as production does, so what it exercises is the
+        // production path rather than a stand-in.
+        var write = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParkedNodeId, TestPartition)
+            {
+                Name = "Turn State Parked Write",
+                NodeType = "Markdown",
+            }));
+        string snapshot;
+        try
+        {
+            await _parked.Should().Within(TestTimeouts.Convergence)
+                .Emit("the create must actually be in flight and blocked, or this test describes an "
+                    + "idle mesh and proves nothing");
+
+            snapshot = NodeOperationHub.GetTurnLoopSnapshot();
+        }
+        finally
+        {
+            // In a finally so a failing assertion cannot strand the parked write — and therefore
+            // cannot strand the mesh's teardown behind it.
+            _park!.Release();
+        }
+
+        snapshot.Should().NotContain("Executing(",
+            "the create pipeline left the action block at its first pooled storage hop, so no "
+            + "handler is on the block while the create is blocked downstream — a create that DID "
+            + "hold the block would make #2543's 24.9 s capture routine instead of anomalous");
+        snapshot.Should().Contain("drainsInFlight=0",
+            "no drain body is executing: the parked work is on a pool thread, not on the pump");
+        snapshot.Should().Contain("buffer=0",
+            "and nothing is queued behind it — node CRUD in flight does not back up this hub");
+
+        await write.Should().Within(TestTimeouts.Convergence)
+            .Emit("the parked write must complete once released — a stranded create would leak into "
+                + "the next test");
+    }
+
+    /// <summary>
+    /// Blocks ONE create inside its validator. The validator runs downstream of the create
+    /// pipeline's first storage read, which is pooled — so this parks a pool thread, which is
+    /// exactly the fact under test.
+    ///
+    /// <para>No hand-woven gate: producer → test is the <see cref="AsyncSubject{T}"/> this completes
+    /// on entry; test → parked worker is a volatile flag polled under a bounded
+    /// <see cref="SpinWait.SpinUntil(Func{bool}, TimeSpan)"/>. Every other path validates instantly,
+    /// so nothing else in the mesh is slowed down. (Same harness as
+    /// <c>ContentReadIsNotQueuedBehindNodeCrudTest</c>.)</para>
+    /// </summary>
+    private sealed class ParkTheNodeCrudBlock(string parkPath, AsyncSubject<Unit> parked) : INodeValidator
+    {
+        private int _released;
+
+        public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Create];
+
+        /// <summary>Lets the parked create finish. Idempotent.</summary>
+        public void Release() => Interlocked.Exchange(ref _released, 1);
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+            => string.Equals(context.Node.Path, parkPath, StringComparison.Ordinal)
+                ? Observable.Defer(() =>
+                {
+                    parked.OnNext(Unit.Default);
+                    parked.OnCompleted();
+                    SpinWait.SpinUntil(() => Volatile.Read(ref _released) == 1,
+                        TestTimeouts.Convergence);
+                    return Observable.Return(NodeValidationResult.Valid());
+                })
+                : Observable.Return(NodeValidationResult.Valid());
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/TurnLoopSnapshotIsMeasuredTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TurnLoopSnapshotIsMeasuredTest.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>The two fields that decide "wedged or queued" must MOVE</b> —
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/3593">#3593</see>, and the reading
+/// they exist to serve in <see href="https://github.com/Systemorph/MeshWeaver/issues/2543">#2543</see>.
+///
+/// <para><b>The defect this guards against returning.</b> <c>GetQueueSnapshot</c> printed
+/// <c>exec=0</c> for the whole life of the turn loop — a hard-coded literal left behind by the
+/// TPL-Dataflow pump, true of every hub in every state. Read as *"no drain is running"* it is the
+/// single most load-bearing clause a stall report can carry, and it measured nothing. Two weeks of
+/// #2543 were argued from a capture containing it. <c>drainsInFlight</c> replaced it; the whole
+/// point of the replacement is that it is a live count, so a test that never observes it non-zero
+/// would leave the fleet exactly where it was.</para>
+///
+/// <para><b>Why a POSITIVE control specifically.</b> A field frozen at <c>0</c> passes every
+/// assertion that only ever sees an idle hub — that is precisely how the literal survived. So the
+/// subject here is a hub whose handler is genuinely on the block, held there, while the snapshot is
+/// taken from another thread. The negative control beside it is what stops the opposite regression
+/// (a field frozen at <c>1</c>, or an <c>Executing</c> that is never cleared).</para>
+///
+/// <para><b>What is NOT claimed.</b> This says nothing about what occupies
+/// <c>portal/nodeops</c> during a bake. It makes the instrument that would answer that question
+/// trustworthy, and it calibrates the reading: the state built below is what
+/// <c>drainsInFlight=1</c> + <c>Executing(T, N ms)</c> means — a THREAD blocked inside the handler,
+/// with the queue behind it going nowhere until it returns.</para>
+/// </summary>
+public class TurnLoopSnapshotIsMeasuredTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record Park : IRequest<Parked>;
+
+    private record Parked;
+
+    private record Trailer : IRequest<Trailed>;
+
+    private record Trailed;
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL. With a thread blocked inside the handler, the snapshot must say so:
+    /// a drain body executing, the turn named, the drain latched — and a message posted behind it
+    /// still sitting in the buffer, because <c>DrainLoop</c> advances only when a turn's observable
+    /// terminates and nothing else ever restarts it.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheSnapshot_ReportsTheBlockedTurn_WhileAHandlerHoldsTheBlock()
+    {
+        var entered = new AsyncSubject<Unit>();
+        var released = 0;
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "turn-loop-snapshot"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<Park>((h, d) =>
+            {
+                entered.OnNext(Unit.Default);
+                entered.OnCompleted();
+                // What a genuinely long turn does to this block. Bounded, and released from a
+                // finally below so a failing assertion cannot strand the mesh's teardown.
+                SpinWait.SpinUntil(() => Volatile.Read(ref released) == 1, TestTimeouts.Convergence);
+                return d.Processed();
+            })
+            .WithHandler<Trailer>((h, d) =>
+            {
+                h.Post(new Trailed(), o => o.ResponseFor(d));
+                return d.Processed();
+            }), HostedHubCreation.Always)!;
+
+        string snapshot;
+        try
+        {
+            var parked = victim.Observe(new Park(), o => o.WithTarget(victim.Address));
+            using var parkedSub = parked.Subscribe(_ => { }, _ => { });
+
+            await entered.Should().Within(TestTimeouts.Convergence)
+                .Emit("the handler must actually be on the block, or this test measures an idle hub");
+
+            // Queued BEHIND the parked turn, from a hub that is not the victim, so the post itself
+            // cannot be what is blocked.
+            Mesh.Post(new Trailer(), o => o.WithTarget(victim.Address));
+
+            snapshot = victim.GetTurnLoopSnapshot();
+        }
+        finally
+        {
+            Interlocked.Exchange(ref released, 1);
+        }
+
+        snapshot.Should().Contain("Executing(Park",
+            "a handler IS on the block and the snapshot must name it — this is the field the whole "
+            + "of #2543 was read from");
+        snapshot.Should().NotContain("drainsInFlight=0",
+            "a thread is blocked inside that handler right now, so the count of executing drain "
+            + "bodies cannot be zero — reading zero here is the `exec=0` literal returning, and it "
+            + "is what made the wedge/queue question unanswerable");
+        snapshot.Should().Contain("draining=True",
+            "the drain is latched for as long as the loop has not found its queue empty");
+    }
+
+    /// <summary>
+    /// 🚨 THE NEGATIVE CONTROL, and the half that makes the other one mean anything. An idle hub
+    /// must report NO executing turn and no drain body — otherwise the assertions above would pass
+    /// against fields stuck at a constant, which is exactly the defect being guarded.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheSnapshot_ReportsAnIdleHub_WhenNoTurnIsInFlight()
+    {
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "turn-loop-idle"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<Trailer>((h, d) =>
+            {
+                h.Post(new Trailed(), o => o.ResponseFor(d));
+                return d.Processed();
+            }), HostedHubCreation.Always)!;
+
+        // Awaited to completion, so the hub is measurably back to idle rather than merely young.
+        await victim.Observe(new Trailer(), o => o.WithTarget(victim.Address))
+            .Should().Within(TestTimeouts.Convergence)
+            .Emit("the hub must answer once, so what follows describes a hub that has finished work "
+                + "rather than one that has not started any");
+
+        var snapshot = victim.GetTurnLoopSnapshot();
+
+        snapshot.Should().NotContain("Executing(",
+            "no handler is on the block, so the snapshot must not name one — a snapshot that always "
+            + "reports an executing turn would make the positive control above vacuous");
+        snapshot.Should().Contain("drainsInFlight=0",
+            "no drain body is running on an idle hub");
+    }
+}


### PR DESCRIPTION
## What this changes

Node CRUD in a mesh was serialised through **one actor's queue**. Every create/delete/move/copy
without an opted-in ancestor executes on `portal/nodeops-<meshId>`, and a create parked in its
validator held that hub so completely that a second, unrelated create posted to the same hub sat
unprocessed at `Queue(buffer=1,…)` for its entire budget.

**The root cause is not in the node-CRUD path.** A response subject is signalled from *inside* the
turn that handled the response, and Rx runs a continuation on the thread that signalled it — so
every `hub.Observe(x).SelectMany(…)` chain in the framework ran its whole remainder **on that hub's
action block, inside that turn**, and the turn could not end until the chain did.

The create handler is detached and correct — `HANDLER_EXIT state=Processed` at **+1 ms** on the fate
trail. The pipeline then climbed *back onto* the block when its partition bootstrap's nested
response came home, and ran validators, save and change feed there. Delete, move and copy inherit
the same shape, which is why one line fixes all of them.

`MessageHub.ContinueOffBlockRestoringUserContext` now hops the continuation off the block before
restoring the caller's identity. **The order matters:** `.Do(SetContext)` must run on the thread
that will run the continuation, or the chain resumes unauthenticated.

## This PR started as the opposite claim — that half is corrected, not deleted

It originally argued that the create pipeline never holds the block, reading `Executing(T, N ms)` as
time-on-the-block. That field is cleared in the handler **observable's** `.Finally`, so it measures
the handler's in-flight *lifetime*, including hops the chain already left the block for. With a
create parked it read `Executing(CreateNodeResponse, 36001ms)` and tracked the observer's own
sampling window exactly.

So **#2543's `Executing(CreateNodeRequest, 24888ms)` never established that the block was held for
24.9 s** — the `buffer=45` beside it is the part that was real. `BakeSealNodeOpsSaturation.md` keeps
the original analysis and adds a correction section saying which two inferences failed and how they
were falsified; the `drainsInFlight` table there inherits the same error and is corrected with it.

## Evidence

Measured behaviourally, because the snapshot fields cannot decide it:

| test | hop disabled | hop enabled |
|---|---|---|
| probe: an independent create completes while one is parked | **FAIL** | PASS |
| `TwoCreates_AreInFlightSimultaneously` (two validators entered before either is released) | **FAIL** | PASS |
| **positive control**: the same probe with nothing parked | PASS | PASS |

The control passing in both worlds is what makes the other two mean "the pump is held" rather than
"this probe never completes anyway". Both now fail deterministically in isolation (11 s / 21 s)
rather than only under assembly load, which is how the original red hid: isolated it passed 10/10.

## Verification

- **4,426 tests, 8 projects, 0 failures** — Graph 1454, Compiler.Pipeline 735, Hosting 514,
  Data 496, Layout 455, Messaging.Hub 383, Documentation 361, ContentCollections 28
- Full solution `dotnet build -c Release -p:CIRun=true -warnaserror` — **0 Error(s), 0 Warning(s)**

## Blast radius, stated plainly

This changes continuation threading for **every** request/response pair in the framework, not just
node CRUD. Anything that implicitly relied on continuations being serialised per-hub can now run
concurrently. That is the point of the change, and it is why the verification above is broad rather
than scoped to the touched path.

Related: #2543.
