### PR TITLE
fix(#3593): a failed drain schedule must not latch the pump, and the verdict must measure its mechanism

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -118,8 +118,8 @@ fell into the wrong bucket.
 `ShutdownRequest` that `Dispose()` posted. The hub was not waiting on a child: at `RunLevel=Started`
 it has not reached `DisposeHostedHubs` and has asked nothing below it to do anything.
 
-**Not established** — the mechanism. Two candidates remain, and the instrumentation of the day could
-not discriminate them:
+**Not established** — the mechanism. Three candidates remain (the third was added later; see below),
+and the instrumentation of the day could not discriminate any of them:
 
 | | **M1 — the wake-up was never delivered** | **M2 — a drain body is blocked before the handler** |
 |---|---|---|
@@ -131,9 +131,63 @@ not discriminate them:
 That table *is* the discriminator, and it is why the counters were added: neither reading existed
 when the 47 reports were filed.
 
-🚨 **Do not "fix" this by adding `PreferFairness`.** It is one of two live hypotheses, and shipping
+### M3 — the latch leaked, and nothing was ever scheduled
+
+🚨 **`drainsInFlight == 0` does not mean a drain is queued.** It means no drain body is *running*,
+and the verdict's own prose used to close that gap by assertion — *"the drain flag is latched (a
+drain **is** scheduled on this hub's TaskScheduler)"* — which nothing measured. Two states read
+identically:
+
+| | **M1** — the scheduler holds it | **M3** — nothing is outstanding |
+|---|---|---|
+| `drainsInFlight` | 0 | 0 |
+| `drainsAwaitingScheduler` (`drainsScheduled - drainsStarted`) | **> 0** | **0** |
+| Owner | the `TaskScheduler` — it accepted work and is not running it | **this file** — `MessageService` |
+
+M3 was **reachable**. `draining = true` is set inside the turn gate in `KickDrain` and the schedule
+happens *outside* it; `Terminal()` re-schedules with the latch still held. A throw from
+`Task.Factory.StartNew` at either site left the flag set with nothing outstanding — and since
+`KickDrain` returns immediately whenever the flag is set, the pump was then frozen **for the life of
+the hub**, silently, with the verdict blaming a scheduler that had never been asked. A real
+scheduler throws here: a completed `ConcurrentExclusiveSchedulerPair`, or an Orleans activation torn
+down underneath the hub.
+
+`ScheduleDrainOne` now releases the latch and logs an Error naming the scheduler when a schedule
+fails, so the invariant *"`draining` ⇒ a drain is running or queued"* holds by construction and
+every verdict that reads it is entitled to.
+
+🚨 **M3 is almost certainly NOT what the 47 reports were**, and saying so is the point of listing
+it. `Task.Factory.StartNew` on `TaskScheduler.Default` does not throw, and a hosted hub gets a
+**fresh** `MessageHubConfiguration` (`IServiceProvider.CreateMessageHub`) — nothing copies a parent's
+`TaskScheduler`, and `WithTaskScheduler`'s own contract says to use the grain's scheduler *only* for
+the root grain hub. So `sync/*` hubs run on the default pool scheduler, where M3 is unreachable and
+a dead activation scheduler cannot reach them either. M3 is a real defect with the identical
+fingerprint, found by reading the code and closed; it narrows the candidate set for the incident
+rather than explaining it. **What remains for the reported population is M1-by-pool-starvation or
+M2**, and the next occurrence prints which.
+
+🚨 **It does not fall back to another scheduler.** The turn scheduler is the hub's serialisation
+guarantee — under Orleans it *is* the grain's activation scheduler — so running a turn elsewhere
+would break the actor model to keep a queue moving. Releasing the latch is the honest recovery: the
+next post tries again and reports again, instead of the pump going dark.
+
+### What Orleans makes of M1
+
+`MessageHubGrain` wires the **root grain hub's** turn scheduler to the grain's
+**`ActivationTaskScheduler`** (`.WithTaskScheduler(grainScheduler)`), and the same file already
+records the consequence one hazard over: *"when a stuck round wedges that scheduler, any rescue that
+is itself a hub message can never be processed"* (#147). For a hub on that scheduler, M1 has a
+specific shape — a wedged or already-deactivated activation parks every turn it will ever take — and
+the verdict now hands the stall to that scheduler by measurement rather than by assertion.
+
+🚨 It does **not** apply to hosted hubs, which is what the 47 reports were: hosted hubs are built
+from a fresh configuration and stay on `TaskScheduler.Default`. Read a
+`drainsAwaitingScheduler > 0` on a `sync/*` hub as **pool starvation or a local-queue LIFO stall**,
+not as a dead activation — the owner is the same (the scheduler), the remedy is not.
+
+🚨 **Do not "fix" this by adding `PreferFairness`.** It is one of the live hypotheses, and shipping
 a change that makes a symptom rarer while the mechanism is unmeasured is the band-aid this
-repository refuses. The next occurrence now names which of M1 or M2 it is; that is what the fix
+repository refuses. The next occurrence now names which of M1, M2 or M3 it is; that is what the fix
 waits on.
 
 ---
@@ -162,12 +216,17 @@ bucket, so it fell through to the catch-all. It now names the pump, prints `drai
 dequeue delta, and says in the line itself which reading means what:
 
 ```text
-THE PUMP IS NOT TURNING: the drain flag is latched (a drain is scheduled on this hub's
-TaskScheduler), drainsInFlight=0, and NO turn was dequeued in that window (0 dequeued in total
-since Dispose()). … drainsInFlight=0 means the scheduled drain never ran: look at the TaskScheduler
-that owes this hub a thread. drainsInFlight>0 means a drain body is running and is blocked before
-the dequeue.
+THE PUMP IS NOT TURNING: the drain flag is latched, drainsInFlight=0,
+drainsAwaitingScheduler=1, and NO turn was dequeued in that window (0 dequeued in total since
+Dispose()). … MECHANISM: the turn scheduler ACCEPTED 1 drain(s) and has not run them
+(drainsInFlight=0). The stall is in THAT SCHEDULER, not in this hub: under Orleans the hub's turn
+scheduler IS the grain's ActivationTaskScheduler (MessageHubGrain.WithTaskScheduler), so a wedged
+or already-deactivated activation parks every turn this hub will ever take.
 ```
+
+The `MECHANISM:` clause is chosen from the two counters, never asserted: `drainsInFlight > 0` names
+M2, `drainsAwaitingScheduler > 0` names M1 and hands the stall to the scheduler, and zero on both
+names M3 — a defect in `MessageService.ScheduleDrainOne`, which that method now makes unreachable.
 
 **7313 is now guarded.** "The stall is in a hosted hub or a join it is waiting on" is printable only
 when there *is* something below — hosted hubs still in the collection, an outstanding hosted-hub

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-latched-pump-that-scheduled-nothing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-latched-pump-that-scheduled-nothing.md
@@ -1,0 +1,50 @@
+---
+Name: A latched pump that scheduled nothing
+Category: Fix
+Description: A hub's message pump marks itself busy before handing a turn to its task scheduler. If that hand-off threw — a torn-down Orleans activation, a completed scheduler pair — the busy flag stayed set with nothing running, and the hub silently stopped processing messages for the rest of its life while its own stall report blamed a scheduler that had never been asked. The flag is now released, and the stall report measures which of the three mechanisms it is instead of asserting one.
+Icon: Wrench
+Order: -20260909
+---
+
+Each hub processes its messages one at a time. A flag says "a turn is running or queued"; while it
+is set, an arriving message just joins the queue instead of starting a second turn. The flag is set
+first, and the turn is then handed to the hub's task scheduler.
+
+If that hand-off **threw**, the flag stayed set. Nothing was running, nothing was queued, and every
+later arrival looked at the flag, concluded someone else was already draining, and returned. The hub
+went dark — permanently, and without a word.
+
+A real scheduler does throw here. Under Orleans a hub's turns run on its grain's activation
+scheduler, and an activation torn down underneath the hub stops accepting work; a completed
+scheduler pair does the same. This is the shape of a shutdown, which is exactly when it hurts most:
+the message the pump then never processes is the hub's own shutdown request.
+
+## What it does now
+
+A failed hand-off releases the flag and logs an error naming the scheduler and how many turns are
+waiting. The next message tries again and reports again, instead of the hub falling silent.
+
+🚨 It does **not** re-route the turn to another scheduler. That scheduler is the hub's ordering
+guarantee — under Orleans it is what keeps a grain's work on the grain — so borrowing a different
+thread to keep a queue moving would trade a stalled hub for a corrupted one. Releasing the flag is
+the honest recovery.
+
+## And the stall report stopped guessing
+
+When a hub is stuck at shutdown the platform prints a verdict. For this state it used to say *"the
+drain flag is latched (a drain **is** scheduled on this hub's TaskScheduler)"* and send the reader
+to that scheduler — a sentence nothing measured. Two quite different situations read identically:
+the scheduler accepted a turn and is not running it, or nothing was ever handed over at all. The
+first is the scheduler's problem; the second is the platform's.
+
+The report now counts both — turns handed over, and turns actually begun — and names the mechanism
+from the difference:
+
+- a turn is running but blocked before it takes work off the queue;
+- the scheduler **accepted** turns and has not run them (on Orleans: a wedged or deactivated
+  activation);
+- nothing is outstanding at all while the flag is set — which is the bug above, and is now
+  unreachable.
+
+Forty-seven of these reports were filed in one shutdown, all pointing at the wrong place. See
+[Reading a Disposal Stall Verdict](@/Doc/Architecture/DisposalStallVerdicts).

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1231,7 +1231,8 @@ public sealed class MessageHub : IMessageHub
         var snapshot = (messageService is MessageService ms)
             ? ms.GetQueueSnapshot()
             : (Buffer: -1, Deferred: -1, DrainsInFlight: -1, OpenGates: -1, Draining: false,
-               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L);
+               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L,
+               DrainsAwaitingScheduler: -1L);
 
         // The discriminator. A hub that was IDLE while waiting genuinely heard nothing: the silence
         // is upstream. A hub that was busy, gated, or holding queued work cannot make that claim —
@@ -2152,30 +2153,61 @@ public sealed class MessageHub : IMessageHub
         // here is a category error, which is precisely what the unguarded fallback below used to do
         // (#3593: 47 sync/* hubs, all at RunLevel=Started with queue depth 1).
         //
-        // What the two counters in the line discriminate:
-        //   drainsInFlight=0 → the scheduled drain never ran. The turn scheduler owes this hub a
-        //                      thread and has not delivered one (a starved pool, a scheduler whose
-        //                      queue is not being serviced, work parked on one thread's local LIFO
-        //                      queue reachable only by stealing).
-        //   drainsInFlight>0 → a drain body IS running and is blocked BEFORE the dequeue — i.e. in
-        //                      the turn gate itself, or in whatever the body does ahead of taking
-        //                      work off the queue.
+        // 🚨 The line used to say "a drain IS scheduled on this hub's TaskScheduler" and then send
+        // the reader to that scheduler — an ASSERTION, not a measurement. Nothing in the snapshot
+        // could tell "the scheduler accepted a drain and never ran it" from "the latch is set and
+        // nothing is outstanding at all", and those have opposite owners. `drainsAwaiting` is that
+        // measurement (#3593): scheduled minus started, read off the pump.
+        //
+        // The three states, in the order the line reports them:
+        //   drainsInFlight > 0   → a drain body IS running and is blocked BEFORE the dequeue — in
+        //                          the turn gate, or in whatever runs ahead of taking work off the
+        //                          queue.
+        //   drainsAwaiting > 0   → the turn scheduler ACCEPTED a drain and has not run it. The
+        //                          cause is outside this hub: a starved pool, work parked on one
+        //                          thread's local LIFO queue, or — for a ROOT GRAIN hub only — an
+        //                          Orleans ActivationTaskScheduler that stopped executing work.
+        //                          🚨 The last one does NOT apply to a hosted hub: hosted hubs are
+        //                          built from a fresh MessageHubConfiguration and inherit no
+        //                          scheduler, which is what WithTaskScheduler's contract asks for.
+        //   drainsAwaiting == 0  → NOTHING is outstanding while the latch is set. That breaks
+        //                          ScheduleDrainOne's invariant and is a defect in the pump itself,
+        //                          not in any scheduler. It is reachable only if a schedule was
+        //                          lost without releasing the latch, which ScheduleDrainOne now
+        //                          refuses to do — so if this branch is ever printed, it is new.
         if (snapshot is { } pumpView && pump is not null
             && pumpView.Draining && pumpView.Buffer > 0 && nothingDequeuedThisBudget)
         {
+            var drainsAwaiting = pumpView.DrainsAwaitingScheduler;
+            var mechanism = pumpView.DrainsInFlight > 0
+                ? "a drain body IS running (drainsInFlight=" + pumpView.DrainsInFlight
+                  + ") and is blocked BEFORE the dequeue — in the turn gate, or in whatever it does "
+                  + "ahead of taking work off the queue"
+                : drainsAwaiting > 0
+                    ? "the turn scheduler ACCEPTED " + drainsAwaiting + " drain(s) and has not run "
+                      + "them (drainsInFlight=0). The stall is in THAT SCHEDULER, not in this hub. "
+                      + "On TaskScheduler.Default (every hosted hub — a hosted hub is built from a "
+                      + "fresh configuration and inherits no scheduler) that is pool starvation or "
+                      + "work parked on one thread's local LIFO queue; on a ROOT GRAIN hub it is the "
+                      + "grain's ActivationTaskScheduler (MessageHubGrain.WithTaskScheduler), where a "
+                      + "wedged or deactivated activation parks every turn this hub will ever take"
+                    : "NOTHING is outstanding (drainsInFlight=0, drainsScheduled==drainsStarted) "
+                      + "while the drain flag is latched. That breaks the pump's own invariant — a "
+                      + "latched flag must mean a drain is running or queued — so this is a defect "
+                      + "in MessageService.ScheduleDrainOne, NOT in any scheduler";
+
             logger.LogError(DisposalPumpNeverDequeued,
                 "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} "
                 + "(last progress: {LastProgress}). RunLevel={RunLevel}, queue depth {Depth}. "
-                + "THE PUMP IS NOT TURNING: the drain flag is latched (a drain is scheduled on this "
-                + "hub's TaskScheduler), drainsInFlight={DrainsInFlight}, and NO turn was dequeued in "
-                + "that window ({Dequeued} dequeued in total since Dispose()). The queued work — the "
+                + "THE PUMP IS NOT TURNING: the drain flag is latched, drainsInFlight={DrainsInFlight}, "
+                + "drainsAwaitingScheduler={DrainsAwaiting}, and NO turn was dequeued in that window "
+                + "({Dequeued} dequeued in total since Dispose()). The queued work — the "
                 + "ShutdownRequest included — has therefore never been handed to a handler, so this "
                 + "stall is in THIS hub's turn scheduling and NOT in a hosted hub or a join. "
-                + "drainsInFlight=0 means the scheduled drain never ran: look at the TaskScheduler "
-                + "that owes this hub a thread. drainsInFlight>0 means a drain body is running and is "
-                + "blocked before the dequeue. Disposal is NOT forced.\n{Diagnostics}",
+                + "MECHANISM: {Mechanism}. Disposal is NOT forced.\n{Diagnostics}",
                 Address, DisposalWatchdogTimeout, lastProgress, RunLevel, pumpView.Buffer,
-                pumpView.DrainsInFlight, dequeued - disposalDequeuedBaseline, DescribeWedge());
+                pumpView.DrainsInFlight, drainsAwaiting, dequeued - disposalDequeuedBaseline,
+                mechanism, DescribeWedge());
             return;
         }
 
@@ -2206,14 +2238,16 @@ public sealed class MessageHub : IMessageHub
         logger.LogError(DisposalStalledUnclassified,
             "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} "
             + "(last progress: {LastProgress}). RunLevel={RunLevel}, queue depth {Depth}, "
-            + "drainsInFlight={DrainsInFlight}, draining={Draining}, {Dequeued} turn(s) dequeued since "
+            + "drainsInFlight={DrainsInFlight}, drainsAwaitingScheduler={DrainsAwaiting}, "
+            + "draining={Draining}, {Dequeued} turn(s) dequeued since "
             + "Dispose(). No turn is on the block, the pump is not holding queued work, and this hub "
             + "has no hosted hubs and no outstanding child-disposal join — so THIS VERDICT DOES NOT "
             + "NAME A CAUSE. What is still outstanding is in the diagnostics below (pending callbacks "
             + "are the usual one: a reply owed from outside this mesh). Disposal is NOT "
             + "forced.\n{Diagnostics}",
             Address, DisposalWatchdogTimeout, lastProgress, RunLevel, snapshot?.Buffer ?? -1,
-            snapshot?.DrainsInFlight ?? -1, snapshot?.Draining ?? false,
+            snapshot?.DrainsInFlight ?? -1, snapshot?.DrainsAwaitingScheduler ?? -1L,
+            snapshot?.Draining ?? false,
             dequeued - disposalDequeuedBaseline, DescribeWedge());
     }
 
@@ -2360,7 +2394,8 @@ public sealed class MessageHub : IMessageHub
         var snapshot = (messageService is MessageService ms)
             ? ms.GetQueueSnapshot()
             : (Buffer: -1, Deferred: -1, DrainsInFlight: -1, OpenGates: -1, Draining: false,
-               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L);
+               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L,
+               DrainsAwaitingScheduler: -1L);
         var pending = SnapshotPendingCallbacks();
         var sb = new System.Text.StringBuilder();
         sb.Append("Hub ").Append(Address)
@@ -2447,7 +2482,8 @@ public sealed class MessageHub : IMessageHub
         var snapshot = (messageService is MessageService ms)
             ? ms.GetQueueSnapshot()
             : (Buffer: -1, Deferred: -1, DrainsInFlight: -1, OpenGates: -1, Draining: false,
-               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L);
+               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L,
+               DrainsAwaitingScheduler: -1L);
         sb.Append(indent)
           .Append("Hub ").Append(Address)
           .Append(" RunLevel=").Append(RunLevel)

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -1003,6 +1003,15 @@ public class MessageService : IMessageService
     // cannot fail is not a measurement.
     private int drainsInFlight;
 
+    // 🚨 The pair that separates "the scheduler never ran our task" from "we latched and scheduled
+    // nothing" (#3593). drainsInFlight=0 alone cannot tell them apart, and the two have opposite
+    // owners: the first is a TaskScheduler that stopped executing work (under Orleans, a wedged or
+    // deactivated ActivationTaskScheduler — MessageHubGrain wires the hub's turn scheduler to the
+    // grain's), the second would be a defect in THIS file. Monotonic; the difference is the number
+    // of drains queued on the turn scheduler that have not begun.
+    private long drainsScheduled;
+    private long drainsStarted;
+
     /// <summary>
     /// Number of turns the pump has taken off its queue so far. Monotonic. Read by the hub's
     /// disposal stall detector: a latched drain flag with this counter frozen means nothing has
@@ -1016,6 +1025,16 @@ public class MessageService : IMessageService
     /// Zero with the drain flag latched means the scheduled drain has not started running.
     /// </summary>
     internal int DrainsInFlight => Volatile.Read(ref drainsInFlight);
+
+    /// <summary>
+    /// Drains handed to the turn scheduler, minus drains that actually began. Positive means the
+    /// scheduler ACCEPTED work and has not run it — the hub is waiting on a thread it will not get
+    /// until that scheduler services its queue. Zero, with the drain flag latched and nothing in
+    /// flight, means no drain is outstanding at all, which the latch invariant forbids: see
+    /// <see cref="ScheduleDrainOne"/>.
+    /// </summary>
+    internal long DrainsAwaitingScheduler =>
+        Interlocked.Read(ref drainsScheduled) - Interlocked.Read(ref drainsStarted);
 
     /// <summary>
     /// Snapshot of the turn loop — used by <see cref="MessageHub.GetDisposalDiagnostics"/> when a
@@ -1035,7 +1054,7 @@ public class MessageService : IMessageService
     /// <c>Doc/Architecture/DisposalStallVerdicts</c> (#3593).</para>
     /// </summary>
     internal (int Buffer, int Deferred, int DrainsInFlight, int OpenGates, bool Draining,
-              string? CurrentMessage, long CurrentMessageElapsedMs)
+              string? CurrentMessage, long CurrentMessageElapsedMs, long DrainsAwaitingScheduler)
         GetQueueSnapshot()
     {
         var current = currentlyExecutingMessageType;
@@ -1047,7 +1066,7 @@ public class MessageService : IMessageService
                 elapsed = (long)((Stopwatch.GetTimestamp() - startedTicks) * 1000.0 / Stopwatch.Frequency);
         }
         return (mainQueue.Count, deferredQueue.Count, Volatile.Read(ref drainsInFlight), gates.Count,
-            draining, current, elapsed);
+            draining, current, elapsed, DrainsAwaitingScheduler);
     }
 
     IMessageDelivery IMessageService.RouteMessageAsync(IMessageDelivery delivery, CancellationToken cancellationToken) =>
@@ -1278,15 +1297,64 @@ public class MessageService : IMessageService
     // an IObservable — we SUBSCRIBE, never await. A synchronous turn completes inline
     // and advances the drain on this thread; a genuinely-async turn advances when it
     // completes. No Task anywhere on the turn path.
-    private void ScheduleDrainOne() =>
-        Task.Factory.StartNew(DrainOne, CancellationToken.None,
-            TaskCreationOptions.DenyChildAttach, turnScheduler);
+    /// <remarks>
+    /// 🚨 <b>The latch invariant: <c>draining == true</c> must always mean "a drain is running or
+    /// queued on the turn scheduler".</b> Every disposal verdict reads it that way — the pump
+    /// verdict says outright <i>"a drain is scheduled on this hub's TaskScheduler"</i> — so a
+    /// scheduling attempt that FAILS must release the latch rather than leave it set forever. It
+    /// used to be able to: <c>draining = true</c> is set inside the gate in <see cref="KickDrain"/>
+    /// and the schedule happens outside it, and <c>Terminal()</c> re-schedules with the latch still
+    /// held. A throw from either site froze the pump permanently AND made every later
+    /// <see cref="KickDrain"/> return immediately, producing exactly the fingerprint #3593 reports
+    /// — queue non-empty, <c>draining=true</c>, <c>drainsInFlight=0</c>, nothing ever dequeued —
+    /// while the verdict blamed a scheduler that had never been asked.
+    ///
+    /// <para>🚨 <b>And it does NOT fall back to another scheduler.</b> The turn scheduler is the
+    /// hub's serialisation guarantee (under Orleans it is the grain's activation scheduler), so
+    /// running a turn anywhere else would break the actor model to keep a queue moving. Releasing
+    /// the latch is the honest recovery: the next <c>KickDrain</c> tries again and reports again,
+    /// instead of the pump going silently dark.</para>
+    /// </remarks>
+    private void ScheduleDrainOne()
+    {
+        Interlocked.Increment(ref drainsScheduled);
+        try
+        {
+            Task.Factory.StartNew(DrainOne, CancellationToken.None,
+                TaskCreationOptions.DenyChildAttach, turnScheduler);
+        }
+        catch (Exception ex)
+        {
+            Interlocked.Decrement(ref drainsScheduled);
+            int depth;
+            lock (turnGate)
+            {
+                draining = false;
+                depth = mainQueue.Count;
+            }
+            try
+            {
+                logger.LogError(ex,
+                    "Hub {Address}: the turn scheduler ({Scheduler}) REFUSED a drain, so no turn "
+                    + "can start. The drain flag has been released — a latched flag with nothing "
+                    + "scheduled would freeze this pump permanently and make every disposal verdict "
+                    + "blame a scheduler that was never asked (#3593). {Depth} turn(s) are queued "
+                    + "and will be retried by the next post; if the scheduler stays dead they will "
+                    + "not be processed, and THAT is the failure to chase.",
+                    Address, turnScheduler.GetType().Name, depth);
+            }
+            catch { /* logger itself failed — the latch is released, which is the load-bearing part */ }
+        }
+    }
 
     // Counts THIS body as executing for as long as it runs, so the disposal snapshot can tell a
     // drain that is running from a drain that was merely scheduled (#3593). The inner loop keeps
     // every one of its early returns; the counter is released in the finally regardless.
     private void DrainOne()
     {
+        // The scheduler actually gave us a thread. Paired with drainsScheduled above; the two are
+        // what make "queued and never started" a MEASUREMENT rather than an inference (#3593).
+        Interlocked.Increment(ref drainsStarted);
         Interlocked.Increment(ref drainsInFlight);
         try
         {

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalStallNamesThePumpTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalStallNamesThePumpTest.cs
@@ -91,6 +91,21 @@ public class DisposalStallNamesThePumpTest : HubTestBase
                 "`exec` used to be a hard-coded literal 0 that no reader could distinguish from a "
                 + "measurement; the field now counts drain bodies actually executing, and reading "
                 + "zero here is what says the scheduled drain never ran");
+            // 🚨 The second half of #3593. drainsInFlight=0 alone does not say WHY nothing is
+            // running: "the scheduler took a drain and never ran it" and "the latch is set and
+            // nothing was ever scheduled" both read zero, and they have opposite owners. This
+            // scheduler ACCEPTED the drain — GetScheduledTasks holds it — so the report must say
+            // so as a measurement rather than assert it.
+            verdict.Should().Contain("drainsAwaitingScheduler=1",
+                "exactly one drain was handed to this scheduler and it is still holding it, which "
+                + "is the fact that distinguishes a dead scheduler from a leaked latch");
+            verdict.Should().Contain("the turn scheduler ACCEPTED",
+                "the MECHANISM clause must name the scheduler as the owner of this stall — the "
+                + "line used to assert 'a drain is scheduled on this hub's TaskScheduler' without "
+                + "anything measuring it");
+            verdict.Should().NotContain("defect in MessageService.ScheduleDrainOne",
+                "the pump did its job here: it scheduled the drain. Blaming the pump for a "
+                + "scheduler that will not run work is the same misattribution as blaming a child");
             verdict.Should().Contain("NO turn was dequeued",
                 "turnsCompleted counts HANDLER completions and is blind to a turn that never "
                 + "reached a handler — the dequeue counter is what separates a pump that never "
@@ -115,6 +130,107 @@ public class DisposalStallNamesThePumpTest : HubTestBase
             "the wedge is in the scheduler, not in the hub — once turns are delivered again the "
             + "teardown completes normally, which is why this PR claims a nameable wedge and not a "
             + "fixed one");
+    }
+
+    /// <summary>
+    /// 🚨 <b>A schedule that FAILS must release the drain latch (#3593).</b>
+    ///
+    /// <para><c>draining == true</c> is read by every disposal verdict as <i>"a drain is running or
+    /// queued"</i>. It is set inside the turn gate and the schedule happens outside it, so a throw
+    /// from <c>Task.Factory.StartNew</c> used to leave the flag set with nothing outstanding — and
+    /// because <c>KickDrain</c> returns immediately whenever the flag is set, the pump was then
+    /// frozen for the life of the hub, silently. The fingerprint is exactly the one #3593 reports
+    /// (queue non-empty, <c>draining=true</c>, <c>drainsInFlight=0</c>, nothing dequeued), with the
+    /// verdict blaming a scheduler that had never been asked.</para>
+    ///
+    /// <para><b>Fails on unfixed code:</b> the pump stays latched after the refusal, so the message
+    /// posted once the scheduler recovers is never dequeued and the response never comes.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ASchedulerThatRefusesADrain_DoesNotLeaveThePumpLatched()
+    {
+        var scheduler = new RefusingTaskScheduler();
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "pump-refused-schedule"), c => c
+            .WithTaskScheduler(scheduler)
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<Ping>((h, d) =>
+            {
+                h.Post(new Pong(), o => o.ResponseFor(d));
+                return d.Processed();
+            }), HostedHubCreation.Always)!;
+
+        // Bring-up on a working scheduler, for the same reason as the test above.
+        await victim.Observe(new Ping(), o => o.WithTarget(victim.Address))
+            .Should().Within(TestTimeouts.Quick)
+            .Emit("the hub must answer once before its scheduler starts refusing");
+
+        // Every schedule from here throws. The post latches `draining`, the schedule fails, and the
+        // latch must come back off — otherwise nothing this hub is ever sent can be processed again.
+        scheduler.Refuse();
+        victim.Post(new Ping(), o => o.WithTarget(victim.Address));
+
+        scheduler.Refusals.Should().BeGreaterThan(0,
+            "PRECONDITION: the scheduler must actually have refused — otherwise this test measures "
+            + "an ordinary post and would pass with the latch leak still present");
+
+        // The recovery, and the whole point: a pump whose latch was released can be driven again.
+        scheduler.Accept();
+        await victim.Observe(new Ping(), o => o.WithTarget(victim.Address))
+            .Should().Within(TestTimeouts.Convergence)
+            .Emit("a refused schedule must not latch the pump: once the scheduler accepts work "
+                + "again the hub processes messages normally. A leaked latch makes every later "
+                + "KickDrain return immediately, so this request would never be dequeued");
+
+        victim.Dispose();
+        await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(TestTimeouts.Convergence);
+        victim.RunLevel.Should().Be(MessageHubRunLevel.Dead);
+    }
+
+    /// <summary>
+    /// A <see cref="TaskScheduler"/> that can be told to THROW on queue rather than to hold —
+    /// the second failure mode of a real scheduler (a completed
+    /// <c>ConcurrentExclusiveSchedulerPair</c>, a torn-down activation) and the one that used to
+    /// leak the drain latch.
+    /// </summary>
+    private sealed class RefusingTaskScheduler : TaskScheduler
+    {
+        private readonly Lock gate = new();
+        private bool refusing;
+        private int refusals;
+
+        /// <summary>How many schedules were refused — the test's precondition.</summary>
+        public int Refusals => Volatile.Read(ref refusals);
+
+        public void Refuse()
+        {
+            lock (gate)
+                refusing = true;
+        }
+
+        public void Accept()
+        {
+            lock (gate)
+                refusing = false;
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            lock (gate)
+            {
+                if (refusing)
+                {
+                    Interlocked.Increment(ref refusals);
+                    throw new InvalidOperationException(
+                        "this scheduler is not accepting work (models a completed scheduler pair "
+                        + "or a torn-down Orleans activation)");
+                }
+            }
+            ThreadPool.UnsafeQueueUserWorkItem(_ => TryExecuteTask(task), null);
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        protected override IEnumerable<Task> GetScheduledTasks() => [];
     }
 
     private async Task<string> FirstVerdict(TimeSpan within) =>


### PR DESCRIPTION
Refs #3593. 🚨 **This does not claim the production wedge is fixed** — see *What this is not* at the
end. It closes a third mechanism nobody had listed, and makes the remaining two tell themselves
apart.

## The verdict asserted the one thing that mattered

#3615 made the stall report honest about three fields that were not measurements. One assertion
survived it. For the pump branch the line reads:

> THE PUMP IS NOT TURNING: the drain flag is latched **(a drain is scheduled on this hub's
> TaskScheduler)**, drainsInFlight=0 … *drainsInFlight=0 means the scheduled drain never ran: look
> at the TaskScheduler that owes this hub a thread.*

Nothing measured the parenthesis. `drainsInFlight == 0` says **no drain body is running**; it does
not say one is queued. Two states read identically and have opposite owners:

| | **M1** — the scheduler holds it | **M3** — nothing is outstanding |
|---|---|---|
| `drainsInFlight` | 0 | 0 |
| `drainsScheduled − drainsStarted` | **> 0** | **0** |
| Owner | the `TaskScheduler` | **`MessageService` — this file** |

## M3 was reachable, and it froze a hub for its whole life

`draining = true` is set inside the turn gate in `KickDrain`; the schedule happens **outside** it,
and `Terminal()` re-schedules with the latch still held. A throw from `Task.Factory.StartNew` at
either site left the flag set with nothing outstanding — and since `KickDrain` returns immediately
whenever the flag is set, **the pump was then frozen for the life of the hub**, silently, producing
exactly this issue's fingerprint (queue non-empty, `draining=true`, `drainsInFlight=0`, nothing ever
dequeued) with the verdict blaming a scheduler that had never been asked.

A real scheduler throws there: a completed `ConcurrentExclusiveSchedulerPair`, or an Orleans
activation torn down underneath the hub.

`ScheduleDrainOne` now releases the latch and logs an Error naming the scheduler and the queue
depth, so the invariant *"`draining` ⇒ a drain is running or queued"* holds by construction and
every verdict that reads it is entitled to.

🚨 **It does not fall back to another scheduler.** The turn scheduler is the hub's serialisation
guarantee — on a root grain hub it *is* the activation scheduler — so running a turn elsewhere would
break the actor model to keep a queue moving. Releasing the latch is the honest recovery: the next
post tries again and reports again, instead of the pump going dark.

## And the verdict now measures its mechanism

`drainsScheduled` / `drainsStarted` are counted at the two ends of the hand-off; the snapshot
carries the difference; the line picks its `MECHANISM:` clause from the counters instead of
asserting one:

- `drainsInFlight > 0` → **M2**: a drain body is running and blocked before the dequeue.
- `drainsAwaitingScheduler > 0` → **M1**: the scheduler accepted work and is not running it. On
  `TaskScheduler.Default` that is pool starvation or a local-LIFO stall; on a **root grain hub** it
  is a wedged or deactivated `ActivationTaskScheduler`.
- both zero → **M3**: a defect in `ScheduleDrainOne`, which the change above makes unreachable.

## Tests

`DisposalStallNamesThePumpTest` — the suite that already builds this exact state:

- the existing pump-verdict test gains `drainsAwaitingScheduler=1`, the `the turn scheduler ACCEPTED`
  mechanism clause, and **`NotContain("defect in MessageService.ScheduleDrainOne")`** — the pump did
  its job there, and blaming it for a scheduler that will not run work is the same misattribution as
  blaming a child;
- **`ASchedulerThatRefusesADrain_DoesNotLeaveThePumpLatched`** (new) — a scheduler that throws on
  queue, then accepts again; the hub must answer the next request. It asserts the refusal actually
  happened first, so it cannot pass over a scheduler that quietly worked.

**Falsified:** with the latch release removed, the new test fails — the post after recovery is never
dequeued and the request times out. Both pass with it. No `SemaphoreSlim`, no `Task.Delay`, no
bridge: both fake schedulers are plain `TaskScheduler` subclasses over a `Lock`.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.Messaging.Hub`,
`MeshWeaver.Documentation`, `MeshWeaver.Messaging.Hub.Test`, `MeshWeaver.Documentation.Test` —
0 Warning(s), 0 Error(s) each. Tests below.

## Docs

- `Doc/Architecture/DisposalStallVerdicts` — M3 added to the mechanism table, the sample verdict
  updated, and the Orleans clause corrected (see below).
- What's New: *A latched pump that scheduled nothing* (`Category: Fix`).

## 🚨 What this is not

**It is almost certainly not what the 47 production reports were, and the doc says so.**
`Task.Factory.StartNew` on `TaskScheduler.Default` does not throw, and a hosted hub is built from a
**fresh** `MessageHubConfiguration` (`IServiceProvider.CreateMessageHub`) — nothing copies a
parent's `TaskScheduler`, which is exactly what `WithTaskScheduler`'s own contract asks for (*"use
the grain's scheduler ONLY for the root grain hub"*). So the `sync/*` hubs in that incident run on
the default pool scheduler, where **M3 is unreachable and a dead activation scheduler cannot reach
them either**.

That narrows the candidate set for the incident to **M1-by-pool-starvation or M2** and leaves #3593
open — the same call #3615 made. What changes is that the next occurrence prints which one it is,
and that a real latch leak with the identical fingerprint can no longer be one of them.
