### PR TITLE
fix: enforce a thirty-day assembly-cache retention floor

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/AssemblyCacheRetention.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/AssemblyCacheRetention.cs
@@ -36,9 +36,9 @@ public sealed record AssemblyCacheRetention
     /// <summary>
     /// A generation is never collected until its newest file is at least this old. A pure backstop
     /// under <see cref="KeepGenerations"/> and the claims: it bounds the damage a wrong answer from
-    /// either can do to "something nobody has written to in a week".
+    /// either can do to "something nobody has written to in 30 days".
     /// </summary>
-    public TimeSpan MinimumAge { get; init; } = TimeSpan.FromDays(7);
+    public TimeSpan MinimumAge { get; init; } = TimeSpan.FromDays(30);
 
     /// <summary>
     /// How long a generation claim counts as evidence that some pod is still running that framework.
@@ -328,6 +328,8 @@ public static class AssemblyCacheGenerations
             .Select(g => g.Tag)
             .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
+        var minimumAge = retention.MinimumAge < TimeSpan.FromDays(30)
+            ? TimeSpan.FromDays(30) : retention.MinimumAge;
         var reasons = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
         var collectable = ImmutableList.CreateBuilder<AssemblyCacheGeneration>();
 
@@ -342,8 +344,8 @@ public static class AssemblyCacheGenerations
                     ? $"claimed by {holders}"
                 : recent.Contains(generation.Tag)
                     ? $"among the {retention.KeepGenerations} most recently written"
-                : nowUtc - generation.NewestWriteUtc < retention.MinimumAge
-                    ? $"newer than the {retention.MinimumAge} minimum age"
+                : nowUtc - generation.NewestWriteUtc < minimumAge
+                    ? $"newer than the {minimumAge} minimum age"
                 : null;
 
             if (reason is null)

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -1547,7 +1547,7 @@ Every rule is a KEEP rule and they are ORed — a generation survives if **any**
 | it is the sweeping process's own framework | a failed claim write must never let a pod delete what it is loading |
 | a claim younger than `ClaimTtl` (24 h) names it | another pod is still running that image |
 | it is among the `KeepGenerations` (3) most recently written | rollback headroom — and the rollout that first introduces claims, where the outgoing image is not asserting one yet |
-| its newest file is younger than `MinimumAge` (7 d) | a backstop bounding what a wrong answer from either of the above can do |
+| its newest file is younger than `MinimumAge` (at least 30 d) | preserve 30 days of history regardless of newer generation count; configuration may extend but cannot shorten this floor |
 
 Anything the sweep cannot attribute to a generation — the claim files, an untagged pre-2026-06 DLL,
 any foreign file — is counted and **never deleted**, and any error reading the tree or the claims

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-assembly-cache-keeps-thirty-days.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-assembly-cache-keeps-thirty-days.md
@@ -1,0 +1,13 @@
+---
+Name: Assembly cache keeps thirty days of history
+Category: Fix
+Description: Assembly-cache cleanup preserves at least 30 days of history alongside active generation claims.
+Icon: Sparkle
+Order: -20260909
+---
+
+# Assembly cache keeps thirty days of history
+
+Assembly-cache cleanup now retains unused compiled artifacts for at least 30 days.
+Older settings cannot shorten this window. Active generation claims and the current
+process continue to protect the files they need.

--- a/src/MeshWeaver.Hosting/AssemblyCacheRetentionHostedService.cs
+++ b/src/MeshWeaver.Hosting/AssemblyCacheRetentionHostedService.cs
@@ -162,7 +162,7 @@ public static class AssemblyCacheRetentionExtensions
         if (int.TryParse(configuration[KeepGenerationsConfigKey], out var keep) && keep >= 1)
             retention = retention with { KeepGenerations = keep };
         if (TimeSpan.TryParse(configuration[MinimumAgeConfigKey], out var minimumAge)
-            && minimumAge > TimeSpan.Zero)
+            && minimumAge >= TimeSpan.FromDays(30))
             retention = retention with { MinimumAge = minimumAge };
         if (TimeSpan.TryParse(configuration[ClaimTtlConfigKey], out var ttl) && ttl > TimeSpan.Zero)
             retention = retention with { ClaimTtl = ttl };

--- a/test/MeshWeaver.Compiler.Pipeline.Test/AssemblyCacheRetentionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/AssemblyCacheRetentionTest.cs
@@ -228,6 +228,28 @@ public class AssemblyCacheRetentionTest : IDisposable
         File.Exists(young).Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(7)]
+    [InlineData(30)]
+    public void ThirtyDayHistory_SurvivesManyNewerGenerations_EvenWithAShortConfiguredAge(int configuredDays)
+    {
+        var recent = WriteAssembly("bbbbbbbb", Now - TimeSpan.FromDays(29));
+        var expired = WriteAssembly("cccccccc", Now - TimeSpan.FromDays(31));
+        for (var i = 0; i < 20; i++)
+            WriteAssembly(i.ToString("x8", CultureInfo.InvariantCulture), Now - TimeSpan.FromDays(1));
+
+        AssemblyCacheGenerations.SweepCore(CacheRoot, LiveTag,
+            AssemblyCacheRetention.ReportOnly with
+            {
+                Delete = true,
+                MinimumAge = TimeSpan.FromDays(configuredDays)
+            }, Now);
+
+        File.Exists(recent).Should().BeTrue();
+        File.Exists(expired).Should().BeFalse();
+    }
+
     /// <summary>A claim older than its TTL stops protecting, and the generation goes.</summary>
     [Fact]
     public void StaleClaim_DoesNotProtectForever()

--- a/test/MeshWeaver.Hosting.Test/AssemblyCacheRetentionConfigurationTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AssemblyCacheRetentionConfigurationTest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+public class AssemblyCacheRetentionConfigurationTest
+{
+    [Theory]
+    [InlineData(null, 30)]
+    [InlineData("7.00:00:00", 30)]
+    [InlineData("30.00:00:00", 30)]
+    [InlineData("60.00:00:00", 60)]
+    [InlineData("invalid", 30)]
+    public void Configuration_ExtendsHistory_WithoutShorteningItOrArmingDeletion(string? age, int days)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [AssemblyCacheRetentionExtensions.MinimumAgeConfigKey] = age
+        }).Build();
+
+        var policy = AssemblyCacheRetentionExtensions.FromConfiguration(config);
+
+        policy.MinimumAge.Should().Be(TimeSpan.FromDays(days));
+        policy.Delete.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Assembly-cache cleanup still used a seven-day age floor. A deployment carrying that older setting could therefore remove unused compiled artifacts before the requested 30-day history window.

Set the default to 30 days and enforce that floor in both configuration parsing and the cleanup planner. Longer retention remains possible. Active claims, the running generation, and existing additional recency protection remain intact; no count limit can remove an artifact within the age window. Cleanup remains report-only by default and this PR does not arm it or change live settings.

Validation: 32 assembly-cache tests, 5 configuration tests and 1 What's New integrity test passed with zero skips. Removing the planner floor produced two expected regression failures (short age settings), while the 30-day control passed. Restored production code passed. Compiler.Pipeline.Test, Hosting.Test, Documentation.Test and directly affected production hosting dependents build clean with Release/CIRun/warnings-as-errors.

Follows the retention policy associated with #3438 and #3842; complementary to #3843. This does not close the publication/consumer inventory or cloud cleanup coordination work. Includes a What's New fix entry. No public surface removed or constructor changed.