### PR TITLE
feat: the provenance line becomes a module control, and a container reports the activity under it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-node-page-says-when-it-last-changed.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-node-page-says-when-it-last-changed.md
@@ -1,0 +1,39 @@
+---
+Name: A node page says when it last changed — and a container says when anything under it did
+Category: Fix
+Description: The Type · Created · Updated line was only ever drawn by pages using the framework's own overview, so a node type that renders its own page shipped without it. Modules can now draw the same line, and a container page can report the newest activity beneath it instead of its own row.
+Icon: Clock
+Order: -20260909
+---
+
+# A node page says when it last changed
+
+Every Markdown node carries a provenance line — `Type: Markdown · Created: … by … · Updated: … by …`.
+Node types that render their **own** default area did not, and the reason was structural rather than
+deliberate: the line rides on the framework's page header, and a type that draws its own page never
+asked for it. The information was on the node the whole time, one click away under Settings.
+
+Two things change.
+
+**The line is now a module-facing control of its own.** `MeshNodeLayoutAreas.BuildMetaRow` renders it
+for any page that wants the standard provenance without also taking the icon/title/action block it
+has already drawn itself. `BuildMetaEntries` behind it is pure — node, viewer's zone, no host — so
+what the line says can be asserted without standing up a mesh.
+
+**A container can report the activity beneath it.** On a node whose subject is a partition rather
+than a document, the node's own `LastModified` is not merely incomplete, it is misleading: a CRM
+client root is written when the account is opened and then barely again, so its own row reports
+whatever last touched the ROOT — on a retyped client, the migration, stamped `system-security` —
+while the deals and documents underneath moved days later. "Updated 2026-08-28 by system-security"
+on a page whose account was worked yesterday is a wrong statement, not a missing one. Passing a
+`NodeActivity` replaces that segment with `Last activity: … by … — …`, and it **replaces** rather
+than joins it: two last-changed answers on one line, one of them a migration's, is worse than the
+weaker of the two. With no activity recorded underneath, the line falls back to the node's own row,
+so an empty container does not read as one that never existed.
+
+The new `Last activity:` label is translated like the four already on the line, and so is the word
+joining a timestamp to whoever made it. That last one took some care: the part of this that can be
+tested without a running mesh is deliberately free of any connection to the viewer, and a translated
+word cannot be chosen without knowing who is reading. So the timestamp, the person and the
+description travel separately and are only joined when the line is drawn — which is the moment the
+viewer's language is known.

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -41,6 +42,44 @@ public record PageLayoutOptions
     /// </summary>
     public string? MaxWidth { get; init; }
 }
+
+/// <summary>
+/// The newest thing that happened UNDER a node, for pages whose subject is a container rather than
+/// a document.
+///
+/// <para>🚨 <b>Why a container cannot use its own <c>LastModified</c>.</b> A partition root — a CRM
+/// client, a space — is written when it is opened and then barely again; the work lives in its
+/// children. So its own row reports whatever last touched the ROOT, which on a retyped client is
+/// the migration, stamped <c>system-security</c>, while the deals and documents underneath moved
+/// days later. Rendering that as "Updated" is not an incomplete answer, it is a wrong one: it tells
+/// a reader the account has been quiet since a date on which nothing about the account happened.
+/// Supplying this record replaces that segment with the question the page is actually asked.</para>
+/// </summary>
+/// <param name="At">When it happened (UTC; rendered in the viewer's zone like every other stamp).</param>
+/// <param name="By">Who did it, or null when the source does not record one.</param>
+/// <param name="What">A few words naming it, or null. Appended after an em dash.</param>
+public record NodeActivity(DateTimeOffset At, string? By = null, string? What = null);
+
+/// <summary>
+/// One segment of a node's provenance line — the label's translation KEY, the rendered value, and
+/// an optional link target.
+///
+/// <para>It carries the key rather than the text because <see cref="MeshNodeLayoutAreas.BuildMetaEntries"/>
+/// is deliberately pure: no host, no service provider, no <c>AccessService</c>. That is what makes
+/// the line assertable without standing up a mesh, and it is why the localization happens in the
+/// renderer that has a host to localize with.</para>
+/// </summary>
+/// <param name="LabelKey">Translation key for the label (e.g. <c>node.meta.created</c>).</param>
+/// <param name="Text">The value, already formatted in the viewer's zone.</param>
+/// <param name="Href">Where the value links, or null for plain text.</param>
+/// <param name="By">Who did it, or null. Carried SEPARATELY rather than appended to
+/// <paramref name="Text"/> because the word joining them is <c>node.meta.by</c> — a translated
+/// string, and the whole reason this record holds keys instead of sentences. Folding it in would
+/// put a hard-coded English "by" inside a value the viewer reads in their own language.</param>
+/// <param name="What">What happened, or null. Author-written and rendered as authored — it is
+/// content, not chrome, so it is never translated.</param>
+public record NodeMetaEntry(
+    string LabelKey, string Text, string? Href = null, string? By = null, string? What = null);
 
 /// <summary>
 /// Layout areas for mesh node content.
@@ -453,6 +492,26 @@ public static class MeshNodeLayoutAreas
     /// <param name="partitionRoot">The node's partition root, or null to skip inheritance.</param>
     public static UiControl BuildHeader(
         LayoutAreaHost host, MeshNode? node, bool canEdit, MeshNode? partitionRoot)
+        => BuildHeader(host, node, canEdit, partitionRoot, null);
+
+    /// <summary>
+    /// <see cref="BuildHeader(LayoutAreaHost, MeshNode?, bool, MeshNode?)"/> for a page whose
+    /// subject is a CONTAINER: <paramref name="lastActivity"/> replaces the provenance line's
+    /// <c>Updated</c> segment with the newest thing that happened underneath the node.
+    ///
+    /// <para>🚨 A fifth OVERLOAD rather than a fifth optional parameter, for the reason the
+    /// four-argument form spells out above: this method is a module-facing contract compiled
+    /// against by out-of-tree modules, and adding a parameter — default or not — replaces the
+    /// signature every already-compiled module was built against. An overload is additive.</para>
+    /// </summary>
+    /// <param name="host">The layout area host.</param>
+    /// <param name="node">The node whose header is being built.</param>
+    /// <param name="canEdit">Whether the viewer may edit (icon picker, inline title).</param>
+    /// <param name="partitionRoot">The node's partition root, or null to skip inheritance.</param>
+    /// <param name="lastActivity">The newest activity beneath the node, or null to report the node's own row.</param>
+    public static UiControl BuildHeader(
+        LayoutAreaHost host, MeshNode? node, bool canEdit, MeshNode? partitionRoot,
+        NodeActivity? lastActivity)
     {
         // Chrome-less pages: a node excluded from the "header" context ships without the
         // icon/title/meta block — the content (a marketing hero, a landing page) starts
@@ -501,7 +560,7 @@ public static class MeshNodeLayoutAreas
         identityRow = identityRow.WithView(BuildHeaderActionRow(host, node, nodePath, canEdit));
 
         // Row 2 — node-type link + timestamps
-        var metaRow = BuildHeaderMetaRow(host, node);
+        var metaRow = BuildMetaRow(host, node, lastActivity);
 
         return Controls.Stack
             .WithWidth("100%")
@@ -627,41 +686,127 @@ public static class MeshNodeLayoutAreas
         return row;
     }
 
+    /// <summary>Translation key for the provenance line's node-type label.</summary>
+    public const string MetaTypeKey = "node.meta.type";
+
+    /// <summary>Translation key for the provenance line's created label.</summary>
+    public const string MetaCreatedKey = "node.meta.created";
+
+    /// <summary>Translation key for the provenance line's updated label.</summary>
+    public const string MetaUpdatedKey = "node.meta.updated";
+
+    /// <summary>Translation key for the provenance line's last-activity label.</summary>
+    public const string MetaLastActivityKey = "node.meta.lastActivity";
+
+    /// <summary>The word joining a stamp to whoever made it — a format string ("by {0}" / "von {0}"),
+    /// which is why the actor is a FIELD on the entry and not part of its text.</summary>
+    public const string MetaByKey = "node.meta.by";
+
+    /// <summary>The one timestamp format the provenance line uses.</summary>
+    private const string MetaStampFormat = "yyyy-MM-dd HH:mm";
+
     /// <summary>
-    /// Meta row under the identity row: shows node-type as a link to the type's Configuration
-    /// area and the Created / LastModified / LastModifiedBy timestamps when present.
+    /// The provenance line's segments — <c>Type</c>, <c>Created</c>, and either <c>Updated</c> or,
+    /// when <paramref name="lastActivity"/> is supplied, <c>Last activity</c>.
+    ///
+    /// <para>🚨 <b>Pure on purpose.</b> No host, no service provider, no <c>AccessService</c>: the
+    /// viewer's zone arrives as an IANA id and every stamp goes through the deterministic
+    /// <see cref="DisplayTimeExtensions.ToDisplayTime(DateTimeOffset, string?)"/>. That is what lets
+    /// the line be asserted without standing up a mesh — the renderer below is then only markup and
+    /// localization, which is where this used to hide three hard-coded English words.</para>
+    ///
+    /// <para>A stamp that was never set emits NO segment rather than an em dash or the epoch: a node
+    /// with no recorded date should say nothing, not something false. Equally, a null
+    /// <paramref name="lastActivity"/> falls through to the node's own <c>LastModified</c>, so a
+    /// container with nothing under it yet still reports when it was itself last written.</para>
     /// </summary>
-    private static UiControl BuildHeaderMetaRow(LayoutAreaHost host, MeshNode? node)
+    /// <param name="node">The node whose provenance is described, or null for no segments.</param>
+    /// <param name="timeZoneId">The viewer's named IANA zone; null/unknown renders UTC.</param>
+    /// <param name="lastActivity">The newest activity beneath a CONTAINER node — see <see cref="NodeActivity"/>.</param>
+    public static ImmutableArray<NodeMetaEntry> BuildMetaEntries(
+        MeshNode? node, string? timeZoneId, NodeActivity? lastActivity = null)
     {
+        if (node is null)
+            return ImmutableArray<NodeMetaEntry>.Empty;
+
+        var entries = ImmutableArray.CreateBuilder<NodeMetaEntry>(3);
+
+        // A NodeType node linking to its own Configuration area would link to the page you are on.
+        if (!string.IsNullOrEmpty(node.NodeType) && node.NodeType != MeshNode.NodeTypePath)
+            entries.Add(new NodeMetaEntry(
+                MetaTypeKey,
+                node.NodeType.Contains('/') ? node.NodeType.Split('/').Last() : node.NodeType,
+                BuildUrl(node.NodeType, NodeTypeLayoutAreas.ConfigurationArea)));
+
+        if (node.CreatedDate != default)
+            entries.Add(new NodeMetaEntry(
+                MetaCreatedKey, Stamp(node.CreatedDate, timeZoneId), By: NullIfBlank(node.CreatedBy)));
+
+        // The override REPLACES the node's own row rather than joining it: two "last changed"
+        // answers on one line, one of them a migration's, is worse than the weaker of the two.
+        if (lastActivity is { } activity)
+            entries.Add(new NodeMetaEntry(
+                MetaLastActivityKey, Stamp(activity.At, timeZoneId),
+                By: NullIfBlank(activity.By), What: NullIfBlank(activity.What)));
+        else if (node.LastModified != default)
+            entries.Add(new NodeMetaEntry(
+                MetaUpdatedKey, Stamp(node.LastModified, timeZoneId),
+                By: NullIfBlank(node.LastModifiedBy)));
+
+        return entries.ToImmutable();
+    }
+
+    /// <summary>The instant, in the viewer's zone. Nothing else.
+    ///
+    /// <para>🚨 It used to append <c>" by {who}"</c> and <c>" — {what}"</c> here, and that was an
+    /// i18n defect hiding inside a pure function: "by" is a translated word (<c>node.meta.by</c>),
+    /// and a pure helper has no host to translate it with. Composing it here would have quietly
+    /// reverted the localization of this very line and put an English word in front of a German
+    /// reader. The actor and the description travel as fields; the renderer, which HAS a host,
+    /// joins them.</para></summary>
+    private static string Stamp(DateTimeOffset at, string? timeZoneId)
+        => DisplayTimeExtensions.ToDisplayTime(at, timeZoneId).ToString(MetaStampFormat);
+
+    /// <summary>Blank and absent mean the same thing here: no segment rather than a dangling "by".</summary>
+    private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    /// <summary>
+    /// The provenance line as a control — node type linking to its Configuration area, then the
+    /// timestamps, every label localized.
+    ///
+    /// <para>Public module-facing contract, and the narrow one: a module page that builds its own
+    /// body but wants the standard provenance line calls THIS rather than
+    /// <see cref="BuildHeader(LayoutAreaHost, MeshNode?, bool)"/>, which would also impose the
+    /// icon/title/action block the page has already drawn itself. Pass
+    /// <paramref name="lastActivity"/> on a container page — see <see cref="NodeActivity"/>.</para>
+    /// </summary>
+    public static UiControl BuildMetaRow(
+        LayoutAreaHost host, MeshNode? node, NodeActivity? lastActivity = null)
+    {
+        var access = host.Hub.ServiceProvider.GetService<AccessService>();
+        var zoneId = access?.Context?.TimeZoneId ?? access?.CircuitContext?.TimeZoneId;
+
         var row = Controls.Stack
             .WithOrientation(Orientation.Horizontal)
             .WithStyle("align-items: center; gap: 24px; flex-wrap: wrap; font-size: 0.85rem; color: var(--neutral-foreground-hint);");
 
-        var access = host.Hub.ServiceProvider.GetService<AccessService>();
-
-        if (node != null && !string.IsNullOrEmpty(node.NodeType) && node.NodeType != MeshNode.NodeTypePath)
+        foreach (var entry in BuildMetaEntries(node, zoneId, lastActivity))
         {
-            var typeHref = BuildUrl(node.NodeType, NodeTypeLayoutAreas.ConfigurationArea);
-            var typeLabel = node.NodeType.Contains('/') ? node.NodeType.Split('/').Last() : node.NodeType;
-            row = row.WithView(Controls.Html(
-                "<span style=\"display: inline-flex; align-items: center; gap: 6px;\">" +
-                $"<span>{System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.type"))}</span>" +
-                $"<a href=\"{typeHref}\" style=\"color: var(--accent-fill-rest); font-weight: 500;\">{System.Web.HttpUtility.HtmlEncode(typeLabel)}</a>" +
-                "</span>"));
-        }
-
-        if (node != null && node.CreatedDate != default)
-        {
-            var created = access.ToDisplayTime(node.CreatedDate).ToString("yyyy-MM-dd HH:mm");
-            var createdBy = string.IsNullOrEmpty(node.CreatedBy) ? "" : $" {System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.by", node.CreatedBy))}";
-            row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">{System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.created"))}</span> {created}{createdBy}</span>"));
-        }
-
-        if (node != null && node.LastModified != default)
-        {
-            var modified = access.ToDisplayTime(node.LastModified).ToString("yyyy-MM-dd HH:mm");
-            var modifiedBy = string.IsNullOrEmpty(node.LastModifiedBy) ? "" : $" {System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.by", node.LastModifiedBy))}";
-            row = row.WithView(Controls.Html($"<span><span style=\"color: var(--neutral-foreground-rest);\">{System.Web.HttpUtility.HtmlEncode(host.Localize("node.meta.updated"))}</span> {modified}{modifiedBy}</span>"));
+            var label = System.Web.HttpUtility.HtmlEncode(host.Localize(entry.LabelKey));
+            var text = System.Web.HttpUtility.HtmlEncode(entry.Text);
+            // "by" is the viewer's word; "what" is the author's sentence, rendered as authored.
+            if (entry.By is { } by)
+                text += " " + System.Web.HttpUtility.HtmlEncode(host.Localize(MetaByKey, by));
+            if (entry.What is { } what)
+                text += " — " + System.Web.HttpUtility.HtmlEncode(what);
+            row = row.WithView(entry.Href is { } href
+                ? Controls.Html(
+                    "<span style=\"display: inline-flex; align-items: center; gap: 6px;\">" +
+                    $"<span>{label}</span>" +
+                    $"<a href=\"{href}\" style=\"color: var(--accent-fill-rest); font-weight: 500;\">{text}</a>" +
+                    "</span>")
+                : Controls.Html(
+                    $"<span><span style=\"color: var(--neutral-foreground-rest);\">{label}</span> {text}</span>"));
         }
 
         return row;

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -109,6 +109,11 @@
   "overview.unresolvedTypeHint": "Die Eigenschaften dieses Nodes können erst angezeigt werden, wenn die Plattform den Typ kennt, mit dem der Inhalt geschrieben wurde. Stammt dieser Typ aus einem im Mesh kompilierten NodeType, löst sich das von selbst, sobald die Kompilierung abgeschlossen ist — die Ansicht aktualisiert sich dann automatisch. Meldet der NodeType bereits eine erfolgreiche Kompilierung und dieser Hinweis bleibt bestehen, beansprucht keine Deklaration diesen Typ und der Inhalt muss repariert werden.",
   "nav.contents": "Inhalt",
   "nav.youAreHere": "Sie sind hier",
+  "node.meta.type": "Typ:",
+  "node.meta.created": "Erstellt:",
+  "node.meta.updated": "Aktualisiert:",
+  "node.meta.lastActivity": "Letzte Aktivität:",
+  "node.meta.by": "von {0}",
   "menu.edit": "Bearbeiten",
   "menu.pin": "Anheften",
   "menu.move": "Verschieben",
@@ -1433,9 +1438,5 @@
   "setup.problem.noCompany": "Geben Sie die Organisation an, zu der diese Instanz gehört.",
   "setup.problem.noOwnerName": "Geben Sie den Namen der Person an, der diese Instanz gehört.",
   "setup.problem.noOwnerEmail": "Geben Sie eine gültige E-Mail-Adresse an — darüber erreicht die Registry die Eigentümerin oder den Eigentümer dieser Instanz.",
-  "setup.problem.noConsent": "Akzeptieren Sie die Datenschutzerklärung und die Plattform-Nutzungsbedingungen, um zu registrieren. Bis dahin wird nichts gesendet.",
-  "node.meta.type": "Typ:",
-  "node.meta.created": "Erstellt:",
-  "node.meta.updated": "Aktualisiert:",
-  "node.meta.by": "von {0}"
+  "setup.problem.noConsent": "Akzeptieren Sie die Datenschutzerklärung und die Plattform-Nutzungsbedingungen, um zu registrieren. Bis dahin wird nichts gesendet."
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -109,6 +109,11 @@
   "overview.unresolvedTypeHint": "The properties of this node cannot be shown until the platform knows the type its content was written with. If that type comes from a NodeType compiled inside the mesh, this resolves itself as soon as the compile finishes and this view refreshes on its own — nothing to do. If the NodeType already reports a successful compile and this notice stays, then no declaration claims that type and the content needs repair.",
   "nav.contents": "Contents",
   "nav.youAreHere": "You are here",
+  "node.meta.type": "Type:",
+  "node.meta.created": "Created:",
+  "node.meta.updated": "Updated:",
+  "node.meta.lastActivity": "Last activity:",
+  "node.meta.by": "by {0}",
   "menu.edit": "Edit",
   "menu.pin": "Pin",
   "menu.move": "Move",
@@ -1433,9 +1438,5 @@
   "setup.problem.noCompany": "Give the organisation this instance belongs to.",
   "setup.problem.noOwnerName": "Give the name of the person who owns this instance.",
   "setup.problem.noOwnerEmail": "Give a valid email address — it is how the registry reaches the owner about this instance.",
-  "setup.problem.noConsent": "Accept the privacy statement and the platform terms to register. Nothing is sent until you do.",
-  "node.meta.type": "Type:",
-  "node.meta.created": "Created:",
-  "node.meta.updated": "Updated:",
-  "node.meta.by": "by {0}"
+  "setup.problem.noConsent": "Accept the privacy statement and the platform terms to register. Nothing is sent until you do."
 }

--- a/test/MeshWeaver.Graph.Test/NodeMetaEntriesTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeMetaEntriesTest.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Linq;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The node header's provenance line — <c>Type · Created · Updated</c> — and the third state it
+/// could not express.
+///
+/// <para>The line is what every Markdown page shows and no custom page does: it rides on
+/// <see cref="MeshNodeLayoutAreas.BuildHeader(LayoutAreaHost, MeshNode?, bool)"/>, so a node type
+/// that renders its OWN default area (a CRM client, a board) silently ships without it. Making the
+/// segments a PURE function of the node, the viewer's zone and an optional activity override is
+/// what lets a module render the same line — and lets this fixture assert it without a mesh, a
+/// host, or a mock.</para>
+///
+/// <para>🚨 <b>Why the override exists.</b> On a CONTAINER node the node's own
+/// <c>LastModified</c> is the wrong answer and reads as a false one. A CRM client root is written
+/// when the account is opened and then barely again — the engagement lives in its children — so
+/// its own timestamp reports the migration that retyped it, by <c>system-security</c>, while the
+/// deals and documents underneath moved days later. "Updated 2026-08-28 by system-security" on a
+/// page whose account was worked yesterday is not a missing feature; it is a wrong statement. The
+/// override replaces that segment with the newest activity across the partition, which is the
+/// question the page is actually asked.</para>
+/// </summary>
+public class NodeMetaEntriesTest
+{
+    private const string Zone = "Europe/Zurich";
+
+    private static MeshNode Node(
+        DateTimeOffset? created = null,
+        string? createdBy = null,
+        DateTimeOffset? modified = null,
+        string? modifiedBy = null,
+        string nodeType = "Crm/Client") =>
+        new("SchenkerLabs")
+        {
+            Name = "Schenker Labs",
+            NodeType = nodeType,
+            CreatedDate = created ?? default,
+            CreatedBy = createdBy,
+            LastModified = modified ?? default,
+            LastModifiedBy = modifiedBy,
+        };
+
+    [Fact]
+    public void The_three_segments_are_type_created_and_updated()
+    {
+        var entries = MeshNodeLayoutAreas.BuildMetaEntries(
+            Node(
+                created: new DateTimeOffset(2026, 8, 27, 7, 59, 0, TimeSpan.Zero), createdBy: "sglauser",
+                modified: new DateTimeOffset(2026, 8, 28, 14, 30, 0, TimeSpan.Zero), modifiedBy: "system-security"),
+            Zone);
+
+        entries.Select(e => e.LabelKey).Should().Equal(
+            MeshNodeLayoutAreas.MetaTypeKey,
+            MeshNodeLayoutAreas.MetaCreatedKey,
+            MeshNodeLayoutAreas.MetaUpdatedKey);
+    }
+
+    [Fact]
+    public void The_type_segment_links_to_the_types_configuration()
+    {
+        var type = MeshNodeLayoutAreas.BuildMetaEntries(Node(), Zone).Single(e => e.LabelKey == MeshNodeLayoutAreas.MetaTypeKey);
+
+        // The label is the LAST segment — "Client", not "Crm/Client" — and it navigates to the type.
+        type.Text.Should().Be("Client");
+        type.Href.Should().Be($"/Crm/Client/{NodeTypeLayoutAreas.ConfigurationArea}");
+    }
+
+    [Fact]
+    public void Timestamps_render_in_the_viewers_zone_with_the_author()
+    {
+        // 07:59 UTC on 27 August is 09:59 in Zurich (CEST, UTC+2). A UTC render would read 07:59
+        // and be wrong for every viewer in the office.
+        var created = MeshNodeLayoutAreas
+            .BuildMetaEntries(Node(created: new DateTimeOffset(2026, 8, 27, 7, 59, 0, TimeSpan.Zero), createdBy: "sglauser"), Zone)
+            .Single(e => e.LabelKey == MeshNodeLayoutAreas.MetaCreatedKey);
+
+        created.Text.Should().Be("2026-08-27 09:59");
+        // 🚨 The actor is a FIELD, never part of the text. The word joining them is node.meta.by
+        // ("by {0}" / "von {0}"), so a test asserting "… by sglauser" would be asserting that a
+        // German reader sees an English word — and would pass while the page was wrong.
+        created.By.Should().Be("sglauser");
+        created.What.Should().BeNull();
+    }
+
+    [Fact]
+    public void An_absent_author_leaves_no_dangling_by()
+    {
+        var created = MeshNodeLayoutAreas
+            .BuildMetaEntries(Node(created: new DateTimeOffset(2026, 8, 27, 7, 59, 0, TimeSpan.Zero)), Zone)
+            .Single(e => e.LabelKey == MeshNodeLayoutAreas.MetaCreatedKey);
+
+        created.Text.Should().Be("2026-08-27 09:59");
+        created.By.Should().BeNull("a blank actor emits no segment rather than a dangling 'by'");
+    }
+
+    [Fact]
+    public void An_unset_timestamp_emits_no_segment_at_all()
+    {
+        // Not "—", not the epoch: a node with no recorded date says nothing rather than something false.
+        var entries = MeshNodeLayoutAreas.BuildMetaEntries(Node(), Zone);
+
+        entries.Should().NotContain(e => e.LabelKey == MeshNodeLayoutAreas.MetaCreatedKey);
+        entries.Should().NotContain(e => e.LabelKey == MeshNodeLayoutAreas.MetaUpdatedKey);
+    }
+
+    [Fact]
+    public void A_null_node_yields_no_segments()
+    {
+        MeshNodeLayoutAreas.BuildMetaEntries(null, Zone).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void The_node_type_node_itself_carries_no_type_segment()
+    {
+        // A NodeType page linking to its own Configuration area is a link to the page you are on.
+        var entries = MeshNodeLayoutAreas.BuildMetaEntries(Node(nodeType: MeshNode.NodeTypePath), Zone);
+
+        entries.Should().NotContain(e => e.LabelKey == MeshNodeLayoutAreas.MetaTypeKey);
+    }
+
+    // ---- The override: a container reports its partition's activity, not its own row's --------
+
+    [Fact]
+    public void An_activity_override_replaces_the_updated_segment()
+    {
+        var entries = MeshNodeLayoutAreas.BuildMetaEntries(
+            Node(
+                created: new DateTimeOffset(2026, 8, 27, 7, 59, 0, TimeSpan.Zero), createdBy: "sglauser",
+                modified: new DateTimeOffset(2026, 8, 28, 14, 30, 0, TimeSpan.Zero), modifiedBy: "system-security"),
+            Zone,
+            new NodeActivity(new DateTimeOffset(2026, 9, 8, 11, 5, 0, TimeSpan.Zero), "mkleiner", "Reply from Jörg"));
+
+        entries.Select(e => e.LabelKey).Should().Equal(
+            MeshNodeLayoutAreas.MetaTypeKey,
+            MeshNodeLayoutAreas.MetaCreatedKey,
+            MeshNodeLayoutAreas.MetaLastActivityKey);
+
+        // 🚨 The whole point: the migration's stamp must NOT survive alongside the real answer.
+        entries.Should().NotContain(e => e.LabelKey == MeshNodeLayoutAreas.MetaUpdatedKey);
+        var activity = entries.Single(e => e.LabelKey == MeshNodeLayoutAreas.MetaLastActivityKey);
+        activity.Text.Should().Be("2026-09-08 13:05");
+        activity.By.Should().Be("mkleiner");
+        // Author-written, so it renders AS AUTHORED — including the umlaut, which is the case that
+        // catches an encoding slip on the way through the renderer.
+        activity.What.Should().Be("Reply from Jörg");
+    }
+
+    [Fact]
+    public void An_override_stands_in_for_an_updated_segment_that_was_never_there()
+    {
+        // A container whose own row has no LastModified still has activity underneath it.
+        var entries = MeshNodeLayoutAreas.BuildMetaEntries(
+            Node(created: new DateTimeOffset(2026, 8, 27, 7, 59, 0, TimeSpan.Zero), createdBy: "sglauser"),
+            Zone,
+            new NodeActivity(new DateTimeOffset(2026, 9, 8, 11, 5, 0, TimeSpan.Zero), "mkleiner"));
+
+        var activity = entries.Single(e => e.LabelKey == MeshNodeLayoutAreas.MetaLastActivityKey);
+        activity.Text.Should().Be("2026-09-08 13:05");
+        activity.By.Should().Be("mkleiner");
+        activity.What.Should().BeNull("no description was recorded — the segment simply ends");
+    }
+
+    [Fact]
+    public void An_override_with_no_activity_yet_falls_back_to_the_nodes_own_row()
+    {
+        // An empty client — nothing recorded under it — must not read as "no activity ever",
+        // which would erase the fact that the account was created at all.
+        var entries = MeshNodeLayoutAreas.BuildMetaEntries(
+            Node(
+                created: new DateTimeOffset(2026, 8, 27, 7, 59, 0, TimeSpan.Zero), createdBy: "sglauser",
+                modified: new DateTimeOffset(2026, 8, 28, 14, 30, 0, TimeSpan.Zero), modifiedBy: "system-security"),
+            Zone,
+            lastActivity: null);
+
+        entries.Select(e => e.LabelKey).Should().Contain(MeshNodeLayoutAreas.MetaUpdatedKey);
+    }
+}


### PR DESCRIPTION
## The provenance line, reusable — cherry-picked from #3805 and **adapted**

`Closes #3823`. The branch that issue points at (`fix/node-provenance-byline`, from the closed #3805) was **57 commits behind main**, and replaying it straight would have reverted a merged fix. This is that cherry-pick with two adaptations, both found by running the tests rather than by reading the diff.

### What it adds — additive only, no existing signature changes

| | |
|---|---|
| `BuildMetaEntries(node, zoneId, lastActivity?)` | **pure** — no host, no `AccessService` — which is what lets the line be asserted without standing up a mesh |
| `BuildMetaRow(host, node, lastActivity?)` | the row **alone**, for a page that has drawn its own title and cannot call `BuildHeader` without rendering a second icon and heading (`Crm/Opportunity` today) |
| `NodeActivity(At, By?, What?)` | **replaces** the `Updated` segment on a container |
| `BuildHeader` | gains a fifth **overload**, never a fifth parameter — its own doc comment gives the reason: out-of-tree modules compile against it, and adding a parameter (default or not) replaces the signature they were built against |

Why a container needs the override: a partition root is written when it is opened and barely again, so its own row reports whatever last touched the **root** — on a retyped CRM client, the migration, stamped `system-security` — while the records underneath moved days later. *"Updated 2026-08-28 by system-security"* on an account worked yesterday is a **wrong** statement, not a missing one. It replaces rather than joins (two last-changed answers, one of them a migration's, is worse than the weaker of the two), and falls back to the node's own row when null, so an empty container does not read as one that never existed.

## 🚨 Adaptation 1 — a straight replay was an i18n regression

The branch predates `bb2f38b0f` *("localize node metadata labels for the viewer")*, which landed on main while it sat. The branch's **pure** `Stamp()` composed:

```csharp
text += $" by {by}";        // hard-coded English
```

— which is exactly the string main had just localized to `node.meta.by`. Replaying it would have quietly reverted a merged fix and put an English word in front of a German reader. **It was invisible in the conflict**: the conflict was in the *renderer*, while the defect sat in a helper that merged cleanly.

Purity is what makes the helper assertable, and a pure helper has no host to translate with — so the two requirements looked opposed. They are not: the entry now carries the actor and the description as **fields**, and the renderer (which has a host) joins them with `host.Localize(MetaByKey, by)`. The author-written description stays as authored — content follows the author, chrome follows the viewer.

The tests moved with it. Asserting `Text == "2026-08-27 09:59 by sglauser"` would have been asserting *that a German reader sees an English word*, and would have **passed while the page was wrong**. They now assert `Text`/`By`/`What` separately, and the umlaut case (`"Reply from Jörg"`) is kept as the encoding control.

## 🚨 Adaptation 2 — the catalog merge produced duplicate keys, invisible to `json.load`

main appended `node.meta.{type,created,updated,by}` at the **end** of both catalogs; the branch had added its own copies of the first three beside the `nav.*` group. Git auto-merged **both** blocks in, so each file declared three keys **twice**.

`json.load` keeps the last silently — my own catalog diff reported *"no changes"* because of it. `NoCatalogDeclaresAKeyTwice` caught it, naming exactly the hazard: *"a duplicate is resolved by parser order and editing one copy leaves the other standing."*

Consolidated to one block, values taken verbatim from main. Verified by parsing with `object_pairs_hook` (which **sees** duplicates) rather than `json.load` (which cannot):

```
en  1440 keys, 0 duplicates   added ['node.meta.lastActivity']  removed []  changed {}
de  1440 keys, 0 duplicates   added ['node.meta.lastActivity']  removed []  changed {}
```

## Verification

- `NodeMetaEntriesTest` **10/10**
- `LocalizationTest` **58/58** (2 failures before the consolidation — that guard is why this PR is correct)
- `DocumentationLinkIntegrityTest` **368/368**
- `MeshWeaver.Graph.Test` and `MeshWeaver.Messaging.Hub.Test` build Release `-warnaserror` at **0 warnings, 0 errors**
- No hard-coded English left in the row — only in the comments explaining why

## Handover after merge

Mirror-sync: MeshWeaver.Plugins runs `npm run sync:i18n -- --ref <this pull request's merge sha>` against clients/react/src/i18n/ — one key added (node.meta.lastActivity, both languages), zero value drift on the 1439 keys that already existed.

The React catalog's guard compares against a **pinned** core commit rather than core's `main`, so adding a key here reds nothing there and leaves the mirror silently stale. That is precisely why the gate asks for the handover rather than the result — the sync runs in the other repository and cannot be done from this one.

`Pairs-with: none — additive only. No public type or member is removed; BuildHeader gains an overload rather than a parameter, precisely so out-of-tree modules keep the signature they were built against.`

Closes #3823
