### PR TITLE
Fix atomic update-queue publication and disposal

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -103,6 +103,7 @@ Each theme starts with its introductory page, followed by related architecture t
 
 - **Start here:** [CQRS — Queries vs. Content Access](CqrsAndContentAccess)
 - [MeshNode Stream Cache](MeshNodeStreamCache)
+- [Update Queue Ownership](UpdateQueueOwnership) — one published queue per path, retained until accepted work settles
 - [Request via Stream Update](RequestViaStreamUpdate)
 - [Data Access Patterns](DataAccessPatterns)
 - [Workspace References](WorkspaceReferences)

--- a/src/MeshWeaver.Documentation/Data/Architecture/UpdateQueueOwnership.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UpdateQueueOwnership.md
@@ -1,0 +1,66 @@
+---
+Name: Update Queue Ownership
+Category: Architecture
+Description: Atomic publication and explicit lifetime ownership keep concurrent node writes on one queue and give every accepted write a terminal result.
+---
+
+# Update Queue Ownership
+
+The [MeshNode stream cache](/Doc/Architecture/MeshNodeStreamCache) owns one update queue per
+path. That queue serializes writes and hands each successor the preceding write's local state.
+Both publication and retirement must preserve that ownership: a caller must never enqueue into
+a queue whose subscriber was silently removed by another caller.
+
+## Atomic publication
+
+The queue table uses `ConcurrentDictionary<string, Lazy<UpdateQueueEntry>>`. Competing factories
+may construct candidate lazies, but `GetOrAdd` returns the stored winner to every caller. Only
+that winner's lazy value starts a subscription. This follows the cache's existing read-entry
+publication pattern.
+
+`MemoryCache.GetOrCreate` does not provide that guarantee. Each overlapping cold factory can
+return its own candidate and replace an entry another caller has just published. A `Lazy` inside
+each candidate prevents duplicate initialization of that candidate, not duplicate queues per path.
+Depending on timing, replacement either leaves two live queues or disposes a queue another caller
+already holds. Disposing the subscription alone gives that caller no completion or error.
+
+## Ownership lasts through accepted work
+
+An entry tracks both outstanding result subjects and accepted `Concat` slots. Those lifetimes
+are distinct: an optimistic result can finish before the queue advances, and advancement can
+precede the final write verdict. A conflict retry retains its result pin across the retry delay;
+the queue owns the delayed subscription along with its in-flight writes.
+
+The existing idle sweep retires a queue only after ten quiet minutes and only when both counts
+are empty. Removal compares the path and the exact stored entry, so a retiring owner cannot
+remove a replacement. The preceding write's pending local state belongs to the queue entry too;
+a late callback from a retired queue cannot supply or erase its replacement's state.
+
+Shutdown or a pipeline fault stops owned subscriptions and gives every still-pending result an
+explicit error, including work buffered in `Concat`. A short state lock protects acceptance and
+retirement; dispatch, disposal, and observer notifications happen outside it. The write pipeline,
+caller identity capture, owner authorization, and existing retry and advancement bounds retain
+their semantics.
+
+## Evidence and attribution
+
+The investigation started with
+[`Two_concurrent_logons_run_a_once_action_exactly_once` timing out in CI](https://github.com/Systemorph/MeshWeaver/actions/runs/34340297438/job/102431137649)
+at baseline `7540a046917edc0691f2aefec7af2efeab4f56a7`. Its combined wait expired after 30 seconds;
+teardown then finished in about 6 milliseconds. The captured Warning-level log does not identify
+where completion was lost, so it cannot establish that queue publication caused this occurrence.
+
+One traced local run at that same baseline passed in 762 milliseconds. Nevertheless, it recorded
+an update queue eviction with reason `Replaced`, followed by two `START` records for the same
+path before either write finished. A passing final assertion therefore did not prove one queue
+owned that path.
+
+A deterministic probe reentered the real cache's cold factory through its clock during entry
+publication. It failed in 431 milliseconds: the overlapping callers received different subjects,
+and the replaced subject had `HasObservers = false`. This proves the publication and subscriber
+lifetime defect independently of the original CI timeout. It does not establish that every
+concurrent-logon timeout, or unrelated native compiler flake, has the same cause.
+
+Regression coverage must force overlapping cold publication, assert the same live queue for both
+callers, and verify that accepted queued work receives a terminal result across retirement and
+disposal. Repeating an unchanged test until it passes is not evidence that ownership is correct.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-update-queue-ownership.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-update-queue-ownership.md
@@ -1,0 +1,18 @@
+---
+Name: Concurrent node updates keep their place in the queue
+Category: Fix
+Description: Updates arriving together now share one queue, and pending writes receive an explicit result when that queue shuts down.
+Icon: CheckCircle
+Order: -20260909
+---
+
+# Concurrent node updates keep their place in the queue
+
+Two updates arriving together for a node could each create a queue. Replacing one queue could
+remove its subscriber while a caller still held it, leaving that caller waiting for a result.
+
+Concurrent callers now share the same queue. Accepted writes keep it alive until their work
+settles, and shutdown reports an error to pending callers instead of leaving them waiting.
+
+The [investigation and ownership rules](/Doc/Architecture/UpdateQueueOwnership) distinguish the
+reproduced defect from the intermittent CI timeout that prompted the investigation.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
@@ -439,41 +440,126 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // with multi-write contention are thread/inbox nodes whose single-digit-
     // per-second write rate is far below the round-trip ceiling.
     //
-    // Storage: `MemoryCache` with 10-minute sliding expiration. The queue
-    // is reusable per path but unbounded retention would leak Subjects for
-    // every node ever written. Sliding expiry tears down the Subject (and
-    // its Concat subscription) for paths quiet for 10 minutes — a fresh
-    // write recreates a fresh queue, no behaviour change for the caller.
-    // Eviction callback completes the Subject so the Concat chain unwinds.
-    private readonly MemoryCache _updateQueues = new(new MemoryCacheOptions
-    {
-        // No size limit — we trim by time, not count.
-    });
-
+    // Publish one Lazy per path atomically, exactly like _streams. MemoryCache.GetOrCreate
+    // returns EACH racing factory's candidate, so Lazy alone did not prevent two live queues.
+    // The existing idle sweep retires only queues with no accepted work, after ten quiet minutes.
+    private readonly ConcurrentDictionary<string, Lazy<UpdateQueueEntry>> _updateQueues = new();
     private static readonly TimeSpan UpdateQueueSlidingExpiration = TimeSpan.FromMinutes(10);
 
-    // 🚨 The state the LAST write on a path left the node in AS ACKNOWLEDGED BY THE OWNER, held only
-    // until the next write on that path consumes it (issues #2305 / #2291). It exists because the
-    // queue above advances on a write's local terminal, NOT on the owner's echo — so the successor's
-    // mirror can still be showing the node as it was BEFORE its predecessor's patch. Diffing against
-    // that ships a base this mirror itself superseded, and the owner three-way-merges it as a conflict
-    // that never happened: the leaf is refused and the writer's newer value is silently dropped while
-    // its non-conflicting siblings land. (An agent round's response cell kept "Generating response..."
-    // in Text while Status went Completed and Summary carried the answer — one write, two verdicts.)
-    //
-    // 🚨 ACKNOWLEDGED, not merely computed — see MeshNodeStreamHandle's onLocalState. A base taken
-    // from a write that never landed is self-perpetuating: it mints no version, so nothing corrects
-    // it, and the next write diffs its own unlanded value into an empty patch and skips silently.
-    //
-    // ONE-SHOT by construction: the dispatch below TryRemoves it, so a stale entry can influence at
-    // most the single next write, and MeshNodeStreamHandle.PatchBaseSource ignores it the moment the
-    // mirror carries a newer Version — which the owner mints on EVERY applied change, from any
-    // writer. Bounded like the queues: the per-path eviction callback drops it, and so does Dispose.
-    private readonly ConcurrentDictionary<string, MeshNode> _pendingSelfWrites = new();
+    internal sealed class UpdateQueueEntry(ILogger logger)
+    {
+        // State-only lock, like the read Entry's subscriber pin: never held while dispatching,
+        // subscribing, disposing or notifying a result. Concat still serializes the actual writes.
+        private readonly object gate = new();
+        private readonly HashSet<ReplaySubject<MeshNode>> pendingResults = [];
+        private int slots;
+        private long lastActiveAt = Environment.TickCount64;
+        private bool retired;
+        private MeshNode? pendingSelfWrite;
 
-    private sealed record UpdateQueueEntry(Subject<UpdateRequest> Subject, IDisposable ConcatSubscription);
+        internal Subject<UpdateRequest> Subject { get; } = new();
+        internal SingleAssignmentDisposable Subscription { get; } = new();
+        internal CompositeDisposable Inflight { get; } = new();
+        internal bool HasObservers => Subject.HasObservers;
+        internal bool IsLive { get { lock (gate) return !retired; } }
 
-    private readonly record struct UpdateRequest(
+        internal bool TryEnqueue(UpdateRequest request)
+        {
+            bool observeResult;
+            lock (gate)
+            {
+                if (retired) return false;
+                slots++;
+                lastActiveAt = Environment.TickCount64;
+                observeResult = pendingResults.Add(request.Result);
+            }
+            // The result and the queue slot settle independently (an optimistic result may precede
+            // the owner ACK). Pin BOTH; the same result also pins the existing delayed conflict retry.
+            if (observeResult)
+                request.Result.Subscribe(_ => { }, _ => ReleaseResult(request.Result),
+                    () => ReleaseResult(request.Result));
+            Subject.OnNext(request);
+            return true;
+        }
+
+        private void ReleaseResult(ReplaySubject<MeshNode> result)
+        {
+            lock (gate)
+            {
+                pendingResults.Remove(result);
+                lastActiveAt = Environment.TickCount64;
+            }
+        }
+
+        internal void ReleaseSlot()
+        {
+            lock (gate)
+            {
+                slots--;
+                lastActiveAt = Environment.TickCount64;
+            }
+        }
+
+        internal bool TryMarkIdleRetired(TimeSpan idleWindow)
+        {
+            lock (gate)
+            {
+                if (retired || slots != 0 || pendingResults.Count != 0
+                    || Environment.TickCount64 - lastActiveAt < idleWindow.TotalMilliseconds)
+                    return false;
+                retired = true;
+                return true;
+            }
+        }
+
+        // A base belongs only to this queue's successor. A late ACK from a retired queue must
+        // neither seed a new queue nor erase that new queue's own handoff on eviction.
+        internal MeshNode? TakePendingSelfWrite()
+        {
+            lock (gate)
+            {
+                var value = pendingSelfWrite;
+                pendingSelfWrite = null;
+                return value;
+            }
+        }
+
+        internal void SetPendingSelfWrite(MeshNode node)
+        {
+            lock (gate)
+                if (!retired) pendingSelfWrite = node;
+        }
+
+        internal void Stop(Exception error)
+        {
+            ReplaySubject<MeshNode>[] results;
+            lock (gate)
+            {
+                retired = true;
+                pendingSelfWrite = null;
+                results = pendingResults.ToArray();
+                pendingResults.Clear();
+            }
+            // Disposal is idempotent. First stop dispatch and in-flight writes, then terminate
+            // every accepted caller, including requests still buffered inside Concat.
+            DisposeOwned(Subscription);
+            DisposeOwned(Inflight);
+            Subject.OnCompleted();
+            foreach (var result in results)
+            {
+                try { result.OnError(error); }
+                catch (Exception ex) { logger.LogError(ex, "Update queue result observer threw during teardown"); }
+            }
+        }
+
+        private void DisposeOwned(IDisposable disposable)
+        {
+            try { disposable.Dispose(); }
+            catch (Exception ex) { logger.LogError(ex, "Update queue subscription threw during teardown"); }
+        }
+    }
+
+    internal readonly record struct UpdateRequest(
         Func<MeshNode, MeshNode> Update,
         ReplaySubject<MeshNode> Result,
         string Path,
@@ -901,21 +987,13 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         _queries = System.Collections.Immutable.ImmutableDictionary<object, QueryCacheEntry>.Empty;
         _optionsWrappedQueries.Clear();
 
-        // 2. Per-path update queues: Clear() fires every entry's
-        //    post-eviction callback (ConcatSubscription.Dispose +
-        //    Subject.OnCompleted) so the serial-update Concat pipelines stop
-        //    keeping owner response-subjects rooted; Dispose() then stops the
-        //    MemoryCache's expiration-scan timer (which otherwise pins this
-        //    singleton — and through it meshHub/cacheHub — past mesh disposal).
-        try { _updateQueues.Clear(); }
-        catch (Exception ex)
+        // 2. Update queues — explicitly retire every materialized owner. An initializer that
+        // overlaps this snapshot checks _disposed before handing its queue to a caller.
+        foreach (var (path, lazy) in _updateQueues)
         {
-            logger.LogDebug(ex, "MeshNodeStreamCache: error clearing update queues");
-        }
-        try { _updateQueues.Dispose(); }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex, "MeshNodeStreamCache: error disposing update-queue cache");
+            if (lazy.IsValueCreated)
+                lazy.Value.Stop(new ObjectDisposedException(nameof(MeshNodeStreamCache)));
+            _updateQueues.TryRemove(new KeyValuePair<string, Lazy<UpdateQueueEntry>>(path, lazy));
         }
 
         // 3. Permission probe cache — drop the cached (path,user,context)⇒Permission
@@ -937,9 +1015,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         _negative.Clear();
         _transientStreaks.Clear();
 
-        // 6. Pending per-path write bases. The queue eviction callbacks above already drop the ones
-        //    whose queue still existed; this covers a path whose queue had expired first.
-        _pendingSelfWrites.Clear();
+
     }
 
     /// <summary>
@@ -1191,6 +1267,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         {
             foreach (var (path, lazy) in _streams)
                 TryReleaseUnwatched(path, lazy, readStreamIdleExpiration, "idle");
+            foreach (var path in _updateQueues.Keys)
+                TryReleaseUpdateQueue(path, UpdateQueueSlidingExpiration);
         }
         catch (Exception ex)
         {
@@ -1839,17 +1917,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // patches that the RFC 7396 owner-side merge cannot resolve (lists
         // collapse to the last writer). Serializing per path makes each
         // lambda observe its predecessor's effect.
-        // DISPOSED-CACHE GUARD (write side): a late write after this cache's Dispose() — the
-        // canonical case is an agent round whose ThreadExecution.PushToResponseMessage is still
-        // streaming when its mesh's cacheHub tore down (State captured by TeardownStragglerCapturer:
-        // UpdateRaw → _updateQueues.TryGetValue → MemoryCache.CheckDisposed) — must NOT touch the
-        // disposed _updateQueues MemoryCache, whose TryGetValue throws a synchronous
-        // ObjectDisposedException on the caller's ThreadPool continuation. Unobserved, that reaches
-        // AppDomain.UnhandledException and xUnit escalates it to a "Catastrophic failure" that reds
-        // an otherwise-green shard. Dispose() sets _disposed=1 BEFORE it disposes _updateQueues, so
-        // this flag check (same Volatile idiom as ReleaseIdleReadStreams) fully covers the straggler.
-        // Return the same graceful Observable.Throw terminal the negative-cache breaker below uses —
-        // observed by the caller's Subscribe (a benign teardown write), never an unobserved throw.
+        // Late writes surface an observable terminal, including a Dispose racing admission.
         if (System.Threading.Volatile.Read(ref _disposed) != 0)
             return Observable.Throw<MeshNode>(new ObjectDisposedException(nameof(MeshNodeStreamCache)));
 
@@ -1863,13 +1931,12 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             && IsMissingNodeFailure(negWrite.Error))
             return Observable.Throw<MeshNode>(negWrite.Error);
 
-        var queue = GetOrCreateUpdateQueue(path);
         var result = new ReplaySubject<MeshNode>();
         var seq = System.Threading.Interlocked.Increment(ref _updateSeq);
         logger.LogDebug(
             "[UpdateQueue] ENQUEUE path={Path} seq={Seq} enteredAt={EnteredAt}",
             path, seq, DateTimeOffset.UtcNow);
-        queue.OnNext(new UpdateRequest(
+        EnqueueUpdate(new UpdateRequest(
             update, result, path, seq, DateTimeOffset.UtcNow, FullNode: null, Caller: CaptureCaller()));
         return result;
     }
@@ -1904,85 +1971,75 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private long _updateSeq;
 
     /// <summary>
-    /// Returns the per-path Subject that the serial-Update Concat consumes.
-    /// Backed by <see cref="MemoryCache"/> with sliding expiration so paths
-    /// that go quiet release their Subject + Concat subscription. A fresh
-    /// write after eviction transparently recreates the queue — eviction is
-    /// invisible to callers.
-    ///
-    /// 🚨 The cached VALUE is a <see cref="Lazy{T}"/>, not the Subject
-    /// directly, because <c>MemoryCacheExtensions.GetOrCreate</c>
-    /// is NOT atomic — the factory can run more than once under contention,
-    /// and only ONE result wins per key. Losers would orphan a Subject +
-    /// Concat subscription that never gets evicted (their eviction
-    /// callback is never registered with the cache). Wrapping in
-    /// <c>Lazy&lt;T&gt;(ThreadSafety.ExecutionAndPublication)</c> ensures
-    /// the heavy work (new Subject, build observable, Subscribe) runs at
-    /// most once per key even when multiple GetOrCreate calls race. Same
-    /// pattern as <see cref="_streams"/>'s <c>Lazy&lt;Entry&gt;</c>.
+    /// Atomically publishes one queue owner per path. Only the stored Lazy is initialized;
+    /// losing candidates have no subscription to orphan or dispose. The optional internal seam
+    /// lets the regression force two cold factories to overlap before either candidate is stored.
     /// </summary>
-    private Subject<UpdateRequest> GetOrCreateUpdateQueue(string path) =>
-        _updateQueues.GetOrCreate(path, entry =>
+    internal UpdateQueueEntry GetOrCreateUpdateQueue(string path, Action? beforePublication = null)
+    {
+        while (true)
         {
-            entry.SlidingExpiration = UpdateQueueSlidingExpiration;
-            var lazy = new Lazy<UpdateQueueEntry>(() =>
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+            var lazy = _updateQueues.GetOrAdd(path, key =>
             {
-                var subject = new Subject<UpdateRequest>();
-                // 🚨 onError is mandatory. Per-request failures route to req.Result
-                // (Materialize() below shields the Concat), so a fault HERE means the
-                // queue plumbing itself died — the Subject then has no consumer and
-                // every later write for this path would enqueue into the void with the
-                // caller hanging on its result. Surface loudly and evict the dead
-                // entry so the next write builds a fresh queue (the same lifecycle as
-                // sliding-expiry eviction — no timer, no resubscribe of the faulted
-                // pipeline; the fault itself stays visible in the log).
-                var sub = BuildUpdateQueueObservable(path, subject).Subscribe(
-                    _ => { },
-                    ex =>
-                    {
-                        logger.LogError(ex,
-                            "[UpdateQueue] queue pipeline FAULTED path={Path} — evicting dead queue",
-                            path);
-                        // DISPOSED-CACHE GUARD (fault side): this callback fires asynchronously,
-                        // so a straggling pipeline can fault AFTER Dispose() — MemoryCache.Dispose
-                        // never runs eviction callbacks, so the Concat subscription outlives the
-                        // cache and its late fault lands here. Touching the disposed MemoryCache
-                        // throws a synchronous ObjectDisposedException INSIDE OnError, which is
-                        // unobserved → AppDomain.UnhandledException → xUnit "catastrophic failure"
-                        // on an otherwise-green shard (CI: MeshWeaver.AI.Test MASKED exit=2 on
-                        // e0faf867b). Same Volatile idiom as the UpdateRaw write-side guard above;
-                        // the narrow catch covers the read-flag-then-Dispose race — inside OnError
-                        // nothing may throw, and evicting an already-disposed cache is a no-op by
-                        // definition (the fault stays visible via the LogError above).
-                        if (System.Threading.Volatile.Read(ref _disposed) == 0)
-                        {
-                            try { _updateQueues.Remove(path); }
-                            catch (ObjectDisposedException) { /* teardown won the race */ }
-                        }
-                    });
-                return new UpdateQueueEntry(subject, sub);
-            }, LazyThreadSafetyMode.ExecutionAndPublication);
-            // Eviction (sliding-expiry timeout, manual Remove, or process
-            // shutdown) tears down the long-lived Concat subscription and
-            // completes the Subject — otherwise the Concat keeps response-
-            // subjects rooted forever. Only fires if the Lazy was actually
-            // materialised; an unrealised Lazy has no subscription to leak.
-            entry.RegisterPostEvictionCallback((key, value, reason, state) =>
-            {
-                logger.LogDebug(
-                    "[UpdateQueue] EVICTED path={Path} reason={Reason}",
-                    key, reason);
-                // The pending base outlives nothing: a path with no queue has no successor to hand it to.
-                if (key is string evictedPath)
-                    _pendingSelfWrites.TryRemove(evictedPath, out _);
-                if (value is Lazy<UpdateQueueEntry> { IsValueCreated: true } lz)
-                {
-                    try { lz.Value.ConcatSubscription.Dispose(); } catch { /* best-effort */ }
-                    try { lz.Value.Subject.OnCompleted(); } catch { /* best-effort */ }
-                }
+                Lazy<UpdateQueueEntry>? candidate = null;
+                candidate = new Lazy<UpdateQueueEntry>(() => CreateUpdateQueue(key, candidate!),
+                    LazyThreadSafetyMode.ExecutionAndPublication);
+                beforePublication?.Invoke();
+                return candidate;
             });
-            return lazy;
-        })!.Value.Subject;
+            var queue = lazy.Value;
+            // Dispose can see an unpublished/uninitialized candidate. The initializer owns that
+            // race: stop its materialized queue rather than leave it beyond the teardown snapshot.
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                queue.Stop(new ObjectDisposedException(nameof(MeshNodeStreamCache)));
+                _updateQueues.TryRemove(new KeyValuePair<string, Lazy<UpdateQueueEntry>>(path, lazy));
+                throw new ObjectDisposedException(nameof(MeshNodeStreamCache));
+            }
+            if (queue.IsLive) return queue;
+            _updateQueues.TryRemove(new KeyValuePair<string, Lazy<UpdateQueueEntry>>(path, lazy));
+        }
+    }
+
+    private UpdateQueueEntry CreateUpdateQueue(string path, Lazy<UpdateQueueEntry> owner)
+    {
+        var queue = new UpdateQueueEntry(logger);
+        queue.Subscription.Disposable = BuildUpdateQueueObservable(path, queue).Subscribe(
+            _ => { },
+            ex =>
+            {
+                logger.LogError(ex, "[UpdateQueue] queue pipeline FAULTED path={Path} — evicting dead queue", path);
+                queue.Stop(ex);
+                _updateQueues.TryRemove(new KeyValuePair<string, Lazy<UpdateQueueEntry>>(path, owner));
+            });
+        return queue;
+    }
+
+    private void EnqueueUpdate(UpdateRequest request)
+    {
+        try
+        {
+            // A stale reference can lose admission to retirement; only UNACCEPTED work re-resolves
+            // the owner, like GetEntry's pin-or-recreate loop. Accepted work is never replayed here.
+            while (!GetOrCreateUpdateQueue(request.Path).TryEnqueue(request)) { }
+        }
+        catch (ObjectDisposedException ex)
+        {
+            request.Result.OnError(ex);
+        }
+    }
+
+    internal bool TryReleaseUpdateQueue(string path, TimeSpan idleWindow)
+    {
+        if (!_updateQueues.TryGetValue(path, out var lazy) || !lazy.IsValueCreated
+            || !lazy.Value.TryMarkIdleRetired(idleWindow))
+            return false;
+        lazy.Value.Stop(new ObjectDisposedException("Idle update queue"));
+        _updateQueues.TryRemove(new KeyValuePair<string, Lazy<UpdateQueueEntry>>(path, lazy));
+        logger.LogDebug("[UpdateQueue] EVICTED path={Path} reason=Idle", path);
+        return true;
+    }
 
     /// <summary>
     /// Builds the per-path Concat pipeline that processes <see cref="UpdateRequest"/>s
@@ -2003,7 +2060,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// state older than write N's, shipped that as its base, and the owner refused the conflicting
     /// leaves of a write that nothing was concurrent with (#2305 / #2291). The invariant is now
     /// DELIVERED rather than asserted: the predecessor's locally-computed node is handed to the
-    /// successor via <see cref="_pendingSelfWrites"/>, and <c>MeshNodeStreamHandle.PatchBaseSource</c>
+    /// successor via <see cref="UpdateQueueEntry.TakePendingSelfWrite"/>, and <c>MeshNodeStreamHandle.PatchBaseSource</c>
     /// prefers it only while the mirror carries nothing newer.</para>
     ///
     /// <para>🚨 …and the SLOT is released by that hand-off, not by LOCAL_EMIT (#2346). For a busy
@@ -2012,8 +2069,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// loaded runs where it matters. The caller still gets its terminal at LOCAL_EMIT; only the next
     /// QUEUED write waits.</para>
     /// </summary>
-    private IObservable<MeshNode> BuildUpdateQueueObservable(string path, Subject<UpdateRequest> subject) =>
-        subject
+    private IObservable<MeshNode> BuildUpdateQueueObservable(string path, UpdateQueueEntry queue) =>
+        queue.Subject
             .Select(req => Observable.Defer<MeshNode>(() =>
             {
                 var waitedToStart = (DateTimeOffset.UtcNow - req.EnteredAt).TotalMilliseconds;
@@ -2037,10 +2094,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     ? accessService.SwitchAccessContext(req.Caller)
                     : null;
 
-                // 🚨 Consume the predecessor's locally-computed state — see _pendingSelfWrites. Taken
+                // 🚨 Consume the predecessor's locally-computed state from this queue owner. Taken
                 // (and REMOVED) here rather than read in place so it can only ever inform the single
                 // next write: if this one produces no local emit, the write after it reads the mirror.
-                _pendingSelfWrites.TryRemove(path, out var pendingSelfWrite);
+                var pendingSelfWrite = queue.TakePendingSelfWrite();
 
                 // 🚨 THE QUEUE'S ADVANCE SIGNAL — issue #2346, and the residual half of #2305 / #2291.
                 //
@@ -2092,7 +2149,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                             // re-enqueued attempt, a late terminal NACK). Release the slot; the
                             // successor re-reads the mirror, which is correct for those cases.
                             if (local is not null)
-                                _pendingSelfWrites[path] = local;
+                                queue.SetPendingSelfWrite(local);
                             SettleHandoff();
                         });
 
@@ -2109,13 +2166,15 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 // it never accumulates.
                 var inflight = new System.Reactive.Disposables.SingleAssignmentDisposable();
                 _inflightWrites[inflight] = 0;
+                queue.Inflight.Add(inflight);
                 var sawLocalEmit = false;
                 void Settle()
                 {
                     _inflightWrites.TryRemove(inflight, out _);
+                    queue.Inflight.Remove(inflight);
                     try { inflight.Dispose(); } catch { /* best-effort */ }
                 }
-                inflight.Disposable = update.Subscribe(
+                inflight.Disposable = update.Finally(Settle).Subscribe(
                     node =>
                     {
                         logger.LogDebug(
@@ -2161,14 +2220,20 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                                 path, req.Seq, retry.Attempt, MaxConflictRetries);
                             SettleHandoff();
                             Settle();
-                            Observable.Timer(ConflictRetryDelay).Subscribe(_ =>
+                            var retryTimer = new SingleAssignmentDisposable();
+                            queue.Inflight.Add(retryTimer);
+                            retryTimer.Disposable = Observable.Timer(ConflictRetryDelay)
+                                .Finally(() => queue.Inflight.Remove(retryTimer))
+                                .Subscribe(_ =>
                             {
                                 try
                                 {
-                                    if (System.Threading.Volatile.Read(ref _disposed) != 0)
+                                    // The unresolved result pins this owner throughout the delay.
+                                    // A retired owner's already-failed write must never reappear on
+                                    // a replacement queue after its caller has received a terminal.
+                                    if (System.Threading.Volatile.Read(ref _disposed) != 0
+                                        || !queue.TryEnqueue(retry))
                                         req.Result.OnError(ex);
-                                    else
-                                        GetOrCreateUpdateQueue(path).OnNext(retry);
                                 }
                                 catch (Exception requeueEx)
                                 {
@@ -2226,7 +2291,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     }))
                     .Take(1)
                     .SelectMany(_ => Observable.Empty<MeshNode>());
-            }))
+            }).Finally(queue.ReleaseSlot))
             .Concat();
 
     /// <summary>
@@ -2296,18 +2361,17 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private IObservable<MeshNode> OverwriteRaw(string path, MeshNode node)
     {
         // Disposed-cache guard — see UpdateRaw. A late overwrite after Dispose() must not hit the
-        // disposed _updateQueues MemoryCache; return a graceful observed terminal, never a throw.
+        // retired queue owner; return a graceful observed terminal, never a throw.
         if (System.Threading.Volatile.Read(ref _disposed) != 0)
             return Observable.Throw<MeshNode>(new ObjectDisposedException(nameof(MeshNodeStreamCache)));
 
-        var queue = GetOrCreateUpdateQueue(path);
         var result = new ReplaySubject<MeshNode>();
         var seq = System.Threading.Interlocked.Increment(ref _updateSeq);
         logger.LogDebug(
             "[UpdateQueue] ENQUEUE-OVERWRITE path={Path} seq={Seq} enteredAt={EnteredAt}",
             path, seq, DateTimeOffset.UtcNow);
         // Update func is a placeholder (never invoked — the FullNode branch is taken).
-        queue.OnNext(new UpdateRequest(
+        EnqueueUpdate(new UpdateRequest(
             static n => n, result, path, seq, DateTimeOffset.UtcNow, node, CaptureCaller()));
         return result;
     }

--- a/test/MeshWeaver.Graph.Test/UpdateQueuePublicationTest.cs
+++ b/test/MeshWeaver.Graph.Test/UpdateQueuePublicationTest.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+public class UpdateQueuePublicationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    [Fact]
+    public async Task OverlappingColdFactories_PublishOneSubscribedQueue_AndCompleteBothWrites()
+    {
+        const string id = "overlapping-queue-publication";
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+            { Name = "initial", Description = "initial description", NodeType = "Markdown" })
+            .Should().Emit();
+        var cache = Cache;
+        MeshNodeStreamCache.UpdateQueueEntry? nested = null;
+
+        // Both lookups miss before either candidate is published. The nested lookup wins
+        // publication; the outer caller must receive that same subscribed queue.
+        var outer = cache.GetOrCreateUpdateQueue(path,
+            () => nested = cache.GetOrCreateUpdateQueue(path));
+        Assert.NotNull(nested);
+        Assert.Same(nested, outer);
+        Assert.True(nested.HasObservers);
+        Assert.True(outer.HasObservers);
+
+        using var first = new ReplaySubject<MeshNode>(1);
+        using var second = new ReplaySubject<MeshNode>(1);
+        Assert.True(nested.TryEnqueue(Request(path, 1, first,
+            node => node with { Name = "first edit" })));
+        Assert.True(outer.TryEnqueue(Request(path, 2, second,
+            node => node with { Description = "second edit" })));
+
+        var firstNode = await first.LastAsync().Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        var secondNode = await second.LastAsync().Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        Assert.Equal("first edit", firstNode.Name);
+        Assert.Equal("first edit", secondNode.Name);
+        Assert.Equal("second edit", secondNode.Description);
+    }
+
+    [Fact]
+    public async Task IdleRelease_PreservesActiveAndQueuedWrites_ThenRetiresTheSettledQueue()
+    {
+        const string id = "queued-write-lifetime";
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+            { Name = "initial", Description = "initial description", NodeType = "Markdown" })
+            .Should().Emit();
+        var cache = Cache;
+        var queue = cache.GetOrCreateUpdateQueue(path);
+        using var first = new ReplaySubject<MeshNode>(1);
+        using var second = new ReplaySubject<MeshNode>(1);
+        var secondRequest = Request(path, 2, second,
+            node => node with { Description = "queued edit" });
+        var reentered = 0;
+        Assert.True(queue.TryEnqueue(Request(path, 1, first, node =>
+        {
+            // The first mutation cannot hand off until this callback returns, so the
+            // second request is provably queued at the attempted idle retirement.
+            if (Interlocked.Exchange(ref reentered, 1) == 0)
+            {
+                Assert.True(queue.TryEnqueue(secondRequest));
+                Assert.False(cache.TryReleaseUpdateQueue(path, TimeSpan.Zero));
+                Assert.Same(queue, cache.GetOrCreateUpdateQueue(path));
+                Assert.True(queue.HasObservers);
+            }
+            return node with { Name = "active edit" };
+        })));
+
+        await first.LastAsync().Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        var final = await second.LastAsync().Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        Assert.Equal(1, Volatile.Read(ref reentered));
+        Assert.Equal("active edit", final.Name);
+        Assert.Equal("queued edit", final.Description);
+
+        // Optimistic results may precede the owner's ACK and the queue-slot handoff.
+        // Wait for that actual ownership to settle, rather than assuming result completion
+        // is permission to dispose the pipeline.
+        await Observable.Interval(TimeSpan.FromMilliseconds(10)).StartWith(0L)
+            .Where(_ => cache.TryReleaseUpdateQueue(path, TimeSpan.Zero))
+            .FirstAsync().Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        Assert.False(queue.HasObservers);
+        var replacement = cache.GetOrCreateUpdateQueue(path);
+        Assert.NotSame(queue, replacement);
+        Assert.True(replacement.HasObservers);
+
+        using var third = new ReplaySubject<MeshNode>(1);
+        var thirdRequest = Request(path, 3, third,
+            node => node with { Name = "replacement edit" });
+        Assert.False(queue.TryEnqueue(thirdRequest));
+        Assert.True(replacement.TryEnqueue(thirdRequest));
+        var replacementNode = await third.LastAsync().Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+        Assert.Equal("replacement edit", replacementNode.Name);
+        Assert.Equal("queued edit", replacementNode.Description);
+    }
+
+    [Fact]
+    public async Task QueueTermination_FaultsBothTheActiveAndBufferedCaller()
+    {
+        const string id = "queue-termination";
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+            { Name = "initial", NodeType = "Markdown" }).Should().Emit();
+        var queue = Cache.GetOrCreateUpdateQueue(path);
+        using var first = new ReplaySubject<MeshNode>(1);
+        using var second = new ReplaySubject<MeshNode>(1);
+        var error = new InvalidOperationException("The queue owner terminated.");
+        var secondStarted = 0;
+        var secondRequest = Request(path, 2, second, node =>
+        {
+            Interlocked.Exchange(ref secondStarted, 1);
+            return node with { Description = "must remain queued" };
+        });
+        var reentered = 0;
+        Assert.True(queue.TryEnqueue(Request(path, 1, first, node =>
+        {
+            if (Interlocked.Exchange(ref reentered, 1) == 0)
+            {
+                Assert.True(queue.TryEnqueue(secondRequest));
+                queue.Stop(error);
+            }
+            return node with { Name = "active mutation" };
+        })));
+
+        var firstTerminal = await first.Materialize().Where(notification => notification.Exception is not null)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+        var secondTerminal = await second.Materialize().Where(notification => notification.Exception is not null)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+        Assert.Same(error, firstTerminal.Exception);
+        Assert.Same(error, secondTerminal.Exception);
+        Assert.Equal(0, Volatile.Read(ref secondStarted));
+        Assert.False(queue.HasObservers);
+    }
+
+    private MeshNodeStreamCache.UpdateRequest Request(
+        string path, long sequence, ReplaySubject<MeshNode> result, Func<MeshNode, MeshNode> update)
+        => new(update, result, path, sequence, DateTimeOffset.UtcNow,
+            Caller: Mesh.ServiceProvider.GetRequiredService<AccessService>().Context);
+}


### PR DESCRIPTION
Concurrent cold writes could receive different per-path queues because MemoryCache.GetOrCreate returned each factory’s Lazy. Replacing an initialized queue disposed its consumer without completing the caller’s result. Publish one queue atomically, keep it alive through both caller results and queue slots, and explicitly terminate accepted work when its owner stops. Queue-owned handoff state and delayed retries cannot affect a replacement owner.

The deterministic pre-fix probe returned different subjects and left the replaced subject without observers. Three new real-mesh regressions cover overlapping publication, buffered work surviving idle retirement, and active/buffered callers receiving a terminal on shutdown. The original concurrent-logon CI timeout is the investigation trigger; its Warning-level log does not establish that this defect caused that specific occurrence.

Validation: Release builds with warnings-as-errors pass; 3 new regressions, 16 related logon/concurrent-write/retry tests, and 14 documentation/concurrency guards pass. No timeout, retry-budget, scheduling, authentication or authorization policy changes.

Investigation: [Update Queue Ownership](src/MeshWeaver.Documentation/Data/Architecture/UpdateQueueOwnership.md). A Fix entry is included in What’s New.
