### PR TITLE
fix: a required package no publisher produces is named, and still never held

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SelfUpdateTargetSelection.md
@@ -366,6 +366,74 @@ is the only diagnostic an operator has *before* turning updates back on; destroy
 showing something stale trades a misleading answer for no answer. Only the framing changes — the
 reason is still quoted in full.
 
+## 8. A record naming a package NOBODY publishes — named, never held
+
+§7 explains why #3706's *evidence* was stale. This is the part of #3706 that was real, and it sat on
+the other side of the same reading: memex's install records still named `Plugins/Agent`,
+`Plugins/Skill` and `Plugins/PlatformUI` after those packages had been withdrawn — Agent and Skill
+**deliberately** (`MeshWeaver.Plugins@7afbd745`, *"remove agents and skill package and serve from the
+main ai package"*; the AI engine's `BuiltInAgentProvider` / `BuiltInSkillProvider` are the live
+master). Nothing publishes them, and nothing ever will again.
+
+The gate's answer was **silence**, and silence was wrong in a way that is easy to mistake for right.
+
+### Not holding was already correct
+
+`ReleaseAvailability.IsUpdatable` did not block on them, and must not: a roll cannot conjure a build
+nobody publishes, so waiting for one waits for ever. That is the shape #3706 is named after, and the
+two fixes that produced it — floors advisory ([#3648]), a missing bake a cost rather than a hold
+([#3651]) — are the right ones. **Saying nothing was the defect.**
+
+The consequence is what makes it worth a section: an operator with a stale install record had *no
+signal at all* from the gate, so the only place the package names appeared was a frozen `heldReason`
+— §7's trap. **The absence of a live diagnosis is what sent a reader to a dead one.** A gate that
+correctly declines to hold still owes an account of what it saw.
+
+### What it says now
+
+A required package is reported as an orphan when three things are true at once:
+
+1. its install record names a **module**,
+2. the module set sealed for the target's framework identity **does not carry** it, and
+3. **no generation of it is landed** on this instance.
+
+Together those mean the instance has never had it and the target does not offer it — an assertion
+about the record, not about the release, so the remedy named is the record:
+
+> `Agent: the install record names module MeshWeaver.Agent, which the module set sealed for framework
+> identity s8055 does not carry, and no generation of it is landed on this instance — so no publisher
+> produces it and no roll can obtain it. Reported, never a hold: holding would wait for ever. If the
+> package is genuinely retired, remove its install record; if it moved, the record must name its new
+> home.`
+
+### The three neighbours it must not swallow
+
+Each is a different absence with a different remedy, and each has a test:
+
+| state | told apart by | remedy |
+|---|---|---|
+| **Orphan** — nobody publishes it | nothing landed, not in the sealed set | fix the **record** |
+| **Landed but unpublished for the target** | something *is* landed | the **link probe** measures the bytes; may legitimately hold |
+| **Content with no bake** | no module to look for | reported as *"would recompile at boot"*; fix the **bake** |
+| **Set unreadable / unobserved** | `SealedModuleSet` null or carrying a `Refusal` | say **nothing** — see below |
+
+🚨 **The fourth row is the one that keeps the other three honest.** A module set that could not be
+read means the module was never *looked for*, and "we did not look" must never be worded as "it does
+not exist" — the conflation [#1754] forbids one severity up. An advisory that fired on an unmeasured
+set would be a confident sentence about evidence nobody gathered, and it would fire hardest exactly
+when the observation infrastructure is broken. Unmeasured stays silent here and is reported by the
+paths that own it.
+
+### The general rule
+
+> A gate that is right not to hold still owes you what it saw. "Did not block" and "found nothing
+> worth mentioning" must not render identically, or the only remaining account of the problem is
+> whatever stale field happens to mention it.
+
+[#1754]: https://github.com/Systemorph/MeshWeaver/issues/1754
+[#3648]: https://github.com/Systemorph/MeshWeaver/issues/3648
+[#3651]: https://github.com/Systemorph/MeshWeaver/issues/3651
+
 ## Where it lives
 
 - `src/MeshWeaver.Plugin.Packaging/PlatformReleaseOrder.cs` — the lineage key (`BuildOrdinal`), the
@@ -389,6 +457,11 @@ reason is still quoted in full.
   and the same event under two policies.
 - `test/Memex.Portal.Shared.Test/FrozenHoldIsHistoryTest.cs` — §7: both framings on the tab, both
   answers on the About surface, and the Red-verdict positive control that must keep holding.
+- `src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs` — `ModuleLane`, §8's three conditions and the
+  unmeasured-set guard.
+- `test/Memex.Portal.Shared.Test/OrphanedPackageRecordTest.cs` — §8: the orphan named without
+  holding, the floor advisory that must keep riding beside it, each neighbouring absence kept
+  distinct, and the unreadable-set control that stops the advisory becoming unconditional.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-retired-package-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-a-retired-package-says-so.md
@@ -1,0 +1,37 @@
+---
+Name: A retired package now says so
+Category: Fix
+Description: An instance whose install records still named withdrawn packages got no word about it from the update check — correctly not blocked, but also not told. Those records are now reported by name, with the remedy, while the check continues not to hold on them.
+Icon: ShieldCheckmark
+Order: -20260909
+---
+
+An install record names a package the instance expects to keep. When a package is withdrawn — as
+the Agent and Skill packages were, deliberately, once the AI engine started serving their content —
+the records naming it outlive it. Nothing publishes it any more, and nothing ever will.
+
+The update check handled that correctly in the only way that matters: it did **not** wait. A release
+cannot conjure a build nobody produces, so holding for one holds for ever.
+
+## What was missing
+
+It also said nothing. An operator whose records had gone stale got no signal from the check at all,
+so the only place those package names still appeared was the record of a hold from days earlier —
+which by then described rules that had since changed. The absence of a live answer is what sent
+people to a dead one.
+
+## What it does now
+
+A required package is reported by name when the instance has never had it and the release does not
+offer it: the record names a module, the release's sealed set does not carry it, and no copy of it is
+installed here. The message says what it means and what to do — the record is what needs fixing,
+either by removing it or by pointing it at the package's new home — and the check still does not
+hold on it.
+
+Neighbouring situations keep their own answers, because their remedies differ: something installed
+that the release does not publish is measured against the release instead, and content awaiting a
+bake still reports that it would be rebuilt at first start.
+
+One case deliberately stays silent. If the release's module list could not be read, the package was
+never looked for — and "we did not look" must not be reported as "it does not exist", least of all
+when the thing that is broken is the ability to look.

--- a/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
+++ b/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
@@ -266,7 +266,33 @@ public static class ReleaseAvailability
         if (artifacts.Modules?.MvidByModule.ContainsKey(package.ModuleName) == true)
             return (null, null);
         if (string.IsNullOrWhiteSpace(package.LandedModulePath))
-            return (null, null);
+            // 🚨 NOTHING LANDED AND THE TARGET DOES NOT CARRY IT — an install record naming a
+            // package NO PUBLISHER PRODUCES (#3706). This used to return silence, and silence is
+            // the wrong answer twice over: the gate correctly does not hold (no roll of this
+            // deployment can conjure a build nobody publishes — holding would be the eternal wait
+            // #3706 was filed about), but nothing told the operator that the record is stale
+            // either, so the only way to learn it was to read a frozen `heldReason` and reach the
+            // wrong conclusion. That is exactly what happened: memex's Agent / Skill / PlatformUI
+            // records outlived the packages (the AI engine serves those now — MeshWeaver.Plugins
+            // 7afbd745, deliberately), and the hold quoted against them had been computed once,
+            // 36 hours earlier, by a code path that no longer decides anything.
+            //
+            // Named, never a hold — which is #3706's option 3 stated as behaviour.
+            //
+            // 🚨 Only when the set was actually READ. A null or refused SealedModuleSet means the
+            // module was not looked for, and "we did not look" must never be worded as "it does
+            // not exist" — the same conflation #1754 forbids one severity up. Unmeasured stays
+            // silent here and is reported by the paths that own it.
+            return artifacts.Modules is { Refusal: null } observed
+                    && !observed.MvidByModule.ContainsKey(package.ModuleName)
+                ? (null,
+                    $"{package.Name}: the install record names module {package.ModuleName}, which "
+                    + $"the module set sealed for framework identity {target.FrameworkIdentity} "
+                    + "does not carry, and no generation of it is landed on this instance — so no "
+                    + "publisher produces it and no roll can obtain it. Reported, never a hold: "
+                    + "holding would wait for ever. If the package is genuinely retired, remove "
+                    + "its install record; if it moved, the record must name its new home")
+                : (null, null);
 
         if (!artifacts.ModuleLinks.TryGetValue(package.Name, out var link))
             return (null,

--- a/test/Memex.Portal.Shared.Test/OrphanedPackageRecordTest.cs
+++ b/test/Memex.Portal.Shared.Test/OrphanedPackageRecordTest.cs
@@ -1,0 +1,181 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>An install record naming a package NO PUBLISHER PRODUCES must be NAMED, and must never
+/// hold (#3706).</b>
+///
+/// <para>memex's install records carried <c>Plugins/Agent</c>, <c>Plugins/Skill</c> and
+/// <c>Plugins/PlatformUI</c> after the packages themselves had gone — Agent and Skill deliberately
+/// (<c>MeshWeaver.Plugins@7afbd745</c>, "remove agents and skill package and serve from the main ai
+/// package"; the AI engine's <c>BuiltInAgentProvider</c>/<c>BuiltInSkillProvider</c> are the live
+/// master). The issue's premise was that their retired floors held every self-update for ever.</para>
+///
+/// <para><b>Half of that premise was already false, and the other half is what this fixes.</b> The
+/// floors stopped deciding anything at #3648 and a missing bake stopped holding at #3651, so
+/// nothing was actually blocking — the sentence quoted as the blocker came from a
+/// <c>heldReason</c> written once, 36 hours before it was read, by a path that no longer runs.
+/// Not holding was right. Saying NOTHING was not: an operator had no way to learn the records were
+/// stale except by reading that frozen field and reaching the wrong conclusion.</para>
+///
+/// <para>These cases pin both halves at once. Asserting only "it does not hold" would pass against
+/// a gate that had never heard of the package — which is precisely the state that made #3706 hard
+/// to diagnose — so every case that asserts <c>IsUpdatable</c> also asserts that the package is
+/// NAMED, and <see cref="AnUnreadableModuleSet_SaysNothing_BecauseNothingWasLookedFor"/> is the
+/// control that stops the advisory degrading into an unconditional sentence.</para>
+/// </summary>
+public class OrphanedPackageRecordTest
+{
+    private const string Identity = "s8055";
+    private static readonly ReleaseTarget Target = new("3.0.0-ci.8195", Identity);
+
+    /// <summary>A module set that WAS read completely and carries only <paramref name="modules"/>.</summary>
+    private static SealedModuleSet SetCarrying(params string[] modules) =>
+        new(modules.ToImmutableDictionary(m => m, m => "mvid:" + new string('a', 32)), [], null);
+
+    private static ReleaseArtifacts Artifacts(SealedModuleSet? modules, params string[] bundles) =>
+        ReleaseArtifacts.Of([.. bundles]) with { Modules = modules };
+
+    /// <summary>The package this instance can never obtain: its module is not in the target's
+    /// sealed set, and no generation of it is landed here.</summary>
+    private static RequiredPackage Orphan(string name) =>
+        new(name, name, MinMeshVersion: "3.0.0", HasContent: false) { ModuleName = "MeshWeaver." + name };
+
+    [Fact]
+    public void APackageNoPublisherProduces_IsNamed_AndDoesNotHold()
+    {
+        var verdict = ReleaseAvailability.IsUpdatable(
+            Target,
+            [Orphan("Agent"), Orphan("Skill"), Orphan("PlatformUI")],
+            Artifacts(SetCarrying("MeshWeaver.AI")));
+
+        // 🚨 Not holding is the point: a roll cannot conjure a build nobody publishes, so waiting
+        // for one waits for ever — the shape #3706 is named after.
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        Assert.Null(verdict.HoldReason);
+        Assert.Empty(verdict.Blockers);
+        Assert.All(verdict.Packages, p => Assert.Equal(PackageAvailabilityKind.Available, p.Kind));
+
+        // 🚨 …and being SILENT about it was the other half of the defect. One orphan advisory per
+        // record, naming the package AND the module, so the operator can act on the record itself.
+        //
+        // Six advisories, not three: each record also declares a 3.0.0 floor the ci target does not
+        // satisfy, and that floor sentence rides BESIDE the orphan one. Asserted deliberately —
+        // the two answer different questions ("this release is older than the module asks for" vs
+        // "nobody publishes this module at all"), and a fix that swallowed the floor advisory while
+        // adding the orphan one would be a regression of #3648 that a total-count assertion of 3
+        // would have called a pass.
+        Assert.Equal(6, verdict.Advisories.Length);
+        var orphanAdvisories = verdict.Advisories
+            .Where(a => a.Contains("no publisher produces it", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Equal(3, orphanAdvisories.Length);
+        foreach (var name in new[] { "Agent", "Skill", "PlatformUI" })
+        {
+            var advisory = Assert.Single(
+                orphanAdvisories, a => a.StartsWith(name + ":", StringComparison.Ordinal));
+            Assert.Contains("MeshWeaver." + name, advisory, StringComparison.Ordinal);
+            // The floor sentence is still there for the same package, untouched.
+            Assert.Contains(
+                verdict.Advisories,
+                a => a.StartsWith(name + ":", StringComparison.Ordinal)
+                     && a.Contains("3.0.0", StringComparison.Ordinal)
+                     && !a.Contains("no publisher produces it", StringComparison.Ordinal));
+            Assert.Contains("no publisher produces it", advisory, StringComparison.Ordinal);
+            Assert.Contains("never a hold", advisory, StringComparison.Ordinal);
+            // The remedy is on the record, not on the roll — the actionable half.
+            Assert.Contains("remove its install record", advisory, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL that keeps the advisory honest. A module set that could not be read means the
+    /// module was never LOOKED for, and "we did not look" must not be worded as "it does not
+    /// exist" — the conflation #1754 forbids one severity up. Without this case the advisory could
+    /// degrade into an unconditional sentence and still pass everything above.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableModuleSet_SaysNothing_BecauseNothingWasLookedFor()
+    {
+        var refused = ReleaseAvailability.IsUpdatable(
+            Target, [Orphan("Agent")],
+            Artifacts(new SealedModuleSet(ImmutableDictionary<string, string>.Empty, [], "a torn module index")));
+
+        Assert.True(refused.IsUpdatable, refused.HoldReason);
+        Assert.DoesNotContain(refused.Advisories, a => a.Contains("no publisher", StringComparison.Ordinal));
+
+        var unobserved = ReleaseAvailability.IsUpdatable(Target, [Orphan("Agent")], Artifacts(null));
+
+        Assert.True(unobserved.IsUpdatable, unobserved.HoldReason);
+        Assert.DoesNotContain(unobserved.Advisories, a => a.Contains("no publisher", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A package the target DOES carry is not an orphan, however retired its declared floor looks.
+    /// This is the case the advisory must not swallow: "3.0.0 floor on a ci target" is the string
+    /// comparison that declined every candidate on every portal on 2026-09-07 (#3648), and it must
+    /// stay a floor advisory rather than becoming a second, wronger sentence.
+    /// </summary>
+    [Fact]
+    public void APackageTheTargetCarries_GetsNoOrphanAdvisory()
+    {
+        var verdict = ReleaseAvailability.IsUpdatable(
+            Target,
+            [new RequiredPackage("AI", "AI", MinMeshVersion: "3.0.0", HasContent: false) { ModuleName = "MeshWeaver.AI" }],
+            Artifacts(SetCarrying("MeshWeaver.AI")));
+
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        Assert.DoesNotContain(verdict.Advisories, a => a.Contains("no publisher", StringComparison.Ordinal));
+        // The floor still rides beside it, unchanged by this work.
+        Assert.Contains(verdict.Advisories, a => a.Contains("3.0.0", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A content-only record has no module to look for, so it takes the bake path and its wording —
+    /// "would recompile at boot" — rather than the orphan sentence. Two different absences, two
+    /// different remedies; conflating them would tell an operator to delete a record that is fine.
+    /// </summary>
+    [Fact]
+    public void AContentOnlyRecordWithNoBake_KeepsTheBakeWording()
+    {
+        var verdict = ReleaseAvailability.IsUpdatable(
+            Target,
+            [new RequiredPackage("Store", "Store", null, HasContent: true)],
+            Artifacts(SetCarrying("MeshWeaver.AI")));
+
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        Assert.Equal(["Store"], verdict.BootCompiles);
+        Assert.DoesNotContain(verdict.Advisories, a => a.Contains("no publisher", StringComparison.Ordinal));
+        Assert.Contains(verdict.Advisories, a => a.Contains("would recompile at boot", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A landed generation is NOT an orphan even when the target publishes no build of it: that is
+    /// the module lane's own case, measured on the bytes by the link probe
+    /// (<c>ModuleLinkState</c>), and it may legitimately end in a HOLD. The orphan advisory must
+    /// not intercept it — the two are told apart by whether anything is landed at all.
+    /// </summary>
+    [Fact]
+    public void ALandedModuleTheTargetDoesNotPublish_StaysWithTheLinkProbe()
+    {
+        var landed = new RequiredPackage("Edu", "Edu", null, HasContent: false)
+        {
+            ModuleName = "MeshWeaver.Edu",
+            LandedModulePath = "/app/modules/MeshWeaver.Edu@7/MeshWeaver.Edu.dll",
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [landed], Artifacts(SetCarrying("MeshWeaver.AI")));
+
+        Assert.DoesNotContain(verdict.Advisories, a => a.Contains("no publisher", StringComparison.Ordinal));
+        // Unmeasured here, so the link lane reports its own "could not be determined" and does not hold.
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        Assert.Contains(verdict.Advisories, a => a.Contains("could not be determined", StringComparison.Ordinal));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ReleaseLinkGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseLinkGateTest.cs
@@ -157,7 +157,16 @@ public class ReleaseLinkGateTest : IDisposable
     }
 
     /// <summary>A module the environment has NOT landed cannot keep running across the roll, so
-    /// there is nothing to measure and nothing to hold on.</summary>
+    /// there is nothing to measure and nothing to hold on.
+    ///
+    /// <para>🚨 This case DOES speak now, and the distinction is the point (#3706). The LINK lane is
+    /// still silent — there are no bytes to link, which is what "is not measured" means and what
+    /// this test is named for. What speaks is the ORPHAN advisory: the target's sealed set does not
+    /// carry the module and nothing is landed, so no publisher produces it. That is a statement
+    /// about the INSTALL RECORD, not about the link, and it neither measures nor holds. The
+    /// assertion moved from "says nothing at all" to "says nothing about the link", because the
+    /// blanket form was written when a link advisory was the only one this lane could emit, and
+    /// blanket emptiness would now re-assert the silence #3706 was filed about.</para></summary>
     [Fact]
     public void AModuleWithNoLandedGeneration_IsNotMeasured()
     {
@@ -167,7 +176,12 @@ public class ReleaseLinkGateTest : IDisposable
             [new RequiredPackage("Views", "Views", HasContent: false) { ModuleName = ViewPack }]);
 
         Assert.True(verdict.IsUpdatable, verdict.HoldReason);
-        Assert.Empty(verdict.Advisories);
+        Assert.DoesNotContain(verdict.Advisories,
+            a => a.Contains("could not be determined", StringComparison.Ordinal)
+                 || a.Contains("cannot load", StringComparison.Ordinal));
+        Assert.Contains(
+            verdict.Advisories,
+            a => a.Contains("no publisher produces it", StringComparison.Ordinal));
     }
 
     // ── Indeterminate is REPORTED — neither clearance nor a hold ───────────────────────────────


### PR DESCRIPTION
## Half of #3706's premise was already false — finding out which half is the fix

The issue reported three install records on memex (`Plugins/Agent`, `Plugins/Skill`, `Plugins/PlatformUI`) as *"holding every self-update forever"*.

### What was already right: nothing was blocking

Floors stopped deciding at [#3648] and a missing bake stopped holding at [#3651], so `IsUpdatable` did **not** hold on those records — and must not. **A roll cannot conjure a build nobody publishes, so waiting for one waits for ever.** The sentence quoted as the blocker came from a `heldReason` written **once, 36 hours before it was read**, by a code path that no longer runs (§7 of `SelfUpdateTargetSelection`).

Agent and Skill were withdrawn **deliberately** — `MeshWeaver.Plugins@7afbd745`, *"remove agents and skill package and serve from the main ai package"*; the AI engine's `BuiltInAgentProvider`/`BuiltInSkillProvider` are the live master. So "no repository publishes them" is intended, not a fault.

### 🚨 What was wrong was the silence

`ModuleLane` returned `(null, null)` for a package with nothing landed. The gate said **nothing at all** about a record it could see was unobtainable, so an operator had no live diagnosis — and that is precisely what sent readers to the frozen field and to the wrong conclusion.

**The absence of a live answer is what makes a dead one authoritative.** A gate that is right not to hold still owes an account of what it saw.

### What it says now

Reported as an orphan when three things hold at once — the record names a **module**, the target's sealed set **does not carry** it, and **nothing is landed** here:

> `Agent: the install record names module MeshWeaver.Agent, which the module set sealed for framework identity s8055 does not carry, and no generation of it is landed on this instance — so no publisher produces it and no roll can obtain it. Reported, never a hold: holding would wait for ever. If the package is genuinely retired, remove its install record; if it moved, the record must name its new home.`

An advisory. The verdict is untouched.

### 🚨 Only when the set was actually read

A null or refused `SealedModuleSet` means the module was never *looked for*, and **"we did not look" must never be worded as "it does not exist"** — the conflation [#1754] forbids one severity up. An advisory firing on an unmeasured set would be a confident sentence about evidence nobody gathered, and it would fire hardest exactly when the observation infrastructure is broken.

### The neighbours it must not swallow

| state | told apart by | remedy |
|---|---|---|
| **Orphan** | nothing landed, not in the sealed set | fix the **record** |
| **Landed but unpublished for the target** | something *is* landed | the **link probe**; may legitimately hold |
| **Content with no bake** | no module to look for | *"would recompile at boot"* — fix the **bake** |
| **Set unreadable/unobserved** | `Modules` null or carrying a `Refusal` | say **nothing** |

### One existing test changed, and why that is correct not convenient

`ReleaseLinkGateTest.AModuleWithNoLandedGeneration_IsNotMeasured` asserted `Assert.Empty(verdict.Advisories)`. Its **subject** — there are no bytes to measure — is unchanged and still asserted (no *link* advisory). Its blanket form was written when a link advisory was the only one this lane could emit; keeping it would have re-asserted the exact silence #3706 is about. It now asserts "no link advisory, **and** the orphan advisory present".

## Verification

- `OrphanedPackageRecordTest` **5/5** — and **red without the change** (the control case fails), so it is not vacuous
- `Memex.Portal.Shared.Test` **1194/1194** on a clean Release `-warnaserror` rebuild
- `DocumentationLinkIntegrityTest` **368/368**

Doc: `SelfUpdateTargetSelection` §8, beside §7's frozen-hold analysis that this completes.

`Pairs-with: none — additive only. No public type or member is removed; the change adds one advisory string to a verdict that already carries an Advisories collection, which breaks no reader.`

Closes #3706

[#1754]: https://github.com/Systemorph/MeshWeaver/issues/1754
[#3648]: https://github.com/Systemorph/MeshWeaver/issues/3648
[#3651]: https://github.com/Systemorph/MeshWeaver/issues/3651
