### PR TITLE
docs: define MeshWeaver and plugin support lifetimes

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -343,6 +343,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Local Dev Workflow](LocalDevWorkflow)
 - [Onboarding a New Environment](OnboardingNewEnvironment)
 - [Release & Self-Update Strategy](ReleaseStrategy)
+- [Release Support Policy](/Doc/Architecture/SupportPolicy)
 - [Self-Update Target Selection](SelfUpdateTargetSelection) — candidates are ranked by the CD run number, not the version string; a mislabelled line outranked every sealed set for ever, and an install on a withdrawn tag could never see anything newer
 - [The Continuous Delivery Contract](ContinuousDeliveryContract) — all-or-nothing publication; verify the image, never the tick
 - [The Self-Update Schema Wall](SelfUpdateSchemaWall) — every schema-bumping release is un-takeable by self-update, the stall is invisible, and a promoted tag is not a deployable tag

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -15,6 +15,9 @@ Tags:
 
 # Release Process & Versioning
 
+Support lifetime and official artifact retention follow the
+[Release Support Policy](/Doc/Architecture/SupportPolicy).
+
 One number, two channels, one set of bytes. The whole scheme lives in
 `Directory.Build.props` and applies to every project in the solution.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
@@ -15,6 +15,9 @@ Tags:
 
 # Release & Self-Update Strategy
 
+Support lifetime and official artifact retention follow the
+[Release Support Policy](/Doc/Architecture/SupportPolicy).
+
 > ✅ **Rule change, 2026-09-07 (maintainer) — [Module Adoption Policy](../ModuleAdoptionPolicy), implemented by [#3648](https://github.com/Systemorph/MeshWeaver/issues/3648), [#3649](https://github.com/Systemorph/MeshWeaver/issues/3649), [#3650](https://github.com/Systemorph/MeshWeaver/issues/3650) and [#3651](https://github.com/Systemorph/MeshWeaver/issues/3651).** This page describes the mechanism as it runs after those changes: a declared floor is advisory, a refused generation falls back to the previous one, a new build is adopted eagerly, and a platform roll is held only by a module that provably cannot load on the target.
 
 The production model in one picture:

--- a/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
@@ -1,0 +1,60 @@
+---
+Name: Release Support Policy
+Category: Architecture
+Description: MeshWeaver major-version support follows the lifecycle of its underlying .NET release.
+---
+
+# Release Support Policy
+
+Each MeshWeaver major release is supported for the remaining support lifetime of the
+.NET release on which it is based. Support ends when Microsoft ends support for that
+underlying .NET release. Shipping a later MeshWeaver minor or patch release does not
+restart or extend the major version's support period.
+
+The authoritative .NET end-of-support dates are published in
+[Microsoft's .NET support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
+Record the underlying .NET release and its end-of-support date in each MeshWeaver major
+release's notes. If Microsoft changes that date, update the recorded date to match.
+A new MeshWeaver major release does not end support for an older major while its
+underlying .NET release remains supported.
+
+## Plugins and connectors
+
+A plugin is supported while both of these conditions hold:
+
+- The underlying MeshWeaver release is supported.
+- The collaboration with the relevant counterparty remains supported, including the
+  data source, third-party service or other external integration on which it depends.
+
+Plugin support ends when either condition ceases to hold. A supported MeshWeaver
+release alone does not extend the lifetime of an integration its counterparty no
+longer supports.
+
+MeshWeaver aims to support a broad variety of connectors. Each connector's
+documentation should identify its supported MeshWeaver releases and the external
+services or data sources on which its support depends.
+
+## Official release retention
+
+Keep official MeshWeaver releases available throughout their support period. This
+includes their container images, sealed bundles, manifests and other artifacts needed
+to install or restore that release. Keeping a version tag while deleting a referenced
+digest does not satisfy this policy.
+
+Regular cleanup must exclude supported official releases and the artifacts they
+reference. Their retention is determined by support status, not a rolling age limit or
+a count of newer releases. An unknown runtime mapping or support date is not evidence
+that a release is unsupported; resolve it before deleting its artifacts.
+
+End of support ends this retention guarantee; it does not itself issue a deletion.
+Any later cleanup must still respect deployment pins and other active references.
+
+## Operational logs
+
+Operational logs are retained for 30 days and cleaned up automatically by age. This
+log-retention window does not apply to official release artifacts. Persistent storage
+and regular cleanup serve different purposes: storage preserves logs across restarts,
+while retention removes logs after their agreed history window.
+
+See [Release Process & Versioning](/Doc/Architecture/ReleaseProcess) for promotion and
+[Release & Self-Update Strategy](/Doc/Architecture/ReleaseStrategy) for deployment behavior.

--- a/src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0.md
+++ b/src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0.md
@@ -7,6 +7,14 @@ Icon: Rocket
 
 # MeshWeaver 3.0.0
 
+## Support lifetime
+
+MeshWeaver 3.x is based on .NET 10 LTS. Its support ends on **November 14, 2028**,
+matching [Microsoft's published .NET 10 lifecycle](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).
+Official 3.x release artifacts are retained throughout that support period. See the
+[Release Support Policy](/Doc/Architecture/SupportPolicy).
+
+
 **3.0.0 is the first clean release of the 3.x line.** It ran as `3.0.0-rc1` through `3.0.0-rc13`
 between 2026-08-13 and 2026-08-31, and none of those was a release of this build: each candidate
 was rebuilt on tagging rather than promoted, and SemVer sorts `rc13` below `rc2`, so the last four


### PR DESCRIPTION
Documents the maintainer-defined support policy: each MeshWeaver major follows the end-of-support date of its underlying .NET release. Plugins require both a supported MeshWeaver release and continued counterparty support; the aim is broad connector coverage. Supported official release artifacts remain available throughout support, independently of the 30-day operational-log retention policy.

Links the policy from the release process and strategy, and records the .NET 10 / November 14, 2028 mapping in the 3.x release notes using Microsoft’s published lifecycle.

Validation: documentation test project built Release with CIRun and warnings-as-errors (0 warnings/errors); DocumentationLinkIntegrityTest passed, 0 skipped. No Whats New entry: documentation of policy only. Cleanup implementation and live storage migration remain separate work.