### PR TITLE
feat(ci): separate content builds and reuse published dependencies

### DIFF
--- a/.github/scripts/node-repo-project-scope.py
+++ b/.github/scripts/node-repo-project-scope.py
@@ -48,11 +48,11 @@ def select(root, policy, files):
 
     if not files:
         return answer(policy, "no reliable diff — full validation")
-    scope = load(Path(__file__).with_name("node-repo-scope.py"), "node_scope")
     try:
+        scope = load(Path(__file__).with_name("node-repo-scope.py"), "node_scope")
         projects = load(root / scope.PROJECTS, "caller_projects")
         graph = projects.graph_of(root)
-    except (OSError, AttributeError, ValueError):
+    except (OSError, AttributeError, ValueError, ImportError, SyntaxError):
         return answer(policy, "project graph unavailable — full validation")
     packages = scope.node_packages(root)
     noop_dirs, _ = scope.resolve_noop_dirs(root)
@@ -126,7 +126,17 @@ def forward(seed, graph): return {seed} | graph.get(seed, set())
                 pass
             else:
                 raise AssertionError("invalid policy accepted")
-    print("compiled project scope: 14 assertions passed")
+        # Load the actual selector from a separate directory: missing or broken helper files
+        # must broaden validation, never turn an unresolved graph into an empty selection.
+        isolated = root / "isolated"
+        isolated.mkdir()
+        selector = isolated / Path(__file__).name
+        selector.write_text(Path(__file__).read_text())
+        fallback = load(selector, "isolated_selector")
+        assert fallback.select(root, policy, ["Alpha/Lesson.md"])["count"] == 2
+        (isolated / "node-repo-scope.py").write_text("this is invalid Python !")
+        assert fallback.select(root, policy, ["Alpha/Lesson.md"])["count"] == 2
+    print("compiled project scope: 16 assertions passed")
 
 
 def main():

--- a/.github/scripts/node-repo-project-scope.py
+++ b/.github/scripts/node-repo-project-scope.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Select compiled host builds and suites using the caller's project graph and input policy.
+
+Policy is a nonempty list of {project, kind: build|test, inputs: [repo-relative prefixes]}.
+Inputs name runtime source scans that ProjectReference cannot express. Declared linked content
+is read from every project in the closure. Unknown paths and unresolved scope run everything.
+This selects validation only; it never decides what gets published.
+"""
+import argparse
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+def load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def under(path, prefix):
+    return prefix == "." or path == prefix.rstrip("/") or path.startswith(prefix.rstrip("/") + "/")
+
+
+def select(root, policy, files):
+    if not isinstance(policy, list) or not policy:
+        raise ValueError("project policy must be a nonempty list")
+    seen = set()
+    for entry in policy:
+        if (entry.get("kind") not in ("build", "test") or not entry.get("project")
+                or entry["project"] in seen or not (root / entry["project"]).is_file()
+                or not isinstance(entry.get("inputs", []), list)):
+            raise ValueError(f"invalid, duplicate or absent project: {entry}")
+        seen.add(entry["project"])
+        for prefix in entry.get("inputs", []):
+            if not isinstance(prefix, str) or not prefix or prefix.startswith("/") or ".." in prefix.split("/"):
+                raise ValueError(f"invalid input prefix: {prefix}")
+
+    def answer(entries, reason):
+        return {"reason": reason, "build": [e["project"] for e in entries if e["kind"] == "build"],
+                "test": [e["project"] for e in entries if e["kind"] == "test"],
+                "count": len(entries), "total": len(policy)}
+
+    if not files:
+        return answer(policy, "no reliable diff — full validation")
+    scope = load(Path(__file__).with_name("node-repo-scope.py"), "node_scope")
+    try:
+        projects = load(root / scope.PROJECTS, "caller_projects")
+        graph = projects.graph_of(root)
+    except (OSError, AttributeError, ValueError):
+        return answer(policy, "project graph unavailable — full validation")
+    packages = scope.node_packages(root)
+    noop_dirs, _ = scope.resolve_noop_dirs(root)
+    if noop_dirs is None:
+        return answer(policy, "content classifier unavailable — full validation")
+    relevant = []
+    for path in files:
+        if path in scope.NOOP_FILES or path.split("/", 1)[0] in noop_dirs:
+            relevant.append(path)  # explicit runtime inputs can still consume documentation
+            continue
+        if path.startswith("src/"):
+            if not any(under(path, project) for project in graph):
+                return answer(policy, f"unclassified compiled input {path} — full validation")
+        elif path.split("/", 1)[0] not in packages:
+            return answer(policy, f"shared or unknown input {path} — full validation")
+        relevant.append(path)
+    chosen = []
+    for entry in policy:
+        closure = projects.forward(projects.entry_dir(entry["project"]), graph)
+        prefixes = list(closure) + entry.get("inputs", [])
+        # Linked files in node packages are dependencies too (e.g. Cornerstone's test data).
+        for directory in closure:
+            for project in (root / directory).glob("*.csproj"):
+                source = project.read_text()
+                for raw in re.findall(r'<(?:Compile|Content|EmbeddedResource|None)\s[^>]*Include=["\']([^"\']+)', source):
+                    raw = raw.replace("\\", "/")
+                    if "$(" in raw or not raw.startswith("../"):
+                        continue
+                    literal = re.split(r"[*?]", raw, maxsplit=1)[0]
+                    try:
+                        prefix = (project.parent / literal).resolve().relative_to(root.resolve()).as_posix()
+                    except ValueError:
+                        continue  # outside this checkout: the pinned platform is its input
+                    prefixes.append(prefix)
+        if any(under(path, prefix) for path in relevant for prefix in prefixes):
+            chosen.append(entry)
+    return answer(chosen, "compiled project closure plus declared runtime/linked inputs")
+
+
+def self_test():
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        scope = load(Path(__file__).with_name("node-repo-scope.py"), "scope_fixture")
+        scope._fixture(root)
+        # A tiny real project graph; the production graph is owned by the caller.
+        (root / scope.PROJECTS).write_text('''from pathlib import Path
+def graph_of(root):
+    return {"src/Acme.Alpha": {"src/Acme.Shared"}, "src/Acme.Shared": set(), "src/Acme.Beta": set()}
+def entry_dir(path): return str(Path(path).parent)
+def forward(seed, graph): return {seed} | graph.get(seed, set())
+''')
+        a = {"project": scope._ENTRY_A["project"], "kind": "build"}
+        b = {"project": scope._ENTRY_B["project"], "kind": "test", "inputs": ["Beta/"]}
+        policy = [a, b]
+        assert select(root, policy, ["Alpha/Lesson.md"])["count"] == 0
+        assert select(root, policy, ["Beta/Lesson.md"])["test"] == [b["project"]]
+        assert select(root, policy, ["src/Acme.Shared/Thing.cs"])["build"] == [a["project"]]
+        assert select(root, policy, ["src/Acme.Beta/Test.cs"])["test"] == [b["project"]]
+        for path in ["src/Directory.Build.props", "scripts/gate.py", "Gone/index.json", ".github/workflows/ci.yml"]:
+            assert select(root, policy, [path])["count"] == 2
+        assert select(root, policy, ["README.md"])["count"] == 0
+        assert select(root, policy, None)["count"] == 2
+        project = root / a["project"]
+        project.write_text('<Project><Content Include="../../Alpha/**" /></Project>')
+        assert select(root, policy, ["Alpha/Lesson.md"])["build"] == [a["project"]]
+        for bad in [[], [a, a], [{**a, "project": "src/Missing/Missing.csproj"}]]:
+            try:
+                select(root, bad, ["Alpha/Lesson.md"])
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("invalid policy accepted")
+    print("compiled project scope: 14 assertions passed")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--root", default=".")
+    p.add_argument("--policy")
+    p.add_argument("--range")
+    p.add_argument("--self-test", action="store_true")
+    a = p.parse_args()
+    if a.self_test:
+        self_test()
+        return 0
+    if not a.policy:
+        p.error("--policy is required")
+    root = Path(a.root).resolve()
+    files = None
+    if a.range:
+        diff = subprocess.run(["git", "diff", "--no-renames", "--name-only", a.range], cwd=root,
+                              capture_output=True, text=True, timeout=120)
+        if diff.returncode == 0:
+            files = diff.stdout.splitlines()
+    result = select(root, json.loads(Path(a.policy).read_text()), files)
+    print(json.dumps(result))
+    if os.environ.get("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+            for key in ("build", "test", "count"):
+                out.write(f"{key}={json.dumps(result[key])}\n")
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as out:
+            out.write(f"### Compiled validation\n\n{result['count']} of {result['total']} projects: "
+                      f"{result['reason']}\n\nBuild: {result['build']}\n\nTest: {result['test']}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-publication-base.py
+++ b/.github/scripts/node-repo-publication-base.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Find a conservative publication baseline from a successful trunk publishing workflow.
+
+The caller opts in by naming a workflow whose successful main PUSH publishes all selected
+outputs. A failed, cancelled, manual or release-follow run cannot advance this baseline.
+An unavailable API or missing ancestor costs a full build, never an omitted publication.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import quote
+
+
+def baseline(runs, branch, ancestor, current_run=""):
+    publishing = {"push", "repository_dispatch", "schedule"}
+    for run in runs:
+        if str(run.get("id")) == str(current_run) or run.get("head_branch") != branch or run.get("event") not in publishing:
+            continue
+        sha = run.get("head_sha", "")
+        if (run.get("event") == "push" and run.get("head_branch") == branch
+                and run.get("status") == "completed" and run.get("conclusion") == "success"
+                and re.fullmatch(r"[0-9a-f]{40}", sha) and ancestor(sha)):
+            return {"sha": sha, "run": run["id"], "url": run["html_url"]}
+        # A later partial publish may have used a different variable-resolved toolchain,
+        # invisible in git history. Without a successful receipt for it, rebuild everything.
+        break
+    return {"sha": "", "run": "", "url": ""}
+
+
+def self_test():
+    good = dict(event="push", head_branch="main", status="completed", conclusion="success",
+                head_sha="a" * 40, id=1, html_url="https://example.test/runs/1")
+    for change in [dict(event="workflow_dispatch"), dict(event="repository_dispatch"),
+                   dict(event="schedule"), dict(conclusion="failure"), dict(conclusion="cancelled"),
+                   dict(status="in_progress"), dict(head_branch="other"), dict(head_sha="short")]:
+        expected = 1 if change.get("event") == "workflow_dispatch" or change.get("head_branch") == "other" else ""
+        assert baseline([{**good, **change}, good], "main", lambda _: True)["run"] == expected
+        assert baseline([{**good, **change}], "main", lambda _: True)["sha"] == ""
+    assert baseline([good], "main", lambda _: False)["sha"] == ""
+    assert baseline([], "main", lambda _: True)["sha"] == ""
+    assert baseline([good], "main", lambda _: True)["sha"] == "a" * 40
+    print("publication baseline: 19 assertions passed")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--workflow")
+    p.add_argument("--inputs", help="current resolved platform/toolchain inputs JSON")
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    p.add_argument("--root", default=".")
+    p.add_argument("--branch", default="main")
+    p.add_argument("--self-test", action="store_true")
+    a = p.parse_args()
+    if a.self_test:
+        self_test()
+        return 0
+    if not a.workflow or not a.inputs or not re.fullmatch(r"[\w.-]+/[\w.-]+", a.repo):
+        p.error("--workflow, --inputs and --repo owner/name are required")
+    current = json.loads(Path(a.inputs).read_text())
+    if not current or not isinstance(current, dict) or not all(current.values()):
+        p.error("resolved publication inputs must be a nonempty object with no empty values")
+    endpoint = (f"repos/{a.repo}/actions/workflows/{quote(a.workflow, safe='')}/runs"
+                f"?branch={quote(a.branch, safe='')}&per_page=100")
+    try:
+        response = subprocess.run(["gh", "api", endpoint], capture_output=True, text=True,
+                                  timeout=60, check=True)
+        runs = json.loads(response.stdout)["workflow_runs"]
+        if not isinstance(runs, list):
+            raise ValueError("workflow_runs is not a list")
+        result = baseline(runs, a.branch, lambda sha: subprocess.run(
+            ["git", "merge-base", "--is-ancestor", sha, "HEAD"], cwd=a.root,
+            capture_output=True, timeout=30).returncode == 0, os.environ.get("GITHUB_RUN_ID", ""))
+        if result["run"]:
+            # Git source alone cannot see a repository variable overriding the platform ref.
+            # Successful runs attest their actual resolved inputs in this run-scoped artifact.
+            with tempfile.TemporaryDirectory() as tmp:
+                subprocess.run(["gh", "run", "download", str(result["run"]), "--repo", a.repo,
+                                "--name", "publication-inputs", "--dir", tmp],
+                               capture_output=True, text=True, timeout=60, check=True)
+                previous = json.loads((Path(tmp) / "publication-inputs.json").read_text())
+                if previous != current:
+                    print("publication toolchain changed — full build", file=sys.stderr)
+                    result = dict(sha="", run="", url="")
+    except (OSError, ValueError, KeyError, subprocess.SubprocessError) as exc:
+        print(f"::warning::publication baseline unavailable ({type(exc).__name__}); full build", file=sys.stderr)
+        result = dict(sha="", run="", url="")
+    print(json.dumps(result))
+    print(f"publication baseline: {result['url'] or 'none — full build'}", file=sys.stderr)
+    if os.environ.get("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+            out.write(f"publication-base={result['sha']}\npublication-run={result['run']}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-publication-reuse.py
+++ b/.github/scripts/node-repo-publication-reuse.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Reuse unchanged gate dependencies from an attested successful publication.
+
+The source selector proves an entry unaffected (test=false). The baseline resolver proves the
+toolchain inputs equal. This helper verifies run identity and artifact availability; absence
+keeps the normal build leg. It uses the module lane's existing reuse/receipt path, not a builder.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def annotate(entries, run, sha, artifacts):
+    if (run.get("status") != "completed" or run.get("conclusion") != "success"
+            or run.get("event") != "push" or run.get("head_branch") != "main"
+            or run.get("head_sha") != sha or not re.fullmatch(r"[0-9a-f]{40}", sha)):
+        return entries
+    live = {a["name"] for a in artifacts if not a.get("expired")}
+    result = []
+    for entry in entries:
+        name = f"module-bundle-{entry['module']}"
+        if entry.get("test") is False and not entry.get("ledger") and name in live:
+            entry = {**entry, "reuse": {"runId": str(run["id"]), "name": name,
+                                        "source": run["html_url"]}}
+        result.append(entry)
+    return result
+
+
+def self_test():
+    entries = [{"module": "Floor", "test": False}, {"module": "Changed", "test": True}]
+    run = dict(status="completed", conclusion="success", event="push", head_branch="main",
+               head_sha="a" * 40, id=10, html_url="https://example.test/runs/10")
+    artifacts = [{"name": "module-bundle-Floor", "expired": False}]
+    got = annotate(entries, run, "a" * 40, artifacts)
+    assert got[0]["reuse"]["runId"] == "10" and "reuse" not in got[1]
+    for change in [dict(conclusion="failure"), dict(event="pull_request"), dict(status="in_progress"),
+                   dict(head_branch="other"), dict(head_sha="b" * 40)]:
+        assert annotate(entries, {**run, **change}, "a" * 40, artifacts) == entries
+    assert annotate(entries, run, "a" * 40, []) == entries
+    assert annotate(entries, run, "a" * 40, [{**artifacts[0], "expired": True}]) == entries
+    assert annotate([{**entries[0], "ledger": {"decision": "build"}}], run, "a" * 40, artifacts)[0].get("reuse") is None
+    print("publication reuse: 9 assertions passed")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--matrix")
+    p.add_argument("--run", default="")
+    p.add_argument("--sha", default="")
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    p.add_argument("--self-test", action="store_true")
+    a = p.parse_args()
+    if a.self_test:
+        self_test()
+        return 0
+    entries = json.loads(a.matrix)
+    if a.run and a.sha and any(e.get("test") is False for e in entries):
+        try:
+            if not a.run.isdigit() or not re.fullmatch(r"[\w.-]+/[\w.-]+", a.repo):
+                raise ValueError("invalid run or repository")
+            def api(path, *args):
+                return json.loads(subprocess.run(["gh", "api", path, *args], capture_output=True,
+                                                 text=True, timeout=60, check=True).stdout)
+            run = api(f"repos/{a.repo}/actions/runs/{a.run}")
+            pages = api(f"repos/{a.repo}/actions/runs/{a.run}/artifacts?per_page=100", "--paginate", "--slurp")
+            entries = annotate(entries, run, a.sha, [art for page in pages for art in page["artifacts"]])
+        except (OSError, ValueError, KeyError, subprocess.SubprocessError):
+            print("::warning::publication artifacts unavailable; retaining normal builds", file=sys.stderr)
+    build = [e for e in entries if not e.get("reuse") and e.get("ledger", {}).get("decision") != "reuse"]
+    print(f"publication reuse: {sum(bool(e.get('reuse')) for e in entries)} unchanged gate dependencies", file=sys.stderr)
+    if os.environ.get("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+            out.write(f"modules={json.dumps(entries)}\nbuild={json.dumps(build)}\n")
+    print(json.dumps(entries))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -328,7 +328,7 @@ def changed_files(root: Path, diff_range: str, say) -> list[str] | None:
 
 def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: str | None,
            override: list[str] | None, say, publishing: bool = False,
-           always: frozenset[str] = frozenset()) -> dict:
+           always: frozenset[str] = frozenset(), publication_base: str = "") -> dict:
     all_packages = sorted(node_packages(root))
     universe = [e["module"] for e in entries]
 
@@ -356,11 +356,24 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
             "'Build everything' and 'everything is nothing' cannot both be true, so this is a "
             "broken input (a --root that does not match the checkout?), not a scope.")
 
-    if publishing:
+    # Only an ancestor from a successful publishing run can narrow a main push. Never use
+    # event.before: it loses changes from failed/cancelled runs. Other events retain full scope.
+    publication_diff = False
+    if event == "push" and publication_base:
+        if not re.fullmatch(r"[0-9a-f]{40}", publication_base):
+            return full("publication baseline is not a full commit SHA")
+        ancestor = subprocess.run(["git", "merge-base", "--is-ancestor", publication_base, "HEAD"],
+                                  cwd=root, capture_output=True, timeout=30)
+        if ancestor.returncode != 0:
+            return full("publication baseline is unavailable or not an ancestor of HEAD")
+        publication_diff = True
+        diff_range = f"{publication_base}..HEAD"
+        override = None  # a publishing decision must read the actual tree, never a supplied list
+    if publishing and not publication_diff:
         return full("this run PUBLISHES, and a publishing run is never narrowed — the derived "
                     "version is the change detector on that path, and a diff that misses a unit "
                     "means that unit silently never ships.")
-    if event not in NARROWABLE:
+    if event not in NARROWABLE and not publication_diff:
         return full(FULL_REASONS[lane].get(
             event, f"event '{event}' has no meaningful content diff — running the full set."))
     if not (root / SELECTOR).is_file():
@@ -374,7 +387,15 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
     if override is not None:
         files = [f for f in override if f.strip()]
     else:
-        got = changed_files(root, diff_range or "", say)
+        if publication_diff:
+            # A failed run may have published SOME bundles. Include every intervening change,
+            # even one later reverted, so HEAD repairs those partial publications too.
+            history = subprocess.run(["git", "log", "--format=", "--name-only", "--no-renames",
+                                      "-m", diff_range], cwd=root, capture_output=True,
+                                     text=True, timeout=120)
+            got = sorted(set(history.stdout.splitlines()) - {""}) if history.returncode == 0 else None
+        else:
+            got = changed_files(root, diff_range or "", say)
         if got is None:
             return full(f"git diff --name-only {diff_range} failed (see above) — the changed set "
                         "is unknown, so the full set runs.")
@@ -632,6 +653,36 @@ def self_test() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         _fixture(root)
+
+        # Real history: a failed intermediate publication followed by a revert still owes
+        # a publish. A net diff would incorrectly select nothing here.
+        def git(*args):
+            return subprocess.run(["git", *args], cwd=root, capture_output=True, text=True,
+                                  check=True).stdout.strip()
+        git("init", "-q")
+        git("config", "user.name", "Scope Test")
+        git("config", "user.email", "scope@example.test")
+        git("add", ".")
+        git("commit", "-qm", "baseline")
+        base = git("rev-parse", "HEAD")
+        node = root / "Alpha" / "index.json"
+        before = node.read_text()
+        node.write_text(before + "\n")
+        git("commit", "-qam", "intermediate partial publication")
+        node.write_text(before)
+        git("commit", "-qam", "restore original content")
+        result = _run(root, "modules", "push", None,
+                      extra=["--publication-base", base, "--publishing"])
+        check("a reverted partial publication is repaired", result["selected"] == ["Acme.Alpha"])
+        for event in ("schedule", "repository_dispatch", "workflow_dispatch"):
+            result = _run(root, "modules", event, None, extra=["--publication-base", base])
+            check(f"{event} ignores publication baseline", result["scope"] == "full")
+        for invalid in ("short", "f" * 40):
+            result = _run(root, "modules", "push", None, extra=["--publication-base", invalid])
+            check("invalid or unavailable baseline builds full", result["scope"] == "full")
+        result = _run(root, "modules", "push", None,
+                      extra=["--publication-base", git("rev-parse", "HEAD")])
+        check("empty publication range builds full", result["scope"] == "full")
 
         print("FULL-run fallbacks — the bias that makes narrowing safe (both lanes):")
         for lane, n in (("modules", 2),):
@@ -931,6 +982,8 @@ def main() -> int:
                    help="the PR base branch — the diff is origin/<base-ref>...HEAD")
     p.add_argument("--changed-list", default=None, dest="changed_list",
                    help="comma-separated changed paths instead of a git diff (tests only)")
+    p.add_argument("--publication-base", default="",
+                   help="successful trunk publication SHA; push only, ancestor-checked")
     p.add_argument("--publishing", action="store_true",
                    help="this run hands its output to a registry or feed — never narrow. The "
                         "publish path's change detector is the derived version, and a diff that "
@@ -964,7 +1017,7 @@ def main() -> int:
     always = frozenset(a.strip() for a in args.always.split(",") if a.strip())
     answer = decide(root, args.lane, entries, args.event,
                     f"origin/{args.base_ref}...HEAD" if args.base_ref else None, changed, say,
-                    publishing=args.publishing, always=always)
+                    publishing=args.publishing, always=always, publication_base=args.publication_base)
 
     # 🚨 A refusal is a BROKEN INPUT, not a scope: exit non-zero so the step fails and the job
     # goes red. Emitting it as an answer is how "build everything, and everything is nothing"

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2028,7 +2028,11 @@ jobs:
     # run; running it here as well is what makes a core PR that breaks the narrowing red on the
     # core PR, rather than on the next satellite to bump its pin.
     - name: "The build-scope selector can say no, and every fallback still falls back (self-test)"
-      run: python3 .github/scripts/node-repo-scope.py --self-test
+      run: |
+        python3 .github/scripts/node-repo-scope.py --self-test
+        python3 .github/scripts/node-repo-publication-base.py --self-test
+        python3 .github/scripts/node-repo-publication-reuse.py --self-test
+        python3 .github/scripts/node-repo-project-scope.py --self-test
     - name: "A satellite's no-op set stays comparable to ours — the gate can fail (self-test)"
       run: python3 .github/scripts/check-noop-scope-parity.py --self-test
 

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -412,6 +412,14 @@ on:
         required: false
         type: string
         default: install
+      build-logic-ref:
+        description: >
+          Optional immutable core SHA for selection scripts. Separate from platform-ref, which
+          selects the framework source the tests build. Set it to opt into publication baseline
+          and dependency reuse; existing callers retain their platform-ref selector.
+        required: false
+        type: string
+        default: ''
       publication-run:
         description: Successful publishing run paired with publication-base and identical resolved toolchain inputs; permits reusing unchanged gate dependencies.
         required: false
@@ -599,7 +607,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
+          ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
           path: meshweaver
       - uses: actions/setup-python@v7
         with:
@@ -608,11 +616,18 @@ jobs:
       # falls back. It runs here, on every run, next to the answer it produces — a selector whose
       # self-test is only run by someone remembering to is a selector nobody checks.
       - name: The selection can say no (self-test)
+        env:
+          BUILD_LOGIC_REF: ${{ inputs.build-logic-ref }}
         run: |
           set -euo pipefail
+          if [ -n "$BUILD_LOGIC_REF" ]; then
+            [[ "$BUILD_LOGIC_REF" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::build-logic-ref must be an immutable SHA'; exit 1; }
+          fi
           python3 meshweaver/.github/scripts/node-repo-scope.py --self-test
-          python3 meshweaver/.github/scripts/node-repo-publication-base.py --self-test
-          python3 meshweaver/.github/scripts/node-repo-publication-reuse.py --self-test
+          if [ -n "$BUILD_LOGIC_REF" ]; then
+            python3 meshweaver/.github/scripts/node-repo-publication-base.py --self-test
+            python3 meshweaver/.github/scripts/node-repo-publication-reuse.py --self-test
+          fi
           python3 meshweaver/.github/scripts/node-repo-pack-verify.py --self-test
           python3 meshweaver/.github/scripts/module-build-key.py --self-test
           python3 meshweaver/.github/scripts/module-build-ledger.py --self-test
@@ -622,6 +637,7 @@ jobs:
           MODULES: ${{ inputs.modules }}
           ALWAYS: ${{ inputs.always-modules }}
           PUBLICATION_BASE: ${{ inputs.publication-base }}
+          BUILD_LOGIC_REF: ${{ inputs.build-logic-ref }}
           EVENT: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           # A merge_group run carries no `base_ref`; its base is on the event payload. Dormant
@@ -638,10 +654,12 @@ jobs:
             git -C repo fetch --no-tags origin \
               "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
+          publication_args=()
+          if [ -n "$BUILD_LOGIC_REF" ]; then publication_args=(--publication-base "$PUBLICATION_BASE"); fi
           python3 meshweaver/.github/scripts/node-repo-scope.py \
             --for modules --root repo --modules "@$RUNNER_TEMP/matrix.json" \
             --event "$EVENT" --base-ref "${BASE_REF:-}" --always "${ALWAYS:-}" \
-            --publication-base "$PUBLICATION_BASE" > "$RUNNER_TEMP/scope.json"
+            "${publication_args[@]}" > "$RUNNER_TEMP/scope.json"
       # ───────────── THE LEDGER: what of this selection is ALREADY BUILT, and who builds the rest ─────────────
       # 🚨 "we should not start the same build multiple times ⇒ coordinate which packages are in
       # progress; track progress through memex … if Plugin X was built against Platform version Y,
@@ -717,10 +735,17 @@ jobs:
         id: reuse
         env:
           MATRIX: ${{ steps.ledger.outputs.modules }}
+          BUILD: ${{ steps.ledger.outputs.build }}
+          BUILD_LOGIC_REF: ${{ inputs.build-logic-ref }}
           PUBLICATION_RUN: ${{ inputs.publication-run }}
           PUBLICATION_BASE: ${{ inputs.publication-base }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ -z "$BUILD_LOGIC_REF" ]; then
+            echo "modules=$MATRIX" >> "$GITHUB_OUTPUT"
+            echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           python3 meshweaver/.github/scripts/node-repo-publication-reuse.py \
             --matrix "$MATRIX" --run "$PUBLICATION_RUN" --sha "$PUBLICATION_BASE"
 

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -412,6 +412,20 @@ on:
         required: false
         type: string
         default: install
+      publication-run:
+        description: Successful publishing run paired with publication-base and identical resolved toolchain inputs; permits reusing unchanged gate dependencies.
+        required: false
+        type: string
+        default: ''
+      publication-base:
+        description: >
+          Optional source SHA of a successful main push of the caller's complete publishing
+          workflow. Only push events use it. The selector verifies ancestry and diffs all changes
+          since that publication; a missing/invalid baseline and release-follow events stay full.
+          Never pass github.event.before or a non-publishing workflow's commit.
+        required: false
+        type: string
+        default: ''
       ledger:
         description: >
           The CI MODULE BUILD LEDGER on the registry portal (Doc/Architecture/ModuleBuildArchitecture →
@@ -489,10 +503,10 @@ jobs:
     outputs:
       # The matrix the pack job expands: the scope's selection, each entry annotated by the ledger
       # (`ledger.decision` build|reuse, `ledger.key`, …) when the ledger is on.
-      modules: ${{ steps.ledger.outputs.modules }}
+      modules: ${{ steps.reuse.outputs.modules }}
       # The SUBSET the one-workspace build compiles — every entry the ledger did not hand a reusable
       # bundle for. The postcondition in build-workspace is fed the SAME list.
-      build-modules: ${{ steps.ledger.outputs.build }}
+      build-modules: ${{ steps.reuse.outputs.build }}
       # The SUBSET whose own test suite must RUN in this call — the entries the pack job's plan
       # would answer `need_test=true` for. It is the `tests` job's matrix; see that job for why
       # the suites are a lane of their own on a non-publishing run.
@@ -597,6 +611,8 @@ jobs:
         run: |
           set -euo pipefail
           python3 meshweaver/.github/scripts/node-repo-scope.py --self-test
+          python3 meshweaver/.github/scripts/node-repo-publication-base.py --self-test
+          python3 meshweaver/.github/scripts/node-repo-publication-reuse.py --self-test
           python3 meshweaver/.github/scripts/node-repo-pack-verify.py --self-test
           python3 meshweaver/.github/scripts/module-build-key.py --self-test
           python3 meshweaver/.github/scripts/module-build-ledger.py --self-test
@@ -605,6 +621,7 @@ jobs:
         env:
           MODULES: ${{ inputs.modules }}
           ALWAYS: ${{ inputs.always-modules }}
+          PUBLICATION_BASE: ${{ inputs.publication-base }}
           EVENT: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           # A merge_group run carries no `base_ref`; its base is on the event payload. Dormant
@@ -623,7 +640,8 @@ jobs:
           fi
           python3 meshweaver/.github/scripts/node-repo-scope.py \
             --for modules --root repo --modules "@$RUNNER_TEMP/matrix.json" \
-            --event "$EVENT" --base-ref "${BASE_REF:-}" --always "${ALWAYS:-}" > "$RUNNER_TEMP/scope.json"
+            --event "$EVENT" --base-ref "${BASE_REF:-}" --always "${ALWAYS:-}" \
+            --publication-base "$PUBLICATION_BASE" > "$RUNNER_TEMP/scope.json"
       # ───────────── THE LEDGER: what of this selection is ALREADY BUILT, and who builds the rest ─────────────
       # 🚨 "we should not start the same build multiple times ⇒ coordinate which packages are in
       # progress; track progress through memex … if Plugin X was built against Platform version Y,
@@ -694,6 +712,17 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Reuse unchanged dependencies from the successful publication
+        id: reuse
+        env:
+          MATRIX: ${{ steps.ledger.outputs.modules }}
+          PUBLICATION_RUN: ${{ inputs.publication-run }}
+          PUBLICATION_BASE: ${{ inputs.publication-base }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 meshweaver/.github/scripts/node-repo-publication-reuse.py \
+            --matrix "$MATRIX" --run "$PUBLICATION_RUN" --sha "$PUBLICATION_BASE"
 
       # ───────────── WHICH OF THE SELECTION STILL OWES A TEST RUN ─────────────
       # The `tests` job's matrix. The predicate is EXACTLY the one the pack job's `Ledger — this
@@ -768,22 +797,24 @@ jobs:
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
       - name: Restore the module-pack tool (per-platform-pin cache)
+        if: needs.select.outputs.build-modules != '[]'
         id: tool-cache
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/pack-tool
           key: pack-tool-${{ inputs.platform-ref }}
       - uses: actions/setup-dotnet@v6
-        if: steps.tool-cache.outputs.cache-hit != 'true'
+        if: needs.select.outputs.build-modules != '[]' && steps.tool-cache.outputs.cache-hit != 'true'
         with:
           dotnet-version: "10.0.x"
       - name: Publish the module-pack tool (once for every pack job)
-        if: steps.tool-cache.outputs.cache-hit != 'true'
+        if: needs.select.outputs.build-modules != '[]' && steps.tool-cache.outputs.cache-hit != 'true'
         run: dotnet publish meshweaver/src/MeshWeaver.Plugin.Build/MeshWeaver.Plugin.Build.csproj -c Release -o "$RUNNER_TEMP/pack-tool"
       # Lane-scoped like every other artifact this workflow drops: two calls in one run publish
       # the tool from their OWN platform pin, and a run-wide name lets one call's pack jobs pack
       # with the other call's builder.
       - name: Hand the tool to the matrix
+        if: needs.select.outputs.build-modules != '[]'
         uses: actions/upload-artifact@v7
         with:
           name: module-pack-tool-${{ needs.select.outputs.lane }}
@@ -1427,6 +1458,7 @@ jobs:
         env:
           LEDGER: ${{ inputs.ledger }}
           ENTRY_LEDGER: ${{ toJSON(matrix.entry.ledger) }}
+          ENTRY_REUSE: ${{ toJSON(matrix.entry.reuse) }}
           RUN_TESTS: ${{ matrix.entry.test != false }}
           PUBLISH: ${{ inputs.publish }}
           MODULE: ${{ matrix.entry.module }}
@@ -1436,7 +1468,13 @@ jobs:
         run: |
           set -euo pipefail
           decision=build; key=""; need_test="$RUN_TESTS"; need_publish="$PUBLISH"; art_run=""; art_name=""; sha=""; holder=""
-          if [ "$LEDGER" = "required" ] && [ "$ENTRY_LEDGER" != "null" ] && [ -n "$ENTRY_LEDGER" ]; then
+          if [ "$ENTRY_REUSE" != "null" ] && [ -n "$ENTRY_REUSE" ]; then
+            decision=reuse; need_test=false; need_publish=false
+            art_run=$(jq -er '.runId' <<< "$ENTRY_REUSE")
+            art_name=$(jq -er '.name' <<< "$ENTRY_REUSE")
+            holder=$(jq -er '.source' <<< "$ENTRY_REUSE")
+            echo "plan: REUSE unchanged $MODULE from successful publication $holder — no compile, tests or publish owed"
+          elif [ "$LEDGER" = "required" ] && [ "$ENTRY_LEDGER" != "null" ] && [ -n "$ENTRY_LEDGER" ]; then
             decision=$(jq -r '.decision // "build"' <<< "$ENTRY_LEDGER")
             key=$(jq -r '.key // ""' <<< "$ENTRY_LEDGER")
             if [ "$decision" = "reuse" ]; then
@@ -1821,7 +1859,7 @@ jobs:
             echo "### \`$MODULE\` — **reused** from run $ART_RUN"
             echo
             echo "- record: $HOLDER"
-            echo "- sha256: \`$actual\` (verified against the ledger)"
+            echo "- sha256: \`$actual\`; source: $HOLDER"
           } >> "$GITHUB_STEP_SUMMARY"
 
       # Published ONCE by the prepare job — `dotnet build` here cost 48–79s in EVERY job (measured
@@ -2125,7 +2163,7 @@ jobs:
           VERSION: ${{ steps.identity.outputs.version }}
           # A reused leg has no compiler of its own: the marker says so, and names the run that did.
           COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
-          CLOSURE: ${{ steps.plan.outputs.decision == 'reuse' && format('reused from run {0} ({1}, sha256 verified against the ledger)', steps.plan.outputs.art_run, steps.plan.outputs.art_name) || steps.build.outputs.closure }}
+          CLOSURE: ${{ steps.plan.outputs.decision == 'reuse' && format('reused from run {0} ({1}, published artifact provenance verified)', steps.plan.outputs.art_run, steps.plan.outputs.art_name) || steps.build.outputs.closure }}
           BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
         run: |
           set -euo pipefail

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -637,6 +637,7 @@ jobs:
           MODULES: ${{ inputs.modules }}
           ALWAYS: ${{ inputs.always-modules }}
           PUBLICATION_BASE: ${{ inputs.publication-base }}
+          PUBLICATION_RUN: ${{ inputs.publication-run }}
           BUILD_LOGIC_REF: ${{ inputs.build-logic-ref }}
           EVENT: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -655,7 +656,9 @@ jobs:
               "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
           publication_args=()
-          if [ -n "$BUILD_LOGIC_REF" ]; then publication_args=(--publication-base "$PUBLICATION_BASE"); fi
+          if [ -n "$BUILD_LOGIC_REF" ] && [[ "$PUBLICATION_RUN" =~ ^[0-9]+$ ]] && [[ "$PUBLICATION_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+            publication_args=(--publication-base "$PUBLICATION_BASE")
+          fi
           python3 meshweaver/.github/scripts/node-repo-scope.py \
             --for modules --root repo --modules "@$RUNNER_TEMP/matrix.json" \
             --event "$EVENT" --base-ref "${BASE_REF:-}" --always "${ALWAYS:-}" \

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
@@ -239,3 +239,10 @@ forces full builds until a successful publication restores the baseline. The con
 reusing results across arbitrary runs; the caller must provision its credential before enabling
 it. Successful-publication reuse needs only the existing GitHub Actions read permission. Do not substitute the bake's two-module composition
 index for evidence that the whole compiled catalogue was published.
+
+
+`build-logic-ref` opts the module call into these selectors at an immutable core commit, separately
+from `platform-ref` (the framework source against which compiled suites run). A workflow update
+must not silently advance that source pin. Existing callers without the new input keep their
+previous selector and do not invoke the new helpers. The publication-input receipt includes both
+resolved framework source and build-logic pins, as well as the image digests.

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
@@ -246,3 +246,10 @@ from `platform-ref` (the framework source against which compiled suites run). A 
 must not silently advance that source pin. Existing callers without the new input keep their
 previous selector and do not invoke the new helpers. The publication-input receipt includes both
 resolved framework source and build-logic pins, as well as the image digests.
+
+The reusable lane accepts the baseline only as a pair: a numeric `publication-run` and a full
+source SHA with `build-logic-ref` enabled. An absent run or malformed pair keeps broad publishing.
+If the compiled-project selector cannot load its scope helper or project graph, it validates the
+entire declared policy; a missing or syntactically invalid helper is covered by its self-test.
+The ledger lane guard verifies that publication reuse receives both ledger outputs and that its
+final build subset feeds the build and postcondition together.

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
@@ -201,3 +201,41 @@ tested 1 before this change and after it.
 moved portal hosts and runs 48 platform suites on every pull request regardless of the diff. That is
 a separate decision, on a job whose suites cover the platform pin rather than this repository's
 modules.
+
+
+## Separate compiled validation from content publication (2026-09-09)
+
+A node-only lesson change does not require rebuilding portal hosts or running unrelated storage,
+AI and Blazor suites. `node-repo-project-scope.py` selects host builds and tests from the caller's
+project graph, linked content and explicit runtime-input prefixes. The caller retains its project
+inventory as policy. A source-scanning guard declares the paths it reads; a linked content folder
+is an input even when it lives outside `src/`. Unknown paths, absent graphs and missing diffs run
+full validation; malformed or missing inventory entries fail. Selection and execution must be
+reconciled by the caller's stable required check.
+
+The module lane accepts an optional `publication-base` on main pushes. Obtain it only from
+`node-repo-publication-base.py`, naming the caller's complete publishing workflow. It reads a
+successful completed **main push**, verifies that commit is an ancestor, and otherwise supplies
+no baseline. Manual runs cannot advance it. A newer failed, cancelled, active or release-follow
+publication forces a full build: its partial writes may have used a different toolchain override,
+which a source diff cannot see. Successful runs record their actual resolved platform ref and
+image digests in `publication-inputs`; a missing or differing receipt also forces a full build.
+The registry's package version and `github.event.before` are not publication evidence.
+
+Selection takes the **union of paths changed by all intervening commits**, not just the net diff.
+A failed run can publish some bundles before it fails; if a later commit reverts that change,
+those bundles must be republished even when HEAD equals the successful baseline. The history union
+retains that repair. A missing baseline or an empty/unreadable history selects everything. A
+workflow/tooling/platform-pin change also selects everything. Release-follow events remain full.
+Floor bundles required by compilation and the sealed bake remain selected; suites run only for
+entries actually affected. `publication-run` pairs the attested baseline with its successful run.
+Unchanged floor entries reuse that run's still-live module artifacts through the existing reuse
+and receipt path. Missing artifacts retain the normal build leg; affected entries never reuse on
+this proof. The module-pack tool is not rebuilt when all selected bundles are reused. The existing receipt verification and supported publication endpoint
+are unchanged. No registry credential or mutable publication ref is introduced.
+
+This is deliberately a conservative first separation. A chronically failing publishing workflow
+forces full builds until a successful publication restores the baseline. The content-addressed module ledger remains the mechanism for coordinating concurrent builds and
+reusing results across arbitrary runs; the caller must provision its credential before enabling
+it. Successful-publication reuse needs only the existing GitHub Actions read permission. Do not substitute the bake's two-module composition
+index for evidence that the whole compiled catalogue was published.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-separate-content-builds.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-separate-content-builds.md
@@ -1,0 +1,17 @@
+---
+Name: Separate content changes from compiled builds
+Category: Feature
+Description: Shared build selection can keep content releases focused while retaining checks for affected compiled consumers.
+Icon: Sparkle
+Order: -20260909
+---
+
+Content changes can select the compiled tests that actually read their files without rebuilding
+unrelated portal hosts. Compiled dependencies, linked content and declared source scans remain
+part of validation.
+
+The shared module release lane can select changes since a successful publication. It retains
+changes from failed or cancelled releases, including reverted partial publications, and runs the
+full build when it cannot establish a safe baseline or the platform changes.
+
+See [Build scope narrowing](/Doc/Architecture/BuildScopeNarrowing) for the selection contract.

--- a/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
@@ -53,9 +53,15 @@ public class ModuleBuildLedgerLaneGuard
         Assert.Contains("inputs.ledger is '$LEDGER'. The only values are 'off' (the default) and 'required'", select, StringComparison.Ordinal);
         // The token is asserted, never tested-and-skipped.
         Assert.Contains("[ -n \"${MW_LEDGER_TOKEN:-}\" ] ||", select, StringComparison.Ordinal);
-        // Both outputs the downstream jobs key on.
-        Assert.Contains("build-modules: ${{ steps.ledger.outputs.build }}", select, StringComparison.Ordinal);
-        Assert.Contains("modules: ${{ steps.ledger.outputs.modules }}", select, StringComparison.Ordinal);
+        // Publication reuse is downstream of the ledger: it must preserve the ledger selection
+        // and its build subset when disabled, then expose the final selection to both consumers.
+        Assert.Contains("MATRIX: ${{ steps.ledger.outputs.modules }}", select, StringComparison.Ordinal);
+        Assert.Contains("BUILD: ${{ steps.ledger.outputs.build }}", select, StringComparison.Ordinal);
+        Assert.Contains("echo \"modules=$MATRIX\" >> \"$GITHUB_OUTPUT\"", select, StringComparison.Ordinal);
+        Assert.Contains("echo \"build=$BUILD\" >> \"$GITHUB_OUTPUT\"", select, StringComparison.Ordinal);
+        Assert.Contains("node-repo-publication-reuse.py", select, StringComparison.Ordinal);
+        Assert.Contains("build-modules: ${{ steps.reuse.outputs.build }}", select, StringComparison.Ordinal);
+        Assert.Contains("modules: ${{ steps.reuse.outputs.modules }}", select, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Content-only changes currently pay for unrelated compiled validation and dependency rebuilds. Add centralized project selection and an opt-in successful-publication baseline to the existing module lane, preserving full fallbacks, platform-release rebuilds and receipt checks.

The baseline attests actual resolved toolchain inputs, ignores manual runs, and refuses narrowing after a newer partial/active/release-follow publication. Module selection retains intervening changes (including reverts). Unchanged gate dependencies can reuse the successful run's available artifacts through the existing reuse path; expired artifacts build normally. Callers retain only project/input policy and pinned workflow calls.

Validation: 71 scope cases; 19 baseline, 9 publication-reuse and 14 project-selection assertions; existing pack receipt self-tests; actionlint; documentation Release build with warnings-as-errors (0 warnings/errors). Architecture and release note are committed under Documentation. Plugins adoption follows in a paired PR; existing callers retain their defaults.
