### PR TITLE
fix(binding): a node-bound write through an array keeps the array (#3862)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-editing-a-list-item-keeps-the-rest-of-the-list.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-editing-a-list-item-keeps-the-rest-of-the-list.md
@@ -1,0 +1,21 @@
+---
+Name: Editing one item in a list keeps the rest of the list
+Category: Fix
+Description: A node-bound field inside a list saves that item without discarding its siblings, and an edit that cannot be placed is refused instead of reshaping the data.
+Icon: CheckCircle
+Order: -20260909
+---
+
+# Editing one item in a list keeps the rest of the list
+
+Editing a field inside a list — a note on one course, one row of a table — could replace the whole
+list with a single object. The other entries were discarded, and because what remained no longer
+had the shape of a list, the page failed to load it back: the edit and everything beside it
+disappeared together.
+
+Fields inside a list now read and save in place. Editing one entry leaves every other entry, and
+every other field of the same entry, exactly as it was.
+
+An edit that cannot be placed — an index that is not there, or a path that runs through a plain
+value — is now refused and reported, instead of quietly reshaping the surrounding data to make
+room for it.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeBindingExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeBindingExtensions.cs
@@ -370,45 +370,137 @@ public static class MeshNodeBindingExtensions
     /// <paramref name="root"/>, case-insensitively, returning the value as a <see cref="JsonElement"/>
     /// (or <c>null</c> when any segment is missing). Leading <c>/</c> is tolerated.
     /// </summary>
-    private static JsonElement? EvaluateField(JsonObject? root, string pointer)
+    internal static JsonElement? EvaluateField(JsonObject? root, string pointer)
     {
         if (root is null) return null;
         JsonNode? node = root;
         foreach (var segment in SplitPointer(pointer))
         {
-            if (node is not JsonObject obj) return null;
-            node = GetCaseInsensitive(obj, segment);
+            node = Descend(node, segment);
             if (node is null) return null;
         }
         if (ReferenceEquals(node, root)) return null; // empty pointer → no field value
         return JsonSerializer.Deserialize<JsonElement>(node.ToJsonString());
     }
 
+    /// <summary>
+    /// One read step: a key on an object (case-insensitively) or an ELEMENT on an array when the
+    /// segment is a valid index. Null for a missing key, an out-of-range or non-numeric index, and
+    /// for a scalar (which has nothing to descend into).
+    ///
+    /// <para>🚨 The array arm is why this exists (issue #3862). Without it every pointer THROUGH an
+    /// array read as absent — `courses/0/notes` returned null even though the value was there — and
+    /// the write side then "repaired" the shape by replacing the array outright.</para>
+    /// </summary>
+    private static JsonNode? Descend(JsonNode? node, string segment) => node switch
+    {
+        JsonObject obj => GetCaseInsensitive(obj, segment),
+        JsonArray arr when TryIndex(segment, arr.Count, out var i) => arr[i],
+        _ => null,
+    };
+
+    /// <summary>A pointer segment that addresses an EXISTING array element: digits only (so no
+    /// sign, no whitespace, no hex) and inside the array's current bounds.</summary>
+    private static bool TryIndex(string segment, int count, out int index)
+        => int.TryParse(segment, System.Globalization.NumberStyles.None,
+               System.Globalization.CultureInfo.InvariantCulture, out index)
+           && index >= 0 && index < count;
+
     /// <summary>Sets the field at <paramref name="pointer"/> on <paramref name="root"/> (creating
     /// intermediate objects), matching an existing key case-insensitively so we patch the SAME key
     /// the node already uses rather than adding a casing-variant duplicate.</summary>
-    private static void SetField(JsonObject root, string pointer, JsonNode? value)
+    internal static void SetField(JsonObject root, string pointer, JsonNode? value)
     {
         var segments = SplitPointer(pointer).ToArray();
         if (segments.Length == 0) return;
-        var obj = root;
+        JsonNode current = root;
         for (var i = 0; i < segments.Length - 1; i++)
-        {
-            var key = ExistingKey(obj, segments[i]) ?? segments[i];
-            if (obj[key] is JsonObject child)
-            {
-                obj = child;
-            }
-            else
-            {
-                var created = new JsonObject();
-                obj[key] = created;
-                obj = created;
-            }
-        }
-        var last = ExistingKey(obj, segments[^1]) ?? segments[^1];
-        obj[last] = value;
+            current = DescendForWrite(current, segments[i], pointer);
+        AssignLeaf(current, segments[^1], value, pointer);
     }
+
+    /// <summary>
+    /// One WRITE step: returns the container to descend into, creating a missing one as an object.
+    ///
+    /// <para>🚨 THE DATA-LOSS FIX (issue #3862). This used to be typed <c>JsonObject</c> and read
+    /// <c>if (obj[key] is JsonObject child) … else obj[key] = new JsonObject()</c> — so an existing
+    /// <see cref="JsonArray"/> did not match the pattern and was REPLACED by an empty object. A
+    /// write to <c>courses/0/notes</c> turned <c>[{"course":"DataModeling","notes":""}]</c> into
+    /// <c>{"0":{"notes":"…"}}</c>: every sibling element gone, and the node then failed to
+    /// deserialize back into <c>ImmutableList&lt;T&gt;</c> at all, so the whole list disappeared.</para>
+    ///
+    /// <para>🚨 An incompatible intermediate now THROWS rather than being replaced. Silently
+    /// replacing is what destroyed data; the caller (<see cref="Write"/>) already surfaces the fault
+    /// through its <c>onError</c> arm, so the edit fails visibly instead of committing a corrupted
+    /// shape.</para>
+    /// </summary>
+    private static JsonNode DescendForWrite(JsonNode current, string segment, string pointer)
+    {
+        switch (current)
+        {
+            case JsonObject obj:
+            {
+                var key = ExistingKey(obj, segment) ?? segment;
+                switch (obj[key])
+                {
+                    case JsonObject child: return child;
+                    case JsonArray arr: return arr;
+                    case null:
+                        var created = new JsonObject();
+                        obj[key] = created;
+                        return created;
+                    default:
+                        throw Incompatible(pointer, segment, obj[key]);
+                }
+            }
+            case JsonArray arr2:
+            {
+                if (!TryIndex(segment, arr2.Count, out var index))
+                    throw new InvalidOperationException(
+                        $"Cannot write '{pointer}': segment '{segment}' does not address an element of "
+                        + $"the array it traverses (length {arr2.Count}). Writing would have replaced the "
+                        + "array and lost every element.");
+                switch (arr2[index])
+                {
+                    case JsonObject child: return child;
+                    case JsonArray nested: return nested;
+                    case null:
+                        var created = new JsonObject();
+                        arr2[index] = created;
+                        return created;
+                    default:
+                        throw Incompatible(pointer, segment, arr2[index]);
+                }
+            }
+            default:
+                throw Incompatible(pointer, segment, current);
+        }
+    }
+
+    /// <summary>Writes the final segment, on an object key or an array element.</summary>
+    private static void AssignLeaf(JsonNode current, string segment, JsonNode? value, string pointer)
+    {
+        switch (current)
+        {
+            case JsonObject obj:
+                obj[ExistingKey(obj, segment) ?? segment] = value;
+                return;
+            case JsonArray arr when TryIndex(segment, arr.Count, out var index):
+                arr[index] = value;
+                return;
+            case JsonArray arr2:
+                throw new InvalidOperationException(
+                    $"Cannot write '{pointer}': segment '{segment}' does not address an element of the "
+                    + $"array it targets (length {arr2.Count}).");
+            default:
+                throw Incompatible(pointer, segment, current);
+        }
+    }
+
+    private static InvalidOperationException Incompatible(string pointer, string segment, JsonNode? found)
+        => new($"Cannot write '{pointer}': segment '{segment}' traverses a "
+               + $"{found?.GetValueKind().ToString() ?? "null"} value, which is not a container. "
+               + "Refusing to replace it — that would discard the value already stored there.");
 
     private static IEnumerable<string> SplitPointer(string pointer)
         => (pointer ?? string.Empty)

--- a/src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj
+++ b/src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj
@@ -18,6 +18,9 @@
     <!-- PresentationScreenExtensions.LastKnownOnFault is observable-in / observable-out precisely so
          the faulting-profile leg (which a live mesh cannot arrange on demand) is directly testable. -->
     <InternalsVisibleTo Include="MeshWeaver.Graph.Test" />
+    <!-- #3862: the array-traversal regressions exercise the SetField/EvaluateField write primitives
+         directly, as the issue asks, rather than through a live hub + node stream. -->
+    <InternalsVisibleTo Include="MeshWeaver.Layout.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MeshWeaver.Layout.Test/MeshNodeBindingExtensionsTest.cs
+++ b/test/MeshWeaver.Layout.Test/MeshNodeBindingExtensionsTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
 using Xunit;
@@ -87,6 +88,111 @@ public class MeshNodeBindingExtensionsTest
         MeshNodeBindingExtensions.ResolveField(
                 node, bindContent: true, subPath: "composer", new JsonPointerReference("harness"), Options)
             !.Value.GetString().Should().Be("agentic");
+    }
+
+    // ---- #3862: a node-bound write through an ARRAY must not flatten it -------------------------
+    //
+    // Reproduced on a live portal (3.0.0-ci.8195) while editing an Edu assessment: a TextAreaControl
+    // bound to `courses/0/notes` turned
+    //     "courses": [ { "course": "DataModeling", "notes": "" } ]
+    // into
+    //     "courses": { "0": { "notes": "…" } }
+    // The array — and every sibling element — was gone, and the node then failed to deserialize back
+    // into ImmutableList<LearningCourse>, so the saved curriculum disappeared entirely.
+
+    private static JsonObject Curriculum() => (JsonObject)JsonNode.Parse(
+        """
+        {
+          "title": "Journey",
+          "courses": [
+            { "course": "DataModeling", "notes": "" },
+            { "course": "Scopes",       "notes": "keep" }
+          ]
+        }
+        """)!;
+
+    [Fact]
+    public void SetField_ThroughAnArrayIndex_WritesTheElement_AndKeepsEverySibling()
+    {
+        var root = Curriculum();
+
+        MeshNodeBindingExtensions.SetField(root, "courses/0/notes", JsonValue.Create("edited"));
+
+        var courses = root["courses"].Should().BeOfType<JsonArray>().Subject;
+        courses.Count.Should().Be(2, "the array must survive the write, not be replaced by an object");
+
+        courses[0]!["notes"]!.GetValue<string>().Should().Be("edited");
+        courses[0]!["course"]!.GetValue<string>().Should().Be("DataModeling",
+            "a sibling FIELD of the edited element is preserved");
+        courses[1]!["course"]!.GetValue<string>().Should().Be("Scopes",
+            "a sibling ELEMENT is preserved — this is the data the old code destroyed");
+        courses[1]!["notes"]!.GetValue<string>().Should().Be("keep");
+        root["title"]!.GetValue<string>().Should().Be("Journey");
+    }
+
+    [Fact]
+    public void EvaluateField_ReadsThroughAnArrayIndex()
+    {
+        var node = MeshNode.FromPath("Space1") with
+        {
+            Content = JsonSerializer.Deserialize<JsonElement>(Curriculum().ToJsonString()),
+        };
+
+        MeshNodeBindingExtensions.ResolveField(
+                node, bindContent: true, subPath: null,
+                new JsonPointerReference("courses/1/course"), Options)
+            !.Value.GetString().Should().Be("Scopes",
+                "a pointer through an array index must READ, not report the field absent");
+    }
+
+    [Fact]
+    public void SetField_RoundTripsThroughTheArrayItWrote()
+    {
+        var root = Curriculum();
+        MeshNodeBindingExtensions.SetField(root, "courses/1/notes", JsonValue.Create("second"));
+
+        // The write and the read agree — the shape a reload would deserialize is still a list.
+        MeshNodeBindingExtensions.EvaluateField(root, "courses/1/notes")
+            !.Value.GetString().Should().Be("second");
+        root["courses"]!.GetValueKind().Should().Be(JsonValueKind.Array);
+    }
+
+    [Theory]
+    [InlineData("courses/2/notes")]   // out of range
+    [InlineData("courses/-1/notes")]  // negative
+    [InlineData("courses/x/notes")]   // not an index
+    public void SetField_InvalidArrayIndex_Throws_RatherThanReplacingTheArray(string pointer)
+    {
+        var root = Curriculum();
+
+        var write = () => MeshNodeBindingExtensions.SetField(root, pointer, JsonValue.Create("v"));
+
+        write.Should().Throw<InvalidOperationException>(
+            "refusing is the point — the old code replaced the array and lost every element");
+        root["courses"].Should().BeOfType<JsonArray>().Which.Count.Should().Be(2,
+            "a refused write must leave the document untouched");
+    }
+
+    [Fact]
+    public void SetField_ThroughAScalar_Throws_RatherThanReplacingTheValue()
+    {
+        var root = Curriculum();
+
+        var write = () => MeshNodeBindingExtensions.SetField(root, "title/nested", JsonValue.Create("v"));
+
+        write.Should().Throw<InvalidOperationException>();
+        root["title"]!.GetValue<string>().Should().Be("Journey");
+    }
+
+    [Fact]
+    public void SetField_StillCreatesMissingIntermediateObjects()
+    {
+        // The pre-existing create path must be unchanged: an ABSENT intermediate is still made.
+        var root = new JsonObject();
+
+        MeshNodeBindingExtensions.SetField(root, "composer/harness", JsonValue.Create("agentic"));
+
+        root["composer"]!["harness"]!.GetValue<string>().Should().Be("agentic");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #3862.

## The data loss

Editing a node-bound field **inside a list** replaced the list with an object and discarded every sibling. Reproduced on a live portal (`3.0.0-ci.8195`) editing an Edu assessment — a `TextAreaControl` bound to `courses/0/notes`:

```jsonc
// before
"courses": [ { "course": "DataModeling", "notes": "" },
             { "course": "Scopes",       "notes": "keep" } ]

// after one edit
"courses": { "0": { "notes": "…" } }
```

The node then no longer deserialized into `ImmutableList<LearningCourse>` at all, so the whole saved curriculum vanished on reload while scalar answers survived — which is what made this look like a typing problem rather than the data-shape mutation it is.

## Two halves of one defect, both in `MeshNodeBindingExtensions`

| | before | after |
|---|---|---|
| `EvaluateField` | traversed only `JsonObject`, so every pointer **through** an array read as absent | descends an array on a valid index |
| `SetField` | cursor typed `JsonObject`; `if (obj[key] is JsonObject child) … else obj[key] = new JsonObject()` — an existing `JsonArray` fell to the `else` and was **replaced** | descends the array, writes the element, leaves siblings alone |

The read half is what disguised the write half: a field that reads as absent looks like a missing key, not like a list about to be flattened.

## An incompatible intermediate is now refused, not replaced

Silently replacing is precisely what destroyed the data. An out-of-range index, a non-numeric segment, or a path running through a scalar now throws a named `InvalidOperationException`:

> Cannot write 'courses/2/notes': segment '2' does not address an element of the array it traverses (length 2). Writing would have replaced the array and lost every element.

`Write` already surfaces faults through its `onError` arm (the Blazor view pops a modal), so the edit fails **visibly** instead of committing a corrupted shape. Creating a genuinely **absent** intermediate is unchanged, and is pinned by its own test so this cannot regress into "refuses everything".

## The control — why these tests are worth having

Test seams are only worth what they'd catch, so I measured it. Holding the test bodies fixed and restoring the previous behaviour (keeping the `internal` seam so it still compiles):

```
Failed!  - Failed: 7, Passed: 6, Total: 13
  MeshWeaver.Reactive.Assertions.AssertionException :
    Expected value to be of type JsonArray, but found JsonObject.
```

That failure **is** the reported corruption, now reproducing in 63 ms instead of on a live portal. With the fix: `Passed! - Failed: 0, Passed: 13`.

Coverage matches the issue's list — read through an index, write through an index, siblings unchanged (both the neighbouring element and the other fields of the edited one), round-trip, invalid indices (out of range, negative, non-numeric), a scalar intermediate, and the unchanged create path.

## Build

`-c Release -warnaserror`, one project per invocation, all `0 Warning(s) 0 Error(s)`: `MeshWeaver.Mesh.Contract`, `MeshWeaver.Hosting`, `MeshWeaver.Graph.Test`, `MeshWeaver.Layout.Test`.

`EvaluateField`/`SetField` become `internal` (additive — no public surface removed, no interface member added) so the regressions exercise the actual binding primitives rather than a live hub + node stream, which is what the issue asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7