### PR TITLE
Fix CI checks that keep reading an outdated PR description

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -410,9 +410,8 @@ jobs:
     - name: "This diff does not shrink what the surface detector can see"
       env:
         EVENT: ${{ github.event_name }}
-        # A pull-request body is attacker-controlled text: it reaches the script through a FILE
-        # written from the environment, never interpolated into a shell command.
-        PR_BODY: ${{ github.event.pull_request.body }}
+        # Read corrected declarations on reruns; keep the body as file data, never shell text.
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         # Already fetched above; repeated explicitly so the steps can be reordered.
@@ -424,7 +423,8 @@ jobs:
         echo "Comparing against merge base $base"
         args=(--base "$base")
         if [ "$EVENT" = "pull_request" ]; then
-          printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+          python3 scripts/test-read-current-pr-body.py
+          python3 scripts/read-current-pr-body.py --output "$RUNNER_TEMP/pr-body.md"
           echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes — a declared decrease can be honoured."
           args+=(--pr-body-file "$RUNNER_TEMP/pr-body.md")
         else
@@ -2531,14 +2531,15 @@ jobs:
     - name: "Prove the pair gate is not vacuous (self-test)"
       run: python3 scripts/check-cross-repo-pair.py --self-test
 
-    # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
-    # never interpolated into a shell command.
+    # The event body is frozen at run creation, even on reruns. Read the current declaration
+    # through REST and verify it still belongs to the event head. It stays file data throughout.
     - name: Capture the pull-request body
       env:
-        PR_BODY: ${{ github.event.pull_request.body }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+        python3 scripts/test-read-current-pr-body.py
+        python3 scripts/read-current-pr-body.py --output "$RUNNER_TEMP/pr-body.md"
         echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes."
 
     - name: "Report the public surface this diff removes"
@@ -2617,14 +2618,15 @@ jobs:
     - name: "Prove the pin gate is not vacuous (self-test)"
       run: python3 scripts/check-package-pin-removal.py --self-test
 
-    # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
-    # never interpolated into a shell command.
+    # The event body is frozen at run creation, even on reruns. Read the current declaration
+    # through REST and verify it still belongs to the event head. It stays file data throughout.
     - name: Capture the pull-request body
       env:
-        PR_BODY: ${{ github.event.pull_request.body }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+        python3 scripts/test-read-current-pr-body.py
+        python3 scripts/read-current-pr-body.py --output "$RUNNER_TEMP/pr-body.md"
         echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes."
 
     - name: "Every removed PackageVersion is declared"
@@ -2701,14 +2703,15 @@ jobs:
     - name: "Prove the interface-addition gate is not vacuous (self-test)"
       run: python3 scripts/check-interface-addition.py --self-test
 
-    # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
-    # never interpolated into a shell command.
+    # The event body is frozen at run creation, even on reruns. Read the current declaration
+    # through REST and verify it still belongs to the event head. It stays file data throughout.
     - name: Capture the pull-request body
       env:
-        PR_BODY: ${{ github.event.pull_request.body }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+        python3 scripts/test-read-current-pr-body.py
+        python3 scripts/read-current-pr-body.py --output "$RUNNER_TEMP/pr-body.md"
         echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes."
 
     - name: "Report the public surface this diff adds"
@@ -2764,8 +2767,8 @@ jobs:
     #   * the self-test runs FIRST and fails this job — an unproven gate is no gate;
     #   * no path filter — a pull request that touches nothing else would otherwise "pass" by not
     #     running, and the catalog is exactly what such a pull request edits;
-    #   * no `continue-on-error:` and no `if:` asking whether a secret is set — this gate needs NO
-    #     credential at all, which is why it also runs on FORK pull requests. The one exemption is
+    #   * no `continue-on-error:` and no `if:` asking whether a secret is set — the metadata read
+    #     uses the built-in token, so it also runs on FORK pull requests. The one exemption is
     #     on the EVENT: `merge_group` carries no pull-request body, and a pull request cannot reach
     #     the queue without this job green, since it is a `needs:` of the required check;
     #   * a CONTROL ARM on the denominator: the catalogs hold 1399 keys each, and a reader that
@@ -2791,14 +2794,15 @@ jobs:
     - name: "Prove the mirror-sync gate is not vacuous (self-test)"
       run: python3 scripts/check-i18n-mirror-sync.py --self-test
 
-    # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
-    # never interpolated into a shell command.
+    # The event body is frozen at run creation, even on reruns. Read the current declaration
+    # through REST and verify it still belongs to the event head. It stays file data throughout.
     - name: Capture the pull-request body
       env:
-        PR_BODY: ${{ github.event.pull_request.body }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+        python3 scripts/test-read-current-pr-body.py
+        python3 scripts/read-current-pr-body.py --output "$RUNNER_TEMP/pr-body.md"
         echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes."
 
     - name: "Every catalog change hands the mirror sync over"

--- a/scripts/read-current-pr-body.py
+++ b/scripts/read-current-pr-body.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Read the current PR declaration text, rather than a frozen Actions event body.
+
+Rerunning a failed declaration gate must see the maintainer's corrected body.
+The original event supplies the PR identity and head only. A changed head, failed
+REST read or malformed response fails closed; none falls back to the stale body.
+The body is written as data and is never evaluated by a shell.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+def read_body(event, repository, read_pr):
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise ValueError("GITHUB_REPOSITORY must identify one owner/repository")
+    original = event["pull_request"]
+    number = original["number"]
+    if type(number) is not int or number < 1:
+        raise ValueError("the event does not identify a pull request")
+    if original["base"]["repo"]["full_name"] != repository:
+        raise ValueError("the event's base repository does not match this workflow")
+    expected_head = original["head"]["sha"]
+    if not re.fullmatch(r"[0-9a-f]{40}", expected_head):
+        raise ValueError("the event does not identify an exact PR head")
+    current = read_pr(f"repos/{repository}/pulls/{number}")
+    if current["number"] != number or current["base"]["repo"]["full_name"] != repository:
+        raise ValueError("the REST response identifies a different pull request")
+    if current["head"]["sha"] != expected_head:
+        raise ValueError("the PR head changed; validate the new head, not this obsolete run")
+    body = current["body"]
+    if body is not None and not isinstance(body, str):
+        raise ValueError("the REST response has no readable PR body")
+    return body or ""
+
+
+def read_pr(path):
+    result = subprocess.run(
+        ["gh", "api", "--method", "GET", path],
+        check=True, capture_output=True, text=True, timeout=45,
+    )
+    return json.loads(result.stdout)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    # Never leave an earlier successful read available after a failed refresh.
+    args.output.unlink(missing_ok=True)
+    try:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+        body = read_body(event, os.environ["GITHUB_REPOSITORY"], read_pr)
+        args.output.write_text(body, encoding="utf-8")
+    except (KeyError, TypeError, ValueError, OSError, subprocess.SubprocessError) as error:
+        # Do not echo arbitrary PR text or authentication output into workflow commands.
+        print(f"::error::Could not read the current PR body ({type(error).__name__}); "
+              "check REST access and whether the PR head changed. No cached body was used.")
+        return 1
+    print(f"Current pull-request body: {len(body.encode('utf-8'))} bytes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-read-current-pr-body.py
+++ b/scripts/test-read-current-pr-body.py
@@ -1,0 +1,84 @@
+"""Regression coverage for declaration gates reading corrected PR metadata."""
+
+import copy
+import importlib.util
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location(
+    "reader", Path(__file__).with_name("read-current-pr-body.py"))
+reader = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reader)
+
+
+class CurrentPrBodyTest(unittest.TestCase):
+    def setUp(self):
+        self.pr = {"number": 3844, "head": {"sha": "a" * 40},
+                   "base": {"repo": {"full_name": "Systemorph/MeshWeaver"}},
+                   "body": "old body without the required declaration"}
+        self.event = {"pull_request": copy.deepcopy(self.pr)}
+
+    def read(self, current):
+        def api(path):
+            self.assertEqual(path, "repos/Systemorph/MeshWeaver/pulls/3844")
+            return current
+        return reader.read_body(self.event, "Systemorph/MeshWeaver", api)
+
+    def test_corrected_body_replaces_frozen_event_and_preserves_literal_text(self):
+        self.pr["body"] = "Mirror-sync: tracked in #3844\n`touch /tmp/unwanted` $(echo nope)\n"
+        self.assertEqual(self.read(self.pr), self.pr["body"])
+        self.assertNotEqual(self.pr["body"], self.event["pull_request"]["body"])
+
+    def test_deleted_declaration_is_not_reused_from_event(self):
+        self.event["pull_request"]["body"] = "Mirror-sync: tracked in #3844"
+        for body in (None, ""):
+            with self.subTest(body=body):
+                self.pr["body"] = body
+                self.assertEqual(self.read(self.pr), "")
+
+    def test_new_head_cannot_authorize_an_obsolete_run(self):
+        self.pr["head"]["sha"] = "b" * 40
+        with self.assertRaisesRegex(ValueError, "head changed"):
+            self.read(self.pr)
+
+    def test_wrong_pr_and_wrong_repository_are_refused(self):
+        for field in ("number", "repository"):
+            with self.subTest(field=field):
+                current = copy.deepcopy(self.pr)
+                if field == "number":
+                    current["number"] += 1
+                else:
+                    current["base"]["repo"]["full_name"] = "Other/Repo"
+                with self.assertRaisesRegex(ValueError, "different pull request"):
+                    self.read(current)
+
+    def test_missing_or_malformed_body_is_not_an_empty_success(self):
+        del self.pr["body"]
+        with self.assertRaises(KeyError):
+            self.read(self.pr)
+        self.pr["body"] = {"unreadable": True}
+        with self.assertRaises(ValueError):
+            self.read(self.pr)
+
+    def test_failed_rest_read_never_falls_back_to_event(self):
+        def fail(_):
+            raise subprocess.CalledProcessError(1, ["gh", "api"])
+        with self.assertRaises(subprocess.CalledProcessError):
+            reader.read_body(self.event, "Systemorph/MeshWeaver", fail)
+
+    def test_failed_refresh_removes_previous_output_and_exits_red(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "body.md"
+            output.write_text("Mirror-sync: stale declaration")
+            with patch("sys.argv", ["read-current-pr-body.py", "--output", str(output)]), \
+                 patch.dict("os.environ", {"GITHUB_EVENT_PATH": directory + "/absent.json"}), \
+                 patch("builtins.print"):
+                self.assertEqual(reader.main(), 1)
+            self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #3870.

Correcting a PR declaration did not clear its failed gate: Actions kept reading the description captured when the run was created. All five declaration consumers now read the current PR body through REST, verify the repository, PR number and unchanged head, and write the text directly to a file. A failed read or changed head stops validation; the reader never falls back to the event body. Rerunning a failed check after a body correction can therefore validate the corrected input.

Validation: seven regression tests pass; restoring the frozen-body read fails the tests. The reader retrieved the corrected #3844 body from GitHub. Workflow syntax, shell, timeout and secret-preflight checks pass. No application projects changed; no application build or release note is needed for this internal CI fix. The PR CI will also exercise each real metadata read with the existing job permissions.

No token permissions, required checks, merge rules or application access behavior change.