### PR TITLE
fix: verify persistent Loki storage and retain logs for 30 days

### DIFF
--- a/.github/workflows/chart-gate.yml
+++ b/.github/workflows/chart-gate.yml
@@ -103,6 +103,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: deploy/aks/scripts/test-chart-drift-compare.sh
 
+      - name: Assert observability installation refuses ephemeral or unverified storage
+        if: ${{ !cancelled() }}
+        run: python3 deploy/aks/scripts/test-observability-storage.py
+
   # The three pieces of shell behind Doc/Architecture/PluginBundlesInTheRegistry — the publisher
   # (.github/scripts/push-bundle-publication.sh), the `bundle-fetch` init container's script and
   # docker_auth's ext_auth hook (deploy/helm/files/) — EXECUTED against the real distribution and

--- a/deploy/aks/scripts/install-observability.sh
+++ b/deploy/aks/scripts/install-observability.sh
@@ -49,10 +49,28 @@ then
   exit 1
 fi
 
+# Verify the RUNNING pod, not just the desired StatefulSet: an orphan left over from
+# the immutable-volume transition can still be serving from emptyDir (#3773).
+if ! storage_volume=$(kubectl -n monitoring get pod loki-0 -o jsonpath='{.spec.containers[?(@.name=="loki")].volumeMounts[?(@.mountPath=="/data")].name}') \
+  || [ -z "$storage_volume" ]; then
+  echo "FATAL: cannot identify Loki's running /data volume." >&2
+  exit 1
+fi
+if ! storage_claim=$(kubectl -n monitoring get pod loki-0 -o "jsonpath={.spec.volumes[?(@.name==\"$storage_volume\")].persistentVolumeClaim.claimName}") \
+  || [ -z "$storage_claim" ]; then
+  echo "FATAL: Loki's running /data volume is not backed by a PVC; log durability is NOT established." >&2
+  exit 1
+fi
+if ! storage_phase=$(kubectl -n monitoring get pvc "$storage_claim" -o jsonpath='{.status.phase}') \
+  || [ "$storage_phase" != Bound ]; then
+  echo "FATAL: Loki's storage PVC is not Bound; log durability is NOT established." >&2
+  exit 1
+fi
+
 echo
-echo "Verify the three things chart defaults get wrong (all must be non-empty / true):"
+echo "Verified: Loki's running /data volume uses Bound PVC $storage_claim."
+echo "Verify the remaining scheduling properties:"
 echo "  kubectl -n monitoring get pod loki-0 -o jsonpath='{.status.qosClass} {.spec.nodeName}'   # NOT BestEffort, NOT a silos node"
-echo "  kubectl -n monitoring get pvc | grep storage-loki-0                                      # the store is durable"
 echo "  kubectl -n monitoring get sts loki -o jsonpath='{.spec.template.spec.nodeSelector}'      # agentpool: system"
 kubectl -n monitoring get pods
 echo

--- a/deploy/aks/scripts/test-observability-storage.py
+++ b/deploy/aks/scripts/test-observability-storage.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Exercise the installer's live-storage verdict without a cluster or credentials."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(os.environ.get('INSTALLER_UNDER_TEST', Path(__file__).with_name('install-observability.sh'))).resolve()
+
+
+class StorageVerdictTest(unittest.TestCase):
+    def run_installer(self, scenario):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'helm').write_text('#!/bin/sh\nexit 0\n')
+            (root / 'kubectl').write_text('''#!/bin/sh
+case "$*" in
+  *volumeMounts*)
+    [ "$SCENARIO" = read_error ] && exit 9
+    [ "$SCENARIO" = missing_mount ] && exit 0
+    printf storage ;;
+  *persistentVolumeClaim.claimName*)
+    [ "$SCENARIO" = claim_error ] && exit 9
+    [ "$SCENARIO" = empty_dir ] && exit 0
+    printf storage-loki-0 ;;
+  *status.phase*)
+    [ "$SCENARIO" = pvc_error ] && exit 9
+    if [ "$SCENARIO" = pending ]; then printf Pending; else printf Bound; fi ;;
+  *'get pods'*) printf 'loki-0 Running\\n' ;;
+  *) exit 8 ;;
+esac
+''')
+            for name in ('helm', 'kubectl'):
+                (root / name).chmod(0o755)
+            (root / 'values.yaml').write_text('loki: {}\n')
+            env = dict(os.environ, PATH=str(root) + os.pathsep + os.environ['PATH'],
+                       GRAFANA_PW='synthetic-test-only', VALUES=str(root / 'values.yaml'),
+                       SCENARIO=scenario)
+            return subprocess.run(['bash', str(SCRIPT)], env=env, capture_output=True,
+                                  text=True, timeout=10)
+
+    def test_bound_claim_passes(self):
+        result = self.run_installer('bound')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('Verified:', result.stdout)
+
+    def test_ephemeral_or_unverified_storage_fails(self):
+        for scenario in ('read_error', 'missing_mount', 'claim_error', 'empty_dir', 'pvc_error', 'pending'):
+            with self.subTest(scenario=scenario):
+                result = self.run_installer(scenario)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn('FATAL:', result.stderr)
+                self.assertNotIn('Verified:', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deploy/aks/scripts/values.observability.yaml
+++ b/deploy/aks/scripts/values.observability.yaml
@@ -42,6 +42,20 @@ loki:
     size: 30Gi
     storageClassName: default
 
+  # Retention is age-based: the compactor deletes logs older than 30 days. The
+  # 24-hour index period from this chart is required by boltdb-shipper retention.
+  # Its working directory and WAL are both below the persistent /data mount.
+  config:
+    compactor:
+      retention_enabled: true
+    limits_config:
+      retention_period: 720h
+    ingester:
+      wal:
+        enabled: true
+        dir: /data/loki/wal
+        flush_on_shutdown: true
+
 promtail:
   # Deliberately NO nodeSelector: Promtail is a DaemonSet and must run on EVERY node, including the
   # silos pool, or those nodes' logs are never shipped. Only the QoS class changes.


### PR DESCRIPTION
The observability installer previously printed storage verification commands and returned success even if the running Loki pod still mounted an emptyDir. It now checks the actual /data mount, requires that volume to reference a PVC, and requires the claim to be Bound. Failed reads also fail the installer. Checking the running pod catches an orphan surviving an immutable StatefulSet transition.

Configures the maintainer-approved 30-day operational-log retention through Loki compaction, with an explicit persistent WAL and flush-on-shutdown. Supported official release artifacts are outside this log cleanup policy. The existing 30Gi PVC request remains the storage capacity.

Validation: six refusal cases and a bound-claim control pass and are wired into Chart invariants CI; the old installer fails all seven assertions. Shell syntax and workflow timeout checks pass. Helm rendering confirms 720h retention, enabled compaction, the required 24h index and a WAL below the PVC mount. The exact deployed grafana/loki:2.6.1 binary reports config is valid. The mount JSONPath was also verified against the live pod.

Related to #3773; does not close it. The live installation still needs a verified storage migration before these settings protect production logs. No live resources were modified. No C# projects changed; no Whats New entry for infrastructure configuration and verification.