### PR TITLE
feat(ea): the Executive Assistant reads Teams — consent scopes, doc

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -46,8 +46,10 @@ namespace Memex.Portal.Shared.Authentication;
 /// <c>ContentAs&lt;T&gt;</c>, and there is no shape switch left to have an arm.</para>
 ///
 /// <para><b>Azure setup (one-time):</b> on the sign-in app registration add the <i>delegated</i> scopes
-/// <c>Mail.ReadWrite Mail.Send Calendars.ReadWrite offline_access</c> and the redirect URI
-/// <c>{BaseUrl}/auth/ea/callback</c>. The user's first use triggers the consent screen.</para>
+/// <c>Mail.ReadWrite Mail.Send Calendars.ReadWrite Team.ReadBasic.All Channel.ReadBasic.All
+/// ChannelMessage.Read.All Chat.Read offline_access</c> and the redirect URI
+/// <c>{BaseUrl}/auth/ea/callback</c>. The user's first use triggers the consent screen;
+/// <c>ChannelMessage.Read.All</c> needs a tenant admin's consent once.</para>
 /// </summary>
 public sealed class EaGraphAuth(
     IServiceProvider rootServices,
@@ -56,10 +58,35 @@ public sealed class EaGraphAuth(
     HttpClient http,
     ILogger<EaGraphAuth>? logger = null) : IEaGraphAuth
 {
-    /// <summary>Delegated scopes the EA needs (space-separated, Graph v2 form).</summary>
+    /// <summary>
+    /// Delegated scopes the EA needs (space-separated, Graph v2 form).
+    ///
+    /// <para><b>Teams, read-only (2026-09-09).</b> <c>Team.ReadBasic.All</c> lists the user's teams,
+    /// <c>Channel.ReadBasic.All</c> a team's channels, <c>ChannelMessage.Read.All</c> a channel's
+    /// messages, <c>Chat.Read</c> the user's chats — the surface the Executive Assistant's
+    /// <c>ListTeams</c> / <c>ListChannels</c> / <c>ReadChannelMessages</c> / <c>ListChats</c> /
+    /// <c>ReadChat</c> tools (MeshWeaver.Plugins) call. Deliberately NO send scope: Teams has no
+    /// draft state, so a send would be immediate and irreversible, and the EA's mail contract is
+    /// draft-by-default; sending gets its own gate and its own consent when it is built.</para>
+    ///
+    /// <para><b>Consent.</b> The v2 authorize endpoint consents to whatever <c>scope</c> asks for
+    /// (dynamic consent), so these need not be pre-listed on the app registration — but
+    /// <c>ChannelMessage.Read.All</c> is admin-restricted: a non-admin user sees "Need admin
+    /// approval" until a tenant admin has consented once (Entra → Enterprise applications → the
+    /// sign-in app → Permissions → Grant admin consent). Every user who connected BEFORE this
+    /// change holds a grant without these scopes and must reconnect once via
+    /// <c>{BaseUrl}/auth/ea/connect</c>; the plugin says so on the 403 it gets until then.</para>
+    ///
+    /// <para><b>Tenant boundary.</b> A grant is minted by the user's HOME tenant. A team the user
+    /// reaches as a guest of another company's tenant is not visible on it — <c>/me/joinedTeams</c>
+    /// omits guest teams — and no scope here changes that; see the <c>/teams</c> skill.</para>
+    /// </summary>
     public const string Scopes =
         "https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send " +
-        "https://graph.microsoft.com/Calendars.ReadWrite offline_access";
+        "https://graph.microsoft.com/Calendars.ReadWrite " +
+        "https://graph.microsoft.com/Team.ReadBasic.All https://graph.microsoft.com/Channel.ReadBasic.All " +
+        "https://graph.microsoft.com/ChannelMessage.Read.All https://graph.microsoft.com/Chat.Read " +
+        "offline_access";
 
     /// <summary>
     /// How long a single credential-node read may take before the answer becomes

--- a/src/MeshWeaver.Documentation/Data/AI/ExecutiveAssistant.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ExecutiveAssistant.md
@@ -11,6 +11,7 @@ Tags:
   - "Agents"
   - "Email"
   - "Calendar"
+  - "Teams"
   - "Access Control"
 ---
 
@@ -48,6 +49,7 @@ The EA agent declares the `Mesh` + `ExecutiveAssistant` plugins. The `ExecutiveA
 | Mail | `ListInbox`, `SearchMail`, `ReadMail`, `DraftMail`, `DraftReply`, `GetDraft`, `UpdateDraft`, `DiscardDraft` — and `SendMail`, `ReplyToMail` **only where the deployment opted in**, see below |
 | Mailings | `PrepareMailing` — one subject and body template merged per recipient into personal mails, saved as a page the person reviews; **never sends** — see below |
 | Calendar | `ListEvents`, `GetEvent`, `CreateEvent` (book + invite attendees), `UpdateEvent`, `CancelEvent` |
+| Teams (read-only) | `ListTeams`, `ListChannels`, `ReadChannelMessages`, `ListChats`, `ReadChat` — the user's own organisation's teams and chats; no send tool, see below |
 
 Example asks: *"Book 30 min with Alice next Tuesday afternoon and invite her"*, *"reply to the vendor that
 we accept"*, *"clear my Friday"*, *"email me when an approval needs me"* (the last manages your
@@ -145,6 +147,26 @@ knowing before anyone edits them:
 | `UpdateDraft` | the patch carries **only** `subject`, `body`, `toRecipients`, `ccRecipients` — the four fields Graph documents as *"Updatable only if **isDraft** = true"*. A patch that arrives after the send is rejected by the **server**, atomically. `importance`, `categories`, `flag` and `isRead` *are* updatable on a sent message; adding one would remove that backstop silently, so the field set is pinned by a test. |
 | `DiscardDraft` | nothing beyond the re-read. `DELETE /me/messages/{id}` deletes whatever it is given, draft or sent — which is why this tool's guard is the only thing between "discard that draft" and destroying a delivered message. |
 
+### Teams is read-only, on the same grant — and a guest team is out of reach
+
+The Teams tools run on the same delegated grant as mail and calendar (`EaGraphAuth.Scopes` carries
+`Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Read.All`, `Chat.Read` since
+2026-09-09). Two consequences the agent states rather than hides:
+
+- **A grant minted before those scopes existed answers 403.** The mailbox still works; only the
+  Teams consent is missing. The tool answers with the connect link (`{BaseUrl}/auth/ea/connect`)
+  and the agent hands it on — one reconnect, a few seconds — instead of reporting Teams as
+  unavailable. `ChannelMessage.Read.All` is admin-restricted: a non-admin sees "Need admin approval"
+  until a tenant admin has consented once.
+- **A team the user joined as a guest of another organisation is not visible.** The grant is the
+  user's home tenant's; `/me/joinedTeams` omits guest teams and their channels answer 403/404. No
+  scope changes that. The agent says so rather than reporting the team as missing. Reading such a
+  team needs the other organisation's cooperation — see the repository's `/teams` skill.
+
+There is deliberately **no Teams send tool**: Teams has no draft state, so a send would be immediate
+and irreversible, against this agent's draft-by-default contract. Sending gets its own gate
+(`Teams:AgentSend`, mirroring `Email:AgentSend`) and its own consent when it is built.
+
 ### Editing an event is READ then PATCH, never cancel-and-recreate
 
 `GetEvent` and `UpdateEvent` exist because their absence caused real data loss. With only
@@ -182,9 +204,13 @@ cost. The agent definition is `Agent/ExecutiveAssistant`.
 The EA reuses the portal's **sign-in** app registration (the `Authentication:Microsoft` client). On it:
 
 1. Add the **delegated** Microsoft Graph permissions: `Mail.ReadWrite`, `Mail.Send`,
-   `Calendars.ReadWrite`, `offline_access`.
+   `Calendars.ReadWrite`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Read.All`,
+   `Chat.Read`, `offline_access`.
 2. Add the redirect URI **`{BaseUrl}/auth/ea/callback`** (e.g. `https://portal.example.com/auth/ea/callback`).
-3. No admin pre-consent is required — each user consents for themselves on first use (that's the point).
+3. No admin pre-consent is required for mail and calendar — each user consents for themselves on
+   first use (that's the point). `ChannelMessage.Read.All` is the one exception: it is
+   admin-restricted, so a tenant admin grants it once (Enterprise applications → the sign-in app →
+   Permissions → Grant admin consent); until then non-admins see "Need admin approval".
 
 No application-wide Graph permission is needed for the EA (the standing `Calendars.ReadWrite` *application*
 grant used by an earlier iteration can be removed; the shared `memex@` ingestion mailbox keeps its

--- a/src/MeshWeaver.Documentation/Data/AI/ExecutiveAssistant.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ExecutiveAssistant.md
@@ -1,7 +1,7 @@
 ---
 NodeType: Markdown
 Name: "The Executive Assistant Agent"
-Abstract: "A personal agent that works your own mailbox and calendar — triage and write mail, read your inbox, do your booking — under per-user, just-in-time delegated consent: no app-wide Graph access, an encrypted per-user refresh token, and short-lived delegated tokens that call Graph as you."
+Abstract: "A personal agent that works your own mailbox, calendar and Teams — triage and write mail, read your inbox, do your booking, read your teams' channels and your chats — under per-user, just-in-time delegated consent: no app-wide Graph access, an encrypted per-user refresh token, and short-lived delegated tokens that call Graph as you."
 Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#6a1b9a'/><rect x='4' y='9' width='16' height='10' rx='2' fill='white'/><path d='M9 9V7a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2' fill='none' stroke='white' stroke-width='2' stroke-linecap='round'/><rect x='10.5' y='12' width='3' height='2' rx='0.5' fill='#6a1b9a'/></svg>"
 Thumbnail: "images/agenticai.svg"
 Authors:
@@ -17,14 +17,16 @@ Tags:
 
 # The Executive Assistant Agent
 
-The **Executive Assistant (EA)** is a personal agent that works your **own** mailbox and calendar on your
-behalf — triage and write mail, read your inbox, and "do your booking" (schedule / reschedule / cancel
-meetings). It also helps you manage your [notification preferences](/Doc/GUI/NotificationPreferences).
+The **Executive Assistant (EA)** is a personal agent that works your **own** mailbox, calendar and Teams
+on your behalf — triage and write mail, read your inbox, "do your booking" (schedule / reschedule /
+cancel meetings), and read your teams' channels and your chats. It also helps you manage your
+[notification preferences](/Doc/GUI/NotificationPreferences).
 
 ## Least-privilege by design: per-user, just-in-time consent
 
-The EA never uses standing, application-wide Graph access. Instead it asks for access to **your** mailbox
-and calendar **only when it first needs them**, and only **you** can grant it:
+The EA never uses standing, application-wide Graph access. Instead it asks for access to **your** mailbox,
+calendar and Teams **only when it first needs them**, and only **you** can grant it (one Teams scope
+needs a tenant admin's consent once — see the Azure setup below):
 
 1. You ask the EA to do something with your mail/calendar (e.g. *"what's on my calendar tomorrow?"*).
 2. If you haven't connected yet, the tool replies with a **connect link** (`/auth/ea/connect`) instead of

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-executive-assistant-reads-your-teams.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-09-the-executive-assistant-reads-your-teams.md
@@ -1,0 +1,17 @@
+---
+Name: The Executive Assistant reads your Teams
+Category: Feature
+Description: The Executive Assistant now lists your teams and reads channel messages and chats on the same connection it holds for mail and calendar. Reconnect once to grant it; a team you joined as a guest of another organisation stays out of reach.
+Icon: Chat
+Order: -20260909
+---
+
+Until now the Executive Assistant could see your mailbox and calendar but not Teams. It now lists
+the teams you belong to, the channels in them, and reads channel messages and your chats, newest
+first, on the same connection it already holds for mail and calendar.
+
+Your existing connection predates the Teams permission, so the assistant hands you a reconnect link
+the first time you ask; it takes a few seconds. Reading channel messages needs your tenant admin's
+consent once. A team you joined as a guest of another organisation is outside what your own
+organisation's connection can see; the assistant says so rather than report it as missing. Reading
+only: the assistant does not post in Teams.


### PR DESCRIPTION
## The Executive Assistant reads Teams — core half

- **`EaGraphAuth.Scopes`** (`memex/Memex.Portal.Shared`, the copy that ships — the Memex repo's tree is frozen, Memex#228): adds delegated `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Read.All`, `Chat.Read`. No send scope on purpose: Teams has no draft state. Dynamic consent on the v2 endpoint needs no app-registration change; `ChannelMessage.Read.All` is admin-restricted and needs one tenant-admin consent. Users who connected before this reconnect once; the Plugins tools say so on the 403.
- **Doc/AI/ExecutiveAssistant**: the tool row, the scopes in the Azure setup, the admin-consent exception, and a section on the reconnect and the guest-tenant boundary.

Companion: the MeshWeaver.Plugins tools PR (`ListTeams` / `ListChannels` / `ReadChannelMessages` / `ListChats` / `ReadChat`), which lands after this. Verified locally: `Memex.Portal.Shared` and its test project build Release -warnaserror; the EA credential tests pass.

Pairs-with: none — additive; no public surface leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)