### PR TITLE
docs: /teams skill — the bot reads nothing; what reading/sending needs; the guest-tenant wall

### DIFF
--- a/.claude/skills/teams/SKILL.md
+++ b/.claude/skills/teams/SKILL.md
@@ -88,7 +88,7 @@ A delegated token is minted by the user's **home** tenant. A team the user reach
 (B2B) lives in the **resource** tenant, and Graph does not cross that line on a home-tenant token:
 `/me/joinedTeams` does not list guest teams, and the channel endpoints answer 403/404 for them —
 measured and documented by others
-([Q&A](https://learn.microsoft.com/en-us/answers/questions/48733/read-teams-channels-using-graph-api-as-a-b2b-(gues),
+([Q&A](https://learn.microsoft.com/en-us/answers/questions/48733/read-teams-channels-using-graph-api-as-a-b2b-%28gues),
 [Tech Community](https://techcommunity.microsoft.com/t5/teams-developer/read-teams-channels-using-graph-api-as-a-b2b-or-guest-user/m-p/1502502)).
 So the scopes above make the EA see **Systemorph's** teams. PartnerRe ESL needs one of:
 

--- a/.claude/skills/teams/SKILL.md
+++ b/.claude/skills/teams/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: teams
+description: Microsoft Teams access from MeshWeaver — what the shipped Teams integration actually is (a bot people message; it reads and sends NOTHING on a user's behalf), and what reading or sending a user's teams, channels and chats needs — the delegated Graph scopes on the Executive Assistant consent link, the tools on the EA plugin, the consent rules, and the TENANT wall that makes "can you see PartnerRe ESL?" a different question from "can you see my teams?". Use when someone asks whether an agent can see, read, summarise or post to Teams, when adding Teams scopes or tools, or when a Teams-related answer from an agent has to be checked against what is wired.
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+---
+
+# /teams — reading and sending Teams on a user's behalf
+
+**Measured 2026-09-09** by asking the Executive Assistant on memex "can you see my Teams channels,
+in particular PartnerRe ESL?": it answered no, and it was right. Nothing in the fleet can enumerate
+a user's teams or read a channel. This skill records what exists, what the ask needs, and the one
+wall that no scope can climb.
+
+## What exists: a bot, not a reader
+
+`MeshWeaver.Teams` (MeshWeaver.Plugins, `src/MeshWeaver.Teams/`) is the Bot Framework channel
+documented in `Doc/AI/TeamsBot`: a person messages the bot in Teams, `TeamsInboundProcessor`
+finds-or-creates one agent thread per conversation, `TeamsReplySender` posts the agent's reply
+back. Its outbound credential is an **app-only connector token** for `api.botframework.com` — it
+can answer in a conversation the bot is part of and nothing else. On memex it is inert
+(`Teams:Enabled=false`, zero `TeamsConversation` nodes).
+
+The Executive Assistant (`src/MeshWeaver.Mail.MicrosoftGraph/ExecutiveAssistantPlugin.cs`) has
+mail and calendar tools only. Its credential is the delegated one minted by the EA consent link,
+and that credential is the seam everything below hangs on.
+
+## The seam: the EA consent link IS a delegated Graph token
+
+`{BaseUrl}/auth/ea/connect` sends the user through Microsoft's authorize endpoint with
+`prompt=consent` and the scope string in `EaGraphAuth.Scopes` — **Memex repo**,
+`Memex.Portal.Shared/Authentication/EaGraphAuth.cs`:
+
+```
+Mail.ReadWrite Mail.Send Calendars.ReadWrite offline_access
+```
+
+Add Teams scopes to that string and every user reconnects once; from then on the same
+`GraphServiceClient` the plugin already builds reaches `/me/joinedTeams`, `/teams/{id}/channels`,
+`/teams/{id}/channels/{id}/messages`, `/me/chats`, `/chats/{id}/messages` — as the user. Nothing
+app-only, no new secret, no new token store. That is the whole point of routing it through the EA.
+
+### Read
+
+| Scope (delegated) | Lets the EA | Admin consent |
+|---|---|---|
+| `Team.ReadBasic.All` | list the user's teams | user-consentable |
+| `Channel.ReadBasic.All` | list a team's channels | user-consentable |
+| `ChannelMessage.Read.All` | read channel messages | **admin consent required** |
+| `Chat.Read` | list and read the user's chats | user-consentable |
+
+### Send
+
+| Scope (delegated) | Lets the EA | Admin consent |
+|---|---|---|
+| `ChannelMessage.Send` | post to a channel as the user | user-consentable |
+| `ChatMessage.Send` | post in a chat as the user | user-consentable |
+
+Re-verify the consent column against the
+[Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+before adding a scope — a tenant's consent policy can make any of them admin-only. The Entra
+**sign-in app registration** must list the same delegated permissions, or the authorize call fails
+before the user sees a screen.
+
+🚨 **Teams has no draft state.** Mail is DraftOnly by design (`Email:AgentSend`, the human presses
+Send); a Teams send is immediate and irreversible. A send tool needs the same gate — a
+`Teams:AgentSend` mode defaulting to a preview page the human confirms, the shape `PrepareMailing`
+already has — and the sending tools must never be handed to the model in the default mode, exactly
+as `SendMail`/`ReplyToMail` are not.
+
+### The three pieces to write
+
+1. **Memex repo:** the scopes in `EaGraphAuth.Scopes`, and the delegated permissions on the app
+   registration (Roland's Entra tenant for the Systemorph portals).
+2. **Plugins repo:** tools on `ExecutiveAssistantPlugin` — `ListTeams`, `ListChannels`,
+   `ReadChannelMessages`, `ListChats`, `ReadChat`, and (gated) `SendChannelMessage` /
+   `SendChatMessage`; the plugin's `ClientAsync()` already yields the delegated
+   `GraphServiceClient`. Model-facing `[Description]`s stay English.
+3. **Plugins repo:** `src/MeshWeaver.AI/Data/Agent/ExecutiveAssistant.md` names the new surface,
+   or the agent will keep answering "I have no Teams tool" from its instructions.
+
+## 🚨 The wall: "PartnerRe ESL" lives in PartnerRe's tenant
+
+A delegated token is minted by the user's **home** tenant. A team the user reaches as a **guest**
+(B2B) lives in the **resource** tenant, and Graph does not cross that line on a home-tenant token:
+`/me/joinedTeams` does not list guest teams, and the channel endpoints answer 403/404 for them —
+measured and documented by others
+([Q&A](https://learn.microsoft.com/en-us/answers/questions/48733/read-teams-channels-using-graph-api-as-a-b2b-(gues),
+[Tech Community](https://techcommunity.microsoft.com/t5/teams-developer/read-teams-channels-using-graph-api-as-a-b2b-or-guest-user/m-p/1502502)).
+So the scopes above make the EA see **Systemorph's** teams. PartnerRe ESL needs one of:
+
+- **A token for PartnerRe's tenant.** Run the same consent flow against
+  `login.microsoftonline.com/<partnerre tenant id>` (the app registration must be multi-tenant),
+  store the resulting refresh token per (user, tenant), and route calls for that team through it.
+  `ChannelMessage.Read.All` then needs **PartnerRe's** admin to consent to the Memex app in their
+  tenant — a conversation with Thomas Mager and their security team (Lucas Mebold), not a setting
+  on our side.
+- **The bot, installed in their team.** The existing `MeshWeaver.Teams` bot with resource-specific
+  consent (`ChannelMessage.Read.Group`) in its manifest, added to the PartnerRe ESL team by a team
+  owner. Messages are then PUSHED to `/api/teams/messages` as they happen; nothing is enumerated.
+  Needs `Teams:Enabled` on the receiving portal and PartnerRe's app-upload policy to allow it.
+- **Their export.** Ask for a channel export; ingest it as content. No integration at all.
+
+Do not promise "I'll read the PartnerRe channel" until one of these exists; the honest answer today
+is the Graph-visible substitute — the mailbox — which the EA already gives.
+
+## Checking what an agent says about Teams
+
+The EA's answer is only as good as its tool list. Before trusting a "no Teams access" or a
+"connected" claim: `get @Agent/ExecutiveAssistant/data/` for the plugins, then read
+`ExecutiveAssistantPlugin.cs` for the tools actually exposed, then `EaGraphAuth.Scopes` for what
+the token can carry. All three moved independently in the past; the doc `Doc/AI/TeamsBot` describes
+the bot only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ it, not before.
 | [/async](.claude/skills/async/SKILL.md) | any hub-reachable or Blazor-view call; IO; AccessContext |
 | [/gui](.claude/skills/gui/SKILL.md) | any layout area, control, editor, form, table |
 | [/i18n](.claude/skills/i18n/SKILL.md) | any string a human reads on screen |
+| [/teams](.claude/skills/teams/SKILL.md) | anything about an agent SEEING, reading or posting to Teams: the shipped bot reads nothing; what the EA consent link needs; the guest-tenant wall |
 | [/debug](.claude/skills/debug/SKILL.md) · [/storm](.claude/skills/storm/SKILL.md) · [/sigsegv](.claude/skills/sigsegv/SKILL.md) | a hang/timeout; a restart/502/log flood; a crashed host |
 
 ## Git Workflow

--- a/src/MeshWeaver.Documentation/Data/AI/TeamsBot.md
+++ b/src/MeshWeaver.Documentation/Data/AI/TeamsBot.md
@@ -114,6 +114,17 @@ secret ([ConfiguringAnInstanceFromAspire](/Doc/Architecture/ConfiguringAnInstanc
 > Until step 5, the bot is completely inert — the code ships with `Teams:Enabled=false`, the endpoint
 > returns `NotFound`, and no reply sender runs.
 
+## What the bot does NOT do
+
+The bot **reads nothing on a user's behalf**: it cannot list a user's teams, enumerate channels,
+read channel history or chats, or post as a user. Its outbound credential is an app-only Bot
+Framework connector token, valid only for conversations the bot is part of. Reading or sending a
+user's Teams content is a different integration — delegated Graph scopes on the Executive
+Assistant's consent link plus tools on its plugin — and a team the user reaches as a **guest**
+(another company's tenant) is not reachable on a home-tenant token at all. An agent that answers
+"I have no Teams access" is describing this accurately; the engineering notes live with the
+repository's `/teams` skill.
+
 ## Notifications over Teams
 
 The [notification system](/Doc/Architecture/EmailIngestionAndNotifications#3-the-notification-system)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-teams-page-says-what-the-bot-does-not-do.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-teams-page-says-what-the-bot-does-not-do.md
@@ -1,0 +1,12 @@
+---
+Name: The Teams page says what the bot does not do
+Category: Fix
+Description: The Connecting Microsoft Teams page now states plainly that the bot reads nothing on a user's behalf, so an assistant's "I have no Teams access" answer no longer reads as a misconfiguration.
+Icon: Chat
+Order: -20260909
+---
+
+The Teams integration page described the bot channel and left readers to infer the rest. Two
+readers in one morning, one of them an assistant agent, took it for a Teams reader. The page now
+has a section on what the bot does not do: list teams, read channels or chats, or post as a user,
+and why a team you join as a guest of another company is out of reach for a token from your own.


### PR DESCRIPTION
## /teams skill — the bot reads nothing; what reading/sending needs; the guest-tenant wall

Measured 2026-09-09: asked the Executive Assistant on memex whether it can see the PartnerRe ESL channel. It cannot, and it was right — nothing in the fleet enumerates a user's teams or reads a channel. Two readers in one morning (one of them an agent) took the bot doc for a Teams reader.

- **`.claude/skills/teams/SKILL.md`** — what exists (`MeshWeaver.Teams` is a Bot Framework channel on an app-only connector token), the seam a read/send needs (delegated scopes on `EaGraphAuth.Scopes` in the Memex repo, tools on `ExecutiveAssistantPlugin`, the agent instructions), the consent column per scope, the no-draft-state gate a Teams send needs (`Teams:AgentSend`, mirroring `Email:AgentSend`), and the wall: a home-tenant delegated token cannot see a team the user reaches as a guest — PartnerRe ESL needs a token for PartnerRe's tenant, the bot installed in their team with RSC, or an export.
- **AGENTS.md** — the skill row.
- **`Doc/AI/TeamsBot`** — a "What the bot does NOT do" section, and a What's New fix entry.

No code. Pairs-with: none — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
