### PR TITLE
ci: a guard for the abbreviated sha a pin move cannot see

### DIFF
--- a/.github/scripts/check-abbreviated-shas.py
+++ b/.github/scripts/check-abbreviated-shas.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Every abbreviated commit sha in a workflow file must have its FULL form in the same file.
+
+🚨 WHY THIS EXISTS. A platform pin is moved by grepping the OLD 40-hex value and substituting the
+new one — that is the documented procedure in every node repo's ci.yml, and it is right, because
+editing the named variable reaches none of the `uses:`/`platform-ref:` literals a reusable
+workflow's `with:` cannot read.
+
+It has ONE blind spot, and it fired THREE TIMES IN THREE REPOS on 2026-09-09 alone
+(MeshWeaver.Reinsurance, MeshWeaver.Crm, MeshWeaver.Manufacturing): the NARRATIVE comment names the
+pin in ABBREVIATED form. A 40-hex substitution cannot see `7bfe2d907`, while the SET NAME in the
+same sentence — `3.0.0-ci.8055` — is a separate substitution that DOES move. What is left is the
+worst available state:
+
+    # Current: 3.0.0-ci.8195 / core 7bfe2d907
+                ^^^^^^^^^^^^^ new         ^^^^^^^^^ old
+
+a comment that names the new set and the old commit, in one breath, confidently. Reinsurance's own
+ci.yml records having had exactly this before ("the previous pin's comment said ci.6353 while the
+pin was ci.6469"), which is what made it worth a guard rather than a fourth catch.
+
+THE RULE. An abbreviated sha is fine — comments are more readable for it — PROVIDED the full form
+appears somewhere in the same file. After a correct move the full form is there (it is the new pin),
+so an abbreviation of it passes. After the defective move the old short sha prefixes nothing the
+file still contains, and this fails naming the line.
+
+🚨 It also makes a DELIBERATE historical mention express itself: "previously core <full sha>" passes
+by carrying the full value, which is better documentation anyway — the reader can resolve it.
+
+Exit 0 = every abbreviation resolves. Exit 1 = at least one dangles, or nothing was examined.
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+# A commit sha written short. Word-bounded so `s8b8f3cc…` (a framework identity, which carries a
+# leading `s`) and the 64-hex tail of `sha256:…` cannot match, and length-capped below 40 so a full
+# sha is not its own abbreviation.
+# 🚨 ANCHORED ON `core`, not on "hex that looks like a sha". Two rounds against real files taught
+# this: a bare 7-39 hex pattern swept up 32-hex MODULE IDS (node-repo-module-pack.yml lists one per
+# module), and narrowing to 7-12 still caught short IMAGE DIGESTS in prose
+# (`memex-portal-ai@7e8c0b20`). Both are legitimate, neither is a pin, and a guard that reports
+# them is one nobody keeps green.
+#
+# The defect has a NAME in front of it every time it has occurred: the narrative sentence reads
+# "core <sha>", because that is how these files describe which platform commit the set was cut
+# from. Anchoring there costs nothing real — a stale pin comment that does NOT say "core" is not
+# the shape that has bitten — and it buys a rule that fires only on the thing it is for.
+SHORT = re.compile(r"\bcore\s+([0-9a-f]{7,12})(?![0-9a-zA-Z_-])")
+FULL = re.compile(r"(?<![0-9a-zA-Z_-])([0-9a-f]{40})(?![0-9a-zA-Z_-])")
+# 🚨 A run id is all digits and 11 chars — valid hex, and NOT a sha. Requiring a letter is what
+# stops this guard reporting every `actions/runs/34353419069` in every comment in the fleet, which
+# would be a gate nobody could keep green and everybody would switch off.
+HAS_LETTER = re.compile(r"[a-f]")
+
+
+def check(files: dict[str, str]) -> list[str]:
+    findings: list[str] = []
+    # 🚨 WHAT THE DENOMINATOR IS, and what it is NOT. Counting abbreviations was wrong (a file
+    # that pins in full and abbreviates nowhere is clean, and the self-test caught that). Counting
+    # full shas was ALSO wrong, and running against the platform repo caught it: core does not pin
+    # `Systemorph/MeshWeaver` lanes by sha — it IS MeshWeaver — so demanding one failed the very
+    # repo the guard ships from. Vacuity here is covered by a sibling that owns it:
+    # check-platform-pins.py already refuses a core checkout that names no ref. This one reports
+    # its denominator and judges only what it can actually resolve.
+    shas_seen = 0
+    for name in sorted(files):
+        text = files[name]
+        full = set(FULL.findall(text))
+        shas_seen += len(full)
+        for number, line in enumerate(text.splitlines(), start=1):
+            for short in SHORT.findall(line):
+                if not HAS_LETTER.search(short):
+                    continue          # a run id / issue number, not a sha
+                if any(f.startswith(short) for f in full):
+                    continue
+                findings.append(
+                    f"{name}:{number}: `{short}` is an abbreviated commit sha that prefixes no "
+                    f"full sha in this file. Either it is STALE — a 40-hex substitution moved the "
+                    f"pins and could not see this one, which is how a comment ends up naming the "
+                    f"new set and the old commit — or it is a deliberate historical reference, in "
+                    f"which case write the full 40-hex value so a reader can resolve it.\n"
+                    f"      {line.strip()[:160]}")
+    # 🚨 A guard that examined nothing must not report a pass: if the workflows moved, or the
+    # pattern stopped matching what a sha looks like, this would go quietly green for ever.
+    # 🚨 The one vacuity that is this guard's own: no workflow files at all means the subject moved.
+    if not files:
+        findings.append(
+            "no workflow file was found under .github/workflows. This guard's subject has moved, "
+            "and a gate that examines nothing must fail rather than report a pass.")
+    return findings
+
+
+def load(root: pathlib.Path) -> dict[str, str]:
+    directory = root / ".github" / "workflows"
+    if not directory.is_dir():
+        return {}
+    return {
+        str(p.relative_to(root)): p.read_text(encoding="utf-8", errors="replace")
+        for p in sorted(directory.glob("*.yml")) + sorted(directory.glob("*.yaml"))
+    }
+
+
+SELF_TESTS: list[tuple[str, dict[str, str], bool]] = [
+    # The shipped shape: an abbreviation whose full form is right there.
+    ("an abbreviation backed by the full sha in the same file",
+     {"ci.yml": "# Current: core 7bfe2d907\nuses: x@7bfe2d9073282473b0b6ba4b5b400f80b46bd5f7\n"}, True),
+    # 🚨 THE DEFECT, exactly as it appeared three times on 2026-09-09.
+    ("the narrative sha left behind by a 40-hex substitution",
+     {"ci.yml": "# Current: 3.0.0-ci.8195 / core 7bfe2d907\n"
+                "uses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, False),
+    # A deliberate history line passes by carrying the full value — which is better documentation.
+    ("a historical reference written in full",
+     {"ci.yml": "# Previously core 7bfe2d9073282473b0b6ba4b5b400f80b46bd5f7.\n"
+                "uses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, True),
+    # 🚨 The false positives that would make this unkeepable, each pinned.
+    ("a run id is all digits and is not a sha",
+     {"ci.yml": "# see actions/runs/34353419069\nuses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, True),
+    ("an image digest is not an abbreviated sha",
+     {"ci.yml": "MW_IMAGE_DIGEST: sha256:61d91c0bfd6a4fc882552d81b789b492093bc20d8030a5adfba4623f87eabd5c\n"
+                "uses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, True),
+    ("a framework identity carries a leading letter and is not a sha",
+     {"ci.yml": "# identity s8b8f3cc3067e3d9d01059c47f677953c\n"
+                "uses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, True),
+    # 🚨 Non-vacuity, both ways.
+    ("a tree that pins in full and abbreviates nowhere is CLEAN",
+     {"ci.yml": "uses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, True),
+    # 🚨 …but a tree with no sha at ALL is vacuous: this guard would have nothing to resolve
+    # abbreviations against and would go green for ever.
+    # The platform repo's own shape: workflows that pin no core lane by sha. Nothing to resolve,
+    # and nothing wrong — check-platform-pins.py owns "a core checkout must name a ref".
+    ("a workflow file pinning no commit at all has nothing to resolve",
+     {"ci.yml": "on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n"}, True),
+    # 🚨 The two false positives measured against real files, each pinned so the anchor cannot be
+    # widened back without a red.
+    ("a short image digest in prose is not a pin",
+     {"ci.yml": "# measured on memex-portal-ai@7e8c0b20, 331 files\n"
+                "uses: x@174f5ab7711e1a107c0c047dfb0dd9ba3bc8b91c\n"}, True),
+    # 🚨 …but an abbreviation with NO full sha anywhere still dangles, and still fails.
+    ("an abbreviation with no full sha anywhere still dangles",
+     {"ci.yml": "# core 7bfe2d907\non: push\n"}, False),
+    ("no workflow files at all is VACUOUS, not clean", {}, False),
+    # A 32-hex module id is not an abbreviated sha (measured on node-repo-module-pack.yml).
+    ("a 32-hex module id is not an abbreviated sha",
+     {"ci.yml": "#   MeshWeaver.AI  395909c22d3042d4b23fb055337db63b  (2 compiler builds)\n"}, True),
+]
+
+
+def self_test() -> int:
+    failures = []
+    for name, files, should_pass in SELF_TESTS:
+        found = check(files)
+        if (not found) != should_pass:
+            verdict = "PASSED" if not found else f"FAILED ({found[0].splitlines()[0]})"
+            failures.append(f"  {name}: {verdict} but should {'pass' if should_pass else 'fail'}")
+    if failures:
+        print(f"\n✗ check-abbreviated-shas self-test: {len(failures)} failure(s)")
+        print("\n".join(failures))
+        return 1
+    print(f"✓ check-abbreviated-shas self-test: {len(SELF_TESTS)} cases, both directions "
+          "(the defect, a deliberate history line, three false-positive shapes, and the vacuous ones)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root)
+    files = load(root)
+    findings = check(files)
+    if findings:
+        print(f"::error::{len(findings)} dangling abbreviated sha(s):")
+        for finding in findings:
+            print(f"  - {finding}")
+        return 1
+    shas = sum(len(set(FULL.findall(t))) for t in files.values())
+    shorts = sum(1 for t in files.values() for line in t.splitlines()
+                 for m in SHORT.findall(line) if HAS_LETTER.search(m))
+    print(f"check-abbreviated-shas: {shorts} abbreviation(s) across {len(files)} workflow file(s) "
+          f"all resolve against {shas} full sha(s), root={root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -744,7 +744,7 @@ jobs:
           }
 
           # ── ONE COMMIT, ONE IMAGE SET (MeshWeaver#3376) ────────────────────────────────────
-          # On 2026-09-05 core 34c3eecec got two publishing runs: the push-triggered run (#7845)
+          # On 2026-09-05 core 34c3eecec4eaa6590c64852a0b7b873541983269 got two publishing runs: the push-triggered run (#7845)
           # and the hourly reconcile (#7846) both passed this step, because "is the set complete?"
           # was asked while the first build was still in flight — not complete YET, so the second
           # built too. Two `dotnet publish`es of one commit are two different digests: each got

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -91,11 +91,33 @@ jobs:
           gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-timeouts.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-timeouts.py" \
             || { echo "::error::could not fetch .github/scripts/check-workflow-timeouts.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
           head -c 400 "$RUNNER_TEMP/check-workflow-timeouts.py" | grep -q "check-workflow-timeouts" || { echo "::error::the fetched check-workflow-timeouts.py at ${PLATFORM_REF} does not look like the guard"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-abbreviated-shas.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-abbreviated-shas.py" \
+            || { echo "::error::could not fetch .github/scripts/check-abbreviated-shas.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/check-abbreviated-shas.py" | grep -q "check-abbreviated-shas" || { echo "::error::the fetched check-abbreviated-shas.py at ${PLATFORM_REF} does not look like the guard"; exit 1; }
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
       - name: "Every job is capped at 45 minutes — the gate can fail (self-test)"
         run: python3 "$RUNNER_TEMP/check-workflow-timeouts.py" --self-test
       - name: "Every job in this repo's workflows is capped at 45 minutes"
         run: python3 "$RUNNER_TEMP/check-workflow-timeouts.py" --root .
+
+      # 🚨 A 40-HEX SUBSTITUTION CANNOT SEE AN ABBREVIATED SHA, and the pin-move procedure in every
+      # node repo's ci.yml is exactly such a substitution ("move each value by grepping its OLD
+      # value"). The narrative comment names the pin SHORT — `core <9-hex>` — so the sed moves the
+      # `uses:`/`platform-ref:` literals and the SET NAME beside it, and leaves the commit. What
+      # remains reads "<new set> / core <old short sha>": new set, old commit, stated confidently.
+      #
+      # (Written with placeholders on purpose: a real short sha here would be flagged by this very
+      # guard, correctly — it would name a commit this file does not pin. It caught exactly that
+      # when this comment first quoted one.)
+      #
+      # Measured 2026-09-09: this fired in THREE repos in one session (MeshWeaver.Reinsurance,
+      # MeshWeaver.Crm, MeshWeaver.Manufacturing), each caught by hand. Reinsurance's own ci.yml
+      # records having had the same class before — "the previous pin's comment said ci.6353 while
+      # the pin was ci.6469" — which is what makes it a guard rather than a fourth catch.
+      - name: "An abbreviated sha resolves in its own file — the gate can fail (self-test)"
+        run: python3 "$RUNNER_TEMP/check-abbreviated-shas.py" --self-test
+      - name: "No pin comment names a commit this repo no longer pins"
+        run: python3 "$RUNNER_TEMP/check-abbreviated-shas.py" --root .
 
       # 🚨 A DUPLICATE MAPPING KEY IS ACCEPTED SILENTLY AND THE LAST ONE WINS (Systemorph/MeshWeaver#3579).
       # `yaml.safe_load` — the loader the guard above and every other guard in this fleet uses — takes


### PR DESCRIPTION
## A guard for the one thing a pin move cannot see

Every node repo's `ci.yml` documents the pin move as a 40-hex substitution — *"move each value by grepping its OLD value"* — and that is right: editing the named variable reaches none of the `uses:`/`platform-ref:` literals a reusable workflow's `with:` cannot read.

It has one blind spot, and it fired **three times in three repos on 2026-09-09 alone** (Reinsurance, Crm, Manufacturing), each caught by hand:

```
# Current: 3.0.0-ci.8195 / core 7bfe2d907
            ^^^^^^^^^^^^^ moved       ^^^^^^^^^ did not
```

The narrative comment names the pin **abbreviated**. A 40-hex `sed` cannot see it, while the **set name** in the same sentence is a separate substitution that *does* move. What is left names the **new set and the old commit**, in one sentence, confidently. Reinsurance's own `ci.yml` records the same class before — *"the previous pin's comment said ci.6353 while the pin was ci.6469"* — which is what makes this worth a guard rather than a fourth catch.

## The rule

An abbreviation is fine — comments read better for it — **provided the full form appears in the same file**. After a correct move it does (it is the new pin). After the defective move the old short sha prefixes nothing the file still holds, and this fails naming the line.

A **deliberate** history line passes by carrying the full value, which is better documentation anyway: the reader can resolve it.

## 🚨 Anchored on `core <sha>`, and two rounds against real files are why

| attempt | what it swept up |
|---|---|
| bare 7–39 hex | 32-hex **module ids** — `node-repo-module-pack.yml` lists one per module |
| narrowed to 7–12 | short **image digests** in prose (`memex-portal-ai@7e8c0b20`) |
| anchored on `core` | the defect, and nothing else |

Both false positives are legitimate content and neither is a pin. A guard that reports them is one nobody keeps green.

## 🚨 The denominator was wrong twice — the self-test caught one, the real files the other

- Counting **abbreviations** failed every file that pins in full and abbreviates nowhere, which is *clean*.
- Counting **full shas** then failed the platform repo itself, which does not pin `Systemorph/MeshWeaver` lanes by sha **because it is MeshWeaver**.

Vacuity here is owned by a sibling that already refuses a core checkout naming no ref (`check-platform-pins.py`). This one reports its denominator and judges only what it can resolve — while its *own* vacuity, no workflow files at all, still fails.

## Verified on the real defect, not only on fixtures

Replaying **just the 40-hex sed** over MeshWeaver.Manufacturing's actual pre-fix `ci.yml`:

```
.github/workflows/ci.yml:48: `1b5350d54` is an abbreviated commit sha that prefixes no full sha in this file…
    # as MW_PLATFORM_SET 3.0.0-ci.8195 / core 1b5350d54 …
```

Exactly the state it exists to prevent, on the real file, at the real line.

**Self-test 12 cases**, both directions, proved by mutation: dropping the letter requirement reports run ids as shas; dropping the prefix test passes the defect.

Wired into `node-repo-validate` so **every satellite** runs it, fetched at the caller's `platform-ref` and fail-closed like its siblings.

One pre-existing hit fixed in `main-cd.yml`: a deliberate 2026-09-05 reference now carries the full sha. And the comment introducing the guard uses placeholders — a real short sha there would be flagged by the guard itself, correctly, which is how I found out it works.
