### PR TITLE
docs: a departed platform assembly breaks every module that binds it (#3221)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -319,6 +319,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Disposable-mesh e2e](DisposableMeshE2E)
 - [Debugging Message Flow](DebuggingMessageFlow)
 - [Debugging Disposal & Leaks](DebuggingDisposalAndLeaks)
+- [Departed Platform Assemblies](DepartedPlatformAssemblies) — an assembly that leaves the platform for a module breaks every OTHER module that binds it, at LOAD time and invisibly to every compile gate; why "those are the platform" is one answer per host
 - [Detached Response Continuations](DetachedResponseContinuations) — why a `hub.Observe(...)` continuation runs on the RESPONDING hub's action block, what that cost on the mesh's one node-CRUD hub, and the six invariants that make the hop an opt-in rather than the default
 - [Reading a Disposal Stall Verdict](DisposalStallVerdicts) — what each field of the disposal snapshot actually measures, the three that were read as evidence while measuring nothing, and the verdict hole that sent 47 reports to children that were not the problem
 - [Ambient Test-Host Hangs](AmbientTestHostHangs) — what decides whether a killed test host can be diagnosed at all, and the readings of it already falsified

--- a/src/MeshWeaver.Documentation/Data/Architecture/DepartedPlatformAssemblies.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DepartedPlatformAssemblies.md
@@ -1,0 +1,120 @@
+---
+Name: Departed Platform Assemblies
+Category: Architecture
+Description: An assembly that leaves the platform for a module breaks every OTHER module that binds it — at load time, invisibly to every compile gate. The break shape, the six-night reproducer that established it, and why "those are the platform" is one answer per host rather than one answer.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h11v10H3z"/><path d="M14 10h4l3 3v4h-7z"/><path d="m17 3-2 4h4l-2 4"/></svg>
+---
+
+# Departed Platform Assemblies
+
+**An assembly that leaves the platform for a module breaks every OTHER module that binds it — at
+LOAD time, invisibly to every compile gate.**
+
+Both halves compile. The platform builds without it. The depending module builds against it — it is
+right there in the same repository. Nothing anywhere asks whether the assembly it moved *into* is in
+the closure of every module that binds it, and the failure surfaces as a module that loads and
+contributes nothing.
+
+## 1. The reproducer that established it
+
+MeshWeaver.Manufacturing's scheduled run, red every night 2026-09-04 → 09-09:
+
+```
+[MeshWeaver.Mesh.IncompatibleModule] Module 'MeshWeaver.AI' did not install against this platform
+build and is CONTRIBUTING NOTHING. It requires
+'MeshWeaver.ContentCollections.Indexing.ChunkPosition
+ (MeshWeaver.ContentCollections.Indexing — this deployment carries no such platform assembly)'
+
+[MeshWeaver.Mesh.IncompatibleModule] Module 'MeshWeaver.Markdown.Collaboration' … requires
+'MeshWeaver.Blazor.BlazorView`2 (MeshWeaver.Blazor — …no such platform assembly)'
+```
+
+**Two modules, two departed assemblies, one shape** — which is what makes it a rule rather than an
+incident. The cascade from there is worth knowing, because none of it names the cause:
+
+| step | what is seen |
+|---|---|
+| AI contributes nothing | its `BuiltInAgentProvider` / `BuiltInSkillProvider` never run |
+| so `Agent` / `Skill` resolve to nothing | `Install of 'Store' failed: NodeType(s) not registered: Skill` |
+| `Store/Plugin` is declared BY `Store` | every package rooted on it fails: *"NodeType 'Store/Plugin' is not registered"* |
+| 36 installs refused | `GATE FAILED — the bake declares 103 NodeType(s), NONE of which this run installed` |
+
+A reader starting at the bottom finds a bake-consumption failure; three levels up is a module that
+could not load. The first three explanations tried on that issue — missing `Agent`/`Skill` packages,
+a stale catalog, an identity skew — were all wrong, and each was reached by stopping at the first
+line that fit.
+
+## 2. Why the compile gates cannot see it
+
+The cross-repo pair gate covers *a public type leaving `src/`*, and #2941 (*"The indexing pipeline,
+the map control and Cornerstone leave the content surface"*) presumably satisfied it — nothing
+failed to compile, because the consumer moved with the assembly. What no gate covers is the
+**runtime closure**: whether the bundle that now owns the assembly is loaded wherever a module
+binding it is loaded.
+
+This is the tenth break shape in AGENTS.md's list in all but name, and the one whose evidence
+arrives latest — a green build, a green publish, and a module that silently does nothing.
+
+## 3. "Those are the platform" is one answer PER HOST
+
+`DepsClosure` decides what a bundle carries with this rule:
+
+> stopping at (and never bundling) `MeshWeaver.*` nodes: **those are the platform**, they ship in the
+> consumer's `/app` by construction
+
+The exclusion list is MeshWeaver.Plugins' `src/platform-shipped.txt`. Both rest on "the platform"
+being one thing. It is not — the two hosts that load these bundles are built from **different
+repositories**:
+
+| host | built from | carries `Blazor` / `Indexing`? |
+|---|---|---|
+| `memex-portal-ai` | **Plugins** — `Memex.Portal.Gui/.Distributed/.Monolith`, alongside `src/MeshWeaver.Blazor*` and `src/MeshWeaver.ContentCollections.Indexing.*` | **yes** |
+| `mw-plugin-test` | **core** — `tools/MeshWeaver.PluginTester`, whose whole closure is seven core projects, none reaching Blazor | **no — neither assembly exists in core at all** |
+
+and `platform-shipped.txt`'s own comments record it being measured *twice against the portal*
+(images `ci.7755` / `ci.7794`, and the three `Memex.Portal.*` closures). **It is right for the host it
+was measured against and wrong for the other**, and because they are built from different
+repositories no re-measurement of a single image reconciles them.
+
+🚨 This is determinable **statically**, from the two reference sets — the investigation that found it
+first proposed extracting both images, which was unnecessary.
+
+## 4. The trap in the obvious fix
+
+Deleting the two roster lines makes the tester work and reintroduces on the portal exactly what the
+roster exists to prevent. Its own comment:
+
+> omitting them is what makes the Indexing bundle carry a second copy of an assembly `/app` already
+> has, which is the **same-identity duplicate this whole file exists to prevent**
+
+— i.e. [#3732](https://github.com/Systemorph/MeshWeaver/issues/3732)'s two-producer defect, whose
+live `heldReason` reads *"the loader keeps whichever it sees first, so the other's NodeTypes are
+declined at adoption"*.
+
+So it is a decision between two real costs, and it belongs to whoever owns the module split:
+
+1. **A per-host roster** — pack per consumer. `module-owned-platform.sh` already takes the host as an
+   argument (`<src> [<platform-app-dir>]`); what is missing is that the pack resolves ONE answer for
+   hosts that do not agree.
+2. **Carry it and let `/app` win** — which is precisely the trade `DepsClosure`'s *diamond* paragraph
+   already argues for non-`MeshWeaver.*` packages: *"the default load context resolves `/app`'s copy
+   first whenever the platform carries one … and the module's copy takes over the moment the platform
+   stops carrying it… shedding a dependency from the platform (the very point of the module split)
+   would silently break every landed module that relied on it."* That is this failure, one
+   assembly-name convention over.
+3. **Make the tester's closure match the portal's** — which changes what the gate gates.
+
+## 5. What to check when it happens again
+
+- `IncompatibleModule … CONTRIBUTING NOTHING` naming an assembly, in the boot or install log — that
+  IS the diagnosis; everything downstream of it is cascade.
+- Whether the named assembly exists in the repository the LOADING host is built from.
+- Whether `platform-shipped.txt` names it — if so, the bundle omitted it on purpose.
+- A green push run proves nothing here: `push` pins the image to the wave the modules came from, so
+  only a release-follow poll exercises the pairing.
+
+Related: [#3221](https://github.com/Systemorph/MeshWeaver/issues/3221) (module closure — the sibling
+question), [#3732](https://github.com/Systemorph/MeshWeaver/issues/3732) (the two-producer half),
+[#3768](https://github.com/Systemorph/MeshWeaver/issues/3768), and
+[#3583](https://github.com/Systemorph/MeshWeaver/issues/3583) (the same asymmetry from the source
+side).

--- a/src/MeshWeaver.Plugin.Build/DepsClosure.cs
+++ b/src/MeshWeaver.Plugin.Build/DepsClosure.cs
@@ -30,6 +30,39 @@ namespace MeshWeaver.Plugin.Build;
 /// landed module that relied on it until re-packed. Versions agree while both carry one, because
 /// platform and modules restore from the same central package pins.</para>
 ///
+/// <para>🚨 <b>"Those are the platform" is not one answer — it is one answer PER HOST, and the
+/// hosts disagree (#3221).</b> The rule above rests on <c>MeshWeaver.*</c> meaning "the consumer's
+/// <c>/app</c> carries it". Measured 2026-09-09, two hosts that both load these bundles are built
+/// from DIFFERENT REPOSITORIES and carry different sets:</para>
+///
+/// <list type="bullet">
+/// <item><b>the portal</b> (<c>memex-portal-ai</c>) is built from MeshWeaver.Plugins'
+/// <c>Memex.Portal.*</c>, alongside <c>src/MeshWeaver.Blazor*</c> and
+/// <c>src/MeshWeaver.ContentCollections.Indexing.*</c> — it carries both;</item>
+/// <item><b>the gate tester</b> (<c>mw-plugin-test</c>) is built from core's
+/// <c>tools/MeshWeaver.PluginTester</c>, whose whole closure is seven core projects, none reaching
+/// Blazor — and neither assembly EXISTS in core at all, so it can never carry either.</item>
+/// </list>
+///
+/// <para>MeshWeaver.Plugins' <c>src/platform-shipped.txt</c> — the declared roster feeding
+/// <c>ownedPlatformNames</c> — was measured against the PORTAL (its own comments cite images
+/// ci.7755/ci.7794 and the three <c>Memex.Portal.*</c> closures). It is therefore right for the
+/// portal and wrong for the tester, and no re-measurement of a single image reconciles them: on
+/// 2026-09-04..09 <c>MeshWeaver.AI</c> and <c>MeshWeaver.Markdown.Collaboration</c> both loaded as
+/// <c>IncompatibleModule … CONTRIBUTING NOTHING</c> on the tester, requiring
+/// <c>ContentCollections.Indexing.ChunkPosition</c> and <c>Blazor.BlazorView`2</c> — assemblies this
+/// walk had excluded as "platform". That cascaded to 36 refused package installs and reddened a
+/// satellite's nightly for six consecutive nights.</para>
+///
+/// <para>🚨 <b>Do not "fix" it by deleting those two roster lines.</b> That makes the tester work
+/// and reintroduces on the PORTAL the same-identity duplicate the roster exists to prevent (#3732).
+/// The diamond paragraph above already argues the opposite trade for non-<c>MeshWeaver.*</c>
+/// packages — <i>"shedding a dependency from the platform … would silently break every landed
+/// module that relied on it"</i> — which is precisely what happened here, one assembly-name
+/// convention over. Reconciling the two is a decision between real costs (a per-host roster, or
+/// carrying the assembly and letting <c>/app</c> win as the diamond rule does), not a line edit;
+/// it is tracked on #3221 and #3732.</para>
+///
 /// <para>Shared-framework assemblies (<c>FrameworkReference</c>) never appear as package nodes in
 /// deps.json, so they are excluded by construction.</para>
 ///


### PR DESCRIPTION
Closes #3221 (in part — it records the finding and names the decision; the reconciliation itself is a scope call, see below).

## The finding

`DepsClosure` decides what a bundle need not carry with one rule: stop at `MeshWeaver.*` nodes, **"those are the platform"**, they ship in the consumer's `/app` by construction.

That rests on "the platform" being *one thing*. It is not. The two hosts that load these bundles are built from **different repositories**:

| host | built from | carries `Blazor` / `Indexing`? |
|---|---|---|
| `memex-portal-ai` | **Plugins** — `Memex.Portal.{Gui,Distributed,Monolith}`, sitting beside `src/MeshWeaver.Blazor*` and `src/MeshWeaver.ContentCollections.Indexing.*` | **yes** |
| `mw-plugin-test` | **core** — `tools/MeshWeaver.PluginTester`, a closure of seven core projects, none reaching Blazor | **no — neither assembly exists in core at all** |

`platform-shipped.txt` (the declared roster feeding `ownedPlatformNames`) was measured against the **portal** — its own comments cite images `ci.7755` / `ci.7794` and the three `Memex.Portal.*` closures. So it is right for the host it was measured against and wrong for the other, and because they are built from different repositories **no re-measurement of a single image reconciles them**.

🚨 This is determinable **statically**, from the two reference sets. The investigation's first instinct — extract both images and diff them — was unnecessary.

## What it broke

MeshWeaver.Manufacturing's scheduled run, red every night 2026-09-04 → 09-09:

```
[MeshWeaver.Mesh.IncompatibleModule] Module 'MeshWeaver.AI' … CONTRIBUTING NOTHING.
  requires 'ContentCollections.Indexing.ChunkPosition (…no such platform assembly)'
[MeshWeaver.Mesh.IncompatibleModule] Module 'MeshWeaver.Markdown.Collaboration' …
  requires 'MeshWeaver.Blazor.BlazorView`2 (…no such platform assembly)'
```

Two modules, two departed assemblies, one shape — which is what makes it a rule rather than an incident. The cascade from there names the cause nowhere:

AI contributes nothing → `BuiltInAgentProvider`/`BuiltInSkillProvider` never run → `Agent`/`Skill` unregistered → `Install of 'Store' failed` → `Store/Plugin` unregistered → 36 installs refused → `GATE FAILED — 103 NodeType(s) declared, NONE installed`.

A reader starting at the bottom finds a bake-consumption failure; three levels up is a module that could not load. The first three explanations reached on that issue were all wrong, each by stopping at the first line that fit.

## Why no gate sees it

The cross-repo pair gate covers *a public type leaving `src/`* — and #2941 presumably satisfied it, because the consumer moved **with** the assembly, so nothing failed to compile. What no gate covers is the **runtime closure**: whether the bundle that now owns the assembly is loaded wherever a module binding it is loaded. It is AGENTS.md's tenth break shape in all but name, and the one whose evidence arrives latest — green build, green publish, module silently does nothing.

## 🚨 The trap in the obvious fix

Deleting the two roster lines makes the tester work and reintroduces **on the portal** exactly what the roster exists to prevent — #3732's same-identity duplicate, whose live `heldReason` reads *"the loader keeps whichever it sees first, so the other's NodeTypes are declined at adoption."*

So this PR deliberately **does not change behaviour**. It records the finding, and names the three candidate reconciliations (per-host roster / carry-it-and-let-`/app`-win, which is the trade the diamond paragraph already argues for non-`MeshWeaver.*` packages / make the tester's closure match the portal's) as a decision for whoever owns the module split.

## Contents

- `Doc/Architecture/DepartedPlatformAssemblies` — the break shape, the reproducer, the per-host analysis, and what to check when it recurs
- the Architecture index line
- a doc-comment on `DepsClosure` itself, where the "those are the platform" rule is implemented — so the next reader of that walk meets the caveat at the rule, not in a separate document

Pairs-with: none — additions only; no public type or member is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
