### PR TITLE
diag(#3704): a short source read now names its own mechanism

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-short-source-read-now-explains-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-short-source-read-now-explains-itself.md
@@ -1,0 +1,49 @@
+---
+Name: A short source read now explains itself
+Category: Fix
+Description: One boot resolved 91 fewer source files than its neighbours on the same portal and the same image, and nothing recorded enough to say why. The batched source discovery now reports, per query, how many result chunks it folded, what each contributed, and the largest gap between them — which is exactly what separates "the fold gave up too early" from "the providers returned less".
+Icon: Search
+Order: -20260909
+---
+
+Before it compiles anything, the platform pulls every source file in the mesh in one batched pass.
+On 2026-09-08 one boot of a portal pulled **1145** files where the boots on either side of it —
+three of them running the identical image — pulled 1236, 1237 and 1241. Content only grew across
+that window, so the short one was a truncation.
+
+The symptom has since stopped. The reason has not been found, and a fact that stops being visible
+stops being investigated.
+
+## Why it could not be answered
+
+The pass folds the query's answer as it streams in, and decides the answer is complete after **one
+second of silence**. It has no alternative: the result protocol carries no "this is the last of it"
+marker, so a quiet window is the only completion signal any reader of it can use. A gap between
+chunks wider than that window ends the fold early and hands the compiler a short list — silently.
+
+But an equally good explanation is that the providers simply returned less, in which case the
+window is innocent and the search belongs somewhere else entirely. Nothing recorded which.
+
+## What it records now
+
+Every source-discovery query reports, on completion:
+
+- how many result chunks were folded, and how many items each carried;
+- the **largest gap between consecutive chunks**, as a percentage of the completion window;
+- the settled file count.
+
+That is the discriminator, and both readings are printed on every pass:
+
+- a largest gap approaching the window ⇒ the completion rule ended the fold early, and the line
+  says so at warning level;
+- all gaps small ⇒ the completion rule is exonerated and the shortfall is upstream, in what the
+  providers actually returned.
+
+The wait for the *first* chunk is deliberately not counted — that is the query's latency, not a gap
+between chunks, and counting it would make every cold start accuse the fold.
+
+## What it deliberately does not do
+
+It does not widen the window, add a retry, or change what a short pass concludes — a short pass
+already costs the batch rather than a rollout. Making a symptom rarer while its mechanism is
+unmeasured is not a fix, and the fix waits on this number.

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text;
@@ -369,30 +370,161 @@ internal static class NodeTypeBatchBake
                 "BatchBake: source query '{Query}' carries its own limit: — discovery overrides it "
                 + "with {Limit}, because a truncated source set compiles WRONG", query, SourceDiscoveryLimit);
         var bounded = $"{query} limit:{SourceDiscoveryLimit}";
-        return Observable
-            // 🚨 .AsSystem() — batch-bake source discovery is framework infrastructure, not a
-            // user-scoped read, and this Defer's subscription does not carry the caller's ambient
-            // identity. Unstamped it would resolve as Anonymous and hand the compiler a silently
-            // TRUNCATED source set, which "compiles WRONG" exactly as the limit: note above warns.
-            // Declared on the request so no scheduler hop can lose it. See
-            // Doc/Architecture/QueryIdentity.
-            .Defer(() => meshService.Query<MeshNode>(new MeshQueryRequest
-            {
-                Query = bounded,
-                Limit = SourceDiscoveryLimit,
-            }.AsSystem()))
-            .Scan(
-                ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
-                NodeCompileShaping.ApplyQueryChange)
-            .Throttle(QueryQuietWindow)
-            .Take(1)
-            .SelectMany(nodes => nodes.Count < SourceDiscoveryLimit
-                ? Observable.Return(nodes)
-                : Observable.Throw<ImmutableDictionary<string, MeshNode>>(
-                    new SourceDiscoveryFailedException(
-                        $"source discovery query '{bounded}' returned {nodes.Count} node(s) — its own "
-                        + $"ceiling of {SourceDiscoveryLimit}, so the source set may be TRUNCATED and "
-                        + "no compile driven from it would be a verdict about the code")));
+        return Observable.Defer(() =>
+        {
+            // Per-SUBSCRIPTION state, created here rather than captured from outside: two
+            // concurrent discoveries of the same query text must not fold their chunk timings
+            // together, and nothing here is static (#3704).
+            var chunks = new ChunkTiming();
+            return Observable
+                // 🚨 .AsSystem() — batch-bake source discovery is framework infrastructure, not a
+                // user-scoped read, and this Defer's subscription does not carry the caller's ambient
+                // identity. Unstamped it would resolve as Anonymous and hand the compiler a silently
+                // TRUNCATED source set, which "compiles WRONG" exactly as the limit: note above warns.
+                // Declared on the request so no scheduler hop can lose it. See
+                // Doc/Architecture/QueryIdentity.
+                .Defer(() => meshService.Query<MeshNode>(new MeshQueryRequest
+                {
+                    Query = bounded,
+                    Limit = SourceDiscoveryLimit,
+                }.AsSystem()))
+                .Do(chunks.Observe)
+                .Scan(
+                    ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
+                    NodeCompileShaping.ApplyQueryChange)
+                .Throttle(QueryQuietWindow)
+                .Take(1)
+                .Do(nodes => chunks.Report(logger, bounded, nodes.Count, QueryQuietWindow))
+                .SelectMany(nodes => nodes.Count < SourceDiscoveryLimit
+                    ? Observable.Return(nodes)
+                    : Observable.Throw<ImmutableDictionary<string, MeshNode>>(
+                        new SourceDiscoveryFailedException(
+                            $"source discovery query '{bounded}' returned {nodes.Count} node(s) — its own "
+                            + $"ceiling of {SourceDiscoveryLimit}, so the source set may be TRUNCATED and "
+                            + "no compile driven from it would be a verdict about the code")));
+        });
+    }
+
+    /// <summary>
+    /// 🚨 <b>The discriminating measurement #3704 asks for, taken where the fold happens.</b>
+    ///
+    /// <para>On 2026-09-08 00:31:22Z one boot of memex resolved a source-discovery set <b>91 Code
+    /// nodes short</b> (1145 against 1236/1237/1241 on the same portal, three of them on the same
+    /// image), and content grows monotonically across that window — so it was a truncation, not a
+    /// smaller mesh. Two mechanisms could produce it and nothing recorded enough to tell them
+    /// apart:</para>
+    ///
+    /// <list type="number">
+    /// <item><b>The completion rule.</b> <see cref="RunQuery"/> decides a chunked query has
+    /// finished answering from <see cref="QueryQuietWindow"/> of silence, because
+    /// <c>QueryResultChange&lt;T&gt;</c> carries no terminal marker — there is no
+    /// "the initial set is complete" for any reader of that protocol. A chunk gap wider than the
+    /// window silently ends the fold and hands the compiler a short map.</item>
+    /// <item><b>An upstream shortfall</b> — the providers simply returned less, in which case the
+    /// window is innocent and the search moves to what answered.</item>
+    /// </list>
+    ///
+    /// <para><b>What this records, per query and per subscription:</b> how many
+    /// <c>QueryResultChange</c> events were folded, what each contributed, and the LARGEST
+    /// inter-chunk gap. That is the whole discriminator: a largest gap approaching the window
+    /// indicts the completion rule; all-small gaps exonerate it and point upstream. Both readings
+    /// are printed on every pass, so the next short read explains itself instead of being compared
+    /// against neighbouring boots by hand.</para>
+    ///
+    /// <para>🚨 It deliberately does NOT widen the window, add a retry, or change what a short pass
+    /// concludes. #3698 already made a short pass cost the batch rather than a rollout; widening a
+    /// bound to make a symptom rarer while the mechanism is unmeasured is the band-aid this
+    /// repository refuses. The fix waits on this number.</para>
+    ///
+    /// <para>Instance state, created per subscription inside the <c>Defer</c> — never static, and
+    /// the per-chunk counts are an <see cref="System.Collections.Immutable.ImmutableList{T}"/>
+    /// (fully qualified: <c>System.Reactive</c> ships one of the same name, and a bare cref is a
+    /// <c>CS0419</c> under -warnaserror). Timing is
+    /// <see cref="Stopwatch"/> ticks, not <c>DateTime</c>: the quantity is an interval.</para>
+    /// </summary>
+    internal sealed class ChunkTiming
+    {
+        /// <summary>Enough per-chunk counts to see the shape without turning a log line into a
+        /// page. A pass that exceeds it says so and keeps the count and the largest gap, which are
+        /// the two figures the verdict actually rests on.</summary>
+        private const int MaxRecordedCounts = 48;
+
+        private readonly Func<long> clock;
+        private readonly long startedTicks;
+        private long lastTicks;
+        private long largestGapTicks;
+        private int chunks;
+        private int items;
+        private ImmutableList<int> counts = ImmutableList<int>.Empty;
+
+        /// <summary>
+        /// <paramref name="clock"/> is <see cref="Stopwatch.GetTimestamp"/> in production and a
+        /// supplied tick source in a test — the same seam <c>RestartDeferredBy</c> uses for the
+        /// roll floor. It exists so the rule below can be pinned as a TRUTH TABLE rather than by
+        /// sleeping through a real inter-chunk gap: a test that waits out half a second to observe
+        /// a timing verdict measures the runner as much as the rule.
+        /// </summary>
+        /// <param name="clock">Monotonic tick source; defaults to <see cref="Stopwatch"/>.</param>
+        internal ChunkTiming(Func<long>? clock = null)
+        {
+            this.clock = clock ?? Stopwatch.GetTimestamp;
+            startedTicks = this.clock();
+            lastTicks = startedTicks;
+        }
+
+        /// <summary>Folds one change's timing and size. Called from the query's own emission
+        /// sequence, which is serial, so no gate is needed or wanted.</summary>
+        internal void Observe(QueryResultChange<MeshNode> change)
+        {
+            var now = clock();
+            var gap = now - lastTicks;
+            if (chunks > 0 && gap > largestGapTicks)
+                largestGapTicks = gap;
+            lastTicks = now;
+            chunks++;
+            var count = change.Items?.Count ?? 0;
+            items += count;
+            if (counts.Count < MaxRecordedCounts)
+                counts = counts.Add(count);
+        }
+
+        /// <summary>Prints the measurement, and says which way it points.</summary>
+        internal void Report(ILogger? logger, string query, int settled, TimeSpan window)
+        {
+            if (logger is null)
+                return;
+            var largestGapMs = Ms(largestGapTicks);
+            var elapsedMs = Ms(clock() - startedTicks);
+            var windowMs = window.TotalMilliseconds;
+            var share = windowMs > 0 ? largestGapMs / windowMs * 100 : 0;
+            var shape = counts.Count < chunks
+                ? string.Join(",", counts) + $",… ({chunks - counts.Count} more)"
+                : string.Join(",", counts);
+
+            logger.LogInformation(
+                "BatchBake: source discovery query '{Query}' settled at {Settled} node(s) from "
+                + "{Chunks} change(s) ({Items} item(s) delivered) in {ElapsedMs}ms. Largest "
+                + "inter-chunk gap {GapMs}ms = {Share}% of the {WindowMs}ms completion window. "
+                + "Per-chunk: [{Shape}].",
+                query, settled, chunks, items, elapsedMs,
+                largestGapMs.ToString("F0"), share.ToString("F0"), windowMs.ToString("F0"), shape);
+
+            // 🚨 The line that makes the next short read self-explaining. The threshold picks the
+            // LEVEL only — every number above is printed unconditionally, so a reader never depends
+            // on where it sits.
+            if (share >= 50)
+                logger.LogWarning(
+                    "BatchBake: source discovery query '{Query}' had an inter-chunk gap of {GapMs}ms "
+                    + "against a {WindowMs}ms completion window ({Share}%). A gap WIDER than that "
+                    + "window ends the fold early and hands the compiler a short source map — the "
+                    + "mechanism named in #3704, where one boot resolved 91 Code nodes short. This "
+                    + "pass settled at {Settled} node(s); compare it with the neighbouring boots on "
+                    + "THIS portal before concluding.",
+                    query, largestGapMs.ToString("F0"), windowMs.ToString("F0"),
+                    share.ToString("F0"), settled);
+        }
+
+        private static double Ms(long ticks) => ticks * 1000.0 / Stopwatch.Frequency;
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Test/SourceDiscoveryChunkTimingTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SourceDiscoveryChunkTimingTest.cs
@@ -1,0 +1,212 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using MeshWeaver.Hosting;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>#3704 — the discriminating measurement, and it has to be DELIVERED.</b>
+///
+/// <para>On 2026-09-08 00:31:22Z one boot of memex resolved a source-discovery set <b>91 Code nodes
+/// short</b> (1145 against 1236 / 1237 / 1241 on the same portal, three of them on the same image),
+/// and content grew monotonically across that window — a truncation, not a smaller mesh. Two
+/// mechanisms could produce it and nothing recorded enough to tell them apart: the fold's
+/// completion rule (a one-second quiet window, which is the ONLY completion signal
+/// <c>QueryResultChange&lt;T&gt;</c> offers a reader — the protocol carries no terminal marker), or
+/// an upstream shortfall in what the providers returned.</para>
+///
+/// <para>The largest inter-chunk gap separates them: approaching the window indicts the rule; all
+/// gaps small exonerates it and moves the search upstream. <c>NodeTypeBatchBake.ChunkTiming</c>
+/// records it, and this suite pins the rule as a truth table with an injected clock — a test that
+/// slept through a real half-second gap would measure the runner as much as the rule.</para>
+///
+/// <para>🚨 Every case asserts the LOG LINE, never a return value. A verdict nothing emits is worth
+/// exactly what the silence it replaced was worth — the lesson of #2553 and #3625, one diagnostic
+/// over, in this same repository.</para>
+/// </summary>
+public class SourceDiscoveryChunkTimingTest
+{
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(1);
+
+    /// <summary>Ticks for <paramref name="ms"/> on this machine's Stopwatch scale.</summary>
+    private static long Ticks(double ms) => (long)(ms * Stopwatch.Frequency / 1000.0);
+
+    /// <summary>
+    /// The measurement itself: chunk count, items delivered and the per-chunk shape all reach the
+    /// line. Without the shape a reader cannot tell "one big answer" from "forty dribbles", which
+    /// is the difference between the two mechanisms.
+    /// </summary>
+    [Fact]
+    public void TheReportCarriesTheChunkCountTheItemTotalAndTheShape()
+    {
+        var log = new Recorder();
+        var clock = new FakeClock();
+        var timing = new NodeTypeBatchBake.ChunkTiming(clock.Now);
+
+        clock.Advance(0);
+        timing.Observe(Change(3));
+        clock.Advance(10);
+        timing.Observe(Change(4));
+        clock.Advance(10);
+        timing.Observe(Change(2));
+
+        timing.Report(log, "nodeType:Code", settled: 9, Window);
+
+        var line = log.Single(LogLevel.Information);
+        line.Should().Contain("3 change(s)", "the number of folded changes is half the shape");
+        line.Should().Contain("9 item(s) delivered");
+        line.Should().Contain("[3,4,2]", "the per-chunk counts are what distinguish one answer from many");
+        line.Should().Contain("settled at 9 node(s)");
+        line.Should().Contain("nodeType:Code", "a reader has to know WHICH of the three global fetches this was");
+    }
+
+    /// <summary>
+    /// 🚨 The acceptance criterion, indicting side: a gap that is a large share of the completion
+    /// window is the mechanism #3704 names, and it is said at Warning — the level an operator's
+    /// filter actually keeps.
+    /// </summary>
+    [Fact]
+    public void AGapNearTheCompletionWindow_IsReportedAsTheNamedMechanism()
+    {
+        var log = new Recorder();
+        var clock = new FakeClock();
+        var timing = new NodeTypeBatchBake.ChunkTiming(clock.Now);
+
+        timing.Observe(Change(500));
+        clock.Advance(900);           // 90% of the 1000 ms window
+        timing.Observe(Change(645));
+
+        timing.Report(log, "nodeType:Code", settled: 1145, Window);
+
+        log.Single(LogLevel.Information).Should().Contain("900ms = 90%");
+        var warning = log.Single(LogLevel.Warning);
+        warning.Should().Contain("900ms");
+        warning.Should().Contain("#3704", "the line must carry the issue that explains it");
+        warning.Should().Contain("1145 node(s)",
+            "the settled count is what a reader compares against the neighbouring boots");
+    }
+
+    /// <summary>
+    /// 🚨 The control, and the half that keeps the diagnostic honest: small gaps must NOT be
+    /// reported as the mechanism. Without this, a rule that warned unconditionally would satisfy
+    /// the test above while telling every reader the same thing on every pass — which is the same
+    /// as telling them nothing.
+    /// </summary>
+    [Fact]
+    public void SmallGaps_AreMeasuredAndExonerateTheCompletionRule()
+    {
+        var log = new Recorder();
+        var clock = new FakeClock();
+        var timing = new NodeTypeBatchBake.ChunkTiming(clock.Now);
+
+        timing.Observe(Change(600));
+        clock.Advance(12);
+        timing.Observe(Change(636));
+
+        timing.Report(log, "nodeType:Code", settled: 1236, Window);
+
+        log.Single(LogLevel.Information).Should().Contain("12ms = 1%",
+            "the number is printed on EVERY pass — a reader never depends on where the threshold sits");
+        log.Lines(LogLevel.Warning).Should().BeEmpty(
+            "all gaps small means the completion rule did not end this fold early, so the search "
+            + "for a short read moves upstream to what the providers returned");
+    }
+
+    /// <summary>
+    /// The FIRST change has no predecessor, so the interval before it is not a gap. Counting it
+    /// would make every cold query — where the first answer legitimately takes hundreds of
+    /// milliseconds to arrive — indict the completion rule, and the diagnostic would be noise from
+    /// its first day.
+    /// </summary>
+    [Fact]
+    public void TheWaitForTheFIRSTChangeIsNotAnInterChunkGap()
+    {
+        var log = new Recorder();
+        var clock = new FakeClock();
+        var timing = new NodeTypeBatchBake.ChunkTiming(clock.Now);
+
+        clock.Advance(4000);          // four seconds of cold start before anything answers
+        timing.Observe(Change(1236));
+
+        timing.Report(log, "nodeType:Code", settled: 1236, Window);
+
+        log.Single(LogLevel.Information).Should().Contain("0ms = 0%",
+            "one change means no INTERVAL between changes; the wait for the first answer is the "
+            + "query's latency, not evidence about the fold's completion rule");
+        log.Lines(LogLevel.Warning).Should().BeEmpty();
+    }
+
+    /// <summary>A pass with more chunks than the line will print says so, and keeps the two figures
+    /// the verdict rests on — the count and the largest gap.</summary>
+    [Fact]
+    public void AVeryChunkyPass_TruncatesTheShapeAndSaysSo()
+    {
+        var log = new Recorder();
+        var clock = new FakeClock();
+        var timing = new NodeTypeBatchBake.ChunkTiming(clock.Now);
+
+        for (var i = 0; i < 60; i++)
+        {
+            clock.Advance(5);
+            timing.Observe(Change(1));
+        }
+
+        timing.Report(log, "nodeType:Code", settled: 60, Window);
+
+        var line = log.Single(LogLevel.Information);
+        line.Should().Contain("60 change(s)");
+        line.Should().Contain("more)", "the shape is capped, and a capped shape must announce itself");
+    }
+
+    private static QueryResultChange<MeshNode> Change(int count) =>
+        new()
+        {
+            ChangeType = QueryChangeType.Initial,
+            Items = [.. Enumerable.Range(0, count).Select(i => new MeshNode($"n{i}", "p"))],
+        };
+
+    /// <summary>A monotonic tick source the test advances by hand. No timer, no delay, no gate.</summary>
+    private sealed class FakeClock
+    {
+        private long ticks;
+
+        public long Now() => Volatile.Read(ref ticks);
+
+        public void Advance(double ms) => Interlocked.Add(ref ticks, Ticks(ms));
+    }
+
+    /// <summary>Captures what was actually logged, which is the property under test.</summary>
+    private sealed class Recorder : ILogger
+    {
+        private readonly ConcurrentQueue<(LogLevel Level, string Message)> lines = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter) =>
+            lines.Enqueue((logLevel, formatter(state, exception)));
+
+        public IReadOnlyList<string> Lines(LogLevel level) =>
+            [.. lines.Where(l => l.Level == level).Select(l => l.Message)];
+
+        public string Single(LogLevel level)
+        {
+            var found = Lines(level);
+            found.Count.Should().Be(1,
+                $"exactly one {level} line is expected; a diagnostic that fires zero times has "
+                + "asserted nothing and one that fires twice is noise. Captured: "
+                + string.Join(" | ", found));
+            return found[0];
+        }
+    }
+}


### PR DESCRIPTION
Refs #3704. 🚨 **This does not fix the short read** — it is the *"discriminating measurement — start
here, do not rebuild it"* the issue asks for, taken where the fold happens.

## The fact, and why nobody could answer it

On 2026-09-08 00:31:22Z one boot of `memex.systemorph.com` resolved a source-discovery set **91 Code
nodes short**: 1145, against 1236 / 1237 / 1241 on the same portal — three of those on the **same
image** — with content growing monotonically across the window. A truncation, not a smaller mesh.
The symptom has since stopped; the fact has not been explained, and #3704 exists because that is the
kind of fact that gets forgotten.

Two mechanisms produce it and nothing recorded enough to tell them apart:

1. **The completion rule.** `RunQuery` decides a chunked query has finished answering from one
   second of silence. It has no alternative — `QueryResultChange<T>` carries **no terminal
   marker**, so a quiet window is the only completion signal *any* reader of that protocol can use.
   A chunk gap wider than the window silently ends the fold and hands the compiler a short map.
2. **An upstream shortfall** — the providers returned less, the window is innocent, and the search
   belongs in the static catalog instead.

**The largest inter-chunk gap separates them**, and that is what this records.

## What it records

Per query, per subscription — folded into the existing pipeline as one `Do` before the `Scan` and
one after the `Take(1)`:

```
BatchBake: source discovery query 'nodeType:Code partitions:all limit:20000' settled at 1145
node(s) from 7 change(s) (1145 item(s) delivered) in 2412ms. Largest inter-chunk gap 900ms = 90%
of the 1000ms completion window. Per-chunk: [500,120,120,120,120,120,45].
```

and, when the gap is a large share of that window, a second line at Warning naming #3704 and the
settled count. **Both readings are printed on every pass**, so the threshold picks only the LEVEL
and no reader ever depends on where it sits:

- largest gap approaching the window ⇒ the completion rule ended the fold early;
- all gaps small ⇒ the rule is exonerated and the search moves upstream, to what the providers
  returned.

🚨 The wait for the **first** change is deliberately not a gap. That is the query's latency, and
counting it would make every cold start accuse the fold — the diagnostic would be noise from day
one. Pinned by its own case.

## Tests

`SourceDiscoveryChunkTimingTest` — 5 cases, **27 ms**, no timing and no delays: `ChunkTiming` takes
its tick source as a `Func<long>` (the seam `RestartDeferredBy` uses for the roll floor), so the
rule is a truth table rather than a test that sleeps through a real half-second gap and measures the
runner as much as the rule.

- the report carries the chunk count, the item total, the per-chunk shape and the query;
- a gap at 90% of the window ⇒ the Warning, naming #3704 and the settled count (the indicting side);
- a 1% gap ⇒ measured and printed, **no** Warning (the control — without it, a rule that warned
  unconditionally would pass the case above while telling every reader the same thing every time);
- a four-second wait for the FIRST chunk ⇒ `0ms = 0%`, no Warning;
- a 60-chunk pass truncates the shape **and says so**.

Every case asserts the **log line**, never a return value — a verdict nothing emits is worth what
the silence it replaced was worth (#2553, #3625, one diagnostic over in this same repository).

**Falsified:** drop the `chunks > 0 &&` guard so the first interval counts as a gap, and
`TheWaitForTheFIRSTChangeIsNotAnInterChunkGap` fails while the other four still pass.

## What it deliberately does not do

No widened window, no retry, no change to what a short pass concludes — #3698 already made a short
pass cost the batch rather than a rollout. Making a symptom rarer while its mechanism is unmeasured
is the band-aid this repository refuses, and the issue says so itself.

**If the next occurrence indicts the completion rule**, the durable fix is a terminal marker on
`QueryResultChange<T>` so the fold completes on a FACT rather than on a timeout. Worth noting it is
cheap and binary-safe: that record has **init properties only and no primary constructor**, so a new
`init` property adds no constructor signature to break. Deliberately not done here — it would be
fixing one of two hypotheses before the measurement that chooses between them.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.Hosting`,
`MeshWeaver.Documentation`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Documentation.Test` — 0 Warning(s),
0 Error(s) each. Tests below.

(One of those builds caught a `CS0419` on my own XML doc — `System.Reactive` ships an
`ImmutableList<T>` too, so the cref is fully qualified with a note saying why. That is the ambiguous-
cref break shape AGENTS.md lists as uncovered by the cross-repo gates; here `-warnaserror` caught it
locally.)

## Docs

What's New: *A short source read now explains itself* (`Category: Fix`).
