### PR TITLE
Fix collection values crashing string-bound labels

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-collection-labels.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-collection-labels.md
@@ -1,0 +1,9 @@
+---
+Name: Collection values remain visible in labels
+Category: Fix
+Description: Labels render collection values consistently instead of failing when they receive an unserialized list.
+Icon: TextDescription
+Order: -20260909
+---
+
+Labels now show list values consistently, including initialization gate names. A locally bound collection uses the same readable text as the equivalent value received over the connection, so rendering it no longer breaks the binding.

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -296,6 +296,13 @@ public static class LayoutClientExtensions
         // `fail` line on EVERY NavLink render (prod error storm) while the icon rendered as nothing.
         if (typeof(T) == typeof(Icon) && TryGetStringValue(value, out var iconString))
             return (T?)(object?)Icon.Parse(iconString);
+        // A label can receive the CLR collection directly from a local binding, or its JSON
+        // representation after transport. Both must use the same display conversion. Collections,
+        // JsonNodes and values such as Guid do not implement IConvertible, so ChangeType cannot
+        // render them. Keep scalar coercion and caller-supplied converters unchanged.
+        if (typeof(T) == typeof(string) && value is not null && value is not IConvertible)
+            return hub.ConvertJson(JsonSerializer.SerializeToElement(value, hub.JsonSerializerOptions),
+                null, defaultValue);
         return value switch
         {
             null => defaultValue,

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -17,6 +17,39 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
     }
 
     [Fact]
+    public void ConvertSingle_CollectionLabel_MatchesItsSerializedValue()
+    {
+        var hub = GetHost();
+        object[] values =
+        [
+            new[] { "Initialize", "MeshNodeInit" },
+            new System.Collections.Generic.List<int> { 1, 2, 3 },
+            new System.Collections.Generic.Dictionary<string, int> { ["pending"] = 2 },
+            System.Text.Json.Nodes.JsonNode.Parse("[\"Initialize\",\"MeshNodeInit\"]")!,
+            System.Text.Json.Nodes.JsonNode.Parse("{\"pending\":2}")!
+        ];
+        foreach (var value in values)
+        {
+            var serialized = JsonSerializer.SerializeToElement(value, hub.JsonSerializerOptions);
+            var expected = hub.ConvertSingle<string>(serialized, null);
+            expected.Should().NotBeNullOrEmpty();
+            hub.ConvertSingle<string>(value, null).Should().Be(expected,
+                "a label must render the same value before and after transport serialization");
+        }
+    }
+
+    [Fact]
+    public void ConvertSingle_GateNames_RenderAsReadableText()
+    {
+        var hub = GetHost();
+        hub.ConvertSingle<string>(new[] { "Initialize", "MeshNodeInit" }, null)
+            .Should().Be("Initialize, MeshNodeInit");
+        hub.ConvertSingle<string>(Array.Empty<string>(), null).Should().BeEmpty();
+        hub.ConvertSingle<string>(Guid.Parse("01234567-89ab-cdef-0123-456789abcdef"), null)
+            .Should().Be("01234567-89ab-cdef-0123-456789abcdef");
+    }
+
+    [Fact]
     public void ConvertSingle_DoubleToInt_ActualBehavior()
     {
         // Arrange


### PR DESCRIPTION
A string-bound label receiving a CLR collection reached `Convert.ChangeType` and threw `InvalidCastException: Object must implement IConvertible`, terminating the binding. JSON values already had a display path; the report’s suggestion that JsonElement lacked one was not the defect.

Route non-IConvertible values bound to string through the hub serializer and the existing JSON display conversion. Collections now display identically before and after transport serialization; custom converters and scalar/numeric conversion keep their existing behavior.

Fixes #3764.

Verification:
- Two new regression tests fail on the original code with the reported stack and pass with the fix. They cover lists, arrays, dictionaries, JsonArray/JsonObject, empty collections and Guid.
- Full Layout suite: 461 passed, 0 failed, 0 skipped; fresh TRX.
- Documentation release-note/link guards: 2 passed, 0 failed.
- Release builds with CIRun=true and warnings-as-errors: Layout.Test, Documentation.Test and Memex.Portal.Shared, including their project dependencies.
- Category: Fix release note included.

The exact production producer behind the `gates` field was not identified. The tested conversion failure reproduces the reported exception and call chain without swallowing faults or substituting an empty label.

Pairs-with: none — no public surface removed.
Implementers: none — no interface member added.
