### PR TITLE
fix: prepare activity mirror cleanup before writer disposal

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -182,6 +182,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - **Start here:** [Thread Operations](ThreadOperations)
 - [Thread Execution Streaming](ThreadExecutionStreaming)
 - [Activity Control Plane](ActivityControlPlane)
+- [Activity Mirror Release Lifetime](/Doc/Architecture/ActivityMirrorReleaseLifetime)
 - [Activity Operations](ActivityOperations)
 - [Notifications](Notifications)
 - [Notification Retention](NotificationRetention) — the platform's first data-retention pass, and why it is a logon action

--- a/src/MeshWeaver.Documentation/Data/Architecture/ActivityMirrorReleaseLifetime.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ActivityMirrorReleaseLifetime.md
@@ -1,0 +1,34 @@
+---
+Name: Activity Mirror Release Lifetime
+Category: Architecture
+Description: "Prepare terminal activity cleanup before starting the write, while the writer's service scope is alive."
+---
+
+# Activity mirror release lifetime
+
+A terminal activity write releases its unwatched mirror on **completion**, after its final value
+has been delivered. Releasing on the value can tear down the write's own upstream subscription
+before its terminal signal arrives. That ordering stays unchanged.
+
+Completion can nevertheless arrive after the writer's service scope has retired. Resolving
+`IMeshNodeStreamCache` from that scope in the completion callback throws `ObjectDisposedException`.
+This was captured in `ActivityLogAppender.Append` during a dependent Monolith test run on
+9 September 2026. Passing test assertions did not establish that cleanup was correct.
+
+`ActivityLogAppender.PrepareMirrorRelease` resolves the cache while preparing the write and returns
+an action accepting the final status. The completion callback invokes that action without resolving
+services. The cache itself owns the disposed-state and subscriber checks: a disposed cache or a
+watched mirror is left alone, and a non-terminal activity never triggers release.
+
+The four framework writers use the same preparation step: `ActivityLogAppender.Append`,
+`BuildProtocolDriver.FinishActivity`, `CodeNodeType.FailActivity`, and
+`ActivityLogLogger.PublishSnapshotLocked`. The existing immediate `ReleaseMirrorWhenFinal` method
+remains available for callers with a live scope; it is not the delayed-completion API.
+
+`ActivityReleaseLifetimeTest` captures cleanup from a real hub, retires that hub and its nested
+service scope, and then invokes the completion. The original callback fails at the disposed Autofac
+scope; the prepared callback succeeds. `TerminalActivityWriterReleaseTest` separately proves that
+terminal writes still release unwatched mirrors and that a Running status releases nothing.
+
+This fixes the late service lookup. It does not establish that all activity producers join their
+work before teardown, or resolve the separate node-CRUD and concurrent-logon scheduling issues.

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -565,6 +565,7 @@ public static class CodeNodeType
             logger?.LogWarning(exception,
                 "CodeNodeType: failing run {Activity} dispatched from {Hub}: {Error}",
                 activityPath, hub.Address, error);
+        var releaseMirror = ActivityLogAppender.PrepareMirrorRelease(hub, activityPath, logger);
         hub.GetWorkspace().GetMeshNodeStream(activityPath).Update(curr =>
                 // 🚨 ContentAs, never `is ActivityLog`. This lambda runs against a LOCAL mirror whose
                 // Content can be a degraded JsonElement, and a plain type test is then null — the
@@ -579,7 +580,6 @@ public static class CodeNodeType
                     "CodeNodeType: failed to reconcile ActivityLog {Activity} to Failed", activityPath),
                 // #3117 — retire the activity's per-node hub on the terminal write rather than
                 // leaving it to the 10-minute idle sweep. Completion, never emission.
-                () => ActivityLogAppender.ReleaseMirrorWhenFinal(
-                    hub, activityPath, ActivityStatus.Failed, logger));
+                () => releaseMirror(ActivityStatus.Failed));
     }
 }

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -574,8 +574,10 @@ public static class BuildProtocolDriver
     // internal, not private: MeshWeaver.Graph.Test drives this directly to pin the #3117
     // release. Nothing outside the test assembly can see it.
     internal static IObservable<MeshNode> FinishActivity(
-        IMessageHub mesh, string activityPath, ActivityStatus status) =>
-        mesh.GetWorkspace().GetMeshNodeStream(activityPath).Update(node =>
+        IMessageHub mesh, string activityPath, ActivityStatus status)
+    {
+        var releaseMirror = ActivityLogAppender.PrepareMirrorRelease(mesh, activityPath);
+        return mesh.GetWorkspace().GetMeshNodeStream(activityPath).Update(node =>
             {
                 var log = node?.ContentAs<ActivityLog>(mesh.JsonSerializerOptions);
                 if (node is null || log is null || log.Status.IsTerminal()) return node!;
@@ -587,7 +589,8 @@ public static class BuildProtocolDriver
             // emitted. An already-terminal log takes the no-op arm above and is released here too,
             // which is correct: the status IS terminal, whoever wrote it.
             .Do(_ => { },
-                () => ActivityLogAppender.ReleaseMirrorWhenFinal(mesh, activityPath, status));
+                () => releaseMirror(status));
+    }
 
     // ── the follower ────────────────────────────────────────────────────────────────────────────
 

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -264,6 +264,7 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
             var returnValue = _terminalReturnValue;
 
             var stream = _stream ??= hub.GetWorkspace().GetMeshNodeStream(activityLogPath);
+            var releaseMirror = ActivityLogAppender.PrepareMirrorRelease(hub, activityLogPath, _diagnostics);
             var options = hub.JsonSerializerOptions;
 
             // 🚨 THE canonical mutation API — see the class remarks for why a hand-posted
@@ -357,8 +358,7 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
                         // On COMPLETION, never on the emission: releasing tears the path's upstream
                         // sync streams down, and the write is still in flight when its value is
                         // emitted. Same rule, same reason, as Append's own Do arm.
-                        () => ActivityLogAppender.ReleaseMirrorWhenFinal(
-                            hub, activityLogPath, status, _diagnostics));
+                        () => releaseMirror(status));
         }
         catch { /* never let logging break the script */ }
     }

--- a/src/MeshWeaver.Mesh.Contract/ActivityLogAppender.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityLogAppender.cs
@@ -79,6 +79,7 @@ public static class ActivityLogAppender
         var workspace = hub.GetWorkspace();
         var options = hub.JsonSerializerOptions;
         var stream = workspace.GetMeshNodeStream(activityPath);
+        var releaseMirror = PrepareMirrorRelease(hub, activityPath, logger);
 
         // 🚨 stream.Update(...) is invoked EAGERLY, here, and it must stay that way — do NOT wrap
         // this in Observable.Defer. UpdateRemote captures the caller's AccessContext AT THE .Update()
@@ -116,7 +117,7 @@ public static class ActivityLogAppender
                 () =>
                 {
                     if (settled is not null)
-                        ReleaseMirrorWhenFinal(hub, activityPath, settled, options, logger);
+                        ReleaseMirrorWhenFinal(releaseMirror, settled, options, logger);
                 });
     }
 
@@ -144,15 +145,14 @@ public static class ActivityLogAppender
     /// so nothing here may fail the write that reported the status.</para>
     /// </summary>
     private static void ReleaseMirrorWhenFinal(
-        IMessageHub hub,
-        string activityPath,
+        Action<ActivityStatus> releaseMirror,
         MeshNode final,
         System.Text.Json.JsonSerializerOptions options,
         ILogger? logger)
     {
         if (final.ContentAs<ActivityLog>(options, logger) is not { } log)
             return;
-        ReleaseMirrorWhenFinal(hub, activityPath, log.Status, logger);
+        releaseMirror(log.Status);
     }
 
     /// <summary>
@@ -182,6 +182,8 @@ public static class ActivityLogAppender
     /// — cutting the stream out from under it strands the write's own terminal and leaves the
     /// per-path queue to advance on its 5 s backstop. See the <c>Do</c> arm in <see cref="Append"/>.</para>
     /// </summary>
+    /// <remarks>This immediate form requires a live service scope. Writers preparing an asynchronous
+    /// completion must use <see cref="PrepareMirrorRelease"/> before starting the write.</remarks>
     /// <param name="hub">The hub that performed the terminal write.</param>
     /// <param name="activityPath">Path of the activity node.</param>
     /// <param name="status">The status just written. A non-terminal status is a no-op.</param>
@@ -194,12 +196,28 @@ public static class ActivityLogAppender
     {
         if (!status.IsTerminal())
             return;
+        PrepareMirrorRelease(hub, activityPath, logger)(status);
+    }
+
+    /// <summary>
+    /// Captures the mirror cache while the writer is alive. Invoke the returned action on write
+    /// completion: the writer's service scope may have retired by then. The cache owns its own
+    /// disposal check, so late cleanup never needs to resolve services from the retired writer.
+    /// </summary>
+    /// <param name="hub">The still-live writer preparing the write.</param>
+    /// <param name="activityPath">The activity whose mirror will be released.</param>
+    /// <param name="logger">Optional diagnostics for a successful release.</param>
+    /// <returns>A completion action; non-terminal statuses and a disposed cache are no-ops.</returns>
+    public static Action<ActivityStatus> PrepareMirrorRelease(
+        IMessageHub hub, string activityPath, ILogger? logger = null)
+    {
         var cache = hub.ServiceProvider.GetService<IMeshNodeStreamCache>();
-        if (cache is null)
-            return;
-        if (cache.ReleaseIfUnwatched(activityPath))
-            logger?.LogDebug(
-                "Activity {Path}: reached {Status} — released its shared mirror", activityPath, status);
+        return status =>
+        {
+            if (status.IsTerminal() && cache?.ReleaseIfUnwatched(activityPath) == true)
+                logger?.LogDebug(
+                    "Activity {Path}: reached {Status} — released its shared mirror", activityPath, status);
+        };
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/ActivityReleaseLifetimeTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityReleaseLifetimeTest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+public class ActivityReleaseLifetimeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact]
+    public async Task TerminalCompletion_DoesNotResolveServicesFromTheDisposedWriter()
+    {
+        using var scope = Mesh.ServiceProvider.CreateScope();
+        var writer = scope.ServiceProvider.CreateMessageHub(
+            new Address("client/release-lifetime"), configuration => configuration.AddData())!;
+        writer.ServiceProvider.Should().NotBeSameAs(Mesh.ServiceProvider);
+        var releaseMirror = ActivityLogAppender.PrepareMirrorRelease(
+            writer, "TestData/_Activity/release-lifetime");
+        Action completed = () => releaseMirror(ActivityStatus.Succeeded);
+
+        writer.Dispose();
+        await writer.DisposalCompleted.Timeout(TimeSpan.FromSeconds(10));
+        scope.Dispose();
+
+        var failure = Record.Exception(completed);
+        failure.Should().BeNull("a completed write must not fail while releasing its mirror after the writer retires");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ActivityReleaseLifetimeTest.cs
+++ b/test/MeshWeaver.Graph.Test/ActivityReleaseLifetimeTest.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -24,7 +24,10 @@ public class ActivityReleaseLifetimeTest(ITestOutputHelper output) : MonolithMes
         Action completed = () => releaseMirror(ActivityStatus.Succeeded);
 
         writer.Dispose();
-        await writer.DisposalCompleted.Timeout(TimeSpan.FromSeconds(10));
+        using var disposalDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await writer.DisposalCompleted.ObserveCompletion(
+            ex => Output.WriteLine($"Writer disposal failed after completion: {ex}"),
+            disposalDeadline.Token);
         scope.Dispose();
 
         var failure = Record.Exception(completed);


### PR DESCRIPTION
A terminal activity write could finish after its writer's service scope retired. Its completion callback then resolved IMeshNodeStreamCache from the disposed scope and threw ObjectDisposedException, even though the write had completed.

PrepareMirrorRelease captures the cache while preparing the write. All four framework writers use that prepared callback: Append, build completion, failed code activity, and kernel log snapshots. Release still happens only on completion and only for a terminal status; the cache retains its existing disposed-state and active-subscriber checks. The immediate public helper remains compatible for live-scope callers.

Validation: the new real-hub regression failed against the original callback at the disposed Autofac lookup. With the fix, it and the three existing terminal-release tests passed (4/4, no skips). Release/CIRun/warnings-as-errors builds for the affected dependency graph and documentation passed with zero warnings/errors; the documentation link guard passed. The investigation is preserved in Doc/Architecture/ActivityMirrorReleaseLifetime.

This addresses the captured late service lookup, not the separate concurrent-logon timeout or the complete teardown-duration investigation. No authentication or scheduling semantics changed. What's New skipped: internal resource cleanup, no user-facing feature change.
