### PR TITLE
fix(operator): ensure-namespace reads then creates — never create --dry-run | kubectl apply (namespaces has no patch)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -260,6 +260,11 @@ az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command \
 
 ## Verify a release is healthy (before declaring done)
 
+🚨 **`/api/version` reports the CD run's RESOLVED target commit**, which can differ from the run's
+`head_sha` when two merges land in one queue group (2026-09-09: set 8131 = run head `e1039813e`,
+`/api/version` = `3853374f7`, one second earlier). To name the set a portal runs, match the commit
+against the run's "Resolve the target commit" job output — never against the run head or `main`.
+
 - Migration log shows `Database migration completed. Version: N` AND the portal serves HTTP 200
   (see [DeploymentAKS.md](../../../src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md)).
 - The self-updater logged its decision (picked newer / already current / held with a reason), not

--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -248,7 +248,12 @@ jobs:
       # scripts will actually execute under in a lifecycle Job.
       - name: Behaviour tests, inside the image
         run: |
+          # The manifests are NOT in the image (only bin/ and the chart are), but the suite's RBAC
+          # coverage case needs the ClusterRole: mount them read-only and name the file, so the
+          # case runs here exactly as on the runner — a missing input is exit 2 and red, not a skip.
           docker run --rm -v "$PWD/deploy/aks/operator/test:/opt/hosting/test:ro" \
+            -v "$PWD/deploy/aks/manifests:/opt/hosting/manifests:ro" \
+            -e HOSTING_RBAC_MANIFEST=/opt/hosting/manifests/hosting-operator/operator-rbac.yaml \
             --entrypoint /bin/bash hosting-operator:ci -c 'cd /opt/hosting && bash test/run-tests.sh'
 
   # ═══════════════════════════════════════════════════════════════════════════════════════════

--- a/deploy/aks/manifests/hosting-operator/README.md
+++ b/deploy/aks/manifests/hosting-operator/README.md
@@ -17,7 +17,9 @@ a nuisance rather than a cloud compromise.
 ```bash
 kubectl apply -f namespace.yaml
 kubectl apply -f operator-serviceaccount.yaml      # edit AZURE_CLIENT_ID annotation first
-kubectl apply -f operator-rbac.yaml
+kubectl apply -f operator-rbac.yaml                # FIRST TIME ONLY — from then on the config repo's
+                                                   # helm-release lane (adopt/deploy) re-applies it from
+                                                   # this repo at the chart pin; see the note below
 kubectl apply -f jobrunner.yaml                    # 🚨 edit the SA/Secret namespace to your CONTROL
                                                    # PORTAL's namespace first — a pod can only mount
                                                    # Secrets from its own namespace, so they live
@@ -84,3 +86,16 @@ The chart's half: `portal.imagePullSecret` renders `imagePullSecrets` on the por
 **and** the migration Job; `selfUpdate.registry` renders `SelfUpdate__Registry`, which makes the
 self-updater list tags over the OCI Distribution API with the same key. Neither is set on the
 mirror instance itself — it cannot serve the image that boots it.
+
+## The ClusterRole follows the chart
+
+`operator-rbac.yaml` is re-applied by `Systemorph/Memex` `helm-release.yml` on every `adopt` and
+`deploy`, read from THIS repository at the same pin the lane renders the chart from. So a script
+that needs a new grant lands with the grant, and the next deploy carries both to the cluster —
+no laptop in the loop. Measured before this existed (2026-09-09): the `storageclasses` rule had
+been on main since the volume-capacity step, the cluster's ClusterRole predated it, and the first
+record-driven Reconcile through the fixed operator stopped at step 1/6 with `Forbidden`.
+`deploy/aks/operator/test/check-rbac-coverage.sh` is the other half: every `kubectl <verb>
+<resource>` a `bin/` script names must be granted here, or the operator test suite is red.
+`kubectl apply` prints `configured` / `unchanged` per resource in the lane's log — that line is
+the change report.

--- a/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
@@ -10,6 +10,20 @@
 #  * NO access to `nodes`, `clusterroles`, or the monitoring namespace — a lifecycle run has no
 #    business there, and the day someone needs it is the day to review this file, not to widen it
 #    pre-emptively.
+#
+# 🚨 HOW THIS FILE REACHES THE CLUSTER. It is applied by the config repo's helm-release lane
+# (Systemorph/Memex `helm-release.yml`, actions adopt and deploy) from THIS repository at the
+# same pin the lane renders the chart from — so a grant and the operator step that needs it move
+# together. It is NOT applied by the operator (a Job must never widen its own ClusterRole) and no
+# longer by a laptop. Measured 2026-09-09 on memex: the `storageclasses` rule below had been on
+# main since the volume-capacity step landed, the cluster's ClusterRole predated it, and the first
+# record-driven Reconcile through the fixed operator stopped at step 1/6 with
+#   storageclasses.storage.k8s.io "azurefile-memex" is forbidden: User
+#   "system:serviceaccount:memex-ops:hosting-operator" cannot get resource "storageclasses"
+# A grant that only a laptop can move is the same defect as an operator image that only a laptop
+# can move (core #3757 / Plugins #1542): the record and the chart are the inputs, and every one of
+# them needs a lane. deploy/aks/operator/test/check-rbac-coverage.py holds the other half — every
+# kubectl verb+resource a bin/ script names must be granted here, or the suite is red.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -64,11 +78,21 @@ rules:
   # READ-ONLY, for hosting-pv-resize. The storage class decides whether a claim can grow
   # (allowVolumeExpansion); the command reads it BEFORE patching, and refuses a class that cannot
   # expand rather than leaving a request in Pending forever. The patch itself is the
-  # persistentvolumeclaims grant above. Re-apply this file when adopting the feature — a Forbidden
-  # here fails the "Ensure volume capacity" step of every Provision / Reconcile by name.
+  # persistentvolumeclaims grant above. A Forbidden here fails the "Ensure volume capacity" step
+  # of every Provision / Reconcile by name (measured 2026-09-09, see the header).
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get"]
+  # For hosting-pv-purge, the Teardown step that releases the Retain-policy PersistentVolumes a
+  # deleted namespace leaves behind. PVs are cluster-scoped, so this is the one cluster-scoped
+  # DELETE in the file; the script lists by the claim's namespace label, reads each PV's phase,
+  # reclaim policy and share handle, and deletes only a Released volume. Without this grant the
+  # purge step fails by name ("could not list PersistentVolumes") — which is the designed
+  # fail-loud shape, but it means a Teardown could never complete. Added 2026-09-09 when the
+  # coverage check below was written; the script had been on main without its grant.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/aks/operator/bin/hosting-deploy
+++ b/deploy/aks/operator/bin/hosting-deploy
@@ -109,9 +109,19 @@ hosting::log "chart     ${CHART}"
 hosting::log "release   ${release} → namespace ${namespace}"
 hosting::log "database  ${database}"
 
-hosting::do kubectl create namespace "$namespace" --dry-run=client -o yaml \
-  | { hosting::dry && cat >/dev/null || kubectl apply -f - ; } \
-  || hosting::die "could not ensure namespace ${namespace}"
+# 🚨 ENSURE = read, then create if absent — NEVER `create --dry-run=client -o yaml | kubectl apply`.
+# That idiom PATCHES an existing namespace (kubectl apply stamps last-applied-configuration), and
+# the operator's ClusterRole grants namespaces get/list/create/delete and no patch — deliberately:
+# a lifecycle run has no business editing a namespace it did not just create. Measured 2026-09-09
+# on memex (Deployments/memex-reconcile-20260909-pv-capacity), the first run to reach this line
+# after the narration fix: `namespaces "memex" is forbidden: … cannot patch resource "namespaces"`.
+# The read is a read (a dry run still performs it); only the create is a mutation.
+if hosting::read kubectl get namespace "$namespace" >/dev/null 2>&1; then
+  hosting::log "namespace ${namespace} exists"
+else
+  hosting::do kubectl create namespace "$namespace" \
+    || hosting::die "could not create namespace ${namespace}"
+fi
 
 # --atomic: a failed install ROLLS BACK rather than leaving a half-created release that the next
 # attempt then has to `helm uninstall` before it can proceed. --wait so "deployed" means the pods

--- a/deploy/aks/operator/bin/hosting-pull-secret
+++ b/deploy/aks/operator/bin/hosting-pull-secret
@@ -60,12 +60,17 @@ hosting::safe_name username "$username"
 hosting::log "pull secret ${name} in ${namespace} for ${registry} (user ${username}), key from vault ${vault} object ${secret}"
 
 # ── 1. the namespace ──────────────────────────────────────────────────────────────────────────
-# Before hosting-deploy in every plan, so the namespace may not exist yet. Idempotent: an existing
-# namespace applies unchanged. The same idiom hosting-deploy uses, so the two agree on the shape.
+# Before hosting-deploy in every plan, so the namespace may not exist yet. Idempotent: read, then
+# create if absent — the same shape hosting-deploy uses, so the two agree. 🚨 NOT
+# `create --dry-run=client -o yaml | kubectl apply`: that patches an existing namespace, and the
+# ClusterRole grants namespaces no patch (measured 2026-09-09 on memex; see hosting-deploy).
 hosting::step "Ensure namespace ${namespace}"
-hosting::do kubectl create namespace "$namespace" --dry-run=client -o yaml \
-  | { hosting::dry && cat >/dev/null || kubectl apply -f - ; } \
-  || hosting::die "could not ensure namespace ${namespace}"
+if hosting::read kubectl get namespace "$namespace" >/dev/null 2>&1; then
+  hosting::log "namespace ${namespace} exists"
+else
+  hosting::do kubectl create namespace "$namespace" \
+    || hosting::die "could not create namespace ${namespace}"
+fi
 
 # ── 2. the key ────────────────────────────────────────────────────────────────────────────────
 hosting::step "Read the instance key from Key Vault"

--- a/deploy/aks/operator/test/check-rbac-coverage.sh
+++ b/deploy/aks/operator/test/check-rbac-coverage.sh
@@ -15,8 +15,11 @@
 # manifest), `kubectl get "$res"` (dynamic), and everything helm does with the chart. Those stay
 # covered by the chart-owner grants in the ClusterRole's own scope notes.
 #
-# Pure bash 3.2 + awk: it runs on the macOS laptop, the ubuntu runner and inside the operator
-# image (Azure Linux, no python on PATH) alike.
+# Pure bash 3.2 + grep/sed/tr (the tools bin/ itself uses): it runs on the macOS laptop, the
+# ubuntu runner and inside the operator image alike. 🚨 NOT awk and NOT python — the image
+# (Azure Linux 3) has neither; the first cut used awk, passed on the laptop and the runner, and
+# the in-image run answered "awk: command not found" (run 34295483037). The image run is the one
+# that proves the check can run where the scripts run.
 set -u
 HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 BIN="${HOSTING_BIN:-$HERE/../bin}"
@@ -52,23 +55,35 @@ resource_of() {
 }
 
 # The ClusterRole's rules as "group resource verb" lines (one per combination). Comments are
-# dropped; a rule is the three bracketed lists that follow an `- apiGroups:` line.
-grants="$(awk '
-  /^[[:space:]]*#/ { next }
-  /^kind:[[:space:]]*ClusterRoleBinding/ { exit }
-  function list(s,   t) { sub(/^[^[]*\[/, "", s); sub(/\].*$/, "", s); gsub(/["'"'"' ]/, "", s); return s }
-  /^[[:space:]]*-[[:space:]]*apiGroups:/ { if (g != "" || r != "") flush(); g = list($0); r = ""; v = ""; next }
-  /^[[:space:]]*resources:/ { r = list($0); next }
-  /^[[:space:]]*verbs:/     { v = list($0); flush(); g = ""; r = ""; v = ""; next }
-  function flush(   ng, nr, nv, gs, rs, vs, i, j, k) {
-    if (g == "" && r == "") return
-    ng = split(g, gs, ","); nr = split(r, rs, ","); nv = split(v, vs, ",")
-    if (ng == 0) { ng = 1; gs[1] = "" }   # apiGroups: [""] is the core group, not "no rule"
-    for (i = 1; i <= ng; i++) for (j = 1; j <= nr; j++) for (k = 1; k <= nv; k++)
-      printf "%s %s %s\n", (gs[i] == "" ? "-" : gs[i]), rs[j], vs[k]
-  }
-  END { flush() }
-' "$RBAC")"
+# dropped; a rule is the three bracketed lists that follow an `- apiGroups:` line; the core API
+# group (`[""]`) is recorded as "-" so a grep can anchor on it.
+list_of() { # the comma-joined items of a `key: ["a", "b"]` line
+  local s="$1"; s="${s#*[}"; s="${s%%]*}"; s="${s//\"/}"; s="${s//\'/}"; s="${s// /}"; printf '%s' "$s"
+}
+grants=""
+flush_rule() {
+  [ -n "${rule_g}${rule_r}" ] || return 0
+  local gs rs vs g r v
+  IFS=, read -ra gs <<<"$rule_g"; IFS=, read -ra rs <<<"$rule_r"; IFS=, read -ra vs <<<"$rule_v"
+  [ "${#gs[@]}" -gt 0 ] || gs=("")      # apiGroups: [""] is the core group, not "no rule"
+  for g in "${gs[@]}"; do for r in "${rs[@]}"; do for v in "${vs[@]}"; do
+    grants="${grants}${g:--} ${r} ${v}
+"
+  done; done; done
+}
+rule_g=""; rule_r=""; rule_v=""
+while IFS= read -r line; do
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ "$line" =~ ^kind:[[:space:]]*ClusterRoleBinding ]] && break
+  if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*apiGroups: ]]; then
+    flush_rule; rule_g="$(list_of "$line")"; rule_r=""; rule_v=""
+  elif [[ "$line" =~ ^[[:space:]]*resources: ]]; then
+    rule_r="$(list_of "$line")"
+  elif [[ "$line" =~ ^[[:space:]]*verbs: ]]; then
+    rule_v="$(list_of "$line")"; flush_rule; rule_g=""; rule_r=""; rule_v=""
+  fi
+done < "$RBAC"
+flush_rule
 
 granted() { # group resource verb
   local g="${1:--}"
@@ -83,7 +98,7 @@ for f in "$BIN"/hosting-* "$BIN"/run.sh; do
   script="$(basename "$f")"
   # verb + first non-flag token after it; `kind/name` keeps only the kind; `rollout status X`
   # is a get on X; `logs` is get on pods/log.
-  while read -r verb res; do
+  while read -r verb res _; do
     [ -n "$verb" ] || continue
     case "$res" in -*|'"$'*|'$'*|*'<'*|"") continue ;; esac
     res="${res%%/*}"
@@ -110,7 +125,8 @@ for f in "$BIN"/hosting-* "$BIN"/run.sh; do
       echo "  MISSING  ${script}: kubectl ${verb} ${res} needs ClusterRole rule apiGroups:[\"${group}\"] resources:[\"${plural}\"] verbs:[\"${verb}\"]"
       missing=$((missing+1))
     fi
-  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*' "$f" | sed 's/^kubectl //; s/^-n [^ ]* //' | awk '$1=="rollout"{print "rollout", $3; next} {print $1, $2}')
+  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*\( [^ ;|)]*\)\?' "$f" \
+             | sed 's/^kubectl //; s/^-n [^ ]* //; s/^rollout [^ ]* /rollout /')
 done
 
 n_distinct="$(printf '%s' "$distinct" | tr '|' '\n' | grep -c .)"

--- a/deploy/aks/operator/test/check-rbac-coverage.sh
+++ b/deploy/aks/operator/test/check-rbac-coverage.sh
@@ -98,7 +98,7 @@ for f in "$BIN"/hosting-* "$BIN"/run.sh; do
   script="$(basename "$f")"
   # verb + first non-flag token after it; `kind/name` keeps only the kind; `rollout status X`
   # is a get on X; `logs` is get on pods/log.
-  while read -r verb res _; do
+  while read -r verb res dry; do
     [ -n "$verb" ] || continue
     case "$res" in -*|'"$'*|'$'*|*'<'*|"") continue ;; esac
     res="${res%%/*}"
@@ -125,8 +125,21 @@ for f in "$BIN"/hosting-* "$BIN"/run.sh; do
       echo "  MISSING  ${script}: kubectl ${verb} ${res} needs ClusterRole rule apiGroups:[\"${group}\"] resources:[\"${plural}\"] verbs:[\"${verb}\"]"
       missing=$((missing+1))
     fi
-  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*\( [^ ;|)]*\)\?' "$f" \
-             | sed 's/^kubectl //; s/^-n [^ ]* //; s/^rollout [^ ]* /rollout /')
+    if [ "$verb" = "create" ] && [ "$dry" = "dry" ] && ! granted "$group" "$plural" "patch"; then
+      echo "  MISSING  ${script}: kubectl create ${res} --dry-run=client … | kubectl apply -f - PATCHES an existing ${plural} — needs verbs:[\"patch\"] on apiGroups:[\"${group}\"] resources:[\"${plural}\"], or ensure = get, then create"
+      missing=$((missing+1))
+    fi
+  done < <(grep 'kubectl ' "$f" | grep -v '^[[:space:]]*#' | while IFS= read -r line; do
+             # `kubectl create <res> … --dry-run=client -o yaml` exists to be piped into `kubectl
+             # apply -f -`, and apply PATCHES an existing object — so the line needs patch too.
+             # Measured 2026-09-09: both ensure-namespace sites did this against a role that grants
+             # namespaces no patch; the first-cut check saw only the `create`.
+             dry=""; case "$line" in *--dry-run=client*) dry="dry" ;; esac
+             printf '%s\n' "$line" \
+               | grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*\( [^ ;|)]*\)\?' \
+               | sed 's/^kubectl //; s/^-n [^ ]* //; s/^rollout [^ ]* /rollout /' \
+               | while read -r v r _; do printf '%s %s %s\n' "$v" "$r" "$dry"; done
+           done)
 done
 
 n_distinct="$(printf '%s' "$distinct" | tr '|' '\n' | grep -c .)"

--- a/deploy/aks/operator/test/check-rbac-coverage.sh
+++ b/deploy/aks/operator/test/check-rbac-coverage.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Every kubectl verb + resource an operator script names must be GRANTED by the operator's
+# ClusterRole — or this check is red, naming the script, the verb and the resource.
+#
+# 🚨 WHY THIS EXISTS. The ClusterRole (deploy/aks/manifests/hosting-operator/operator-rbac.yaml)
+# and the scripts that need its grants live three directories apart and are reviewed separately.
+# Twice a script reached main without its grant: hosting-pv-resize (`get storageclasses`) failed
+# the first record-driven Reconcile of memex through the fixed operator on 2026-09-09 at step 1/6
+# with `Forbidden`, and hosting-pv-purge (`list/delete persistentvolumes`) sat on main with no
+# grant at all, so no Teardown could have completed. Care did not catch either; a control does.
+#
+# What it reads: every `kubectl [-n <ns>] <verb> <resource>` in bin/* whose resource is a literal
+# (an alias such as `pv`, `pvc`, `namespace`, `storageclass` — or `kind/name`). What it cannot
+# read, stated so nobody takes green for more: `kubectl apply -f` (the kinds are inside the
+# manifest), `kubectl get "$res"` (dynamic), and everything helm does with the chart. Those stay
+# covered by the chart-owner grants in the ClusterRole's own scope notes.
+#
+# Pure bash 3.2 + awk: it runs on the macOS laptop, the ubuntu runner and inside the operator
+# image (Azure Linux, no python on PATH) alike.
+set -u
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+BIN="${HOSTING_BIN:-$HERE/../bin}"
+RBAC="${HOSTING_RBAC_MANIFEST:-$HERE/../../manifests/hosting-operator/operator-rbac.yaml}"
+
+if [ ! -f "$RBAC" ]; then
+  echo "check-rbac-coverage: ERROR: ClusterRole manifest not found at ${RBAC} — set HOSTING_RBAC_MANIFEST (in the image run, mount deploy/aks/manifests). A check whose input is absent is red, never skipped." >&2
+  exit 2
+fi
+
+# Alias → "<apiGroup> <plural>". An alias missing here is RED — the map grows deliberately.
+resource_of() {
+  case "$1" in
+    namespace|namespaces|ns)                 echo " namespaces" ;;
+    secret|secrets)                          echo " secrets" ;;
+    configmap|configmaps|cm)                 echo " configmaps" ;;
+    service|services|svc)                    echo " services" ;;
+    serviceaccount|serviceaccounts|sa)       echo " serviceaccounts" ;;
+    pvc|persistentvolumeclaim|persistentvolumeclaims) echo " persistentvolumeclaims" ;;
+    pv|persistentvolume|persistentvolumes)   echo " persistentvolumes" ;;
+    pod|pods|po)                             echo " pods" ;;
+    event|events|ev)                         echo " events" ;;
+    storageclass|storageclasses|sc)          echo "storage.k8s.io storageclasses" ;;
+    deployment|deployments|deploy)           echo "apps deployments" ;;
+    statefulset|statefulsets|sts)            echo "apps statefulsets" ;;
+    replicaset|replicasets|rs)               echo "apps replicasets" ;;
+    ingress|ingresses|ing)                   echo "networking.k8s.io ingresses" ;;
+    job|jobs)                                echo "batch jobs" ;;
+    cronjob|cronjobs|cj)                     echo "batch cronjobs" ;;
+    secretproviderclass|secretproviderclasses|spc) echo "secrets-store.csi.x-k8s.io secretproviderclasses" ;;
+    *) echo "" ;;
+  esac
+}
+
+# The ClusterRole's rules as "group resource verb" lines (one per combination). Comments are
+# dropped; a rule is the three bracketed lists that follow an `- apiGroups:` line.
+grants="$(awk '
+  /^[[:space:]]*#/ { next }
+  /^kind:[[:space:]]*ClusterRoleBinding/ { exit }
+  function list(s,   t) { sub(/^[^[]*\[/, "", s); sub(/\].*$/, "", s); gsub(/["'"'"' ]/, "", s); return s }
+  /^[[:space:]]*-[[:space:]]*apiGroups:/ { if (g != "" || r != "") flush(); g = list($0); r = ""; v = ""; next }
+  /^[[:space:]]*resources:/ { r = list($0); next }
+  /^[[:space:]]*verbs:/     { v = list($0); flush(); g = ""; r = ""; v = ""; next }
+  function flush(   ng, nr, nv, gs, rs, vs, i, j, k) {
+    if (g == "" && r == "") return
+    ng = split(g, gs, ","); nr = split(r, rs, ","); nv = split(v, vs, ",")
+    if (ng == 0) { ng = 1; gs[1] = "" }   # apiGroups: [""] is the core group, not "no rule"
+    for (i = 1; i <= ng; i++) for (j = 1; j <= nr; j++) for (k = 1; k <= nv; k++)
+      printf "%s %s %s\n", (gs[i] == "" ? "-" : gs[i]), rs[j], vs[k]
+  }
+  END { flush() }
+' "$RBAC")"
+
+granted() { # group resource verb
+  local g="${1:--}"
+  printf '%s\n' "$grants" | grep -qx -- "${g} ${2} ${3}" && return 0
+  printf '%s\n' "$grants" | grep -qx -- "${g} ${2} \*" && return 0
+  return 1
+}
+
+calls=0; distinct=""; reported=""; missing=0; unknown=0
+for f in "$BIN"/hosting-* "$BIN"/run.sh; do
+  [ -f "$f" ] || continue
+  script="$(basename "$f")"
+  # verb + first non-flag token after it; `kind/name` keeps only the kind; `rollout status X`
+  # is a get on X; `logs` is get on pods/log.
+  while read -r verb res; do
+    [ -n "$verb" ] || continue
+    case "$res" in -*|'"$'*|'$'*|*'<'*|"") continue ;; esac
+    res="${res%%/*}"
+    res="$(printf '%s' "$res" | tr -cd 'A-Za-z0-9')"   # a prose mention ends in ` or '. — the word is what matters
+    [ -n "$res" ] || continue
+    case "$verb" in
+      apply) continue ;;                          # kinds live in the manifest, not on the line
+      rollout) verb="get" ;;
+      logs) verb="get"; res="pods/log" ;;
+      annotate|label) verb="patch" ;;
+    esac
+    calls=$((calls+1))
+    if [ "$res" = "pods/log" ]; then mapped=" pods/log"; else mapped="$(resource_of "$res")"; fi
+    if [ -z "$mapped" ]; then
+      echo "  UNKNOWN  ${script}: kubectl ${verb} ${res} — add the alias to resource_of() in $(basename "$0")"
+      unknown=$((unknown+1)); continue
+    fi
+    group="${mapped%% *}"; plural="${mapped#* }"
+    key="${group:--} ${plural} ${verb}"
+    case "$distinct" in *"|${key}|"*) ;; *) distinct="${distinct}|${key}|" ;; esac
+    case "$reported" in *"|${script} ${key}|"*) continue ;; esac
+    reported="${reported}|${script} ${key}|"
+    if ! granted "$group" "$plural" "$verb"; then
+      echo "  MISSING  ${script}: kubectl ${verb} ${res} needs ClusterRole rule apiGroups:[\"${group}\"] resources:[\"${plural}\"] verbs:[\"${verb}\"]"
+      missing=$((missing+1))
+    fi
+  done < <(grep -o 'kubectl \(-n [^ ]* \)\?\(get\|create\|delete\|patch\|apply\|label\|annotate\|scale\|logs\|rollout\) [^ ;|)]*' "$f" | sed 's/^kubectl //; s/^-n [^ ]* //' | awk '$1=="rollout"{print "rollout", $3; next} {print $1, $2}')
+done
+
+n_distinct="$(printf '%s' "$distinct" | tr '|' '\n' | grep -c .)"
+echo "check-rbac-coverage: ${calls} kubectl call(s) with a literal resource across bin/, ${n_distinct} distinct grant(s) checked against $(basename "$RBAC"), ${missing} missing, ${unknown} unknown alias(es)"
+# A zero denominator is a broken parser, not a clean fleet.
+[ "$calls" -gt 0 ] || { echo "check-rbac-coverage: ERROR: found no kubectl calls at all — the parser is broken, not the scripts clean" >&2; exit 2; }
+[ "$missing" -eq 0 ] && [ "$unknown" -eq 0 ]

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -506,6 +506,20 @@ emits "a dry run still audits (read-only)" "::hosting:: audit_verdict=clean" \
   env HOSTING_DRY_RUN=true PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/clean" \
   hosting-audit --namespace memex --release memex
 
+# ── every kubectl verb+resource in bin/ is GRANTED by the operator's ClusterRole ─────────────────
+# The manifest lives three directories away from the scripts and is reviewed separately; twice a
+# script reached main without its grant (storageclasses for pv-resize — failed the first Reconcile
+# through the fixed operator on memex, 2026-09-09, step 1/6 Forbidden; persistentvolumes for
+# pv-purge — never granted). The check names the script, the verb, the resource and the rule to
+# add. Its manifest input is REQUIRED: absent (as in an image without deploy/aks/manifests) it
+# exits 2 and this case is red, never skipped — mount the manifests dir and set HOSTING_RBAC_MANIFEST.
+rbac_out="$(bash "$(dirname -- "${BASH_SOURCE[0]}")/check-rbac-coverage.sh" 2>&1)"; rbac_rc=$?
+if [ "$rbac_rc" -eq 0 ]; then
+  ok "every kubectl verb+resource in bin/ is granted by operator-rbac.yaml ($(printf '%s' "$rbac_out" | tail -1 | sed 's/^check-rbac-coverage: //'))"
+else
+  bad "every kubectl verb+resource in bin/ is granted by operator-rbac.yaml" "$rbac_out"
+fi
+
 echo
 echo "─────────────────────────────────────────────────────────────────"
 echo "${pass} passed, ${fail} failed"

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -235,16 +235,25 @@ if grep -v '^  <stdin>' "$_ps_log" | grep -q 'mwi_'; then
 else
   ok "pull-secret never puts the key on a command line"
 fi
-# Ordering: the namespace is ensured (create --dry-run | apply) BEFORE the Secret is applied.
-_ns_line="$(grep -n 'kubectl create namespace acme --dry-run=client' "$_ps_log" | head -1 | cut -d: -f1)"
+# Ordering: the namespace is ensured (read, then created — the stub answers NotFound) BEFORE the
+# Secret is applied.
+_ns_line="$(grep -n '^kubectl create namespace acme$' "$_ps_log" | head -1 | cut -d: -f1)"
 _sec_line="$(grep -n 'kubectl -n acme create secret generic registry-pull' "$_ps_log" | head -1 | cut -d: -f1)"
 if [ -n "$_ns_line" ] && [ -n "$_sec_line" ] && [ "$_ns_line" -lt "$_sec_line" ]; then
-  ok "pull-secret ensures the namespace before it applies the Secret"
+  ok "pull-secret creates an absent namespace before it applies the Secret"
 else
-  bad "pull-secret ensures the namespace before it applies the Secret" "namespace at line '${_ns_line}', secret at '${_sec_line}' in: $(cat "$_ps_log")"
+  bad "pull-secret creates an absent namespace before it applies the Secret" "create at line '${_ns_line}', secret at '${_sec_line}' in: $(cat "$_ps_log")"
 fi
-grep -q 'kubectl apply -f -' "$_ps_log" && ok "the namespace manifest is APPLIED, not only rendered" \
-  || bad "the namespace manifest is APPLIED" "no 'kubectl apply -f -' in: $(cat "$_ps_log")"
+# 🚨 ENSURE IS NEVER `create --dry-run=client -o yaml | kubectl apply -f -`. apply PATCHES an
+# existing namespace and the ClusterRole grants namespaces no patch — measured 2026-09-09 on memex,
+# Deployments/memex-reconcile-20260909-pv-capacity, the first run to reach the line after #3757:
+# `namespaces "memex" is forbidden: … cannot patch resource "namespaces"`. The only apply in the
+# log is the Secret's.
+if grep '^  <stdin>' "$_ps_log" | grep -q 'kind: Namespace'; then
+  bad "pull-secret never APPLIES a namespace manifest" "$(grep '^  <stdin>' "$_ps_log" | grep 'kind: Namespace')"
+else
+  ok "pull-secret never APPLIES a namespace manifest (apply = patch, which the role does not grant)"
+fi
 # Content: the applied Secret is a dockerconfigjson for the registry, with the default username.
 if [ -f "$_ps_dir/applied-secret.yaml" ] \
    && grep -q '^type: kubernetes.io/dockerconfigjson' "$_ps_dir/applied-secret.yaml" \
@@ -257,6 +266,21 @@ case "$_ps_out" in *"::hosting:: pull_secret=registry-pull"*) ok "pull-secret re
   *) bad "pull-secret reports the Secret name" "said: ${_ps_out}" ;; esac
 case "$_ps_out" in *"::hosting:: pull_secret_verify=true"*) ok "pull-secret reports verified=true only after reading the Secret back" ;;
   *) bad "pull-secret reports verified=true" "said: ${_ps_out}" ;; esac
+rm -rf "$_ps_dir"
+
+# An EXISTING namespace (the Reconcile / Roll case — every instance after its first Provision):
+# read, left alone, and the Secret still applied into it.
+_ps_dir="$(mktemp -d)"; _ps_log="$_ps_dir/calls.log"; : > "$_ps_log"
+_ps_out="$(env PATH="$PS_STUBS:$PATH" HOSTING_PULL_SECRET_STUB_LOG="$_ps_log" HOSTING_PULL_SECRET_STUB_DIR="$_ps_dir" HOSTING_PULL_SECRET_STUB_NS_EXISTS=1 \
+  hosting-pull-secret --namespace acme --registry cr.meshweaver.cloud --vault Systemorph --secret acme-PluginCatalog-RegistryToken --name registry-pull 2>&1)"; _ps_rc=$?
+[ "$_ps_rc" -eq 0 ] && ok "pull-secret succeeds when the namespace already exists" || bad "pull-secret succeeds when the namespace already exists" "exited ${_ps_rc}: ${_ps_out}"
+if grep -q '^kubectl get namespace acme' "$_ps_log" && ! grep -q '^kubectl create namespace' "$_ps_log" && ! { grep '^  <stdin>' "$_ps_log" | grep -q 'kind: Namespace'; }; then
+  ok "an existing namespace is read and left alone — no create, no apply"
+else
+  bad "an existing namespace is read and left alone" "$(cat "$_ps_log")"
+fi
+grep -q 'kubectl -n acme create secret generic registry-pull' "$_ps_log" && ok "…and the Secret is still applied into it" \
+  || bad "the Secret is still applied into an existing namespace" "$(cat "$_ps_log")"
 rm -rf "$_ps_dir"
 
 # The refusals a stubbed estate can reach: an absent vault object, and a pre-existing Secret of

--- a/deploy/aks/operator/test/stubs/pull-secret/kubectl
+++ b/deploy/aks/operator/test/stubs/pull-secret/kubectl
@@ -23,8 +23,11 @@ case "${1:-}" in
   create)
     case "${2:-}" in
       namespace)
-        # `create namespace X --dry-run=client -o yaml` → a manifest on stdout, as kubectl does.
-        printf 'apiVersion: v1\nkind: Namespace\nmetadata:\n  name: %s\n' "${3:-}" ;;
+        # `create namespace X` → created, as kubectl does. A `--dry-run=client -o yaml` form would
+        # be the retired apply idiom (it patches an existing namespace, which the ClusterRole does
+        # not grant) — the stub refuses it so the retirement cannot silently come back.
+        for arg in "$@"; do case "$arg" in --dry-run=*) echo "kubectl stub: create namespace --dry-run is the retired apply idiom — ensure = get, then create" >&2; exit 1 ;; esac; done
+        echo "namespace/${3:-} created" ;;
       secret)
         # `create secret generic NAME --type=… --from-file=.dockerconfigjson=PATH --dry-run=client -o yaml`
         name="${3:-}"; file=""; type=""
@@ -48,6 +51,11 @@ case "${1:-}" in
     fi
     echo "applied" ;;
   get)
+    # `get namespace X` → exists only when the test says so (HOSTING_PULL_SECRET_STUB_NS_EXISTS=1).
+    if [ "${2:-}" = "namespace" ]; then
+      if [ "${HOSTING_PULL_SECRET_STUB_NS_EXISTS:-0}" = "1" ]; then echo "NAME   STATUS   AGE"; exit 0; fi
+      echo "Error from server (NotFound): namespaces \"${3:-}\" not found" >&2; exit 1
+    fi
     # `get secret NAME -o jsonpath={.type}` / `jsonpath={.data.\.dockerconfigjson}`
     [ "${2:-}" = "secret" ] || { echo "kubectl stub: unexpected get $2" >&2; exit 1; }
     [ -f "$dir/applied-secret.yaml" ] || { echo "Error from server (NotFound): secrets \"${3:-}\" not found" >&2; exit 1; }

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -112,6 +112,18 @@ and how to reconcile it in the same session. Do not re-derive that list here —
   scheme is `X.Y.Z-ci.<n>` (temporary) → clean `X.Y.Z` (final); `rc` is retired.
 - **A cancelled delivery run with zero jobs is a superseded queue entry**, not a lost seal —
   [ReadingCiSignals](/Doc/Architecture/ReadingCiSignals).
+- **The operator's ClusterRole follows the chart:** `deploy/aks/manifests/hosting-operator/operator-rbac.yaml`
+  is applied by the config repository's helm-release lane on every `adopt` / `deploy`, from the
+  chart at the pin; the operator test suite refuses a script that names a `kubectl` verb+resource
+  the role does not grant (`check-rbac-coverage.sh`). Measured 2026-09-09: the first Reconcile
+  through the fixed operator stopped at step 1/6 with `storageclasses … is forbidden` — the grant
+  had been on `main` for hours, the cluster's role predated it, and only a laptop could have moved
+  it. A control-plane input with no lane is a defect, whichever file it lives in.
+- **`/api/version` names the delivery run's RESOLVED target commit, not the set's queue tip.**
+  `3.0.0-ci.8131` is CD run 34260408777 with head `e1039813e`; its "Resolve the target commit"
+  job picked `3853374f7` (the merge one second earlier in the same queue group), and that is what
+  the image answers. Compare a portal's commit against the run's resolve job, never against the
+  run's head or `main` — read as "not 8131", it cost an hour on 2026-09-09.
 - **Steady state is self-update and CD**, never a hand roll —
   [ReleaseStrategy](/Doc/Architecture/ReleaseStrategy), [DeploymentAKS](/Doc/Architecture/DeploymentAKS)
   (the bootstrap runbook, now read under rule 1 above).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operators-permissions-follow-the-chart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operators-permissions-follow-the-chart.md
@@ -37,6 +37,11 @@ that only a laptop could move: an input of the control plane with no lane to car
   the scripts name and refuses one the ClusterRole does not grant — naming the script, the verb,
   the resource and the rule to add. It ran red on the manifest as it was, for both scripts.
 - The volume-purge step's grant is added.
+- Ensuring a namespace is now "read it, create it if absent". It used to be a client-side
+  dry-run piped into `kubectl apply`, which *patches* a namespace that already exists — a verb the
+  role does not grant, on purpose. The Reconcile that first reached that line after the RBAC was
+  applied grew memex's data share from 16Gi to 128Gi through the lane and then stopped there. The
+  coverage check now reads that idiom as needing `patch`, and flagged both places it was used.
 
 What the check cannot see is stated in the script: manifests handed to `kubectl apply`, resources
 named at run time, and what helm does with the chart.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operators-permissions-follow-the-chart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operators-permissions-follow-the-chart.md
@@ -1,0 +1,42 @@
+---
+Name: The operator's permissions follow the chart
+Category: Fix
+Description: The first record-driven Reconcile of memex through the fixed operator stopped one step in, refused by the cluster — the operator's ClusterRole had never received a grant that had been in the repository for hours. The grant now travels with the chart on every deploy, and a test refuses a script that names a permission its role does not hold.
+Icon: Shield
+Order: -20260909
+---
+
+The hosting operator runs each instance action as a short-lived Job under its own identity, and
+what that identity may do is one file in this repository — the `hosting-operator` ClusterRole.
+On 2026-09-09 the first Reconcile of memex through the operator carrying the
+namespace fix of 2026-09-08 got past the
+line that had stopped every earlier run, rendered its six steps, and stopped at the first:
+
+```
+hosting-pv-resize: ERROR: could not read StorageClass azurefile-memex
+  (Error from server (Forbidden): storageclasses.storage.k8s.io "azurefile-memex" is forbidden:
+   User "system:serviceaccount:memex-ops:hosting-operator" cannot get resource "storageclasses")
+```
+
+## What was happening
+
+The rule that grants exactly that read had been on `main` since the volume-capacity step landed.
+Nothing applied it: the ClusterRole manifest was one `kubectl apply` in a README, run once from a
+laptop when the operator was first set up, and the cluster's copy predated the rule. A second
+script — the one that releases a torn-down instance's volumes — had been merged with no grant at
+all, so no teardown could have completed either. Both are the same shape as the operator image
+that only a laptop could move: an input of the control plane with no lane to carry it.
+
+## What it does now
+
+- The config repository's helm-release lane applies the ClusterRole from this repository at the
+  same pin it renders the chart from, on every `adopt` and `deploy`. A grant and the step that
+  needs it move together, and the log names every resource as `configured` or `unchanged`.
+  A pin with no manifest is a red run, never a skipped step.
+- `check-rbac-coverage.sh` in the operator's test suite reads every `kubectl <verb> <resource>`
+  the scripts name and refuses one the ClusterRole does not grant — naming the script, the verb,
+  the resource and the rule to add. It ran red on the manifest as it was, for both scripts.
+- The volume-purge step's grant is added.
+
+What the check cannot see is stated in the script: manifests handed to `kubectl apply`, resources
+named at run time, and what helm does with the chart.


### PR DESCRIPTION
## Ensure-namespace reads, then creates — never `create --dry-run | kubectl apply`

Follow-up to #3769 (branched from its head; the diff shrinks to this change once #3769 lands).

**Measured 2026-09-09 00:42Z on memex** (`Deployments/memex-reconcile-20260909-pv-capacity`, filed through the API after Memex#256's lane applied the ClusterRole): the first run to reach this line after the narration fix. Steps 1–3 worked — **memex-data grew 16Gi → 128Gi through the lane** (`::hosting:: pv_capacity=128Gi`, `pv_resized=1`) — then step 4/6 "Re-apply the record":

```
namespaces "memex" is forbidden: User "system:serviceaccount:memex-ops:hosting-operator"
cannot patch resource "namespaces" in API group "" in the namespace "memex"
```

`kubectl create namespace X --dry-run=client -o yaml | kubectl apply -f -` **patches** an existing namespace (last-applied-configuration). The ClusterRole grants namespaces get/list/create/delete and no patch — deliberately: a lifecycle run has no business editing a namespace it did not just create. This was the wall behind the wall #3757 removed.

### What changes
- `hosting-deploy` and `hosting-pull-secret`: ensure = `kubectl get namespace X || kubectl create namespace X`. The read is a read (a dry run still performs it); only the create is a mutation.
- `check-rbac-coverage.sh` reads `create <res> … --dry-run=client` as needing `patch` on `<res>` too. Falsified: against main's scripts it names both sites; against the fixed ones, 0 missing.
- pull-secret kubectl stub: `get namespace` answers NotFound unless `HOSTING_PULL_SECRET_STUB_NS_EXISTS=1`; `create namespace` creates; the dry-run form is refused so the idiom cannot come back.
- `run-tests.sh`: absent namespace → created before the Secret, never applied; existing namespace → read and left alone, Secret still applied. **136 passed, 0 failed** locally.

### After this lands
The Hosting Operator workflow publishes the image on the main push; `Deployments/memex.operator.image` moves to it through the API (memex's Hosting copy reads the record first — Plugins #1542 is live there), then the Reconcile again, then pearl's Provision.
