### PR TITLE
Give every generated form field an accessible name (#3863)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/GUI/Editor.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/Editor.md
@@ -250,6 +250,41 @@ Each property becomes a named area inside the `EditorControl`. The reactive over
 
 ---
 
+# Accessible names
+
+A generated field paints its caption **outside** the input — the `PropertySkin` renders it as the
+`<dt>` of a definition list and the control itself is created with **no `Label`**, so the caption is
+not drawn twice. That is deliberate, and it costs the input its accessible name unless something
+puts one back.
+
+So `MapToControl` sets **`AriaLabel`** on every generated control, read from the same
+`GetEditorLabel()` source the visible caption comes from — `[Display(Name = …)]`, then
+`[DisplayName(…)]`, then the property name word-split. The two can therefore never disagree, which
+is what WCAG's *label in name* asks for.
+
+```csharp
+public record Assessment
+{
+    [DisplayName("1. What topics do you want to cover?")]
+    [UiControl<TextAreaControl>]
+    public string Topics { get; init; } = null!;
+}
+// renders: <dt>1. What topics …</dt>
+//          <dd><fluent-text-area aria-label="1. What topics …"> …
+```
+
+🚨 **`aria-label`, not `<label for>` — and this is not a style preference.** A Fluent input is a web
+component that keeps its real `<input>` inside a **shadow root**, and `for`/`id` do not associate
+across that boundary. The generated form used to emit `<label for="topics">` pointing at an element
+that could not exist: the caption was visible, the textbox was unnamed, and
+`getByRole('textbox', { name: question })` matched nothing (MeshWeaver#3863). `aria-label` sits on
+the host element, so it survives the boundary and needs no id plumbing.
+
+Setting `Label` yourself still works and still renders a second, visible caption — use it for a
+control you compose by hand, not for a field the editor generates.
+
+---
+
 # See Also
 
 - [Property Attributes](../Attributes) — every supported attribute in detail

--- a/src/MeshWeaver.Documentation/Data/GUI/Editor.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/Editor.md
@@ -257,10 +257,11 @@ A generated field paints its caption **outside** the input — the `PropertySkin
 not drawn twice. That is deliberate, and it costs the input its accessible name unless something
 puts one back.
 
-So `MapToControl` sets **`AriaLabel`** on every generated control, read from the same
-`GetEditorLabel()` source the visible caption comes from — `[Display(Name = …)]`, then
-`[DisplayName(…)]`, then the property name word-split. The two can therefore never disagree, which
-is what WCAG's *label in name* asks for.
+So `MapToControl` sets **`AriaLabel`** on every generated **input** control — every `IFormControl`:
+text, multi-line text, number, date, checkbox, switch, select, combobox, listbox, radio group. It is
+read from the same `GetEditorLabel()` source the visible caption comes from — `[Display(Name = …)]`,
+then `[DisplayName(…)]`, then the property name word-split. The two can therefore never disagree,
+which is what WCAG's *label in name* asks for.
 
 ```csharp
 public record Assessment
@@ -282,6 +283,14 @@ the host element, so it survives the boundary and needs no id plumbing.
 
 Setting `Label` yourself still works and still renders a second, visible caption — use it for a
 control you compose by hand, not for a field the editor generates.
+
+**Two generated surfaces are NOT covered yet**, and both are named here rather than left to be
+rediscovered:
+
+| Surface | Why it is still unnamed |
+|---|---|
+| A `[Markdown]` / `[UiControl<MarkdownEditorControl>]` property | `MarkdownEditorControl` is not an `IFormControl` — it is a composite editor with its own toolbar, so its accessible name is an `aria-labelledby` question about that composite, not an `aria-label` on one input. |
+| The click-to-edit path (`MapToToggleableControl`) | It renders its caption as a sibling `LabelControl`, which emits a `FluentLabel` with no `for` — the same association hole, on a different surface. |
 
 ---
 

--- a/src/MeshWeaver.Layout/DateTimeControl.cs
+++ b/src/MeshWeaver.Layout/DateTimeControl.cs
@@ -67,8 +67,8 @@ public record DateTimeControl(object Data) : FormControlBase<DateTimeControl>(Da
     /// </summary>
     public object? PopupHorizontalPosition { get; init; }
 
-    /// <summary>
-    /// Gets or initializes the ARIA label for accessibility.
-    /// </summary>
-    public object? AriaLabel { get; init; }
+    // NB: AriaLabel used to be declared here. It moved UP to FormControlBase (MeshWeaver#3863) so
+    // that EVERY form control can carry an accessible name, not just this one — it is still
+    // readable and settable on DateTimeControl exactly as before, by inheritance. Re-declaring it
+    // here would shadow the base property and give the record two backing fields.
 }

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -695,6 +695,14 @@ public static class EditorExtensions
             return (UiControl)((IListControl)factory2.Invoke(host, propertyInfo, reference, parameter!))
                 .WithLabel(label!)
                 .WithAriaLabel(ariaLabel);
+        // 🚨 NOT covered, and deliberately so rather than by oversight. A SpecialControl is not an
+        // IFormControl — MarkdownEditorControl is a composite editor with its own toolbar and its own
+        // Blazor view, so its accessible name is an aria-labelledby/region question about that
+        // composite, not an aria-label on a single input, and guessing at it here would ship an
+        // unmeasured answer. The generated-field guarantee in Doc/GUI/Editor is stated over
+        // IFormControl for the same reason. Tracked with the click-to-edit path
+        // (MapToToggleableControl), which has the same shape: a visible FluentLabel sibling that
+        // names nothing.
         if (SpecialControls.TryGetValue(controlType, out var specialFactory))
             return specialFactory.Invoke(propertyInfo, reference);
 

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -515,14 +515,15 @@ public static class EditorExtensions
         if (dimensionAttribute != null)
         {
             if (dimensionAttribute.Options is not null)
-                return editor.WithView((host, _) => RenderListControl(host, Controls.Select, jsonPointerReference, dimensionAttribute.Options));
+                return editor.WithView((host, _) => RenderListControl(host, Controls.Select, jsonPointerReference, dimensionAttribute.Options).WithAriaLabel(label));
             return editor.WithView((host, ctx) =>
             {
                 var id = Guid.NewGuid().AsString();
                 host.RegisterForDisposal(ctx.Area,
                     GetStream(host, dimensionAttribute)
                         .Subscribe(x => host.UpdateData(id, x)));
-                return Controls.Select(jsonPointerReference, new JsonPointerReference(LayoutAreaReference.GetDataPointer(id)));
+                return Controls.Select(jsonPointerReference, new JsonPointerReference(LayoutAreaReference.GetDataPointer(id)))
+                    .WithAriaLabel(label);
             });
         }
 
@@ -590,13 +591,13 @@ public static class EditorExtensions
         if (dimensionAttribute != null)
         {
             if (dimensionAttribute.Options is not null)
-                return editor.WithView((host, _) => RenderListControl(host, Controls.Select, jsonPointerReference, dimensionAttribute.Options), skinConfiguration);
+                return editor.WithView((host, _) => RenderListControl(host, Controls.Select, jsonPointerReference, dimensionAttribute.Options).WithAriaLabel(propertySkinLabel), skinConfiguration);
             return editor.WithView((host, ctx) =>
             {
                 var id = Guid.NewGuid().AsString();
                 host.RegisterForDisposal(ctx.Area,
                     GetStream(host, dimensionAttribute).Subscribe(x => host.UpdateData(id, x)));
-                return RenderListControl(host, Controls.Select, jsonPointerReference, id);
+                return RenderListControl(host, Controls.Select, jsonPointerReference, id).WithAriaLabel(propertySkinLabel);
             }, skinConfiguration);
         }
 
@@ -675,10 +676,25 @@ public static class EditorExtensions
         JsonPointerReference reference,
         object? parameter = null)
     {
+        // 🚨 The ACCESSIBLE name, and it is not the same thing as `label` (MeshWeaver#3863).
+        // `label` is deliberately null on the skinned path so the caption is not painted twice —
+        // the PropertySkin renders it as the surrounding <dt>. That left the input with no
+        // accessible name at all: `getByRole('textbox', { name: question })` matched nothing, and
+        // an HTML <label for> cannot reach it because the Fluent host keeps its real input in a
+        // SHADOW ROOT. aria-label sits on the host element and survives that boundary.
+        //
+        // Read from GetEditorLabel() — the SAME single source the PropertySkin's own label comes
+        // from — so the accessible name and the visible term can never disagree (WCAG label-in-name).
+        var ariaLabel = propertyInfo.GetEditorLabel();
+
         if (BasicControls.TryGetValue(controlType, out var factory))
-            return (UiControl)((IFormControl)factory.Invoke(reference, propertyInfo, parameter!)).WithLabel(label!);
+            return (UiControl)((IFormControl)factory.Invoke(reference, propertyInfo, parameter!))
+                .WithLabel(label!)
+                .WithAriaLabel(ariaLabel);
         if (ListControls.TryGetValue(controlType, out var factory2))
-            return (UiControl)((IListControl)factory2.Invoke(host, propertyInfo, reference, parameter!)).WithLabel(label!);
+            return (UiControl)((IListControl)factory2.Invoke(host, propertyInfo, reference, parameter!))
+                .WithLabel(label!)
+                .WithAriaLabel(ariaLabel);
         if (SpecialControls.TryGetValue(controlType, out var specialFactory))
             return specialFactory.Invoke(propertyInfo, reference);
 

--- a/src/MeshWeaver.Layout/FormControlBase.cs
+++ b/src/MeshWeaver.Layout/FormControlBase.cs
@@ -29,6 +29,23 @@ public abstract record FormControlBase <TControl>(object Data)
         => WithLabel(label);
 
     /// <summary>
+    /// The accessible name rendered as <c>aria-label</c> on the underlying input. See
+    /// <see cref="IFormControl.AriaLabel"/> for why a form control needs one in addition to
+    /// <see cref="Label"/>.
+    /// </summary>
+    public object? AriaLabel { get; init; }
+
+    /// <summary>
+    /// Sets the accessible name (<c>aria-label</c>) of the control.
+    /// </summary>
+    /// <param name="ariaLabel">The accessible name, or a binding expression resolving to one.</param>
+    public TControl WithAriaLabel(object ariaLabel)
+        => This with { AriaLabel = ariaLabel };
+
+    IFormControl IFormControl.WithAriaLabel(object ariaLabel)
+        => WithAriaLabel(ariaLabel);
+
+    /// <summary>
     /// Whether the number field is disabled.
     /// </summary>
     public object? Disabled { get; init; }

--- a/src/MeshWeaver.Layout/IFormControl.cs
+++ b/src/MeshWeaver.Layout/IFormControl.cs
@@ -23,6 +23,36 @@ public interface IFormControl : IUiControl
     IFormControl WithLabel(object label);
 
     /// <summary>
+    /// Accessible name for the control, rendered as <c>aria-label</c> on the underlying input.
+    ///
+    /// <para>
+    /// 🚨 This is NOT a second visible label — it exists because the visible one frequently lives
+    /// OUTSIDE the control. A generated editor field renders its caption in the surrounding
+    /// <see cref="PropertySkin"/> (a <c>&lt;dt&gt;</c>) and deliberately leaves <see cref="Label"/>
+    /// null so the caption is not painted twice; the input is then left with no accessible name at
+    /// all. An HTML <c>&lt;label for&gt;</c> cannot rescue it either: the Fluent web components put
+    /// their real input inside a SHADOW ROOT, and <c>for</c>/<c>id</c> do not associate across that
+    /// boundary — which is why <c>getByRole('textbox', { name })</c> found nothing (MeshWeaver#3863).
+    /// <c>aria-label</c> is set on the host element and survives the shadow boundary.
+    /// </para>
+    /// </summary>
+    object? AriaLabel => null;
+
+    /// <summary>
+    /// Returns a copy of the control carrying <paramref name="ariaLabel"/> as its accessible name.
+    /// </summary>
+    /// <param name="ariaLabel">The accessible name, or a binding expression resolving to one.</param>
+    /// <returns>A new instance of the form control with the specified accessible name.</returns>
+    /// <remarks>
+    /// The default implementation returns the control unchanged — a form control that carries no
+    /// accessible name of its own. <c>FormControlBase</c>, which every control in this repository
+    /// derives from, overrides both this and <see cref="AriaLabel"/> with the real record copy.
+    /// The default exists so that adding this member cannot oblige an out-of-repo implementer to
+    /// write code before it can compile (see <c>scripts/check-interface-addition.py</c>).
+    /// </remarks>
+    IFormControl WithAriaLabel(object ariaLabel) => this;
+
+    /// <summary>
     /// Whether the form control is disabled.
     /// </summary>
     object? Disabled { get; init; }

--- a/test/MeshWeaver.Layout.Test/EditorTest.cs
+++ b/test/MeshWeaver.Layout.Test/EditorTest.cs
@@ -275,6 +275,103 @@ public class EditorTest(ITestOutputHelper output) : HubTestBase(output)
     }
 
 
+    #region Accessible names (#3863)
+
+    /// <summary>
+    /// The shape MeshWeaver#3863 was reported on: an assessment form whose questions are declared
+    /// with <see cref="DisplayNameAttribute"/> and rendered through an explicit
+    /// <c>[UiControl&lt;TextAreaControl&gt;]</c>.
+    /// </summary>
+    private record AssessmentForm
+    {
+        [DisplayName("1. What topics do you want to cover?")]
+        [Description("The learner's own words")]
+        [UiControl<TextAreaControl>]
+        public string Topics { get; init; } = null!;
+
+        [DisplayName("2. How much time can you invest each week?")]
+        [Description("Hours per week")]
+        public string Commitment { get; init; } = null!;
+    }
+
+    private UiControl? AssessmentEditor(LayoutAreaHost host, RenderingContext ctx) =>
+        host.Hub.Edit(new AssessmentForm(), "assessment");
+
+    /// <summary>
+    /// 🚨 The generated input must carry the question as its ACCESSIBLE name, and must still NOT
+    /// carry it as a visible <c>Label</c>.
+    ///
+    /// <para>
+    /// Both halves matter and they pull against each other, which is exactly how #3863 was created:
+    /// <c>MapToControl</c> passes <c>label = null</c> to the control on purpose, because the caption
+    /// is already painted by the surrounding <see cref="PropertySkin"/> (the <c>&lt;dt&gt;</c>) and
+    /// setting it twice would render it twice. The consequence nobody accounted for is that the
+    /// input was then left with NO accessible name at all — Playwright's
+    /// <c>getByRole('textbox', { name: question })</c> matched nothing on a live portal, and an HTML
+    /// <c>&lt;label for&gt;</c> cannot fix it because the Fluent host keeps its real input inside a
+    /// SHADOW ROOT, across which <c>for</c>/<c>id</c> do not associate.
+    /// </para>
+    ///
+    /// <para>
+    /// So the assertion is: <c>AriaLabel</c> == the skin's visible <c>Label</c> (WCAG label-in-name —
+    /// they are read from the one <c>GetEditorLabel()</c> source so they cannot drift), and
+    /// <c>Label</c> stays null. Reverting the <c>WithAriaLabel</c> calls in <c>EditorExtensions</c>
+    /// fails this test on the first assertion.
+    /// </para>
+    ///
+    /// <para>
+    /// This is the half of #3863 that a unit test CAN see. The rendered-DOM half — the Fluent host
+    /// actually emitting <c>aria-label</c> — lives in MeshWeaver.Plugins' Blazor views, so the
+    /// browser regression the issue asks for can only go green once that half ships.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task GeneratedFieldsCarryTheirQuestionAsAccessibleName()
+    {
+        var host = GetHost();
+        var workspace = host.GetWorkspace();
+        var area = workspace.GetStream(new LayoutAreaReference(nameof(AssessmentEditor)));
+
+        var control = await area
+            .GetControlStream(nameof(AssessmentEditor))
+            .Should().Within(10.Seconds()).Match(x => x is not null);
+
+        var editor = control.Should().BeOfType<EditorControl>().Subject;
+        editor.Areas.Should().HaveCount(2);
+
+        foreach (var namedArea in editor.Areas)
+        {
+            var skin = namedArea.Skins.OfType<PropertySkin>().Should().ContainSingle().Subject;
+            skin.Label.Should().BeOfType<string>();
+            var question = (string)skin.Label!;
+
+            var field = await area
+                .GetControlStream(namedArea.Area.ToString()!)
+                .Should().Within(10.Seconds()).Match(x => x is not null);
+
+            field.Should().BeAssignableTo<IFormControl>();
+            var formControl = (IFormControl)field!;
+
+            // The accessible name — absent before #3863, which is what left the textbox unnamed.
+            formControl.AriaLabel.Should().Be(question,
+                "the generated input must expose the question as its accessible name (#3863)");
+
+            // …and NOT a second visible label: the caption is the PropertySkin's <dt>.
+            formControl.Label.Should().BeNull(
+                "the visible caption is rendered by the PropertySkin, so duplicating it on the control would paint it twice");
+        }
+
+        // The declared control type is honoured — this is the exact shape reported on the portal.
+        var topics = await area
+            .GetControlStream(editor.Areas.First().Area.ToString()!)
+            .Should().Within(10.Seconds()).Match(x => x is not null);
+        topics.Should().BeOfType<TextAreaControl>()
+            .Which.AriaLabel.Should().Be("1. What topics do you want to cover?");
+    }
+
+    #endregion
+
+
     protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
     {
         return base.ConfigureHost(configuration).AddLayout(layout => layout
@@ -282,6 +379,7 @@ public class EditorTest(ITestOutputHelper output) : HubTestBase(output)
             .WithView(nameof(EditorWithResult), EditorWithResult)
             .WithView(nameof(EditorWithDelayedResult), EditorWithDelayedResult)
             .WithView(nameof(EditorWithListFormProperties), EditorWithListFormProperties)
+            .WithView(nameof(AssessmentEditor), AssessmentEditor)
         ).AddData(data => data
             .AddSource(source =>
                 source.WithType<MyDimension>(type => type.WithInitialData(Dimensions))));


### PR DESCRIPTION
Fixes #3863 — **core half**. The observable fix needs the Plugins half as well; see below.

## The defect

The native `Edit`-generated form renders a question as the `<dt>` of a definition list and the input
in the `<dd>` beside it. The input had **no accessible name at all**: the accessibility snapshot read
`term: 1. What topics …` then a bare `definition: textbox`, and Playwright's
`getByRole('textbox', { name: question })` matched nothing.

Two independent causes, and both have to change:

1. **Here.** `EditorExtensions.MapToControl` builds the control with `label = null` **on purpose** —
   the caption is already painted by the surrounding `PropertySkin`, and setting it on the control
   too would render it twice. The consequence nobody accounted for is that the control was then left
   with nothing to name it: the control's own `Label` is what produces the `aria-label` on the Fluent
   host, which is why an explicit `TextAreaControl.Label` worked and a generated field did not.
2. **MeshWeaver.Plugins.** `PropertyView.razor` emitted `<label for="@(Skin?.Name)">` — a target that
   *cannot exist*, because a Fluent input keeps its real `<input>` inside a **shadow root** and
   `for`/`id` do not associate across that boundary.

`aria-label` is the only one of the two that survives the shadow boundary, and it needs no id
plumbing through `DispatchView` — so that is the association this uses.

## What this half changes

* `IFormControl` gains `AriaLabel` and `WithAriaLabel(object)`, **both with default implementations**
  (`null` / return-unchanged) so no out-of-repo implementer is obliged to write code before it can
  compile. `FormControlBase<TControl>` carries the real record copy, so every form control has an
  accessible name, exactly as `DataGridControl.WithAriaLabel` already does for grids.
* `DateTimeControl.AriaLabel` **moves up** to `FormControlBase` — it was the only control that had
  one. It is still readable and settable on `DateTimeControl` by inheritance; re-declaring it there
  would shadow the base property and give the record two backing fields.
* `EditorExtensions` sets `AriaLabel` on every generated control from `GetEditorLabel()` — the SAME
  single source the `PropertySkin` caption is read from, so the accessible name and the visible term
  can never drift apart (WCAG *label in name*). **`label` stays null**, so the caption is still not
  painted twice.
* `Doc/GUI/Editor` gains an "Accessible names" section recording why it is `aria-label` and not
  `<label for>`.

**Scope, stated narrowly on purpose** (review finding, second commit). The guarantee is over
`IFormControl` — text, multi-line text, number, date, checkbox, switch, select, combobox, listbox,
radio group. TWO generated surfaces are still unnamed, and both are recorded in `Doc/GUI/Editor` and
at the code site rather than left to be rediscovered from a symptom:

| Surface | Why not covered here |
|---|---|
| `[Markdown]` / `[UiControl<MarkdownEditorControl>]` (the `SpecialControls` branch) | `MarkdownEditorControl` is not an `IFormControl`; it is a composite editor with its own toolbar and view, so its accessible name is an `aria-labelledby` question about that composite, not an `aria-label` on one input. Guessing at it here would ship an unmeasured answer. |
| The click-to-edit path (`MapToToggleableControl`) | It renders its caption as a sibling `LabelControl`, which emits a `FluentLabel` with no `for` — the same association hole, on a different feature surface. |

## Control result — the test fails without the fix

`EditorTest.GeneratedFieldsCarryTheirQuestionAsAccessibleName` renders the exact shape from the issue
(`[DisplayName]` + `[UiControl<TextAreaControl>]`) and asserts both halves of the tension: the
control carries the question as `AriaLabel`, **and** still carries no visible `Label`.

Reverting `src/MeshWeaver.Layout/EditorExtensions.cs` and rebuilding fails it on the first assertion:

```
Expected value to be "1. What topics do you want to cover?" because the generated input must
expose the question as its accessible name (#3863), but found <null>.
```

With the fix: `Failed: 0, Passed: 1`.

## What this half does NOT do

Nothing observable. The rendered `aria-label` comes from the Blazor views in **MeshWeaver.Plugins**,
so the browser regression the issue asks for
(`getByRole('textbox', { name: question })`) can only go green once that half ships. It is open as
**Systemorph/MeshWeaver.Plugins#1578**, which also carries the DOM-level regression
(`GeneratedFieldAccessibleNameTest`) and the What's New entry. Per AGENTS.md the core half lands
first.

Pairs-with: none — nothing left the public surface. DateTimeControl.AriaLabel was not deleted, it moved UP to its base class FormControlBase, so every existing read, object-initializer write and `with` expression on DateTimeControl still compiles unchanged by inheritance — including in-mesh C#, which the compiler cannot see. The detector reports the move as a member removal because it compares declaration sites, not effective surfaces.

Local verification (Release, warnings-as-errors, one project per invocation): MeshWeaver.Layout,
MeshWeaver.Documentation, MeshWeaver.Mesh.Operations, MeshWeaver.Hosting.AspNetCore,
MeshWeaver.Layout.Test, MeshWeaver.Documentation.Test — all `0 Warning(s) 0 Error(s)`;
`DocumentationLinkIntegrityTest` green.
