### PR TITLE
test: make late-NACK correlation regression deterministic

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md
@@ -159,6 +159,59 @@ no cluster, no scheduler and no wall clock are involved:
 it go red. It is deliberately **not** verified by re-running `LateNackReenqueueTest` hoping to catch
 the 1/330 — the race stays unreproduced, and a test that can only pass by luck proves nothing.
 
+## Correlation-test timeout is a separate observation
+
+Static review of core `e29d540a038f55d6f41f3cc298d236db8bb60654` on 2026-09-09
+identifies a test-contract defect in `LateNackReenqueueCorrelationTest`. This does not establish
+the cause of every failure recorded under #3477, including the original durable-storage timeout
+and the later 90-second method timeout. No new test runs were used for this finding.
+
+The test parks an owner merge until either its release flag is set or `owner.IsShuttingDown`
+becomes true. Disposing the owner therefore releases accepted work, which may finish with an ACK.
+`LateNackReenqueueTest` explicitly documents that ACK as the normal graceful-shutdown outcome;
+a retryable NACK is only a safety net. The correlation test nevertheless waits unconditionally
+for `LATE_NACK_REENQUEUE`. A successful durable write can therefore leave this log wait unsatisfied.
+
+Its timing fence also does not establish a late response. `LatePatchResponseRegistry.ArmedCount`
+is the dictionary entry count. `UpdateRemote` registers that entry before posting through
+`Hub.Observe` and starting `UpdateResponseWaitBound`. Seeing an entry proves neither expiration
+of that bound nor owner acceptance of the patch. An early retryable NACK takes the separate
+`OWNER_NACK_REENQUEUE` branch, whose warning also cannot satisfy the test's regex.
+
+The logger lifetime does not supply a demonstrated alternative explanation. `UpdateRemote`
+captures the cache workspace logger on entry and emits the late-NACK warning immediately before
+the recursive retry. Owner shutdown closes the owner's child scope, not the cache/root scope.
+The test's capturing provider has a no-op `Dispose`, and its sink accepts the emitted category.
+Persistence alone cannot prove that the late-NACK branch ran or that a warning was lost.
+
+### Deterministic correlation regression
+
+The corrected test constructs a late verdict rather than racing for a shutdown NACK:
+
+1. Capture the specific patch request ID and correlation ID, and fence on the unique path's
+   response-timeout transition rather than the global registry count. That path has only the
+   original attempt until the controlled NACK is supplied.
+2. Dispatch an explicit late `OwnerDisposing` verdict through the existing registry seam.
+   `ArmedRequestIds` documents this purpose: construct a late verdict for an actual in-flight patch.
+3. Assert that the resulting child attempt retains the correlation ID, has a distinct request ID,
+   and is actually armed in the registry. The previous test only checked that the warning's
+   correlation value was nonblank and had no spaces.
+4. Release the parked merge in cleanup and verify caller termination and durable persistence with
+   an idempotent update. Keep graceful-disposal coverage accepting either valid terminal verdict.
+
+Before parking the merge, a test-local Debug sentinel through the actual cache logger factory
+proves that this capture sees the diagnostics. The regression requires no production log-level
+changes or increased timing bounds. Synthetic dispatch does not cancel the original accepted patch;
+both pending assignments are idempotent, and the gate is released before awaiting completion.
+This exercises correlation propagation through the late callback, not natural shutdown verdict
+generation. The corrected correlation test and its unchanged disposal sibling both pass locally
+under the two-processor CI shape, with Release warnings-as-errors builds.
+As a negative control, temporarily replacing the late retry's inherited correlation with a newly
+minted one makes the corrected test fail at the parent/child equality assertion in two seconds;
+the control is reverted and is not part of the change.
+The queue-owned delayed conflict retry fixed by #3818 is a different path from `UpdateRemote`'s
+direct recursive late-NACK retry; its passing regressions do not close #3477.
+
 ## Related
 
 - [Write Verdict Totality](../WriteVerdictTotality) — the sibling fail-open on the base read

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
@@ -20,38 +20,15 @@ using Xunit;
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>
-/// 🚨 #3477: after <c>LATE_NACK_REENQUEUE</c> the trail went dark. The late registry mints a FRESH
-/// <c>requestId</c> per attempt, so the re-enqueued write registered under an id unrelated to the
-/// one that produced it — and "the re-enqueue never left the cache hub", "it never activated the
-/// owner" and "it activated and never answered" were indistinguishable in the log. A write that was
-/// NACKed, re-enqueued and then neither applied nor answered is the write-loss class the sibling
-/// test exists to refuse, and it could not be attributed.
+/// Pins #3477's correlation chain through the real late-verdict callback. Every attempt
+/// registers a fresh request id, while the logical write keeps its original correlation id.
 ///
-/// <para>The fix threads ONE correlation id, minted at the caller's entry and passed unchanged into
-/// every re-attempt. This test pins that inheritance: the re-attempt's own <c>BEGIN</c> must carry
-/// the SAME <c>corr=</c> as the <c>LATE_NACK_REENQUEUE</c> that caused it.</para>
-///
-/// <para>🚨 It deliberately asserts on the RE-ENQUEUE, not on the write landing: everything it
-/// needs has already happened by the time the re-enqueue is logged, and it stays silent about
-/// landing, which is the open defect rather than this one.</para>
-///
-/// <para>🚨 An earlier revision of this comment claimed this test was "deterministic where the
-/// sibling is not". THAT WAS FALSE, and measurement said so: on queue-build 34089526911 the
-/// sibling passed in the same shard, on the same host, while this test wedged for 90 s and was
-/// killed. The cause was this test's own log capture awaiting a live Subject — see
-/// <c>CapturingLoggerProvider.FirstMatching</c>. Asserting on a log line rather than on storage
-/// buys determinism only if OBSERVING the line cannot perturb what produced it; here it did.</para>
-///
-/// <para>🚨 WHAT THIS TEST DOES NOT COVER, stated so a green suite is not read as more than it
-/// checked. It pins that the re-enqueue line CARRIES a correlation id. It does NOT pin that the
-/// re-attempt INHERITS the same one — that assertion needs the re-attempt's own <c>BEGIN</c>, which
-/// is <c>LogDebug</c> (one per write, on the hot path) and is dropped by the harness's log filter
-/// before any provider sees it. Two attempts to raise that filter for one category did not reach the
-/// factory the hub resolves; the honest options were to promote a hot-path line to Information so a
-/// test could see it — forbidden, <c>src/</c> levels are committed contract — or to say so here.
-/// The inheritance is therefore guaranteed only by the two re-enqueue call sites passing
-/// <c>correlationId: corr</c>, which the compiler checks and no test does. That gap is real and is
-/// recorded on #3477 rather than left for someone to discover.</para>
+/// The original test disposed an owner whose parked merge released on shutdown, then required
+/// a late NACK log. That setup also permits a successful ACK, and an armed registry entry does
+/// not imply the fast response wait expired: it is registered before the patch is posted.
+/// This test observes the response-timeout transition, delivers an explicit late NACK through
+/// the registry's existing verdict seam, and checks the child attempt and caller to completion.
+/// Owner-disposal verdict delivery itself is covered by LateNackReenqueueTest.
 /// </summary>
 public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -71,7 +48,6 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
                 // src/ log levels are committed contract and are never edited to make a test pass.
                 .Configure<LoggerFilterOptions>(o =>
                 {
-                    o.MinLevel = LogLevel.Debug;
                     o.Rules.Add(new LoggerFilterRule(
                         providerName: null,
                         categoryName: "MeshWeaver.Mesh.MeshNodeStreamHandle",
@@ -99,15 +75,26 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
         var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
         Assert.NotNull(nodeHub);
 
-        // Park the owner's merge executor — the same gating pattern the sibling test uses, and the
-        // only way to force a verdict that arrives after the caller's response bound. No hand-woven
-        // gate: the turn→test signal is an AsyncSubject the parked turn completes, and the release
-        // travels back INTO the parked turn, so it is a volatile int under a bounded SpinUntil,
-        // written in a `finally` so a failing assertion cannot strand the executor.
+        // Prove Debug reaches THIS capture through the exact factory UpdateRemote resolves.
+        // The ordinary test-file logger may independently filter Debug; its output is not the
+        // evidence that this provider is attached and can observe the transition below.
+        Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        var cacheHub = Mesh.GetHostedHub(new Address("cache", Mesh.Address.Id), HostedHubCreation.Never);
+        Assert.NotNull(cacheHub);
+        var logger = cacheHub!.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("MeshWeaver.Mesh.MeshNodeStreamHandle");
+        Assert.True(logger.IsEnabled(LogLevel.Debug));
+        var captureProbe = $"correlation-capture-{Guid.NewGuid():N}";
+        logger.LogDebug("{CaptureProbe}", captureProbe);
+        Assert.True(captured.Contains(captureProbe), "the effective cache logger must reach the capture");
+
+        // Keep the real merge pending until the fast waiter times out and the controlled
+        // late verdict has spawned its child. The producer-to-test signal is replayed;
+        // the bounded worker release is always written in finally.
         var primary = nodeHub!.GetWorkspace().DataContext
             .GetDataSourceForType(typeof(MeshNode))!
             .GetStreamForPartition(null)!;
-        var gateEntered = new AsyncSubject<Unit>();
+        using var gateEntered = new AsyncSubject<Unit>();
         var releaseGate = 0;
         var owner = nodeHub!;
         primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
@@ -127,38 +114,65 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
 
             captured.Clear();
 
-            // The production cross-hub mirror path. Subscribe rather than await — awaiting a
-            // verdict the parked owner cannot give is what would hang.
+            // Capture the caller's terminal as well as its value. It must be the chained
+            // re-attempt's verdict, not a successful-looking optimistic snapshot.
             var workspace = Mesh.GetWorkspace();
+            using var caller = new AsyncSubject<MeshNode>();
             using var writeSub = workspace.GetMeshNodeStream(path)
                 .Update(n => n with { Name = "corr-probe" })
-                .Subscribe(_ => { }, _ => { });
+                .Subscribe(caller);
+            var target = Regex.Escape(path);
+            var registration = await captured.FirstMatching(
+                    $@"LATE_VERDICT_REGISTERED .*target={target} attempt=0 corr=(?<corr>\S+) requestId=(?<request>\S+)",
+                    TestTimeouts.Convergence)
+                .Await(ct);
+            var corr = registration.Groups["corr"].Value;
+            var requestId = registration.Groups["request"].Value;
 
-            // Fence on the patch being in flight — the ARMED late watch is that fact, and it is
-            // the same fact the disposal NACK will land on. Never a delay.
+            // This path has exactly one attempt until we supply the NACK. Unlike ArmedCount,
+            // RESPONSE_TIMEOUT proves its fast waiter has handed off to the late callback.
+            // The merge remains parked, so neither an ACK nor an actual NACK can win the race.
+            await captured.FirstMatching(
+                    $@"RESPONSE_TIMEOUT .*target={target} — owner busy;",
+                    TestTimeouts.Convergence)
+                .Await(ct);
             var registry = Mesh.ServiceProvider.GetRequiredService<LatePatchResponseRegistry>();
+            Assert.Contains(requestId, registry.ArmedRequestIds);
+            Assert.True(registry.Dispatch(requestId, new PatchDataResponse(false, 0)
+            {
+                NodeError = new MeshNodeError(MeshNodeErrorCode.OwnerDisposing, path,
+                    "Controlled late verdict for correlation inheritance."),
+            }), "the exact armed request must consume the controlled late verdict");
+
+            var nack = await captured.FirstMatching(
+                    $@"LATE_NACK_REENQUEUE .*target={target} attempt=1 code=OwnerDisposing corr=(?<corr>\S+)",
+                    TestTimeouts.Convergence)
+                .Await(ct);
+            var child = await captured.FirstMatching(
+                    $@"LATE_VERDICT_REGISTERED .*target={target} attempt=1 corr=(?<corr>\S+) requestId=(?<request>\S+)",
+                    TestTimeouts.Convergence)
+                .Await(ct);
+            Assert.False(string.IsNullOrWhiteSpace(corr));
+            Assert.Equal(corr, nack.Groups["corr"].Value);
+            Assert.Equal(corr, child.Groups["corr"].Value);
+            var childRequestId = child.Groups["request"].Value;
+            Assert.NotEqual(requestId, childRequestId);
+            // Registration is logged immediately before insertion. Fence on the child
+            // actually being armed, while no accepted merge can yet complete it.
             await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
-                .Where(_ => registry.ArmedCount > 0)
+                .Where(_ => registry.ArmedRequestIds.Contains(childRequestId))
                 .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
 
-            // Fence: the patch handler has provably run on the owner before the dispose below.
-            await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
-                .Should().Within(10.Seconds()).Emit();
-
-            // Dispose the owner AFTER the caller's response bound expired, so its OwnerDisposing
-            // NACK is necessarily LATE — which is the arm that re-enqueues.
-            nodeHub!.Dispose();
-
-            var reenqueue = await captured.FirstMatching(
-                @"LATE_NACK_REENQUEUE .*corr=(?<corr>[^\s]+)", TestTimeouts.Convergence);
-            var corr = reenqueue.Groups["corr"].Value;
-
-            // 🚨 WHAT THIS PINS: the re-enqueue line carries a correlation id at all. Before #3477
-            // it carried none, so the write became unfollowable at exactly the point it was handed
-            // to a fresh attempt. If the field is dropped or renamed, this goes red.
-            Assert.False(string.IsNullOrWhiteSpace(corr),
-                "LATE_NACK_REENQUEUE must carry the corr that makes the re-attempt followable");
-            Assert.DoesNotContain(" ", corr);
+            // Both accepted patches use the same idempotent assignment. Releasing the real
+            // executor lets the re-attempt finish; its terminal must reach the original caller.
+            Volatile.Write(ref releaseGate, 1);
+            var terminal = await caller.Timeout(TestTimeouts.Convergence).Await(ct);
+            Assert.Equal("corr-probe", terminal.Name);
+            var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+                .Where(n => n is not null && n.Name == "corr-probe")
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
+            Assert.Equal("corr-probe", persisted!.Name);
         }
         finally
         {
@@ -176,6 +190,7 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
         public ILogger CreateLogger(string categoryName) => new Sink(this, categoryName);
         public void Dispose() { }
         public void Clear() => lines.Clear();
+        public bool Contains(string line) => lines.Contains(line);
 
         // 🚨 Enqueue ONLY. There is deliberately no Subject here — see FirstMatching.
         private void Add(string line) => lines.Enqueue(line);


### PR DESCRIPTION
The correlation test disposed an owner whose parked merge released on shutdown, then required a late-NACK warning even when the accepted write could ACK successfully. Its registry-count fence also ran before the response timeout, so an early NACK could miss the required warning too.

Construct the late verdict through the existing registry seam after the specific write's response-timeout transition. Verify the actual cache logger captures Debug, the child attempt inherits the parent's correlation with a distinct armed request ID, and the caller completes with the marker durably persisted. The graceful-disposal sibling continues to accept either valid verdict. Production behavior and log levels are unchanged.

Validation: Release builds with CIRun=true and warnings-as-errors pass. The corrected correlation regression and disposal sibling pass under DOTNET_PROCESSOR_COUNT=2; documentation integrity passes. A temporary negative control that dropped correlation inheritance failed the exact parent/child equality assertion in two seconds; restoring it passed. No timing bounds or retries were increased.

Related to #3477, not a closure: the historical no-land failure and later method timeout remain unproven. Findings and the regression boundary are committed in [The Phantom Base After Owner Disposal](src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md).

No What's New entry: internal test correction with no user-facing runtime change.
