### PR TITLE
Render the PodDisruptionBudget for every two-replica portal and spread replicas across nodes (#3772)

### DIFF
--- a/deploy/aks/scripts/check-chart-invariants.py
+++ b/deploy/aks/scripts/check-chart-invariants.py
@@ -153,6 +153,32 @@ if pdb is not None:
             "the floor in the same change that introduces the budget.",
         )
 
+# ---- 14./15. a floor > 1 must be PROTECTED (MeshWeaver#3772) -----------------
+# The converse of 6. memex ran `replicas.portal: 2` with NO budget for weeks — pdb.yaml was gated
+# on keda.enabled, which memex's overlay never set — and an AKS node drain on 2026-09-09 evicted
+# both pods in the same second (503 for ~90 s). Invariant 6 was green throughout: it only asked
+# whether a budget that IS rendered has a floor under it.
+checks += 1
+if floor > 1 and pdb is None:
+    finding(
+        f"the replica floor is {floor} but no PodDisruptionBudget is rendered",
+        "without a budget the eviction API may take every replica at once — one node drain "
+        "shut down both memex pods in the same second on 2026-09-09. Render memex-portal-pdb "
+        "(maxUnavailable: 1) whenever the floor is two or more, KEDA or not.",
+    )
+checks += 1
+if floor > 1:
+    anti = ((pod.get("affinity") or {}).get("podAntiAffinity")) or {}
+    spread = pod.get("topologySpreadConstraints") or []
+    if not anti and not spread:
+        finding(
+            f"the replica floor is {floor} but the pod template declares neither podAntiAffinity "
+            "nor topologySpreadConstraints",
+            "nothing stops the scheduler from co-locating every replica on one node, where one "
+            "drain or one node failure takes them all — a budget cannot help when 'the other "
+            "pod' shares the host. Declare a preferred podAntiAffinity on kubernetes.io/hostname.",
+        )
+
 # ---- 7. surge-first rolls ---------------------------------------------------
 checks += 1
 if scaled is not None:

--- a/deploy/aks/scripts/check-chart-invariants.sh
+++ b/deploy/aks/scripts/check-chart-invariants.sh
@@ -34,6 +34,9 @@
 #   8. every values key the platform must let a deploy set is actually RENDERED, and never blank
 #   9. a key whose consumer parses it must never render BLANK   absent is fine; blank throws at bind
 #  10. readiness and liveness probe DIFFERENT paths           one path cannot answer two questions
+#  11. the platform pull secret is on BOTH pods or neither the migration and the portal pull one image
+#  12. a chart-created PVC is sized, classed, kept, mounted    or the claim exists and nothing uses it
+#  13. the bundle-fetch shelf is the pre-warm root, pod cred   or the portal reads a shelf nobody filled
 #  14. a replica floor > 1 implies a PDB                     or one node drain evicts every replica at once
 #  15. a replica floor > 1 implies anti-affinity / spread    or every replica shares one node
 #

--- a/deploy/aks/scripts/check-chart-invariants.sh
+++ b/deploy/aks/scripts/check-chart-invariants.sh
@@ -34,6 +34,8 @@
 #   8. every values key the platform must let a deploy set is actually RENDERED, and never blank
 #   9. a key whose consumer parses it must never render BLANK   absent is fine; blank throws at bind
 #  10. readiness and liveness probe DIFFERENT paths           one path cannot answer two questions
+#  14. a replica floor > 1 implies a PDB                     or one node drain evicts every replica at once
+#  15. a replica floor > 1 implies anti-affinity / spread    or every replica shares one node
 #
 # NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"). Every input is IN THIS REPO:
 # the chart and the tracked values files. There is no secret to be absent, so there is no condition
@@ -101,6 +103,12 @@ COMBOS=(
   # that renders the `bundle-fetch` init container, its shelf, its script and the projected pull
   # secret. Invariant 13 asserts the shelf is the pre-warm's root and the credential is the pod's.
   "mirror consumer + bundles from the fleet registry (fixture)|deploy/helm/values.yaml:deploy/aks/scripts/testdata/values.mirror-consumer.yaml:deploy/aks/scripts/testdata/values.bundle-fetch.yaml"
+  # The memex.systemorph.com shape (MeshWeaver#3772): TWO PLAIN REPLICAS with KEDA OFF. Its lane
+  # renders the vault values plus its own overlay — never values.aks.yaml — so this is the only
+  # combination here with a replica floor above one and no ScaledObject. Until 2026-09-09 it
+  # rendered NO PodDisruptionBudget (pdb.yaml was gated on keda.enabled) and invariants 14/15 did
+  # not exist: an AKS node drain evicted both pods in the same second, 503 for ~90 s.
+  "two plain replicas, KEDA off (the memex shape)|deploy/helm/values.yaml:deploy/aks/scripts/testdata/values.two-replicas-no-keda.yaml"
 )
 
 WORK="$(mktemp -d)"

--- a/deploy/aks/scripts/testdata/values.two-replicas-no-keda.yaml
+++ b/deploy/aks/scripts/testdata/values.two-replicas-no-keda.yaml
@@ -1,0 +1,42 @@
+# FIXTURE for check-chart-invariants.sh — the memex.systemorph.com shape (MeshWeaver#3772).
+#
+# Two plain replicas, KEDA OFF. memex's helm-release lane (Systemorph/Memex) renders the Key Vault
+# values plus `values.memex.public.yaml` and never `deploy/aks/values.aks.yaml`, so the shared AKS
+# overlay's `keda.enabled: true` is not memex's, and its overlay's `replicas.portal: 2` is the whole
+# HA declaration. Everything else here is only what invariants 2–4 demand of ANY floor above one:
+# AdoNet clustering with a membership connection string, and ReadWriteMany on every claim.
+# Placeholders, no credential.
+replicas:
+  portal: 2
+keda:
+  enabled: false
+config:
+  memex_portal:
+    Deployment__Orleans__Clustering: "AdoNet"
+secrets:
+  memex_portal:
+    ConnectionStrings__memex: "Host=pg.example.test;Database=memex;Username=memex;Password=placeholder"
+    ConnectionStrings__orleans: "Host=pg.example.test;Database=orleans;Username=memex;Password=placeholder"
+  memex_migration:
+    ConnectionStrings__memex: "Host=pg.example.test;Database=memex;Username=memex;Password=placeholder"
+    ConnectionStrings__orleans: "Host=pg.example.test;Database=orleans;Username=memex;Password=placeholder"
+persistence:
+  data:
+    claimName: "memex-data"
+    create: true
+    size: "128Gi"
+    storageClass: "azurefile-memex"
+    accessMode: "ReadWriteMany"
+  content:
+    claimName: "memex-content"
+    create: true
+    size: "64Gi"
+    storageClass: "azurefile-memex"
+    accessMode: "ReadWriteMany"
+    mountPath: "/mnt/content"
+  users:
+    claimName: "memex-users"
+    create: true
+    size: "32Gi"
+    storageClass: "azurefile-memex"
+    accessMode: "ReadWriteMany"

--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -78,6 +78,24 @@ spec:
       # complaint this closes. Grains follow the same budget for free — MessageHubGrain is
       # [PreferLocalPlacement], so a circuit's hubs live on the pod serving that circuit, and a pod
       # that stays alive keeps them running against the code they activated with.
+      # 🚨 Two replicas on ONE node are one replica for every purpose that matters
+      # (MeshWeaver#3772): an AKS node drain evicted both memex pods in the same second on
+      # 2026-09-09 and the portal answered 503 until a replacement passed the startup gate.
+      # PREFERRED, not required: with two schedulable nodes the replicas land on two nodes; with
+      # one (a drained node's replacement has to land on the survivor) the pod still schedules
+      # instead of sitting Pending — the PodDisruptionBudget (pdb.yaml) is what then throttles the
+      # NEXT eviction to one pod at a time, so the survivor keeps serving while its twin moves.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: "{{ .Chart.Name }}"
+                    app.kubernetes.io/component: "memex-portal"
+                    app.kubernetes.io/instance: "{{ .Release.Name }}"
       terminationGracePeriodSeconds: {{ .Values.portal.drainSeconds | default 1800 }}
       initContainers:
         # Postgres and the portal start concurrently on a fresh install; the portal's hub

--- a/deploy/helm/templates/memex-portal/pdb.yaml
+++ b/deploy/helm/templates/memex-portal/pdb.yaml
@@ -1,7 +1,18 @@
-{{- if .Values.keda.enabled }}
-# A PodDisruptionBudget for the portal. Rendered only under KEDA autoscaling (min 2) — i.e. the HA
-# deployments (AKS). A single-replica self-host leaves KEDA off, where a PDB would only block node
-# maintenance, so it is templated out there.
+{{- $floor := ternary (int .Values.keda.minReplicas) (int ((.Values.replicas).portal | default 1)) .Values.keda.enabled }}
+{{- if ge $floor 2 }}
+# A PodDisruptionBudget for the portal. Rendered whenever the REPLICA FLOOR is two or more — under
+# KEDA autoscaling (minReplicas) or a plain `replicas.portal: 2` — i.e. every HA deployment. A
+# single-replica self-host renders none: over one pod a budget would only block node maintenance.
+#
+# 🚨 The gate used to be `keda.enabled` alone, and that is how memex.systemorph.com ran TWO
+# replicas with NO budget (MeshWeaver#3772). memex's helm-release lane renders the vault values
+# plus `values.memex.public.yaml` — never `deploy/aks/values.aks.yaml`, where KEDA is on — so the
+# overlay's `replicas.portal: 2` rendered two pods the eviction API could take together. On
+# 2026-09-09 an AKS node drain did exactly that at 01:05:01Z: both pods logged "Application is
+# shutting down" in the same second and the portal answered 503 until a replacement passed the
+# startup gate (~90 s). The pod template's anti-affinity (deployment.yaml) is the other half:
+# the budget throttles eviction to one pod at a time, the anti-affinity makes "the other pod"
+# live on another node so there is one left to serve while the drained one is replaced.
 #
 # 🚨 maxUnavailable, NOT minAvailable — and that is the whole point of this file.
 #

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -270,6 +270,38 @@ above 1, and `strategy.maxUnavailable: 0` under KEDA. Every input is in this rep
 runs unconditionally on every pull request (`.github/workflows/chart-gate.yml`) — no secret to be
 absent means no condition under which it may decline to run.
 
+## Node drains — the disruption budget and where the replicas sit
+
+An AKS node-pool operation (node image upgrade, OS patching, autoscaler consolidation) cordons a
+node and **evicts** its pods through the eviction API, one node after another. Two facts decide
+what the portal's users see while that happens:
+
+- **The eviction API honours a `PodDisruptionBudget`, and nothing else.** The chart renders
+  `memex-portal-pdb` with `maxUnavailable: 1` whenever the replica floor is two or more —
+  `keda.minReplicas` under autoscaling, `replicas.portal` otherwise. Under it a drain evicts one
+  pod, waits until the Deployment has a replacement Ready, then evicts the next.
+  `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` speaks only to the autoscaler's
+  bin-packing; a drain ignores it.
+- **A budget cannot help when "the other pod" is on the same node.** The pod template declares a
+  *preferred* `podAntiAffinity` on `kubernetes.io/hostname`, so two replicas land on two nodes
+  when two are schedulable and still schedule when only one is (a drained node's replacement has
+  to land on the survivor).
+
+🚨 **Measured 2026-09-09 (MeshWeaver#3772):** memex ran `replicas.portal: 2` with **no budget** —
+`pdb.yaml` was gated on `keda.enabled`, and memex's helm-release lane renders the vault values
+plus `values.memex.public.yaml`, never `deploy/aks/values.aks.yaml` where KEDA is on. Both pods
+sat on one node; a drain at 01:05:01Z shut both down in the same second and the portal answered
+503 until a replacement passed the startup gate (~90 s). Reading it needed the *cluster-wide*
+log — pods in three namespaces stopping together — because inside the memex namespace it looked
+like a rollout that changed nothing. `check-chart-invariants.py` now refuses a floor above one
+with no budget (invariant 11) or no spreading (invariant 12); before, it only asked whether a
+budget that exists has replicas under it.
+
+Loki loses whatever its ingester had not flushed when `loki-0` itself is drained (the 01:05Z lines
+were readable at 01:08Z and gone at 01:11Z) — read a cluster-wide incident promptly, and see the
+header of `deploy/aks/scripts/values.observability.yaml` for what the loki-stack chart can and
+cannot persist.
+
 ## Self-update ops — pausing, pinning, and the rules that bite
 
 Operational facts about the in-pod updater (learned the hard way — each cost a debugging session):

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -294,7 +294,7 @@ sat on one node; a drain at 01:05:01Z shut both down in the same second and the 
 503 until a replacement passed the startup gate (~90 s). Reading it needed the *cluster-wide*
 log — pods in three namespaces stopping together — because inside the memex namespace it looked
 like a rollout that changed nothing. `check-chart-invariants.py` now refuses a floor above one
-with no budget (invariant 11) or no spreading (invariant 12); before, it only asked whether a
+with no budget (invariant 14) or no spreading (invariant 15); before, it only asked whether a
 budget that exists has replicas under it.
 
 Loki loses whatever its ingester had not flushed when `loki-0` itself is drained (the 01:05Z lines

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-two-replicas-no-longer-leave-together-on-a-node-drain.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-two-replicas-no-longer-leave-together-on-a-node-drain.md
@@ -1,0 +1,34 @@
+---
+Name: Two replicas no longer leave together on a node drain
+Category: Fix
+Description: memex answered 503 for about ninety seconds in the night of 2026-09-09 when the cluster drained a node and both portal pods were on it, with no disruption budget to hold the second one back. The chart now renders the budget for every two-replica deployment, not only autoscaled ones, and asks the scheduler to keep replicas on different nodes.
+Icon: Shield
+Order: -20260909
+---
+
+At 01:05:01Z both memex portal pods logged "Application is shutting down" in the same second.
+Nothing had been deployed: the replacements came from the same ReplicaSet, on the same image, and
+there was no crash. Read across every namespace, the cluster was draining its nodes one by one —
+Loki, its alertmanager, the dashboards and the memex-cloud website pods all stopped within
+fifteen seconds of the next memex pod four minutes later. That is a node-pool operation, and a
+routine one.
+
+## What was missing
+
+A drain evicts pods through the eviction API, and the eviction API honours a
+`PodDisruptionBudget` — if there is one. The chart had one, but only rendered it under KEDA
+autoscaling. memex is not autoscaled; its overlay declares two plain replicas, so the budget
+never existed there, and the drain took both pods at once. The pod template also said nothing
+about where the two replicas should live, so the scheduler had put them on the same node.
+
+## What it does now
+
+- The budget renders whenever the replica floor is two or more — autoscaled or not — and
+  throttles voluntary disruption to one pod at a time, as before.
+- The pod template declares a preferred anti-affinity on the node name, so two replicas land on
+  two nodes when two are schedulable, and still schedule when only one is.
+- The chart invariants gate on every pull request now refuses a rendering with a replica floor
+  above one and no budget, or no spreading — the shape that was green for weeks.
+
+The lane that gates its own inputs could not have seen this: the check asked whether a budget
+that exists has replicas under it, never whether replicas that exist have a budget over them.


### PR DESCRIPTION
Closes #3772

## Incident

memex.systemorph.com answered 503 for ~90 s from 01:05:45Z on 2026-09-09. Both portal pods logged `Application is shutting down...` at **01:05:01Z simultaneously**; the replacements came from the same ReplicaSet on the same image (no rollout, no crash). Read cluster-wide through Loki, the cluster was draining its nodes one by one: at 01:09:08Z `loki-0`, `loki-alertmanager-0`, the pushgateway, `memex-cloud/memex-website` and both `k8s-dashboard` pods stopped within 15 s, then the next memex pod and a memex-cloud pod at 01:09:23Z. An AKS node-pool operation — not an application event. (`Modules:AutoRecycleOnStaleBuild` is a hub `DisposeRequest`, never a process exit, and is excluded.)

## Defect

- `pdb.yaml` was gated on `keda.enabled`. memex's helm-release lane renders `-f vault-values.yaml -f values.memex.public.yaml` (never `deploy/aks/values.aks.yaml`, where KEDA is on) and its overlay never sets `keda`, so `replicas.portal: 2` rendered two pods and **no PodDisruptionBudget** — the eviction API took both.
- No `podAntiAffinity` / `topologySpreadConstraints`: both replicas on one node.
- `check-chart-invariants.py` asserted "a PDB implies a floor > 1" but not the converse.

## Change

- Budget renders whenever the replica floor ≥ 2 (`keda.minReplicas` or `replicas.portal`), `maxUnavailable: 1`.
- Preferred `podAntiAffinity` on `kubernetes.io/hostname` in the portal pod template.
- Invariants 14 (floor > 1 ⇒ budget) and 15 (floor > 1 ⇒ anti-affinity/spread), and the memex shape as a fixture combination.
- DeploymentAKS section + What's New (Fix).

## Verification

- `check-chart-invariants.sh`: 7/7 combinations self-consistent.
- Negative control (chart fix reverted, gate + fixture kept): red on `two plain replicas, KEDA off` for BOTH invariants and on the shared AKS overlay for 15.
- `helm template` of the memex shape: `PodDisruptionBudget` with `maxUnavailable: 1`, `podAntiAffinity` on hostname, `replicas: 2`.
- `check-values-are-read.sh`: 119/119 keys read.
- `MeshWeaver.Documentation.Test` (built Release `-warnaserror` after the doc edits): WhatsNewEntryIntegrityTest, DocumentationLinkIntegrityTest, NoConflictMarkersGuard — 3/3 passed.

No C# change; no public surface touched. Pairs-with: none — chart + scripts + docs only.

Follow-up filed separately: #3773 (Loki drops unflushed chunks when `loki-0` is drained — the 01:05Z lines were readable at 01:08Z and gone at 01:11Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
