### PR TITLE
ci: the node-repo gate exposes nothing-to-gate to its callers

### DIFF
--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -75,6 +75,26 @@ on:
           summary in the file, so a concatenation would ratchet 1/N of the NodeTypes and report a
           clean sweep.)
         value: ${{ jobs.verify.outputs.gate-log-artifact }}
+      nothing-to-gate:
+        description: >-
+          `true` when this run had NOTHING to gate — a pull request whose diff reaches no module
+          content, under `affected-narrowing` (which is ON by default). The plan then emits an empty
+          matrix, every shard is SKIPPED, and no gate log is produced.
+
+          🚨 This is the OTHER HALF of `gate-log-artifact`, and without it that output is
+          undecidable. Its own description tells a caller "empty ⇒ there was no gate run to
+          ratchet" — but an empty artifact has two causes, and only one of them is benign: nothing
+          to gate, or a gate that was meant to run and did not. A caller's ratchet keying on
+          emptiness alone must therefore either accept both (a skipped gate renders as a pass — the
+          skip-trapdoor AGENTS.md forbids) or reject both (every content-free pull request reds).
+          MeshWeaver.SocialMedia#161 is the second, measured: its ratchet reds every pull request
+          whose diff touches no module content.
+
+          Pair them: accept an empty artifact ONLY when this is `true`, and stay red otherwise.
+          The distinction was always computed here (`plan.outputs.nothing-to-gate`, which this
+          workflow already guards its own aggregate on) and simply never reachable from a caller —
+          a job output is not a `workflow_call` output.
+        value: ${{ jobs.plan.outputs.nothing-to-gate }}
     inputs:
       test-image:
         description: The mw-plugin-test image reference (the caller's vars.MW_TEST_IMAGE).


### PR DESCRIPTION
The core half of Systemorph/MeshWeaver.SocialMedia#161. Additive: one `workflow_call` output.

## An empty artifact has two causes, and a caller can only see one of them

`gate-log-artifact`'s own description states the contract:

> EMPTY when the gate ran nothing (a PR whose diff reaches no module content). A caller's own ratchet
> keys on this: present ⇒ download and read it… **empty ⇒ there was no gate run to ratchet**

A caller cannot act on that, because "empty" means either **nothing to gate** (benign) or **a gate
that was meant to run and did not** (the thing a ratchet exists to catch). Keying on emptiness alone
forces a caller to pick one of two wrong behaviours:

| the caller accepts empty | the caller rejects empty |
|---|---|
| a skipped gate renders as a pass — the **skip-trapdoor** AGENTS.md forbids | every content-free pull request reds |

SocialMedia is living the second. On [run 34340981609](https://github.com/Systemorph/MeshWeaver.SocialMedia/actions/runs/34340981609) — #160, a one-file `e2e/` change — the chain ran exactly as designed: `run_all=false` → empty mount → `nothing_to_gate=true` → `matrix=[]` → shard **skipped** → no artifact → ratchet **red**.

## 🚨 The distinction was always computed here — just not reachable

`plan.outputs.nothing-to-gate` is a **job** output, and a job output is not a `workflow_call` output.
This workflow already guards its own aggregate on it in three places:

```
 408   if: needs.plan.result == 'success' && needs.plan.outputs.nothing-to-gate != 'true'
1289   NOTHING_TO_GATE: ${{ needs.plan.outputs.nothing-to-gate }}
1388   if: always() && needs.plan.outputs.nothing-to-gate != 'true'
```

Callers could not see the one field that makes the other output decidable. Now they can, and the
pairing is one-way: accept an empty artifact **only** when `nothing-to-gate` is `true`, stay red
otherwise — so a gate skipped for any other reason still fails.

## It also writes down the default that inverted a caller's premise

SocialMedia's `ci.yml` comments say *"this repo passes no `affected-narrowing`, so it runs the FULL
set on every event"*. The input is `default: true` — narrowing is **on** unless a caller turns it
off. MeshWeaver.Education passes `affected-narrowing: false` explicitly and its identical ratchet is
sound. That reading ("not passed ⇒ off") is now called out in the new output's description, where
the next caller will be looking.

## Scope and verification

No job, no input, no behaviour change for any existing caller — the value was already being computed
and consumed internally.

```
YAML parses; workflow_call outputs = ['gate-log-artifact', 'nothing-to-gate']
check-workflow-timeouts ....... 82 jobs, 0 violations, cap=45 min
check-workflow-yaml-keys ...... OK
check-workflow-shell .......... OK
check-pr-secret-preflight ..... OK
```

The satellite half (accepting an empty artifact only when this is `true`, and correcting the comment
and error text) follows in SocialMedia once this is on `main` — the ordering the `Implementers:`
rule uses: the core half lands first, since a caller cannot reference an output that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
