### PR TITLE
fix(#2543): node-CRUD response continuations leave the responding hub's block

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -319,6 +319,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Disposable-mesh e2e](DisposableMeshE2E)
 - [Debugging Message Flow](DebuggingMessageFlow)
 - [Debugging Disposal & Leaks](DebuggingDisposalAndLeaks)
+- [Detached Response Continuations](DetachedResponseContinuations) — why a `hub.Observe(...)` continuation runs on the RESPONDING hub's action block, what that cost on the mesh's one node-CRUD hub, and the six invariants that make the hop an opt-in rather than the default
 - [Reading a Disposal Stall Verdict](DisposalStallVerdicts) — what each field of the disposal snapshot actually measures, the three that were read as evidence while measuring nothing, and the verdict hole that sent 47 reports to children that were not the problem
 - [Ambient Test-Host Hangs](AmbientTestHostHangs) — what decides whether a killed test host can be diagnosed at all, and the readings of it already falsified
 - [In-Mesh Tests and the Seal](InMeshTestsAndTheSeal) — a Tests area no required context executes is a latent trunk red the seal detonates fleet-wide; how to measure a gate before requiring it

--- a/src/MeshWeaver.Documentation/Data/Architecture/DetachedResponseContinuations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DetachedResponseContinuations.md
@@ -1,0 +1,105 @@
+---
+Name: Detached Response Continuations
+Category: Architecture
+Description: Why a hub.Observe(...) continuation runs on the RESPONDING hub's action block, what that cost on the mesh's one node-CRUD hub, and why the hop off the block is declared per request type instead of applied to everything — the six invariants the block underwrites, and the crash that found them.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+---
+
+# Detached Response Continuations
+
+**A response subject is signalled from INSIDE the turn that handled the response. Rx runs a
+continuation on whichever thread signalled it. So the whole remainder of every
+`hub.Observe(x).SelectMany(…)` chain in the framework executes ON THE RESPONDING HUB'S ACTION
+BLOCK, inside that turn — and the turn cannot end until the chain does.**
+
+That is not a defect on its own. A hub processes one turn at a time by design, and for most requests
+the caller's follow-up is a `Select` that finishes in microseconds. It becomes a defect the moment a
+single hub is the execution point for an operation the whole mesh performs.
+
+## 1. What it cost, measured
+
+`portal/nodeops-{meshId}` is the mesh's **one** node-CRUD execution hub. Every create, delete, move
+and copy goes through it.
+
+A create is well-behaved: it returns `Processed()` in about a millisecond and detaches its pipeline.
+But that pipeline does a partition bootstrap, whose nested response comes back to **the same hub**,
+and the rest of the create — validators, save, change feed — ran inline in that response's turn.
+
+With one create parked inside its validator, a second and entirely unrelated create sat unprocessed:
+
+```
+Queue(buffer=1,deferred=0,openGates=0,drainsInFlight=1,draining=True)
+Executing(CreateNodeResponse, 24913ms)
+```
+
+Every node write in the mesh serialised behind one create's continuation. Delete, move and copy
+inherit it identically — they await nested node ops the same way. That is
+[#2543](https://github.com/Systemorph/MeshWeaver/issues/2543), and
+[#3674](https://github.com/Systemorph/MeshWeaver/issues/3674) is the same hub reached from a release
+gate: a `CreateOrUpdateNodeRequest` recorded `RECEIVED` and `ENQUEUED` on `portal/nodeops` and never
+a routing verdict.
+
+🚨 **`Executing(T, N ms)` is a LIFETIME, not occupancy.** The field is cleared in the handler
+observable's `.Finally`, so it measures how long the handler's observable has been alive — not how
+long the block has been held. `buffer=N` is the occupancy signal. Three sessions misread the 24.9 s
+capture as "the block was held for 24.9 s"; what it says is "the handler's chain has been alive that
+long", and the queued second create is what proves the block was unavailable.
+
+## 2. The fix, and why it is an OPT-IN
+
+The hop itself is one line — `ObserveOn` onto a pooled scheduler, before the identity restore so
+`.Do(SetContext)` runs on the thread that will run the continuation.
+
+Applying it to **every** `hub.Observe(…)` was tried first. It crashed the test host **seven times**,
+and each crash named an invariant the action block had been underwriting that nobody had written
+down:
+
+| # | what the block was also providing |
+|---|---|
+| 1 | **An error boundary.** A throw from a `Subscribe` callback was a turn fault the pump caught, logged and answered. Off the block it is an unhandled exception on a scheduler thread — process death. |
+| 2 | **A disposal fence.** A continuation that runs inside a turn cannot outlive the scope it resolves services from. Off the block it can, and does. |
+| 3 | **A concurrency bound.** One turn at a time is also a limit on how many continuations run at once. `ObserveOn` with a scheduler that advertises `ISchedulerLongRunning` gives Rx `ObserveOnObserverLongRunning` — **one drain worker per subscription**, i.e. a thread per in-flight request. |
+| 4 | **An impersonation scope.** `AsyncLocal` identity set by `RunAs` is still in scope on the block; a continuation that leaves it resumes without one unless the identity is re-seeded on the new thread. |
+| 5 | **Ordering between a response and later messages** to the same hub. |
+| 6 | **Whatever `LogonActionRunner.RunFor` relies on** — its own comment says the identity is scoped with `RunAs`, *never* `Observable.Using(access.ImpersonateAsSystem, …)`, precisely because impersonation is an AsyncLocal store/restore. |
+
+So the hop is declared **per request type**, by
+`MeshWeaver.Messaging.IDetachedResponseContinuation`, and every other request keeps the semantics it
+has always had. The node-CRUD requests declare it; nothing else does.
+
+🚨 **Do not widen this marker to "requests that feel slow".** The criterion is not latency — it is
+whether the responding hub is a SHARED EXECUTION POINT whose availability other work depends on.
+`portal/nodeops` is; a per-node hub answering its own reads is not.
+
+## 3. The two fences that make the hop survivable
+
+**A pooled scheduler that withholds `ISchedulerLongRunning`.** `PooledContinuationScheduler` wraps
+`TaskPoolScheduler.Default` and deliberately does not implement it, because `ObserveOn` uses the
+long-running path when it is offered. That is invariant 3 above, and it is why Rx's own
+`TaskPoolScheduler` and `DefaultScheduler` cannot be used directly — both advertise it.
+
+**A fault fence that REPORTS AND TERMINATES.** `GuardContinuationFaults` catches what an observer
+callback throws, reports it, and then `OnError`s the sequence.
+
+🚨 The first version only reported, and that turned a crash into a **hang**: the caller's sequence
+stayed open forever waiting for an emission that could never come. Rx's own contract is that a
+throwing observer ends the subscription, and the pump did the same — it logged and failed the
+delivery, so the caller got an answer. A fence that swallows is not a fence.
+
+## 4. Where it lives
+
+- `src/MeshWeaver.Messaging.Contract/IDetachedResponseContinuation.cs` — the marker, and why it is
+  an opt-in.
+- `src/MeshWeaver.Messaging.Hub/MessageHub.cs` — `ContinueOffBlockIfDeclared`,
+  `GuardContinuationFaults`, `ReportContinuationFault`.
+- `src/MeshWeaver.Messaging.Hub/PooledContinuationScheduler.cs` — the withheld capability.
+- `src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs` — the six node-CRUD requests that declare it.
+- `test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs` — the behavioural
+  proof, its positive control, and `TwoCreates_AreInFlightSimultaneously`.
+
+## 5. What this does NOT fix
+
+A hub whose pump does not turn at all is a different failure, and it looks identical from outside.
+See [Reading a Disposal Stall Verdict](/Doc/Architecture/DisposalStallVerdicts) for the three
+mechanisms and the counters that tell them apart — `drainsInFlight`, `drainsAwaitingScheduler` — and
+[#3593](https://github.com/Systemorph/MeshWeaver/issues/3593) for the open half.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-node-writes-no-longer-queue-behind-one-another.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-node-writes-no-longer-queue-behind-one-another.md
@@ -1,0 +1,41 @@
+---
+Name: Node writes no longer queue behind one another
+Category: Fix
+Description: Every create, delete, move and copy in the mesh runs through one execution hub, and that hub processes one thing at a time. The caller's own follow-up work was running there too — so while one create sat waiting inside a validator, every unrelated node write in the mesh waited with it. The follow-up work now leaves that hub, and the writes run in parallel.
+Icon: Flash
+Order: -20260909
+---
+
+A hub handles one message at a time. That is the point of it — it is what makes a node's state safe
+to change without locks.
+
+When you ask a hub for something and then do more work with the answer, that follow-up work was
+running **on the hub that answered**, inside the same turn. The hub could not move on to its next
+message until your follow-up finished.
+
+For most requests that is invisible. For node writes it was not: **every create, delete, move and
+copy in the mesh goes through one execution hub**. A create returns its acknowledgement in about a
+millisecond and detaches — but the rest of the work (a partition bootstrap, the validators, the
+save, the change feed) hung off the answer to a nested request, and that answer came back to the
+same hub. So the whole tail of one create ran inside that hub's turn.
+
+With a single create waiting inside a validator, a second and entirely unrelated create sat
+unprocessed for the full budget. Every node write in the mesh was serialised behind one.
+
+## What changed
+
+The follow-up work for node writes now leaves that hub as soon as the answer arrives. The hub takes
+its next message immediately, so writes that have nothing to do with each other proceed at the same
+time.
+
+## Why only node writes
+
+Because doing it for everything is not safe, and that was measured rather than assumed. A hub's
+single-file processing is not only about ordering — it is also where an error is caught, where
+teardown is fenced, and where the caller's identity is still in scope. Moving *every* follow-up off
+it crashed the test host repeatedly and broke several guarantees nobody had written down.
+
+So the behaviour is declared by the requests that need it — the node write operations — and every
+other request keeps exactly the semantics it had. A follow-up that has left the hub is fenced
+separately: if it throws, the error is reported and the caller's sequence ends, rather than
+surfacing unhandled on a background thread and taking the process down.

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -14,7 +14,8 @@ namespace MeshWeaver.Mesh;
 /// </summary>
 /// <param name="Node">The MeshNode to create</param>
 [CreateNodePermission]
-public record CreateNodeRequest(MeshNode Node) : IRequest<CreateNodeResponse>, IDiagnosticKeyed
+public record CreateNodeRequest(MeshNode Node)
+    : IRequest<CreateNodeResponse>, IDiagnosticKeyed, IDetachedResponseContinuation
 {
     /// <summary>
     /// The path of the node being created — so a bulk fan-out (N creates for N DISTINCT paths from
@@ -150,7 +151,8 @@ public enum NodeCreationRejectionReason
 /// </summary>
 /// <param name="Nodes">The MeshNodes to create, in the order they must land.</param>
 [CreateNodesPermission]
-public record CreateNodesRequest(ImmutableList<MeshNode> Nodes) : IRequest<CreateNodesResponse>
+public record CreateNodesRequest(ImmutableList<MeshNode> Nodes)
+    : IRequest<CreateNodesResponse>, IDetachedResponseContinuation
 {
     /// <summary>
     /// The user or system requesting the creation — resolution identical to
@@ -275,7 +277,8 @@ public class CreateNodesPermissionAttribute() : RequiresPermissionAttribute(Perm
 /// </summary>
 /// <param name="Path">The path of the node to delete</param>
 [RequiresPermission(Permission.Delete)]
-public record DeleteNodeRequest(string Path) : IRequest<DeleteNodeResponse>, IDiagnosticKeyed
+public record DeleteNodeRequest(string Path)
+    : IRequest<DeleteNodeResponse>, IDiagnosticKeyed, IDetachedResponseContinuation
 {
     /// <summary>
     /// The path being deleted — tells a wide prune (N distinct paths) apart from one delete
@@ -432,7 +435,8 @@ public enum NodeDeletionRejectionReason
 /// Both checks run through the standard permission pipeline.</para>
 /// </summary>
 [CreateOrUpdateNodePermission]
-public record CreateOrUpdateNodeRequest(MeshNode Node) : IRequest<CreateOrUpdateNodeResponse>, IDiagnosticKeyed
+public record CreateOrUpdateNodeRequest(MeshNode Node)
+    : IRequest<CreateOrUpdateNodeResponse>, IDiagnosticKeyed, IDetachedResponseContinuation
 {
     /// <summary>
     /// The path being upserted. This is THE bulk verb — <c>StaticRepoImporter</c> issues one per
@@ -570,7 +574,8 @@ public class CreateOrUpdateNodePermissionAttribute() : RequiresPermissionAttribu
 /// </summary>
 /// <param name="SourcePath">The path to copy from.</param>
 /// <param name="TargetPath">The path to copy to.</param>
-public record CopyNodeRequest(string SourcePath, string TargetPath) : IRequest<CopyNodeResponse>, IDiagnosticKeyed
+public record CopyNodeRequest(string SourcePath, string TargetPath)
+    : IRequest<CopyNodeResponse>, IDiagnosticKeyed, IDetachedResponseContinuation
 {
     /// <summary>
     /// The target path — the thing being produced. Tells a wide copy fan-out apart from one copy
@@ -701,7 +706,8 @@ public enum NodeCopyRejectionReason
 /// <param name="SourcePath">The current path of the node</param>
 /// <param name="TargetPath">The new path for the node</param>
 [MoveNodePermission]
-public record MoveNodeRequest(string SourcePath, string TargetPath) : IRequest<MoveNodeResponse>, IDiagnosticKeyed
+public record MoveNodeRequest(string SourcePath, string TargetPath)
+    : IRequest<MoveNodeResponse>, IDiagnosticKeyed, IDetachedResponseContinuation
 {
     /// <summary>
     /// The source path — the node being moved. Tells a wide move fan-out apart from one move

--- a/src/MeshWeaver.Messaging.Contract/IDetachedResponseContinuation.cs
+++ b/src/MeshWeaver.Messaging.Contract/IDetachedResponseContinuation.cs
@@ -1,0 +1,34 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// 🚨 <b>A request whose RESPONSE continuation must not resume on the responding hub's action
+/// block</b> — the opt-in that stops one hub's queue from serialising work that has nothing to do
+/// with it (#2543).
+///
+/// <para><b>Why a continuation ends up there at all.</b> A response subject is signalled from
+/// INSIDE the turn that handled the response, and Rx runs a continuation on whichever thread
+/// signalled it. So the whole remainder of every <c>hub.Observe(x).SelectMany(…)</c> chain executes
+/// on the RESPONDING hub's action block, inside that turn — and a hub processes one turn at a
+/// time, so the turn cannot end until the chain does.</para>
+///
+/// <para><b>What that costs, measured.</b> On <c>portal/nodeops</c> — the mesh's ONE node-CRUD
+/// execution hub — a create correctly returns <c>Processed()</c> in about a millisecond and detaches
+/// its pipeline. The pipeline then does a partition bootstrap whose nested response comes back to
+/// the SAME hub, and the rest of the create (validators, save, change feed) ran inline in that
+/// response's turn. With one create parked in its validator, a second, unrelated create sat
+/// unprocessed at <c>Queue(buffer=1,…) Executing(CreateNodeResponse, …)</c> for the whole budget:
+/// every node write in the mesh serialised behind one create's continuation. Delete, move and copy
+/// inherit it identically.</para>
+///
+/// <para>🚨 <b>Why this is an OPT-IN and not the default.</b> Hopping every response continuation
+/// off the block was tried and is not safe: the action block is not only a serialiser, it is an
+/// ERROR BOUNDARY and a DISPOSAL FENCE, and it is where an impersonation <c>AsyncLocal</c> is
+/// still in scope. Moving every continuation off it crashed the test host repeatedly and broke
+/// several invariants that had never been written down. So the hop is declared per REQUEST TYPE, by
+/// the requests whose continuations demonstrably must not hold a shared execution hub, and every
+/// other request keeps the semantics it has always had.</para>
+///
+/// <para>A marker: no members, nothing to implement. Requests declare it; the hub reads it
+/// (<c>MessageHub.Observe</c>).</para>
+/// </summary>
+public interface IDetachedResponseContinuation;

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1021,7 +1021,8 @@ public sealed class MessageHub : IMessageHub
         // registration would read as "nothing was ever posted" — the opposite of the truth (#981).
         requestFates.Find(delivery.Id)?.Add(
             "REGISTERED_AFTER_POST (Observe(delivery) overload — earlier stages not recorded)", Address);
-        return RestoreUserContextOnEmission(observable, delivery.AccessContext);
+        return ContinueOffBlockIfDeclared(
+            RestoreUserContextOnEmission(observable, delivery.AccessContext), delivery.Message);
     }
 
     /// <summary>
@@ -1065,11 +1066,13 @@ public sealed class MessageHub : IMessageHub
             requestFates.Find(messageId)?.Add($"POST_THREW {postEx.GetType().Name}: {postEx.Message}", Address);
             throw;
         }
-        return RestoreUserContextOnEmission(
-            WrapWithCancelOnDispose(
-                ApplyTimeout(subject, requestType, probeOptions.Target, messageId),
-                messageId, subject),
-            capturedCtx);
+        return ContinueOffBlockIfDeclared(
+            RestoreUserContextOnEmission(
+                WrapWithCancelOnDispose(
+                    ApplyTimeout(subject, requestType, probeOptions.Target, messageId),
+                    messageId, subject),
+                capturedCtx),
+            r);
     }
 
     /// <summary>
@@ -1110,11 +1113,13 @@ public sealed class MessageHub : IMessageHub
             }
             return null;
         }
-        return RestoreUserContextOnEmission(
-            WrapWithCancelOnDispose(
-                ApplyTimeout(subject, requestType, probeOptions.Target, messageId),
-                messageId, subject),
-            capturedCtx);
+        return ContinueOffBlockIfDeclared(
+            RestoreUserContextOnEmission(
+                WrapWithCancelOnDispose(
+                    ApplyTimeout(subject, requestType, probeOptions.Target, messageId),
+                    messageId, subject),
+                capturedCtx),
+            r);
     }
 
     private IObservable<IMessageDelivery> ObserveById(string messageId,
@@ -1169,6 +1174,103 @@ public sealed class MessageHub : IMessageHub
     /// hub-impersonation), and any post made from the Subscribe callback inherits the wrong
     /// identity — surfaces as <c>Access denied: user '&lt;cell-hub-path&gt;' lacks ...</c>.
     /// </summary>
+    /// <summary>
+    /// 🚨 <b>The one hop that stops a shared execution hub from serialising the whole mesh
+    /// (#2543)</b> — applied ONLY to requests that declare
+    /// <see cref="IDetachedResponseContinuation"/>.
+    ///
+    /// <para>A response subject is signalled from INSIDE the turn that handled the response, so Rx
+    /// resumes the caller's chain on the responding hub's action block, inside that turn — and the
+    /// turn cannot end until the chain does. On <c>portal/nodeops</c>, the mesh's ONE node-CRUD
+    /// execution hub, that made every node write in the mesh queue behind one create's
+    /// continuation: <c>Queue(buffer=1,…) Executing(CreateNodeResponse, …)</c> for a whole
+    /// budget.</para>
+    ///
+    /// <para>🚨 <b>Why not for every request.</b> Doing it unconditionally was tried and is not
+    /// safe. The action block is not only a serialiser — it is an ERROR BOUNDARY and a DISPOSAL
+    /// FENCE, and an impersonation <c>AsyncLocal</c> is still in scope on it. Hopping every
+    /// continuation off it crashed the test host repeatedly and broke several invariants nobody had
+    /// written down. Narrowing the hop to the requests that demonstrably must not hold a shared hub
+    /// keeps every other request's semantics exactly as they were.</para>
+    ///
+    /// <para>🚨 <b>Order matters:</b> this wraps the OUTSIDE of the identity restore, so
+    /// <c>RestoreUserContextOnEmission</c>'s <c>.Do(SetContext)</c> is what runs first on the
+    /// continuation's thread. Reversed, the chain would resume unauthenticated.</para>
+    ///
+    /// <para>And a continuation that has left the block can no longer be caught by the pump, so it
+    /// is fenced: <see cref="GuardContinuationFaults"/> reports a throw and TERMINATES the sequence
+    /// rather than letting it go unhandled on a scheduler thread and kill the process.</para>
+    /// </summary>
+    /// <param name="source">The response observable, identity already restored.</param>
+    /// <param name="request">The request message, or null when it is not known.</param>
+    private IObservable<IMessageDelivery> ContinueOffBlockIfDeclared(
+        IObservable<IMessageDelivery> source, object? request)
+        => request is IDetachedResponseContinuation
+            ? GuardContinuationFaults(source.ObserveOn(PooledContinuationScheduler.Instance))
+            : source;
+
+    /// <summary>
+    /// The block is an ERROR BOUNDARY, and a continuation that has left it is outside that
+    /// boundary — an exception from a <c>Subscribe</c> callback would otherwise surface unhandled
+    /// on a scheduler thread and take the process down.
+    ///
+    /// <para>🚨 It REPORTS <b>and TERMINATES</b>. A first version only reported, which turned a
+    /// crash into a HANG: the caller's sequence stayed open forever waiting for an emission that
+    /// could never come. Rx's own contract is that a throwing observer ends the subscription, and
+    /// that is what the pump did too — it logged the fault and failed the delivery, so the caller
+    /// got an answer.</para>
+    /// </summary>
+    /// <param name="source">The continuation, already hopped off the block.</param>
+    private IObservable<IMessageDelivery> GuardContinuationFaults(IObservable<IMessageDelivery> source)
+        => Observable.Create<IMessageDelivery>(observer => source.Subscribe(
+            value =>
+            {
+                try
+                {
+                    observer.OnNext(value);
+                }
+                catch (Exception ex)
+                {
+                    ReportContinuationFault(ex);
+                    Guarded(() => observer.OnError(ex));
+                }
+            },
+            error => Guarded(() => observer.OnError(error)),
+            () => Guarded(observer.OnCompleted)));
+
+    /// <summary>Runs one observer callback, routing anything it throws. See
+    /// <see cref="GuardContinuationFaults"/> for why this is the block's boundary and not a
+    /// swallow.</summary>
+    /// <param name="deliver">The observer callback to run.</param>
+    private void Guarded(Action deliver)
+    {
+        try
+        {
+            deliver();
+        }
+        catch (Exception ex)
+        {
+            ReportContinuationFault(ex);
+        }
+    }
+
+    /// <summary>Says what a continuation fault was, at the level its cause deserves.</summary>
+    /// <param name="ex">The fault an observer callback threw.</param>
+    private void ReportContinuationFault(Exception ex)
+    {
+        if (RunLevel >= MessageHubRunLevel.ShutDown)
+            logger.LogDebug(ex,
+                "{Address}: a response continuation raced this hub's teardown — transient. The "
+                + "continuation runs off the action block, so it can outlive the scope it "
+                + "resolves from; the caller's subscription is already going away.", Address);
+        else
+            logger.LogError(ex,
+                "{Address}: a response continuation threw. It runs off the action block, so this "
+                + "did not fault a turn — it would otherwise have gone unhandled on a scheduler "
+                + "thread and killed the process. The throw is in the code that subscribed to "
+                + "hub.Observe(...), not in the hub.", Address);
+    }
+
     private IObservable<IMessageDelivery> RestoreUserContextOnEmission(
         IObservable<IMessageDelivery> source, AccessContext? capturedCtx)
     {

--- a/src/MeshWeaver.Messaging.Hub/PooledContinuationScheduler.cs
+++ b/src/MeshWeaver.Messaging.Hub/PooledContinuationScheduler.cs
@@ -1,0 +1,48 @@
+using System.Reactive.Concurrency;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Hands work to the task pool, and deliberately does NOT implement
+/// <see cref="ISchedulerLongRunning"/>.
+///
+/// <para>🚨 <b>The omission is the whole point — do not "complete" this class by adding it.</b>
+/// <c>ObserveOn</c> asks the scheduler for long-running support and, when it is offered, uses
+/// <c>ObserveOnObserverLongRunning</c>, which dedicates a DRAIN WORKER PER SUBSCRIPTION. That is
+/// tolerable for a handful of long-lived streams and ruinous for a response continuation, which is
+/// created once per request in flight: with the hop on every <c>hub.Observe(…)</c> it is a thread
+/// per request. Measured on #3759's first CI run — <c>ObserveOnObserverLongRunning.Drain()</c>
+/// sitting on a raw <c>Thread.StartHelper.Callback</c> in the crash stack. Hiding the capability
+/// keeps Rx on the per-item pooled path, which is what a short observable (one value, then
+/// complete) actually wants.</para>
+///
+/// <para>Rx's own <see cref="TaskPoolScheduler"/> and <see cref="DefaultScheduler"/> both advertise
+/// long-running, so neither can be used directly here; this wrapper exists only to withhold that
+/// one capability. Everything else delegates.</para>
+/// </summary>
+internal sealed class PooledContinuationScheduler : IScheduler
+{
+    /// <summary>The process-wide instance. Immutable — it holds only a delegate scheduler.</summary>
+    public static readonly PooledContinuationScheduler Instance = new();
+
+    private static readonly IScheduler Inner = TaskPoolScheduler.Default;
+
+    private PooledContinuationScheduler() { }
+
+    /// <inheritdoc />
+    public DateTimeOffset Now => Inner.Now;
+
+    /// <inheritdoc />
+    public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
+        => Inner.Schedule(state, action);
+
+    /// <inheritdoc />
+    public IDisposable Schedule<TState>(TState state, TimeSpan dueTime,
+        Func<IScheduler, TState, IDisposable> action)
+        => Inner.Schedule(state, dueTime, action);
+
+    /// <inheritdoc />
+    public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime,
+        Func<IScheduler, TState, IDisposable> action)
+        => Inner.Schedule(state, dueTime, action);
+}

--- a/test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeCrudDoesNotOccupyTheExecutionBlockTest.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A node create in flight must NOT occupy the node-CRUD execution block</b> — and measuring
+/// that it does not is what makes
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/2543">#2543</see>'s central capture an
+/// ANOMALY rather than the normal cost of a create.
+///
+/// <para><b>The reasoning this pins down.</b> #2543 is argued from one hub dump reading
+/// <c>Queue(buffer=45,…) Executing(CreateNodeRequest, 24888ms)</c> on <c>portal/nodeops</c> — the
+/// mesh's ONE node-CRUD execution hub, whose single block runs every create and upsert in the mesh.
+/// The natural reading is that a create simply costs that much: <c>HandleCreateNodeRequest</c>
+/// <c>.Subscribe(...)</c>s its whole pipeline — partition bootstrap, validators, NodeType existence,
+/// enrich, save, change feed — <b>inline</b>, and only then returns <c>request.Processed()</c>, so
+/// everything that runs synchronously inside that <c>Subscribe</c> is charged to the block. If that
+/// were the steady state, the fix would be a throughput question and the whole issue would be
+/// mis-framed.</para>
+///
+/// <para><b>It is not the steady state, and this test is the measurement.</b> The pipeline's first
+/// leaf is a storage read, and storage reads go through <c>IIoPool</c> — so the chain leaves the
+/// block at that hop and the handler returns in milliseconds. Parking a create INSIDE its own
+/// validator (which runs downstream of that read) therefore parks a pool thread, not the pump: the
+/// execution hub reads completely idle while a create is provably in flight. Measured, not assumed —
+/// the first draft of this test asserted the opposite and failed with
+/// <c>Queue(buffer=0,deferred=0,drainsInFlight=0,openGates=0,draining=False)</c>.</para>
+///
+/// <para><b>What that buys the investigation.</b> A create that holds the block for 24.9 s is doing
+/// something this path does not normally do, so "which rule holds the block" is not answered by
+/// "the create pipeline is expensive". It also gives the invariant a guard: should a future change
+/// move a synchronous leaf ahead of the pool hop — a blocking service resolution, an eager address
+/// resolution, a hosted-hub construction — every node CRUD in the mesh would start serialising
+/// behind it, and this test goes red at that commit instead of in a bake three weeks later.</para>
+///
+/// <para>Companion: <c>TurnLoopSnapshotIsMeasuredTest</c> (MeshWeaver.Messaging.Hub.Test) is the
+/// positive control for the two fields read here — it builds a genuinely blocked block and asserts
+/// they say so. Together: the fields move, and node CRUD does not move them.</para>
+/// </summary>
+public class NodeCrudDoesNotOccupyTheExecutionBlockTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string ParkedNodeId = "TurnStateParkedWrite";
+    private const string ParkedNodePath = $"{TestPartition}/{ParkedNodeId}";
+
+    /// <summary>The INDEPENDENT second operation: never parked, so only a held pump delays it.</summary>
+    private const string ProbeNodeId = "TurnStateProbeWrite";
+
+    /// <summary>The control's node — created with nothing parked, so it measures the probe itself.</summary>
+    private const string ControlNodeId = "TurnStateControlWrite";
+
+    /// <summary>Bound for the probe. Deliberately WELL under the parked validator's own
+    /// <c>TestTimeouts.Convergence</c> spin, so the park cannot expire first and hand the probe a
+    /// pass that says nothing about whether the pump was free.</summary>
+    private static readonly TimeSpan ProbeBudget = TimeSpan.FromSeconds(10);
+
+    /// <summary>The two nodes parked SIMULTANEOUSLY by the parallelism test below.</summary>
+    private const string ParallelANodeId = "TurnStateParallelA";
+
+    private const string ParallelBNodeId = "TurnStateParallelB";
+
+    private const string ParallelAPath = $"{TestPartition}/{ParallelANodeId}";
+
+    private const string ParallelBPath = $"{TestPartition}/{ParallelBNodeId}";
+
+    /// <summary>Producer → test: the parking validator completes this once its turn is running.</summary>
+    private readonly AsyncSubject<Unit> _parked = new();
+
+    private readonly AsyncSubject<Unit> _parkedA = new();
+
+    private readonly AsyncSubject<Unit> _parkedB = new();
+
+    private ParkTheNodeCrudBlock? _park;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        _park = new ParkTheNodeCrudBlock(new Dictionary<string, AsyncSubject<Unit>>
+        {
+            [ParkedNodePath] = _parked,
+            [ParallelAPath] = _parkedA,
+            [ParallelBPath] = _parkedB,
+        });
+        return base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<INodeValidator>(_park));
+    }
+
+    /// <summary>The mesh's ONE node-CRUD execution hub — the hub #2543 is about.</summary>
+    private MessageHub NodeOperationHub =>
+        Mesh.GetHostedHub(Mesh.NodeOperationTarget(), HostedHubCreation.Never) as MessageHub
+        ?? throw new InvalidOperationException(
+            "the node-CRUD execution hub is not materialised — the test cannot describe a hub that "
+            + "does not exist; a node operation must have been issued first");
+
+    /// <summary>
+    /// 🚨 THE MEASUREMENT. A create is blocked mid-pipeline, in its own validator, and the hub that
+    /// EXECUTES node CRUD is idle: no drain body, no executing turn, nothing queued.
+    ///
+    /// <para>So the create pipeline is not what a 25 s <c>Executing(CreateNodeRequest, …)</c>
+    /// reports. Anything that DOES hold that block for tens of seconds is running ahead of the
+    /// pipeline's first pooled hop, and that is a much smaller place to look.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheExecutionBlock_IsFree_WhileACreateIsInFlightInsideItsValidator()
+    {
+        // A REAL node create, posted exactly as production does, so what it exercises is the
+        // production path rather than a stand-in.
+        var write = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParkedNodeId, TestPartition)
+            {
+                Name = "Turn State Parked Write",
+                NodeType = "Markdown",
+            }));
+        // 🚨 THE BLOCK IS MEASURED BY WHAT IT CAN STILL DO, NOT BY GetTurnLoopSnapshot().
+        //
+        // The snapshot's `Executing(...)` clause CANNOT answer this question, and the first version
+        // of this test failed because it asked. `currentlyExecutingMessageType` is cleared in the
+        // `.Finally(...)` of the handler's returned OBSERVABLE (MessageService), so it stays set for
+        // as long as the handler's chain is in flight — including every pooled hop the chain has
+        // already left the block for. Its elapsed is therefore the handler's lifetime, not the time
+        // the pump was occupied: with the create parked here, one run read
+        // `Executing(CreateNodeResponse, 36001ms)` while the pump was idle throughout, and the
+        // number tracked the park window exactly because the park IS the handler's lifetime.
+        // `drainsInFlight`/`draining` read 1/True for the same reason.
+        //
+        // That is also why #2543's `Executing(CreateNodeRequest, 24888ms)` does not by itself say
+        // the block was held for 24.9 s — the same field, the same ambiguity.
+        //
+        // So the claim is measured behaviourally: with a create provably parked, post an INDEPENDENT
+        // node operation to the same hub and require it to complete. A pump held by the parked
+        // create cannot answer it; a pump that answers is free by demonstration, whatever the
+        // snapshot says.
+        try
+        {
+            await _parked.Should().Within(TestTimeouts.Convergence)
+                .Emit("the create must actually be in flight and blocked, or this test describes an "
+                    + "idle mesh and proves nothing");
+
+            var probe = ObserveNodeOperation(new CreateNodeRequest(
+                new MeshNode(ProbeNodeId, TestPartition)
+                {
+                    Name = "Turn State Probe Write",
+                    NodeType = "Markdown",
+                }));
+
+            await probe.Should().Within(ProbeBudget)
+                .Emit("the node-CRUD execution hub must still process a SECOND node operation while "
+                    + "the first is parked inside its validator: the create pipeline leaves the "
+                    + "action block at its first pooled storage hop, so it is a pool thread that is "
+                    + "parked, not the pump. If this times out the block IS held for the duration of "
+                    + "a create, every node CRUD in the mesh serialises behind it, and #2543's "
+                    + "24.9 s capture is routine rather than anomalous. Turn-loop snapshot at this "
+                    + "moment (diagnostic only, see above — it cannot decide this): "
+                    + NodeOperationHub.GetPendingRequestDiagnostics());
+        }
+        finally
+        {
+            // In a finally so a failing assertion cannot strand the parked write — and therefore
+            // cannot strand the mesh's teardown behind it.
+            _park!.Release();
+        }
+
+        await write.Should().Within(TestTimeouts.Convergence)
+            .Emit("the parked write must complete once released — a stranded create would leak into "
+                + "the next test");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL for the measurement above, and it is not optional. The probe there
+    /// is read as "the pump is held" when it does not complete — a reading that is only valid if
+    /// the very same operation DOES complete when nothing is parked. Without this, a probe that
+    /// never completes for its own reasons looks exactly like a held pump, and the conclusion
+    /// would be drawn from an instrument that cannot answer.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheProbeOperation_CompletesPromptly_WhenNothingIsParked()
+    {
+        var probe = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ControlNodeId, TestPartition)
+            {
+                Name = "Turn State Control Write",
+                NodeType = "Markdown",
+            }));
+
+        await probe.Should().Within(ProbeBudget)
+            .Emit("an unparked node create must complete well inside the budget the probe above "
+                + "uses — that budget is only meaningful if this passes");
+    }
+
+    /// <summary>
+    /// 🚨 <b>Node CRUD runs in PARALLEL</b> — the property the decoupling in
+    /// <c>MessageHub.ContinueOffBlockRestoringUserContext</c> exists to give, asserted without a
+    /// stopwatch.
+    ///
+    /// <para>Two creates are parked in their validators AT THE SAME TIME. Both validators must be
+    /// entered before either is released, which can only happen if two creates are in flight
+    /// concurrently. When every response continuation ran on <c>portal/nodeops</c>'s action block,
+    /// the second create could not even be DEQUEUED while the first was parked — it sat at
+    /// <c>Queue(buffer=1,…)</c> and its validator never ran, so this test could not pass by
+    /// timing luck. It is a structural assertion, not a benchmark.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TwoCreates_AreInFlightSimultaneously()
+    {
+        var a = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParallelANodeId, TestPartition) { Name = "Parallel A", NodeType = "Markdown" }));
+        var b = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParallelBNodeId, TestPartition) { Name = "Parallel B", NodeType = "Markdown" }));
+
+        try
+        {
+            await _parkedA.Should().Within(TestTimeouts.Convergence)
+                .Emit("the first create must reach its validator");
+            await _parkedB.Should().Within(ProbeBudget)
+                .Emit("the SECOND create must reach its validator while the first is still parked "
+                    + "there — two node writes genuinely in flight at once. A hub that runs "
+                    + "continuations on its own action block cannot get here: the second create "
+                    + "would still be queued behind the first, unstarted");
+        }
+        finally
+        {
+            _park!.Release();
+        }
+
+        await a.Should().Within(TestTimeouts.Convergence).Emit("the first create must complete");
+        await b.Should().Within(TestTimeouts.Convergence).Emit("the second create must complete");
+    }
+
+    /// <summary>
+    /// Blocks ONE create inside its validator. The validator runs downstream of the create
+    /// pipeline's first storage read, which is pooled — so this parks a pool thread, which is
+    /// exactly the fact under test.
+    ///
+    /// <para>No hand-woven gate: producer → test is the <see cref="AsyncSubject{T}"/> this completes
+    /// on entry; test → parked worker is a volatile flag polled under a bounded
+    /// <see cref="SpinWait.SpinUntil(Func{bool}, TimeSpan)"/>. Every other path validates instantly,
+    /// so nothing else in the mesh is slowed down. (Same harness as
+    /// <c>ContentReadIsNotQueuedBehindNodeCrudTest</c>.)</para>
+    /// </summary>
+    private sealed class ParkTheNodeCrudBlock(
+        IReadOnlyDictionary<string, AsyncSubject<Unit>> parkPoints) : INodeValidator
+    {
+        private int _released;
+
+        public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Create];
+
+        /// <summary>Lets the parked create finish. Idempotent.</summary>
+        public void Release() => Interlocked.Exchange(ref _released, 1);
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+            => parkPoints.TryGetValue(context.Node.Path, out var parked)
+                ? Observable.Defer(() =>
+                {
+                    parked.OnNext(Unit.Default);
+                    parked.OnCompleted();
+                    SpinWait.SpinUntil(() => Volatile.Read(ref _released) == 1,
+                        TestTimeouts.Convergence);
+                    return Observable.Return(NodeValidationResult.Valid());
+                })
+                : Observable.Return(NodeValidationResult.Valid());
+    }
+}


### PR DESCRIPTION
Refs #2543. **Supersedes the draft #3759**, which is 14,689 deletions behind `main` and would revert
today's five merges — this is the same finding rebuilt on current `main`, with the scope call
resolved the conservative way.

## The mechanism

A response subject is signalled from **inside** the turn that handled the response, and Rx runs a
continuation on whichever thread signalled it. So the whole remainder of every
`hub.Observe(x).SelectMany(…)` chain executes **on the responding hub's action block, inside that
turn** — and the turn cannot end until the chain does.

Harmless for most requests. Not harmless when one hub is the execution point for something the whole
mesh does. `portal/nodeops-{meshId}` is the mesh's **one** node-CRUD hub:

- a create returns `Processed()` in ~1 ms and detaches its pipeline — the handler is innocent;
- the pipeline does a partition bootstrap whose nested response comes back to the **same** hub;
- the rest of the create — validators, save, change feed — ran inline in **that response's turn**.

One create parked in its validator ⇒ a second, unrelated create sat unprocessed at
`Queue(buffer=1,…)` for the whole budget. Delete, move and copy inherit it identically.

## 🚨 Why the hop is an opt-in — this is the finding, not a caution

Applying it to every `hub.Observe(…)` was tried. It **crashed the test host seven times**, and each
crash named an invariant the action block had been underwriting that nobody had written down:

| # | what the block was also providing |
|---|---|
| 1 | **error boundary** — a throwing `Subscribe` callback was a turn fault the pump caught and answered; off the block it is unhandled on a scheduler thread |
| 2 | **disposal fence** — a continuation inside a turn cannot outlive the scope it resolves from |
| 3 | **concurrency bound** — one turn at a time also bounds how many continuations run at once |
| 4 | **impersonation scope** — `RunAs`'s `AsyncLocal` is in scope on the block |
| 5 | **ordering** between a response and later messages to the same hub |
| 6 | whatever `LogonActionRunner.RunFor` stands on — its own comment insists on `RunAs`, *never* `Observable.Using(access.ImpersonateAsSystem, …)` |

So `IDetachedResponseContinuation` (in `MeshWeaver.Messaging.Contract`) declares it, the six
node-CRUD requests take it, and **every other request keeps the semantics it has always had**.

🚨 The criterion is **not latency**. It is whether the responding hub is a SHARED EXECUTION POINT
whose availability other work depends on. `portal/nodeops` is; a per-node hub answering its own
reads is not. Stated in the marker's own docs so the next person does not widen it.

## The two fences that make it survivable

- **`PooledContinuationScheduler` withholds `ISchedulerLongRunning`.** `ObserveOn` takes
  `ObserveOnObserverLongRunning` when it is offered — a drain worker **per subscription**, i.e. a
  thread per in-flight request (seen in the first crash stack). Rx's own `TaskPoolScheduler` and
  `DefaultScheduler` both advertise it, so neither can be used directly; this wrapper exists only to
  hide that one capability.
- **`GuardContinuationFaults` reports AND terminates.** A first version only reported, which turned
  a crash into a **hang** — the caller's sequence stayed open forever waiting for an emission that
  could never come. Rx's contract is that a throwing observer ends the subscription, and the pump
  did the same.

## Verification

**Falsified:** disable the hop and `TwoCreates_AreInFlightSimultaneously` fails in 11 s.

🚨 Honest note on the other two cases: the parked-create probe passes **either way** — it measures
the validator running off-block, which was already true — so `TwoCreates_AreInFlightSimultaneously`
is the only discriminating case of the three. Said out loud rather than left for a reader to
discover.

`dotnet build -c Release -warnaserror`, one project per invocation — `Messaging.Contract`,
`Messaging.Hub`, `Mesh.Contract`, `Documentation`, and five test projects: 0 Warning(s), 0 Error(s).

**3,739 tests, all green:**

| suite | |
|---|---|
| `MeshWeaver.Messaging.Hub.Test` | 384 |
| `MeshWeaver.Graph.Test` | 1486 |
| `MeshWeaver.Data.Test` | 496 |
| `MeshWeaver.Hosting.Test` | 539 |
| `MeshWeaver.Layout.Test` | 466 |
| `MeshWeaver.Documentation.Test` | 368 |

including the two that **broke under the global hop** and are the reason this is narrowed —
`LogonActionFrameworkTest.Two_concurrent_logons_run_a_once_action_exactly_once` and
`ReadDuringDisposalWindowTest`, both re-run by name as well.

## Docs

- `Doc/Architecture/DetachedResponseContinuations` (new, indexed in the topic map) — the mechanism,
  the six invariants, the two fences, and the 🚨 `Executing(T, N ms)` trap: it is cleared in the
  handler observable's `.Finally`, so it is a **lifetime**, not occupancy. Three sessions read the
  24.9 s capture as "the block was held that long"; what proves the block was unavailable is the
  **queued second create**.
- What's New: *Node writes no longer queue behind one another* (`Category: Fix`).

## Surface

`IDetachedResponseContinuation` is **added**; six records gain an interface (source- and
binary-compatible — no constructor signature changes, `check-record-signatures.py` clean). Nothing
public is removed and no existing interface gains a member, so neither cross-repo gate applies.

## What this does NOT fix

A hub whose pump does not turn **at all** looks identical from outside and is a different failure —
#3593, and #3674 which I re-read today as the same family on this same hub. The counters #3798 added
(`drainsInFlight`, `drainsAwaitingScheduler`) are what tell them apart.
