### PR TITLE
fix(#3510): the retyped-root recycle only runs when it has a job

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-teardown-with-no-job-no-longer-happens.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-teardown-with-no-job-no-longer-happens.md
@@ -1,0 +1,43 @@
+---
+Name: A teardown with no job no longer happens
+Category: Fix
+Description: After installing a package the platform tears down and re-activates that package's root, so the new hub binds the package's own configuration. It did that even when the install had written nothing at all — a teardown that could change nothing, which cancelled whatever work was in flight underneath it. It now runs only when the install actually rebuilt something, on the same condition as the recompiles either side of it.
+Icon: ArrowSync
+Order: -20260909
+---
+
+Installing a package ends with the package's root being recycled: the hub is torn down so the one
+that comes back binds the package's own configuration instead of the placeholder it was created
+with. That is worth doing when the install rebuilt the root's type — and only then.
+
+It ran unconditionally. Measured on a delivery run of 2026-09-08: one package logged
+**`0 written, 21 unchanged`** and recycled its root anyway, and another was recycled **twice in one
+bake**. Nothing could come of those teardowns — no type had been rebuilt, so the hub that came back
+bound exactly what the old one already had.
+
+They were not free. Each teardown cut off the correlated work in flight beneath the root — the
+root's own background reconcile — which the shutdown could not answer. It was force-cancelled at the
+shutdown's two-second window and reached the caller as *"the hub was disposed before the response
+arrived"*.
+
+## What changed
+
+The recycle now runs only when the install wrote something. That is the same condition the two
+recompile waves on either side of it already used, and the inconsistency was the bug: the waves knew
+an install that changed nothing has nothing to recompile, while the teardown between them did not.
+
+## And the log line stopped over-promising
+
+It used to end *"Work in flight beneath this root is answered by the teardown, not abandoned."* That
+was measurably untrue — pending work was force-cancelled at the window, not answered — and a
+diagnostic asserting a guarantee the code does not keep is worse than one that says nothing, because
+it sends the next reader looking for a different cause. It now says what actually happens: work gets
+the shutdown window, and anything still pending at that bound is cancelled and surfaces to whoever
+issued it.
+
+## What this does not fix
+
+An install that *did* write still recycles a root whose background pipeline may be issuing requests,
+and a hub that keeps accepting new work while it is shutting down is a separate defect. What is gone
+is the class where the teardown could accomplish nothing — removed by making the recycle agree with
+its neighbours, not by widening any window.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1562,11 +1562,58 @@ public static class PackageInstaller
     /// skipped), and it WAITS for the root to answer before the install proceeds. Called only when
     /// the placeholder dance actually ran, i.e. when there is a placeholder binding to replace.</para>
     /// </summary>
+    /// <summary>
+    /// 🚨 <b>Why this install would NOT recycle its root, or <c>null</c> when it should — pure, so
+    /// the rule is pinned without a mesh (#3510).</b>
+    ///
+    /// <para>The recycle exists for exactly one purpose: after the root's in-package NodeType has
+    /// been REBUILT, tear the root down so the hub that comes back binds the package's own
+    /// configuration instead of the fallback. An install that wrote NOTHING rebuilt nothing — the
+    /// two <c>RequestReleases</c> waves this recycle sits between are both gated on
+    /// <c>result.Written &gt; 0</c> for that very reason — so there is nothing to rebind to, and
+    /// the teardown is pure loss.</para>
+    ///
+    /// <para><b>And it is not a theoretical loss.</b> Measured on CD run 34190841613
+    /// (2026-09-08): package <c>Video</c> logged <c>0 written, 21 unchanged</c> and recycled its
+    /// root anyway, and <c>Chess</c> was recycled TWICE per bake. Each teardown killed the
+    /// correlated work in flight beneath the root — its own <c>PluginGating</c> reconcile — which
+    /// the quiesce could not answer and force-cancelled at its 2 s bound, surfacing as
+    /// <c>HubDisposedBeforeResponseException</c>.</para>
+    ///
+    /// <para>🚨 This does NOT fix the case where an install DID write: a recycle that has a job to
+    /// do still tears down a root whose background pipeline is issuing correlated requests, and
+    /// a hub that keeps accepting work while quiescing is its own defect (#3261's family). What
+    /// this removes is the class where the teardown was provably pointless — and it removes it by
+    /// making the recycle agree with the two waves around it, not by widening a bound.</para>
+    /// </summary>
+    /// <param name="rootPath">The retyped root, or null when the placeholder dance did not run.</param>
+    /// <param name="written">How many nodes this install actually wrote.</param>
+    /// <returns>The sentence to log, or <c>null</c> when the recycle should proceed.</returns>
+    internal static string? RecycleDeclineReason(string? rootPath, int written)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath))
+            return null;   // nothing to recycle; the caller returns before logging anything
+        return written > 0
+            ? null
+            : "this install wrote nothing, so its in-package NodeType was not rebuilt (the release "
+              + "waves either side of the recycle are gated on the same condition) and a fresh hub "
+              + "would bind exactly what the current one already has. The teardown would only "
+              + "cancel the work in flight beneath the root.";
+    }
+
     private static IObservable<Unit> SettleRetypedRoot(
-        IMessageHub hub, string? rootPath, IReadOnlyCollection<MeshNode> nodes, ILogger? logger)
+        IMessageHub hub, string? rootPath, IReadOnlyCollection<MeshNode> nodes, int written,
+        ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(rootPath))
             return Observable.Return(Unit.Default);
+
+        if (RecycleDeclineReason(rootPath, written) is { } declined)
+        {
+            logger?.LogInformation(
+                "[PackageInstaller] not recycling root {Root}: {Reason}", rootPath, declined);
+            return Observable.Return(Unit.Default);
+        }
 
         return MayPublishIntoRoot(hub, rootPath!, nodes, logger)
             .SelectMany(rebindable =>
@@ -1601,10 +1648,19 @@ public static class PackageInstaller
                 // the next occurrence a read instead of a reconstruction. Information, not Debug:
                 // it is one line per package install, it names a deliberate teardown of a live
                 // hub, and the reader needing it is looking at a failed install, not a trace.
+                // 🚨 The second sentence used to read "Work in flight beneath this root is answered
+                // by the teardown, not abandoned." That is FALSE as written, and it was measured
+                // false: on CD 34190841613 the pending CreateOrUpdateNodeRequest was neither
+                // answered nor NACKed — the quiesce force-cancelled it at its 2 s bound and it
+                // reached its issuer as HubDisposedBeforeResponseException. A diagnostic that
+                // asserts a guarantee the code does not keep is worse than one that says nothing:
+                // it sends the next reader looking for a different cause (#3510).
                 logger?.LogInformation(
                     "[PackageInstaller] recycling root {Root} now that its in-package NodeType has a "
                     + "loadable build — the hub re-activates against the package's own configuration. "
-                    + "Work in flight beneath this root is answered by the teardown, not abandoned.",
+                    + "Work in flight beneath this root is given the quiesce window to finish; "
+                    + "anything still pending at that bound is force-cancelled and surfaces to its "
+                    + "issuer as HubDisposedBeforeResponseException.",
                     rootPath);
                 using (accessService?.ImpersonateAsSystem())
                     hub.NodeOperationIssuingHub()
@@ -3056,7 +3112,7 @@ public static class PackageInstaller
                     // its rebuild, so the hub that comes back binds the package's own configuration
                     // instead of the fallback — and the install no longer returns while a teardown
                     // it started is still running.
-                    .SelectMany(pruned => SettleRetypedRoot(hub, retypedRoot, nodes, logger)
+                    .SelectMany(pruned => SettleRetypedRoot(hub, retypedRoot, nodes, result.Written, logger)
                         .Select(_ => pruned))
                     // …and ONLY NOW the rest of the package's types. Their compiles read the root
                     // (ValidateCellSurfaceSingleHome → GetMeshNode('<packageRoot>') for every

--- a/test/Memex.Portal.Shared.Test/RetypedRootRecycleNeedsAJobTest.cs
+++ b/test/Memex.Portal.Shared.Test/RetypedRootRecycleNeedsAJobTest.cs
@@ -1,0 +1,77 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>#3510 — a teardown that cannot accomplish anything must not happen.</b>
+///
+/// <para><c>PackageInstaller</c> recycles a package's root after an install so the hub that comes
+/// back binds the package's OWN configuration rather than the fallback. That is worth a teardown
+/// only when the root's in-package NodeType was actually rebuilt — and the two
+/// <c>RequestReleases</c> waves the recycle sits between are both gated on
+/// <c>result.Written &gt; 0</c> for exactly that reason. The recycle alone ran unconditionally.</para>
+///
+/// <para><b>Measured on CD run 34190841613 (2026-09-08):</b> package <c>Video</c> logged
+/// <c>0 written, 21 unchanged</c> and recycled its root anyway; <c>Chess</c> was recycled TWICE per
+/// bake. Each teardown killed the correlated work in flight beneath the root — its own
+/// <c>PluginGating</c> reconcile — which the quiesce could not answer and force-cancelled at its
+/// 2 s bound, surfacing to the issuer as <c>HubDisposedBeforeResponseException</c>.</para>
+///
+/// <para>🚨 <b>What this does NOT claim.</b> It does not fix the case where an install DID write.
+/// A recycle with a real job still tears down a root whose background pipeline is issuing
+/// correlated requests, and a hub that keeps accepting work while quiescing is its own defect.
+/// This removes only the class where the teardown was provably pointless, and it removes it by
+/// making the recycle agree with its neighbours rather than by widening any bound.</para>
+///
+/// <para>🚨 It lives HERE, next to the self-update suites, rather than beside the installer: the
+/// rule is an <c>internal</c> of <c>MeshWeaver.PluginCatalog</c>, and this is the only test project
+/// in THIS repository that both references that assembly and appears in its
+/// <c>InternalsVisibleTo</c> list (<c>MeshWeaver.PluginCatalog.Test</c> lives in
+/// MeshWeaver.Plugins). Moving the assembly's tests is a bigger change than this fix.</para>
+/// </summary>
+public class RetypedRootRecycleNeedsAJobTest
+{
+    /// <summary>
+    /// 🚨 THE REGRESSION CASE. A re-install that changed nothing rebuilt nothing, so the recycle
+    /// has nothing to rebind to — and the sentence has to SAY that, because a silent skip and a
+    /// skip nobody chose read identically in a log.
+    /// </summary>
+    [Fact]
+    public void AnInstallThatWroteNothing_DoesNotRecycleAndSaysWhy()
+    {
+        var reason = PackageInstaller.RecycleDeclineReason("Video", written: 0);
+
+        Assert.NotNull(reason);
+        Assert.Contains("wrote nothing", reason);
+        Assert.Contains("not rebuilt", reason);
+        Assert.Contains("cancel the work in flight", reason);
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL. An install that wrote SOMETHING did rebuild the in-package type, and the
+    /// recycle is the whole point of the ordering it sits in (#1732). Without this case a
+    /// predicate that declined every recycle would satisfy the test above while silently
+    /// re-breaking the binding the recycle exists to fix.
+    /// </summary>
+    [Fact]
+    public void AnInstallThatWroteSomething_StillRecycles()
+        => Assert.Null(PackageInstaller.RecycleDeclineReason("Video", written: 1));
+
+    /// <summary>
+    /// No retyped root means the placeholder dance never ran, so there is no binding to replace
+    /// and the caller returns before it would log anything. Null — never a decline SENTENCE, which
+    /// would report a skip that is not a decision.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoRetypedRoot_IsNotADecline(string? rootPath)
+    {
+        Assert.Null(PackageInstaller.RecycleDeclineReason(rootPath, written: 0));
+        Assert.Null(PackageInstaller.RecycleDeclineReason(rootPath, written: 5));
+    }
+}


### PR DESCRIPTION
Refs #3510. 🚨 **This does not close it** — it removes the class of these teardowns that could
accomplish nothing, and corrects a diagnostic that was measurably lying. The case where an install
*did* write is untouched and is what keeps the issue open.

## The disposer is named; this is the half of it that is pure loss

#3510's central question was answered by measurement in the thread: the disposer is
`PackageInstaller.SettleRetypedRoot` — the installer's own retyped-root recycle — read off #3603's
"THE RECYCLE NAMES ITSELF" line on CD run 34190841613 (2026-09-08). Two facts in that same trace are
the subject here:

- package **`Video`** logged `0 written, 21 unchanged` and **recycled its root anyway**;
- package **`Chess`** was recycled **twice per bake**, each teardown killing a `PluginGating`
  reconcile pass.

## The inconsistency, in one chain

`SettleRetypedRoot` exists for exactly one purpose: after the root's in-package NodeType has been
**rebuilt**, tear the root down so the hub that comes back binds the package's own configuration
instead of the fallback. An install that wrote nothing rebuilt nothing — and the code already knows
that, twice, on either side of the recycle:

```csharp
.SelectMany(pruned => (result.Written > 0 ? RequestReleases(hub, firstWave, logger)    : …))   // gated
.SelectMany(pruned =>  SettleRetypedRoot(hub, retypedRoot, nodes, logger))                     // NOT gated
.SelectMany(pruned => (result.Written > 0 ? RequestReleases(hub, deferredWave, logger) : …))   // gated
```

`retypedRoot` is non-null whenever the package has a root with a non-static NodeType
(`placeholderRoot is not null ? root?.Path : null`) — which is true on **every** install of such a
package, including a re-install that changed nothing. So the recycle ran unconditionally between two
neighbours that both refuse to do anything on a no-op install.

The teardown was not free. It cut off the correlated work in flight beneath the root — the root's own
`PluginGating` reconcile — which the quiesce could not answer and force-cancelled at its 2 s bound,
reaching the issuer as `HubDisposedBeforeResponseException`.

**The fix is to make the recycle agree with its neighbours**, not to widen a bound.
`RecycleDeclineReason(rootPath, written)` is the rule, pure, and the decline is *said* — a silent
skip and a skip nobody chose read identically in a log.

## And the log line stopped over-promising

It ended: *"Work in flight beneath this root is answered by the teardown, not abandoned."*

Measured false in the same trace — the pending `CreateOrUpdateNodeRequest` was neither answered nor
NACKed; it was force-cancelled at the quiesce bound. A diagnostic that asserts a guarantee the code
does not keep is worse than one that says nothing: it sends the next reader looking for a different
cause, which is precisely what the archaeology on CD 7950 had to undo. It now says what happens —
work gets the quiesce window, and anything pending at that bound is force-cancelled and surfaces as
`HubDisposedBeforeResponseException`.

## Tests

`RetypedRootRecycleNeedsAJobTest` — 5 cases, 22 ms, pure:

- **`AnInstallThatWroteNothing_DoesNotRecycleAndSaysWhy`** — the regression case, and it asserts the
  sentence, not just the decision;
- **`AnInstallThatWroteSomething_StillRecycles`** — the control. Without it, a predicate that
  declined *every* recycle would pass the case above while silently re-breaking the binding the
  recycle exists to fix (#1732);
- no-retyped-root ⇒ **null, never a decline sentence** — reporting a skip that is not a decision is
  its own noise.

**Falsified:** make `RecycleDeclineReason` never decline and only
`AnInstallThatWroteNothing_DoesNotRecycleAndSaysWhy` fails; the other four still pass.

🚨 The test lives in `Memex.Portal.Shared.Test` rather than beside the installer because the rule is
an `internal` of `MeshWeaver.PluginCatalog`, and that is the only test project **in this repository**
which both references the assembly and appears in its `InternalsVisibleTo`
(`MeshWeaver.PluginCatalog.Test` lives in MeshWeaver.Plugins). Said out loud rather than left as a
puzzle.

## What this does NOT fix — and why #3510 stays open

An install that *did* write still recycles a root whose background pipeline is issuing correlated
requests, and the quiesce still force-cancels whatever is outstanding at 2 s. The thread's own
reading names the deeper half: the trace reads `RECEIVED runLevel=Quiescing@Chess`, i.e. **the root
kept taking correlated work from its own pipeline while being torn down under it** — a hub accepting
new work past quiesce, which is its own defect and its own family. Merging that into this change
would be conflating two mechanisms, and widening the 2 s window would be the band-aid this
repository refuses.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.PluginCatalog`,
`MeshWeaver.Documentation`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` —
0 Warning(s), 0 Error(s) each. Tests below.

## Docs

What's New: *A teardown with no job no longer happens* (`Category: Fix`).
