### PR TITLE
fix(#3645): the untyped-content gate reports the VERDICT, not the event

### DIFF
--- a/.github/scripts/check-untyped-content.sh
+++ b/.github/scripts/check-untyped-content.sh
@@ -58,15 +58,45 @@
 # asserted by UntypedContentDegradationReachesTheTraceSinkTest, which drives the PRODUCTION emitter
 # and evaluates the sink's own condition against the captured record. Modelled on
 # EmitDeadAttributionReachesTheTraceSinkTest, which exists for the same trap one diagnostic over.
+#
+# 🚨 WHY THE KEY MOVED FROM THE EVENT TO THE VERDICT (MeshWeaver#3645).
+#
+# For its next stretch this gate could fire, and fired on the WRONG POPULATION. It keyed on
+# MeshNodeContentDegradedException, which is emitted at the INSTANT of a read — and at that instant
+# nothing can know whether the type registers a moment later. That is the ordinary state during a
+# portal boot: a NodeType's runtime compile lands after the first readers have been served, and
+# MeshWeaver#2952 exists precisely to re-type those readers when the registration arrives. The
+# sibling seam one layer down (MeshNodeTypeSource) already said so in its own message — "content
+# stays an untyped JsonElement FOR NOW … (a) … has not registered it YET, which is TRANSIENT … or
+# (b) no declaration will ever claim this discriminator" — and, passing no exception, reddened
+# nothing. One event, two descriptions, opposite CI consequences.
+#
+# Measured on #3628: two of LateContentTypeRegistrationTest's three cases degrade and RECOVER inside
+# a single test — the recovery IS the assertion — and both produced a gate-reddening record. So a
+# hit meant "content was unreadable at a read", never "content is unreadable".
+#
+# The denominator is now the FINAL state, and the platform already had the machinery for it.
+# ContentDegradationRegistry keeps what a replica could not type; MeshNodeStreamCache.Dispose calls
+# Unresolved(), which RE-ASKS the mesh-wide content-type registry per entry — both routes
+# TryRecoverForNodeType takes, two pure map lookups, no content needed — and logs one
+# MeshNodeContentUnresolvedException per node type that is STILL unresolvable. A boot that read
+# before its compile landed leaves nothing behind; a discriminator no declaration will ever claim
+# leaves exactly one record, naming the node type.
+#
+# So the marker below is the VERDICT, not the event. The per-read
+# MeshNodeContentDegradedException records stay in the logs and stay useful — they are how you find
+# WHICH read degraded once the verdict tells you a type never recovered — but they no longer red a
+# shard on their own.
 set -euo pipefail
 
-# The event's IDENTITY. Primary key: compiler-bound, and pinned to this string by
+# The verdict's IDENTITY. Primary key: compiler-bound, and pinned to this string by
 # UntypedContentDegradationGate via nameof(...).
-MARKER='MeshNodeContentDegradedException'
-# The event's DESCRIPTION. Secondary net, kept deliberately: a per-test file log
+MARKER='MeshNodeContentUnresolvedException'
+# The verdict's DESCRIPTION. Secondary net, kept deliberately: a per-test file log
 # (MESHWEAVER_TEST_FILE_LOGS, on in node-repo-module-pack.yml) carries the formatted message with
-# no exception attached at all.
-PHRASE='stayed an untyped JsonElement'
+# no exception attached at all. 🚨 It must match the FINAL report only — the per-read warnings say
+# "stayed an untyped JsonElement", which is the transient population this gate no longer reds on.
+PHRASE='was NEVER resolvable on this replica'
 DIR="${1:?usage: check-untyped-content.sh <collected-logs-dir>}"
 scan_err="$(mktemp)"
 trap 'rm -f "$scan_err"' EXIT
@@ -117,22 +147,27 @@ if [ "$scan_rc" -gt 1 ]; then
 fi
 
 if [ -z "$matches" ]; then
-  echo "No content-type degradation in $DIR (scan exit $scan_rc)."
+  echo "No unresolved content type in $DIR (scan exit $scan_rc) — a transient degradation that later recovered is not a hit."
   exit 0
 fi
 
-echo "::error::A node's content degraded to an untyped JsonElement — a content type was not registered on the hub that read it."
+echo "::error::A node's content was NEVER resolvable — a content type was not registered on the hub that read it, and still was not when the mesh ended."
 echo ""
 echo "This does NOT throw. The value reads as absent: an 'is MyType' check misses, a view renders"
 echo "empty, a reactive wait never completes. It is caught here or not at all."
 echo ""
+echo "This is the VERDICT, not the event: the content-type registry was re-asked at teardown and"
+echo "answered no, so the transient boot race (a NodeType read before its own compile landed) is"
+echo "already excluded. Search the same logs for MeshNodeContentDegradedException to see WHICH"
+echo "reads degraded on it."
+echo ""
 echo "Occurrences:"
-# Trim to the node path — the whole line carries a serialised payload and drowns the signal.
-# Both record shapes name the node: the log message says "Content for <path> stayed …", the
-# exception says "content for '<path>' (nodeType …)". Reduce either to the path.
+# Reduce to the NODE TYPE — the verdict is per node type, not per node. Both record shapes name
+# it: the log message says "content for nodeType <X> was NEVER…", the exception says
+# "content for nodeType '<X>' (discriminator …)".
 grep -rh "${EXCLUDES[@]}" -e "$MARKER" -e "$PHRASE" "$DIR" 2>/dev/null \
-  | sed -E -e "s/.*Content for ([^ ]+) stayed.*/  \1/" \
-           -e "s/.*content for '([^']*)'.*/  \1/" \
+  | sed -E -e "s/.*content for nodeType '([^']*)'.*/  \1/" \
+           -e "s/.*content for nodeType ([^ ]+) was NEVER.*/  \1/" \
   | sort | uniq -c | sort -rn | head -20
 echo ""
 echo "Files: $(printf '%s' "$matches" | tr '\n' ' ')"

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ContentTypeHealthCheck.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ContentTypeHealthCheck.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Hosting;
+using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -12,6 +13,16 @@ namespace Memex.Portal.ServiceDefaults;
 /// registry); this host-side check only reads it, exactly as the bake gate's check reads
 /// <see cref="NodeTypeBakeGateState"/>. The registry is resolved per call because the mesh's
 /// services are composed after the host's health checks are registered.
+///
+/// <para>🚨 <b>It reports what is unresolvable NOW, not what once degraded (#3645).</b> A
+/// degradation is recorded at the instant of a read, and during a boot that instant routinely
+/// precedes the NodeType's own runtime compile — the transient race #2952 re-types live readers
+/// for. Reporting the raw snapshot therefore left a replica reading <c>Degraded</c> until some
+/// later read of the same type happened to clear the entry, which is a probe answering about the
+/// past. <see cref="ContentDegradationRegistry.Unresolved"/> re-asks the mesh-wide content-type
+/// registry per entry (two pure map lookups, no content), so a boot-race entry disappears from
+/// <c>/health</c> the moment its type registers, and only a type that genuinely never arrived keeps
+/// the replica degraded.</para>
 /// </summary>
 public sealed class ContentTypeHealthCheck(IServiceProvider services) : IHealthCheck
 {
@@ -23,7 +34,10 @@ public sealed class ContentTypeHealthCheck(IServiceProvider services) : IHealthC
         if (registry is null || registry.IsEmpty)
             return Task.FromResult(HealthCheckResult.Healthy(ContentDegradationRegistry.Describe([])));
 
-        var degraded = registry.Snapshot();
+        var degraded = registry.Unresolved(services.GetService<IMeshContentTypeRegistry>());
+        if (degraded.Count == 0)
+            return Task.FromResult(HealthCheckResult.Healthy(ContentDegradationRegistry.Describe([])));
+
         var data = degraded.ToDictionary(
             d => d.NodeType,
             d => (object)$"{d.Count} degraded read(s), last {d.LastPath} at {d.LastAt:O} via {d.Seam}",

--- a/src/MeshWeaver.Data.Contract/MeshNodeContentUnresolvedException.cs
+++ b/src/MeshWeaver.Data.Contract/MeshNodeContentUnresolvedException.cs
@@ -1,0 +1,86 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// 🚨 <b>A content degradation that NEVER RECOVERED — the verdict, as opposed to
+/// <see cref="MeshNodeContentDegradedException"/>, which is the event.</b> Constructed once per
+/// node type when a mesh ends with that type still unresolvable, and deliberately never thrown.
+///
+/// <para><b>Why two markers (#3645).</b> The degradation marker is emitted at the INSTANT of a
+/// read, and at that instant nothing can know whether the type will register a moment later. That
+/// is the normal state during a portal boot — a NodeType's runtime compile lands after the first
+/// readers have already been served — and it is precisely the race #2952 fixed by re-typing every
+/// live reader when the registration arrives. The sibling seam one layer down
+/// (<c>MeshNodeTypeSource</c>) says so in its own message: <i>"…is not a registered type on the
+/// owning hub — content stays an untyped JsonElement FOR NOW … (a) the NodeType's runtime compile
+/// has not registered it YET, which is TRANSIENT … or (b) no declaration will ever claim this
+/// discriminator"</i>.</para>
+///
+/// <para>So the two seams described one event and disagreed about whether it was a failure: the
+/// shard gate <c>check-untyped-content.sh</c> reddened on any occurrence, which made it report a
+/// normal transient as a defect. Measured on #3628: two of
+/// <c>LateContentTypeRegistrationTest</c>'s three cases degrade and RECOVER inside a single test —
+/// the recovery IS the assertion — and both produced a gate-reddening record. The gate was worth
+/// having and its denominator was wrong: a hit meant <i>"content was unreadable at a read"</i>,
+/// never <i>"content is unreadable"</i>.</para>
+///
+/// <para><b>This marker is the second one.</b> <c>ContentDegradationRegistry</c> keeps what a
+/// replica could not type; at the end of the mesh's life it RE-ASKS the mesh-wide content-type
+/// registry about each entry (<c>TryResolveByNodeType</c> / <c>TryResolveByDiscriminator</c> — pure
+/// lookups, no content needed) and reports only what is still unresolvable. A boot that read before
+/// its compile landed leaves nothing; a discriminator no declaration will ever claim leaves exactly
+/// one record, naming the node type. That is the sentence the gate keys on.</para>
+///
+/// <para>🚨 <b>The exception argument is load-bearing</b>, for the same reason it is on the
+/// degradation marker: a CI shard's authoritative sink takes a record <b>if and only if</b>
+/// <c>exception is not null &amp;&amp; logLevel &gt;= Warning</c>, so a report without one could
+/// reach <c>collected-logs/</c> by construction never (#3625). And the gate keys on this TYPE NAME
+/// rather than on prose: the type is bound by the compiler at its construction site, and
+/// <c>UntypedContentDegradationGate</c> pins the script's key to
+/// <c>nameof(MeshNodeContentUnresolvedException)</c> so a rename that forgets the script reds.</para>
+/// </summary>
+public sealed class MeshNodeContentUnresolvedException : System.Exception
+{
+    /// <summary>The NodeType whose content type never became resolvable on this replica.</summary>
+    public string NodeType { get; }
+
+    /// <summary>The stored <c>$type</c> discriminator, when the degraded content carried one.</summary>
+    public string? Discriminator { get; }
+
+    /// <summary>How many reads degraded on it.</summary>
+    public int Count { get; }
+
+    /// <summary>The most recent node path read under it.</summary>
+    public string? LastPath { get; }
+
+    /// <summary>The read seam that observed it first.</summary>
+    public string Seam { get; }
+
+    /// <summary>Creates the unresolved-at-end verdict marker.</summary>
+    /// <param name="nodeType">The NodeType that never resolved.</param>
+    /// <param name="discriminator">The stored <c>$type</c>, when there was one.</param>
+    /// <param name="count">How many reads degraded.</param>
+    /// <param name="lastPath">The most recent node path.</param>
+    /// <param name="seam">The seam that observed it first.</param>
+    public MeshNodeContentUnresolvedException(
+        string nodeType, string? discriminator, int count, string? lastPath, string seam)
+        // 🚨 The gate's phrase — "was NEVER resolvable on this replica" — is kept CONTIGUOUS in one
+        // literal on purpose. UntypedContentDegradationGate greps the SOURCE line by line, so a
+        // phrase the formatter splits across two literals is emitted correctly and yet reads as
+        // absent to the guard: a rewording that "passes" while retiring the coupling.
+        : base(
+            $"content for nodeType '{nodeType}' (discriminator '{discriminator ?? "<none>"}') "
+            + $"was NEVER resolvable on this replica: {count} read(s) degraded to an untyped "
+            + $"JsonElement (first seen at {seam}, last {lastPath ?? "<unknown>"}) and the type had "
+            + "STILL not registered when the mesh ended. This is NOT the transient boot race — the "
+            + "registry was re-asked at the end and answered no. The module that declares the type "
+            + "is not loaded here, or no declaration claims that discriminator at all, so every "
+            + "'Content is X' / 'as X' consumer reads it as ABSENT: views render empty and reactive "
+            + "waits never complete.")
+    {
+        NodeType = nodeType;
+        Discriminator = discriminator;
+        Count = count;
+        LastPath = lastPath;
+        Seam = seam;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -643,7 +643,7 @@ classified before anything was changed. Two node paths, two opposite verdicts:
 | occurrence | verdict |
 |---|---|
 | `Ops/Modules/{deployment}` (`Hosting/ModuleInventory`) | **TRUE POSITIVE — a live defect in `src/`.** `DeploymentReportService` stamped `$type = "ModuleInventoryContent"`, a literal naming **no CLR type in the fleet**, while the real record `DeploymentReport` was registered nowhere. Its own comment said the stamp existed because *"content without the discriminator … materialises as NOTHING"* — and it materialised as nothing anyway. Every instance's self-reported module inventory read back untyped. Fixed: the record is registered and the constant is `nameof(DeploymentReport)`. |
-| `{partition}/Live` (`LateContentTypeRegistrationTest`) | **A true degradation, but NOT the gate's subject.** That test asserts content *stays* untyped when an unrelated type registers; its `$type` is literally `AContentTypeTheMeshNeverCompiled`. The keying is not at fault — the event really happened — but the gate cannot distinguish a degradation that is a test's SUBJECT from one nobody intended. |
+| `{partition}/Live` (`LateContentTypeRegistrationTest`) | **A true degradation, but NOT the gate's subject.** That test asserts content *stays* untyped when an unrelated type registers; its `$type` is literally `AContentTypeTheMeshNeverCompiled`. The keying was not at fault — the event really happened — but the gate could not distinguish a degradation that is a test's SUBJECT from one nobody intended, nor a transient one from a final one. The second half is answered by #3645 (see *TRANSIENT from FINAL* below); the first is still answered by capture-and-assert. |
 
 🚨 **The guard on the true positive was asserting the defect.** `AnInstanceReportsWhatItRunsTest`
 checked `content.GetProperty("$type") == InventoryContentType` — and a `$type` **property** is only
@@ -701,20 +701,48 @@ degradation this test reproduces"*. So the regression is now caught by a **test*
 gate that must first see a whole shard's logs. With the fix in place: 3/3 pass, marker count in the
 shared trace **3 → 0**, `check-untyped-content.sh` **exit 1 → exit 0**.
 
-🚨 **What the gate still cannot tell you: TRANSIENT from FINAL.** `MeshNodeStreamCache` warns at the
-instant of a read, and at that instant it cannot know the type will register moments later — which
-is the normal state during portal boot, before the NodeType compiles land, and is exactly the race
-#2952 fixed by re-typing every live reader when the registration arrives. The sibling seam one layer
-down already says so in its own message: `MeshNodeTypeSource` prints **both** causes — *"(a) the
-NodeType's runtime compile has not registered it YET, which is TRANSIENT … (b) no declaration will
-ever claim this discriminator"* — and it passes **no exception**, so it never reaches the trace file
-and reds nothing. One event, two descriptions, opposite CI consequences: the cache's is a shard
-failure, the type source's is invisible. Two of `LateContentTypeRegistrationTest`'s three cases are
-the transient one, and they degrade *and recover* inside a single test. Telling them apart means
-recording a degradation and reporting only the ones never recovered, which needs a window nothing in
-a process naturally closes — a rework rather than a repair, and deliberately left to its own issue.
-Until then read a gate hit as *"content was unreadable at a read"*, and check the node's
-`compilationStatus` before calling it (b).
+🚨 **TRANSIENT from FINAL — the gate's denominator, answered by #3645.** `MeshNodeStreamCache` warns
+at the instant of a read, and at that instant it cannot know the type will register moments later —
+which is the normal state during portal boot, before the NodeType compiles land, and is exactly the
+race #2952 fixed by re-typing every live reader when the registration arrives. The sibling seam one
+layer down already said so in its own message: `MeshNodeTypeSource` prints **both** causes — *"(a)
+the NodeType's runtime compile has not registered it YET, which is TRANSIENT … (b) no declaration
+will ever claim this discriminator"* — and it passes **no exception**, so it never reaches the trace
+file and reds nothing. One event, two descriptions, opposite CI consequences: the cache's was a
+shard failure, the type source's invisible. Two of `LateContentTypeRegistrationTest`'s three cases
+are the transient one, and they degrade *and recover* inside a single test — so a gate hit meant
+*"content was unreadable at a read"*, never *"content is unreadable"*.
+
+**What closed it was not a window; it was asking again.** The platform already kept the state
+(`ContentDegradationRegistry`, one entry per node type, added for `/health`), and the content-type
+registry already answers *"is this resolvable"* as a pure map lookup by either of the two routes
+`TryRecoverForNodeType` takes. So the verdict is computed by **re-asking at report time**:
+`ContentDegradationRegistry.Unresolved(registry)` drops every entry whose type has since
+registered, and `MeshNodeStreamCache.Dispose` logs one `MeshNodeContentUnresolvedException` per
+entry that survives. `check-untyped-content.sh` keys on **that** type now, not on the per-read
+`MeshNodeContentDegradedException`.
+
+| record | when | meaning | reds a shard? |
+|---|---|---|---|
+| `MeshNodeContentDegradedException` | at each degraded read | *this read was untyped* — an EVENT, possibly the boot race | **no** (since #3645) |
+| `MeshNodeContentUnresolvedException` | once per node type, at cache teardown | *the registry was re-asked and still says no* — a VERDICT | **yes** |
+
+So a boot that reads a runtime-compiled NodeType before its compile lands now produces **no** gate
+hit, while a discriminator nothing will ever claim produces exactly one, naming the node type and
+the discriminator. The per-read records stay in the logs and stay useful: once the verdict names a
+type, they are how you find which reads degraded on it.
+
+🚨 `/health` was wrong the same way and is fixed in the same change: `ContentTypeHealthCheck` fed
+`Snapshot()`, so a replica stayed `Degraded` after a boot race until some later read of that type
+happened to clear the entry — a probe answering about the past. It reads `Unresolved(...)` now.
+
+**Falsified in both directions, as the issue asked.** With `Unresolved` reduced to `Snapshot()`, the
+recovered case is reported and `ARecoveredDegradation_IsNotTheVerdict` fails; with the teardown
+report removed, `AnUnrecoverableDegradation_IsTheVerdict_AndReachesTheSink` fails on *"the teardown
+must REPORT what never resolved"*. `UntypedContentDegradationGate` pins the script's key to
+`nameof(MeshNodeContentUnresolvedException)`, that the emitter constructs it, that the report is
+computed from `Unresolved(`, and that both read seams still emit the per-read record the verdict is
+derived from.
 
 **The instrument that does answer it** is `MessageTrace`
 (`MeshWeaver.Messaging.Hub/MessageService.cs`): `MESHWEAVER_MSG_TRACE=1` makes every delivery write

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-degradation-that-recovered-is-not-a-defect.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-degradation-that-recovered-is-not-a-defect.md
@@ -1,0 +1,60 @@
+---
+Name: A degradation that recovered is not a defect
+Category: Fix
+Description: The CI gate that catches unreadable node content reddened a shard for the ordinary boot race — a NodeType read a moment before its own compile registered the type. It now reports the verdict rather than the event: at teardown the platform re-asks the content-type registry about everything that degraded, and only what is still unresolvable is a hit. The same correction makes /health stop calling a replica Degraded over a race it already won.
+Icon: Filter
+Order: -20260909
+---
+
+A node whose content carries a `$type` the reading hub cannot resolve does not fail. The value
+degrades to a raw `JsonElement`, and everything downstream reads it as absent — an `is MyType` check
+misses, a view renders empty, a reactive wait never completes. That silence is why there is a CI
+gate for it at all.
+
+The gate was catching the wrong population. It keyed on the record the stream cache writes **at the
+instant of a read**, and at that instant nothing can know whether the type registers a moment later.
+That is the normal state during a portal boot: a NodeType's runtime compile lands after the first
+readers have already been served, and re-typing those live readers when the registration arrives is
+a fixed, working behaviour. The seam one layer down said as much in its own message — *"content
+stays an untyped JsonElement **for now** … (a) the compile has not registered it **yet, which is
+transient** … or (b) no declaration will ever claim this discriminator"* — and reddened nothing. One
+event, two descriptions, opposite consequences.
+
+Measured: two of the three cases in the test that covers this race degrade **and recover inside a
+single test** — the recovery is the assertion — and both produced a gate-reddening record.
+
+## What it does now
+
+Nothing new was invented. The platform already kept a per-node-type record of what a replica could
+not type, and the content-type registry already answers *"is this resolvable"* as a pure lookup. So
+the verdict is computed by **asking again**:
+
+- at the end of the stream cache's life, every recorded degradation is re-checked against the
+  registry — by the node's own NodeType and by the stored `$type`, the same two routes recovery
+  takes;
+- what has since registered is dropped: it was the boot race, and it healed;
+- what is still unresolvable is reported once, naming the node type and the discriminator, and
+  **that** is what the gate keys on.
+
+A boot that reads a runtime-compiled NodeType before its compile lands therefore produces no gate
+hit. A discriminator no declaration will ever claim produces exactly one. The per-read records stay
+in the logs and stay useful — once the verdict names a type, they are how you find which reads
+degraded on it.
+
+## `/health` was wrong the same way
+
+`ContentTypeHealthCheck` reported everything that had ever degraded, so a replica stayed `Degraded`
+after a boot race until some later read of the same type happened to clear the entry — a probe
+answering about the past. It re-asks now, so a race that healed disappears from `/health`
+immediately and only a type that genuinely never arrived keeps the replica degraded.
+
+## Pinned in both directions
+
+Reduce the re-ask to the raw snapshot and the recovered case is reported again — the transient test
+fails. Remove the teardown report and the unrecoverable case has nothing to find — the final test
+fails on *"the teardown must REPORT what never resolved"*. The gate's own control arm additionally
+pins that the script keys on the verdict type, that the emitter constructs it, that the report is
+computed from the re-asked set, and that both read seams still emit the per-read record the verdict
+is derived from.
+
+See [Reading CI Signals](@/Doc/Architecture/ReadingCiSignals) → *TRANSIENT from FINAL*.

--- a/src/MeshWeaver.Hosting/ContentDegradationRegistry.cs
+++ b/src/MeshWeaver.Hosting/ContentDegradationRegistry.cs
@@ -10,12 +10,23 @@ namespace MeshWeaver.Hosting;
 /// <param name="Count">How many reads degraded.</param>
 /// <param name="LastPath">The most recent node path.</param>
 /// <param name="LastAt">When.</param>
-/// <param name="Discriminator">The stored <c>$type</c>, when the degraded content carried one — the
-/// second key <see cref="ContentDegradationRegistry.Unresolved"/> re-asks the content-type registry
-/// under, for content whose NodeType is absent or unregistered.</param>
 public sealed record ContentDegradation(
-    string NodeType, string Seam, int Count, string? LastPath, DateTimeOffset LastAt,
-    string? Discriminator = null);
+    string NodeType, string Seam, int Count, string? LastPath, DateTimeOffset LastAt)
+{
+    /// <summary>
+    /// The stored <c>$type</c>, when the degraded content carried one — the second key
+    /// <see cref="ContentDegradationRegistry.Unresolved"/> re-asks the content-type registry under,
+    /// for content whose NodeType is absent or unregistered.
+    ///
+    /// <para>🚨 An <c>init</c> PROPERTY, deliberately not a primary-constructor parameter. Adding a
+    /// parameter — even with a default — REPLACES the record's constructor signature, so every
+    /// assembly already compiled against the 5-parameter one calls a constructor this build no
+    /// longer has. That is a binary break for module bundles built on a previous platform, and the
+    /// repo's <c>Public surface (binary compatibility)</c> gate refuses it (it caught this exact
+    /// change). A property leaves the arity untouched.</para>
+    /// </summary>
+    public string? Discriminator { get; init; }
+}
 
 /// <summary>
 /// 🚨 <b>What this replica could not read — kept, so it can be SEEN.</b> A node whose
@@ -47,7 +58,7 @@ public sealed class ContentDegradationRegistry
         var now = DateTimeOffset.UtcNow;
         byNodeType.AddOrUpdate(
             key,
-            _ => new ContentDegradation(key, seam, 1, nodePath, now, discriminator),
+            _ => new ContentDegradation(key, seam, 1, nodePath, now) { Discriminator = discriminator },
             (_, existing) => existing with
             {
                 Count = existing.Count + 1,

--- a/src/MeshWeaver.Hosting/ContentDegradationRegistry.cs
+++ b/src/MeshWeaver.Hosting/ContentDegradationRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using MeshWeaver.Mesh.Services;
 
 namespace MeshWeaver.Hosting;
 
@@ -9,8 +10,12 @@ namespace MeshWeaver.Hosting;
 /// <param name="Count">How many reads degraded.</param>
 /// <param name="LastPath">The most recent node path.</param>
 /// <param name="LastAt">When.</param>
+/// <param name="Discriminator">The stored <c>$type</c>, when the degraded content carried one — the
+/// second key <see cref="ContentDegradationRegistry.Unresolved"/> re-asks the content-type registry
+/// under, for content whose NodeType is absent or unregistered.</param>
 public sealed record ContentDegradation(
-    string NodeType, string Seam, int Count, string? LastPath, DateTimeOffset LastAt);
+    string NodeType, string Seam, int Count, string? LastPath, DateTimeOffset LastAt,
+    string? Discriminator = null);
 
 /// <summary>
 /// 🚨 <b>What this replica could not read — kept, so it can be SEEN.</b> A node whose
@@ -30,14 +35,28 @@ public sealed class ContentDegradationRegistry
         new(StringComparer.Ordinal);
 
     /// <summary>Records one degraded read.</summary>
-    public void Record(string? nodeType, string? nodePath, string seam)
+    /// <param name="nodeType">The node's NodeType.</param>
+    /// <param name="nodePath">The node path.</param>
+    /// <param name="seam">The read seam that observed it.</param>
+    /// <param name="discriminator">The content's stored <c>$type</c>, when it carried one. Kept so
+    /// <see cref="Unresolved"/> can re-ask the registry by NAME as well as by NodeType — the same
+    /// two routes <c>TryRecoverForNodeType</c> takes.</param>
+    public void Record(string? nodeType, string? nodePath, string seam, string? discriminator = null)
     {
         var key = string.IsNullOrEmpty(nodeType) ? "(no node type)" : nodeType;
         var now = DateTimeOffset.UtcNow;
         byNodeType.AddOrUpdate(
             key,
-            _ => new ContentDegradation(key, seam, 1, nodePath, now),
-            (_, existing) => existing with { Count = existing.Count + 1, LastPath = nodePath, LastAt = now });
+            _ => new ContentDegradation(key, seam, 1, nodePath, now, discriminator),
+            (_, existing) => existing with
+            {
+                Count = existing.Count + 1,
+                LastPath = nodePath,
+                LastAt = now,
+                // First-seen wins: a later read of the same NodeType whose element happens to carry
+                // no $type must not erase the name the FIRST one gave us to re-ask under.
+                Discriminator = existing.Discriminator ?? discriminator,
+            });
     }
 
     /// <summary>Forgets a node type — called when a later read of it typed cleanly, so a
@@ -46,6 +65,45 @@ public sealed class ContentDegradationRegistry
     {
         if (!string.IsNullOrEmpty(nodeType))
             byNodeType.TryRemove(nodeType, out _);
+    }
+
+    /// <summary>
+    /// 🚨 <b>The verdict, as opposed to the event (#3645).</b> The entries whose content type is
+    /// STILL unresolvable — re-asked against <paramref name="contentTypes"/> at the moment of the
+    /// call, rather than believed from when the read happened.
+    ///
+    /// <para>A degradation is recorded at the INSTANT of a read, and at that instant nothing can
+    /// know whether the type will register a moment later. That is the ordinary state during a
+    /// portal boot — a NodeType's runtime compile lands after the first readers are served — and
+    /// #2952 exists precisely to re-type those readers when the registration arrives. So a
+    /// snapshot of what degraded answers <i>"content was unreadable at a read"</i>, while the
+    /// question every consumer of this registry actually asks (<c>/health</c>, and the CI gate) is
+    /// <i>"content is unreadable"</i>.</para>
+    ///
+    /// <para>Both routes <c>TryRecoverForNodeType</c> takes are re-asked, and nothing else: the
+    /// EXACT route on the node's own NodeType, and the NAME route on the stored <c>$type</c>. Both
+    /// are pure map lookups, so this needs no content and can be called on any thread, as often as
+    /// a health probe likes.</para>
+    ///
+    /// <para>🚨 <b>A null registry means UNRESOLVED, never resolved.</b> There is no registry to
+    /// clear an entry with, so the honest answer is the one that keeps reporting — a missing
+    /// instrument may not read as a clean result.</para>
+    /// </summary>
+    /// <param name="contentTypes">The mesh-wide content-type registry, or <c>null</c>.</param>
+    /// <returns>The still-unresolvable degradations, most recent first.</returns>
+    public ImmutableList<ContentDegradation> Unresolved(IMeshContentTypeRegistry? contentTypes) =>
+        Snapshot().Where(d => !IsResolvable(d, contentTypes)).ToImmutableList();
+
+    /// <summary>Whether one recorded degradation's type resolves NOW. Pure given the registry.</summary>
+    private static bool IsResolvable(ContentDegradation degradation, IMeshContentTypeRegistry? contentTypes)
+    {
+        if (contentTypes is null)
+            return false;
+        if (!string.IsNullOrEmpty(degradation.NodeType)
+            && contentTypes.TryResolveByNodeType(degradation.NodeType, out _))
+            return true;
+        return !string.IsNullOrEmpty(degradation.Discriminator)
+               && contentTypes.TryResolveByDiscriminator(degradation.Discriminator!, out _);
     }
 
     /// <summary>Every node type currently degraded, most recent first.</summary>

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -777,6 +777,56 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     }
 
     /// <summary>
+    /// 🚨 <b>The one place that can say "this one never recovered" (#3645).</b> Emits one
+    /// <see cref="MeshNodeContentUnresolvedException"/>-bearing record per node type this replica
+    /// degraded and STILL cannot type, at the end of the cache's life.
+    ///
+    /// <para><b>Why here and not at the read.</b> The per-read warning
+    /// (<see cref="MeshNodeContentDegradedException"/>) is emitted at an instant that cannot know
+    /// whether the type registers a moment later — which is the ordinary boot race #2952 re-types
+    /// live readers for. So it describes an EVENT and cannot answer the question the CI gate and
+    /// <c>/health</c> both ask, which is about a STATE. The registry keeps the events;
+    /// <c>Unresolved</c> re-asks the mesh-wide content-type registry about each one, by both routes
+    /// <c>TryRecoverForNodeType</c> takes, and only what is still unresolvable reaches this log.
+    /// A boot that read before its compile landed therefore produces nothing here.</para>
+    ///
+    /// <para>🚨 It runs FIRST in <see cref="Dispose"/>, before any teardown: the registry is a
+    /// plain mesh-scoped record store, but the logger and the service provider are not guaranteed
+    /// alive further down, and a verdict nobody can emit is the failure mode this whole gate exists
+    /// to prevent (#3625). Everything is wrapped: a teardown must never fault on its own
+    /// diagnostics.</para>
+    ///
+    /// <para>Level is <c>Warning</c>, which with a non-null exception is exactly the sink's
+    /// predicate (<c>exception is not null &amp;&amp; logLevel &gt;= Warning</c>) — reaching the
+    /// trace log is a property of the CALL, not of the wording.</para>
+    /// </summary>
+    private void ReportUnresolvedContentTypes()
+    {
+        try
+        {
+            if (degradations is null || degradations.IsEmpty)
+                return;
+            foreach (var degradation in degradations.Unresolved(contentTypeRegistry))
+                logger.LogWarning(
+                    new MeshNodeContentUnresolvedException(
+                        degradation.NodeType, degradation.Discriminator, degradation.Count,
+                        degradation.LastPath, degradation.Seam),
+                    // 🚨 The gate's phrase stays CONTIGUOUS in one literal — see the same note on
+                    // MeshNodeContentUnresolvedException's message. The guard greps this file line
+                    // by line, so a split phrase retires the coupling silently.
+                    "MeshNodeStreamCache: content for nodeType {NodeType} "
+                    + "was NEVER resolvable on this replica — {Count} read(s) degraded and the type "
+                    + "had still not registered when the mesh ended (last {Path}). This is not the "
+                    + "transient boot race: the registry was re-asked just now and answered no.",
+                    degradation.NodeType, degradation.Count, degradation.LastPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "MeshNodeStreamCache: error reporting unresolved content types");
+        }
+    }
+
+    /// <summary>
     /// Releases every subscription and rooted subject the cache holds. Fires
     /// when the silo/mesh goes down (cacheHub disposal) and on DI container
     /// teardown (IDisposable). Idempotent via the <see cref="_disposed"/> guard.
@@ -785,6 +835,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     {
         if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0)
             return; // already torn down by the other disposal path
+
+        // 0a. THE VERDICT, before anything is torn down (#3645). Everything recorded that is
+        //     still unresolvable NOW never recovered, and this is the last moment anyone can say
+        //     so — see ReportUnresolvedContentTypes.
+        ReportUnresolvedContentTypes();
 
         // 0. Idle sweep FIRST — no new sweep pass may start once teardown begins
         //    (an in-flight pass is harmless: entry teardown is idempotent and the
@@ -2313,7 +2368,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // to fire at all. The job log is not an equivalent sink: it carries only the output
                 // of tests that FAILED, and a degradation is overwhelmingly logged under a test
                 // that passes. Reaching the sink is a property of the CALL, not of the wording.
-                degradations?.Record(node.NodeType, node.Path, "MeshNodeStreamCache.GetStream");
+                degradations?.Record(
+                    node.NodeType, node.Path, "MeshNodeStreamCache.GetStream", Discriminator(degraded));
                 logger.LogWarning(
                     new MeshNodeContentDegradedException(
                         "MeshNodeStreamCache.GetStream", node.Path, node.NodeType, TruncateRaw(je)),
@@ -2327,6 +2383,18 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         }
         return node;
     }
+
+    /// <summary>The stored <c>$type</c> of a degraded element, or <c>null</c> when it carries
+    /// none. Read ONCE at the degradation, so <c>ContentDegradationRegistry.Unresolved</c> can
+    /// re-ask the content-type registry by NAME later without keeping the document (#3645).
+    /// Content without a <c>$type</c> stays legal by design (ContentDiscriminatorValidator), so a
+    /// null here is an ordinary state, not a fault.</summary>
+    private static string? Discriminator(JsonElement content) =>
+        content.ValueKind == JsonValueKind.Object
+        && content.TryGetProperty("$type", out var type)
+        && type.ValueKind == JsonValueKind.String
+            ? type.GetString()
+            : null;
 
     // Truncated raw JSON for diagnostics — bad-data warnings include the offending
     // content so the corrupt row is identifiable in Loki without flooding the log.
@@ -2816,7 +2884,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // 🚨 Carries the exception for the same reason the GetStream seam does — see there.
                 // A record with no exception object cannot reach the trace log, which is the only
                 // sink the untyped-content shard gate scans (#3625).
-                degradations?.Record(node.NodeType, node.Path, "MeshNodeStreamCache.GetQuery");
+                degradations?.Record(
+                    node.NodeType, node.Path, "MeshNodeStreamCache.GetQuery", Discriminator(degraded));
                 logger.LogWarning(
                     new MeshNodeContentDegradedException(
                         "MeshNodeStreamCache.GetQuery", node.Path, node.NodeType, TruncateRawText(rawText)),
@@ -2840,6 +2909,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             // never match it either. Keying the gate on the exception TYPE rather than on prose is
             // what closes that third blind spot; `ex` rides along as the inner exception, so the
             // deserialization stack is still in the record.
+            // No parsed element here — the parse is what failed — so the NodeType is the only key
+            // Unresolved() can re-ask under, which is the exact route it prefers anyway.
             degradations?.Record(node.NodeType, node.Path, "MeshNodeStreamCache.GetQuery");
             logger.LogWarning(
                 new MeshNodeContentDegradedException(

--- a/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
+++ b/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
@@ -57,13 +57,26 @@ namespace MeshWeaver.Documentation.Test;
 /// </summary>
 public class UntypedContentDegradationGate
 {
-    /// <summary>The exact phrase. Both ends are asserted against THIS constant, so the two can
-    /// never agree with each other while disagreeing with reality.</summary>
-    private const string Phrase = "stayed an untyped JsonElement";
+    /// <summary>The exact phrase the gate greps — the VERDICT's wording (#3645). Both ends are
+    /// asserted against THIS constant, so the two can never agree with each other while
+    /// disagreeing with reality.</summary>
+    private const string Phrase = "was NEVER resolvable on this replica";
+
+    /// <summary>The per-READ diagnostic's phrase. Not what the gate keys on any more — it is the
+    /// transient population — but it must keep being emitted, because it is the record that says
+    /// WHICH read degraded once the verdict names a type that never recovered.</summary>
+    private const string DegradationPhrase = "stayed an untyped JsonElement";
 
     /// <summary>The gate's PRIMARY key, taken from the type itself so a rename cannot leave the
-    /// script grepping for a name nothing constructs.</summary>
-    private static readonly string Marker = nameof(MeshWeaver.Mesh.MeshNodeContentDegradedException);
+    /// script grepping for a name nothing constructs. 🚨 It is the VERDICT type, not the event
+    /// type: a degradation observed at a read cannot know whether the type registers a moment
+    /// later, so keying on it made the gate report the ordinary boot race as a defect (#3645).</summary>
+    private static readonly string Marker = nameof(MeshWeaver.Mesh.MeshNodeContentUnresolvedException);
+
+    /// <summary>The per-READ diagnostic's type. Still required at every seam — it is what makes
+    /// the record reach the trace sink at all, and it is the INPUT the verdict is computed
+    /// from.</summary>
+    private static readonly string DegradationMarker = nameof(MeshWeaver.Mesh.MeshNodeContentDegradedException);
 
     private const string Script = ".github/scripts/check-untyped-content.sh";
     private const string EmittingSource = "src/MeshWeaver.Hosting/MeshNodeStreamCache.cs";
@@ -82,7 +95,7 @@ public class UntypedContentDegradationGate
     /// is the state this whole gate was in before #3625.
     /// </summary>
     [Fact]
-    public void EverySeamAttachesTheMarkerExceptionTheGateKeysOn()
+    public void EveryReadSeamAttachesTheDegradationExceptionTheVerdictIsComputedFrom()
     {
         // 🚨 Count CONSTRUCTIONS in code, not lines that happen to contain a substring (Copilot
         // review). The first version split on newlines and looked for `"new " + Marker`, which is
@@ -94,19 +107,21 @@ public class UntypedContentDegradationGate
         // second failure mode outright; the regex removes the first.
         var source = SourceScan.MaskCommentsAndStrings(Read(EmittingSource));
         var constructions = new Regex(
-                @"\bnew\s+(?:[A-Za-z_][\w]*\s*\.\s*)*" + Regex.Escape(Marker) + @"\s*\(",
+                @"\bnew\s+(?:[A-Za-z_][\w]*\s*\.\s*)*" + Regex.Escape(DegradationMarker) + @"\s*\(",
                 RegexOptions.Compiled)
             .Matches(source).Count;
 
         Assert.True(
             constructions >= 3,
-            $"Only {constructions} construction(s) of {Marker} in {EmittingSource}; expected at least 3 "
+            $"Only {constructions} construction(s) of {DegradationMarker} in {EmittingSource}; expected at least 3 "
             + "(GetStream, GetQuery, and GetQuery's deserialization catch).\n"
             + "A degradation warning WITHOUT this exception cannot reach "
             + "collected-logs/_meshweaver-test-trace.log — the sink takes a record if and only if "
-            + "`exception is not null && logLevel >= Warning` — so the shard gate that scans that "
-            + "directory has nothing to match, and passes having checked nothing. That is exactly "
-            + "how this gate spent its first five days (#3625).");
+            + "`exception is not null && logLevel >= Warning` — so nothing can name WHICH read "
+            + "degraded when the verdict reports a node type that never recovered. That "
+            + "unreachability is exactly how this gate spent its first five days (#3625), and the "
+            + "records are also the registry entries Unresolved() computes the verdict from: no "
+            + "Record at a seam, no verdict from it either.");
     }
 
     /// <summary>
@@ -194,6 +209,50 @@ public class UntypedContentDegradationGate
             + "leaving the script grepping for a name nothing writes any more.");
     }
 
+    /// <summary>
+    /// 🚨 <b>The VERDICT must exist, and be constructed where it is reported (#3645).</b> The gate
+    /// keys on <see cref="Marker"/>; if nothing in the emitting source constructs it, the script
+    /// greps for a name nobody writes and passes every run having matched nothing — which is the
+    /// same silent retirement #3625 was, one type over.
+    /// </summary>
+    [Fact]
+    public void TheVerdictExceptionIsConstructedWhereItIsReported()
+    {
+        var source = SourceScan.MaskCommentsAndStrings(Read(EmittingSource));
+        var constructions = new Regex(
+                @"\bnew\s+(?:[A-Za-z_][\w]*\s*\.\s*)*" + Regex.Escape(Marker) + @"\s*\(",
+                RegexOptions.Compiled)
+            .Matches(source).Count;
+
+        Assert.True(
+            constructions >= 1,
+            $"Nothing in {EmittingSource} constructs {Marker}, which is what {Script} keys on. "
+            + "The gate now reports the VERDICT — a node type still unresolvable when the mesh "
+            + "ended — rather than the per-read event, so with no construction it matches nothing "
+            + "and passes forever. Either restore the teardown report "
+            + "(MeshNodeStreamCache.ReportUnresolvedContentTypes) or retire the gate deliberately.");
+    }
+
+    /// <summary>
+    /// 🚨 The verdict is computed by RE-ASKING the content-type registry, and that is the whole
+    /// difference between this gate and the one it replaced. A report built from the raw snapshot
+    /// would red on every boot race again — silently, because the assertion above would still
+    /// pass.
+    /// </summary>
+    [Fact]
+    public void TheVerdictIsComputedFromTheReAskedSet()
+    {
+        var source = SourceScan.MaskCommentsAndStrings(Read(EmittingSource));
+
+        Assert.True(
+            source.Contains("Unresolved(", StringComparison.Ordinal),
+            $"{EmittingSource} no longer computes its report from "
+            + "ContentDegradationRegistry.Unresolved(...). Reporting Snapshot() instead re-reds "
+            + "every transient boot degradation — the exact defect #3645 fixed — and would do it "
+            + "invisibly, because the marker would still be constructed and the gate would still "
+            + "match.");
+    }
+
     [Fact]
     public void TheSourceStillEmitsThePhraseTheGateGrepsFor()
     {
@@ -205,16 +264,28 @@ public class UntypedContentDegradationGate
             + $"{Script} greps for exactly that phrase, so it now matches NOTHING and passes every "
             + "run having checked nothing — the silent retirement this test exists to prevent.\n"
             + "If the message was reworded, update the phrase in BOTH this test and the script. If "
-            + "the degradation warning was removed entirely, remove the gate deliberately and say "
+            + "the verdict report was removed entirely, remove the gate deliberately and say "
             + "why in the commit — do not leave a gate grepping for a string nobody writes.");
+    }
 
-        // Both read seams — GetStream and GetQuery — must keep reporting. A degradation reachable
-        // through only one of them is still a view that renders empty.
+    /// <summary>
+    /// The per-READ diagnostic still fires at BOTH read seams. It no longer reds a shard on its
+    /// own — that was the defect — but it is the record that names which read degraded, and it is
+    /// the registry entry the verdict is computed from. A seam that falls silent takes its node
+    /// types out of the verdict's denominator entirely.
+    /// </summary>
+    [Fact]
+    public void BothReadSeamsStillEmitTheDegradationPhrase()
+    {
+        var emitted = Read(EmittingSource).Split('\n')
+            .Count(l => l.Contains(DegradationPhrase, StringComparison.Ordinal));
+
         Assert.True(
             emitted >= 2,
-            $"Only {emitted} occurrence(s) of \"{Phrase}\" in {EmittingSource}; expected at least 2 "
-            + "(GetStream and GetQuery). One read seam falling silent means content can degrade "
-            + "down that path with nothing said, which is exactly the state before this gate.");
+            $"Only {emitted} occurrence(s) of \"{DegradationPhrase}\" in {EmittingSource}; expected "
+            + "at least 2 (GetStream and GetQuery). One read seam falling silent means content can "
+            + "degrade down that path with nothing said AND with no registry entry, so the verdict "
+            + "cannot report it either.");
     }
 
     [Fact]

--- a/test/MeshWeaver.Graph.Test/LateContentTypeRegistrationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateContentTypeRegistrationTest.cs
@@ -316,6 +316,155 @@ public class LateContentTypeRegistrationTest(ITestOutputHelper output) : Monolit
         contentType.GetProperty("Label")!.GetValue(typed.Content).Should().Be("by name only");
     }
 
+    // ══════════════════════════════════════════════════════════════════════════
+    //  #3645 — the VERDICT: which of these degradations was actually a defect
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>The acceptance criterion, transient half.</b> A read that degrades and then RECOVERS —
+    /// exactly what the first test in this class reproduces, and what a portal boot does on every
+    /// NodeType whose compile lands after its first reader — must produce <b>no</b> gate hit.
+    ///
+    /// <para>Before #3645 it produced one: <c>check-untyped-content.sh</c> keyed on the per-read
+    /// <c>MeshNodeContentDegradedException</c>, so two of this class's three cases reddened a shard
+    /// for doing the thing they assert. The verdict is now the RE-ASKED set: the registry keeps
+    /// what degraded, and <c>Unresolved</c> asks the mesh-wide content-type registry again — both
+    /// routes <c>TryRecoverForNodeType</c> takes, two pure lookups — at the moment of the report.</para>
+    ///
+    /// <para><b>Fails on unfixed code:</b> a report built from <c>Snapshot()</c> lists the recovered
+    /// type here.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task ARecoveredDegradation_IsNotTheVerdict()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<IMeshContentTypeRegistry>();
+        var degradationRegistry = Mesh.ServiceProvider.GetRequiredService<ContentDegradationRegistry>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var contentType = EmitCollectibleType("RecoveredGadget", "Label");
+        var partition = "vrc" + Guid.NewGuid().ToString("N")[..9];
+        var typePath = $"{partition}/Gadget";
+        var instancePath = $"{partition}/Live";
+
+        await Seed(meshService, partition, typePath, contentType, "recovered frame");
+
+        var degraded = await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Where(n => n is not null).FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit("the node must be readable while its type is unknown");
+        degraded!.Content.Should().BeOfType<JsonElement>(
+            "PRECONDITION: the degradation this test then cures must actually have happened");
+        degradations.AssertReportedFor(instancePath,
+            "the transient degradation is this test's premise — it is what the verdict must then "
+            + "decline to report");
+
+        degradationRegistry.Snapshot().Should().NotBeEmpty(
+            "PRECONDITION: the registry must hold the entry whose fate is under test — otherwise "
+            + "the assertion below would pass over an empty set and mean nothing");
+
+        // The compile finishing.
+        registry.Register(contentType, typePath);
+
+        degradationRegistry.Unresolved(registry).Should().BeEmpty(
+            "the type registered, so the degradation was TRANSIENT — the boot race #2952 re-types "
+            + "live readers for. A gate hit here means 'content was unreadable at a read', which is "
+            + "not a defect and is what #3645 stopped reporting");
+        degradationRegistry.Snapshot().Should().NotBeEmpty(
+            "and the EVENT is still on record — the verdict narrows what is reported, it does not "
+            + "erase the history a reader needs to find which read degraded");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The acceptance criterion, final half — and the control that stops the fix from being
+    /// "report nothing".</b> A discriminator no declaration will ever claim is still a defect: the
+    /// view renders empty forever, and the teardown report names it.
+    ///
+    /// <para>The report is driven through the PRODUCTION path — <c>MeshNodeStreamCache.Dispose</c>
+    /// — rather than by calling the reporter directly, because the thing that failed for five days
+    /// in #3625 was never the wording: it was whether a record could reach the sink at all. So this
+    /// asserts the record the sink's own predicate would take.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task AnUnrecoverableDegradation_IsTheVerdict_AndReachesTheSink()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<IMeshContentTypeRegistry>();
+        var degradationRegistry = Mesh.ServiceProvider.GetRequiredService<ContentDegradationRegistry>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var contentType = EmitCollectibleType("OrphanGadget", "Label");
+        var partition = "vun" + Guid.NewGuid().ToString("N")[..9];
+        var typePath = $"{partition}/Gadget";
+        var instancePath = $"{partition}/Live";
+
+        await Seed(meshService, partition, typePath, contentType, "orphan frame");
+
+        var degraded = await Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Where(n => n is not null).FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit("the node must be readable while its type is unknown");
+        degraded!.Content.Should().BeOfType<JsonElement>();
+        degradations.AssertReportedFor(instancePath, "nothing will ever claim this discriminator");
+
+        // 🚨 NOTHING registers it. That is the entire difference from the test above.
+        degradationRegistry.Unresolved(registry).Select(d => d.NodeType).Should().Contain(typePath,
+            "no declaration claims this discriminator, so re-asking the registry answers no — this "
+            + "is the population the gate exists for, and a fix that reported nothing would fail here");
+
+        // The production emission, through the real teardown. Disposal is idempotent (the cache
+        // guards on _disposed), so the fixture's own disposal after this test is unaffected — and
+        // this is the LAST thing the test does with the mesh.
+        (Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>() as IDisposable)
+            .Should().NotBeNull("the cache is what reports the verdict at teardown").And.Subject
+            .As<IDisposable>().Dispose();
+
+        var verdicts = degradations.Verdicts();
+        verdicts.Should().NotBeEmpty(
+            "the teardown must REPORT what never resolved — a verdict nobody emits is the "
+            + "permanently-green gate #3625 was");
+        var verdict = verdicts.Single(v => v.Exception.NodeType == typePath);
+
+        // Restates the sink's own condition over the shape the sink sees, exactly as
+        // AssertReportedFor does for the per-read record.
+        Exception? asTheSinkSeesIt = verdict.Exception;
+        (asTheSinkSeesIt is not null && verdict.Level >= LogLevel.Warning).Should().BeTrue(
+            "the verdict must be a record the trace sink WOULD have written (exception is not null "
+            + "&& level >= Warning) — otherwise check-untyped-content.sh has nothing to scan and "
+            + "passes having matched nothing. Captured: level={0}", verdict.Level);
+        verdict.Message.Should().Contain("was NEVER resolvable on this replica",
+            "the prose net the gate keeps as its second key must be in the formatted message");
+        verdict.Exception.Discriminator.Should().Be(contentType.Name,
+            "the verdict must name the discriminator — that is the second key Unresolved re-asks "
+            + "under, and the one an operator searches the logs for");
+        verdict.Exception.Count.Should().BeGreaterThan(0);
+    }
+
+    /// <summary>Seeds a NodeType declaration plus one instance whose stored content carries a
+    /// discriminator the mesh cannot resolve — the shared premise of both verdict tests.</summary>
+    private async Task Seed(
+        IMeshService meshService, string partition, string typePath, Type contentType, string label)
+    {
+        await meshService.CreateNode(new MeshNode("Gadget", partition)
+        {
+            Name = "Gadget",
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { Description = "A NodeType with no compile lifecycle" }
+        }).Should().Within(TestTimeouts.Convergence).Emit("the NodeType declaration must land first");
+
+        var instance = Activator.CreateInstance(contentType)!;
+        contentType.GetProperty("Label")!.SetValue(instance, label);
+        var storedJson = JsonSerializer.Serialize(instance, contentType, Mesh.JsonSerializerOptions);
+        var stored = JsonSerializer.Deserialize<JsonElement>(storedJson);
+        stored.TryGetProperty("$type", out _).Should().BeTrue(
+            "PRECONDITION: the stored row must carry the discriminator the reader has to resolve");
+
+        await meshService.CreateNode(new MeshNode("Live", partition)
+        {
+            Name = "Live frame",
+            NodeType = typePath,
+            State = MeshNodeState.Active,
+            Content = stored
+        }).Should().Within(TestTimeouts.Convergence).Emit("the instance carrying the unresolvable $type must land");
+    }
+
     /// <summary>
     /// 🚨 The private sink for this test class's degradation records — see
     /// <see cref="degradations"/> for why the records must not reach the shared trace file, and why
@@ -338,6 +487,13 @@ public class LateContentTypeRegistrationTest(ITestOutputHelper output) : Monolit
 
         /// <summary>One captured degradation, with the two facts the trace sink's predicate reads.</summary>
         internal sealed record Captured(LogLevel Level, string Message, MeshNodeContentDegradedException Exception);
+
+        /// <summary>One captured VERDICT — the teardown report (#3645), kept separately because it
+        /// answers a different question from the per-read records above.</summary>
+        internal sealed record CapturedVerdict(
+            LogLevel Level, string Message, MeshNodeContentUnresolvedException Exception);
+
+        private ImmutableList<CapturedVerdict> verdicts = ImmutableList<CapturedVerdict>.Empty;
 
         /// <summary>Wires the real logger everything else is forwarded to, and returns this recorder
         /// so it can be registered inline as the closed <c>ILogger&lt;MeshNodeStreamCache&gt;</c>.</summary>
@@ -362,6 +518,18 @@ public class LateContentTypeRegistrationTest(ITestOutputHelper output) : Monolit
             {
                 lock (gate)
                     captured = captured.Add(new Captured(logLevel, formatter(state, exception), degraded));
+                return;
+            }
+
+            // 🚨 The VERDICT is diverted for the same reason the events are: this class's whole
+            // subject is content nothing can resolve, so its teardown report is a legitimate hit
+            // that must not red the shard through check-untyped-content.sh. Diverting it obliges
+            // the class to ASSERT it, which AVerdict_* below does.
+            if (exception is MeshNodeContentUnresolvedException unresolved)
+            {
+                lock (gate)
+                    verdicts = verdicts.Add(
+                        new CapturedVerdict(logLevel, formatter(state, exception), unresolved));
                 return;
             }
 
@@ -415,6 +583,13 @@ public class LateContentTypeRegistrationTest(ITestOutputHelper output) : Monolit
         {
             lock (gate)
                 return captured;
+        }
+
+        /// <summary>Every teardown verdict captured so far.</summary>
+        internal ImmutableList<CapturedVerdict> Verdicts()
+        {
+            lock (gate)
+                return verdicts;
         }
     }
 


### PR DESCRIPTION
Closes #3645.

## The gate was right; its denominator was wrong

A node whose content carries a `$type` the reading hub cannot resolve does not fail. The value
degrades to a raw `JsonElement` and reads as absent everywhere downstream — an `is MyType` check
misses, a view renders empty, a reactive wait never completes. That silence is why there is a gate.

It keyed on `MeshNodeContentDegradedException`, which is emitted **at the instant of a read** — and
at that instant nothing can know whether the type registers a moment later. That is the ordinary
state during a portal boot: a NodeType's runtime compile lands after its first readers are served,
and #2952 exists precisely to re-type those readers when the registration arrives. The seam one
layer down already said so in its own message — *"content stays an untyped JsonElement **for now** …
(a) … has not registered it **YET, which is TRANSIENT** … or (b) no declaration will ever claim this
discriminator"* — and, passing no exception, reddened nothing.

One event, two descriptions, opposite CI consequences. Measured on #3628: **two of
`LateContentTypeRegistrationTest`'s three cases degrade and RECOVER inside a single test** — the
recovery *is* the assertion — and both produced a gate-reddening record. So a hit meant *"content
was unreadable at a read"*, never *"content is unreadable"*.

## The fix invents nothing — it asks again

Both halves already existed. `ContentDegradationRegistry` keeps one entry per node type (added for
`/health`), and `IMeshContentTypeRegistry` answers *"is this resolvable"* as a **pure map lookup** by
either route `TryRecoverForNodeType` takes. So the verdict is computed by re-asking, and needs no
window, no timer and no retained content:

- **`Record`** now keeps the stored `$type` beside the NodeType, so both routes can be re-asked
  later. (First-seen wins — a later read whose element carries no `$type` must not erase the name
  the first one gave us.)
- **`Unresolved(registry)`** drops every entry whose type has since registered. 🚨 A null registry
  means UNRESOLVED, never resolved: a missing instrument may not read as a clean result.
- **`MeshNodeStreamCache.Dispose`** logs one `MeshNodeContentUnresolvedException` per surviving
  entry — **first**, before any teardown, because a verdict nobody can emit is the exact failure
  #3625 was.
- **`check-untyped-content.sh`** keys on that type. The per-read records stay in the logs and stay
  useful: once the verdict names a type, they are how you find which reads degraded on it.

| record | when | meaning | reds a shard? |
|---|---|---|---|
| `MeshNodeContentDegradedException` | at each degraded read | *this read was untyped* — an EVENT, possibly the boot race | **no** (this PR) |
| `MeshNodeContentUnresolvedException` | once per node type, at cache teardown | *the registry was re-asked and still says no* — a VERDICT | **yes** |

## `/health` was wrong the same way

`ContentTypeHealthCheck` fed `Snapshot()`, so a replica stayed `Degraded` after a boot race until
some later read of that type happened to clear the entry — a probe answering about the past. It
reads `Unresolved(...)` now, so a race that healed disappears immediately and only a type that
genuinely never arrived keeps the replica degraded.

## The acceptance criterion, falsified in both directions

Two new cases in `LateContentTypeRegistrationTest` — the file whose subject this already is, which
is also why they belong there rather than in a new file (the diverted-logger guard requires the
capture and the assertion to live together).

- **`ARecoveredDegradation_IsNotTheVerdict`** — degrade, then `registry.Register(...)`:
  `Unresolved` is empty while `Snapshot` is not. *Reduce `Unresolved` to `Snapshot()` and it fails.*
- **`AnUnrecoverableDegradation_IsTheVerdict_AndReachesTheSink`** — nothing ever registers the type;
  drives the **production** teardown (`Dispose`, idempotent) and asserts the record the trace sink's
  own predicate would take (`exception is not null && level >= Warning`), that it names the
  discriminator, and that it carries the phrase the script greps. *Remove the report and it fails on
  "the teardown must REPORT what never resolved".*

Both were run against the reverted code: **2 failed / 3 passed**, each failing exactly its own half.

`UntypedContentDegradationGate` grew from 4 assertions to 6 and now pins: the script keys on
`nameof(MeshNodeContentUnresolvedException)`; the emitter constructs it; **the report is computed
from `Unresolved(`** (a report built from `Snapshot()` would re-red every boot race *invisibly*,
because the marker would still be constructed and the gate would still match); and both read seams
still emit the per-read record the verdict is derived from.

🚨 One thing the guard caught on me: both messages keep the gate's phrase **contiguous in one string
literal**. The guard greps the source line by line, so a phrase the formatter splits across two
literals is emitted correctly and yet reads as absent — a rewording that "passes" while retiring the
coupling. Noted in a comment at both sites.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation — `MeshWeaver.Data.Contract`,
`MeshWeaver.Hosting`, `Memex.Portal.ServiceDefaults`, `MeshWeaver.Documentation`, and the three test
projects: **0 Warning(s), 0 Error(s)** each. Tests: `MeshWeaver.Graph.Test` **1483/1483**,
`MeshWeaver.Hosting.Test` **534/534** (includes `UntypedContentDegradationReachesTheTraceSinkTest`,
unaffected), `MeshWeaver.Documentation.Test` **368/368** (includes the link-integrity test).

## Docs

- `Doc/Architecture/ReadingCiSignals` → *TRANSIENT from FINAL* rewritten: it recorded this as
  *"needs a window nothing in a process naturally closes — a rework, deliberately left to its own
  issue"*, and that is the issue.
- What's New: *A degradation that recovered is not a defect* (`Category: Fix`).

## Surface

`MeshNodeContentUnresolvedException` is **added**, nothing public is removed, and no interface gains
a member — so neither the cross-repo pair gate nor the interface-additions gate applies.
`ContentDegradation` gains an optional trailing parameter and `Record` an optional trailing
argument, so every existing caller still compiles.
