### PR TITLE
Preserve initialization gate names in shutdown discard reports

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-deferred-gate-diagnostics.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-deferred-gate-diagnostics.md
@@ -1,0 +1,9 @@
+---
+Name: Shutdown diagnostics preserve initialization gate names
+Category: Fix
+Description: Discarded-delivery reports name the gates that held the request even after shutdown has opened them.
+Icon: Info
+Order: -20260909
+---
+
+When a hub shuts down with a request still deferred, its diagnostic and the failure returned to the sender now name the initialization gates recorded when the request was deferred. Shutdown no longer erases those names before the report is written.

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -175,7 +175,7 @@ public class MessageService : IMessageService
     /// timer fires <see cref="ReportFailure"/> for any entry still here when its
     /// deadline elapses.
     /// </summary>
-    private readonly ConcurrentDictionary<string, (IMessageDelivery Delivery, CancellationTokenSource TimeoutCts)>
+    private readonly ConcurrentDictionary<string, (IMessageDelivery Delivery, CancellationTokenSource TimeoutCts, string GatesAtDeferral)>
         deferredDeliveries = new();
     private TaskScheduler turnScheduler = TaskScheduler.Default;
     private readonly HierarchicalRouting hierarchicalRouting;
@@ -311,7 +311,7 @@ public class MessageService : IMessageService
         var stillClosed = string.Join(",", gates.Keys);
         var reason = $"Message hub {Address} failed to initialize in {hub.Configuration.StartupTimeout} — gates still closed: [{stillClosed}]";
         logger.LogError(reason);
-        DrainDeferredDeliveries(delivery => ReportFailure(delivery.WithProperty("Error", reason)));
+        DrainDeferredDeliveries((delivery, _) => ReportFailure(delivery.WithProperty("Error", reason)));
     }
 
     /// <summary>
@@ -337,7 +337,7 @@ public class MessageService : IMessageService
     /// prevent. A deferral arriving after the snapshot keeps its own timeout tracker and is retired
     /// by whichever claimant reaches it next.</para>
     /// </summary>
-    private void DrainDeferredDeliveries(Action<IMessageDelivery> answer)
+    private void DrainDeferredDeliveries(Action<IMessageDelivery, string> answer)
     {
         foreach (var id in deferredDeliveries.Keys)
         {
@@ -345,7 +345,7 @@ public class MessageService : IMessageService
                 continue; // someone else owns this tracker — it will answer and dispose it
             tracker.TimeoutCts.Cancel();
             tracker.TimeoutCts.Dispose();
-            answer(tracker.Delivery);
+            answer(tracker.Delivery, tracker.GatesAtDeferral);
         }
     }
 
@@ -503,7 +503,7 @@ public class MessageService : IMessageService
     /// </summary>
     private void FailDeferredBacklog(string reason)
     {
-        DrainDeferredDeliveries(delivery => AnswerUnreleasableDelivery(delivery, reason));
+        DrainDeferredDeliveries((delivery, _) => AnswerUnreleasableDelivery(delivery, reason));
         // The parked turns are the same deliveries, already answered — running them later
         // (a subsequent OpenGate, the disposal drain) would answer them a second time.
         lock (turnGate)
@@ -1792,7 +1792,10 @@ public class MessageService : IMessageService
     private void ScheduleDeferralTimeout(IMessageDelivery delivery)
     {
         var cts = new CancellationTokenSource();
-        var tracker = (delivery, cts);
+        // Called under gateStateLock at the deferral decision. Teardown opens the gates before
+        // draining these trackers, so reading gates.Keys during Dispose loses the cause (#3712).
+        var gatesAtDeferral = string.Join(",", gates.Keys.OrderBy(x => x, StringComparer.Ordinal));
+        var tracker = (delivery, cts, gatesAtDeferral);
 
         // 🚨 RETIRE THE DISPLACED TRACKER. This write used to be a bare indexer assignment, so a
         // re-deferred id (a repost keeps its Id) silently orphaned the previous tracker: with the
@@ -2531,20 +2534,20 @@ public class MessageService : IMessageService
         // reproduce it: the hub, the message type and id, its sender, the gates it was parked
         // behind and this hub's run level.
         var discarded = 0;
-        DrainDeferredDeliveries(delivery =>
+        DrainDeferredDeliveries((delivery, gatesAtDeferral) =>
         {
             discarded++;
             logger.LogError(DisposalDiscardedDeferredDelivery,
                 "[DISPOSE-DISCARD] Hub {Address} is disposing with {MessageType} (id={MessageId}, from {Sender}) "
-                + "still deferred behind its initialization gates [{Gates}] — the message is NOT processed; "
+                + "still deferred; initialization gates closed at deferral: [{Gates}] — the message is NOT processed; "
                 + "the sender is answered ShuttingDown. RunLevel={RunLevel}. Accepted work must be drained "
-                + "before a hub goes down; find why this hub disposed with its gates still shut.",
+                + "before a hub goes down; find why this hub disposed before its deferred work could run.",
                 Address, delivery.Message.GetType().Name, delivery.Id, delivery.Sender,
-                string.Join(",", gates.Keys), hub.RunLevel);
+                gatesAtDeferral, hub.RunLevel);
             NackThroughParent(delivery,
                 $"Hub {Address} was disposed while {delivery.Message.GetType().Name} "
-                + $"(id={delivery.Id}) was still deferred behind its initialization gates "
-                + $"[{string.Join(",", gates.Keys)}] — the message was never processed. The address "
+                + $"(id={delivery.Id}) was still deferred; initialization gates closed at deferral: "
+                + $"[{gatesAtDeferral}] — the message was never processed. The address "
                 + "may reactivate (recycle / restart); retry to get the authoritative answer.");
         });
 

--- a/test/MeshWeaver.Messaging.Hub.Test/DeferredDeliveryNackedOnDisposeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeferredDeliveryNackedOnDisposeTest.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.Messaging.Hub.Test;
@@ -34,8 +38,15 @@ namespace MeshWeaver.Messaging.Hub.Test;
 /// "ask again", not "gone"; consumers with their own recovery machinery (SynchronizationStream's
 /// resubscribe latch) rely on exactly that classification.</para>
 /// </summary>
-public class DeferredDeliveryNackedOnDisposeTest(ITestOutputHelper output) : HubTestBase(output)
+public class DeferredDeliveryNackedOnDisposeTest : HubTestBase
 {
+    private readonly DeferredLog log = new();
+
+    public DeferredDeliveryNackedOnDisposeTest(ITestOutputHelper output) : base(output)
+    {
+        Services.AddLogging(l => l.Services.AddSingleton<ILoggerProvider>(log));
+    }
+
     private record GatedRequest : IRequest<GatedResponse>;
 
     private record GatedResponse;
@@ -87,6 +98,11 @@ public class DeferredDeliveryNackedOnDisposeTest(ITestOutputHelper output) : Hub
         // TRANSIENT, so a recycled address reads as "retry", never as "gone".
         failure.Failure.Should().NotBeNull();
         failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown);
+        failure.Failure.Message.Should().Contain("test-never-opens",
+            "the shutdown answer must name the gates recorded before teardown opened them");
+        log.Messages.Should().Contain(message => message.Contains("test-never-opens"),
+            "event 7301 must preserve the gate that actually held the delivery (#3712)");
+
         failure.Failure.Message.Should().Contain("deferred",
             "the NACK must name WHY the message was abandoned — a bare failure sends the next "
             + "investigator hunting the wrong layer");
@@ -99,17 +115,31 @@ public class DeferredDeliveryNackedOnDisposeTest(ITestOutputHelper output) : Hub
     /// </summary>
     private static async Task WaitForDeferredBacklog(IMessageHub host)
     {
-        for (var i = 0; i < 100; i++)
-        {
-            foreach (Match m in Regex.Matches(host.GetDisposalDiagnostics(), @"deferred=(\d+)"))
-                if (int.Parse(m.Groups[1].Value) > 0)
-                    return;
-            await Task.Delay(50);
-        }
-
-        Assert.Fail(
-            "The request never reached the gated hub's deferred queue, so this test never "
-            + "exercised the disposal path it exists to pin. Check that GatedRequest still "
-            + "defers behind a closed initialization gate.");
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .Select(_ => host.GetDisposalDiagnostics())
+            .Where(snapshot => Regex.Matches(snapshot, @"deferred=(\d+)")
+                .Any(m => int.Parse(m.Groups[1].Value) > 0))
+            .Take(1)
+            .Timeout(TestTimeouts.Convergence);
     }
+    private sealed class DeferredLog : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new Capture(Messages);
+        public void Dispose() { }
+
+        private sealed class Capture(ConcurrentQueue<string> messages) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel level) => level >= LogLevel.Error;
+            public void Log<TState>(LogLevel level, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (eventId.Id == 7301)
+                    messages.Enqueue(formatter(state, exception));
+            }
+        }
+    }
+
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/DeferredDeliveryNackedOnDisposeTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DeferredDeliveryNackedOnDisposeTest.cs
@@ -121,7 +121,8 @@ public class DeferredDeliveryNackedOnDisposeTest : HubTestBase
             .Where(snapshot => Regex.Matches(snapshot, @"deferred=(\d+)")
                 .Any(m => int.Parse(m.Groups[1].Value) > 0))
             .Take(1)
-            .Timeout(TestTimeouts.Convergence);
+            .Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
     }
     private sealed class DeferredLog : ILoggerProvider
     {


### PR DESCRIPTION
Disposal opened all initialization gates before its deferred-delivery error read their names. Event 7301 and the sender’s ShuttingDown answer therefore printed `[]`, losing the information needed to investigate the request.

Record the closed gate names with each deferral tracker, while the deferral decision holds gateStateLock. Disposal reports that snapshot and explicitly describes it as the gates closed at deferral. Tracker claims, cancellation, error level and delivery outcomes are unchanged.

Fixes #3712.

Verification:
- The regression fails on the original code with the exact empty-gates failure message and event 7301 log; it passes with the fix and checks both the sender’s answer and captured event.
- Full messaging suite: 383 passed, 0 failed, 0 skipped, fresh TRX.
- Release-note and documentation-link guards: 2 passed.
- Release/CIRun/warnings-as-errors builds clean for Messaging.Hub.Test, Memex.Portal.Shared and Documentation.Test, including their project dependencies.
- Replaced the touched test’s sleep loop with a bounded observable condition wait.
- Category: Fix release note included.

Pairs-with: none — changes are private implementation details; no public surface removed.
Implementers: none — no interface member added.
