### PR TITLE
fix(operator): the ClusterRole follows the chart; a script cannot name a permission its role lacks

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -260,6 +260,11 @@ az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command \
 
 ## Verify a release is healthy (before declaring done)
 
+🚨 **`/api/version` reports the CD run's RESOLVED target commit**, which can differ from the run's
+`head_sha` when two merges land in one queue group (2026-09-09: set 8131 = run head `e1039813e`,
+`/api/version` = `3853374f7`, one second earlier). To name the set a portal runs, match the commit
+against the run's "Resolve the target commit" job output — never against the run head or `main`.
+
 - Migration log shows `Database migration completed. Version: N` AND the portal serves HTTP 200
   (see [DeploymentAKS.md](../../../src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md)).
 - The self-updater logged its decision (picked newer / already current / held with a reason), not

--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -248,7 +248,12 @@ jobs:
       # scripts will actually execute under in a lifecycle Job.
       - name: Behaviour tests, inside the image
         run: |
+          # The manifests are NOT in the image (only bin/ and the chart are), but the suite's RBAC
+          # coverage case needs the ClusterRole: mount them read-only and name the file, so the
+          # case runs here exactly as on the runner — a missing input is exit 2 and red, not a skip.
           docker run --rm -v "$PWD/deploy/aks/operator/test:/opt/hosting/test:ro" \
+            -v "$PWD/deploy/aks/manifests:/opt/hosting/manifests:ro" \
+            -e HOSTING_RBAC_MANIFEST=/opt/hosting/manifests/hosting-operator/operator-rbac.yaml \
             --entrypoint /bin/bash hosting-operator:ci -c 'cd /opt/hosting && bash test/run-tests.sh'
 
   # ═══════════════════════════════════════════════════════════════════════════════════════════

--- a/deploy/aks/manifests/hosting-operator/README.md
+++ b/deploy/aks/manifests/hosting-operator/README.md
@@ -17,7 +17,9 @@ a nuisance rather than a cloud compromise.
 ```bash
 kubectl apply -f namespace.yaml
 kubectl apply -f operator-serviceaccount.yaml      # edit AZURE_CLIENT_ID annotation first
-kubectl apply -f operator-rbac.yaml
+kubectl apply -f operator-rbac.yaml                # FIRST TIME ONLY — from then on the config repo's
+                                                   # helm-release lane (adopt/deploy) re-applies it from
+                                                   # this repo at the chart pin; see the note below
 kubectl apply -f jobrunner.yaml                    # 🚨 edit the SA/Secret namespace to your CONTROL
                                                    # PORTAL's namespace first — a pod can only mount
                                                    # Secrets from its own namespace, so they live
@@ -84,3 +86,16 @@ The chart's half: `portal.imagePullSecret` renders `imagePullSecrets` on the por
 **and** the migration Job; `selfUpdate.registry` renders `SelfUpdate__Registry`, which makes the
 self-updater list tags over the OCI Distribution API with the same key. Neither is set on the
 mirror instance itself — it cannot serve the image that boots it.
+
+## The ClusterRole follows the chart
+
+`operator-rbac.yaml` is re-applied by `Systemorph/Memex` `helm-release.yml` on every `adopt` and
+`deploy`, read from THIS repository at the same pin the lane renders the chart from. So a script
+that needs a new grant lands with the grant, and the next deploy carries both to the cluster —
+no laptop in the loop. Measured before this existed (2026-09-09): the `storageclasses` rule had
+been on main since the volume-capacity step, the cluster's ClusterRole predated it, and the first
+record-driven Reconcile through the fixed operator stopped at step 1/6 with `Forbidden`.
+`deploy/aks/operator/test/check-rbac-coverage.sh` is the other half: every `kubectl <verb>
+<resource>` a `bin/` script names must be granted here, or the operator test suite is red.
+`kubectl apply` prints `configured` / `unchanged` per resource in the lane's log — that line is
+the change report.

--- a/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
@@ -10,6 +10,20 @@
 #  * NO access to `nodes`, `clusterroles`, or the monitoring namespace — a lifecycle run has no
 #    business there, and the day someone needs it is the day to review this file, not to widen it
 #    pre-emptively.
+#
+# 🚨 HOW THIS FILE REACHES THE CLUSTER. It is applied by the config repo's helm-release lane
+# (Systemorph/Memex `helm-release.yml`, actions adopt and deploy) from THIS repository at the
+# same pin the lane renders the chart from — so a grant and the operator step that needs it move
+# together. It is NOT applied by the operator (a Job must never widen its own ClusterRole) and no
+# longer by a laptop. Measured 2026-09-09 on memex: the `storageclasses` rule below had been on
+# main since the volume-capacity step landed, the cluster's ClusterRole predated it, and the first
+# record-driven Reconcile through the fixed operator stopped at step 1/6 with
+#   storageclasses.storage.k8s.io "azurefile-memex" is forbidden: User
+#   "system:serviceaccount:memex-ops:hosting-operator" cannot get resource "storageclasses"
+# A grant that only a laptop can move is the same defect as an operator image that only a laptop
+# can move (core #3757 / Plugins #1542): the record and the chart are the inputs, and every one of
+# them needs a lane. deploy/aks/operator/test/check-rbac-coverage.py holds the other half — every
+# kubectl verb+resource a bin/ script names must be granted here, or the suite is red.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -64,11 +78,21 @@ rules:
   # READ-ONLY, for hosting-pv-resize. The storage class decides whether a claim can grow
   # (allowVolumeExpansion); the command reads it BEFORE patching, and refuses a class that cannot
   # expand rather than leaving a request in Pending forever. The patch itself is the
-  # persistentvolumeclaims grant above. Re-apply this file when adopting the feature — a Forbidden
-  # here fails the "Ensure volume capacity" step of every Provision / Reconcile by name.
+  # persistentvolumeclaims grant above. A Forbidden here fails the "Ensure volume capacity" step
+  # of every Provision / Reconcile by name (measured 2026-09-09, see the header).
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get"]
+  # For hosting-pv-purge, the Teardown step that releases the Retain-policy PersistentVolumes a
+  # deleted namespace leaves behind. PVs are cluster-scoped, so this is the one cluster-scoped
+  # DELETE in the file; the script lists by the claim's namespace label, reads each PV's phase,
+  # reclaim policy and share handle, and deletes only a Released volume. Without this grant the
+  # purge step fails by name ("could not list PersistentVolumes") — which is the designed
+  # fail-loud shape, but it means a Teardown could never complete. Added 2026-09-09 when the
+  # coverage check below was written; the script had been on main without its grant.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/aks/operator/test/check-rbac-coverage.sh
+++ b/deploy/aks/operator/test/check-rbac-coverage.sh
@@ -15,8 +15,11 @@
 # manifest), `kubectl get "$res"` (dynamic), and everything helm does with the chart. Those stay
 # covered by the chart-owner grants in the ClusterRole's own scope notes.
 #
-# Pure bash 3.2 + awk: it runs on the macOS laptop, the ubuntu runner and inside the operator
-# image (Azure Linux, no python on PATH) alike.
+# Pure bash 3.2 + grep/sed/tr (the tools bin/ itself uses): it runs on the macOS laptop, the
+# ubuntu runner and inside the operator image alike. 🚨 NOT awk and NOT python — the image
+# (Azure Linux 3) has neither; the first cut used awk, passed on the laptop and the runner, and
+# the in-image run answered "awk: command not found" (run 34295483037). The image run is the one
+# that proves the check can run where the scripts run.
 set -u
 HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 BIN="${HOSTING_BIN:-$HERE/../bin}"
@@ -52,23 +55,35 @@ resource_of() {
 }
 
 # The ClusterRole's rules as "group resource verb" lines (one per combination). Comments are
-# dropped; a rule is the three bracketed lists that follow an `- apiGroups:` line.
-grants="$(awk '
-  /^[[:space:]]*#/ { next }
-  /^kind:[[:space:]]*ClusterRoleBinding/ { exit }
-  function list(s,   t) { sub(/^[^[]*\[/, "", s); sub(/\].*$/, "", s); gsub(/["'"'"' ]/, "", s); return s }
-  /^[[:space:]]*-[[:space:]]*apiGroups:/ { if (g != "" || r != "") flush(); g = list($0); r = ""; v = ""; next }
-  /^[[:space:]]*resources:/ { r = list($0); next }
-  /^[[:space:]]*verbs:/     { v = list($0); flush(); g = ""; r = ""; v = ""; next }
-  function flush(   ng, nr, nv, gs, rs, vs, i, j, k) {
-    if (g == "" && r == "") return
-    ng = split(g, gs, ","); nr = split(r, rs, ","); nv = split(v, vs, ",")
-    if (ng == 0) { ng = 1; gs[1] = "" }   # apiGroups: [""] is the core group, not "no rule"
-    for (i = 1; i <= ng; i++) for (j = 1; j <= nr; j++) for (k = 1; k <= nv; k++)
-      printf "%s %s %s\n", (gs[i] == "" ? "-" : gs[i]), rs[j], vs[k]
-  }
-  END { flush() }
-' "$RBAC")"
+# dropped; a rule is the three bracketed lists that follow an `- apiGroups:` line; the core API
+# group (`[""]`) is recorded as "-" so a grep can anchor on it.
+list_of() { # the comma-joined items of a `key: ["a", "b"]` line
+  local s="$1"; s="${s#*[}"; s="${s%%]*}"; s="${s//\"/}"; s="${s//\'/}"; s="${s// /}"; printf '%s' "$s"
+}
+grants=""
+flush_rule() {
+  [ -n "${rule_g}${rule_r}" ] || return 0
+  local gs rs vs g r v
+  IFS=, read -ra gs <<<"$rule_g"; IFS=, read -ra rs <<<"$rule_r"; IFS=, read -ra vs <<<"$rule_v"
+  [ "${#gs[@]}" -gt 0 ] || gs=("")      # apiGroups: [""] is the core group, not "no rule"
+  for g in "${gs[@]}"; do for r in "${rs[@]}"; do for v in "${vs[@]}"; do
+    grants="${grants}${g:--} ${r} ${v}
+"
+  done; done; done
+}
+rule_g=""; rule_r=""; rule_v=""
+while IFS= read -r line; do
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ "$line" =~ ^kind:[[:space:]]*ClusterRoleBinding ]] && break
+  if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*apiGroups: ]]; then
+    flush_rule; rule_g="$(list_of "$line")"; rule_r=""; rule_v=""
+  elif [[ "$line" =~ ^[[:space:]]*resources: ]]; then
+    rule_r="$(list_of "$line")"
+  elif [[ "$line" =~ ^[[:space:]]*verbs: ]]; then
+    rule_v="$(list_of "$line")"; flush_rule; rule_g=""; rule_r=""; rule_v=""
+  fi
+done < "$RBAC"
+flush_rule
 
 granted() { # group resource verb
   local g="${1:--}"
@@ -83,7 +98,7 @@ for f in "$BIN"/hosting-* "$BIN"/run.sh; do
   script="$(basename "$f")"
   # verb + first non-flag token after it; `kind/name` keeps only the kind; `rollout status X`
   # is a get on X; `logs` is get on pods/log.
-  while read -r verb res; do
+  while read -r verb res _; do
     [ -n "$verb" ] || continue
     case "$res" in -*|'"$'*|'$'*|*'<'*|"") continue ;; esac
     res="${res%%/*}"
@@ -110,7 +125,8 @@ for f in "$BIN"/hosting-* "$BIN"/run.sh; do
       echo "  MISSING  ${script}: kubectl ${verb} ${res} needs ClusterRole rule apiGroups:[\"${group}\"] resources:[\"${plural}\"] verbs:[\"${verb}\"]"
       missing=$((missing+1))
     fi
-  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*' "$f" | sed 's/^kubectl //; s/^-n [^ ]* //' | awk '$1=="rollout"{print "rollout", $3; next} {print $1, $2}')
+  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*\( [^ ;|)]*\)\?' "$f" \
+             | sed 's/^kubectl //; s/^-n [^ ]* //; s/^rollout [^ ]* /rollout /')
 done
 
 n_distinct="$(printf '%s' "$distinct" | tr '|' '\n' | grep -c .)"

--- a/deploy/aks/operator/test/check-rbac-coverage.sh
+++ b/deploy/aks/operator/test/check-rbac-coverage.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Every kubectl verb + resource an operator script names must be GRANTED by the operator's
+# ClusterRole — or this check is red, naming the script, the verb and the resource.
+#
+# 🚨 WHY THIS EXISTS. The ClusterRole (deploy/aks/manifests/hosting-operator/operator-rbac.yaml)
+# and the scripts that need its grants live three directories apart and are reviewed separately.
+# Twice a script reached main without its grant: hosting-pv-resize (`get storageclasses`) failed
+# the first record-driven Reconcile of memex through the fixed operator on 2026-09-09 at step 1/6
+# with `Forbidden`, and hosting-pv-purge (`list/delete persistentvolumes`) sat on main with no
+# grant at all, so no Teardown could have completed. Care did not catch either; a control does.
+#
+# What it reads: every `kubectl [-n <ns>] <verb> <resource>` in bin/* whose resource is a literal
+# (an alias such as `pv`, `pvc`, `namespace`, `storageclass` — or `kind/name`). What it cannot
+# read, stated so nobody takes green for more: `kubectl apply -f` (the kinds are inside the
+# manifest), `kubectl get "$res"` (dynamic), and everything helm does with the chart. Those stay
+# covered by the chart-owner grants in the ClusterRole's own scope notes.
+#
+# Pure bash 3.2 + awk: it runs on the macOS laptop, the ubuntu runner and inside the operator
+# image (Azure Linux, no python on PATH) alike.
+set -u
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BIN="${HOSTING_BIN:-$HERE/../bin}"
+RBAC="${HOSTING_RBAC_MANIFEST:-$HERE/../../manifests/hosting-operator/operator-rbac.yaml}"
+
+if [ ! -f "$RBAC" ]; then
+  echo "check-rbac-coverage: ERROR: ClusterRole manifest not found at ${RBAC} — set HOSTING_RBAC_MANIFEST (in the image run, mount deploy/aks/manifests). A check whose input is absent is red, never skipped." >&2
+  exit 2
+fi
+
+# Alias → "<apiGroup> <plural>". An alias missing here is RED — the map grows deliberately.
+resource_of() {
+  case "$1" in
+    namespace|namespaces|ns)                 echo " namespaces" ;;
+    secret|secrets)                          echo " secrets" ;;
+    configmap|configmaps|cm)                 echo " configmaps" ;;
+    service|services|svc)                    echo " services" ;;
+    serviceaccount|serviceaccounts|sa)       echo " serviceaccounts" ;;
+    pvc|persistentvolumeclaim|persistentvolumeclaims) echo " persistentvolumeclaims" ;;
+    pv|persistentvolume|persistentvolumes)   echo " persistentvolumes" ;;
+    pod|pods|po)                             echo " pods" ;;
+    event|events|ev)                         echo " events" ;;
+    storageclass|storageclasses|sc)          echo "storage.k8s.io storageclasses" ;;
+    deployment|deployments|deploy)           echo "apps deployments" ;;
+    statefulset|statefulsets|sts)            echo "apps statefulsets" ;;
+    replicaset|replicasets|rs)               echo "apps replicasets" ;;
+    ingress|ingresses|ing)                   echo "networking.k8s.io ingresses" ;;
+    job|jobs)                                echo "batch jobs" ;;
+    cronjob|cronjobs|cj)                     echo "batch cronjobs" ;;
+    secretproviderclass|secretproviderclasses|spc) echo "secrets-store.csi.x-k8s.io secretproviderclasses" ;;
+    *) echo "" ;;
+  esac
+}
+
+# The ClusterRole's rules as "group resource verb" lines (one per combination). Comments are
+# dropped; a rule is the three bracketed lists that follow an `- apiGroups:` line.
+grants="$(awk '
+  /^[[:space:]]*#/ { next }
+  /^kind:[[:space:]]*ClusterRoleBinding/ { exit }
+  function list(s,   t) { sub(/^[^[]*\[/, "", s); sub(/\].*$/, "", s); gsub(/["'"'"' ]/, "", s); return s }
+  /^[[:space:]]*-[[:space:]]*apiGroups:/ { if (g != "" || r != "") flush(); g = list($0); r = ""; v = ""; next }
+  /^[[:space:]]*resources:/ { r = list($0); next }
+  /^[[:space:]]*verbs:/     { v = list($0); flush(); g = ""; r = ""; v = ""; next }
+  function flush(   ng, nr, nv, gs, rs, vs, i, j, k) {
+    if (g == "" && r == "") return
+    ng = split(g, gs, ","); nr = split(r, rs, ","); nv = split(v, vs, ",")
+    if (ng == 0) { ng = 1; gs[1] = "" }   # apiGroups: [""] is the core group, not "no rule"
+    for (i = 1; i <= ng; i++) for (j = 1; j <= nr; j++) for (k = 1; k <= nv; k++)
+      printf "%s %s %s\n", (gs[i] == "" ? "-" : gs[i]), rs[j], vs[k]
+  }
+  END { flush() }
+' "$RBAC")"
+
+granted() { # group resource verb
+  local g="${1:--}"
+  printf '%s\n' "$grants" | grep -qx -- "${g} ${2} ${3}" && return 0
+  printf '%s\n' "$grants" | grep -qx -- "${g} ${2} \*" && return 0
+  return 1
+}
+
+calls=0; distinct=""; reported=""; missing=0; unknown=0
+for f in "$BIN"/hosting-* "$BIN"/run.sh; do
+  [ -f "$f" ] || continue
+  script="$(basename "$f")"
+  # verb + first non-flag token after it; `kind/name` keeps only the kind; `rollout status X`
+  # is a get on X; `logs` is get on pods/log.
+  while read -r verb res; do
+    [ -n "$verb" ] || continue
+    case "$res" in -*|'"$'*|'$'*|*'<'*|"") continue ;; esac
+    res="${res%%/*}"
+    res="$(printf '%s' "$res" | tr -cd 'A-Za-z0-9')"   # a prose mention ends in ` or '. — the word is what matters
+    [ -n "$res" ] || continue
+    case "$verb" in
+      apply) continue ;;                          # kinds live in the manifest, not on the line
+      rollout) verb="get" ;;
+      logs) verb="get"; res="pods/log" ;;
+      annotate|label) verb="patch" ;;
+    esac
+    calls=$((calls+1))
+    if [ "$res" = "pods/log" ]; then mapped=" pods/log"; else mapped="$(resource_of "$res")"; fi
+    if [ -z "$mapped" ]; then
+      echo "  UNKNOWN  ${script}: kubectl ${verb} ${res} — add the alias to resource_of() in $(basename "$0")"
+      unknown=$((unknown+1)); continue
+    fi
+    group="${mapped%% *}"; plural="${mapped#* }"
+    key="${group:--} ${plural} ${verb}"
+    case "$distinct" in *"|${key}|"*) ;; *) distinct="${distinct}|${key}|" ;; esac
+    case "$reported" in *"|${script} ${key}|"*) continue ;; esac
+    reported="${reported}|${script} ${key}|"
+    if ! granted "$group" "$plural" "$verb"; then
+      echo "  MISSING  ${script}: kubectl ${verb} ${res} needs ClusterRole rule apiGroups:[\"${group}\"] resources:[\"${plural}\"] verbs:[\"${verb}\"]"
+      missing=$((missing+1))
+    fi
+  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*' "$f" | sed 's/^kubectl //; s/^-n [^ ]* //' | awk '$1=="rollout"{print "rollout", $3; next} {print $1, $2}')
+done
+
+n_distinct="$(printf '%s' "$distinct" | tr '|' '\n' | grep -c .)"
+echo "check-rbac-coverage: ${calls} kubectl call(s) with a literal resource across bin/, ${n_distinct} distinct grant(s) checked against $(basename "$RBAC"), ${missing} missing, ${unknown} unknown alias(es)"
+# A zero denominator is a broken parser, not a clean fleet.
+[ "$calls" -gt 0 ] || { echo "check-rbac-coverage: ERROR: found no kubectl calls at all — the parser is broken, not the scripts clean" >&2; exit 2; }
+[ "$missing" -eq 0 ] && [ "$unknown" -eq 0 ]

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -506,6 +506,20 @@ emits "a dry run still audits (read-only)" "::hosting:: audit_verdict=clean" \
   env HOSTING_DRY_RUN=true PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/clean" \
   hosting-audit --namespace memex --release memex
 
+# ── every kubectl verb+resource in bin/ is GRANTED by the operator's ClusterRole ─────────────────
+# The manifest lives three directories away from the scripts and is reviewed separately; twice a
+# script reached main without its grant (storageclasses for pv-resize — failed the first Reconcile
+# through the fixed operator on memex, 2026-09-09, step 1/6 Forbidden; persistentvolumes for
+# pv-purge — never granted). The check names the script, the verb, the resource and the rule to
+# add. Its manifest input is REQUIRED: absent (as in an image without deploy/aks/manifests) it
+# exits 2 and this case is red, never skipped — mount the manifests dir and set HOSTING_RBAC_MANIFEST.
+rbac_out="$(bash "$(dirname -- "${BASH_SOURCE[0]}")/check-rbac-coverage.sh" 2>&1)"; rbac_rc=$?
+if [ "$rbac_rc" -eq 0 ]; then
+  ok "every kubectl verb+resource in bin/ is granted by operator-rbac.yaml ($(printf '%s' "$rbac_out" | tail -1 | sed 's/^check-rbac-coverage: //'))"
+else
+  bad "every kubectl verb+resource in bin/ is granted by operator-rbac.yaml" "$rbac_out"
+fi
+
 echo
 echo "─────────────────────────────────────────────────────────────────"
 echo "${pass} passed, ${fail} failed"

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -112,6 +112,18 @@ and how to reconcile it in the same session. Do not re-derive that list here —
   scheme is `X.Y.Z-ci.<n>` (temporary) → clean `X.Y.Z` (final); `rc` is retired.
 - **A cancelled delivery run with zero jobs is a superseded queue entry**, not a lost seal —
   [ReadingCiSignals](/Doc/Architecture/ReadingCiSignals).
+- **The operator's ClusterRole follows the chart:** `deploy/aks/manifests/hosting-operator/operator-rbac.yaml`
+  is applied by the config repository's helm-release lane on every `adopt` / `deploy`, from the
+  chart at the pin; the operator test suite refuses a script that names a `kubectl` verb+resource
+  the role does not grant (`check-rbac-coverage.sh`). Measured 2026-09-09: the first Reconcile
+  through the fixed operator stopped at step 1/6 with `storageclasses … is forbidden` — the grant
+  had been on `main` for hours, the cluster's role predated it, and only a laptop could have moved
+  it. A control-plane input with no lane is a defect, whichever file it lives in.
+- **`/api/version` names the delivery run's RESOLVED target commit, not the set's queue tip.**
+  `3.0.0-ci.8131` is CD run 34260408777 with head `e1039813e`; its "Resolve the target commit"
+  job picked `3853374f7` (the merge one second earlier in the same queue group), and that is what
+  the image answers. Compare a portal's commit against the run's resolve job, never against the
+  run's head or `main` — read as "not 8131", it cost an hour on 2026-09-09.
 - **Steady state is self-update and CD**, never a hand roll —
   [ReleaseStrategy](/Doc/Architecture/ReleaseStrategy), [DeploymentAKS](/Doc/Architecture/DeploymentAKS)
   (the bootstrap runbook, now read under rule 1 above).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operators-permissions-follow-the-chart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operators-permissions-follow-the-chart.md
@@ -1,0 +1,42 @@
+---
+Name: The operator's permissions follow the chart
+Category: Fix
+Description: The first record-driven Reconcile of memex through the fixed operator stopped one step in, refused by the cluster — the operator's ClusterRole had never received a grant that had been in the repository for hours. The grant now travels with the chart on every deploy, and a test refuses a script that names a permission its role does not hold.
+Icon: Shield
+Order: -20260909
+---
+
+The hosting operator runs each instance action as a short-lived Job under its own identity, and
+what that identity may do is one file in this repository — the `hosting-operator` ClusterRole.
+On 2026-09-09 the first Reconcile of memex through the operator carrying the
+namespace fix of 2026-09-08 got past the
+line that had stopped every earlier run, rendered its six steps, and stopped at the first:
+
+```
+hosting-pv-resize: ERROR: could not read StorageClass azurefile-memex
+  (Error from server (Forbidden): storageclasses.storage.k8s.io "azurefile-memex" is forbidden:
+   User "system:serviceaccount:memex-ops:hosting-operator" cannot get resource "storageclasses")
+```
+
+## What was happening
+
+The rule that grants exactly that read had been on `main` since the volume-capacity step landed.
+Nothing applied it: the ClusterRole manifest was one `kubectl apply` in a README, run once from a
+laptop when the operator was first set up, and the cluster's copy predated the rule. A second
+script — the one that releases a torn-down instance's volumes — had been merged with no grant at
+all, so no teardown could have completed either. Both are the same shape as the operator image
+that only a laptop could move: an input of the control plane with no lane to carry it.
+
+## What it does now
+
+- The config repository's helm-release lane applies the ClusterRole from this repository at the
+  same pin it renders the chart from, on every `adopt` and `deploy`. A grant and the step that
+  needs it move together, and the log names every resource as `configured` or `unchanged`.
+  A pin with no manifest is a red run, never a skipped step.
+- `check-rbac-coverage.sh` in the operator's test suite reads every `kubectl <verb> <resource>`
+  the scripts name and refuses one the ClusterRole does not grant — naming the script, the verb,
+  the resource and the rule to add. It ran red on the manifest as it was, for both scripts.
+- The volume-purge step's grant is added.
+
+What the check cannot see is stated in the script: manifests handed to `kubectl apply`, resources
+named at run time, and what helm does with the chart.


### PR DESCRIPTION
## The operator's ClusterRole follows the chart — and a script cannot name a permission its role lacks

**Measured 2026-09-09 00:25Z on memex** (`Deployments/memex-reconcile-20260909-operator-lane`, filed through the API): the first record-driven Reconcile through the operator carrying #3757 (`hosting-operator:00dc0e8`, from the 8131 pods' config) got past ensure-namespace, rendered its 6 steps, and stopped at step 1/6:

```
hosting-pv-resize: ERROR: could not read StorageClass azurefile-memex
  (Error from server (Forbidden): storageclasses.storage.k8s.io "azurefile-memex" is forbidden:
   User "system:serviceaccount:memex-ops:hosting-operator" cannot get resource "storageclasses")
```

The grant has been in `deploy/aks/manifests/hosting-operator/operator-rbac.yaml` since the volume-capacity step landed. Nothing applied it: the manifest reaches the cluster by one `kubectl apply` in a README, once, from a laptop. And `hosting-pv-purge` had been merged with **no** grant (`persistentvolumes`), so no Teardown could have completed either. Same defect as the operator image that only a laptop could move (#3757 / Plugins #1542): a control-plane input with no lane.

### What changes
- **`operator-rbac.yaml`**: `persistentvolumes` get/list/delete for `hosting-pv-purge` (the one cluster-scoped delete; scope note in the file). Header states which lane applies the file and why the operator never applies it itself.
- **`deploy/aks/operator/test/check-rbac-coverage.sh`** (bash 3.2 + awk, runs on macOS, the runner and inside the image): every `kubectl <verb> <resource>` a `bin/` script names must be granted by the ClusterRole, or the suite is red naming script, verb, resource and the rule to add. What it cannot see is stated in the script (`apply -f`, dynamic resources, helm).
  - Falsified: main's manifest → `2 missing` (pv-purge); the storageclasses resource line removed → `1 missing` (pv-resize). Absent manifest → exit 2, red, never a skip. Zero calls found → exit 2 (a broken parser is not a clean fleet).
- **`run-tests.sh`** runs it as one case — `133 passed, 0 failed` locally. **`hosting-operator.yml`** mounts `deploy/aks/manifests` into the in-image run so the case runs there too.
- **Docs**: manifests README; `OperatingFromThePortal` (the lane, and: `/api/version` reports the CD run's *resolved target commit*, not the run head — 3.0.0-ci.8131 answers `3853374f7`); release skill; What's New (Fix).

### Pairs with
Systemorph/Memex — the helm-release lane applies this manifest from the chart checkout at the pin on every adopt/deploy. Lands after this so the pin it applies carries the persistentvolumes grant.

No kubectl or az was used to find or fix this; the cluster is untouched until the Memex lane runs.
