### PR TITLE
fix(operator): run.sh signs in to Azure through Workload Identity before the first step

### DIFF
--- a/deploy/aks/operator/bin/run.sh
+++ b/deploy/aks/operator/bin/run.sh
@@ -69,6 +69,38 @@ if [ -n "${HOSTING_VALUES:-}" ]; then
   fi
 fi
 
+# ── Azure sign-in through Workload Identity ──────────────────────────────────────────────────
+# The Job runs as the hosting-operator ServiceAccount, federated to the operator's managed identity
+# (backups.bicep); the workload-identity webhook projects a token into the pod and sets
+# AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE. 🚨 az DOES NOT READ THOSE ON ITS
+# OWN — the Azure SDKs do (WorkloadIdentityCredential), the CLI does not. Measured 2026-09-09 01:33Z
+# on the first Provision ever run through the lane (Deployments/pearl-provision-20260909): step 1/14
+# `az postgres flexible-server db create` answered "ERROR: Please run 'az login' to setup account."
+# Every earlier run (memex Reconcile/Restart) was kubectl+helm only, which authenticate in-cluster,
+# so no run had reached an az step before. Sign in ONCE here, as the identity, and say so.
+#
+# The token never reaches a command line or the log: it is read from the file straight into az's
+# argument by this process, and az is not wrapped in hosting::do (which narrates argv).
+if [ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
+  [ -r "$AZURE_FEDERATED_TOKEN_FILE" ] \
+    || hosting::die "AZURE_FEDERATED_TOKEN_FILE=${AZURE_FEDERATED_TOKEN_FILE} is not readable — the workload-identity webhook set the variable but the projected token is missing"
+  hosting::need_env AZURE_CLIENT_ID "the operator identity's client id (Hosting:Operator:Environment or the record's operator.environment; the webhook also sets it)"
+  hosting::need_env AZURE_TENANT_ID "set by the workload-identity webhook from the ServiceAccount's azure.workload.identity/tenant-id annotation or the webhook default"
+  if az login --service-principal --username "$AZURE_CLIENT_ID" --tenant "$AZURE_TENANT_ID" \
+       --federated-token "$(cat "$AZURE_FEDERATED_TOKEN_FILE")" --allow-no-subscriptions --output none 2>/tmp/az-login.err; then
+    az_sub="$(az account show --query id -o tsv 2>/dev/null || true)"
+    hosting::log "azure     signed in as ${AZURE_CLIENT_ID} (subscription ${az_sub:-none})"
+    hosting::say az_login true
+  else
+    hosting::die "az login as workload identity ${AZURE_CLIENT_ID} failed: $(tr -d '\n' < /tmp/az-login.err). Check the federated credential on the operator identity (subject system:serviceaccount:memex-ops:hosting-operator, issuer AZ_OIDC_ISSUER) — a subject/issuer mismatch fails here and nowhere else."
+  fi
+else
+  # Not a refusal: a Reconcile/Roll/Restart is kubectl+helm only and needs no Azure session. A step
+  # that DOES need az then fails by name — and this line, above it in the log, says what was missing.
+  hosting::log "azure     no workload-identity token (AZURE_FEDERATED_TOKEN_FILE unset) — steps that call az will fail. The Job needs the pod label azure.workload.identity/use=true and the hosting-operator ServiceAccount annotated azure.workload.identity/client-id (manifests/hosting-operator/operator-serviceaccount.yaml)."
+  hosting::say az_login false
+fi
+
 total=0
 while IFS=$'\t' read -r name command; do
   [ -n "${name:-}" ] || continue

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -354,6 +354,55 @@ out="$(env HOSTING_DRY_RUN=true HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d \
 case "$out" in *"DRY-RUN would run"*) ok "a dry run narrates what it would do" ;;
   *) bad "a dry run narrates" "said: ${out}" ;; esac
 
+# ── run.sh signs in to Azure through Workload Identity, once, before the first step ─────────────
+# Measured 2026-09-09 01:33Z: the first Provision through the lane died at step 1/14 with az's own
+# "Please run 'az login'" — the webhook projects a token and sets the AZURE_* variables, but the CLI
+# never reads them by itself. The stub records argv, which is how the test proves the token is
+# handed to az as an argument and appears nowhere in run.sh's OUTPUT (a `+ az login …` narration
+# would print it — az is deliberately not wrapped in hosting::do).
+RUN_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/run" && pwd)"
+_rl_dir="$(mktemp -d)"; _rl_log="$_rl_dir/calls.log"; : > "$_rl_log"
+printf 'eyJ0b2tlbi1zZW50aW5lbC1ORVZFUi1QUklOVEVEIjp0cnVlfQ' > "$_rl_dir/token"
+_rl_out="$(env PATH="$RUN_STUBS:$PATH" HOSTING_RUN_STUB_LOG="$_rl_log" \
+  AZURE_FEDERATED_TOKEN_FILE="$_rl_dir/token" AZURE_CLIENT_ID=11111111-2222-3333-4444-555555555555 AZURE_TENANT_ID=tenant-t \
+  HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan "First	echo one >> ${_rl_dir}/steps")" "$BIN/run.sh" 2>&1)"; _rl_rc=$?
+[ "$_rl_rc" -eq 0 ] && ok "run.sh succeeds with a workload-identity token" || bad "run.sh succeeds with a workload-identity token" "exited ${_rl_rc}: ${_rl_out}"
+if grep -q '^az login --service-principal --username 11111111-2222-3333-4444-555555555555 --tenant tenant-t --federated-token eyJ0b2tlbi1zZW50aW5lbC1ORVZFUi1QUklOVEVEIjp0cnVlfQ --allow-no-subscriptions' "$_rl_log"; then
+  ok "run.sh signs in as the identity with the projected token"
+else
+  bad "run.sh signs in as the identity with the projected token" "$(cat "$_rl_log")"
+fi
+case "$_rl_out" in *eyJ0b2tlbi1zZW50aW5lbC1ORVZFUi1QUklOVEVEIjp0cnVlfQ*) bad "the federated token never appears in the run's output" "it did: ${_rl_out}" ;;
+  *) ok "the federated token never appears in the run's output" ;; esac
+case "$_rl_out" in *"::hosting:: az_login=true"*) ok "the sign-in is reported to the mesh (az_login=true)" ;;
+  *) bad "the sign-in is reported (az_login=true)" "said: ${_rl_out}" ;; esac
+# Order: the sign-in precedes the first step's marker in the output.
+_rl_login_pos="$(printf '%s' "$_rl_out" | grep -n 'azure     signed in' | head -1 | cut -d: -f1)"
+_rl_step_pos="$(printf '%s' "$_rl_out" | grep -n '::hosting:: step=First' | head -1 | cut -d: -f1)"
+if [ -n "$_rl_login_pos" ] && [ -n "$_rl_step_pos" ] && [ "$_rl_login_pos" -lt "$_rl_step_pos" ]; then
+  ok "the sign-in happens before the first step"
+else
+  bad "the sign-in happens before the first step" "login at '${_rl_login_pos}', step at '${_rl_step_pos}'"
+fi
+# A federation mismatch is a refusal that names the subject/issuer to check, before any step runs.
+: > "$_rl_log"; rm -f "$_rl_dir/steps"
+refuses_hard "a failed sign-in stops the run before any step" "federated credential on the operator identity" \
+  env PATH="$RUN_STUBS:$PATH" HOSTING_RUN_STUB_LOG="$_rl_log" HOSTING_RUN_STUB_LOGIN_FAIL=1 \
+  AZURE_FEDERATED_TOKEN_FILE="$_rl_dir/token" AZURE_CLIENT_ID=c AZURE_TENANT_ID=t \
+  HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan "First	echo one >> ${_rl_dir}/steps")" "$BIN/run.sh"
+[ ! -e "$_rl_dir/steps" ] && ok "…and the first step never ran" || bad "the first step never ran after a failed sign-in" "it did"
+# A token file that is set but unreadable, and a missing tenant, are named.
+refuses "a token variable without the file is named" "is not readable" \
+  env PATH="$RUN_STUBS:$PATH" HOSTING_RUN_STUB_LOG="$_rl_log" AZURE_FEDERATED_TOKEN_FILE="$_rl_dir/nope" AZURE_CLIENT_ID=c AZURE_TENANT_ID=t \
+  HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan 'First	echo one')" "$BIN/run.sh"
+refuses "a missing tenant id is named" "AZURE_TENANT_ID" \
+  env -u AZURE_TENANT_ID PATH="$RUN_STUBS:$PATH" HOSTING_RUN_STUB_LOG="$_rl_log" AZURE_FEDERATED_TOKEN_FILE="$_rl_dir/token" AZURE_CLIENT_ID=c \
+  HOSTING_ACTION=provision HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan 'First	echo one')" "$BIN/run.sh"
+# No token at all (a kubectl+helm-only run): not a refusal, but said, and reported as az_login=false.
+emits "without a token the run says so and reports az_login=false" "::hosting:: az_login=false" \
+  env -u AZURE_FEDERATED_TOKEN_FILE HOSTING_ACTION=reconcile HOSTING_DEPLOYMENT=d HOSTING_PLAN="$(plan 'First	echo one')" "$BIN/run.sh"
+rm -rf "$_rl_dir"
+
 echo
 echo "── hosting-pv-resize: capacity is a record property ──────────────"
 # The stub answers the command's reads from a per-scenario fixture and RECORDS the writes, so

--- a/deploy/aks/operator/test/stubs/run/az
+++ b/deploy/aks/operator/test/stubs/run/az
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# A stand-in `az` for run.sh's sign-in tests. Records every invocation (argv, verbatim — which is
+# exactly how the test proves the federated token is passed as an argument to az and appears
+# NOWHERE in run.sh's own output) and answers `login` / `account show`.
+#   HOSTING_RUN_STUB_LOG          every invocation, one line each
+#   HOSTING_RUN_STUB_LOGIN_FAIL=1 login fails as a federation mismatch would
+set -uo pipefail
+printf 'az %s\n' "$*" >> "${HOSTING_RUN_STUB_LOG:?the az stub needs HOSTING_RUN_STUB_LOG}"
+case "${1:-} ${2:-}" in
+  "login "*)
+    if [ "${HOSTING_RUN_STUB_LOGIN_FAIL:-0}" = "1" ]; then
+      echo "ERROR: AADSTS70021: No matching federated identity record found for presented assertion." >&2; exit 1
+    fi
+    exit 0 ;;
+  "account show") echo "00000000-0000-0000-0000-000000000000"; exit 0 ;;
+  *) echo "az stub: unexpected invocation: $*" >&2; exit 1 ;;
+esac

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operator-signs-in-to-azure-as-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operator-signs-in-to-azure-as-itself.md
@@ -1,0 +1,34 @@
+---
+Name: The operator signs in to Azure as itself
+Category: Fix
+Description: The first new instance provisioned through the control portal stopped at its first step — Azure asked the operator to log in. The job had the identity all along; the CLI just never used it. The job now signs in once, as its workload identity, before the first step, and a run that cannot is refused by name.
+Icon: Wrench
+Order: -20260909
+---
+
+On 2026-09-09 the first `Provision` of a new instance (pearl) was filed through the control
+portal, on an operator that had by then made it through every earlier wall. It rendered its
+fourteen steps and stopped at the first:
+
+```
+[1/14] Create database
+ERROR: Please run 'az login' to setup account.
+```
+
+## What was happening
+
+The operator runs as a Kubernetes ServiceAccount federated to a managed identity, and the
+cluster's workload-identity webhook projects a token into the job and sets the `AZURE_*`
+variables for it. The Azure **SDKs** read those on their own; the Azure **CLI** does not. Nothing
+in the job ever ran `az login`, so every step that touches Azure — the database, the Key Vault
+secrets, the federation, DNS, TLS — had never worked through the lane. No earlier run had reached
+one: memex's reconciles are kubectl and helm only, which authenticate in-cluster.
+
+## What it does now
+
+The job signs in once, before the first step, as its identity with the projected token, and logs
+`signed in as <client id>`; the token never reaches a command line or the log. A sign-in that
+fails stops the run before any step and names what to check — the federated credential's subject
+and issuer, which is the one place a mismatch shows. A run with no token at all (a reconcile that
+needs no Azure) says so and carries on. The operator's test suite asserts all of it against a
+stubbed CLI.


### PR DESCRIPTION
## run.sh signs in to Azure through Workload Identity before the first step

**Measured 2026-09-09 01:33Z**, `Deployments/pearl-provision-20260909` — the first `Provision` ever run through the lane, on operator 0b79490 after #3757 / #3769 / #3770 and Memex #256 had cleared every earlier wall. Fourteen steps rendered; step 1/14 `az postgres flexible-server db create`:

```
ERROR: Please run 'az login' to setup account.
```

Nothing in the operator runs `az login`. The Job is federated (pod label `azure.workload.identity/use`, the ServiceAccount annotation, the identity from backups.bicep) and the webhook projects a token and sets `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` — the Azure **SDKs** pick those up, the **CLI** never does. No run had reached an az step before: memex's Reconcile / Restart are kubectl + helm only, which authenticate in-cluster. Nothing was created on Azure (step 1 was the first az call).

### What changes (`run.sh`, before the first step)
- `AZURE_FEDERATED_TOKEN_FILE` set → require `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` by name, `az login --service-principal --username … --tenant … --federated-token <file contents> --allow-no-subscriptions`, log `signed in as <id> (subscription <s>)`, report `::hosting:: az_login=true`.
- A failed login is a hard refusal before any step, naming the federated credential's subject and issuer (the one place a mismatch shows). An unreadable token file is named.
- No token variable (a kubectl+helm-only run) → said, `az_login=false`, the plan runs; an az step then fails by name with the hint above it in the log.
- The token is passed as an argument by this process and never printed — az is deliberately not wrapped in `hosting::do`, which narrates argv.

### Tests (`stubs/run/az` records argv)
signed in with the projected token · token absent from the run's output · `az_login=true` · sign-in before the first step marker · failed login = hard refusal, first step never ran · unreadable file named · missing tenant named · no-token run reports false. **146 passed, 0 failed.**

### Chain
#3775 (adopt before helm) + this → operator image → `Deployments/{memex,pearl}.operator.image` (API) → memex Reconcile (expect `adopted=1`, success) and pearl Provision re-filed.
