### PR TITLE
fix(#3790): a trigger whose verdict is a foregone conclusion is not a check

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -170,6 +170,10 @@ public class SelfUpdateHostedService : IHostedService
             // ordering: it silently dropped the startup pass. policy is Replay(1), so Take(1) yields
             // the latest value immediately and deterministically.
             .SelectMany(trigger => policy.Take(1).Select(content => (trigger, content)))
+            // 🚨 #3790 — an externally paced trigger whose verdict is already a foregone
+            // conclusion is not a check. See IsDecisionPoint: this is a rate decision, NOT the
+            // silence #2553 removed, and the two are one line apart.
+            .Where(check => IsDecisionPoint(check.trigger, check.content))
             .SelectMany(check => RunOnce(check.content)
                 // wedges-to-zero: a check error (ACR outage, k8s 403) is a VERDICT, not a silence,
                 // and the watch stays live. No outer .Retry — that would be a resubscribe storm.
@@ -221,6 +225,44 @@ public class SelfUpdateHostedService : IHostedService
     /// state it produced — never race a timer against it.
     /// </summary>
     protected internal IObservable<Unit> ChecksReported => _checksReported;
+
+    /// <summary>
+    /// 🚨 <b>Is this trigger a decision point under this policy? (#3790)</b>
+    ///
+    /// <para>Under <see cref="UpdatePolicyKind.None"/> a check can change nothing, and the code
+    /// says so in two places already: <see cref="RunOnce"/> returns
+    /// <see cref="SelfUpdateVerdict.UpdatesDisabled"/> before it lists a single tag, and
+    /// <see cref="SelfUpdateVerdict.MayRestartAfter"/> answers <c>false</c> for that outcome, so
+    /// the module-restart half (#3650) is not taken either. The whole effect of such a check is a
+    /// log line and a bookkeeping stamp repeating a verdict the record already carries.</para>
+    ///
+    /// <para>That would be harmless if the checks were paced by this install. They are not. The
+    /// <c>BuildCompletion</c> and <c>ModuleSetProposed</c> triggers are paced by the FLEET — every
+    /// platform and module publication anywhere wakes every replica — and on memex that measured
+    /// <b>158 checks in 5 h</b>, each writing <c>LastCheckedAt</c> cross-hub into one shared leaf
+    /// from both replicas at once: 14 <c>[MergeGuard] refused stale/reordered</c>, 10
+    /// <c>OWNER_NACK_REENQUEUE</c>, two 10-second <c>[UpdateQueue] FAILED</c> stalls in the hub
+    /// that also carries user writes, and <c>Admin/UpdatePolicy</c> at <b>version 62,671</b> for a
+    /// content decision that had not changed in two days.</para>
+    ///
+    /// <para>🚨 <b>This is NOT the <c>Where</c> that #2553 removed</b>, and the distinction is the
+    /// whole design. That one dropped EVERY check under <c>None</c>, so an install an admin had
+    /// deliberately pinned and an install whose updater was broken both left the record empty —
+    /// indistinguishable. Here <see cref="SelfUpdateTrigger.Startup"/> still runs (the record
+    /// always carries the disabled verdict and the time this pod established it),
+    /// <see cref="SelfUpdateTrigger.PolicyChange"/> still runs (enabling updates must not wait for
+    /// a publication) and <see cref="SelfUpdateTrigger.SafetyNet"/> still runs (so
+    /// <c>LastCheckedAt</c> keeps moving on THIS service's own period and a dead checker is still
+    /// visible as a stale stamp). What stops is only the repetition, at a rate nobody here
+    /// chooses, of a sentence already on the node.</para>
+    ///
+    /// <para>Pure and static so the rule is pinned without a mesh, exactly as
+    /// <see cref="SelfUpdateVerdict.RestartDeferredBy"/> pins the floor arithmetic. Internal
+    /// rather than private for the same reason — the truth table is the test.</para>
+    /// </summary>
+    internal static bool IsDecisionPoint(SelfUpdateTrigger trigger, UpdatePolicyContent policy)
+        => policy.Policy != UpdatePolicyKind.None
+           || trigger is not (SelfUpdateTrigger.BuildCompletion or SelfUpdateTrigger.ModuleSetProposed);
 
     /// <summary>
     /// The safety net (#2494): a bounded liveness floor on the CHECK, never on the roll.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
@@ -240,7 +240,59 @@ the lowest assembly `MeshWeaver.Hosting`, `MeshWeaver.PluginCatalog` and `Memex.
 reference directly. `PlatformReleaseOrderTest.ThePreReleaseLabelIsTextToSemVer_WhichIsWhyTheFloorNeedsItsOwnPredicate`
 pins the boundary so the floor decision is taken knowingly rather than by reusing the update one.
 
-## 5. What this does NOT fix
+## 5. A trigger whose verdict is a foregone conclusion is not a check
+
+**The rate of a check is a property the install must own.** Everything above is about *what* a check
+selects; this is about *when* one happens, and the two failed in the same direction on
+[#3790](https://github.com/Systemorph/MeshWeaver/issues/3790).
+
+The self-updater is event-driven, which is right: `BuildCompletion` ticks once per publication
+**anywhere in the fleet**, and nothing beats an event for latency. But the rate that carries is the
+fleet's build cadence, not anything about this install — and under `UpdatePolicyKind.None` a check
+can act on none of it. Two places in the code already say so:
+
+- `RunOnce` returns `SelfUpdateVerdict.UpdatesDisabled()` **before it lists a single tag**; and
+- `SelfUpdateVerdict.MayRestartAfter` answers `false` for that outcome, so the module-restart half
+  ([#3650](https://github.com/Systemorph/MeshWeaver/issues/3650)) is not taken either.
+
+So the whole effect of such a check is a log line plus a bookkeeping stamp repeating a sentence the
+node already carries. Measured on memex, 2026-09-09 01:30–06:36Z, policy `None`, two replicas:
+
+| | |
+|---|---|
+| `[SelfUpdate] check (BuildCompletion): updates are disabled …` | **158** in 5 h |
+| `[MergeGuard] refused stale/reordered cross-hub write to 'lastCheckedAt'` | 14 |
+| `[UpdateRemote] OWNER_NACK_REENQUEUE … code=Conflict` | 10 |
+| `[UpdateQueue] FAILED path=Admin/UpdatePolicy … elapsedMs=10015` | 2 |
+| `Admin/UpdatePolicy` version | **62,671** |
+
+Two replicas writing one leaf on the same event is a conflict by construction; at event rate it is a
+sustained one, in the update queue that also carries user writes.
+
+`SelfUpdateHostedService.IsDecisionPoint(trigger, policy)` is the rule, and it is a filter on the
+**trigger**, never on the check:
+
+| trigger | paced by | a decision point under `None`? |
+|---|---|---|
+| `BuildCompletion` | the fleet | **no** |
+| `ModuleSetProposed` | the fleet | **no** |
+| `Startup` | this pod | yes — the record must carry the disabled verdict and when this pod established it |
+| `PolicyChange` | an admin | yes — enabling updates must not wait for a publication |
+| `SafetyNet` | this service | yes — `LastCheckedAt` keeps moving on its own period, so a dead checker still reads as stale |
+
+Under any policy that can act, every trigger is a decision point.
+
+🚨 **This is the opposite of the `Where` that #2553 removed, and they are one line apart.** That one
+dropped *every* check under `None`, so an install an administrator had deliberately pinned and an
+install whose updater was broken both left the record empty — indistinguishable, and memex sat three
+builds behind for seven hours in that state. What #3790 stops is only the **repetition**, at a rate
+nobody here chooses, of an answer already on the node. Because the regression that would undo #2553
+is one enum member away, the rule is pinned as a truth table over every trigger × every policy
+(`SelfUpdateChecksOnlyAtDecisionPointsTest.TheDecisionPointRule`), and the integration half is a
+controlled experiment: the same event, pushed through the same seam, is *not* a check under `None`
+and *is* one under `Continuous`.
+
+## 6. What this does NOT fix
 
 - **The withdrawn tags themselves.** Ordering makes them lose; it does not remove them. Measured
   2026-09-08 (`az acr repository show-tags -n meshweaver --repository memex-portal-ai`): **1403 tags,
@@ -264,7 +316,8 @@ pins the boundary so the floor decision is taken knowingly rather than by reusin
   (`Newest`), in the lowest assembly all of them reach.
 - `memex/Memex.Portal.Shared/SelfUpdate/VersionSelect.cs` — the tag-shape filters, the policy,
   `CheckInstalledTag` and `SelectCandidates`. Pure; no hub, no registry, no Rx.
-- `memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs` — `RunOnce` / `NothingToRoll`.
+- `memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs` — `RunOnce` / `NothingToRoll`,
+  and `IsDecisionPoint` (§5).
 - `src/MeshWeaver.Hosting/SealedPublicationIndex.cs` — identity → its newest published version.
 - `src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs` — which sealed publication a tolerant adoption
   takes (`Modules:VersionStrictness`, [Module Versioning](/Doc/Architecture/ModuleVersioning)).
@@ -275,6 +328,8 @@ pins the boundary so the floor decision is taken knowingly rather than by reusin
   sweep, each in both directions.
 - `test/Memex.Portal.Shared.Test/VersionSelectTest.cs` — the ordering and the three-valued check.
 - `test/Memex.Portal.Shared.Test/SelfUpdateStrandRecoveryTest.cs` — the poller, against a real mesh.
+- `test/Memex.Portal.Shared.Test/SelfUpdateChecksOnlyAtDecisionPointsTest.cs` — §5's truth table,
+  and the same event under two policies.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
@@ -303,8 +303,14 @@ and *is* one under `Continuous`.
   the same action — the ordering's job is to make the slip HARMLESS while its tags are still there.
   🚨 The `_releases/` markers are the same set of labels and are **not** covered by that deletion;
   retention removes a pre-release marker only when the identity it names is collected.
-- **The policy record losing its own policy** under its bookkeeping writes (issue #3542, proposal 3 —
-  settled by #3619 for the clobber, still open for the `[MergeGuard]` refusals).
+- **The policy record losing its own policy** under its bookkeeping writes (issue #3542, proposal 3).
+  Settled by #3619: the framework's own typed write (`Update<UpdatePolicyContent>`) refuses a record
+  it cannot read instead of persisting defaults over it, and all four bookkeeping writes are pinned
+  with positive controls in `UnreadablePolicyRecordIsNotClobberedTest`. 🚨 The `[MergeGuard] refused
+  stale/reordered cross-hub write` lines that accompanied it were a **rate**, not a write shape, and
+  §5 removes the rate. Two replicas may still write the install-scoped stamp — that is deliberate,
+  it describes "this install checked" rather than "this pod checked" — and a refusal of the older of
+  two is the merge guard being RIGHT, not a defect to remove.
 - **"Installed" is what the pod RUNS.** This reads `ShippedReleaseSeed.InstalledPlatformVersion` —
   the injected `MESHWEAVER_PLATFORM_VERSION`, never the record's `LatestAvailableTag`, which after a
   manual roll-back kept naming a version no pod ran.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-check-that-can-decide-nothing-is-not-a-check.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-check-that-can-decide-nothing-is-not-a-check.md
@@ -1,0 +1,66 @@
+---
+Name: A check that can decide nothing is not a check
+Category: Fix
+Description: An install pinned to "no automatic updates" was still running a full self-update check on every platform or module publication anywhere in the fleet — 158 of them in five hours on memex, each one rewriting the same "updates are disabled" sentence onto Admin/UpdatePolicy from both replicas at once. The fleet-paced triggers now stop while the policy is None; the ones this install paces itself keep running, so the record still says what it always said.
+Icon: Clock
+Order: -20260909
+---
+
+`Admin/UpdatePolicy` on memex stood at **version 62,671** on the morning of 2026-09-09, for a
+content decision that had not changed since 2026-09-07. Reading five hours of both replicas' logs
+explains every one of those versions:
+
+```
+[SelfUpdate] check (BuildCompletion): updates are disabled on this install
+             (Admin/UpdatePolicy = None); the registry was not listed.        ×158
+[MergeGuard] Admin/UpdatePolicy: refused stale/reordered cross-hub write
+             to 'lastCheckedAt'                                               ×14
+[UpdateRemote] OWNER_NACK_REENQUEUE … code=Conflict                           ×10
+[UpdateQueue] FAILED path=Admin/UpdatePolicy seq=576 elapsedMs=10015          ×2
+```
+
+Nothing user-visible broke — the contested field is a timestamp — but two replicas were writing one
+leaf on the same event, roughly once every two minutes, in the update queue that also carries user
+writes, and the resulting log volume buried the lines that mattered: the same window's real signal
+was **4 lines in 212**.
+
+## What was wrong
+
+The check's rate was not this install's to choose. `BuildCompletion` ticks once per publication
+**anywhere in the fleet** — that is the point of it, and under a policy that can act it is exactly
+right: an event beats a poll, and #2494 exists because this service used to have neither.
+
+Under `None` it decides nothing, and the code already said so twice. `RunOnce` returns
+`UpdatesDisabled` before it lists a single tag, and `SelfUpdateVerdict.MayRestartAfter` answers
+`false` for that outcome — so the module-restart half is not taken either. The entire effect of such
+a check was a log line and a stamp repeating a sentence the node already carried.
+
+## What it does now
+
+While the policy is `None`, the two **fleet-paced** triggers — `BuildCompletion` and
+`ModuleSetProposed` — are not decision points and do not run a check. The three this install paces
+itself still do:
+
+- **Startup**, so the record always carries the disabled verdict and the time this pod established
+  it;
+- **PolicyChange**, so enabling updates never waits for the next publication; and
+- **the safety net**, so `LastCheckedAt` keeps moving on this service's own hourly period and a
+  checker that has actually died still reads as a stale stamp rather than a frozen one.
+
+That is the whole change: what stops is the repetition, at a rate nobody here chooses, of an answer
+already on the node. On the measured window it takes a pinned install from ~158 checks in five
+hours to about five.
+
+## Why this is not the silence that was removed
+
+An earlier version of this service dropped **every** check under `None` with a bare `Where`, and
+that was the defect [#2553](https://github.com/Systemorph/MeshWeaver/issues/2553) was filed about:
+an install an administrator had deliberately pinned and an install whose updater was broken both
+left the record empty, so nobody could tell them apart and memex sat three builds behind for seven
+hours. The two changes are one line apart and point in opposite directions, so the rule is pinned as
+a truth table over every trigger × every policy, and the suite asserts both halves — the fleet-paced
+triggers stop, **and** the disabled verdict, the moving stamp and the policy-change wake-up all
+survive.
+
+See [Self-Update Target Selection](@/Doc/Architecture/SelfUpdateTargetSelection) for how a check that
+does run picks what to roll to.

--- a/test/Memex.Portal.Shared.Test/SelfUpdateChecksOnlyAtDecisionPointsTest.cs
+++ b/test/Memex.Portal.Shared.Test/SelfUpdateChecksOnlyAtDecisionPointsTest.cs
@@ -1,0 +1,341 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>#3790 — "Self-update check runs on every build completion on every replica under
+/// UpdatePolicy=None, and the replicas fight over Admin/UpdatePolicy.lastCheckedAt".</b>
+///
+/// <para>Measured on memex 2026-09-09, 01:30–06:36Z: <b>158</b> checks in 5 h, every one of them
+/// reporting <c>"updates are disabled on this install (Admin/UpdatePolicy = None)"</c> — a verdict
+/// the record already carried — and every one of them writing <c>LastCheckedAt</c> cross-hub into
+/// the same leaf from both replicas. 14 <c>[MergeGuard] refused stale/reordered</c>, 10
+/// <c>OWNER_NACK_REENQUEUE</c>, five <c>STALE_MIRROR</c>, three <c>ADVANCE_WITHOUT_HANDOFF</c> and
+/// two ten-second <c>[UpdateQueue] FAILED</c> stalls in the hub that also carries user writes, with
+/// <c>Admin/UpdatePolicy</c> standing at <b>version 62,671</b>.</para>
+///
+/// <para>The cause is a rate, and the rate is not this install's: <c>BuildCompletion</c> ticks once
+/// per publication ANYWHERE in the fleet. Under <c>None</c> such a check is decision-free by
+/// construction — <see cref="SelfUpdateVerdict.MayRestartAfter"/> is <c>false</c> for
+/// <c>UpdatesDisabled</c>, so it cannot roll and cannot restart either.</para>
+///
+/// <para>🚨 <b>The line these tests walk:</b> #2553 removed a <c>Where</c> that dropped every check
+/// under <c>None</c> and left an admin-pinned install indistinguishable from a broken one. So the
+/// suite asserts BOTH directions — the fleet-paced triggers stop, and the record still carries the
+/// disabled verdict, still moves on the safety net, and still wakes on a policy change.</para>
+///
+/// <para><b>Fails on unfixed code:</b> <see cref="UnderNone_ABuildCompletion_IsNotACheck"/> sees the
+/// second check its control proves the driver is capable of.</para>
+/// </summary>
+public class SelfUpdateChecksOnlyAtDecisionPointsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    private static string Installed => ShippedReleaseSeed.InstalledPlatformVersion;
+
+    private static string InstalledTag => Installed.Split('+')[0];
+
+    /// <summary>A registry with nothing newer than this install, in which its own tag resolves —
+    /// so under <c>Continuous</c> a check reaches "no newer release" and rolls nothing.</summary>
+    private static string[] NothingNewer => ["1.9.0-ci.0", "2.0.0-ci.0", InstalledTag];
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The rule, pinned without a mesh
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 The whole truth table, every trigger × every policy — because the defect and the
+    /// regression that would undo #2553 are one enum member apart, and a test that only checked
+    /// the <c>None</c>/<c>BuildCompletion</c> cell would pass on a predicate that returned
+    /// <c>false</c> for everything.
+    /// </summary>
+    [Theory]
+    // Under None the FLEET-paced triggers decide nothing: RunOnce short-circuits to UpdatesDisabled
+    // before it lists a tag, and MayRestartAfter(UpdatesDisabled) is false.
+    [InlineData(UpdatePolicyKind.None, SelfUpdateTrigger.BuildCompletion, false)]
+    [InlineData(UpdatePolicyKind.None, SelfUpdateTrigger.ModuleSetProposed, false)]
+    // …but the three this install paces itself still run, and each one is a #2553 obligation:
+    // Startup puts the disabled verdict on the record at all, PolicyChange is how updates get
+    // enabled, SafetyNet is what keeps LastCheckedAt moving so a dead checker reads as stale.
+    [InlineData(UpdatePolicyKind.None, SelfUpdateTrigger.Startup, true)]
+    [InlineData(UpdatePolicyKind.None, SelfUpdateTrigger.PolicyChange, true)]
+    [InlineData(UpdatePolicyKind.None, SelfUpdateTrigger.SafetyNet, true)]
+    // Under every policy that can act, every trigger is a decision point. This half is what stops
+    // the predicate from being "narrow the poller until the log is quiet".
+    [InlineData(UpdatePolicyKind.Continuous, SelfUpdateTrigger.BuildCompletion, true)]
+    [InlineData(UpdatePolicyKind.Continuous, SelfUpdateTrigger.ModuleSetProposed, true)]
+    [InlineData(UpdatePolicyKind.Continuous, SelfUpdateTrigger.Startup, true)]
+    [InlineData(UpdatePolicyKind.Continuous, SelfUpdateTrigger.PolicyChange, true)]
+    [InlineData(UpdatePolicyKind.Continuous, SelfUpdateTrigger.SafetyNet, true)]
+    [InlineData(UpdatePolicyKind.Stable, SelfUpdateTrigger.BuildCompletion, true)]
+    [InlineData(UpdatePolicyKind.Stable, SelfUpdateTrigger.ModuleSetProposed, true)]
+    [InlineData(UpdatePolicyKind.Stable, SelfUpdateTrigger.Startup, true)]
+    [InlineData(UpdatePolicyKind.Stable, SelfUpdateTrigger.PolicyChange, true)]
+    [InlineData(UpdatePolicyKind.Stable, SelfUpdateTrigger.SafetyNet, true)]
+    public void TheDecisionPointRule(UpdatePolicyKind policy, SelfUpdateTrigger trigger, bool expected) =>
+        SelfUpdateHostedService.IsDecisionPoint(trigger, new UpdatePolicyContent { Policy = policy })
+            .Should().Be(expected);
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  The same driver, under two policies — a controlled experiment
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>The acceptance criterion.</b> Policy <c>None</c>; the startup check lands; a build
+    /// completion is then pushed through the REAL trigger seam — and no second check happens.
+    ///
+    /// <para>The bound below would also be satisfied by a service that had simply stopped, which is
+    /// why <see cref="UnderContinuous_ABuildCompletion_IsACheck"/> pushes the identical event
+    /// through the identical seam and asserts the second check DOES arrive. Neither test means
+    /// anything alone.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task UnderNone_ABuildCompletion_IsNotACheck()
+    {
+        await Seed(UpdatePolicyKind.None);
+        await using var run = await Start();
+
+        await run.FirstCheck;
+
+        run.PushBuildCompletion();
+
+        await run.LaterChecks.Should().NotEmit(TestTimeouts.Quick,
+            "under None a build completion can neither roll nor restart (MayRestartAfter is false "
+            + "for UpdatesDisabled), so all it could do is rewrite a verdict the node already "
+            + "carries — 158 times in 5 h on memex, from both replicas, onto one leaf");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The positive control</b>, and the guard against "fix" by making the service deaf: the
+    /// same seam, the same push, a policy that can act — and the check happens.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task UnderContinuous_ABuildCompletion_IsACheck()
+    {
+        await Seed(UpdatePolicyKind.Continuous);
+        await using var run = await Start();
+
+        await run.FirstCheck;
+
+        run.PushBuildCompletion();
+
+        await run.LaterChecks.FirstAsync().Timeout(Budget).Await(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// 🚨 The #2553 obligation, which is the whole reason the predicate is a filter on the TRIGGER
+    /// and not a filter on the check: an install pinned to <c>None</c> still says so, durably, on
+    /// the node — "an admin pinned this" and "the updater is broken" must never look alike again.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task UnderNone_TheRecordStillCarriesTheDisabledVerdict()
+    {
+        await Seed(UpdatePolicyKind.None);
+        await using var run = await Start();
+
+        await run.FirstCheck;
+        var content = await WaitForContent(c => c.LastCheckVerdict is not null);
+
+        content.LastCheckVerdict.Should().Contain("updates are disabled",
+            "the durable half of the report is what an operator reads on the Updates tab");
+        content.LastCheckedAt.Should().NotBeNull(
+            "a stamp is what distinguishes an install that checked from one that never did");
+        content.LastCheckTrigger.Should().Be(nameof(SelfUpdateTrigger.Startup));
+    }
+
+    /// <summary>
+    /// 🚨 And the stamp keeps MOVING, on this service's own period: the safety net still runs under
+    /// <c>None</c>, so a checker that has died still reads as a stale <c>LastCheckedAt</c> rather
+    /// than as one frozen by design. This is the cell that stops the fix from becoming a freeze.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task UnderNone_TheSafetyNet_StillChecks()
+    {
+        await Seed(UpdatePolicyKind.None);
+        await using var run = await Start();
+
+        await run.FirstCheck;
+
+        run.PushSafetyNet();
+
+        await run.LaterChecks.FirstAsync().Timeout(Budget).Await(TestContext.Current.CancellationToken);
+        var content = await WaitForContent(c => c.LastCheckTrigger == nameof(SelfUpdateTrigger.SafetyNet));
+        content.LastCheckVerdict.Should().Contain("updates are disabled");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  Harness
+    // ══════════════════════════════════════════════════════════════════════════
+
+    private sealed class FakeAcrTagLister(IReadOnlyList<string> tags) : IAcrTagLister
+    {
+        public Task<IReadOnlyList<string>> ListTagsAsync(string repository, CancellationToken ct) =>
+            Task.FromResult(tags);
+    }
+
+    /// <summary>Detect-and-notify: this suite is about which triggers reach a check, never about
+    /// what a check then does to a cluster.</summary>
+    private sealed class InertUpdater : IDeploymentUpdater
+    {
+        public bool CanPatch => false;
+
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+            Task.FromResult<DateTimeOffset?>(null);
+
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class AlwaysAvailable(IMessageHub hub, IConfiguration configuration)
+        : ReleaseAvailabilityService(hub, configuration)
+    {
+        public override IObservable<UpdatabilityVerdict> IsUpdatable(string? targetVersion) =>
+            Observable.Return(UpdatabilityVerdict.NotEnforced("this test host consumes no CI bakes"));
+    }
+
+    /// <summary>The poller with its two fleet-paced trigger seams driven by hand, so a build
+    /// completion is an EVENT the test pushes rather than a timer it waits out.</summary>
+    private sealed class DrivenSelfUpdateService(
+        IMessageHub hub,
+        IAcrTagLister acr,
+        SelfUpdateOptions options,
+        ILogger<SelfUpdateHostedService>? logger,
+        ReleaseAvailabilityService gate,
+        IObservable<SelfUpdateTrigger> builds,
+        IObservable<SelfUpdateTrigger> safetyNet)
+        : SelfUpdateHostedService(hub, acr, new InertUpdater(), options, logger)
+    {
+        public IObservable<Unit> Evaluations => ChecksReported;
+
+        protected override ReleaseAvailabilityService? ResolveAvailabilityGate() => gate;
+
+        protected override ComboVerificationGate? ResolveComboGate() => null;
+
+        protected override ModuleLandingService? ResolveLandingService() => null;
+
+        protected override IObservable<SelfUpdateTrigger> BuildCompletionTicks() => builds;
+
+        protected override IObservable<SelfUpdateTrigger> SafetyNetTicks() => safetyNet;
+    }
+
+    /// <summary>One running service plus the two things every test here needs: a signal that the
+    /// startup check has been REPORTED, and a stream of every check after it.
+    ///
+    /// <para>🚨 The checks are <c>Replay()</c>ed and connected BEFORE <c>StartAsync</c>. A live
+    /// <c>Publish()</c> would make every assertion here a race against the startup check landing in
+    /// the gap between subscribe and start — and the shape that race fails in is a HANG, which is
+    /// how a suite about a rate would end up bounding one.</para></summary>
+    private sealed class Run(
+        SelfUpdateHostedService service,
+        Subject<SelfUpdateTrigger> builds,
+        Subject<SelfUpdateTrigger> safetyNet,
+        IObservable<Unit> checks,
+        IDisposable connection) : IAsyncDisposable
+    {
+        /// <summary>The startup check, reported. Replayed, so awaiting it after the fact works.</summary>
+        public Task FirstCheck => checks.FirstAsync().Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+
+        /// <summary>Every check reported after the startup one.</summary>
+        public IObservable<Unit> LaterChecks => checks.Skip(1);
+
+        public void PushBuildCompletion() => builds.OnNext(SelfUpdateTrigger.BuildCompletion);
+
+        public void PushSafetyNet() => safetyNet.OnNext(SelfUpdateTrigger.SafetyNet);
+
+        public async ValueTask DisposeAsync()
+        {
+            await service.StopAsync(CancellationToken.None);
+            connection.Dispose();
+            builds.Dispose();
+            safetyNet.Dispose();
+        }
+    }
+
+    private async Task<Run> Start()
+    {
+        var builds = new Subject<SelfUpdateTrigger>();
+        var safetyNet = new Subject<SelfUpdateTrigger>();
+        var service = new DrivenSelfUpdateService(
+            Mesh, new FakeAcrTagLister(NothingNewer),
+            new SelfUpdateOptions
+            {
+                RetryInterval = TimeSpan.FromMilliseconds(500),
+                EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
+                DefaultPolicy = UpdatePolicyKind.Continuous,
+                DefaultPattern = "*-ci*",
+            },
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(),
+            new AlwaysAvailable(Mesh, new ConfigurationBuilder().Build()),
+            builds, safetyNet);
+        var checks = service.Evaluations.Replay();
+        var connection = checks.Connect();
+        await service.StartAsync(CancellationToken.None);
+        return new Run(service, builds, safetyNet, checks, connection);
+    }
+
+    private Task Seed(UpdatePolicyKind policy)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var node = new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+        {
+            NodeType = UpdatePolicyNodeType.NodeType,
+            Name = "Update Policy",
+            State = MeshNodeState.Active,
+            Content = new UpdatePolicyContent
+            {
+                Policy = policy,
+                Pattern = policy == UpdatePolicyKind.Continuous ? "*-ci*" : null,
+            },
+        };
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return (IDisposable)meshService.CreateNode(node).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+    }
+
+    private Task<UpdatePolicyContent> WaitForContent(Func<UpdatePolicyContent, bool> predicate) =>
+        Observable.Create<UpdatePolicyContent>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return Mesh.GetWorkspace()
+                        .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                        .Where(node => node is not null)
+                        .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
+                        .Subscribe(observer);
+            })
+            .Where(predicate)
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+}


### PR DESCRIPTION
Closes #3790.

## The measurement

`Admin/UpdatePolicy` on memex stood at **version 62,671** this morning, for a content decision
unchanged since 2026-09-07. Five hours of both replicas' logs (01:30–06:36Z, policy `None`) account
for it:

| line | count |
|---|---|
| `[SelfUpdate] check (BuildCompletion): updates are disabled on this install …` | **158** |
| `[MergeGuard] Admin/UpdatePolicy: refused stale/reordered cross-hub write to 'lastCheckedAt'` | 14 |
| `[UpdateRemote] OWNER_NACK_REENQUEUE … code=Conflict` | 10 |
| `[UpdateQueue] ADVANCE_WITHOUT_HANDOFF` / `STALE_MIRROR` | 3 / 5 |
| `[UpdateQueue] FAILED path=Admin/UpdatePolicy … elapsedMs=10015` | 2 |

The contested field is a timestamp, so nothing user-visible broke — but two replicas were writing one
leaf every ~2 minutes in the update queue that also carries user writes, and the volume buried the
window's real signal (#3768 was **4 lines in 212**).

## The cause: a rate this install does not choose

`BuildCompletion` ticks once per publication **anywhere in the fleet**. Under a policy that can act
that is exactly right and stays unchanged — an event beats a poll, which is what #2494 is about.

Under `None` such a check decides nothing, and the code already said so in two places:

- `RunOnce` returns `SelfUpdateVerdict.UpdatesDisabled()` **before it lists a single tag**; and
- `SelfUpdateVerdict.MayRestartAfter` answers `false` for that outcome, so the module-restart half
  (#3650) is not taken either.

So the whole effect was a log line plus a stamp repeating a sentence the node already carried.

## The change

`SelfUpdateHostedService.IsDecisionPoint(trigger, policy)` — one `Where` on the **trigger**, after
the policy is read at decision time, so the single long-lived watch is never re-subscribed (no
re-baselining; the `WithLatestFrom`-not-`Switch` rule above it is untouched).

| trigger | paced by | decision point under `None`? |
|---|---|---|
| `BuildCompletion` | the fleet | **no** |
| `ModuleSetProposed` | the fleet | **no** |
| `Startup` | this pod | yes |
| `PolicyChange` | an admin | yes |
| `SafetyNet` | this service | yes |

~158 checks in five hours becomes ~5 on a pinned install. Under any policy that can act, nothing
changes at all.

## 🚨 Why this is not the silence #2553 removed

An earlier version dropped **every** check under `None` with a bare `Where`, and that was #2553's
defect: an install an admin had deliberately pinned and an install whose updater was broken both left
the record empty, so memex sat three builds behind for seven hours with nothing able to say so. The
two changes are one line apart and point in opposite directions, so all three of #2553's obligations
are kept and asserted:

- **Startup** still runs → the record always carries the disabled verdict and when this pod
  established it;
- **PolicyChange** still runs → enabling updates never waits for a publication;
- **the safety net** still runs → `LastCheckedAt` keeps moving on this service's own hourly period,
  so a checker that has actually died still reads as a *stale* stamp, not a frozen one.

What stops is only the repetition, at a rate nobody here chooses, of an answer already on the node.

## Tests

`test/Memex.Portal.Shared.Test/SelfUpdateChecksOnlyAtDecisionPointsTest.cs` — 15 + 4:

- **`TheDecisionPointRule`** — the full truth table, every trigger × every policy. A predicate that
  returned `false` for everything (the #2553 regression) fails 12 of the 15 cases.
- **`UnderNone_ABuildCompletion_IsNotACheck`** — the acceptance criterion, with
  **`UnderContinuous_ABuildCompletion_IsACheck`** as its positive control: the same event, pushed
  through the same real trigger seam, under two policies. Neither means anything alone.
- **`UnderNone_TheRecordStillCarriesTheDisabledVerdict`** and
  **`UnderNone_TheSafetyNet_StillChecks`** — the #2553 half.

**Falsification, measured:** with the `Where` removed, `UnderNone_ABuildCompletion_IsNotACheck` fails
in 298 ms — *"Expected the observable not to emit … but it emitted ()"* — and the other 18 cases pass,
so the controls are not vacuous in either direction.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation: `Memex.Portal.Shared`,
`MeshWeaver.Documentation`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` — **0 Warning(s),
0 Error(s)** each. `Memex.Portal.Shared.Test` **1175/1175** (1152 before, +23), 2 m 42 s;
`MeshWeaver.Documentation.Test` **365/365** including `DocumentationLinkIntegrityTest`.

## Docs

- `Doc/Architecture/SelfUpdateTargetSelection` §5 — the rule, the measurement and the #2553 boundary
  (the old §5 becomes §6).
- What's New: *A check that can decide nothing is not a check* (`Category: Fix`).

## What this does NOT change

`LastCheckedAt` remains an install-scoped field that any replica may write, and that is deliberate:
it describes "this install checked", not "this pod checked", and a MergeGuard refusal of an older
stamp is the framework being **right**. What made it a storm was the rate, which is what this fixes.
Under `Continuous` the check rate is unchanged.

No public surface is removed and no interface member is added — `IsDecisionPoint` is `internal
static` (the truth table is its test, via the existing `InternalsVisibleTo`).
