### PR TITLE
fix(#3816): the in-memory store materialises content, like every serializing backend

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StorageAdapterImplementation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StorageAdapterImplementation.md
@@ -230,6 +230,31 @@ The only boot-time work is `PostgreSqlPartitionSubscriptionHostedService`, which
 > **Reaching for `Observable.FromAsync`.**
 > Forbidden outside `IoPool`. Bridge every async / blocking leaf through `IIoPool`.
 
+> 🚨 **Storing the INSTANCE and forgetting what the serialization boundary does for free (#3816).**
+> An in-memory adapter that keeps the `MeshNode` object hands the same object back on `Read` — so
+> everything a serializing backend does *on the way through* silently does not happen. Each such
+> effect has to be reproduced by hand, and each one that is missed is a difference in behaviour
+> between backends that only shows up as a test failing on one of them.
+>
+> Two are known, and they arrived a year apart:
+>
+> - `MeshNode.HubConfiguration` — an in-process delegate a durable store cannot hold; stripped
+>   explicitly, because FileSystem and Postgres drop it at the boundary.
+> - **Content materialisation** — a node whose `Content` is the as-written `JsonObject` DOM is
+>   returned as a `JsonObject`, so `node.Content is TRecord` (what every ordinary reader does)
+>   answers `false` on that backend and `true` on the others.
+>
+> The second cost two full-project runs to find: `AnInstanceReportsWhatItRunsTest` failed **2 of 2**
+> under load on an unmodified `main` and passed under `--filter`, because whether the *last* write
+> left a typed record or the DOM is a matter of ordering. Deterministic in both directions is the
+> tell that it is not a flake.
+>
+> 🚨 Reproduce the serializing backends, never improve on them. An unresolvable discriminator must
+> still degrade to a `JsonElement` here, because that is what FileSystem and Postgres yield for the
+> same content — an in-memory store that materialised what the others cannot would be a different
+> lie in the other direction, and it would hide exactly the defect the degradation exists to
+> surface.
+
 ---
 
 ## Migration Notes from the Old `Matches` Design

--- a/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/InMemoryStorageAdapter.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.Logging;
@@ -97,6 +98,20 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
             // makes the in-memory adapter behave exactly like every serializing backend.
             if (node.HubConfiguration is not null)
                 node = node with { HubConfiguration = null };
+
+            // 🚨 …and the SECOND consequence of storing the instance: content that never
+            // MATERIALISES (#3816). The strip above compensates for ONE effect of holding the
+            // object rather than its bytes, and states the goal as "behave exactly like every
+            // serializing backend" — but a node whose Content is still the as-written JsonObject
+            // DOM is handed straight back by Read, for ever, on this backend alone. FileSystem and
+            // Postgres re-type it at their serialization boundary, so `node.Content is TRecord` —
+            // what every ordinary reader does — answers differently depending on the store.
+            //
+            // Measured 2026-09-09: AnInstanceReportsWhatItRunsTest failed 2 of 2 full-project runs
+            // on a clean main and passed in isolation, because whether the LAST write left a typed
+            // record or the DOM is a matter of ordering. The test was right; the backend was the
+            // odd one out.
+            node = MaterializeContent(node, options);
             if (string.IsNullOrEmpty(node.Path))
                 return Observable.Return<MeshNode?>(node);
 
@@ -145,10 +160,14 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
         MeshNode node, long expectedVersion, JsonSerializerOptions options)
         => Observable.Defer(() =>
         {
-            // Same delegate strip as Write — a store of record must never hold an in-process
-            // HubConfiguration (see the note there).
+            // Same delegate strip AND the same content materialisation as Write — a store of
+            // record must never hold an in-process HubConfiguration, and must not hand back an
+            // as-written DOM that every serializing backend would have re-typed (see the notes
+            // there). Both write paths or neither: a node reaching the store through the
+            // version-gated path is read back by exactly the same readers.
             if (node.HubConfiguration is not null)
                 node = node with { HubConfiguration = null };
+            node = MaterializeContent(node, options);
             var path = Norm(node.Path);
             if (string.IsNullOrEmpty(path))
                 return Observable.Return<bool?>(null);
@@ -181,6 +200,36 @@ public sealed class InMemoryStorageAdapter : SimpleMeshNodeStorage, IStorageAdap
             _changes.OnNext(DataChangeNotification.Updated(path, node));
             return Observable.Return<bool?>(true);
         });
+
+    /// <summary>
+    /// Re-types an as-written JSON DOM through <paramref name="options"/>, exactly as a serializing
+    /// backend does at its storage boundary (#3816). Only a <see cref="JsonNode"/> is touched: an
+    /// already-typed record costs nothing, so the common path pays no JSON round-trip.
+    ///
+    /// <para>🚨 An unresolvable discriminator degrades to a <see cref="JsonElement"/> — which is
+    /// what FileSystem and Postgres yield for that same content. This REPRODUCES their behaviour
+    /// rather than improving on it; making the in-memory store the only one that materialises what
+    /// the others cannot would be a different lie in the other direction.</para>
+    /// </summary>
+    /// <param name="node">The node about to be stored.</param>
+    /// <param name="options">The serializer options the write was given.</param>
+    /// <returns>The node, with its content re-typed when it was a DOM.</returns>
+    private static MeshNode MaterializeContent(MeshNode node, JsonSerializerOptions options)
+    {
+        if (node.Content is not JsonNode dom)
+            return node;
+        try
+        {
+            return node with { Content = JsonSerializer.Deserialize<object>(dom, options) };
+        }
+        catch (JsonException)
+        {
+            // 🚨 Keep the DOM, never null. A store that silently dropped content it could not
+            // re-type would turn a serialization problem into DATA LOSS, and this adapter is the
+            // store of record for every test that uses it.
+            return node;
+        }
+    }
 
     /// <inheritdoc />
     public override IObservable<string> Delete(string path)


### PR DESCRIPTION
Closes #3816.

## The in-memory store was the only backend where content never materialised

`InMemoryStorageAdapter.Read` returns the stored **instance** — it never round-trips through the
`JsonSerializerOptions` it is handed:

```csharp
public override IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
    => Observable.Defer(() =>
    {
        _nodes.TryGetValue(Norm(path), out var node);
        return Observable.Return<MeshNode?>(node);   // ← the stored instance, verbatim
    });
```

So whatever `Content` a write handed it is what every reader gets back. If that was the as-written
`JsonObject` DOM, `node.Content is TRecord` — **what every ordinary reader does** — answers `false`,
for ever, on this backend alone. FileSystem and Postgres serialise and deserialise on the way
through and re-type it.

## 🚨 The adapter already knew, and compensated for exactly one consequence

Its own `Write`, unchanged, says:

> A durable store cannot hold an in-process delegate. FileSystem/Postgres strip
> `MeshNode.HubConfiguration` **naturally at the serialization boundary**; **this adapter stores the
> INSTANCE**, so without this strip … Stripping here makes the in-memory adapter **behave exactly
> like every serializing backend**.

It names the asymmetry, states that goal, and patches `HubConfiguration`. **Content materialisation
is the second consequence of the same cause**, and was not patched. This adds it, in both write
paths — `Write` and `WriteIfVersion` — because a node reaching the store through the version-gated
path is read back by exactly the same readers.

## How it surfaced

`AnInstanceReportsWhatItRunsTest.TheReport_CarriesBothModuleShapesAndThePlatform_AndLandsWhereAReportedOneWould`
failed **2 of 2 full-project runs on a clean `origin/main` worktree with no diff**, and passed under
`--filter`. That split is deterministic in *both* directions, which is what ruled out a flake: under
load a different write lands last, and whether the stored instance happens to be the typed record or
the DOM is a matter of ordering.

🚨 Its assertion message theorises an **unresolvable `$type` discriminator**, which degrades to a
`JsonElement`. What it caught was a **`JsonObject`** — the as-written DOM, a different one of the
three silent-null cases AGENTS.md enumerates. Reading the shape rather than the message is what
moved this from "a flaky test" to a named backend asymmetry.

## Scope, deliberately narrow

- **Only a `JsonNode` is re-typed.** An already-typed record costs nothing, so the common path pays
  no JSON round-trip — this is not "serialise every node on every write to fix one seam".
- **An unresolvable discriminator still degrades to `JsonElement`**, exactly as FileSystem and
  Postgres yield for that content. This REPRODUCES their behaviour rather than improving on it;
  making the in-memory store the only backend that materialises what the others cannot would be a
  different lie in the other direction.
- **A failure keeps the DOM, never null.** A store that silently dropped content it could not
  re-type would turn a serialization problem into data loss, and this adapter is the store of record
  for every test that uses it.

## Verified, with the control that matters

```
solution build, Release -warnaserror ......... 0 Warning(s)  0 Error(s)
Memex.Portal.Shared.Test ..................... 1180 passed, 0 failed   ← the target, was 2-of-2 RED
MeshWeaver.Hosting.Test ......................  539 passed, 0 failed
MeshWeaver.Data.Test .........................  496 passed, 0 failed
MeshWeaver.Messaging.Hub.Test ................  384 passed, 0 failed
MeshWeaver.Layout.Test .......................  466 passed, 0 failed
MeshWeaver.Graph.Test ........................ 1485 passed, 1 failed   ← see below
```

**4550 tests over six projects; one failure, and it is not this diff.**
`LogonActionFrameworkTest.Two_concurrent_logons_run_a_once_action_exactly_once` fails
`Graph.Test` **run 2 of 3 on a clean `origin/main` worktree at `3ba04254c`** — the exact commit this
branch is cut from, with none of this diff — and it has failed today on three unrelated branches:
#3807 (a hosted-service registration), #3821 (a log line), and here. Filed separately.

I also checked the mechanism statically rather than resting on the control alone: nothing in `src/`
requires `Content` to be a `JsonNode` (`grep` for `Content is/as JsonNode` returns nothing), and
`NodeUpdatePipeline.WithContentTypedLikeTheProposal` exists *because* the stored snapshot comes back
degraded and validators silently skip their own `if` on it — this makes the store hand back the typed
value to begin with, so that recovery short-circuits on `ReferenceEquals` rather than conflicting
with it.

Pairs-with: none — additions only; no public type or member is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
