### PR TITLE
fix: retain builds reported as adopted by remote portals

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentInventory.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentInventory.md
@@ -65,6 +65,8 @@ healthy and reports almost nothing (memex, 2026-08-10: 42 sync configs, zero ins
 | `platformVersion` | `PlatformBuildInfo.PlatformVersion` — the string Settings ▸ About shows and `Admin/PlatformVersion` records; never a third opinion |
 | `commitSha` | `PlatformBuildInfo.CommitHash` — the core commit the image was built from |
 | `frameworkIdentity` | the live framework identity (`PrebuiltAssemblySeeder.LiveFrameworkMvid`) — the key every prebuilt bundle is filed under ([ModuleVersioning](/Doc/Architecture/ModuleVersioning)) |
+| `adoptedFrameworkIdentities` | distinct `CompiledFrameworkVersion` stamps from the instance's NodeType definitions, including older builds still adopted by modules |
+| `adoptedFrameworkInventoryComplete` | `true` only after the adoption query completes and every returned definition is readable; `false` on failure, absent in legacy reports |
 | `updatePolicy` | the `Admin/UpdatePolicy` node's policy, read as a children listing of the partition (a point read of an absent node trips the routing NotFound and its storm-breaker; a test mesh has no such node) |
 | `sampledAt` | UTC, second precision |
 | `modules[]` | per module: `id`, `origin` (`GitSync` or `Package`), `repository`, `ref`, `subdirectory`, `commitSha`, `lastSyncedAt`, `moduleVersion`. A module recorded under both shapes reports as `GitSync` carrying the install record's version — the receiver's fold keeps exactly that |
@@ -73,6 +75,25 @@ healthy and reports almost nothing (memex, 2026-08-10: 42 sync configs, zero ins
 
 Fields the control instance's inbox does not read yet (`commitSha`, `frameworkIdentity`,
 `updatePolicy`, `reporter`) ride along: an older control instance ignores them, a newer one shows them.
+
+## Retention reads the adopted builds too
+
+The running platform identity is not the whole consumer inventory. A portal running build Y can
+still serve a module adopted from X. The report reads those adoption stamps from the local mesh and
+includes X separately; the control instance's retention reference reader protects both identities.
+The receiver support is in MeshWeaver.Plugins#1564 and must be available before remote reports can
+preserve these fields.
+
+An explicitly complete empty adoption list is valid. An absent, malformed, or explicitly incomplete
+list blocks the retention pass instead of implying that no older build is used. The reporter still
+sends the rest of its inventory on a failed adoption read, with the failure visible in its warnings.
+Legacy reports block cleanup until replaced by a complete report from an upgraded reporter and
+receiver.
+
+These fields describe an individual report, not proof that every fleet member reported or that an
+old report is current. Fleet coverage, freshness, and coordination with active publishers remain
+requirements of the complete retention protocol in #3438 and #3842. No cleanup setting is enabled
+by adding this report contract.
 
 ## Delivery
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-retain-remotely-adopted-builds.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-retain-remotely-adopted-builds.md
@@ -1,0 +1,11 @@
+---
+Name: Retain builds still adopted by remote portals
+Category: Fix
+Description: Instance reports identify older adopted builds so central cleanup can protect them.
+Icon: Sparkle
+Order: -20260909
+---
+
+# Retain builds still adopted by remote portals
+
+Instance reports now include older builds still adopted by their modules, alongside the platform they currently run. Central bundle retention includes these reported builds in its protected references. An incomplete or legacy adoption report blocks cleanup until a complete report arrives. The remote receiver must also support these fields; adding the contract does not enable deletion.

--- a/src/MeshWeaver.PluginCatalog/DeploymentPinnedReferences.cs
+++ b/src/MeshWeaver.PluginCatalog/DeploymentPinnedReferences.cs
@@ -13,17 +13,17 @@ namespace MeshWeaver.PluginCatalog;
 /// <summary>
 /// The <see cref="PinnedPlatformReferenceSource"/> of a control instance: every platform build a
 /// <c>Hosting/Deployment</c> record PINS (<c>pinnedImageTag</c>) and every platform build a
-/// registered instance REPORTS running (<c>Hosting/ModuleInventory</c> —
+/// registered instance REPORTS running or adopted (<c>Hosting/ModuleInventory</c> —
 /// <see cref="DeploymentReport.PlatformVersion"/> and <see cref="DeploymentReport.FrameworkIdentity"/>).
 ///
 /// <para>On the registry (memex-cloud) a remote instance pulls its OWN identity's seal over the
 /// HTTP prebuilt surface, so an identity such an instance pins or runs is referenced however old
-/// it is — and the prebuilt-bundle retention's newest-N rule cannot see it. This is how it does.
+/// it is. Age alone cannot reveal whether a remote instance still uses that build.
 /// A Deployment record's <c>pinnedImageTag</c> is a mesh NodeType defined outside this assembly,
 /// so it is read as JSON (case-insensitively) rather than through a CLR type.</para>
 ///
 /// <para>Read as System, mesh-wide, on every pass. Errors propagate: a pin set that could not be
-/// read aborts the pass, which is what fail-closed means here.</para>
+/// read aborts the pass, as does a report with an incomplete adoption inventory.</para>
 /// </summary>
 public static class DeploymentPinnedReferences
 {
@@ -57,7 +57,7 @@ public static class DeploymentPinnedReferences
             Records(meshService, DeploymentNodeType)
                 .Zip(Records(meshService, DeploymentReportService.InventoryNodeType), (deployments, inventories) =>
                     deployments.Select(n => DeploymentPinOf(n, hub.JsonSerializerOptions))
-                        .Concat(inventories.Select(n => ReportedBuildOf(n, hub.JsonSerializerOptions)))
+                        .Concat(inventories.SelectMany(n => ReportedBuildsOf(n, hub.JsonSerializerOptions)))
                         .Where(r => r is not null)
                         .Select(r => r!)
                         .ToImmutableList())
@@ -80,6 +80,33 @@ public static class DeploymentPinnedReferences
         return string.IsNullOrWhiteSpace(tag)
             ? null
             : new PinnedPlatformReference($"Deployment {node.Path}", tag, null);
+    }
+
+    /// <summary>
+    /// The running platform and every adopted build in a complete consumer inventory.
+    /// Legacy, incomplete or malformed inventories abort retention instead of implying no consumers.
+    /// </summary>
+    public static ImmutableList<PinnedPlatformReference> ReportedBuildsOf(MeshNode node, JsonSerializerOptions options)
+    {
+        var content = node.Content is JsonElement element ? element : JsonSerializer.SerializeToElement(node.Content, options);
+        JsonElement Find(string name) => content.ValueKind == JsonValueKind.Object
+            ? content.EnumerateObject().FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)).Value
+            : default;
+        var complete = Find(nameof(DeploymentReport.AdoptedFrameworkInventoryComplete));
+        var identities = Find(nameof(DeploymentReport.AdoptedFrameworkIdentities));
+        if (complete.ValueKind != JsonValueKind.True || identities.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException($"instance report {node.Path}: adopted artifact inventory is incomplete or legacy; retention must not delete");
+        var references = ImmutableList.CreateBuilder<PinnedPlatformReference>();
+        var running = ReportedBuildOf(node, options)
+            ?? throw new InvalidOperationException($"instance report {node.Path}: running build is missing; retention must not delete");
+        references.Add(running);
+        foreach (var identity in identities.EnumerateArray())
+        {
+            if (identity.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(identity.GetString()))
+                throw new InvalidOperationException($"instance report {node.Path}: an adopted artifact identity is malformed; retention must not delete");
+            references.Add(new PinnedPlatformReference($"adopted build reported by {node.Path}", null, identity.GetString()));
+        }
+        return references.ToImmutable();
     }
 
     /// <summary>An inventory record's reported build, or null when it reports neither a version nor an identity.</summary>

--- a/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
+++ b/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
@@ -247,7 +247,7 @@ public sealed class DeploymentReportService : IHostedService, IDisposable
                     foreach (var node in change.Items)
                     {
                         var definition = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions, logger)
-                            ?? throw new InvalidOperationException("a NodeType adoption record could not be read");
+                            ?? throw new InvalidOperationException($"NodeType adoption record {node.Path} could not be read");
                         if (!string.IsNullOrWhiteSpace(definition.CompiledFrameworkVersion))
                             identities.Add(definition.CompiledFrameworkVersion);
                     }

--- a/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
+++ b/src/MeshWeaver.PluginCatalog/DeploymentReportService.cs
@@ -224,8 +224,40 @@ public sealed class DeploymentReportService : IHostedService, IDisposable
         return comboReader.Read()
             .Take(1)
             .Zip(ReadUpdatePolicy(), (combo, policy) => Compose(settings, combo, policy))
+            .Zip(ReadAdoptedFrameworks(), (report, adopted) => report with
+            {
+                AdoptedFrameworkIdentities = adopted.Identities,
+                AdoptedFrameworkInventoryComplete = adopted.Complete,
+                Warnings = adopted.Complete ? report.Warnings
+                    : report.Warnings.Add("adopted artifact inventory is incomplete; retention must not delete"),
+            })
             .SelectMany(report => Deliver(settings, report));
     }
+
+    private IObservable<(ImmutableList<string> Identities, bool Complete)> ReadAdoptedFrameworks() =>
+        hub.ServiceProvider.GetRequiredService<AccessService>().RunAsSystem(() =>
+            hub.ServiceProvider.GetRequiredService<IMeshService>()
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
+                .Where(change => change.ChangeType == QueryChangeType.Initial)
+                .Take(1)
+                .Timeout(ReadBudget)
+                .Select(change =>
+                {
+                    var identities = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+                    foreach (var node in change.Items)
+                    {
+                        var definition = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions, logger)
+                            ?? throw new InvalidOperationException("a NodeType adoption record could not be read");
+                        if (!string.IsNullOrWhiteSpace(definition.CompiledFrameworkVersion))
+                            identities.Add(definition.CompiledFrameworkVersion);
+                    }
+                    return (Identities: identities.OrderBy(id => id, StringComparer.Ordinal).ToImmutableList(), Complete: true);
+                }))
+            .Catch<(ImmutableList<string> Identities, bool Complete), Exception>(ex =>
+            {
+                logger.LogWarning(ex, "[DeploymentReport] adopted artifact inventory could not be completed; retention must not delete");
+                return Observable.Return((Identities: ImmutableList<string>.Empty, Complete: false));
+            });
 
     private DeploymentReport Compose(Settings settings, InstanceCombo combo, string? updatePolicy)
     {
@@ -450,6 +482,10 @@ public sealed record DeploymentReport
     public string? PlatformVersion { get; init; }
     public string? CommitSha { get; init; }
     public string? FrameworkIdentity { get; init; }
+    /// <summary>Framework identities of the builds actually adopted by this instance's NodeTypes.</summary>
+    public ImmutableList<string>? AdoptedFrameworkIdentities { get; init; }
+    /// <summary>True only after a complete adoption-stamp read. Null identifies a legacy report.</summary>
+    public bool? AdoptedFrameworkInventoryComplete { get; init; }
     public string? UpdatePolicy { get; init; }
     public string Reporter { get; init; } = "hosted";
     public string SampledAt { get; init; } = "";

--- a/test/Memex.Portal.Shared.Test/AnInstanceReportsWhatItRunsTest.cs
+++ b/test/Memex.Portal.Shared.Test/AnInstanceReportsWhatItRunsTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.SelfUpdate;
 using MeshWeaver.Mesh;
@@ -108,6 +109,8 @@ public class AnInstanceReportsWhatItRunsTest(ITestOutputHelper output) : Monolit
         report.Host.Should().Be("https://unit.example");
         report.PlatformVersion.Should().NotBeNullOrWhiteSpace("the standard platform version, never a bespoke key");
         report.FrameworkIdentity.Should().NotBeNullOrWhiteSpace("bundles are keyed on it, so the fleet must see it");
+        report.AdoptedFrameworkInventoryComplete.Should().Be(true);
+        report.AdoptedFrameworkIdentities.Should().NotBeNull();
         report.UpdatePolicy.Should().Be(nameof(UpdatePolicyKind.Stable));
         report.SampledAt.Should().EndWith("Z");
 
@@ -190,6 +193,30 @@ public class AnInstanceReportsWhatItRunsTest(ITestOutputHelper output) : Monolit
         var node = await Read($"{DeploymentReportService.DefaultOperationalSpace}/Modules/{Deployment}");
         Element(node!.Content!).GetProperty("modules").GetArrayLength().Should().Be(2,
             "the record is the LATER request's write — an earlier read landing last would say what the instance carried a moment ago");
+    }
+
+    [Fact(Timeout = 180_000)]
+    public async Task TheReport_PreservesAnOlderAdoptedBuild_AlongsideItsRunningPlatform()
+    {
+        const string adopted = "older-adopted-framework";
+        await Seed(new MeshNode("OldModuleType", "Sample")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Name = "Old module type",
+            Content = new NodeTypeDefinition { CompiledFrameworkVersion = adopted },
+        });
+
+        var outcome = await Reporter.Report().Timeout(Budget).Await(TestContext.Current.CancellationToken);
+
+        outcome.Delivery.Should().Be(DeploymentReportDelivery.Written);
+        outcome.Report!.FrameworkIdentity.Should().NotBe(adopted);
+        outcome.Report.AdoptedFrameworkInventoryComplete.Should().Be(true);
+        outcome.Report.AdoptedFrameworkIdentities!.Should().Contain(adopted,
+            "the running platform must not replace the identity of an older build a module still uses");
+        var node = await Read($"{DeploymentReportService.DefaultOperationalSpace}/Modules/{Deployment}");
+        var landed = Assert.IsType<DeploymentReport>(node!.Content);
+        landed.AdoptedFrameworkIdentities!.Should().Contain(adopted);
+        landed.AdoptedFrameworkInventoryComplete.Should().Be(true);
     }
 
     [Fact]

--- a/test/Memex.Portal.Shared.Test/DeploymentPinnedReferencesTest.cs
+++ b/test/Memex.Portal.Shared.Test/DeploymentPinnedReferencesTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using MeshWeaver.Hosting;
@@ -83,4 +85,52 @@ public class DeploymentPinnedReferencesTest
         };
         DeploymentPinnedReferences.ReportedBuildOf(node, Options).Should().BeNull();
     }
+    [Fact]
+    public void ARemoteAdoptedFallback_IsProtectedAlongsideTheRunningFramework()
+    {
+        var node = new MeshNode("remote", "Ops/Modules")
+        {
+            Content = JsonNode.Parse("""{"frameworkIdentity":"s-current","platformVersion":"4.0.0-ci.1","adoptedFrameworkInventoryComplete":true,"adoptedFrameworkIdentities":["s-old"]}""")
+        };
+        var references = DeploymentPinnedReferences.ReportedBuildsOf(node, Options);
+        references.Select(r => r.Identity).Should().Equal("s-current", "s-old");
+        var now = DateTimeOffset.UtcNow;
+        var old = now.AddDays(-100);
+        PrebuiltIdentityEntry Identity(string id) => new(id, "/store/" + id,
+            [new PrebuiltSourceEntry("plugins", true, old, old, null)], 1024, old);
+        var scan = new PrebuiltStoreScan([Identity("s-current"), Identity("s-old"), Identity("s-newer")],
+            [new ReleaseMarkerEntry("3.0.0-ci.1", "s-old", "/markers/old", old, null),
+             new ReleaseMarkerEntry("3.0.0-ci.2", "s-newer", "/markers/newer", old, null)]);
+        var policy = new PrebuiltBundleRetention { KeepNewestPerSource = 0 };
+
+        var before = PrebuiltBundleStore.Plan("s-current", "4.0.0-ci.1", scan, [], [], policy, now);
+        before.Collectable.Select(i => i.Identity).Should().Contain("s-old");
+        var protectedPlan = PrebuiltBundleStore.Plan("s-current", "4.0.0-ci.1", scan, [], references, policy, now);
+        protectedPlan.Collectable.Select(i => i.Identity).Should().NotContain("s-old");
+        protectedPlan.Protected["s-old"].Should().Contain("adopted build reported by");
+    }
+
+    [Theory]
+    [InlineData("""{"frameworkIdentity":"s-current"}""")]
+    [InlineData("""{"frameworkIdentity":"s-current","adoptedFrameworkInventoryComplete":false,"adoptedFrameworkIdentities":[]}""")]
+    [InlineData("""{"frameworkIdentity":"s-current","adoptedFrameworkInventoryComplete":true}""")]
+    [InlineData("""{"frameworkIdentity":"s-current","adoptedFrameworkInventoryComplete":true,"adoptedFrameworkIdentities":[null]}""")]
+    [InlineData("""{"frameworkIdentity":"s-current","adoptedFrameworkInventoryComplete":true,"adoptedFrameworkIdentities":[""]}""")]
+    [InlineData("""{"adoptedFrameworkInventoryComplete":true,"adoptedFrameworkIdentities":[]}""")]
+    public void AnIncompleteOrMalformedConsumerInventory_CannotAuthorizeCleanup(string json)
+    {
+        var node = new MeshNode("remote", "Ops/Modules") { Content = JsonNode.Parse(json) };
+        Assert.Throws<InvalidOperationException>(() => DeploymentPinnedReferences.ReportedBuildsOf(node, Options));
+    }
+
+    [Fact]
+    public void AnExplicitCompleteEmptyAdoptionInventory_IsValid_AndStillProtectsTheRunningBuild()
+    {
+        var node = new MeshNode("remote", "Ops/Modules")
+        {
+            Content = JsonSerializer.Deserialize<JsonElement>("""{"FrameworkIdentity":"s-current","AdoptedFrameworkInventoryComplete":true,"AdoptedFrameworkIdentities":[]}""")
+        };
+        DeploymentPinnedReferences.ReportedBuildsOf(node, Options).Select(r => r.Identity).Should().Equal("s-current");
+    }
+
 }


### PR DESCRIPTION
A portal running platform Y can still have a module adopted from build X. Reporting only Y lets central retention treat X as unused. Read the NodeType adoption stamps into each instance report and protect every reported adopted identity alongside the running build.

Missing legacy fields, malformed identities, and explicitly incomplete adoption inventories abort retention instead of implying there are no older consumers. A failed adoption read remains visible in report warnings while the rest of the inventory is delivered. Existing public report/reference surfaces remain available.

**Receiver dependency satisfied:** Systemorph/MeshWeaver.Plugins#1564 is merged and published. The normal Hosting sync on Systemorph completed at 2026-09-09 18:57:36 UTC; the ModuleInventory definition, source versions, and successful Release node confirm that the receiver fields are live.

**Publication hold released:** [CD 34389781884](https://github.com/Systemorph/MeshWeaver/actions/runs/34389781884) completed successfully at 2026-09-09 19:21:48 UTC, including image verification, platform bake, plugin publication to both targets and registration. This PR is ready for the normal green-check merge queue. Old receiver/report combinations intentionally block cleanup; this PR does not arm deletion. Remaining work is tracked by #3438, with fleet coverage/freshness in #3858, publisher/cleanup coordination in #3859, and supported-release artifact closure in #3860.

Validation: 17 focused real-mesh/report/reference tests passed, including a portal reporting and persisting a distinct older adopted build, and a retention plan that protects a remote adopted identity otherwise eligible for collection. The receiver half has 22 passing tests and a negative control that fails when its identity assignment is removed. Memex.Portal.Shared.Test and its production tool dependents (ComboAssembler, ComboVerifier, PluginTester) built Release/CIRun with warnings as errors and zero warnings/errors. All 368 documentation tests passed. Documentation and What’s New included.

Pairs-with: Systemorph/MeshWeaver.Plugins#1564

No credentials, signing rules, or live cleanup settings are changed.
