### PR TITLE
The Deployment record is the ONE input: Aspire builds it fluently, Helm renders it, the image binds it

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -206,7 +206,12 @@ jobs:
             || { echo "::error::MeshWeaver.Aspire.Hosting.Memex.$V.nupkg was not produced"; exit 1; }
           count="$(find "$RUNNER_TEMP/nupkgs" -name '*.nupkg' | wc -l | tr -d ' ')"
           [ "$count" -eq 1 ] || { echo "::error::expected exactly 1 package, found $count — a project has regained packability; see Directory.Build.props"; exit 1; }
-          echo "1 package at $V"
+          # The Deployment record assembly is BUNDLED into this package (Memex.Aspire.Hosting.csproj,
+          # PackContractAssembly) — a customer AppHost builds its record from one reference. A nupkg
+          # without it installs, compiles nothing, and cannot be recalled.
+          unzip -l "$RUNNER_TEMP/nupkgs/MeshWeaver.Aspire.Hosting.Memex.$V.nupkg" | grep -q 'lib/net10.0/MeshWeaver.Deployment.Contract.dll' \
+            || { echo "::error::MeshWeaver.Deployment.Contract.dll is not inside the nupkg — the PackContractAssembly target in Memex.Aspire.Hosting.csproj no longer bundles it"; exit 1; }
+          echo "1 package at $V, with the Deployment record assembly bundled"
 
       - name: Log in to nuget.org (Trusted Publishing — a short-lived key, nothing stored)
         if: ${{ !inputs.dry-run }}

--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -36,6 +36,7 @@
     <Project Path="src/MeshWeaver.Connection.Orleans/MeshWeaver.Connection.Orleans.csproj" />
     <Project Path="src/MeshWeaver.ContentCollections/MeshWeaver.ContentCollections.csproj" />
     <Project Path="src/MeshWeaver.Data.Contract/MeshWeaver.Data.Contract.csproj" />
+    <Project Path="src/MeshWeaver.Deployment.Contract/MeshWeaver.Deployment.Contract.csproj" />
     <Project Path="src/MeshWeaver.Data/MeshWeaver.Data.csproj" />
     <Project Path="src/MeshWeaver.Documentation/MeshWeaver.Documentation.csproj" />
     <Project Path="src/MeshWeaver.Domain/MeshWeaver.Domain.csproj" />
@@ -78,6 +79,7 @@
     <Project Path="test/MeshWeaver.Cli.Test/MeshWeaver.Cli.Test.csproj" />
     <Project Path="test/MeshWeaver.ContentCollections.Test/MeshWeaver.ContentCollections.Test.csproj" />
     <Project Path="test/MeshWeaver.Data.Test/MeshWeaver.Data.Test.csproj" />
+    <Project Path="test/MeshWeaver.Deployment.Contract.Test/MeshWeaver.Deployment.Contract.Test.csproj" />
     <Project Path="test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj" />
     <Project Path="test/MeshWeaver.Data.TestDomain/MeshWeaver.Data.TestDomain.csproj" />
     <Project Path="test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj" />

--- a/deploy/aspire/Memex.Deploy.AppHost/Memex.Deploy.AppHost.csproj
+++ b/deploy/aspire/Memex.Deploy.AppHost/Memex.Deploy.AppHost.csproj
@@ -15,12 +15,19 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\memex\aspire\Memex.Aspire.Hosting\Memex.Aspire.Hosting.csproj"
                       IsAspireProjectResource="false" />
+    <!-- The Deployment record the adapter builds on. The published package BUNDLES this assembly
+         (one PackageReference brings both); in-repo the adapter references it PrivateAssets=all,
+         so the AppHost names it directly — the same two assemblies a customer AppHost sees. -->
+    <ProjectReference Include="..\..\..\src\MeshWeaver.Deployment.Contract\MeshWeaver.Deployment.Contract.csproj"
+                      IsAspireProjectResource="false" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.Docker" />
-    <PackageReference Include="Aspire.Hosting.Kubernetes" />
+    <!-- No Aspire.Hosting.Kubernetes: Aspire emits a Deployment RECORD (the record-out argument in
+         Program.cs), never a chart. The Hosting module renders Helm from the record (maintainer,
+         2026-09-08; core #3646). -->
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />
   </ItemGroup>
 </Project>

--- a/deploy/aspire/Memex.Deploy.AppHost/Program.cs
+++ b/deploy/aspire/Memex.Deploy.AppHost/Program.cs
@@ -1,34 +1,35 @@
 // Dedicated, image-based deployment AppHost for the MeshWeaver Memex portal.
 //
 // Mirrors the conventions of the main memex/aspire/Memex.AppHost, but deploys the PUBLISHED
-// GHCR images via the MeshWeaver.Aspire.Hosting.Memex integration (builder.AddMemex → AddContainer) rather
-// than building the portal from source. One model → many artifacts via the Aspire publishers:
+// GHCR images via the MeshWeaver.Aspire.Hosting.Memex integration (builder.AddMemex) rather than
+// building the portal from source. The instance is declared ONCE, as a Deployment record: every
+// fluent call below is a pure transform of that record, the containers, volumes and environment
+// are derived from it, and `--record-out <path>` writes the final record — the file the setup
+// wizard or a Provision action on the control instance takes (Doc/Architecture/
+// ConfiguringAnInstanceFromAspire). The Aspire publishers turn the same model into artifacts:
 //
 //   aspire publish --apphost deploy/aspire/Memex.Deploy.AppHost/Memex.Deploy.AppHost.csproj \
 //       -o deploy/compose -- --mode compose          # Docker Compose (single)
 //   aspire publish ... -o deploy/compose-ha -- --mode compose-ha     # Docker Compose (HA)
-//   aspire publish ... -o deploy/helm    -- --mode kubernetes        # Kubernetes / Helm
 //   aspire publish ... -o deploy/aca     -- --mode azure             # Azure Container Apps (bicep)
+//
+// 🚨 The Kubernetes/Helm publisher is deliberately NOT wired: Aspire emits a RECORD, never a chart
+// (maintainer, 2026-09-08). The chart is rendered from the record by the Hosting module.
 //
 // Tunables (dotnet user-secrets / env / GitHub secrets), all optional:
 //   Parameters:image-registry  (default ghcr.io/systemorph)
-//   Parameters:image-tag       (default latest)
+//   Parameters:image-tag       (default <major>-latest)
 //   Parameters:include-ai-clis (default true → portal-ai image)
 //   Parameters:key-protection-master-key  (REQUIRED for production)
+//   record-out                 (a path; writes the final Deployment record there on start)
 
 var builder = DistributedApplication.CreateBuilder(args);
+var cfg = builder.Configuration;
 
-var mode = builder.Configuration["mode"]?.ToLowerInvariant() ?? "compose";
+var mode = cfg["mode"]?.ToLowerInvariant() ?? "compose";
 var ha = mode.EndsWith("-ha", StringComparison.Ordinal);
 
-if (mode.StartsWith("kubernetes", StringComparison.Ordinal))
-{
-    builder.AddKubernetesEnvironment("k8s")
-        .WithHelm(helm => helm
-            .WithChartName("memex")
-            .WithChartDescription("MeshWeaver Memex portal — Azure-free Kubernetes self-host."));
-}
-else if (mode == "azure")
+if (mode == "azure")
 {
     builder.AddAzureContainerAppEnvironment("memex-aca");
 }
@@ -37,69 +38,83 @@ else
     builder.AddDockerComposeEnvironment("self-host");
 }
 
-var portal = builder.AddMemex("memex", o => o
-    .WithImage(
-        builder.Configuration["Parameters:image-registry"],
-        builder.Configuration["Parameters:image-tag"])
-    .WithAiClis(!string.Equals(builder.Configuration["Parameters:include-ai-clis"], "false",
-        StringComparison.OrdinalIgnoreCase))
-    .WithBackend("Filesystem")
+var registry = (cfg["Parameters:image-registry"] ?? MemexOptions.DefaultImageRegistry).TrimEnd('/');
+var includeAiClis = !string.Equals(cfg["Parameters:include-ai-clis"], "false", StringComparison.OrdinalIgnoreCase);
+var repository = $"{registry}/{(includeAiClis ? MemexOptions.DefaultPortalRepository : "memex-portal")}";
+
+var portal = builder.AddMemex("memex")
+    // A null tag keeps the default (<major>-latest); a stated one pins the record.
+    .WithImage(repository, cfg["Parameters:image-tag"])
     // Real, Postgres-backed cluster membership in every deployment (never Localhost in prod).
     // Works for a single silo or an HA replica set; the `ha` flag only drives replica count.
     .WithOrleansClustering("AdoNet")
-    .WithMasterKey(builder.Configuration["Parameters:key-protection-master-key"])
+    .WithReplicas(ha ? 2 : 1)
+    // External sign-in (OAuth) providers — client IDs are record fields; the secrets are below.
+    // Each provider is offered only when its ClientId is set. Register the redirect URI on each
+    // app: {BaseUrl}/signin-{microsoft|google|linkedin}.
+    .WithSignIn(
+        microsoftClientId: cfg["Parameters:microsoft-client-id"],
+        microsoftTenantId: cfg["Parameters:microsoft-tenant-id"],
+        googleClientId: cfg["Parameters:google-client-id"],
+        linkedInClientId: cfg["Parameters:linkedin-client-id"])
+    // The same LinkedIn app powers sign-in AND post publishing.
+    .WithSocialLinkedIn(cfg["Parameters:linkedin-client-id"]);
 
-    // Embeddings (vector search). With the endpoint + key set, the one-shot migration
-    // vector-indexes the built-in documentation and the portal embeds search-bar queries.
-    // Leave unset to ship docs as full-text-searchable only (no external AI dependency).
-    .WithEmbeddings(
-        builder.Configuration["Parameters:embedding-endpoint"],
-        builder.Configuration["Parameters:embedding-key"],
-        builder.Configuration["Parameters:embedding-model"])
+// Outbound email (Microsoft Graph /sendMail) — invitations + script-triggered notifications — and
+// the inbound email→agent channel (Graph subscription + webhook; needs Mail.ReadWrite + a public
+// URL). Both are fields of the record's email block; the client secret is a secret (below).
+if (ParseBool(cfg["Parameters:email-enabled"]) is { } emailEnabled)
+    portal.WithEmail(
+        enabled: emailEnabled,
+        mailboxAddress: cfg["Parameters:email-mailbox-address"],
+        clientId: cfg["Parameters:email-client-id"],
+        tenantId: cfg["Parameters:email-tenant-id"],
+        useManagedIdentity: ParseBool(cfg["Parameters:email-use-managed-identity"]),
+        inboundEnabled: ParseBool(cfg["Parameters:email-inbound-enabled"]),
+        webhookBaseUrl: cfg["Parameters:email-webhook-base-url"]);
 
-    // External sign-in (OAuth) providers — deploy parameters. Provide via
-    // `dotnet user-secrets` / env / GitHub secrets locally, or the Marketplace
-    // createUiDefinition wizard for an Azure Application install. Each provider is
-    // offered only when its ClientId is set. Register the redirect URI on each app:
-    // {BaseUrl}/signin-{microsoft|google|linkedin}.
-    .WithMicrosoftSignIn(
-        builder.Configuration["Parameters:microsoft-client-id"],
-        builder.Configuration["Parameters:microsoft-client-secret"],
-        builder.Configuration["Parameters:microsoft-tenant-id"])
-    .WithGoogleSignIn(
-        builder.Configuration["Parameters:google-client-id"],
-        builder.Configuration["Parameters:google-client-secret"])
-    .WithLinkedIn(
-        builder.Configuration["Parameters:linkedin-client-id"],
-        builder.Configuration["Parameters:linkedin-client-secret"])
+// The advanced rung — portal configuration keys the typed surface does not carry, on the record's
+// extraPortalConfig: embeddings (the migration vector-indexes the built-in docs with the same
+// settings the portal embeds search-bar queries with), invitation-only onboarding, the Teams bot.
+foreach (var (key, value) in new (string Key, string? Value)[]
+{
+    ("Embedding__Endpoint", cfg["Parameters:embedding-endpoint"]),
+    ("Embedding__Model", cfg["Parameters:embedding-model"]),
+    ("Features__Onboarding__InvitationOnly", Flag(cfg["Parameters:invitation-only"])),
+    ("Teams__Enabled", Flag(cfg["Parameters:teams-enabled"])),
+    ("Teams__AppId", cfg["Parameters:teams-app-id"]),
+    ("Teams__TenantId", cfg["Parameters:teams-tenant-id"]),
+})
+{
+    if (!string.IsNullOrEmpty(value))
+        portal.WithPortalConfig(key, value);
+}
 
-    // Outbound email (Microsoft Graph /sendMail) — invitations + script-triggered notifications.
-    // On AKS the client secret comes from Key Vault (email-clientsecret → Email__ClientSecret via
-    // the SecretProviderClass), so it is NOT passed here; the rest are non-secret parameters.
-    .WithOutboundEmail(
-        enabled: ParseBool(builder.Configuration["Parameters:email-enabled"]),
-        mailboxAddress: builder.Configuration["Parameters:email-mailbox-address"],
-        tenantId: builder.Configuration["Parameters:email-tenant-id"],
-        clientId: builder.Configuration["Parameters:email-client-id"],
-        clientSecret: builder.Configuration["Parameters:email-client-secret"],
-        useManagedIdentity: ParseBool(builder.Configuration["Parameters:email-use-managed-identity"]))
+// 🚨 Secrets are NEVER on the record (it syncs to git). Under Aspire they are values handed to the
+// container directly; on AKS the same keys come from Key Vault through the record's
+// keyVaultSecrets map (email-clientsecret → Email__ClientSecret, teams-apppassword →
+// Teams__AppPassword, …). `--record-out` never writes any of these.
+foreach (var (key, value) in new (string Key, string? Value)[]
+{
+    ("Ai__KeyProtection__MasterKey", cfg["Parameters:key-protection-master-key"]),
+    ("Embedding__ApiKey", cfg["Parameters:embedding-key"]),
+    ("Authentication__Microsoft__ClientSecret", cfg["Parameters:microsoft-client-secret"]),
+    ("Authentication__Google__ClientSecret", cfg["Parameters:google-client-secret"]),
+    ("Authentication__LinkedIn__ClientSecret", cfg["Parameters:linkedin-client-secret"]),
+    ("Social__LinkedIn__ClientSecret", cfg["Parameters:linkedin-client-secret"]),
+    ("Email__ClientSecret", cfg["Parameters:email-client-secret"]),
+    ("Email__SubscriptionClientState", cfg["Parameters:email-subscription-client-state"]),
+    ("Teams__AppPassword", cfg["Parameters:teams-app-password"]),
+})
+{
+    if (!string.IsNullOrEmpty(value))
+        portal.WithSecret(key, value);
+}
 
-    // Inbound email→agent channel (Graph subscription + webhook). Needs Mail.ReadWrite + a public URL.
-    .WithInboundEmail(
-        enabled: ParseBool(builder.Configuration["Parameters:email-inbound-enabled"]),
-        webhookBaseUrl: builder.Configuration["Parameters:email-webhook-base-url"],
-        clientState: builder.Configuration["Parameters:email-subscription-client-state"])
-
-    // Invitation-only onboarding (Features:Onboarding:InvitationOnly).
-    .WithInvitationOnly(ParseBool(builder.Configuration["Parameters:invitation-only"]))
-
-    // Microsoft Teams bot (bidirectional). Needs an Azure Bot resource + a Teams app. On AKS the bot
-    // secret comes from Key Vault (teams-apppassword → Teams__AppPassword); the rest are non-secret.
-    .WithTeams(
-        enabled: ParseBool(builder.Configuration["Parameters:teams-enabled"]),
-        appId: builder.Configuration["Parameters:teams-app-id"],
-        appPassword: builder.Configuration["Parameters:teams-app-password"],
-        tenantId: builder.Configuration["Parameters:teams-tenant-id"]));
+// The record leaves the AppHost: the file a developer hands to the setup wizard or a Provision
+// action on the control instance.
+if (cfg["record-out"] is { Length: > 0 } recordOut)
+    portal.PublishRecord(recordOut);
 
 // Self-host filesystem backend: the portal writes DataProtection keys, the NodeType
 // assembly cache, and the NuGet cache under /data. The aspnet base image runs as the
@@ -107,9 +122,9 @@ var portal = builder.AddMemex("memex", o => o
 // app cannot create those directories — startup dies with
 // `UnauthorizedAccessException: Access to the path '/data/dataprotection-keys' is denied`.
 // Run the portal as root in the Compose targets so it owns its mounted data volume.
-// (Kubernetes/AKS handles this via the platform overlay — Azure Files CSI mounts 0777 /
-// uid-mapped — and ACA runs containers as root by default, so this is Compose-only.)
-if (!mode.StartsWith("kubernetes", StringComparison.Ordinal) && mode != "azure")
+// (Kubernetes/AKS handles this via the chart — Azure Files CSI mounts 0777 / uid-mapped — and
+// ACA runs containers as root by default, so this is Compose-only.)
+if (mode != "azure")
 {
     portal.PublishAsDockerComposeService((_, service) => service.User = "root");
 }
@@ -117,6 +132,9 @@ if (!mode.StartsWith("kubernetes", StringComparison.Ordinal) && mode != "azure")
 builder.Build().Run();
 
 // Parses an optional bool deploy parameter: null when unset (leave the portal default),
-// otherwise true/false. Hoisted local function — usable from the AddMemex lambda above.
+// otherwise true/false.
 static bool? ParseBool(string? value) =>
     string.IsNullOrEmpty(value) ? null : string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+
+// The same, as the portal-config literal ("true"/"false") or null when unset.
+static string? Flag(string? value) => ParseBool(value) is { } b ? (b ? "true" : "false") : null;

--- a/deploy/aspire/Memex.Deploy.AppHost/Program.cs
+++ b/deploy/aspire/Memex.Deploy.AppHost/Program.cs
@@ -29,13 +29,25 @@ var cfg = builder.Configuration;
 var mode = cfg["mode"]?.ToLowerInvariant() ?? "compose";
 var ha = mode.EndsWith("-ha", StringComparison.Ordinal);
 
-if (mode == "azure")
+// The modes are a closed set: an unknown one (including the retired `kubernetes[-ha]`) must not
+// silently render a Compose file — that is the wrong artifact with no signal.
+switch (mode)
 {
-    builder.AddAzureContainerAppEnvironment("memex-aca");
-}
-else
-{
-    builder.AddDockerComposeEnvironment("self-host");
+    case "compose":
+    case "compose-ha":
+        builder.AddDockerComposeEnvironment("self-host");
+        break;
+    case "azure":
+        builder.AddAzureContainerAppEnvironment("memex-aca");
+        break;
+    case "kubernetes":
+    case "kubernetes-ha":
+        throw new InvalidOperationException(
+            $"--mode {mode} is retired: Aspire emits a Deployment record, never a chart. Run with "
+            + "--record-out <path> and hand the record to the control instance's Provision action "
+            + "(Doc/Architecture/ConfiguringAnInstanceFromAspire).");
+    default:
+        throw new InvalidOperationException($"unknown --mode '{mode}'; expected compose, compose-ha or azure.");
 }
 
 var registry = (cfg["Parameters:image-registry"] ?? MemexOptions.DefaultImageRegistry).TrimEnd('/');

--- a/memex/aspire/Memex.Aspire.Hosting/Memex.Aspire.Hosting.csproj
+++ b/memex/aspire/Memex.Aspire.Hosting/Memex.Aspire.Hosting.csproj
@@ -14,11 +14,31 @@
     <Description>Aspire hosting integration for the MeshWeaver Memex portal. builder.AddMemex() wires Postgres (pgvector) + a one-shot DB migration + the portal from published GHCR images; publish to Docker Compose, Kubernetes/Helm, or Azure Container Apps with the standard Aspire publishers.</Description>
     <Authors>Systemorph</Authors>
     <PackageTags>aspire;hosting;meshweaver;memex;mesh</PackageTags>
+    <!-- The Deployment record assembly rides INSIDE this package (lib/net10.0/) rather than as a
+         package of its own — the maintainer retired every NuGet id but two on 2026-09-07
+         (Doc/Architecture/NuGetPackageRetirement), and a customer AppHost needs exactly one
+         reference to build a record. PrivateAssets=all keeps it out of the nuspec's dependency
+         list; the target below copies the built dll into the package output.
+         publish-packages.yml asserts the dll is in the nupkg before pushing. -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);PackContractAssembly</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
+
+  <!-- Runs in pack's inner per-TFM call, which does not resolve references by itself — without
+       DependsOnTargets the item is empty and the package silently ships without the record
+       assembly (measured 2026-09-08: nupkg with lib/ holding only Memex.Aspire.Hosting.*). -->
+  <Target Name="PackContractAssembly" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths)"
+                            Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'MeshWeaver.Deployment.Contract' and ('%(ReferenceCopyLocalPaths.Extension)' == '.dll' or '%(ReferenceCopyLocalPaths.Extension)' == '.xml')" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <!-- The Deployment record — the ONE input this adapter and the Helm chart both render from.
+         A zero-MeshWeaver-dependency assembly bundled INTO this package (see PackContractAssembly). -->
+    <ProjectReference Include="..\..\..\src\MeshWeaver.Deployment.Contract\MeshWeaver.Deployment.Contract.csproj" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/memex/aspire/Memex.Aspire.Hosting/MemexHostingExtensions.cs
+++ b/memex/aspire/Memex.Aspire.Hosting/MemexHostingExtensions.cs
@@ -112,7 +112,8 @@ public static class MemexHostingExtensions
             context.EnvironmentVariables[DeploymentRecordJson.EnvironmentKey] = DeploymentRecordJson.Write(r);
             foreach (var (key, value) in DeploymentPortalConfig.PortalConfig(r, PortalConfigOptions.Aspire(mcpBaseUrl: null)))
                 context.EnvironmentVariables[key] = value;
-            // The MCP back-connection URL is the endpoint Aspire allocates (substituted at publish).
+            // The MCP back-connection URL is the endpoint Aspire allocates (substituted at publish);
+            // the derivation above deliberately emits nothing for it (PortalConfigOptions.Aspire).
             context.EnvironmentVariables["Mcp__BaseUrl"] = resource.GetEndpoint("http");
             // Orleans clustering as the feature flag the Distributed host reads.
             context.EnvironmentVariables["Features__Orleans__Clustering"] = DeploymentPortalConfig.OrleansClustering(r);
@@ -284,13 +285,29 @@ public static class MemexHostingExtensions
     private static void SyncReplicas(IResourceBuilder<MemexPortalResource> portal, DeploymentContent record) =>
         portal.WithAnnotation(new ReplicaAnnotation(record.Replicas is > 0 ? record.Replicas.Value : 1), ResourceAnnotationMutationBehavior.Replace);
 
+    /// <summary>
+    /// The container's named volumes ARE the record's volumes: one Docker volume
+    /// (<c>{resource}-{volume.Name}</c>) per declared mount path, and a mount derived earlier from
+    /// a volume the record no longer declares is removed — the model never diverges from the
+    /// record. A mount the caller added through Aspire's own <c>WithVolume</c>/<c>WithBindMount</c>
+    /// (a source not carrying this resource's prefix) is left alone.
+    /// </summary>
     private static void SyncVolumes(IResourceBuilder<MemexPortalResource> portal, DeploymentContent record)
     {
+        var prefix = $"{portal.Resource.Name}-";
+        var desired = record.Volumes
+            .Where(v => !string.IsNullOrWhiteSpace(v.MountPath))
+            .ToDictionary(v => v.MountPath!, v => prefix + v.Name, StringComparer.Ordinal);
+
+        foreach (var stale in portal.Resource.Annotations.OfType<ContainerMountAnnotation>()
+                     .Where(m => m.Type == ContainerMountType.Volume && m.Source is { } s && s.StartsWith(prefix, StringComparison.Ordinal))
+                     .Where(m => !desired.TryGetValue(m.Target, out var source) || source != m.Source)
+                     .ToList())
+            portal.Resource.Annotations.Remove(stale);
+
         var mounted = portal.Resource.Annotations.OfType<ContainerMountAnnotation>().Select(m => m.Target).ToHashSet(StringComparer.Ordinal);
-        foreach (var volume in record.Volumes)
-        {
-            if (string.IsNullOrWhiteSpace(volume.MountPath) || mounted.Contains(volume.MountPath)) continue;
-            ContainerResourceBuilderExtensions.WithVolume(portal, $"{portal.Resource.Name}-{volume.Name}", volume.MountPath);
-        }
+        foreach (var (mountPath, source) in desired)
+            if (!mounted.Contains(mountPath))
+                ContainerResourceBuilderExtensions.WithVolume(portal, source, mountPath);
     }
 }

--- a/memex/aspire/Memex.Aspire.Hosting/MemexHostingExtensions.cs
+++ b/memex/aspire/Memex.Aspire.Hosting/MemexHostingExtensions.cs
@@ -1,135 +1,296 @@
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+using MeshWeaver.Deployment;
 
 namespace Aspire.Hosting;
 
 /// <summary>
-/// Aspire hosting integration for the MeshWeaver Memex portal. A single <c>builder.AddMemex()</c>
-/// wires the full runnable topology — Postgres (pgvector), a one-shot DB migration that gates
-/// portal startup, and the portal itself — from published GHCR images, so ANY AppHost can add
-/// Memex as one participant and then generate Docker Compose / Kubernetes-Helm / Azure-ACA
-/// artifacts with the standard Aspire publishers. Object storage, the NodeType compile cache,
-/// the NuGet cache, and DataProtection keys live on mounted volumes (the filesystem backend);
-/// mesh data lives in the Postgres database.
+/// The Memex portal as an Aspire resource, carrying the ONE input every renderer reads: its
+/// <see cref="Record"/>, a <see cref="DeploymentContent"/>. The fluent methods on
+/// <c>IResourceBuilder&lt;MemexPortalResource&gt;</c> are pure transforms of that record (they
+/// delegate to <see cref="DeploymentRecordExtensions"/> one-to-one); the container's image, volumes
+/// and environment are DERIVED from it when the application starts, and the same record is what
+/// the Helm chart renders from through the Hosting module. Aspire emits a record, never a chart.
+/// </summary>
+public sealed class MemexPortalResource(string name) : ContainerResource(name)
+{
+    /// <summary>The Deployment record this portal is built from. Immutable; replaced by every fluent call.</summary>
+    public DeploymentContent Record { get; internal set; } = MemexOptions.DefaultRecord(name);
+
+    /// <summary>The one-shot migration container paired with this portal (same tag, always).</summary>
+    public ContainerResource? Migration { get; internal set; }
+}
+
+/// <summary>
+/// Aspire hosting integration for the MeshWeaver Memex portal. <c>builder.AddMemex()</c> wires the
+/// full runnable topology — Postgres (pgvector), a one-shot DB migration that gates portal startup,
+/// and the portal itself — from the Deployment record: the same <see cref="DeploymentContent"/>
+/// the Hosting module renders Helm from, so an AppHost, a Kubernetes namespace and the setup
+/// wizard all read one declaration of what an instance IS.
+///
+/// <para>The record reaches the portal as configuration the way Orleans' Aspire integration hands
+/// the silo its clustering: one section injected as environment — <c>Deployment__Record</c>
+/// (the whole record as JSON, see <see cref="DeploymentRecordJson"/>) beside the derived per-key
+/// surface (<see cref="DeploymentPortalConfig.PortalConfig"/>: <c>Storage__*</c>,
+/// <c>PluginCatalog__*</c>, <c>Modules__Required__N</c>, …) — and the portal binds it at boot.
+/// The Helm chart renders the same section from the same record, so both routes hand the process
+/// an identical configuration surface. The parity table (method → record field → Helm value →
+/// config key) is <c>Doc/Architecture/ConfiguringAnInstanceFromAspire</c>.</para>
+///
+/// <para>🚨 Secrets are never on the record (it syncs to git). In Kubernetes they are Key Vault
+/// NAMES on the record and values mounted by the CSI driver; in Aspire they are parameters —
+/// <see cref="WithSecret(IResourceBuilder{MemexPortalResource}, string, IResourceBuilder{ParameterResource})"/>.</para>
 /// </summary>
 public static class MemexHostingExtensions
 {
     /// <summary>
     /// Adds the Memex portal — plus its Postgres database and one-shot migration — to the
-    /// application model. Returns the portal container resource so the caller can layer on
-    /// deployment-specific configuration (LLM provider keys, OAuth secrets, scaling, etc.).
+    /// application model, built from a record: the default record for <paramref name="name"/>
+    /// transformed by <paramref name="configure"/>. Chain the fluent methods on the returned builder
+    /// for anything the callback did not settle; both are the same pure transforms.
     /// </summary>
     /// <param name="builder">The distributed application builder.</param>
-    /// <param name="name">Resource name prefix (default <c>memex</c>). The portal resource takes this exact name.</param>
-    /// <param name="configure">
-    /// Optional <see cref="MemexOptions"/> customization. Takes the default options and returns a
-    /// configured copy — chain the <c>With…</c> helpers or use a raw record <c>with</c> expression.
-    /// </param>
-    public static IResourceBuilder<ContainerResource> AddMemex(
+    /// <param name="name">Resource name prefix (default <c>memex</c>); also the record's namespace and Helm release.</param>
+    /// <param name="configure">Optional transform of the default record (<see cref="MemexOptions.DefaultRecord"/>).</param>
+    public static IResourceBuilder<MemexPortalResource> AddMemex(
         this IDistributedApplicationBuilder builder,
         string name = "memex",
-        Func<MemexOptions, MemexOptions>? configure = null)
+        Func<DeploymentContent, DeploymentContent>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        var record = configure?.Invoke(MemexOptions.DefaultRecord(name)) ?? MemexOptions.DefaultRecord(name);
+        return builder.AddMemex(name, record);
+    }
 
-        var options = configure?.Invoke(new MemexOptions()) ?? new MemexOptions();
+    /// <summary>Adds the Memex portal from an explicit record — a file handed over, a registry's copy, a test's fixture.</summary>
+    public static IResourceBuilder<MemexPortalResource> AddMemex(
+        this IDistributedApplicationBuilder builder,
+        string name,
+        DeploymentContent record)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(record);
 
-        var registry = options.ImageRegistry.TrimEnd('/');
-        var tag = options.ImageTag;
-        var portalRepo = options.IncludeAiClis ? "memex-portal-ai" : "memex-portal";
-
-        // --- Postgres (pgvector) — mesh data, in every topology ---
+        // --- Postgres (pgvector) — mesh data, in every topology. Under Aspire the database is an
+        // Aspire resource: Aspire owns its connection string and injects ConnectionStrings__memex,
+        // so the record's DatabaseServer/DatabaseHost (a Kubernetes concern) is not rendered here —
+        // PortalConfigOptions.Aspire says so explicitly. ---
         var postgres = builder.AddPostgres($"{name}-postgres")
             .WithImage("pgvector/pgvector", "pg17")
             .WithDataVolume($"{name}-pgdata");
         var db = postgres.AddDatabase("memex");
-        // Orleans cluster-membership lives on the SAME Postgres server in a SEPARATE database,
-        // so silo membership never shares tables/locks with mesh data. Aspire owns the DB + its
-        // connection string (injected as ConnectionStrings:orleans); the migration creates the
-        // Orleans membership tables and the portal silo uses AdoNet clustering against it.
+        // Orleans cluster-membership lives on the SAME Postgres server in a SEPARATE database.
         var clusteringDb = postgres.AddDatabase("orleans");
 
         // --- One-shot DB migration; the portal waits for it to complete (mirrors DbVersionGate) ---
-        // The migration also mirrors the built-in documentation into the `doc` Postgres schema for
-        // search (with the embedding endpoint/key set it vector-indexes them too) and creates the
-        // Orleans membership tables in the `orleans` database.
-        var migration = builder.AddContainer($"{name}-migration", $"{registry}/memex-migration", tag)
+        var (portalImage, portalTag, migrationImage, migrationTag) = Images(record);
+        var migration = builder.AddContainer($"{name}-migration", migrationImage, migrationTag)
             .WithReference(db)
             .WithReference(clusteringDb)
             .WaitFor(db)
             .WaitFor(clusteringDb);
 
-        foreach (var kv in options.EmbeddingEnvironment())
-            migration.WithEnvironment(kv.Key, kv.Value);
-
         // --- Portal (co-hosted Orleans silo + Blazor web) ---
-        // Resource name is "{name}-portal" so it never collides with the "memex" database
-        // resource that AddDatabase("memex") creates (Aspire resource names are case-insensitive
-        // and must be unique). The DB resource name stays "memex" because WithReference injects
-        // ConnectionStrings__memex, which the portal reads as ConnectionStrings:memex.
-        var portal = builder.AddContainer($"{name}-portal", $"{registry}/{portalRepo}", tag)
-            .WithHttpEndpoint(targetPort: 8080, name: "http")
+        var resource = new MemexPortalResource($"{name}-portal") { Record = record, Migration = migration.Resource };
+        var portal = builder.AddResource(resource);
+        ContainerResourceBuilderExtensions.WithImage(portal, portalImage, portalTag);
+        portal
+            .WithHttpEndpoint(targetPort: DeploymentPortalConfig.HttpPort(record), name: "http")
             .WithExternalHttpEndpoints()
             .WithReference(db)
             .WithReference(clusteringDb)
             .WaitFor(db)
-            .WaitForCompletion(migration)
-            .WithEnvironment("ASPNETCORE_HTTP_PORTS", "8080")
-            // Backend axis (Phase-0 switch in Memex.Portal.Distributed/Program.cs).
-            .WithEnvironment("Deployment__Backend", options.Backend)
-            .WithEnvironment("Deployment__DataRoot", "/data")
-            // Orleans clustering provider — a feature flag (Features:Orleans:Clustering). The
-            // silo reads ConnectionStrings:orleans (injected by WithReference(clusteringDb)).
-            .WithEnvironment("Features__Orleans__Clustering", options.OrleansClustering)
-            // Content storage + graph base paths (filesystem backend).
-            .WithEnvironment("Storage__Name", "content")
-            .WithEnvironment("Storage__SourceType", "FileSystem")
-            .WithEnvironment("Storage__BasePath", "/data/content")
-            .WithEnvironment("Graph__Storage__Type", "PostgreSql")
-            .WithEnvironment("Graph__Storage__BasePath", "/data/graph")
-            // Object storage / NodeType compile cache / NuGet cache / DataProtection keys.
-            .WithVolume($"{name}-data", "/data")
-            // Per-user co-hosted-CLI config (.claude / copilot) — a shared volume in HA.
-            .WithVolume($"{name}-users", "/mnt/users");
+            .WaitForCompletion(migration);
 
-        if (!string.IsNullOrEmpty(options.MasterKey))
-            portal.WithEnvironment("Ai__KeyProtection__MasterKey", options.MasterKey);
+        // The record as configuration — evaluated when the application starts, so every fluent
+        // call made after AddMemex is in it (the Orleans shape: resource → env → options binding).
+        portal.WithEnvironment(context =>
+        {
+            var r = resource.Record;
+            context.EnvironmentVariables[DeploymentRecordJson.EnvironmentKey] = DeploymentRecordJson.Write(r);
+            foreach (var (key, value) in DeploymentPortalConfig.PortalConfig(r, PortalConfigOptions.Aspire(mcpBaseUrl: null)))
+                context.EnvironmentVariables[key] = value;
+            // The MCP back-connection URL is the endpoint Aspire allocates (substituted at publish).
+            context.EnvironmentVariables["Mcp__BaseUrl"] = resource.GetEndpoint("http");
+            // Orleans clustering as the feature flag the Distributed host reads.
+            context.EnvironmentVariables["Features__Orleans__Clustering"] = DeploymentPortalConfig.OrleansClustering(r);
+        });
+        // Embeddings — the migration vector-indexes the built-in docs with the same settings the
+        // portal embeds search-bar queries with, so the vector dimensions line up.
+        migration.WithEnvironment(context =>
+        {
+            foreach (var (key, value) in resource.Record.ExtraPortalConfig)
+                if (key.StartsWith("Embedding__", StringComparison.Ordinal))
+                    context.EnvironmentVariables[key] = value;
+        });
 
-        // Observability: export OTLP traces/metrics to a collector when one is configured.
-        // Logs are scraped from container stdout by the cluster log agent (Promtail), so this
-        // only wires the OTLP push path; ServiceDefaults no-ops the exporter when it's unset.
-        if (!string.IsNullOrEmpty(options.OtlpEndpoint))
-            portal.WithEnvironment("OTEL_EXPORTER_OTLP_ENDPOINT", options.OtlpEndpoint);
-
-        // Embeddings — the portal embeds search-bar queries so they hit the HNSW index that the
-        // migration populated. Same config flows to both so the vector dimensions line up.
-        foreach (var kv in options.EmbeddingEnvironment())
-            portal.WithEnvironment(kv.Key, kv.Value);
-
-        foreach (var kv in options.FeatureEnvironment())
-            portal.WithEnvironment(kv.Key, kv.Value);
-
-        // External sign-in (OAuth) providers — only the ones whose ClientId is set.
-        foreach (var kv in options.AuthEnvironment())
-            portal.WithEnvironment(kv.Key, kv.Value);
-
-        // Outbound email (Microsoft Graph) — invitations + script-triggered notifications.
-        // The client secret is normally supplied out-of-band (Key Vault → Email__ClientSecret);
-        // any value set here is emitted too.
-        foreach (var kv in options.EmailEnvironment())
-            portal.WithEnvironment(kv.Key, kv.Value);
-
-        // Microsoft Teams bot (bidirectional). Secret normally via Key Vault → Teams__AppPassword.
-        foreach (var kv in options.TeamsEnvironment())
-            portal.WithEnvironment(kv.Key, kv.Value);
-
-        // MCP back-connection base URL for the co-hosted CLIs ({BaseUrl}/mcp). Defaults to the
-        // portal's own allocated external endpoint (Aspire substitutes the real URL at publish).
-        if (!string.IsNullOrEmpty(options.BaseUrl))
-            portal.WithEnvironment("Mcp__BaseUrl", options.BaseUrl);
-        else
-            portal.WithEnvironment("Mcp__BaseUrl", portal.GetEndpoint("http"));
-
+        // Volumes, images and replicas follow the record; all are re-applied by every fluent call.
+        SyncVolumes(portal, resource.Record);
+        SyncReplicas(portal, resource.Record);
         return portal;
+    }
+
+    /// <summary>Adds the Memex portal from a record FILE (a bare record, or a full mesh node with a <c>content</c> object).</summary>
+    public static IResourceBuilder<MemexPortalResource> AddMemexFromFile(
+        this IDistributedApplicationBuilder builder, string name, string recordPath) =>
+        builder.AddMemex(name, DeploymentRecordJson.ReadFile(recordPath));
+
+    // ── the fluent surface: one-to-one with DeploymentRecordExtensions ─────────────────────────
+
+    /// <summary>
+    /// Applies a pure transform to the portal's record and re-syncs what Aspire derives from it
+    /// (images, volumes). Every named method below is this with one transform.
+    /// </summary>
+    public static IResourceBuilder<MemexPortalResource> Configure(
+        this IResourceBuilder<MemexPortalResource> portal, Func<DeploymentContent, DeploymentContent> transform)
+    {
+        var resource = portal.Resource;
+        resource.Record = transform(resource.Record);
+        var (portalImage, portalTag, migrationImage, migrationTag) = Images(resource.Record);
+        // Explicitly Aspire's container extensions — the fluent WithImage/WithVolume above shadow them on this builder type.
+        ContainerResourceBuilderExtensions.WithImage(portal, portalImage, portalTag);
+        if (resource.Migration is { } migration)
+            ContainerResourceBuilderExtensions.WithImage(portal.ApplicationBuilder.CreateResourceBuilder(migration), migrationImage, migrationTag);
+        SyncVolumes(portal, resource.Record);
+        SyncReplicas(portal, resource.Record);
+        return portal;
+    }
+
+    /// <summary>The public host (and DNS zone) — <see cref="DeploymentRecordExtensions.WithHost"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithHost(this IResourceBuilder<MemexPortalResource> p, string host, string? dnsZone = null) => p.Configure(r => r.WithHost(host, dnsZone));
+    /// <summary>The namespace / Helm release — <see cref="DeploymentRecordExtensions.WithNamespace"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithNamespace(this IResourceBuilder<MemexPortalResource> p, string ns, string? helmRelease = null) => p.Configure(r => r.WithNamespace(ns, helmRelease));
+    /// <summary>The cluster — <see cref="DeploymentRecordExtensions.WithCluster"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithCluster(this IResourceBuilder<MemexPortalResource> p, string cluster) => p.Configure(r => r.WithCluster(cluster));
+    /// <summary>Owner and purpose — <see cref="DeploymentRecordExtensions.WithOwner"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithOwner(this IResourceBuilder<MemexPortalResource> p, string owner, string? purpose = null) => p.Configure(r => r.WithOwner(owner, purpose));
+    /// <summary>The database — <see cref="DeploymentRecordExtensions.WithDatabase"/>. Under Aspire the server is the Aspire Postgres resource; the name is what the record and the migration use.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithDatabase(this IResourceBuilder<MemexPortalResource> p, string database, string? server = null, string? username = null, string? host = null, int? port = null, string? connectionSecret = null) => p.Configure(r => r.WithDatabase(database, server, username, host, port, connectionSecret));
+    /// <summary>The images — <see cref="DeploymentRecordExtensions.WithImage"/>. Re-tags the portal AND the migration container.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithImage(this IResourceBuilder<MemexPortalResource> p, string repository, string? tag = null, string? pullSecret = null, string? migrationRepository = null) => p.Configure(r => r.WithImage(repository, tag, pullSecret, migrationRepository));
+    /// <summary>Pin the image tag — <see cref="DeploymentRecordExtensions.WithPinnedImageTag"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithPinnedImageTag(this IResourceBuilder<MemexPortalResource> p, string? tag) => p.Configure(r => r.WithPinnedImageTag(tag));
+    /// <summary>Self-update policy — <see cref="DeploymentRecordExtensions.WithUpdatePolicy"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithUpdatePolicy(this IResourceBuilder<MemexPortalResource> p, string policy) => p.Configure(r => r.WithUpdatePolicy(policy));
+    /// <summary>A plugin repository mount — <see cref="DeploymentRecordExtensions.WithPluginRepo"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithPluginRepo(this IResourceBuilder<MemexPortalResource> p, string name, string url, string? gitRef = null, bool isRegistrySource = false, string? secretName = null) => p.Configure(r => r.WithPluginRepo(name, url, gitRef, isRegistrySource, secretName));
+    /// <summary>Packages a fresh boot seeds — <see cref="DeploymentRecordExtensions.PreInstall"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> PreInstall(this IResourceBuilder<MemexPortalResource> p, params string[] packageIds) => p.Configure(r => r.PreInstall(packageIds));
+    /// <summary>Boot modules — <see cref="DeploymentRecordExtensions.WithRequiredModules"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithRequiredModules(this IResourceBuilder<MemexPortalResource> p, params string[] assemblies) => p.Configure(r => r.WithRequiredModules(assemblies));
+    /// <summary>One boot module — <see cref="DeploymentRecordExtensions.WithRequiredModule"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithRequiredModule(this IResourceBuilder<MemexPortalResource> p, string assembly) => p.Configure(r => r.WithRequiredModule(assembly));
+    /// <summary>A boot module at a slot — <see cref="DeploymentRecordExtensions.WithRequiredModuleSlot"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithRequiredModuleSlot(this IResourceBuilder<MemexPortalResource> p, int slot, string assembly) => p.Configure(r => r.WithRequiredModuleSlot(slot, assembly));
+    /// <summary>Replicas — <see cref="DeploymentRecordExtensions.WithReplicas"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithReplicas(this IResourceBuilder<MemexPortalResource> p, int replicas) => p.Configure(r => r.WithReplicas(replicas));
+    /// <summary>Orleans clustering — <see cref="DeploymentRecordExtensions.WithOrleansClustering"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithOrleansClustering(this IResourceBuilder<MemexPortalResource> p, string? clustering) => p.Configure(r => r.WithOrleansClustering(clustering));
+    /// <summary>Resources — <see cref="DeploymentRecordExtensions.WithResources"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithResources(this IResourceBuilder<MemexPortalResource> p, string? requestsCpu = null, string? requestsMemory = null, string? limitsCpu = null, string? limitsMemory = null) => p.Configure(r => r.WithResources(requestsCpu, requestsMemory, limitsCpu, limitsMemory));
+    /// <summary>Autoscaling — <see cref="DeploymentRecordExtensions.WithAutoscaling"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithAutoscaling(this IResourceBuilder<MemexPortalResource> p, bool enabled = true, int? minReplicas = null, int? maxReplicas = null, int? cpuTarget = null, int? memoryTarget = null) => p.Configure(r => r.WithAutoscaling(enabled, minReplicas, maxReplicas, cpuTarget, memoryTarget));
+    /// <summary>A volume — <see cref="DeploymentRecordExtensions.WithVolume"/>; under Aspire it is a named Docker volume mounted at the same path.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithVolume(this IResourceBuilder<MemexPortalResource> p, string name, string mountPath, string? size = null, string? claimName = null, string? storageClass = null, string? accessMode = null, bool create = false) => p.Configure(r => r.WithVolume(name, mountPath, size, claimName, storageClass, accessMode, create));
+    /// <summary>Ingress — <see cref="DeploymentRecordExtensions.WithIngress"/> (a Kubernetes concern; recorded, not applied locally).</summary>
+    public static IResourceBuilder<MemexPortalResource> WithIngress(this IResourceBuilder<MemexPortalResource> p, string? className = null, string? tlsSecret = null, IEnumerable<KeyValuePair<string, string>>? annotations = null, bool? sessionAffinity = null, string? affinityCookie = null) => p.Configure(r => r.WithIngress(className, tlsSecret, annotations, sessionAffinity, affinityCookie));
+    /// <summary>Startup probe — <see cref="DeploymentRecordExtensions.WithStartupProbe"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithStartupProbe(this IResourceBuilder<MemexPortalResource> p, int? periodSeconds = null, int? timeoutSeconds = null, int? failureThreshold = null) => p.Configure(r => r.WithStartupProbe(periodSeconds, timeoutSeconds, failureThreshold));
+    /// <summary>Storage layout — <see cref="DeploymentRecordExtensions.WithStorageLayout"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithStorageLayout(this IResourceBuilder<MemexPortalResource> p, Func<StorageLayout, StorageLayout> configure) => p.Configure(r => r.WithStorageLayout(configure));
+    /// <summary>A language gate sidecar — <see cref="DeploymentRecordExtensions.WithGate"/> (recorded; the sidecar container is a Kubernetes concern).</summary>
+    public static IResourceBuilder<MemexPortalResource> WithGate(this IResourceBuilder<MemexPortalResource> p, string language, string? image = null, string? address = null, bool enabled = true) => p.Configure(r => r.WithGate(language, image, address, enabled));
+    /// <summary>Key Vault name and prefix — <see cref="DeploymentRecordExtensions.WithKeyVault"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithKeyVault(this IResourceBuilder<MemexPortalResource> p, string vault, string? prefix = null) => p.Configure(r => r.WithKeyVault(vault, prefix));
+    /// <summary>Key Vault secret class — <see cref="DeploymentRecordExtensions.WithKeyVaultSecrets"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithKeyVaultSecrets(this IResourceBuilder<MemexPortalResource> p, Func<KeyVaultSecretsSpec, KeyVaultSecretsSpec> map, string? vaultName = null, string? tenantId = null, string? identityClientId = null, string? className = null, string? syncedSecret = null, string? volumeName = null, string? mountPath = null) => p.Configure(r => r.WithKeyVaultSecrets(map, vaultName, tenantId, identityClientId, className, syncedSecret, volumeName, mountPath));
+    /// <summary>Sign-in — <see cref="DeploymentRecordExtensions.WithSignIn"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithSignIn(this IResourceBuilder<MemexPortalResource> p, string? provider = null, string? microsoftClientId = null, string? microsoftTenantId = null, string? googleClientId = null, string? linkedInClientId = null, string? appleClientId = null, bool? enableDevLogin = null) => p.Configure(r => r.WithSignIn(provider, microsoftClientId, microsoftTenantId, googleClientId, linkedInClientId, appleClientId, enableDevLogin));
+    /// <summary>Email — <see cref="DeploymentRecordExtensions.WithEmail"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithEmail(this IResourceBuilder<MemexPortalResource> p, bool enabled = true, string? mailboxAddress = null, string? clientId = null, string? tenantId = null, bool? useManagedIdentity = null, bool? inboundEnabled = null, string? webhookBaseUrl = null, string? inboundForwardAddress = null) => p.Configure(r => r.WithEmail(enabled, mailboxAddress, clientId, tenantId, useManagedIdentity, inboundEnabled, webhookBaseUrl, inboundForwardAddress));
+    /// <summary>The LinkedIn app for post publishing — <see cref="DeploymentRecordExtensions.WithSocialLinkedIn"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithSocialLinkedIn(this IResourceBuilder<MemexPortalResource> p, string? clientId) => p.Configure(r => r.WithSocialLinkedIn(clientId));
+    /// <summary>GitHub App — <see cref="DeploymentRecordExtensions.WithGitHubApp"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithGitHubApp(this IResourceBuilder<MemexPortalResource> p, string clientId, string installationId, string? installationOwner = null) => p.Configure(r => r.WithGitHubApp(clientId, installationId, installationOwner));
+    /// <summary>AI providers — <see cref="DeploymentRecordExtensions.WithAi"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithAi(this IResourceBuilder<MemexPortalResource> p, Func<AiProviders, AiProviders> configure) => p.Configure(r => r.WithAi(configure));
+    /// <summary>The hosting operator — <see cref="DeploymentRecordExtensions.WithOperator"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithOperator(this IResourceBuilder<MemexPortalResource> p, bool enabled = true, string? ns = null, string? serviceAccount = null, string? image = null, IEnumerable<KeyValuePair<string, string>>? environment = null) => p.Configure(r => r.WithOperator(enabled, ns, serviceAccount, image, environment));
+    /// <summary>Telemetry — <see cref="DeploymentRecordExtensions.WithTelemetry"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithTelemetry(this IResourceBuilder<MemexPortalResource> p, string? otlpEndpoint, string? otlpProtocol = null) => p.Configure(r => r.WithTelemetry(otlpEndpoint, otlpProtocol));
+    /// <summary>Idle policy — <see cref="DeploymentRecordExtensions.WithIdlePolicy"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithIdlePolicy(this IResourceBuilder<MemexPortalResource> p, int? suspendAfterDays, int? teardownAfterDays = null) => p.Configure(r => r.WithIdlePolicy(suspendAfterDays, teardownAfterDays));
+    /// <summary>A webhook inbox slot — <see cref="DeploymentRecordExtensions.WithWebhookInbox"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithWebhookInbox(this IResourceBuilder<MemexPortalResource> p, string target, string? secretConfigKey = null) => p.Configure(r => r.WithWebhookInbox(target, secretConfigKey));
+    /// <summary>One portal configuration key — <see cref="DeploymentRecordExtensions.WithPortalConfig(DeploymentContent, string, string)"/>.</summary>
+    public static IResourceBuilder<MemexPortalResource> WithPortalConfig(this IResourceBuilder<MemexPortalResource> p, string key, string value) => p.Configure(r => r.WithPortalConfig(key, value));
+
+    // ── secrets: Aspire parameters, never the record ────────────────────────────────────────────
+
+    /// <summary>
+    /// A secret VALUE for one configuration key, from an Aspire parameter (<c>builder.AddParameter(name, secret: true)</c>).
+    /// This is the Aspire counterpart of a Key Vault NAME on the record; the record itself never
+    /// holds it, and <c>PublishRecord</c> never writes it.
+    /// </summary>
+    public static IResourceBuilder<MemexPortalResource> WithSecret(
+        this IResourceBuilder<MemexPortalResource> portal, string configurationKey, IResourceBuilder<ParameterResource> parameter)
+    {
+        portal.WithEnvironment(configurationKey.Replace(":", "__"), parameter);
+        return portal;
+    }
+
+    /// <summary>A secret VALUE for one configuration key, given inline (development only — prefer a parameter).</summary>
+    public static IResourceBuilder<MemexPortalResource> WithSecret(
+        this IResourceBuilder<MemexPortalResource> portal, string configurationKey, string value)
+    {
+        portal.WithEnvironment(configurationKey.Replace(":", "__"), value);
+        return portal;
+    }
+
+    // ── the record leaves the AppHost ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Writes the FINAL record (every fluent call applied) to <paramref name="path"/> when the
+    /// application starts — the file a developer hands to the setup wizard or a <c>Provision</c>
+    /// action on the control instance. Secrets are never in it, by construction.
+    /// </summary>
+    public static IResourceBuilder<MemexPortalResource> PublishRecord(
+        this IResourceBuilder<MemexPortalResource> portal, string path)
+    {
+        var resource = portal.Resource;
+        portal.ApplicationBuilder.Eventing.Subscribe<BeforeStartEvent>((_, _) =>
+        {
+            DeploymentRecordJson.WriteFile(resource.Record, path);
+            return Task.CompletedTask;
+        });
+        return portal;
+    }
+
+    // ── derivations ─────────────────────────────────────────────────────────────────────────────
+
+    private static (string PortalImage, string PortalTag, string MigrationImage, string MigrationTag) Images(DeploymentContent record)
+    {
+        var tag = DeploymentPortalConfig.Tag(record, MemexOptions.DefaultImageTag) ?? MemexOptions.DefaultImageTag;
+        var portal = string.IsNullOrWhiteSpace(record.ImageRepository)
+            ? $"{MemexOptions.DefaultImageRegistry}/{MemexOptions.DefaultPortalRepository}"
+            : record.ImageRepository!.Trim();
+        var migration = DeploymentPortalConfig.MigrationImage(record with { ImageRepository = portal }, tag)!;
+        var colon = migration.LastIndexOf(':');
+        return (portal, tag, migration[..colon], migration[(colon + 1)..]);
+    }
+
+    private static void SyncReplicas(IResourceBuilder<MemexPortalResource> portal, DeploymentContent record) =>
+        portal.WithAnnotation(new ReplicaAnnotation(record.Replicas is > 0 ? record.Replicas.Value : 1), ResourceAnnotationMutationBehavior.Replace);
+
+    private static void SyncVolumes(IResourceBuilder<MemexPortalResource> portal, DeploymentContent record)
+    {
+        var mounted = portal.Resource.Annotations.OfType<ContainerMountAnnotation>().Select(m => m.Target).ToHashSet(StringComparer.Ordinal);
+        foreach (var volume in record.Volumes)
+        {
+            if (string.IsNullOrWhiteSpace(volume.MountPath) || mounted.Contains(volume.MountPath)) continue;
+            ContainerResourceBuilderExtensions.WithVolume(portal, $"{portal.Resource.Name}-{volume.Name}", volume.MountPath);
+        }
     }
 }

--- a/memex/aspire/Memex.Aspire.Hosting/MemexOptions.cs
+++ b/memex/aspire/Memex.Aspire.Hosting/MemexOptions.cs
@@ -1,379 +1,48 @@
+using MeshWeaver.Deployment;
+
 namespace Aspire.Hosting;
 
 /// <summary>
-/// Options for <see cref="MemexHostingExtensions.AddMemex"/>. Sensible defaults give a
-/// single-node, Azure-free self-host out of the box; override for HA, Azure, or to gate
-/// AI capabilities. Every value maps 1:1 to a portal config key, so the same surface flows
-/// through Docker Compose <c>.env</c>, Kubernetes config, and ACA / ARM container env.
-/// <para>
-/// This is an immutable <see langword="record"/>: configure it either by chaining the
-/// <c>With…</c> helpers (each returns a new instance) or with a raw record <c>with</c>
-/// expression. Both forms compose inside the <see cref="MemexHostingExtensions.AddMemex"/>
-/// <c>configure</c> lambda:
-/// <code>
-/// builder.AddMemex("memex", o => o
-///     .WithBackend("Filesystem")
-///     .WithOrleansClustering("AdoNet")
-///     .WithImage(tag: imageTag)
-///     .WithMicrosoftSignIn(clientId, clientSecret, tenantId));
-///
-/// // equivalent, raw record form:
-/// builder.AddMemex("memex", o => o with { Backend = "Filesystem", ImageTag = imageTag });
-/// </code>
-/// </para>
+/// The Aspire adapter's only inputs that are NOT part of the Deployment record: where the images
+/// come from when the record names no repository, and which version to start on. Everything else
+/// an instance is — host, database, plugins, modules, volumes, sign-in, email, AI, operator — lives
+/// on the <see cref="DeploymentContent"/> record the AppHost builds fluently
+/// (<see cref="MemexHostingExtensions.AddMemex(IDistributedApplicationBuilder, string, Func{DeploymentContent, DeploymentContent}?)"/>),
+/// which is the ONE input Helm renders from too. This type used to be a second, adapter-only copy
+/// of half of those fields; that copy is gone by design (maintainer, 2026-09-08: "the record must
+/// be the only input").
 /// </summary>
-public sealed record MemexOptions
+public static class MemexOptions
 {
-    /// <summary>Container registry + namespace holding the Memex images. Default GHCR / Systemorph.</summary>
-    public string ImageRegistry { get; init; } = "ghcr.io/systemorph";
+    /// <summary>Container registry + namespace the published Memex images live under. Default GHCR / Systemorph.</summary>
+    public const string DefaultImageRegistry = "ghcr.io/systemorph";
+
+    /// <summary>The portal image with the co-hosted Claude Code + GitHub Copilot CLIs baked in (the default).</summary>
+    public const string DefaultPortalRepository = "memex-portal-ai";
 
     /// <summary>
-    /// Image tag applied to all Memex images (portal, migration). Default: the MAJOR-LINE POINTER of
-    /// this adapter's own version — <c>3-latest</c> for a 3.x adapter, <c>4-latest</c> for 4.x —
-    /// which CD moves to every sealed set of that major (across minors) and never to another major.
-    /// The registry also carries <c>&lt;major.minor&gt;-latest</c> and
-    /// <c>&lt;major.minor.patch&gt;-latest</c> for a narrower line, and every exact version; pick
-    /// one with <see cref="WithImage"/>. The portal starts on the pointer and its own self-updater
-    /// takes over from there, so the package version and the image version are independent.
-    /// </summary>
-    public string ImageTag { get; init; } = DefaultImageTag;
-
-    /// <summary>
-    /// <c>&lt;major&gt;-latest</c> for the major of the assembly this record ships in. Derived,
-    /// not typed, so a 4.x adapter cannot be published still naming <c>3-latest</c>. The assembly
-    /// version is stamped by the platform's Directory.Build.props; the <c>latest</c> fallback exists
-    /// only for an unstamped local build, never for a published package.
+    /// <c>&lt;major&gt;-latest</c> for the major of the assembly this adapter ships in. Derived,
+    /// not typed, so a 4.x adapter cannot be published still naming <c>3-latest</c>. CD moves the
+    /// pointer to every sealed set of that major and never to another major; the portal starts on
+    /// it and its own self-updater takes over from there, so the package version and the image
+    /// version are independent. The <c>latest</c> fallback exists only for an unstamped local build.
     /// </summary>
     public static string DefaultImageTag { get; } =
         typeof(MemexOptions).Assembly.GetName().Version is { Major: > 0 } v ? $"{v.Major}-latest" : "latest";
 
     /// <summary>
-    /// Use the <c>memex-portal-ai</c> image (co-hosted Claude Code + GitHub Copilot CLIs baked in)
-    /// rather than the lean <c>memex-portal</c>. Default <c>true</c>. The runtime
-    /// <see cref="Anthropic"/>/<see cref="ClaudeCode"/>/<see cref="Copilot"/> flags still gate
-    /// whether those providers are actually registered.
+    /// The record a bare <c>AddMemex(name)</c> starts from: the default images on the default
+    /// registry, one replica, and the fleet's three volumes at the record's default storage
+    /// layout paths — <c>/data</c> (the state root: DataProtection keys, the module cache, the
+    /// NuGet cache), <c>/mnt/content</c> (the content collection) and <c>/mnt/users</c> (the
+    /// per-user co-hosted-CLI config). Every other field is the record's own default — the
+    /// builder adds nothing (rule (c) of the fluent surface).
     /// </summary>
-    public bool IncludeAiClis { get; init; } = true;
-
-    /// <summary>
-    /// Object-storage / NodeType cache / NuGet cache / DataProtection backend:
-    /// <c>Filesystem</c> (default, mounted volumes) or <c>Azure</c> (blob). Mesh data always lives in Postgres.
-    /// </summary>
-    public string Backend { get; init; } = "Filesystem";
-
-    /// <summary>
-    /// Orleans clustering: <c>Localhost</c> (single node, default), <c>AdoNet</c> (HA, Postgres-backed),
-    /// or <c>AzureTables</c>.
-    /// </summary>
-    public string OrleansClustering { get; init; } = "Localhost";
-
-    /// <summary>Encryption master key for provider credentials (<c>Ai:KeyProtection:MasterKey</c>). Required for production.</summary>
-    public string? MasterKey { get; init; }
-
-    // --- Embeddings (vector search) -----------------------------------------
-    // When the endpoint + key are set, the one-shot migration vector-indexes the built-in
-    // documentation and the portal embeds search-bar queries → semantic search. Without them,
-    // docs are still copied to Postgres and searchable, just full-text only (no vector ranking).
-
-    /// <summary>Azure AI Foundry embeddings endpoint (Cohere embed-v4). Empty = vector search off (FTS still works).</summary>
-    public string? EmbeddingEndpoint { get; init; }
-
-    /// <summary>Embeddings API key (secret). Only emitted to containers when set.</summary>
-    public string? EmbeddingApiKey { get; init; }
-
-    /// <summary>Embeddings model / deployment name. Default <c>embed-v-4-0</c> (the Cohere embed-v4 Azure AI Foundry deployment name).</summary>
-    public string EmbeddingModel { get; init; } = "embed-v-4-0";
-
-    /// <summary>The portal's externally reachable base URL; the co-hosted CLIs connect back to <c>{BaseUrl}/mcp</c>. Defaults to the portal's own endpoint.</summary>
-    public string? BaseUrl { get; init; }
-
-    /// <summary>
-    /// OTLP collector endpoint for telemetry export (sets <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> on the portal).
-    /// Empty = telemetry no-ops (<c>ServiceDefaults</c> skips the exporter when unset). Point this at an
-    /// in-cluster OpenTelemetry collector / Grafana Alloy (e.g. <c>http://otel-collector:4317</c>) to ship
-    /// traces + metrics. NOTE: container <b>logs</b> are collected out-of-band by the cluster log agent
-    /// (Promtail in the grafana/loki-stack — see <c>deploy/aks/scripts/install-observability.sh</c>), so this
-    /// endpoint is only needed for OTLP traces/metrics, not for log shipping.
-    /// </summary>
-    public string? OtlpEndpoint { get; init; }
-
-    // Deploy-time capability flags. null = leave the portal default (on); set false to disable explicitly.
-    public bool? Anthropic { get; init; }
-    public bool? AzureFoundry { get; init; }
-    public bool? AzureOpenAI { get; init; }
-    public bool? OpenAI { get; init; }
-    public bool? ClaudeCode { get; init; }
-    public bool? Copilot { get; init; }
-
-    // --- External sign-in (OAuth) providers ---------------------------------
-    // Set the ClientId to OFFER a provider on the login page; each provider self-skips when
-    // its ClientId is empty (so leaving these unset = that provider simply isn't shown). Register
-    // the matching redirect URI on the provider app: {BaseUrl}/signin-{microsoft|google|linkedin}.
-
-    /// <summary>Entra/Microsoft app registration Application (client) id. Empty = Microsoft sign-in off.</summary>
-    public string? MicrosoftClientId { get; init; }
-    /// <summary>Microsoft client secret.</summary>
-    public string? MicrosoftClientSecret { get; init; }
-    /// <summary>Microsoft/Entra tenant GUID for the HOME directory. Empty/omitted = "common" (any Microsoft account).</summary>
-    public string? MicrosoftTenantId { get; init; }
-
-    /// <summary>Google OAuth client id. Empty = Google sign-in off.</summary>
-    public string? GoogleClientId { get; init; }
-    /// <summary>Google OAuth client secret.</summary>
-    public string? GoogleClientSecret { get; init; }
-
-    /// <summary>LinkedIn OAuth client id (powers both sign-in AND post publishing). Empty = LinkedIn off.</summary>
-    public string? LinkedInClientId { get; init; }
-    /// <summary>LinkedIn OAuth client secret.</summary>
-    public string? LinkedInClientSecret { get; init; }
-
-    // --- Outbound email (Microsoft Graph /sendMail) -------------------------
-    // When EmailEnabled is true the portal sends mail (invitations, notifications) as the
-    // configured no-reply mailbox via the Mail.Send application permission. Left unset = disabled
-    // (the portal registers a NoOp sender). See Doc/Architecture/SendingEmail.md.
-
-    /// <summary>Enable outbound email. null/false = NoOp sender (no mail sent).</summary>
-    public bool? EmailEnabled { get; init; }
-    /// <summary>Mailbox to send as (e.g. <c>no-reply@yourtenant.com</c>).</summary>
-    public string? EmailMailboxAddress { get; init; }
-    /// <summary>Entra tenant GUID for the mail app (client-secret flow).</summary>
-    public string? EmailTenantId { get; init; }
-    /// <summary>Mail app registration client id (client-secret flow).</summary>
-    public string? EmailClientId { get; init; }
-    /// <summary>Mail app client secret (keep in Key Vault).</summary>
-    public string? EmailClientSecret { get; init; }
-    /// <summary>Authenticate via managed identity instead of a client secret (prod).</summary>
-    public bool? EmailUseManagedIdentity { get; init; }
-
-    /// <summary>Enable the inbound email→agent channel (Graph subscription + webhook). Needs Mail.ReadWrite + a public WebhookBaseUrl.</summary>
-    public bool? EmailInboundEnabled { get; init; }
-    /// <summary>Public base URL Graph calls back for inbound notifications (e.g. <c>https://portal.example.com</c>).</summary>
-    public string? EmailWebhookBaseUrl { get; init; }
-    /// <summary>Shared secret echoed by Graph on each inbound notification (webhook validation).</summary>
-    public string? EmailSubscriptionClientState { get; init; }
-
-    /// <summary>Require an invitation to onboard (<c>Features:Onboarding:InvitationOnly</c>). null = portal default (false).</summary>
-    public bool? InvitationOnly { get; init; }
-
-    // --- Microsoft Teams bot (bidirectional channel) ------------------------
-    /// <summary>Enable the Teams bot channel. null/false = inert (endpoint NotFound, no reply sender).</summary>
-    public bool? TeamsEnabled { get; init; }
-    /// <summary>Azure Bot / app registration id (Bot Framework <c>MicrosoftAppId</c>).</summary>
-    public string? TeamsAppId { get; init; }
-    /// <summary>Bot app client secret (<c>MicrosoftAppPassword</c>). Keep in Key Vault.</summary>
-    public string? TeamsAppPassword { get; init; }
-    /// <summary>Entra tenant id for a single-tenant bot (optional; multi-tenant when empty).</summary>
-    public string? TeamsTenantId { get; init; }
-
-    // === Fluent configuration ===============================================
-    // Each helper returns a NEW MemexOptions (record `with`); chain them in the AddMemex
-    // lambda. Empty/null arguments leave the existing value untouched where keeping a
-    // baked-in default matters (image, embedding model); the grouped sign-in/email helpers
-    // assign through verbatim (including null) so the env-emission helpers can self-skip.
-
-    /// <summary>Override the image registry and/or tag. Null/empty arguments keep the current value.</summary>
-    public MemexOptions WithImage(string? registry = null, string? tag = null) =>
-        this with
-        {
-            ImageRegistry = string.IsNullOrEmpty(registry) ? ImageRegistry : registry,
-            ImageTag = string.IsNullOrEmpty(tag) ? ImageTag : tag,
-        };
-
-    /// <summary>Select the AI-CLI portal image (<c>memex-portal-ai</c> vs lean <c>memex-portal</c>).</summary>
-    public MemexOptions WithAiClis(bool include = true) => this with { IncludeAiClis = include };
-
-    /// <summary>Object-storage / cache / DataProtection backend: <c>Filesystem</c> or <c>Azure</c>.</summary>
-    public MemexOptions WithBackend(string backend) => this with { Backend = backend };
-
-    /// <summary>Orleans clustering provider: <c>Localhost</c>, <c>AdoNet</c>, or <c>AzureTables</c>.</summary>
-    public MemexOptions WithOrleansClustering(string clustering) => this with { OrleansClustering = clustering };
-
-    /// <summary>Provider-credential encryption master key (<c>Ai:KeyProtection:MasterKey</c>).</summary>
-    public MemexOptions WithMasterKey(string? masterKey) => this with { MasterKey = masterKey };
-
-    /// <summary>The portal's externally reachable base URL ({BaseUrl}/mcp for the co-hosted CLIs).</summary>
-    public MemexOptions WithBaseUrl(string? baseUrl) => this with { BaseUrl = baseUrl };
-
-    /// <summary>OTLP collector endpoint for trace/metric export.</summary>
-    public MemexOptions WithOtlpEndpoint(string? endpoint) => this with { OtlpEndpoint = endpoint };
-
-    /// <summary>
-    /// Configure vector-search embeddings. <paramref name="endpoint"/> + <paramref name="apiKey"/>
-    /// turn on semantic search; an empty <paramref name="model"/> keeps the default deployment name.
-    /// </summary>
-    public MemexOptions WithEmbeddings(string? endpoint, string? apiKey = null, string? model = null) =>
-        this with
-        {
-            EmbeddingEndpoint = endpoint,
-            EmbeddingApiKey = apiKey,
-            EmbeddingModel = string.IsNullOrEmpty(model) ? EmbeddingModel : model,
-        };
-
-    /// <summary>
-    /// Toggle individual AI providers / CLIs. A <see langword="null"/> argument leaves that flag
-    /// at its current value (so callers flip only what they name, e.g. <c>WithAiProviders(openAI: false)</c>).
-    /// </summary>
-    public MemexOptions WithAiProviders(
-        bool? anthropic = null,
-        bool? azureFoundry = null,
-        bool? azureOpenAI = null,
-        bool? openAI = null,
-        bool? claudeCode = null,
-        bool? copilot = null) =>
-        this with
-        {
-            Anthropic = anthropic ?? Anthropic,
-            AzureFoundry = azureFoundry ?? AzureFoundry,
-            AzureOpenAI = azureOpenAI ?? AzureOpenAI,
-            OpenAI = openAI ?? OpenAI,
-            ClaudeCode = claudeCode ?? ClaudeCode,
-            Copilot = copilot ?? Copilot,
-        };
-
-    /// <summary>Microsoft / Entra sign-in. Omit <paramref name="tenantId"/> for "common" (any Microsoft account).</summary>
-    public MemexOptions WithMicrosoftSignIn(string? clientId, string? clientSecret, string? tenantId = null) =>
-        this with
-        {
-            MicrosoftClientId = clientId,
-            MicrosoftClientSecret = clientSecret,
-            MicrosoftTenantId = tenantId,
-        };
-
-    /// <summary>Google sign-in.</summary>
-    public MemexOptions WithGoogleSignIn(string? clientId, string? clientSecret) =>
-        this with { GoogleClientId = clientId, GoogleClientSecret = clientSecret };
-
-    /// <summary>LinkedIn — the one app powers both sign-in and post publishing.</summary>
-    public MemexOptions WithLinkedIn(string? clientId, string? clientSecret) =>
-        this with { LinkedInClientId = clientId, LinkedInClientSecret = clientSecret };
-
-    /// <summary>
-    /// Outbound email via Microsoft Graph /sendMail. A <see langword="null"/> <paramref name="enabled"/>
-    /// leaves the portal default (NoOp sender); the secret is normally supplied out-of-band (Key Vault).
-    /// </summary>
-    public MemexOptions WithOutboundEmail(
-        bool? enabled = true,
-        string? mailboxAddress = null,
-        string? tenantId = null,
-        string? clientId = null,
-        string? clientSecret = null,
-        bool? useManagedIdentity = null) =>
-        this with
-        {
-            EmailEnabled = enabled,
-            EmailMailboxAddress = mailboxAddress,
-            EmailTenantId = tenantId,
-            EmailClientId = clientId,
-            EmailClientSecret = clientSecret,
-            EmailUseManagedIdentity = useManagedIdentity,
-        };
-
-    /// <summary>
-    /// Inbound email→agent channel (Graph subscription + webhook). Needs Mail.ReadWrite and a
-    /// public <paramref name="webhookBaseUrl"/>; a <see langword="null"/> <paramref name="enabled"/>
-    /// leaves the portal default (off).
-    /// </summary>
-    public MemexOptions WithInboundEmail(
-        bool? enabled = true,
-        string? webhookBaseUrl = null,
-        string? clientState = null) =>
-        this with
-        {
-            EmailInboundEnabled = enabled,
-            EmailWebhookBaseUrl = webhookBaseUrl,
-            EmailSubscriptionClientState = clientState,
-        };
-
-    /// <summary>Require an invitation to onboard. <see langword="null"/> leaves the portal default (false).</summary>
-    public MemexOptions WithInvitationOnly(bool? invitationOnly = true) => this with { InvitationOnly = invitationOnly };
-
-    /// <summary>
-    /// Microsoft Teams bot (bidirectional). Needs an Azure Bot resource + a Teams app; the secret is
-    /// normally supplied out-of-band (Key Vault → <c>Teams__AppPassword</c>). A <see langword="null"/>
-    /// <paramref name="enabled"/> leaves it inert.
-    /// </summary>
-    public MemexOptions WithTeams(
-        bool? enabled = true,
-        string? appId = null,
-        string? appPassword = null,
-        string? tenantId = null) =>
-        this with
-        {
-            TeamsEnabled = enabled,
-            TeamsAppId = appId,
-            TeamsAppPassword = appPassword,
-            TeamsTenantId = tenantId,
-        };
-
-    internal IEnumerable<KeyValuePair<string, string>> AuthEnvironment()
-    {
-        if (!string.IsNullOrEmpty(MicrosoftClientId)) yield return new("Authentication__Microsoft__ClientId", MicrosoftClientId);
-        if (!string.IsNullOrEmpty(MicrosoftClientSecret)) yield return new("Authentication__Microsoft__ClientSecret", MicrosoftClientSecret);
-        if (!string.IsNullOrEmpty(MicrosoftTenantId)) yield return new("Authentication__Microsoft__TenantId", MicrosoftTenantId);
-        if (!string.IsNullOrEmpty(GoogleClientId)) yield return new("Authentication__Google__ClientId", GoogleClientId);
-        if (!string.IsNullOrEmpty(GoogleClientSecret)) yield return new("Authentication__Google__ClientSecret", GoogleClientSecret);
-        if (!string.IsNullOrEmpty(LinkedInClientId))
-        {
-            // The same LinkedIn app id powers sign-in (Authentication) AND post publishing (Social).
-            yield return new("Authentication__LinkedIn__ClientId", LinkedInClientId);
-            yield return new("Social__LinkedIn__ClientId", LinkedInClientId);
-        }
-        if (!string.IsNullOrEmpty(LinkedInClientSecret))
-        {
-            yield return new("Authentication__LinkedIn__ClientSecret", LinkedInClientSecret);
-            yield return new("Social__LinkedIn__ClientSecret", LinkedInClientSecret);
-        }
-    }
-
-    /// <summary>
-    /// Embedding config shared by the migration (vector-indexes docs) and the portal (embeds
-    /// search-bar queries). Model is always emitted so both sides size the vector column the same
-    /// way; endpoint + key are emitted only when configured (ACA rejects empty secrets).
-    /// </summary>
-    internal IEnumerable<KeyValuePair<string, string>> EmbeddingEnvironment()
-    {
-        yield return new("Embedding__Model", EmbeddingModel);
-        if (!string.IsNullOrEmpty(EmbeddingEndpoint)) yield return new("Embedding__Endpoint", EmbeddingEndpoint);
-        if (!string.IsNullOrEmpty(EmbeddingApiKey)) yield return new("Embedding__ApiKey", EmbeddingApiKey);
-    }
-
-    internal IEnumerable<KeyValuePair<string, string>> FeatureEnvironment()
-    {
-        if (Anthropic is { } an) yield return new("Features__Ai__Providers__Anthropic", an ? "true" : "false");
-        if (AzureFoundry is { } af) yield return new("Features__Ai__Providers__AzureFoundry", af ? "true" : "false");
-        if (AzureOpenAI is { } ao) yield return new("Features__Ai__Providers__AzureOpenAI", ao ? "true" : "false");
-        if (OpenAI is { } op) yield return new("Features__Ai__Providers__OpenAI", op ? "true" : "false");
-        if (ClaudeCode is { } cc) yield return new("Features__Ai__Clis__ClaudeCode", cc ? "true" : "false");
-        if (Copilot is { } co) yield return new("Features__Ai__Clis__Copilot", co ? "true" : "false");
-        if (InvitationOnly is { } io) yield return new("Features__Onboarding__InvitationOnly", io ? "true" : "false");
-    }
-
-    /// <summary>
-    /// Outbound-email config. Emitted only when configured (ACA rejects empty secrets). The client
-    /// secret is best supplied out-of-band (Key Vault → <c>Email__ClientSecret</c>) rather than here.
-    /// </summary>
-    internal IEnumerable<KeyValuePair<string, string>> EmailEnvironment()
-    {
-        if (EmailEnabled is { } en) yield return new("Email__Enabled", en ? "true" : "false");
-        if (!string.IsNullOrEmpty(EmailMailboxAddress)) yield return new("Email__MailboxAddress", EmailMailboxAddress);
-        if (!string.IsNullOrEmpty(EmailTenantId)) yield return new("Email__TenantId", EmailTenantId);
-        if (!string.IsNullOrEmpty(EmailClientId)) yield return new("Email__ClientId", EmailClientId);
-        if (!string.IsNullOrEmpty(EmailClientSecret)) yield return new("Email__ClientSecret", EmailClientSecret);
-        if (EmailUseManagedIdentity is { } mi) yield return new("Email__UseManagedIdentity", mi ? "true" : "false");
-        if (EmailInboundEnabled is { } ib) yield return new("Email__InboundEnabled", ib ? "true" : "false");
-        if (!string.IsNullOrEmpty(EmailWebhookBaseUrl)) yield return new("Email__WebhookBaseUrl", EmailWebhookBaseUrl);
-        if (!string.IsNullOrEmpty(EmailSubscriptionClientState)) yield return new("Email__SubscriptionClientState", EmailSubscriptionClientState);
-    }
-
-    /// <summary>
-    /// Teams bot config. Emitted only when set; the bot secret is best supplied out-of-band (Key Vault →
-    /// <c>Teams__AppPassword</c>) rather than here.
-    /// </summary>
-    internal IEnumerable<KeyValuePair<string, string>> TeamsEnvironment()
-    {
-        if (TeamsEnabled is { } en) yield return new("Teams__Enabled", en ? "true" : "false");
-        if (!string.IsNullOrEmpty(TeamsAppId)) yield return new("Teams__AppId", TeamsAppId);
-        if (!string.IsNullOrEmpty(TeamsAppPassword)) yield return new("Teams__AppPassword", TeamsAppPassword);
-        if (!string.IsNullOrEmpty(TeamsTenantId)) yield return new("Teams__TenantId", TeamsTenantId);
-    }
+    public static DeploymentContent DefaultRecord(string name) =>
+        new DeploymentContent { Namespace = name, HelmRelease = name }
+            .WithImage($"{DefaultImageRegistry}/{DefaultPortalRepository}", tag: DefaultImageTag)
+            .WithReplicas(1)
+            .WithVolume("data", "/data")
+            .WithVolume("content", "/mnt/content")
+            .WithVolume("users", "/mnt/users");
 }

--- a/memex/aspire/Memex.Aspire.Hosting/README.md
+++ b/memex/aspire/Memex.Aspire.Hosting/README.md
@@ -1,28 +1,48 @@
 # MeshWeaver.Aspire.Hosting.Memex
 
-Aspire hosting integration for the MeshWeaver Memex portal. `builder.AddMemex(...)` composes
-a complete portal deployment from published container images — no portal source tree needed —
-and the standard Aspire publishers turn that one model into Docker Compose, Kubernetes/Helm,
-or Azure Container Apps artifacts.
+Aspire hosting integration for the MeshWeaver Memex portal. `builder.AddMemex(...)` composes a
+complete portal deployment from published container images — no portal source tree needed — and
+the instance is declared ONCE, as a **Deployment record**: the same `DeploymentContent` the Helm
+chart renders from and the portal itself binds at boot. Every fluent call is a pure transform of
+that record; the containers, volumes and environment are derived from it. The package bundles the
+record assembly (`MeshWeaver.Deployment.Contract`), so one reference is all an AppHost needs.
 
 ## Usage
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddMemex("memex", o => o
-    .WithBackend("Filesystem")
+builder.AddMemex("memex")
+    .WithImage("ghcr.io/systemorph/memex-portal-ai", tag: "3.1.0")   // a release, or "3.1.0-ci.<n>"
     .WithOrleansClustering("AdoNet")
-    .WithImage(tag: "3.0.0"));   // a release, or a continuous build: "3.0.0-ci.<n>"
+    .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")
+    .PreInstall("MeshWeaver.Plugins/Hosting")
+    .WithRequiredModule("MeshWeaver.Hosting.Postgres")
+    .WithSignIn(microsoftClientId: "<client id>", microsoftTenantId: "<tenant>")
+    .WithSecret("Authentication__Microsoft__ClientSecret", builder.AddParameter("microsoft-client-secret", secret: true))
+    .PublishRecord("deployments/memex.json");   // the record, ready for the setup wizard or a Provision action
 
 builder.Build().Run();
 ```
 
+`AddMemex(name, record)` and `AddMemexFromFile(name, path)` start from an existing record instead
+of the default one. Secrets are never on the record — `WithSecret` hands a value to the container
+directly (an Aspire parameter, or a literal in development); on Kubernetes the same keys come from
+Key Vault through the record's `keyVaultSecrets` map.
+
 ## What it wires
 
-- PostgreSQL (pgvector) with a persistent volume
-- The one-shot database migration container, ordered before the portal
-- The portal container (`memex-portal` / `memex-portal-ai`) from the published image tag
+- PostgreSQL (pgvector) with a persistent volume, plus the separate `orleans` clustering database
+- The one-shot database migration container, ordered before the portal, at the SAME image tag
+- The portal container from the record's image, with the record's volumes as named Docker volumes
+- The record itself as configuration: `Deployment__Record` (the whole record as JSON) beside the
+  derived per-key surface the Helm chart also renders — `Storage__*`, `Graph__Storage__*`,
+  `PluginCatalog__*`, `Modules__Required__N`, `Authentication__*`, `Email__*`, …
+
+The parity table (fluent method → record field → Helm value → configuration key) is
+[Configuring an instance from Aspire](https://memex.meshweaver.cloud/Doc/Architecture/ConfiguringAnInstanceFromAspire).
+Aspire emits a record, never a chart: the Kubernetes/Helm side renders from the same record on the
+control instance.
 
 ## Links
 

--- a/src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs
+++ b/src/MeshWeaver.Compiler/FrameworkBuildIdentity.cs
@@ -140,6 +140,12 @@ public static class FrameworkBuildIdentity
         // moved to MeshWeaver.Mesh.Contract, which both remaining consumers already reference.
         "MeshWeaver.Data",
         "MeshWeaver.Data.Contract",
+        // The Deployment record (DeploymentContent, its fluent builder, the portal-config
+        // derivation): the ONE input the in-mesh Hosting module renders Helm from, the Aspire
+        // adapter derives a run from, and the portal binds at boot. In the closure through
+        // MeshWeaver.PluginCatalog so the Hosting sources compile against it — a dependency-free
+        // assembly that changes only when the record's shape does.
+        "MeshWeaver.Deployment.Contract",
         "MeshWeaver.Domain",
         "MeshWeaver.GitSync",
         "MeshWeaver.Graph",

--- a/src/MeshWeaver.Deployment.Contract/DeploymentContent.cs
+++ b/src/MeshWeaver.Deployment.Contract/DeploymentContent.cs
@@ -1,0 +1,528 @@
+// The Deployment record — the ONE input every renderer reads (Helm via the Hosting module, the Aspire adapter, the portal binding its own record from configuration). Moved out of the in-mesh Hosting module (MeshWeaver.Plugins Hosting/Deployment/Source) on 2026-09-08, byte-compatible on the wire ($type + camelCase). Zero MeshWeaver dependencies by design: this assembly rides the published Aspire package.
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System;
+
+namespace MeshWeaver.Deployment;
+
+/// <summary>
+/// Content of an Hosting/Deployment node — one operated MeshWeaver installation (a namespace on a
+/// cluster, its host, its database). This is the INTENDED state, recorded in git; what the cluster
+/// actually runs is read live and compared against it (see <c>DeploymentLayoutAreas</c>).
+///
+/// Immutable; every mutation goes through <c>workspace.GetMeshNodeStream(path).Update(...)</c>.
+///
+/// 🚨 NOTHING SECRET GOES IN HERE. These nodes sync to a git repository, so they carry only
+/// identifiers and topology — never connection strings, client secrets, or Key Vault VALUES. The
+/// Key Vault fields below name secrets; they never hold them.
+/// </summary>
+public record DeploymentContent
+{
+    /// <summary>Public host the portal serves on (e.g. "memex.systemorph.com"). Null → not routed yet.</summary>
+    public string? Host { get; init; }
+
+    /// <summary>Kubernetes namespace. Conventionally the same token as the node id.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Cluster the namespace lives on (e.g. "memexaks-cluster").</summary>
+    public string? Cluster { get; init; }
+
+    /// <summary>Database name on the shared PostgreSQL server — one database per deployment.</summary>
+    public string? Database { get; init; }
+
+    /// <summary>PostgreSQL server hosting <see cref="Database"/> (e.g. "memexaks-pg"). Name only.</summary>
+    public string? DatabaseServer { get; init; }
+
+    /// <summary>Container image repository this deployment pulls (e.g. "meshweaver.azurecr.io/memex-portal-ai").</summary>
+    public string? ImageRepository { get; init; }
+
+    /// <summary>
+    /// Image tag this deployment is INTENDED to run. Empty means "whatever the self-updater picks",
+    /// which is the normal state — pin it only to hold a deployment back deliberately.
+    /// The tag actually running is read from the cluster, never stored here.
+    /// </summary>
+    public string? PinnedImageTag { get; init; }
+
+    /// <summary>
+    /// The Kubernetes Secret (type <c>kubernetes.io/dockerconfigjson</c>) in the instance's own
+    /// namespace that the pods present when they pull <see cref="ImageRepository"/>. A NAME only —
+    /// the credential inside it is the instance's plugin-registry key, written by the provision's
+    /// <c>hosting-pull-secret</c> step from the vault object <c>hosting-kv-ensure</c> already
+    /// requires. Blank → none: the fleet's ACR pull rides the node identity, so an instance on
+    /// <c>meshweaver.azurecr.io</c> states nothing here.
+    ///
+    /// <para>🚨 The rule the fleet follows (maintainer directive, 2026-09-08): every installation
+    /// EXCEPT the one serving the images pulls them from that portal's <c>/v2</c> — the
+    /// read-through mirror — instead of ACR, at creation and on every self-update. The mirror
+    /// instance itself stays on ACR, because a portal cannot serve the image that boots it. So a
+    /// record whose <see cref="ImageRepository"/> names a registry other than ACR MUST name this
+    /// Secret (<c>HelmValues.Problems</c> refuses it otherwise): without one the very first pull
+    /// answers 401 and the instance never starts. It renders as <c>portal.imagePullSecret</c>,
+    /// and the registry host of the repository renders as <c>selfUpdate.registry</c> so the
+    /// self-updater polls and rolls against the same registry the pods pull from.</para>
+    /// </summary>
+    [Description("Image pull Secret name in the instance namespace — required when the image registry is not ACR")]
+    public string? ImagePullSecret { get; init; }
+
+    /// <summary>Self-update policy: Continuous (default), Stable, or None.</summary>
+    public string? UpdatePolicy { get; init; }
+
+    /// <summary>Who this deployment is for — a customer name, or "Systemorph" for our own.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>What it is for, in one line. Shown in the overview.</summary>
+    public string? Purpose { get; init; }
+
+    /// <summary>True when this deployment serves the plugin registry other deployments read from.</summary>
+    public bool IsPluginRegistry { get; init; }
+
+    /// <summary>
+    /// The id this deployment is REGISTERED under at the plugin registry — the value its
+    /// <c>PluginCatalog__InstanceId</c> carries and the <c>MeshWeaverInstance</c> record's id. Blank
+    /// means the deployment id (the fleet's convention: <c>memex</c>, <c>memex-cloud</c>). A key
+    /// rotation adopts the new hash on THIS instance, so a mismatch here rotates the wrong instance
+    /// out from under a running portal — state it when the two differ.
+    /// </summary>
+    [Description("Instance id at the plugin registry — blank means the deployment id")]
+    public string? RegistryInstanceId { get; init; }
+
+    /// <summary>Lifecycle: Planned, Live, Suspended, Decommissioned. Null is treated as Live.</summary>
+    public string? Status { get; init; }
+
+    /// <summary>Key Vault holding this deployment's secrets (e.g. "Systemorph"). NAME only.</summary>
+    public string? KeyVault { get; init; }
+
+    /// <summary>Prefix its Key Vault secrets share (e.g. "memex-"). A prefix, never a value.</summary>
+    public string? KeyVaultSecretPrefix { get; init; }
+
+    /// <summary>Grafana base URL for this deployment's logs. Empty → no logs link in the overview.</summary>
+    public string? GrafanaBaseUrl { get; init; }
+
+    /// <summary>
+    /// Path, relative to the repository root, of the per-environment cluster config for this
+    /// deployment (e.g. "deployments/aks/memex"). Lets the overview link a record to the files that
+    /// realise it.
+    /// </summary>
+    public string? ConfigPath { get; init; }
+
+    /// <summary>
+    /// URL of the git repository holding this deployment's config and this record itself
+    /// (e.g. "https://github.com/Systemorph/Memex"). With <see cref="ConfigPath"/> it lets the
+    /// record link straight to the files that realise it.
+    /// </summary>
+    public string? Repository { get; init; }
+
+    /// <summary>Free-form operator notes (markdown) — quirks, migrations, anything worth knowing.</summary>
+    public string? Notes { get; init; }
+
+    // ───────────────────────────────── the instance spec ─────────────────────────────────
+    // What it takes to CREATE this deployment, not merely to describe one that exists. Every
+    // field below is read by Hosting/InstanceAction when it provisions or tears the instance
+    // down; recording them is what makes an instance reproducible by someone other than whoever
+    // built the last one.
+
+    /// <summary>
+    /// The plugin repositories this instance mounts. Empty means the instance comes up with NO
+    /// plugins and its Plugin Catalog reads "not configured" — a legitimate state for a bare
+    /// deployment, and a silent surprise for any other, which is why it is recorded rather than
+    /// assumed. Rendered into the portal's own <c>PluginCatalog</c> configuration by
+    /// <see cref="DeploymentPortalConfig.ConfigurationEntries"/>.
+    /// </summary>
+    public ImmutableList<PluginRepoMount> PluginRepos { get; init; } = ImmutableList<PluginRepoMount>.Empty;
+
+    /// <summary>
+    /// Packages a FRESH instance seeds itself with, beyond the platform baseline every
+    /// installation gets. Package ids (<c>Edu</c>) or explicit <c>Source/Package</c> patterns
+    /// (<c>Plugins/Edu</c>, <c>Plugins/*</c>); a bare id is qualified against
+    /// <see cref="PluginRepos"/>, because the catalog matches source-scoped and FAILS CLOSED on an
+    /// unqualified one. Rendered into <c>PluginCatalog:InstallByDefault</c>, which the portal
+    /// applies once, on an installation with no install records.
+    /// </summary>
+    public ImmutableList<string> PreInstall { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// Key Vault secret NAME holding the MAIN database connection string. Blank → the convention
+    /// <c>{KeyVaultSecretPrefix}db-connection</c> (<see cref="DeploymentPortalConfig.DatabaseSecretName"/>).
+    /// A NAME, never a value — the value lives in the vault, written by the provision's
+    /// <c>hosting-kv-ensure</c> step or by an operator's hand.
+    /// </summary>
+    public string? DatabaseConnectionSecret { get; init; }
+
+    /// <summary>
+    /// Azure storage account backing this deployment's file shares and content (the PVC storage
+    /// class and blob/content storage). NAME only. Blank → the deployment rides the cluster's
+    /// shared account, which is the fleet default today.
+    /// </summary>
+    public string? StorageAccount { get; init; }
+
+    /// <summary>
+    /// Key Vault secret NAME holding the MAIN storage account's connection string. Blank → the
+    /// convention <c>{KeyVaultSecretPrefix}storage-connection</c>
+    /// (<see cref="DeploymentPortalConfig.StorageSecretName"/>). A NAME, never a value — same rule as every
+    /// other field here.
+    /// </summary>
+    public string? StorageConnectionSecret { get; init; }
+
+    /// <summary>
+    /// Module assemblies this instance must BOOT — the database driver, the AI engine, the MCP
+    /// endpoint (<c>MeshWeaver.Hosting.PostgreSql.dll</c>, <c>MeshWeaver.AI.dll</c>,
+    /// <c>MeshWeaver.Mcp.dll</c>, …). Rendered into <c>Modules:Required</c> by
+    /// <see cref="DeploymentPortalConfig.ModuleEntries"/>, so a missing module STALLS the rollout instead of
+    /// booting green without the feature (the 2026-08-26/27 AI-engine shape).
+    ///
+    /// <para>🚨 <c>Modules:Required</c> configuration overrides the image's own list BY INDEX —
+    /// entry N here replaces the image's entry N, it never appends. So when this list is used at
+    /// all, record the COMPLETE required set for the instance (the image baseline included), not a
+    /// delta; a partial list silently rewrites what the image's leading indices name.</para>
+    /// </summary>
+    public ImmutableList<string> RequiredModules { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// Where this deployment's database backups go — the path of a <c>Hosting/BackupStore</c> node.
+    /// Blank → the fleet default store. A teardown that is asked to back up and finds NO store
+    /// resolvable is REFUSED, never silently skipped.
+    /// </summary>
+    public string? BackupStore { get; init; }
+
+    /// <summary>
+    /// Days without recorded activity before the instance is SUSPENDED automatically — the
+    /// reversible paywall + verified dump, exactly the manual Suspend. Null = never. The idle
+    /// reconciler acts only when a status sample actually carries an activity timestamp
+    /// (<c>DeploymentStatusContent.LastActivityAt</c>); no signal, no automatic action.
+    /// </summary>
+    public int? IdleSuspendDays { get; init; }
+
+    /// <summary>
+    /// Days a suspension may stand before the instance is TORN DOWN automatically. The suspension
+    /// IS the notice period. Null = never automatically. See <c>IdlePolicy</c>.
+    /// </summary>
+    public int? IdleTeardownDays { get; init; }
+
+    /// <summary>
+    /// Public DNS zone this deployment's host lives in (e.g. <c>meshweaver.cloud</c>). Provision
+    /// adds the A-record in it; teardown removes it. Blank → DNS is managed outside this record,
+    /// and both phases skip it and SAY SO rather than guessing a zone.
+    /// </summary>
+    public string? DnsZone { get; init; }
+
+    /// <summary>
+    /// Helm release name for this deployment. Blank → the namespace. Recorded because a release
+    /// named differently from its namespace is invisible until an upgrade targets the wrong one.
+    /// </summary>
+    public string? HelmRelease { get; init; }
+
+    /// <summary>
+    /// Intended portal replicas. Null → the chart's default. Intent only: what is RUNNING is
+    /// sampled into Hosting/DeploymentStatus, never written back here. A suspension records the
+    /// value it scaled DOWN from here, so reactivation restores the same shape.
+    /// </summary>
+    public int? Replicas { get; init; }
+
+    /// <summary>
+    /// When this instance was suspended. Null → never, or already reactivated. The grace period
+    /// before a teardown may proceed is measured from here, so it is part of the RECORD rather
+    /// than something reconstructed from an activity log.
+    /// </summary>
+    public DateTimeOffset? SuspendedAt { get; init; }
+
+    /// <summary>
+    /// Days a suspension is held before this instance may be torn down. 0 → the platform default.
+    /// The suspension IS the notice period: the host answers with the paywall throughout it and
+    /// the owner can export their data the whole time.
+    /// </summary>
+    public int GracePeriodDays { get; init; }
+
+    /// <summary>Why the instance was suspended, in one line. Shown to nobody but operators.</summary>
+    public string? SuspensionReason { get; init; }
+
+    // ───────────────────────────────── the instance SHAPE ─────────────────────────────────
+    // What the helm chart's values used to carry per environment, by hand, and what its
+    // templates hard-coded — typed here so the record is the ONLY source of an instance's
+    // deployment. HelmValues projects this onto the chart's values surface today; the manifest
+    // generator that replaces the hand-written chart projects the same fields tomorrow. Every
+    // property is optional: a null means "not stated here" and renders NOTHING, so a record that
+    // omits a section neither invents a value nor blanks one the Key Vault half supplies.
+    // See InstanceShape.cs for the records and the rationale each carries.
+
+    /// <summary>
+    /// The database server's HOST as the portal connects to it. Blank → derived from
+    /// <see cref="DatabaseServer"/> as an Azure flexible server
+    /// (<c>{server}.postgres.database.azure.com</c>), or the in-cluster service when no server is
+    /// named. Always the FQDN, never the private IP: the IP changes on server maintenance.
+    /// </summary>
+    [Description("Database host (FQDN) — blank derives it from the server name")]
+    public string? DatabaseHost { get; init; }
+
+    /// <summary>The database port. Null → 5432.</summary>
+    [Description("Database port")]
+    public int? DatabasePort { get; init; }
+
+    /// <summary>The database user the portal and the migration connect as. Blank → <c>postgres</c>. The password is a secret and rides the Key Vault half.</summary>
+    [Description("Database user")]
+    public string? DatabaseUsername { get; init; }
+
+    /// <summary>
+    /// Whether the chart runs its own in-cluster Postgres. False on every fleet instance — they
+    /// share an Azure flexible server, and the retired in-cluster StatefulSet must STAY at zero;
+    /// rendering it again would scale a dead database back up beside the live one.
+    /// </summary>
+    [Description("Run an in-cluster Postgres (self-host only)")]
+    public bool InClusterPostgres { get; init; }
+
+    /// <summary>The migration image repository. Blank → the portal repository with <c>memex-portal-ai</c> replaced by <c>memex-migration</c> (the fleet's pairing).</summary>
+    [Description("Migration image repository — blank derives it from the portal's")]
+    public string? MigrationImageRepository { get; init; }
+
+    /// <summary>The portal's HTTP port inside the pod. Null → 8080.</summary>
+    [Description("HTTP port")]
+    public int? HttpPort { get; init; }
+
+    /// <summary>The RAM/CPU envelope — the first thing an operator sizes.</summary>
+    [Description("Resources (RAM / CPU)")]
+    public ResourceEnvelope? Resources { get; init; }
+
+    /// <summary>KEDA autoscaling. Null → not stated; the chart renders a fixed <see cref="Replicas"/>.</summary>
+    [Description("Autoscaling")]
+    public Autoscaling? Autoscaling { get; init; }
+
+    /// <summary>The persistent volumes the portal mounts.</summary>
+    [Description("Volumes")]
+    public ImmutableList<VolumeClaim> Volumes { get; init; } = ImmutableList<VolumeClaim>.Empty;
+
+    /// <summary>How the host reaches the portal.</summary>
+    [Description("Ingress")]
+    public IngressSpec? Ingress { get; init; }
+
+    /// <summary>
+    /// The Next.js React front end served at <c>/next</c> beside the Blazor portal. Null → nothing
+    /// renders and the chart's default (off) stands, so a record that does not mention it deploys
+    /// exactly as before. Stating it here is what stops a re-render of the values file from
+    /// DELETING a deployed front end: the block used to live only in a hand-written overlay under
+    /// a header claiming the file is generated from this record (MeshWeaver.Plugins#1408).
+    /// </summary>
+    [Description("React front end at /next")]
+    public PortalNextSpec? PortalNext { get; init; }
+
+    /// <summary>
+    /// The pod's FIRST Key Vault secret class, DECLARED by name — the chart renders the
+    /// SecretProviderClass, the CSI volume, its mount and the envFrom from this one section.
+    /// Null → nothing renders. Names only, never values; see <see cref="KeyVaultSecretsSpec"/>.
+    ///
+    /// <para>An instance that reads MORE than one vault-secret set declares the rest in
+    /// <see cref="KeyVaultSecretClasses"/>; the two together are the instance's classes, in that
+    /// order, and that order is env PRECEDENCE.</para>
+    /// </summary>
+    [Description("Key Vault secrets (declared by name)")]
+    public KeyVaultSecretsSpec? KeyVaultSecrets { get; init; }
+
+    /// <summary>
+    /// ADDITIONAL Key Vault secret classes — one entry per further SecretProviderClass the instance
+    /// reads, same shape as <see cref="KeyVaultSecrets"/>.
+    ///
+    /// <para>🚨 WHY IT EXISTS, measured. <c>memex</c> runs TWO classes: the hand-made <c>memex-kv</c>
+    /// (13 keys — the connection string, the GitHub App private key, the AI provider keys) and the
+    /// chart-owned <c>memex-portal-keyvault</c> (the plugin-registry token). With one slot the
+    /// record had to CHOOSE, and whichever it named a re-render DROPPED the other. On 2026-09-06
+    /// the record named <c>memex-kv</c> while the deployed overlay named <c>memex-portal-keyvault</c>:
+    /// a re-render from the record would have removed the class that had just fixed the registry
+    /// poll (MeshWeaver#3201 / Memex#164) AND rendered a class for <c>memex-kv</c> naming a vault
+    /// object that does not exist — a failed CSI mount, i.e. a portal that cannot start. The record
+    /// could not describe the instance, so re-deriving the overlay from it was destructive.</para>
+    ///
+    /// <para>ORDER IS PRECEDENCE. The classes are appended to the pod's <c>envFrom</c> after the
+    /// chart's ConfigMap and Secret, in this order; Kubernetes keeps the LAST entry on a key clash.
+    /// A key declared by two classes is therefore ambiguous to a reader and is a named problem —
+    /// see <c>HelmValues.Problems</c>.</para>
+    /// </summary>
+    [Description("Additional Key Vault secret classes (a second SecretProviderClass, and further)")]
+    public ImmutableList<KeyVaultSecretsSpec> KeyVaultSecretClasses { get; init; }
+        = ImmutableList<KeyVaultSecretsSpec>.Empty;
+
+    /// <summary>
+    /// Configuration keys the chart's OWN Secret (<c>memex-portal-secrets</c>) supplies, by NAME.
+    /// That Secret is rendered from the Key Vault "values half" — the captured
+    /// <c>secrets.memex_portal.*</c> block that <c>helm-release</c> layers under the committed
+    /// overlay — so its keys are decided outside this record and outside the repository.
+    ///
+    /// <para>Declarative: this renders NOTHING. It exists so the record knows what that layer
+    /// supplies, which is what makes the precedence stack complete and shadow analysis honest. On
+    /// <c>memex</c> six of its eleven keys are ALSO supplied by a declared class
+    /// (<c>Ai__KeyProtection__MasterKey</c>, <c>Authentication__Microsoft__ClientSecret</c>,
+    /// <c>AzureFoundry__ApiKey</c>, <c>ConnectionStrings__memex</c>, <c>OpenRouter__ApiKey</c>,
+    /// <c>PluginCatalog__RegistryToken</c>) and the class wins, because it sits later in
+    /// <c>envFrom</c>. Without this list, a reader of the record cannot tell that the chart's Secret
+    /// even carries them.</para>
+    ///
+    /// <para>NAMES ONLY. Never a value — the same rule as every other field here.</para>
+    /// </summary>
+    [Description("Keys the chart's own Secret supplies, from the Key Vault values half (names only)")]
+    public ImmutableList<string> VaultValuesKeys { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// Environment variables set INLINE on the live Deployment — the layer above every
+    /// <c>envFrom</c>, and the only one no file renders.
+    ///
+    /// <para>Declarative: this renders NOTHING, and that is the point. <c>helm upgrade</c> does not
+    /// remove an inline entry (three-way merge removes only what helm previously owned, measured
+    /// 2026-09-03), so one SURVIVES every deploy and keeps outranking the ConfigMap and every synced
+    /// Secret. A record that cannot state them disagrees with the pod at every read, which makes
+    /// every real difference indistinguishable from the known ones. See
+    /// <see cref="InlineEnvOverride"/> — and never record a credential's value there.</para>
+    /// </summary>
+    [Description("Inline env entries on the live Deployment (declarative — renders nothing)")]
+    public ImmutableList<InlineEnvOverride> InlineEnv { get; init; }
+        = ImmutableList<InlineEnvOverride>.Empty;
+
+    /// <summary>
+    /// Foreign-language GATE sidecars in the portal pod (python, node, pandas). Empty → the pod runs
+    /// the portal container alone. Rendered into the chart's <c>grpc.gates</c>.
+    /// </summary>
+    [Description("Language gate sidecars")]
+    public ImmutableList<GateSpec> Gates { get; init; } = ImmutableList<GateSpec>.Empty;
+
+    /// <summary>
+    /// ⚠️ LEGACY — mounts of HAND-MADE SecretProviderClasses, by name. Declare the secrets under
+    /// <see cref="KeyVaultSecrets"/> instead; kept for the transition (a mount that names the same
+    /// volume or class as the declaration is a named problem).
+    /// </summary>
+    [Description("Key Vault secret mounts (legacy — hand-made SecretProviderClass by name)")]
+    public ImmutableList<KeyVaultSecretMount> SecretMounts { get; init; } = ImmutableList<KeyVaultSecretMount>.Empty;
+
+    /// <summary>AI providers and the tier map.</summary>
+    [Description("AI providers")]
+    public AiProviders? Ai { get; init; }
+
+    /// <summary>Sign-in providers — client ids; secrets ride the Key Vault half.</summary>
+    [Description("Sign-in")]
+    public SignInSpec? SignIn { get; init; }
+
+    /// <summary>System email through Microsoft Graph.</summary>
+    [Description("Email")]
+    public EmailSpec? Email { get; init; }
+
+    /// <summary>The GitHub App identity (identifiers only).</summary>
+    [Description("GitHub App")]
+    public GitHubAppIdentity? GitHubApp { get; init; }
+
+    /// <summary>The lifecycle operator — the control instance only.</summary>
+    [Description("Hosting operator")]
+    public HostingOperatorSpec? Operator { get; init; }
+
+    /// <summary>
+    /// The container registry service this instance HOSTS for the fleet (MeshWeaver#3353) —
+    /// <c>cr.meshweaver.cloud</c>, an off-the-shelf blob-backed OCI registry the portal chart
+    /// deploys beside the portal under <c>registry.enabled</c>. Only the PUBLIC instance sets it;
+    /// null → nothing renders and no registry runs in the namespace. Every other installation is a
+    /// consumer: it names <c>{host}/memex-portal-ai</c> as its <see cref="ImageRepository"/> and
+    /// the pull Secret in <see cref="ImagePullSecret"/>, and pulls with its plugin-registry key.
+    /// Names only — see <see cref="RegistrySpec"/>.
+    /// </summary>
+    [Description("Container registry this instance hosts (the public instance only)")]
+    public RegistrySpec? Registry { get; init; }
+
+    /// <summary>OpenTelemetry export.</summary>
+    [Description("Telemetry")]
+    public TelemetrySpec? Telemetry { get; init; }
+
+    /// <summary>The rollout drain. Null → the platform defaults (1800 s ceiling, 120 s margin).</summary>
+    [Description("Rollout drain")]
+    public DrainSpec? Drain { get; init; }
+
+    /// <summary>The startup probe budget. Null → the platform default (5 × 60 = 5 minutes).</summary>
+    [Description("Startup probe")]
+    public StartupProbeSpec? StartupProbe { get; init; }
+
+    /// <summary>Where the portal keeps its state. Null → the platform layout.</summary>
+    [Description("Storage layout")]
+    public StorageLayout? Storage { get; init; }
+
+    /// <summary>
+    /// Orleans clustering: <c>AdoNet</c> or <c>Localhost</c>. Blank → AdoNet when the instance runs
+    /// more than one pod (fixed replicas above 1, or autoscaling), else Localhost. "Localhost" on a
+    /// multi-pod instance is single-process membership: every pod becomes its OWN one-silo cluster,
+    /// every singleton runs N times, node writes collide and cross-pod calls fail (measured live
+    /// 2026-08-25) — which is why the derivation exists.
+    /// </summary>
+    [Description("Orleans clustering — blank derives it from the replica count")]
+    public string? OrleansClustering { get; init; }
+
+    /// <summary>The self-updater's restart floor. Blank → <c>01:00:00</c>, matched to the publication tick.</summary>
+    [Description("Minimum interval between self-update rolls")]
+    public string? MinRollInterval { get; init; }
+
+    /// <summary>
+    /// Converge onto every newly published NodeType build (MeshWeaver#2192). Off, every publication
+    /// wave leaves serving pods on their old assemblies behind the Recycle banner until the
+    /// type-hosting silos go GC-bound at 17–20 GB while still Ready. Null → not stated.
+    /// </summary>
+    [Description("Auto-recycle on a stale NodeType build")]
+    public bool? AutoRecycleOnStaleBuild { get; init; }
+
+    /// <summary>
+    /// Boot modules placed at an EXPLICIT index past the contiguous <see cref="RequiredModules"/>
+    /// list — the by-index override. <c>Modules:Required</c> replaces the image's entry N and never
+    /// appends, so "require MCP without touching the image's slots 5 and 6" is slot 7 here, not a
+    /// sixth list entry (the Memex#131 replacement that silently un-required a module).
+    /// </summary>
+    [Description("Boot modules at explicit slots (by-index override)")]
+    public ImmutableSortedDictionary<int, string> RequiredModuleSlots { get; init; }
+        = ImmutableSortedDictionary<int, string>.Empty;
+
+    /// <summary>
+    /// Webhook inbox targets by slot. Both fleet slots are stated explicitly where used, because a
+    /// hand-set <c>env:</c> on the live Deployment permanently shadows whatever the ConfigMap renders
+    /// for the same name (#2235).
+    /// </summary>
+    [Description("Webhook inbox targets, by slot (legacy — prefer the typed slots)")]
+    public ImmutableList<string> WebhookInboxTargets { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// 🚨 The webhook inbox slots WITH their authentication (MeshWeaver.Plugins#1442). The chart
+    /// renders two keys per slot — <c>WebhookInbox__Targets__N</c> (where a delivery goes) and
+    /// <c>WebhookInbox__Targets__N__SecretConfigKey</c> (the configuration key holding the HMAC the
+    /// inbox verifies <c>X-Hub-Signature-256</c> against; empty = accept unverified). Stating the
+    /// second half in the free-form extras is how memex-cloud's key was reverted by the next
+    /// automated write while the target survived (Systemorph/Memex#205): reachability was typed,
+    /// authentication was not, and the two came apart. Here they are one record per slot.
+    /// <para>When this list is set, <see cref="WebhookInboxTargets"/> must be empty
+    /// (<c>HelmValues.Problems</c> names a record that states both), and an extra naming a
+    /// slot's key is a collision, not an override.</para>
+    /// </summary>
+    [Description("Webhook inbox slots: target + the config key holding its HMAC secret")]
+    public ImmutableList<WebhookInboxSlot> WebhookInbox { get; init; } = ImmutableList<WebhookInboxSlot>.Empty;
+
+    /// <summary>The Social plugin's LinkedIn app client id (identifier only).</summary>
+    [Description("Social LinkedIn client id")]
+    public string? SocialLinkedInClientId { get; init; }
+
+    /// <summary>
+    /// The advanced rung: portal configuration keys (<c>Section__Key</c>) beyond the typed surface,
+    /// rendered verbatim under the portal config. A key the chart's ConfigMap does not list never
+    /// reaches a container — the typed properties above are the ones it is known to read.
+    /// </summary>
+    [Description("Extra portal configuration (Section__Key = value)")]
+    public ImmutableSortedDictionary<string, string> ExtraPortalConfig { get; init; }
+        = ImmutableSortedDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// One webhook inbox slot: where a delivery is routed and how it is authenticated — both halves
+/// of what the chart renders per slot, on one record so they cannot be edited, rendered, reverted
+/// or migrated independently (MeshWeaver.Plugins#1442).
+/// </summary>
+public sealed record WebhookInboxSlot
+{
+    /// <summary>The mesh path the slot routes deliveries to, e.g. <c>Hosting/PlatformBuilds</c>.</summary>
+    [Description("Target path the slot routes deliveries to")]
+    public string Target { get; init; } = "";
+
+    /// <summary>
+    /// The CONFIGURATION KEY holding this slot's shared HMAC secret — never the secret itself. When
+    /// set, the inbox verifies <c>X-Hub-Signature-256</c> over the raw body and answers 401 to a
+    /// delivery it cannot verify; blank keeps the unverified contract, which is the only safe default
+    /// for a slot whose sender does not sign GitHub-style (a Stripe target signs
+    /// <c>Stripe-Signature</c>, which this endpoint does not speak).
+    /// </summary>
+    [Description("Configuration key holding the slot's HMAC secret (blank = unverified)")]
+    public string? SecretConfigKey { get; init; }
+}

--- a/src/MeshWeaver.Deployment.Contract/DeploymentPortalConfig.cs
+++ b/src/MeshWeaver.Deployment.Contract/DeploymentPortalConfig.cs
@@ -1,0 +1,454 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Deployment;
+
+/// <summary>
+/// The PURE derivations every renderer of a <see cref="DeploymentContent"/> shares — what the
+/// record MEANS as portal configuration, independent of who renders it: the Helm chart (through the
+/// in-mesh Hosting module's <c>HelmValues</c>), the Aspire adapter (a local container), and the
+/// portal reading its own record. One place, so a Kubernetes pod and an Aspire container receive
+/// the same keys for the same record, and a difference between the two is a bug here rather than
+/// a drift between two renderers (the record/overlay gate measured 41 silent differences between
+/// two renderers of one intent on 2026-09-06 — this type is why there will not be a third).
+///
+/// <para>Ported verbatim from the in-mesh <c>InstanceSpec</c> and <c>HelmValues</c> on 2026-09-08;
+/// the in-mesh code delegates here. Hub-free, allocation-light, unit-testable without a mesh.</para>
+/// </summary>
+public static class DeploymentPortalConfig
+{
+    /// <summary>The configuration key prefix the portal reads its catalog wiring from.</summary>
+    public const string CatalogSection = "PluginCatalog";
+
+    /// <summary>The configuration key prefix the portal reads its module policy from.</summary>
+    public const string ModulesSection = "Modules";
+
+    /// <summary>Conventional suffix of the vault secret holding the main DB connection string.</summary>
+    public const string DatabaseSecretSuffix = "db-connection";
+
+    /// <summary>Conventional suffix of the vault secret holding the storage connection string.</summary>
+    public const string StorageSecretSuffix = "storage-connection";
+
+    /// <summary>Azure Database for PostgreSQL host suffix appended to a bare server name.</summary>
+    public const string AzurePostgresDomain = ".postgres.database.azure.com";
+
+    /// <summary>The in-cluster Postgres service a record without a server name resolves to.</summary>
+    public const string InClusterPostgresService = "memex-postgres-service";
+
+    /// <summary>The portal's in-cluster service name (what <c>Mcp:BaseUrl</c> points at in Kubernetes).</summary>
+    public const string PortalService = "memex-portal-service";
+
+    /// <summary>Default self-update spacing when the record states none.</summary>
+    public const string DefaultMinRollInterval = "01:00:00";
+
+    // ───────────────────────────────── secret NAMES (never values) ─────────────────────────────
+
+    /// <summary>
+    /// The Key Vault secret NAME the main database connection string lives under: the record's
+    /// explicit <see cref="DeploymentContent.DatabaseConnectionSecret"/>, else the convention
+    /// <c>{KeyVaultSecretPrefix}db-connection</c>. Always a name — the VALUE never appears on any
+    /// record. Pure.
+    /// </summary>
+    public static string DatabaseSecretName(DeploymentContent? record) =>
+        !string.IsNullOrWhiteSpace(record?.DatabaseConnectionSecret)
+            ? record!.DatabaseConnectionSecret!.Trim()
+            : (record?.KeyVaultSecretPrefix ?? "").Trim() + DatabaseSecretSuffix;
+
+    /// <summary>
+    /// The Key Vault secret NAME the storage connection string lives under, or null when the
+    /// record names no <see cref="DeploymentContent.StorageAccount"/>. Pure.
+    /// </summary>
+    public static string? StorageSecretName(DeploymentContent? record) =>
+        string.IsNullOrWhiteSpace(record?.StorageAccount) ? null
+        : !string.IsNullOrWhiteSpace(record!.StorageConnectionSecret)
+            ? record.StorageConnectionSecret!.Trim()
+            : (record.KeyVaultSecretPrefix ?? "").Trim() + StorageSecretSuffix;
+
+    // ───────────────────────────────── database + ports ────────────────────────────────────────
+
+    /// <summary>Database host: the explicit FQDN, else the Azure server's FQDN, else the in-cluster service.</summary>
+    public static string DatabaseHost(DeploymentContent d) =>
+        !string.IsNullOrWhiteSpace(d.DatabaseHost) ? d.DatabaseHost!.Trim()
+        : !string.IsNullOrWhiteSpace(d.DatabaseServer) ? d.DatabaseServer!.Trim() + AzurePostgresDomain
+        : InClusterPostgresService;
+
+    /// <summary>Database port, 5432 unless stated.</summary>
+    public static int DatabasePort(DeploymentContent d) => d.DatabasePort ?? 5432;
+
+    /// <summary>Database user, <c>postgres</c> unless stated.</summary>
+    public static string DatabaseUsername(DeploymentContent d) =>
+        string.IsNullOrWhiteSpace(d.DatabaseUsername) ? "postgres" : d.DatabaseUsername!.Trim();
+
+    /// <summary>Database name, trimmed ("" when unset).</summary>
+    public static string DatabaseName(DeploymentContent d) => (d.Database ?? "").Trim();
+
+    /// <summary>The JDBC string the migration uses — host, port and database, never a credential.</summary>
+    public static string JdbcConnectionString(DeploymentContent d) =>
+        $"jdbc:postgresql://{DatabaseHost(d)}:{DatabasePort(d)}/{DatabaseName(d)}";
+
+    /// <summary>HTTP port the portal listens on, 8080 unless stated.</summary>
+    public static int HttpPort(DeploymentContent d) => d.HttpPort ?? 8080;
+
+    /// <summary>
+    /// Orleans clustering: the stated provider, else <c>AdoNet</c> for a multi-pod record
+    /// (autoscaling or more than one replica), else <c>Localhost</c>.
+    /// </summary>
+    public static string OrleansClustering(DeploymentContent d) =>
+        !string.IsNullOrWhiteSpace(d.OrleansClustering) ? d.OrleansClustering!.Trim()
+        : (d.Autoscaling?.Enabled ?? false) || (d.Replicas ?? 1) > 1 ? "AdoNet"
+        : "Localhost";
+
+    // ───────────────────────────────── images ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// The tag a render resolves to: the record's pin when it states one, else the caller's
+    /// resolved tag, else null — a roll never guesses <c>latest</c>.
+    /// </summary>
+    public static string? Tag(DeploymentContent d, string? resolvedTag) =>
+        !string.IsNullOrWhiteSpace(d.PinnedImageTag) ? d.PinnedImageTag!.Trim()
+        : !string.IsNullOrWhiteSpace(resolvedTag) ? resolvedTag!.Trim()
+        : null;
+
+    /// <summary>The portal image reference, or null when the record names no repository or no tag resolves.</summary>
+    public static string? PortalImage(DeploymentContent d, string? resolvedTag)
+    {
+        var tag = Tag(d, resolvedTag);
+        return string.IsNullOrWhiteSpace(d.ImageRepository) || tag is null
+            ? null
+            : $"{d.ImageRepository!.Trim()}:{tag}";
+    }
+
+    /// <summary>
+    /// The migration image paired with the portal's: the explicit
+    /// <see cref="DeploymentContent.MigrationImageRepository"/>, else the portal repository with
+    /// <c>memex-portal-ai</c>/<c>memex-portal</c> replaced by <c>memex-migration</c>. Same tag,
+    /// always — a migration from a different build lands the schema half-applied.
+    /// </summary>
+    public static string? MigrationImage(DeploymentContent d, string? resolvedTag)
+    {
+        var tag = Tag(d, resolvedTag);
+        if (tag is null) return null;
+        var repository = !string.IsNullOrWhiteSpace(d.MigrationImageRepository)
+            ? d.MigrationImageRepository!.Trim()
+            : string.IsNullOrWhiteSpace(d.ImageRepository) ? null
+            : d.ImageRepository!.Trim().Replace("memex-portal-ai", "memex-migration").Replace("memex-portal", "memex-migration");
+        return repository is null ? null : $"{repository}:{tag}";
+    }
+
+    // ───────────────────────────────── modules ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The <c>Modules:Required:N</c> entries for a record's boot modules — trimmed, <c>.dll</c>
+    /// appended when the author wrote the bare assembly name, deduplicated case-insensitively,
+    /// order preserved. 🚨 These entries override the image's own list BY INDEX (an array key never
+    /// appends), so a non-empty list is the COMPLETE required set.
+    /// </summary>
+    public static ImmutableList<string> ModuleEntries(IEnumerable<string>? requiredModules)
+    {
+        var names = (requiredModules ?? Enumerable.Empty<string>())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name.Trim())
+            .Select(name => name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ? name : name + ".dll")
+            .ToArray();
+        var entries = ImmutableList.CreateBuilder<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var index = 0;
+        foreach (var name in names)
+            if (seen.Add(name))
+                entries.Add($"{ModulesSection}:Required:{index++}={name}");
+        return entries.ToImmutable();
+    }
+
+    /// <summary>
+    /// The boot-module slots: the contiguous <see cref="ModuleEntries"/> first, then the record's
+    /// explicit <see cref="DeploymentContent.RequiredModuleSlots"/> where no contiguous entry took
+    /// the slot. Sorted by slot.
+    /// </summary>
+    public static ImmutableSortedDictionary<int, string> ModuleSlots(DeploymentContent d)
+    {
+        var builder = ImmutableSortedDictionary.CreateBuilder<int, string>();
+        var contiguous = ModuleEntries(d.RequiredModules);
+        for (var i = 0; i < contiguous.Count; i++)
+            builder[i] = contiguous[i][(contiguous[i].IndexOf('=') + 1)..];
+        foreach (var (slot, assembly) in d.RequiredModuleSlots)
+        {
+            if (builder.ContainsKey(slot) || string.IsNullOrWhiteSpace(assembly))
+                continue;
+            var name = assembly.Trim();
+            builder[slot] = name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ? name : name + ".dll";
+        }
+        return builder.ToImmutable();
+    }
+
+    // ───────────────────────────────── plugin catalog wiring ───────────────────────────────────
+
+    /// <summary>
+    /// The mounts that are actually usable, with their problems collected. A half-configured mount
+    /// is REPORTED rather than dropped — dropping it is how an instance comes up empty with nothing
+    /// anywhere saying why. Pure.
+    /// </summary>
+    public static (ImmutableList<PluginRepoMount> Usable, ImmutableList<string> Problems) Validate(
+        IEnumerable<PluginRepoMount>? mounts)
+    {
+        var usable = ImmutableList.CreateBuilder<PluginRepoMount>();
+        var problems = ImmutableList.CreateBuilder<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var mount in mounts ?? Enumerable.Empty<PluginRepoMount>())
+        {
+            if (mount is null)
+                continue;
+            if (mount.Problem() is { } problem)
+            {
+                problems.Add(problem);
+                continue;
+            }
+            if (!seen.Add(mount.NormalizedName))
+            {
+                problems.Add($"plugin mount '{mount.NormalizedName}' is declared twice");
+                continue;
+            }
+            usable.Add(mount);
+        }
+        return (usable.ToImmutable(), problems.ToImmutable());
+    }
+
+    /// <summary>
+    /// The flat <c>Key=Value</c> catalog configuration a new instance is deployed with — consumer
+    /// mounts as <c>PluginCatalog:Registries:N:*</c>, registry sources as
+    /// <c>PluginCatalog:Sources:N:*</c>, the pre-install seed as <c>PluginCatalog:InstallByDefault:N</c>.
+    /// Deterministic and ordered.
+    /// </summary>
+    public static ImmutableList<string> ConfigurationEntries(
+        IEnumerable<PluginRepoMount>? mounts, IEnumerable<string>? preInstall)
+    {
+        var (usable, _) = Validate(mounts);
+        var entries = ImmutableList.CreateBuilder<string>();
+        var consumers = usable.Where(m => !m.IsRegistrySource).ToArray();
+        for (var i = 0; i < consumers.Length; i++)
+        {
+            entries.Add($"{CatalogSection}:Registries:{i}:Name={consumers[i].NormalizedName}");
+            entries.Add($"{CatalogSection}:Registries:{i}:Url={consumers[i].NormalizedUrl}");
+        }
+        var sources = usable.Where(m => m.IsRegistrySource).ToArray();
+        for (var i = 0; i < sources.Length; i++)
+        {
+            entries.Add($"{CatalogSection}:Sources:{i}:Name={sources[i].NormalizedName}");
+            entries.Add($"{CatalogSection}:Sources:{i}:RepoPath={sources[i].NormalizedUrl}");
+            entries.Add($"{CatalogSection}:Sources:{i}:Ref={sources[i].EffectiveRef}");
+        }
+        var patterns = InstallPatterns(mounts, preInstall);
+        for (var i = 0; i < patterns.Count; i++)
+            entries.Add($"{CatalogSection}:InstallByDefault:{i}={patterns[i]}");
+        return entries.ToImmutable();
+    }
+
+    /// <summary>
+    /// The <c>InstallByDefault</c> patterns for the declared pre-installs — an unqualified id is
+    /// qualified against every usable mount (the catalog fails closed on a bare id); an id that
+    /// already carries a source passes through untouched.
+    /// </summary>
+    public static ImmutableList<string> InstallPatterns(
+        IEnumerable<PluginRepoMount>? mounts, IEnumerable<string>? preInstall)
+    {
+        var ids = (preInstall ?? Enumerable.Empty<string>())
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .ToArray();
+        if (ids.Length == 0)
+            return ImmutableList<string>.Empty;
+        var (usable, _) = Validate(mounts);
+        var sourceNames = usable.Select(m => m.NormalizedName).ToArray();
+        var patterns = ImmutableList.CreateBuilder<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var id in ids)
+        {
+            if (id.Contains('/') || sourceNames.Length == 0)
+            {
+                if (seen.Add(id)) patterns.Add(id);
+                continue;
+            }
+            foreach (var source in sourceNames)
+            {
+                var pattern = $"{source}/{id}";
+                if (seen.Add(pattern)) patterns.Add(pattern);
+            }
+        }
+        return patterns.ToImmutable();
+    }
+
+    /// <summary>
+    /// The FULL flat configuration a new instance is born with: the catalog wiring plus the
+    /// module policy — one deterministic list, so "what will this instance boot with" is
+    /// answerable from the record alone.
+    /// </summary>
+    public static ImmutableList<string> BootConfigurationEntries(DeploymentContent? record) =>
+        ConfigurationEntries(record?.PluginRepos, record?.PreInstall)
+            .AddRange(ModuleEntries(record?.RequiredModules));
+
+    /// <summary>
+    /// Why the instance spec cannot bring an instance up, or an empty list when it can — the
+    /// per-mount problems plus "packages declared for pre-install with nowhere to install from".
+    /// </summary>
+    public static ImmutableList<string> SpecProblems(
+        IEnumerable<PluginRepoMount>? mounts, IEnumerable<string>? preInstall)
+    {
+        var (usable, problems) = Validate(mounts);
+        var builder = problems.ToBuilder();
+        var wanted = (preInstall ?? Enumerable.Empty<string>())
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToArray();
+        if (wanted.Length > 0 && usable.Count == 0)
+            builder.Add(
+                $"{wanted.Length} package(s) are declared for pre-install but the deployment mounts "
+                + "no plugin repository — nothing could be installed from anywhere");
+        return builder.ToImmutable();
+    }
+
+    // ───────────────────────────────── the portal config surface ───────────────────────────────
+
+    /// <summary>
+    /// Every portal configuration key a record declares, as the portal reads it
+    /// (<c>Section__Key</c>) — THE parity contract. The Helm chart renders exactly this map into the
+    /// portal ConfigMap; the Aspire adapter injects exactly this map as container environment,
+    /// with two documented substitutions (<see cref="PortalConfigOptions.DatabaseKeys"/> and
+    /// <see cref="PortalConfigOptions.McpBaseUrl"/>), so both routes hand the process the same
+    /// surface. Typed keys win over <see cref="DeploymentContent.ExtraPortalConfig"/>,
+    /// case-insensitively.
+    /// </summary>
+    public static SortedDictionary<string, string> PortalConfig(DeploymentContent d, PortalConfigOptions? options = null)
+    {
+        options ??= PortalConfigOptions.Helm;
+        var c = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        void Set(string key, string? value) { if (value is not null) c[key] = value; }
+        void SetBool(string key, bool? value) { if (value is bool b) c[key] = b ? "true" : "false"; }
+
+        if (options.DatabaseKeys)
+        {
+            Set("MEMEX_DATABASENAME", DatabaseName(d));
+            Set("MEMEX_HOST", DatabaseHost(d));
+            Set("MEMEX_JDBCCONNECTIONSTRING", JdbcConnectionString(d));
+            Set("MEMEX_PORT", DatabasePort(d).ToString());
+            Set("MEMEX_USERNAME", DatabaseUsername(d));
+        }
+        Set("ASPNETCORE_HTTP_PORTS", HttpPort(d).ToString());
+        Set("Mcp__BaseUrl", options.McpBaseUrl ?? $"http://{PortalService}:{HttpPort(d)}");
+
+        var s = d.Storage ?? new StorageLayout();
+        Set("Deployment__Backend", s.Backend);
+        Set("Deployment__DataRoot", s.DataRoot);
+        Set("Modules__Root", string.IsNullOrWhiteSpace(s.ModulesRoot) ? s.DataRoot : s.ModulesRoot!.Trim());
+        Set("Graph__Storage__Type", s.GraphStorageType);
+        Set("Graph__Storage__BasePath", string.IsNullOrWhiteSpace(s.GraphStoragePath)
+            ? s.DataRoot.TrimEnd('/') + "/graph" : s.GraphStoragePath!.Trim());
+        Set("Storage__Name", s.ContentName);
+        Set("Storage__SourceType", s.ContentSourceType);
+        Set("Storage__BasePath", s.ContentPath);
+        Set("ClaudeCode__ConfigDirRoot", s.ClaudeCodeConfigDirRoot);
+
+        Set("Deployment__Orleans__Clustering", OrleansClustering(d));
+        Set("SelfUpdate__MinRollInterval", string.IsNullOrWhiteSpace(d.MinRollInterval) ? DefaultMinRollInterval : d.MinRollInterval!.Trim());
+        SetBool("Modules__AutoRecycleOnStaleBuild", d.AutoRecycleOnStaleBuild);
+        foreach (var (slot, assembly) in ModuleSlots(d))
+            Set($"Modules__Required__{slot}", assembly);
+
+        // The catalog wiring rides with the record on BOTH routes, but the chart delivers it through
+        // the operator's catalog config file (BootConfigurationEntries → HOSTING_CATALOG_CONFIG)
+        // rather than the portal ConfigMap, so it is emitted here only for a renderer with no second
+        // file — the Aspire adapter.
+        if (options.IncludeBootEntries)
+            foreach (var entry in ConfigurationEntries(d.PluginRepos, d.PreInstall))
+            {
+                var eq = entry.IndexOf('=');
+                Set(entry[..eq].Replace(":", "__"), entry[(eq + 1)..]);
+            }
+
+        Set("OTEL_EXPORTER_OTLP_ENDPOINT", d.Telemetry?.OtlpEndpoint);
+        Set("OTEL_EXPORTER_OTLP_PROTOCOL", d.Telemetry?.OtlpProtocol);
+
+        Set("GitHub__App__ClientId", d.GitHubApp?.ClientId);
+        Set("GitHub__App__InstallationId", d.GitHubApp?.InstallationId);
+        Set("GitHub__App__InstallationOwner", d.GitHubApp?.InstallationOwner);
+
+        if (d.SignIn is { } signIn)
+        {
+            Set("Authentication__Provider", string.IsNullOrWhiteSpace(signIn.Provider) ? "Custom" : signIn.Provider!.Trim());
+            SetBool("Authentication__EnableDevLogin", signIn.EnableDevLogin);
+            Set("Authentication__Microsoft__ClientId", signIn.MicrosoftClientId);
+            Set("Authentication__Microsoft__TenantId", signIn.MicrosoftTenantId);
+            Set("Authentication__Google__ClientId", signIn.GoogleClientId);
+            Set("Authentication__LinkedIn__ClientId", signIn.LinkedInClientId);
+            Set("Authentication__Apple__ClientId", signIn.AppleClientId);
+        }
+        Set("Social__LinkedIn__ClientId", d.SocialLinkedInClientId);
+
+        if (d.Ai is { } ai)
+        {
+            Provider(c, "Anthropic", ai.Anthropic, "Features__Ai__Providers__Anthropic");
+            Provider(c, "AzureAIS", ai.AzureAis, null);
+            Provider(c, "AzureFoundry", ai.AzureFoundry, "Features__Ai__Providers__AzureFoundry");
+            Provider(c, "OpenRouter", ai.OpenRouter, null);
+            Set("ModelTier__Heavy", ai.Tiers?.Heavy);
+            Set("ModelTier__Standard", ai.Tiers?.Standard);
+            Set("ModelTier__Light", ai.Tiers?.Light);
+            Set("ModelTier__Utility", ai.Tiers?.Utility);
+        }
+
+        if (d.Email is { } email)
+        {
+            SetBool("Email__Enabled", email.Enabled);
+            Set("Email__ClientId", email.ClientId);
+            Set("Email__TenantId", email.TenantId);
+            Set("Email__MailboxAddress", email.MailboxAddress);
+            SetBool("Email__UseManagedIdentity", email.UseManagedIdentity);
+            SetBool("Email__InboundEnabled", email.InboundEnabled);
+            Set("Email__WebhookBaseUrl", email.WebhookBaseUrl);
+            Set("Email__Inbound__ForwardAddress", email.InboundForwardAddress);
+        }
+
+        if (d.WebhookInbox.Count > 0)
+            for (var i = 0; i < d.WebhookInbox.Count; i++)
+            {
+                Set($"WebhookInbox__Targets__{i}", d.WebhookInbox[i].Target);
+                c[$"WebhookInbox__Targets__{i}__SecretConfigKey"] = d.WebhookInbox[i].SecretConfigKey ?? "";
+            }
+        else
+            for (var i = 0; i < d.WebhookInboxTargets.Count; i++)
+                Set($"WebhookInbox__Targets__{i}", d.WebhookInboxTargets[i]);
+
+        if (d.Operator is { Enabled: true })
+            Set("Hosting__Operator__Enabled", "true");
+
+        foreach (var (key, value) in d.ExtraPortalConfig)
+            if (!c.Keys.Contains(key, StringComparer.OrdinalIgnoreCase))
+                c[key] = value ?? "";
+
+        return c;
+    }
+
+    private static void Provider(SortedDictionary<string, string> c, string section, ModelProvider? p, string? flagKey)
+    {
+        if (p is null) return;
+        if (p.Endpoint is not null) c[$"{section}__Endpoint"] = p.Endpoint;
+        for (var i = 0; i < p.Models.Count; i++) c[$"{section}__Models__{i}"] = p.Models[i] ?? "";
+        if (p.Order is int order) c[$"{section}__Order"] = order.ToString();
+        if (flagKey is not null && p.Enabled is bool enabled) c[flagKey] = enabled ? "true" : "false";
+    }
+}
+
+/// <summary>
+/// The two places the two renderers legitimately differ, stated as options so the difference is
+/// declared rather than discovered: in Kubernetes the database is a server the record names and
+/// the portal is reached through its Service; under Aspire the database is an Aspire resource
+/// whose connection string Aspire injects (<c>ConnectionStrings__memex</c>) and the portal's URL
+/// is the endpoint Aspire allocates.
+/// </summary>
+/// <param name="DatabaseKeys">Emit the <c>MEMEX_*</c> database keys (Helm: yes; Aspire: no — the Postgres resource supplies them).</param>
+/// <param name="McpBaseUrl">The MCP back-connection URL to emit; null = the in-cluster portal Service.</param>
+/// <param name="IncludeBootEntries">Emit the plugin-catalog wiring (<c>PluginCatalog__*</c>) as portal keys (Aspire: yes; Helm: no — the operator's catalog config file carries the same entries).</param>
+public sealed record PortalConfigOptions(bool DatabaseKeys, string? McpBaseUrl, bool IncludeBootEntries)
+{
+    /// <summary>The chart's view: database keys from the record, the in-cluster Service as the MCP base URL, catalog wiring via the catalog file.</summary>
+    public static PortalConfigOptions Helm { get; } = new(DatabaseKeys: true, McpBaseUrl: null, IncludeBootEntries: false);
+
+    /// <summary>The Aspire view: no database keys (the Postgres resource injects them); the MCP base URL is the allocated endpoint the adapter supplies; catalog wiring as env.</summary>
+    public static PortalConfigOptions Aspire(string? mcpBaseUrl) => new(DatabaseKeys: false, McpBaseUrl: mcpBaseUrl ?? "", IncludeBootEntries: true);
+}

--- a/src/MeshWeaver.Deployment.Contract/DeploymentPortalConfig.cs
+++ b/src/MeshWeaver.Deployment.Contract/DeploymentPortalConfig.cs
@@ -330,7 +330,7 @@ public static class DeploymentPortalConfig
             Set("MEMEX_USERNAME", DatabaseUsername(d));
         }
         Set("ASPNETCORE_HTTP_PORTS", HttpPort(d).ToString());
-        Set("Mcp__BaseUrl", options.McpBaseUrl ?? $"http://{PortalService}:{HttpPort(d)}");
+        Set("Mcp__BaseUrl", options.McpBaseUrl ?? (options.InClusterMcpBaseUrl ? $"http://{PortalService}:{HttpPort(d)}" : null));
 
         var s = d.Storage ?? new StorageLayout();
         Set("Deployment__Backend", s.Backend);
@@ -442,13 +442,18 @@ public static class DeploymentPortalConfig
 /// is the endpoint Aspire allocates.
 /// </summary>
 /// <param name="DatabaseKeys">Emit the <c>MEMEX_*</c> database keys (Helm: yes; Aspire: no — the Postgres resource supplies them).</param>
-/// <param name="McpBaseUrl">The MCP back-connection URL to emit; null = the in-cluster portal Service.</param>
+/// <param name="McpBaseUrl">The MCP back-connection URL to emit, when the caller knows it as text.</param>
+/// <param name="InClusterMcpBaseUrl">When <paramref name="McpBaseUrl"/> is null: derive it from the in-cluster portal Service (Helm: yes; Aspire: no — the adapter sets the key to the endpoint Aspire allocates, which is not text until publish, so the derivation emits NOTHING rather than a blank).</param>
 /// <param name="IncludeBootEntries">Emit the plugin-catalog wiring (<c>PluginCatalog__*</c>) as portal keys (Aspire: yes; Helm: no — the operator's catalog config file carries the same entries).</param>
-public sealed record PortalConfigOptions(bool DatabaseKeys, string? McpBaseUrl, bool IncludeBootEntries)
+public sealed record PortalConfigOptions(bool DatabaseKeys, string? McpBaseUrl, bool InClusterMcpBaseUrl, bool IncludeBootEntries)
 {
     /// <summary>The chart's view: database keys from the record, the in-cluster Service as the MCP base URL, catalog wiring via the catalog file.</summary>
-    public static PortalConfigOptions Helm { get; } = new(DatabaseKeys: true, McpBaseUrl: null, IncludeBootEntries: false);
+    public static PortalConfigOptions Helm { get; } = new(DatabaseKeys: true, McpBaseUrl: null, InClusterMcpBaseUrl: true, IncludeBootEntries: false);
 
-    /// <summary>The Aspire view: no database keys (the Postgres resource injects them); the MCP base URL is the allocated endpoint the adapter supplies; catalog wiring as env.</summary>
-    public static PortalConfigOptions Aspire(string? mcpBaseUrl) => new(DatabaseKeys: false, McpBaseUrl: mcpBaseUrl ?? "", IncludeBootEntries: true);
+    /// <summary>
+    /// The Aspire view: no database keys (the Postgres resource injects them); the MCP base URL is
+    /// <paramref name="mcpBaseUrl"/> when given as text, else NOT emitted here — the adapter sets
+    /// <c>Mcp__BaseUrl</c> to the endpoint reference Aspire allocates; catalog wiring as env.
+    /// </summary>
+    public static PortalConfigOptions Aspire(string? mcpBaseUrl) => new(DatabaseKeys: false, McpBaseUrl: mcpBaseUrl, InClusterMcpBaseUrl: false, IncludeBootEntries: true);
 }

--- a/src/MeshWeaver.Deployment.Contract/DeploymentRecordExtensions.cs
+++ b/src/MeshWeaver.Deployment.Contract/DeploymentRecordExtensions.cs
@@ -1,0 +1,523 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Deployment;
+
+/// <summary>
+/// The fluent language over the Deployment record. Every method is a PURE record transform
+/// (<c>record with { … }</c>): immutable, composable, usable from an Aspire AppHost, a test, the
+/// setup wizard or the template generator alike — and its only output is a
+/// <see cref="DeploymentContent"/>, so nothing is configurable fluently that the record cannot
+/// hold, by construction (maintainer, 2026-09-08: "create fluent language to configure … the record
+/// must be the only input").
+///
+/// <para>Rules, stated once: every field of the record is reachable here; defaults come from the
+/// record's own defaults, never from the builder (a method with no argument given leaves the
+/// field as it is); a null argument means "leave unchanged" unless the method's name says
+/// otherwise; list-valued fields are APPENDED to (call the <c>Clear…</c> form to start over), map-valued
+/// fields are merged key-wise. The Aspire adapter's <c>IResourceBuilder</c> methods of the same
+/// names delegate here one-to-one, so the table in
+/// <c>Doc/Architecture/ConfiguringAnInstanceFromAspire</c> (method → record field → Helm value →
+/// config key) is the parity contract for both.</para>
+/// </summary>
+public static class DeploymentRecordExtensions
+{
+    // ── identity ────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The public host the portal serves on, and optionally the DNS zone the record's DNS step writes into.</summary>
+    public static DeploymentContent WithHost(this DeploymentContent d, string host, string? dnsZone = null) =>
+        d with { Host = host, DnsZone = dnsZone ?? d.DnsZone };
+
+    /// <summary>The Kubernetes namespace (conventionally the deployment id) and, optionally, the Helm release name.</summary>
+    public static DeploymentContent WithNamespace(this DeploymentContent d, string ns, string? helmRelease = null) =>
+        d with { Namespace = ns, HelmRelease = helmRelease ?? d.HelmRelease };
+
+    /// <summary>The cluster the namespace lives on.</summary>
+    public static DeploymentContent WithCluster(this DeploymentContent d, string cluster) => d with { Cluster = cluster };
+
+    /// <summary>Who this instance is for and what it is for.</summary>
+    public static DeploymentContent WithOwner(this DeploymentContent d, string owner, string? purpose = null) =>
+        d with { Owner = owner, Purpose = purpose ?? d.Purpose };
+
+    /// <summary>The lifecycle status word the record carries (<c>Planned</c>, <c>Provisioning</c>, <c>Live</c>, …).</summary>
+    public static DeploymentContent WithStatus(this DeploymentContent d, string status) => d with { Status = status };
+
+    /// <summary>Free-form operator notes (markdown). Replaces; use <see cref="AppendNote"/> to add a dated paragraph.</summary>
+    public static DeploymentContent WithNotes(this DeploymentContent d, string? notes) => d with { Notes = notes };
+
+    /// <summary>Appends a paragraph to the notes, separated by a blank line.</summary>
+    public static DeploymentContent AppendNote(this DeploymentContent d, string paragraph) =>
+        d with { Notes = string.IsNullOrWhiteSpace(d.Notes) ? paragraph : d.Notes.TrimEnd() + "\n\n" + paragraph };
+
+    /// <summary>The config repository and path this record is written through to.</summary>
+    public static DeploymentContent WithConfigRepository(this DeploymentContent d, string repository, string? configPath = null) =>
+        d with { Repository = repository, ConfigPath = configPath ?? d.ConfigPath };
+
+    /// <summary>Grafana base URL for this instance's dashboards.</summary>
+    public static DeploymentContent WithGrafana(this DeploymentContent d, string? baseUrl) => d with { GrafanaBaseUrl = baseUrl };
+
+    // ── database ────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The PostgreSQL database: its name, optionally the server (Azure server name, FQDN derived),
+    /// user, explicit host/port, and the Key Vault secret NAME holding the connection string.
+    /// </summary>
+    public static DeploymentContent WithDatabase(
+        this DeploymentContent d,
+        string database,
+        string? server = null,
+        string? username = null,
+        string? host = null,
+        int? port = null,
+        string? connectionSecret = null) =>
+        d with
+        {
+            Database = database,
+            DatabaseServer = server ?? d.DatabaseServer,
+            DatabaseUsername = username ?? d.DatabaseUsername,
+            DatabaseHost = host ?? d.DatabaseHost,
+            DatabasePort = port ?? d.DatabasePort,
+            DatabaseConnectionSecret = connectionSecret ?? d.DatabaseConnectionSecret,
+        };
+
+    /// <summary>Run an in-cluster Postgres (self-host only) instead of a managed server.</summary>
+    public static DeploymentContent WithInClusterPostgres(this DeploymentContent d, bool enabled = true) =>
+        d with { InClusterPostgres = enabled };
+
+    // ── images ──────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The portal image repository and, optionally, the tag to PIN (empty = the self-updater
+    /// decides), the image pull Secret name (required off ACR) and an explicit migration repository.
+    /// </summary>
+    public static DeploymentContent WithImage(
+        this DeploymentContent d,
+        string repository,
+        string? tag = null,
+        string? pullSecret = null,
+        string? migrationRepository = null) =>
+        d with
+        {
+            ImageRepository = repository,
+            PinnedImageTag = tag ?? d.PinnedImageTag,
+            ImagePullSecret = pullSecret ?? d.ImagePullSecret,
+            MigrationImageRepository = migrationRepository ?? d.MigrationImageRepository,
+        };
+
+    /// <summary>Pin the image tag (a deliberate hold or a deliberate roll); null unpins.</summary>
+    public static DeploymentContent WithPinnedImageTag(this DeploymentContent d, string? tag) => d with { PinnedImageTag = tag };
+
+    /// <summary>Self-update policy name (<c>None</c>, <c>Continuous</c>, <c>Stable</c>).</summary>
+    public static DeploymentContent WithUpdatePolicy(this DeploymentContent d, string policy) => d with { UpdatePolicy = policy };
+
+    /// <summary>Minimum interval between self-update rolls (a <see cref="TimeSpan"/> string, e.g. <c>01:00:00</c>).</summary>
+    public static DeploymentContent WithMinRollInterval(this DeploymentContent d, string? interval) => d with { MinRollInterval = interval };
+
+    /// <summary>Recycle a node's hub automatically when its NodeType build goes stale.</summary>
+    public static DeploymentContent WithAutoRecycleOnStaleBuild(this DeploymentContent d, bool? enabled = true) =>
+        d with { AutoRecycleOnStaleBuild = enabled };
+
+    // ── plugin catalog ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Mount a plugin repository: a registry to consume (<paramref name="isRegistrySource"/> false)
+    /// or, on the registry installation, a git repo to serve. The name is the registry/source name
+    /// a bare pre-install id is qualified against.
+    /// </summary>
+    public static DeploymentContent WithPluginRepo(
+        this DeploymentContent d,
+        string name,
+        string url,
+        string? gitRef = null,
+        bool isRegistrySource = false,
+        string? secretName = null) =>
+        d with
+        {
+            PluginRepos = d.PluginRepos.Add(new PluginRepoMount
+            {
+                Name = name, Url = url, Ref = gitRef, IsRegistrySource = isRegistrySource, SecretName = secretName,
+            }),
+        };
+
+    /// <summary>Removes every plugin mount.</summary>
+    public static DeploymentContent ClearPluginRepos(this DeploymentContent d) => d with { PluginRepos = ImmutableList<PluginRepoMount>.Empty };
+
+    /// <summary>Packages a fresh boot seeds itself with (bare ids are qualified against the mounts).</summary>
+    public static DeploymentContent PreInstall(this DeploymentContent d, params string[] packageIds) =>
+        d with { PreInstall = d.PreInstall.AddRange(packageIds) };
+
+    /// <summary>Removes every pre-install.</summary>
+    public static DeploymentContent ClearPreInstall(this DeploymentContent d) => d with { PreInstall = ImmutableList<string>.Empty };
+
+    /// <summary>This deployment IS the plugin registry (serves repos, consumes none).</summary>
+    public static DeploymentContent AsPluginRegistry(this DeploymentContent d, bool isRegistry = true) => d with { IsPluginRegistry = isRegistry };
+
+    /// <summary>The instance id at the plugin registry (blank = the deployment id).</summary>
+    public static DeploymentContent WithRegistryInstanceId(this DeploymentContent d, string? instanceId) => d with { RegistryInstanceId = instanceId };
+
+    // ── modules ─────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Boot modules the image MUST load (assembly file names; <c>.dll</c> appended when omitted).
+    /// 🚨 A non-empty list overrides the image's own list BY INDEX — it is the complete set.
+    /// </summary>
+    public static DeploymentContent WithRequiredModules(this DeploymentContent d, params string[] assemblies) =>
+        d with { RequiredModules = d.RequiredModules.AddRange(assemblies) };
+
+    /// <summary>One boot module (see <see cref="WithRequiredModules"/>).</summary>
+    public static DeploymentContent WithRequiredModule(this DeploymentContent d, string assembly) => d.WithRequiredModules(assembly);
+
+    /// <summary>Removes every required module.</summary>
+    public static DeploymentContent ClearRequiredModules(this DeploymentContent d) =>
+        d with { RequiredModules = ImmutableList<string>.Empty, RequiredModuleSlots = ImmutableSortedDictionary<int, string>.Empty };
+
+    /// <summary>A boot module at an explicit slot (a by-index override of the image's list).</summary>
+    public static DeploymentContent WithRequiredModuleSlot(this DeploymentContent d, int slot, string assembly) =>
+        d with { RequiredModuleSlots = d.RequiredModuleSlots.SetItem(slot, assembly) };
+
+    // ── shape ───────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Replica count. Two or more implies <c>AdoNet</c> clustering unless stated otherwise.</summary>
+    public static DeploymentContent WithReplicas(this DeploymentContent d, int replicas) => d with { Replicas = replicas };
+
+    /// <summary>Orleans clustering provider (<c>Localhost</c>, <c>AdoNet</c>, <c>AzureTables</c>); null derives it from the replica count.</summary>
+    public static DeploymentContent WithOrleansClustering(this DeploymentContent d, string? clustering) => d with { OrleansClustering = clustering };
+
+    /// <summary>HTTP port the portal listens on.</summary>
+    public static DeploymentContent WithHttpPort(this DeploymentContent d, int port) => d with { HttpPort = port };
+
+    /// <summary>CPU / memory requests and limits (Kubernetes quantities, e.g. <c>4</c>, <c>8Gi</c>).</summary>
+    public static DeploymentContent WithResources(
+        this DeploymentContent d,
+        string? requestsCpu = null, string? requestsMemory = null,
+        string? limitsCpu = null, string? limitsMemory = null)
+    {
+        var r = d.Resources ?? new ResourceEnvelope();
+        return d with
+        {
+            Resources = r with
+            {
+                Requests = new ResourceQuantities { Cpu = requestsCpu ?? r.Requests?.Cpu, Memory = requestsMemory ?? r.Requests?.Memory },
+                Limits = new ResourceQuantities { Cpu = limitsCpu ?? r.Limits?.Cpu, Memory = limitsMemory ?? r.Limits?.Memory },
+            },
+        };
+    }
+
+    /// <summary>Horizontal autoscaling bounds and targets.</summary>
+    public static DeploymentContent WithAutoscaling(
+        this DeploymentContent d, bool enabled = true, int? minReplicas = null, int? maxReplicas = null,
+        int? cpuTarget = null, int? memoryTarget = null)
+    {
+        var a = d.Autoscaling ?? new Autoscaling();
+        return d with
+        {
+            Autoscaling = a with
+            {
+                Enabled = enabled,
+                MinReplicas = minReplicas ?? a.MinReplicas,
+                MaxReplicas = maxReplicas ?? a.MaxReplicas,
+                CpuTarget = cpuTarget ?? a.CpuTarget,
+                MemoryTarget = memoryTarget ?? a.MemoryTarget,
+            },
+        };
+    }
+
+    /// <summary>
+    /// A persistent volume: its name, mount path, size, the claim name (defaults to <c>memex-{name}</c>
+    /// when created by the chart), storage class, access mode, and whether the chart CREATES the claim
+    /// (a fresh namespace) or binds an existing one.
+    /// </summary>
+    public static DeploymentContent WithVolume(
+        this DeploymentContent d,
+        string name,
+        string mountPath,
+        string? size = null,
+        string? claimName = null,
+        string? storageClass = null,
+        string? accessMode = null,
+        bool create = false)
+    {
+        var existing = d.Volumes.FirstOrDefault(v => string.Equals(v.Name, name, StringComparison.OrdinalIgnoreCase));
+        var volume = (existing ?? new VolumeClaim { Name = name }) with
+        {
+            MountPath = mountPath,
+            Size = size ?? existing?.Size,
+            ClaimName = claimName ?? existing?.ClaimName ?? $"memex-{name}",
+            StorageClass = storageClass ?? existing?.StorageClass,
+            AccessMode = accessMode ?? existing?.AccessMode,
+            Create = create || (existing?.Create ?? false),
+        };
+        var volumes = existing is null ? d.Volumes.Add(volume) : d.Volumes.Replace(existing, volume);
+        return d with { Volumes = volumes };
+    }
+
+    /// <summary>Removes every volume.</summary>
+    public static DeploymentContent ClearVolumes(this DeploymentContent d) => d with { Volumes = ImmutableList<VolumeClaim>.Empty };
+
+    /// <summary>Ingress class, TLS secret, annotations (merged) and cookie-based session affinity.</summary>
+    public static DeploymentContent WithIngress(
+        this DeploymentContent d,
+        string? className = null,
+        string? tlsSecret = null,
+        IEnumerable<KeyValuePair<string, string>>? annotations = null,
+        bool? sessionAffinity = null,
+        string? affinityCookie = null)
+    {
+        var i = d.Ingress ?? new IngressSpec();
+        var merged = i.Annotations;
+        foreach (var (k, v) in annotations ?? Enumerable.Empty<KeyValuePair<string, string>>()) merged = merged.SetItem(k, v);
+        var affinity = i.SessionAffinity;
+        if (sessionAffinity is not null || affinityCookie is not null)
+            affinity = (affinity ?? new SessionAffinity()) with
+            {
+                Enabled = sessionAffinity ?? affinity?.Enabled ?? true,
+                CookieName = affinityCookie ?? affinity?.CookieName,
+            };
+        return d with
+        {
+            Ingress = i with
+            {
+                ClassName = className ?? i.ClassName,
+                TlsSecret = tlsSecret ?? i.TlsSecret,
+                Annotations = merged,
+                SessionAffinity = affinity,
+            },
+        };
+    }
+
+    /// <summary>The React front end at <c>/next</c>: on/off, its image and replica count.</summary>
+    public static DeploymentContent WithPortalNext(this DeploymentContent d, bool enabled = true, string? image = null, int? replicas = null, string? portalOrigin = null)
+    {
+        var p = d.PortalNext ?? new PortalNextSpec();
+        return d with { PortalNext = p with { Enabled = enabled, Image = image ?? p.Image, Replicas = replicas ?? p.Replicas, PortalOrigin = portalOrigin ?? p.PortalOrigin } };
+    }
+
+    /// <summary>Startup probe cadence and the failure threshold (their product is the startup budget).</summary>
+    public static DeploymentContent WithStartupProbe(this DeploymentContent d, int? periodSeconds = null, int? timeoutSeconds = null, int? failureThreshold = null)
+    {
+        var p = d.StartupProbe ?? new StartupProbeSpec();
+        return d with
+        {
+            StartupProbe = p with
+            {
+                PeriodSeconds = periodSeconds ?? p.PeriodSeconds,
+                TimeoutSeconds = timeoutSeconds ?? p.TimeoutSeconds,
+                FailureThreshold = failureThreshold ?? p.FailureThreshold,
+            },
+        };
+    }
+
+    /// <summary>Rollout drain: how long a pod keeps serving after the stop signal, and the shutdown margin.</summary>
+    public static DeploymentContent WithDrain(this DeploymentContent d, int? drainSeconds = null, int? shutdownMarginSeconds = null)
+    {
+        var s = d.Drain ?? new DrainSpec();
+        return d with { Drain = s with { DrainSeconds = drainSeconds ?? s.DrainSeconds, ShutdownMarginSeconds = shutdownMarginSeconds ?? s.ShutdownMarginSeconds } };
+    }
+
+    /// <summary>The storage layout (backend, data root, content path, graph storage, …) as a transform of the current one.</summary>
+    public static DeploymentContent WithStorageLayout(this DeploymentContent d, Func<StorageLayout, StorageLayout> configure) =>
+        d with { Storage = configure(d.Storage ?? new StorageLayout()) };
+
+    /// <summary>Object storage account name and the secret NAME of its connection string.</summary>
+    public static DeploymentContent WithStorageAccount(this DeploymentContent d, string? account, string? connectionSecret = null) =>
+        d with { StorageAccount = account, StorageConnectionSecret = connectionSecret ?? d.StorageConnectionSecret };
+
+    /// <summary>A language gate sidecar (<c>python</c>, <c>node</c>, …).</summary>
+    public static DeploymentContent WithGate(this DeploymentContent d, string language, string? image = null, string? address = null, bool enabled = true)
+    {
+        var existing = d.Gates.FirstOrDefault(g => string.Equals(g.Language, language, StringComparison.OrdinalIgnoreCase));
+        var gate = (existing ?? new GateSpec { Language = language }) with { Image = image ?? existing?.Image, Address = address ?? existing?.Address, Enabled = enabled };
+        return d with { Gates = existing is null ? d.Gates.Add(gate) : d.Gates.Replace(existing, gate) };
+    }
+
+    // ── secrets by NAME ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The Key Vault this instance's secrets are NAMED in, and the per-instance name prefix.</summary>
+    public static DeploymentContent WithKeyVault(this DeploymentContent d, string vault, string? prefix = null) =>
+        d with { KeyVault = vault, KeyVaultSecretPrefix = prefix ?? d.KeyVaultSecretPrefix };
+
+    /// <summary>
+    /// The chart-owned Key Vault secret class: which vault objects land under which configuration
+    /// keys (names only, never values). <paramref name="map"/> receives the class to extend with
+    /// <see cref="Map"/>.
+    /// </summary>
+    public static DeploymentContent WithKeyVaultSecrets(
+        this DeploymentContent d,
+        Func<KeyVaultSecretsSpec, KeyVaultSecretsSpec> map,
+        string? vaultName = null, string? tenantId = null, string? identityClientId = null,
+        string? className = null, string? syncedSecret = null, string? volumeName = null, string? mountPath = null)
+    {
+        var s = d.KeyVaultSecrets ?? new KeyVaultSecretsSpec();
+        s = s with
+        {
+            VaultName = vaultName ?? s.VaultName ?? d.KeyVault,
+            TenantId = tenantId ?? s.TenantId,
+            IdentityClientId = identityClientId ?? s.IdentityClientId,
+            Name = className ?? s.Name,
+            SyncedSecret = syncedSecret ?? s.SyncedSecret,
+            VolumeName = volumeName ?? s.VolumeName,
+            MountPath = mountPath ?? s.MountPath,
+        };
+        return d with { KeyVaultSecrets = map(s) };
+    }
+
+    /// <summary>Maps one configuration key onto a vault object NAME (an object may feed several keys).</summary>
+    public static KeyVaultSecretsSpec Map(this KeyVaultSecretsSpec s, string key, string vaultSecret) =>
+        s with { Secrets = s.Secrets.Add(new KeyVaultSecretRef { Key = key, VaultSecret = vaultSecret }) };
+
+    /// <summary>An additional (second, third, …) Key Vault secret class.</summary>
+    public static DeploymentContent WithKeyVaultSecretClass(this DeploymentContent d, KeyVaultSecretsSpec secretClass) =>
+        d with { KeyVaultSecretClasses = d.KeyVaultSecretClasses.Add(secretClass) };
+
+    /// <summary>Keys the chart's own Secret supplies from the Key Vault values half (names only).</summary>
+    public static DeploymentContent WithVaultValuesKeys(this DeploymentContent d, params string[] keys) =>
+        d with { VaultValuesKeys = d.VaultValuesKeys.AddRange(keys) };
+
+    /// <summary>A legacy hand-made SecretProviderClass mount, by name.</summary>
+    public static DeploymentContent WithSecretMount(this DeploymentContent d, string volumeName, string secretProviderClass, string syncedSecret, string mountPath) =>
+        d with { SecretMounts = d.SecretMounts.Add(new KeyVaultSecretMount { VolumeName = volumeName, SecretProviderClass = secretProviderClass, SyncedSecret = syncedSecret, MountPath = mountPath }) };
+
+    /// <summary>Records an inline env entry that exists on the live Deployment (declarative — renders nothing).</summary>
+    public static DeploymentContent WithInlineEnv(this DeploymentContent d, string key, string? value = null, bool isSecret = false, string? shadows = null, bool? agreesWithShadowed = null, string? reason = null) =>
+        d with { InlineEnv = d.InlineEnv.Add(new InlineEnvOverride { Key = key, Value = value, IsSecret = isSecret, Shadows = shadows, AgreesWithShadowed = agreesWithShadowed, Reason = reason }) };
+
+    // ── sign-in, email, integrations ────────────────────────────────────────────────────────────
+
+    /// <summary>Sign-in providers by CLIENT ID (secrets are Key Vault names, mapped separately).</summary>
+    public static DeploymentContent WithSignIn(
+        this DeploymentContent d,
+        string? provider = null,
+        string? microsoftClientId = null, string? microsoftTenantId = null,
+        string? googleClientId = null, string? linkedInClientId = null, string? appleClientId = null,
+        bool? enableDevLogin = null)
+    {
+        var s = d.SignIn ?? new SignInSpec();
+        return d with
+        {
+            SignIn = s with
+            {
+                Provider = provider ?? s.Provider,
+                MicrosoftClientId = microsoftClientId ?? s.MicrosoftClientId,
+                MicrosoftTenantId = microsoftTenantId ?? s.MicrosoftTenantId,
+                GoogleClientId = googleClientId ?? s.GoogleClientId,
+                LinkedInClientId = linkedInClientId ?? s.LinkedInClientId,
+                AppleClientId = appleClientId ?? s.AppleClientId,
+                EnableDevLogin = enableDevLogin ?? s.EnableDevLogin,
+            },
+        };
+    }
+
+    /// <summary>Outbound (and optionally inbound) email through Microsoft Graph — the non-secret half.</summary>
+    public static DeploymentContent WithEmail(
+        this DeploymentContent d,
+        bool enabled = true,
+        string? mailboxAddress = null, string? clientId = null, string? tenantId = null,
+        bool? useManagedIdentity = null, bool? inboundEnabled = null, string? webhookBaseUrl = null, string? inboundForwardAddress = null)
+    {
+        var e = d.Email ?? new EmailSpec();
+        return d with
+        {
+            Email = e with
+            {
+                Enabled = enabled,
+                MailboxAddress = mailboxAddress ?? e.MailboxAddress,
+                ClientId = clientId ?? e.ClientId,
+                TenantId = tenantId ?? e.TenantId,
+                UseManagedIdentity = useManagedIdentity ?? e.UseManagedIdentity,
+                InboundEnabled = inboundEnabled ?? e.InboundEnabled,
+                WebhookBaseUrl = webhookBaseUrl ?? e.WebhookBaseUrl,
+                InboundForwardAddress = inboundForwardAddress ?? e.InboundForwardAddress,
+            },
+        };
+    }
+
+    /// <summary>The GitHub App identity the instance acts as.</summary>
+    public static DeploymentContent WithGitHubApp(this DeploymentContent d, string clientId, string installationId, string? installationOwner = null) =>
+        d with { GitHubApp = new GitHubAppIdentity { ClientId = clientId, InstallationId = installationId, InstallationOwner = installationOwner ?? d.GitHubApp?.InstallationOwner } };
+
+    /// <summary>The LinkedIn client id the Social plugin posts with.</summary>
+    public static DeploymentContent WithSocialLinkedIn(this DeploymentContent d, string? clientId) => d with { SocialLinkedInClientId = clientId };
+
+    /// <summary>AI providers and model tiers, as a transform of the current block (see the <c>AiProviders</c> helpers).</summary>
+    public static DeploymentContent WithAi(this DeploymentContent d, Func<AiProviders, AiProviders> configure) =>
+        d with { Ai = configure(d.Ai ?? new AiProviders()) };
+
+    /// <summary>OpenRouter models (and optionally an endpoint / order).</summary>
+    public static AiProviders OpenRouter(this AiProviders a, IEnumerable<string> models, string? endpoint = null, int? order = null, bool? enabled = null) =>
+        a with { OpenRouter = Provider(a.OpenRouter, models, endpoint, order, enabled) };
+
+    /// <summary>Anthropic models behind an endpoint (an Azure AI Foundry Anthropic endpoint, or Anthropic's own).</summary>
+    public static AiProviders Anthropic(this AiProviders a, IEnumerable<string> models, string? endpoint = null, int? order = null, bool? enabled = null) =>
+        a with { Anthropic = Provider(a.Anthropic, models, endpoint, order, enabled) };
+
+    /// <summary>Azure AI Foundry models.</summary>
+    public static AiProviders AzureFoundry(this AiProviders a, IEnumerable<string> models, string? endpoint = null, int? order = null, bool? enabled = null) =>
+        a with { AzureFoundry = Provider(a.AzureFoundry, models, endpoint, order, enabled) };
+
+    /// <summary>Azure AI Services models.</summary>
+    public static AiProviders AzureAis(this AiProviders a, IEnumerable<string> models, string? endpoint = null, int? order = null, bool? enabled = null) =>
+        a with { AzureAis = Provider(a.AzureAis, models, endpoint, order, enabled) };
+
+    /// <summary>Which model serves each tier.</summary>
+    public static AiProviders Tiers(this AiProviders a, string? heavy = null, string? standard = null, string? light = null, string? utility = null)
+    {
+        var t = a.Tiers ?? new ModelTiers();
+        return a with { Tiers = t with { Heavy = heavy ?? t.Heavy, Standard = standard ?? t.Standard, Light = light ?? t.Light, Utility = utility ?? t.Utility } };
+    }
+
+    private static ModelProvider Provider(ModelProvider? current, IEnumerable<string> models, string? endpoint, int? order, bool? enabled)
+    {
+        var p = current ?? new ModelProvider();
+        return p with
+        {
+            Models = p.Models.AddRange(models),
+            Endpoint = endpoint ?? p.Endpoint,
+            Order = order ?? p.Order,
+            Enabled = enabled ?? p.Enabled,
+        };
+    }
+
+    // ── operations ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The hosting operator this instance runs actions through (the control instance sets it).</summary>
+    public static DeploymentContent WithOperator(this DeploymentContent d, bool enabled = true, string? ns = null, string? serviceAccount = null, string? image = null, IEnumerable<KeyValuePair<string, string>>? environment = null)
+    {
+        var o = d.Operator ?? new HostingOperatorSpec();
+        var env = o.Environment;
+        foreach (var (k, v) in environment ?? Enumerable.Empty<KeyValuePair<string, string>>()) env = env.SetItem(k, v);
+        return d with { Operator = o with { Enabled = enabled, Namespace = ns ?? o.Namespace, ServiceAccount = serviceAccount ?? o.ServiceAccount, Image = image ?? o.Image, Environment = env } };
+    }
+
+    /// <summary>The container registry this instance HOSTS (the public instance only).</summary>
+    public static DeploymentContent WithRegistry(this DeploymentContent d, Func<RegistrySpec, RegistrySpec> configure) =>
+        d with { Registry = configure(d.Registry ?? new RegistrySpec()) };
+
+    /// <summary>OTLP telemetry export.</summary>
+    public static DeploymentContent WithTelemetry(this DeploymentContent d, string? otlpEndpoint, string? otlpProtocol = null) =>
+        d with { Telemetry = new TelemetrySpec { OtlpEndpoint = otlpEndpoint, OtlpProtocol = otlpProtocol ?? d.Telemetry?.OtlpProtocol } };
+
+    /// <summary>Where this instance's database backups go (a <c>Hosting/BackupStore</c> path).</summary>
+    public static DeploymentContent WithBackupStore(this DeploymentContent d, string? backupStore) => d with { BackupStore = backupStore };
+
+    /// <summary>Idle policy in days (null = never).</summary>
+    public static DeploymentContent WithIdlePolicy(this DeploymentContent d, int? suspendAfterDays, int? teardownAfterDays = null) =>
+        d with { IdleSuspendDays = suspendAfterDays, IdleTeardownDays = teardownAfterDays };
+
+    /// <summary>The grace period a suspended instance keeps its data for.</summary>
+    public static DeploymentContent WithGracePeriod(this DeploymentContent d, int days) => d with { GracePeriodDays = days };
+
+    /// <summary>A webhook inbox slot: the target path and the configuration key holding its HMAC secret.</summary>
+    public static DeploymentContent WithWebhookInbox(this DeploymentContent d, string target, string? secretConfigKey = null) =>
+        d with { WebhookInbox = d.WebhookInbox.Add(new WebhookInboxSlot { Target = target, SecretConfigKey = secretConfigKey }) };
+
+    /// <summary>The advanced rung: one portal configuration key (<c>Section__Key</c>) beyond the typed surface.</summary>
+    public static DeploymentContent WithPortalConfig(this DeploymentContent d, string key, string value) =>
+        d with { ExtraPortalConfig = d.ExtraPortalConfig.SetItem(key, value) };
+
+    /// <summary>Several portal configuration keys at once (merged).</summary>
+    public static DeploymentContent WithPortalConfig(this DeploymentContent d, IEnumerable<KeyValuePair<string, string>> entries)
+    {
+        var map = d.ExtraPortalConfig;
+        foreach (var (k, v) in entries) map = map.SetItem(k, v);
+        return d with { ExtraPortalConfig = map };
+    }
+}

--- a/src/MeshWeaver.Deployment.Contract/DeploymentRecordJson.cs
+++ b/src/MeshWeaver.Deployment.Contract/DeploymentRecordJson.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+
+namespace MeshWeaver.Deployment;
+
+/// <summary>
+/// The record on the wire and in configuration — ONE shape, used by the Aspire adapter to emit it,
+/// by the portal to bind it, and by anyone handing a record file to the setup wizard or a
+/// <c>Provision</c> action.
+///
+/// <para><b>The configuration section is a single JSON value, <c>Deployment:Record</c>
+/// (environment: <c>Deployment__Record</c>).</b> Not one key per field: the record is a tree of
+/// immutable records with <c>init</c> properties, immutable lists and sorted dictionaries, and a
+/// nested <c>$type</c> on the mesh — <c>IConfiguration.Bind</c> handles none of those faithfully,
+/// while one JSON value round-trips the exact document the mesh stores (minus the mesh's own
+/// <c>$type</c>, which this reader ignores). A Kubernetes ConfigMap and an Aspire container env
+/// carry the same value byte-for-byte, so the portal reads its own record identically on both.
+/// The per-field keys the portal ALSO reads (<c>Storage__*</c>, <c>PluginCatalog__*</c>, …) are
+/// the DERIVED surface, <see cref="DeploymentPortalConfig.PortalConfig"/>, emitted beside it.</para>
+///
+/// <para>The mesh's own node JSON differs in ONE respect: it carries <c>$type</c> discriminators
+/// (<c>"$type": "DeploymentContent"</c>, <c>"KeyVaultSecretsSpec"</c>, …) written by the mesh's
+/// polymorphic converter. <see cref="Read"/> accepts either form — unknown members are skipped —
+/// which is what the round-trip test over the real <c>Deployments/memex</c> and
+/// <c>Deployments/pearl</c> records asserts.</para>
+/// </summary>
+public static class DeploymentRecordJson
+{
+    /// <summary>The configuration key the portal binds its record from.</summary>
+    public const string ConfigurationKey = "Deployment:Record";
+
+    /// <summary>The same key as an environment variable name.</summary>
+    public const string EnvironmentKey = "Deployment__Record";
+
+    /// <summary>
+    /// Wire options: camelCase, nulls omitted on write, unknown members skipped on read (the mesh's
+    /// <c>$type</c>), case-insensitive property matching (a hand-written record file forgives case).
+    /// </summary>
+    public static JsonSerializerOptions Options { get; } = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        // The computed getters (PluginRepoMount.EffectiveRef, ResourceEnvelope.IsEmpty,
+        // StartupProbeSpec.BudgetSeconds, …) are derivations, not fields: the mesh never writes
+        // them (no fleet record carries one), and a record injected as Deployment:Record must read
+        // as the record does at rest. RecordRoundTripTest pins this on three real records.
+        IgnoreReadOnlyProperties = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+        WriteIndented = false,
+    };
+
+    /// <summary>The record as one JSON document (no <c>$type</c>; nulls omitted).</summary>
+    public static string Write(DeploymentContent record, bool indented = false) =>
+        JsonSerializer.Serialize(record, indented ? new JsonSerializerOptions(Options) { WriteIndented = true } : Options);
+
+    /// <summary>
+    /// A record from JSON — the configuration value, a record file, or the mesh node's
+    /// <c>content</c> object. Throws on malformed JSON; returns null for an empty value.
+    /// </summary>
+    public static DeploymentContent? Read(string? json) =>
+        string.IsNullOrWhiteSpace(json) ? null : JsonSerializer.Deserialize<DeploymentContent>(json, Options);
+
+    /// <summary>
+    /// The record a process was started with: <see cref="ConfigurationKey"/> parsed, or null when
+    /// the configuration carries none (a portal not launched from a record — the dev Monolith, an
+    /// image started by hand). Never guesses: a present-but-malformed value throws, because a
+    /// record the process cannot read is not "no record".
+    /// </summary>
+    public static DeploymentContent? FromConfiguration(IConfiguration configuration) =>
+        Read(configuration[ConfigurationKey]);
+
+    /// <summary>
+    /// A record from a file on disk — what a developer hands to the setup wizard or a
+    /// <c>Provision</c> action, and what <c>AddMemex(...).PublishRecord(path)</c> writes. Accepts
+    /// both the bare record and a full mesh node (<c>{"content": {…}}</c>).
+    /// </summary>
+    public static DeploymentContent ReadFile(string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var root = doc.RootElement;
+        var content = root.ValueKind == JsonValueKind.Object && root.TryGetProperty("content", out var c) ? c : root;
+        return content.Deserialize<DeploymentContent>(Options)
+               ?? throw new InvalidDataException($"'{path}' holds no Deployment record");
+    }
+
+    /// <summary>Writes the record as an indented JSON document (the record file shape).</summary>
+    public static void WriteFile(DeploymentContent record, string path)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+        File.WriteAllText(path, Write(record, indented: true) + Environment.NewLine);
+    }
+}

--- a/src/MeshWeaver.Deployment.Contract/InstanceShape.cs
+++ b/src/MeshWeaver.Deployment.Contract/InstanceShape.cs
@@ -1,0 +1,890 @@
+// The nested records of the Deployment record — moved with it (see DeploymentContent.cs).
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System;
+
+namespace MeshWeaver.Deployment;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// The typed SHAPE of an instance: what the helm chart's templates used to encode as hard-coded
+// Kubernetes concerns and what its per-environment values files used to carry by hand. Every
+// record below is intent, recorded in git through the Deployment node, and projected onto the
+// chart's values surface by HelmValues — and, next, straight onto manifests by the generator that
+// replaces the hand-written chart. Where a template carried a 🚨 rationale for a number, that
+// number is a property here with the same default and the rationale in its description, so the
+// knowledge survives the move out of Go templates and into code.
+//
+// 🚨 Nothing secret. These records sync to a git repository: identifiers, sizes, names of secrets
+// — never a value of one. The Key Vault half stays in Key Vault and is referenced by name only.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The container registry service one instance HOSTS for the fleet (MeshWeaver#3353): an
+/// off-the-shelf OCI <c>distribution</c> registry, blob-backed, fronted by <c>docker_auth</c>,
+/// deployed by the portal chart under <c>registry.enabled</c>. Only the public instance sets it —
+/// every other installation CONSUMES it through its own <see cref="DeploymentContent.ImageRepository"/>
+/// (<c>{host}/memex-portal-ai</c>) and <see cref="DeploymentContent.ImagePullSecret"/>.
+///
+/// <para>Names only, as everywhere in the record: the TLS certificate, the token-signing key and
+/// the HTTP secret are Key Vault OBJECTS named in <see cref="KeyVault"/>; the publisher's
+/// password is stated as its bcrypt HASH, which is what <c>docker_auth</c> compares against and
+/// which cannot be turned back into the password. The registry's own pull is decided by the
+/// portal at <see cref="ValidationUrl"/> — the same instance-key gate the plugin registry uses —
+/// so a consumer holds ONE credential for both.</para>
+/// </summary>
+public sealed record RegistrySpec
+{
+    /// <summary>The public host the registry serves on (<c>cr.meshweaver.cloud</c>). Consumers name it as the host of their image repository.</summary>
+    [Description("Registry host (e.g. cr.meshweaver.cloud)")]
+    public string? Host { get; init; }
+
+    /// <summary>The <c>distribution</c> image, fully qualified with its tag. Pulled from ACR by the node identity — a registry cannot serve the image that boots it.</summary>
+    [Description("Registry image (repository:tag)")]
+    public string? Image { get; init; }
+
+    /// <summary>The <c>docker_auth</c> image, fully qualified with its tag.</summary>
+    [Description("Token-authentication image (repository:tag)")]
+    public string? AuthImage { get; init; }
+
+    /// <summary>The token issuer name the registry and the auth service agree on. Blank → <c>memex-registry</c>.</summary>
+    [Description("Token issuer — blank means memex-registry")]
+    public string? Issuer { get; init; }
+
+    /// <summary>The Azure storage account holding the blobs. NAME only; the registry reaches it through its workload identity.</summary>
+    [Description("Storage account holding the image blobs (name only)")]
+    public string? StorageAccountName { get; init; }
+
+    /// <summary>The blob container in that account. Blank → <c>registry</c>.</summary>
+    [Description("Blob container — blank means registry")]
+    public string? StorageContainer { get; init; }
+
+    /// <summary>The Kubernetes ServiceAccount the registry pods run as — the one federated to the identity that reads the storage account and the vault.</summary>
+    [Description("ServiceAccount the registry pods run as")]
+    public string? ServiceAccount { get; init; }
+
+    /// <summary>The Key Vault objects the registry reads — the TLS pair, the token-signing key, the HTTP secret. Names only.</summary>
+    [Description("Key Vault objects (names only)")]
+    public RegistryKeyVaultSpec? KeyVault { get; init; }
+
+    /// <summary>The one account that may PUSH — CD's publish lane. Blank → <c>publisher</c>.</summary>
+    [Description("Publisher username — blank means publisher")]
+    public string? PublisherUsername { get; init; }
+
+    /// <summary>
+    /// The publisher password as its bcrypt HASH (<c>$2y$…</c>) — what <c>docker_auth</c> stores
+    /// and compares against. A hash, never the password: it cannot be reversed, which is what makes
+    /// it recordable in a git-synced node.
+    /// </summary>
+    [Description("Publisher password, bcrypt hash — never the password itself")]
+    public string? PublisherPasswordBcrypt { get; init; }
+
+    /// <summary>
+    /// The portal endpoint that decides a PULL: the auth service forwards the caller's instance key
+    /// there and grants <c>pull</c> when the portal answers 200 — so a consumer's plugin-registry
+    /// key IS its image-pull credential. Blank → <c>https://memex.meshweaver.cloud/api/instances/token</c>,
+    /// the key→JWT exchange: cheap (~0.2 s) and authoritative, where the catalog URL
+    /// (<c>/api/plugins?ref=HEAD</c>) is a 14–18 s render that overruns the auth service's budget
+    /// and is not a validator.
+    /// </summary>
+    [Description("Portal URL that validates a consumer's key — blank means the public instance's token exchange")]
+    public string? ValidationUrl { get; init; }
+
+    /// <summary>Where the registry POSTs its push/pull notifications (the portal's inbox). Blank → no notifications.</summary>
+    [Description("Notification endpoint URL — blank means none")]
+    public string? NotificationsUrl { get; init; }
+
+    /// <summary>Registry replicas. Null → 1. Stateless in front of the blob store, so it scales freely.</summary>
+    [Description("Replicas — blank means 1")]
+    public int? Replicas { get; init; }
+}
+
+/// <summary>
+/// The Key Vault objects a hosted registry reads (<see cref="RegistrySpec.KeyVault"/>): the
+/// vault's coordinates and the NAMES of the TLS certificate, its private key, the HTTP secret and
+/// the notification secret. Names only — the values live in the vault and reach the pods through
+/// the CSI driver, the same path every other declared secret takes.
+/// </summary>
+public sealed record RegistryKeyVaultSpec
+{
+    /// <summary>The vault holding the registry's objects. Stated, never derived — a registry's TLS pair is not a portal secret, and naming the vault beside the objects keeps the four together.</summary>
+    [Description("Key Vault name")]
+    public string? Name { get; init; }
+
+    /// <summary>The vault's Entra tenant. Blank → the record's <c>keyVaultSecrets.tenantId</c>.</summary>
+    [Description("Tenant id — blank means the record's keyVaultSecrets tenant")]
+    public string? TenantId { get; init; }
+
+    /// <summary>The identity that reads the vault. Blank → the record's <c>keyVaultSecrets.identityClientId</c>.</summary>
+    [Description("Identity client id — blank means the record's keyVaultSecrets identity")]
+    public string? IdentityClientId { get; init; }
+
+    /// <summary>The vault object holding the token-signing CERTIFICATE (PEM).</summary>
+    [Description("Vault object: token-signing certificate")]
+    public string? CertObject { get; init; }
+
+    /// <summary>The vault object holding the token-signing private KEY (PEM).</summary>
+    [Description("Vault object: token-signing private key")]
+    public string? KeyObject { get; init; }
+
+    /// <summary>The vault object holding the registry's HTTP secret (the one every replica must share for upload sessions). Blank → the chart generates none and the registry runs single-replica.</summary>
+    [Description("Vault object: registry HTTP secret")]
+    public string? HttpSecretObject { get; init; }
+
+    /// <summary>The vault object holding the bearer the registry presents on notifications. Blank → unauthenticated notifications.</summary>
+    [Description("Vault object: notification bearer secret")]
+    public string? NotificationSecretObject { get; init; }
+}
+
+/// <summary>CPU and memory for one side of a resource envelope, as Kubernetes quantities.</summary>
+public sealed record ResourceQuantities
+{
+    /// <summary>CPU quantity (<c>"4"</c>, <c>"500m"</c>).</summary>
+    [Description("CPU (e.g. 4 or 500m)")]
+    public string? Cpu { get; init; }
+
+    /// <summary>Memory quantity (<c>"8Gi"</c>).</summary>
+    [Description("Memory (e.g. 8Gi)")]
+    public string? Memory { get; init; }
+
+    /// <summary>True when neither side is stated. Pure.</summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Cpu) && string.IsNullOrWhiteSpace(Memory);
+}
+
+/// <summary>
+/// The portal container's RAM/CPU envelope — the standard-rung knob an operator sets first.
+/// Requests decide where the pod may be scheduled and what it is guaranteed; limits bound the
+/// blast radius on whatever node it lands on. An instance with NO envelope runs BestEffort:
+/// unconstrained on the way up and able to OOM the whole node its neighbours share (the memex
+/// shape before 2026-08-12). Size the limit for the post-roll NodeType warm-up burst, not for
+/// steady state, or every self-update roll OOMs the pod.
+/// </summary>
+public sealed record ResourceEnvelope
+{
+    /// <summary>What the pod is guaranteed and scheduled by.</summary>
+    [Description("Requests — guaranteed and used for scheduling")]
+    public ResourceQuantities? Requests { get; init; }
+
+    /// <summary>The ceiling; memory above it is an OOM kill.</summary>
+    [Description("Limits — the ceiling (memory above it is an OOM kill)")]
+    public ResourceQuantities? Limits { get; init; }
+
+    /// <summary>True when nothing at all is stated. Pure.</summary>
+    public bool IsEmpty => (Requests?.IsEmpty ?? true) && (Limits?.IsEmpty ?? true);
+}
+
+/// <summary>
+/// KEDA autoscaling of the portal. While it is on, the autoscaler OWNS the replica count and the
+/// chart renders no <c>replicas</c> field at all — rendering it would make helm and the HPA fight
+/// over one field, and every upgrade would yank a scaled-out deployment back to the chart's
+/// number. <see cref="MinReplicas"/> is then the single place the floor is written.
+/// </summary>
+public sealed record Autoscaling
+{
+    /// <summary>Whether KEDA owns the replica count.</summary>
+    [Description("Autoscale with KEDA")]
+    public bool Enabled { get; init; }
+
+    /// <summary>The floor — also the Orleans cluster seed; 2 is the HA minimum.</summary>
+    [Description("Minimum replicas (the HA floor; 2 seeds the Orleans cluster)")]
+    public int MinReplicas { get; init; } = 2;
+
+    /// <summary>The ceiling under load.</summary>
+    [Description("Maximum replicas")]
+    public int MaxReplicas { get; init; } = 8;
+
+    /// <summary>% CPU utilisation to scale up past. Null → the chart's 70.</summary>
+    [Description("CPU target % (scale up past this)")]
+    public int? CpuTarget { get; init; }
+
+    /// <summary>% memory utilisation to scale up past. Null → the chart's 80.</summary>
+    [Description("Memory target %")]
+    public int? MemoryTarget { get; init; }
+}
+
+/// <summary>
+/// One persistent volume the portal mounts. <see cref="ClaimName"/> is THE field the chart reads:
+/// an entry without one renders NOTHING for content/attachments/workspace, and for data/users it
+/// falls back to an <c>emptyDir</c> — which is how a namespace once ran <c>/data</c> ephemeral and
+/// every restart wiped the store-landed modules so nothing could ever activate (2026-08-20).
+/// Size and storage class describe the claim; they provision nothing by themselves, the PVC
+/// pre-exists in the namespace.
+/// </summary>
+public sealed record VolumeClaim
+{
+    /// <summary>The volume's role: <c>data</c>, <c>users</c>, <c>content</c>, <c>attachments</c>, <c>workspace</c>, <c>source-replica</c>, <c>postgres</c>.</summary>
+    [Description("Role (data, users, content, attachments, workspace, …)")]
+    public string Name { get; init; } = "";
+
+    /// <summary>The pre-existing PVC to bind. Blank renders no volume (or an ephemeral one for data/users).</summary>
+    [Description("PersistentVolumeClaim name — blank means ephemeral or unmounted")]
+    public string? ClaimName { get; init; }
+
+    /// <summary>Where it is mounted in the container.</summary>
+    [Description("Mount path")]
+    public string? MountPath { get; init; }
+
+    /// <summary>Requested size (<c>"64Gi"</c>).</summary>
+    [Description("Size (e.g. 64Gi)")]
+    public string? Size { get; init; }
+
+    /// <summary>Storage class. RWX (Azure Files) is a prerequisite for more than one replica.</summary>
+    [Description("Storage class (RWX is required above one replica)")]
+    public string? StorageClass { get; init; }
+
+    /// <summary><c>ReadWriteMany</c> for anything more than one pod touches.</summary>
+    [Description("Access mode (ReadWriteMany for shared volumes)")]
+    public string? AccessMode { get; init; }
+
+    /// <summary>
+    /// Render the claim itself — the chart then creates the PersistentVolumeClaim named
+    /// <see cref="ClaimName"/> (annotated <c>helm.sh/resource-policy: keep</c>, so a later
+    /// uninstall leaves the data), which needs <see cref="Size"/> and <see cref="StorageClass"/>;
+    /// <see cref="AccessMode"/> defaults to <c>ReadWriteMany</c>.
+    ///
+    /// <para>🚨 Default false, because existing instances' claims are UNMANAGED by helm — they were
+    /// made by hand — and rendering them would fail the next upgrade with
+    /// <c>resource already exists</c>. Set it only on a record whose claims do not exist yet: a
+    /// brand-new Provision, which without it comes up on emptyDir or with Pending pods, since the
+    /// chart renders no claim on its own.</para>
+    /// </summary>
+    [Description("Create the PersistentVolumeClaim — only on a record whose claims do not exist yet")]
+    public bool Create { get; init; }
+}
+
+/// <summary>
+/// Sticky sessions at the ingress. A Blazor circuit and its per-circuit hubs live on ONE pod
+/// (<c>[PreferLocalPlacement]</c>), so a client bouncing between pods loses its session — the
+/// cookie pins it. The nginx/AGIC annotation maps are the controller-specific spellings of the
+/// same intent; the future manifest generator derives them, the chart today reads only the
+/// flat <c>ingress.annotations</c>, so these are recorded intent until it does.
+/// </summary>
+public sealed record SessionAffinity
+{
+    /// <summary>Whether sessions are pinned to a pod.</summary>
+    [Description("Pin sessions to one pod")]
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>The affinity cookie name (<c>MEMEX_AFFINITY</c>).</summary>
+    [Description("Affinity cookie name")]
+    public string? CookieName { get; init; }
+
+    /// <summary>ingress-nginx annotations expressing the affinity.</summary>
+    [Description("nginx annotations")]
+    public ImmutableSortedDictionary<string, string> NginxAnnotations { get; init; }
+        = ImmutableSortedDictionary<string, string>.Empty;
+
+    /// <summary>Application Gateway annotations expressing the affinity.</summary>
+    [Description("Application Gateway annotations")]
+    public ImmutableSortedDictionary<string, string> AgicAnnotations { get; init; }
+        = ImmutableSortedDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// How the host reaches the portal: the ingress class, the TLS secret and the annotations the
+/// controller needs. The TLS secret is the FLAT field the chart reads — a nested
+/// <c>tls: {secretName}</c> block was a dead key that left <c>spec.tls</c> without a secret and had
+/// the controller serve ANOTHER host's default certificate (live cert errors, 2026-08-20, twice).
+/// The secret pre-exists in the namespace; issuing and renewing it is the TLS step, not this record.
+/// </summary>
+public sealed record IngressSpec
+{
+    /// <summary>Ingress class (<c>webapprouting.kubernetes.azure.com</c> on AKS app routing).</summary>
+    [Description("Ingress class")]
+    public string? ClassName { get; init; }
+
+    /// <summary>The <c>kubernetes.io/tls</c> secret for the host. Blank → <c>{namespace}-tls</c>.</summary>
+    [Description("TLS secret name — blank means {namespace}-tls")]
+    public string? TlsSecret { get; init; }
+
+    /// <summary>
+    /// Controller annotations. The OIDC login callback answers with several large Set-Cookie
+    /// headers; a large claims set exceeds nginx's default 4k proxy_buffer_size and the LOGIN
+    /// answers 502, deterministically per user (2026-08-23) — hence
+    /// <c>proxy-buffer-size: 16k</c> on every fleet instance.
+    /// </summary>
+    [Description("Ingress annotations")]
+    public ImmutableSortedDictionary<string, string> Annotations { get; init; }
+        = ImmutableSortedDictionary<string, string>.Empty;
+
+    /// <summary>Sticky sessions. Null → not stated here.</summary>
+    [Description("Session affinity")]
+    public SessionAffinity? SessionAffinity { get; init; }
+}
+
+/// <summary>
+/// The Next.js React front end (<c>clients/portal-next</c>), served at <c>/next</c> beside the
+/// Blazor portal as its OWN Deployment and Service. When it is on, the chart also routes the
+/// <c>/next</c> ingress path to it and renders <c>Portal__ReactAppUrl</c> into the portal's
+/// ConfigMap, which is what lights up the per-user "Try the new frontend" toggle. Null → the
+/// section renders nothing and the chart's own default (off) stands, so every record that does not
+/// mention it deploys exactly as before.
+///
+/// <para>🚨 WHY IT IS A RECORD FIELD, measured. Until this existed the record could not say it, so
+/// on both production portals <c>portal-next</c> ran as CLUSTER-ONLY DRIFT — a hand-applied
+/// Deployment and Service with no Helm ownership, on an image tag that had never existed in ACR,
+/// and 5+ days of <c>ImagePullBackOff</c> that no repository described because there was nowhere to
+/// describe it (Systemorph/Memex#172). The overlays then carried a HAND-WRITTEN <c>portalNext:</c>
+/// block under a header claiming the file is generated from this record — so the first re-render
+/// would have deleted it and reverted <c>/next</c> to "not deployed", silently
+/// (MeshWeaver.Plugins#1408).</para>
+///
+/// <para>🚨 ENABLED WITHOUT AN IMAGE IS REFUSED. The chart's default image is the LOCAL developer
+/// tag (<c>meshweaver/portal-next:local</c>), which no cluster node can pull, so turning the flag
+/// on without naming a pullable image is the ImagePullBackOff above arrived at from the record
+/// instead of by hand — <c>HelmValues.Problems</c> names it and the render refuses.</para>
+/// </summary>
+public sealed record PortalNextSpec
+{
+    /// <summary>Whether the React front end is deployed and the <c>/next</c> path is routed to it.</summary>
+    [Description("Deploy the React front end at /next")]
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// The container image, fully qualified with its tag. There is NO derivation from the portal's
+    /// repository or tag: this front end is built and versioned on its own line
+    /// (<c>memex-portal-next:3.0.0-next.N</c>), so a derived tag would name an image that does not
+    /// exist. Blank while <see cref="Enabled"/> is a named problem, never a chart default.
+    /// </summary>
+    [Description("Container image (repository:tag) — its own release line, never derived")]
+    public string? Image { get; init; }
+
+    /// <summary>Replicas. Null → the chart's 1. Stateless by design (every request mints its own token), so it scales with no sticky sessions.</summary>
+    [Description("Replicas — blank means the chart's 1")]
+    public int? Replicas { get; init; }
+
+    /// <summary>
+    /// The origin server-side rendering reaches the portal at, skipping the ingress round-trip.
+    /// Blank → the chart's in-cluster Service. The BROWSER always talks same-origin, so this
+    /// affects SSR only.
+    /// </summary>
+    [Description("Portal origin for server-side rendering — blank means the in-cluster Service")]
+    public string? PortalOrigin { get; init; }
+}
+
+/// <summary>
+/// One Key Vault secret the pod reads, by NAME: the configuration key it lands as, and the vault
+/// object that holds it. <see cref="VaultSecret"/> may stay blank — it is then DERIVED from the
+/// key by the fleet's naming rule <c>{keyVaultSecretPrefix}{Section}-{Key}</c>
+/// (<c>Email__ClientSecret</c> → <c>memexcloud-Email-ClientSecret</c>), so a record that follows
+/// the convention names each secret exactly once. A legacy object that does not follow it (the
+/// unprefixed <c>github-app-privatekey</c>) states its name explicitly. Never a value.
+/// </summary>
+public sealed record KeyVaultSecretRef
+{
+    /// <summary>The configuration key the secret lands as — <c>Section__Key</c>, exactly as the portal reads it.</summary>
+    [Description("Configuration key it lands as (Section__Key, e.g. Email__ClientSecret)")]
+    public string Key { get; init; } = "";
+
+    /// <summary>The vault object's name. Blank → derived from <see cref="Key"/> by the naming rule.</summary>
+    [Description("Key Vault secret name — blank derives it as {prefix}{Section}-{Key}")]
+    public string? VaultSecret { get; init; }
+}
+
+/// <summary>
+/// The pod's Key Vault secrets, DECLARED: the vault, the identity that reads it, and the secrets
+/// by name. The chart renders the whole path from this one section — the SecretProviderClass
+/// (<c>keyVaultSecrets</c> in values → <c>secretproviderclass.yaml</c>), the CSI volume, its
+/// mount and the <c>envFrom</c> on the synced Secret — so a declared secret cannot be half-wired
+/// and the record is the ONLY place a secret's NAME lives. Values never: the driver fetches them
+/// from the vault at pod start.
+///
+/// <para>Why it exists: until 2026-08-30 every SecretProviderClass in the fleet was a hand-made
+/// object, present in no repository, and the record could only point at it by name
+/// (<see cref="KeyVaultSecretMount"/>, now the legacy escape hatch). Which secrets a pod carried
+/// was knowable only from the cluster — and on the memex install a hand-made Secret patched onto
+/// the live Deployment carried a SECOND copy of the Email configuration, in another letter case,
+/// so which copy won was decided per pod start. The portal crashed with
+/// <c>EmailConfigurationGuard</c>; nothing in any repo could see either half.</para>
+///
+/// <para>Adopting a hand-made SecretProviderClass: state its live <see cref="Name"/> and
+/// <see cref="SyncedSecret"/> here, so <c>helm-release adopt</c> stamps ownership on the existing
+/// objects instead of creating a second pair beside them — and drop the matching
+/// <c>secretMounts</c> entry in the same change (a mount that names the same volume or class is a
+/// named problem, never a silent duplicate).</para>
+/// </summary>
+public sealed record KeyVaultSecretsSpec
+{
+    /// <summary>The vault. Blank → the record's <c>keyVault</c>.</summary>
+    [Description("Key Vault name — blank means the record's keyVault")]
+    public string? VaultName { get; init; }
+
+    /// <summary>The Entra tenant the vault lives in.</summary>
+    [Description("Tenant id of the vault")]
+    public string? TenantId { get; init; }
+
+    /// <summary>
+    /// The client id of the identity that READS the vault — the Key Vault Secrets Provider add-on's
+    /// user-assigned identity (<c>az aks show … --query addonProfiles.azureKeyvaultSecretsProvider.identity.clientId</c>),
+    /// which needs secret GET on the vault. An identifier, committed on purpose.
+    /// </summary>
+    [Description("Client id of the identity that reads the vault (the Key Vault Secrets Provider add-on's identity)")]
+    public string? IdentityClientId { get; init; }
+
+    /// <summary>The SecretProviderClass's name. Blank → <c>memex-portal-keyvault</c>. State the live name to adopt a hand-made one.</summary>
+    [Description("SecretProviderClass name — blank means memex-portal-keyvault")]
+    public string? Name { get; init; }
+
+    /// <summary>The Kubernetes Secret the driver syncs into and the pod reads via envFrom. Blank → the SecretProviderClass's name.</summary>
+    [Description("Synced Kubernetes Secret name — blank means the SecretProviderClass name")]
+    public string? SyncedSecret { get; init; }
+
+    /// <summary>The CSI volume's name. Blank → <c>kv-secrets</c>.</summary>
+    [Description("Volume name — blank means kv-secrets")]
+    public string? VolumeName { get; init; }
+
+    /// <summary>Where the CSI volume is mounted (the mount is what keeps the sync alive). Blank → <c>/mnt/secrets-store</c>.</summary>
+    [Description("Mount path — blank means /mnt/secrets-store")]
+    public string? MountPath { get; init; }
+
+    /// <summary>The secrets, by name. Empty renders nothing at all.</summary>
+    [Description("The secrets, by name — configuration key and vault object")]
+    public ImmutableList<KeyVaultSecretRef> Secrets { get; init; } = ImmutableList<KeyVaultSecretRef>.Empty;
+}
+
+/// <summary>
+/// ⚠️ LEGACY ESCAPE HATCH — a Key Vault secret set the pod reads through a HAND-MADE
+/// SecretProviderClass the record can only point at by name. Declare the secrets under
+/// <see cref="KeyVaultSecretsSpec"/> instead: that renders the SecretProviderClass itself, so the
+/// record says WHICH secrets, not merely where a cluster object lives. Kept for the transition —
+/// all THREE halves still render from the chart: the CSI volume (its mount is what makes the driver
+/// sync and rotate), the mount, and the <c>envFrom</c> on the synced Secret. Until 2026-08-23 they
+/// were live <c>kubectl</c> patches that the next <c>helm upgrade</c> silently dropped, detaching
+/// every AI provider key. The values in that Secret are secrets; this record names the objects only.
+/// </summary>
+public sealed record KeyVaultSecretMount
+{
+    /// <summary>The pod volume's name (<c>kv-secrets</c>).</summary>
+    [Description("Volume name")]
+    public string VolumeName { get; init; } = "";
+
+    /// <summary>The SecretProviderClass in the namespace that maps vault secrets to keys.</summary>
+    [Description("SecretProviderClass")]
+    public string SecretProviderClass { get; init; } = "";
+
+    /// <summary>The Kubernetes Secret the driver syncs it into (read via envFrom).</summary>
+    [Description("Synced Kubernetes Secret name")]
+    public string SyncedSecret { get; init; } = "";
+
+    /// <summary>Where the CSI volume is mounted (the mount is what keeps the sync alive).</summary>
+    [Description("Mount path")]
+    public string MountPath { get; init; } = "";
+}
+
+/// <summary>
+/// One language-model provider: its endpoint, the model ids it serves, its rank among providers.
+/// A stated EMPTY endpoint is meaningful — it is how an instance turns a provider off that the
+/// chart or a captured vault value would otherwise configure (AzureFoundry, 2026-08-25). Null
+/// means "not stated here", and the projection then writes nothing for it.
+/// </summary>
+public sealed record ModelProvider
+{
+    /// <summary>The provider endpoint. "" = explicitly off; null = not stated.</summary>
+    [Description("Endpoint — empty turns the provider off")]
+    public string? Endpoint { get; init; }
+
+    /// <summary>Model ids, by slot. A blank slot renders blank on purpose.</summary>
+    [Description("Models, by slot")]
+    public ImmutableList<string> Models { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>Rank among providers (0 first). Null → not stated.</summary>
+    [Description("Order among providers (0 first)")]
+    public int? Order { get; init; }
+
+    /// <summary>Feature-flag for the provider. Null → not stated.</summary>
+    [Description("Enabled")]
+    public bool? Enabled { get; init; }
+}
+
+/// <summary>Which model serves each tier — keyed by RANK, not by kind: Heavy is coding, not reasoning.</summary>
+public sealed record ModelTiers
+{
+    /// <summary>The heavy tier (coding).</summary>
+    [Description("Heavy tier model")]
+    public string? Heavy { get; init; }
+
+    /// <summary>The standard tier (reasoning).</summary>
+    [Description("Standard tier model")]
+    public string? Standard { get; init; }
+
+    /// <summary>The light tier (chat).</summary>
+    [Description("Light tier model")]
+    public string? Light { get; init; }
+
+    /// <summary>The utility tier.</summary>
+    [Description("Utility tier model")]
+    public string? Utility { get; init; }
+}
+
+/// <summary>The instance's AI providers and tier map. Keys ride the Key Vault half; these are endpoints and model ids.</summary>
+public sealed record AiProviders
+{
+    /// <summary>Anthropic (direct or through an Azure AI services /anthropic/ endpoint).</summary>
+    [Description("Anthropic")]
+    public ModelProvider? Anthropic { get; init; }
+
+    /// <summary>Azure AI Services (the /models endpoint).</summary>
+    [Description("Azure AI Services")]
+    public ModelProvider? AzureAis { get; init; }
+
+    /// <summary>Azure AI Foundry — the MODEL provider only; embeddings read their own config.</summary>
+    [Description("Azure AI Foundry (models only)")]
+    public ModelProvider? AzureFoundry { get; init; }
+
+    /// <summary>OpenRouter — the converged frontier catalog through one funded key.</summary>
+    [Description("OpenRouter")]
+    public ModelProvider? OpenRouter { get; init; }
+
+    /// <summary>The tier map.</summary>
+    [Description("Model tiers")]
+    public ModelTiers? Tiers { get; init; }
+}
+
+/// <summary>
+/// Sign-in. Client ids are identifiers and live here; every client SECRET rides the Key Vault
+/// half. A stated EMPTY client id is meaningful: the chart's defaults inject CHANGE_ME
+/// placeholders for providers an instance never configured, which register half-schemes whose
+/// empty secret throws on every request (no pod ever became ready, 2026-08-20) — "" makes the
+/// app skip the scheme, null leaves the question to the vault half.
+/// </summary>
+public sealed record SignInSpec
+{
+    /// <summary>The authentication provider scheme; <c>Custom</c> on every fleet instance.</summary>
+    [Description("Provider (Custom)")]
+    public string? Provider { get; init; }
+
+    /// <summary>The built-in developer login. Never on a public instance.</summary>
+    [Description("Enable developer login")]
+    public bool EnableDevLogin { get; init; }
+
+    /// <summary>Entra app registration client id.</summary>
+    [Description("Microsoft client id")]
+    public string? MicrosoftClientId { get; init; }
+
+    /// <summary>
+    /// Entra tenant. Null → the chart's <c>organizations</c> (multi-tenant). Never "" — an env var
+    /// cannot be null, so "" reached the portal as a tenant and the OIDC authority became
+    /// <c>login.microsoftonline.com//v2.0</c>; every Microsoft sign-in 500-ed (2026-08-28).
+    /// </summary>
+    [Description("Microsoft tenant id — blank means multi-tenant")]
+    public string? MicrosoftTenantId { get; init; }
+
+    /// <summary>Google OAuth client id. "" = scheme off; null = not stated.</summary>
+    [Description("Google client id — empty turns the scheme off")]
+    public string? GoogleClientId { get; init; }
+
+    /// <summary>LinkedIn OAuth client id. "" = scheme off; null = not stated.</summary>
+    [Description("LinkedIn client id — empty turns the scheme off")]
+    public string? LinkedInClientId { get; init; }
+
+    /// <summary>Apple sign-in client id.</summary>
+    [Description("Apple client id")]
+    public string? AppleClientId { get; init; }
+}
+
+/// <summary>
+/// System email through Microsoft Graph (client-secret flow). The sender must be a DEDICATED mail
+/// app holding <c>Mail.Send</c> as an admin-consented APPLICATION role — the portal's own sign-in
+/// app carries only delegated scopes and cannot send in this flow; wiring it here looks complete
+/// and delivers nothing. The client secret rides the Key Vault half — declared as
+/// <c>Email__ClientSecret</c> under <see cref="KeyVaultSecretsSpec"/>. This section is the WHOLE
+/// non-secret half: every <c>Email__*</c> key the chart's ConfigMap renders comes from here (the
+/// shared <c>Email__SubscriptionClientState</c> webhook guard is a chart global). On 2026-08-30 the
+/// memex install carried a SECOND copy of this section as a hand-made Secret on the live pod, in
+/// another letter case, and which copy won was decided per pod start — hence "one home".
+/// </summary>
+public sealed record EmailSpec
+{
+    /// <summary>Whether outbound mail is on. Off falls through with almost no signal: one Error line per host start, /health still 200.</summary>
+    [Description("Enable system email")]
+    public bool Enabled { get; init; }
+
+    /// <summary>The Graph sender app's client id.</summary>
+    [Description("Sender app client id")]
+    public string? ClientId { get; init; }
+
+    /// <summary>The tenant the sender app lives in.</summary>
+    [Description("Tenant id")]
+    public string? TenantId { get; init; }
+
+    /// <summary>The virtual inbox (an M365 shared mailbox, not a person).</summary>
+    [Description("Mailbox address")]
+    public string? MailboxAddress { get; init; }
+
+    /// <summary>Managed identity instead of a client secret.</summary>
+    [Description("Use managed identity")]
+    public bool UseManagedIdentity { get; init; }
+
+    /// <summary>
+    /// Inbound mail through a Graph change-notification subscription on the mailbox. Needs the
+    /// <c>Mail.ReadWrite</c> application permission and a public <see cref="WebhookBaseUrl"/>;
+    /// on without either, the subscription is never created and inbound silently stays off.
+    /// </summary>
+    [Description("Enable inbound email (Graph subscription on the mailbox)")]
+    public bool InboundEnabled { get; init; }
+
+    /// <summary>The public base URL Graph calls back for notifications; the webhook is <c>{WebhookBaseUrl}/api/email</c>. Null → not stated.</summary>
+    [Description("Public webhook base URL (Graph calls {url}/api/email)")]
+    public string? WebhookBaseUrl { get; init; }
+
+    /// <summary>Where the inbound triage lane's Forward action sends a mail. Empty makes the action report itself unavailable.</summary>
+    [Description("Inbound forward address — empty disables Forward")]
+    public string? InboundForwardAddress { get; init; }
+}
+
+/// <summary>
+/// The GitHub App IDENTITY — identifiers, committed on purpose; the private key is the secret and
+/// rides the Key Vault half. These live under the PORTAL config: committed one section up (under
+/// the migration) they are never read, the overlay looks safe, and every deploy renders them
+/// empty (2026-08-24 and again 2026-08-25, MeshWeaver#2210).
+/// </summary>
+public sealed record GitHubAppIdentity
+{
+    /// <summary>The App's client id.</summary>
+    [Description("GitHub App client id")]
+    public string? ClientId { get; init; }
+
+    /// <summary>The installation id on the owner.</summary>
+    [Description("Installation id")]
+    public string? InstallationId { get; init; }
+
+    /// <summary>The installation's owner (organisation).</summary>
+    [Description("Installation owner")]
+    public string? InstallationOwner { get; init; }
+}
+
+/// <summary>
+/// The instance-lifecycle operator: on the CONTROL instance, and only there. The identity it arms
+/// can delete namespaces and drop databases across the fleet — this block on a tenant record
+/// would hand that tenant's pod a start-a-cluster-powerful-job token. Off by default is a
+/// security property. The environment is named keys (KEY=VALUE reach every operator Job);
+/// nothing here is secret.
+/// </summary>
+public sealed record HostingOperatorSpec
+{
+    /// <summary>Whether this instance runs lifecycle actions for the fleet.</summary>
+    [Description("Run the hosting operator here (the control instance only)")]
+    public bool Enabled { get; init; }
+
+    /// <summary>The namespace operator Jobs run in. Blank → <c>memex-ops</c>.</summary>
+    [Description("Operator namespace")]
+    public string? Namespace { get; init; }
+
+    /// <summary>The service account the Jobs run as. Blank → <c>hosting-operator</c>.</summary>
+    [Description("Operator service account")]
+    public string? ServiceAccount { get; init; }
+
+    /// <summary>The operator image — THE chart version it deploys, baked in.</summary>
+    [Description("Operator image")]
+    public string? Image { get; init; }
+
+    /// <summary>Environment for every Job: resource group, DNS group, portal identity, OIDC issuer, ingress IP, paywall URL.</summary>
+    [Description("Job environment (KEY=VALUE)")]
+    public ImmutableSortedDictionary<string, string> Environment { get; init; }
+        = ImmutableSortedDictionary<string, string>.Empty;
+}
+
+/// <summary>OpenTelemetry export.</summary>
+public sealed record TelemetrySpec
+{
+    /// <summary>The OTLP collector endpoint.</summary>
+    [Description("OTLP endpoint")]
+    public string? OtlpEndpoint { get; init; }
+
+    /// <summary>The OTLP protocol (<c>grpc</c>).</summary>
+    [Description("OTLP protocol")]
+    public string? OtlpProtocol { get; init; }
+}
+
+/// <summary>
+/// The rollout drain. <see cref="DrainSeconds"/> is the answer to "how long may a user keep working
+/// on the OLD build after a roll?": the pod's preStop waits for its last Blazor circuit to close,
+/// bounded by this ceiling. 120s cut people off mid-task; the k8s default of 30s SIGKILLed the
+/// portal mid-drain with a live Orleans silo, leaving ZOMBIE membership entries that timed out
+/// writes mesh-wide. The session drain stops <see cref="ShutdownMarginSeconds"/> short of the
+/// ceiling and RETURNS, so SIGTERM is delivered with room to shut down in (#1971).
+/// </summary>
+public sealed record DrainSpec
+{
+    /// <summary>Termination grace and the drain ceiling, seconds.</summary>
+    [Description("Drain ceiling in seconds (termination grace)")]
+    public int DrainSeconds { get; init; } = 1800;
+
+    /// <summary>How much of the ceiling is reserved for the host's own shutdown.</summary>
+    [Description("Shutdown margin in seconds")]
+    public int ShutdownMarginSeconds { get; init; } = 120;
+}
+
+/// <summary>
+/// The startup probe budget: <c>periodSeconds × failureThreshold</c> is how long a cold boot may
+/// take before the pod is killed. The default 5 × 60 = 5 minutes fits a plain boot. It is what
+/// bounds a NodeType BAKE (PreWarm gate) and a cold assembly-cache recycle on an SMB volume —
+/// an identity flip on Azure Files exceeded it and looped (2026-08-29). The rollout's
+/// progress deadline is DERIVED from this budget by the chart, never a second free number.
+/// </summary>
+public sealed record StartupProbeSpec
+{
+    /// <summary>Seconds between probes.</summary>
+    [Description("Probe period in seconds")]
+    public int PeriodSeconds { get; init; } = 5;
+
+    /// <summary>Seconds one probe may take.</summary>
+    [Description("Probe timeout in seconds")]
+    public int TimeoutSeconds { get; init; } = 5;
+
+    /// <summary>Failures before the pod is killed.</summary>
+    [Description("Failures before the pod is killed")]
+    public int FailureThreshold { get; init; } = 60;
+
+    /// <summary>The whole budget in seconds. Pure.</summary>
+    public int BudgetSeconds => PeriodSeconds * FailureThreshold;
+}
+
+/// <summary>
+/// Where the portal keeps its state inside the pod. <see cref="DataRoot"/> holds what MUST survive
+/// restarts and be SHARED across replicas (DataProtection keys, the NodeType assembly cache, the
+/// NuGet cache) — it is the <c>data</c> volume. Content and users have their own volumes so a
+/// heap-sized cache never fills the content share.
+/// </summary>
+public sealed record StorageLayout
+{
+    /// <summary>The persistence backend; <c>Filesystem</c> on every fleet instance.</summary>
+    [Description("Persistence backend")]
+    public string Backend { get; init; } = "Filesystem";
+
+    /// <summary>The shared state root (the data volume's mount).</summary>
+    [Description("Data root")]
+    public string DataRoot { get; init; } = "/data";
+
+    /// <summary>Where landed modules live. Blank → the data root.</summary>
+    [Description("Modules root — blank means the data root")]
+    public string? ModulesRoot { get; init; }
+
+    /// <summary>The content collection's base path (the content volume's mount).</summary>
+    [Description("Content path")]
+    public string ContentPath { get; init; } = "/mnt/content";
+
+    /// <summary>The content collection's name.</summary>
+    [Description("Content collection name")]
+    public string ContentName { get; init; } = "content";
+
+    /// <summary>The content source type.</summary>
+    [Description("Content source type")]
+    public string ContentSourceType { get; init; } = "FileSystem";
+
+    /// <summary>The graph store.</summary>
+    [Description("Graph storage type")]
+    public string GraphStorageType { get; init; } = "PostgreSql";
+
+    /// <summary>The graph store's file path (the filesystem fallback). Blank → <c>{DataRoot}/graph</c>.</summary>
+    [Description("Graph storage path — blank means {DataRoot}/graph")]
+    public string? GraphStoragePath { get; init; }
+
+    /// <summary>Where Claude Code keeps per-user config (the users volume). Null → not stated.</summary>
+    [Description("Claude Code config root (per-user)")]
+    public string? ClaudeCodeConfigDirRoot { get; init; }
+}
+
+// ─────────────────────────────── the LIVE-ONLY layers ───────────────────────────────
+// Two things reach a running pod that no values file renders, and that a record with no slot for
+// them cannot compare itself against: the chart's own Secret, whose keys come from the Key Vault
+// "values half" an operator captured, and the inline `env:` entries somebody set with `kubectl`.
+// Both are DECLARATIVE here — they render nothing. Their whole job is to make the record and the
+// cluster comparable without a false diff, and to make an instance's ENV PRECEDENCE readable from
+// one file. See HelmValues.EnvPrecedence.
+
+/// <summary>
+/// One environment variable set INLINE on the live Deployment's pod spec — the highest-precedence
+/// layer there is, above every <c>envFrom</c>.
+///
+/// <para>🚨 THIS RENDERS NOTHING, DELIBERATELY. An inline entry is out-of-band by construction: the
+/// chart never emits one, and <c>helm upgrade</c> does not remove one either — three-way merge
+/// removes only what helm previously OWNED, measured 2026-09-03 on helm v3.21.1 and v4.2.4 with a
+/// positive control (<c>Doc/Architecture/ChartDriftSemantics</c>). So an inline entry SURVIVES
+/// every deploy and keeps outranking the ConfigMap and every synced Secret. Recording it does not
+/// create it and dropping it does not delete it; what recording buys is that the record stops
+/// silently DISAGREEING with the pod, and that a drift report can subtract what is known and
+/// deliberate from what is a surprise.</para>
+///
+/// <para>🚨 NEVER A CREDENTIAL VALUE. Where the entry carries a secret — <c>memex</c> and
+/// <c>memex-cloud</c> each hold a plugin-registry instance key inline, in plaintext, readable by
+/// anything that can <c>get deploy</c> — set <see cref="IsSecret"/> and leave <see cref="Value"/>
+/// null. <c>HelmValues.Problems</c> REFUSES a record that states both, because these nodes sync to
+/// a git repository.</para>
+/// </summary>
+public sealed record InlineEnvOverride
+{
+    /// <summary>The environment variable's name, exactly as it appears on the pod (<c>Section__Key</c>).</summary>
+    [Description("Environment variable name, as set on the pod")]
+    public string Key { get; init; } = "";
+
+    /// <summary>
+    /// The value, when it is not a credential. Null means "not recorded" — either because it is a
+    /// secret (<see cref="IsSecret"/>) or because nobody has written it down yet; the two are
+    /// different and only the first is a good reason.
+    /// </summary>
+    [Description("Value — omit for a credential")]
+    public string? Value { get; init; }
+
+    /// <summary>True when the value is a credential. It is then NEVER recorded here.</summary>
+    [Description("The value is a credential and is not recorded here")]
+    public bool IsSecret { get; init; }
+
+    /// <summary>
+    /// What this entry stands over, if anything: the name of the <c>envFrom</c> source that also
+    /// supplies the key (a synced Secret, or <c>memex-portal-config</c> for the chart's ConfigMap).
+    /// Blank means the inline entry is the SOLE source — dropping it would EMPTY the key, which is
+    /// the opposite of the usual worry and true of more entries than people expect
+    /// (<c>PluginCatalog__RegistryUrl</c> on both fleet instances, <c>Features__Ai__Clis__*</c> on
+    /// memex, <c>Speech__*</c> and <c>Commerce__BaseUrl</c> on memex-cloud).
+    /// </summary>
+    [Description("The envFrom source it shadows — blank means it is the only source")]
+    public string? Shadows { get; init; }
+
+    /// <summary>
+    /// Whether the shadowed source is known to carry the SAME value. <c>true</c> = redundant today
+    /// (removing it changes nothing now, but the next change to the other source will silently fail
+    /// to take effect); <c>false</c> = the pod runs something no committed file states; null = not
+    /// compared, which is the honest answer whenever the other source is a Secret, because a drift
+    /// check must not copy the credentials it audits onto a CI runner's disk.
+    /// </summary>
+    [Description("Does the shadowed source agree? Unset means not compared (a Secret)")]
+    public bool? AgreesWithShadowed { get; init; }
+
+    /// <summary>Why it is still there, in one line. An entry with no reason is a to-do, not a decision.</summary>
+    [Description("Why it is still set inline")]
+    public string? Reason { get; init; }
+
+    /// <summary>What retires it — an issue reference, so the entry has an end rather than a history.</summary>
+    [Description("What retires it (issue reference)")]
+    public string? RetiredBy { get; init; }
+}
+
+/// <summary>
+/// A foreign-language GATE sidecar in the portal pod — a participant that reaches the portal's
+/// loopback-bound trusted gRPC endpoint, so that reachability across the shared pod network
+/// namespace IS the authentication. It executes Code nodes of its language exactly as the
+/// in-process Roslyn kernel executes C# ones.
+///
+/// <para>Recorded because it is a container the instance RUNS: on <c>memex</c> the python and node
+/// gates have been in the pod since 2026-08-24 as a hand-applied <c>kubectl patch</c>, declared in
+/// no repository, while the chart has supported rendering them from values all along. A record that
+/// cannot state them describes an instance with one container where three run.</para>
+/// </summary>
+public sealed record GateSpec
+{
+    /// <summary>The language key the chart renders the sidecar under (<c>python</c>, <c>node</c>, <c>pandas</c>).</summary>
+    [Description("Language (python, node, pandas)")]
+    public string Language { get; init; } = "";
+
+    /// <summary>Whether the gate is included. A gate RUNS when it is enabled AND an image is supplied.</summary>
+    [Description("Enabled")]
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>The sidecar image. Blank ⇒ no sidecar, so a bare install never crash-loops on a missing image.</summary>
+    [Description("Sidecar image — blank means the gate does not run")]
+    public string? Image { get; init; }
+
+    /// <summary>The mesh address the gate registers at. Blank → the chart's default for the language.</summary>
+    [Description("Mesh address — blank means the chart's default")]
+    public string? Address { get; init; }
+}

--- a/src/MeshWeaver.Deployment.Contract/MeshWeaver.Deployment.Contract.csproj
+++ b/src/MeshWeaver.Deployment.Contract/MeshWeaver.Deployment.Contract.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- 🚨 ZERO MeshWeaver references, on purpose. This assembly is the Deployment record — the ONE
+         input the in-mesh Hosting module renders Helm from, the Aspire adapter derives a local run
+         from and emits, and the portal binds its own record from (Deployment:Record). It ships INSIDE
+         the published Aspire package: NOT as a package of its own (the maintainer retired every
+         NuGet id but two on 2026-09-07) but as a second assembly in MeshWeaver.Aspire.Hosting.Memex's
+         lib folder (that csproj's PackContractAssembly target), so it must stay free of anything
+         that is not itself published: no MeshWeaver.Messaging.Contract (its DI/Logging/ShortGuid
+         closure is not a package), no Domain, no Layout. That is also why the property labels carry
+         only the BCL [Description] — the German [Translation] texts of the in-mesh original are in
+         Doc/Architecture/ConfiguringAnInstanceFromAspire under "Labels" until the localizer reads a
+         catalog for declarations (follow-up named there). Inside the image it is referenced by
+         MeshWeaver.PluginCatalog, which puts it in the application closure the in-mesh Hosting
+         sources compile against. -->
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Description>The MeshWeaver Deployment record (DeploymentContent): the one declaration of an instance that Helm, the Aspire adapter and the portal itself all read. Pure records, a fluent builder, the configuration binding (Deployment:Record) and the portal-config derivation shared with the chart.</Description>
+    <ProjectGuid>{5a0f3d21-8c7e-4b6a-9d13-2e7f4c8a1b90}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/src/MeshWeaver.Deployment.Contract/PluginRepoMount.cs
+++ b/src/MeshWeaver.Deployment.Contract/PluginRepoMount.cs
@@ -1,0 +1,68 @@
+// One plugin repository a deployment mounts — moved with the Deployment record (see DeploymentContent.cs).
+using System;
+
+namespace MeshWeaver.Deployment;
+
+/// <summary>
+/// ONE plugin repository a deployment mounts — a registry to consume, or (on the registry
+/// installation itself) a git repo to serve. This is the recorded half of what AGENTS.md calls
+/// "a module with no sync entry is simply not on the mesh": an instance created without its
+/// mounts comes up empty, and the reason is invisible.
+///
+/// <para>🚨 Records, not secrets — like every other field on a Deployment. A consumer's registry
+/// token and a registry's git credential are named through <see cref="SecretName"/> (a Key Vault
+/// secret NAME); their values never appear here, because these records sync to git.</para>
+/// </summary>
+public record PluginRepoMount
+{
+    /// <summary>
+    /// The mount's name. For a consumer it is the registry name (<c>PluginCatalog:Registries:N:Name</c>);
+    /// for the registry installation it is the SOURCE name that stamps every package it serves
+    /// (<c>Plugins</c>, <c>Education</c>, …) — which is what a pre-install pattern matches on.
+    /// </summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>
+    /// Where the packages come from: a registry BASE URL for a consumer
+    /// (<c>https://memex.meshweaver.cloud</c>), or a git repository URL when
+    /// <see cref="IsRegistrySource"/> — the registry alone holds a git credential.
+    /// </summary>
+    public string Url { get; init; } = "";
+
+    /// <summary>Git ref, for a registry source. Blank → <c>main</c>. Ignored by a consumer mount.</summary>
+    public string? Ref { get; init; }
+
+    /// <summary>
+    /// True when this deployment SERVES this repo (it is the registry) rather than consuming it.
+    /// The distinction decides which configuration section the mount renders into, and only a
+    /// registry mount needs a git credential.
+    /// </summary>
+    public bool IsRegistrySource { get; init; }
+
+    /// <summary>
+    /// The Key Vault secret NAME carrying this mount's credential — a consumer's registry token,
+    /// or a registry source's git token. Never a value. Blank → the deployment's default.
+    /// </summary>
+    public string? SecretName { get; init; }
+
+    /// <summary>Trimmed name, or "" — the form every renderer uses. Pure.</summary>
+    public string NormalizedName => (Name ?? "").Trim();
+
+    /// <summary>Trimmed URL with any trailing slash removed, or "". Pure.</summary>
+    public string NormalizedUrl => (Url ?? "").Trim().TrimEnd('/');
+
+    /// <summary>Git ref, defaulted to <c>main</c> the way the catalog defaults it. Pure.</summary>
+    public string EffectiveRef => string.IsNullOrWhiteSpace(Ref) ? "main" : Ref!.Trim();
+
+    /// <summary>
+    /// Why this mount cannot be used, or null when it is usable. A mount without a name or a URL
+    /// is not "partially configured" — it silently contributes nothing, which is the failure this
+    /// whole record exists to make visible. Pure.
+    /// </summary>
+    public string? Problem() =>
+        string.IsNullOrWhiteSpace(NormalizedName) ? "a plugin mount needs a name"
+        : string.IsNullOrWhiteSpace(NormalizedUrl) ? $"plugin mount '{NormalizedName}' needs a url"
+        : !NormalizedUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            ? $"plugin mount '{NormalizedName}' must be an https url — got '{NormalizedUrl}'"
+        : null;
+}

--- a/src/MeshWeaver.Documentation/Data/AI/TeamsBot.md
+++ b/src/MeshWeaver.Documentation/Data/AI/TeamsBot.md
@@ -79,21 +79,22 @@ Key points:
 | `Teams:AppPassword` | the bot app client secret (`MicrosoftAppPassword`) — keep in Key Vault |
 | `Teams:TenantId` | Entra tenant id for a single-tenant bot (optional; multi-tenant when empty) |
 
-Configured through the AppHost fluent API, exactly like email:
+Configured on the Deployment record's advanced rung (portal configuration keys), and the secret
+handed over separately — never on the record:
 
 ```csharp
-builder.AddMemex("memex", o => o
+builder.AddMemex("memex")
     // …
-    .WithTeams(
-        enabled: true,
-        appId: "<bot app id>",
-        appPassword: "<from Key Vault>",
-        tenantId: "<tenant>"));
+    .WithPortalConfig("Teams__Enabled", "true")
+    .WithPortalConfig("Teams__AppId", "<bot app id>")
+    .WithPortalConfig("Teams__TenantId", "<tenant>")
+    .WithSecret("Teams__AppPassword", builder.AddParameter("teams-app-password", secret: true));
 ```
 
 Deploy parameters (`Memex.Deploy.AppHost`): `teams-enabled`, `teams-app-id`, `teams-app-password`,
-`teams-tenant-id` → emitted as `Teams__*`. On AKS the secret comes from Key Vault
-(`teams-apppassword → Teams__AppPassword`), like the email client secret.
+`teams-tenant-id` → emitted as `Teams__*`. On AKS the secret comes from Key Vault through the
+record's `keyVaultSecrets` map (`teams-apppassword → Teams__AppPassword`), like the email client
+secret ([ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire)).
 
 ## Azure setup (one-time, by an admin)
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ConfiguringAnInstanceFromAspire.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ConfiguringAnInstanceFromAspire.md
@@ -124,7 +124,7 @@ discovered:
 | Difference | Helm (`PortalConfigOptions.Helm`) | Aspire (`PortalConfigOptions.Aspire(mcpBaseUrl)`) |
 |---|---|---|
 | Database keys (`MEMEX_*`) | from the record (`DatabaseServer`, `DatabaseHost`, …) | not emitted — the Aspire Postgres resource injects `ConnectionStrings__memex` / `__orleans` |
-| `Mcp__BaseUrl` | the in-cluster portal Service | the endpoint Aspire allocates (substituted at publish) |
+| `Mcp__BaseUrl` | the in-cluster portal Service | not emitted by the derivation (never a blank) — the adapter sets the key to the endpoint Aspire allocates, substituted at publish |
 | Plugin-catalog boot wiring (`PluginCatalog__*`) | the operator's catalog config file, not the ConfigMap | emitted as environment — Aspire has no second file |
 
 `FluentBuilderTest.TheSameRecordRendersTheSameKeysForHelmAndForAspire` renders the real `memex`

--- a/src/MeshWeaver.Documentation/Data/Architecture/ConfiguringAnInstanceFromAspire.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ConfiguringAnInstanceFromAspire.md
@@ -1,0 +1,431 @@
+---
+Name: Configuring an instance from Aspire
+Category: Architecture
+Description: The Deployment record is the ONE input — Aspire and Helm render from it, the image receives it as configuration, and Aspire emits a record, never a chart. The fluent builder over the record, how the record reaches the portal (Deployment:Record), and the parity table (method → record field → Helm value → config key) that RendererParityTest holds the code to.
+Icon: Cloud
+---
+
+# Configuring an instance from Aspire
+
+**The Deployment record is the ONE input.** Aspire and Helm render from it; the image receives it
+as configuration (`Deployment:Record`); Aspire emits a record, never a chart. (Maintainer,
+2026-09-08: *"yes, must be the only input"* · *"pipe it somehow into the memex image via config ⇒
+see how e.g. orleans interfaces"* · *"create fluent language to configure. give possibilities to
+configure in the aspire api"* · on generating Helm from Aspire: *"ok. retire"*.)
+
+An instance IS a `DeploymentContent` record — the `Hosting/Deployment` node the control instance
+holds at `Deployments/<name>` ([Operating from the portal](/Doc/Architecture/OperatingFromThePortal)).
+Before this change the record had a second, adapter-only copy in `MemexOptions` (half its fields,
+different names, a hand-maintained chart beside both), and on 2026-09-06 the record and the
+rendered overlay disagreed in **41 places** that nothing reported. Now there is one declaration and
+three readers of it:
+
+| Reader | Where | What it does with the record |
+|---|---|---|
+| **The Hosting module** (MeshWeaver.Plugins, `Hosting/**`) | the control instance | renders the Helm values (`HelmValues.Render`) and the operator's catalog file; runs `Provision`, `Roll`, `Reconcile`, `Audit` against it |
+| **The Aspire adapter** (`MeshWeaver.Aspire.Hosting.Memex`) | a developer's AppHost, the ACA lanes | derives the local containers, volumes and environment from it; injects it into the portal; writes it out (`PublishRecord`) |
+| **The portal itself** | inside the image | binds its own record from configuration at boot (`DeploymentRecordJson.FromConfiguration`) |
+
+The contract they share is one assembly, **`MeshWeaver.Deployment.Contract`** (namespace
+`MeshWeaver.Deployment`; `src/MeshWeaver.Deployment.Contract/`): the record and its nested specs,
+the fluent builder (`DeploymentRecordExtensions`), the configuration binding
+(`DeploymentRecordJson`) and the portal-config derivation the chart and the adapter both use
+(`DeploymentPortalConfig`). It has **zero MeshWeaver references** so it can ride inside the
+published Aspire package (bundled into its `lib/` folder — no third NuGet id; the maintainer
+retired all but two on 2026-09-07), and inside the image it is referenced by
+`MeshWeaver.PluginCatalog`, which puts it in the application closure the in-mesh Hosting sources
+compile against.
+
+## The fluent surface
+
+Every method is a **pure transform of the record**: it returns a new `DeploymentContent`, leaves
+its input untouched, composes, and needs no Aspire — the same calls serve an AppHost, the setup
+wizard, the `dotnet new` template generator and a test. Defaults live on the record, never on the
+builder: a bare `new DeploymentContent()` already renders a bootable portal (`PostgreSql` graph
+store, `Filesystem` backend, port 8080).
+
+```csharp
+using MeshWeaver.Deployment;
+
+var record = new DeploymentContent()
+    .WithHost("portal.example.com", dnsZone: "example.com")
+    .WithNamespace("portal")
+    .WithDatabase("portal", server: "pg-portal", connectionSecret: "portal-pg-connection")
+    .WithImage("ghcr.io/systemorph/memex-portal-ai", tag: "3.1.0")
+    .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")
+    .PreInstall("MeshWeaver.Plugins/Hosting")
+    .WithRequiredModule("MeshWeaver.Hosting.Postgres")
+    .WithVolume("data", "/data", size: "128Gi", storageClass: "azurefile", accessMode: "ReadWriteMany")
+    .WithKeyVault("kv-portal", prefix: "portal-")
+    .WithKeyVaultSecrets(secrets => secrets.Map("Email__ClientSecret", "email-clientsecret"))
+    .WithSignIn(microsoftClientId: "<client id>", microsoftTenantId: "<tenant>")
+    .WithEmail(mailboxAddress: "portal@example.com", clientId: "<client id>", tenantId: "<tenant>")
+    .WithAi(ai => ai.OpenRouter(["anthropic/claude-sonnet-4"]).Tiers(heavy: "anthropic/claude-opus-4"))
+    .WithReplicas(2)
+    .WithResources(requestsCpu: "500m", requestsMemory: "2Gi", limitsCpu: "2", limitsMemory: "8Gi")
+    .WithStartupProbe(periodSeconds: 10, failureThreshold: 60)
+    .WithOperator(ns: "hosting")
+    .WithPortalConfig("Embedding__Endpoint", "https://openrouter.ai/api/v1");
+```
+
+In an AppHost the entry point stays **`AddMemex`**, and it returns a resource builder that
+**carries the record**. Each `With*` on the resource builder delegates one-to-one to the record
+transform above, then re-syncs what Aspire derives (images, volumes, replicas); `Configure(record
+=> …)` applies any transform the named wrappers do not carry.
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddMemex("memex")                       // the default record: default images, one replica, the fleet's three volumes
+    .WithImage("ghcr.io/systemorph/memex-portal-ai", tag: "3.1.0")
+    .WithOrleansClustering("AdoNet")
+    .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")
+    .PreInstall("MeshWeaver.Plugins/Hosting")
+    .WithSignIn(microsoftClientId: "<client id>", microsoftTenantId: "<tenant>")
+    .WithSecret("Authentication__Microsoft__ClientSecret", builder.AddParameter("microsoft-client-secret", secret: true))
+    .PublishRecord("deployments/memex.json");   // the FINAL record, written when the application starts
+
+builder.Build().Run();
+```
+
+`AddMemex(name, record)` starts from a record you already have; `AddMemexFromFile(name, path)`
+reads one (a bare record, or a full mesh node with a `content` object — what `get
+Deployments/memex` returns). `MemexOptions` is what is left of the old options type: the default
+image registry, the default portal repository, the derived default tag (`<major>-latest`) and
+`DefaultRecord(name)`.
+
+**Secrets are never on the record** — it syncs to git. On Kubernetes a secret is a Key Vault
+*name* on the record (`keyVaultSecrets`, `vaultValuesKeys`) and a value the CSI driver mounts;
+under Aspire it is `WithSecret(configurationKey, parameter)` — an Aspire parameter, or a literal in
+development — handed to the container directly. `PublishRecord` never writes one, by construction.
+
+## How the record reaches the image
+
+The way Orleans' Aspire integration hands a silo its clustering — resource → environment → the app
+binds from configuration — the adapter injects the record into the portal container as **one
+configuration section**:
+
+| Key | Aspire (environment) | Helm (ConfigMap) | Value |
+|---|---|---|---|
+| `Deployment:Record` | `Deployment__Record` | `config.memex_portal.Deployment__Record` | the whole record, as JSON (`DeploymentRecordJson.Write`) |
+| the derived surface | `Storage__*`, `Graph__Storage__*`, `Modules__Required__N`, `Authentication__*`, `Email__*`, … | the same keys, in `config.memex_portal` | `DeploymentPortalConfig.PortalConfig(record, options)` — one derivation, both routes |
+
+It is **one JSON value on purpose**: `DeploymentContent` is an init-only record over immutable
+collections, carrying the mesh's `$type`, and none of that binds through the configuration binder
+— while one JSON value is byte-identical on a ConfigMap and in an Aspire environment. The portal
+reads it with `DeploymentRecordJson.FromConfiguration(configuration)` (null when the section is
+absent — a Monolith, a test). The derived per-key surface stays beside it because that is what
+every existing `IOptions` reader in the image already binds; the record is the source, the keys
+are its projection.
+
+The two routes differ in exactly the places `PortalConfigOptions` names — declared, not
+discovered:
+
+| Difference | Helm (`PortalConfigOptions.Helm`) | Aspire (`PortalConfigOptions.Aspire(mcpBaseUrl)`) |
+|---|---|---|
+| Database keys (`MEMEX_*`) | from the record (`DatabaseServer`, `DatabaseHost`, …) | not emitted — the Aspire Postgres resource injects `ConnectionStrings__memex` / `__orleans` |
+| `Mcp__BaseUrl` | the in-cluster portal Service | the endpoint Aspire allocates (substituted at publish) |
+| Plugin-catalog boot wiring (`PluginCatalog__*`) | the operator's catalog config file, not the ConfigMap | emitted as environment — Aspire has no second file |
+
+`FluentBuilderTest.TheSameRecordRendersTheSameKeysForHelmAndForAspire` renders the real `memex`
+record both ways and asserts the difference is exactly these three.
+
+## The parity table
+
+This table is the contract between the fluent surface, the record and the two renderers.
+**`RendererParityTest` (`test/MeshWeaver.Deployment.Contract.Test`) reads it**: every method it
+names exists on `DeploymentRecordExtensions`; every record transform the code has is in it; every
+field it names is on the record; every public field of the record is reached by some row (or is in
+the "written by the operator" table below); and every configuration key it names is emitted by
+`DeploymentPortalConfig.PortalConfig` for a fully populated record (`Prefix__*` names a family).
+Editing the code without the table, or the table without the code, is red.
+
+Helm values are the paths in the values file `HelmValues.Render` produces (`config.memex_portal.*`
+is the portal ConfigMap). A dash means the field is the record's or the operator's alone — it
+configures no container.
+
+| Method | Record field | Helm value | Config key |
+|---|---|---|---|
+| `WithHost(host, dnsZone)` | `Host`, `DnsZone` | `ingress` (host) — the DNS record is the operator's | — |
+| `WithNamespace(ns, helmRelease)` | `Namespace`, `HelmRelease` | the release itself (`helm upgrade --install <release> -n <ns>`) | — |
+| `WithCluster(cluster)` | `Cluster` | — (which cluster the operator targets) | — |
+| `WithOwner(owner, purpose)` | `Owner`, `Purpose` | — | — |
+| `WithStatus(status)` | `Status` | — | — |
+| `WithNotes(notes)` | `Notes` | — | — |
+| `AppendNote(paragraph)` | `Notes` | — | — |
+| `WithConfigRepository(repository, configPath)` | `Repository`, `ConfigPath` | — (where the rendered overlay is committed) | — |
+| `WithGrafana(baseUrl)` | `GrafanaBaseUrl` | — | — |
+| `WithDatabase(database, server, username, host, port, connectionSecret)` | `Database`, `DatabaseServer`, `DatabaseUsername`, `DatabaseHost`, `DatabasePort`, `DatabaseConnectionSecret` | `config.memex_migration.MEMEX_*`, `config.memex_portal.MEMEX_*` | `MEMEX_DATABASENAME`, `MEMEX_HOST`, `MEMEX_PORT`, `MEMEX_USERNAME`, `MEMEX_JDBCCONNECTIONSTRING` (Helm only) |
+| `WithInClusterPostgres(enabled)` | `InClusterPostgres` | `postgres.enabled` | — |
+| `WithImage(repository, tag, pullSecret, migrationRepository)` | `ImageRepository`, `PinnedImageTag`, `ImagePullSecret`, `MigrationImageRepository` | `portal.image`, `portal.imagePullSecret`, `migration.image`, `selfUpdate.registry` | — |
+| `WithPinnedImageTag(tag)` | `PinnedImageTag` | `portal.image` (the tag; the pin IS the roll) | — |
+| `WithUpdatePolicy(policy)` | `UpdatePolicy` | — (the self-updater reads the record) | — |
+| `WithMinRollInterval(interval)` | `MinRollInterval` | `config.memex_portal.SelfUpdate__MinRollInterval` | `SelfUpdate__MinRollInterval` |
+| `WithAutoRecycleOnStaleBuild(enabled)` | `AutoRecycleOnStaleBuild` | `config.memex_portal.Modules__AutoRecycleOnStaleBuild` | `Modules__AutoRecycleOnStaleBuild` |
+| `WithPluginRepo(name, url, gitRef, isRegistrySource, secretName)` | `PluginRepos[].Name`, `PluginRepos[].Url`, `PluginRepos[].Ref`, `PluginRepos[].IsRegistrySource`, `PluginRepos[].SecretName` | `pluginCatalog.sources` (the operator's catalog file) | `PluginCatalog__*` (Aspire only) |
+| `ClearPluginRepos()` | `PluginRepos` | `pluginCatalog.sources` | — |
+| `PreInstall(packageIds)` | `PreInstall` | `pluginCatalog.installByDefault` | `PluginCatalog__*` (Aspire only) |
+| `ClearPreInstall()` | `PreInstall` | `pluginCatalog.installByDefault` | — |
+| `AsPluginRegistry(isRegistry)` | `IsPluginRegistry` | `registry` (with `WithRegistry`) | — |
+| `WithRegistryInstanceId(instanceId)` | `RegistryInstanceId` | — (the instance's key at the registry) | — |
+| `WithRequiredModules(assemblies)` | `RequiredModules` | `config.memex_portal.Modules__Required__N` | `Modules__Required__0` |
+| `WithRequiredModule(assembly)` | `RequiredModules` | `config.memex_portal.Modules__Required__N` | `Modules__Required__0` |
+| `ClearRequiredModules()` | `RequiredModules`, `RequiredModuleSlots` | `config.memex_portal.Modules__Required__N` | — |
+| `WithRequiredModuleSlot(slot, assembly)` | `RequiredModuleSlots` | `config.memex_portal.Modules__Required__N` | `Modules__Required__*` |
+| `WithReplicas(replicas)` | `Replicas` | `replicas` | — |
+| `WithOrleansClustering(clustering)` | `OrleansClustering` | `config.memex_portal.Deployment__Orleans__Clustering` | `Deployment__Orleans__Clustering` |
+| `WithHttpPort(port)` | `HttpPort` | `config.memex_portal.ASPNETCORE_HTTP_PORTS` | `ASPNETCORE_HTTP_PORTS` |
+| `WithResources(requestsCpu, requestsMemory, limitsCpu, limitsMemory)` | `Resources.Requests.Cpu`, `Resources.Requests.Memory`, `Resources.Limits.Cpu`, `Resources.Limits.Memory` | `resources` | — |
+| `WithAutoscaling(enabled, minReplicas, maxReplicas, cpuTarget, memoryTarget)` | `Autoscaling.Enabled`, `Autoscaling.MinReplicas`, `Autoscaling.MaxReplicas`, `Autoscaling.CpuTarget`, `Autoscaling.MemoryTarget` | `keda` | — |
+| `WithVolume(name, mountPath, size, claimName, storageClass, accessMode, create)` | `Volumes[].Name`, `Volumes[].MountPath`, `Volumes[].Size`, `Volumes[].ClaimName`, `Volumes[].StorageClass`, `Volumes[].AccessMode`, `Volumes[].Create` | `persistence`, `extraVolumes`, `extraVolumeMounts` (Aspire: a named Docker volume at the mount path) | — |
+| `ClearVolumes()` | `Volumes` | `persistence` | — |
+| `WithIngress(className, tlsSecret, annotations, sessionAffinity, affinityCookie)` | `Ingress.ClassName`, `Ingress.TlsSecret`, `Ingress.Annotations`, `Ingress.SessionAffinity.Enabled`, `Ingress.SessionAffinity.CookieName` | `ingress` | — |
+| `WithPortalNext(enabled, image, replicas, portalOrigin)` | `PortalNext.Enabled`, `PortalNext.Image`, `PortalNext.Replicas`, `PortalNext.PortalOrigin` | `portalNext` | — |
+| `WithStartupProbe(periodSeconds, timeoutSeconds, failureThreshold)` | `StartupProbe.PeriodSeconds`, `StartupProbe.TimeoutSeconds`, `StartupProbe.FailureThreshold` | `probes.startup` | — |
+| `WithDrain(drainSeconds, shutdownMarginSeconds)` | `Drain.DrainSeconds`, `Drain.ShutdownMarginSeconds` | the pod's termination grace period | — |
+| `WithStorageLayout(configure)` | `Storage.Backend`, `Storage.DataRoot`, `Storage.ModulesRoot`, `Storage.ContentPath`, `Storage.ContentName`, `Storage.ContentSourceType`, `Storage.GraphStorageType`, `Storage.GraphStoragePath`, `Storage.ClaudeCodeConfigDirRoot` | `config.memex_portal.*` | `Deployment__Backend`, `Deployment__DataRoot`, `Modules__Root`, `Storage__BasePath`, `Storage__Name`, `Storage__SourceType`, `Graph__Storage__Type`, `Graph__Storage__BasePath`, `ClaudeCode__ConfigDirRoot` |
+| `WithStorageAccount(account, connectionSecret)` | `StorageAccount`, `StorageConnectionSecret` | `keyVaultSecrets` (the connection string's vault object) | — |
+| `WithGate(language, image, address, enabled)` | `Gates[].Language`, `Gates[].Image`, `Gates[].Address`, `Gates[].Enabled` | `grpc` | — |
+| `WithKeyVault(vault, prefix)` | `KeyVault`, `KeyVaultSecretPrefix` | `keyVaultSecrets.vaultName` | — |
+| `WithKeyVaultSecrets(map, vaultName, tenantId, identityClientId, className, syncedSecret, volumeName, mountPath)` | `KeyVaultSecrets.VaultName`, `KeyVaultSecrets.TenantId`, `KeyVaultSecrets.IdentityClientId`, `KeyVaultSecrets.Name`, `KeyVaultSecrets.SyncedSecret`, `KeyVaultSecrets.VolumeName`, `KeyVaultSecrets.MountPath`, `KeyVaultSecrets.Secrets[].Key`, `KeyVaultSecrets.Secrets[].VaultSecret` | `keyVaultSecrets` | — (the keys are the secrets' own; values never touch the record) |
+| `WithKeyVaultSecretClass(secretClass)` | `KeyVaultSecretClasses` | `keyVaultSecretClasses` | — |
+| `WithVaultValuesKeys(keys)` | `VaultValuesKeys` | `extraEnvFrom` | — |
+| `WithSecretMount(volumeName, secretProviderClass, syncedSecret, mountPath)` | `SecretMounts[].VolumeName`, `SecretMounts[].SecretProviderClass`, `SecretMounts[].SyncedSecret`, `SecretMounts[].MountPath` | `extraVolumes`, `extraVolumeMounts` | — |
+| `WithInlineEnv(key, value, isSecret, shadows, agreesWithShadowed, reason)` | `InlineEnv[].Key`, `InlineEnv[].Value`, `InlineEnv[].IsSecret`, `InlineEnv[].Shadows`, `InlineEnv[].AgreesWithShadowed`, `InlineEnv[].Reason`, `InlineEnv[].RetiredBy` | the env-precedence ledger the `Audit` reads | — |
+| `WithSignIn(provider, microsoftClientId, microsoftTenantId, googleClientId, linkedInClientId, appleClientId, enableDevLogin)` | `SignIn.Provider`, `SignIn.MicrosoftClientId`, `SignIn.MicrosoftTenantId`, `SignIn.GoogleClientId`, `SignIn.LinkedInClientId`, `SignIn.AppleClientId`, `SignIn.EnableDevLogin` | `config.memex_portal.Authentication__*` | `Authentication__Provider`, `Authentication__EnableDevLogin`, `Authentication__Microsoft__ClientId`, `Authentication__Microsoft__TenantId`, `Authentication__Google__ClientId`, `Authentication__LinkedIn__ClientId`, `Authentication__Apple__ClientId` |
+| `WithEmail(enabled, mailboxAddress, clientId, tenantId, useManagedIdentity, inboundEnabled, webhookBaseUrl, inboundForwardAddress)` | `Email.Enabled`, `Email.MailboxAddress`, `Email.ClientId`, `Email.TenantId`, `Email.UseManagedIdentity`, `Email.InboundEnabled`, `Email.WebhookBaseUrl`, `Email.InboundForwardAddress` | `config.memex_portal.Email__*` | `Email__Enabled`, `Email__MailboxAddress`, `Email__ClientId`, `Email__TenantId`, `Email__UseManagedIdentity`, `Email__InboundEnabled`, `Email__WebhookBaseUrl`, `Email__Inbound__ForwardAddress` |
+| `WithGitHubApp(clientId, installationId, installationOwner)` | `GitHubApp.ClientId`, `GitHubApp.InstallationId`, `GitHubApp.InstallationOwner` | `config.memex_portal.GitHub__App__*` | `GitHub__App__ClientId`, `GitHub__App__InstallationId`, `GitHub__App__InstallationOwner` |
+| `WithSocialLinkedIn(clientId)` | `SocialLinkedInClientId` | `config.memex_portal.Social__LinkedIn__ClientId` | `Social__LinkedIn__ClientId` |
+| `WithAi(configure)` | `Ai.OpenRouter`, `Ai.Anthropic`, `Ai.AzureFoundry`, `Ai.AzureAis`, `Ai.Tiers.Heavy`, `Ai.Tiers.Standard`, `Ai.Tiers.Light`, `Ai.Tiers.Utility` | `config.memex_portal.<Provider>__*`, `config.memex_portal.ModelTier__*` | `OpenRouter__Models__0`, `Anthropic__Models__0`, `AzureFoundry__Models__0`, `AzureAIS__Models__0`, `Features__Ai__Providers__Anthropic`, `Features__Ai__Providers__AzureFoundry`, `ModelTier__Heavy`, `ModelTier__Standard`, `ModelTier__Light`, `ModelTier__Utility` |
+| `WithOperator(enabled, ns, serviceAccount, image, environment)` | `Operator.Enabled`, `Operator.Namespace`, `Operator.ServiceAccount`, `Operator.Image`, `Operator.Environment` | `hostingOperator` | `Hosting__Operator__Enabled` |
+| `WithRegistry(configure)` | `Registry.Host`, `Registry.Image`, `Registry.AuthImage`, `Registry.Issuer`, `Registry.StorageAccountName`, `Registry.StorageContainer`, `Registry.ServiceAccount`, `Registry.KeyVault`, `Registry.PublisherUsername`, `Registry.PublisherPasswordBcrypt`, `Registry.ValidationUrl`, `Registry.NotificationsUrl`, `Registry.Replicas` | `registry` | — |
+| `WithTelemetry(otlpEndpoint, otlpProtocol)` | `Telemetry.OtlpEndpoint`, `Telemetry.OtlpProtocol` | `config.memex_portal.OTEL_*` | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL` |
+| `WithBackupStore(backupStore)` | `BackupStore` | — (the `Backup` action's target) | — |
+| `WithIdlePolicy(suspendAfterDays, teardownAfterDays)` | `IdleSuspendDays`, `IdleTeardownDays` | — (the idle reaper) | — |
+| `WithGracePeriod(days)` | `GracePeriodDays` | — | — |
+| `WithWebhookInbox(target, secretConfigKey)` | `WebhookInbox[].Target`, `WebhookInbox[].SecretConfigKey` | `config.memex_portal.WebhookInbox__Targets__N` | `WebhookInbox__Targets__0`, `WebhookInbox__Targets__0__SecretConfigKey` |
+| `WithPortalConfig(key, value)` | `ExtraPortalConfig` | `config.memex_portal.<key>` — the advanced rung, any key the typed surface does not carry | `Embedding__*` (for instance) |
+
+The nested builders these rows lean on: `KeyVaultSecretsSpec.Map(key, vaultSecret)`;
+`AiProviders.OpenRouter(models, endpoint, order, enabled)` / `.Anthropic(…)` / `.AzureFoundry(…)`
+/ `.AzureAis(…)` / `.Tiers(heavy, standard, light, utility)`; `WithStorageLayout(s => s with {…})`
+and `WithRegistry(r => r with {…})` take the spec record directly.
+
+Fields no method sets — the operator writes them, or they are a legacy shape kept for records that
+still carry it:
+
+| Field | Written by |
+|---|---|
+| `SuspendedAt` | the `Suspend` / `Reactivate` actions |
+| `SuspensionReason` | the `Suspend` action |
+| `WebhookInboxTargets` | legacy of `WebhookInbox` — read when the typed list is empty, never written |
+
+## Retired: generating the Helm chart from Aspire
+
+Core [#3646](https://github.com/Systemorph/MeshWeaver/issues/3646) asked for the chart to be
+generated from the Aspire model through Aspire's Kubernetes/Helm publisher. That direction is
+**retired** (maintainer, 2026-09-08: *"ok. retire"*), for measured reasons:
+
+- **The chart's operational contract is not expressible in Aspire's publisher.** The publisher
+  emits a Deployment, a Service and an Ingress per container. The chart renders what an instance
+  actually needs to run on the fleet: the run-once migration `Job` that gates the portal
+  (`DbVersionGate`), the `SecretProviderClass` per Key Vault class and the CSI mounts, KEDA
+  scaling, the startup probe and drain contract, the hosting operator and its service account,
+  the hosted registry, the language-gate sidecars, session affinity and the per-ingress-class
+  annotations. Each of these is a field on the record and a section of `HelmValues.Render`;
+  none is a container-level property a generic publisher could derive.
+- **The duplication it meant to remove was the adapter's own second copy of the record**, not
+  the chart. On 2026-09-06 the record and the rendered overlay disagreed in 41 places because the
+  values were declared twice (`MemexOptions` and the record) and rendered by two hands. With the
+  record as the one input the chart is a *renderer* of it, exactly like the adapter — the
+  duplication is gone without generating anything.
+- **What Aspire does emit is the record** (`PublishRecord`), which the control instance turns
+  into a chart release through `Provision` — so the developer path and the fleet path meet at the
+  record, not at a YAML file.
+
+`Aspire.Hosting.Kubernetes` is therefore not referenced by the deploy AppHost
+(`deploy/aspire/Memex.Deploy.AppHost`), and `--mode kubernetes` is gone.
+
+## What is still open
+
+- **The Plugins half.** The in-mesh Hosting module (`Hosting/Deployment/Source/*`) still compiles
+  its own copy of `DeploymentContent`; its PR replaces that copy with `using
+  MeshWeaver.Deployment;` and makes `HelmValues.PortalConfig` delegate to
+  `DeploymentPortalConfig`. It stays a DRAFT until the fleet's images carry this assembly (merging
+  to Plugins main edits live portals — a registration syncs sources at main's HEAD).
+- **German labels.** The in-mesh record carries `[Translation("de", …)]` on every property; the
+  contract cannot (the attribute is read by concrete type from `MeshWeaver.Messaging.Contract`,
+  which is not a published package). The pairs are preserved in the appendix below, and return to
+  the declarations once the localizer reads a catalog for declarations.
+
+## Labels
+
+The property labels of the record, English (`[Description]`, on the contract) and German (the
+in-mesh `[Translation]` texts, preserved here until the catalog follow-up above).
+
+| Record | Property | English (`[Description]`) | German |
+|---|---|---|---|
+| `DeploymentContent` | `ImagePullSecret` | Image pull Secret name in the instance namespace — required when the image registry is not ACR | Name des Image-Pull-Secrets im Instanz-Namespace — Pflicht, wenn die Image-Registry nicht ACR ist |
+| `DeploymentContent` | `RegistryInstanceId` | Instance id at the plugin registry — blank means the deployment id | Instanz-ID in der Plugin-Registry — leer bedeutet die Deployment-ID |
+| `DeploymentContent` | `DatabaseHost` | Database host (FQDN) — blank derives it from the server name | Datenbank-Host (FQDN) — leer leitet ihn vom Servernamen ab |
+| `DeploymentContent` | `DatabasePort` | Database port | Datenbank-Port |
+| `DeploymentContent` | `DatabaseUsername` | Database user | Datenbank-Benutzer |
+| `DeploymentContent` | `InClusterPostgres` | Run an in-cluster Postgres (self-host only) | In-Cluster-Postgres betreiben (nur Selbst-Hosting) |
+| `DeploymentContent` | `MigrationImageRepository` | Migration image repository — blank derives it from the portal's | Repository des Migrations-Images — leer leitet es vom Portal ab |
+| `DeploymentContent` | `HttpPort` | HTTP port | HTTP-Port |
+| `DeploymentContent` | `Resources` | Resources (RAM / CPU) | Ressourcen (RAM / CPU) |
+| `DeploymentContent` | `Autoscaling` | Autoscaling | Automatische Skalierung |
+| `DeploymentContent` | `Volumes` | Volumes | Volumes |
+| `DeploymentContent` | `Ingress` | Ingress | Ingress |
+| `DeploymentContent` | `PortalNext` | React front end at /next | React-Oberfläche unter /next |
+| `DeploymentContent` | `KeyVaultSecrets` | Key Vault secrets (declared by name) | Key-Vault-Secrets (nach Namen deklariert) |
+| `DeploymentContent` | `KeyVaultSecretClasses` | Additional Key Vault secret classes (a second SecretProviderClass, and further) | Weitere Key-Vault-Secret-Klassen (eine zweite SecretProviderClass und weitere) |
+| `DeploymentContent` | `VaultValuesKeys` | Keys the chart's own Secret supplies, from the Key Vault values half (names only) | Schlüssel aus dem eigenen Secret des Charts, aus der Key-Vault-Wertehälfte (nur Namen) |
+| `DeploymentContent` | `InlineEnv` | Inline env entries on the live Deployment (declarative — renders nothing) | Inline-Env-Einträge auf dem laufenden Deployment (deklarativ — rendert nichts) |
+| `DeploymentContent` | `Gates` | Language gate sidecars | Sprach-Gate-Sidecars |
+| `DeploymentContent` | `SecretMounts` | Key Vault secret mounts (legacy — hand-made SecretProviderClass by name) | Key-Vault-Secret-Einhängungen (veraltet — handgemachte SecretProviderClass nach Namen) |
+| `DeploymentContent` | `Ai` | AI providers | KI-Anbieter |
+| `DeploymentContent` | `SignIn` | Sign-in | Anmeldung |
+| `DeploymentContent` | `Email` | Email | E-Mail |
+| `DeploymentContent` | `GitHubApp` | GitHub App | GitHub-App |
+| `DeploymentContent` | `Operator` | Hosting operator | Hosting-Operator |
+| `DeploymentContent` | `Registry` | Container registry this instance hosts (the public instance only) | Container-Registry, die diese Instanz betreibt (nur die öffentliche Instanz) |
+| `DeploymentContent` | `Telemetry` | Telemetry | Telemetrie |
+| `DeploymentContent` | `Drain` | Rollout drain | Rollout-Drain |
+| `DeploymentContent` | `StartupProbe` | Startup probe | Start-Prüfung |
+| `DeploymentContent` | `Storage` | Storage layout | Speicherlayout |
+| `DeploymentContent` | `OrleansClustering` | Orleans clustering — blank derives it from the replica count | Orleans-Clustering — leer leitet es aus der Replikatzahl ab |
+| `DeploymentContent` | `MinRollInterval` | Minimum interval between self-update rolls | Mindestabstand zwischen Selbst-Update-Rollouts |
+| `DeploymentContent` | `AutoRecycleOnStaleBuild` | Auto-recycle on a stale NodeType build | Bei veraltetem NodeType-Build automatisch neu laden |
+| `DeploymentContent` | `RequiredModuleSlots` | Boot modules at explicit slots (by-index override) | Boot-Module an expliziten Slots (Überschreiben nach Index) |
+| `DeploymentContent` | `WebhookInboxTargets` | Webhook inbox targets, by slot (legacy — prefer the typed slots) | Webhook-Eingangsziele, nach Slot (veraltet — die typisierten Slots bevorzugen) |
+| `DeploymentContent` | `WebhookInbox` | Webhook inbox slots: target + the config key holding its HMAC secret | Webhook-Eingangs-Slots: Ziel + Konfigurationsschlüssel des HMAC-Geheimnisses |
+| `DeploymentContent` | `SocialLinkedInClientId` | Social LinkedIn client id | LinkedIn-Client-ID des Social-Plugins |
+| `DeploymentContent` | `ExtraPortalConfig` | Extra portal configuration (Section__Key = value) | Zusätzliche Portal-Konfiguration (Section__Key = Wert) |
+| `WebhookInboxSlot` | `Target` | Target path the slot routes deliveries to | Zielpfad, an den der Slot Zustellungen weiterleitet |
+| `WebhookInboxSlot` | `SecretConfigKey` | Configuration key holding the slot's HMAC secret (blank = unverified) | Konfigurationsschlüssel des HMAC-Geheimnisses (leer = unverifiziert) |
+| `RegistrySpec` | `Host` | Registry host (e.g. cr.meshweaver.cloud) | Registry-Host (z. B. cr.meshweaver.cloud) |
+| `RegistrySpec` | `Image` | Registry image (repository:tag) | Registry-Image (Repository:Tag) |
+| `RegistrySpec` | `AuthImage` | Token-authentication image (repository:tag) | Token-Authentifizierungs-Image (Repository:Tag) |
+| `RegistrySpec` | `Issuer` | Token issuer — blank means memex-registry | Token-Aussteller — leer bedeutet memex-registry |
+| `RegistrySpec` | `StorageAccountName` | Storage account holding the image blobs (name only) | Storage-Konto mit den Image-Blobs (nur Name) |
+| `RegistrySpec` | `StorageContainer` | Blob container — blank means registry | Blob-Container — leer bedeutet registry |
+| `RegistrySpec` | `ServiceAccount` | ServiceAccount the registry pods run as | ServiceAccount, unter dem die Registry-Pods laufen |
+| `RegistrySpec` | `KeyVault` | Key Vault objects (names only) | Key-Vault-Objekte (nur Namen) |
+| `RegistrySpec` | `PublisherUsername` | Publisher username — blank means publisher | Publisher-Benutzername — leer bedeutet publisher |
+| `RegistrySpec` | `PublisherPasswordBcrypt` | Publisher password, bcrypt hash — never the password itself | Publisher-Passwort als bcrypt-Hash — nie das Passwort selbst |
+| `RegistrySpec` | `ValidationUrl` | Portal URL that validates a consumer's key — blank means the public instance's token exchange | Portal-URL zur Prüfung eines Konsumenten-Schlüssels — leer bedeutet den Token-Austausch der öffentlichen Instanz |
+| `RegistrySpec` | `NotificationsUrl` | Notification endpoint URL — blank means none | URL des Benachrichtigungs-Endpunkts — leer bedeutet keine |
+| `RegistrySpec` | `Replicas` | Replicas — blank means 1 | Replikate — leer bedeutet 1 |
+| `RegistryKeyVaultSpec` | `Name` | Key Vault name | Key-Vault-Name |
+| `RegistryKeyVaultSpec` | `TenantId` | Tenant id — blank means the record's keyVaultSecrets tenant | Tenant-ID — leer bedeutet der Tenant aus keyVaultSecrets |
+| `RegistryKeyVaultSpec` | `IdentityClientId` | Identity client id — blank means the record's keyVaultSecrets identity | Client-ID der Identität — leer bedeutet die Identität aus keyVaultSecrets |
+| `RegistryKeyVaultSpec` | `CertObject` | Vault object: token-signing certificate | Vault-Objekt: Zertifikat zum Signieren der Tokens |
+| `RegistryKeyVaultSpec` | `KeyObject` | Vault object: token-signing private key | Vault-Objekt: privater Schlüssel zum Signieren der Tokens |
+| `RegistryKeyVaultSpec` | `HttpSecretObject` | Vault object: registry HTTP secret | Vault-Objekt: HTTP-Secret der Registry |
+| `RegistryKeyVaultSpec` | `NotificationSecretObject` | Vault object: notification bearer secret | Vault-Objekt: Bearer-Secret für Benachrichtigungen |
+| `ResourceQuantities` | `Cpu` | CPU (e.g. 4 or 500m) | CPU (z. B. 4 oder 500m) |
+| `ResourceQuantities` | `Memory` | Memory (e.g. 8Gi) | Arbeitsspeicher (z. B. 8Gi) |
+| `ResourceEnvelope` | `Requests` | Requests — guaranteed and used for scheduling | Anforderungen — garantiert, bestimmt die Platzierung |
+| `ResourceEnvelope` | `Limits` | Limits — the ceiling (memory above it is an OOM kill) | Limits — Obergrenze (Speicher darüber wird abgebrochen) |
+| `Autoscaling` | `Enabled` | Autoscale with KEDA | Mit KEDA automatisch skalieren |
+| `Autoscaling` | `MinReplicas` | Minimum replicas (the HA floor; 2 seeds the Orleans cluster) | Minimale Replikate (HA-Untergrenze; 2 startet den Orleans-Cluster) |
+| `Autoscaling` | `MaxReplicas` | Maximum replicas | Maximale Replikate |
+| `Autoscaling` | `CpuTarget` | CPU target % (scale up past this) | CPU-Ziel in % (darüber wird hochskaliert) |
+| `Autoscaling` | `MemoryTarget` | Memory target % | Speicher-Ziel in % |
+| `VolumeClaim` | `Name` | Role (data, users, content, attachments, workspace, …) | Rolle (data, users, content, attachments, workspace, …) |
+| `VolumeClaim` | `ClaimName` | PersistentVolumeClaim name — blank means ephemeral or unmounted | Name des PersistentVolumeClaim — leer heißt flüchtig oder nicht eingehängt |
+| `VolumeClaim` | `MountPath` | Mount path | Einhängepfad |
+| `VolumeClaim` | `Size` | Size (e.g. 64Gi) | Größe (z. B. 64Gi) |
+| `VolumeClaim` | `StorageClass` | Storage class (RWX is required above one replica) | Storage-Klasse (RWX ist ab mehr als einem Replikat Pflicht) |
+| `VolumeClaim` | `AccessMode` | Access mode (ReadWriteMany for shared volumes) | Zugriffsmodus (ReadWriteMany für gemeinsame Volumes) |
+| `VolumeClaim` | `Create` | Create the PersistentVolumeClaim — only on a record whose claims do not exist yet | PersistentVolumeClaim anlegen — nur bei einem Datensatz, dessen Claims noch nicht existieren |
+| `SessionAffinity` | `Enabled` | Pin sessions to one pod | Sitzungen an einen Pod binden |
+| `SessionAffinity` | `CookieName` | Affinity cookie name | Name des Affinitäts-Cookies |
+| `SessionAffinity` | `NginxAnnotations` | nginx annotations | nginx-Annotationen |
+| `SessionAffinity` | `AgicAnnotations` | Application Gateway annotations | Application-Gateway-Annotationen |
+| `IngressSpec` | `ClassName` | Ingress class | Ingress-Klasse |
+| `IngressSpec` | `TlsSecret` | TLS secret name — blank means {namespace}-tls | Name des TLS-Secrets — leer heißt {namespace}-tls |
+| `IngressSpec` | `Annotations` | Ingress annotations | Ingress-Annotationen |
+| `IngressSpec` | `SessionAffinity` | Session affinity | Sitzungsaffinität |
+| `PortalNextSpec` | `Enabled` | Deploy the React front end at /next | React-Oberfläche unter /next bereitstellen |
+| `PortalNextSpec` | `Image` | Container image (repository:tag) — its own release line, never derived | Container-Image (Repository:Tag) — eigene Release-Linie, nie abgeleitet |
+| `PortalNextSpec` | `Replicas` | Replicas — blank means the chart's 1 | Replikate — leer heißt 1 (Standard des Charts) |
+| `PortalNextSpec` | `PortalOrigin` | Portal origin for server-side rendering — blank means the in-cluster Service | Portal-Origin für serverseitiges Rendern — leer heißt der clusterinterne Service |
+| `KeyVaultSecretRef` | `Key` | Configuration key it lands as (Section__Key, e.g. Email__ClientSecret) | Konfigurationsschlüssel, unter dem es ankommt (Section__Key, z. B. Email__ClientSecret) |
+| `KeyVaultSecretRef` | `VaultSecret` | Key Vault secret name — blank derives it as {prefix}{Section}-{Key} | Name des Key-Vault-Secrets — leer leitet ihn als {prefix}{Section}-{Key} ab |
+| `KeyVaultSecretsSpec` | `VaultName` | Key Vault name — blank means the record's keyVault | Name des Key Vault — leer heißt der keyVault des Datensatzes |
+| `KeyVaultSecretsSpec` | `TenantId` | Tenant id of the vault | Mandanten-ID des Vaults |
+| `KeyVaultSecretsSpec` | `IdentityClientId` | Client id of the identity that reads the vault (the Key Vault Secrets Provider add-on's identity) | Client-ID der Identität, die den Vault liest (Identität des Key-Vault-Secrets-Provider-Add-ons) |
+| `KeyVaultSecretsSpec` | `Name` | SecretProviderClass name — blank means memex-portal-keyvault | Name der SecretProviderClass — leer heißt memex-portal-keyvault |
+| `KeyVaultSecretsSpec` | `SyncedSecret` | Synced Kubernetes Secret name — blank means the SecretProviderClass name | Name des synchronisierten Kubernetes-Secrets — leer heißt der Name der SecretProviderClass |
+| `KeyVaultSecretsSpec` | `VolumeName` | Volume name — blank means kv-secrets | Volume-Name — leer heißt kv-secrets |
+| `KeyVaultSecretsSpec` | `MountPath` | Mount path — blank means /mnt/secrets-store | Einhängepfad — leer heißt /mnt/secrets-store |
+| `KeyVaultSecretsSpec` | `Secrets` | The secrets, by name — configuration key and vault object | Die Secrets, nach Namen — Konfigurationsschlüssel und Vault-Objekt |
+| `KeyVaultSecretMount` | `VolumeName` | Volume name | Volume-Name |
+| `KeyVaultSecretMount` | `SecretProviderClass` | SecretProviderClass | SecretProviderClass |
+| `KeyVaultSecretMount` | `SyncedSecret` | Synced Kubernetes Secret name | Name des synchronisierten Kubernetes-Secrets |
+| `KeyVaultSecretMount` | `MountPath` | Mount path | Einhängepfad |
+| `ModelProvider` | `Endpoint` | Endpoint — empty turns the provider off | Endpunkt — leer schaltet den Anbieter ab |
+| `ModelProvider` | `Models` | Models, by slot | Modelle, nach Slot |
+| `ModelProvider` | `Order` | Order among providers (0 first) | Reihenfolge unter den Anbietern (0 zuerst) |
+| `ModelProvider` | `Enabled` | Enabled | Aktiviert |
+| `ModelTiers` | `Heavy` | Heavy tier model | Modell der Stufe „Heavy“ |
+| `ModelTiers` | `Standard` | Standard tier model | Modell der Stufe „Standard“ |
+| `ModelTiers` | `Light` | Light tier model | Modell der Stufe „Light“ |
+| `ModelTiers` | `Utility` | Utility tier model | Modell der Stufe „Utility“ |
+| `AiProviders` | `Anthropic` | Anthropic | Anthropic |
+| `AiProviders` | `AzureAis` | Azure AI Services | Azure AI Services |
+| `AiProviders` | `AzureFoundry` | Azure AI Foundry (models only) | Azure AI Foundry (nur Modelle) |
+| `AiProviders` | `OpenRouter` | OpenRouter | OpenRouter |
+| `AiProviders` | `Tiers` | Model tiers | Modellstufen |
+| `SignInSpec` | `Provider` | Provider (Custom) | Anbieter (Custom) |
+| `SignInSpec` | `EnableDevLogin` | Enable developer login | Entwickler-Anmeldung aktivieren |
+| `SignInSpec` | `MicrosoftClientId` | Microsoft client id | Microsoft-Client-ID |
+| `SignInSpec` | `MicrosoftTenantId` | Microsoft tenant id — blank means multi-tenant | Microsoft-Mandanten-ID — leer heißt mandantenübergreifend |
+| `SignInSpec` | `GoogleClientId` | Google client id — empty turns the scheme off | Google-Client-ID — leer schaltet das Schema ab |
+| `SignInSpec` | `LinkedInClientId` | LinkedIn client id — empty turns the scheme off | LinkedIn-Client-ID — leer schaltet das Schema ab |
+| `SignInSpec` | `AppleClientId` | Apple client id | Apple-Client-ID |
+| `EmailSpec` | `Enabled` | Enable system email | System-E-Mail aktivieren |
+| `EmailSpec` | `ClientId` | Sender app client id | Client-ID der Absender-App |
+| `EmailSpec` | `TenantId` | Tenant id | Mandanten-ID |
+| `EmailSpec` | `MailboxAddress` | Mailbox address | Postfach-Adresse |
+| `EmailSpec` | `UseManagedIdentity` | Use managed identity | Verwaltete Identität verwenden |
+| `EmailSpec` | `InboundEnabled` | Enable inbound email (Graph subscription on the mailbox) | Eingehende E-Mail aktivieren (Graph-Abonnement auf dem Postfach) |
+| `EmailSpec` | `WebhookBaseUrl` | Public webhook base URL (Graph calls {url}/api/email) | Öffentliche Webhook-Basis-URL (Graph ruft {url}/api/email auf) |
+| `EmailSpec` | `InboundForwardAddress` | Inbound forward address — empty disables Forward | Weiterleitungsadresse — leer deaktiviert „Weiterleiten“ |
+| `GitHubAppIdentity` | `ClientId` | GitHub App client id | GitHub-App-Client-ID |
+| `GitHubAppIdentity` | `InstallationId` | Installation id | Installations-ID |
+| `GitHubAppIdentity` | `InstallationOwner` | Installation owner | Inhaber der Installation |
+| `HostingOperatorSpec` | `Enabled` | Run the hosting operator here (the control instance only) | Hosting-Operator hier ausführen (nur die Kontrollinstanz) |
+| `HostingOperatorSpec` | `Namespace` | Operator namespace | Operator-Namespace |
+| `HostingOperatorSpec` | `ServiceAccount` | Operator service account | Operator-Dienstkonto |
+| `HostingOperatorSpec` | `Image` | Operator image | Operator-Image |
+| `HostingOperatorSpec` | `Environment` | Job environment (KEY=VALUE) | Job-Umgebung (KEY=VALUE) |
+| `TelemetrySpec` | `OtlpEndpoint` | OTLP endpoint | OTLP-Endpunkt |
+| `TelemetrySpec` | `OtlpProtocol` | OTLP protocol | OTLP-Protokoll |
+| `DrainSpec` | `DrainSeconds` | Drain ceiling in seconds (termination grace) | Drain-Obergrenze in Sekunden (Beendigungsfrist) |
+| `DrainSpec` | `ShutdownMarginSeconds` | Shutdown margin in seconds | Reserve für das Herunterfahren in Sekunden |
+| `StartupProbeSpec` | `PeriodSeconds` | Probe period in seconds | Prüfintervall in Sekunden |
+| `StartupProbeSpec` | `TimeoutSeconds` | Probe timeout in seconds | Prüf-Timeout in Sekunden |
+| `StartupProbeSpec` | `FailureThreshold` | Failures before the pod is killed | Fehlversuche bis der Pod beendet wird |
+| `StorageLayout` | `Backend` | Persistence backend | Persistenz-Backend |
+| `StorageLayout` | `DataRoot` | Data root | Datenwurzel |
+| `StorageLayout` | `ModulesRoot` | Modules root — blank means the data root | Modulwurzel — leer heißt Datenwurzel |
+| `StorageLayout` | `ContentPath` | Content path | Inhaltspfad |
+| `StorageLayout` | `ContentName` | Content collection name | Name der Inhaltssammlung |
+| `StorageLayout` | `ContentSourceType` | Content source type | Typ der Inhaltsquelle |
+| `StorageLayout` | `GraphStorageType` | Graph storage type | Typ des Graph-Speichers |
+| `StorageLayout` | `GraphStoragePath` | Graph storage path — blank means {DataRoot}/graph | Pfad des Graph-Speichers — leer heißt {DataRoot}/graph |
+| `StorageLayout` | `ClaudeCodeConfigDirRoot` | Claude Code config root (per-user) | Claude-Code-Konfigurationswurzel (pro Benutzer) |
+| `InlineEnvOverride` | `Key` | Environment variable name, as set on the pod | Name der Umgebungsvariable, wie auf dem Pod gesetzt |
+| `InlineEnvOverride` | `Value` | Value — omit for a credential | Wert — bei Anmeldedaten weglassen |
+| `InlineEnvOverride` | `IsSecret` | The value is a credential and is not recorded here | Der Wert ist ein Geheimnis und wird hier nicht erfasst |
+| `InlineEnvOverride` | `Shadows` | The envFrom source it shadows — blank means it is the only source | Die envFrom-Quelle, die es überdeckt — leer heißt einzige Quelle |
+| `InlineEnvOverride` | `AgreesWithShadowed` | Does the shadowed source agree? Unset means not compared (a Secret) | Stimmt die überdeckte Quelle überein? Nicht gesetzt heißt nicht verglichen (ein Secret) |
+| `InlineEnvOverride` | `Reason` | Why it is still set inline | Warum es weiterhin inline gesetzt ist |
+| `InlineEnvOverride` | `RetiredBy` | What retires it (issue reference) | Was es ablöst (Issue-Referenz) |
+| `GateSpec` | `Language` | Language (python, node, pandas) | Sprache (python, node, pandas) |
+| `GateSpec` | `Enabled` | Enabled | Aktiviert |
+| `GateSpec` | `Image` | Sidecar image — blank means the gate does not run | Sidecar-Image — leer heißt, das Gate läuft nicht |
+| `GateSpec` | `Address` | Mesh address — blank means the chart's default | Mesh-Adresse — leer heißt der Standard des Charts |

--- a/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Deployment.md
@@ -14,10 +14,13 @@ MeshWeaver has **two distinct deploy routes**. They target different infrastruct
 | **AKS** | Shared cluster `<aks-cluster>` — every `Deployments/<name>` record (memex, memex-cloud, …) | A `Roll` `Hosting/InstanceAction` on the control instance (the record's image pin); the operator runs build images → `kubectl set image` + rollout. Direct `az aks command invoke` is break-glass | [OperatingFromThePortal.md](/Doc/Architecture/OperatingFromThePortal) · [DeploymentAKS.md](/Doc/Architecture/DeploymentAKS) |
 | **Azure Container Apps** | .NET Aspire `test` / `prod` modes (ACA, Sweden Central) | `tools/deploy.sh prod\|test` (wraps `aspire deploy` + migration-exit + db-version gate) | [DeploymentContainerApps.md](/Doc/Architecture/DeploymentContainerApps) |
 
+🚨 **The Deployment record is the ONE input; Aspire and Helm render from it; the image receives it as configuration (`Deployment:Record`); Aspire emits a record, never a chart.** An instance is a `DeploymentContent` record (`Deployments/<name>` on the control instance), built fluently (`builder.AddMemex("memex").WithImage(…).WithPluginRepo(…)…`) or by hand, and every route reads that record — nothing is configured twice. Maintainer, 2026-09-08; [ConfiguringAnInstanceFromAspire.md](/Doc/Architecture/ConfiguringAnInstanceFromAspire) carries the fluent surface and the parity table.
+
 **Which doc do I need?**
 
 | Scenario | Read |
 |---|---|
+| **Declare an instance ONCE** — the Deployment record, the fluent builder, how Aspire and Helm render from it and how the image receives it (`Deployment:Record`); the parity table method → field → Helm value → config key | [ConfiguringAnInstanceFromAspire.md](/Doc/Architecture/ConfiguringAnInstanceFromAspire) |
 | **Operate an instance without cluster access** — roll, restart, suspend, audit, reconcile as `Hosting/InstanceAction`s; which reads the API does not answer yet; how to read every `kubectl` recipe in this tree | [OperatingFromThePortal.md](/Doc/Architecture/OperatingFromThePortal) |
 | See every **running instance** — who it's for, its infra, database, and version — and how to create or delete one | [Instances.md](/Doc/Architecture/Instances) |
 | Know **what each instance actually runs** — platform build, commit, framework identity, update policy and every module's pinned coordinate, reported by the instance itself, hourly | [DeploymentInventory.md](/Doc/Architecture/DeploymentInventory) |
@@ -166,7 +169,7 @@ dotnet user-secrets set "Parameters:azure-foundry-key" "<your-key>"
 ```
 memex/aspire/
 ├── Memex.AppHost/                  # Aspire orchestrator — defines all resources
-├── Memex.Aspire.Hosting/           # Shared Aspire hosting extensions
+├── Memex.Aspire.Hosting/           # The Aspire adapter (builder.AddMemex) — derives everything from the Deployment record
 ├── Memex.Portal.Distributed/       # Portal with co-hosted Orleans silo
 ├── Memex.Portal.ServiceDefaults/   # Shared service defaults (health, telemetry)
 └── Memex.Database.Migration/       # Database migration project (runs MigrationRegistry.All)

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentOptions.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentOptions.md
@@ -137,5 +137,6 @@ az aks command invoke -g <aks-resource-group> -n <aks-cluster> \
 
 ## Related
 
+- [Configuring an instance from Aspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire) — the Deployment record is the ONE input: every option on this page that is a value the portal reads is a field on the record (or an `extraPortalConfig` key), rendered by Helm and by Aspire alike
 - [Setting Up Model Providers](/Doc/AI/ModelProviderSetup) — the node model + which query goes where
 - [AI Provider Configuration](/Doc/AI/ProviderConfiguration) — credential/endpoint wiring + factory routing

--- a/src/MeshWeaver.Documentation/Data/Architecture/EmailIngestionAndNotifications.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EmailIngestionAndNotifications.md
@@ -282,9 +282,10 @@ inbound adds the subscription block. The client secret comes from Key Vault in p
 | `Email:SubscriptionClientState` | shared secret echoed on each inbound notification (webhook validation) |
 | — | the model the triage agent runs on is DATA, not config: label one model node `"tier": "chat"` ([Model Tiers](/Doc/AI/ModelTiers)). The deprecated `ModelTier:Light` key still works. |
 
-Deploy parameters (`Memex.Deploy.AppHost` → `MemexOptions`) map 1:1: `email-enabled`, `email-mailbox-address`,
-`email-tenant-id`, `email-client-id`, `email-inbound-enabled`, `email-webhook-base-url`,
-`email-subscription-client-state`, plus the KV mapping for the secret.
+Deploy parameters (`Memex.Deploy.AppHost` → the Deployment record's `email` block, `WithEmail(…)`) map 1:1: `email-enabled`, `email-mailbox-address`,
+`email-tenant-id`, `email-client-id`, `email-inbound-enabled`, `email-webhook-base-url`; the client secret and
+`email-subscription-client-state` are secrets (`WithSecret` under Aspire, the record's `keyVaultSecrets` map on AKS) —
+[ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire).
 
 > **Graph permissions:** the shared-mailbox app registration needs the **application** permissions
 > `Mail.Send` and `Mail.ReadWrite` with tenant-admin consent, and a real licensed/shared mailbox it may

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalDevWorkflow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalDevWorkflow.md
@@ -76,6 +76,13 @@ When you change code in `Memex.Portal.Distributed` (or any project it references
 
 ## Starting Aspire
 
+> The image-based AppHost (`deploy/aspire/Memex.Deploy.AppHost`, and any customer AppHost on the
+> published `MeshWeaver.Aspire.Hosting.Memex` package) declares its instance as a **Deployment
+> record** — `builder.AddMemex("memex").WithImage(…).WithPluginRepo(…)…` — the same record the
+> Helm chart renders from and the portal binds at boot (`Deployment:Record`). `--record-out
+> <path>` writes the final record for the setup wizard or a `Provision` action.
+> [ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire).
+
 Three modes — pick by whether you want to hold a terminal and whether you need a build:
 
 ```bash

--- a/src/MeshWeaver.Documentation/Data/Architecture/MemexCloudDeployment.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MemexCloudDeployment.md
@@ -160,7 +160,7 @@ The Postgres connection uses the **server FQDN + password + SSL** (`Host=<pg-ser
 5. Patches the portal to 1 replica (the Azure Files mounts render from the chart itself — `persistence:` in `values.aks.yaml` — so there is no volume patch any more).
 6. **Patches the connection-string secret** to the external Postgres.
 
-> **Known chart-generation gaps** (fix at the AddMemex generator):
+> **Known chart gaps** (the chart renders from the Deployment record — [ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire); it is not generated from Aspire, that direction is retired):
 > - The chart's `secrets.yaml` hardcodes the in-cluster Postgres connection string → `deploy.sh` patches it post-install.
 > - `deploy.sh` used to carry TWO commands against a `memex-migration-deployment` — a `set image` and a `rollout restart` — and only the first was guarded with `|| true`; the second printed an error on every documented deploy. Both are gone (#1788): the chart renders the migration as a run-once **Job** (`memex-migration-<Release.Revision>`), so there is no such Deployment. The migration runs from the `helm upgrade` in step 2; override its image through the chart (`--set migration.image=…`), never with `kubectl set image`.
 
@@ -187,7 +187,7 @@ To expose another private tool publicly (e.g. Grafana), create a second `Ingress
 
 ## 6. External Sign-In (OAuth)
 
-Deploy parameters flow through `AddMemex` → `MemexOptions` → portal environment variables (`Authentication__<Provider>__ClientId/Secret/TenantId`, `Social__LinkedIn__*`). A provider is offered in the sign-in UI only when its `ClientId` is set.
+Sign-in is the record's `signIn` block (`AddMemex(…).WithSignIn(microsoftClientId: …, googleClientId: …)`), rendered as the portal keys `Authentication__<Provider>__ClientId/TenantId` and `Social__LinkedIn__ClientId` by Helm and by Aspire alike; the client SECRETS are Key Vault names on the record (`keyVaultSecrets`) or `WithSecret(…)` under Aspire — never record fields ([ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire)). A provider is offered in the sign-in UI only when its `ClientId` is set.
 
 **Microsoft / Entra**
 Register an app (`<entra-app-client-id>`) in your tenant (`<tenant-guid>`). Use single-tenant (`AzureADMyOrg`) for an internal portal. Set the redirect URI to `https://<your-domain>/signin-microsoft`. Also set `Authentication__Provider=Custom` and `Authentication__EnableDevLogin=false`.
@@ -219,7 +219,7 @@ curl -sS "https://<your-domain>/bootstrap/first-admin?secret=<bootstrap-secret>&
 `deploy/aks/scripts/install-observability.sh` installs the `grafana/loki-stack` chart (Grafana + Loki + Promtail + Prometheus) into the `monitoring` namespace.
 
 - **Promtail** scrapes every pod's stdout into Loki — no portal-side configuration needed.
-- **OTLP traces/metrics:** `AddMemex`'s `OtlpEndpoint` option wires `OTEL_EXPORTER_OTLP_ENDPOINT` (not needed for logs).
+- **OTLP traces/metrics:** the record's `telemetry` block (`WithTelemetry(otlpEndpoint)`) renders `OTEL_EXPORTER_OTLP_ENDPOINT` (not needed for logs).
 - **Grafana** defaults to ClusterIP (private). Reach it via the VPN (§9) + port-forward, or expose it publicly behind its own login (§5).
 
 The observability stack is folded into the standard deploy: export `GRAFANA_PW` alongside `MEMEX_PG_CONN` and `deploy.sh` brings it up automatically.
@@ -339,7 +339,7 @@ Visiting an auth-flow route (`/onboarding`, `/login`, `/welcome`) can create a s
 If a static node provider seeds a User for the admin email, a fresh `CreateUser` fails with "Node already exists" and the interactive form shows "user exists" even with 0 DB users. Remove the seed so real onboarding can persist the partition root.
 
 **Secrets in Key Vault (done)**
-The master key, PG connection string, Microsoft client secret, and `Bootstrap:Secret` live in Key Vault; a `SecretProviderClass` + the AKS CSI Secrets Store add-on sync them into a k8s Secret the portal reads via `envFrom` (see §10.6). Remaining: the Grafana admin password (monitoring namespace), and folding the `SecretProviderClass` + deployment CSI volume/`envFrom` into the chart/AddMemex so a fresh deploy wires Key Vault automatically instead of requiring the current post-`deploy.sh` patch.
+The master key, PG connection string, Microsoft client secret, and `Bootstrap:Secret` live in Key Vault; a `SecretProviderClass` + the AKS CSI Secrets Store add-on sync them into a k8s Secret the portal reads via `envFrom` (see §10.6). The `SecretProviderClass` + CSI volume/`envFrom` are the record's `keyVaultSecrets` / `keyVaultSecretClasses` / `vaultValuesKeys` (rendered by the chart from the record — [ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire)), so a fresh deploy wires Key Vault from the record. Remaining: the Grafana admin password (monitoring namespace).
 
 **Multi-replica HA**
 Needs Orleans `AzureTables`/`AdoNet` clustering wired on the Filesystem backend.

--- a/src/MeshWeaver.Documentation/Data/Architecture/NuGetPackageRetirement.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NuGetPackageRetirement.md
@@ -89,31 +89,37 @@ prebuilt image pulled from GHCR. A `PackageReference` a customer adds to their A
 add a driver to a running portal even in principle — so a fan-out of `MeshWeaver.Hosting.<driver>`
 packages would buy nothing and cost a version matrix that must agree with the image tag.
 
-What does work is already in place. `MemexOptions` is the single config surface, and every value on
-it maps 1:1 to a portal config key emitted as container environment:
+What does work is in place. The **Deployment record** (`DeploymentContent`, the assembly
+`MeshWeaver.Deployment.Contract`, bundled INSIDE the Aspire package) is the single config surface —
+the ONE input Aspire and the Helm chart both render from — and every field on it maps to a portal
+config key emitted as container environment:
 
 ```csharp
-builder.AddMemex("memex", o => o
-    .WithBackend("Filesystem")            // → Backend
-    .WithOrleansClustering("AdoNet")      // → Orleans__Clustering
-    .WithEmbeddings(endpoint, key)        // → Embedding__Endpoint / __ApiKey
-    .WithAiProviders(openAI: false));     // → Features__Ai__Providers__OpenAI
+builder.AddMemex("memex")
+    .WithStorageLayout(s => s with { Backend = "Filesystem" })   // → Deployment__Backend
+    .WithOrleansClustering("AdoNet")                             // → Deployment__Orleans__Clustering
+    .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")
+    .PreInstall("MeshWeaver.Plugins/Hosting")                    // → PluginCatalog__* (Aspire) / the catalog file (Helm)
+    .WithRequiredModule("MeshWeaver.Hosting.Postgres")           // → Modules__Required__0
+    .WithAi(a => a.Anthropic(models, enabled: false));           // → Features__Ai__Providers__Anthropic
 ```
 
-Driver selection is already done this way — `Backend` picks Filesystem or Azure blob,
-`OrleansClustering` picks Localhost, AdoNet or Azure Tables — as **config strings the image
-interprets at startup**, not as assemblies the customer resolves. Selecting which plugins the image
-loads at startup is the same shape: a value on `MemexOptions`, a config key on the container, and
-the plugin fetched at runtime from the plugin catalog as a module bundle. Adding a startup-time
-capability means **adding an option to the adapter**, never adding a package.
+Driver selection is done this way — the storage layout picks the backend, `OrleansClustering`
+picks Localhost, AdoNet or Azure Tables — as **config strings the image interprets at startup**,
+not as assemblies the customer resolves. Selecting which plugins the image loads at startup is the
+same shape: a field on the record (`pluginRepos`, `preInstall`, `requiredModules`), a config key on
+the container, and the plugin fetched at runtime from the plugin catalog as a module bundle. Adding
+a startup-time capability means **adding a field to the record** (and its fluent method), never
+adding a package. The full surface and the parity table are
+[ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire).
 
-> 🚧 **Open direction, not yet built —
-> [#3646](https://github.com/Systemorph/MeshWeaver/issues/3646).** Two consequences of this ground
-> rule are recorded so they are not rediscovered: the adapter should grow explicit plugin selection
-> (today plugins are configured portal-side, not from the AppHost), and the hand-maintained Helm
-> chart under `deploy/helm/` duplicates keys that `MemexOptions` already owns — it should be
-> **generated** from the same surface rather than kept in parallel. Aspire's own Kubernetes/Helm
-> publisher is the mechanism.
+> ✅ **Settled, 2026-09-08 —
+> [#3646](https://github.com/Systemorph/MeshWeaver/issues/3646).** Plugin selection from the
+> AppHost is the record's `WithPluginRepo` / `PreInstall` / `WithRequiredModule`. Generating the
+> Helm chart from Aspire is **retired**: the duplication was the adapter's own second copy of the
+> record (`MemexOptions`), not the chart, and the chart's operational contract (the migration Job,
+> the Key Vault classes, KEDA, the operator, the registry, the gates) is not expressible in Aspire's
+> publisher. Aspire emits a record, never a chart; the chart is a renderer of the same record.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -92,6 +92,11 @@ and how to reconcile it in the same session. Do not re-derive that list here —
 
 ## Related rules decided the same day
 
+- **The Deployment record is the ONE input.** Aspire and Helm render from it; the image receives
+  it as configuration (`Deployment:Record`); Aspire emits a record, never a chart. The record is
+  built fluently (`AddMemex("memex").WithImage(…).WithPluginRepo(…)`), the adapter's own copy of
+  it (`MemexOptions`) is gone, and generating the chart from Aspire (#3646) is retired —
+  [ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire).
 - **Volume capacity is a record property:** `volumes[].size` on the Deployment record is what a
   claim holds. `Provision` and `Reconcile` grow every declared claim to it through
   `hosting-pv-resize` (grow-only, read back from the claim's status, refuses a class that cannot

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-deployment-record-is-the-one-input.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-08-the-deployment-record-is-the-one-input.md
@@ -1,0 +1,42 @@
+---
+Name: The Deployment record is the one input
+Category: Feature
+Description: An instance is declared once, as a Deployment record. Aspire and Helm render from it, the portal receives it as configuration (Deployment:Record), and the AppHost builds it fluently — AddMemex("memex").WithImage(…).WithPluginRepo(…).PreInstall(…).WithSignIn(…) — with a parity table the tests hold the code to. The adapter's second copy of the record (MemexOptions) is gone, and generating the Helm chart from Aspire is retired.
+Icon: Cloud
+Order: -20260908
+---
+
+# The Deployment record is the one input
+
+Until now an instance was declared in two places that could not see each other: the
+`Hosting/Deployment` record on the control instance (what the Helm chart renders from) and the
+Aspire adapter's own `MemexOptions` (half the fields, different names). On 2026-09-06 the record and
+the rendered overlay of one instance disagreed in **41 places** that nothing reported.
+
+**There is one declaration now.** The record — `DeploymentContent`, in the dependency-free assembly
+`MeshWeaver.Deployment.Contract` — is what the Hosting module renders Helm from, what the Aspire
+adapter derives a local run from, and what the portal binds at boot from one configuration value,
+`Deployment:Record` (`Deployment__Record` as environment), beside the per-key surface both routes
+derive from it with the same code.
+
+- **Build it fluently.** `builder.AddMemex("memex").WithImage(…).WithPluginRepo(…).PreInstall(…)
+  .WithRequiredModule(…).WithVolume(…).WithKeyVault(…, secrets => secrets.Map(…)).WithSignIn(…)
+  .WithEmail(…).WithAi(a => a.OpenRouter(…).Tiers(…)).WithReplicas(2).WithResources(…)
+  .WithStartupProbe(…).WithOperator(…).WithPortalConfig(…)`. Every method is a pure transform of the
+  record — the same calls serve the setup wizard, the template generator and a test — and every
+  record field is reachable. `AddMemex(name, record)` and `AddMemexFromFile(name, path)` start from
+  a record you have; `PublishRecord(path)` writes the final one, ready for a `Provision` action.
+  Secrets never touch the record: `WithSecret(key, parameter)` under Aspire, Key Vault names on the
+  record for Kubernetes.
+- **The parity table is a test.** [ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanceFromAspire)
+  lists method → record field → Helm value → config key, and `RendererParityTest` fails when the
+  code and the page disagree. Three real fleet records round-trip through the contract with every
+  field intact, and the `memex` record renders the same keys for Helm and for Aspire except the
+  three differences the options declare.
+- **Retired: generating Helm from Aspire** (#3646). The duplication was the adapter's copy, not the
+  chart; the chart's operational contract is not expressible in Aspire's publisher. Aspire emits a
+  record, never a chart.
+
+The rule, in one line, now heads [Deployment](/Doc/Architecture/Deployment): *the Deployment record
+is the ONE input; Aspire and Helm render from it; the image receives it as configuration; Aspire
+emits a record, never a chart.*

--- a/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
+++ b/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The Deployment record lives in a zero-dependency contract; referencing it here puts it in the
+         portal's application closure, which is what lets the in-mesh Hosting module compile against
+         it (PlatformShippedAssemblies: ApplicationClosure). -->
+    <ProjectReference Include="..\MeshWeaver.Deployment.Contract\MeshWeaver.Deployment.Contract.csproj" />
     <ProjectReference Include="..\MeshWeaver.Graph\MeshWeaver.Graph.csproj" />
     <ProjectReference Include="..\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\MeshWeaver.GitSync\MeshWeaver.GitSync.csproj" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -70,12 +70,13 @@
          Imported globally here so the ~330 existing call sites need no churn, and so exactly ONE
          implementation exists — a forward in the old namespace made every .Await(ct) ambiguous
          (CS0121) in the files that import both. -->
-    <!-- Excluded: the three test projects with no messaging dependency at all (they assert JSON,
-         image packing and browser E2E). A global using cannot resolve a namespace the project does
+    <!-- Excluded: the test projects with no messaging dependency at all (they assert JSON,
+         image packing, browser E2E, and the dependency-free Deployment record contract). A global using cannot resolve a namespace the project does
          not reference, so naming them is honest; adding a ProjectReference just to satisfy a using
          would be the wrong direction. -->
     <Using Include="MeshWeaver.Messaging"
            Condition="'$(MSBuildProjectName)' != 'MeshWeaver.Cli.Test'
+                  and '$(MSBuildProjectName)' != 'MeshWeaver.Deployment.Contract.Test'
                   and '$(MSBuildProjectName)' != 'MeshWeaver.Json.Test'
                   and '$(MSBuildProjectName)' != 'MeshWeaver.PluginImage.Test'
                   and '$(MSBuildProjectName)' != 'MeshWeaver.Portal.E2E.Test'

--- a/test/Memex.Portal.Shared.Test/DeploymentPathsSupplyStorageTest.cs
+++ b/test/Memex.Portal.Shared.Test/DeploymentPathsSupplyStorageTest.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.RegularExpressions;
+using MeshWeaver.Deployment;
 using Xunit;
 
 namespace Memex.Portal.Shared.Test;
@@ -56,19 +57,25 @@ public class DeploymentPathsSupplyStorageTest
         // The Azure Container Apps lane, which does not use the chart at all — so the chart guard
         // above says nothing about it. It was the ACA portals that made this worth checking:
         // they configure the portal purely through environment variables.
+        //
+        // Since the Deployment record became the ONE input (2026-09-08), the adapter states no key
+        // itself: every portal key is DERIVED from the record by the contract's
+        // DeploymentPortalConfig.PortalConfig — the same derivation the Helm chart renders. So the
+        // guard has two halves, each with its subject: the adapter must still route through that
+        // derivation, and the derivation must state the storage type for a record that says
+        // NOTHING about storage (a bare AddMemex(name) is exactly that record).
         var hosting = Path.Combine(RepoRoot().FullName, "memex", "aspire",
             "Memex.Aspire.Hosting", "MemexHostingExtensions.cs");
         Assert.True(File.Exists(hosting), $"the Aspire hosting extensions are not at {hosting}");
+        Assert.Contains("DeploymentPortalConfig.PortalConfig(", File.ReadAllText(hosting));
 
-        var text = File.ReadAllText(hosting);
-        var match = Regex.Match(text,
-            @"WithEnvironment\(\s*""Graph__Storage__Type""\s*,\s*""(?<v>[^""]*)""");
+        var config = DeploymentPortalConfig.PortalConfig(new DeploymentContent(), PortalConfigOptions.Aspire(mcpBaseUrl: null));
 
-        Assert.True(match.Success,
-            $"{hosting} no longer sets Graph__Storage__Type. The deployed image carries no default, "
-            + "so an Aspire/ACA portal would boot into the first-run SETUP WIZARD rather than "
-            + "serving its data.");
-        Assert.False(string.IsNullOrWhiteSpace(match.Groups["v"].Value),
-            "Graph__Storage__Type is set to an EMPTY value, which reads as 'not configured'.");
+        Assert.True(config.TryGetValue("Graph__Storage__Type", out var type),
+            "the record's portal-config derivation no longer emits Graph__Storage__Type for a record "
+            + "that states no storage layout. The deployed image carries no default, so an Aspire/ACA "
+            + "portal would boot into the first-run SETUP WIZARD rather than serving its data.");
+        Assert.False(string.IsNullOrWhiteSpace(type),
+            "Graph__Storage__Type derives to an EMPTY value, which reads as 'not configured'.");
     }
 }

--- a/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
+++ b/test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj
@@ -19,6 +19,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\memex\Memex.Portal.Shared\Memex.Portal.Shared.csproj" />
+    <!-- DeploymentPathsSupplyStorageTest asserts the Aspire lane's storage keys on the contract's
+         own derivation (DeploymentPortalConfig.PortalConfig) — the adapter no longer states them. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Deployment.Contract\MeshWeaver.Deployment.Contract.csproj" />
     <!-- SealedModuleCompositionTest drives the REAL `memex build plugin` sealed-module composition
          (MeshWeaver#3401) against the REAL registry endpoints in this project's TestServer. The
          defect is a client that reads a publication's index and then its bundles without pinning

--- a/test/MeshWeaver.Deployment.Contract.Test/ConfigurationBindingTest.cs
+++ b/test/MeshWeaver.Deployment.Contract.Test/ConfigurationBindingTest.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Configuration;
+using MeshWeaver.Deployment;
+using Xunit;
+
+namespace MeshWeaver.Deployment.Contract.Test;
+
+/// <summary>
+/// The record reaches the portal as ONE configuration value, <c>Deployment:Record</c> — a JSON
+/// document — whether the Aspire adapter injects it as the <c>Deployment__Record</c> environment
+/// variable or the Helm chart renders it into the ConfigMap. The portal binds it at boot with
+/// <see cref="DeploymentRecordJson.FromConfiguration"/>. This is the Orleans shape (resource →
+/// environment → the app binds from configuration), and it is one value on purpose: init-only
+/// records, immutable collections and the mesh's <c>$type</c> do not bind through the
+/// configuration binder, and one JSON value is byte-identical on a ConfigMap and in Aspire.
+/// </summary>
+public class ConfigurationBindingTest
+{
+    [Fact]
+    public void TheEnvironmentKeyIsTheConfigurationKeyInEnvironmentForm()
+    {
+        Assert.Equal("Deployment:Record", DeploymentRecordJson.ConfigurationKey);
+        Assert.Equal(DeploymentRecordJson.EnvironmentKey, DeploymentRecordJson.ConfigurationKey.Replace(":", "__"));
+    }
+
+    [Fact]
+    public void ARecordInjectedAsConfigurationBindsBackIdentically()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "memex.json");
+        var record = DeploymentRecordJson.ReadFile(path);
+        var injected = DeploymentRecordJson.Write(record);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { [DeploymentRecordJson.ConfigurationKey] = injected })
+            .Build();
+
+        var bound = DeploymentRecordJson.FromConfiguration(configuration);
+
+        Assert.NotNull(bound);
+        Assert.Equal(injected, DeploymentRecordJson.Write(bound!));
+        Assert.Equal(record.Host, bound!.Host);
+        Assert.Equal(record.PluginRepos.Count, bound.PluginRepos.Count);
+        Assert.True(bound.PluginRepos.Count > 0, "the memex record declares plugin repositories — a zero here means the fixture changed, not that the binding works");
+    }
+
+    [Fact]
+    public void AnAbsentSectionBindsToNoRecord()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        Assert.Null(DeploymentRecordJson.FromConfiguration(configuration));
+    }
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/Fixtures/memex-cloud.json
+++ b/test/MeshWeaver.Deployment.Contract.Test/Fixtures/memex-cloud.json
@@ -1,0 +1,635 @@
+{
+  "$type": "MeshNode",
+  "id": "memex-cloud",
+  "namespace": "Deployments",
+  "path": "Deployments/memex-cloud",
+  "mainNode": "Deployments/memex-cloud",
+  "name": "memex-cloud",
+  "description": "Public instance and the plugin registry — collaboration, showcase, demos.",
+  "nodeType": "Hosting/Deployment",
+  "state": "Active",
+  "content": {
+    "$type": "DeploymentContent",
+    "cluster": "memexaks-cluster",
+    "databaseServer": "memexaks-pg",
+    "imageRepository": "meshweaver.azurecr.io/memex-portal-ai",
+    "keyVault": "Systemorph",
+    "owner": "Systemorph",
+    "host": "memex.meshweaver.cloud",
+    "namespace": "memex-cloud",
+    "database": "memexcloud",
+    "purpose": "Public instance — collaboration, showcase and demos. **Also the plugin registry**: it alone holds the git credential for the plugin repos and re-serves the catalog to every other deployment.",
+    "isPluginRegistry": true,
+    "keyVaultSecretPrefix": "memexcloud-",
+    "configPath": "deployments/aks/memex-cloud",
+    "notes": "Also serves the marketing hosts (`meshweaver.cloud`, `www.meshweaver.cloud`, `portal.meshweaver.cloud`, `systemorph.com`, `www.systemorph.com`) and the static brand site.\n\nIngress has three legs: web, gRPC (`/meshweaver.v1.Mesh/Open`) and MCP (`/mcp`, `/register`, `/authorize`, `/token`). The MCP leg pins `upstream-hash-by: $host` instead of cookie affinity — an MCP client carries no cookie, so cookie affinity cannot pin its session to a silo.\n\n2026-08-29: **the record is now the source of the helm values** (`values.memexcloud.public.yaml` is RENDERED from it by the Hosting plugin's `HelmValues`; the hand-maintained overlay is gone). The reproduction gate that proved the render found ONE inconsistency in the old overlay, corrected here: its `config.memex_migration` section named database `memex` — the systemorph instance's database — while the portal section and the live portal serve `memexcloud`. The overlay was captured from the live release on 2026-08-17, so the live `memex-migration-config` ConfigMap carries the same `memex`; whether the migration Job ever acted on it depends on whether it reads `MEMEX_DATABASENAME`/JDBC or the vault-supplied `ConnectionStrings__memex`. Worth a look before the next migration runs. The record has ONE `database` field feeding both sections, which is exactly the drift the typed record makes impossible.\n\n2026-09-06: **`PreWarm__PrebuiltBundleRoot` added — and a live inline `env:` entry is SHADOWING the gate this record declares.** Measured on the live cluster:\n\n- container env `PreWarm__GateReadiness=false`, owned by `kubectl-set` at **2026-09-03T17:32:45Z** — the same minute as the `kubectl set image` roll to `rc9.ci.7693` that ended the sign-in outage. The record has declared the gate ARMED since 2026-09-02 (#137); the release in the cluster predates that and has never been deployed, and even after it is, **an inline `env:` entry beats `envFrom`, so the pod will keep running the gate OFF**.\n- 🚨 `helm upgrade` cannot clear it. Helm's three-way merge removes only what helm previously owned, and this entry was never in a rendered manifest (measured 2026-09-03; and on this very Deployment, the helm run of 2026-08-30T06:48:35Z left the 2026-08-14 inline entry untouched). Clearing the shadow is a separate, deliberate cluster action AFTER the deploy: `kubectl -n memex-cloud set env deployment/memex-portal-deployment PreWarm__GateReadiness-`. The post-deploy assertion in `helm-release.yml` reads `helm get values --all`, i.e. the RELEASE — it is green on a shadowed pod, so it cannot catch this.\n- container env `PreWarm__BatchBake=true` and `PreWarm__PrebuiltBundleRoot=/data/prebuilt-bundles`, both owned by `kubectl-set` 2026-09-03T17:32:45Z. `BatchBake` was already on the record; `PrebuiltBundleRoot` was declared nowhere and is added here, so a deploy stops rendering it blank. `/data/prebuilt-bundles` is a directory on the existing `memex-data` PVC — no new mount.\n- rollout settings match the chart already: maxSurge 1 / maxUnavailable 0, `revisionHistoryLimit` 3. `progressDeadlineSeconds` is 900 live against 11400 rendered, because the live release still carries the chart-default startup budget rather than this record's 10 s x 1080; both move together on the next deploy, by derivation.\n\n2026-09-06, LATER THE SAME DAY — **the deploy ran (helm release `memexcloud` v23, 11:59:47Z) and the shadow behaved exactly as predicted: the gate is still OFF.** Measured on the live cluster after it:\n\n- ConfigMap `memex-portal-config` now renders `PreWarm__GateReadiness=\"true\"` and `PreWarm__DynamicTypes=\"true\"`, and the inline `env:` `PreWarm__GateReadiness=false` (`kubectl-set`, 2026-09-03T17:32:45Z) still wins — `printenv` in the running container reports `false`. So every readable artefact for this instance now says ARMED and the pod is not.\n- Positive evidence of non-registration, not an inference from the env var: **zero `nodetype_bake` log lines in any of the three pods**, across bakes of 3 m 56 s and 1 m 04 s, and pod `memex-portal-deployment-58c859d4cc-b8pfg` reached Ready at 11:35:51Z — 2 m 12 s after its 11:33:39Z start, while its own sweep still had 1 m 44 s to run. An armed gate cannot let that happen; on `memex` the same image held readiness for the whole bake.\n- Clearing it (`kubectl -n memex-cloud set env deployment/memex-portal-deployment PreWarm__GateReadiness-`) is therefore a real behaviour change, not a cleanup: it ARMS the gate on the busiest instance. Before doing it, note that memex-cloud also runs `PreWarm__BuildProtocol=true` and carries `previouslybroken=13` / one NodeType at `compilationStatus:Error` (`LinkedIn/Skill`), and that MeshWeaver#3404 (readiness refused after an `Admin/Build` SubscribeRequest timeout) and MeshWeaver#3395 (one boot resolving two module sets 15 s apart, turning a healthy type FAILED) are both open and both make an armed gate costlier here than on memex.\n\n2026-09-06: **this record now holds BOTH SecretProviderClasses and the whole env precedence stack**, the same change as on memex and for the same measured reason. Before it, the record's single `keyVaultSecrets` described `memexcloud-portal-ai-secrets` while the committed overlay described `memexcloud-portal-keyvault`, so a re-render would have DROPPED the AI-secrets class outright — 17 keys including `Ai__KeyProtection__MasterKey` (overwriting or losing which makes every stored `enc:` provider key undecryptable), the Stripe pair and the GitHub App private key. Now: `keyVaultSecrets` = `memexcloud-portal-keyvault` (the registry token plus `Embedding__ApiKey`), `keyVaultSecretClasses[0]` = `memexcloud-portal-ai-secrets` with all 17 live mappings, and `vaultValuesKeys` = the 12 keys of the chart's own `memex-portal-secrets`.\n\n🚨 `AzureAIS__ApiKey` WAS BEING LOST, and the old projection is why. The live SPC maps ONE vault object, `memexcloud-AzureAIS-ApiKey`, onto TWO keys — `AzureAIS__ApiKey` and `AzureFoundry__ApiKey` — and `HelmValues.Problems` refused exactly that shape (`maps vault object X onto more than one key`), so the record could hold only the `AzureFoundry__ApiKey` half. The rule was wrong: a KEY has one home, an OBJECT may have as many keys as the portal reads it under. Both mappings are now recorded.\n\n🚨 `inlineEnv` records the 34 entries `kubectl set env` put on this Deployment, and the first of them is load-bearing: `PreWarm__GateReadiness=false` while the ConfigMap renders `true`, so the NodeType bake gate is INERT on the public instance. Removing that inline entry is what ARMS the gate here — the opposite act to memex, where the inline entry already agrees and removing it changes nothing. Also sole-source (no ConfigMap key at all): `Speech__{Endpoint,Enabled,Language}` — the whisper deployment in this namespace is reachable only through them — plus `Commerce__BaseUrl` and `PluginCatalog__DefaultGrants__0`. And the inline `PluginCatalog__Sources__*` list covers sources 0-2 only, while source 3 (`Crm`) exists solely in the ConfigMap: the two lists are index-aligned by POSITION, so inserting into or reordering either one silently re-points a source with no error anywhere.\n\n🚨 As on memex, the committed overlay declares `memexcloud-Embedding-ApiKey` → `Embedding__ApiKey` and **no secret of that name exists in Key Vault `Systemorph`** (measured 2026-09-06). A declared object the vault does not hold fails the whole CSI mount, so the next deploy of this namespace stalls until the vault secret is provisioned.\n\n2026-09-06: **`volumes.data.size` corrected 16Gi → 128Gi.** Measured: `kubectl -n memex-cloud get pvc` → memex-data is 128Gi (memex’s is 16Gi; the record had memex’s number). The PVCs pre-exist and the chart reads only `claimName`/`mountPath` for the portal, so `size` is descriptive rather than provisioning — but a record that states a wrong number is a record someone will act on. Every other entry here checked out against the live PVC set and the live pod: all six carry a claimName, all six PVCs exist. That is what memex did NOT do (see its record), which is why the same sweep found a real defect there and only a wrong number here.\n\n2026-09-07: **`WebhookInbox__Targets__1__SecretConfigKey` committed (Memex#205) — the inbox had been accepting every signed release event UNVERIFIED.** The key was set on the LIVE node on 2026-09-05 (v25) and the next automated write of this record (v26, `system-security`, 1 h 42 min later) reverted it, because it existed in no repository: a fleet-wide code search returned two hits, both in MeshWeaver's chart, where the slot is deliberately rendered empty. Every OTHER key in `extraPortalConfig` survived v25 -> v26 for exactly the reason this one did not — they are committed here and it was not. Register is not persist.\n\nThe value is a CONFIG PATH, not a secret: `Hosting:PlatformWebhookSecret` -> env `Hosting__PlatformWebhookSecret`, already mapped on `keyVaultSecretClasses[0]` (`/mnt/secrets-store`), so nothing new has to be provisioned. Slot `__1` and only `__1`: `__0` is `Store/Payments`, which Stripe signs with `Stripe-Signature` and no `X-Hub-Signature-256`, so demanding one there would 401 every payment delivery. The pairing is PER-SLOT — reordering `webhookInboxTargets` renames this key with it.\n\n🚨 THE HALF THIS DOES NOT FIX. `SecretConfigKey` has no typed field on `DeploymentContent`, so it can only ride in the free-form bag while its own target is typed (`webhookInboxTargets`) — the reachability of a target and its authentication are expressed in two different places and can come apart again. That is the same render gap as MeshWeaver.Plugins#1408 (`portalNext`), tracked as its neighbour. Until it is typed, this key is only as safe as this file.\n\nCommitted, not deployed: hop (C) has to run before the running ConfigMap carries it. Until then the live inbox still verifies nothing — and MeshWeaver#3455 means the first `helm upgrade` that rolls the post-#3312 endpoint is when both publishing lanes go RED naming this key.\n\n2026-09-07 (Memex#202): **the record's `Embedding__*` half was three values behind the overlay it renders, and a re-render would have re-broken what PR #215 fixed.** PR #215 corrected only the two overlay files — `gh api repos/Systemorph/Memex/pulls/215/files` returns exactly two filenames — so the record kept declaring ``memexcloud-Embedding-ApiKey``, a Key Vault object that does not exist, plus `Embedding__Endpoint = https://s-meshweaver.cognitiveservices.azure.com/openai/v1` and `Embedding__Model = embed-v-4-0`. A declared vault object the vault does not hold fails the WHOLE CSI mount, so a render from this record would have left every new pod in ContainerCreating — the exact failure #202 was opened for, re-introduced by the mechanism this record IS.\n\nAll three now match the overlay: ``memexcloud-OpenRouter-ApiKey``, `https://openrouter.ai/api/v1`, `openai/text-embedding-3-small`. The reasoning for the OpenRouter object is the overlay's and is unchanged — embeddings and chat are ONE OpenRouter account, so a separate `Embedding-ApiKey` object would be a second copy of one secret to rotate, and a rotation that missed one would fail silently.\n\n🚨 **The class, not the instance.** Nothing could see this: `scripts/` held only drift, doc-links and image-pins, and no gate compared a record's declarations against the overlay it renders. `scripts/check-record-renders-overlay.py` now does, on every PR and every push to main, with no credential — it asserts that every `extraPortalConfig` key reaches `config.memex_portal` with the same value and that the `keyVaultSecrets` maps are identical in both directions. It cannot check whether a named vault object EXISTS (that needs a credential); it checks that the two halves of this repository agree, which is what silently came apart here.\n\n2026-09-07 (Memex#202, same pass): **the four retired `FrameworkBroadcast__Subscribers__*` entries are removed from `extraPortalConfig`.** The chart RETIRED those slots on 2026-09-03 (MeshWeaver ffea396a9) and the overlay dropped them on 2026-09-04; the record kept them, so a re-render would have put back four keys the chart renders nowhere — turning `config-key-coverage` red and re-creating the Memex#140 empty-slot shape in the same move. The subscriber set is `pluginRepos[].isRegistrySource` on this record, derived by `PlatformBuildInboxWatcher` at broadcast time; note it is NOT the list those keys named — `.SocialMedia` is not a registry source here and `MeshWeaver.Crm` is, so the retired names were also the WRONG answer to restore (Memex#152).\n\n2026-09-08: **`data` (`memex-data`) — the overlay said 16Gi while this record and the live claim say 128Gi.** Measured the same day: 128 GiB, 28 GiB used. The overlay and the `portal-pvcs.yaml` capture are corrected to the measured truth; nothing on the cluster changes. Capacity is a record property from this change on: `Reconcile`/`Provision` grow every declared claim to `volumes[].size` through the operator's `hosting-pv-resize` (grow-only, refuses to shrink — which is why a record BELOW the claim is a refusal, never a silent pass), and `Audit` reports a claim below its record.",
+    "repository": "https://github.com/Systemorph/Memex",
+    "helmRelease": "memexcloud",
+    "databaseUsername": "postgres",
+    "inClusterPostgres": false,
+    "resources": {
+      "requests": {
+        "cpu": "4",
+        "memory": "8Gi"
+      },
+      "limits": {
+        "cpu": "6",
+        "memory": "16Gi"
+      }
+    },
+    "autoscaling": {
+      "enabled": true,
+      "minReplicas": 2,
+      "maxReplicas": 8
+    },
+    "replicas": 2,
+    "volumes": [
+      {
+        "name": "attachments",
+        "claimName": "memex-attachments",
+        "mountPath": "/mnt/attachments",
+        "size": "64Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "content",
+        "claimName": "memex-content",
+        "mountPath": "/mnt/content",
+        "size": "128Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "data",
+        "claimName": "memex-data",
+        "mountPath": "/data",
+        "size": "128Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "users",
+        "claimName": "memex-users",
+        "mountPath": "/mnt/users",
+        "size": "32Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "workspace",
+        "claimName": "memex-workspace",
+        "mountPath": "/workspace",
+        "size": "64Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "source-replica",
+        "claimName": "memex-source-replica",
+        "mountPath": "/source-replica",
+        "size": "32Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      }
+    ],
+    "ingress": {
+      "className": "webapprouting.kubernetes.azure.com",
+      "tlsSecret": "memexcloud-tls",
+      "annotations": {
+        "nginx.ingress.kubernetes.io/proxy-buffer-size": "16k",
+        "nginx.ingress.kubernetes.io/proxy-buffers-number": "4"
+      },
+      "sessionAffinity": {
+        "enabled": true,
+        "cookieName": "MEMEXCLOUD_AFFINITY"
+      }
+    },
+    "gitHubApp": {
+      "clientId": "Iv23liBtPCOxYjqyK3Yx",
+      "installationId": "144517285",
+      "installationOwner": "Systemorph"
+    },
+    "autoRecycleOnStaleBuild": true,
+    "requiredModules": [
+      "MeshWeaver.Blazor.Radzen.dll",
+      "MeshWeaver.Blazor.Analysis.dll",
+      "MeshWeaver.Blazor.EntityViews.dll",
+      "MeshWeaver.Blazor.GoogleMaps.dll",
+      "MeshWeaver.Speech.dll"
+    ],
+    "requiredModuleSlots": {
+      "7": "MeshWeaver.Mcp.dll"
+    },
+    "ai": {
+      "anthropic": {
+        "endpoint": "https://s-meshweaver.services.ai.azure.com/anthropic/",
+        "models": [
+          "claude-opus-4-7",
+          "claude-sonnet-4-6",
+          "claude-haiku-4-5"
+        ],
+        "order": 1
+      },
+      "azureAis": {
+        "endpoint": "https://fy-meshweaver3-dev-swc-001.services.ai.azure.com/models",
+        "order": 0
+      },
+      "azureFoundry": {
+        "endpoint": "",
+        "models": [
+          "",
+          "",
+          ""
+        ]
+      },
+      "openRouter": {
+        "models": [
+          "z-ai/glm-5.3",
+          "moonshotai/kimi-k3",
+          "openai/gpt-5.2",
+          "openai/gpt-5-mini",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3.7-flash",
+          "anthropic/claude-opus-5",
+          "anthropic/claude-sonnet-5",
+          "deepseek/deepseek-v4-pro",
+          "x-ai/grok-4.6",
+          "qwen/qwen3-max",
+          "qwen/qwen3.6-35b-a3b"
+        ]
+      },
+      "tiers": {
+        "heavy": "moonshotai/kimi-k3",
+        "standard": "z-ai/glm-5.3",
+        "light": "qwen/qwen3.6-35b-a3b",
+        "utility": "z-ai/glm-5.3"
+      }
+    },
+    "signIn": {
+      "provider": "Custom",
+      "enableDevLogin": false,
+      "microsoftClientId": "77bc55bb-f33c-4dfa-8cd9-b67eb865716a",
+      "linkedInClientId": "780dsuvyxglmc4"
+    },
+    "socialLinkedInClientId": "780dsuvyxglmc4",
+    "email": {
+      "enabled": true,
+      "clientId": "e18a4307-f81b-4e42-a79b-2d50427c8035",
+      "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+      "mailboxAddress": "memex@systemorph.com",
+      "useManagedIdentity": false,
+      "inboundForwardAddress": "info@systemorph.com"
+    },
+    "storage": {
+      "claudeCodeConfigDirRoot": "/mnt/users"
+    },
+    "telemetry": {
+      "otlpEndpoint": "http://otel-collector:4317",
+      "otlpProtocol": "grpc"
+    },
+    "startupProbe": {
+      "periodSeconds": 10,
+      "timeoutSeconds": 5,
+      "failureThreshold": 1080
+    },
+    "webhookInboxTargets": [
+      "Store/Payments",
+      "Hosting/PlatformBuilds"
+    ],
+    "extraPortalConfig": {
+      "Commerce__BaseUrl": "https://memex.meshweaver.cloud",
+      "Embedding__Endpoint": "https://openrouter.ai/api/v1",
+      "Embedding__Model": "openai/text-embedding-3-small",
+      "Embedding__Provider": "OpenAICompatible",
+      "Features__Ai__Providers__AzureOpenAI": "false",
+      "Features__Ai__Providers__OpenAI": "false",
+      "Features__Ai__Providers__OpenAICompatible": "false",
+      "Features__Ai__Providers__OpenRouter": "true",
+      "Hosting__Deployment": "memex-cloud",
+      "Hosting__ReportTo": "https://memex.systemorph.com",
+      "ModelCredit__RateFeed__Enabled": "true",
+      "ModelCredit__RateFeed__Pairs": "USD:CHF",
+      "PreWarm__BatchBake": "true",
+      "PreWarm__BuildProtocol": "true",
+      "PreWarm__DynamicTypes": "true",
+      "PreWarm__GateReadiness": "true",
+      "PreWarm__PrebuiltBundleRoot": "/data/prebuilt-bundles",
+      "Speech__Enabled": "true",
+      "Speech__Endpoint": "http://whisper-swiss-german:8080",
+      "Speech__Language": "de",
+      "WebhookInbox__Targets__1__SecretConfigKey": "Hosting:PlatformWebhookSecret"
+    },
+    "pluginRepos": [
+      {
+        "name": "Plugins",
+        "url": "https://github.com/Systemorph/MeshWeaver.Plugins",
+        "ref": "main",
+        "isRegistrySource": true
+      },
+      {
+        "name": "Education",
+        "url": "https://github.com/Systemorph/education",
+        "ref": "main",
+        "isRegistrySource": true
+      },
+      {
+        "name": "Reinsurance",
+        "url": "https://github.com/Systemorph/MeshWeaver.Reinsurance",
+        "ref": "main",
+        "isRegistrySource": true
+      },
+      {
+        "name": "Crm",
+        "url": "https://github.com/Systemorph/MeshWeaver.Crm",
+        "ref": "main",
+        "isRegistrySource": true
+      }
+    ],
+    "preInstall": [
+      "Plugins/*",
+      "Education/*",
+      "Reinsurance/*",
+      "Crm/*"
+    ],
+    "registryInstanceId": "memex-cloud",
+    "keyVaultSecrets": {
+      "$type": "KeyVaultSecretsSpec",
+      "vaultName": "Systemorph",
+      "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+      "identityClientId": "6c9dcc8d-d5b3-4545-afa1-209b33e8a1ba",
+      "name": "memexcloud-portal-keyvault",
+      "syncedSecret": "memexcloud-portal-keyvault",
+      "volumeName": "kv-portal-keyvault",
+      "mountPath": "/mnt/kv-portal-keyvault",
+      "secrets": [
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "PluginCatalog__RegistryToken",
+          "vaultSecret": "memexcloud-PluginCatalog-RegistryToken"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "Embedding__ApiKey",
+          "vaultSecret": "memexcloud-OpenRouter-ApiKey"
+        }
+      ]
+    },
+    "keyVaultSecretClasses": [
+      {
+        "$type": "KeyVaultSecretsSpec",
+        "vaultName": "Systemorph",
+        "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+        "identityClientId": "6c9dcc8d-d5b3-4545-afa1-209b33e8a1ba",
+        "name": "memexcloud-portal-ai-secrets",
+        "syncedSecret": "memexcloud-portal-ai-secrets",
+        "volumeName": "kv-ai-secrets",
+        "mountPath": "/mnt/secrets-store",
+        "secrets": [
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Ai__KeyProtection__MasterKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Anthropic__ApiKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "AzureAIS__ApiKey",
+            "vaultSecret": "memexcloud-AzureAIS-ApiKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "AzureFoundry__ApiKey",
+            "vaultSecret": "memexcloud-AzureAIS-ApiKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Authentication__Microsoft__ClientSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Authentication__LinkedIn__ClientSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Authentication__Google__ClientSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Social__LinkedIn__ClientSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "OpenRouter__ApiKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Email__ClientSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "GitHub__OAuth__ClientSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "GitHub__App__PrivateKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "GitHub__Webhook__Secret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Commerce__Stripe__SecretKey",
+            "vaultSecret": "memexcloud-Stripe-SecretKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Commerce__Stripe__WebhookSecret",
+            "vaultSecret": "memexcloud-Stripe-WebhookSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Plugins__Registry__PublishToken"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Hosting__PlatformWebhookSecret"
+          }
+        ]
+      }
+    ],
+    "vaultValuesKeys": [
+      "Authentication__EnableDevLogin",
+      "Authentication__Google__ClientId",
+      "Authentication__LinkedIn__ClientId",
+      "Authentication__Microsoft__ClientId",
+      "ConnectionStrings__memex",
+      "ConnectionStrings__orleans",
+      "GitHub__OAuth__ClientId",
+      "GitHub__OAuth__ClientSecret",
+      "MEMEX_PASSWORD",
+      "MEMEX_URI",
+      "PluginCatalog__OpenRegistration__Key",
+      "Social__LinkedIn__ClientId"
+    ],
+    "inlineEnv": [
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PreWarm__GateReadiness",
+        "value": "false",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": false,
+        "reason": "🚨 DISAGREES, AND IT IS THE LOAD-BEARING ONE. The ConfigMap renders `true`; this entry renders the NodeType bake gate INERT on the public instance. Removing it is what ARMS the gate here — the opposite act to memex, where the inline entry already reads `true` and removing it changes nothing."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__RegistryToken",
+        "isSecret": true,
+        "shadows": "memexcloud-portal-keyvault",
+        "reason": "The pre-vault copy, in plaintext on the Deployment spec. It outranks every envFrom, so the vault copy stays dead until this is deleted; delete, roll, then rotate.",
+        "retiredBy": "MeshWeaver#3404"
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__RegistryUrl",
+        "value": "https://memex.meshweaver.cloud",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": false,
+        "reason": "SOLE SOURCE — the ConfigMap renders this key empty (this instance IS the registry and is configured with pluginCatalog.sources, not registries)."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__RequireInstanceKey",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__DefaultGrants__0",
+        "value": "Plugins/*",
+        "reason": "SOLE SOURCE — the ConfigMap renders no PluginCatalog__DefaultGrants__* key at all."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__0__RepoPath",
+        "value": "https://github.com/Systemorph/MeshWeaver.Plugins",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true,
+        "reason": "🚨 The inline list covers sources 0-2 ONLY; source 3 (Crm) exists solely in the ConfigMap. The two lists are index-aligned by position, so inserting or reordering either one silently re-points a source."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__0__Name",
+        "value": "Plugins",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__0__Ref",
+        "value": "main",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__0__Format",
+        "value": "node-repo",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__1__RepoPath",
+        "value": "https://github.com/Systemorph/education",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__1__Name",
+        "value": "Education",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__1__Ref",
+        "value": "main",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__1__Format",
+        "value": "node-repo",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__2__RepoPath",
+        "value": "https://github.com/Systemorph/MeshWeaver.Reinsurance",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__2__Name",
+        "value": "Reinsurance",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__2__Ref",
+        "value": "main",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__Sources__2__Format",
+        "value": "node-repo",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Commerce__BaseUrl",
+        "value": "https://memex.meshweaver.cloud",
+        "reason": "SOLE SOURCE on the pod — the ConfigMap carries no Commerce__BaseUrl. Chart-renderable behind the same hasKey guard, declared by no committed file."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Speech__Endpoint",
+        "value": "http://whisper-swiss-german:8080",
+        "reason": "SOLE SOURCE on the pod — the ConfigMap carries no Speech__* key, so the whisper deployment in this namespace is reachable only through these three inline entries. Precisely: the chart CAN render them (`config.yaml`, guarded by `{{ if hasKey .Values.config.memex_portal \"Speech__Endpoint\" }}`), but no committed values file declares them. Putting them in this record's `extraPortalConfig` is what would give them a ConfigMap home."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Speech__Enabled",
+        "value": "true",
+        "reason": "SOLE SOURCE — as above."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Speech__Language",
+        "value": "de",
+        "reason": "SOLE SOURCE — as above."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "WebhookInbox__Targets__0",
+        "value": "Store/Payments",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PreWarm__BatchBake",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PreWarm__PrebuiltBundleRoot",
+        "value": "/data/prebuilt-bundles",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Grpc__TrustedPort",
+        "value": "8082",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__Http__Url",
+        "value": "http://0.0.0.0:8080",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__Grpc__Url",
+        "value": "http://0.0.0.0:8081",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__Grpc__Protocols",
+        "value": "Http2",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__GrpcTrusted__Url",
+        "value": "http://127.0.0.1:8082",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__GrpcTrusted__Protocols",
+        "value": "Http2",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "DOTNET_DbgEnableMiniDump",
+        "value": "1",
+        "shadows": "memex-portal-config",
+        "reason": "The chart renders the four DOTNET_Dbg* entries as inline env itself; on this namespace kubectl-set owns them, so they are recorded rather than left as an unexplained difference between the two portals."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "DOTNET_DbgMiniDumpType",
+        "value": "2"
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "DOTNET_DbgMiniDumpName",
+        "value": "/data/dumps/coredump.%p.%t"
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "DOTNET_CreateDumpDiagnostics",
+        "value": "1"
+      }
+    ],
+    "registry": {
+      "$type": "RegistrySpec",
+      "host": "cr.meshweaver.cloud",
+      "image": "ghcr.io/distribution/distribution:3.1.1@sha256:bca24727f4002e51f959c18c42e816e4d1078198081a9837e16b8b7d7e43ebf8",
+      "authImage": "cesanta/docker_auth:1.14.0@sha256:98e0307e0d2dcbafe10098814a97d248143b78ca478693f78c3c0d67fe776ab4",
+      "issuer": "memex-registry",
+      "storageAccountName": "meshweaverregistry",
+      "storageContainer": "registry",
+      "serviceAccount": "memex-portal-sa",
+      "keyVault": {
+        "$type": "RegistryKeyVaultSpec",
+        "name": "Systemorph",
+        "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+        "identityClientId": "6c9dcc8d-d5b3-4545-afa1-209b33e8a1ba",
+        "certObject": "memexcloud-Registry-TokenCert",
+        "keyObject": "memexcloud-Registry-TokenKey",
+        "httpSecretObject": "memexcloud-Registry-HttpSecret"
+      },
+      "publisherUsername": "publisher",
+      "publisherPasswordBcrypt": "$2y$05$nwNE91JVAgwJOC1M7o1OPOZqDNE65TTZtGgldRGDAGwnSt4qVGeWy",
+      "validationUrl": "https://memex.meshweaver.cloud/api/instances/token",
+      "replicas": 2
+    }
+  }
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/Fixtures/memex.json
+++ b/test/MeshWeaver.Deployment.Contract.Test/Fixtures/memex.json
@@ -1,0 +1,475 @@
+{
+  "$type": "MeshNode",
+  "id": "memex",
+  "namespace": "Deployments",
+  "path": "Deployments/memex",
+  "mainNode": "Deployments/memex",
+  "name": "memex",
+  "description": "Systemorph company instance — client work, infra control, accounting.",
+  "nodeType": "Hosting/Deployment",
+  "state": "Active",
+  "content": {
+    "$type": "DeploymentContent",
+    "cluster": "memexaks-cluster",
+    "databaseServer": "memexaks-pg",
+    "imageRepository": "meshweaver.azurecr.io/memex-portal-ai",
+    "pinnedImageTag": "3.0.0-ci.8131",
+    "keyVault": "Systemorph",
+    "owner": "Systemorph",
+    "host": "memex.systemorph.com",
+    "namespace": "memex",
+    "database": "memex",
+    "purpose": "Systemorph's own instance — client work, infrastructure control, accounting. Private to Systemorph staff. This is the control instance, and the natural home for the Deployments Space itself.",
+    "keyVaultSecretPrefix": "memexsystemorph-",
+    "configPath": "deployments/aks/memex",
+    "notes": "**Differences from the other two — resolved 2026-08-12** (they were an artifact of this environment predating version-controlled config, not decisions):\n\n- **`nodeSelector` + resources: to be normalised.** `deployments/aks/memex/portal-patch.json` now pins `workload=silos` and carries the memex-cloud envelope (requests 4 CPU / 8Gi, limits 6 / 16Gi). Applying it reschedules the pod, so it lands at the next deliberate apply, not by itself.\n- **Key Vault naming: deliberately KEPT.** SecretProviderClass `memex-kv` → secret `memex-kv-secrets` stays; renaming live objects buys consistency only and risks the secret mount.\n- **PVC `app.kubernetes.io/component` labels: applied 2026-08-12** to `memex-content` and `memex-data` (labelling a bound PVC is safe; it was an oversight at creation).\n\n2026-08-12: live Deployment was missing the chart's `preStop` drain (sleep 15) and ran 30s termination grace — every self-update roll dropped connections and cut Orleans shutdown short. Patched live to the chart's values (preStop + 120s grace); the chart owns them from here.\n\n2026-08-29: **`keyVaultSecretPrefix` changed `memex-` → `memexsystemorph-`.** Two reasons, both discovered while making teardown purge Key Vault by enumeration rather than by a hard-coded suffix list.\n\n1. `memex-` never held this instance's per-instance secrets. They are the UNPREFIXED legacy names in the vault (`ai-keyprotection-masterkey`, `Authentication-Microsoft-ClientSecret`, `github-oauth-clientsecret`, …). What `memex-` *does* match is `memex-connectionstring` and `memex-postgres-password` — INFRASTRUCTURE secrets that are not this instance's to delete. A prefix-enumerating teardown of memex would therefore have deleted exactly the two wrong secrets and missed every right one.\n\n2. `memex-` is a prefix that other instance prefixes can live under (a future `memex-dev` would be swallowed by it). `memexsystemorph-` matches the `memexcloud-` convention and cannot contain, or be contained by, another instance's prefix.\n\n🚨 NOTHING WAS RENAMED IN THE VAULT and nothing needs to be: no secret named `memex-*` belongs to this instance, so the new prefix simply stops pointing at other people's. The unprefixed legacy names stay as they are — moving them is a separate, live-affecting change.\n\n2026-09-06: **the bake gate is now declared HERE, and `deployments/aks/memex/values.gate.yaml` is deleted.** Measured on the live cluster the same day (`kubectl -n memex get deploy memex-portal-deployment -o json`):\n\n- container env `PreWarm__GateReadiness=true` — an inline `env:` entry owned by `kubectl-patch`, 2026-08-24T06:43:49Z. Nothing in this repo put it there.\n- ConfigMap `memex-portal-config`: `PreWarm__GateReadiness=\"false\"`, `PreWarm__DynamicTypes=\"false\"`, `PreWarm__BatchBake=\"\"`, `PreWarm__PrebuiltBundleRoot=\"\"`. An inline `env:` entry overrides `envFrom`, so the pod ran `true` while every committed file said `false`.\n- container env `PreWarm__BatchBake=true` and `PreWarm__PrebuiltBundleRoot=/data/prebuilt-bundles` — both owned by `kubectl-set`, 2026-09-03T17:14:02Z, and declared nowhere in the repo.\n- `strategy` maxSurge 1 / maxUnavailable 0, `progressDeadlineSeconds` 900, `revisionHistoryLimit` 3, startupProbe `/health` 5 s x 60. All four already match what the chart renders from these values — they need no keys here and none were added.\n\n🚨 **THE ARMING WAS NEVER REAL, and that is why `DynamicTypes` moves with it.** The deployed host (`MeshWeaver.Plugins/src/Memex.Portal.Distributed/Program.cs`, `gateBake = gateBakeConfigured && bakeSweepEnabled`) refuses to register the `nodetype_bake` health check when the sweep is off, forces `GatesReadiness` false, and logs at **Critical** that the gate \"has been DISARMED rather than left registered and permanently green\". The gate reads bake state that ONLY the `PreWarm__DynamicTypes` sweep writes — the unconditional prebuilt-bundle adoption writes none of it — so `GateReadiness=true` with `DynamicTypes=false` has protected nothing since 2026-08-24, silently. Persisting only the env var would have committed that same empty claim, so the record declares the whole pairing the chart, `deployments/aks/README.md` and `values.pearl.public.yaml` all state together: sweep on, gate on, batch bake on, and the startup budget raised to cover a cold bake (10 s x 1080 = 3 h; `progressDeadlineSeconds` follows it automatically as period x threshold + 600).\n\n**So the next `deploy` of memex is the one that actually arms the gate**, and it is a real behaviour change, not a no-op: the boot-time sweep turns on and the startup budget goes from 5 min to 3 h.\n\n2026-09-06, LATER THE SAME DAY — **that deploy ran (helm release `memex` v29, 11:24:20Z) and the gate is now ARMED AND ENFORCING.** Measured on the live cluster:\n\n- ConfigMap `memex-portal-config` now renders `PreWarm__GateReadiness=\"true\"`, `PreWarm__DynamicTypes=\"true\"`, `PreWarm__BatchBake=\"true\"`, `PreWarm__PrebuiltBundleRoot=\"/data/prebuilt-bundles\"`. `printenv` inside the running container reports the same, so the surviving inline `PreWarm__GateReadiness=true` is now REDUNDANT rather than shadowing — it agrees with `envFrom`.\n- The `nodetype_bake` health check is REGISTERED and it withheld `/health`. Pod `memex-portal-deployment-5fc89b764-sb7cz`: started 11:24:21Z, `nodetype_bake` **Unhealthy** (`NodeType bake in progress — enumerating dynamic NodeTypes`) 11:25:42Z→11:27:22Z, sweep `compiled=78 alreadyBaked=122 compileErrors=4 timedOut=0 skipped=3 contentBroken=1 faulted=0`, **Ready 11:27:33Z** — 3 m 12 s of held readiness with the old pod serving. Pod `…-dcdcq`: 11:27:33Z → Ready 11:29:05Z. No `DISARMED`, no `GATE NOT ARMED`, no `REFUSING READINESS`.\n- The remaining cluster action is `kubectl -n memex set env deployment/memex-portal-deployment PreWarm__GateReadiness-`, which now removes a redundant entry and leaves the pod ARMED. It is NOT the same act on memex-cloud, where the inline entry is `false` and removing it ARMS the gate.\n\n🚨 **The arming precondition stated above was over-stated, and this roll measured it.** A `previouslybroken` type CANNOT gate: `NodeTypeBakeEntry.WasHealthy` is false for `BakeState.PreviouslyBroken` and `NodeTypeBakeGateState.MarkOutcome` returns before recording anything when `!WasHealthyBeforeBake`, precisely so one abandoned NodeType cannot freeze every future deploy. memex armed with `previouslybroken=8` and `compileErrors=4` and was Ready in 3 m 12 s. What gates is a REGRESSION — a previously-healthy type that fails on this image, directly (`CompileError`) or as `UpstreamFailed` behind one that did. `TimedOut`, `UpstreamUnevaluated`, `NoSources` and `UpstreamContentBroken` never gate.\n\nNot folded in, deliberately: the live `readinessProbe`/`livenessProbe` `initialDelaySeconds` (20/60). Kubernetes suspends both probes until the startupProbe passes, so a delay measured from container start is dead config wherever a startupProbe exists. The chart is the authoritative side of that drift (MeshWeaver#2355 concluded the opposite three times). The live readiness path `/alive` is likewise not folded in: the chart moved readiness to its own `/ready` in MeshWeaver#3330 and a deploy is meant to apply that.\n\n2026-09-06: **the plugin-registry token has TWO env-key names and only one of them existed.** `values.memex.public.yaml` now maps the SAME vault object `PluginCatalog-RegistryToken` to a SECOND key, `PluginCatalog__Registries__0__Token`, alongside the legacy `PluginCatalog__RegistryToken`. Measured live the same day (key NAMES only): ConfigMap `memex-portal-config` carries `PluginCatalog__Registries__0__{Name,Ref,Url}` (the NAMED shape) with no token; Secret `memex-portal-secrets` carries only the LEGACY `PluginCatalog__RegistryToken`; Secret `memex-kv-secrets` carries ZERO `PluginCatalog*` keys; the inline container `env:` carries `PluginCatalog__RegistryToken`, `__RegistryUrl` and `__AutoUpdateByDefault` and NO `Registries__*`. So the per-registry token existed in no layer at all, `RegistryTokenResolver` resolved \"\", and `RegistryPackageSource.Request()` attaches the bearer only when it is non-empty — the poll `GET https://memex.meshweaver.cloud/api/plugins?ref=HEAD` went out with NO Authorization header and was refused 401 on **740 consecutive passes**. `RegistryTokenResolver.WithLegacyTokens` bridges the legacy key onto a sole/URL-matching named registry, but only on the paths that call it (boot reconcile, consent service); the Store's `Store/Publishing/Source/RegistryPackages.Reference` path in MeshWeaver.Plugins does not, which is the real fix for the class (MeshWeaver#3201). Diagnosis: session meshweaver-education-34 on Memex#164.\n\n🚨 THE MAPPING IS INDEX-POSITIONAL. `Registries__0__Token` binds to `pluginCatalog.registries[0]` by POSITION, not by name; reordering, inserting into or removing from that list silently re-points the token with no error anywhere, and the only symptom is another 401 storm. The list and the mapping move together. memex-cloud is deliberately excluded: it is the REGISTRY, configured with `pluginCatalog.sources[]` and no `registries:` at all, so an index-positional token would bind to nothing there.\n\n🚨 DRIFT TO CLOSE: this `keyVaultSecrets` block — the chart-owned SPC `memex-portal-keyvault`, added to the overlay by Memex#180 — is NOT on this record. The record's `keyVaultSecrets` still describes the LEGACY hand-made `memex-kv` class (rendered as the overlay's extraEnvFrom/extraVolumes pair), so a re-render from this record would DROP both PluginCatalog mappings and every comment around them. Folding the second class onto the record needs a record shape that can hold two SPCs; until then the overlay is ahead of the record for this block only.\n\n2026-09-06, CLOSED — **the record now holds BOTH classes, the whole env precedence stack, and the pod's sidecars.** The drift above was measured before it was closed: rendering the OLD record and diffing it structurally against the committed overlay gave **41 differences**, and every one was a silent loss. A re-render would have (1) replaced the chart-owned `memex-portal-keyvault` class with a `memex-kv` one, deleting BOTH PluginCatalog mappings — the registry-poll fix of that morning; (2) dropped `extraEnvFrom: memex-kv-secrets`, detaching all 13 keys of the hand-made class (the connection string, the GitHub App private key, the AI provider keys) from the pod; (3) ADDED a mapping for `memexsystemorph-PluginCatalog-RegistryToken`, a vault object that does not exist, which fails the whole CSI mount and leaves every new pod in ContainerCreating; and (4) dropped `Embedding__*` and `ModelCredit__InstanceTier`. What the record now carries, all measured read-only on the live cluster the same day (names and lengths only, never a value):\n\n- **`keyVaultSecrets`** = the chart-owned `memex-portal-keyvault` → Secret `memex-portal-keyvault`, mounted at `/mnt/kv-portal-keyvault`. It maps the ONE vault object `PluginCatalog-RegistryToken` onto TWO keys, which is the #3201 fix and which the projection used to REFUSE (`maps vault object X onto more than one key`). A key has one home; an object may have as many keys as the portal reads it under.\n- **`keyVaultSecretClasses[0]`** = the hand-made `memex-kv` → Secret `memex-kv-secrets` at `/mnt/kv-secrets`, with all 13 live mappings. Four of them were on no record and in no file: `GitHub__Webhook__Secret`, `Plugins__Registry__PublishToken`, `Hosting__PlatformWebhookSecret` and `Email__ClientSecret` (`memexsystemorph-Email-ClientSecret`, added to the live SPC by `kubectl patch` on 2026-08-30). The `PluginCatalog__RegistryToken` entry the record used to claim for this class was never in it: `memex-kv-secrets` carries ZERO `PluginCatalog*` keys.\n- **`vaultValuesKeys`** = the 11 keys of `memex-portal-secrets`, the chart's OWN Secret, rendered from the Key Vault values half (`helm-values-memex`) that no repository holds. Six of them are also supplied by `memex-kv-secrets`, which sits LATER in `envFrom` and therefore wins; without this list nothing said the chart's Secret carried them at all.\n- **`inlineEnv`** = the 16 entries `kubectl` set directly on the Deployment. These render NOTHING — `helm upgrade` does not remove an inline entry (three-way merge removes only what helm previously owned, measured 2026-09-03), so recording one neither creates nor deletes it. Recording them is what stops the record from disagreeing with the pod at every read. Two of them disagree with the ConfigMap and are therefore live behaviour no committed file states: `Features__Ai__Providers__AzureOpenAI=true` (ConfigMap says `false`) and `PluginCatalog__RegistryUrl` (ConfigMap renders it EMPTY, so the inline entry is the SOLE source, not a shadow). `Features__Ai__Clis__ClaudeCode` and `__Copilot` have no ConfigMap key at all.\n- **`gates`** = the `python` and `node` sidecars (`meshweaver.azurecr.io/meshweaver/{python,node}-gate:8aa1a79`), in the pod since a `kubectl patch` on 2026-08-24 and declared in no repository, while the chart has been able to render them from `grpc.gates` all along. The pod runs THREE containers; the record used to describe one.\n\n2026-09-06, CORRECTION to the above — **the `volumes` block was wrong, and the entry that closed the Key Vault drift did not close this.** Found by re-running the render-vs-live check over the FULL persistence set instead of only the CSI volumes; the hunk is taken from Memex#175, whose author measured it first (2026-09-03).\n\n- **`content` had no `claimName`, so the chart rendered NO content volume at all.** `deployment.yaml` gates every persistence entry on `{{- if and $spec $spec.claimName $spec.mountPath … }}`, so an entry without one is silently inert — while `Storage__BasePath: /mnt/content` stays set. A deploy from the record as it stood gave the portal a content path with nothing mounted at it. Fixed: `claimName: memex-content`.\n- **`size` said 128Gi; the PVC is 64Gi.** Measured: `kubectl -n memex get pvc` → `memex-content 64Gi`, `memex-data 16Gi`, `memex-users 32Gi`.\n- **`attachments` was a PHANTOM.** Namespace `memex` has no `memex-attachments` PVC (memex-cloud does), the live pod has no such volume and no `/mnt/attachments` mount. It rendered nothing only because it also lacked a `claimName` — inert *and* false. Removed.\n\n`postgres` stays as it is: the in-cluster Postgres StatefulSet is gated on `postgres.enabled` (false here) and does not read `persistence.postgres` at all, so that entry is inert BY DESIGN rather than by accident.\n\n🚨 The lesson generalises past this one field: a render that reproduces the SecretProviderClasses, the envFrom order and the CSI mounts can still omit an ordinary volume, because the two are gated by different conditions. The check now compares the whole volume and volumeMount set, and asserts that every persistence entry names a PVC that exists.\n\n🚨 STILL OPEN, and it will stall the next deploy of this namespace: the committed overlay declares `Embedding-ApiKey` → `Embedding__ApiKey` on `memex-portal-keyvault`, and **no secret of that name exists in Key Vault `Systemorph`** (measured 2026-09-06: `SecretNotFound`; the live SPC carries only the two PluginCatalog mappings, because that entry has not been deployed yet). A declared object the vault does not hold fails the WHOLE mount — the pod stays ContainerCreating, the old pod keeps serving and the rollout stalls. The record states the entry because it states the overlay's intent; provisioning the vault secret is what unblocks it. The same is true of `memexcloud-Embedding-ApiKey` on memex-cloud.\n\n2026-09-07 (Memex#202): **the record's `Embedding__*` half was three values behind the overlay it renders, and a re-render would have re-broken what PR #215 fixed.** PR #215 corrected only the two overlay files — `gh api repos/Systemorph/Memex/pulls/215/files` returns exactly two filenames — so the record kept declaring ``Embedding-ApiKey``, a Key Vault object that does not exist, plus `Embedding__Endpoint = https://s-meshweaver.cognitiveservices.azure.com/openai/v1` and `Embedding__Model = embed-v-4-0`. A declared vault object the vault does not hold fails the WHOLE CSI mount, so a render from this record would have left every new pod in ContainerCreating — the exact failure #202 was opened for, re-introduced by the mechanism this record IS.\n\nAll three now match the overlay: ``OpenRouter-ApiKey``, `https://openrouter.ai/api/v1`, `openai/text-embedding-3-small`. The reasoning for the OpenRouter object is the overlay's and is unchanged — embeddings and chat are ONE OpenRouter account, so a separate `Embedding-ApiKey` object would be a second copy of one secret to rotate, and a rotation that missed one would fail silently.\n\n🚨 **The class, not the instance.** Nothing could see this: `scripts/` held only drift, doc-links and image-pins, and no gate compared a record's declarations against the overlay it renders. `scripts/check-record-renders-overlay.py` now does, on every PR and every push to main, with no credential — it asserts that every `extraPortalConfig` key reaches `config.memex_portal` with the same value and that the `keyVaultSecrets` maps are identical in both directions. It cannot check whether a named vault object EXISTS (that needs a credential); it checks that the two halves of this repository agree, which is what silently came apart here.\n\n2026-09-08: **`volumes[].size` for `data` (`memex-data`) 16Gi → 128Gi — the share was FULL.** Measured 13:51Z: 16 GiB, 3 MiB free, while memex-cloud's `/data` ran 128 GiB with 28 GiB used. `/data` holds the DataProtection keys, the NodeType assembly cache and the NuGet cache; a full share stops every compile and every sign-in key rotation. Capacity is a RECORD property from this change on (MeshWeaver `hosting-pv-resize`, Plugins Hosting 1.14): `Reconcile` (and `Provision`) grow every declared claim to the record's size — grow-only, online on Azure Files, read back from the claim's status — and `Audit` reports a claim below its record under `volumeCapacityBelowRecord`. Until the operator image carrying the command is rolled, this record's 128Gi is a declaration the audit will show as drift; the number is what the claim SHOULD hold, never a measurement of what it does. No claim is created or shrunk by this: `memex-content` (64Gi) and `memex-users` (32Gi) are declared at their measured sizes.",
+    "repository": "https://github.com/Systemorph/Memex",
+    "helmRelease": "memex",
+    "databaseUsername": "memexadmin",
+    "inClusterPostgres": false,
+    "resources": {
+      "requests": {
+        "cpu": "4",
+        "memory": "8Gi"
+      },
+      "limits": {
+        "cpu": "6",
+        "memory": "16Gi"
+      }
+    },
+    "replicas": 2,
+    "volumes": [
+      {
+        "name": "content",
+        "claimName": "memex-content",
+        "mountPath": "/mnt/content",
+        "size": "64Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "data",
+        "claimName": "memex-data",
+        "mountPath": "/data",
+        "size": "128Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      },
+      {
+        "name": "postgres",
+        "size": "128Gi",
+        "storageClass": "managed-csi",
+        "accessMode": "ReadWriteOnce"
+      },
+      {
+        "name": "users",
+        "claimName": "memex-users",
+        "mountPath": "/mnt/users",
+        "size": "32Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany"
+      }
+    ],
+    "ingress": {
+      "className": "webapprouting.kubernetes.azure.com",
+      "tlsSecret": "memex-tls",
+      "annotations": {
+        "nginx.ingress.kubernetes.io/proxy-buffer-size": "16k",
+        "nginx.ingress.kubernetes.io/proxy-buffers-number": "4"
+      },
+      "sessionAffinity": {
+        "enabled": true,
+        "cookieName": "MEMEX_AFFINITY",
+        "nginxAnnotations": {
+          "nginx.ingress.kubernetes.io/affinity": "cookie",
+          "nginx.ingress.kubernetes.io/affinity-mode": "persistent",
+          "nginx.ingress.kubernetes.io/proxy-read-timeout": "3600",
+          "nginx.ingress.kubernetes.io/proxy-send-timeout": "3600",
+          "nginx.ingress.kubernetes.io/session-cookie-max-age": "172800",
+          "nginx.ingress.kubernetes.io/session-cookie-name": "MEMEX_AFFINITY"
+        },
+        "agicAnnotations": {
+          "appgw.ingress.kubernetes.io/cookie-based-affinity": "true",
+          "appgw.ingress.kubernetes.io/request-timeout": "3600"
+        }
+      }
+    },
+    "gitHubApp": {
+      "clientId": "Iv23liBtPCOxYjqyK3Yx",
+      "installationId": "144517285",
+      "installationOwner": "Systemorph"
+    },
+    "autoRecycleOnStaleBuild": true,
+    "requiredModules": [
+      "MeshWeaver.Blazor.Radzen.dll",
+      "MeshWeaver.Blazor.Analysis.dll",
+      "MeshWeaver.Blazor.EntityViews.dll",
+      "MeshWeaver.Blazor.GoogleMaps.dll",
+      "MeshWeaver.Speech.dll"
+    ],
+    "ai": {
+      "anthropic": {
+        "endpoint": "https://s-meshweaver.services.ai.azure.com/anthropic/",
+        "models": [
+          "claude-opus-4-7",
+          "claude-sonnet-4-6",
+          "claude-haiku-4-5"
+        ],
+        "enabled": true
+      },
+      "azureFoundry": {
+        "endpoint": "",
+        "models": [
+          "",
+          "",
+          ""
+        ]
+      },
+      "openRouter": {
+        "models": [
+          "z-ai/glm-5.3",
+          "moonshotai/kimi-k3",
+          "openai/gpt-5.2",
+          "openai/gpt-5-mini",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3.7-flash",
+          "anthropic/claude-opus-5",
+          "anthropic/claude-sonnet-5",
+          "deepseek/deepseek-v4-pro",
+          "x-ai/grok-4.6",
+          "qwen/qwen3-max",
+          "qwen/qwen3.6-35b-a3b"
+        ]
+      },
+      "tiers": {
+        "heavy": "moonshotai/kimi-k3",
+        "standard": "z-ai/glm-5.3",
+        "light": "qwen/qwen3.6-35b-a3b",
+        "utility": "z-ai/glm-5.3"
+      }
+    },
+    "signIn": {
+      "provider": "Custom",
+      "enableDevLogin": false,
+      "microsoftClientId": "eed68df1-f267-4426-9dda-c0b43c68435b",
+      "microsoftTenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+      "googleClientId": "",
+      "linkedInClientId": ""
+    },
+    "email": {
+      "enabled": true,
+      "clientId": "f5d635fd-78e3-4bc6-b9d0-01a851d1ecbc",
+      "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+      "mailboxAddress": "memex@systemorph.com",
+      "useManagedIdentity": false,
+      "inboundEnabled": true,
+      "webhookBaseUrl": "https://memex.systemorph.com"
+    },
+    "telemetry": {
+      "otlpEndpoint": "http://otel-collector:4317",
+      "otlpProtocol": "grpc"
+    },
+    "operator": {
+      "enabled": true,
+      "namespace": "memex-ops",
+      "serviceAccount": "hosting-operator",
+      "image": "meshweaver.azurecr.io/hosting-operator:00dc0e8",
+      "environment": {
+        "AZURE_CLIENT_ID": "280fd351-ee78-4468-8f92-fb64f20a43f0",
+        "AZ_DNS_RESOURCE_GROUP": "dns",
+        "AZ_OIDC_ISSUER": "https://swedencentral.oic.prod-aks.azure.com/3a01d7ac-3330-444d-942d-975eb491b5d6/619052c2-c044-493e-b05a-b1bd12efbd06/",
+        "AZ_PORTAL_IDENTITY": "memexaks-portal-mi",
+        "AZ_RESOURCE_GROUP": "memex-aks-rg",
+        "INGRESS_IP": "74.241.238.18",
+        "PAYWALL_URL": "https://memex.systemorph.com/Deployments/{instance}/area/Suspended"
+      }
+    },
+    "startupProbe": {
+      "periodSeconds": 10,
+      "timeoutSeconds": 5,
+      "failureThreshold": 1080
+    },
+    "extraPortalConfig": {
+      "Embedding__Endpoint": "https://openrouter.ai/api/v1",
+      "Embedding__Model": "openai/text-embedding-3-small",
+      "Embedding__Provider": "OpenAICompatible",
+      "Features__Ai__Clis__ClaudeCode": "true",
+      "Features__Ai__Clis__Copilot": "true",
+      "Features__Ai__Providers__AzureOpenAI": "true",
+      "Features__Ai__Providers__OpenAI": "false",
+      "Features__Ai__Providers__OpenAICompatible": "false",
+      "Features__Ai__Providers__OpenRouter": "true",
+      "Hosting__Deployment": "memex",
+      "LogWatch__DefaultRepository": "Systemorph/MeshWeaver",
+      "LogWatch__Routes__0__Prefix": "MeshWeaver.",
+      "LogWatch__Routes__0__Repository": "Systemorph/MeshWeaver",
+      "LogWatch__Routes__1__Prefix": "Memex.",
+      "LogWatch__Routes__1__Repository": "Systemorph/Memex",
+      "ModelCredit__InstanceTier": "enterprise",
+      "PreWarm__BatchBake": "true",
+      "PreWarm__DynamicTypes": "true",
+      "PreWarm__GateReadiness": "true",
+      "PreWarm__PrebuiltBundleRoot": "/data/prebuilt-bundles"
+    },
+    "gates": [
+      {
+        "$type": "GateSpec",
+        "language": "node",
+        "enabled": true,
+        "image": "meshweaver.azurecr.io/meshweaver/node-gate:8aa1a79",
+        "address": "node/node-kernel"
+      },
+      {
+        "$type": "GateSpec",
+        "language": "python",
+        "enabled": true,
+        "image": "meshweaver.azurecr.io/meshweaver/python-gate:8aa1a79",
+        "address": "py/python-kernel"
+      }
+    ],
+    "pluginRepos": [
+      {
+        "name": "Plugins",
+        "url": "https://memex.meshweaver.cloud",
+        "isRegistrySource": false
+      }
+    ],
+    "preInstall": [],
+    "registryInstanceId": "memex",
+    "keyVaultSecrets": {
+      "$type": "KeyVaultSecretsSpec",
+      "vaultName": "Systemorph",
+      "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+      "identityClientId": "6c9dcc8d-d5b3-4545-afa1-209b33e8a1ba",
+      "name": "memex-portal-keyvault",
+      "syncedSecret": "memex-portal-keyvault",
+      "volumeName": "kv-portal-keyvault",
+      "mountPath": "/mnt/kv-portal-keyvault",
+      "secrets": [
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "PluginCatalog__RegistryToken",
+          "vaultSecret": "PluginCatalog-RegistryToken"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "PluginCatalog__Registries__0__Token",
+          "vaultSecret": "PluginCatalog-RegistryToken"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "Embedding__ApiKey",
+          "vaultSecret": "OpenRouter-ApiKey"
+        }
+      ]
+    },
+    "keyVaultSecretClasses": [
+      {
+        "$type": "KeyVaultSecretsSpec",
+        "vaultName": "Systemorph",
+        "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+        "identityClientId": "6c9dcc8d-d5b3-4545-afa1-209b33e8a1ba",
+        "name": "memex-kv",
+        "syncedSecret": "memex-kv-secrets",
+        "volumeName": "kv-secrets",
+        "mountPath": "/mnt/kv-secrets",
+        "secrets": [
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Ai__KeyProtection__MasterKey",
+            "vaultSecret": "ai-keyprotection-masterkey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Bootstrap__Secret",
+            "vaultSecret": "bootstrap-secret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Authentication__Microsoft__ClientSecret",
+            "vaultSecret": "microsoft-clientsecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "ConnectionStrings__memex",
+            "vaultSecret": "memex-connectionstring"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Authentication__LinkedIn__ClientSecret",
+            "vaultSecret": "linkedin-clientsecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "OpenRouter__ApiKey",
+            "vaultSecret": "OpenRouter-ApiKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "GitHub__OAuth__ClientSecret",
+            "vaultSecret": "github-oauth-clientsecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "GitHub__App__PrivateKey",
+            "vaultSecret": "github-app-privatekey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "AzureFoundry__ApiKey",
+            "vaultSecret": "AzureFoundry-ApiKey"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "GitHub__Webhook__Secret",
+            "vaultSecret": "github-webhook-secret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Plugins__Registry__PublishToken",
+            "vaultSecret": "Plugins-Registry-PublishToken"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Hosting__PlatformWebhookSecret",
+            "vaultSecret": "Hosting-PlatformWebhookSecret"
+          },
+          {
+            "$type": "KeyVaultSecretRef",
+            "key": "Email__ClientSecret",
+            "vaultSecret": "memexsystemorph-Email-ClientSecret"
+          }
+        ]
+      }
+    ],
+    "vaultValuesKeys": [
+      "Ai__KeyProtection__MasterKey",
+      "Anthropic__ApiKey",
+      "Authentication__Microsoft__ClientSecret",
+      "AzureFoundry__ApiKey",
+      "ConnectionStrings__memex",
+      "ConnectionStrings__orleans",
+      "LogWatch__IngestToken",
+      "MEMEX_PASSWORD",
+      "MEMEX_URI",
+      "OpenRouter__ApiKey",
+      "PluginCatalog__RegistryToken"
+    ],
+    "inlineEnv": [
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__RegistryToken",
+        "isSecret": true,
+        "shadows": "memex-portal-keyvault",
+        "reason": "The pre-vault copy, set by `kubectl set env` 2026-09-03. It outranks every envFrom, so the vault copy on memex-portal-keyvault stays dead until this is deleted — which is why the SECOND key (PluginCatalog__Registries__0__Token, unshadowed) is what actually fixed the poll. Deleting it is a Deployment-spec edit and a rollout, and the key must be rotated afterwards: it has sat in plaintext in a spec readable by anything that can `get deploy`.",
+        "retiredBy": "MeshWeaver#3404"
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__RegistryUrl",
+        "value": "https://memex.meshweaver.cloud",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": false,
+        "reason": "SOLE SOURCE, not a shadow in the usual direction: the ConfigMap renders this key EMPTY (the chart default; the instance uses the NAMED registry shape instead). Deleting this entry would blank the legacy single-registry URL rather than fall back to anything."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PluginCatalog__AutoUpdateByDefault",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Features__Ai__Clis__ClaudeCode",
+        "value": "true",
+        "reason": "SOLE SOURCE on the pod — the ConfigMap carries no such key, so nothing in any repository states that the Claude Code CLI harness is on. Precisely: the chart CAN render it (`config.yaml`, guarded by `{{ if hasKey .Values.config.memex_portal \"Features__Ai__Clis__ClaudeCode\" }}`), but no committed values file declares it, so nothing is rendered and the inline entry is the only source. Putting it in this record's `extraPortalConfig` is what would give it a ConfigMap home."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Features__Ai__Clis__Copilot",
+        "value": "true",
+        "reason": "SOLE SOURCE on the pod — as above, for the Copilot CLI harness: chart-renderable behind the same hasKey guard, declared by no committed file."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Features__Ai__Providers__AzureOpenAI",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": false,
+        "reason": "🚨 DISAGREES. The ConfigMap renders `false` and the pod runs `true`: the AzureOpenAI provider is ON live while every committed file says it is off. Recorded rather than reconciled, because turning it off is a behaviour decision, not a tidy-up."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Features__Ai__Providers__AzureFoundry",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PreWarm__GateReadiness",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true,
+        "reason": "Redundant since the 2026-09-06 11:24Z deploy rendered the same value. Removing it here leaves the gate ARMED — the opposite act to memex-cloud, where the inline entry reads `false` and removing it arms the gate."
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PreWarm__BatchBake",
+        "value": "true",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "PreWarm__PrebuiltBundleRoot",
+        "value": "/data/prebuilt-bundles",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "Grpc__TrustedPort",
+        "value": "8082",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__Http__Url",
+        "value": "http://0.0.0.0:8080",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__Grpc__Url",
+        "value": "http://0.0.0.0:8081",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__Grpc__Protocols",
+        "value": "Http2",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__GrpcTrusted__Url",
+        "value": "http://127.0.0.1:8082",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      },
+      {
+        "$type": "InlineEnvOverride",
+        "key": "ASPNETCORE_Kestrel__Endpoints__GrpcTrusted__Protocols",
+        "value": "Http2",
+        "shadows": "memex-portal-config",
+        "agreesWithShadowed": true
+      }
+    ]
+  }
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/Fixtures/pearl.json
+++ b/test/MeshWeaver.Deployment.Contract.Test/Fixtures/pearl.json
@@ -1,0 +1,177 @@
+{
+  "$type": "MeshNode",
+  "id": "pearl",
+  "namespace": "Deployments",
+  "path": "Deployments/pearl",
+  "mainNode": "Deployments/pearl",
+  "name": "pearl",
+  "description": "Customer portal (Pearl Technology AG).",
+  "nodeType": "Hosting/Deployment",
+  "state": "Active",
+  "content": {
+    "$type": "DeploymentContent",
+    "host": "pearl.meshweaver.cloud",
+    "namespace": "pearl",
+    "cluster": "memexaks-cluster",
+    "database": "pearl",
+    "databaseServer": "memexaks-pg",
+    "imageRepository": "cr.meshweaver.cloud/memex-portal-ai",
+    "updatePolicy": "Stable",
+    "owner": "Pearl Technology AG",
+    "purpose": "Customer portal for Pearl Technology AG — trial deployment following the 2026-08-21 workshop.",
+    "status": "Provisioning",
+    "keyVault": "Systemorph",
+    "keyVaultSecretPrefix": "pearl-",
+    "configPath": "deployments/aks/pearl",
+    "repository": "https://github.com/Systemorph/Memex",
+    "dnsZone": "meshweaver.cloud",
+    "helmRelease": "pearl",
+    "backupStore": "Deployments/aks-db-backups",
+    "extraPortalConfig": {
+      "Hosting__Deployment": "pearl",
+      "Hosting__ReportTo": "https://memex.systemorph.com",
+      "PreWarm__BatchBake": "true",
+      "PreWarm__DynamicTypes": "true",
+      "PreWarm__GateReadiness": "true"
+    },
+    "pluginRepos": [
+      {
+        "$type": "PluginRepoMount",
+        "name": "Plugins",
+        "url": "https://memex.meshweaver.cloud",
+        "isRegistrySource": false
+      }
+    ],
+    "preInstall": [
+      "Essentials"
+    ],
+    "notes": "Record created for Memex#119. Resource envelope is the lighter customer-portal one (requests 2 CPU / 4Gi, limits 4 / 8Gi; PVCs data 16Gi, content 64Gi, attachments 32Gi, users 16Gi) — a customer portal with a lighter load than `memex-cloud`.\n\nThe four decisions Memex#119 §7 left open are now ANSWERED (2026-08-27), and this is what was decided:\n\n1. `preInstall: [\"Essentials\"]` — the basic plugins. `Essentials` is 'the platform's default skills, the chat / menu, pre-installed for everyone' and declares the baseline closure through `requires`: Agent, Store, Export, Observability, Mcp, Notifications, Mail, Teams, OpenAI, AzureFoundry, WebSearch, Indexing. Naming the one id keeps the record honest about the INTENT; the closure is resolved by the installer rather than frozen here. ⚠️ An empty `preInstall` would NOT have meant 'the baseline' — `InstanceSpec.InstallPatterns` returns no patterns for an empty list, so `PluginCatalog:InstallByDefault` renders nothing and the instance seeds nothing.\n\n2. `pluginRepos[0].name = \"Plugins\"` — NOT `pearl`. For a consumer mount the name is the REGISTRY's name (`PluginCatalog:Registries:0:Name`), and it is what a bare pre-install id is qualified against: `Essentials` becomes `Plugins/Essentials`. The catalog matches that against the package's own `Source` stamp and FAILS CLOSED when it cannot. A mount named after this instance would render `pearl/Essentials`, match nothing, and bring the portal up with an empty catalog and no error. `Plugins` is the source name memex-cloud stamps on the MeshWeaver.Plugins packages (asserted in Hosting/Deployment/Test). If Pearl Technology also needs the Education catalogue, that is a SECOND mount named `Education`.\n\n3. Idle policy — INDEFINITE, decided deliberately. `idleSuspendDays` and `idleTeardownDays` are both left unset, which the schema reads as 'never' (`DeploymentContent.IdleSuspendDays`, null = never). The instance therefore never lapses on its own: ending the two-month engagement is an explicit Suspend, taken by a person. Recorded here so the absence reads as a decision rather than an oversight.\n\n4. `database: pearl` per the customer brief, confirmed. The self-service `InstanceRequest` flow would derive `pearldb`; the divergence is accepted, not accidental.\n\n**2026-09-08 — provisioning from the fleet's own registry (Memex#119, MeshWeaver#3353, MeshWeaver.Plugins#1514, Memex#244).** `imageRepository` moved to `cr.meshweaver.cloud/memex-portal-ai` with `imagePullSecret: registry-pull` (the operator's `hosting-pull-secret` creates that Secret from the instance key in Key Vault); `pinnedImageTag: 3.0.0-ci.8080` is the build memex.meshweaver.cloud runs on 2026-09-08 08:0xZ (`/api/version` commit `67cbbe0ee` = CD #8080, ACR tag `3.0.0-ci.8080`); the `Stable` policy rolls it to the clean `3.0.0` when that exists. `volumes[].create: true` makes the chart render the four PersistentVolumeClaims itself (`persistence.<name>.create`, MeshWeaver#3696) — this is a NEW namespace, nothing was ever applied by hand there. `status: Provisioning`. Two decisions are deliberately OPEN and recorded here so the absence reads as a decision:\n\n1. **Email is DISABLED for the first boot** (`email.enabled: false`). The overlay had borrowed memex-cloud's Email client id and secret (Memex#119, 2026-09-03 comment); a customer portal must not send through the public instance's mail app. Pearl gets its own mail app registration before any invitation is sent — until then the NoOp sender is selected and invitations are NOT delivered.\n\n2. **No AI provider is configured.** The offer has Pearl Technology sourcing models through their own OpenRouter account; no key exists yet, so no provider is set and the AI stack stays off until a key is provisioned as the vault object `pearl-OpenRouter-ApiKey` and mapped here.",
+    "pinnedImageTag": "3.0.0-ci.8080",
+    "imagePullSecret": "registry-pull",
+    "replicas": 1,
+    "databaseUsername": "memexadmin",
+    "databaseConnectionSecret": "pearl-db-connection",
+    "resources": {
+      "requests": {
+        "cpu": "2",
+        "memory": "4Gi"
+      },
+      "limits": {
+        "cpu": "4",
+        "memory": "8Gi"
+      }
+    },
+    "volumes": [
+      {
+        "name": "data",
+        "claimName": "memex-data",
+        "mountPath": "/data",
+        "size": "16Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany",
+        "create": true
+      },
+      {
+        "name": "content",
+        "claimName": "memex-content",
+        "mountPath": "/mnt/content",
+        "size": "64Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany",
+        "create": true
+      },
+      {
+        "name": "attachments",
+        "claimName": "memex-attachments",
+        "mountPath": "/mnt/attachments",
+        "size": "32Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany",
+        "create": true
+      },
+      {
+        "name": "users",
+        "claimName": "memex-users",
+        "mountPath": "/mnt/users",
+        "size": "16Gi",
+        "storageClass": "azurefile-memex",
+        "accessMode": "ReadWriteMany",
+        "create": true
+      }
+    ],
+    "ingress": {
+      "className": "webapprouting.kubernetes.azure.com",
+      "tlsSecret": "pearl-tls",
+      "annotations": {
+        "nginx.ingress.kubernetes.io/proxy-buffer-size": "16k",
+        "nginx.ingress.kubernetes.io/proxy-buffers-number": "4"
+      },
+      "sessionAffinity": {
+        "enabled": true,
+        "cookieName": "PEARL_AFFINITY",
+        "nginxAnnotations": {},
+        "agicAnnotations": {}
+      }
+    },
+    "keyVaultSecrets": {
+      "$type": "KeyVaultSecretsSpec",
+      "vaultName": "Systemorph",
+      "tenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6",
+      "identityClientId": "6c9dcc8d-d5b3-4545-afa1-209b33e8a1ba",
+      "name": "pearl-portal-keyvault",
+      "syncedSecret": "pearl-portal-keyvault",
+      "volumeName": "kv-portal-keyvault",
+      "mountPath": "/mnt/kv-portal-keyvault",
+      "secrets": [
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "ConnectionStrings__memex",
+          "vaultSecret": "pearl-db-connection"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "Ai__KeyProtection__MasterKey",
+          "vaultSecret": "pearl-Ai-KeyProtection-MasterKey"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "Authentication__Microsoft__ClientSecret",
+          "vaultSecret": "pearl-Authentication-Microsoft-ClientSecret"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "PluginCatalog__RegistryToken",
+          "vaultSecret": "pearl-PluginCatalog-RegistryToken"
+        },
+        {
+          "$type": "KeyVaultSecretRef",
+          "key": "PluginCatalog__Registries__0__Token",
+          "vaultSecret": "pearl-PluginCatalog-RegistryToken"
+        }
+      ]
+    },
+    "signIn": {
+      "provider": "Custom",
+      "microsoftClientId": "0bf432c4-acbe-4a61-96f3-b78742e341be",
+      "microsoftTenantId": "3a01d7ac-3330-444d-942d-975eb491b5d6"
+    },
+    "email": {
+      "enabled": false
+    },
+    "storage": {
+      "backend": "Filesystem",
+      "dataRoot": "/data",
+      "contentPath": "/mnt/content",
+      "contentName": "content",
+      "contentSourceType": "FileSystem",
+      "graphStorageType": "PostgreSql",
+      "claudeCodeConfigDirRoot": "/mnt/users"
+    },
+    "startupProbe": {
+      "periodSeconds": 10,
+      "timeoutSeconds": 5,
+      "failureThreshold": 1080,
+      "budgetSeconds": 10800
+    }
+  }
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/FluentBuilderTest.cs
+++ b/test/MeshWeaver.Deployment.Contract.Test/FluentBuilderTest.cs
@@ -61,9 +61,11 @@ public class FluentBuilderTest
     public void TheSameRecordRendersTheSameKeysForHelmAndForAspire()
     {
         // The two renderers differ in exactly the ways PortalConfigOptions names: Helm emits the
-        // MEMEX_* database keys from the record (Aspire's Postgres resource injects its own), and
-        // Aspire emits the plugin-catalog boot wiring as env (Helm hands the same entries to the
-        // operator's catalog config file). Everything else is one derivation, key for key.
+        // MEMEX_* database keys from the record (Aspire's Postgres resource injects its own) and
+        // the in-cluster Mcp__BaseUrl (the adapter sets that key to the endpoint Aspire allocates,
+        // so the derivation emits nothing for it — never a blank); Aspire emits the plugin-catalog
+        // boot wiring as env (Helm hands the same entries to the operator's catalog config file).
+        // Everything else is one derivation, key for key.
         var record = DeploymentRecordJson.ReadFile(Path.Combine(AppContext.BaseDirectory, "Fixtures", "memex.json"));
         var helm = DeploymentPortalConfig.PortalConfig(record, PortalConfigOptions.Helm);
         var aspire = DeploymentPortalConfig.PortalConfig(record, PortalConfigOptions.Aspire(mcpBaseUrl: null));
@@ -71,17 +73,18 @@ public class FluentBuilderTest
         var helmOnly = helm.Keys.Except(aspire.Keys).ToList();
         var aspireOnly = aspire.Keys.Except(helm.Keys).ToList();
 
-        Assert.True(helmOnly.All(k => k.StartsWith("MEMEX_", StringComparison.Ordinal)),
-            "keys Helm renders and Aspire does not, beyond the database keys: " + string.Join(", ", helmOnly));
+        Assert.False(aspire.ContainsKey("Mcp__BaseUrl"), "the Aspire view must not emit a blank Mcp__BaseUrl — the adapter owns that key");
+        Assert.True(helmOnly.All(k => k.StartsWith("MEMEX_", StringComparison.Ordinal) || k == "Mcp__BaseUrl"),
+            "keys Helm renders and Aspire does not, beyond the database keys and the in-cluster MCP URL: " + string.Join(", ", helmOnly));
         Assert.True(aspireOnly.All(k => k.StartsWith("PluginCatalog__", StringComparison.Ordinal)),
             "keys Aspire renders and Helm does not, beyond the catalog boot wiring: " + string.Join(", ", aspireOnly));
         Assert.True(helmOnly.Count > 0 && aspireOnly.Count > 0, "the memex record should exercise both documented differences");
 
         var shared = helm.Keys.Intersect(aspire.Keys).ToList();
-        var differing = shared.Where(k => k != "Mcp__BaseUrl" && helm[k] != aspire[k]).ToList();
+        var differing = shared.Where(k => helm[k] != aspire[k]).ToList();
         Assert.True(shared.Count > 40, $"only {shared.Count} shared keys — the memex record renders far more");
         Assert.True(differing.Count == 0,
-            "shared keys whose value differs between the renderers (only Mcp__BaseUrl may): " + string.Join(", ", differing));
+            "shared keys whose value differs between the renderers: " + string.Join(", ", differing));
     }
 
     [Fact]

--- a/test/MeshWeaver.Deployment.Contract.Test/FluentBuilderTest.cs
+++ b/test/MeshWeaver.Deployment.Contract.Test/FluentBuilderTest.cs
@@ -1,0 +1,96 @@
+using MeshWeaver.Deployment;
+using Xunit;
+
+namespace MeshWeaver.Deployment.Contract.Test;
+
+/// <summary>
+/// The fluent surface is a set of PURE transforms of the record: each call returns a new record,
+/// leaves its input untouched, composes, and needs no Aspire — the same calls serve an AppHost,
+/// the setup wizard, the template generator and a test. Defaults come from the record, never
+/// from the builder.
+/// </summary>
+public class FluentBuilderTest
+{
+    [Fact]
+    public void EveryTransformLeavesItsInputUntouched()
+    {
+        var bare = new DeploymentContent();
+        var built = bare
+            .WithHost("portal.example.com", "example.com")
+            .WithNamespace("portal")
+            .WithDatabase("portal", server: "pg-portal")
+            .WithImage("ghcr.io/systemorph/memex-portal-ai", tag: "3.1.0")
+            .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")
+            .PreInstall("MeshWeaver.Plugins/Hosting")
+            .WithRequiredModule("MeshWeaver.Hosting.Postgres")
+            .WithVolume("data", "/data", size: "128Gi")
+            .WithReplicas(2)
+            .WithKeyVault("kv-portal", "portal-")
+            .WithKeyVaultSecrets(s => s.Map("Email__ClientSecret", "email-clientsecret"))
+            .WithSignIn(microsoftClientId: "client", microsoftTenantId: "tenant")
+            .WithEmail(mailboxAddress: "portal@example.com")
+            .WithAi(a => a.OpenRouter(["anthropic/claude-sonnet-4"]).Tiers(heavy: "anthropic/claude-opus-4"))
+            .WithOperator(ns: "hosting")
+            .WithStartupProbe(periodSeconds: 10, failureThreshold: 60)
+            .WithPortalConfig("Features__Onboarding__InvitationOnly", "true");
+
+        // The input is what it was.
+        Assert.Equal(DeploymentRecordJson.Write(new DeploymentContent()), DeploymentRecordJson.Write(bare));
+
+        // And the output carries every call.
+        Assert.Equal("portal.example.com", built.Host);
+        Assert.Equal("portal", built.Namespace);
+        Assert.Equal("portal", built.Database);
+        Assert.Equal("3.1.0", built.PinnedImageTag);
+        Assert.Single(built.PluginRepos);
+        Assert.Equal(["MeshWeaver.Plugins/Hosting"], built.PreInstall);
+        Assert.Contains("MeshWeaver.Hosting.Postgres", built.RequiredModules);
+        Assert.Single(built.Volumes);
+        Assert.Equal(2, built.Replicas);
+        Assert.Equal("kv-portal", built.KeyVault);
+        Assert.Contains(built.KeyVaultSecrets!.Secrets, s => s.Key == "Email__ClientSecret" && s.VaultSecret == "email-clientsecret");
+        Assert.Equal("client", built.SignIn!.MicrosoftClientId);
+        Assert.Equal("portal@example.com", built.Email!.MailboxAddress);
+        Assert.Equal("anthropic/claude-opus-4", built.Ai!.Tiers!.Heavy);
+        Assert.Equal("hosting", built.Operator!.Namespace);
+        Assert.Equal(60, built.StartupProbe!.FailureThreshold);
+        Assert.Equal("true", built.ExtraPortalConfig["Features__Onboarding__InvitationOnly"]);
+    }
+
+    [Fact]
+    public void TheSameRecordRendersTheSameKeysForHelmAndForAspire()
+    {
+        // The two renderers differ in exactly the ways PortalConfigOptions names: Helm emits the
+        // MEMEX_* database keys from the record (Aspire's Postgres resource injects its own), and
+        // Aspire emits the plugin-catalog boot wiring as env (Helm hands the same entries to the
+        // operator's catalog config file). Everything else is one derivation, key for key.
+        var record = DeploymentRecordJson.ReadFile(Path.Combine(AppContext.BaseDirectory, "Fixtures", "memex.json"));
+        var helm = DeploymentPortalConfig.PortalConfig(record, PortalConfigOptions.Helm);
+        var aspire = DeploymentPortalConfig.PortalConfig(record, PortalConfigOptions.Aspire(mcpBaseUrl: null));
+
+        var helmOnly = helm.Keys.Except(aspire.Keys).ToList();
+        var aspireOnly = aspire.Keys.Except(helm.Keys).ToList();
+
+        Assert.True(helmOnly.All(k => k.StartsWith("MEMEX_", StringComparison.Ordinal)),
+            "keys Helm renders and Aspire does not, beyond the database keys: " + string.Join(", ", helmOnly));
+        Assert.True(aspireOnly.All(k => k.StartsWith("PluginCatalog__", StringComparison.Ordinal)),
+            "keys Aspire renders and Helm does not, beyond the catalog boot wiring: " + string.Join(", ", aspireOnly));
+        Assert.True(helmOnly.Count > 0 && aspireOnly.Count > 0, "the memex record should exercise both documented differences");
+
+        var shared = helm.Keys.Intersect(aspire.Keys).ToList();
+        var differing = shared.Where(k => k != "Mcp__BaseUrl" && helm[k] != aspire[k]).ToList();
+        Assert.True(shared.Count > 40, $"only {shared.Count} shared keys — the memex record renders far more");
+        Assert.True(differing.Count == 0,
+            "shared keys whose value differs between the renderers (only Mcp__BaseUrl may): " + string.Join(", ", differing));
+    }
+
+    [Fact]
+    public void ABareRecordStatesItsStorageAndPort()
+    {
+        // Rule (c): defaults live on the record. A bare record already renders a bootable portal.
+        var config = DeploymentPortalConfig.PortalConfig(new DeploymentContent(), PortalConfigOptions.Aspire(mcpBaseUrl: null));
+        Assert.Equal("PostgreSql", config["Graph__Storage__Type"]);
+        Assert.Equal("Filesystem", config["Deployment__Backend"]);
+        Assert.Equal("8080", config["ASPNETCORE_HTTP_PORTS"]);
+    }
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/MeshWeaver.Deployment.Contract.Test.csproj
+++ b/test/MeshWeaver.Deployment.Contract.Test/MeshWeaver.Deployment.Contract.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- The Deployment record contract: real fleet records round-trip through it without losing a
+       field, the record binds from configuration the way the portal reads it (Deployment:Record),
+       the fluent builder is a set of pure transforms, and the parity table in
+       Doc/Architecture/ConfiguringAnInstanceFromAspire IS the contract between the fluent surface,
+       the record's fields and the keys both renderers emit (RendererParityTest reads the page). -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.Deployment.Contract\MeshWeaver.Deployment.Contract.csproj" />
+    <!-- ConfigurationBuilder + AddInMemoryCollection (Microsoft.Extensions.Configuration rides in). -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Three Hosting/Deployment records as the control instance holds them (Systemorph/Memex,
+         main, 2026-09-08): memex (40 content keys), pearl (35), memex-cloud (44). -->
+    <None Include="Fixtures\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/test/MeshWeaver.Deployment.Contract.Test/RecordRoundTripTest.cs
+++ b/test/MeshWeaver.Deployment.Contract.Test/RecordRoundTripTest.cs
@@ -1,0 +1,114 @@
+using System.Text.Json.Nodes;
+using MeshWeaver.Deployment;
+using Xunit;
+
+namespace MeshWeaver.Deployment.Contract.Test;
+
+/// <summary>
+/// A real fleet record, read through the contract and written back, loses NOTHING. This is the
+/// assertion that makes <see cref="DeploymentContent"/> the ONE input: a field the contract
+/// silently drops (the JSON options skip unmapped members on purpose, so a renamed or forgotten
+/// property is invisible to the compiler) would reach Helm from the mesh and never reach Aspire —
+/// the 41 silent record/overlay differences measured on 2026-09-06 were exactly this shape.
+/// </summary>
+public class RecordRoundTripTest
+{
+    public static TheoryData<string> Fixtures => new() { "memex.json", "pearl.json", "memex-cloud.json" };
+
+    [Theory]
+    [MemberData(nameof(Fixtures))]
+    public void EveryFieldOfARealRecordSurvivesTheContract(string fixture)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", fixture);
+        Assert.True(File.Exists(path), $"fixture not copied to the test output: {path}");
+
+        var content = JsonNode.Parse(File.ReadAllText(path))!["content"]!.AsObject();
+        var record = DeploymentRecordJson.ReadFile(path);
+        var json = DeploymentRecordJson.Write(record);
+        var written = JsonNode.Parse(json)!.AsObject();
+
+        // The contract writes fields, never derivations — what Deployment:Record carries is the
+        // record as it rests in the mesh (IgnoreReadOnlyProperties).
+        foreach (var derivation in Derivations)
+            Assert.DoesNotContain($"\"{derivation}\"", json);
+
+        // Every value the record holds must come back as it was. The contract may write MORE — a
+        // record has defaults (`enabled: false`, an empty list, the default storage layout) that a
+        // node at rest omits — so the comparison is "the record is a subset of what was written",
+        // recursively, with the same values at every leaf.
+        var compared = 0;
+        var mismatches = new List<string>();
+        foreach (var (key, value) in content)
+        {
+            if (key == "$type" || value is null) continue;
+            compared++;
+            Subset(key, value, written[key], mismatches);
+        }
+
+        // 🚨 The denominator: an empty content object would compare nothing and pass.
+        Assert.True(compared >= 30, $"{fixture} compared only {compared} fields — the fixture is not a full record");
+        Assert.True(mismatches.Count == 0,
+            $"{fixture}: {mismatches.Count} values did not survive the contract (of {compared} top-level fields):\n" + string.Join("\n", mismatches));
+    }
+
+    /// <summary>
+    /// The record's computed getters, which a node at rest MAY carry (the mesh wrote pearl's
+    /// <c>startupProbe.budgetSeconds</c> once) and which the contract never writes
+    /// (<c>DeploymentRecordJson.Options.IgnoreReadOnlyProperties</c>): derivations, not fields.
+    /// </summary>
+    private static readonly HashSet<string> Derivations = new(StringComparer.Ordinal)
+        { "budgetSeconds", "effectiveRef", "normalizedName", "normalizedUrl", "isEmpty" };
+
+    /// <summary>Every value under <paramref name="expected"/> is present, with the same value, under <paramref name="actual"/>.</summary>
+    private static void Subset(string path, JsonNode expected, JsonNode? actual, List<string> mismatches)
+    {
+        switch (expected)
+        {
+            case JsonObject o:
+                if (actual is not JsonObject ao) { mismatches.Add($"{path}: expected an object, the contract wrote {Describe(actual)}"); return; }
+                foreach (var (key, value) in o)
+                {
+                    if (key == "$type" || value is null || Derivations.Contains(key)) continue;
+                    Subset($"{path}.{key}", value, ao[key], mismatches);
+                }
+                return;
+            case JsonArray a:
+                if (actual is not JsonArray aa) { mismatches.Add($"{path}: expected an array, the contract wrote {Describe(actual)}"); return; }
+                if (aa.Count != a.Count) { mismatches.Add($"{path}: expected {a.Count} elements, the contract wrote {aa.Count}"); return; }
+                for (var i = 0; i < a.Count; i++)
+                    if (a[i] is { } element) Subset($"{path}[{i}]", element, aa[i], mismatches);
+                return;
+            default:
+                var expectedLeaf = expected.ToJsonString();
+                var actualLeaf = actual is null or JsonObject or JsonArray ? null : actual.ToJsonString();
+                if (actualLeaf != expectedLeaf)
+                    mismatches.Add($"{path}: record {expectedLeaf}, the contract wrote {Describe(actual)}");
+                return;
+        }
+    }
+
+    private static string Describe(JsonNode? node) => node is null
+        ? "<absent — the field is not on DeploymentContent, or is skipped>"
+        : Canonical(node);
+
+    [Theory]
+    [MemberData(nameof(Fixtures))]
+    public void ReadingWritingAndReadingAgainIsAFixedPoint(string fixture)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", fixture);
+        var once = DeploymentRecordJson.Write(DeploymentRecordJson.ReadFile(path));
+        var twice = DeploymentRecordJson.Write(DeploymentRecordJson.Read(once)!);
+        Assert.Equal(once, twice);
+    }
+
+    /// <summary>A key-sorted, null-free, <c>$type</c>-free rendering — what "the same value" means across the mesh's serializer and the contract's.</summary>
+    internal static string Canonical(JsonNode node) => node switch
+    {
+        JsonObject o => "{" + string.Join(",",
+            o.Where(p => p.Key != "$type" && p.Value is not null)
+             .OrderBy(p => p.Key, StringComparer.Ordinal)
+             .Select(p => $"\"{p.Key}\":{Canonical(p.Value!)}")) + "}",
+        JsonArray a => "[" + string.Join(",", a.Where(i => i is not null).Select(i => Canonical(i!))) + "]",
+        _ => node.ToJsonString(),
+    };
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/RendererParityTest.cs
+++ b/test/MeshWeaver.Deployment.Contract.Test/RendererParityTest.cs
@@ -1,0 +1,208 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using MeshWeaver.Deployment;
+using Xunit;
+
+namespace MeshWeaver.Deployment.Contract.Test;
+
+/// <summary>
+/// The parity table in <c>Doc/Architecture/ConfiguringAnInstanceFromAspire</c> (method → record
+/// field → Helm value → config key) IS the contract between the fluent surface, the record and the
+/// two renderers, and this test holds the code to the page: every method the table names exists,
+/// every method the code has is in the table, every field the table names is on the record, every
+/// public field of the record is reachable from the table, and every config key the table names is
+/// emitted by the derivation both renderers share.
+/// </summary>
+public class RendererParityTest
+{
+    private static readonly Regex Row = new(@"^\|\s*`(?<method>[^`]+)`\s*\|(?<fields>[^|]*)\|(?<helm>[^|]*)\|(?<keys>[^|]*)\|", RegexOptions.Compiled);
+    private static readonly Regex Code = new(@"`([^`]+)`", RegexOptions.Compiled);
+
+    private sealed record TableRow(string Method, string[] Fields, string[] Keys, int Line);
+
+    private static readonly Regex StateRow = new(@"^\|\s*`(?<field>[^`]+)`\s*\|", RegexOptions.Compiled);
+
+    /// <summary>The "Fields no method sets" table: record fields the operator writes, exempt from fluent reachability.</summary>
+    private static HashSet<string> ReadStateFields()
+    {
+        var root = RepoRoot()!;
+        var page = Path.Combine(root, "src", "MeshWeaver.Documentation", "Data", "Architecture", "ConfiguringAnInstanceFromAspire.md");
+        var fields = new HashSet<string>(StringComparer.Ordinal);
+        var inTable = false;
+        foreach (var line in File.ReadAllLines(page))
+        {
+            if (line.StartsWith("| Field | Written by |", StringComparison.Ordinal)) { inTable = true; continue; }
+            if (!inTable) continue;
+            if (!line.StartsWith("|", StringComparison.Ordinal)) break;
+            if (line.StartsWith("|---", StringComparison.Ordinal)) continue;
+            var m = StateRow.Match(line);
+            if (m.Success) fields.Add(m.Groups["field"].Value);
+        }
+        return fields;
+    }
+
+    private static string? RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName;
+    }
+
+    private static List<TableRow> ReadTable()
+    {
+        var root = RepoRoot();
+        Assert.SkipWhen(root is null, "repository tree not reachable from the test bin — the parity table lives in the doc tree");
+        var page = Path.Combine(root!, "src", "MeshWeaver.Documentation", "Data", "Architecture", "ConfiguringAnInstanceFromAspire.md");
+        Assert.True(File.Exists(page), $"the parity page is not at {page}");
+
+        var rows = new List<TableRow>();
+        var lines = File.ReadAllLines(page);
+        var inTable = false;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.StartsWith("| Method |", StringComparison.Ordinal)) { inTable = true; continue; }
+            if (!inTable) continue;
+            if (!line.StartsWith("|", StringComparison.Ordinal)) break;
+            if (line.StartsWith("|---", StringComparison.Ordinal)) continue;
+            var m = Row.Match(line);
+            Assert.True(m.Success, $"line {i + 1} of the parity table does not parse as a row: {line}");
+            var method = m.Groups["method"].Value;
+            method = method[..method.IndexOf('(')].Trim();
+            var fields = Code.Matches(m.Groups["fields"].Value).Select(x => x.Groups[1].Value).ToArray();
+            var keys = Code.Matches(m.Groups["keys"].Value).Select(x => x.Groups[1].Value).ToArray();
+            rows.Add(new TableRow(method, fields, keys, i + 1));
+        }
+        Assert.True(rows.Count >= 40, $"the parity table has {rows.Count} rows — the fluent surface has far more methods");
+        return rows;
+    }
+
+    private static IEnumerable<MethodInfo> RecordTransforms() =>
+        typeof(DeploymentRecordExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(m => m.GetParameters().Length > 0 && m.GetParameters()[0].ParameterType == typeof(DeploymentContent));
+
+    [Fact]
+    public void EveryMethodInTheTableExistsAndEveryMethodIsInTheTable()
+    {
+        var rows = ReadTable();
+        var code = RecordTransforms().Select(m => m.Name).ToHashSet(StringComparer.Ordinal);
+        var table = rows.Select(r => r.Method).ToHashSet(StringComparer.Ordinal);
+
+        var phantom = table.Except(code).ToList();
+        Assert.True(phantom.Count == 0, "methods the table names that DeploymentRecordExtensions does not have: " + string.Join(", ", phantom));
+
+        var undocumented = code.Except(table).ToList();
+        Assert.True(undocumented.Count == 0, "record transforms missing from the parity table (add a row): " + string.Join(", ", undocumented));
+    }
+
+    [Fact]
+    public void EveryFieldInTheTableIsOnTheRecordAndEveryRecordFieldIsInTheTable()
+    {
+        var rows = ReadTable();
+        var bad = new List<string>();
+        foreach (var row in rows)
+            foreach (var field in row.Fields)
+                if (field != "—" && Resolve(typeof(DeploymentContent), field) is null)
+                    bad.Add($"line {row.Line}: `{field}`");
+        Assert.True(bad.Count == 0, "fields the table names that the record does not have: " + string.Join("; ", bad));
+
+        var documentedTopLevel = rows.SelectMany(r => r.Fields).Select(f => f.Split('.', '[')[0]).ToHashSet(StringComparer.Ordinal);
+        var stateFields = ReadStateFields();
+        Assert.True(stateFields.Count is >= 1 and <= 5, $"the operator-written table lists {stateFields.Count} fields — it is an exemption list, and it is growing");
+        documentedTopLevel.UnionWith(stateFields);
+        var recordFields = typeof(DeploymentContent).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanWrite).Select(p => p.Name).ToList();
+        Assert.True(recordFields.Count >= 40, $"DeploymentContent exposes {recordFields.Count} fields — the transcription is incomplete");
+        var unreachable = recordFields.Except(documentedTopLevel).ToList();
+        Assert.True(unreachable.Count == 0, "record fields no row of the parity table reaches: " + string.Join(", ", unreachable));
+    }
+
+    [Fact]
+    public void EveryConfigKeyInTheTableIsEmittedByTheSharedDerivation()
+    {
+        var rows = ReadTable();
+        var record = FullyPopulated();
+        var helm = DeploymentPortalConfig.PortalConfig(record, PortalConfigOptions.Helm);
+        var aspire = DeploymentPortalConfig.PortalConfig(record, PortalConfigOptions.Aspire("http://localhost:8080"));
+        var emitted = helm.Keys.Union(aspire.Keys).ToHashSet(StringComparer.Ordinal);
+
+        var checkedKeys = 0;
+        var missing = new List<string>();
+        foreach (var row in rows)
+            foreach (var key in row.Keys)
+            {
+                if (key == "—") continue;
+                checkedKeys++;
+                // A `Prefix__*` names a family (the extras, the model providers); one member suffices.
+                var ok = key.EndsWith("*", StringComparison.Ordinal)
+                    ? emitted.Any(k => k.StartsWith(key[..^1], StringComparison.Ordinal))
+                    : emitted.Contains(key);
+                if (!ok) missing.Add($"line {row.Line}: {key}");
+            }
+
+        Assert.True(checkedKeys >= 40, $"only {checkedKeys} config keys named in the table");
+        Assert.True(missing.Count == 0,
+            $"config keys the table promises that neither renderer emits for a fully populated record ({emitted.Count} keys emitted):\n" + string.Join("\n", missing));
+    }
+
+    /// <summary>A record with every typed block set — so a key that depends on a block being present is emitted.</summary>
+    internal static DeploymentContent FullyPopulated() =>
+        new DeploymentContent()
+            .WithHost("portal.example.com", "example.com")
+            .WithNamespace("portal", "portal")
+            .WithCluster("aks-fleet")
+            .WithOwner("owner", "purpose")
+            .WithConfigRepository("Systemorph/Memex", "environments/portal")
+            .WithGrafana("https://grafana.example.com")
+            .WithDatabase("portal", server: "pg-portal", username: "memex", host: "pg-portal.postgres.database.azure.com", port: 5432, connectionSecret: "portal-pg-connection")
+            .WithImage("ghcr.io/systemorph/memex-portal-ai", tag: "3.1.0", pullSecret: "ghcr-pull")
+            .WithUpdatePolicy("stable").WithMinRollInterval("00:30:00").WithAutoRecycleOnStaleBuild(true)
+            .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")
+            .PreInstall("MeshWeaver.Plugins/Hosting")
+            .WithRequiredModule("MeshWeaver.Hosting.Postgres")
+            .WithReplicas(2).WithOrleansClustering("AdoNet").WithHttpPort(8080)
+            .WithResources("500m", "2Gi", "2", "8Gi")
+            .WithAutoscaling(true, 1, 4, 70, 80)
+            .WithVolume("data", "/data", size: "128Gi", storageClass: "azurefile", accessMode: "ReadWriteMany")
+            .WithIngress("nginx", "portal-tls", sessionAffinity: true)
+            .WithStartupProbe(10, 5, 60)
+            .WithDrain(30, 10)
+            .WithStorageLayout(s => s with { ClaudeCodeConfigDirRoot = "/mnt/users" })
+            .WithStorageAccount("stportal", "portal-storage-connection")
+            .WithGate("python", "ghcr.io/systemorph/gate-python:1")
+            .WithKeyVault("kv-portal", "portal-")
+            .WithKeyVaultSecrets(s => s.Map("Email__ClientSecret", "email-clientsecret"), tenantId: "tenant", identityClientId: "identity")
+            .WithVaultValuesKeys("Ai__KeyProtection__MasterKey")
+            .WithInlineEnv("LOG_LEVEL", "Information")
+            .WithSignIn("Custom", microsoftClientId: "ms", microsoftTenantId: "tenant", googleClientId: "google", linkedInClientId: "linkedin", appleClientId: "apple", enableDevLogin: false)
+            .WithEmail(true, "portal@example.com", "email-client", "tenant", useManagedIdentity: false, inboundEnabled: true, webhookBaseUrl: "https://portal.example.com", inboundForwardAddress: "inbox@example.com")
+            .WithGitHubApp("gh-client", "12345", "Systemorph")
+            .WithSocialLinkedIn("linkedin")
+            .WithAi(a => a.OpenRouter(["anthropic/claude-sonnet-4"]).Anthropic(["claude-sonnet-4"], enabled: true).AzureFoundry(["gpt-5"], enabled: true).AzureAis(["deepseek"]).Tiers("heavy", "standard", "light", "utility"))
+            .WithOperator(true, "hosting", "hosting-operator", "ghcr.io/systemorph/hosting-operator:1")
+            .WithTelemetry("http://otel:4317", "grpc")
+            .WithBackupStore("stbackups")
+            .WithIdlePolicy(30, 90)
+            .WithGracePeriod(14)
+            .WithWebhookInbox("GitHub", "GitHub__WebhookSecret")
+            .WithPortalConfig("Embedding__Endpoint", "https://openrouter.ai/api/v1");
+
+    /// <summary>`Top`, `Top.Nested`, `List[].Element` — resolved against the record's CLR shape.</summary>
+    private static PropertyInfo? Resolve(Type type, string path)
+    {
+        PropertyInfo? property = null;
+        foreach (var raw in path.Split('.'))
+        {
+            var segment = raw.EndsWith("[]", StringComparison.Ordinal) ? raw[..^2] : raw;
+            property = type.GetProperty(segment, BindingFlags.Public | BindingFlags.Instance);
+            if (property is null) return null;
+            type = property.PropertyType;
+            if (raw.EndsWith("[]", StringComparison.Ordinal))
+                type = type.IsGenericType && typeof(IEnumerable).IsAssignableFrom(type) ? type.GetGenericArguments()[0] : type;
+            type = Nullable.GetUnderlyingType(type) ?? type;
+        }
+        return property;
+    }
+}

--- a/test/MeshWeaver.Deployment.Contract.Test/RendererParityTest.cs
+++ b/test/MeshWeaver.Deployment.Contract.Test/RendererParityTest.cs
@@ -156,7 +156,7 @@ public class RendererParityTest
             .WithOwner("owner", "purpose")
             .WithConfigRepository("Systemorph/Memex", "environments/portal")
             .WithGrafana("https://grafana.example.com")
-            .WithDatabase("portal", server: "pg-portal", username: "memex", host: "pg-portal.postgres.database.azure.com", port: 5432, connectionSecret: "portal-pg-connection")
+            .WithDatabase("portal", server: "pg-portal", username: "memex", host: "pg-portal.example.internal", port: 5432, connectionSecret: "portal-pg-connection")
             .WithImage("ghcr.io/systemorph/memex-portal-ai", tag: "3.1.0", pullSecret: "ghcr-pull")
             .WithUpdatePolicy("stable").WithMinRollInterval("00:30:00").WithAutoRecycleOnStaleBuild(true)
             .WithPluginRepo("plugins", "https://github.com/Systemorph/MeshWeaver.Plugins", gitRef: "main")


### PR DESCRIPTION
## The Deployment record is the ONE input

**Maintainer, 2026-09-08:** the record *"must be the only input"* for the Aspire adapter and Helm; *"pipe it somehow into the memex image via config ⇒ see how e.g. orleans interfaces"*; *"create fluent language to configure. give possibilities to configure in the aspire api"*; generating Helm from Aspire (#3646): *"ok. retire"*.

**Rule, now heading `Doc/Architecture/Deployment`:** the Deployment record is the ONE input; Aspire and Helm render from it; the image receives it as configuration (`Deployment:Record`); Aspire emits a record, never a chart.

### What lands

- **`MeshWeaver.Deployment.Contract`** (`src/`, namespace `MeshWeaver.Deployment`): `DeploymentContent` and its nested specs transcribed from the in-mesh Hosting module, `DeploymentRecordExtensions` (the fluent builder — every record field reachable through a pure, composable transform), `DeploymentRecordJson` (`Deployment:Record` / `Deployment__Record`, `Write`/`Read`/`FromConfiguration`/`ReadFile`/`WriteFile`), `DeploymentPortalConfig` (the portal-config derivation the chart and the adapter share; the two renderer differences declared as `PortalConfigOptions.Helm` / `.Aspire`). Zero MeshWeaver references; **bundled inside the `MeshWeaver.Aspire.Hosting.Memex` nupkg** (`PackContractAssembly`, asserted by `publish-packages.yml`) — no third NuGet id. Referenced by `MeshWeaver.PluginCatalog` so it is in the application closure the in-mesh Hosting sources compile against.
- **The Aspire adapter over the record:** `AddMemex(name)` / `AddMemex(name, record)` / `AddMemexFromFile(name, path)` return a builder carrying the record; `With*` delegate one-to-one to the record transforms and re-sync images, volumes, replicas; `WithSecret` (never on the record); `PublishRecord(path)`. The record is injected as `Deployment__Record` plus the derived per-key surface, evaluated at start (the Orleans shape). `MemexOptions` keeps only the defaults that are not record fields.
- **Tests** (`test/MeshWeaver.Deployment.Contract.Test`, 15): three real fleet records (memex, pearl, memex-cloud) round-trip through the contract without losing a value; the record binds back from configuration identically; the memex record renders the same keys for Helm and Aspire except the declared differences; **`RendererParityTest` reads the doc page's parity table** (method → record field → Helm value → config key) and holds the code to it. `DeploymentPathsSupplyStorageTest`'s Aspire half follows its subject to the derivation.
- **Docs:** `Doc/Architecture/ConfiguringAnInstanceFromAspire` (the rule, the fluent surface, the config section, the parity table, the retirement of #3646 with measured reasons, the German labels appendix), the one-line rule + row in `Deployment.md`, cross-links in `DeploymentOptions`, `LocalDevWorkflow`, `OperatingFromThePortal`, `NuGetPackageRetirement` §2 rewritten, `TeamsBot` / `EmailIngestionAndNotifications` / `MemexCloudDeployment` examples; What's New (Feature).
- **`deploy/aspire/Memex.Deploy.AppHost`** declares its instance as a record (`--record-out <path>` writes it) and no longer references `Aspire.Hosting.Kubernetes`.

### Verified locally (Release, `-warnaserror`)

`MeshWeaver.Deployment.Contract`, `Memex.Aspire.Hosting`, `Memex.Deploy.AppHost`, `MeshWeaver.Deployment.Contract.Test`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` build clean. Tests: contract 15/15, `DeploymentPathsSupplyStorageTest` 2/2, `DocumentationLinkIntegrityTest` 1/1. `dotnet pack` of the Aspire integration: one nupkg, `lib/net10.0/MeshWeaver.Deployment.Contract.dll` inside, no new nuspec dependency.

### Framework identity

`MeshWeaver.Deployment.Contract` is in the bake host's closure (through `MeshWeaver.PluginCatalog`), so it joins `FrameworkBuildIdentity.ContentSurfaceAssemblies` — the content surface gains one dependency-free assembly that changes only when the record's shape does. Satellites re-bake once on the release event, as for any new surface assembly.

### Cross-repo

Pairs-with: none — this change adds `src/` surface and removes nothing public from `src/`; the members it deletes (`MemexOptions.*`) live under `memex/aspire/`, which no node repository compiles against.

Plugins half: Systemorph/MeshWeaver.Plugins#1541 (a DRAFT until fleet images carry the assembly and its pin moves — merging to Plugins main edits live portals): the in-mesh Hosting module compiles against the contract instead of its own copy (`using MeshWeaver.Deployment;`, `HelmValues.PortalConfig` → `DeploymentPortalConfig`), and the template AppHost injects the record.

Closes #3646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
