### PR TITLE
fix: retain bundles by age and released major instead of build count

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -346,6 +346,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Onboarding a New Environment](OnboardingNewEnvironment)
 - [Release & Self-Update Strategy](ReleaseStrategy)
 - [Release Support Policy](/Doc/Architecture/SupportPolicy)
+- [Released Artifact Retention](ReleasedArtifactRetention) — retain artifacts for at least 30 days, supported releases for their support lifetime, and every artifact still needed by a published set or consumer
 - [Self-Update Target Selection](SelfUpdateTargetSelection) — candidates are ranked by the CD run number, not the version string; a mislabelled line outranked every sealed set for ever, and an install on a withdrawn tag could never see anything newer
 - [The Continuous Delivery Contract](ContinuousDeliveryContract) — all-or-nothing publication; verify the image, never the tick
 - [The Self-Update Schema Wall](SelfUpdateSchemaWall) — every schema-bumping release is un-takeable by self-update, the stall is invisible, and a promoted tag is not a deployable tag

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -716,9 +716,10 @@ which is the part that must never drift.
 
 ## Retention: the published store is pruned by REFERENCE, never by age alone
 
-> Maintainer directive, 2026-09-08: *"please also set up a recurring process in memex.systemorph.com
-> to clean up these shares from old releases. typically when final release is out, we can remove all
-> -CI"* — *"let's maybe leave last 10 -CI"*.
+The current policy is the 30-day age window and release/consumer protection contract in
+[Released Artifact Retention](/Doc/Architecture/ReleasedArtifactRetention) (#3842).
+It supersedes the earlier request to keep ten CI builds. Module repositories resolve
+the released platform at run time; retention must not restore platform pins.
 
 Every CI build that publishes a bake adds one `<root>/<identity>/` directory to the store, and until
 this pass nothing ever removed one. Measured 2026-09-08 on memex.systemorph.com through the memex
@@ -729,39 +730,38 @@ silently and reports the failure far from the cause — every runtime NodeType r
 
 ### The rule, stated once for two stores
 
-The same predicate governs this store and the container registry's pinned digests
-([Pinned Image Retention](../PinnedImageRetention), #3438):
+The same required outcome applies to this store and the container registry (#3438):
 
 > **An artifact that anything pins, names, runs or may adopt is kept — regardless of age and
 > regardless of how many newer ones exist. Only an artifact NOTHING references is collected, and an
 > artifact whose references cannot be READ counts as referenced.**
 
-For the registry the references are CI pins; for this store they are the following, each a KEEP,
-ORed together (`PrebuiltBundleStore.Plan`, `MeshWeaver.Hosting`):
+Registry protection must cover advertised last-green sets and their consumers; the
+legacy pin scanner is still a migration component, not that complete inventory. In
+this store the following KEEP rules are ORed (`PrebuiltBundleStore.Plan`, `MeshWeaver.Hosting`):
 
 | # | an identity directory is kept when… | why that is a reference |
 |---|---|---|
 | 1 | it is the framework identity **this process runs** | its own boot and every install-time adoption read it |
-| 2 | a **clean release marker** `_releases/X.Y.Z` names it | a release line stays adoptable forever and is the rollback target |
+| 2 | a **clean release marker** `_releases/X.Y.Z` names it | support has not been established as ended, so official releases stay available |
 | 3 | a NodeType record's **adoption stamp** (`CompiledFrameworkVersion`, written by `PrebuiltAssemblySeeder` and by every local compile) names it | a record was built under it; a re-seed may ask for it again |
-| 3b | a **Deployment record pins it** (`Hosting/Deployment` → `pinnedImageTag`) or a **registered instance reports running it** (`Hosting/ModuleInventory` → `platformVersion` / `frameworkIdentity`), the version mapped to its identity through the `_releases/<version>` marker (`DeploymentPinnedReferences`, `MeshWeaver.PluginCatalog`; any `PinnedPlatformReferenceSource` is unioned) | on the registry a remote instance pulls exactly its OWN identity's seal over the HTTP prebuilt surface — pearl on `3.0.0-ci.8080` sits far outside the newest ten and would compile from source at every boot. A pinned version's marker is never retired either. 🚨 **A pinned version no marker names keeps NOTHING** — nothing can say which directory it would have been — and the ledger line states it: `pins mapping to no marker (keep nothing): Deployment Deployments/x=3.0.0-ci.1` |
-| 4 | it holds, for some source, the **newest sealed publication on the running major line** | exactly what `Modules:VersionStrictness=Family` adopts ([Module Versioning](../ModuleVersioning)) |
-| 5 | a pre-release marker of an **open line** names it and it is among the newest **N** (`KeepNewestPerSource`, default **10**) such identities for some source, by version | the maintainer's "leave the last 10 -CI"; once the clean `X.Y.Z` marker exists the line is CLOSED and this rule keeps none of its `X.Y.Z-ci.<n>` identities |
-| 6 | **no marker names it** and it is among the newest N for some source **by seal time** | nothing can place an unnamed identity on a line, so recency is the only signal it has — such identities are pruned by recency, not by line |
-| 7 | a source under it is **unsealed and younger than the grace** (`UnsealedGrace`, default 2 h) | the publisher writes bundles first and `_complete` last: a young unsealed directory is a seal in flight. A bounded grace is a reference-like signal; an age cutoff on a *sealed* directory would not be, and there is none |
+| 3b | a Deployment reference or registered instance report identifies it, directly or through `_releases/<version>` (`PinnedPlatformReferenceSource`) | running consumers need their adopted version regardless of age; an unresolved version aborts cleanup rather than keeping nothing |
+| 4 | it holds the **newest sealed publication per source for each represented major** | a registry can serve consumers on a different major from its own process; unsealed successors cannot displace this protection |
+| 5 | its newest content write or a release marker naming it is younger than **30 days** (or an explicitly longer `MinimumAge`) | rapid publishing must not delete recent history; this covers sealed and unnamed identities alike |
+| 7 | a source under it is unsealed and younger than `UnsealedGrace` | additional in-flight publication protection; the 30-day floor also applies |
 | 8 | its seal **cannot be read** | unreadable is never unreferenced (the modules GC's #2509 rule) |
 
 Everything else is collected **oldest first, one identity at a time**, each removal logged with the
 bytes reclaimed. The sentinel of every source is deleted before the directory, so a reader that
 lists mid-removal sees "unsealed" and backs off rather than a sealed listing whose bundles are
 vanishing. The `-ci` **markers** of a removed identity — and of an identity already gone for longer
-than the grace — are removed with it, so `_releases/` does not grow forever; a clean release marker
+than the minimum age — are removed with it, so `_releases/` does not grow forever; a clean release marker
 is never removed. The release gates read the same directory
 ([Release Availability Gates](../ReleaseGates)), so a retired `-ci` version simply reads as
 "published no bake" there, which is the truth once its bundles are gone.
 
 **Fail closed, the way `ModuleSetStore.Prune` does.** A store that cannot be listed, or a release
-marker that cannot be read, aborts the pass with nothing collected — which identity an unreadable
+marker that cannot be read, or a consumer version that cannot be resolved, aborts the pass with nothing collected — which identity an unreadable
 marker names is unknown, so no identity can be called unreferenced. The NodeType stamps are read
 from the mesh on every pass (system-scoped, mesh-wide — the pre-warmer's own enumeration); an
 enumeration that cannot be taken aborts that pass too. A removal that fails is counted and the
@@ -785,7 +785,8 @@ blocking filesystem work on the file-system `IIoPool`, never a hub. Then **recur
 | key | default | meaning |
 |---|---|---|
 | `PreWarm:PrebuiltBundleRetention:Delete` | `true` | `false` measures and reports only |
-| `PreWarm:PrebuiltBundleRetention:KeepNewestPerSource` | `10` | rules 5 and 6 |
+| `PreWarm:PrebuiltBundleRetention:MinimumAge` | `30.00:00:00` | may extend the window; values below 30 days cannot shorten it |
+| `PreWarm:PrebuiltBundleRetention:KeepNewestPerSource` | ignored | legacy key retained for compatibility; no count-based cleanup rule |
 | `PreWarm:PrebuiltBundleRetention:UnsealedGrace` | `02:00:00` | rule 7 |
 | `PreWarm:PrebuiltBundleRetention:Interval` | `1.00:00:00` | the recurrence |
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinnedImageRetention.md
@@ -7,6 +7,16 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # Pinned Image Retention
 
+> **Policy superseded by #3842 (2026-09-09).** Module repositories must resolve the
+> released platform at build time, without committed platform pins or staleness gates.
+> This page records the old incident and the protection code still deployed during
+> migration; its statements that every satellite must pin are historical, not guidance
+> to restore pins. The current contract is
+> [Released Artifact Retention](/Doc/Architecture/ReleasedArtifactRetention).
+> Existing locks must not be released merely because de-pinning removes their source
+> declarations. The replacement inventory must first account for published releases,
+> running portals, active builds and supported official releases.
+
 **A container registry's retention policy and a CI pin are two rules about the same bytes, and
 nothing was reconciling them.** On 2026-09-05 the `meshweaver` registry's nightly purge deleted the
 manifests `MeshWeaver.Education`'s `main` pinned. Every run of that repo's `Disposable-mesh gate`

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleasedArtifactRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleasedArtifactRetention.md
@@ -1,0 +1,109 @@
+---
+Name: Released Artifact Retention
+Category: Architecture
+Description: Retain what released sets and their consumers need while cleaning unused continuous artifacts after 30 days.
+---
+
+# Released Artifact Retention
+
+The release contract in #3842 governs retention: module builds resolve a released,
+sealed platform at run time; compatibility follows declared major versions; consumers
+see the last green publication; and portals announce adoption. Retention must preserve
+that behavior through cleanup. It must not reintroduce platform pins to make an
+inventory easier to compute.
+
+## Protection follows use
+
+The publisher identifies the last green set it actually advertises per served major
+and channel. A successful source build alone is insufficient: the set must be sealed
+and released. Failed, cancelled and unfinished publications cannot displace it.
+
+Deployment reports identify the versions actually serving, including the adopted
+same-major fallback. Build records identify the released platform resolved for an
+active run. Official release records identify supported versions and their underlying
+.NET lifecycle. These records identify exact artifacts for storage protection; they
+are not exact-identity compatibility gates.
+
+Expand every protected record to its artifact closure across the registry and bundle
+stores. Include the images and referenced manifests, bundles, release markers and
+restorable source version. A tag retained without its referenced content is a broken
+release, not a retained release. Follow declared dependencies across versions rather
+than constructing a closure from identical tag names.
+
+## Publication and cleanup ordering
+
+Protection must be established and verified before a set is advertised or a build
+starts consuming it. Publication, consumption registration and cleanup must share an
+ordering mechanism that prevents a new reference racing with deletion. Separate nightly
+lock and purge timers do not establish this ordering.
+
+A new publication does not retire the old one until the publisher no longer advertises
+it and consumers no longer need it. A readiness notification does not acknowledge
+adoption by every portal. Missing or stale consumer inventory must prevent deletion;
+it must never silently count as zero consumers. Failed and cancelled builds release
+only their unused consumption records after terminal-state reconciliation.
+
+Unreferenced continuous artifacts become eligible after 30 days. There is no retained
+build-count quota. A last green set may therefore survive much longer than 30 days
+when newer builds fail. A serving fallback also survives regardless of age.
+
+Official releases and their closure remain available throughout support. MeshWeaver
+major support follows the underlying .NET release. Plugin support additionally depends
+on the supported collaboration with its counterparty. Unknown support mappings are
+retained until resolved. End of support alone does not delete a still-consumed release.
+
+## Bundle-store implementation
+
+The portal bundle sweep uses a minimum 30-day age window, keeps adoption stamps and
+reported consumer identities, and protects the latest sealed publication per source
+for every represented major. An unresolved consumer version aborts the sweep.
+`PreWarm:PrebuiltBundleRetention:MinimumAge` may extend the window; values below 30 days
+cannot shorten it. The legacy `KeepNewestPerSource` member and configuration-key
+constant remain for binary/source compatibility but no longer control cleanup.
+
+This is not yet proof of the complete publisher/consumer coordination below. A sealed
+bundle is a local publication signal; the registry's last-green advertised set and
+active builds must still participate in the common protection inventory.
+
+## Transition from the pin scanner
+
+The existing `lock-pinned-digests.py` scans workflow pins and deployment overlays and
+protects official image tags. It does not yet inventory every running portal, released
+module bundle or active build. Its zero-pin assertion is a historical denominator
+check and must be replaced by positive evidence that the new inventories were read
+completely. Removing that assertion alone would not establish protection.
+
+Keep existing protection while consumers migrate. Once the released-set and consumer
+inventories cover the fleet, their coverage replaces source-pin counts; do not restore
+pins or add a pin freshness check. Only reconcile old locks against that complete
+inventory. No pin removal, green build or major-version comparison authorizes an unlock
+on its own.
+
+The files under `.github/acr-retention/` record the cloud tasks last read; they are not
+automatically deployed. The recorded 7-day/count-based CI cleanup is not the desired
+30-day policy. Update the live task only with the coordinated protection path ready,
+a reviewed report-only deletion list, and verification that the superseded task stays
+disabled. Verify the actual purge-tool version enforces age for untagged artifacts and
+preserves referenced manifests. Never include locked manifests in a purge.
+
+## Acceptance evidence
+
+- A last green release older than 30 days survives repeated red and cancelled successors.
+- An older same-major bundle still serving on a portal survives a newer publication.
+- A build resolving a released set concurrently with cleanup cannot consume deleted bytes.
+- Removing every module platform pin leaves complete release/consumer coverage and succeeds;
+  an unreadable inventory fails and permits no deletion.
+- Missing closure members block cleanup; keeping a marker alone never passes.
+- Unreferenced continuous artifacts older than 30 days are eligible; younger artifacts
+  and supported official releases remain protected, without a count quota.
+- A declared major incompatibility affects adoption; it does not delete the old major
+  while that major remains supported or consumed.
+- Terminal-build and completed-adoption reconciliation releases only unused references.
+- The live cleanup and publication use the same ordering mechanism, with no independent
+  purge timer capable of bypassing it.
+
+This is the target contract. The transition is complete only when the publication and
+consumer producers, retention reader and live cleanup satisfy these checks. Policy
+text and a successful legacy pin scan do not prove that cutover happened.
+
+See [Release Support Policy](/Doc/Architecture/SupportPolicy).

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -146,18 +146,24 @@ directory:
 
 ### Retention
 
-A pointer swap must never delete what a reader is mid-way through: a consumer doing N+1 reads may
-have resolved the previous generation seconds ago.
+Follow [Released Artifact Retention](/Doc/Architecture/ReleasedArtifactRetention)
+(#3842). The 30-day age window and release/consumer references supersede the earlier
+24-hour previous-generation grace proposal.
 
-- Never delete the generation `_current` names.
-- Keep the previous generation for at least as long as the slowest consumer's N+1 read plus its
-  backoff. The `503` ladder is `15 30 60 90`, so **24 hours** is a bound with three orders of
-  magnitude of headroom and no measurable storage cost at ~43 files per publication.
-- The sweep is the **publisher's**, at the end of its own run, after the pointer moves. Nothing else
-  knows when a publication stopped applying.
-- 🚨 A retention sweep is not a garbage collector to be tuned down when the share fills. Deleting a
-  generation a reader still holds re-creates a torn read — which is the state this layout exists to
-  make impossible.
+- Preserve the generation `_current` advertises and every generation still consumed,
+  including a same-major adopted fallback. A pointer swap does not prove that all
+  readers or portals have finished with the old generation.
+- Unreferenced continuous generations become eligible after 30 days. Supported
+  official releases and their complete artifact closure survive throughout support.
+- Publication must establish protection before moving `_current`. Generation cleanup
+  must participate in the same publication/consumer ordering as other artifact cleanup;
+  running an independent purge after a pointer swap is insufficient.
+- Missing consumer or publication inventory prevents deletion. A retry/backoff duration
+  is not an adoption lifetime and cannot authorize collecting a serving fallback.
+
+This is the cleanup contract to implement with the release inventory. The identity-level
+bundle sweep never reaches inside a retained identity and therefore does not itself
+prove that generation-level protection and collection are implemented.
 
 ## Who actually publishes — measured, 2026-09-07
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SupportPolicy.md
@@ -47,13 +47,49 @@ a count of newer releases. An unknown runtime mapping or support date is not evi
 that a release is unsupported; resolve it before deleting its artifacts.
 
 End of support ends this retention guarantee; it does not itself issue a deletion.
-Any later cleanup must still respect deployment pins and other active references.
+Any later cleanup must still respect running deployments, active builds and other active references.
 
 ## Continuous build artifacts
 
 Use regular age-based cleanup for continuous build artifacts, with a 30-day retention
-window rather than a quota of newer builds. Exclude active deployment and CI pins,
-supported official releases, and the artifacts those releases reference.
+window rather than a quota of newer builds. Age alone never makes an artifact eligible
+while it is still needed by a published release, a running deployment or an active build.
+
+Module repositories resolve the released, sealed platform at build time; they do not
+carry a platform pin or a staleness gate. Retention must therefore derive protection
+from publication and consumption records, not require pins to exist in source control.
+Compatibility follows declared major versions: a same-major adopted module can keep
+serving while its successor is pending. An exact build identity remains useful for
+locating and retaining bytes; it must not become a compatibility refusal.
+
+Protect the complete artifact closure of:
+
+- The last green released set available to consumers for each served major/channel.
+  A red, cancelled or merely unsealed newer build does not replace that set.
+- The versions actually adopted by running portals, including a same-major fallback
+  still serving while a replacement is being prepared.
+- The released set resolved by an active build, and a publication being prepared for
+  exposure to consumers.
+- Supported official releases, regardless of whether a portal currently uses them.
+
+The closure includes container manifests and their referenced images, sealed module
+bundles, release records and the sources needed to install or restore the release.
+Resolve it from the publication records rather than assuming all dependencies have
+matching version strings. Never keep a tag or marker while deleting the bytes it names.
+
+Protect a set before advertising it or letting a build consume it. Reconcile these
+references with cleanup under one ordering contract so a new reference cannot appear
+between the cleanup inventory and deletion. Keep the previous set protected until it
+is no longer advertised or consumed; publishing a successor is not evidence that every
+portal adopted it. Announcing readiness is a notification, not proof that the old
+version is unused.
+
+An unavailable deployment report, incomplete publication inventory or unresolved
+artifact prevents deletion. Explicitly reported zero CI pins is valid after migration;
+it is neither evidence of an empty protected set nor permission to unlock old images.
+Legacy references remain protected during migration until their consumers are accounted
+for. See [Released Artifact Retention](/Doc/Architecture/ReleasedArtifactRetention) for
+the transition and its verification requirements.
 
 The image-protection script treats clean version tags in the image repositories
 promoted by MeshWeaver's official release workflow as official releases, even when

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-bundle-retention-follows-released-versions.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-bundle-retention-follows-released-versions.md
@@ -1,0 +1,14 @@
+---
+Name: Bundle cleanup preserves released versions
+Category: Fix
+Description: Bundle cleanup keeps 30 days of history and protects adopted versions while newer releases are prepared.
+Icon: Sparkle
+Order: -20260909
+---
+
+# Bundle cleanup preserves released versions
+
+Publishing many builds no longer removes recent bundles through a build-count limit.
+Unused bundles stay for at least 30 days. Adopted versions, official releases and the
+latest sealed bundle for each major version remain protected regardless of age.
+Cleanup stops when a reported consumer version cannot be resolved.

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
@@ -20,24 +20,19 @@ namespace MeshWeaver.Hosting;
 /// </summary>
 public sealed record PrebuiltBundleRetention
 {
-    /// <summary>The shipped default: deletion armed, ten pre-release identities per source and open line.</summary>
+    /// <summary>The shipped default: retain unused continuous artifacts for 30 days.</summary>
     public static readonly PrebuiltBundleRetention Default = new();
 
     /// <summary>
-    /// How many of the newest pre-release (<c>X.Y.Z-ci.&lt;n&gt;</c>) identities to keep per source
-    /// on a line that has no clean release yet — the maintainer's "leave the last 10 -ci"
-    /// (2026-09-08). The same count bounds the unnamed identities (no release marker at all),
-    /// which nothing can place on a line and which are therefore kept by seal time alone.
+    /// Compatibility member for callers compiled against the former count-based policy.
+    /// This value no longer affects retention; cleanup uses <see cref="MinimumAge"/>.
     /// </summary>
     public int KeepNewestPerSource { get; init; } = 10;
 
-    /// <summary>
-    /// How long an UNSEALED source directory (no <see cref="ShippedPrebuiltBundles.CompletionSentinelFileName"/>)
-    /// is presumed to be a seal in flight. The publisher writes the bundles first and the sentinel
-    /// strictly last, so a young unsealed directory is a publication being written; an old one is
-    /// a publish that died. A bounded grace is a reference-like signal — an age cutoff on a SEALED
-    /// directory would not be, and none exists here.
-    /// </summary>
+    /// <summary>The minimum age of unreferenced artifacts before cleanup. Values below 30 days are clamped.</summary>
+    public TimeSpan MinimumAge { get; init; } = TimeSpan.FromDays(30);
+
+    /// <summary>Additional protection for an unsealed publication in flight, beyond the minimum age.</summary>
     public TimeSpan UnsealedGrace { get; init; } = TimeSpan.FromHours(2);
 
     /// <summary>How often the recurring pass runs after the boot pass.</summary>
@@ -108,7 +103,7 @@ public static class PlatformVersionLine
 /// reported platform version / framework identity. On the registry (memex-cloud) remote
 /// instances fetch their OWN identity's seal over the HTTP prebuilt surface, so such an identity
 /// is referenced however old it is — pearl pinned to <c>3.0.0-ci.8080</c> would otherwise fall
-/// outside the newest-ten rule and compile from source at every boot.
+/// outside the age window and lose its bundle at the next boot.
 /// </summary>
 /// <param name="Origin">Who pins it — the record or instance, for the ledger.</param>
 /// <param name="Version">The pinned platform version or image tag (normalised by <see cref="PlatformVersionLine.Normalize"/>), or null.</param>
@@ -189,7 +184,7 @@ public sealed record PrebuiltStoreScan(
 /// <param name="Protected">Why each surviving identity survived, keyed by identity.</param>
 /// <param name="CollectableMarkers">The pre-release markers whose identity goes with this plan, or is already gone.</param>
 /// <param name="AbortReason">Why NOTHING may be collected, or null when the plan is sound.</param>
-/// <param name="UnresolvedPins">Pinned references whose version maps to no <c>_releases</c> marker and that name no identity — they keep nothing, and the ledger says so.</param>
+/// <param name="UnresolvedPins">Pinned references whose version maps to no <c>_releases</c> marker and that name no identity — they abort cleanup because the consumer inventory is incomplete.</param>
 public sealed record PrebuiltBundleSweepPlan(
     string LiveIdentity,
     string? LivePlatformVersion,
@@ -211,7 +206,7 @@ public sealed record PrebuiltBundleSweepPlan(
         $"{Identities.Count} identity directory(ies) / {Mb(TotalBytes)} — live={LiveIdentity}"
         + $" ({LivePlatformVersion ?? "version unknown"}), collectable={Collectable.Count} / {Mb(CollectableBytes)}"
         + $", markers to retire={CollectableMarkers.Count}"
-        + (UnresolvedPins.IsEmpty ? "" : $", pins mapping to no marker (keep nothing): {string.Join(", ", UnresolvedPins)}")
+        + (UnresolvedPins.IsEmpty ? "" : $", unresolved consumer references (cleanup blocked): {string.Join(", ", UnresolvedPins)}")
         + (AbortReason is null ? "" : $", ABORTED: {AbortReason}");
 
     internal static string Mb(long bytes) =>
@@ -265,19 +260,13 @@ public sealed record PrebuiltBundleSweepResult(
 /// <list type="number">
 /// <item>it is the framework identity <b>this process runs</b>;</item>
 /// <item>a <b>clean release marker</b> (<c>_releases/X.Y.Z</c>, no pre-release label) names it —
-/// a release line stays adoptable forever, and it is the rollback target;</item>
+/// support has not been established as ended, so the release stays available;</item>
 /// <item>a <b>NodeType record's adoption stamp</b> (<c>CompiledFrameworkVersion</c>, written by
 /// <c>PrebuiltAssemblySeeder</c> and by every local compile) names it;</item>
-/// <item>it holds, for some source, the <b>newest sealed publication on the running major line</b> —
+/// <item>it holds, for some source, the <b>newest sealed publication on each represented major line</b> —
 /// exactly what <c>Modules:VersionStrictness=Family</c> adopts at boot;</item>
-/// <item>a pre-release marker of an <b>OPEN line</b> names it (a line with no clean release yet) and
-/// it is among the newest <see cref="PrebuiltBundleRetention.KeepNewestPerSource"/> such identities
-/// for some source, by version — once the clean <c>X.Y.Z</c> marker exists, every
-/// <c>X.Y.Z-ci.&lt;n&gt;</c> identity of that line is unreferenced by this rule (maintainer,
-/// 2026-09-08: <i>"when final release is out, we can remove all -CI … leave last 10"</i>);</item>
-/// <item>no marker names it at all and it is among the newest <see cref="PrebuiltBundleRetention.KeepNewestPerSource"/>
-/// such identities for some source <b>by seal time</b> — nothing can place an unnamed identity on
-/// a line, so recency is the only signal it has;</item>
+/// <item>its newest content write or release marker is younger than
+/// <see cref="PrebuiltBundleRetention.MinimumAge"/> (at least 30 days), regardless of build count;</item>
 /// <item>a source under it is <b>unsealed and younger than <see cref="PrebuiltBundleRetention.UnsealedGrace"/></b>
 /// — a seal in flight;</item>
 /// <item>its seal <b>could not be read</b> — unreadable is never unreferenced.</item>
@@ -285,7 +274,7 @@ public sealed record PrebuiltBundleSweepResult(
 ///
 /// <para>Everything else is collected, oldest first, one identity at a time, each removal logged
 /// with the bytes reclaimed. The pre-release markers of a removed identity (and of an identity
-/// already gone for longer than the grace) are removed with it, so <c>_releases/</c> does not grow
+/// already gone for longer than the age window) are removed with it, so <c>_releases/</c> does not grow
 /// forever; a clean release marker is never removed. A release marker that cannot be read, or a
 /// store that cannot be listed, ABORTS the sweep with nothing collected: a partial picture licenses
 /// no deletion. This sweep is IDENTITY-level; the per-source generation retention that follows a
@@ -433,15 +422,6 @@ public static class PrebuiltBundleStore
             .Where(m => !m.IsPrerelease)
             .GroupBy(m => m.Identity!, StringComparer.Ordinal)
             .ToImmutableDictionary(g => g.Key, g => string.Join(", ", g.Select(m => m.Version)), StringComparer.Ordinal);
-        var closedLines = readable.Where(m => !m.IsPrerelease).Select(m => m.Line).Where(l => l is not null)
-            .Select(l => l!).ToImmutableHashSet(StringComparer.Ordinal);
-        var openLines = readable.Where(m => m.IsPrerelease).Select(m => m.Line).Where(l => l is not null && !closedLines.Contains(l))
-            .Select(l => l!).ToImmutableHashSet(StringComparer.Ordinal);
-        var linesOf = readable.Where(m => m.IsPrerelease && m.Line is not null)
-            .GroupBy(m => m.Identity!, StringComparer.Ordinal)
-            .ToImmutableDictionary(g => g.Key, g => g.Select(m => m.Line!).ToImmutableHashSet(StringComparer.Ordinal),
-                StringComparer.Ordinal);
-
         var reasons = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
         void Keep(string identity, string reason)
         {
@@ -451,8 +431,8 @@ public static class PrebuiltBundleStore
 
         var sources = scan.Identities.SelectMany(i => i.Sources.Where(s => s.IsSealed).Select(s => s.Name))
             .Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(s => s, StringComparer.OrdinalIgnoreCase).ToList();
-        var liveMajor = PrebuiltAdoptionPolicy.MajorOf(livePlatformVersion);
-        var keep = Math.Max(0, retention.KeepNewestPerSource);
+        var minimumAge = retention.MinimumAge < TimeSpan.FromDays(30)
+            ? TimeSpan.FromDays(30) : retention.MinimumAge;
 
         // version (marker file name, normalised) → every identity a marker of that version names.
         var identitiesOfVersion = readable
@@ -478,6 +458,12 @@ public static class PrebuiltBundleStore
                 unresolvedPins.Add($"{pin.Origin}={version ?? "(no version)"}");
         }
 
+        if (unresolvedPins.Count > 0)
+            return new PrebuiltBundleSweepPlan(liveIdentity, livePlatformVersion, scan.Identities,
+                [], ImmutableDictionary<string, string>.Empty, [],
+                "consumer references could not be resolved; the protected inventory is incomplete",
+                unresolvedPins.ToImmutable());
+
         foreach (var identity in scan.Identities)
         {
             if (string.Equals(identity.Identity, liveIdentity, StringComparison.Ordinal))
@@ -499,35 +485,25 @@ public static class PrebuiltBundleStore
                 .Where(i => i.Sources.Any(s => s.IsSealed && string.Equals(s.Name, source, StringComparison.OrdinalIgnoreCase)))
                 .ToList();
 
-            // 4. what Family strictness adopts: the newest sealed publication on the running line.
-            if (liveMajor is { } major)
+            // Preserve the newest sealed publication for every represented major, including
+            // consumers running a different major than this registry process (#3842).
+            foreach (var family in sealedHere
+                         .Where(i => newestVersionOf.ContainsKey(i.Identity))
+                         .GroupBy(i => PrebuiltAdoptionPolicy.MajorOf(newestVersionOf[i.Identity]))
+                         .Where(g => g.Key is not null))
             {
-                var family = sealedHere
-                    .Where(i => newestVersionOf.TryGetValue(i.Identity, out var v) && PrebuiltAdoptionPolicy.MajorOf(v) == major)
-                    .OrderByDescending(i => newestVersionOf[i.Identity], comparer)
-                    .FirstOrDefault();
-                if (family is not null)
-                    Keep(family.Identity,
-                        $"the newest sealed '{source}' publication on platform line {major} ({newestVersionOf[family.Identity]}) — what Family strictness adopts");
+                var latest = family.OrderByDescending(i => newestVersionOf[i.Identity], comparer).First();
+                Keep(latest.Identity,
+                    $"the newest sealed '{source}' publication on platform major {family.Key} ({newestVersionOf[latest.Identity]}) — what Family strictness adopts");
             }
-
-            // 5. the newest N pre-release identities of every OPEN line.
-            foreach (var line in openLines.OrderBy(l => l, StringComparer.Ordinal))
-                foreach (var kept in sealedHere
-                             .Where(i => linesOf.TryGetValue(i.Identity, out var lines) && lines.Contains(line))
-                             .OrderByDescending(i => newestVersionOf[i.Identity], comparer)
-                             .Take(keep))
-                    Keep(kept.Identity,
-                        $"among the newest {keep} sealed '{source}' publications of open line {line} ({newestVersionOf[kept.Identity]})");
-
-            // 6. unnamed identities: recency by seal time is the only signal they have.
-            foreach (var kept in sealedHere
-                         .Where(i => !newestVersionOf.ContainsKey(i.Identity))
-                         .OrderByDescending(i => i.Sources.First(s => s.IsSealed && string.Equals(s.Name, source, StringComparison.OrdinalIgnoreCase)).SealUtc)
-                         .Take(keep))
-                Keep(kept.Identity,
-                    $"no release marker names it; among the newest {keep} sealed '{source}' publications by seal time");
         }
+
+        // An age window applies to sealed, unnamed and abandoned publications alike.
+        // A recent marker is also a publication reference: old bytes can just have been released.
+        foreach (var identity in scan.Identities)
+            if (nowUtc - identity.NewestWriteUtc < minimumAge
+                || readable.Any(m => m.Identity == identity.Identity && nowUtc - m.WrittenUtc < minimumAge))
+                Keep(identity.Identity, $"within the {minimumAge.TotalDays:N0}-day retention window");
 
         // 7. a seal in flight.
         foreach (var identity in scan.Identities)
@@ -556,7 +532,7 @@ public static class PrebuiltBundleStore
             .Where(m => !pinnedVersions.Contains(PlatformVersionLine.Normalize(m.Version) ?? m.Version)
                         && !pinnedReasons.ContainsKey(m.Identity!))
             .Where(m => collectableIdentities.Contains(m.Identity!)
-                        || (!present.Contains(m.Identity!) && nowUtc - m.WrittenUtc >= retention.UnsealedGrace))
+                        || (!present.Contains(m.Identity!) && nowUtc - m.WrittenUtc >= minimumAge))
             .ToImmutableList();
 
         return new PrebuiltBundleSweepPlan(

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetentionHostedService.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetentionHostedService.cs
@@ -85,10 +85,10 @@ public sealed class PrebuiltBundleRetentionHostedService(
             return Task.CompletedTask;
         }
         logger.LogInformation(
-            "PrebuiltBundleRetention: sweeping {Root} at boot and every {Interval}; keeps the newest {Keep} "
-            + "pre-release identity(ies) per source and open line, {Grace} grace for an unsealed publication, "
+            "PrebuiltBundleRetention: sweeping {Root} at boot and every {Interval}; keeps unreferenced artifacts for at least {MinimumAge}, "
+            + "{Grace} grace for an unsealed publication, "
             + "collection {Armed}",
-            root, retention.Interval, retention.KeepNewestPerSource, retention.UnsealedGrace,
+            root, retention.Interval, retention.MinimumAge, retention.UnsealedGrace,
             retention.Delete ? "ARMED" : "NOT armed (report only)");
         startedRegistration = lifetime.ApplicationStarted.Register(() => KickSchedule(root));
         return Task.CompletedTask;
@@ -199,8 +199,11 @@ public static class PrebuiltBundleRetentionExtensions
     /// <summary>Config key disarming DELETION (<c>false</c> ⇒ report only). Default <c>true</c>.</summary>
     public const string DeleteConfigKey = "PreWarm:PrebuiltBundleRetention:Delete";
 
-    /// <summary>Config key overriding how many newest pre-release identities are kept per source and open line.</summary>
+    /// <summary>Legacy count key retained for caller compatibility; it no longer changes retention.</summary>
     public const string KeepNewestPerSourceConfigKey = "PreWarm:PrebuiltBundleRetention:KeepNewestPerSource";
+
+    /// <summary>Config key extending the minimum artifact age beyond 30 days.</summary>
+    public const string MinimumAgeConfigKey = "PreWarm:PrebuiltBundleRetention:MinimumAge";
 
     /// <summary>Config key overriding the grace (a <see cref="TimeSpan"/> string) an unsealed publication is presumed in flight.</summary>
     public const string UnsealedGraceConfigKey = "PreWarm:PrebuiltBundleRetention:UnsealedGrace";
@@ -230,8 +233,8 @@ public static class PrebuiltBundleRetentionExtensions
         var retention = PrebuiltBundleRetention.Default;
         if (bool.TryParse(configuration[DeleteConfigKey], out var delete))
             retention = retention with { Delete = delete };
-        if (int.TryParse(configuration[KeepNewestPerSourceConfigKey], out var keep) && keep >= 0)
-            retention = retention with { KeepNewestPerSource = keep };
+        if (TimeSpan.TryParse(configuration[MinimumAgeConfigKey], out var age) && age >= TimeSpan.FromDays(30))
+            retention = retention with { MinimumAge = age };
         if (TimeSpan.TryParse(configuration[UnsealedGraceConfigKey], out var grace) && grace > TimeSpan.Zero)
             retention = retention with { UnsealedGrace = grace };
         if (TimeSpan.TryParse(configuration[IntervalConfigKey], out var interval) && interval > TimeSpan.Zero)

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
@@ -63,7 +63,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
         Directory.CreateDirectory(dir);
         var path = Path.Combine(dir, version);
         File.WriteAllText(path, identity + "\n");
-        File.SetLastWriteTimeUtc(path, (writtenAt ?? Now - TimeSpan.FromDays(10)).UtcDateTime);
+        File.SetLastWriteTimeUtc(path, (writtenAt ?? Now - TimeSpan.FromDays(100)).UtcDateTime);
         return path;
     }
 
@@ -83,7 +83,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
     {
         Sealed(Live, "plugins", DaysAgo(400));
         Sealed("s-old", "plugins", DaysAgo(400));
-        // Two newer unnamed publications take the whole recency budget, so nothing but rule 1 keeps Live.
+        // Only the running-identity rule keeps the old live publication.
         Sealed("s-u1", "plugins", DaysAgo(2));
         Sealed("s-u2", "plugins", DaysAgo(3));
 
@@ -98,6 +98,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
     [Fact]
     public void AnIdentityNamedByACleanReleaseMarker_IsKept_AndItsCiSiblingsOfThatLineGo()
     {
+        Marker("3.1.0-ci.9000", Live);
         Marker("3.0.0", "s-release"); Sealed("s-release", "plugins", DaysAgo(300));
         Marker("3.0.0-ci.10", "s-ci10"); Sealed("s-ci10", "plugins", DaysAgo(320));
         Marker("3.0.0-ci.20", "s-ci20"); Sealed("s-ci20", "plugins", DaysAgo(310));
@@ -115,14 +116,14 @@ public class PrebuiltBundleRetentionTest : IDisposable
     }
 
     [Fact]
-    public void AnOpenLine_KeepsItsNewestNCiIdentities_PerSource_ByVersionNotByText()
+    public void EachMajor_KeepsItsLatestSealedPublicationPerSource_AndRecentArtifactsWithoutACountQuota()
     {
         Sealed(Live, "plugins", DaysAgo(1));
         // ci.900 sorts above ci.3758 as TEXT; by version it is the oldest.
         Marker("3.1.0-ci.900", "s-900"); Sealed("s-900", "plugins", DaysAgo(30));
         Marker("3.1.0-ci.3758", "s-3758"); Sealed("s-3758", "plugins", DaysAgo(20));
         Marker("3.1.0-ci.4000", "s-4000"); Sealed("s-4000", "plugins", DaysAgo(10));
-        // A different source on the same line has its own budget.
+        // Preserve each source's latest sealed publication even beyond 30 days.
         Marker("3.1.0-ci.50", "s-edu50"); Sealed("s-edu50", "education", DaysAgo(40));
 
         var plan = PlanNow(liveVersion: "4.0.0-ci.1");
@@ -137,7 +138,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
     [Fact]
     public void TheNewestSealedPublicationOnTheRunningLine_IsKept_BecauseFamilyStrictnessAdoptsIt()
     {
-        // Line 3.0.0 is closed and the budget is spent on line 3.2.0 — only the Family rule keeps s-fam.
+        // The older education publication is still its source's latest on this major.
         Marker("3.0.0", "s-rel"); Sealed("s-rel", "plugins", DaysAgo(200));
         Marker("3.0.0-ci.5", "s-fam"); Sealed("s-fam", "education", DaysAgo(150));
         Marker("3.2.0-ci.1", "s-a"); Sealed("s-a", "plugins", DaysAgo(3));
@@ -156,7 +157,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
         Sealed(Live, "plugins", DaysAgo(1));
         Sealed("s-stamped", "plugins", DaysAgo(500));
         Sealed("s-forgotten", "plugins", DaysAgo(600));
-        // The unnamed recency budget (2) goes to Live and this one, so only the stamp keeps s-stamped.
+        // Only the adoption stamp keeps the old stamped publication.
         Sealed("s-recent", "plugins", DaysAgo(2));
 
         var plan = PlanNow(stamps: ["s-stamped"]);
@@ -166,7 +167,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
     }
 
     [Fact]
-    public void UnnamedIdentities_AreKeptByRecencyOnly_TheNewestNPerSourceBySealTime()
+    public void UnnamedIdentities_KeepThirtyDays_RegardlessOfNewerBuildCount()
     {
         Sealed(Live, "plugins", DaysAgo(1));
         Sealed("s-u1", "plugins", DaysAgo(30));
@@ -175,9 +176,10 @@ public class PrebuiltBundleRetentionTest : IDisposable
 
         var plan = PlanNow();
 
-        // Budget 2 by seal time: Live (1 day) and s-u3 (10 days); s-u2 and s-u1 are older and go.
-        plan.Protected[ "s-u3"].Should().Contain("no release marker names it");
-        Ids(plan).Should().Equal("s-u1", "s-u2");
+        // Only the artifact at the 30-day boundary is eligible; newer count is irrelevant.
+        plan.Protected[ "s-u3"].Should().Contain("30-day retention window");
+        plan.Protected.Keys.Should().Contain("s-u2");
+        Ids(plan).Should().Equal("s-u1");
     }
 
     [Fact]
@@ -185,11 +187,11 @@ public class PrebuiltBundleRetentionTest : IDisposable
     {
         Sealed(Live, "plugins", DaysAgo(1));
         Unsealed("s-inflight", "plugins", Now - TimeSpan.FromMinutes(5));
-        Unsealed("s-dead", "plugins", DaysAgo(3));
+        Unsealed("s-dead", "plugins", DaysAgo(40));
 
         var plan = PlanNow();
 
-        plan.Protected[ "s-inflight"].Should().Contain("in flight");
+        plan.Protected[ "s-inflight"].Should().Contain("30-day retention window");
         Ids(plan).Should().Equal("s-dead");
     }
 
@@ -202,6 +204,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
     [Fact]
     public void AnIdentityADeploymentRecordPins_IsKept_ViaItsReleaseMarker_RegardlessOfLineAndRecency()
     {
+        Marker("3.1.0-ci.9000", Live);
         Sealed(Live, "plugins", DaysAgo(1));
         Marker("3.0.0", "s-rel"); Sealed("s-rel", "plugins", DaysAgo(100));
         Marker("3.0.0-ci.8080", "s-8080"); Sealed("s-8080", "plugins", DaysAgo(120));
@@ -235,7 +238,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
     }
 
     [Fact]
-    public void APinnedVersionNoMarkerNames_KeepsNothing_AndTheLedgerSaysSo()
+    public void AConsumerVersionNoMarkerNames_AbortsCleanup_AndTheLedgerSaysSo()
     {
         Sealed(Live, "plugins", DaysAgo(1));
         Sealed("s-old", "plugins", DaysAgo(500));
@@ -245,11 +248,12 @@ public class PrebuiltBundleRetentionTest : IDisposable
         var plan = PlanNow(pinned: pinned);
 
         plan.UnresolvedPins.Should().Equal("Deployment Deployments/ghost=3.0.0-ci.1");
-        Ids(plan).Should().Equal("s-old");
+        plan.AbortReason.Should().Contain("inventory is incomplete");
+        Ids(plan).Should().BeEmpty();
 
         var result = PrebuiltBundleStore.SweepCore(root, Live, "3.1.0-ci.9000", [], pinned, retention with { Delete = false }, Now);
         File.ReadAllText(PrebuiltBundleStore.LedgerPathOf(root))
-            .Should().Contain("pins mapping to no marker (keep nothing): Deployment Deployments/ghost=3.0.0-ci.1");
+            .Should().Contain("unresolved consumer references (cleanup blocked): Deployment Deployments/ghost=3.0.0-ci.1");
         result.Plan!.UnresolvedPins.Should().HaveCount(1);
     }
 
@@ -312,11 +316,12 @@ public class PrebuiltBundleRetentionTest : IDisposable
     [Fact]
     public void SweepCore_RemovesOnlyTheCollectable_OldestFirst_AndRetiresTheirMarkers()
     {
+        Marker("3.1.0-ci.9000", Live);
         Sealed(Live, "plugins", DaysAgo(1));
         Marker("3.0.0", "s-rel"); Sealed("s-rel", "plugins", DaysAgo(200));
         Marker("3.0.0-ci.1", "s-c1"); Sealed("s-c1", "plugins", DaysAgo(230), bytes: 4096);
         Marker("3.0.0-ci.2", "s-c2"); Sealed("s-c2", "plugins", DaysAgo(220), bytes: 2048);
-        Unsealed("s-dead", "plugins", DaysAgo(5));
+        Unsealed("s-dead", "plugins", DaysAgo(40));
         // A -ci marker whose identity is long gone retires as well — _releases must not grow forever.
         Marker("3.0.0-ci.0", "s-gone");
         // …but a young dangling marker may precede its bundles (the publisher writes it per run).
@@ -337,7 +342,7 @@ public class PrebuiltBundleRetentionTest : IDisposable
 
         var markers = Directory.GetFiles(Path.Combine(root, SealedPublicationIndex.ReleaseMarkerDirectoryName))
             .Select(Path.GetFileName).OrderBy(n => n).ToArray();
-        markers.Should().Equal("3.0.0", "3.0.0-ci.3");
+        markers.Should().Equal("3.0.0", "3.0.0-ci.3", "3.1.0-ci.9000");
         result.DeletedMarkers.Should().Be(3);
 
         var ledger = File.ReadAllLines(PrebuiltBundleStore.LedgerPathOf(root));
@@ -390,6 +395,57 @@ public class PrebuiltBundleRetentionTest : IDisposable
         result.AbortReason.Should().Contain("does not exist");
     }
 
+    [Fact]
+    public void MoreThanTenNewerBuilds_CannotCollectARecentBundle()
+    {
+        Sealed("s-recent", "plugins", DaysAgo(29));
+        for (var i = 0; i < 20; i++)
+            Sealed($"s-new-{i}", "plugins", DaysAgo(1));
+        Sealed("s-expired", "plugins", DaysAgo(31));
+
+        Ids(PlanNow()).Should().Equal("s-expired");
+    }
+
+    [Fact]
+    public void ARecentPublicationMarker_ProtectsOlderBytes()
+    {
+        Sealed("s-republished", "plugins", DaysAgo(100));
+        Marker("3.0.0-ci.1", "s-republished", DaysAgo(1));
+        Sealed("s-newer", "plugins", DaysAgo(100));
+        Marker("3.0.0-ci.2", "s-newer");
+
+        PlanNow().Protected.Keys.Should().Contain("s-republished");
+    }
+
+    [Fact]
+    public void AReportedFallback_SurvivesANewerSameMajorPublication()
+    {
+        Sealed("s-fallback", "plugins", DaysAgo(100));
+        Marker("3.0.0-ci.1", "s-fallback");
+        Sealed("s-newer", "plugins", DaysAgo(90));
+        Marker("3.0.0-ci.2", "s-newer");
+
+        var plan = PlanNow(pinned: [new PinnedPlatformReference("adopted fallback", null, "s-fallback")]);
+
+        plan.Protected.Keys.Should().Contain("s-fallback");
+        plan.Protected.Keys.Should().Contain("s-newer");
+        Ids(plan).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnUnsealedSuccessor_DoesNotDisplaceTheLastSealedPublication()
+    {
+        Sealed("s-green", "plugins", DaysAgo(100));
+        Marker("3.0.0-ci.1", "s-green");
+        Unsealed("s-failed", "plugins", DaysAgo(50));
+        Marker("3.0.0-ci.2", "s-failed");
+
+        var plan = PlanNow(liveVersion: "4.0.0-ci.1");
+
+        plan.Protected.Keys.Should().Contain("s-green");
+        Ids(plan).Should().Equal("s-failed");
+    }
+
     // ---- version lines ------------------------------------------------------------------------
 
     [Theory]
@@ -402,6 +458,27 @@ public class PrebuiltBundleRetentionTest : IDisposable
     {
         PlatformVersionLine.LineOf(version).Should().Be(line);
         PlatformVersionLine.IsPrerelease(version).Should().Be(prerelease);
+    }
+
+    [Theory]
+    [InlineData("00:00:00", 30)]
+    [InlineData("1.00:00:00", 30)]
+    [InlineData("30.00:00:00", 30)]
+    [InlineData("60.00:00:00", 60)]
+    public void Configuration_CanExtendButCannotShortenTheThirtyDayWindow(string age, int days)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new System.Collections.Generic.Dictionary<string, string?>
+            {
+                [PrebuiltBundleRetentionExtensions.MinimumAgeConfigKey] = age,
+                [PrebuiltBundleRetentionExtensions.KeepNewestPerSourceConfigKey] = "0",
+            }).Build();
+
+        var configured = PrebuiltBundleRetentionExtensions.FromConfiguration(configuration);
+        configured.MinimumAge.Should().Be(TimeSpan.FromDays(days));
+        Sealed("s-recent", "plugins", DaysAgo(29));
+        PrebuiltBundleStore.Plan(Live, null, PrebuiltBundleStore.Scan(root), [], [], configured, Now)
+            .Collectable.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/MeshWeaver.Hosting.Test/SealedPublicationLineageTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SealedPublicationLineageTest.cs
@@ -162,7 +162,7 @@ public class SealedPublicationLineageTest : IDisposable
             // unrelated reason and make the ordering assertion below unfalsifiable.
             pinned: [],
             retention: new PrebuiltBundleRetention { KeepNewestPerSource = 1 },
-            nowUtc: At(10));
+            nowUtc: At(10).AddDays(31));
 
     private static DateTimeOffset At(int hours) =>
         new DateTimeOffset(2026, 9, 8, 0, 0, 0, TimeSpan.Zero).AddHours(hours);


### PR DESCRIPTION
Bundle cleanup previously kept a fixed number of pre-release builds, so rapid publishing could collect bundles younger than 30 days. It also protected the latest same-major publication only for the registry process's own major, and continued cleanup when a consumer version could not be resolved.

Use a minimum 30-day age window without a build-count quota. Preserve the latest sealed publication per source for every represented major, adoption stamps, reported consumer references and official releases. An unresolved consumer reference now aborts cleanup. Recent release markers protect their underlying older bytes. The old count property and configuration-key constant remain source/binary compatible but no longer drive deletion.

Updates the support policy and records the #3842 release/consumer retention contract. The old pin-retention page explicitly marks its pin doctrine as historical. Includes a What's New fix entry.

Validation: Release/CIRun/warnings-as-errors builds of Hosting.Test, Documentation.Test and direct production dependents; 41 focused retention/lineage tests passed, zero skipped; What's New integrity passed. Removing the age-protection block made both targeted regression tests fail; restoring it passed. Coverage includes more than ten younger builds, 30-day eligibility, recent publication of old bytes, other-major sealed fallback, unsealed successors, unresolved consumer references and configuration bounds.

This is the bundle-store and policy portion of #3438 / #3842, not their closure. The ACR task record and live cloud cleanup are unchanged. Publisher/active-build inventory and atomic coordination with cleanup still need integration with the release work. A local seal is not claimed to prove the registry's advertised last-green pointer. Official versions remain protected until support end is established. No new credentials or permissions.

Behavior change with unchanged API: KeepNewestPerSource no longer affects retention; MinimumAge defaults to 30 days and cannot shorten that floor. Consumer providers may now block cleanup if their version has no resolvable marker. Existing provider interfaces and record constructors are preserved.
