### PR TITLE
fix: localize node metadata labels for the viewer

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-node-metadata-language.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-node-metadata-language.md
@@ -1,0 +1,11 @@
+---
+Name: Node details follow your language
+Category: Fix
+Description: Node type and timestamp labels now follow your selected language.
+Icon: Globe
+Order: -20260909
+---
+
+Node pages now show their type, creation and update labels in your selected language,
+including the word before the author's name. German viewers see “Typ”, “Erstellt”,
+“Aktualisiert” and “von”.

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -645,7 +645,7 @@ public static class MeshNodeLayoutAreas
             var typeLabel = node.NodeType.Contains('/') ? node.NodeType.Split('/').Last() : node.NodeType;
             row = row.WithView(Controls.Html(
                 "<span style=\"display: inline-flex; align-items: center; gap: 6px;\">" +
-                "<span>Type:</span>" +
+                $"<span>{System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.type"))}</span>" +
                 $"<a href=\"{typeHref}\" style=\"color: var(--accent-fill-rest); font-weight: 500;\">{System.Web.HttpUtility.HtmlEncode(typeLabel)}</a>" +
                 "</span>"));
         }
@@ -653,15 +653,15 @@ public static class MeshNodeLayoutAreas
         if (node != null && node.CreatedDate != default)
         {
             var created = access.ToDisplayTime(node.CreatedDate).ToString("yyyy-MM-dd HH:mm");
-            var createdBy = string.IsNullOrEmpty(node.CreatedBy) ? "" : $" by {System.Web.HttpUtility.HtmlEncode(node.CreatedBy)}";
-            row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">Created:</span> {created}{createdBy}</span>"));
+            var createdBy = string.IsNullOrEmpty(node.CreatedBy) ? "" : $" {System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.by", node.CreatedBy))}";
+            row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">{System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.created"))}</span> {created}{createdBy}</span>"));
         }
 
         if (node != null && node.LastModified != default)
         {
             var modified = access.ToDisplayTime(node.LastModified).ToString("yyyy-MM-dd HH:mm");
-            var modifiedBy = string.IsNullOrEmpty(node.LastModifiedBy) ? "" : $" by {System.Web.HttpUtility.HtmlEncode(node.LastModifiedBy)}";
-            row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">Updated:</span> {modified}{modifiedBy}</span>"));
+            var modifiedBy = string.IsNullOrEmpty(node.LastModifiedBy) ? "" : $" {System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.by", node.LastModifiedBy))}";
+            row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">{System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.updated"))}</span> {modified}{modifiedBy}</span>"));
         }
 
         return row;

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1431,5 +1431,9 @@
   "setup.problem.noCompany": "Geben Sie die Organisation an, zu der diese Instanz gehört.",
   "setup.problem.noOwnerName": "Geben Sie den Namen der Person an, der diese Instanz gehört.",
   "setup.problem.noOwnerEmail": "Geben Sie eine gültige E-Mail-Adresse an — darüber erreicht die Registry die Eigentümerin oder den Eigentümer dieser Instanz.",
-  "setup.problem.noConsent": "Akzeptieren Sie die Datenschutzerklärung und die Plattform-Nutzungsbedingungen, um zu registrieren. Bis dahin wird nichts gesendet."
+  "setup.problem.noConsent": "Akzeptieren Sie die Datenschutzerklärung und die Plattform-Nutzungsbedingungen, um zu registrieren. Bis dahin wird nichts gesendet.",
+  "node.meta.type": "Typ:",
+  "node.meta.created": "Erstellt:",
+  "node.meta.updated": "Aktualisiert:",
+  "node.meta.by": "von {0}"
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1431,5 +1431,9 @@
   "setup.problem.noCompany": "Give the organisation this instance belongs to.",
   "setup.problem.noOwnerName": "Give the name of the person who owns this instance.",
   "setup.problem.noOwnerEmail": "Give a valid email address — it is how the registry reaches the owner about this instance.",
-  "setup.problem.noConsent": "Accept the privacy statement and the platform terms to register. Nothing is sent until you do."
+  "setup.problem.noConsent": "Accept the privacy statement and the platform terms to register. Nothing is sent until you do.",
+  "node.meta.type": "Type:",
+  "node.meta.created": "Created:",
+  "node.meta.updated": "Updated:",
+  "node.meta.by": "by {0}"
 }


### PR DESCRIPTION
Node pages showed Type, Created and Updated in English for German viewers. Resolve these labels through the viewer's localization context and translate the adjacent author attribution (by/von), preserving HTML encoding and existing timestamp formatting.

Adds a What's New entry. The separate metadata-extension proposal (#3823) remains outside this change; its future Last activity label can be added when it has a caller.

Validation: Release builds with CIRun=true and warnings as errors; 58 LocalizationTest cases and the What's New integrity guard passed, with fresh TRX results and no skipped tests.

Adds four core catalog keys. After this core change merges, synchronize the MeshWeaver.Plugins web-client catalogs and catalog-source pin to the merged SHA; that follow-up remains part of delivery.

Closes #3824.

Mirror-sync: MeshWeaver.Plugins will run `npm run sync:i18n -- --ref <merged core sha>` after this core PR merges; the same maintenance task owns the generated catalogs, catalog-source pin, client checks and follow-up PR through merge.