### PR TITLE
test: define API compatibility independently of platform versions

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/README.md
+++ b/src/MeshWeaver.Compiler.Pipeline/README.md
@@ -1,5 +1,13 @@
 # MeshWeaver.Compiler.Pipeline
 
+Follow the [Module Adoption Policy](../MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md):
+accept compatible APIs across platform/dependency releases. A different NodeType bake identity
+invalidates reuse of that artifact; under the normal policy, compile its source against the
+current platform. It does not by itself make the feature incompatible or require the platform
+to stay on an old version. Preserve the last working module where the loader can fall back, and
+surface actual linking, compilation or loading failures with their dependency evidence. Strict
+prebuilt mode is an explicit exception, not the default compatibility rule.
+
 The **mesh-actor half** of NodeType compilation, factored out of `MeshWeaver.Graph`. It drives the
 pure toolchain in `MeshWeaver.Compiler`:
 

--- a/src/MeshWeaver.Compiler/README.md
+++ b/src/MeshWeaver.Compiler/README.md
@@ -1,5 +1,12 @@
 # MeshWeaver.Compiler
 
+Runtime compatibility follows the APIs actually used, not equality with a platform version or
+commit. See [Module Adoption Policy](../MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md).
+The identities below are compilation/cache provenance: a changed key can require recompilation
+without making the source or feature incompatible. Compile source against the current reference
+set; diagnose missing types, incompatible members or other concrete compile errors. Do not turn
+cache identity equality into a platform hold or a version gate for compiled plugins.
+
 The MeshWeaver NodeType compile toolchain, factored out of `MeshWeaver.Graph` (issue #1707) so
 the framework build identity's full-MVID rule pins a small, low-churn assembly.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -17,6 +17,27 @@ still describes the older mechanism, it says so in a banner that names the imple
 
 ## The three rules
 
+**Maintainer clarification, 2026-09-09: compatibility follows the used API, not a platform pin.**
+Keep a module usable across platform and dependency releases when the contracts it uses remain
+compatible. A different version, build commit or MVID is not evidence of incompatibility. A
+removed type/member, changed required signature or another actual linking/loading failure is.
+Conversely, identical version strings do not make incompatible bytes safe.
+
+This is a runtime contract. Reproducible compiler inputs and content-addressed cache keys record
+what produced an artifact; they must not become an exact-version requirement for running a
+compiled module. A NodeType bake with another build identity is not reused blindly: compile its
+source against the current platform. That cache miss is not a declaration that the feature is
+incompatible. Explicit strict-prebuilt policy remains an operator choice.
+
+The compatibility regression suite must include positive and negative controls: unchanged used
+APIs across different assembly versions, additive APIs/body changes, removal of a referenced API
+even with an unchanged version, incompatible member signatures, and preservation of a working
+generation when an upgrade fails. Exercise real metadata/loader paths; tests that compare version
+strings alone cannot prove these claims. `ModulePlatformLinkTest` covers the type measurement and
+rejected-upgrade continuity. Member compatibility also needs actual loading/execution: the current
+type-level probe cannot establish it. Do not describe a successful type probe as proof that every
+method call is compatible.
+
 | # | Rule | What it replaces |
 |---|---|---|
 | **R1 — continuity** | An installation always runs *some* version of every module it has installed: the newest one that **loads**. If nothing newer ships for the platform it runs, the version it has keeps running. Nothing removes a working module because a newer one exists but cannot load. | A landed generation that does not load leaves the module **absent** (only image-shipped modules had a baseline to fall back to); a shelved landing overwrote the only reference to the loadable generation. |

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -11,6 +11,15 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 **A module is adopted on what this process can LOAD, never on a version string.**
 
+The 2026-09-09 maintainer clarification is explicit: different platform/dependency versions are
+acceptable while the referenced API is compatible; identical versions are insufficient when the
+API is not. `ModulePlatformLinkTest` compiles separate contract assemblies to exercise both
+directions of version skew, additive API changes, and removal of a referenced type without a
+version change. It also verifies that a refused upgrade leaves the installed generation and its
+bytes intact. This probe checks **types**, not member signatures; actual load/install/execution
+checks must cover missing methods or changed constructors. A successful type probe is not a
+claim that those member checks ran.
+
 Until MeshWeaver#3538 the module lane had exactly one platform gate: the module's declared
 `minMeshVersion` FLOOR, compared as SemVer against the running platform's version. That gate is a
 *claim* — a string a module author writes by hand. The module's real requirement is not a version

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -8,6 +8,14 @@ icon: /static/NodeTypeIcons/code.svg
 
 # NodeType Compilation & Releases
 
+**Compatibility follows the APIs used, not a fixed platform version**
+([Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy), maintainer clarification
+2026-09-09). Reuse a compiled artifact only when its cache contract permits it; otherwise compile
+the source against the current platform and installed dependencies. A different build identity
+alone is a cache miss, not proof of an incompatible feature and not a reason to pin the running
+platform. Diagnose concrete missing types, changed member contracts and compiler/load failures.
+The explicit `Modules:RequirePrebuilt` policy remains a separate operational choice.
+
 A **dynamic NodeType** carries its behaviour as C# source (`Source/*.cs`) plus a
 `configuration` lambda — and that source is compiled **at runtime, on demand**.
 You never redeploy the portal to add or change a NodeType. This page is the

--- a/src/MeshWeaver.Documentation/Data/Architecture/Plugins.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Plugins.md
@@ -18,6 +18,15 @@ Compilation](/Doc/Architecture/NodeTypeCompilation), and the mesh's node/version
 
 ## A plugin is mesh nodes
 
+**Compatibility is API-based.** A plugin should continue working across platform and dependency
+versions while the APIs it uses remain compatible. Version/build-identity differences alone are
+not runtime refusals; missing or incompatible referenced APIs are. Follow the
+[Module Adoption Policy](@/Doc/Architecture/ModuleAdoptionPolicy) for measured loadability,
+continuity and eager adoption. Preserve a working generation when a newer one cannot load, and
+report the actual missing contract. Dependency declarations describe intent; they do not replace
+measurement. For source NodeTypes, an unusable prebuilt cache entry normally means compilation
+against the current platform, rather than holding the platform to that entry's build.
+
 A node repo is exactly the on-disk shape the sample partitions use — a `*.json` per node plus its
 `Source/` (and `Test/`) C# — e.g. the `Publish` plugin and its Slide type:
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-api-compatibility-over-platform-pins.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-api-compatibility-over-platform-pins.md
@@ -1,0 +1,19 @@
+---
+Name: Module compatibility follows the APIs you use
+Category: Feature
+Description: The module and compiler documentation states the API-based compatibility rule, with regression coverage for version differences, removed APIs and preservation of a working module.
+Icon: 🔗
+Order: -20260909
+---
+
+Modules should keep working across platform and dependency releases when the APIs they use remain
+compatible. A version or build-identity difference alone does not establish incompatibility, and
+identical version numbers cannot make a removed API safe.
+
+The [adoption policy](@/Doc/Architecture/ModuleAdoptionPolicy),
+[plugin mechanism](@/Doc/Architecture/Plugins) and
+[compiler lifecycle](@/Doc/Architecture/NodeTypeCompilation) now state this rule together. The
+regression tests use real compiled contracts and the real metadata/landing paths. They cover
+compatible APIs across versions, removed types with unchanged versions, and an incompatible
+upgrade preserving the working module. The docs also distinguish type checks from member checks
+and explain why a NodeType bake cache miss normally means recompilation, not a platform hold.

--- a/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
@@ -4,6 +4,8 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.Mesh;
@@ -437,6 +439,139 @@ public class ModulePlatformLinkTest : IDisposable
     }
 
     // ───────────────────────────────────────────────────────────── harness
+
+    /// <summary>Different assembly versions and additive APIs do not remove a referenced type.
+    /// Exercise the real metadata probe with separately compiled contracts in both directions.</summary>
+    [Theory]
+    [InlineData("1.0.0.0", "9.0.0.0")]
+    [InlineData("9.0.0.0", "1.0.0.0")]
+    public void CompatibleApiAcrossPlatformVersions_IsLinkable(string builtVersion, string runningVersion)
+    {
+        const string contractName = "MeshWeaver.Test.VersionedContract";
+        const string moduleName = "MeshWeaver.Test.VersionTolerantPack";
+        var builtContract = Emit(contractName, $$"""
+            [assembly: System.Reflection.AssemblyVersion("{{builtVersion}}")]
+            namespace MeshWeaver.Test;
+            public class StableApi { public int Answer() => 1; }
+            """);
+        var module = Emit(moduleName, """
+            public class View {
+                public int Render(MeshWeaver.Test.StableApi api) => api.Answer();
+            }
+            """, extra: MetadataReference.CreateFromImage(builtContract));
+        var runningContract = Emit(contractName, $$"""
+            [assembly: System.Reflection.AssemblyVersion("{{runningVersion}}")]
+            namespace MeshWeaver.Test;
+            public class StableApi { public int Answer() => 42; public string Extra() => "new"; }
+            public class UnusedAddition { }
+            """);
+
+        var surface = ModulePlatformSurface.OfFiles([Write(contractName, runningContract)]);
+        var verdict = ModulePlatformLink.Check(module, moduleName, new HashSet<string> { moduleName }, surface);
+
+        Assert.Equal(ModuleLinkState.Linkable, verdict.State);
+        Assert.True(verdict.MayLoad, verdict.Report());
+        Assert.True(verdict.CheckedTypeReferences > 0);
+        Assert.Contains(contractName, verdict.CheckedAssemblies);
+        Assert.Empty(verdict.MissingTypes);
+    }
+
+    /// <summary>The same version can contain incompatible bytes. Version equality must never
+    /// replace the type measurement, even when an unrelated type remains in the assembly.</summary>
+    [Fact]
+    public void IdenticalPlatformVersionWithRemovedApi_IsUnlinkable()
+    {
+        const string contractName = "MeshWeaver.Test.SameVersionContract";
+        const string moduleName = "MeshWeaver.Test.RemovedApiPack";
+        var builtContract = Emit(contractName, """
+            [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+            namespace MeshWeaver.Test;
+            public class RequiredApi { }
+            """);
+        var module = Emit(moduleName, """
+            public class View { public MeshWeaver.Test.RequiredApi Render() => new(); }
+            """, extra: MetadataReference.CreateFromImage(builtContract));
+        var runningContract = Emit(contractName, """
+            [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+            namespace MeshWeaver.Test;
+            public class UnrelatedApi { }
+            """);
+
+        var verdict = ModulePlatformLink.Check(module, moduleName, new HashSet<string> { moduleName },
+            ModulePlatformSurface.OfFiles([Write(contractName, runningContract)]));
+
+        Assert.Equal(ModuleLinkState.Unlinkable, verdict.State);
+        Assert.False(verdict.MayLoad);
+        Assert.Contains(verdict.MissingTypes, missing => missing.Contains("MeshWeaver.Test.RequiredApi", StringComparison.Ordinal));
+        Assert.Contains(contractName, verdict.Report(), StringComparison.Ordinal);
+    }
+
+    /// <summary>Exercise real method binding as well as type metadata. A changed method body or
+    /// added overload keeps the used signature working; removing/changing it fails when invoked.
+    /// The type probe alone deliberately makes no member-compatibility claim.</summary>
+    [Theory]
+    [InlineData("public int Answer() => 42; public int Answer(int extra) => extra;", true)]
+    [InlineData("public long Answer() => 42;", false)]
+    [InlineData("public int Answer(int extra) => extra;", false)]
+    public void MemberCompatibility_IsMeasuredByBindingTheUsedSignature(string runtimeMember, bool compatible)
+    {
+        const string contractName = "MeshWeaver.Test.MemberContract";
+        const string moduleName = "MeshWeaver.Test.MemberConsumer";
+        var builtContract = Emit(contractName,
+            "namespace MeshWeaver.Test; public class Api { public int Answer() => 1; }");
+        var consumer = Emit(moduleName,
+            "public static class View { public static int Render() => new MeshWeaver.Test.Api().Answer(); }",
+            extra: MetadataReference.CreateFromImage(builtContract));
+        var runtimeContract = Emit(contractName,
+            "namespace MeshWeaver.Test; public class Api { " + runtimeMember + " }");
+
+        var typeVerdict = ModulePlatformLink.Check(consumer, moduleName, new HashSet<string> { moduleName },
+            ModulePlatformSurface.OfFiles([Write(contractName, runtimeContract)]));
+        Assert.Equal(ModuleLinkState.Linkable, typeVerdict.State);
+
+        var context = new AssemblyLoadContext("member-contract-" + Guid.NewGuid().ToString("N"), isCollectible: true);
+        try
+        {
+            using var runtime = new MemoryStream(runtimeContract);
+            context.LoadFromStream(runtime);
+            using var module = new MemoryStream(consumer);
+            var render = context.LoadFromStream(module).GetType("View")!.GetMethod("Render")!;
+            if (compatible)
+                Assert.Equal(42, render.Invoke(null, null));
+            else
+            {
+                var error = Assert.Throws<TargetInvocationException>(() => render.Invoke(null, null));
+                var missing = Assert.IsType<MissingMethodException>(error.InnerException);
+                Assert.Contains("Answer", missing.Message, StringComparison.Ordinal);
+            }
+        }
+        finally { context.Unload(); }
+    }
+
+    /// <summary>An incompatible incoming generation must not replace the working activation.
+    /// Run both real landings and verify the previous bytes and activation pointer survive.</summary>
+    [Fact]
+    public async Task MissingApiInUpgrade_PreservesWorkingModuleAndItsBytes()
+    {
+        const string name = "MeshWeaver.Test.ContinuityPack";
+        var good = ModuleBuiltAgainstThisPlatform(name);
+        await landing.LandModule(name, [(name + ".dll", good)], version: "1.0.0")
+            .Timeout(TestTimeouts.Convergence).Await();
+        var before = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        var goodPath = Path.Combine(ModuleLandingService.ModuleDirectoryFor(root, name, before), name + ".dll");
+
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await landing.LandModule(name, [(name + ".dll", ModuleBuiltAgainstAFuturePlatform(name))],
+                    version: "2.0.0", minMeshVersion: "0.0.1")
+                .Timeout(TestTimeouts.Convergence).Await());
+
+        Assert.Contains(FutureType, refusal.Message, StringComparison.Ordinal);
+        var after = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal(before.Directory, after.Directory);
+        Assert.Equal(before.Version, after.Version);
+        Assert.True(after.Enabled);
+        Assert.Equal(good, File.ReadAllBytes(goodPath));
+    }
 
     /// <summary>
     /// A module compiled against a STAND-IN <c>MeshWeaver.Mesh.Contract</c> that carries


### PR DESCRIPTION
Platform and module versions must not act as exact runtime compatibility pins. Document the standing rule in the main adoption policy, plugin mechanism, NodeType lifecycle and both compiler projects: accept compatible used APIs, diagnose actual missing/incompatible contracts, and keep a working generation when an upgrade cannot load.

Add regression cases using real Roslyn-compiled assemblies and the production metadata/landing paths: compatible API surfaces across assembly-version changes in both directions; a removed type despite an unchanged version; changed method bodies and added overloads continuing to execute; changed return/parameter signatures failing actual CLR binding; and an incompatible upgrade preserving its predecessor’s activation and bytes.

The docs distinguish the current type-only preflight from member checks and distinguish NodeType bake cache identity from module runtime compatibility. No runtime policy, dependency floor or platform pin is changed.

Validation: Release build with warnings as errors (zero warnings/errors); 59 compatibility/adoption tests passed with zero skips; documentation link and WhatsNew integrity tests passed (2/2).
