### PR TITLE
Capture failed emit references on explicit CI opt-in

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/EmitReferenceCaptureScheduler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/EmitReferenceCaptureScheduler.cs
@@ -1,0 +1,79 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Optional CI diagnostics use the existing, drainable file pool. They never join
+/// the compile's deadline and never retain source trees or an entire compilation.
+/// </summary>
+internal sealed class EmitReferenceCaptureScheduler(
+    IIoPool pool, string directory, Action<IDisposable> registerForDisposal)
+{
+    internal static Action<CSharpCompilation, Exception>? ForCi(IMessageHub hub)
+    {
+        var directory = EmitReferenceCapture.GetCiDirectory(Environment.GetEnvironmentVariable);
+        if (directory is null)
+            return null;
+
+        // Resolve while the service scope is alive, never from a deferred diagnostic.
+        // No untracked/unbounded fallback: absent infrastructure means no capture.
+        try
+        {
+            var registry = hub.ServiceProvider.GetService<IoPoolRegistry>();
+            if (registry is null)
+                return (_, error) => error.Data[EmitPipeline.EmitReferenceCaptureDataKey] =
+                    "incomplete:no-file-pool";
+
+            var scheduler = new EmitReferenceCaptureScheduler(registry.Get(IoPoolNames.FileSystem),
+                directory, item => hub.RegisterForDisposal(item));
+            return scheduler.Schedule;
+        }
+        catch (Exception)
+        {
+            // An opt-in diagnostic cannot prevent construction of the compiler
+            // service when its optional diagnostic infrastructure is unavailable.
+            return (_, error) => error.Data[EmitPipeline.EmitReferenceCaptureDataKey] =
+                "incomplete:file-pool-unavailable";
+        }
+    }
+
+    internal void Schedule(CSharpCompilation compilation, Exception error)
+    {
+        // Preserve only the reference sequence. No source, configuration, service
+        // resolution or mesh mutation occurs in the I/O leaf.
+        var references = compilation.References.ToArray();
+        var failureType = error.GetType().FullName ?? error.GetType().Name;
+        var captureDirectory = directory; // Do not close over this scheduler and its hub-owned registration delegate.
+        var captureId = Guid.NewGuid().ToString("N");
+        var owner = new SerialDisposable();
+        try
+        {
+            registerForDisposal(owner);
+            if (owner.IsDisposed)
+            {
+                error.Data[EmitPipeline.EmitReferenceCaptureDataKey] = "incomplete:owner-disposed";
+                return;
+            }
+            error.Data[EmitPipeline.EmitReferenceCaptureDataKey] =
+                $"requested id={captureId}; missing, mismatched or incomplete manifest is not a captured closure";
+            owner.Disposable = pool.InvokeBlocking(ct =>
+                    EmitReferenceCapture.Capture(references, captureDirectory, failureType, ct, captureId))
+                // Errors can arrive asynchronously (including a draining pool).
+                // The original emit error has already been reported unchanged.
+                .Catch<string, Exception>(_ => Observable.Return("incomplete:io-pool"))
+                .Subscribe(_ => owner.Dispose());
+        }
+        catch
+        {
+            owner.Dispose();
+            throw; // The emit boundary records scheduling failure and rethrows its original.
+        }
+    }
+}

--- a/src/MeshWeaver.Compiler.Pipeline/EmitReferenceCaptureScheduler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/EmitReferenceCaptureScheduler.cs
@@ -14,7 +14,8 @@ namespace MeshWeaver.Graph.Configuration;
 /// the compile's deadline and never retain source trees or an entire compilation.
 /// </summary>
 internal sealed class EmitReferenceCaptureScheduler(
-    IIoPool pool, string directory, Action<IDisposable> registerForDisposal)
+    IIoPool pool, string directory, Action<IDisposable> registerForDisposal,
+    EmitReferenceCaptureReservation reservation)
 {
     internal static Action<CSharpCompilation, Exception>? ForCi(IMessageHub hub)
     {
@@ -31,8 +32,13 @@ internal sealed class EmitReferenceCaptureScheduler(
                 return (_, error) => error.Data[EmitPipeline.EmitReferenceCaptureDataKey] =
                     "incomplete:no-file-pool";
 
+            var reservation = hub.ServiceProvider.GetService<EmitReferenceCaptureReservation>();
+            if (reservation is null)
+                return (_, error) => error.Data[EmitPipeline.EmitReferenceCaptureDataKey] =
+                    "incomplete:no-reservation";
+
             var scheduler = new EmitReferenceCaptureScheduler(registry.Get(IoPoolNames.FileSystem),
-                directory, item => hub.RegisterForDisposal(item));
+                directory, item => hub.RegisterForDisposal(item), reservation);
             return scheduler.Schedule;
         }
         catch (Exception)
@@ -46,6 +52,15 @@ internal sealed class EmitReferenceCaptureScheduler(
 
     internal void Schedule(CSharpCompilation compilation, Exception error)
     {
+        // Claim before enumerating references or registering/enqueueing work. All
+        // compiler hubs in this mesh share the root-owned reservation. Never retry
+        // a failed/cancelled capture during a cascade; the manifest remains incomplete.
+        if (!reservation.TryReserve())
+        {
+            error.Data[EmitPipeline.EmitReferenceCaptureDataKey] = "incomplete:already-requested";
+            return;
+        }
+
         // Preserve only the reference sequence. No source, configuration, service
         // resolution or mesh mutation occurs in the I/O leaf.
         var references = compilation.References.ToArray();
@@ -68,7 +83,7 @@ internal sealed class EmitReferenceCaptureScheduler(
                 // Errors can arrive asynchronously (including a draining pool).
                 // The original emit error has already been reported unchanged.
                 .Catch<string, Exception>(_ => Observable.Return("incomplete:io-pool"))
-                .Subscribe(_ => owner.Dispose());
+                .Subscribe(_ => owner.Dispose(), _ => owner.Dispose());
         }
         catch
         {
@@ -76,4 +91,12 @@ internal sealed class EmitReferenceCaptureScheduler(
             throw; // The emit boundary records scheduling failure and rethrows its original.
         }
     }
+}
+
+/// <summary>Root-service-owned once gate; no static state or actor-side file I/O.</summary>
+internal sealed class EmitReferenceCaptureReservation
+{
+    private int requested;
+
+    internal bool TryReserve() => Interlocked.CompareExchange(ref requested, 1, 0) == 0;
 }

--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
@@ -40,6 +40,8 @@ internal class MeshNodeCompilationService(
 {
     private readonly IAssemblyStore _assemblyStore = assemblyStore ?? NullAssemblyStore.Instance;
     private readonly CompilationCacheOptions _cacheOptions = cacheOptions.Value ?? new CompilationCacheOptions();
+    private readonly Action<CSharpCompilation, Exception>? _captureEmitFailure =
+        EmitReferenceCaptureScheduler.ForCi(hub);
 
     // Compile pool for the bare-async leaf (CompilationInputs assembly): a plain
     // Observable.FromAsync deadlocks under a blocking subscriber because SubscribeOn
@@ -1954,7 +1956,7 @@ internal class MeshNodeCompilationService(
             actualPath = EmitPipeline.EmitToDiskWithRetry(
                 cacheService.CacheDirectory, nodeName, EmitPipeline.DiskEmitAttempts, logger,
                 releaseDir => emitted = EmitPipeline.EmitCompilationToDirectory(
-                    compilation, nodeName, node.Path, releaseDir, ct));
+                    compilation, nodeName, node.Path, releaseDir, [], ct, _captureEmitFailure));
             warnings = emitted.Warnings;
         }
         else

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -3285,6 +3285,9 @@ internal static class NodeTypeCompilationHelpers
             { } other => $"{other.GetType().Name}: {other.Message}"
                 + (other.Data[EmitPipeline.EmitCanaryDataKey] is string canary
                     ? $" [{canary}]"
+                    : string.Empty)
+                + (other.Data[EmitPipeline.EmitReferenceCaptureDataKey] is string capture
+                    ? $" [emit-reference-capture: {capture}]"
                     : string.Empty),
         };
 

--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -163,6 +163,16 @@ public static class EmitPipeline
     internal static EmittedArtifact EmitCompilationToDirectory(
         CSharpCompilation compilation, string nodeName, string nodePath, string releaseDir,
         IReadOnlyCollection<ResourceDescription> manifestResources, CancellationToken ct)
+        => EmitCompilationToDirectory(compilation, nodeName, nodePath, releaseDir,
+            manifestResources, ct, null);
+
+    // The existing entry points keep their signatures and default behavior. Only the
+    // NodeType pipeline supplies the optional CI diagnostic scheduler; it must not do
+    // blocking I/O here or replace the exception that caused the capture.
+    internal static EmittedArtifact EmitCompilationToDirectory(
+        CSharpCompilation compilation, string nodeName, string nodePath, string releaseDir,
+        IReadOnlyCollection<ResourceDescription> manifestResources, CancellationToken ct,
+        Action<CSharpCompilation, Exception>? captureFailure)
     {
         var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
         var pdbPath = Path.Combine(releaseDir, $"{nodeName}.pdb");
@@ -193,6 +203,16 @@ public static class EmitPipeline
             // reporting funnel via SummarizeCompileError — no second log from here, the
             // log-once contract above still holds.
             ex.Data[EmitCanaryDataKey] = ProbeSharedEmitState(compilation);
+            try
+            {
+                captureFailure?.Invoke(compilation, ex);
+            }
+            catch (Exception captureError)
+            {
+                // Scheduling/ownership can fail during teardown. Diagnostic failure
+                // must never wrap, replace or suppress the original Roslyn exception.
+                ex.Data[EmitReferenceCaptureDataKey] = "incomplete:scheduling-" + captureError.GetType().Name;
+            }
             throw;
         }
 
@@ -224,6 +244,8 @@ public static class EmitPipeline
     /// <c>NodeTypeCompilationHelpers.SummarizeCompileError</c> reads it back.
     /// </summary>
     internal const string EmitCanaryDataKey = "MeshWeaver.EmitCanary";
+
+    internal const string EmitReferenceCaptureDataKey = "MeshWeaver.EmitReferenceCapture";
 
     /// <summary>
     /// Did the canary PROVE that this PROCESS can no longer emit — as opposed to this

--- a/src/MeshWeaver.Compiler/EmitReferenceCapture.cs
+++ b/src/MeshWeaver.Compiler/EmitReferenceCapture.cs
@@ -180,8 +180,13 @@ internal static class EmitReferenceCapture
     {
         refusal = null;
         ct.ThrowIfCancellationRequested();
-        if (input.Length > limits.MaxFileBytes) { refusal = "file-too-large"; return null; }
-        if (input.Length > limits.MaxTotalBytes - total) { refusal = "total-limit"; return null; }
+        var initialLength = input.Length;
+        var initialPosition = input.Position;
+        if (initialPosition < 0 || initialPosition > initialLength)
+        { refusal = "incomplete-read"; return null; }
+        var expectedBytes = initialLength - initialPosition;
+        if (expectedBytes > limits.MaxFileBytes) { refusal = "file-too-large"; return null; }
+        if (expectedBytes > limits.MaxTotalBytes - total) { refusal = "total-limit"; return null; }
         using var bytes = new MemoryStream();
         var buffer = new byte[64 * 1024];
         while (true)
@@ -203,6 +208,11 @@ internal static class EmitReferenceCapture
             bytes.Write(buffer, 0, count);
         }
         ct.ThrowIfCancellationRequested();
+        // EOF alone is not proof of a complete image: a shared file may shrink while
+        // being read, including at the exact budget boundary above. Preserve the read
+        // charge, but never let a shortened image become successful capture evidence.
+        if (bytes.Length != expectedBytes || input.Position != initialLength || input.Length != initialLength)
+        { refusal = "incomplete-read"; return null; }
         return bytes.ToArray();
     }
 

--- a/src/MeshWeaver.Compiler/EmitReferenceCapture.cs
+++ b/src/MeshWeaver.Compiler/EmitReferenceCapture.cs
@@ -1,0 +1,233 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>Opt-in CI evidence writer. Scheduling and cancellation belong to the caller.</summary>
+internal static class EmitReferenceCapture
+{
+    internal sealed record CaptureLimits(
+        int MaxReferences = 1024,
+        long MaxFileBytes = 64L * 1024 * 1024,
+        long MaxTotalBytes = 256L * 1024 * 1024);
+
+    internal static string? GetCiDirectory(Func<string, string?> readEnvironment)
+    {
+        try
+        {
+            if (readEnvironment("GITHUB_ACTIONS") != "true" ||
+                readEnvironment("MW_CAPTURE_EMIT_REFERENCES") != "1") return null;
+            var root = readEnvironment("RUNNER_TEMP");
+            if (string.IsNullOrWhiteSpace(root) || !Path.IsPathFullyQualified(root) || root.Contains('\0'))
+                return null;
+            return Path.Combine(Path.GetFullPath(root), "straggler-logs", "emit-reference-capture",
+                $"process-{Environment.ProcessId}");
+        }
+        catch { return null; }
+    }
+
+    internal static string Capture(IReadOnlyList<MetadataReference> references, string directory,
+        Exception failure, CancellationToken ct)
+        => Capture(references, directory, failure.GetType().FullName ?? failure.GetType().Name, ct);
+
+    internal static string Capture(IReadOnlyList<MetadataReference> references, string directory,
+        string failureType, CancellationToken ct)
+        => Capture(references, directory, failureType, ct, new CaptureLimits());
+
+    internal static string Capture(IReadOnlyList<MetadataReference> references, string directory,
+        string failureType, CancellationToken ct, string captureId)
+        => Capture(references, directory, failureType, ct, new CaptureLimits(), captureId);
+
+    internal static string Capture(IReadOnlyList<MetadataReference> references, string directory,
+        string failureType, CancellationToken ct, CaptureLimits limits, string? captureId = null)
+    {
+        try
+        {
+            Directory.CreateDirectory(directory);
+            try
+            {
+                using var sentinel = new FileStream(Path.Combine(directory, "started.json"),
+                    FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+                JsonSerializer.Serialize(sentinel, new { complete = false, reason = "started", captureId });
+            }
+            catch (IOException) when (File.Exists(Path.Combine(directory, "started.json")))
+            { return "already-started"; }
+
+            var entries = new List<Dictionary<string, object?>>();
+            var writtenHashes = new HashSet<string>(StringComparer.Ordinal);
+            long total = 0;
+            var reason = references.Count > limits.MaxReferences ? "reference-limit" : "complete";
+            for (var ordinal = 0; ordinal < Math.Min(references.Count, limits.MaxReferences); ordinal++)
+            {
+                var reference = references[ordinal];
+                var entry = new Dictionary<string, object?>
+                {
+                    ["ordinal"] = ordinal, ["referenceType"] = reference.GetType().FullName,
+                    ["kind"] = reference.Properties.Kind.ToString(),
+                    ["aliases"] = reference.Properties.Aliases.ToArray(),
+                    ["embedInteropTypes"] = reference.Properties.EmbedInteropTypes,
+                    ["path"] = (reference as PortableExecutableReference)?.FilePath,
+                    ["status"] = "error"
+                };
+                entries.Add(entry);
+                try
+                {
+                    ct.ThrowIfCancellationRequested();
+                    CaptureReference(reference, entry, directory, writtenHashes, limits, ref total, ct);
+                }
+                catch (OperationCanceledException)
+                { entry["status"] = "cancelled"; reason = "cancelled"; break; }
+                catch (FileNotFoundException) { entry["status"] = "missing-file"; }
+                catch (DirectoryNotFoundException) { entry["status"] = "missing-file"; }
+                catch (Exception ex) { entry["errorType"] = ex.GetType().FullName; }
+                if (!Equals(entry["status"], "captured") && reason == "complete") reason = "partial";
+            }
+            if (ct.IsCancellationRequested) reason = "cancelled";
+            var complete = reason == "complete" && entries.Count == references.Count;
+            var manifest = new
+            {
+                complete, reason, captureId, referenceCount = references.Count, readBytes = total,
+                failureType,
+                runtime = new
+                {
+                    framework = RuntimeInformation.FrameworkDescription,
+                    version = Environment.Version.ToString(),
+                    architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                    os = RuntimeInformation.OSDescription,
+                    processId = Environment.ProcessId,
+                    managedThreadId = Environment.CurrentManagedThreadId,
+                    processorCount = Environment.ProcessorCount,
+                    compiler = Identity(typeof(CSharpCompilation).Assembly),
+                    coreLib = Identity(typeof(object).Assembly),
+                    jitFlags = JitFlags()
+                },
+                references = entries,
+                limitation = "File bytes are reread after failure; matching MVIDs do not prove byte identity with held metadata. Object caches and process history are not captured."
+            };
+            var temporary = Path.Combine(directory, "manifest.tmp");
+            using (var output = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                JsonSerializer.Serialize(output, manifest);
+            File.Move(temporary, Path.Combine(directory, "manifest.json"));
+            return complete ? "captured" : "incomplete";
+        }
+        catch { return "incomplete"; }
+    }
+
+    private static void CaptureReference(MetadataReference reference, Dictionary<string, object?> entry,
+        string directory, HashSet<string> writtenHashes, CaptureLimits limits,
+        ref long total, CancellationToken ct)
+    {
+        if (reference is not PortableExecutableReference pe || string.IsNullOrEmpty(pe.FilePath))
+        { entry["status"] = "unsupported-reference"; return; }
+        // GetMetadata returns a copy; Roslyn documents that this copy need not be disposed.
+        var metadata = pe.GetMetadata();
+        var heldMvids = metadata switch
+        {
+            AssemblyMetadata assembly => assembly.GetModules().Select(Mvid).ToArray(),
+            ModuleMetadata module => new[] { Mvid(module) },
+            _ => Array.Empty<string>()
+        };
+        entry["metadataMvids"] = heldMvids;
+        using var input = new FileStream(pe.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        entry["size"] = input.Length;
+        var image = ReadImage(input, limits, ref total, ct, out var refusal);
+        if (image is null) { entry["status"] = refusal; return; }
+        entry["size"] = image.LongLength;
+        var hash = Convert.ToHexString(SHA256.HashData(image)).ToLowerInvariant();
+        entry["sha256"] = hash;
+        using var bytes = new MemoryStream(image, writable: false);
+        using var reader = new PEReader(bytes, PEStreamOptions.LeaveOpen);
+        var md = reader.GetMetadataReader();
+        var fileMvids = new[] { md.GetGuid(md.GetModuleDefinition().Mvid).ToString("D") };
+        entry["fileMvids"] = fileMvids;
+        if (md.IsAssembly)
+        {
+            var definition = md.GetAssemblyDefinition();
+            var name = new AssemblyName { Name = md.GetString(definition.Name), Version = definition.Version,
+                CultureName = definition.Culture.IsNil ? null : md.GetString(definition.Culture) };
+            if (!definition.PublicKey.IsNil) name.SetPublicKey(md.GetBlobBytes(definition.PublicKey));
+            entry["fileAssemblyIdentity"] = name.FullName;
+        }
+        var imagePath = Path.Combine(directory, hash + ".pe");
+        if (!writtenHashes.Contains(hash))
+        {
+            // A preexisting file is not evidence from this capture. Never reread it outside
+            // the budget or accept an interrupted write under its content-addressed name.
+            using var output = new FileStream(imagePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+            const int chunkSize = 64 * 1024;
+            for (var offset = 0; offset < image.Length; offset += chunkSize)
+            {
+                ct.ThrowIfCancellationRequested();
+                output.Write(image, offset, Math.Min(chunkSize, image.Length - offset));
+            }
+            output.Flush();
+            writtenHashes.Add(hash);
+        }
+        entry["file"] = Path.GetFileName(imagePath);
+        entry["status"] = heldMvids.SequenceEqual(fileMvids) ? "captured" : "metadata-mismatch";
+    }
+
+    // The actual file-reading leaf, separated only to exercise partial I/O failures with
+    // ordinary Streams. The caller owns input and retains the charged count on exceptions.
+    internal static byte[]? ReadImage(Stream input, CaptureLimits limits, ref long total,
+        CancellationToken ct, out string? refusal)
+    {
+        refusal = null;
+        ct.ThrowIfCancellationRequested();
+        if (input.Length > limits.MaxFileBytes) { refusal = "file-too-large"; return null; }
+        if (input.Length > limits.MaxTotalBytes - total) { refusal = "total-limit"; return null; }
+        using var bytes = new MemoryStream();
+        var buffer = new byte[64 * 1024];
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var fileRemaining = limits.MaxFileBytes - bytes.Length;
+            var totalRemaining = limits.MaxTotalBytes - total;
+            var available = Math.Min(fileRemaining, totalRemaining);
+            if (available <= 0)
+            {
+                if (input.Position == input.Length) break;
+                refusal = fileRemaining <= 0 ? "file-too-large" : "total-limit";
+                return null;
+            }
+            var count = input.Read(buffer, 0, (int)Math.Min(buffer.Length, available));
+            if (count == 0) break;
+            // Charge immediately: cancellation, growth or a later error must not refund reads.
+            total += count;
+            bytes.Write(buffer, 0, count);
+        }
+        ct.ThrowIfCancellationRequested();
+        return bytes.ToArray();
+    }
+
+    private static string Mvid(ModuleMetadata module)
+    {
+        var reader = module.GetMetadataReader();
+        return reader.GetGuid(reader.GetModuleDefinition().Mvid).ToString("D");
+    }
+
+    private static object Identity(Assembly assembly) => new
+    {
+        name = assembly.GetName().FullName,
+        informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+        mvid = assembly.ManifestModule.ModuleVersionId.ToString("D")
+    };
+
+    private static Dictionary<string, string?> JitFlags()
+    {
+        var result = new Dictionary<string, string?>();
+        foreach (var name in new[] { "DOTNET_TieredPGO", "DOTNET_TieredCompilation", "DOTNET_ReadyToRun",
+                     "COMPlus_TieredPGO", "COMPlus_TieredCompilation", "COMPlus_ReadyToRun" })
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            result[name] = value is null or "0" or "1" ? value : "other";
+        }
+        return result;
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -229,6 +229,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Dangling NodeTypes](DanglingNodeTypes) — a node whose type resolves to nothing, and the two write paths that allowed it
 - [Node Type Compilation](NodeTypeCompilation)
 - [Execute-Time Interlock](ExecuteTimeInterlock) — a build proven stale is never armed
+- [Emit Reference Capture](EmitReferenceCapture) — bounded, opt-in CI evidence for runtime compiler failures
 - [Graph / Compiler Layering](GraphCompilerLayering) — the four assemblies, the cycle, and the full-MVID size rule
 - [Toolchain Re-evaluation Lane](ToolchainReevaluationLane) — why a toolchain change stopped rebaking the world
 - [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes

--- a/src/MeshWeaver.Documentation/Data/Architecture/EmitReferenceCapture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EmitReferenceCapture.md
@@ -28,6 +28,11 @@ job already uploads the `straggler-logs` directory recursively. A different runn
 preserve that directory through its existing artifact mechanism. No additional permissions
 or credentials are required. The first successful atomic creation of `started.json`
 claims that process directory; later emit failures never overwrite the first capture.
+Before snapshotting references or enqueueing I/O, each mesh root admits only one request
+through an injected atomic reservation shared by its compiler hubs. Cancellation or a
+scheduling failure never resets that reservation. Multiple independent mesh roots in a
+test process can each enqueue once, but the file sentinel still permits only one artifact
+capture for the process. No mutable static registry or actor-side file I/O is introduced.
 The request ID in the existing error summary must match the manifest's `captureId`;
 a different failure's manifest is not evidence for the current request.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/EmitReferenceCapture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EmitReferenceCapture.md
@@ -1,0 +1,76 @@
+---
+NodeType: Markdown
+Name: CI Emit Reference Capture
+Category: Architecture
+Abstract: "Opt-in capture of a failed emit's reference files, without changing compiler scheduling or production settings."
+---
+
+# CI emit reference capture
+
+Plugins issue #890's failing run `34402293577` did not preserve the ordered references
+used by its compiler process. A native standalone control (core run `34414443069`)
+then emitted 4,000/4,000 successfully both with default settings and with tiered PGO
+disabled. Those controls did not reproduce the failure and do not establish its cause.
+Reconstructing a reference set from a portal image would not recover the test runner's
+selected TPA, module and NuGet references.
+
+## Explicit opt-in
+
+The NodeType disk-emit path requests a capture only when **both** named variables are
+present: `GITHUB_ACTIONS=true` and `MW_CAPTURE_EMIT_REFERENCES=1`. `RUNNER_TEMP` must be
+an absolute path. Set the latter flag only on the affected CI test job when requesting
+that evidence; it is not enabled by this change. No production configuration is changed.
+Ordinary C# diagnostics do not trigger it: Roslyn must throw during emit.
+
+Output is fixed beneath
+`RUNNER_TEMP/straggler-logs/emit-reference-capture/process-<pid>/`. The Plugins moved-suite
+job already uploads the `straggler-logs` directory recursively. A different runner must
+preserve that directory through its existing artifact mechanism. No additional permissions
+or credentials are required. The first successful atomic creation of `started.json`
+claims that process directory; later emit failures never overwrite the first capture.
+The request ID in the existing error summary must match the manifest's `captureId`;
+a different failure's manifest is not evidence for the current request.
+
+## Scheduling and lifetime
+
+The existing emit signatures retain their default behavior. The NodeType service supplies
+an optional failure callback which snapshots only the ordered references and exception type.
+It submits a separate leaf through the existing registry's **FileSystem `IIoPool`**, with
+the subscription registered to the hub before work starts. Completion releases it; hub
+disposal cancels it, and the pool participates in the existing drain. No new pool, untracked
+fallback, blocking actor wait or compiler scheduling change is introduced.
+
+The compile does not await the capture or extend its deadline. The original exception
+and canary result continue through the existing reporting funnel. A scheduling failure is
+reported as incomplete diagnostic evidence and cannot replace the original exception.
+If the scope has no registered file pool, capture is explicitly unavailable. Missing or
+invalid opt-in inputs leave the callback disabled.
+
+## Evidence and limits
+
+`manifest.json` records each reference's ordinal, kind, aliases, EmbedInteropTypes,
+file path, retained-file SHA256 and size, and file versus held-metadata MVIDs. Referenced
+PE bytes are stored under their hash. Named process evidence includes actual runtime,
+compiler/CoreLib assembly and informational versions, MVIDs, architecture, processor count
+and capture thread. Only six named JIT flags are read; values are limited to unset, `0`,
+`1` or `other`. No general environment/configuration dump, source text, exception message,
+credentials or mesh data is captured.
+
+The writer limits one capture to 1,024 references, 64 MiB per file and 256 MiB of file
+bytes read (including repeated references). It checks cancellation between reads/writes.
+Unreadable, unsupported, missing, mismatched or over-budget references make the manifest
+incomplete. `started.json` itself says incomplete; a missing final manifest remains
+incomplete, including a cancelled or failed write. Only the final atomic manifest can
+declare completion. A complete capture requires every entry to have been retained and
+its file MVIDs to match the held metadata MVIDs.
+
+**Completion is an evidence inventory, not a claim of identical mapped state.** Files are
+reread after failure. Matching MVIDs alone cannot prove the bytes are the same ones Roslyn
+previously mapped, and a new process cannot reproduce its reference-object caches, JIT
+history, heap or interleavings. A changed/missing reference must not be silently substituted
+in a replay. Full workload replay would also need generated trees and compiler options;
+this minimal capture deliberately provides only what the unchanged canary comparison needs.
+
+Regression tests cover opt-in/default behavior, real PE bytes/properties, incomplete and
+cancelled captures, first-capture preservation, the original emit exception, ordinary
+diagnostics, and execution on the real file pool rather than an actor's event-loop thread.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -345,6 +345,8 @@ public static class GraphConfigurationExtensions
 
                 // Register compilation cache service
                 services.AddSingleton<ICompilationCacheService, CompilationCacheService>();
+                // Shared by every compiler hub; capture cascades enqueue at most once per mesh root.
+                services.AddSingleton<EmitReferenceCaptureReservation>();
 
                 // Mesh-scoped Open Graph link-preview reader for the OgCard layout area:
                 // one promise-cached fetch per external URL, replayed to every card render.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureBoundaryTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureBoundaryTest.cs
@@ -1,0 +1,149 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+public sealed class EmitReferenceCaptureBoundaryTest
+{
+    [Fact]
+    public void SchedulingFailureCannotReplaceTheOriginalEmitException()
+    {
+        var original = new InvalidOperationException("original compiler failure");
+        var compilation = CSharpCompilation.Create("Broken",
+            [CSharpSyntaxTree.ParseText("public class C {}")], [new ThrowingReference(original)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Exception? callbackError = null;
+        var caught = Record.Exception(() => EmitPipeline.EmitCompilationToDirectory(
+            compilation, "Broken", "Test/Broken", Path.GetTempPath(), [], CancellationToken.None,
+            (_, failure) =>
+            {
+                callbackError = failure;
+                throw new IOException("diagnostic scheduling failure");
+            }));
+
+        caught.Should().BeSameAs(original);
+        callbackError.Should().BeSameAs(original);
+        original.Data[EmitPipeline.EmitCanaryDataKey].Should().NotBeNull();
+        original.Data[EmitPipeline.EmitReferenceCaptureDataKey].Should()
+            .Be("incomplete:scheduling-IOException");
+        NodeTypeCompilationHelpers.SummarizeCompileError(null, original).Should()
+            .Contain("emit-reference-capture: incomplete:scheduling-IOException");
+    }
+
+    [Fact]
+    public void ExistingEmitEntryPointDoesNotRequestCapture()
+    {
+        var original = new InvalidOperationException("original");
+        var compilation = CSharpCompilation.Create("Broken",
+            [CSharpSyntaxTree.ParseText("public class C {}")], [new ThrowingReference(original)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var caught = Record.Exception(() => EmitPipeline.EmitCompilationToDirectory(
+            compilation, "Broken", "Test/Broken", Path.GetTempPath(), CancellationToken.None));
+
+        caught.Should().BeSameAs(original);
+        original.Data.Contains(EmitPipeline.EmitReferenceCaptureDataKey).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OrdinaryCompilerDiagnosticsDoNotConsumeTheFailureCapture()
+    {
+        var requested = false;
+        var compilation = EmitPipeline.CreateEmitCompilation("this is invalid source", "Invalid",
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)], "", CancellationToken.None);
+
+        var caught = Record.Exception(() => EmitPipeline.EmitCompilationToDirectory(compilation,
+            "Invalid", "Test/Invalid", Path.GetTempPath(), [], CancellationToken.None,
+            (_, _) => requested = true));
+
+        caught.Should().BeOfType<CompilationException>();
+        requested.Should().BeFalse("source diagnostics are not thrown-from-Emit runtime failures");
+    }
+
+    [Fact]
+    public async Task AnAlreadyDisposedOwnerDoesNotStartDiagnosticIo()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "emit-disposed-" + Guid.NewGuid().ToString("N"));
+        var pool = new IoPool(1);
+        try
+        {
+            var scheduler = new EmitReferenceCaptureScheduler(pool, directory, item => item.Dispose());
+            var error = new InvalidOperationException("original");
+            scheduler.Schedule(CSharpCompilation.Create("Unused"), error);
+            error.Data[EmitPipeline.EmitReferenceCaptureDataKey].Should().Be("incomplete:owner-disposed");
+            (await pool.InvokeBlocking(_ => Directory.Exists(directory)).Timeout(TimeSpan.FromSeconds(10)))
+                .Should().BeFalse();
+        }
+        finally
+        {
+            pool.Dispose();
+            (await pool.Disposed.FirstAsync().Timeout(TimeSpan.FromSeconds(10))).Should().Be(0);
+            if (Directory.Exists(directory)) Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
+    public async Task CaptureUsesTheFilePoolAndReleasesItsOwnedSubscription()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "emit-boundary-" + Guid.NewGuid().ToString("N"));
+        var pool = new IoPool(1);
+        using var owner = new CompositeDisposable();
+        using var actor = new EventLoopScheduler();
+        SerialDisposable? registered = null;
+        var scheduler = new EmitReferenceCaptureScheduler(pool, directory, disposable =>
+        {
+            registered = (SerialDisposable)disposable;
+            owner.Add(disposable);
+        });
+        var compilation = CSharpCompilation.Create("NoSourceIsCaptured",
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var failure = new InvalidOperationException("not recorded");
+        try
+        {
+            var actorThread = await Observable.Start(() =>
+            {
+                scheduler.Schedule(compilation, failure);
+                return Environment.CurrentManagedThreadId;
+            }, actor).Timeout(TimeSpan.FromSeconds(10));
+
+            // The real single-slot file pool queues this read after the capture. The
+            // actor itself never waits for a file or a diagnostic completion.
+            var json = await pool.InvokeBlocking(_ => File.ReadAllText(Path.Combine(directory, "manifest.json")))
+                .Timeout(TimeSpan.FromSeconds(10));
+            using var manifest = JsonDocument.Parse(json);
+            manifest.RootElement.GetProperty("complete").GetBoolean().Should().BeTrue();
+            var captureId = manifest.RootElement.GetProperty("captureId").GetString();
+            captureId.Should().NotBeNullOrEmpty();
+            NodeTypeCompilationHelpers.SummarizeCompileError(null, failure).Should().Contain($"id={captureId}");
+            manifest.RootElement.GetProperty("runtime").GetProperty("managedThreadId").GetInt32()
+                .Should().NotBe(actorThread);
+            registered.Should().NotBeNull();
+            await Observable.Interval(TimeSpan.FromMilliseconds(10))
+                .Where(_ => registered!.IsDisposed).Take(1).Timeout(TimeSpan.FromSeconds(10));
+            registered!.IsDisposed.Should().BeTrue("a completed diagnostic must release its owner");
+        }
+        finally
+        {
+            owner.Dispose();
+            pool.Dispose();
+            (await pool.Disposed.FirstAsync().Timeout(TimeSpan.FromSeconds(10))).Should().Be(0);
+            if (Directory.Exists(directory)) Directory.Delete(directory, true);
+        }
+    }
+
+    private sealed class ThrowingReference(Exception failure) : PortableExecutableReference(MetadataReferenceProperties.Assembly)
+    {
+        protected override DocumentationProvider CreateDocumentationProvider() => DocumentationProvider.Default;
+        protected override Metadata GetMetadataImpl() => throw failure;
+        protected override PortableExecutableReference WithPropertiesImpl(MetadataReferenceProperties properties)
+            => new ThrowingReference(failure);
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureBoundaryTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureBoundaryTest.cs
@@ -75,7 +75,7 @@ public sealed class EmitReferenceCaptureBoundaryTest
         var pool = new IoPool(1);
         try
         {
-            var scheduler = new EmitReferenceCaptureScheduler(pool, directory, item => item.Dispose());
+            var scheduler = new EmitReferenceCaptureScheduler(pool, directory, item => item.Dispose(), new EmitReferenceCaptureReservation());
             var error = new InvalidOperationException("original");
             scheduler.Schedule(CSharpCompilation.Create("Unused"), error);
             error.Data[EmitPipeline.EmitReferenceCaptureDataKey].Should().Be("incomplete:owner-disposed");
@@ -102,7 +102,7 @@ public sealed class EmitReferenceCaptureBoundaryTest
         {
             registered = (SerialDisposable)disposable;
             owner.Add(disposable);
-        });
+        }, new EmitReferenceCaptureReservation());
         var compilation = CSharpCompilation.Create("NoSourceIsCaptured",
             references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
         var failure = new InvalidOperationException("not recorded");
@@ -129,6 +129,44 @@ public sealed class EmitReferenceCaptureBoundaryTest
             await Observable.Interval(TimeSpan.FromMilliseconds(10))
                 .Where(_ => registered!.IsDisposed).Take(1).Timeout(TimeSpan.FromSeconds(10));
             registered!.IsDisposed.Should().BeTrue("a completed diagnostic must release its owner");
+        }
+        finally
+        {
+            owner.Dispose();
+            pool.Dispose();
+            (await pool.Disposed.FirstAsync().Timeout(TimeSpan.FromSeconds(10))).Should().Be(0);
+            if (Directory.Exists(directory)) Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentCompilerHubsShareOneReservationBeforeRegisteringWork()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "emit-cascade-" + Guid.NewGuid().ToString("N"));
+        var pool = new IoPool(1);
+        using var owner = new CompositeDisposable();
+        var reservation = new EmitReferenceCaptureReservation();
+        var registered = 0;
+        var compilation = CSharpCompilation.Create("Cascade",
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var errors = Enumerable.Range(0, 64).Select(_ => new InvalidOperationException("original")).ToArray();
+        try
+        {
+            Parallel.ForEach(errors, error =>
+                new EmitReferenceCaptureScheduler(pool, directory, disposable =>
+                {
+                    Interlocked.Increment(ref registered);
+                    owner.Add(disposable);
+                }, reservation).Schedule(compilation, error));
+
+            registered.Should().Be(1, "a cascade must not register or enqueue redundant captures");
+            errors.Count(error => Equals(error.Data[EmitPipeline.EmitReferenceCaptureDataKey],
+                "incomplete:already-requested")).Should().Be(63);
+            var json = await pool.InvokeBlocking(_ => File.ReadAllText(Path.Combine(directory, "manifest.json")))
+                .Timeout(TimeSpan.FromSeconds(10));
+            using var manifest = JsonDocument.Parse(json);
+            manifest.RootElement.GetProperty("complete").GetBoolean().Should().BeTrue();
+            reservation.TryReserve().Should().BeFalse("completion does not re-arm capture");
         }
         finally
         {

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureTest.cs
@@ -151,6 +151,61 @@ public sealed class EmitReferenceCaptureTest : IDisposable
         Assert.Equal(3, total);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EarlyEofNeverCountsAsCompleteEvenWhenCurrentLengthShrinks(bool truncate)
+    {
+        using var input = new EarlyEofStream(truncate);
+        long total = 0;
+        var image = EmitReferenceCapture.ReadImage(input,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 8, MaxTotalBytes: 8),
+            ref total, CancellationToken.None, out var refusal);
+        Assert.Null(image);
+        Assert.Equal("incomplete-read", refusal);
+        Assert.Equal(3, total);
+    }
+
+    [Fact]
+    public void TruncationAtExactBudgetBoundaryStillRefusesCapture()
+    {
+        using var input = new LengthChangesAfterReadStream(3);
+        long total = 0;
+        var image = EmitReferenceCapture.ReadImage(input,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 8, MaxTotalBytes: 8),
+            ref total, CancellationToken.None, out var refusal);
+        Assert.Null(image);
+        Assert.Equal("incomplete-read", refusal);
+        Assert.Equal(8, total);
+    }
+
+    [Fact]
+    public void FileGrowthCannotBeMistakenForTheInitialImage()
+    {
+        using var input = new LengthChangesAfterReadStream(9);
+        long total = 0;
+        var image = EmitReferenceCapture.ReadImage(input,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 16, MaxTotalBytes: 16),
+            ref total, CancellationToken.None, out var refusal);
+        Assert.Null(image);
+        Assert.Equal("incomplete-read", refusal);
+        Assert.Equal(9, total);
+    }
+
+    [Fact]
+    public void UnchangedStreamAccountsForItsInitialPosition()
+    {
+        using var input = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+        input.Position = 2;
+        long total = 0;
+        var image = EmitReferenceCapture.ReadImage(input,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 3, MaxTotalBytes: 3),
+            ref total, CancellationToken.None, out var refusal);
+        Assert.Equal(new byte[] { 3, 4, 5 }, image);
+        Assert.Null(refusal);
+        Assert.Equal(3, total);
+    }
+
     [Fact]
     public void InvalidPeReadConsumesBudgetEvenThoughItCannotBeCaptured()
     {
@@ -243,5 +298,41 @@ public sealed class EmitReferenceCaptureTest : IDisposable
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class EarlyEofStream(bool truncate) : MemoryStream(new byte[8])
+    {
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (Position != 0)
+                return 0;
+            var read = base.Read(buffer, offset, Math.Min(count, 3));
+            if (truncate)
+                SetLength(3);
+            return read;
+        }
+    }
+
+    private sealed class LengthChangesAfterReadStream : MemoryStream
+    {
+        private readonly long changedLength;
+        private bool changed;
+
+        public LengthChangesAfterReadStream(long changedLength)
+        {
+            this.changedLength = changedLength;
+            SetLength(8);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = base.Read(buffer, offset, count);
+            if (!changed)
+            {
+                changed = true;
+                SetLength(changedLength);
+            }
+            return read;
+        }
     }
 }

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitReferenceCaptureTest.cs
@@ -1,0 +1,247 @@
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+using System.Text.Json;
+using MeshWeaver.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+public sealed class EmitReferenceCaptureTest : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "emit-reference-test-" + Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData(null, "1", "/tmp/runner")]
+    [InlineData("false", "1", "/tmp/runner")]
+    [InlineData("true", null, "/tmp/runner")]
+    [InlineData("true", "0", "/tmp/runner")]
+    [InlineData("true", "1", null)]
+    [InlineData("true", "1", "relative-runner")]
+    public void CaptureIsOffUnlessExplicitlyEnabledInCi(string? githubActions, string? enabled, string? runnerTemp)
+    {
+        Assert.Null(EmitReferenceCapture.GetCiDirectory(key => key switch
+        {
+            "GITHUB_ACTIONS" => githubActions,
+            "MW_CAPTURE_EMIT_REFERENCES" => enabled,
+            "RUNNER_TEMP" => runnerTemp,
+            _ => throw new InvalidOperationException("Unexpected environment read: " + key)
+        }));
+    }
+
+    [Fact]
+    public void EnabledCiCaptureUsesOnlyRunnerTemporaryArtifacts()
+    {
+        var result = EmitReferenceCapture.GetCiDirectory(key => key switch
+        {
+            "GITHUB_ACTIONS" => "true",
+            "MW_CAPTURE_EMIT_REFERENCES" => "1",
+            "RUNNER_TEMP" => directory,
+            _ => throw new InvalidOperationException("Unexpected environment read: " + key)
+        });
+        Assert.Equal(Path.Combine(directory, "straggler-logs", "emit-reference-capture", "process-" + Environment.ProcessId), result);
+        Assert.False(Directory.Exists(directory));
+    }
+
+    [Fact]
+    public void CapturedReferencesRetainOrderPropertiesAndExactPeBytes()
+    {
+        var path = typeof(object).Assembly.Location;
+        MetadataReference[] references =
+        [
+            MetadataReference.CreateFromFile(path, new MetadataReferenceProperties(
+                MetadataImageKind.Assembly, ImmutableArray.Create("Second", "First"), embedInteropTypes: true)),
+            MetadataReference.CreateFromFile(path)
+        ];
+
+        Assert.Equal("captured", EmitReferenceCapture.Capture(references, directory, new InvalidOperationException("private exception detail"), CancellationToken.None));
+        using var manifest = ReadManifest();
+        Assert.True(manifest.RootElement.GetProperty("complete").GetBoolean());
+        Assert.Equal("complete", manifest.RootElement.GetProperty("reason").GetString());
+        var entries = manifest.RootElement.GetProperty("references").EnumerateArray().ToArray();
+        Assert.Equal(2, entries.Length);
+        Assert.Equal(new[] { "Second", "First" }, entries[0].GetProperty("aliases").EnumerateArray().Select(x => x.GetString()).ToArray());
+        Assert.True(entries[0].GetProperty("embedInteropTypes").GetBoolean());
+        Assert.Empty(entries[1].GetProperty("aliases").EnumerateArray());
+        Assert.False(entries[1].GetProperty("embedInteropTypes").GetBoolean());
+        var bytes = File.ReadAllBytes(path);
+        var hash = Convert.ToHexString(SHA256.HashData(bytes));
+        for (var ordinal = 0; ordinal < entries.Length; ordinal++)
+        {
+            var entry = entries[ordinal];
+            Assert.Equal(ordinal, entry.GetProperty("ordinal").GetInt32());
+            Assert.Equal("captured", entry.GetProperty("status").GetString());
+            Assert.Equal("Assembly", entry.GetProperty("kind").GetString());
+            Assert.Equal(hash, entry.GetProperty("sha256").GetString(), ignoreCase: true);
+            Assert.Equal(bytes.LongLength, entry.GetProperty("size").GetInt64());
+            Assert.False(string.IsNullOrEmpty(entry.GetProperty("fileAssemblyIdentity").GetString()));
+            Assert.Equal(entry.GetProperty("fileMvids").GetRawText(), entry.GetProperty("metadataMvids").GetRawText());
+            var capturedFile = entry.GetProperty("file").GetString();
+            Assert.NotNull(capturedFile);
+            Assert.Equal(Path.GetFileName(capturedFile), capturedFile);
+            Assert.Equal(bytes, File.ReadAllBytes(Path.Combine(directory, capturedFile)));
+        }
+    }
+
+    [Fact]
+    public void UnavailableAndUnsupportedReferencesMakeCaptureExplicitlyIncomplete()
+    {
+        Directory.CreateDirectory(directory);
+        var missingPath = Path.Combine(directory, "deleted-input.dll");
+        File.Copy(typeof(object).Assembly.Location, missingPath);
+        var missing = MetadataReference.CreateFromFile(missingPath);
+        File.Delete(missingPath);
+        var image = MetadataReference.CreateFromImage(File.ReadAllBytes(typeof(object).Assembly.Location));
+        var compilation = CSharpCompilation.Create("SensitiveSource", [CSharpSyntaxTree.ParseText("class PrivateSourceMarker {}")]).ToMetadataReference();
+        MetadataReference[] references = [missing, image, compilation, MetadataReference.CreateFromFile(typeof(object).Assembly.Location)];
+
+        Assert.Equal("incomplete", EmitReferenceCapture.Capture(references, directory, new InvalidOperationException("private exception detail"), CancellationToken.None));
+        using var manifest = ReadManifest();
+        Assert.False(manifest.RootElement.GetProperty("complete").GetBoolean());
+        Assert.Equal("partial", manifest.RootElement.GetProperty("reason").GetString());
+        Assert.Equal(new[] { "missing-file", "unsupported-reference", "unsupported-reference", "captured" },
+            manifest.RootElement.GetProperty("references").EnumerateArray().Select(x => x.GetProperty("status").GetString()).ToArray());
+        var json = File.ReadAllText(Path.Combine(directory, "manifest.json"));
+        Assert.DoesNotContain("PrivateSourceMarker", json);
+        Assert.DoesNotContain("private exception detail", json);
+        Assert.DoesNotContain("stackTrace", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("environment", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PreCancelledCaptureWritesIncompleteVerdictWithoutCopyingReferences()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Equal("incomplete", EmitReferenceCapture.Capture(
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)], directory,
+            new InvalidOperationException(), cancellation.Token));
+        using var manifest = ReadManifest();
+        Assert.False(manifest.RootElement.GetProperty("complete").GetBoolean());
+        Assert.Equal("cancelled", manifest.RootElement.GetProperty("reason").GetString());
+        Assert.Equal(new[] { "manifest.json", "started.json" },
+            Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories).Select(Path.GetFileName).Order().ToArray());
+    }
+
+    [Fact]
+    public void LaterFailureCannotOverwriteFirstCaptureOrItsReferences()
+    {
+        MetadataReference[] references = [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)];
+        Assert.Equal("captured", EmitReferenceCapture.Capture(references, directory, new InvalidOperationException(), CancellationToken.None));
+        var before = Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+            .ToDictionary(path => path, File.ReadAllBytes);
+        Assert.Equal("already-started", EmitReferenceCapture.Capture([], directory, new ArgumentException("later secret"), CancellationToken.None));
+        Assert.Equal(before.Keys.Order(), Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories).Order());
+        foreach (var (path, bytes) in before)
+            Assert.Equal(bytes, File.ReadAllBytes(path));
+    }
+
+    private JsonDocument ReadManifest() => JsonDocument.Parse(File.ReadAllText(Path.Combine(directory, "manifest.json")));
+
+    [Fact]
+    public void ReadErrorAfterPartialChunkDoesNotRefundConsumedBudget()
+    {
+        using var input = new PartialReadThenFailureStream();
+        long total = 0;
+        Assert.Throws<IOException>(() => EmitReferenceCapture.ReadImage(input,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 8, MaxTotalBytes: 8),
+            ref total, CancellationToken.None, out _));
+        Assert.Equal(3, total);
+    }
+
+    [Fact]
+    public void InvalidPeReadConsumesBudgetEvenThoughItCannotBeCaptured()
+    {
+        Directory.CreateDirectory(directory);
+        var first = Path.Combine(directory, "invalid-first.dll");
+        var second = Path.Combine(directory, "invalid-second.dll");
+        File.WriteAllBytes(first, new byte[64]);
+        File.WriteAllBytes(second, new byte[64]);
+        using var metadata = AssemblyMetadata.CreateFromImage(File.ReadAllBytes(typeof(object).Assembly.Location));
+        MetadataReference[] references = [metadata.GetReference(filePath: first), metadata.GetReference(filePath: second)];
+
+        Assert.Equal("incomplete", EmitReferenceCapture.Capture(references, directory,
+            "System.InvalidOperationException", CancellationToken.None,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 100, MaxTotalBytes: 100)));
+        using var manifest = ReadManifest();
+        Assert.False(manifest.RootElement.GetProperty("complete").GetBoolean());
+        Assert.Equal(64, manifest.RootElement.GetProperty("readBytes").GetInt64());
+        var entries = manifest.RootElement.GetProperty("references").EnumerateArray().ToArray();
+        Assert.Equal("error", entries[0].GetProperty("status").GetString());
+        // No CLI metadata and malformed metadata have different PEReader exceptions;
+        // both are incomplete captures, and neither may refund already-read bytes.
+        Assert.Contains(entries[0].GetProperty("errorType").GetString(),
+            new[] { "System.BadImageFormatException", "System.InvalidOperationException" });
+        Assert.Equal("total-limit", entries[1].GetProperty("status").GetString());
+        Assert.Empty(Directory.EnumerateFiles(directory, "*.pe"));
+    }
+
+    [Fact]
+    public void FileLargerThanBudgetIsRefusedBeforeReading()
+    {
+        Assert.Equal("incomplete", EmitReferenceCapture.Capture(
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)], directory,
+            "System.InvalidOperationException", CancellationToken.None,
+            new EmitReferenceCapture.CaptureLimits(MaxFileBytes: 1, MaxTotalBytes: 1)));
+        using var manifest = ReadManifest();
+        Assert.Equal(0, manifest.RootElement.GetProperty("readBytes").GetInt64());
+        Assert.Equal("file-too-large", manifest.RootElement.GetProperty("references")[0].GetProperty("status").GetString());
+        Assert.Empty(Directory.EnumerateFiles(directory, "*.pe"));
+    }
+
+    [Fact]
+    public void ExistingPeArtifactIsNeverOverwrittenOrAcceptedAsThisCapturesEvidence()
+    {
+        Directory.CreateDirectory(directory);
+        var bytes = File.ReadAllBytes(typeof(object).Assembly.Location);
+        var hash = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+        var existing = Path.Combine(directory, hash + ".pe");
+        byte[] marker = [1, 2, 3];
+        File.WriteAllBytes(existing, marker);
+
+        Assert.Equal("incomplete", EmitReferenceCapture.Capture(
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)], directory,
+            new InvalidOperationException(), CancellationToken.None));
+        Assert.Equal(marker, File.ReadAllBytes(existing));
+        using var manifest = ReadManifest();
+        Assert.False(manifest.RootElement.GetProperty("complete").GetBoolean());
+        Assert.NotEqual("captured", manifest.RootElement.GetProperty("references")[0].GetProperty("status").GetString());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory))
+            Directory.Delete(directory, recursive: true);
+    }
+
+    private sealed class PartialReadThenFailureStream : Stream
+    {
+        private bool suppliedChunk;
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 8;
+        public override long Position
+        {
+            get => suppliedChunk ? 3 : 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (suppliedChunk)
+                throw new IOException("Input failed after delivering a partial chunk");
+            Assert.True(count >= 3);
+            buffer.AsSpan(offset, 3).Fill(1);
+            suppliedChunk = true;
+            return 3;
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
The failing #890 CI process did not retain its ordered compiler references, so existing logs and separately built module artifacts cannot support an exact replay. Add an explicitly enabled CI capture of reference properties and hashed PE bytes when Roslyn throws during NodeType disk emit.

Capture requires both `GITHUB_ACTIONS=true` and `MW_CAPTURE_EMIT_REFERENCES=1`. It runs on the existing FileSystem I/O pool, is owned by the hub, and does not delay or replace the original compiler exception. The default path and existing emit signatures remain unchanged. Partial reads, cancellation, metadata mismatch and failed writes remain incomplete; an ID correlates the artifact with the original error. The existing Plugins `straggler-logs` upload retains the files. No workflow permission, production setting, or general environment/source/credential capture is added.

An injected reservation shared by compiler hubs admits at most one scheduled capture per mesh root before reference snapshotting or I/O registration. The process-directory sentinel permits one artifact even when a test process hosts multiple independent mesh roots. EOF is accepted only when the initial remaining byte count, final position and current length agree.

The evidence limits and opt-in procedure are committed in `src/MeshWeaver.Documentation/Data/Architecture/EmitReferenceCapture.md`. File rereads and matching MVIDs do not prove identical pre-failure mapped bytes or process state; this does not claim to fix #890.

Validation: Release builds with CI warnings-as-errors completed with zero warnings/errors; 79 capture and adjacent canary/failure/stamp regressions passed; 18 documentation checks passed, including the previously failing topic-map and subscription-error-arm guards. A controlled mutation removing per-chunk byte accounting made the new partial-read regression fail (expected 3, actual 0); the mutation was restored before the final passing build/run. Independent review covered bounds, cancellation, reference lifetime and exception preservation.

No What's New entry: this is disabled-by-default internal CI diagnostics with no user-visible product change.