### PR TITLE
fix: keep JSON recovery payloads out of error logs

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/ObjectAsExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/ObjectAsExtensions.cs
@@ -92,15 +92,14 @@ public static class ObjectAsExtensions
                 catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
                 {
                     // Don't rethrow (a throw on read faults the caller), don't swallow: log loud
-                    // with the raw JSON so the corruption is visible.
+                    // with structural diagnostics; node content and converter messages are private.
                     //
                     // The catch set matches the foreign-type branch below on purpose. A missing
                     // converter throws NotSupportedException and an unsupported target shape throws
                     // InvalidOperationException — neither derives from JsonException, so catching
                     // JsonException alone would let a read fault its caller, which is the one thing
                     // this accessor exists to prevent.
-                    logger?.LogError(ex, "As<{TargetType}> could not recover {What}: {RawJson}",
-                        typeof(T).Name, what ?? "value", Excerpt(je.GetRawText()));
+                    LogRecoveryFailure(logger, typeof(T), ex);
                     return null;
                 }
             case JsonNode jn:
@@ -110,8 +109,7 @@ public static class ObjectAsExtensions
                 }
                 catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
                 {
-                    logger?.LogError(ex, "As<{TargetType}> could not recover {What}: {RawJson}",
-                        typeof(T).Name, what ?? "value", Excerpt(jn.ToJsonString()));
+                    LogRecoveryFailure(logger, typeof(T), ex);
                     return null;
                 }
             default:
@@ -194,8 +192,7 @@ public static class ObjectAsExtensions
                 }
                 catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
                 {
-                    logger?.LogError(ex, "As<{TargetType}> could not recover {What}: {RawJson}",
-                        type.Name, what ?? "value", Excerpt(je.GetRawText()));
+                    LogRecoveryFailure(logger, type, ex);
                     return null;
                 }
             case JsonNode jn:
@@ -205,8 +202,7 @@ public static class ObjectAsExtensions
                 }
                 catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
                 {
-                    logger?.LogError(ex, "As<{TargetType}> could not recover {What}: {RawJson}",
-                        type.Name, what ?? "value", Excerpt(jn.ToJsonString()));
+                    LogRecoveryFailure(logger, type, ex);
                     return null;
                 }
             default:
@@ -235,15 +231,13 @@ public static class ObjectAsExtensions
     }
 
     /// <summary>
-    /// The head of a payload, for a diagnostic log line. Bounded because the value being logged is
-    /// by definition the one we could NOT parse — a degraded content blob or a whole snapshot can be
-    /// megabytes, and these lines ship to the log store. The first 2 KB is what a human reads to
-    /// recognise the shape; the tail never adds diagnosis, it only adds cost.
+    /// Record the failed conversion without exporting node content, node paths, or exception
+    /// messages. Custom converters can put the entire value into an exception, and JsonException
+    /// paths can contain user-controlled dictionary keys, so neither is safe diagnostic metadata.
     /// </summary>
-    private static string Excerpt(string raw) =>
-        raw.Length <= RawJsonLogLimit
-            ? raw
-            : $"{raw[..RawJsonLogLimit]}… [{raw.Length - RawJsonLogLimit} more chars]";
-
-    private const int RawJsonLogLimit = 2048;
+    private static void LogRecoveryFailure(ILogger? logger, Type target, Exception exception) =>
+        logger?.LogError(
+            "As<{TargetType}> could not recover value: {ExceptionType}. "
+            + "Content and exception details withheld.",
+            target.Name, exception.GetType().Name);
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/ObjectAsPrivatePayloadTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ObjectAsPrivatePayloadTest.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+public class ObjectAsPrivatePayloadTest
+{
+    [Theory]
+    [InlineData(false, false, 0)]
+    [InlineData(false, true, 0)]
+    [InlineData(true, false, 0)]
+    [InlineData(true, true, 0)]
+    [InlineData(false, false, 1)]
+    [InlineData(false, true, 1)]
+    [InlineData(true, false, 1)]
+    [InlineData(true, true, 1)]
+    [InlineData(false, false, 2)]
+    [InlineData(false, true, 2)]
+    [InlineData(true, false, 2)]
+    [InlineData(true, true, 2)]
+    public void FailedReadReportsTheFailureWithoutPublishingContentOrExceptionText(
+        bool node, bool runtimeType, int failure)
+    {
+        const string privateText = "synthetic-private-correspondence";
+        var json = JsonSerializer.Serialize(new { message = privateText });
+        object value = node ? JsonNode.Parse(json)! : JsonSerializer.Deserialize<JsonElement>(json);
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RejectPayload(failure));
+        var logger = new CapturingLogger();
+
+        var result = runtimeType
+            ? value.As(typeof(Payload), options, logger, privateText)
+            : value.As<Payload>(options, logger, privateText);
+
+        result.Should().BeNull();
+        logger.Entries.Should().ContainSingle();
+        var entry = logger.Entries[0];
+        entry.Level.Should().Be(LogLevel.Error);
+        entry.Text.Should().NotContain(privateText);
+        entry.Exception.Should().BeNull("converter exceptions may contain the entire private value");
+        entry.Text.Should().Contain(nameof(Payload));
+        entry.Text.Should().Contain(failure switch
+        {
+            0 => nameof(JsonException),
+            1 => nameof(NotSupportedException),
+            _ => nameof(InvalidOperationException),
+        });
+    }
+
+    private sealed record Payload(string Message);
+
+    private sealed class RejectPayload(int failure) : JsonConverter<Payload>
+    {
+        public override Payload Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            var content = document.RootElement.GetRawText();
+            throw failure switch
+            {
+                0 => new JsonException(content),
+                1 => new NotSupportedException(content),
+                _ => new InvalidOperationException(content),
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, Payload value, JsonSerializerOptions options) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Text, Exception? Exception)> Entries { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception), exception));
+    }
+}


### PR DESCRIPTION
Failed JSON recovery currently writes the payload excerpt and original converter exception to the error log. Both can contain private content. Both accessor overloads now report the target type and exception type without attaching the payload, caller-provided node identifier, or exception text; the read still returns null and the error level is unchanged.

Validation: Release build with CIRun and warnings-as-errors completed with zero warnings/errors. All 20 accessor tests passed with a fresh TRX. The 12 synthetic privacy cases cover JsonElement/JsonNode, generic/runtime-type accessors, and all three caught exception types; all 12 failed against the original implementation.

Related to #3803. This fixes the source logging exposure only: the node-type conversion defect and the separate automated issue publication boundary remain open. No real incident content is included in this change.

What's New skipped: internal diagnostic logging change; no UI behavior change.
