### PR TITLE
Honor package README nodes during Git sync

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/InstallCompleteness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InstallCompleteness.md
@@ -260,6 +260,24 @@ Stated so nobody reads a green sweep as more than it is.
   naming the count. It never reads the first N silently: the roots it skipped would then be spelled
   exactly like roots that are fine, which is the failure this whole page is about.
 
+## Package README pages and Git updates
+
+A package installer sees repo-relative `Store/README.md` and writes `Store/README`.
+Git sync sees that same file as `README.md` after selecting the `Store` subdirectory.
+These paths must agree when the package's root `manifest.lock` declares the README in its
+repo-relative `files` map. Git sync then imports it as a node, including when the node is missing.
+A later package manifest that retires the file retains ordinary mirror deletion behavior.
+
+Without a package manifest, the root README is a generated repository landing page, not a node.
+Skipping that display file must not make an existing README node a deletion candidate. Export
+also preserves an authored README instead of appending another generated file with the same path.
+An unreadable package manifest fails the import before it can make this ownership decision.
+
+The distinction matters when diagnosing a repair: a Git update activity is not evidence that
+`PackageInstaller` performed a full reinstall. In #3686 the cited update activity explicitly fetched
+Git deltas; the package reinstall path restored the README in a local real-mesh reproduction, while
+the Git sync full-import reproduction deleted it before this correction.
+
 ## Related
 
 - [CQRS — Queries vs. Content Access](../CqrsAndContentAccess) — why the observed side is a batched

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-git-sync-preserves-package-readmes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-git-sync-preserves-package-readmes.md
@@ -1,0 +1,9 @@
+---
+Name: Git updates restore package README pages
+Category: Fix
+Description: Updating a package through Git now restores its declared README page instead of skipping it or deleting an existing copy.
+Icon: ArrowSync
+Order: -20260909
+---
+
+Git updates now recognize README pages declared by a package. Missing pages are restored, and pages still present in the package survive a full import. A generated repository landing page remains separate from the mesh's content, and exporting an authored README no longer adds a second generated copy.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -220,11 +220,14 @@ public sealed class GitHubSyncService
     /// <summary>
     /// Adds a top-level <c>README.md</c> rendered from the Space root's body so the GitHub
     /// repo page shows a landing page. The authoritative root remains <c>index.json</c>;
-    /// import skips <c>README.md</c> so it never becomes a stray node.
+    /// import skips an undeclared display <c>README.md</c> so it never becomes a stray node.
+    /// An authored README already exported as a node takes precedence over generated text.
     /// </summary>
     private IReadOnlyList<RepoFile> AppendReadme(IList<RepoFile> files, IReadOnlyList<MeshNode> nodes, string partition)
     {
         var list = files.ToList();
+        if (list.Any(f => string.Equals(f.Path, "README.md", StringComparison.OrdinalIgnoreCase)))
+            return list;
         var root = nodes.FirstOrDefault(n => string.Equals(n.Path, partition, StringComparison.Ordinal));
         var readme = root is null ? null : BuildReadme(root);
         if (!string.IsNullOrEmpty(readme))
@@ -633,7 +636,8 @@ public sealed class GitHubSyncService
                     // withheld, because a stale extra is recoverable and a silent delete is not.
                     var source = new InMemoryStaticRepoSource(
                         spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs, ignore,
-                        listingIsComplete: snapshot.ListingIsComplete);
+                        listingIsComplete: snapshot.ListingIsComplete,
+                        ownsReadme: ReadmeFilePolicy.From(snapshot).IsPackage);
                     var changedNodePaths = ChangedNodePaths(changedFiles, spaceId);
                     if (changedNodePaths is not null)
                         logger?.LogInformation(
@@ -686,6 +690,7 @@ public sealed class GitHubSyncService
         // node), so committed course videos/posters land and stop getting wiped. Everything else flows
         // to node parsing as before.
         var kept = snapshot.Files.Where(f => !ignore.IsIgnored(f.Path)).ToArray();
+        var readmePolicy = ReadmeFilePolicy.From(snapshot);
         // Cheap path-only precheck first (no byte materialization for the common node file), then
         // classify only the content paths — f.Bytes is realized ONLY for an actual content asset.
         var classified = kept
@@ -698,7 +703,7 @@ public sealed class GitHubSyncService
 
         return classified
             .Where(c => c.Asset is null)
-            .Select(c => ParseFile(c.File, spaceId))
+            .Select(c => ParseFile(c.File, spaceId, readmePolicy.IsDeclaredNode))
             .Merge(8)
             .ToList()
             .Select(list =>
@@ -733,10 +738,11 @@ public sealed class GitHubSyncService
     /// concurrent on one node as well as quadratic. Same defect class as #1341 / #1172.</para>
     /// </summary>
     private IObservable<(MeshNode? Node, bool IsRoot, string? Problem)> ParseFile(
-        RepoFile file, string spaceId)
+        RepoFile file, string spaceId, bool readmeIsNode = false)
     {
-        // The top-level README.md is a GitHub display file emitted on export — never a node.
-        if (string.Equals(file.Path, "README.md", StringComparison.OrdinalIgnoreCase))
+        // A generated repository README is display-only; a package manifest can instead declare
+        // this same file as a real node. Honor that declaration on the Git sync update lane too.
+        if (!readmeIsNode && string.Equals(file.Path, "README.md", StringComparison.OrdinalIgnoreCase))
             return Observable.Return(((MeshNode?)null, false, (string?)null));
 
         var ext = System.IO.Path.GetExtension(file.Path);

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -621,11 +621,12 @@ public sealed class GitHubSyncService
             // truncated, or a compare error) falls back to a full import — never a silent
             // under-import. This is what stops a routine push from re-materialising the whole
             // partition and storming the live compiler (the memex-cloud outage loop, 2026-07-23).
+            var readmePolicy = ReadmeFilePolicy.From(snapshot);
             var diff = string.IsNullOrEmpty(baseSha) || policy?.Force == true
                 ? Observable.Return<IReadOnlyList<string>?>(null)
                 : repoClient.GetChangedPaths(repoUrl, baseSha!, snapshot.CommitSha, subdirectory, token);
             return diff.SelectMany(changedFiles =>
-                ParseSnapshot(snapshot, spaceId, ignore, progress).SelectMany(parsed =>
+                ParseSnapshot(snapshot, spaceId, ignore, readmePolicy, progress).SelectMany(parsed =>
                 {
                     // 🚨 The ignore rules travel WITH the source (issue #1326): the importer's prune
                     // needs them to tell "the repo dropped this node" from "this node never syncs".
@@ -637,7 +638,7 @@ public sealed class GitHubSyncService
                     var source = new InMemoryStaticRepoSource(
                         spaceId, parsed.Children, parsed.Root, parsed.ContentSyncs, ignore,
                         listingIsComplete: snapshot.ListingIsComplete,
-                        ownsReadme: ReadmeFilePolicy.From(snapshot).IsPackage);
+                        ownsReadme: readmePolicy.IsPackage);
                     var changedNodePaths = ChangedNodePaths(changedFiles, spaceId);
                     if (changedNodePaths is not null)
                         logger?.LogInformation(
@@ -677,7 +678,8 @@ public sealed class GitHubSyncService
         string.IsNullOrEmpty(sha) ? "(none)" : sha.Length <= 8 ? sha : sha[..8];
 
     private IObservable<(MeshNode? Root, IReadOnlyList<MeshNode> Children, IReadOnlyList<StaticContentSync> ContentSyncs)> ParseSnapshot(
-        RepoSnapshot snapshot, string spaceId, SyncIgnore ignore, Action<string, LogLevel>? progress = null)
+        RepoSnapshot snapshot, string spaceId, SyncIgnore ignore, ReadmeFilePolicy readmePolicy,
+        Action<string, LogLevel>? progress = null)
     {
         if (snapshot.Files.Count == 0)
             return Observable.Return(((MeshNode?)null, (IReadOnlyList<MeshNode>)Array.Empty<MeshNode>(),
@@ -690,7 +692,6 @@ public sealed class GitHubSyncService
         // node), so committed course videos/posters land and stop getting wiped. Everything else flows
         // to node parsing as before.
         var kept = snapshot.Files.Where(f => !ignore.IsIgnored(f.Path)).ToArray();
-        var readmePolicy = ReadmeFilePolicy.From(snapshot);
         // Cheap path-only precheck first (no byte materialization for the common node file), then
         // classify only the content paths — f.Bytes is realized ONLY for an actual content asset.
         var classified = kept

--- a/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
+++ b/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
@@ -30,8 +30,8 @@ namespace MeshWeaver.GitSync;
 /// <param name="listingIsComplete">Whether <paramref name="children"/> is the WHOLE repo listing at
 /// that commit (<see cref="RepoSnapshot.ListingIsComplete"/>). False when GitHub truncated the
 /// recursive tree — see <see cref="IStaticRepoSource.ListingIsComplete"/>.</param>
-/// <param name="ownsReadme">A package manifest makes README a source-owned node when declared;
-/// ordinary repository landing pages are outside this source's node mirror.</param>
+/// <param name="ownsReadme">A package manifest owns the README slot, including retiring a
+/// previously declared README. Ordinary repository landing pages are outside the node mirror.</param>
 internal sealed class InMemoryStaticRepoSource(
     string partition,
     IReadOnlyList<MeshNode> children,

--- a/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
+++ b/src/MeshWeaver.GitSync/InMemoryStaticRepoSource.cs
@@ -30,13 +30,16 @@ namespace MeshWeaver.GitSync;
 /// <param name="listingIsComplete">Whether <paramref name="children"/> is the WHOLE repo listing at
 /// that commit (<see cref="RepoSnapshot.ListingIsComplete"/>). False when GitHub truncated the
 /// recursive tree — see <see cref="IStaticRepoSource.ListingIsComplete"/>.</param>
+/// <param name="ownsReadme">A package manifest makes README a source-owned node when declared;
+/// ordinary repository landing pages are outside this source's node mirror.</param>
 internal sealed class InMemoryStaticRepoSource(
     string partition,
     IReadOnlyList<MeshNode> children,
     MeshNode? root,
     IReadOnlyList<StaticContentSync>? contentSyncs = null,
     SyncIgnore? ignore = null,
-    bool listingIsComplete = true) : IStaticRepoSource
+    bool listingIsComplete = true,
+    bool ownsReadme = false) : IStaticRepoSource
 {
     private readonly SyncIgnore ignoreRules = ignore ?? SyncIgnore.For(null);
 
@@ -77,6 +80,8 @@ internal sealed class InMemoryStaticRepoSource(
         // Space-relative, so matching them against a foreign absolute path would be meaningless.
         if (!nodePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             return false;
+        if (!ownsReadme && string.Equals(nodePath[prefix.Length..], "README", StringComparison.OrdinalIgnoreCase))
+            return true;
         return ignoreRules.IsIgnored(nodePath[prefix.Length..]);
     }
 }

--- a/src/MeshWeaver.GitSync/ReadmeFilePolicy.cs
+++ b/src/MeshWeaver.GitSync/ReadmeFilePolicy.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>Distinguishes a package's declared README node from a generated repository landing page.</summary>
+internal readonly record struct ReadmeFilePolicy(bool IsPackage, bool IsDeclaredNode)
+{
+    internal static ReadmeFilePolicy From(RepoSnapshot snapshot)
+    {
+        var manifest = snapshot.Files.FirstOrDefault(f =>
+            string.Equals(f.Path, "manifest.lock", StringComparison.OrdinalIgnoreCase));
+        if (manifest is null)
+            return default;
+
+        // A malformed declaration cannot safely decide whether an existing node is retired.
+        // Do not turn an unreadable manifest into the display-only case and proceed with pruning.
+        using var document = JsonDocument.Parse(manifest.Content);
+        var root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object
+            || !root.TryGetProperty("module", out var module)
+            || module.ValueKind != JsonValueKind.String
+            || string.IsNullOrWhiteSpace(module.GetString())
+            || !root.TryGetProperty("files", out var files)
+            || files.ValueKind != JsonValueKind.Object)
+            throw new InvalidDataException("manifest.lock must declare its module and files before Git sync can interpret its README.");
+
+        var path = module.GetString()!.TrimEnd('/') + "/README.md";
+        return new ReadmeFilePolicy(true, files.EnumerateObject().Any(f =>
+            string.Equals(f.Name, path, StringComparison.OrdinalIgnoreCase)));
+    }
+}


### PR DESCRIPTION
A full Git sync import could delete Store/README while README.md was still present in the repository: parsing treated it as a generated display file, then mirroring treated the omitted node as retired. Git updates also could not restore the missing page.

A root package manifest now distinguishes its declared README node from a generated repository landing page. Declared pages are imported and restored; actual package retirement still prunes them. Display-only README handling cannot prune an existing node it does not own. Export preserves an authored README instead of appending a duplicate generated file. An unreadable package declaration fails before this ownership decision.

Validation: deterministic real-mesh deletion repro failed before the fix with PrunedPaths=[Store/README]; all three new regressions and all 193 existing Git sync tests pass against this core checkout. Release builds with CIRun and warnings-as-errors are clean. All 368 documentation tests pass. Includes a Fix release note.

Refs #3686. The historical deletion is not claimed proven, and no live portal data was modified. The companion tests live in MeshWeaver.Plugins and will remain draft until this implementation is available there.