### PR TITLE
ci: a reusable lane fetches its OWN scripts at scripts-ref, not at the platform's commit

### DIFF
--- a/.github/scripts/check-abbreviated-shas.py
+++ b/.github/scripts/check-abbreviated-shas.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Every abbreviated commit sha in a workflow file must have its FULL form in the same file.
+"""check-abbreviated-shas.py — every abbreviated commit sha in a workflow file must have its FULL form in the same file.
+(The name on this first line is load-bearing: node-repo-validate.yml fetches this file at its scripts
+ref and refuses a body whose first 400 bytes do not name it — the same shape as
+check-workflow-timeouts.py. Without it, every caller fetching the lane's guards at `main` failed with
+"the fetched check-abbreviated-shas.py at main does not look like the guard" — Plugins#1566, 2026-09-09.)
 
 🚨 WHY THIS EXISTS. A platform pin is moved by grepping the OLD 40-hex value and substituting the
 new one — that is the documented procedure in every node repo's ci.yml, and it is right, because

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -227,13 +227,31 @@ on:
         default: ''
       platform-ref:
         description: >-
-          The Systemorph/MeshWeaver ref whose .github/scripts this gate runs (compose-sealed-modules.sh).
+          The Systemorph/MeshWeaver ref that names the PLATFORM this gate runs against; also the ref
+          this lane's own .github/scripts are fetched at when `scripts-ref` (below) is empty.
           Default main; pin it to the same sha as the `uses:` line for a reproducible run.
           (`github.job_workflow_sha` is EMPTY inside a reusable called from another repo — measured
           2026-08-30 — so the script's ref is an input, never inferred.)
         required: false
         type: string
         default: main
+      scripts-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref this lane's OWN helper scripts are fetched at (the guards,
+          compose scripts and mergers under .github/scripts that the lane itself runs). Distinct from
+          `platform-ref`, which names the PLATFORM the caller builds against (compile references,
+          images, core source). Empty (the default) means "the same as platform-ref" — right for a
+          caller that pins the lane and the platform to one commit. A caller that pins NOTHING
+          (MeshWeaver#3842: the platform resolved at run time to the newest SEALED set, the lane
+          called at `@main`) passes `main` here, because a sealed set is hours behind the lane's own
+          tip: on 2026-09-09 this lane at @main fetched check-abbreviated-shas.py — added at 17:06Z
+          (022ab4a9d) — at a platform-ref cut at 3cda3efde a few hours earlier, and the fetch 404'd
+          (Plugins#1566). `github.job_workflow_sha` cannot stand in for this: it is EMPTY inside a
+          reusable called from another repository (measured 2026-08-30), so the lane's own ref is an
+          input, never inferred.
+        required: false
+        type: string
+        default: ''
       shards:
         description: >-
           How many runners to fan the gate out across. 1 (the default) is exactly the pre-fan-out
@@ -637,22 +655,24 @@ jobs:
           [ -n "$identity" ] || { echo "::error::framework-identity printed no identity for the portal's /app"; exit 1; }
           echo "identity=$identity" >> "$GITHUB_OUTPUT"
           echo "this gate runs as framework identity $identity (the portal's; the tester resolves the same); upstream bundles must be sealed under it"
-      # The compose script, from the platform at platform-ref — same fetch shape as
-      # compose-sealed-modules.sh below, for the same reason (job_workflow_sha is empty here).
+      # The compose script, from the platform at the lane's SCRIPTS ref (`scripts-ref`, falling back
+      # to platform-ref) — same fetch shape as compose-sealed-modules.sh below, for the same reason
+      # (job_workflow_sha is empty here). Not platform-ref itself: this is the LANE's tooling, and an
+      # unpinned caller's platform (the newest sealed set) is hours behind the lane (MeshWeaver#3842).
       - name: Compose the gate host (the portal's /app + the tester CLI)
         id: host
         env:
           PORTAL_APP: ${{ steps.hosts.outputs.portal_app }}
           TESTER_APP: ${{ steps.hosts.outputs.tester_app }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           SCRIPT="${RUNNER_TEMP:-/tmp}/compose-gate-host.sh"
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — compose-gate-host.sh has no ref to be fetched at"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-gate-host.sh?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$SCRIPT" \
-            || { echo "::error::could not fetch compose-gate-host.sh at ${PLATFORM_REF} from Systemorph/MeshWeaver"; exit 1; }
-          head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched compose-gate-host.sh at ${PLATFORM_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — compose-gate-host.sh has no ref to be fetched at"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-gate-host.sh?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$SCRIPT" \
+            || { echo "::error::could not fetch compose-gate-host.sh at ${SCRIPTS_REF} from Systemorph/MeshWeaver"; exit 1; }
+          head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched compose-gate-host.sh at ${SCRIPTS_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
           chmod +x "$SCRIPT"
           HOST="$RUNNER_TEMP/gate-host"
           "$SCRIPT" "$PORTAL_APP" "$TESTER_APP" "$HOST"
@@ -930,7 +950,7 @@ jobs:
           SEAL_UPSTREAMS: ${{ inputs.upstream-seed }}
           IDENTITY: ${{ steps.identity.outputs.identity }}
           TARGETS: ${{ inputs.bake-publish-targets }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -941,14 +961,15 @@ jobs:
               # 🚨 The publication is the unit of consistency (MeshWeaver#2698): module bytes come
               # from the SEALED upstream publication for this identity, never the registry's
               # package endpoint. No fallback — a missing seal or module set is RED in the script.
-              # The compose script at inputs.platform-ref (default main; pin it beside the `uses:` sha for a
-              # reproducible run). NOT github.job_workflow_sha: it is empty inside a reusable called from
-              # another repository, so a fetch keyed on it silently read main while claiming a pin.
+              # The compose script at the lane's SCRIPTS ref (`scripts-ref`, falling back to platform-ref
+              # for a caller that pins both to one commit; an unpinned caller passes `main`, MeshWeaver#3842).
+              # NOT github.job_workflow_sha: it is empty inside a reusable called from another repository,
+              # so a fetch keyed on it silently read main while claiming a pin.
               SCRIPT="${RUNNER_TEMP:-/tmp}/compose-sealed-modules.sh"
-              [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the compose script has no ref to be fetched at"; exit 1; }
-              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$SCRIPT" \
-                || { echo "::error::could not fetch compose-sealed-modules.sh at ${PLATFORM_REF} from Systemorph/MeshWeaver"; exit 1; }
-              head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched compose-sealed-modules.sh at ${PLATFORM_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
+              [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the compose script has no ref to be fetched at"; exit 1; }
+              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$SCRIPT" \
+                || { echo "::error::could not fetch compose-sealed-modules.sh at ${SCRIPTS_REF} from Systemorph/MeshWeaver"; exit 1; }
+              head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched compose-sealed-modules.sh at ${SCRIPTS_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
               chmod +x "$SCRIPT"
               if [ -n "${REGISTRY_URL:-}" ]; then
                 "$SCRIPT" --identity "$IDENTITY" --packages "$REGISTRY_MODULES" --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" \
@@ -1267,11 +1288,13 @@ jobs:
     outputs:
       gate-log-artifact: ${{ steps.fold.outputs.artifact }}
     steps:
-      - name: Check out Systemorph/MeshWeaver at the pinned ref
+      # The lane's own merger (gate-shard-merge.py) — the lane's SCRIPTS ref, not the platform's
+      # (MeshWeaver#3842: an unpinned caller's platform is hours behind the lane).
+      - name: Check out Systemorph/MeshWeaver at the lane's scripts ref
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
+          ref: ${{ inputs.scripts-ref || inputs.platform-ref }}
           path: meshweaver
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -292,6 +292,23 @@ on:
         required: false
         type: string
         default: 'main'
+      scripts-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref this lane's OWN helper scripts are fetched at (the guards,
+          compose scripts and mergers under .github/scripts that the lane itself runs). Distinct from
+          `platform-ref`, which names the PLATFORM the caller builds against (compile references,
+          images, core source). Empty (the default) means "the same as platform-ref" — right for a
+          caller that pins the lane and the platform to one commit. A caller that pins NOTHING
+          (MeshWeaver#3842: the platform resolved at run time to the newest SEALED set, the lane
+          called at `@main`) passes `main` here, because a sealed set is hours behind the lane's own
+          tip: on 2026-09-09 this lane at @main fetched check-abbreviated-shas.py — added at 17:06Z
+          (022ab4a9d) — at a platform-ref cut at 3cda3efde a few hours earlier, and the fetch 404'd
+          (Plugins#1566). `github.job_workflow_sha` cannot stand in for this: it is EMPTY inside a
+          reusable called from another repository (measured 2026-08-30), so the lane's own ref is an
+          input, never inferred.
+        required: false
+        type: string
+        default: ''
       module-artifacts:
         description: >-
           Artifact-name pattern (actions/download-artifact `pattern`) of module bundles UPLOADED
@@ -755,11 +772,14 @@ jobs:
       # path: it carries no root index.json, so the tester never treats it as a module (identical
       # reasoning to `cross-repo-stage/`).
       # Unconditional since MeshWeaver#3022: compose-gate-host.sh runs on every bake.
+      # At the lane's SCRIPTS ref (`scripts-ref`, falling back to platform-ref): these are the LANE's
+      # tooling, and an unpinned caller's platform-ref — the newest sealed set — is hours behind the
+      # lane's own tip (MeshWeaver#3842, Plugins#1566).
       - name: Fetch the canonical gate + bake-scope scripts (platform repo)
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
+          ref: ${{ inputs.scripts-ref || inputs.platform-ref }}
           path: mw-platform-gate
           sparse-checkout: .github/scripts
       # ───────────── TWO IMAGES, ONE BUILD: pull, extract, compose (MeshWeaver#3022) ─────────────
@@ -1226,7 +1246,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
+          # The lane's SCRIPTS ref, as for the gate scripts above (MeshWeaver#3842).
+          ref: ${{ inputs.scripts-ref || inputs.platform-ref }}
           path: mw-platform
           sparse-checkout: .github/scripts
       # ───────────── KEEP THE PUBLICATION COMPLETE (the reason the bake used to be full) ─────────────

--- a/.github/workflows/node-repo-supersede.yml
+++ b/.github/workflows/node-repo-supersede.yml
@@ -27,6 +27,23 @@ on:
         required: false
         type: string
         default: main
+      scripts-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref this lane's OWN helper scripts are fetched at (the guards,
+          compose scripts and mergers under .github/scripts that the lane itself runs). Distinct from
+          `platform-ref`, which names the PLATFORM the caller builds against (compile references,
+          images, core source). Empty (the default) means "the same as platform-ref" — right for a
+          caller that pins the lane and the platform to one commit. A caller that pins NOTHING
+          (MeshWeaver#3842: the platform resolved at run time to the newest SEALED set, the lane
+          called at `@main`) passes `main` here, because a sealed set is hours behind the lane's own
+          tip: on 2026-09-09 this lane at @main fetched check-abbreviated-shas.py — added at 17:06Z
+          (022ab4a9d) — at a platform-ref cut at 3cda3efde a few hours earlier, and the fetch 404'd
+          (Plugins#1566). `github.job_workflow_sha` cannot stand in for this: it is EMPTY inside a
+          reusable called from another repository (measured 2026-08-30), so the lane's own ref is an
+          input, never inferred.
+        required: false
+        type: string
+        default: ''
       protected-jobs:
         description: >-
           Regex over the CALLER-JOB segment of job names (the text before " / "; a plain job
@@ -52,15 +69,16 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - name: Fetch the platform's supersede script at the pinned ref
+      # The lane's SCRIPTS ref (`scripts-ref`, falling back to platform-ref) — MeshWeaver#3842.
+      - name: Fetch the platform's supersede script at the lane's scripts ref
         env:
           GH_TOKEN: ${{ github.token }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
         run: |
           set -euo pipefail
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the script has no ref to be fetched at"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/supersede-main-runs.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/supersede-main-runs.py"
-          [ -s "$RUNNER_TEMP/supersede-main-runs.py" ] || { echo "::error::fetched an EMPTY supersede-main-runs.py at ${PLATFORM_REF}"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the script has no ref to be fetched at"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/supersede-main-runs.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/supersede-main-runs.py"
+          [ -s "$RUNNER_TEMP/supersede-main-runs.py" ] || { echo "::error::fetched an EMPTY supersede-main-runs.py at ${SCRIPTS_REF}"; exit 1; }
       - name: The decision can say no (self-test)
         run: python3 "$RUNNER_TEMP/supersede-main-runs.py" --self-test
       - name: Cancel the runs this push supersedes

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -34,6 +34,23 @@ on:
         required: false
         type: string
         default: main
+      scripts-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref this lane's OWN helper scripts are fetched at (the guards,
+          compose scripts and mergers under .github/scripts that the lane itself runs). Distinct from
+          `platform-ref`, which names the PLATFORM the caller builds against (compile references,
+          images, core source). Empty (the default) means "the same as platform-ref" — right for a
+          caller that pins the lane and the platform to one commit. A caller that pins NOTHING
+          (MeshWeaver#3842: the platform resolved at run time to the newest SEALED set, the lane
+          called at `@main`) passes `main` here, because a sealed set is hours behind the lane's own
+          tip: on 2026-09-09 this lane at @main fetched check-abbreviated-shas.py — added at 17:06Z
+          (022ab4a9d) — at a platform-ref cut at 3cda3efde a few hours earlier, and the fetch 404'd
+          (Plugins#1566). `github.job_workflow_sha` cannot stand in for this: it is EMPTY inside a
+          reusable called from another repository (measured 2026-08-30), so the lane's own ref is an
+          input, never inferred.
+        required: false
+        type: string
+        default: ''
       check-versions-always:
         description: >-
           Run the derived-version check on EVERY event instead of main-only. Correct for a repo
@@ -78,22 +95,31 @@ jobs:
       # 🚨 THE 45-MINUTE CAP, fleet-wide (maintainer, 2026-09-02: "hard cut CI runs after 45min — we pay all
       # this"). GitHub's default job timeout is 360 minutes; an uncapped job that hangs bills a runner for six
       # hours and, when a required check `needs:` it, blocks every merge behind it (the Plugins Mcp bundle,
-      # 19 runs in_progress at once). The guard is the PLATFORM's script fetched at platform-ref — the same
-      # centralization as compile-check.py — and it runs against the CALLER's tree. No fallback: a ref the
-      # script cannot be fetched at fails RED naming it, never "skipped".
-      - name: Fetch the platform's workflow-timeout guard at the pinned ref
+      # 19 runs in_progress at once). The guard is the PLATFORM's script fetched at the lane's SCRIPTS ref
+      # (`scripts-ref`, falling back to platform-ref for a caller that pins both to one commit) — the
+      # same centralization as compile-check.py — and it runs against the CALLER's tree. No fallback: a
+      # ref the script cannot be fetched at fails RED naming it, never "skipped".
+      #
+      # 🚨 WHY THE SCRIPTS REF IS NOT `platform-ref` (MeshWeaver#3842). A caller that pins nothing calls
+      # this lane at `@main` and resolves its platform to the newest SEALED set — a commit hours behind
+      # the lane. Every guard fetched here is the LANE's tooling and must be the lane's vintage: fetched
+      # at the platform commit, a guard core added since the seal does not exist there and the lane
+      # fails on the 404 while the caller changed nothing (check-abbreviated-shas.py, 2026-09-09,
+      # Plugins#1566). `github.job_workflow_sha` is empty inside a cross-repo reusable, so the lane's
+      # own ref is the `scripts-ref` input.
+      - name: Fetch the platform's workflow-timeout guard at the lane's scripts ref
         env:
           GH_TOKEN: ${{ github.token }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
         run: |
           set -euo pipefail
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the timeout guard has no ref to be fetched at"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-timeouts.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-timeouts.py" \
-            || { echo "::error::could not fetch .github/scripts/check-workflow-timeouts.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
-          head -c 400 "$RUNNER_TEMP/check-workflow-timeouts.py" | grep -q "check-workflow-timeouts" || { echo "::error::the fetched check-workflow-timeouts.py at ${PLATFORM_REF} does not look like the guard"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-abbreviated-shas.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-abbreviated-shas.py" \
-            || { echo "::error::could not fetch .github/scripts/check-abbreviated-shas.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
-          head -c 400 "$RUNNER_TEMP/check-abbreviated-shas.py" | grep -q "check-abbreviated-shas" || { echo "::error::the fetched check-abbreviated-shas.py at ${PLATFORM_REF} does not look like the guard"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the timeout guard has no ref to be fetched at"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-timeouts.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-timeouts.py" \
+            || { echo "::error::could not fetch .github/scripts/check-workflow-timeouts.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/check-workflow-timeouts.py" | grep -q "check-workflow-timeouts" || { echo "::error::the fetched check-workflow-timeouts.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-abbreviated-shas.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-abbreviated-shas.py" \
+            || { echo "::error::could not fetch .github/scripts/check-abbreviated-shas.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/check-abbreviated-shas.py" | grep -q "check-abbreviated-shas" || { echo "::error::the fetched check-abbreviated-shas.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
       - name: "Every job is capped at 45 minutes — the gate can fail (self-test)"
         run: python3 "$RUNNER_TEMP/check-workflow-timeouts.py" --self-test
@@ -138,16 +164,16 @@ jobs:
       # `timeout-minutes:` is invisible to it and to everything else. This gate is the general form:
       # any duplicate key, any mapping, at the first job. It needs NO credential, so it runs on forks
       # and on Dependabot pull requests too.
-      - name: Fetch the platform's duplicate-key guard at the pinned ref
+      - name: Fetch the platform's duplicate-key guard at the lane's scripts ref
         env:
           GH_TOKEN: ${{ github.token }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
         run: |
           set -euo pipefail
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the duplicate-key guard has no ref to be fetched at"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-yaml-keys.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-yaml-keys.py" \
-            || { echo "::error::could not fetch .github/scripts/check-workflow-yaml-keys.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
-          head -c 400 "$RUNNER_TEMP/check-workflow-yaml-keys.py" | grep -q "check-workflow-yaml-keys" || { echo "::error::the fetched check-workflow-yaml-keys.py at ${PLATFORM_REF} does not look like the guard"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the duplicate-key guard has no ref to be fetched at"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-yaml-keys.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-yaml-keys.py" \
+            || { echo "::error::could not fetch .github/scripts/check-workflow-yaml-keys.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/check-workflow-yaml-keys.py" | grep -q "check-workflow-yaml-keys" || { echo "::error::the fetched check-workflow-yaml-keys.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
           # Do not lean on the timeout guard above having installed it — a reorder there would
           # break this step with an ImportError instead of a verdict.
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
@@ -172,16 +198,16 @@ jobs:
       # A name legitimately passed but never consumed on a PR — or asserted inside a shared lane
       # this repo only CALLS, which the guard cannot see through — is declared once, with a reason,
       # in the caller's `.github/pr-secret-preflight-allow.txt`. A stale entry there fails too.
-      - name: Fetch the platform's PR-secret preflight guard at the pinned ref
+      - name: Fetch the platform's PR-secret preflight guard at the lane's scripts ref
         env:
           GH_TOKEN: ${{ github.token }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
         run: |
           set -euo pipefail
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the PR-secret guard has no ref to be fetched at"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-pr-secret-preflight.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-pr-secret-preflight.py" \
-            || { echo "::error::could not fetch .github/scripts/check-pr-secret-preflight.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
-          head -c 400 "$RUNNER_TEMP/check-pr-secret-preflight.py" | grep -q "check-pr-secret-preflight" || { echo "::error::the fetched check-pr-secret-preflight.py at ${PLATFORM_REF} does not look like the guard"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the PR-secret guard has no ref to be fetched at"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-pr-secret-preflight.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-pr-secret-preflight.py" \
+            || { echo "::error::could not fetch .github/scripts/check-pr-secret-preflight.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/check-pr-secret-preflight.py" | grep -q "check-pr-secret-preflight" || { echo "::error::the fetched check-pr-secret-preflight.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
           # Do not lean on the timeout guard above having installed it — a reorder there would
           # break this step with an ImportError instead of a verdict.
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
@@ -202,17 +228,17 @@ jobs:
       # runner time being spent. `app` missing from three satellites' copies is dormant in all
       # three: none of them has an `app/`.)
       # Static, two files and a directory listing — no credential, so it runs on forks too.
-      - name: Fetch the platform's no-op parity guard at the pinned ref
+      - name: Fetch the platform's no-op parity guard at the lane's scripts ref
         env:
           GH_TOKEN: ${{ github.token }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
         run: |
           set -euo pipefail
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the no-op parity guard has no ref to be fetched at"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the no-op parity guard has no ref to be fetched at"; exit 1; }
           for script in check-noop-scope-parity.py node-repo-scope.py; do
-            gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/${script}?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/${script}" \
-              || { echo "::error::could not fetch .github/scripts/${script} at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
-            head -c 400 "$RUNNER_TEMP/${script}" | grep -q "${script%.py}" || { echo "::error::the fetched ${script} at ${PLATFORM_REF} does not look like the guard"; exit 1; }
+            gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/${script}?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/${script}" \
+              || { echo "::error::could not fetch .github/scripts/${script} at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+            head -c 400 "$RUNNER_TEMP/${script}" | grep -q "${script%.py}" || { echo "::error::the fetched ${script} at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
           done
       - name: "This repo's no-op set is comparable and agrees — the gate can fail (self-test)"
         run: python3 "$RUNNER_TEMP/check-noop-scope-parity.py" --self-test
@@ -222,16 +248,16 @@ jobs:
       # guards above and like compile-check.py: asserted RED when unavailable, never fallen back to
       # a drifted per-repo copy. The fetch and the self-test run on EVERY call, whichever copy is
       # believed below, so "the platform's checker is intact" is never a thing a run can skip.
-      - name: Fetch the platform's manifest checker at the pinned ref
+      - name: Fetch the platform's manifest checker at the lane's scripts ref
         env:
           GH_TOKEN: ${{ github.token }}
-          PLATFORM_REF: ${{ inputs.platform-ref }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.platform-ref }}
         run: |
           set -euo pipefail
-          [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the canonical gen-manifests.py has no ref to be fetched at"; exit 1; }
-          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/gen-manifests.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/gen-manifests.py" \
-            || { echo "::error::could not fetch .github/scripts/gen-manifests.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — a pin older than the centralization needs the older lane, not a drifted local copy"; exit 1; }
-          head -c 400 "$RUNNER_TEMP/gen-manifests.py" | grep -q "manifest.lock" || { echo "::error::the fetched gen-manifests.py at ${PLATFORM_REF} does not look like the manifest generator"; exit 1; }
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / platform-ref are both empty — the canonical gen-manifests.py has no ref to be fetched at"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/gen-manifests.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/gen-manifests.py" \
+            || { echo "::error::could not fetch .github/scripts/gen-manifests.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the centralization needs the older lane, not a drifted local copy"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/gen-manifests.py" | grep -q "manifest.lock" || { echo "::error::the fetched gen-manifests.py at ${SCRIPTS_REF} does not look like the manifest generator"; exit 1; }
       - name: "The manifest checker can fail — --resolve, the trunk baseline and the config contract (self-test)"
         run: python3 "$RUNNER_TEMP/gen-manifests.py" --self-test
 


### PR DESCRIPTION
## Why

Under **no platform pins** (#3842) a caller runs a `node-repo-*` lane at `@main` and resolves its platform at run time to the newest **sealed** set — a core commit hours behind the lane's own tip. Every lane fetched its guards, compose scripts and mergers at `inputs.platform-ref`, so the lane at `main` asked for a script at a commit that predates it.

Measured on Systemorph/MeshWeaver.Plugins#1566 (2026-09-09), two runs:

1. `node-repo-validate.yml@main` fetched `check-abbreviated-shas.py` — added at 17:06Z in 022ab4a9d (#3850) — at the sealed set's commit `3cda3efde` from a few hours earlier: **`could not fetch .github/scripts/check-abbreviated-shas.py at 3cda3efde… — a pin older than the guard needs the older lane`**. The caller had changed nothing; `compile-check` and the Tests-area gate went red behind it on their fail-RED-on-a-failed-need guards.
2. With the caller passing `platform-ref: main` instead, the same step failed on the lane's own sanity check: **`the fetched check-abbreviated-shas.py at main does not look like the guard`** — the new guard does not name itself in its first 400 bytes, which the lane asserts of every guard it fetches.

`github.job_workflow_sha` cannot name the lane's own commit — it is **empty** inside a reusable called from another repository (measured 2026-08-30, recorded in `node-repo-gate.yml`) — so the lane's ref has to be an input.

## What changes

- New optional input **`scripts-ref`** on `node-repo-validate`, `node-repo-gate`, `node-repo-publish-bake`, `node-repo-supersede`: the ref this lane's **own** helper scripts are fetched at. Default `''` = *the same as `platform-ref`*, so a caller that pins the lane and the platform to one commit is unchanged; an unpinned caller passes `main`. `platform-ref` keeps naming the **platform** (compile references, images, core source): `node-repo-compile-check`'s `compile-check.py` fetch and `node-repo-module-pack`'s core checkouts are deliberately untouched.
- Lane steps routed through `${{ inputs.scripts-ref || inputs.platform-ref }}`:

  | lane | steps |
  |---|---|
  | `node-repo-validate.yml` | *Fetch the platform's workflow-timeout guard* (timeouts + abbreviated shas), *duplicate-key guard*, *PR-secret preflight guard*, *no-op parity guard*, *manifest checker* — all five, renamed "…at the lane's scripts ref" |
  | `node-repo-gate.yml` | *Compose the gate host* (`compose-gate-host.sh`), the `compose-sealed-modules.sh` fetch inside *Fetch the upstream publications…*, and the `Systemorph/MeshWeaver` checkout in `verify` that runs `gate-shard-merge.py` |
  | `node-repo-publish-bake.yml` | *Fetch the canonical gate + bake-scope scripts*, *Fetch the canonical publish script* (both sparse `.github/scripts` checkouts) |
  | `node-repo-supersede.yml` | *Fetch the platform's supersede script* |

- `check-abbreviated-shas.py`: its first docstring line now carries the script's name, the way `check-workflow-timeouts.py`'s load-bearing first line does, so the lane's `head -c 400 | grep` accepts it.

## Gates run locally

`check-workflow-timeouts.py --self-test` ✓ / `--root .`: `83 job(s) checked, 2 reusable-call job(s) exempt, 0 violation(s)` · `check-workflow-yaml-keys.py --self-test` ✓ / `--root .`: `33 workflow file(s) …, 0 violation(s)` · `check-workflow-shell.py --self-test` ✓ / run: `1 finding(s): 0 live, 1 allow-listed, 0 stale` · `check-abbreviated-shas.py --self-test` ✓ (12 cases) / `--root .`: `0 abbreviation(s) across 33 workflow file(s)` · `check-shared-rules.py --self-test` ✓ (18 cases) · actionlint over the four lanes: same 10 pre-existing shellcheck infos as `main`.

Follow-up on the caller side once this lands: MeshWeaver.Plugins passes `scripts-ref: main` on every lane call and returns `platform-ref` to the resolved sealed-set commit (today it passes `platform-ref: main` on the scripts-only lanes as the interim).

Refs #3842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
