### PR TITLE
Protect official releases independently of deployment pins

### DIFF
--- a/.github/scripts/lock-pinned-digests.py
+++ b/.github/scripts/lock-pinned-digests.py
@@ -543,6 +543,12 @@ def build_plan(axis1: list, axis2: list[OverlayScan]) -> Plan:
     return plan
 
 
+# These are the ACR/GHCR image repositories promoted by release.yml. Numeric tags
+# in cached third-party images or independently versioned helpers are not MW releases.
+# --check-retention-record checks this set against the publisher's explicit repo loops.
+OFFICIAL_RELEASE_REPOSITORIES = frozenset({"memex-migration", "mw-plugin-test", "memex-portal-ai"})
+
+
 def resolve_and_classify(plan: Plan, registry: Registry,
                          inventory: dict[str, list[Manifest]],
                          inventory_errors: dict[str, str]) -> None:
@@ -576,6 +582,8 @@ def resolve_and_classify(plan: Plan, registry: Registry,
     # cannot authorize removing it. Preserve every clean release (including legacy v
     # prefixes) and keep it out of the optional unlock arm as well.
     for acr_repo, manifests in sorted(inventory.items()):
+        if acr_repo not in OFFICIAL_RELEASE_REPOSITORIES:
+            continue
         for manifest in manifests:
             release_tags = sorted(tag for tag in manifest.tags
                                   if re.fullmatch(r"v?[0-9]+\.[0-9]+\.[0-9]+", tag))
@@ -949,6 +957,19 @@ def check_retention_record(root: str) -> int:
         print(f"::error::{record} does not exist — the retention record is the only copy of the "
               "purge tasks' reasoning; the tasks themselves are cloud-only (`contextPath: null`).")
         return 1
+    release_workflow = Path(root) / ".github" / "workflows" / "release.yml"
+    if not release_workflow.is_file():
+        problems.append("release.yml is missing; official image protection scope could not be checked")
+    else:
+        published_repos = {
+            repo for group in re.findall(r"for repo in ([^;\n]+); do",
+                                         release_workflow.read_text(encoding="utf-8"))
+            for repo in group.split()
+        }
+        if published_repos != OFFICIAL_RELEASE_REPOSITORIES:
+            problems.append(
+                "release.yml image repositories differ from official retention protection: "
+                f"publisher={sorted(published_repos)}, protection={sorted(OFFICIAL_RELEASE_REPOSITORIES)}")
     manifest_path = record / "tasks.json"
     if not manifest_path.is_file():
         print(f"::error::{manifest_path} is missing.")
@@ -1248,6 +1269,13 @@ def self_test() -> int:
                        FakeRegistry(_inventory(extra=[malformed_release]), FAKE_TAGS))
     check(any("official release" in b and "valid" in b for b in plan.blockers),
           "OFFICIAL: a release without a usable digest was reported as protectable")
+
+    third_party = Manifest("grafana/loki", "sha256:" + "4" * 64, True, True, ["3.3.2"])
+    helper = Manifest("memex-log-watcher", "sha256:" + "5" * 64, True, True, ["1.3.0"])
+    plan, _, _ = _drive(axis1, axis2,
+                       FakeRegistry(_inventory(extra=[third_party, helper]), FAKE_TAGS))
+    check(not any(w.digest in {third_party.digest, helper.digest} for w in plan.wanted),
+          "OFFICIAL: third-party or independently versioned helper images were classified as MW releases")
 
     # ── ARM 2: idempotence — an already-protected manifest is not re-locked ─────────────────────
     plan, _, registry = _drive(

--- a/.github/scripts/lock-pinned-digests.py
+++ b/.github/scripts/lock-pinned-digests.py
@@ -570,6 +570,31 @@ def resolve_and_classify(plan: Plan, registry: Registry,
             plan.wanted.append(merged)
         merged.sources.extend(f"{where} (tag {tag})" for where in wheres)
 
+    # release.yml publishes clean major.minor.patch image tags. Support follows the
+    # underlying .NET lifecycle, not whether a deployment currently pins the release.
+    # Until an authoritative end-of-support mapping is available, absence of a pin
+    # cannot authorize removing it. Preserve every clean release (including legacy v
+    # prefixes) and keep it out of the optional unlock arm as well.
+    for acr_repo, manifests in sorted(inventory.items()):
+        for manifest in manifests:
+            release_tags = sorted(tag for tag in manifest.tags
+                                  if re.fullmatch(r"v?[0-9]+\.[0-9]+\.[0-9]+", tag))
+            if not release_tags:
+                continue
+            if not re.fullmatch(r"sha256:[0-9a-f]{64}", manifest.digest):
+                plan.blockers.append(
+                    f"official release {acr_repo}:{', '.join(release_tags)} has no valid "
+                    "manifest digest, so its protection could not be established")
+                continue
+            entry = next((w for w in plan.wanted
+                          if w.acr_repo == acr_repo and w.digest == manifest.digest), None)
+            if entry is None:
+                entry = Wanted(acr_repo=acr_repo, digest=manifest.digest)
+                plan.wanted.append(entry)
+            entry.sources.append(
+                "official release tag(s) " + ", ".join(release_tags)
+                + " — support has not been established as ended")
+
     # Which of them are already protected?
     known: dict[tuple[str, str], Manifest] = {}
     for acr_repo, manifests in inventory.items():
@@ -675,7 +700,7 @@ def report(plan: Plan, axis1, axis2: list[OverlayScan], registry_name: str,
     emit(f"      tag pin SITES found                      {getattr(plan, 'axis2_sites', 0)}")
     emit(f"      …FLOATING tags (no fixed manifest)       {len(floating)}")
     emit("")
-    emit("    UNION — manifests the fleet pins")
+    emit("    UNION — fleet pins and official release manifests")
     emit(f"      distinct manifests wanted                {len(plan.wanted)}")
     emit(f"      …already protected (deleteEnabled false) {len(plan.already_protected)}")
     emit(f"      …TO LOCK                                 {len(plan.to_lock)}")
@@ -1188,6 +1213,42 @@ def self_test() -> int:
     check(all(digest != "{{" for _, digest, _ in registry.writes),
           "ARM 1: a `{{ … }}` template was read as a tag")
 
+    # Official releases remain protected even when no current deployment pins them.
+    official_digest = "sha256:" + "1" * 64
+    official = Manifest("memex-portal-ai", official_digest, True, True, ["3.0.0"])
+    plan, fails, registry = _drive(axis1, axis2,
+                                  FakeRegistry(_inventory(extra=[official]), FAKE_TAGS))
+    check(not fails, "OFFICIAL: protection failed")
+    check(("memex-portal-ai", official_digest, False) in registry.writes,
+          "OFFICIAL: an unpinned official release was left purgeable")
+    plan, _, registry = _drive(axis1, axis2,
+                              FakeRegistry(_inventory(extra=[Manifest("memex-portal-ai", official_digest,
+                                  False, True, ["3.0.0"])]), FAKE_TAGS),
+                              release_enabled=True)
+    check(not any(m.digest == official_digest for m in plan.release_candidates),
+          "OFFICIAL: a protected release became an unpinned unlock candidate")
+    check(("memex-portal-ai", official_digest, True) not in registry.writes,
+          "OFFICIAL: an enabled release arm unlocked an official release")
+
+    unknown = Manifest("memex-portal-ai", "sha256:" + "2" * 64, True, True,
+                       ["v999.0.0", "999.0.0"])
+    ci_only = Manifest("memex-portal-ai", "sha256:" + "3" * 64, True, True,
+                       ["3.0.0-ci.9000"])
+    plan, _, registry = _drive(axis1, axis2,
+                              FakeRegistry(_inventory(extra=[unknown, ci_only]), FAKE_TAGS))
+    check((unknown.acr_repo, unknown.digest, False) in registry.writes,
+          "OFFICIAL: an unknown support mapping was treated as end of support")
+    check(sum(w.digest == unknown.digest for w in plan.wanted) == 1,
+          "OFFICIAL: two release tags produced duplicate locks for one digest")
+    check(not any(w.digest == ci_only.digest for w in plan.wanted),
+          "OFFICIAL: an unpinned CI build was retained as an official release")
+
+    malformed_release = Manifest("memex-portal-ai", "", True, True, ["3.0.0"])
+    plan, _, _ = _drive(axis1, axis2,
+                       FakeRegistry(_inventory(extra=[malformed_release]), FAKE_TAGS))
+    check(any("official release" in b and "valid" in b for b in plan.blockers),
+          "OFFICIAL: a release without a usable digest was reported as protectable")
+
     # ── ARM 2: idempotence — an already-protected manifest is not re-locked ─────────────────────
     plan, _, registry = _drive(
         axis1, axis2,
@@ -1386,7 +1447,7 @@ def self_test() -> int:
         print(f"::error::self-test: {line}")
     if failures:
         return 1
-    print("self-test: 15 arms — lock requested on both axes and both overlay shapes, idempotent, "
+    print("self-test: official-release protection and 15 existing arms — lock requested on both axes and both overlay shapes, idempotent, "
           "unreadable repo / truncated tree / zero pins / unclassified / malformed / gone / "
           "unresolved tag / indeterminate / unreadable registry all RED with nothing released, "
           "release arm off by default and live when enabled, report-only writes nothing, a lock "

--- a/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
@@ -55,8 +55,10 @@ Use regular age-based cleanup for continuous build artifacts, with a 30-day rete
 window rather than a quota of newer builds. Exclude active deployment and CI pins,
 supported official releases, and the artifacts those releases reference.
 
-The image-protection script treats clean version tags as official releases even when
-no current deployment pins them. Until their support end is established, they remain
+The image-protection script treats clean version tags in the image repositories
+promoted by MeshWeaver's official release workflow as official releases, even when
+no current deployment pins them. Independently versioned helpers and cached third-party
+images are not classified as MeshWeaver releases merely because their tags are numeric. Until their support end is established, they remain
 protected and are not candidates for the optional unpinning cleanup.
 
 The existing cloud cleanup schedule must be brought into line with this policy;

--- a/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
@@ -49,6 +49,20 @@ that a release is unsupported; resolve it before deleting its artifacts.
 End of support ends this retention guarantee; it does not itself issue a deletion.
 Any later cleanup must still respect deployment pins and other active references.
 
+## Continuous build artifacts
+
+Use regular age-based cleanup for continuous build artifacts, with a 30-day retention
+window rather than a quota of newer builds. Exclude active deployment and CI pins,
+supported official releases, and the artifacts those releases reference.
+
+The image-protection script treats clean version tags as official releases even when
+no current deployment pins them. Until their support end is established, they remain
+protected and are not candidates for the optional unpinning cleanup.
+
+The existing cloud cleanup schedule must be brought into line with this policy;
+this policy alone does not change its settings. Protection must succeed before cleanup
+runs, and the cleanup tool must enforce the age window for untagged artifacts too.
+
 ## Operational logs
 
 Operational logs are retained for 30 days and cleaned up automatically by age. This

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-official-release-retention.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-official-release-retention.md
@@ -1,0 +1,12 @@
+---
+Name: Official releases stay protected without deployment pins
+Category: Fix
+Description: The image-protection job now retains official release images even when no deployment currently pins them, preserving releases whose support period has not been established as ended.
+Icon: ShieldCheckmark
+Order: -20260909
+---
+
+A release must remain available throughout its support period, including when every current
+installation has moved to a newer version. Official release tags now keep their images protected
+from cleanup independently of deployment pins. An unknown support date is not treated as permission
+to remove the release.


### PR DESCRIPTION
An official release with no current deployment pin was absent from the protection set and could even be selected by the optional unlock arm. Release support must not depend on which version today's deployments happen to pin.

Include clean release-tagged manifests in the protected union only for the repositories promoted by release.yml (memex-migration, mw-plugin-test, memex-portal-ai), matching release.yml's numeric major.minor.patch tags and retaining legacy v-prefixed tags. Unknown support-end mappings preserve protection. This does not authorize retiring releases or unlock anything; it adds no credential or permission requirements. Ordinary unpinned CI builds remain outside this classification. The policy now states the requested 30-day age-based cleanup for continuous artifacts explicitly.

Validation: the existing offline self-test and retention-record check pass. Removing the new protection deterministically fails five official-release assertions, including unlock prevention; restored implementation passes. Controls cover CI tags, duplicate release aliases, unknown support mappings, missing digests, cached third-party images and independently versioned helpers. The retention-record guard compares the protected repository set with release.yml; adding an unprotected publisher repository deterministically fails. A live report-only inventory across nine fleet repositories identified and drove the scope correction; no registry writes occurred. Documentation.Test builds with Release CIRun warnings-as-errors (0 warnings/errors); What's New integrity passes.

Related to #3438. This is the official-release protection prerequisite, not closure of retention: the independent cloud purge still needs interlocking with protection, its 7d/keep10 policy needs the 30-day age policy, and the actual purge-tool version must enforce age for untagged manifests. No live cleanup settings or registry deletions were changed in this work.
