### PR TITLE
fix: restore native collection labels alongside numeric fallback

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-native-collection-labels.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-native-collection-labels.md
@@ -1,0 +1,9 @@
+---
+Name: Collection labels retain their readable text
+Category: Fix
+Description: Labels render native collections consistently with values received over the mesh.
+Icon: Info
+Order: -20260909
+---
+
+Labels bound to arrays, lists, or dictionaries retain their readable text before transport serialization. This restores collection rendering while preserving safe fallback handling for values that cannot be converted to numbers.

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -296,6 +296,11 @@ public static class LayoutClientExtensions
         // `fail` line on EVERY NavLink render (prod error storm) while the icon rendered as nothing.
         if (typeof(T) == typeof(Icon) && TryGetStringValue(value, out var iconString))
             return (T?)(object?)Icon.Parse(iconString);
+        // Labels must render the same value before and after transport serialization.
+        // Collections and other non-convertible values use the existing JSON text conversion.
+        if (typeof(T) == typeof(string) && value is not null && value is not IConvertible)
+            return hub.ConvertJson(JsonSerializer.SerializeToElement(value, hub.JsonSerializerOptions),
+                null, defaultValue);
         return value switch
         {
             null => defaultValue,

--- a/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
+++ b/src/MeshWeaver.Layout/Client/LayoutClientExtensions.cs
@@ -299,8 +299,21 @@ public static class LayoutClientExtensions
         // Labels must render the same value before and after transport serialization.
         // Collections and other non-convertible values use the existing JSON text conversion.
         if (typeof(T) == typeof(string) && value is not null && value is not IConvertible)
-            return hub.ConvertJson(JsonSerializer.SerializeToElement(value, hub.JsonSerializerOptions),
-                null, defaultValue);
+        {
+            try
+            {
+                return hub.ConvertJson(JsonSerializer.SerializeToElement(value, hub.JsonSerializerOptions),
+                    null, defaultValue);
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException)
+            {
+                // Match the unreadable-string policy: report the rejected value's type and keep
+                // the subscription alive so a later valid emission can render normally.
+                hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Layout.ConvertString")
+                    .LogDebug(ex, "Could not serialize label value of type {Type} — using default", value.GetType().Name);
+                return defaultValue;
+            }
+        }
         return value switch
         {
             null => defaultValue,

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Globalization;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.Fixture;
 using MeshWeaver.Layout.Client;
@@ -47,6 +49,26 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
         hub.ConvertSingle<string>(Array.Empty<string>(), null).Should().BeEmpty();
         hub.ConvertSingle<string>(Guid.Parse("01234567-89ab-cdef-0123-456789abcdef"), null)
             .Should().Be("01234567-89ab-cdef-0123-456789abcdef");
+    }
+
+    [Fact]
+    public void ConvertSingle_UnserializableLabel_DoesNotEndBinding()
+    {
+        var hub = GetHost();
+        var cycle = new System.Collections.Generic.List<object>();
+        cycle.Add(cycle);
+        var rendered = new System.Collections.Generic.List<string?>();
+        Exception? failure = null;
+        using var source = new Subject<object>();
+        using var subscription = source.Select(value => hub.ConvertSingle<string>(value, null, "unreadable"))
+            .Subscribe(rendered.Add, error => failure = error);
+
+        source.OnNext(typeof(string));
+        source.OnNext(cycle);
+        source.OnNext(new[] { "Initialize", "MeshNodeInit" });
+
+        failure.Should().BeNull();
+        rendered.Should().Equal("unreadable", "unreadable", "Initialize, MeshNodeInit");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutClientExtensionsTest.cs
@@ -16,6 +16,39 @@ public class LayoutClientExtensionsTest(ITestOutputHelper output) : HubTestBase(
         return base.ConfigureHost(config);
     }
 
+    [Fact]
+    public void ConvertSingle_CollectionLabel_MatchesItsSerializedValue()
+    {
+        var hub = GetHost();
+        object[] values =
+        [
+            new[] { "Initialize", "MeshNodeInit" },
+            new System.Collections.Generic.List<int> { 1, 2, 3 },
+            new System.Collections.Generic.Dictionary<string, int> { ["pending"] = 2 },
+            System.Text.Json.Nodes.JsonNode.Parse("[\"Initialize\",\"MeshNodeInit\"]")!,
+            System.Text.Json.Nodes.JsonNode.Parse("{\"pending\":2}")!
+        ];
+        foreach (var value in values)
+        {
+            var serialized = JsonSerializer.SerializeToElement(value, hub.JsonSerializerOptions);
+            var expected = hub.ConvertSingle<string>(serialized, null);
+            expected.Should().NotBeNullOrEmpty();
+            hub.ConvertSingle<string>(value, null).Should().Be(expected,
+                "a label must render the same value before and after transport serialization");
+        }
+    }
+
+    [Fact]
+    public void ConvertSingle_GateNames_RenderAsReadableText()
+    {
+        var hub = GetHost();
+        hub.ConvertSingle<string>(new[] { "Initialize", "MeshNodeInit" }, null)
+            .Should().Be("Initialize, MeshNodeInit");
+        hub.ConvertSingle<string>(Array.Empty<string>(), null).Should().BeEmpty();
+        hub.ConvertSingle<string>(Guid.Parse("01234567-89ab-cdef-0123-456789abcdef"), null)
+            .Should().Be("01234567-89ab-cdef-0123-456789abcdef");
+    }
+
     /// <summary>
     /// 🚨 A value that is not <see cref="IConvertible"/> must not END THE BINDING (#3764).
     ///


### PR DESCRIPTION
A native collection bound to a label renders as null after #3793 removed the string-conversion branch and regression tests introduced in #3788. For example, the gate names `["Initialize", "MeshNodeInit"]` should render as `Initialize, MeshNodeInit` before and after transport serialization.

Restore the existing JSON text-conversion path for non-IConvertible string sources while preserving #3793's numeric fallback handling. Restore both regression tests covering arrays, lists, dictionaries, JsonNode values, empty collections and Guid text.

Validation: both restored tests fail on the unchanged production code. With the fix, all 465 Layout tests pass; release-note and documentation-link guards pass (2 tests). Layout.Test, Documentation.Test and Memex.Portal.Shared build in Release with CIRun=true and warnings as errors, with zero warnings/errors. Fresh TRX files were produced. Includes a Category: Fix release note.

Closes #3764.

Pairs-with: none — restores internal conversion behavior without removing public surface.
