### PR TITLE
fix(operator): the role writes every chart kind; refuse before helm what helm refuses inside; the Azure grants a Provision needs

### DIFF
--- a/deploy/aks/infra/modules/backups.bicep
+++ b/deploy/aks/infra/modules/backups.bicep
@@ -53,6 +53,12 @@ param operatorIdentityName string = 'hosting-operator'
 @description('Resource id of the PostgreSQL Flexible Server instances live on. Empty skips that grant.')
 param postgresServerId string = ''
 
+@description('Resource id of the PORTAL user-assigned identity (memexaks-portal-mi) that every instance namespace federates to. Empty skips that grant — and then hosting-federate fails by name on every Provision.')
+param portalIdentityId string = ''
+
+@description('Resource id of the public DNS zone instances get their host records in (e.g. meshweaver.cloud in resource group dns). Empty skips that grant — and then hosting-dns fails by name on every Provision.')
+param dnsZoneId string = ''
+
 @description('Tags applied to every resource.')
 param tags object = {}
 
@@ -183,6 +189,47 @@ resource operatorPostgresRole 'Microsoft.Authorization/roleAssignments@2022-04-0
     principalId: operatorIdentity.properties.principalId
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', contributorRoleId)
     principalType: 'ServicePrincipal'
+  }
+}
+
+// 🚨 THE TWO GRANTS PROVISIONING NEEDS, measured missing on 2026-09-09 (the first Provision ever run
+// through the lane, Deployments/pearl-provision-20260909-b): step 3/14 `hosting-federate` —
+//   AuthorizationFailed: … does not have authorization to perform action
+//   'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write' over
+//   …/userAssignedIdentities/memexaks-portal-mi/federatedIdentityCredentials/hosting-pearl
+// The operator creates ONE federated credential per instance namespace on the PORTAL identity
+// (subject system:serviceaccount:<ns>:memex-portal-sa) so the new portal can reach Key Vault and
+// storage as that identity. That is a write on the portal identity resource — Managed Identity
+// Contributor, scoped to that ONE identity, never to the resource group. hosting-dns (step 4)
+// needs DNS Zone Contributor on the ONE zone for the same reason. Both scoped to the resource.
+// Neither is applied by any lane: this module is deployed by hand (`az deployment group create`),
+// which is the documented break-glass — see deploy/aks/manifests/hosting-operator/README.md.
+var managedIdentityContributorRoleId = 'f1a07417-d97a-45cb-824c-7a7467783830'
+
+resource existingPortalIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = if (!empty(portalIdentityId)) {
+  name: last(split(portalIdentityId, '/'))
+}
+
+resource operatorPortalIdentityRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(portalIdentityId)) {
+  name: guid(portalIdentityId, operatorIdentity.id, managedIdentityContributorRoleId)
+  scope: existingPortalIdentity
+  properties: {
+    principalId: operatorIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', managedIdentityContributorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// The DNS zone lives in ANOTHER resource group (dns), and a role assignment is deployed at its
+// target's scope — so the zone grant is its own module, deployed into that group:
+//   modules/dns-zone-operator-role.bicep  (params: zoneName, operatorPrincipalId)
+// dnsZoneId is accepted here only so one parameter file names every input; see the README.
+module operatorDnsZoneRole 'dns-zone-operator-role.bicep' = if (!empty(dnsZoneId)) {
+  name: 'hosting-operator-dns-zone-role'
+  scope: resourceGroup(split(dnsZoneId, '/')[4])
+  params: {
+    zoneName: last(split(dnsZoneId, '/'))
+    operatorPrincipalId: operatorIdentity.properties.principalId
   }
 }
 

--- a/deploy/aks/infra/modules/dns-zone-operator-role.bicep
+++ b/deploy/aks/infra/modules/dns-zone-operator-role.bicep
@@ -1,0 +1,31 @@
+// DNS Zone Contributor for the hosting operator identity on ONE public DNS zone — the grant
+// `hosting-dns upsert` needs to create <instance>.<zone> A records on a Provision (and delete them
+// on a Teardown). Its own module because the zone lives in a different resource group from the
+// operator identity (backups.bicep), and a role assignment deploys at its target's scope.
+//
+// Deployed from backups.bicep when dnsZoneId is set, or on its own:
+//   az deployment group create -g dns -f dns-zone-operator-role.bicep \
+//     -p zoneName=meshweaver.cloud operatorPrincipalId=<operatorIdentityPrincipalId>
+targetScope = 'resourceGroup'
+
+@description('Name of the DNS zone in this resource group (e.g. meshweaver.cloud).')
+param zoneName string
+
+@description('Principal id of the hosting operator identity (backups.bicep output operatorIdentityPrincipalId).')
+param operatorPrincipalId string
+
+var dnsZoneContributorRoleId = 'befefa01-2a29-4197-83a8-272ff33ce314'
+
+resource zone 'Microsoft.Network/dnsZones@2023-07-01-preview' existing = {
+  name: zoneName
+}
+
+resource operatorDnsZoneRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(zone.id, operatorPrincipalId, dnsZoneContributorRoleId)
+  scope: zone
+  properties: {
+    principalId: operatorPrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', dnsZoneContributorRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/deploy/aks/manifests/hosting-operator/README.md
+++ b/deploy/aks/manifests/hosting-operator/README.md
@@ -99,3 +99,32 @@ record-driven Reconcile through the fixed operator stopped at step 1/6 with `For
 <resource>` a `bin/` script names must be granted here, or the operator test suite is red.
 `kubectl apply` prints `configured` / `unchanged` per resource in the lane's log — that line is
 the change report.
+
+## The Azure grants a Provision needs — and who applies them
+
+`backups.bicep` gives the operator identity Blob Data Contributor on the backup account and
+Contributor on the PostgreSQL server. A Provision needs two more, both scoped to ONE resource:
+
+| Step | Command | Grant | Where |
+|---|---|---|---|
+| 3 · Federate namespace identity | `hosting-federate` → `az identity federated-credential create` on the PORTAL identity | **Managed Identity Contributor** on `memexaks-portal-mi` | `backups.bicep`, param `portalIdentityId` |
+| 4 · Create DNS record | `hosting-dns upsert` → `az network dns record-set a add-record` | **DNS Zone Contributor** on the zone | `dns-zone-operator-role.bicep` (the zone's resource group), or `backups.bicep` param `dnsZoneId` |
+
+Measured 2026-09-09 (`Deployments/pearl-provision-20260909-b`, the first Provision ever run
+through the lane): step 3 failed with `AuthorizationFailed … federatedIdentityCredentials/write`
+over `…/memexaks-portal-mi/federatedIdentityCredentials/hosting-pearl` — the identity had never
+been granted anything on the portal identity.
+
+🚨 **No lane deploys bicep.** Applying these is the documented break-glass, run by a person with
+Owner on the resource group (the operator identity itself deliberately cannot assign roles):
+
+```bash
+# from deploy/aks/infra/modules — parameters as your environment names them
+az deployment group create -g memex-aks-rg -f backups.bicep \
+  -p oidcIssuerUrl=<AZ_OIDC_ISSUER> postgresServerId=<memexaks-pg resource id> \
+     portalIdentityId=<memexaks-portal-mi resource id> \
+     dnsZoneId=/subscriptions/<sub>/resourceGroups/dns/providers/Microsoft.Network/dnsZones/meshweaver.cloud
+```
+
+After it: re-request the Provision — the plan is idempotent from the top (the database and the
+vault secrets the first run created are found, not re-created).

--- a/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
@@ -47,9 +47,11 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # jobs: the chart's migration Job is a release object helm PATCHES on every upgrade (labels,
+  # annotations) — check-chart-kinds-granted.sh found the missing patch on 2026-09-09.
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]
-    verbs: ["get", "list", "create", "delete"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
   - apiGroups: ["secrets-store.csi.x-k8s.io"]
     resources: ["secretproviderclasses"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
@@ -60,21 +62,39 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets"]
     verbs: ["get", "list"]
-  - apiGroups: ["policy"]
-    resources: ["poddisruptionbudgets"]
-    verbs: ["get", "list"]
   - apiGroups: ["autoscaling"]
     resources: ["horizontalpodautoscalers"]
-    verbs: ["get", "list"]
-  - apiGroups: ["keda.sh"]
-    resources: ["scaledobjects"]
     verbs: ["get", "list"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "list"]
+  # 🚨 EVERY KIND THE CHART RENDERS MUST BE WRITABLE HERE — helm applies the release under this
+  # identity. Measured 2026-09-09 01:59Z (Deployments/memex-reconcile-20260909-adopt): the chart at
+  # core #3774 rendered a PodDisruptionBudget for every two-replica instance, the role granted
+  # poddisruptionbudgets get+list (the audit's read-only block), and helm answered
+  #   UPGRADE FAILED: failed to create resource: poddisruptionbudgets.policy is forbidden
+  # and its --atomic rollback then erred as well. A chart change that renders a NEW kind must land
+  # with its grant; deploy/aks/operator/test/check-chart-kinds-granted.sh holds that ratchet, and
+  # hosting-deploy refuses BEFORE helm (kubectl auth can-i per rendered kind) so a missing grant is
+  # named in one line instead of discovered by a failed upgrade. Excluded on purpose, and refused by
+  # name if a record renders them: ClusterRole/ClusterRoleBinding (instancesAdmin.clusterRead) — a
+  # Job must never widen cluster-scoped RBAC.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["keda.sh"]
+    resources: ["scaledobjects"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # The chart's rbac.yaml (ungated) renders the portal's own Role + RoleBinding (self-update: get/
+  # patch its Deployment). Kubernetes refuses a Role that grants more than its creator holds, so
+  # this cannot escalate past the rules in this file.
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # ollama/service.yaml renders an Endpoints object for an external model host (ollama.external).
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
   # READ-ONLY, for hosting-pv-resize. The storage class decides whether a claim can grow
   # (allowVolumeExpansion); the command reads it BEFORE patching, and refuses a class that cannot
   # expand rather than leaving a request in Pending forever. The patch itself is the

--- a/deploy/aks/operator/bin/hosting-deploy
+++ b/deploy/aks/operator/bin/hosting-deploy
@@ -170,6 +170,40 @@ fi
 hosting::log "adoption  ${adopted} adopted, ${owned} already owned, ${absent} to be created"
 hosting::say adopted "$adopted"
 
+# ── preflight: can this identity write every kind the record renders? ────────────────────────
+# helm applies the release under the operator's ClusterRole. A kind the role cannot create is an
+# UPGRADE FAILED inside helm followed by an --atomic rollback — measured 2026-09-09 01:59Z on memex
+# (poddisruptionbudgets after core #3774 rendered a PDB; the rollback then erred as well). A
+# SelfSubjectAccessReview is always permitted, so ask BEFORE helm, once per rendered kind, and
+# refuse with the whole list — one line names every grant to add, instead of one failed upgrade
+# per missing kind. deploy/aks/operator/test/check-chart-kinds-granted.sh is the static half.
+if [ -n "$rendered" ]; then
+  denied=""
+  while IFS= read -r kind; do
+    [ -n "$kind" ] || continue
+    for verb in create patch delete; do
+      answer="$(hosting::read kubectl -n "$namespace" auth can-i "$verb" "$kind" 2>/dev/null || true)"
+      [ "$answer" = "yes" ] || denied="${denied} ${verb}:${kind}"
+    done
+  done <<EOF_KINDS
+$(printf '%s\n' "$names" | sed 's#/.*##' | sort -u)
+EOF_KINDS
+  [ -z "$denied" ] \
+    || hosting::die "the operator's ClusterRole cannot write every kind the record renders — denied:${denied}. Grant them in deploy/aks/manifests/hosting-operator/operator-rbac.yaml (the config repo's helm-release lane applies it on the next adopt/deploy); helm would otherwise fail inside the upgrade and roll back. ClusterRole/ClusterRoleBinding are excluded by design — a record that renders them (instancesAdmin.clusterRead) is a decision for a person."
+  hosting::log "preflight every rendered kind is writable by this identity"
+fi
+
+# A release helm cannot upgrade is refused by name, not by helm's "another operation is in
+# progress" after a 15-minute wait: pending-install / pending-upgrade / pending-rollback are the
+# states a cut-off run leaves behind, and the fix (helm rollback to the last deployed revision)
+# is a person's call.
+release_state="$(hosting::read helm status "$release" --namespace "$namespace" -o json 2>/dev/null | jq -r '.info.status // ""' 2>/dev/null || true)"
+case "$release_state" in
+  pending-*) hosting::die "release ${release} in ${namespace} is '${release_state}' — a previous operation was cut off and helm refuses every upgrade until it is resolved (helm history ${release} -n ${namespace}; helm rollback ${release} <last deployed revision>). Not done here: choosing the revision is a person's call." ;;
+  "") hosting::log "release   ${release} is not installed yet (first install)" ;;
+  *) hosting::log "release   ${release} is '${release_state}'" ;;
+esac
+
 # --atomic: a failed install ROLLS BACK rather than leaving a half-created release that the next
 # attempt then has to `helm uninstall` before it can proceed. --wait so "deployed" means the pods
 # actually came up; the plan's next step (rollout status) then verifies rather than discovers.

--- a/deploy/aks/operator/test/check-chart-kinds-granted.sh
+++ b/deploy/aks/operator/test/check-chart-kinds-granted.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Every KIND the chart can render must be writable by the operator's ClusterRole — helm applies
+# the release under that identity, so a kind the role cannot create/patch/delete is an upgrade
+# that fails inside helm and rolls back (or, worse, half-applies).
+#
+# 🚨 WHY THIS EXISTS. core #3774 (2026-09-09) made the chart render a PodDisruptionBudget for
+# every two-replica instance. The ClusterRole granted poddisruptionbudgets get+list only. The next
+# record-driven Reconcile of memex (Deployments/memex-reconcile-20260909-adopt) got through
+# adoption and died in helm: "failed to create resource: poddisruptionbudgets.policy is forbidden",
+# and helm's --atomic rollback erred too. Nothing paired the chart change with its grant; this
+# check does. Every Provision of a two-replica instance would have hit the same wall.
+#
+# Excluded on purpose (listed here, refused by name at run time by hosting-deploy's preflight):
+# ClusterRole and ClusterRoleBinding (instances-rbac.yaml, `instancesAdmin.clusterRead`) — a Job
+# must never widen cluster-scoped RBAC. A record that enables that block is a design decision for
+# a person, not a grant to add here.
+#
+# Pure bash 3.2 + grep/sed (no awk, no python — the operator image has neither).
+set -u
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CHART="${HOSTING_CHART_TEMPLATES:-$HERE/../../../helm/templates}"
+# Inside the operator image the chart is baked at /opt/hosting/chart (COPY helm/ …); the repo
+# layout is not there. Fall back to it so the in-image run checks the chart it will actually deploy.
+[ -d "$CHART" ] || [ ! -d /opt/hosting/chart/templates ] || CHART=/opt/hosting/chart/templates
+RBAC="${HOSTING_RBAC_MANIFEST:-$HERE/../../manifests/hosting-operator/operator-rbac.yaml}"
+[ -d "$CHART" ] || { echo "check-chart-kinds-granted: ERROR: chart templates not found at ${CHART} — set HOSTING_CHART_TEMPLATES; an absent input is red, never a skip" >&2; exit 2; }
+[ -f "$RBAC" ]  || { echo "check-chart-kinds-granted: ERROR: ClusterRole manifest not found at ${RBAC} — set HOSTING_RBAC_MANIFEST" >&2; exit 2; }
+
+# kind → "<apiGroup> <plural>"; a kind missing here is RED so the map grows deliberately.
+resource_of() {
+  case "$1" in
+    Service) echo " services" ;;                 ConfigMap) echo " configmaps" ;;
+    Secret) echo " secrets" ;;                   ServiceAccount) echo " serviceaccounts" ;;
+    PersistentVolumeClaim) echo " persistentvolumeclaims" ;;  Endpoints) echo " endpoints" ;;
+    Namespace) echo " namespaces" ;;             Pod) echo " pods" ;;
+    Deployment) echo "apps deployments" ;;       StatefulSet) echo "apps statefulsets" ;;
+    DaemonSet) echo "apps daemonsets" ;;         Job) echo "batch jobs" ;;
+    CronJob) echo "batch cronjobs" ;;            Ingress) echo "networking.k8s.io ingresses" ;;
+    NetworkPolicy) echo "networking.k8s.io networkpolicies" ;;
+    PodDisruptionBudget) echo "policy poddisruptionbudgets" ;;
+    HorizontalPodAutoscaler) echo "autoscaling horizontalpodautoscalers" ;;
+    ScaledObject) echo "keda.sh scaledobjects" ;;
+    SecretProviderClass) echo "secrets-store.csi.x-k8s.io secretproviderclasses" ;;
+    Role) echo "rbac.authorization.k8s.io roles" ;;  RoleBinding) echo "rbac.authorization.k8s.io rolebindings" ;;
+    ClusterRole|ClusterRoleBinding) echo "EXCLUDED" ;;
+    *) echo "" ;;
+  esac
+}
+
+# The role's rules as "group resource verb" lines (same parser as check-rbac-coverage.sh).
+list_of() { local s="$1"; s="${s#*[}"; s="${s%%]*}"; s="${s//\"/}"; s="${s//\'/}"; s="${s// /}"; printf '%s' "$s"; }
+grants=""; rule_g=""; rule_r=""; rule_v=""
+flush_rule() {
+  [ -n "${rule_g}${rule_r}" ] || return 0
+  local gs rs vs g r v
+  IFS=, read -ra gs <<<"$rule_g"; IFS=, read -ra rs <<<"$rule_r"; IFS=, read -ra vs <<<"$rule_v"
+  [ "${#gs[@]}" -gt 0 ] || gs=("")
+  for g in "${gs[@]}"; do for r in "${rs[@]}"; do for v in "${vs[@]}"; do grants="${grants}${g:--} ${r} ${v}
+"; done; done; done
+}
+while IFS= read -r line; do
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ "$line" =~ ^kind:[[:space:]]*ClusterRoleBinding ]] && break
+  if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*apiGroups: ]]; then flush_rule; rule_g="$(list_of "$line")"; rule_r=""; rule_v=""
+  elif [[ "$line" =~ ^[[:space:]]*resources: ]]; then rule_r="$(list_of "$line")"
+  elif [[ "$line" =~ ^[[:space:]]*verbs: ]]; then rule_v="$(list_of "$line")"; flush_rule; rule_g=""; rule_r=""; rule_v=""
+  fi
+done < "$RBAC"
+flush_rule
+granted() { local g="${1:--}"; printf '%s\n' "$grants" | grep -qx -- "${g} ${2} ${3}" || printf '%s\n' "$grants" | grep -qx -- "${g} ${2} \*"; }
+
+kinds="$(grep -rh '^kind:' "$CHART" | sed 's/^kind:[[:space:]]*//; s/"//g; s/[[:space:]]*$//' | sort -u)"
+checked=0; missing=0; unknown=0; excluded=0
+while IFS= read -r kind; do
+  [ -n "$kind" ] || continue
+  mapped="$(resource_of "$kind")"
+  case "$mapped" in
+    "") echo "  UNKNOWN  kind ${kind} — add it to resource_of() in $(basename "$0")"; unknown=$((unknown+1)); continue ;;
+    EXCLUDED) excluded=$((excluded+1)); continue ;;
+  esac
+  checked=$((checked+1))
+  group="${mapped%% *}"; plural="${mapped#* }"
+  for verb in create patch delete; do
+    granted "$group" "$plural" "$verb" || { echo "  MISSING  chart renders ${kind} but the ClusterRole lacks verbs:[\"${verb}\"] on apiGroups:[\"${group}\"] resources:[\"${plural}\"]"; missing=$((missing+1)); }
+  done
+done <<< "$kinds"
+echo "check-chart-kinds-granted: $(printf '%s\n' "$kinds" | grep -c .) kind(s) rendered by the chart, ${checked} checked for create/patch/delete against $(basename "$RBAC"), ${excluded} excluded by design (cluster-scoped RBAC), ${missing} missing, ${unknown} unknown"
+[ "$checked" -gt 0 ] || { echo "check-chart-kinds-granted: ERROR: found no kinds — the parser is broken, not the chart empty" >&2; exit 2; }
+[ "$missing" -eq 0 ] && [ "$unknown" -eq 0 ]

--- a/deploy/aks/operator/test/fixtures/deploy/status.json
+++ b/deploy/aks/operator/test/fixtures/deploy/status.json
@@ -1,0 +1,1 @@
+{"name":"memex","info":{"status":"deployed"},"version":42}

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -632,6 +632,45 @@ else
 fi
 rm -rf "$_dp_dir"
 
+# ── hosting-deploy refuses BEFORE helm when the identity cannot write a rendered kind ───────────
+# Measured 2026-09-09 01:59Z on memex: helm died on `poddisruptionbudgets.policy is forbidden`
+# and its --atomic rollback erred too. The preflight asks `kubectl auth can-i` per rendered kind
+# and names every denial in ONE refusal, with helm never reached.
+echo
+echo "── hosting-deploy: writable-kinds preflight and release state ───"
+_pf_dir="$(mktemp -d)"; cp -R "$DP_FIXTURES/." "$_pf_dir/"; _pf_log="$_pf_dir/calls.log"; : > "$_pf_log"
+_pf_vals="$_pf_dir/values.yaml"; printf '# GENERATED from the Hosting/Deployment record by HelmValues\nreplicas:\n  portal: 1\n' > "$_pf_vals"
+printf 'create secretproviderclass.secrets-store.csi.x-k8s.io\npatch deployment.apps\n' > "$_pf_dir/denied.txt"
+_pf_out="$(env PATH="$DP_STUBS:$PATH" HOSTING_CHART=/tmp HOSTING_DEPLOY_FIXTURE="$_pf_dir" HOSTING_DEPLOY_STUB_LOG="$_pf_log" \
+  hosting-deploy --namespace memex --release memex --database memex --values "$_pf_vals" --image cr.example.test/memex-portal-ai:1 2>&1)"; _pf_rc=$?
+if [ "$_pf_rc" -ne 0 ] && printf '%s' "$_pf_out" | grep -q 'denied:.*create:secretproviderclass.secrets-store.csi.x-k8s.io' \
+   && printf '%s' "$_pf_out" | grep -q 'denied:.*patch:deployment.apps' && ! grep -q '^helm upgrade' "$_pf_log"; then
+  ok "every denied verb:kind is named in ONE refusal, and helm never runs"
+else
+  bad "denied kinds are named before helm" "rc=${_pf_rc} out: ${_pf_out} log: $(cat "$_pf_log")"
+fi
+# A release helm cannot upgrade (pending-*) is refused by name before helm.
+rm -f "$_pf_dir/denied.txt"; printf '{"name":"memex","info":{"status":"pending-upgrade"},"version":41}\n' > "$_pf_dir/status.json"; : > "$_pf_log"
+_pf_out="$(env PATH="$DP_STUBS:$PATH" HOSTING_CHART=/tmp HOSTING_DEPLOY_FIXTURE="$_pf_dir" HOSTING_DEPLOY_STUB_LOG="$_pf_log" \
+  hosting-deploy --namespace memex --release memex --database memex --values "$_pf_vals" --image cr.example.test/memex-portal-ai:1 2>&1)"; _pf_rc=$?
+if [ "$_pf_rc" -ne 0 ] && printf '%s' "$_pf_out" | grep -q "is 'pending-upgrade'" && ! grep -q '^helm upgrade' "$_pf_log"; then
+  ok "a pending-* release is refused by name, and helm never runs"
+else
+  bad "a pending-* release is refused by name" "rc=${_pf_rc} out: ${_pf_out}"
+fi
+rm -rf "$_pf_dir"
+
+# ── every kind the CHART renders is writable by the operator's ClusterRole ─────────────────────
+# core #3774 rendered a PodDisruptionBudget; the role could only read them; the next Reconcile of
+# memex failed inside helm. A chart change that renders a new kind lands with its grant, or this
+# case is red naming the kind and the rule.
+ck_out="$(bash "$(dirname -- "${BASH_SOURCE[0]}")/check-chart-kinds-granted.sh" 2>&1)"; ck_rc=$?
+if [ "$ck_rc" -eq 0 ]; then
+  ok "every kind the chart renders is writable by operator-rbac.yaml ($(printf '%s' "$ck_out" | tail -1 | sed 's/^check-chart-kinds-granted: //'))"
+else
+  bad "every kind the chart renders is writable by operator-rbac.yaml" "$ck_out"
+fi
+
 # ── every kubectl verb+resource in bin/ is GRANTED by the operator's ClusterRole ─────────────────
 # The manifest lives three directories away from the scripts and is reviewed separately; twice a
 # script reached main without its grant (storageclasses for pv-resize — failed the first Reconcile

--- a/deploy/aks/operator/test/stubs/deploy/helm
+++ b/deploy/aks/operator/test/stubs/deploy/helm
@@ -8,6 +8,8 @@ fixture="${HOSTING_DEPLOY_FIXTURE:?the helm stub needs HOSTING_DEPLOY_FIXTURE}"
 printf 'helm %s\n' "$*" >> "$log"
 case "${1:-}" in
   template) cat "$fixture/rendered.yaml" ;;
+  status)   # `helm status <rel> --namespace <ns> -o json` → $FIXTURE/status.json, else "not found"
+    [ -f "$fixture/status.json" ] && cat "$fixture/status.json" || { echo "Error: release: not found" >&2; exit 1; } ;;
   upgrade)  echo "Release \"${2:-}\" has been upgraded." ;;
   *) echo "helm stub: unexpected invocation: $*" >&2; exit 1 ;;
 esac

--- a/deploy/aks/operator/test/stubs/deploy/kubectl
+++ b/deploy/aks/operator/test/stubs/deploy/kubectl
@@ -16,6 +16,10 @@ ns=""
 if [ "${1:-}" = "-n" ]; then ns="${2:-}"; shift 2; fi
 live_file() { printf '%s/live/%s.json' "$fixture" "$(printf '%s' "$1" | tr '/' '_')"; }
 case "${1:-}" in
+  auth)
+    # `auth can-i <verb> <kind>` → yes unless $FIXTURE/denied.txt lists "<verb> <kind>"
+    if [ -f "$fixture/denied.txt" ] && grep -qx "${3:-} ${4:-}" "$fixture/denied.txt"; then echo "no"; exit 1; fi
+    echo "yes" ;;
   get)
     if [ "${2:-}" = "namespace" ]; then echo "NAME STATUS AGE"; exit 0; fi
     if [ "${2:-}" = "deploy" ]; then echo "Error from server (NotFound)" >&2; exit 1; fi

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operator-refuses-before-helm-what-helm-would-refuse-inside.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-operator-refuses-before-helm-what-helm-would-refuse-inside.md
@@ -1,0 +1,40 @@
+---
+Name: The operator refuses before helm what helm would refuse inside
+Category: Fix
+Description: A record-driven upgrade of memex got through adoption and then failed inside helm because the chart had started rendering a PodDisruptionBudget the operator's role could only read; helm's rollback erred as well. The role now covers every kind the chart renders, a test refuses a chart change that adds one without its grant, and the operator asks the cluster what it may write before helm runs.
+Icon: Shield
+Order: -20260909
+---
+
+On 2026-09-09, the first Reconcile of memex to get past adoption failed inside helm:
+
+```
+UPGRADE FAILED: failed to create resource: poddisruptionbudgets.policy is forbidden:
+User "system:serviceaccount:memex-ops:hosting-operator" cannot create resource "poddisruptionbudgets"
+```
+
+## What was happening
+
+The chart had just started rendering a PodDisruptionBudget for every two-replica instance — the
+fix for the morning's node drain that took both memex pods at once. The operator's ClusterRole
+knew that kind only from its read-only audit block. Nothing paired the chart change with the
+grant, and helm found out mid-upgrade; its automatic rollback then tripped over an ingress whose
+service the upgrade had already removed.
+
+## What it does now
+
+- The ClusterRole can write every kind the chart renders — disruption budgets, KEDA scaled
+  objects, the portal's own Role and RoleBinding, an external model host's Endpoints, and
+  `patch` on the migration Job. ClusterRole and ClusterRoleBinding stay excluded on purpose: a job
+  must never widen cluster-scoped RBAC.
+- `check-chart-kinds-granted.sh` in the operator's test suite reads every `kind:` the chart
+  templates can produce and refuses one the role cannot create, patch and delete. Against the
+  role as it was it found sixteen gaps.
+- Before `helm upgrade`, the operator asks the cluster (`kubectl auth can-i`) about every kind the
+  record renders and refuses with the whole list in one line, so a missing grant is named once
+  instead of discovered one failed upgrade at a time. A release helm cannot upgrade —
+  `pending-upgrade` after a cut-off run — is refused by name too, with the rollback that resolves
+  it left to a person.
+- On the Azure side, the bicep module now carries the two grants a Provision needs and never had:
+  Managed Identity Contributor on the portal identity (the federated credential per instance) and
+  DNS Zone Contributor on the zone. No lane deploys bicep; the README names the command.


### PR DESCRIPTION
## The role can write every chart kind; hosting-deploy refuses before helm what helm would refuse inside; the Azure grants a Provision needs

**Measured 2026-09-09 01:59Z** (`Deployments/memex-reconcile-20260909-adopt`, operator 921bcdb, through the API): adoption worked (`adopted=1`, 15 owned, 2 to create), then helm:

```
UPGRADE FAILED: an error occurred while rolling back the release. original upgrade error: failed to create
resource: poddisruptionbudgets.policy is forbidden: User "system:serviceaccount:memex-ops:hosting-operator"
cannot create resource "poddisruptionbudgets" in API group "policy" in the namespace "memex"
```

#3774 made the chart render a PodDisruptionBudget for every two-replica instance; the ClusterRole knew that kind from its read-only audit block only. Nothing paired a chart change with its grant — every Provision of a two-replica instance would have hit it. The `--atomic` rollback landed as revision 42 (audit read-only: release readable, memex 200).

**And** `Deployments/pearl-provision-20260909-b` (the first Provision ever run through the lane, after #3776's sign-in): database created, vault secrets created/found, then step 3/14 `hosting-federate` → `AuthorizationFailed … federatedIdentityCredentials/write over …/memexaks-portal-mi/…` — the operator identity had never been granted anything on the portal identity.

### What changes
- **`operator-rbac.yaml`**: `poddisruptionbudgets`, `scaledobjects`, `roles`/`rolebindings`, `endpoints` create/update/patch/delete; `jobs` patch/update (helm patches the migration Job on every upgrade). ClusterRole/ClusterRoleBinding stay excluded by design — a Job must never widen cluster-scoped RBAC.
- **`check-chart-kinds-granted.sh`** (bash 3.2 + grep/sed): every `kind:` under `deploy/helm/templates` must be create/patch/delete-able by the role. Against main's role: **16 missing**; now 0. Falls back to `/opt/hosting/chart/templates` in the image. Wired into `run-tests.sh`.
- **`hosting-deploy`**: after adoption, `kubectl auth can-i <verb> <kind>` per rendered kind — ONE refusal naming every denial, helm never reached (test: two denials named, `helm upgrade` absent from the stub log). `helm status` `pending-*` refused by name (the rollback revision is a person's call).
- **Bicep**: `backups.bicep` gains Managed Identity Contributor on the portal identity (param `portalIdentityId`, scoped to that one resource) and deploys `dns-zone-operator-role.bicep` (DNS Zone Contributor on the zone, in the zone's resource group) when `dnsZoneId` is set. Both compile. **No lane deploys bicep** — `manifests/hosting-operator/README.md` names the break-glass `az deployment group create` for a person with Owner.
- What's New (Fix). **Suite: 157 passed, 0 failed.** RBAC coverage: 0 missing.

### Also found tonight, recorded for the next reader
memex's record carried no `portalNext` block, so the record-driven upgrade removed `/next` before it failed on the PDB — that is the rollback's "no Service portal-next-service" line. The live record now carries `portalNext` (v55); the repo record follows in Systemorph/Memex.
