### PR TITLE
docs(#3699): one entry per line in the topic map, and a guard that a page is LISTED

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -63,7 +63,7 @@ MeshWeaver is a distributed platform for building data-driven applications with 
 
 ## Topic map
 
-The catalog below lists every page; these are the load-bearing reads per theme.
+Each theme starts with its introductory page, followed by related architecture topics.
 
 <!-- 🚨 ONE ENTRY PER LINE, and it must stay that way (#3699).
      This map used to be a table whose cells each held the whole entry list on ONE line
@@ -90,6 +90,14 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Hub Disposal Model](HubDisposalModel)
 - [Transient Node Probes](TransientNodeProbes) — a probe hub's own address is not a node
 - [Executive Assistant Credential Reads](ExecutiveAssistantCredentialReads) — a turn that waits for a mesh read holds the queue that read's reply must travel through, and the timeout was rendered as "you never connected"
+- [Bounds Must Be Ordered](BoundsMustBeOrdered)
+- [Message-Based Communication](MessageBasedCommunication)
+- [No Static State](NoStaticState)
+- [Observable Hub Pipeline (migration design)](ObservableHubPipeline)
+- [Per-Hub TaskScheduler — Actor Isolation Across the Mesh](OrleansTaskScheduler)
+- [Removing Hand-Woven Concurrency Gates](RemovingHandWovenGates)
+- [Removing Observable-to-Task Bridges](RemovingObservableToTaskBridges)
+- [JSON Serialization](Serialization)
 
 ### Reading & writing nodes
 
@@ -110,6 +118,18 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [The sync/ Hub Population](SyncHubPopulation) — a `sync/` hub is one field of a stream and a subscription makes two of them; the only reaper of a Started one is an idle sweep the traffic keeps re-arming
 - [The Evicted-Stream Retention](EvictedStreamRetention) — a change-feed eviction parks a remote stream and `ReclaimIfUnheld` refuses to dispose one that carries no lease entry, so every unleased call site retains one stream, and two `sync/` hubs, per change event
 - [The Recursive-Delete Drain](RecursiveDeleteDrain) — the plan is a snapshot the removals may exceed, the completion check must include the ROOT, and the stage bound measures progress, not duration
+- [Business Rules & Calculations](BusinessRules)
+- [Data Versioning Strategies](DataVersioning)
+- [Mesh Graph Architecture](MeshGraph)
+- [MeshNode Versioning](MeshNodeVersioning)
+- [Query Provider Parity](QueryProviderParity)
+- [Query Result Scoring](QueryResultScoring)
+- [Reading a Write Verdict](ReadingAWriteVerdict)
+- [Satellite Entity Patterns](SatelliteEntityPatterns)
+- [Satellite Node Patterns](SatelliteNodePatterns)
+- [Repairing a Stale MainNode — When the Broken Field Guards Itself](StaleMainNodeRepair)
+- [Synced Mesh Node Queries](SyncedMeshNodeQueries)
+- [Update Validators See Typed Content](UpdateValidatorsSeeTypedContent)
 
 ### Storage & partitions
 
@@ -129,6 +149,17 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Instance-Key Resolution](InstanceKeyResolution) — the registry reads an instance key through live mirrors, never a per-request point read
 - [Cross-Schema Fan-Out Elimination](CrossSchemaFanOutElimination) — an unanchored query is a lock bomb; the census and the per-caller plan
 - [Addressed Notifications](AddressedNotifications) — plan 1 worked out: deliver a notification to its addressee so the bell reads two schemas, not 199
+- [Content Indexing Activation](ContentIndexingActivation)
+- [Cross-Instance Mirror](CrossInstanceMirror)
+- [Data Synchronization and CRDT](DataSyncAndCrdt)
+- [Setting Up Data Sync](DataSyncSetup)
+- [DatabaseBackups](DatabaseBackups)
+- [Declarative export and import](DeclarativeImportExport)
+- [Syncing a Space with GitHub](GitHubSync)
+- [The Import Marker Records Convergence](ImportMarkerRecordsConvergence)
+- [Instance Sync — bi-directional space replication between MeshWeaver instances](InstanceSync)
+- [Managing Partition Sync (Admin Guide)](PartitionSyncGuide)
+- [Static Node Providers](StaticNodeProviders)
 
 ### Security
 
@@ -142,6 +173,9 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Logon Actions](LogonActions) — per-user work at logon, run as the user
 - [Unanchored Security Reads](UnanchoredSecurityReads) — why the permission fold reads mesh-wide, and why pinning it to the viewer's partition is a silent revocation-fails-open bug
 - [A Denial Is an Answer](DenialIsAnAnswer) — a check on a hub with no evaluator grants Permission.All, and a refusal the mesh decided is rendered, never raised
+- [Who Owns a Partition's Access Shape](PartitionAccessOwnership)
+- [OWASP ZAP Scan — 3.0.0 (6 September 2026)](SecurityScan_3_0_0)
+- [OWASP ZAP Scan — Every Release](SecurityScanning)
 
 ### Threads, activities & AI
 
@@ -153,6 +187,17 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Notification Retention](NotificationRetention) — the platform's first data-retention pass, and why it is a logon action
 - [Agentic AI](AgenticAI)
 - [Script Execution](ScriptExecution)
+- [Agent Framework Stores — mesh nodes behind Microsoft's abstractions](AgentFrameworkStores)
+- [Centralized speech — Whisper Swiss German as a container](CentralizedSpeech)
+- [Email Ingestion, Channels and Notifications](EmailIngestionAndNotifications)
+- [Event Subscriptions — the durable 'when THIS fires, run THAT' engine](EventSubscriptions)
+- [Foreign-Language Bridge (Python, Bun/Node) over gRPC](ForeignLanguageBridge)
+- [Foreign-Language & Cross-Platform Integration](ForeignLanguageIntegration)
+- [Model Providers and BYO Credentials](ModelProviders)
+- [On-device voice — Whisper + Swiss German](OnDeviceVoice)
+- [Python Code Nodes](PythonCodeNodes)
+- [Script Execution — Try It](ScriptExecutionDemo)
+- [Sending Email](SendingEmail)
 
 ### UI
 
@@ -167,6 +212,13 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Localization](Localization) — the viewer's language, resolved explicitly, never from ambient culture
 - [Chrome and Content Language](ChromeAndContentLanguage) — ownership decides the language, and in-flow chrome minimises words
 - [The Supplied Navigation Rail](SuppliedNavigationRail) — a module supplies its own left-hand index, and core renders it in the order the module gave
+- [The Apps Home](AppsHome)
+- [Content Favicon Rasterization](ContentFaviconRasterization)
+- [Controls That Cannot Fail](ControlsThatCannotFail)
+- [Link Previews](LinkPreviews)
+- [Local-First Client & Bootstrap](LocalFirstClient)
+- [PDF Export — one browser, two fidelities](PixelFaithfulExport)
+- [UI Extensibility](UiExtensibility)
 
 ### Node types
 
@@ -183,14 +235,20 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Import Write Ordering](ImportWriteOrdering) — type before instance, and what a foreign type does
 - [Language Services](LanguageServices)
 - [Extensible Defaults](ExtensibleDefaults)
+- [Build coordination — the Build node protocol](BuildCoordination)
+- [Build Identity Admission](BuildIdentityAdmission)
+- [The Build Process — compile and test as a dependency cascade](BuildProcess)
+- [What a Pull Request Rebuilds](BuildScopeNarrowing)
+- [The Build Server](BuildServer)
+- [The Compile Program — State of Record](CompileProgramStateOfRecord)
+- [Content-Type Registration](ContentTypeRegistration)
+- [NodeType Catalogs (shipping instances of a NodeType)](NodeTypeCatalogs)
+- [NodeType Release Redesign](Postmortems/NodeTypeReleaseRedesign)
 
 ### Plugins & content delivery
 
 - **Start here:** [Plugins](Plugins) — node repos from git, no NuGet
-- [Plugin Manual](PluginAuthoring) — author
-- publish
-- install
-- own registry
+- [Plugin Manual](PluginAuthoring) — author · publish · install · own registry
 - [Plugin Registry](PluginRegistry) — memex re-serves plugins over REST
 - [Webhook Inbox](WebhookInbox) — external services deliver into {target}/_Inbox
 - [Plugin Packaging](PluginPackaging) — bundles, the framework identity, and the `Release` node that links a release to its assemblies per architecture
@@ -203,6 +261,25 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Sealed Publication Reads](SealedPublicationReads) — a publication is unreadable for ~90s per target per publish and the `plugins` prefix has two writers; the three answers (404/503/412), the generation that pins one instance, and the mix no reader can detect
 - [Sealed Publication Generations](SealedPublicationGenerations) — the layout that makes that mix UNREPRESENTABLE (a directory per publication plus a pointer swapped last), the reader contract, the retention rule, and the ordered migration that avoids a new-writer/old-writer half-state
 - [Install Completeness](InstallCompleteness) — what an install RECORD declares landed, compared against what is actually in the mesh; the comparison nothing made until #3485, and why only one of its five verdicts is a pass
+- [CI Content Bake](CiContentBake)
+- [Deploying a plugin change — merging is not shipping](DeployingPluginChanges)
+- [Module Adoption Policy](ModuleAdoptionPolicy)
+- [Module Build Architecture](ModuleBuildArchitecture)
+- [Module Closure Accounting](ModuleClosureAccounting)
+- [The Module Identity Anchor](ModuleIdentityAnchor)
+- [Module-Owned Siblings Ride](ModuleOwnedSiblingsRide)
+- [The Module Platform Link Gate](ModulePlatformLinkGate)
+- [Module Set Convergence](ModuleSetConvergence)
+- [Module Versioning](ModuleVersioning)
+- [Modules](Modules)
+- [Package Mark Inheritance](PackageMarkInheritance)
+- [Pin-Boundary Contracts](PinBoundaryContracts)
+- [Platform and content — two layers, two cadences](PlatformAndContent)
+- [Platform Build Identity](PlatformBuildIdentity)
+- [The Platform-Shipped Witness](PlatformShippedWitness)
+- [The Plugin Build Contract](PluginBuildContract)
+- [Plugin Bundles in the Registry](PluginBundlesInTheRegistry)
+- [Plugin Update on Green Build](PluginUpdateOnGreenBuild)
 
 ### Reliability & wedges
 
@@ -224,6 +301,14 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [The /api/content 503](ContentRoute503) — two causes with opposite fixes, and the one field in the line already printed that tells them apart
 - [Refused Replies During Teardown](RefusedRepliesDuringTeardown) — every failure route answers the SENDER, which for a reply is the responder; the answer the caller is parked on is dropped with nobody told
 - [Refusing a Lost User Action](RefusingALostUserAction) — a click whose stream is gone is refused out loud instead of dropped as churn; why "deliver it anyway" is not implementable as stated
+- [Guards and Unknown States](GuardsAndUnknownStates)
+- [Mesh Admission](MeshAdmission)
+- [Mesh Lifecycle — Build Up & Tear Down](MeshLifecycle)
+- [Pod-Hub Delivery — the Transport Swap and its Roll Plan](PodHubDeliveryRollPlan)
+- [The Portal Heap Is Hubs](PortalHeapIsHubs)
+- [SignalR Mesh Participant — joining the mesh over a WebSocket](SignalRMeshParticipant)
+- [Teardown Layers — work finishes, nothing is forced](TeardownLayers)
+- [Teardown Verdicts Are Causal, Not Timed](TeardownVerdictsAreCausal)
 
 ### Testing & debugging
 
@@ -238,6 +323,14 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Ambient Test-Host Hangs](AmbientTestHostHangs) — what decides whether a killed test host can be diagnosed at all, and the readings of it already falsified
 - [In-Mesh Tests and the Seal](InMeshTestsAndTheSeal) — a Tests area no required context executes is a latent trunk red the seal detonates fleet-wide; how to measure a gate before requiring it
 - [Cancel and Join Are Two Questions](CancelAndJoinSequencing) — a deadline that asks work to stop and a deadline that waits for it to have stopped must not share one clock
+- [Collection-Scoped Test Fixtures](CollectionScopedTestFixtures)
+- [Debugging Native Crashes (core dumps)](DebuggingNativeCrashes)
+- [Debugging Postgres in Prod / Test](DebuggingPostgres)
+- [Decentralised Tests](DecentralisedTests)
+- [Gate Content Assets](GateContentAssets)
+- [In-Mesh Build and Test](InMeshBuildAndTest)
+- [Orleans Test Routing Pattern](OrleansTestRoutingPattern)
+- [Reading CI Signals](ReadingCiSignals)
 
 ### Deployment & ops
 
@@ -277,6 +370,34 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [What a Synthetic Probe May Assert](SyntheticProbeTargets) — a probe naming one deployment's installed content is broken by construction; the platform floor, the negative control that tells "absent" from "down", and reading the target's own declaration
 - [Why a GC-Bound Pod Stays in Rotation](WhyAGcBoundPodStaysInRotation) — the GC's hard limit sits below the container limit, so a portal short of memory is defended rather than restarted
 - [Self-hosted CI runners on AKS](SelfHostedRunners) — ARC beside the portals on one pool; three brakes, a negative priority class, and the reserve arithmetic that decides the cap
+- [Candidate Release Protocol](CandidateReleaseProtocol)
+- [Chart Drift — what a deploy actually does](ChartDriftSemantics)
+- [Configuring an instance from Aspire](ConfiguringAnInstanceFromAspire)
+- [The Dependabot Secret Store](DependabotSecretStore)
+- [Deployment env layers — what a record must be able to hold](DeploymentEnvLayers)
+- [DeploymentInventory](DeploymentInventory)
+- [Deployment Options (AKS)](DeploymentOptions)
+- [Environment Composition](EnvironmentComposition)
+- [Feature Flags](FeatureFlags)
+- [First-Run Setup](FirstRunSetup)
+- [Image Cleanup](ImageCleanup)
+- [Instance Identity and Setup](InstanceIdentityAndSetup)
+- [Instance Lifecycle — State of Record](InstanceLifecycleStateOfRecord)
+- [Instances](Instances)
+- [Local memex on Colima k3s (Mac)](LocalColimaMac)
+- [Mac local stack — on-device AI + local observability (M-series)](MacLocalStack)
+- [Memex Cloud Deployment](MemexCloudDeployment)
+- [Merge Queue Mechanics](MergeQueueMechanics)
+- [Operating from the portal, not the cluster](OperatingFromThePortal)
+- [The Payment Provider Contract](PaymentProviderContract)
+- [Pre-Boot Service Substitution](PreBootServiceSubstitution)
+- [Project Templates](ProjectTemplates)
+- [The Release Event Bus](ReleaseEventBus)
+- [The Release Gate's Denominator](ReleaseGateDenominator)
+- [Release to Production — the whole path](ReleaseToProductionPipeline)
+- [Renaming a Required Status Check](RenamingARequiredCheck)
+- [Repository Topology](RepositoryTopology)
+- [The Release Wave — one emitter, and who resolves the digest](TheReleaseWave)
 
 ### Contributing docs
 
@@ -284,6 +405,8 @@ The catalog below lists every page; these are the load-bearing reads per theme.
 - [Docs Follow The Functionality](DocsFollowTheFunctionality) — which repo a page belongs in, and what pins the rest here
 - [Specifying Software](SpecifyingSoftware)
 - [Glossary](/Doc/Glossary)
+- [Developing from within MeshWeaver](DevelopingFromMeshWeaver)
+- [Shared Rule Blocks](SharedRuleBlocks)
 
 ### Licensing
 

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -65,21 +65,229 @@ MeshWeaver is a distributed platform for building data-driven applications with 
 
 The catalog below lists every page; these are the load-bearing reads per theme.
 
-| Theme | Start here | Go deeper |
-|---|---|---|
-| **Reactive core** | [Asynchronous Calls](AsynchronousCalls) — the no-`await` rulebook |[Actor Model](ActorModel) · [Turn-Loop Arrival Order](TurnLoopArrivalOrder) — a hub has TWO queues and a delivery moves between them at turn time, so a turn can be in neither when the last gate opens; the permutation names which message straddled the window, never which defect is live · [Controlled I/O Pooling](ControlledIoPooling) · [Subscription Ownership](SubscriptionOwnership) — a pending timer is a GC root · [Silent Completion](SilentCompletion) — an empty completion is invisible to every timeout · [AsyncLocal Across Scheduler Hops](AsyncLocalAcrossHops) · [Initialization Gates](InitializationGates) · [Aggregating Providers](AggregatingProviders) · [Hub Disposal Model](HubDisposalModel) · [Transient Node Probes](TransientNodeProbes) — a probe hub's own address is not a node · [Executive Assistant Credential Reads](ExecutiveAssistantCredentialReads) — a turn that waits for a mesh read holds the queue that read's reply must travel through, and the timeout was rendered as "you never connected"|
-| **Reading & writing nodes** | [CQRS — Queries vs. Content Access](CqrsAndContentAccess) |[MeshNode Stream Cache](MeshNodeStreamCache) · [Request via Stream Update](RequestViaStreamUpdate) · [Data Access Patterns](DataAccessPatterns) · [Workspace References](WorkspaceReferences) · [Content Chunk Navigation](ContentChunkNavigation) · [Moving Nodes](MovingNodes) — a move relocates the node and everything that belongs to it, or it refuses · [Moved-Node Redirects](NodeRedirects) — keeping links alive after a move · [MainNode and Rebasing](MainNodeRebasing) — a `with { Namespace = … }` copy un-lists a node with nothing logged · [Write Verdict Totality](WriteVerdictTotality) — a write whose base read ends empty answers nobody, and arms no deadline either · [The Phantom Base After Owner Disposal](PhantomBaseAfterOwnerDisposal) — the owner echoes a merge BEFORE it flushes it, so a "never applied" NACK's re-attempt can find its own unpersisted write in the mirror, diff to nothing and report success · [Conditional Writes Across Hubs](ConditionalWritesAcrossHubs) — on a node you do not own the lambda runs on YOUR mirror and ships a diff, so a field it decided not to write is absent from the patch and a concurrent write to it survives · [Live Mirrors and the Change Feed](LiveMirrorsAndTheChangeFeed) — a write must not end its own streams · [Stream Liveness and the Hub Reference](StreamLivenessAndTheHubReference) — a stream outlived the hub it held, and the contract said it could not · [The sync/ Hub Population](SyncHubPopulation) — a `sync/` hub is one field of a stream and a subscription makes two of them; the only reaper of a Started one is an idle sweep the traffic keeps re-arming · [The Evicted-Stream Retention](EvictedStreamRetention) — a change-feed eviction parks a remote stream and `ReclaimIfUnheld` refuses to dispose one that carries no lease entry, so every unleased call site retains one stream, and two `sync/` hubs, per change event · [The Recursive-Delete Drain](RecursiveDeleteDrain) — the plan is a snapshot the removals may exceed, the completion check must include the ROOT, and the stage bound measures progress, not duration|
-| **Storage & partitions** | [Postgres Schema Architecture](PostgresSchemaArchitecture) | [Partition Storage Routing](PartitionStorageRouting) · [Partition Teardown](PartitionTeardown) — deleting a partition ROOT drops its backing store; keyed on the node's SHAPE, never its NodeType · [Partition Storage Hubs](PartitionStorageHubs) · [Partitioned Persistence](PartitionedPersistence) · [Storage Adapter Implementation](StorageAdapterImplementation) · [Change-Feed Isolation](ChangeFeedIsolation) — one throwing subscriber must never starve the others · [A Container Registry in Memex](ContainerRegistryInMemex) — PROPOSAL: serving OCI images from the mesh, and the bootstrap circularity that keeps the boot image on ACR · [Static Repo Import](StaticRepoImport) · [The Prune Requires a Complete Listing](PruneRequiresACompleteListing) — an import prunes on "absent from the source ⇒ deleted"; a truncated GitHub tree arrives as HTTP 200 and turns every unread file into a deletion · [Import Write Ordering](ImportWriteOrdering) — a NodeType lands before the instances that name it · [Vector Search](VectorSearch) · [Durable But Unreadable](DurableButUnreadable) — a write that is acknowledged, versioned and invisible · [Instance-Key Resolution](InstanceKeyResolution) — the registry reads an instance key through live mirrors, never a per-request point read · [Cross-Schema Fan-Out Elimination](CrossSchemaFanOutElimination) — an unanchored query is a lock bomb; the census and the per-caller plan · [Addressed Notifications](AddressedNotifications) — plan 1 worked out: deliver a notification to its addressee so the bell reads two schemas, not 199 |
-| **Security** | [Access Control](AccessControl) | [Granting Access](GrantingAccess) · [AccessContext Propagation](AccessContextPropagation) · [Query Identity](QueryIdentity) — an unstamped read answers as Anonymous, which reads as absence · [Owner Injection](OwnerInjection) · [Permission API](PermissionApi) · [Invitation-Only Onboarding](InvitationOnlyOnboarding) · [Logon Actions](LogonActions) — per-user work at logon, run as the user · [Unanchored Security Reads](UnanchoredSecurityReads) — why the permission fold reads mesh-wide, and why pinning it to the viewer's partition is a silent revocation-fails-open bug · [A Denial Is an Answer](DenialIsAnAnswer) — a check on a hub with no evaluator grants Permission.All, and a refusal the mesh decided is rendered, never raised |
-| **Threads, activities & AI** | [Thread Operations](ThreadOperations) | [Thread Execution Streaming](ThreadExecutionStreaming) · [Activity Control Plane](ActivityControlPlane) · [Activity Operations](ActivityOperations) · [Notifications](Notifications) · [Notification Retention](NotificationRetention) — the platform's first data-retention pass, and why it is a logon action · [Agentic AI](AgenticAI) · [Script Execution](ScriptExecution) |
-| **UI** | [User Interface](UserInterface) | [Blazor Data Binding](BlazorDataBinding) · [Per-Tab Session State](PerTabSessionState) — a node is shared by every tab of one account, so "which page is this viewer on" and "navigate ME there" can never live on one · [Blazor Async](BlazorAsync) · [Available Controls](UserInterface/AvailableControls) · [Menus as Data](MenuAsData) — re-word a menu without a build · [The Menu Contribution Boundary](MenuContributionBoundary) — what may be data, what stays compiled · [Markdown Fence Extensions](MarkdownFenceExtensions) — the platform emits a marker, the clients hydrate it; a new fence is always a two-repo change · [Localization](Localization) — the viewer's language, resolved explicitly, never from ambient culture · [Chrome and Content Language](ChromeAndContentLanguage) — ownership decides the language, and in-flow chrome minimises words · [The Supplied Navigation Rail](SuppliedNavigationRail) — a module supplies its own left-hand index, and core renders it in the order the module gave |
-| **Node types** | [Adding a New Node Type](AddingANewNodeType) | [Retiring a NodeType](RetiringANodeType) — the prune keeps the definition and deletes its sources · [Dangling NodeTypes](DanglingNodeTypes) — a node whose type resolves to nothing, and the two write paths that allowed it · [Node Type Compilation](NodeTypeCompilation) · [Execute-Time Interlock](ExecuteTimeInterlock) — a build proven stale is never armed · [Graph / Compiler Layering](GraphCompilerLayering) — the four assemblies, the cycle, and the full-MVID size rule · [Toolchain Re-evaluation Lane](ToolchainReevaluationLane) — why a toolchain change stopped rebaking the world · [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes · [Source-Set Establishment](SourceSetEstablishment) — a resolved source set of ZERO is ambiguous, and only the type's own persisted snapshot tells "owns no Code" from "the discovery pass came back short"; the boot that resolved 91 fewer Code nodes than its neighbours and held a portal out of rotation for the startup probe's full three hours · [Install-Time Prebuilt Adoption](InstallTimePrebuiltAdoption) — the only lane that serves a package installed AFTER boot, and the four answers its zero must keep apart because a silent non-adoption reads exactly like a successful one · [Import Write Ordering](ImportWriteOrdering) — type before instance, and what a foreign type does · [Language Services](LanguageServices) · [Extensible Defaults](ExtensibleDefaults) |
-| **Plugins & content delivery** | [Plugins](Plugins) — node repos from git, no NuGet | [Plugin Manual](PluginAuthoring) — author · publish · install · own registry · [Plugin Registry](PluginRegistry) — memex re-serves plugins over REST · [Webhook Inbox](WebhookInbox) — external services deliver into {target}/_Inbox · [Plugin Packaging](PluginPackaging) — bundles, the framework identity, and the `Release` node that links a release to its assemblies per architecture · [Install Readability](InstallReadability) — the two doors an install can open, and the cover-grant deadlock detector · [A Module's Static Web Assets](ModuleStaticAssets) — a module's CSS/JS ride the bundle in their own folder and must land MODULE-RELATIVE beside the entry assembly; anything that copies only the closure loads perfectly and 404s every asset behind one Debug line · [Static Repo Import](StaticRepoImport) · [The Sync-Ref Contract](SyncRefContract) — an UNATTENDED import reads a commit CI proved; only a person clicking Update may read a branch tip, and resolving the ref twice put sources no build had compiled onto two production portals for five hours · [Node Type Compilation](NodeTypeCompilation) · [The Platform Image's Closure](PlatformImageClosure) — the image IS the reference set every satellite's modules compile against; the two invariants, and why every consumer used to discover them by failing to compile · [Sealed Publication Reads](SealedPublicationReads) — a publication is unreadable for ~90s per target per publish and the `plugins` prefix has two writers; the three answers (404/503/412), the generation that pins one instance, and the mix no reader can detect · [Sealed Publication Generations](SealedPublicationGenerations) — the layout that makes that mix UNREPRESENTABLE (a directory per publication plus a pointer swapped last), the reader contract, the retention rule, and the ordered migration that avoids a new-writer/old-writer half-state · [Install Completeness](InstallCompleteness) — what an install RECORD declares landed, compared against what is actually in the mesh; the comparison nothing made until #3485, and why only one of its five verdicts is a pass |
-| **Reliability & wedges** | [Error Propagation & Wedges](ErrorPropagationAndWedges) — drive wedges to 0 | [Action-Block Wedge Prevention](ActionBlockWedgePrevention) · [Riding Out a ShuttingDown Address](RidingOutAShuttingDownAddress) — the one transient NACK, and the two axes a ride-out must bound separately · [Hub Initialization Failure](HubInitializationFailure) · [Orleans Stream Pub-Sub Durability](OrleansStreamPubSubDurability) — a publish with no subscriber succeeds, so a cross-silo reply can vanish with nothing logged · [Durable Streams Are Mesh Nodes](DurableStreamsViaMeshNodes) — the design that retires the memory stream without a provider · [The Pod-Hub Claim Must Be Re-Asserted](PodHubClaimReassertion) — a claim asserted once into a directory that is re-partitioned on every membership change is lost silently, and forever · [Oversized Delivery Refusal](OversizedDeliveryRefusal) — a message too large for its transport destroys the connection carrying it; refuse at the producer, never raise the limit · [Content Sync Visibility](ContentSyncVisibility) — a Space whose assets the transport refuses says so, on the Space itself, naming the file, its size and the limit · [Out-of-Band Content Transfer](OutOfBandContentTransfer) — a content file too large for one delivery travels through the content store behind a content-addressed handle, never on the message · [An Unreachable Store Is Not a Refusal](StoreUnreachableIsNotARefusal) — one classification, three consumers; reporting an availability failure as a verdict is how a retried create becomes a duplicate · [Undetermined Is Not No](UndeterminedIsNotNo) — a read that did not answer is a THIRD state; the second door that shared the first door's failure domain, and the rule for what a gate does with "I could not determine" · [Reading a Silo Eviction](ReadingASiloEviction) — a heartbeat newer than the suspect votes is not proof the silo was healthy; the control arm that tells a correct eviction from a false positive · [Dead-Circuit Fan-Out Storm](DeadCircuitFanOutStorm) — a closed tab's owner pushed to the corpse for 46 minutes because the only verdict the eviction acts on could not be said; the release tombstone that says it · [Bake Seal — NodeOps Saturation](BakeSealNodeOpsSaturation) — the mesh's ONE node-CRUD hub stops draining under a bulk burst, and every consumer then reports its own bound · [The /api/content 503](ContentRoute503) — two causes with opposite fixes, and the one field in the line already printed that tells them apart · [Refused Replies During Teardown](RefusedRepliesDuringTeardown) — every failure route answers the SENDER, which for a reply is the responder; the answer the caller is parked on is dropped with nobody told · [Refusing a Lost User Action](RefusingALostUserAction) — a click whose stream is gone is refused out loud instead of dropped as churn; why "deliver it anyway" is not implementable as stated |
-| **Testing & debugging** | [Writing Tests](WritingTests) | [Negative Controls](NegativeControls) — a pin is only a pin if it fails against the defect · [Reactive Test Assertions](ReactiveTestAssertions) · [Test State Isolation](TestStateIsolation) · [Disposable-mesh e2e](DisposableMeshE2E) · [Debugging Message Flow](DebuggingMessageFlow) · [Debugging Disposal & Leaks](DebuggingDisposalAndLeaks) · [Reading a Disposal Stall Verdict](DisposalStallVerdicts) — what each field of the disposal snapshot actually measures, the three that were read as evidence while measuring nothing, and the verdict hole that sent 47 reports to children that were not the problem · [Ambient Test-Host Hangs](AmbientTestHostHangs) — what decides whether a killed test host can be diagnosed at all, and the readings of it already falsified · [In-Mesh Tests and the Seal](InMeshTestsAndTheSeal) — a Tests area no required context executes is a latent trunk red the seal detonates fleet-wide; how to measure a gate before requiring it · [Cancel and Join Are Two Questions](CancelAndJoinSequencing) — a deadline that asks work to stop and a deadline that waits for it to have stopped must not share one clock |
-| **Deployment & ops** | [Deployment](Deployment) (the router) | [AKS](DeploymentAKS) · [Database Migration Procedure](DatabaseMigrationProcedure) — the schema moves before the image, every roll; the 2026-09-03 wedge behind a 200, the recovery, and why a migration deadlocks under load · [Container Apps](DeploymentContainerApps) · [Local Dev Workflow](LocalDevWorkflow) · [Onboarding a New Environment](OnboardingNewEnvironment) · [Release & Self-Update Strategy](ReleaseStrategy) · [Self-Update Target Selection](SelfUpdateTargetSelection) — candidates are ranked by the CD run number, not the version string; a mislabelled line outranked every sealed set for ever, and an install on a withdrawn tag could never see anything newer · [The Continuous Delivery Contract](ContinuousDeliveryContract) — all-or-nothing publication; verify the image, never the tick · [The Self-Update Schema Wall](SelfUpdateSchemaWall) — every schema-bumping release is un-takeable by self-update, the stall is invisible, and a promoted tag is not a deployable tag · [Bake Identity Mismatch](BakeIdentityMismatch) — why a green CD can publish a bake no portal adopts, and the one rule that keeps two images of one commit on one address · [Release Availability Gates](ReleaseGates) — one predicate; never roll or build into a release a package cannot survive · [Combo Gate Wiring](ComboGateWiring) — the roll consults the combo verdict; Red refuses, and "could not find out" is neither · [Roll Selection](RollSelection) — completeness as a SELECTION criterion: pick the latest release that ships all of an environment's plugins, refuse an empty denominator, and never roll backwards · [Release Process](ReleaseProcess) · [NuGet Package Retirement](NuGetPackageRetirement) — two packages survive (the Aspire integration and the `dotnet new` template) and the other forty-three are unlisted; what unlisting does and does not break, the derived retirement sweep, and the ground rule that startup dependencies become Aspire options rather than new packages · [Repository Dependency Direction](RepositoryDependencyDirection) — the platform never depends on a plugin repo; the inventory of every edge that still does · [The Cross-Repo Pair Gate](CrossRepoPairGate) — a removal here reds a plugin repo's trunk hours later; the deleting half lands LAST · [Platform Script Resolution](PlatformScriptResolution) — a repo runs the platform's gate scripts, never a copy; the local runner must resolve the ref the LANE resolves, which is per-script, so a loader copied from another repo refuses on every call (one repo demands one lane sha, another pins four and the pin gate calls that consistent) · [Keeping the Platform Source Pin Current](PlatformRefBumpLane) — a satellite pins WHICH core commit its `src/` compiles against, the image set had a mover and the source ref had none, and a bump PR opened with `GITHUB_TOKEN` is a PR no CI ever runs · [Transitional Allow Entries](TransitionalAllowEntries) — an allow entry is written for ONE merge and expires with it by mechanism; the instruction that was ignored once cost every C#-touching PR in the fleet ~40 minutes of red · [Pinned Image Retention](PinnedImageRetention) — registry retention deletes what CI pins, and republishing frequency is what destroys a pin rather than what protects it; the guard that names a dead pin, and the retention design that stops the deletion · [The Image Tag Contract](ImageTagContract) — which image tags the promotion actually publishes, why the portal has no `latest`, and the two-writer history of the one that had no producer at all: retired lane, then retention, and every check green throughout · [Pin Set Consistency](PinSetConsistency) — every pinned digest EXISTING is not every pinned digest naming the same BUILD; the invariants that red a half-moved set, three written deliberately weaker than the obvious version, and the falsification that found the vacuity trap inside the gate itself · [Duplicate Keys in Workflow YAML](WorkflowDuplicateKeys) — a duplicate mapping key is accepted silently and the LAST one wins, so a pin can move in the diff and not in the job; the near-miss, why every existing gate was blind, and the guard that names the file, the key and both lines at the first job · [Image Pair Skew](ImagePairSkew) — a promoted image pairs a core commit with a Plugins head resolved hours later; each half green, the pair never run (the 2026-09-03 sign-in outage) · [The Merge Queue](MergeQueue) — one entry built at a time so nothing churns, and a steward that re-queues an ejected PR on evidence and never re-runs · [Carving Projects Out Of Core](CarvingProjectsOutOfCore) — what a SOURCE move costs and what it does not · [Red-Log Watching & Ticketing](LogWatchTriage) — every `fail:`/`crit:` becomes exactly one triaged issue · [Measuring a Live Portal Read-Only](MeasuringALivePortalReadOnly) — the four read-only instruments, and why an absence needs a coverage fact before it counts as evidence · [Chart Ownership and the Runner Pool](ChartOwnershipAndRunnerPool) — why the chart's gate is here, what a relocation must carry, and why path-filtering it is unsafe · [Sharding the Node-Repo Gate](NodeRepoGateSharding) — a cap cut reports as `cancelled`, so the fan-out that removes it, and the fold that keeps ONE required context and ONE gate log · [Probe Semantics](ProbeSemantics) — readiness, liveness and startup ask three different questions with three different remedies; why they get three paths and three tags · [What a Synthetic Probe May Assert](SyntheticProbeTargets) — a probe naming one deployment's installed content is broken by construction; the platform floor, the negative control that tells "absent" from "down", and reading the target's own declaration · [Why a GC-Bound Pod Stays in Rotation](WhyAGcBoundPodStaysInRotation) — the GC's hard limit sits below the container limit, so a portal short of memory is defended rather than restarted · [Self-hosted CI runners on AKS](SelfHostedRunners) — ARC beside the portals on one pool; three brakes, a negative priority class, and the reserve arithmetic that decides the cap |
-| **Contributing docs** | [Authoring Documentation](AuthoringDocumentation) | [Docs Follow The Functionality](DocsFollowTheFunctionality) — which repo a page belongs in, and what pins the rest here · [Specifying Software](SpecifyingSoftware) · [Glossary](/Doc/Glossary) |
-| **Licensing** | [Dependency Licensing](DependencyLicensing) — Apache-2.0/MIT compatible only; the CI gate that enforces it | |
+<!-- 🚨 ONE ENTRY PER LINE, and it must stay that way (#3699).
+     This map used to be a table whose cells each held the whole entry list on ONE line
+     (the longest was 5,877 characters carrying 34 entries). Adding a page meant appending
+     to that line, so two doc pull requests conflicted BY CONSTRUCTION however unrelated
+     their subjects — and the failure was silent: keeping one side of the merge dropped the
+     other side's page from the index, the page stayed reachable by URL, and
+     DocumentationLinkIntegrityTest still passed because it checks that links RESOLVE, not
+     that pages are LISTED. Appends now land on their own lines and git merges them
+     unaided. ArchitectureTopicMapTest asserts both halves: every page under
+     Data/Architecture/ is listed here, and no line carries two entries. -->
+
+### Reactive core
+
+- **Start here:** [Asynchronous Calls](AsynchronousCalls) — the no-`await` rulebook
+- [Actor Model](ActorModel)
+- [Turn-Loop Arrival Order](TurnLoopArrivalOrder) — a hub has TWO queues and a delivery moves between them at turn time, so a turn can be in neither when the last gate opens; the permutation names which message straddled the window, never which defect is live
+- [Controlled I/O Pooling](ControlledIoPooling)
+- [Subscription Ownership](SubscriptionOwnership) — a pending timer is a GC root
+- [Silent Completion](SilentCompletion) — an empty completion is invisible to every timeout
+- [AsyncLocal Across Scheduler Hops](AsyncLocalAcrossHops)
+- [Initialization Gates](InitializationGates)
+- [Aggregating Providers](AggregatingProviders)
+- [Hub Disposal Model](HubDisposalModel)
+- [Transient Node Probes](TransientNodeProbes) — a probe hub's own address is not a node
+- [Executive Assistant Credential Reads](ExecutiveAssistantCredentialReads) — a turn that waits for a mesh read holds the queue that read's reply must travel through, and the timeout was rendered as "you never connected"
+
+### Reading & writing nodes
+
+- **Start here:** [CQRS — Queries vs. Content Access](CqrsAndContentAccess)
+- [MeshNode Stream Cache](MeshNodeStreamCache)
+- [Request via Stream Update](RequestViaStreamUpdate)
+- [Data Access Patterns](DataAccessPatterns)
+- [Workspace References](WorkspaceReferences)
+- [Content Chunk Navigation](ContentChunkNavigation)
+- [Moving Nodes](MovingNodes) — a move relocates the node and everything that belongs to it, or it refuses
+- [Moved-Node Redirects](NodeRedirects) — keeping links alive after a move
+- [MainNode and Rebasing](MainNodeRebasing) — a `with { Namespace = … }` copy un-lists a node with nothing logged
+- [Write Verdict Totality](WriteVerdictTotality) — a write whose base read ends empty answers nobody, and arms no deadline either
+- [The Phantom Base After Owner Disposal](PhantomBaseAfterOwnerDisposal) — the owner echoes a merge BEFORE it flushes it, so a "never applied" NACK's re-attempt can find its own unpersisted write in the mirror, diff to nothing and report success
+- [Conditional Writes Across Hubs](ConditionalWritesAcrossHubs) — on a node you do not own the lambda runs on YOUR mirror and ships a diff, so a field it decided not to write is absent from the patch and a concurrent write to it survives
+- [Live Mirrors and the Change Feed](LiveMirrorsAndTheChangeFeed) — a write must not end its own streams
+- [Stream Liveness and the Hub Reference](StreamLivenessAndTheHubReference) — a stream outlived the hub it held, and the contract said it could not
+- [The sync/ Hub Population](SyncHubPopulation) — a `sync/` hub is one field of a stream and a subscription makes two of them; the only reaper of a Started one is an idle sweep the traffic keeps re-arming
+- [The Evicted-Stream Retention](EvictedStreamRetention) — a change-feed eviction parks a remote stream and `ReclaimIfUnheld` refuses to dispose one that carries no lease entry, so every unleased call site retains one stream, and two `sync/` hubs, per change event
+- [The Recursive-Delete Drain](RecursiveDeleteDrain) — the plan is a snapshot the removals may exceed, the completion check must include the ROOT, and the stage bound measures progress, not duration
+
+### Storage & partitions
+
+- **Start here:** [Postgres Schema Architecture](PostgresSchemaArchitecture)
+- [Partition Storage Routing](PartitionStorageRouting)
+- [Partition Teardown](PartitionTeardown) — deleting a partition ROOT drops its backing store; keyed on the node's SHAPE, never its NodeType
+- [Partition Storage Hubs](PartitionStorageHubs)
+- [Partitioned Persistence](PartitionedPersistence)
+- [Storage Adapter Implementation](StorageAdapterImplementation)
+- [Change-Feed Isolation](ChangeFeedIsolation) — one throwing subscriber must never starve the others
+- [A Container Registry in Memex](ContainerRegistryInMemex) — PROPOSAL: serving OCI images from the mesh, and the bootstrap circularity that keeps the boot image on ACR
+- [Static Repo Import](StaticRepoImport)
+- [The Prune Requires a Complete Listing](PruneRequiresACompleteListing) — an import prunes on "absent from the source ⇒ deleted"; a truncated GitHub tree arrives as HTTP 200 and turns every unread file into a deletion
+- [Import Write Ordering](ImportWriteOrdering) — a NodeType lands before the instances that name it
+- [Vector Search](VectorSearch)
+- [Durable But Unreadable](DurableButUnreadable) — a write that is acknowledged, versioned and invisible
+- [Instance-Key Resolution](InstanceKeyResolution) — the registry reads an instance key through live mirrors, never a per-request point read
+- [Cross-Schema Fan-Out Elimination](CrossSchemaFanOutElimination) — an unanchored query is a lock bomb; the census and the per-caller plan
+- [Addressed Notifications](AddressedNotifications) — plan 1 worked out: deliver a notification to its addressee so the bell reads two schemas, not 199
+
+### Security
+
+- **Start here:** [Access Control](AccessControl)
+- [Granting Access](GrantingAccess)
+- [AccessContext Propagation](AccessContextPropagation)
+- [Query Identity](QueryIdentity) — an unstamped read answers as Anonymous, which reads as absence
+- [Owner Injection](OwnerInjection)
+- [Permission API](PermissionApi)
+- [Invitation-Only Onboarding](InvitationOnlyOnboarding)
+- [Logon Actions](LogonActions) — per-user work at logon, run as the user
+- [Unanchored Security Reads](UnanchoredSecurityReads) — why the permission fold reads mesh-wide, and why pinning it to the viewer's partition is a silent revocation-fails-open bug
+- [A Denial Is an Answer](DenialIsAnAnswer) — a check on a hub with no evaluator grants Permission.All, and a refusal the mesh decided is rendered, never raised
+
+### Threads, activities & AI
+
+- **Start here:** [Thread Operations](ThreadOperations)
+- [Thread Execution Streaming](ThreadExecutionStreaming)
+- [Activity Control Plane](ActivityControlPlane)
+- [Activity Operations](ActivityOperations)
+- [Notifications](Notifications)
+- [Notification Retention](NotificationRetention) — the platform's first data-retention pass, and why it is a logon action
+- [Agentic AI](AgenticAI)
+- [Script Execution](ScriptExecution)
+
+### UI
+
+- **Start here:** [User Interface](UserInterface)
+- [Blazor Data Binding](BlazorDataBinding)
+- [Per-Tab Session State](PerTabSessionState) — a node is shared by every tab of one account, so "which page is this viewer on" and "navigate ME there" can never live on one
+- [Blazor Async](BlazorAsync)
+- [Available Controls](UserInterface/AvailableControls)
+- [Menus as Data](MenuAsData) — re-word a menu without a build
+- [The Menu Contribution Boundary](MenuContributionBoundary) — what may be data, what stays compiled
+- [Markdown Fence Extensions](MarkdownFenceExtensions) — the platform emits a marker, the clients hydrate it; a new fence is always a two-repo change
+- [Localization](Localization) — the viewer's language, resolved explicitly, never from ambient culture
+- [Chrome and Content Language](ChromeAndContentLanguage) — ownership decides the language, and in-flow chrome minimises words
+- [The Supplied Navigation Rail](SuppliedNavigationRail) — a module supplies its own left-hand index, and core renders it in the order the module gave
+
+### Node types
+
+- **Start here:** [Adding a New Node Type](AddingANewNodeType)
+- [Retiring a NodeType](RetiringANodeType) — the prune keeps the definition and deletes its sources
+- [Dangling NodeTypes](DanglingNodeTypes) — a node whose type resolves to nothing, and the two write paths that allowed it
+- [Node Type Compilation](NodeTypeCompilation)
+- [Execute-Time Interlock](ExecuteTimeInterlock) — a build proven stale is never armed
+- [Graph / Compiler Layering](GraphCompilerLayering) — the four assemblies, the cycle, and the full-MVID size rule
+- [Toolchain Re-evaluation Lane](ToolchainReevaluationLane) — why a toolchain change stopped rebaking the world
+- [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes
+- [Source-Set Establishment](SourceSetEstablishment) — a resolved source set of ZERO is ambiguous, and only the type's own persisted snapshot tells "owns no Code" from "the discovery pass came back short"; the boot that resolved 91 fewer Code nodes than its neighbours and held a portal out of rotation for the startup probe's full three hours
+- [Install-Time Prebuilt Adoption](InstallTimePrebuiltAdoption) — the only lane that serves a package installed AFTER boot, and the four answers its zero must keep apart because a silent non-adoption reads exactly like a successful one
+- [Import Write Ordering](ImportWriteOrdering) — type before instance, and what a foreign type does
+- [Language Services](LanguageServices)
+- [Extensible Defaults](ExtensibleDefaults)
+
+### Plugins & content delivery
+
+- **Start here:** [Plugins](Plugins) — node repos from git, no NuGet
+- [Plugin Manual](PluginAuthoring) — author
+- publish
+- install
+- own registry
+- [Plugin Registry](PluginRegistry) — memex re-serves plugins over REST
+- [Webhook Inbox](WebhookInbox) — external services deliver into {target}/_Inbox
+- [Plugin Packaging](PluginPackaging) — bundles, the framework identity, and the `Release` node that links a release to its assemblies per architecture
+- [Install Readability](InstallReadability) — the two doors an install can open, and the cover-grant deadlock detector
+- [A Module's Static Web Assets](ModuleStaticAssets) — a module's CSS/JS ride the bundle in their own folder and must land MODULE-RELATIVE beside the entry assembly; anything that copies only the closure loads perfectly and 404s every asset behind one Debug line
+- [Static Repo Import](StaticRepoImport)
+- [The Sync-Ref Contract](SyncRefContract) — an UNATTENDED import reads a commit CI proved; only a person clicking Update may read a branch tip, and resolving the ref twice put sources no build had compiled onto two production portals for five hours
+- [Node Type Compilation](NodeTypeCompilation)
+- [The Platform Image's Closure](PlatformImageClosure) — the image IS the reference set every satellite's modules compile against; the two invariants, and why every consumer used to discover them by failing to compile
+- [Sealed Publication Reads](SealedPublicationReads) — a publication is unreadable for ~90s per target per publish and the `plugins` prefix has two writers; the three answers (404/503/412), the generation that pins one instance, and the mix no reader can detect
+- [Sealed Publication Generations](SealedPublicationGenerations) — the layout that makes that mix UNREPRESENTABLE (a directory per publication plus a pointer swapped last), the reader contract, the retention rule, and the ordered migration that avoids a new-writer/old-writer half-state
+- [Install Completeness](InstallCompleteness) — what an install RECORD declares landed, compared against what is actually in the mesh; the comparison nothing made until #3485, and why only one of its five verdicts is a pass
+
+### Reliability & wedges
+
+- **Start here:** [Error Propagation & Wedges](ErrorPropagationAndWedges) — drive wedges to 0
+- [Action-Block Wedge Prevention](ActionBlockWedgePrevention)
+- [Riding Out a ShuttingDown Address](RidingOutAShuttingDownAddress) — the one transient NACK, and the two axes a ride-out must bound separately
+- [Hub Initialization Failure](HubInitializationFailure)
+- [Orleans Stream Pub-Sub Durability](OrleansStreamPubSubDurability) — a publish with no subscriber succeeds, so a cross-silo reply can vanish with nothing logged
+- [Durable Streams Are Mesh Nodes](DurableStreamsViaMeshNodes) — the design that retires the memory stream without a provider
+- [The Pod-Hub Claim Must Be Re-Asserted](PodHubClaimReassertion) — a claim asserted once into a directory that is re-partitioned on every membership change is lost silently, and forever
+- [Oversized Delivery Refusal](OversizedDeliveryRefusal) — a message too large for its transport destroys the connection carrying it; refuse at the producer, never raise the limit
+- [Content Sync Visibility](ContentSyncVisibility) — a Space whose assets the transport refuses says so, on the Space itself, naming the file, its size and the limit
+- [Out-of-Band Content Transfer](OutOfBandContentTransfer) — a content file too large for one delivery travels through the content store behind a content-addressed handle, never on the message
+- [An Unreachable Store Is Not a Refusal](StoreUnreachableIsNotARefusal) — one classification, three consumers; reporting an availability failure as a verdict is how a retried create becomes a duplicate
+- [Undetermined Is Not No](UndeterminedIsNotNo) — a read that did not answer is a THIRD state; the second door that shared the first door's failure domain, and the rule for what a gate does with "I could not determine"
+- [Reading a Silo Eviction](ReadingASiloEviction) — a heartbeat newer than the suspect votes is not proof the silo was healthy; the control arm that tells a correct eviction from a false positive
+- [Dead-Circuit Fan-Out Storm](DeadCircuitFanOutStorm) — a closed tab's owner pushed to the corpse for 46 minutes because the only verdict the eviction acts on could not be said; the release tombstone that says it
+- [Bake Seal — NodeOps Saturation](BakeSealNodeOpsSaturation) — the mesh's ONE node-CRUD hub stops draining under a bulk burst, and every consumer then reports its own bound
+- [The /api/content 503](ContentRoute503) — two causes with opposite fixes, and the one field in the line already printed that tells them apart
+- [Refused Replies During Teardown](RefusedRepliesDuringTeardown) — every failure route answers the SENDER, which for a reply is the responder; the answer the caller is parked on is dropped with nobody told
+- [Refusing a Lost User Action](RefusingALostUserAction) — a click whose stream is gone is refused out loud instead of dropped as churn; why "deliver it anyway" is not implementable as stated
+
+### Testing & debugging
+
+- **Start here:** [Writing Tests](WritingTests)
+- [Negative Controls](NegativeControls) — a pin is only a pin if it fails against the defect
+- [Reactive Test Assertions](ReactiveTestAssertions)
+- [Test State Isolation](TestStateIsolation)
+- [Disposable-mesh e2e](DisposableMeshE2E)
+- [Debugging Message Flow](DebuggingMessageFlow)
+- [Debugging Disposal & Leaks](DebuggingDisposalAndLeaks)
+- [Reading a Disposal Stall Verdict](DisposalStallVerdicts) — what each field of the disposal snapshot actually measures, the three that were read as evidence while measuring nothing, and the verdict hole that sent 47 reports to children that were not the problem
+- [Ambient Test-Host Hangs](AmbientTestHostHangs) — what decides whether a killed test host can be diagnosed at all, and the readings of it already falsified
+- [In-Mesh Tests and the Seal](InMeshTestsAndTheSeal) — a Tests area no required context executes is a latent trunk red the seal detonates fleet-wide; how to measure a gate before requiring it
+- [Cancel and Join Are Two Questions](CancelAndJoinSequencing) — a deadline that asks work to stop and a deadline that waits for it to have stopped must not share one clock
+
+### Deployment & ops
+
+- **Start here:** [Deployment](Deployment) (the router)
+- [AKS](DeploymentAKS)
+- [Database Migration Procedure](DatabaseMigrationProcedure) — the schema moves before the image, every roll; the 2026-09-03 wedge behind a 200, the recovery, and why a migration deadlocks under load
+- [Container Apps](DeploymentContainerApps)
+- [Local Dev Workflow](LocalDevWorkflow)
+- [Onboarding a New Environment](OnboardingNewEnvironment)
+- [Release & Self-Update Strategy](ReleaseStrategy)
+- [Self-Update Target Selection](SelfUpdateTargetSelection) — candidates are ranked by the CD run number, not the version string; a mislabelled line outranked every sealed set for ever, and an install on a withdrawn tag could never see anything newer
+- [The Continuous Delivery Contract](ContinuousDeliveryContract) — all-or-nothing publication; verify the image, never the tick
+- [The Self-Update Schema Wall](SelfUpdateSchemaWall) — every schema-bumping release is un-takeable by self-update, the stall is invisible, and a promoted tag is not a deployable tag
+- [Bake Identity Mismatch](BakeIdentityMismatch) — why a green CD can publish a bake no portal adopts, and the one rule that keeps two images of one commit on one address
+- [Release Availability Gates](ReleaseGates) — one predicate; never roll or build into a release a package cannot survive
+- [Combo Gate Wiring](ComboGateWiring) — the roll consults the combo verdict; Red refuses, and "could not find out" is neither
+- [Roll Selection](RollSelection) — completeness as a SELECTION criterion: pick the latest release that ships all of an environment's plugins, refuse an empty denominator, and never roll backwards
+- [Release Process](ReleaseProcess)
+- [NuGet Package Retirement](NuGetPackageRetirement) — two packages survive (the Aspire integration and the `dotnet new` template) and the other forty-three are unlisted; what unlisting does and does not break, the derived retirement sweep, and the ground rule that startup dependencies become Aspire options rather than new packages
+- [Repository Dependency Direction](RepositoryDependencyDirection) — the platform never depends on a plugin repo; the inventory of every edge that still does
+- [The Cross-Repo Pair Gate](CrossRepoPairGate) — a removal here reds a plugin repo's trunk hours later; the deleting half lands LAST
+- [Platform Script Resolution](PlatformScriptResolution) — a repo runs the platform's gate scripts, never a copy; the local runner must resolve the ref the LANE resolves, which is per-script, so a loader copied from another repo refuses on every call (one repo demands one lane sha, another pins four and the pin gate calls that consistent)
+- [Keeping the Platform Source Pin Current](PlatformRefBumpLane) — a satellite pins WHICH core commit its `src/` compiles against, the image set had a mover and the source ref had none, and a bump PR opened with `GITHUB_TOKEN` is a PR no CI ever runs
+- [Transitional Allow Entries](TransitionalAllowEntries) — an allow entry is written for ONE merge and expires with it by mechanism; the instruction that was ignored once cost every C#-touching PR in the fleet ~40 minutes of red
+- [Pinned Image Retention](PinnedImageRetention) — registry retention deletes what CI pins, and republishing frequency is what destroys a pin rather than what protects it; the guard that names a dead pin, and the retention design that stops the deletion
+- [The Image Tag Contract](ImageTagContract) — which image tags the promotion actually publishes, why the portal has no `latest`, and the two-writer history of the one that had no producer at all: retired lane, then retention, and every check green throughout
+- [Pin Set Consistency](PinSetConsistency) — every pinned digest EXISTING is not every pinned digest naming the same BUILD; the invariants that red a half-moved set, three written deliberately weaker than the obvious version, and the falsification that found the vacuity trap inside the gate itself
+- [Duplicate Keys in Workflow YAML](WorkflowDuplicateKeys) — a duplicate mapping key is accepted silently and the LAST one wins, so a pin can move in the diff and not in the job; the near-miss, why every existing gate was blind, and the guard that names the file, the key and both lines at the first job
+- [Image Pair Skew](ImagePairSkew) — a promoted image pairs a core commit with a Plugins head resolved hours later; each half green, the pair never run (the 2026-09-03 sign-in outage)
+- [The Merge Queue](MergeQueue) — one entry built at a time so nothing churns, and a steward that re-queues an ejected PR on evidence and never re-runs
+- [Carving Projects Out Of Core](CarvingProjectsOutOfCore) — what a SOURCE move costs and what it does not
+- [Red-Log Watching & Ticketing](LogWatchTriage) — every `fail:`/`crit:` becomes exactly one triaged issue
+- [Measuring a Live Portal Read-Only](MeasuringALivePortalReadOnly) — the four read-only instruments, and why an absence needs a coverage fact before it counts as evidence
+- [Chart Ownership and the Runner Pool](ChartOwnershipAndRunnerPool) — why the chart's gate is here, what a relocation must carry, and why path-filtering it is unsafe
+- [Sharding the Node-Repo Gate](NodeRepoGateSharding) — a cap cut reports as `cancelled`, so the fan-out that removes it, and the fold that keeps ONE required context and ONE gate log
+- [Probe Semantics](ProbeSemantics) — readiness, liveness and startup ask three different questions with three different remedies; why they get three paths and three tags
+- [What a Synthetic Probe May Assert](SyntheticProbeTargets) — a probe naming one deployment's installed content is broken by construction; the platform floor, the negative control that tells "absent" from "down", and reading the target's own declaration
+- [Why a GC-Bound Pod Stays in Rotation](WhyAGcBoundPodStaysInRotation) — the GC's hard limit sits below the container limit, so a portal short of memory is defended rather than restarted
+- [Self-hosted CI runners on AKS](SelfHostedRunners) — ARC beside the portals on one pool; three brakes, a negative priority class, and the reserve arithmetic that decides the cap
+
+### Contributing docs
+
+- **Start here:** [Authoring Documentation](AuthoringDocumentation)
+- [Docs Follow The Functionality](DocsFollowTheFunctionality) — which repo a page belongs in, and what pins the rest here
+- [Specifying Software](SpecifyingSoftware)
+- [Glossary](/Doc/Glossary)
+
+### Licensing
+
+- **Start here:** [Dependency Licensing](DependencyLicensing) — Apache-2.0/MIT compatible only; the CI gate that enforces it
 
 ## Getting started
 

--- a/test/MeshWeaver.Documentation.Test/ArchitectureTopicMapTest.cs
+++ b/test/MeshWeaver.Documentation.Test/ArchitectureTopicMapTest.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using MeshWeaver.Reactive.Assertions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 The topic map in <c>Data/Architecture.md</c> must LIST every architecture page, and must keep
+/// one entry per line.
+///
+/// <para><b>Why the second half matters as much as the first (#3699).</b> The map used to be a table
+/// whose cells each carried the whole entry list on ONE line — the longest was 5,877 characters
+/// holding 34 entries. Adding a page meant appending to that line, so two doc pull requests
+/// conflicted BY CONSTRUCTION however unrelated their subjects: 24 commits touched the file in one
+/// day and the conflict was hand-resolved four times, twice on PRs that had gone <c>DIRTY</c> and
+/// were therefore running no CI at all.</para>
+///
+/// <para><b>And the failure was SILENT.</b> Keeping one side of such a merge drops the other side's
+/// page from the index. The page stays reachable by URL, so
+/// <c>DocumentationLinkIntegrityTest</c> still passes — it checks that links RESOLVE, not that pages
+/// are LISTED. The page simply loses its only discoverable entry point and no gate says a word.
+/// That is the hole this guard closes, and it is the guard the issue asked for rather than the
+/// reformat alone.</para>
+/// </summary>
+public class ArchitectureTopicMapTest
+{
+    /// <summary>
+    /// How many architecture pages the topic map does NOT list, as measured when this guard was
+    /// written (2026-09-09: 291 pages under Data/Architecture/, 168 distinct pages listed).
+    ///
+    /// <para>🚨 <b>A ratchet, not a budget, and RAISING IT IS NOT A FIX.</b> Zero is the right
+    /// number and 125 is what the tree actually had the day the hole was first measured — nobody had
+    /// counted before, because nothing asked. Listing all 125 is a classification exercise (which
+    /// theme does each page belong under?) that a guard cannot do and should not fake by seeding an
+    /// allow list: an unexplained allow entry IS the silent unlisting this exists to prevent, just
+    /// moved somewhere greener. So the count is pinned here and may only go DOWN, which gives the
+    /// property that matters immediately — a NEW page cannot be added without being listed.</para>
+    /// </summary>
+    private const int UnlistedBaseline = 125;
+
+    [Fact]
+    public void EveryArchitecturePage_IsListedInTheTopicMap()
+    {
+        var unlisted = Unlisted();
+
+        Assert.True(unlisted.Count <= UnlistedBaseline,
+            $"{unlisted.Count} architecture page(s) are listed nowhere in the topic map, up from the "
+            + $"baseline of {UnlistedBaseline}. A page reachable by URL but listed nowhere has lost "
+            + "its only discoverable entry point, and no other gate notices — "
+            + "DocumentationLinkIntegrityTest checks that links RESOLVE, not that pages are LISTED. "
+            + "Add an entry to Data/Architecture.md under the theme it belongs to. Do NOT raise this "
+            + "baseline: it may only go down.\n  "
+            + string.Join("\n  ", unlisted.Except(new string[0]).Take(20)));
+    }
+
+    /// <summary>
+    /// Caps the slack, so the baseline cannot quietly become permanent headroom: if the tree has
+    /// fallen well below it, the baseline is stale and should be lowered in the same change that
+    /// earned it. Same shape as <c>TestTimeoutLiteralRatchetGuard</c>'s companion.
+    /// </summary>
+    [Fact]
+    public void TheBaselineStaysCloseToTheTree()
+    {
+        var actual = Unlisted().Count;
+        Assert.True(UnlistedBaseline - actual <= 10,
+            $"the topic map now omits only {actual} page(s) but UnlistedBaseline is still "
+            + $"{UnlistedBaseline} — lower it to {actual}. A baseline left far above the tree is "
+            + "headroom a future change can spend without any gate objecting, which is exactly what "
+            + "a ratchet is meant to stop.");
+    }
+
+    [Fact]
+    public void TheTopicMap_KeepsOneEntryPerLine()
+    {
+        var (map, _) = ReadMap();
+        var crowded = map.Split('\n')
+            .Select((text, i) => (Line: i + 1, text))
+            .Where(l => l.text.TrimStart().StartsWith("- ", StringComparison.Ordinal))
+            .Where(l => Regex.Matches(l.text, @"\]\([^)]+\)").Count > 1)
+            .Select(l => $"line {l.Line}: {l.text.Trim()[..Math.Min(120, l.text.Trim().Length)]}…")
+            .ToList();
+
+        crowded.Should().BeEmpty(
+            "the topic map carries ONE entry per line so that two doc PRs appending pages touch "
+            + "DIFFERENT lines and git merges them unaided. Packing several entries onto one line "
+            + "restores the conflict-by-construction this format exists to remove — and its silent "
+            + "failure, where a hand-merge keeps one side and drops the other side's page from the "
+            + "index with every gate still green (#3699)");
+    }
+
+    /// <summary>Architecture pages with no entry in the topic map, by file name.</summary>
+    private static List<string> Unlisted()
+    {
+        var (map, dir) = ReadMap();
+        var listed = Regex.Matches(map, @"\]\(([^)]+)\)")
+            .Select(m => m.Groups[1].Value)
+            .Select(href => href.Split('#')[0].TrimEnd('/'))
+            .Select(href => href.Contains('/') ? href[(href.LastIndexOf('/') + 1)..] : href)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return dir.GetFiles("*.md", SearchOption.TopDirectoryOnly)
+            .Select(f => Path.GetFileNameWithoutExtension(f.Name))
+            .Where(name => !listed.Contains(name))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static (string Map, DirectoryInfo Dir) ReadMap()
+    {
+        var root = FindRepoRoot();
+        var data = Path.Combine(root, "src", "MeshWeaver.Documentation", "Data");
+        var map = File.ReadAllText(Path.Combine(data, "Architecture.md"));
+        var dir = new DirectoryInfo(Path.Combine(data, "Architecture"));
+        Assert.True(dir.Exists, $"Data/Architecture not found under {data} — the guard would pass vacuously");
+        return (map, dir);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/ArchitectureTopicMapTest.cs
+++ b/test/MeshWeaver.Documentation.Test/ArchitectureTopicMapTest.cs
@@ -28,49 +28,39 @@ namespace MeshWeaver.Documentation.Test;
 /// </summary>
 public class ArchitectureTopicMapTest
 {
-    /// <summary>
-    /// How many architecture pages the topic map does NOT list, as measured when this guard was
-    /// written (2026-09-09: 291 pages under Data/Architecture/, 168 distinct pages listed).
-    ///
-    /// <para>🚨 <b>A ratchet, not a budget, and RAISING IT IS NOT A FIX.</b> Zero is the right
-    /// number and 125 is what the tree actually had the day the hole was first measured — nobody had
-    /// counted before, because nothing asked. Listing all 125 is a classification exercise (which
-    /// theme does each page belong under?) that a guard cannot do and should not fake by seeding an
-    /// allow list: an unexplained allow entry IS the silent unlisting this exists to prevent, just
-    /// moved somewhere greener. So the count is pinned here and may only go DOWN, which gives the
-    /// property that matters immediately — a NEW page cannot be added without being listed.</para>
-    /// </summary>
-    private const int UnlistedBaseline = 125;
-
     [Fact]
     public void EveryArchitecturePage_IsListedInTheTopicMap()
     {
-        var unlisted = Unlisted();
+        var (map, dir) = ReadMap();
+        var pages = dir.GetFiles("*.md", SearchOption.AllDirectories)
+            .Select(f => Path.ChangeExtension(Path.GetRelativePath(dir.FullName, f.FullName), null)
+                .Replace(Path.DirectorySeparatorChar, '/'))
+            .ToArray();
+        Assert.NotEmpty(pages);
+        var unlisted = Unlisted(map, pages);
 
-        Assert.True(unlisted.Count <= UnlistedBaseline,
-            $"{unlisted.Count} architecture page(s) are listed nowhere in the topic map, up from the "
-            + $"baseline of {UnlistedBaseline}. A page reachable by URL but listed nowhere has lost "
-            + "its only discoverable entry point, and no other gate notices — "
-            + "DocumentationLinkIntegrityTest checks that links RESOLVE, not that pages are LISTED. "
-            + "Add an entry to Data/Architecture.md under the theme it belongs to. Do NOT raise this "
-            + "baseline: it may only go down.\n  "
-            + string.Join("\n  ", unlisted.Except(new string[0]).Take(20)));
+        Assert.True(unlisted.Count == 0,
+            "Architecture pages missing from Data/Architecture.md. Add each page under its theme; "
+            + "a working URL alone does not make it discoverable.\n  "
+            + string.Join("\n  ", unlisted));
     }
 
-    /// <summary>
-    /// Caps the slack, so the baseline cannot quietly become permanent headroom: if the tree has
-    /// fallen well below it, the baseline is stale and should be lowered in the same change that
-    /// earned it. Same shape as <c>TestTimeoutLiteralRatchetGuard</c>'s companion.
-    /// </summary>
     [Fact]
-    public void TheBaselineStaysCloseToTheTree()
+    public void Coverage_RequiresTheCorrectPathForNestedPages()
     {
-        var actual = Unlisted().Count;
-        Assert.True(UnlistedBaseline - actual <= 10,
-            $"the topic map now omits only {actual} page(s) but UnlistedBaseline is still "
-            + $"{UnlistedBaseline} — lower it to {actual}. A baseline left far above the tree is "
-            + "headroom a future change can spend without any gate objecting, which is exactly what "
-            + "a ratchet is meant to stop.");
+        var missing = Unlisted(
+            "- [Elsewhere](/Doc/Other/Page)\n- [Top level](Page)",
+            ["Page", "Nested/Page"]);
+        Assert.Equal(new[] { "Nested/Page" }, missing);
+        Assert.Empty(Unlisted("- [Nested](Nested/Page)", ["Nested/Page"]));
+    }
+
+    [Fact]
+    public void Coverage_ResolvesArchitectureLinksWithFragments()
+    {
+        Assert.Empty(Unlisted(
+            "- [One](/Doc/Architecture/One#details)\n- [Two](./Nested/Two.md#example)",
+            ["One", "Nested/Two"]));
     }
 
     [Fact]
@@ -80,33 +70,44 @@ public class ArchitectureTopicMapTest
         var crowded = map.Split('\n')
             .Select((text, i) => (Line: i + 1, text))
             .Where(l => l.text.TrimStart().StartsWith("- ", StringComparison.Ordinal))
-            .Where(l => Regex.Matches(l.text, @"\]\([^)]+\)").Count > 1)
+            .Where(l => Regex.Matches(l.text, @"\]\([^)]+\)").Count != 1)
             .Select(l => $"line {l.Line}: {l.text.Trim()[..Math.Min(120, l.text.Trim().Length)]}…")
             .ToList();
 
         crowded.Should().BeEmpty(
-            "the topic map carries ONE entry per line so that two doc PRs appending pages touch "
+            "each topic-map bullet must carry exactly ONE linked entry so that two doc PRs appending pages touch "
             + "DIFFERENT lines and git merges them unaided. Packing several entries onto one line "
             + "restores the conflict-by-construction this format exists to remove — and its silent "
             + "failure, where a hand-merge keeps one side and drops the other side's page from the "
             + "index with every gate still green (#3699)");
     }
 
-    /// <summary>Architecture pages with no entry in the topic map, by file name.</summary>
-    private static List<string> Unlisted()
+    /// <summary>Architecture pages with no entry, retaining their path below Architecture/.</summary>
+    private static List<string> Unlisted(string map, IEnumerable<string> pages)
     {
-        var (map, dir) = ReadMap();
         var listed = Regex.Matches(map, @"\]\(([^)]+)\)")
-            .Select(m => m.Groups[1].Value)
-            .Select(href => href.Split('#')[0].TrimEnd('/'))
-            .Select(href => href.Contains('/') ? href[(href.LastIndexOf('/') + 1)..] : href)
+            .Select(m => NormalizeArchitectureLink(m.Groups[1].Value))
+            .Where(path => path is not null)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        return dir.GetFiles("*.md", SearchOption.TopDirectoryOnly)
-            .Select(f => Path.GetFileNameWithoutExtension(f.Name))
-            .Where(name => !listed.Contains(name))
-            .OrderBy(n => n, StringComparer.Ordinal)
+        return pages.Where(path => !listed.Contains(path))
+            .OrderBy(path => path, StringComparer.Ordinal)
             .ToList();
+    }
+
+    private static string? NormalizeArchitectureLink(string href)
+    {
+        var path = href.Split('#')[0].TrimEnd('/');
+        const string prefix = "/Doc/Architecture/";
+        if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            path = path[prefix.Length..];
+        else if (path.StartsWith('/') || path.Contains(':'))
+            return null;
+        if (path.StartsWith("./", StringComparison.Ordinal))
+            path = path[2..];
+        if (path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            path = path[..^3];
+        return path;
     }
 
     private static (string Map, DirectoryInfo Dir) ReadMap()


### PR DESCRIPTION
Closes #3699.

The Architecture topic map now has one linked entry per line under each theme, so unrelated documentation additions no longer edit the same long table row. All existing links remain, and the Plugin Manual description stays on its own entry.

The index now also lists all 293 architecture pages, including 126 previously omitted pages (one nested). Each addition uses the page's existing title under the corresponding theme; the architecture documents themselves are unchanged.

`ArchitectureTopicMapTest` requires zero missing pages, scans nested directories, and compares full relative paths so a link to an identically named page elsewhere cannot satisfy coverage. Each list bullet must contain exactly one link. Regression cases cover nested-path collisions and absolute/relative links with fragments. There is no omission baseline or slack allowance.

Validation: Release build with CI flags and warnings as errors: 0 warnings, 0 errors. Full Documentation.Test suite: 365 passed, 0 failed or skipped, with fresh TRX. Local Markdown browser preview inspected: 13 theme headings, no malformed bullets, no horizontal overflow. Existing link destinations preserved.

No What's New entry: internal engineering documentation maintenance.
