### PR TITLE
ci(scripts): a platform canary — tell a node repo on the DAY core breaks it, not at the next pin bump

### DIFF
--- a/.github/scripts/test-platform-canary.py
+++ b/.github/scripts/test-platform-canary.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Exercise the exact embedded canary evidence code without a GitHub runner."""
+from pathlib import Path
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+workflow = Path(__file__).resolve().parents[1] / 'workflows/node-repo-platform-canary.yml'
+source = workflow.read_text().split("<<'PYTHON'\n", 1)[1].split('\n          PYTHON', 1)[0]
+namespace = {'__name__': 'canary_under_test'}
+exec(compile('\n'.join(line[10:] for line in source.splitlines()), str(workflow), 'exec'), namespace)
+compare = namespace['compare']
+read_results = namespace['read_results']
+
+
+def arm(**results):
+    return {'suite': {'results': results}}
+
+
+class CanaryEvidenceTest(unittest.TestCase):
+    def test_only_a_recorded_pass_can_be_a_regression(self):
+        delta, incomplete = compare(arm(good='Passed', old='Failed'), arm(good='Failed', old='Failed'))
+        self.assertEqual(['suite: good'], delta)
+        self.assertEqual([], incomplete)
+
+    def test_candidate_compiler_failure_has_a_successful_build_control(self):
+        pin = {'suite': {'build': 'passed', 'results': {'test': 'Passed'}}}
+        main = {'suite': {'build': 'failed', 'error': 'CS0246'}}
+        self.assertEqual((['suite: BUILD FAILED at main (build passed at pin)'], []), compare(pin, main))
+
+    def test_candidate_infrastructure_failure_is_not_a_build_regression(self):
+        pin = {'suite': {'build': 'passed', 'results': {'test': 'Passed'}}}
+        main = {'suite': {'build': 'unknown', 'error': 'host died'}}
+        delta, incomplete = compare(pin, main)
+        self.assertEqual([], delta)
+        self.assertTrue(incomplete)
+
+    def test_baseline_build_failure_never_establishes_a_pass(self):
+        delta, incomplete = compare({'suite': {'error': 'BUILD FAILED'}}, arm(test='Failed'))
+        self.assertEqual([], delta)
+        self.assertTrue(incomplete)
+
+    def test_both_builds_failing_is_not_a_clean_comparison(self):
+        failed = {'suite': {'error': 'BUILD FAILED'}}
+        self.assertTrue(compare(failed, failed)[1])
+
+    def test_missing_candidate_test_cannot_heal_a_report(self):
+        self.assertTrue(compare(arm(test='Failed'), arm(other='Passed'))[1])
+
+    def test_skipped_candidate_test_cannot_heal_a_report(self):
+        self.assertTrue(compare(arm(test='Failed'), arm(test='NotExecuted'))[1])
+
+    def test_skipped_baseline_is_not_a_pass(self):
+        delta, incomplete = compare(arm(test='NotExecuted'), arm(test='Failed'))
+        self.assertEqual([], delta)
+        self.assertTrue(incomplete)
+
+    def test_new_failed_test_has_no_baseline(self):
+        self.assertTrue(compare(arm(control='Passed'), arm(control='Passed', new='Failed'))[1])
+
+    def test_no_regressions_with_two_measured_arms(self):
+        self.assertEqual(([], []), compare(arm(test='Passed'), arm(test='Passed')))
+
+    def test_suite_denominator_is_required(self):
+        for left, right in [({}, {}), (arm(test='Passed'), {})]:
+            with self.assertRaises(ValueError):
+                compare(left, right)
+
+    def trx(self, outcomes, code=0, total=None, summary='Completed'):
+        ns = 'http://microsoft.com/schemas/VisualStudio/TeamTest/2010'
+        root = ET.Element('TestRun', xmlns=ns)
+        results = ET.SubElement(root, 'Results')
+        for name, outcome in outcomes:
+            ET.SubElement(results, 'UnitTestResult', testName=name, outcome=outcome)
+        result_summary = ET.SubElement(root, 'ResultSummary', outcome=summary)
+        ET.SubElement(result_summary, 'Counters', total=str(len(outcomes) if total is None else total),
+                      failed=str(sum(v == 'Failed' for _, v in outcomes)))
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'results.trx'
+            ET.ElementTree(root).write(path)
+            return read_results(path, code)
+
+    def test_real_trx_names_preserve_theory_arguments(self):
+        name = 'Example.Tests.Case(value: "a)b")'
+        self.assertEqual({name: 'Passed'}, self.trx([(name, 'Passed')]))
+
+    def test_no_execution_and_partial_results_are_incomplete(self):
+        for outcomes in [[], [('test', 'NotExecuted')], [('test', 'InProgress')]]:
+            with self.assertRaises(ValueError):
+                self.trx(outcomes)
+        with self.assertRaises(ValueError):
+            self.trx([('test', 'Passed')], total=2)
+
+    def test_host_crash_and_exit_mismatch_are_incomplete(self):
+        for code in [1, 124, 139]:
+            with self.assertRaises(ValueError):
+                self.trx([('test', 'Passed')], code=code)
+        with self.assertRaises(ValueError):
+            self.trx([('test', 'Failed')], code=0)
+        with self.assertRaises(ValueError):
+            self.trx([('test', 'Passed')], summary='Aborted')
+
+    def test_ambiguous_names_are_not_merged_silently(self):
+        with self.assertRaises(ValueError):
+            self.trx([('test', 'Passed'), ('test', 'Failed')], code=1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/workflows/node-repo-platform-canary.yml
+++ b/.github/workflows/node-repo-platform-canary.yml
@@ -1,0 +1,231 @@
+name: Node repo platform canary (reusable)
+
+# ♻️ REUSABLE (workflow_call) — tells a node repo, ON THE DAY IT HAPPENS, that a core change it
+# has not adopted yet would break it.
+#
+# 🚨 WHY IT EXISTS, measured on MeshWeaver.Plugins 2026-09-08. Twice in one day a core behaviour
+# change behind an UNCHANGED SIGNATURE reddened that repo, and both times it was discovered by the
+# pin bump rather than before it:
+#
+#   Plugins#1506  core #3681 restricted the legacy access heal to pre-installed partitions.
+#                 Found by reading core's open PRs — luck, not a gate.
+#   Plugins#1518  core #3648 made the platform floor ADVISORY; 14 tests asserted the hold/refuse/
+#                 skip it replaced. Found by the bump itself, WITH THE TRUNK ALREADY RED.
+#
+# The structural reason, from Plugins#1518: no surface detector sees this class by construction —
+# the cross-repo pair gate looks for REMOVED types and members, and nothing was removed. And for a
+# dependent that PINS core, the release event resolves the same pin as a pull request does. So
+# THE PIN BUMP IS THE INTEGRATION TEST — and because the bump is a hand PR wherever the App lacks
+# `workflows` (Plugins#1464/#1547), in practice it runs when the staleness ratchet forces it. That
+# is the worst possible moment: the break surfaces with the trunk red and every open PR blocked on
+# a gate none of their diffs can reach.
+#
+# This lane runs that same integration test on a schedule, without moving anything.
+#
+# 🚨 IT NEVER GATES, and that is not timidity. Core `main` moves under this lane, so a red canary
+# must never block a pull request that is fine at the pin — a caller that made this required would
+# be blocked by someone else's core merge. It reports; a human decides when to adopt.
+#
+# 🚨 THE CONTROL ARM IS THE LOAD-BEARING HALF. The suites are run TWICE — once at the caller's
+# CURRENT pin, once at core `main` — and only tests that pass at the pin AND fail at main are
+# reported. Without that, every pre-existing red reads as pin drift, the report is noise, and the
+# lane is ignored inside a week. That is precisely the failure AGENTS.md names for a gate that is
+# red when nothing is wrong, and the one Plugins#1510 had just finished fixing in compile-check.py.
+#
+# CALLER (a scheduled workflow of its own, never a `pull_request` job):
+#
+#     on:
+#       schedule: [{cron: "37 5 * * *"}]
+#       workflow_dispatch:
+#     jobs:
+#       canary:
+#         permissions: {contents: read, issues: write}
+#         uses: Systemorph/MeshWeaver/.github/workflows/node-repo-platform-canary.yml@<sha>
+#         with:
+#           pin-key: MW_PLATFORM_REF
+#           workflow-file: .github/workflows/ci.yml
+#           suites: |
+#             src/MeshWeaver.PluginCatalog.Test
+#             src/MeshWeaver.Hosting.Monolith.Test
+
+on:
+  workflow_call:
+    inputs:
+      workflow-file:
+        description: The caller's workflow file carrying the pin.
+        type: string
+        default: .github/workflows/ci.yml
+      pin-key:
+        description: The env key holding the platform commit.
+        type: string
+        default: MW_PLATFORM_REF
+      upstream-repo:
+        description: The repo whose default branch the pin tracks.
+        type: string
+        default: Systemorph/MeshWeaver
+      suites:
+        description: >-
+          Newline-separated test project paths, relative to the caller. Choose the suites a pin
+          bump has actually reddened — for MeshWeaver.Plugins those are
+          src/MeshWeaver.PluginCatalog.Test and src/MeshWeaver.Hosting.Monolith.Test, where both
+          of 2026-09-08's breaks landed. Running everything would cost more and report the same.
+        type: string
+        required: true
+      issue-label:
+        description: Label put on the tracking issue, so a repo can route it.
+        type: string
+        default: platform-canary
+
+jobs:
+  canary:
+    name: Would core main break this repo
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out the caller
+        uses: actions/checkout@v7
+        with:
+          path: repo
+
+      - name: Read the pin, and resolve core main ONCE
+        id: refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM: ${{ inputs.upstream-repo }}
+          WORKFLOW_FILE: ${{ inputs.workflow-file }}
+          PIN_KEY: ${{ inputs.pin-key }}
+        run: |
+          set -euo pipefail
+          pin=$(grep -m1 -E "^[[:space:]]*${PIN_KEY}:" "repo/${WORKFLOW_FILE}" | sed -E 's/.*:[[:space:]]*//' | tr -d '"'"'"' \r')
+          [ -n "$pin" ] || { echo "::error::could not read ${PIN_KEY} from ${WORKFLOW_FILE} — the canary has no baseline to compare against and will not guess one"; exit 1; }
+          head=$(gh api "repos/${UPSTREAM}" --jq .default_branch)
+          main=$(gh api "repos/${UPSTREAM}/commits/${head}" --jq .sha)
+          # 🚨 Resolved ONCE, here, and both checkouts below read this output — the same discipline
+          # ci.yml's `platform-ref` job exists for. Two checkouts of a branch name in one run
+          # legitimately take two different commits; core merges several times an hour.
+          echo "pin=$pin"   >> "$GITHUB_OUTPUT"
+          echo "main=$main" >> "$GITHUB_OUTPUT"
+          echo "behind=$(gh api "repos/${UPSTREAM}/compare/${pin}...${main}" --jq .ahead_by)" >> "$GITHUB_OUTPUT"
+          echo "### Canary" >> "$GITHUB_STEP_SUMMARY"
+          echo "pin \`${pin}\` → core main \`${main}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check out core at the PIN (the control arm)
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.upstream-repo }}
+          ref: ${{ steps.refs.outputs.pin }}
+          path: core-pin
+
+      - name: Check out core at MAIN
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.upstream-repo }}
+          ref: ${{ steps.refs.outputs.main }}
+          path: core-main
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      # Both arms run the SAME suites with the SAME command; only MeshWeaverRoot differs. A
+      # failure list is written per arm; the diff below is what gets reported.
+      # 🚨 Failures are collected, never fatal. A suite that cannot even BUILD at one arm is a
+      # result (recorded as `<suite>: BUILD FAILED`), not a reason to abandon the comparison — and
+      # a build that fails at BOTH arms cancels out in the delta, which is the control working.
+      - name: Write the per-arm runner (one command, two MeshWeaverRoots)
+        run: |
+          cat > "$GITHUB_WORKSPACE/canary-run.sh" <<'SH'
+          set -uo pipefail
+          : > "$RUNNER_TEMP/$OUT"
+          while IFS= read -r suite; do
+            suite="$(echo "$suite" | xargs)"
+            [ -n "$suite" ] || continue
+            cd "$GITHUB_WORKSPACE/repo"
+            if ! dotnet test "$suite" -c Release -p:MeshWeaverRoot="$GITHUB_WORKSPACE/$CORE/" \
+                 --logger "trx;LogFileName=$RUNNER_TEMP/$CORE-$(basename "$suite").trx" > "$RUNNER_TEMP/out.log" 2>&1; then
+              if grep -qE 'error [A-Z]+[0-9]+' "$RUNNER_TEMP/out.log"; then
+                echo "$suite: BUILD FAILED" >> "$RUNNER_TEMP/$OUT"
+              fi
+            fi
+            # Fully-qualified names of failed tests, from the runner's own output.
+            grep -oE '[A-Za-z0-9_.]+\.[A-Za-z0-9_]+(\([^)]*\))? \[FAIL\]' "$RUNNER_TEMP/out.log" \
+              | sed 's/ \[FAIL\]//' >> "$RUNNER_TEMP/$OUT" || true
+          done <<< "$SUITES"
+          sort -u -o "$RUNNER_TEMP/$OUT" "$RUNNER_TEMP/$OUT"
+          echo "$CORE: $(wc -l < "$RUNNER_TEMP/$OUT" | tr -d ' ') failing test(s)"
+          SH
+
+      - name: Run the suites at the PIN (the control arm)
+        continue-on-error: true
+        env:
+          SUITES: ${{ inputs.suites }}
+          CORE: core-pin
+          OUT: pin.txt
+        run: bash "$GITHUB_WORKSPACE/canary-run.sh"
+
+      - name: Run the suites at core MAIN
+        continue-on-error: true
+        env:
+          SUITES: ${{ inputs.suites }}
+          CORE: core-main
+          OUT: main.txt
+        run: bash "$GITHUB_WORKSPACE/canary-run.sh"
+
+      - name: The delta — passes at the pin, fails at core main
+        id: delta
+        run: |
+          set -euo pipefail
+          touch "$RUNNER_TEMP/pin.txt" "$RUNNER_TEMP/main.txt"
+          # Only tests that FAIL at main and do NOT fail at the pin. A test already red at the pin
+          # is this repo's own business and says nothing about core.
+          comm -13 <(sort -u "$RUNNER_TEMP/pin.txt") <(sort -u "$RUNNER_TEMP/main.txt") > "$RUNNER_TEMP/delta.txt" || true
+          count=$(wc -l < "$RUNNER_TEMP/delta.txt" | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Canary delta: ${count} test(s) pass at the pin and fail at core main"
+            echo ""
+            if [ "$count" != "0" ]; then sed 's/^/- `/;s/$/`/' "$RUNNER_TEMP/delta.txt"; else echo "_None._"; fi
+            echo ""
+            echo "Also red at the pin (NOT reported — this repo's own): $(wc -l < "$RUNNER_TEMP/pin.txt" | tr -d ' ')"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: File or close the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COUNT: ${{ steps.delta.outputs.count }}
+          PIN: ${{ steps.refs.outputs.pin }}
+          MAIN: ${{ steps.refs.outputs.main }}
+          BEHIND: ${{ steps.refs.outputs.behind }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LABEL: ${{ inputs.issue-label }}
+        run: |
+          set -euo pipefail
+          marker="<!-- platform-canary -->"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$marker in:body" --json number --jq '.[0].number // empty' || true)
+          if [ "$COUNT" = "0" ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
+                --comment "Core \`${MAIN}\` no longer breaks anything this repo tests that the pin does not. Closed by the canary ([run](${RUN_URL}))."
+            fi
+            echo "canary clean — nothing to report"
+            exit 0
+          fi
+          {
+            printf 'Core `%s` breaks **%s** test(s) that pass at this repo'"'"'s pin (`%s`, **%s** commits behind).\n\n' "$MAIN" "$COUNT" "$PIN" "$BEHIND"
+            sed 's/^/- `/;s/$/`/' "$RUNNER_TEMP/delta.txt"
+            printf '\nThese are **not** red on this repo today, and this is **not** a gate — nothing here blocks a pull request. It is what the next pin bump will hit, reported on the day core merged it rather than days later under a red trunk.\n\n'
+            printf '🚨 **The list is a DELTA, not a failure list.** Each test was run twice — once with core at the pin, once at core main — and only those that pass at the pin and fail at main are here. A test already red at the pin is this repo'"'"'s own business and is excluded.\n\n'
+            printf '[Canary run](%s)\n\n%s\n' "$RUN_URL" "$marker"
+          } > "$RUNNER_TEMP/body.md"
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/body.md"
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "Still ${COUNT} at core \`${MAIN}\` ([run](${RUN_URL}))."
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --label "$LABEL" \
+              --title "Platform canary: core main breaks ${COUNT} test(s) this pin does not" --body-file "$RUNNER_TEMP/body.md" || \
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Platform canary: core main breaks ${COUNT} test(s) this pin does not" --body-file "$RUNNER_TEMP/body.md"
+          fi

--- a/.github/workflows/node-repo-platform-canary.yml
+++ b/.github/workflows/node-repo-platform-canary.yml
@@ -90,6 +90,11 @@ jobs:
         with:
           path: repo
 
+      - name: Check out an independent caller for the main arm
+        uses: actions/checkout@v7
+        with:
+          path: repo-main
+
       - name: Read the pin, and resolve core main ONCE
         id: refs
         env:
@@ -130,67 +135,161 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      # Both arms run the SAME suites with the SAME command; only MeshWeaverRoot differs. A
-      # failure list is written per arm; the diff below is what gets reported.
-      # 🚨 Failures are collected, never fatal. A suite that cannot even BUILD at one arm is a
-      # result (recorded as `<suite>: BUILD FAILED`), not a reason to abandon the comparison — and
-      # a build that fails at BOTH arms cancels out in the delta, which is the control working.
-      - name: Write the per-arm runner (one command, two MeshWeaverRoots)
+      # Results are evidence, not console-output patterns. Both arms must execute tests;
+      # an incomplete arm cannot clear an existing report or establish a baseline pass.
+      - name: Write the evidence runner
         run: |
-          cat > "$GITHUB_WORKSPACE/canary-run.sh" <<'SH'
-          set -uo pipefail
-          : > "$RUNNER_TEMP/$OUT"
-          while IFS= read -r suite; do
-            suite="$(echo "$suite" | xargs)"
-            [ -n "$suite" ] || continue
-            cd "$GITHUB_WORKSPACE/repo"
-            if ! dotnet test "$suite" -c Release -p:MeshWeaverRoot="$GITHUB_WORKSPACE/$CORE/" \
-                 --logger "trx;LogFileName=$RUNNER_TEMP/$CORE-$(basename "$suite").trx" > "$RUNNER_TEMP/out.log" 2>&1; then
-              if grep -qE 'error [A-Z]+[0-9]+' "$RUNNER_TEMP/out.log"; then
-                echo "$suite: BUILD FAILED" >> "$RUNNER_TEMP/$OUT"
-              fi
-            fi
-            # Fully-qualified names of failed tests, from the runner's own output.
-            grep -oE '[A-Za-z0-9_.]+\.[A-Za-z0-9_]+(\([^)]*\))? \[FAIL\]' "$RUNNER_TEMP/out.log" \
-              | sed 's/ \[FAIL\]//' >> "$RUNNER_TEMP/$OUT" || true
-          done <<< "$SUITES"
-          sort -u -o "$RUNNER_TEMP/$OUT" "$RUNNER_TEMP/$OUT"
-          echo "$CORE: $(wc -l < "$RUNNER_TEMP/$OUT" | tr -d ' ') failing test(s)"
-          SH
+          cat > "$GITHUB_WORKSPACE/canary-evidence.py" <<'PYTHON'
+          import json
+          import os
+          import re
+          from pathlib import Path
+          import subprocess
+          import sys
+          import xml.etree.ElementTree as ET
+
+
+          def read_results(path, exit_code):
+              if exit_code not in (0, 1):
+                  raise ValueError(f"test process exited {exit_code}")
+              root = ET.parse(path).getroot()
+              ns = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
+              summary = root.find("t:ResultSummary", ns)
+              if summary is None or summary.get("outcome") not in ("Completed", "Passed", "Failed"):
+                  raise ValueError("missing or incomplete TRX summary")
+              rows = root.findall("t:Results/t:UnitTestResult", ns)
+              if not rows or any(r.get("outcome") not in ("Passed", "Failed", "NotExecuted") for r in rows):
+                  raise ValueError("no test results, or a nonterminal result")
+              results = {}
+              for row in rows:
+                  name, outcome = row.get("testName"), row.get("outcome")
+                  if not name or name in results:
+                      raise ValueError("missing or ambiguous test name")
+                  results[name] = outcome
+              counters = summary.find("t:Counters", ns)
+              if counters is None or int(counters.get("total", "-1")) != len(results):
+                  raise ValueError("TRX counters do not cover the reported tests")
+              if not any(v in ("Passed", "Failed") for v in results.values()):
+                  raise ValueError("no tests executed")
+              failed = sum(v == "Failed" for v in results.values())
+              if int(counters.get("failed", "-1")) != failed or (exit_code == 0) != (failed == 0):
+                  raise ValueError("test exit status and TRX failures disagree")
+              return results
+
+
+          def compare(pin, main):
+              if not pin or set(pin) != set(main):
+                  raise ValueError("the arms did not report the same nonempty suite set")
+              delta, incomplete = [], []
+              for suite in pin:
+                  left, right = pin[suite], main[suite]
+                  if left.get("build") == "passed" and right.get("build") == "failed":
+                      delta.append(f"{suite}: BUILD FAILED at main (build passed at pin)")
+                      continue
+                  if "error" in left or "error" in right:
+                      incomplete.append(f"{suite}: pin={left.get('error', 'measured')}; main={right.get('error', 'measured')}")
+                      continue
+                  for name, outcome in right["results"].items():
+                      baseline = left["results"].get(name)
+                      if outcome == "Failed" and baseline == "Passed":
+                          delta.append(f"{suite}: {name}")
+                      elif outcome == "Failed" and baseline != "Failed":
+                          incomplete.append(f"{suite}: {name} failed without an executed baseline")
+                  # A removed or skipped test is not evidence that a previously observed failure healed.
+                  for name, outcome in left["results"].items():
+                      if outcome in ("Passed", "Failed") and right["results"].get(name) not in ("Passed", "Failed"):
+                          incomplete.append(f"{suite}: {name} was not executed at main")
+              return sorted(delta), incomplete
+
+
+          def run_arm():
+              suites = [x.strip() for x in os.environ["SUITES"].splitlines() if x.strip()]
+              if not suites or len(suites) != len(set(suites)):
+                  raise ValueError("suites must name a nonempty, unique set")
+              workspace = Path(os.environ["GITHUB_WORKSPACE"])
+              scratch = Path(os.environ["RUNNER_TEMP"])
+              core = os.environ["CORE"]
+              evidence = {}
+              for index, suite in enumerate(suites):
+                  directory = scratch / f"canary-{core}-{index}"
+                  directory.mkdir()  # Never reuse results from an earlier invocation.
+                  log = directory / "test.log"
+                  common = [suite, "-c", "Release", "-p:CIRun=true", "-warnaserror",
+                            f"-p:MeshWeaverRoot={workspace / core}/"]
+                  command = ["dotnet", "test", suite, "--no-build", "-c", "Release", "-p:CIRun=true", "-warnaserror",
+                             f"-p:MeshWeaverRoot={workspace / core}/", "--logger", "trx;LogFileName=results.trx",
+                             "--results-directory", str(directory)]
+                  build_passed = False
+                  try:
+                      with (directory / "build.log").open("w") as output:
+                          build = subprocess.run(["dotnet", "build", *common],
+                              cwd=workspace / ("repo" if core == "core-pin" else "repo-main"),
+                              stdout=output, stderr=subprocess.STDOUT, timeout=480)
+                      if build.returncode != 0:
+                          compiler_error = re.search(r"error (?:CS|FS|BC)[0-9]+", (directory / "build.log").read_text())
+                          evidence[suite] = {"build": "failed" if build.returncode == 1 and compiler_error else "unknown",
+                                             "error": f"build exited {build.returncode}; see build.log"}
+                          continue
+                      build_passed = True
+                      with log.open("w") as output:
+                          result = subprocess.run(command, cwd=workspace / ("repo" if core == "core-pin" else "repo-main"), stdout=output,
+                                                  stderr=subprocess.STDOUT, timeout=480)
+                      evidence[suite] = {"build": "passed", "results": read_results(directory / "results.trx", result.returncode)}
+                  except (OSError, ValueError, ET.ParseError, subprocess.TimeoutExpired) as error:
+                      evidence[suite] = {"build": "passed" if build_passed else "unknown", "error": str(error)}
+                      print(f"::warning::{suite}: comparison incomplete: {error}; log: {log}")
+              (scratch / os.environ["OUT"]).write_text(json.dumps(evidence))
+
+
+          def report():
+              scratch = Path(os.environ["RUNNER_TEMP"])
+              delta, incomplete = compare(json.loads((scratch / "pin.json").read_text()),
+                                          json.loads((scratch / "main.json").read_text()))
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+                  summary.write("### Canary evidence\n\n")
+                  summary.write("\n".join(f"- {line}" for line in delta + incomplete) + "\n")
+              if incomplete:
+                  raise ValueError("comparison incomplete; preserving the existing tracking issue")
+              (scratch / "delta.txt").write_text("\n".join(delta) + ("\n" if delta else ""))
+              with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+                  output.write(f"count={len(delta)}\n")
+
+
+          if __name__ == "__main__":
+              if sys.argv[1] == "run":
+                  run_arm()
+              else:
+                  report()
+          PYTHON
 
       - name: Run the suites at the PIN (the control arm)
-        continue-on-error: true
         env:
           SUITES: ${{ inputs.suites }}
           CORE: core-pin
-          OUT: pin.txt
-        run: bash "$GITHUB_WORKSPACE/canary-run.sh"
+          OUT: pin.json
+        run: python3 "$GITHUB_WORKSPACE/canary-evidence.py" run
 
       - name: Run the suites at core MAIN
-        continue-on-error: true
         env:
           SUITES: ${{ inputs.suites }}
           CORE: core-main
-          OUT: main.txt
-        run: bash "$GITHUB_WORKSPACE/canary-run.sh"
+          OUT: main.json
+        run: python3 "$GITHUB_WORKSPACE/canary-evidence.py" run
 
-      - name: The delta — passes at the pin, fails at core main
+      - name: Preserve the comparison evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: platform-canary-evidence
+          path: |
+            ${{ runner.temp }}/canary-*/
+            ${{ runner.temp }}/pin.json
+            ${{ runner.temp }}/main.json
+          if-no-files-found: error
+
+      - name: The delta — recorded passes at the pin, failures at main
         id: delta
-        run: |
-          set -euo pipefail
-          touch "$RUNNER_TEMP/pin.txt" "$RUNNER_TEMP/main.txt"
-          # Only tests that FAIL at main and do NOT fail at the pin. A test already red at the pin
-          # is this repo's own business and says nothing about core.
-          comm -13 <(sort -u "$RUNNER_TEMP/pin.txt") <(sort -u "$RUNNER_TEMP/main.txt") > "$RUNNER_TEMP/delta.txt" || true
-          count=$(wc -l < "$RUNNER_TEMP/delta.txt" | tr -d ' ')
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Canary delta: ${count} test(s) pass at the pin and fail at core main"
-            echo ""
-            if [ "$count" != "0" ]; then sed 's/^/- `/;s/$/`/' "$RUNNER_TEMP/delta.txt"; else echo "_None._"; fi
-            echo ""
-            echo "Also red at the pin (NOT reported — this repo's own): $(wc -l < "$RUNNER_TEMP/pin.txt" | tr -d ' ')"
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: python3 "$GITHUB_WORKSPACE/canary-evidence.py" report
 
       - name: File or close the tracking issue
         env:
@@ -204,7 +303,9 @@ jobs:
         run: |
           set -euo pipefail
           marker="<!-- platform-canary -->"
-          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$marker in:body" --json number --jq '.[0].number // empty' || true)
+          existing=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues?state=open&per_page=100" \
+            --jq '.[] | select(.pull_request == null and ((.body // "") | contains("<!-- platform-canary -->"))) | .number')
+          [ "$(printf '%s\n' "$existing" | sed '/^$/d' | wc -l | tr -d ' ')" -le 1 ] || { echo "::error::multiple canary issues; refusing to choose one"; exit 1; }
           if [ "$COUNT" = "0" ]; then
             if [ -n "$existing" ]; then
               gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
@@ -214,10 +315,10 @@ jobs:
             exit 0
           fi
           {
-            printf 'Core `%s` breaks **%s** test(s) that pass at this repo'"'"'s pin (`%s`, **%s** commits behind).\n\n' "$MAIN" "$COUNT" "$PIN" "$BEHIND"
+            printf 'Core `%s` breaks **%s** regression(s) against this repo'"'"'s pin (`%s`, **%s** commits behind).\n\n' "$MAIN" "$COUNT" "$PIN" "$BEHIND"
             sed 's/^/- `/;s/$/`/' "$RUNNER_TEMP/delta.txt"
             printf '\nThese are **not** red on this repo today, and this is **not** a gate — nothing here blocks a pull request. It is what the next pin bump will hit, reported on the day core merged it rather than days later under a red trunk.\n\n'
-            printf '🚨 **The list is a DELTA, not a failure list.** Each test was run twice — once with core at the pin, once at core main — and only those that pass at the pin and fail at main are here. A test already red at the pin is this repo'"'"'s own business and is excluded.\n\n'
+            printf '🚨 **The list is a DELTA, not a failure list.** Test regressions require an executed pass at the pin and a failure at main. Build regressions require a successful build at the pin and a failed build at main. A test already red at the pin is this repo'"'"'s own business and is excluded.\n\n'
             printf '[Canary run](%s)\n\n%s\n' "$RUN_URL" "$marker"
           } > "$RUNNER_TEMP/body.md"
           if [ -n "$existing" ]; then
@@ -225,7 +326,7 @@ jobs:
             gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "Still ${COUNT} at core \`${MAIN}\` ([run](${RUN_URL}))."
           else
             gh issue create --repo "$GITHUB_REPOSITORY" --label "$LABEL" \
-              --title "Platform canary: core main breaks ${COUNT} test(s) this pin does not" --body-file "$RUNNER_TEMP/body.md" || \
+              --title "Platform canary: core main breaks ${COUNT} regression(s) against this pin" --body-file "$RUNNER_TEMP/body.md" || \
             gh issue create --repo "$GITHUB_REPOSITORY" \
-              --title "Platform canary: core main breaks ${COUNT} test(s) this pin does not" --body-file "$RUNNER_TEMP/body.md"
+              --title "Platform canary: core main breaks ${COUNT} regression(s) against this pin" --body-file "$RUNNER_TEMP/body.md"
           fi


### PR DESCRIPTION
Implements the platform-canary proposal in Systemorph/MeshWeaver.Plugins#1519. The caller workflow is a separate change in that repository.

The scheduled canary compares selected dependent suites at their current core pin and at one resolved core-main commit. It reports compatibility regressions without becoming a required PR check or moving the pin.

## Evidence and outcomes

- Each arm uses its own caller checkout and builds Release with CI warnings-as-errors flags, then runs tests against that build.
- Test regressions require a recorded **Passed** result at the pin and **Failed** at main, read from fresh TRX files. A missing failure line is never interpreted as a pass.
- A compiler failure at main is reported as a build regression only when the same suite built successfully at the pin. Other process/build failures are incomplete evidence.
- Missing, partial, empty, skipped-only, ambiguous, or inconsistent results prevent a clean verdict. An incomplete comparison cannot close an existing tracking issue. A baseline build failure does not cancel against another failed build and become green.
- A missing or skipped candidate test also cannot establish that an earlier failure healed.
- Per-suite build/test logs, TRX files, and arm evidence are retained as artifacts. The 45-minute job cap remains; each build and test invocation is bounded at eight minutes.
- Tracking-issue discovery uses REST and refuses multiple matching issues.

## Verification

`python3 .github/scripts/test-platform-canary.py`: **15 tests pass**, covering the demonstrated baseline-build-failure false regression, real pass-to-fail comparisons, compiler versus infrastructure failure, missing/skipped tests, partial results, host exits, duplicate names, and theory names. The parser also successfully read an actual five-test xUnit TRX from the local radio-binding reproduction.

Workflow shell, YAML-key, timeout, and secret-preflight checks pass. The actual scheduled comparison still needs its first run after the dependent caller is wired; fixture tests do not establish that the dependent suites pass against core main.

No What's New entry: internal CI reporting only.

Pairs-with: none — CI only; no public framework surface changes.
