### PR TITLE
feat(chart): a per-key requiredSecrets predicate, so an empty credential fails at RENDER (Memex#204)

### DIFF
--- a/deploy/helm/templates/_required-secrets.tpl
+++ b/deploy/helm/templates/_required-secrets.tpl
@@ -1,0 +1,63 @@
+{{/*
+🚨 THE PER-KEY REQUIRED-SECRET PREDICATE (Systemorph/Memex#204).
+
+The defect it closes: a Secret key rendered with an EMPTY value is INVISIBLE to a `keys[]` audit —
+it reads as configured. `MEMEX_PASSWORD` sat at base64 length 0 on memex-cloud in both
+`memex-portal-secrets` and `memex-migration-secrets` for exactly that reason. An unconfigured
+credential then fails at CONNECT time, in a running portal, instead of at render time where the
+operator is standing.
+
+🚨 DELIBERATELY NOT a blanket `required`. Which optional providers a given deployment must have is
+POLICY, and it varies by deployment shape and role — a demo instance legitimately runs with no
+Anthropic key, and `Ai__KeyProtection__MasterKey` is worse than that: its legality is STATEFUL
+(fine until the first `enc:` provider key is stored, fatal after). A chart-wide `required` would
+encode one deployment's policy as everyone's, and #204 names those calls as the maintainer's.
+So this ships as a MECHANISM with an EMPTY default list: it enforces exactly what an operator
+declares, and nothing at all until they declare something.
+
+Declare in values (or an env values file):
+
+    requiredSecrets:
+      - key: Anthropic__ApiKey
+        because: this deployment routes the `heavy` tier to Anthropic; without it every agent round
+                 fails at the provider call with no configuration error anywhere.
+      - key: memex_postgres_password
+        component: memex_migration      # default: memex_portal
+      - key: GitHub__App__PrivateKey
+        when: false                     # see the note on `when` below
+
+Fields:
+  key        (required) the values key under `secrets.<component>`, i.e. the name the Secret renders.
+  because    (optional) why THIS deployment needs it. Quoted verbatim in the failure, because a
+             refusal that does not say why gets worked around rather than fixed.
+  component  (optional) `memex_portal` (default) or `memex_migration`.
+  when       (optional) a BOOLEAN, default true. 🚨 Helm cannot evaluate an expression here — there
+             is no `eval`. So `when` is a value an env values file SETS (e.g. `when: false` to stand
+             an entry down for one environment) rather than a condition the chart computes. Anything
+             needing a computed condition belongs in the caller's values, not in a string here.
+
+An entry naming a key that is empty (or absent) fails the render, naming the key, the component and
+the reason. Empty list ⇒ this template does nothing, which is the shipped default.
+*/}}
+{{- define "memex.assertRequiredSecrets" -}}
+{{- $root := . -}}
+{{- range $i, $entry := (.Values.requiredSecrets | default list) -}}
+  {{- if not $entry.key -}}
+    {{- fail (printf "requiredSecrets[%d] has no `key`. Each entry must name the values key under secrets.<component> that has to be non-empty; an entry without one can never be checked and would pass silently, which is the shape #204 exists to refuse." $i) -}}
+  {{- end -}}
+  {{- $component := $entry.component | default "memex_portal" -}}
+  {{- if not (has $component (list "memex_portal" "memex_migration")) -}}
+    {{- fail (printf "requiredSecrets[%d] (key %s) names component %q, which is not a secrets block this chart renders. Use `memex_portal` (default) or `memex_migration`." $i $entry.key $component) -}}
+  {{- end -}}
+  {{- $when := true -}}
+  {{- if hasKey $entry "when" -}}{{- $when = $entry.when -}}{{- end -}}
+  {{- if $when -}}
+    {{- $block := index $root.Values.secrets $component | default dict -}}
+    {{- $value := index $block $entry.key -}}
+    {{- if not $value -}}
+      {{- $because := $entry.because | default "no reason was recorded on the requiredSecrets entry" -}}
+      {{- fail (printf "secrets.%s.%s is required by this deployment and is empty or unset.\n\nWhy: %s\n\n🚨 An empty value is NOT the same as an absent one: the chart would render the key present-but-empty, an audit that enumerates keys[] would read it as configured, and the credential would fail at CONNECT time inside a running portal instead of here (Systemorph/Memex#204). Set it in this release's values (or supply it out-of-band and drop this requiredSecrets entry), then re-run." $component $entry.key $because) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/templates/memex-portal/secrets.yaml
+++ b/deploy/helm/templates/memex-portal/secrets.yaml
@@ -1,3 +1,7 @@
+{{- /* Systemorph/Memex#204: refuse the render when a secret this deployment DECLARES as required
+       is empty. Invoked here because this is the first Secret the chart renders, so the refusal
+       lands before anything is applied. No-op unless `requiredSecrets` is populated. */ -}}
+{{- include "memex.assertRequiredSecrets" . -}}
 ---
 apiVersion: "v1"
 kind: "Secret"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -78,7 +78,31 @@ selfUpdate:
 # /v2 route answers 404 (never a partial service). 🚨 `ContainerImages__Password` is a SECRET and
 # is NOT rendered from values: it arrives through the Key Vault CSI mapping like every other
 # credential —
-#   keyVaultSecrets.secrets:
+#   keyVaultSecrets.# ---- Required secrets (Systemorph/Memex#204) ---------------------------------
+# Per-key statement of whether an EMPTY value is legal. EMPTY BY DEFAULT — this enforces exactly
+# what a deployment declares and nothing otherwise.
+#
+# 🚨 The defect it closes: a Secret key rendered EMPTY is invisible to a `keys[]` audit — it reads
+# as configured. `MEMEX_PASSWORD` sat at base64 length 0 on memex-cloud in both the portal and the
+# migration Secret for exactly that reason, and an unconfigured credential then fails at CONNECT
+# time in a running portal rather than at render time.
+#
+# 🚨 NOT a blanket `required`: which optional providers a deployment must have is policy that varies
+# by shape and role, and `Ai__KeyProtection__MasterKey` is stateful (fine until the first `enc:` key
+# is stored, fatal after). Declare per deployment, in that deployment's values file.
+#
+#   requiredSecrets:
+#     - key: Anthropic__ApiKey
+#       because: this deployment routes the `heavy` tier to Anthropic.
+#     - key: memex_postgres_password
+#       component: memex_migration     # memex_portal (default) | memex_migration
+#     - key: GitHub__App__PrivateKey
+#       when: false                    # a BOOLEAN a values file sets; Helm has no `eval` here
+#
+# See templates/_required-secrets.tpl for the full contract.
+requiredSecrets: []
+
+secrets:
 #     - vaultSecret: <prefix>ContainerImages-Password
 #       key: ContainerImages__Password
 # The mirror is off unless Upstream, Username AND Password are all present.


### PR DESCRIPTION
Closes the second of the two core-side items on Systemorph/Memex#204. (The first, the `MEMEX_URI` / `MEMEX_PASSWORD` conditionals, landed in #3632.)

## The defect

A Secret key rendered with an **empty** value is invisible to a `keys[]` audit — it reads as *configured*. Measured on memex-cloud: `MEMEX_PASSWORD` at **base64 length 0** in both `memex-portal-secrets` and `memex-migration-secrets`. An unconfigured credential then fails at **connect** time inside a running portal, rather than at render time where the operator is standing.

## What this adds

Exactly the shape #204 specifies:

```yaml
requiredSecrets:
  - key: Anthropic__ApiKey
    because: this deployment routes the `heavy` tier to Anthropic.
  - key: memex_postgres_password
    component: memex_migration     # memex_portal (default) | memex_migration
  - key: GitHub__App__PrivateKey
    when: false
```

rendered through `fail`, invoked from the portal Secret — the first the chart renders — so a refusal lands before anything is applied.

## 🚨 Mechanism, not policy — and the empty default is the point

#204 explicitly reserves *"which optional providers a deployment must have"* as a maintainer decision, noting it varies by deployment shape and role, and that `Ai__KeyProtection__MasterKey` is **stateful** (fine until the first `enc:` provider key is stored, fatal after). A blanket `required` would encode one deployment's policy as everyone's.

So this ships the seam and enforces **nothing** until a deployment declares something. `requiredSecrets: []` is the default and a no-op. Populating it is a per-deployment values decision, not mine.

## 🚨 `when` is a boolean, and the docs say why

Helm has no `eval`, so `when` is a value an env values file **sets** — not a condition the chart computes. A string that *looked* like a predicate but was never evaluated would read as enforcement while enforcing nothing, which is the same class of defect as the empty value this closes. Stated in both the helper and `values.yaml` rather than left to be discovered.

## Verified by rendering, not by reading

`helm template` over the whole matrix:

| # | case | result |
|---|---|---|
| 1 | default (empty list) | **RENDERS** |
| 2 | required key, empty | **REFUSES** — names key, component and reason |
| 3 | required key, set | **RENDERS** |
| 4 | `when: false` on an empty key | **RENDERS** |
| 5 | `when: true` on an empty key | **REFUSES** |
| 6 | `component: memex_migration`, empty | **REFUSES** |
| 7 | entry with no `key` | **REFUSES** — an unnameable check would pass silently |
| 8 | unknown component | **REFUSES** |

`helm lint`: `1 chart(s) linted, 0 chart(s) failed` (only the pre-existing `icon is recommended` INFO).

The refusal an operator sees:

```
Error: execution error at (memex/templates/memex-portal/secrets.yaml:4:4):
secrets.memex_migration.memex_postgres_password is required by this deployment and is empty or unset.

Why: this deployment runs the migration Job against an external Postgres

🚨 An empty value is NOT the same as an absent one: the chart would render the key
present-but-empty, an audit that enumerates keys[] would read it as configured, and the
credential would fail at CONNECT time inside a running portal instead of here
(Systemorph/Memex#204). Set it in this release's values (or supply it out-of-band and drop
this requiredSecrets entry), then re-run.
```

Cases 7 and 8 are there deliberately: a `requiredSecrets` entry that cannot be evaluated must refuse, never skip — a check that silently passes is the shape #204 is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7