### PR TITLE
fix: keep logs across a Loki restart, and gate the settings that keep them

### DIFF
--- a/.github/workflows/chart-gate.yml
+++ b/.github/workflows/chart-gate.yml
@@ -107,6 +107,17 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 deploy/aks/scripts/test-observability-storage.py
 
+      # The observability-values CHECKER's own logic, with helm and docker stubbed — so it runs
+      # here, offline, rather than in the job that reaches the network. Same reason as the
+      # chart-drift comparator above: a gate that has quietly lost the ability to fail reports a
+      # tick nobody re-examines, and this one has already done it once. The first version of that
+      # checker passed a deliberately mis-nested `ingestor:` key, because loki-stack merges
+      # `loki.config` through verbatim and the unknown key reached the render intact — it could not
+      # fail for the very component #3773 was about. These cases are that regression, pinned.
+      - name: Assert the observability values checker still classifies each defect
+        if: ${{ !cancelled() }}
+        run: python3 deploy/aks/scripts/test-observability-values.py
+
   # The three pieces of shell behind Doc/Architecture/PluginBundlesInTheRegistry — the publisher
   # (.github/scripts/push-bundle-publication.sh), the `bundle-fetch` init container's script and
   # docker_auth's ext_auth hook (deploy/helm/files/) — EXECUTED against the real distribution and
@@ -119,6 +130,48 @@ jobs:
   #
   # 🛡️ NO SKIP-TRAPDOOR: every input is in this repository or pinned by digest/checksum; no
   # secret, no cluster; no `continue-on-error:`, no input-shaped `if:`, no path filter.
+  # The observability stack's values, checked the only two ways that can actually fail.
+  #
+  # 🚨 WHY IT IS A SEPARATE JOB. `Chart invariants` above states, as a property worth keeping true,
+  # that every input it reads is in this repository — no secret, no cluster, NO NETWORK. This check
+  # fetches a third-party chart (grafana/loki-stack) and a container image, so folding it in there
+  # would quietly falsify that header. It gets its own job and states its own dependencies instead.
+  #
+  # 🚨 WHAT IT GUARDS. On 2026-09-09 a drain of loki-0 took every namespace's log history with it
+  # (#3773): `persistence.enabled` preserves flushed chunks, and nothing was enabling the ingester
+  # WAL that covers the rest. The WAL keys are set now — but this same values file already
+  # documents, in prose, a key that is set-able and INERT (`promtail.config.wal` renders to
+  # nothing, because the deprecated loki-stack chart does not template it). A prose warning about
+  # silently-dropped keys is exactly the thing that should be executable, so that the next one
+  # fails RED in the pull request that adds it instead of reading as coverage for weeks.
+  #
+  # Two checks, because the components fail in OPPOSITE directions and neither is sufficient alone:
+  #   • promtail — its chart builds config from named fields and drops the rest, so the RENDER
+  #     check catches it.
+  #   • loki — its chart merges `config` through VERBATIM, so the render check is vacuous there: a
+  #     typo'd `ingestor:` arrives in the render intact and passes. Only `loki -verify-config`
+  #     knows it is not a field. Measured 2026-09-09, both directions, on this exact typo.
+  #
+  # 🛡️ NO SKIP-TRAPDOOR: helm missing, PyYAML missing, docker missing or not running, the chart
+  # unfetchable, the render empty, or too few leaves examined are each RED and name themselves.
+  # No `continue-on-error:`, no input-shaped `if:`, no path filter.
+  observability-values:
+    name: Observability values (rendered + binary-validated)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.3
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      - name: Assert every observability config key survives the render, and Loki accepts it
+        run: deploy/aks/scripts/check-observability-values.sh
+
   bundle-registry:
     name: Bundle registry scripts (executed)
     runs-on: ubuntu-latest

--- a/deploy/aks/scripts/check-observability-values.py
+++ b/deploy/aks/scripts/check-observability-values.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Assert the observability values produce a configuration the components actually read.
+
+Driven by check-observability-values.sh (see that file for why this exists). Two checks, because
+the two components fail in opposite directions and neither check alone is sufficient:
+
+  RENDER   every `<component>.config.<KEY>` a values file sets must arrive, unaltered, in that
+           component's rendered configuration. This is the check that matters for PROMTAIL, whose
+           chart builds its config from named fields and silently drops anything else.
+
+  BINARY   the rendered Loki configuration is handed to `loki -verify-config`. This is the check
+           that matters for LOKI, whose chart merges `loki.config` into its defaults VERBATIM —
+           so the render check is vacuous there (a typo'd `ingestor:` reaches the render intact
+           and would pass). Only the binary knows that `ingestor` is not a field. Measured
+           2026-09-09: the render check passes that typo, the binary rejects it with
+           `field ingestor not found in type loki.ConfigWrapper`.
+
+Reports EVERY finding, never just the first, so one run tells you the whole story.
+
+Exit 0 = every leaf examined arrives unaltered AND the rendered Loki config is valid.
+Exit 1 = an orphaned/altered key, an invalid config, or too little examined to report a pass.
+"""
+import base64
+import subprocess
+import sys
+
+import yaml
+
+# Where each chart component's rendered configuration actually lands, and which check is
+# AUTHORITATIVE for it. Both are Secrets in loki-stack and they differ in encoding — `loki` uses
+# base64 `data`, `promtail` uses `stringData` — the kind of detail a hand-written check gets wrong
+# once and then reports a false pass forever. Resolved by kind+name, never by position.
+#
+# `verbatim_config` records that the chart merges the component's `config:` through untouched. For
+# such a component the render check CANNOT fail on an unknown key, and saying so here is what stops
+# the next reader treating its green as coverage it is not.
+COMPONENT_DOCS = {
+    "loki": {"kind": "Secret", "name": "loki", "key": "loki.yaml", "verbatim_config": True},
+    "promtail": {"kind": "Secret", "name": "loki-promtail", "key": "promtail.yaml",
+                 "verbatim_config": False},
+}
+
+# Below this, a "pass" is not evidence. The values file sets the ingester WAL (3 leaves), the
+# compactor's retention switch and the retention period — so a run that examines fewer than five
+# leaves has lost sight of its subject and must say so rather than render a tick.
+MIN_LEAVES = 5
+
+
+def leaves(node, prefix=()):
+    """Every scalar leaf under a mapping, as (path tuple, value)."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from leaves(value, prefix + (str(key),))
+    elif isinstance(node, list):
+        # A list is compared whole: order and content both matter, and half a list reaching the
+        # render is not a partial pass.
+        yield prefix, node
+    else:
+        yield prefix, node
+
+
+def dig(node, path):
+    """Follow `path` through the rendered config; returns (found, value)."""
+    for segment in path:
+        if not isinstance(node, dict) or segment not in node:
+            return False, None
+        node = node[segment]
+    return True, node
+
+
+def run(command, stdin=None):
+    return subprocess.run(command, input=stdin, capture_output=True, text=True)
+
+
+def render(chart, version, values_paths):
+    command = ["helm", "template", "loki", chart, "--namespace", "monitoring"]
+    if version:
+        command += ["--version", version]
+    for path in values_paths:
+        command += ["-f", path]
+    result = run(command)
+    if result.returncode != 0:
+        print(f"::error::`{' '.join(command)}` failed — the chart could not be rendered, so NOTHING "
+              f"was checked. This is a failure, not a skip.\n{result.stderr.strip()}")
+        sys.exit(1)
+    return result.stdout
+
+
+def loki_app_version(chart, version):
+    """The image tag whose binary must accept the config — taken from the PINNED chart, never
+    hard-coded, so a chart bump moves the validator with the thing it validates."""
+    result = run(["helm", "show", "chart", chart] + (["--version", version] if version else []))
+    if result.returncode != 0:
+        print(f"::error::`helm show chart {chart}` failed — cannot determine which Loki binary to "
+              f"validate against, so the binary check would silently not happen.\n{result.stderr.strip()}")
+        sys.exit(1)
+    metadata = yaml.safe_load(result.stdout) or {}
+    app_version = str(metadata.get("appVersion") or "").lstrip("v")
+    if not app_version:
+        print(f"::error::the pinned chart declares no appVersion — cannot pick a Loki image, and a "
+              f"guessed tag would validate against a binary the cluster never runs.")
+        sys.exit(1)
+    return app_version
+
+
+def verify_with_binary(config_text, app_version):
+    """Hand the rendered config to the real Loki binary. Piped over stdin rather than bind-mounted:
+    a mount depends on the host sharing the path with the container runtime (it does not, on a
+    default macOS Docker Desktop), and a check that only runs on CI's filesystem is a check nobody
+    can reproduce while fixing it."""
+    image = f"grafana/loki:{app_version}"
+    result = run(
+        ["docker", "run", "-i", "--rm", "--entrypoint", "sh", image,
+         "-c", "cat > /tmp/rendered.yaml && exec loki -config.file=/tmp/rendered.yaml -verify-config"],
+        stdin=config_text)
+    output = (result.stdout + result.stderr).strip()
+    if result.returncode != 0:
+        return [f"the rendered Loki configuration is REJECTED by {image}:\n"
+                + "\n".join(f"      {line}" for line in output.splitlines()[-6:])]
+    if "config is valid" not in output:
+        return [f"{image} exited 0 but never said `config is valid` — the validator did not run, "
+                f"so nothing was verified. Output:\n"
+                + "\n".join(f"      {line}" for line in output.splitlines()[-6:])]
+    return []
+
+
+def main():
+    chart, version, *values_paths = sys.argv[1:]
+    if not values_paths:
+        print("::error::no values file given — usage: check-observability-values.py CHART VERSION VALUES...")
+        return 1
+
+    manifest = render(chart, version, values_paths)
+    documents = [d for d in yaml.safe_load_all(manifest) if d]
+    if not documents:
+        print(f"::error::`helm template {chart}` rendered NOTHING. Every key would look orphaned, "
+              f"so this is a FAILURE rather than a report on evidence that was never gathered.")
+        return 1
+
+    rendered: dict[str, dict] = {}
+    rendered_text: dict[str, str] = {}
+    for component, where in COMPONENT_DOCS.items():
+        for document in documents:
+            if (document.get("kind") != where["kind"]
+                    or document.get("metadata", {}).get("name") != where["name"]):
+                continue
+            data = document.get("data") or {}
+            string_data = document.get("stringData") or {}
+            if where["key"] in string_data:
+                text = string_data[where["key"]]
+            elif where["key"] in data:
+                text = base64.b64decode(data[where["key"]]).decode()
+            else:
+                continue
+            rendered_text[component] = text
+            rendered[component] = yaml.safe_load(text) or {}
+            break
+
+    findings: list[str] = []
+    examined = 0
+
+    for path in values_paths:
+        with open(path) as handle:
+            values = yaml.safe_load(handle) or {}
+        for component, section in values.items():
+            if not isinstance(section, dict) or "config" not in section:
+                continue
+            if component not in COMPONENT_DOCS:
+                findings.append(
+                    f"{path}: `{component}.config` is set, but this check does not know where "
+                    f"{component}'s rendered configuration lands. Add it to COMPONENT_DOCS — an "
+                    f"unknown component must not pass silently.")
+                continue
+            where = COMPONENT_DOCS[component]
+            if component not in rendered:
+                findings.append(
+                    f"{path}: `{component}.config` is set, but the render contains no "
+                    f"{where['kind']}/{where['name']} carrying `{where['key']}`. Either the chart "
+                    f"moved or the component is disabled — either way nothing was verified.")
+                continue
+            for key_path, expected in leaves(section["config"]):
+                examined += 1
+                found, actual = dig(rendered[component], key_path)
+                dotted = ".".join(key_path)
+                if not found:
+                    findings.append(
+                        f"{path}: `{component}.config.{dotted}` reaches NOTHING — the rendered "
+                        f"{component} configuration has no `{dotted}`. helm accepts the key and "
+                        f"reports success, so this reads as configured while being inert.")
+                elif str(actual) != str(expected):
+                    findings.append(
+                        f"{path}: `{component}.config.{dotted}` is set to {expected!r} but renders "
+                        f"as {actual!r} — the chart overrode it.")
+
+    # The binary half. Unconditional: it does not ask whether anyone set `loki.config`, because the
+    # defaults the chart supplies are just as capable of being invalid as anything we add.
+    if "loki" not in rendered_text:
+        findings.append(
+            "the render contains no Secret/loki carrying `loki.yaml`, so the Loki configuration "
+            "could not be validated against the binary at all.")
+    else:
+        findings += verify_with_binary(rendered_text["loki"], loki_app_version(chart, version))
+
+    if findings:
+        print(f"::error::{len(findings)} observability configuration finding(s):")
+        for finding in findings:
+            print(f"  - {finding}")
+        return 1
+
+    if examined < MIN_LEAVES:
+        print(f"::error::only {examined} config leaf/leaves examined (minimum {MIN_LEAVES}). A pass "
+              f"on this little is not evidence — the values file lost its `config` sections, or the "
+              f"components were renamed.")
+        return 1
+
+    verbatim = sorted(c for c, w in COMPONENT_DOCS.items() if w["verbatim_config"] and c in rendered)
+    print(f"Verified: {examined} config leaf/leaves reach the rendered configuration of "
+          f"{', '.join(sorted(rendered))}, and the rendered Loki configuration is accepted by the "
+          f"Loki binary itself (the check that carries {', '.join(verbatim)}, whose chart merges "
+          f"`config` through verbatim).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/aks/scripts/check-observability-values.sh
+++ b/deploy/aks/scripts/check-observability-values.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Assert that every config key deploy/aks/scripts/values.observability.yaml sets actually arrives in
+# the rendered configuration of the component it sits under.
+#
+# Usage: deploy/aks/scripts/check-observability-values.sh [values-file ...]
+#
+# 🚨 WHY THIS EXISTS. On 2026-09-09 loki-0 was drained with its node and every namespace's log
+# history restarted from that moment (#3773) — the ingester's unflushed chunks went with it, and the
+# lines lost were the first shutdown of the pair the incident (#3772) needed. `persistence.enabled`
+# preserves FLUSHED chunks; what preserves the rest is the ingester WAL, which the values file now
+# sets.
+#
+# 🚨 AND WHY IT IS A GATE RATHER THAN A NOTE. This same values file already documents, in prose, a
+# key that is set-able and inert: `promtail.config.wal` produces ZERO occurrences of "wal" in the
+# render, because the deprecated loki-stack chart does not template it. That was found by hand, once,
+# and written down. Nothing re-checks it, and nothing was checking the Loki side either — so
+# `loki.config.ingester.wal` was believed rather than known until it was rendered by hand on
+# 2026-09-09 (it does arrive; measured, not assumed). A prose warning about silently-dropped keys is
+# exactly the thing that should be an executable invariant: this script makes the next such key fail
+# RED naming itself, in the pull request that adds it, instead of reading as coverage for weeks.
+#
+# It is the observability twin of check-values-are-read.sh — same defect class (#1778, #1780, #1925,
+# #2210: a values key consumed by nothing, helm reporting success), different chart. That one reads
+# the chart's TEMPLATES because the chart is in this repository. This one cannot: loki-stack is a
+# third-party chart, so it asserts against the RENDER instead, which is the stronger test of the two
+# — it sees an override as well as an omission.
+#
+# 🛡️ NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"). Every failure mode is RED:
+# helm missing, PyYAML missing, the chart unfetchable, the render empty, a component's rendered
+# document absent, or fewer leaves examined than the file is known to set. There is no
+# `continue-on-error:` and no input-shaped `if:` anywhere in its lane.
+#
+# 🌐 IT NEEDS THE NETWORK, and that is stated rather than worked around. loki-stack is fetched from
+# grafana.github.io — the same dependency install-observability.sh has. A fetch failure fails the
+# gate; it never skips it. This is why the check runs in its own job and NOT in `Chart invariants`,
+# whose header asserts that it reads nothing outside this repository. That property is worth keeping
+# true.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The chart version is PINNED, and the pin is the reason a render proves anything at all. An
+# unpinned `helm upgrade --install grafana/loki-stack` (which is what this repo shipped until #3773)
+# installs whatever upstream published most recently, so a chart bump could restructure `loki.config`
+# and silently stop templating the WAL — the failure this gate exists to catch would arrive through
+# the very mechanism the gate could not see. Keep it in step with install-observability.sh.
+CHART_VERSION="${LOKI_STACK_VERSION:-2.10.3}"
+CHART_REPO_URL="https://grafana.github.io/helm-charts"
+CHART="${LOKI_STACK_CHART:-grafana/loki-stack}"
+
+missing=()
+command -v helm >/dev/null 2>&1 || missing+=("helm (install it, or use azure/setup-helm in CI)")
+command -v python3 >/dev/null 2>&1 || missing+=("python3")
+python3 -c 'import yaml' >/dev/null 2>&1 || missing+=("the PyYAML module (pip install pyyaml)")
+command -v docker >/dev/null 2>&1 || missing+=("docker (the rendered Loki config is validated by the Loki binary itself)")
+docker info >/dev/null 2>&1 || missing+=("a running container runtime — 'docker info' failed, so the Loki binary check could not run")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "::error::check-observability-values cannot run — provide the following:"
+  for item in "${missing[@]}"; do echo "  - $item"; done
+  echo "Nothing was checked. This is a failure, not a skip: a gate that declines to run must not"
+  echo "render the same tick as one that passed."
+  exit 1
+fi
+
+if [ $# -gt 0 ]; then
+  VALUES=("$@")
+else
+  VALUES=("$SELF_DIR/values.observability.yaml")
+fi
+
+for file in "${VALUES[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "::error::values file not found: $file"
+    exit 1
+  fi
+done
+
+if ! helm repo add grafana "$CHART_REPO_URL" >/dev/null 2>&1; then
+  # `helm repo add` fails when the repo already exists under a different URL — report it rather
+  # than continuing against whatever that other URL serves.
+  existing="$(helm repo list -o json 2>/dev/null | python3 -c 'import json,sys
+try:
+    print(next(r["url"] for r in json.load(sys.stdin) if r["name"] == "grafana"))
+except Exception:
+    print("<none>")' 2>/dev/null || echo "<none>")"
+  if [ "$existing" != "$CHART_REPO_URL" ]; then
+    echo "::error::a helm repo named 'grafana' already points at $existing, not $CHART_REPO_URL."
+    exit 1
+  fi
+fi
+
+if ! helm repo update grafana >/dev/null 2>&1; then
+  echo "::error::could not refresh the 'grafana' helm repo from $CHART_REPO_URL — the chart could"
+  echo "not be fetched, so NOTHING was checked. This is a failure, not a skip."
+  exit 1
+fi
+
+echo "Rendering $CHART --version $CHART_VERSION with: ${VALUES[*]}"
+python3 "$SELF_DIR/check-observability-values.py" "$CHART" "$CHART_VERSION" "${VALUES[@]}"

--- a/deploy/aks/scripts/install-observability.sh
+++ b/deploy/aks/scripts/install-observability.sh
@@ -37,7 +37,20 @@ helm repo update >/dev/null 2>&1
 # allowed to fail when the repo already exists), so without this a failed install would be followed
 # by the verification echoes below and the script would still exit 0 — an install failure that reads
 # like success. Exactly the shape the repo bans in CI gates, and it belongs here too.
-if ! helm upgrade --install loki grafana/loki-stack -n monitoring --create-namespace \
+# 🚨 THE CHART VERSION IS PINNED, and the pin is what makes any verification of these values mean
+# anything. Until #3773 this read `grafana/loki-stack` with no --version, so every run installed
+# whatever upstream had published most recently. That matters more than it looks: this DEPRECATED
+# chart is already known to drop a config key silently (`promtail.config.wal` renders to nothing —
+# see the values file), so an unannounced upstream restructure of `loki.config` could stop
+# templating the ingester WAL and the only symptom would be the next drain losing the logs again.
+# An unpinned third-party chart turns a deliberate upgrade into an invisible one.
+#
+# Moving the pin is a normal, welcome change — make it deliberately, and in the same commit as
+# CHART_VERSION in check-observability-values.sh, which renders THIS version and asserts the keys
+# still arrive and that the Loki binary of the chart's appVersion accepts the result.
+CHART_VERSION="${LOKI_STACK_VERSION:-2.10.3}"
+
+if ! helm upgrade --install loki grafana/loki-stack --version "$CHART_VERSION" -n monitoring --create-namespace \
   -f "$VALUES" \
   --set grafana.enabled=true --set prometheus.enabled=true \
   --set grafana.adminPassword="$GRAFANA_PW" --set grafana.service.type=ClusterIP \

--- a/deploy/aks/scripts/test-observability-values.py
+++ b/deploy/aks/scripts/test-observability-values.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Exercise check-observability-values.sh's verdicts without the network or a container runtime.
+
+🚨 WHY THIS EXISTS. The checker it tests is itself a gate, and a gate that has quietly stopped
+being able to fail is worse than no gate — it reports a tick nobody re-examines. That is not
+hypothetical here: the FIRST version of check-observability-values.py did exactly that. It compared
+the values against the rendered config and passed a deliberately mis-nested `ingestor:` key,
+because loki-stack merges `loki.config` through VERBATIM, so an unknown key arrives in the render
+intact. The check could not fail for the one component #3773 was about. That is what the binary
+half is for, and this file is what stops the pair regressing to that state silently.
+
+Every case below is a control that MUST be red. `test_clean_values_pass` is the positive control:
+without it, a checker that failed everything would pass this file.
+
+helm and docker are stubbed on PATH, so this runs anywhere, offline, in about a second — the same
+technique as test-observability-storage.py. What it CANNOT tell you is whether the real chart still
+renders these keys or the real Loki binary still accepts them; that is the gate itself, in CI.
+"""
+import base64
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+import yaml
+
+SCRIPT = Path(os.environ.get('CHECKER_UNDER_TEST',
+                             Path(__file__).with_name('check-observability-values.sh'))).resolve()
+
+# A minimal but STRUCTURALLY REAL render: the two Secrets the checker resolves, in the two
+# different encodings loki-stack actually uses (loki base64 under `data`, promtail plaintext under
+# `stringData`). A fixture that used one encoding for both would let an encoding bug pass.
+LOKI_CONFIG = {
+    'ingester': {'wal': {'enabled': True, 'dir': '/data/loki/wal', 'flush_on_shutdown': True}},
+    'compactor': {'retention_enabled': True},
+    'limits_config': {'retention_period': '720h'},
+}
+PROMTAIL_CONFIG = {'clients': [{'url': 'http://loki:3100/loki/api/v1/push'}]}
+
+
+def manifest(loki_config=None, promtail_config=None, omit_loki=False):
+    documents = []
+    if not omit_loki:
+        documents.append({
+            'kind': 'Secret', 'metadata': {'name': 'loki'},
+            'data': {'loki.yaml': base64.b64encode(
+                yaml.safe_dump(LOKI_CONFIG if loki_config is None else loki_config).encode()
+            ).decode()},
+        })
+    documents.append({
+        'kind': 'Secret', 'metadata': {'name': 'loki-promtail'},
+        'stringData': {'promtail.yaml': yaml.safe_dump(
+            PROMTAIL_CONFIG if promtail_config is None else promtail_config)},
+    })
+    return '\n---\n'.join(yaml.safe_dump(d) for d in documents)
+
+
+class CheckerVerdictTest(unittest.TestCase):
+    def run_checker(self, values, *, rendered=None, binary_valid=True, binary_exit=0,
+                    app_version='2.9.3'):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'render.yaml').write_text(rendered if rendered is not None else manifest())
+            (root / 'helm').write_text(textwrap.dedent(f'''\
+                #!/bin/sh
+                case "$1" in
+                  template) cat "{root}/render.yaml" ;;
+                  show) printf 'apiVersion: v2\\nname: loki-stack\\nversion: 2.10.3\\nappVersion: v{app_version}\\n' ;;
+                  repo) exit 0 ;;
+                  *) exit 0 ;;
+                esac
+                '''))
+            # The docker stub CONSUMES stdin: the checker pipes the rendered config into the
+            # container, and a stub that did not read it would leave the pipe unexamined and pass
+            # a checker that had stopped sending anything.
+            (root / 'docker').write_text(textwrap.dedent(f'''\
+                #!/bin/sh
+                case "$1" in
+                  info) exit 0 ;;
+                  run)
+                    piped=$(cat)
+                    [ -n "$piped" ] || {{ echo "stub: nothing was piped in" >&2; exit 3; }}
+                    {'echo "level=info msg=\\"config is valid\\""' if binary_valid else 'echo "failed parsing config: field ingestor not found in type loki.ConfigWrapper" >&2'}
+                    exit {binary_exit} ;;
+                esac
+                exit 0
+                '''))
+            for name in ('helm', 'docker'):
+                (root / name).chmod(0o755)
+            values_path = root / 'values.yaml'
+            values_path.write_text(yaml.safe_dump(values))
+            env = dict(os.environ, PATH=str(root) + os.pathsep + os.environ['PATH'])
+            return subprocess.run(['bash', str(SCRIPT), str(values_path)], env=env,
+                                  capture_output=True, text=True, timeout=60)
+
+    # The values the repository actually ships, in shape: every leaf reaches the render.
+    CLEAN = {'loki': {'config': LOKI_CONFIG}}
+
+    def test_clean_values_pass(self):
+        """POSITIVE CONTROL. Without this, a checker that failed everything would pass this file."""
+        result = self.run_checker(self.CLEAN)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn('Verified:', result.stdout)
+
+    def test_orphaned_key_fails(self):
+        """The promtail.config.wal shape: helm accepts the key, the chart templates nothing."""
+        values = {'loki': {'config': LOKI_CONFIG},
+                  'promtail': {'config': {'wal': {'enabled': True}}}}
+        result = self.run_checker(values)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('reaches NOTHING', result.stdout)
+        self.assertIn('promtail.config.wal.enabled', result.stdout)
+
+    def test_overridden_value_fails(self):
+        """Set, arrives, but the chart wins — invisible to a presence-only check."""
+        overridden = json.loads(json.dumps(LOKI_CONFIG))
+        overridden['limits_config']['retention_period'] = '24h'
+        result = self.run_checker(self.CLEAN, rendered=manifest(loki_config=overridden))
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('the chart overrode it', result.stdout)
+
+    def test_binary_rejection_fails(self):
+        """🚨 THE CASE THE RENDER CHECK CANNOT SEE — loki-stack merges `loki.config` verbatim, so a
+        mis-nested key arrives intact and every leaf 'reaches' the render. Only the binary knows."""
+        result = self.run_checker(self.CLEAN, binary_valid=False, binary_exit=1)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('REJECTED by grafana/loki:', result.stdout)
+
+    def test_binary_silence_fails(self):
+        """Exit 0 without the verdict line means the validator never ran. Silence is not success."""
+        result = self.run_checker(self.CLEAN, binary_valid=False, binary_exit=0)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('never said `config is valid`', result.stdout)
+
+    def test_missing_loki_document_fails(self):
+        """No Secret/loki means nothing was validated — that is a failure, not an empty pass."""
+        result = self.run_checker(self.CLEAN, rendered=manifest(omit_loki=True))
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('could not be validated against the binary', result.stdout)
+
+    def test_empty_render_fails(self):
+        """A render that produced nothing would make every key look present-by-absence."""
+        result = self.run_checker(self.CLEAN, rendered='')
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('rendered NOTHING', result.stdout)
+
+    def test_too_few_leaves_fails(self):
+        """A values file that lost its config section must not report a pass on nothing."""
+        result = self.run_checker({'loki': {'config': {'compactor': {'retention_enabled': True}}}})
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('is not evidence', result.stdout)
+
+    def test_unknown_component_fails(self):
+        """A component whose rendered config the checker cannot locate must not pass silently."""
+        values = {'loki': {'config': LOKI_CONFIG}, 'grafana': {'config': {'anything': 1}}}
+        result = self.run_checker(values)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn('does not know where', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deploy/aks/scripts/values.observability.yaml
+++ b/deploy/aks/scripts/values.observability.yaml
@@ -45,6 +45,35 @@ loki:
   # Retention is age-based: the compactor deletes logs older than 30 days. The
   # 24-hour index period from this chart is required by boltdb-shipper retention.
   # Its working directory and WAL are both below the persistent /data mount.
+  #
+  # 4. THE INGESTER WAL. The PVC above preserves FLUSHED chunks; everything still in the ingester's
+  #    memory dies with the process, and that is a real loss and not a rounding error. On
+  #    2026-09-09 (#3773) loki-0 was drained with its node at 01:09Z and every namespace's history
+  #    restarted from that moment — the lines lost were the two portal pods' shutdown at 01:05:01Z,
+  #    which is precisely what the incident being investigated (#3772) needed. A read at 01:08Z had
+  #    them; the same query at 01:11Z returned nothing.
+  #
+  #    `flush_on_shutdown` is the half that matters for a DRAIN specifically: it turns a graceful
+  #    termination into a flush instead of a loss. The WAL covers the ungraceful case.
+  #
+  # 🚨 A DRAIN OF loki-0 IS A READ-IT-NOW WINDOW, still. The WAL narrows the loss, it does not
+  #    remove the gap: loki-0 sits on the system pool (`nodeSelector: agentpool: system`) and is
+  #    drained with its node like anything else, and while it is restarting Promtail is buffering
+  #    in memory with no WAL of its own (see the promtail section — this chart cannot give it one).
+  #    If you are reading an incident and see loki-0 restart, pull what you need BEFORE it does.
+  #
+  # 🚨 THESE KEYS ARE VERIFIED, NOT ASSUMED — and the verification is a gate, not a note.
+  #    The promtail section below documents a key that is set-able and inert, found by hand once
+  #    and written down. That is not good enough for keys the next outage depends on, so
+  #    `check-observability-values.sh` runs in CI on every pull request: it renders THIS file
+  #    against the PINNED chart and fails RED if a key here reaches nothing, is overridden, or
+  #    produces a config the Loki binary rejects. Measured 2026-09-09: all three keys below do
+  #    arrive in the rendered `loki.yaml`, and `loki -verify-config` accepts the result.
+  #
+  #    🚨 Do not read that gate's render check as covering the Loki keys on its own — it cannot.
+  #    This chart merges `loki.config` through VERBATIM, so a typo'd `ingestor:` reaches the
+  #    render intact and the render check passes it. The Loki binary is what rejects it
+  #    (`field ingestor not found in type loki.ConfigWrapper`), which is why that half exists.
   config:
     compactor:
       retention_enabled: true

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -368,6 +368,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [The Merge Queue](MergeQueue) — one entry built at a time so nothing churns, and a steward that re-queues an ejected PR on evidence and never re-runs
 - [Carving Projects Out Of Core](CarvingProjectsOutOfCore) — what a SOURCE move costs and what it does not
 - [Red-Log Watching & Ticketing](LogWatchTriage) — every `fail:`/`crit:` becomes exactly one triaged issue
+- [Verifying Chart Values](VerifyingChartValues) — a key can be set, reach the render, and still not be read; why the obvious gate was vacuous for the one component it existed to guard, and the binary check that closes it (the drain that erased every namespace's log history)
 - [Measuring a Live Portal Read-Only](MeasuringALivePortalReadOnly) — the four read-only instruments, and why an absence needs a coverage fact before it counts as evidence
 - [Chart Ownership and the Runner Pool](ChartOwnershipAndRunnerPool) — why the chart's gate is here, what a relocation must carry, and why path-filtering it is unsafe
 - [Sharding the Node-Repo Gate](NodeRepoGateSharding) — a cap cut reports as `cancelled`, so the fan-out that removes it, and the fold that keeps ONE required context and ONE gate log

--- a/src/MeshWeaver.Documentation/Data/Architecture/VerifyingChartValues.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/VerifyingChartValues.md
@@ -1,0 +1,124 @@
+# A values key can be set, rendered, and still not read
+
+Three different things can be true of a key in a third-party chart's values file, and they look
+identical from the outside — helm reports success for all three:
+
+| | the key reaches the render | the component reads it |
+|---|---|---|
+| **Read** | yes | yes |
+| **Dropped by the chart** | no | no |
+| **Passed through but not a field** | **yes** | **no** |
+
+Only the first is what you meant. The other two are inert configuration that reads as coverage, and
+the third is the one that defeats the obvious check.
+
+## What it cost
+
+On 2026-09-09, `loki-0` was drained with its node at 01:09Z and **every namespace's log history in
+the cluster restarted from that moment** ([#3773]). A query at 01:08Z returned both portal pods'
+`Application is shutting down...` lines at 01:05:01Z; the same query over the same window at 01:11Z
+returned nothing at all, and the pods no longer appeared in
+`sum by (pod) (count_over_time({namespace="memex"}[70m]))`. The lines lost were the ones the
+incident under investigation ([#3772]) actually needed.
+
+`persistence.enabled: true` was already set, and it was doing its job — it preserves **flushed**
+chunks and the index. What dies with the process is whatever the ingester still holds in memory, and
+that is covered by a different knob: the ingester **write-ahead log**, plus `flush_on_shutdown`,
+which turns a graceful drain into a flush rather than a loss.
+
+## Why "we set the key" was not good enough
+
+The same values file already documented, in prose, a key that is set-able and inert:
+
+> Rendering with `--set promtail.config.wal.enabled=true` yields ZERO occurrences of "wal" in the
+> output. Setting it anyway would be a silent no-op that reads like coverage.
+
+That was measured by hand, once, and written down. Nothing re-checked it, and nothing was checking
+the Loki side either — so when the ingester WAL keys were added, "they arrive" was a belief. They do
+arrive; that was rendered and confirmed. But a belief that happens to be true is not a control, and
+the whole point of the incident is that the evidence went missing without anyone being told.
+
+## The trap: the obvious check is vacuous for the component that matters
+
+The natural gate is *render the chart and assert every `<component>.config.<KEY>` the values set
+appears in the component's rendered configuration*. That is the right check for **Promtail**, whose
+chart builds its config from named fields and silently discards the rest — it catches
+`promtail.config.wal` exactly.
+
+For **Loki** it cannot fail. loki-stack merges `loki.config` into its defaults **verbatim**, so
+anything you write arrives in the render intact — including a key that is not a field at all.
+Measured, with `ingester:` deliberately misspelled as `ingestor:`:
+
+```
+render check     Verified: 5 config leaf/leaves … all reach the rendered configuration   exit 0
+loki -verify-config   line 18: field ingestor not found in type loki.ConfigWrapper       exit 1
+```
+
+The first version of the gate shipped that render check alone. It passed the typo — it could not
+fail for the one component [#3773] was about. **A gate that cannot fail for its own subject is worse
+than no gate**, because it reports a tick nobody re-examines.
+
+What closes it is handing the rendered configuration to the component's own binary. Loki validates
+its config strictly and rejects unknown fields and unparseable values, so
+`loki -verify-config` answers the question the render never could.
+
+## The shape that works
+
+`deploy/aks/scripts/check-observability-values.sh` runs both halves, on every pull request
+(`Chart Gate` → *Observability values (rendered + binary-validated)*):
+
+```
+values.observability.yaml ──▶ helm template (PINNED version) ──┬──▶ every config leaf present
+                                                               │    and unaltered?      ← promtail
+                                                               └──▶ loki -verify-config  ← loki
+```
+
+Three properties are load-bearing:
+
+- **The chart version is pinned.** Until [#3773] `install-observability.sh` ran
+  `helm upgrade --install loki grafana/loki-stack` with no `--version`, so every run installed
+  whatever upstream had published most recently. Against an unpinned third-party chart a render
+  proves nothing about tomorrow: an upstream restructure of `loki.config` could stop templating the
+  WAL, and the first symptom would be the next drain losing the logs again. The pin turns an
+  invisible upgrade into a deliberate one. `CHART_VERSION` appears in the installer and in the
+  checker, and they move together.
+- **The validating binary comes from the pin, never a literal.** The image tag is read from the
+  pinned chart's `appVersion`, so bumping the chart moves the validator with the thing it validates.
+  A hard-coded tag would eventually validate against a binary the cluster does not run.
+- **Every failure mode is red, and none is a skip.** helm missing, PyYAML missing, docker missing or
+  not running, the chart unfetchable, the render empty, a component's document absent, or fewer
+  leaves examined than the file is known to set — each names itself and fails. The check needs the
+  network, which is why it is its own job: `Chart invariants` states that everything it reads is in
+  this repository, and that property is worth keeping true rather than quietly falsifying.
+
+`deploy/aks/scripts/test-observability-values.py` is the checker's own control — nine cases with
+helm and docker stubbed, so it runs offline in the `Chart invariants` job. Its positive case exists
+so that a checker which failed everything could not pass it, and deleting either half of the real
+checker turns it red.
+
+## What is still not covered
+
+- **Promtail has no WAL.** When Loki is unreachable, Promtail buffers in memory and eventually
+  discards. The binary supports a WAL, but this deprecated chart does not pass
+  `promtail.config.wal` through at all — that is the inert key above, and the gate now *fails* if
+  anyone sets it, pointing at this. Getting it needs a full `promtail.config.file` override or a
+  migration to the maintained `grafana/loki` + `grafana/promtail` charts.
+- **A drain of `loki-0` is still a read-it-now window.** The WAL narrows the loss; it does not
+  remove the gap. `loki-0` sits on the system pool and is drained with its node like anything else,
+  and Promtail is buffering with no WAL of its own while it restarts. If you are reading an incident
+  and see `loki-0` restart, pull what you need first.
+- **This says nothing about the cluster.** It compares the values against the chart, not against
+  what is installed. That is [Chart Drift](../ChartDriftSemantics).
+
+## The general rule
+
+> When a values key matters, the question is never "is it set" and rarely "does it reach the
+> render". It is **does the component read it** — and for a chart that passes configuration through
+> verbatim, only the component itself can answer.
+
+Related: [Chart Ownership and the Runner Pool](../ChartOwnershipAndRunnerPool) ·
+[Chart Drift](../ChartDriftSemantics) · [Red-Log Watching & Ticketing](../LogWatchTriage) ·
+[Measuring a Live Portal Read-Only](../MeasuringALivePortalReadOnly)
+
+[#3772]: https://github.com/Systemorph/MeshWeaver/issues/3772
+[#3773]: https://github.com/Systemorph/MeshWeaver/issues/3773

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-logs-survive-a-loki-restart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-logs-survive-a-loki-restart.md
@@ -1,0 +1,42 @@
+---
+Name: Logs survive a Loki restart
+Category: Fix
+Description: A drain of the log store took every namespace's history with it — a query that returned the two portal shutdowns at 01:08Z returned nothing at 01:11Z. The ingester now keeps a write-ahead log and flushes on shutdown, the chart version is pinned, and a gate on every pull request renders these settings and hands the result to the Loki binary itself.
+Icon: ShieldCheckmark
+Order: -20260909
+---
+
+In the night of 2026-09-09, while an incident was being read out of the logs, the log store was
+itself drained with its node. A query over `{namespace="memex"}` at 01:08Z returned both portal
+pods' `Application is shutting down` lines from 01:05:01Z. The same query, over the same window,
+at 01:11Z returned nothing — and the pods no longer appeared in the per-pod counts either. Every
+namespace's history now started at the moment of the restart.
+
+## What was missing
+
+Loki already had a persistent volume, and it was working: it preserves chunks that have been
+**flushed**, plus the index. Whatever the ingester is still holding in memory is a separate matter,
+and covered by a separate setting — the ingester write-ahead log, together with a flush on
+shutdown, which turns a graceful drain into a flush instead of a loss. Neither was enabled.
+
+## What it does now
+
+- The ingester keeps a write-ahead log on the persistent volume and flushes what it holds when it
+  is asked to stop.
+- The chart version is pinned. It was not: every install pulled whatever had been published most
+  recently, so an upstream change could have quietly stopped applying these settings.
+- A gate on every pull request renders the values against the pinned chart, checks that each
+  setting arrives unaltered, and hands the result to the Loki binary to validate.
+
+## Why the gate has two halves
+
+The obvious check — render the chart, assert the settings are in it — is the right one for
+Promtail, whose chart silently discards anything it does not recognise. It is useless for Loki,
+whose chart copies the whole configuration section through untouched: a misspelled setting arrives
+intact and passes. Only Loki itself knows the difference, and it says so plainly
+(`field ingestor not found`). The first version of the gate had only the render half and passed a
+deliberately misspelled setting — it could not fail for the component it existed to guard.
+
+A drain of the log store is still a read-it-now window: the write-ahead log narrows the loss, and
+Promtail, which this chart cannot give a buffer of its own, is holding lines in memory while Loki
+restarts.


### PR DESCRIPTION
## The drain that erased every namespace's log history

At 01:09Z on 2026-09-09 `loki-0` was drained with its node, while an incident was being read out of the logs. A query over `{namespace="memex"}` at **01:08Z** returned both portal pods' `Application is shutting down` lines from 01:05:01Z — exactly what [#3772] needed. The same query, same window, at **01:11Z** returned nothing, and the pods were gone from `count_over_time` too.

`persistence.enabled` was set and was working: it preserves **flushed** chunks and the index. What dies with the process is whatever the ingester still holds, and that needs the ingester WAL plus `flush_on_shutdown` — which turns a graceful drain into a flush instead of a loss.

**Those keys already landed** (c41bb0fe0, ~12 h after the issue was filed). What was missing is any reason to believe they *do* anything — and that is most of this PR.

## 🚨 The obvious gate is vacuous for Loki

The natural check is *render the chart, assert every config key arrives*. That is the right check for **Promtail**, whose chart builds its config from named fields and silently discards the rest — this very values file already documents, in prose, that `promtail.config.wal` renders to **zero** occurrences of "wal".

For **Loki** it cannot fail. loki-stack merges `loki.config` into its defaults **verbatim**, so anything you write arrives intact — including a key that is not a field at all. Measured, with `ingester:` deliberately misspelt `ingestor:`:

```
render check          Verified: 5 leaves … all reach the render        exit 0
loki -verify-config   field ingestor not found in loki.ConfigWrapper   exit 1
```

**The first version of this gate shipped the render half alone and passed that typo.** It could not fail for the one component #3773 is about. It was caught by running the negative control, not by reading the code — which is the whole argument for running one.

What closes it is the component's own binary: Loki validates strictly and rejects unknown fields and unparseable values. The image tag is read from the **pinned chart's `appVersion`**, so a chart bump moves the validator with the thing it validates, instead of validating against a binary the cluster never runs.

## 🚨 And the chart was unpinned — which is how any verification here rots

`install-observability.sh` ran `helm upgrade --install loki grafana/loki-stack` with **no `--version`**: every run installed whatever upstream had published most recently. Against an unpinned third-party chart a render proves nothing about tomorrow — an upstream restructure of `loki.config` could stop templating the WAL, and the first symptom would be the next drain losing the logs again. Now pinned to `2.10.3`, in the installer and in the checker, and they move together.

## What is here

| | |
|---|---|
| `check-observability-values.{sh,py}` | both halves; every failure mode red and none a skip — helm/PyYAML/docker missing, runtime down, chart unfetchable, render empty, a component's document absent, or fewer leaves examined than the file is known to set |
| `test-observability-values.py` | the checker's **own** control — 9 cases with helm and docker stubbed, so it runs offline in ~1 s |
| `chart-gate.yml` | the network-needing check gets its **own job**. `Chart invariants` states in its header that everything it reads is in this repository; that property is worth keeping true rather than quietly falsifying. The offline control joins `Chart invariants`. |
| `values.observability.yaml` | records the measurement, and that a drain of `loki-0` is **still** a read-it-now window — the WAL narrows the loss, it does not remove the gap, and Promtail is buffering with no WAL of its own while Loki restarts |
| `Doc/Architecture/VerifyingChartValues` | a key can be set, reach the render, and still not be read; which check catches which, and why |

## Verification

- Gate **green** against the real chart: `Verified: 5 config leaf/leaves … accepted by the Loki binary itself`
- **3 negative controls red**, exit 1 each (unpiped): a dropped key (`promtail.config.wal`), a mis-nest (`ingestor`), an unparseable value (`chunk_idle_period: not-a-duration`)
- Checker control **9/9**; both mutants caught — deleting the binary half fails 2 cases, making the render check presence-only fails 1
- `DocumentationLinkIntegrityTest` **368/368** (after a clean rebuild — `--no-build` re-ran the stale embedded docs and reported the pre-fix links)
- `shellcheck` clean; `check-workflow-timeouts` 83 jobs, 0 violations

Closes #3773

[#3772]: https://github.com/Systemorph/MeshWeaver/issues/3772
