### PR TITLE
Report an unknown outcome when an inner create times out

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -465,6 +465,15 @@ follows, and the run contains **zero `[CreateOrUpdate]` lines of any kind** — 
 ever ran. Silence, not a fault. The install then ran out its ten-minute bound with no name for what
 happened.
 
+### A create timeout cannot establish that nothing was written
+
+The inner-create bound guarantees an answer to the upsert caller; it does not establish rollback.
+The create handler persists the row before running post-creation handlers and sending its response.
+A pending post-creation handler can therefore outlive that bound with the row already present.
+The timeout reports an **unknown outcome**, never "NOT applied" or an unconditional safe retry.
+`CreateTimeoutOutcomeTest` pins this with a real stored node and a held post-creation handler,
+letting the production bound expire without altering its duration.
+
 ### 🚨 The recycle is by design, it succeeds, and it is NOT the defect
 
 The disposer is `PackageInstaller.SettleRetypedRoot` — the installer's own ordered recycle of the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-create-timeout-outcome.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-create-timeout-outcome.md
@@ -1,0 +1,11 @@
+---
+Name: Create timeouts report an unknown outcome
+Category: Fix
+Description: A create request that times out no longer claims the write was not applied: the node may already be stored while its remaining creation steps or response are pending.
+Icon: Info
+Order: -20260909
+---
+
+A timed-out create request could tell callers that nothing was written even when the node was
+already stored. The error now reports an unknown outcome and advises checking the node before
+retrying. A missing response does not establish that the operation was rolled back.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4774,16 +4774,14 @@ public static class MeshExtensions
                             logger.LogWarning(
                                 "[CreateOrUpdate] the inner CreateNode for {Path} produced no response "
                                 + "within {Bound} — answering the caller with a refusal rather than "
-                                + "leaving it to wait out its budget. The usual cause is the owner being "
-                                + "recycled under its own install (PackageInstaller.SettleRetypedRoot "
-                                + "retypes then recycles the package root on every plugin install), in "
-                                + "which case the create was NOT applied and is safe to retry against "
-                                + "the fresh activation (#3510).",
+                                + "leaving it to wait out its budget. The outcome is unknown: the node "
+                                + "may already be persisted while post-creation work or its response "
+                                + "is still pending. A missing response does not prove rollback.",
                                 node.Path, InnerCreateVerdictBound);
                             PostFail(
                                 $"The create for '{node.Path}' produced no response within "
-                                + $"{InnerCreateVerdictBound.TotalSeconds:0}s. It was NOT applied; retry "
-                                + "against the fresh activation.",
+                                + $"{InnerCreateVerdictBound.TotalSeconds:0}s. The outcome is unknown; "
+                                + "the node may already have been persisted. Check its state before retrying.",
                                 NodeUpsertRejectionReason.Unknown);
                             return;
                         }

--- a/test/MeshWeaver.Graph.Test/CreateTimeoutOutcomeTest.cs
+++ b/test/MeshWeaver.Graph.Test/CreateTimeoutOutcomeTest.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+public class CreateTimeoutOutcomeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private readonly HeldPostCreation handler = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder).ConfigureServices(s => s.AddSingleton<INodePostCreationHandler>(handler));
+
+    [Fact]
+    public async Task CreateTimeout_DoesNotClaimAnAlreadyPersistedNodeWasNotApplied()
+    {
+        var path = $"{TestPartition}/held-create-outcome";
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        try
+        {
+            var pending = access.RunAsSystem(() => ObserveNodeOperation(
+                    new CreateOrUpdateNodeRequest(new MeshNode("held-create-outcome", TestPartition)
+                    {
+                        Name = "Persisted before the response", NodeType = "Markdown"
+                    })))
+                .FirstAsync().Await(TestContext.Current.CancellationToken);
+            await handler.Entered.Should().Within(TestTimeouts.Convergence).Emit(
+                "the post-creation handler holds the reply only after the row has been saved");
+            var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+            var persisted = await storage.Read(path, Mesh.JsonSerializerOptions)
+                .FirstAsync().Await(TestContext.Current.CancellationToken);
+            persisted.Should().NotBeNull();
+
+            // Let the actual production verdict bound expire; never shorten it for this test.
+            var answer = await pending.WaitAsync(
+                MeshExtensions.InnerCreateVerdictBound + TestTimeouts.Convergence,
+                TestContext.Current.CancellationToken);
+            answer.Message.Success.Should().BeFalse();
+            answer.Message.Error.Should().Contain("outcome is unknown");
+            answer.Message.Error.Should().NotContain("NOT applied",
+                "the row is already persisted and a missing reply cannot prove otherwise");
+        }
+        finally
+        {
+            handler.Release.OnNext(Unit.Default);
+            handler.Release.OnCompleted();
+        }
+    }
+
+    private sealed class HeldPostCreation : INodePostCreationHandler
+    {
+        public string NodeType => "Markdown";
+        public AsyncSubject<Unit> Entered { get; } = new();
+        public AsyncSubject<Unit> Release { get; } = new();
+
+        public IObservable<Unit> Handle(MeshNode createdNode, string? createdBy)
+        {
+            if (createdNode.Id != "held-create-outcome")
+                return Observable.Return(Unit.Default);
+            Entered.OnNext(Unit.Default);
+            Entered.OnCompleted();
+            return Release;
+        }
+    }
+}


### PR DESCRIPTION
The inner-create timeout said the create was NOT applied and safe to retry. A deterministic real-mesh regression proves the opposite: the row is persisted before a held post-creation handler runs out the 36-second response bound.

Report an unknown outcome and advise checking the node before retrying. The warning also stops guessing that root recycling proves rollback. Timeout duration, persistence, and post-creation handler behavior are unchanged.

Related to #3510; this fixes the false outcome claim, not the remaining pending-create/disposal mechanism.

Validation: regression failed before the correction with a row read successfully from storage and the contradictory NOT applied response. After correction, that regression and the owner-disposal upsert control pass (2 tests, zero skips). Release CIRun warnings-as-errors builds for Graph.Test and Documentation.Test are clean; What's New integrity passes. The test uses the real production bound, not a shortened timeout.
