### PR TITLE
Refuse new outgoing requests from a quiescing hub

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
@@ -209,9 +209,14 @@ The gate is now two tiers, and the new one is deliberately NARROWER than the old
 |---|---|---|
 | `ShutdownRequest` / `DisposeRequest` | passes | passes |
 | a reply carrying `PostOptions.RequestId` | **passes** — this is what the drain is waiting for | refused |
-| transit to a hosted child | **passes** — the children are alive until the next phase | refused |
+| third-party transit to another hub | **passes** — the children are alive until the next phase | refused |
 | fire-and-forget nobody awaits | **passes** — no promise to break, and answering it is the storm shape `AnswerPolicy` prevents | refused (silently) |
-| a NEW request addressed to this hub | **refused**, `ErrorType.ShuttingDown` | refused, `ErrorType.ShuttingDown` |
+| a NEW request addressed to or originating from this hub | **refused**, `ErrorType.ShuttingDown` | refused, `ErrorType.ShuttingDown` |
+
+A new outgoing request owned by the draining hub is also refused: an external target does
+not turn it into third-party transit. Otherwise a background pipeline can register new callbacks
+after the drain begins. The refusal identifies the originating hub, not the destination; requests
+forwarded on behalf of other hubs still pass. The same test fixture pins both cases.
 
 The refusal is the same transient, owner-minted NACK tier 2 already posted — `ShutdownNack.RejectingNow`,
 activation identity and all — so a caller reads "ask again at the fresh activation", never "gone",

--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
@@ -209,7 +209,7 @@ The gate is now two tiers, and the new one is deliberately NARROWER than the old
 |---|---|---|
 | `ShutdownRequest` / `DisposeRequest` | passes | passes |
 | a reply carrying `PostOptions.RequestId` | **passes** — this is what the drain is waiting for | refused |
-| third-party transit to another hub | **passes** — the children are alive until the next phase | refused |
+| third-party transit to another hub | **passes** — transit is not new work owned by the draining hub | refused |
 | fire-and-forget nobody awaits | **passes** — no promise to break, and answering it is the storm shape `AnswerPolicy` prevents | refused (silently) |
 | a NEW request addressed to or originating from this hub | **refused**, `ErrorType.ShuttingDown` | refused, `ErrorType.ShuttingDown` |
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-shutdown-refuses-new-outgoing-requests.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-shutdown-refuses-new-outgoing-requests.md
@@ -1,0 +1,15 @@
+---
+Name: Shutdown refuses new outgoing requests
+Category: Fix
+Description: A component that is already shutting down now refuses new outgoing requests immediately instead of starting work whose response may be cancelled by teardown.
+Icon: CheckmarkCircle
+Order: -20260909
+---
+
+Background work could start a new request after its owning component had begun shutting down.
+The request passed the forwarding rule because its destination was another component, leaving
+shutdown responsible for a new response it might cancel before it arrived.
+
+The component now reports that it is shutting down before sending that new request. Responses
+to previously accepted requests and traffic forwarded for other components can still pass while
+existing work drains.

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -657,8 +657,11 @@ public class MessageService : IMessageService
         // Compare without Host — Host tracks the routing path, the inner address is the identity
         // (same test HierarchicalRouting.RouteMessageAsync makes to decide "are we the target").
         // A null Target is handled locally, so it counts as addressed here.
+        // Only third-party traffic gets the routing exemption. Our own outgoing request
+        // would register new work during the drain, even though its target is elsewhere.
         if (delivery.Target is not null
-            && !(delivery.Target with { Host = null }).Equals(Address))
+            && !(delivery.Target with { Host = null }).Equals(Address)
+            && !(delivery.Sender is { } sender && (sender with { Host = null }).Equals(Address)))
             return false;
 
         return IsAwaitedBySender(delivery);

--- a/test/MeshWeaver.Messaging.Hub.Test/QuiescingHubRefusesNewWorkTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/QuiescingHubRefusesNewWorkTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
-using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using Xunit;
@@ -208,7 +207,7 @@ public class QuiescingHubRefusesNewWorkTest(ITestOutputHelper output) : HubTestB
         {
             // Feed the router a third party's envelope: it owes no response callback for it.
             var delivery = new MessageDelivery<NewWorkRequest>(fixture.Host.Address,
-                targetAddress, new NewWorkRequest(), new JsonSerializerOptions())
+                targetAddress, new NewWorkRequest(), fixture.Host.JsonSerializerOptions)
             {
                 AccessContext = new AccessContext { ObjectId = "forwarding-test" }
             };

--- a/test/MeshWeaver.Messaging.Hub.Test/QuiescingHubRefusesNewWorkTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/QuiescingHubRefusesNewWorkTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
+using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using Xunit;
@@ -150,6 +151,75 @@ public class QuiescingHubRefusesNewWorkTest(ITestOutputHelper output) : HubTestB
         await fixture.Victim.DisposalCompleted.FirstOrDefaultAsync().Await()
             .WaitAsync(TestTimeouts.Convergence);
         fixture.Victim.RunLevel.Should().Be(MessageHubRunLevel.Dead);
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task NewRequestOriginatingDuringQuiesce_IsRefusedBeforeItReachesAnotherHub()
+    {
+        var fixture = await ArrangeQuiescingVictim();
+        var received = new HandlerRan();
+        var targetAddress = new Address("quiescing-outbound-target", "1");
+        fixture.Host.GetHostedHub(targetAddress, c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithTypes(typeof(NewWorkRequest), typeof(NewWorkResponse))
+            .WithHandler<NewWorkRequest>((h, d) =>
+            {
+                received.Record();
+                h.Post(new NewWorkResponse(), o => o.ResponseFor(d));
+                return d.Processed();
+            }));
+
+        try
+        {
+            var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() =>
+                fixture.Victim.Observe(new NewWorkRequest(), o => o.WithTarget(targetAddress))
+                    .FirstAsync().Timeout(TestTimeouts.Convergence)
+                    .Await(TestContext.Current.CancellationToken));
+            failure.Failure!.ErrorType.Should().Be(ErrorType.ShuttingDown);
+            ShutdownNack.IsAnsweredByOwner(failure.Failure.Message, VictimAddress).Should().BeTrue();
+            ShutdownNack.IsAnsweredByOwner(failure.Failure.Message, targetAddress).Should().BeFalse(
+                "the origin refused to start the request; the destination did not refuse it");
+            received.Did.Should().BeFalse(
+                "a draining hub must not start another request whose callback teardown will cancel");
+        }
+        finally
+        {
+            await fixture.ReleaseAndDispose();
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task RequestFromAnotherHub_StillForwardsDuringQuiesce()
+    {
+        var fixture = await ArrangeQuiescingVictim();
+        using var arrived = new AsyncSubject<IMessageDelivery>();
+        var targetAddress = new Address("quiescing-forward-target", "1");
+        fixture.Host.GetHostedHub(targetAddress, c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithTypes(typeof(NewWorkRequest), typeof(NewWorkResponse))
+            .WithHandler<NewWorkRequest>((_, d) =>
+            {
+                arrived.OnNext(d);
+                arrived.OnCompleted();
+                return d.Processed();
+            }));
+
+        try
+        {
+            // Feed the router a third party's envelope: it owes no response callback for it.
+            var delivery = new MessageDelivery<NewWorkRequest>(fixture.Host.Address,
+                targetAddress, new NewWorkRequest(), new JsonSerializerOptions())
+            {
+                AccessContext = new AccessContext { ObjectId = "forwarding-test" }
+            };
+            fixture.Victim.DeliverMessage(delivery);
+            await arrived.Should().Within(TestTimeouts.Convergence).Emit(
+                "quiescing stops new work owned by this hub, but preserves transit traffic");
+        }
+        finally
+        {
+            await fixture.ReleaseAndDispose();
+        }
     }
 
     private sealed record QuiescingVictim(


### PR DESCRIPTION
A background pipeline could start a new awaited request after its hub entered Quiescing: the intake gate treated any external destination as transit traffic. The request could then lose its callback during teardown.

Restrict that exemption to requests originating elsewhere. New requests owned by the draining hub now receive ShuttingDown immediately, while existing replies and third-party transit still pass. The refusal identifies the origin rather than claiming the destination rejected the request.

Related to #3510; does not close its remaining in-flight installation/recycle work.

Validation: the new outbound regression failed deterministically before the fix (the destination answered). Release builds with CIRun and warnings-as-errors are clean for messaging, graph, and documentation tests. Full Messaging.Hub.Test: 405 passed, zero skipped. Graph teardown controls: 7 passed. What's New integrity: 1 passed. Four focused controls also verify inbound refusal, outbound refusal, reply drain, and third-party forwarding.
