### PR TITLE
fix: hosting-deploy applies; it no longer waits, and never reverts a good upgrade

### DIFF
--- a/deploy/aks/operator/bin/hosting-deploy
+++ b/deploy/aks/operator/bin/hosting-deploy
@@ -204,14 +204,62 @@ case "$release_state" in
   *) hosting::log "release   ${release} is '${release_state}'" ;;
 esac
 
-# --atomic: a failed install ROLLS BACK rather than leaving a half-created release that the next
-# attempt then has to `helm uninstall` before it can proceed. --wait so "deployed" means the pods
-# actually came up; the plan's next step (rollout status) then verifies rather than discovers.
+# ── apply, and ONLY apply ───────────────────────────────────────────────────────────────────────
+# 🚨 NO --atomic AND NO --wait, and that is the whole point of this block. helm APPLIES here; the
+# rollout is OBSERVED by the caller, with a budget taken from the record.
+#
+# Measured 2026-09-09 02:35-02:51Z on memex (#3782). This ran with `--atomic --wait --timeout 15m`
+# from a Reconcile. The upgrade LANDED: at 02:50:11Z a read-only audit showed revision 44 with the
+# record's full render — 20 chart-managed objects, portal-next kept, memex-kv owned, the PDB
+# created. Nothing was wrong with it. It was simply still inside its own startup gate, which is
+# what a gated two-replica roll looks like when a generation recompiles, and the record BUDGETS
+# 10800 seconds for exactly that (`startupProbe.budgetSeconds`). Nine seconds later helm's fixed
+# fifteen minutes expired and --atomic rolled the whole thing back to revision 43's manifest. A
+# correct upgrade was destroyed by a timer that had never read the record it was applying.
+#
+# The three reasons this shape cannot be repaired by raising the number:
+#
+#   1. A wait inside helm cannot outlast the process running it. The operator Job's
+#      activeDeadlineSeconds (3600) caps every in-Job wait, so no --timeout can express a budget
+#      the record is allowed to set above it. Raising 15m to 60m moves the cliff; it does not
+#      remove it — and the failure mode at the cliff is a ROLLBACK of work that succeeded.
+#   2. --atomic converts "slow" into "reverted". Slow and broken are indistinguishable to a timer,
+#      and the two deserve opposite treatments. Only something watching the rollout can tell them
+#      apart, because only it can see whether progress is being made.
+#   3. It is not needed for the state it was there to prevent. The comment it replaces argued that
+#      --atomic avoids "a half-created release the next attempt must `helm uninstall`". A `failed`
+#      release is upgradable — helm rolls forward over it. The states that genuinely block the next
+#      upgrade are `pending-*`, and those are refused BY NAME a few lines above, before helm runs.
+#      So the guard rail is already there, and it is a better one: it names the problem and hands
+#      the revision choice to a person instead of silently reverting.
+#
+# This is the same decision the config repository's helm-release lane made deliberately (Memex#188):
+# helm applies, a separate step observes with its own budget. Two implementations of one operation
+# had opposite answers; this is the disagreement resolved, in favour of the one that did not lose a
+# good upgrade.
+#
+# 🚨 WHAT THE CALLER MUST NOW DO. Success here means APPLIED, not ROLLED OUT — the pods may still
+# be coming up, and that is the normal case rather than an edge one. The caller observes the
+# rollout against the record's own budget and reports Done only when it completes. It is told which
+# revision to watch by `::hosting:: helm_revision=<n>` below; never report a rollout no one saw
+# finish.
 hosting::do helm upgrade "$release" "$CHART" \
   --install --namespace "$namespace" --create-namespace \
-  --atomic --wait --timeout 15m \
   "${files[@]}" "${sets[@]}" \
-  || hosting::die "helm upgrade of ${release} in ${namespace} failed (rolled back by --atomic)"
+  || hosting::die "helm upgrade of ${release} in ${namespace} failed. The release was NOT rolled back (no --atomic, by design — see #3782): read \`helm status ${release} -n ${namespace}\` and \`helm history ${release} -n ${namespace}\`. A 'failed' release is upgradable, so the next attempt can roll forward over it."
+
+# The revision this apply produced — the handle the caller needs to observe the right rollout, and
+# the one piece of state that is otherwise only in helm's head. Read back rather than counted:
+# `--install` may have created revision 1 or upgraded to revision 45, and a caller that guessed
+# would watch the wrong generation. In a dry run helm was never called, so there is nothing to read
+# and nothing is claimed.
+if ! hosting::dry; then
+  helm_revision="$(hosting::read helm status "$release" --namespace "$namespace" -o json 2>/dev/null | jq -r '.version // ""' 2>/dev/null || true)"
+  [ -n "$helm_revision" ] \
+    || hosting::die "helm upgrade of ${release} in ${namespace} reported success but \`helm status\` returned no revision — the caller would have nothing to observe, and reporting an unobservable rollout as done is the failure this whole block exists to prevent."
+  hosting::log "applied   revision ${helm_revision} (NOT yet rolled out — the caller observes it)"
+  hosting::say helm_revision "$helm_revision"
+fi
 
 hosting::say release "$release"
 hosting::say namespace "$namespace"

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -632,6 +632,72 @@ else
 fi
 rm -rf "$_dp_dir"
 
+# ── hosting-deploy APPLIES; it never waits, and never rolls back a good upgrade ─────────────────
+# 🚨 Measured 2026-09-09 02:35-02:51Z on memex (#3782). `--atomic --wait --timeout 15m` DESTROYED a
+# correct upgrade: revision 44 had landed with the record's full render and was inside its own
+# startup gate (the record budgets 10800s for it) when helm's fixed fifteen minutes expired, and
+# --atomic reverted it to revision 43. Slow and broken are indistinguishable to a timer; only
+# something watching the rollout can tell them apart. helm now applies and the CALLER observes,
+# which is why the applied revision has to come back out.
+#
+# These cases are that decision, pinned. The first is written against the ARGUMENT LIST rather than
+# an outcome on purpose: `--atomic` reappearing is a silent regression that no stubbed run can
+# fail on, because a stub always "succeeds" — the flag itself is the defect.
+echo
+echo "── hosting-deploy: applies without waiting, reports the revision ─"
+_ap_dir="$(mktemp -d)"; cp -R "$DP_FIXTURES/." "$_ap_dir/"; _ap_log="$_ap_dir/calls.log"; : > "$_ap_log"
+_ap_vals="$_ap_dir/values.yaml"; printf '# GENERATED from the Hosting/Deployment record by HelmValues\nreplicas:\n  portal: 1\n' > "$_ap_vals"
+_ap_run() { env PATH="$DP_STUBS:$PATH" HOSTING_CHART=/tmp HOSTING_DEPLOY_FIXTURE="$_ap_dir" HOSTING_DEPLOY_STUB_LOG="$_ap_log" "$@" \
+  hosting-deploy --namespace memex --release memex --database memex --values "$_ap_vals" --image cr.example.test/memex-portal-ai:1 2>&1; }
+_ap_out="$(_ap_run env)"; _ap_rc=$?
+_ap_upgrade="$(grep '^helm upgrade' "$_ap_log" | head -1)"
+if [ "$_ap_rc" -eq 0 ] && [ -n "$_ap_upgrade" ] \
+   && ! printf '%s' "$_ap_upgrade" | grep -q -- '--atomic' \
+   && ! printf '%s' "$_ap_upgrade" | grep -q -- '--wait' \
+   && ! printf '%s' "$_ap_upgrade" | grep -q -- '--timeout'; then
+  ok "helm upgrade carries no --atomic, no --wait and no --timeout"
+else
+  bad "helm upgrade carries no --atomic/--wait/--timeout" "rc=${_ap_rc} upgrade line: '${_ap_upgrade}' out: ${_ap_out}"
+fi
+case "$_ap_out" in *"::hosting:: helm_revision=42"*) ok "the applied revision is reported for the caller to observe" ;;
+  *) bad "the applied revision is reported" "said: ${_ap_out}" ;; esac
+# The revision is READ BACK from helm, not guessed — and read AFTER the apply, or it names the
+# revision the upgrade replaced.
+_ap_up_line="$(grep -n '^helm upgrade' "$_ap_log" | head -1 | cut -d: -f1)"
+_ap_st_line="$(grep -n '^helm status' "$_ap_log" | tail -1 | cut -d: -f1)"
+if [ -n "$_ap_up_line" ] && [ -n "$_ap_st_line" ] && [ "$_ap_st_line" -gt "$_ap_up_line" ]; then
+  ok "the revision is read back AFTER the apply, never guessed"
+else
+  bad "the revision is read back after the apply" "upgrade at '${_ap_up_line}', status at '${_ap_st_line}' in: $(cat "$_ap_log")"
+fi
+# Success here means APPLIED, not rolled out — and it must say so, or a caller reads a tick as a
+# finished rollout, which is precisely what #3782 asks never to report.
+case "$_ap_out" in *"NOT yet rolled out"*) ok "the log states the rollout has NOT happened yet" ;;
+  *) bad "the log states the rollout has not happened yet" "said: ${_ap_out}" ;; esac
+
+# A FAILED upgrade must not claim a rollback that no longer happens, and must name the way forward.
+: > "$_ap_log"
+_ap_out="$(_ap_run env HOSTING_DEPLOY_STUB_UPGRADE_FAILS=true)"; _ap_rc=$?
+if [ "$_ap_rc" -ne 0 ] && printf '%s' "$_ap_out" | grep -q 'was NOT rolled back' \
+   && printf '%s' "$_ap_out" | grep -q 'helm history' \
+   && ! printf '%s' "$_ap_out" | grep -q 'rolled back by --atomic'; then
+  ok "a failed upgrade says it was NOT rolled back and names helm history"
+else
+  bad "a failed upgrade reports honestly" "rc=${_ap_rc} out: ${_ap_out}"
+fi
+
+# 🚨 An apply whose revision cannot be read is a REFUSAL, not a quiet success. Without this the
+# script would report a release the caller has no handle on, and "observed" would degrade back to
+# "assumed" — the exact regression this change exists to prevent.
+printf '{"name":"memex","info":{"status":"deployed"}}\n' > "$_ap_dir/status.json"; : > "$_ap_log"
+_ap_out="$(_ap_run env)"; _ap_rc=$?
+if [ "$_ap_rc" -ne 0 ] && printf '%s' "$_ap_out" | grep -q 'returned no revision'; then
+  ok "an apply with no readable revision is refused, not reported as done"
+else
+  bad "an apply with no readable revision is refused" "rc=${_ap_rc} out: ${_ap_out}"
+fi
+rm -rf "$_ap_dir"
+
 # ── hosting-deploy refuses BEFORE helm when the identity cannot write a rendered kind ───────────
 # Measured 2026-09-09 01:59Z on memex: helm died on `poddisruptionbudgets.policy is forbidden`
 # and its --atomic rollback erred too. The preflight asks `kubectl auth can-i` per rendered kind

--- a/deploy/aks/operator/test/stubs/deploy/helm
+++ b/deploy/aks/operator/test/stubs/deploy/helm
@@ -10,6 +10,12 @@ case "${1:-}" in
   template) cat "$fixture/rendered.yaml" ;;
   status)   # `helm status <rel> --namespace <ns> -o json` → $FIXTURE/status.json, else "not found"
     [ -f "$fixture/status.json" ] && cat "$fixture/status.json" || { echo "Error: release: not found" >&2; exit 1; } ;;
-  upgrade)  echo "Release \"${2:-}\" has been upgraded." ;;
+  upgrade)
+    # A failing upgrade, on demand: the refusal text must name the roll-forward path and must NOT
+    # claim a rollback, because there is no longer an --atomic to perform one (#3782).
+    if [ "${HOSTING_DEPLOY_STUB_UPGRADE_FAILS:-false}" = "true" ]; then
+      echo "Error: UPGRADE FAILED: stubbed failure" >&2; exit 1
+    fi
+    echo "Release \"${2:-}\" has been upgraded." ;;
   *) echo "helm stub: unexpected invocation: $*" >&2; exit 1 ;;
 esac

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -371,6 +371,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Measuring a Live Portal Read-Only](MeasuringALivePortalReadOnly) — the four read-only instruments, and why an absence needs a coverage fact before it counts as evidence
 - [Chart Ownership and the Runner Pool](ChartOwnershipAndRunnerPool) — why the chart's gate is here, what a relocation must carry, and why path-filtering it is unsafe
 - [Sharding the Node-Repo Gate](NodeRepoGateSharding) — a cap cut reports as `cancelled`, so the fan-out that removes it, and the fold that keeps ONE required context and ONE gate log
+- [Applying Is Not Rolling Out](ApplyingIsNotRollingOut) — helm applies, the caller observes; the fixed fifteen-minute `--atomic --wait` that reverted a correct upgrade mid-startup-gate, and why a bigger timeout only moves the cliff
 - [Probe Semantics](ProbeSemantics) — readiness, liveness and startup ask three different questions with three different remedies; why they get three paths and three tags
 - [What a Synthetic Probe May Assert](SyntheticProbeTargets) — a probe naming one deployment's installed content is broken by construction; the platform floor, the negative control that tells "absent" from "down", and reading the target's own declaration
 - [Why a GC-Bound Pod Stays in Rotation](WhyAGcBoundPodStaysInRotation) — the GC's hard limit sits below the container limit, so a portal short of memory is defended rather than restarted

--- a/src/MeshWeaver.Documentation/Data/Architecture/ApplyingIsNotRollingOut.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ApplyingIsNotRollingOut.md
@@ -1,0 +1,96 @@
+# Applying is not rolling out
+
+A deploy has two distinct moments, and conflating them destroys correct work:
+
+```
+  helm upgrade  ─────▶  APPLIED           the API server holds the new manifest
+                                          (a new helm revision exists)
+                          │
+                          │  pods restart, probes run, a startup gate may take
+                          │  a very long time on purpose
+                          ▼
+                        ROLLED OUT        updated == ready == replicas, at the new generation
+```
+
+**Only the first belongs to helm.** The second is observed, against a budget that comes from the
+record being deployed — because how long it legitimately takes is a property of the instance, and
+helm has never read the record.
+
+## What conflating them cost
+
+`hosting-deploy` ran `helm upgrade --install --atomic --wait --timeout 15m`. Measured 2026-09-09 on
+memex ([#3782]):
+
+| | |
+|---|---|
+| 02:35:20Z | `Deployments/memex-reconcile-20260909-final` starts; adoption 0/19, writable-kinds preflight passed |
+| 02:50:11Z | read-only audit: **revision 44, 20 chart-managed objects** — the record's full render. The upgrade had LANDED |
+| 02:50:20Z | helm's fifteen minutes expire. `--atomic` rolls back |
+| 02:51:57Z | audit: **revision 45, 19 objects** = revision 43's manifest |
+
+Nothing was wrong with revision 44. It was inside its own startup gate, which is what a gated
+two-replica roll looks like while a generation recompiles — and the record budgets **10800 seconds**
+for exactly that, in `startupProbe.budgetSeconds`. The portal answered 200 throughout. A correct
+upgrade was reverted by a timer that had never read the record it was applying.
+
+## Why a bigger timeout is not the fix
+
+1. **A wait inside helm cannot outlast the process running it.** The operator Job's
+   `activeDeadlineSeconds` (3600) caps every in-Job wait, so no `--timeout` can express a budget the
+   record is allowed to set above it. Raising the number moves the cliff; the behaviour *at* the
+   cliff — reverting work that succeeded — is unchanged.
+2. **`--atomic` turns "slow" into "reverted".** Slow and broken are indistinguishable to a timer, and
+   they deserve opposite treatments. Only something watching the rollout can tell them apart,
+   because only it can see whether progress is being made.
+3. **It was not preventing what it claimed to.** The argument for `--atomic` was that it avoids "a
+   half-created release the next attempt must `helm uninstall`". A `failed` release is upgradable —
+   helm rolls forward over it. The states that genuinely block the next upgrade are `pending-*`, and
+   `hosting-deploy` refuses those **by name, before helm runs**, handing the revision choice to a
+   person. That is the better guard, and it was already there.
+
+## The shape now
+
+```
+hosting-deploy   helm upgrade --install          (no --atomic, no --wait, no --timeout)
+                 helm status → ::hosting:: helm_revision=<n>
+                          │
+                          ▼
+caller           observe generation <n> until updated == ready == replicas,
+                 with a budget from the record; report Done only then
+```
+
+Two things are load-bearing on the boundary:
+
+- **The applied revision is reported, read back from `helm status` rather than counted.** `--install`
+  may have created revision 1 or upgraded to revision 45, and a caller that guessed would watch the
+  wrong generation. If the revision cannot be read, the script **refuses** — a release the caller has
+  no handle on would silently degrade "observed" back to "assumed".
+- **Success from `hosting-deploy` means applied, not rolled out**, and it says so in the log. Never
+  report a rollout no one saw complete.
+
+This is the decision the configuration repository's helm-release lane had already made deliberately
+(Memex#188): helm applies, a separate step observes with its own budget. Two implementations of one
+operation held opposite answers; this is that disagreement resolved in favour of the one that did not
+lose a good upgrade.
+
+## The caller's half
+
+Sizing the observation is the other side of the pair, in `InstanceActionPlan` (MeshWeaver.Plugins).
+Every "Wait for rollout" step there is `kubectl rollout status --timeout=600s`, which would have
+failed the same rollout one step later — a *failed report* rather than a *reverted deploy*, so the
+core half alone is already a strict improvement, but it is not the whole fix. What it needs:
+
+- a budget from the record — `min(startupProbe.budgetSeconds × replicas, Job deadline − elapsed)`;
+- when the budget exceeds what one Job may run, end the plan with the rollout **observed, not
+  complete**, and let the control plane re-observe until it finishes, stamping Done only then.
+
+## The general rule
+
+> A deploy step that reports success must have *seen* the thing it reports. When the budget for
+> seeing it belongs to the record, the wait cannot live inside a command that never reads the record
+> — and it must never be allowed to undo what it merely failed to watch.
+
+Related: [Deployment (AKS)](../DeploymentAKS) · [Instance lifecycle — the state of record](../InstanceLifecycleStateOfRecord) ·
+[Probe Semantics](../ProbeSemantics) · [Chart Drift](../ChartDriftSemantics)
+
+[#3782]: https://github.com/Systemorph/MeshWeaver/issues/3782

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-slow-deploy-is-no-longer-a-reverted-one.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-slow-deploy-is-no-longer-a-reverted-one.md
@@ -1,0 +1,37 @@
+---
+Name: A slow deploy is no longer a reverted one
+Category: Fix
+Description: An upgrade that had landed correctly was rolled back because helm's fixed fifteen-minute wait expired while the new pods were still inside their startup gate — a gate the instance's own record budgets three hours for. helm now applies and nothing more; the rollout is observed separately, against the record's budget.
+Icon: ShieldCheckmark
+Order: -20260909
+---
+
+A reconcile of memex on 2026-09-09 applied its new configuration successfully. Fifteen minutes
+later it was undone. An audit taken nine seconds before the rollback showed the intended state in
+place — the full render, every object the record describes — and the portal answered normally
+throughout. The pods were simply still starting, which is what a gated two-replica roll looks like
+while a generation recompiles, and the instance's record allows three hours for it.
+
+## What went wrong
+
+The deploy step asked helm to apply the change *and* wait for it, with a fixed fifteen-minute
+budget and an instruction to roll everything back if the wait ran out. helm has no way to read the
+instance's record, so the budget could not reflect what this instance was allowed to take. To a
+timer, slow and broken look the same — and the response it had been given, reverting, is the right
+answer to only one of them.
+
+Raising the number would not have fixed it. A wait inside helm cannot outlast the job running it,
+which has its own one-hour ceiling, so no timeout can express a budget the record is permitted to
+set higher. It would have moved the cliff, not removed it.
+
+## What it does now
+
+The deploy step applies the change and stops there, reporting which revision it produced. Watching
+that revision reach a healthy state is a separate step with its own budget, taken from the record.
+
+Nothing is left half-finished by dropping the rollback: a failed release can be upgraded straight
+over, and the states that genuinely block the next attempt were already refused by name — before
+helm runs, naming the release and leaving the decision to a person.
+
+A deploy step that reports success now has to have seen what it is reporting. If the applied
+revision cannot be read back, the step refuses rather than reporting a release nobody can observe.


### PR DESCRIPTION
## A correct upgrade, reverted by a timer that had never read the record

Measured 2026-09-09 on memex, all through `Hosting/InstanceAction` ([#3782]). `hosting-deploy` ran `helm upgrade --install --atomic --wait --timeout 15m`:

| | |
|---|---|
| 02:35:20Z | `Deployments/memex-reconcile-20260909-final`; adoption 0/19, writable-kinds preflight passed |
| **02:50:11Z** | audit: **revision 44, 20 chart-managed objects** — the record's full render. **The upgrade had landed.** |
| 02:50:20Z | helm's fifteen minutes expire. `--atomic` rolls back |
| 02:51:57Z | audit: **revision 45, 19 objects** = revision 43's manifest |

Nothing was wrong with revision 44. It was inside its own startup gate — what a gated two-replica roll looks like while a generation recompiles — and the record budgets **10800 seconds** for exactly that (`startupProbe.budgetSeconds`). memex answered 200 throughout.

## Why a bigger timeout is not the fix

1. **A wait inside helm cannot outlast the process running it.** The operator Job's `activeDeadlineSeconds` (3600) caps every in-Job wait, so no `--timeout` can express a budget the record is *allowed* to set above it. Raising 15m moves the cliff; the behaviour **at** the cliff — reverting work that succeeded — is unchanged.
2. **`--atomic` turns "slow" into "reverted".** Slow and broken are indistinguishable to a timer and deserve opposite treatments. Only something watching the rollout can tell them apart, because only it can see whether progress is being made.
3. **It was not preventing what it claimed to.** The comment argued `--atomic` avoids "a half-created release the next attempt must `helm uninstall`". A `failed` release is **upgradable** — helm rolls forward over it. The states that genuinely block the next upgrade are `pending-*`, and `hosting-deploy` already refuses those **by name, before helm runs**, handing the revision choice to a person. That guard is strictly better, and it was already there.

## What it does now

```
helm upgrade --install          (no --atomic, no --wait, no --timeout)
helm status → ::hosting:: helm_revision=<n>
        │
        ▼
caller observes generation <n> against a budget from the record
```

- The revision is **read back** from `helm status`, never counted — `--install` may have created revision 1 or upgraded to 45, and a caller that guessed would watch the wrong generation.
- An apply whose revision **cannot be read is a refusal**: a release the caller has no handle on degrades "observed" straight back to "assumed".
- **Success here means applied, not rolled out**, and the log says so.

This is the decision the configuration repository's helm-release lane already made deliberately (Memex#188): helm applies, a separate step observes with its own budget. Two implementations of one operation held opposite answers; this resolves it in favour of the one that did not lose a good upgrade.

## Tests

Six new cases in `deploy/aks/operator/test/run-tests.sh` — **163 passed / 0 failed** here, and against `origin/main`'s copy of the script restored, **157 passed / 6 failed**, so every one of them is non-vacuous:

- helm upgrade carries **no** `--atomic`, `--wait` or `--timeout` — asserted against the **argument list**, not an outcome, on purpose: `--atomic` reappearing is a regression no stubbed run can fail on, because a stub always succeeds. The flag itself is the defect.
- the applied revision is reported (`::hosting:: helm_revision=42`)
- the revision is read back **after** the apply, never guessed
- the log states the rollout has **not** happened yet
- a failed upgrade says it was **NOT** rolled back and names `helm history` (no false claim of a rollback that no longer occurs)
- an apply with no readable revision is **refused**, not reported done

`DocumentationLinkIntegrityTest` 368/368. `shellcheck` unchanged from `origin/main` (SC1091 info on the `_common.sh` source, pre-existing — same exit code before and after).

## What remains — this is half of a pair

`Part of #3782`, deliberately not `Closes`. The caller's half is `InstanceActionPlan` in **MeshWeaver.Plugins**, where every "Wait for rollout" is `kubectl rollout status --timeout=600s` and would have failed the same rollout one step later. It needs a budget from the record — `min(startupProbe.budgetSeconds × replicas, Job deadline − elapsed)` — and, when that exceeds what one Job may run, must end the plan with the rollout **observed, not complete**, letting the control plane re-observe until it finishes.

**The core half alone is already a strict improvement**, which is why it lands first and independently: the failure mode changes from *a good upgrade reverted* to *a slow rollout reported as failed*. The second is recoverable by looking; the first destroyed correct work.

`Pairs-with: none — this removes no public type or member; the diff is shell scripts, their tests and docs. The `::hosting:: helm_revision=` line is an ADDITION to the output contract the mesh's OperatorOutput parser reads, and additive output breaks no reader.`

Doc: [Applying Is Not Rolling Out](https://github.com/Systemorph/MeshWeaver/blob/fix/3782-hosting-deploy-no-atomic/src/MeshWeaver.Documentation/Data/Architecture/ApplyingIsNotRollingOut.md)

[#3782]: https://github.com/Systemorph/MeshWeaver/issues/3782
