### PR TITLE
Handle publication seals removed before their file open

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -232,7 +232,7 @@ public static class PluginBundleEndpoints
             return NothingPublished(identity, source);
         var reading = PublishedBundleCatalogue.SealedPublicationOf(directory, Log(http));
         if (reading.Bundles is null)
-            return BeingRepublished(http, identity, source, reading.TornReason!);
+            return BeingRepublished(http, identity, source, directory, reading.TornReason!);
         http.Response.Headers.ETag = $"\"{reading.Generation}\"";
         return Results.Json(
             new { identity, source, bundles = reading.Bundles, generation = reading.Generation });
@@ -255,8 +255,11 @@ public static class PluginBundleEndpoints
     /// the wrong status cost the whole investigation.
     /// </summary>
     private static IResult BeingRepublished(
-        HttpContext http, string identity, string source, string reason)
+        HttpContext http, string identity, string source, string directory, string reason)
     {
+        // Retention may remove the directory after PrebuiltDirectory observed it (#3876).
+        if (!Directory.Exists(directory))
+            return NothingPublished(identity, source);
         http.Response.Headers.RetryAfter = "30";
         return Results.Json(
             new { error = $"{reason} — source '{source}', framework identity '{identity}'" },
@@ -304,7 +307,7 @@ public static class PluginBundleEndpoints
             return NothingPublished(identity, source);
         var reading = PublishedBundleCatalogue.SealedPublicationOf(directory, Log(http));
         if (reading.Bundles is null)
-            return BeingRepublished(http, identity, source, reading.TornReason!);
+            return BeingRepublished(http, identity, source, directory, reading.TornReason!);
         if (HeldGeneration(http) is { } held && held != reading.Generation)
             return GenerationMoved(held, reading.Generation!);
         if (!reading.Bundles.Contains(bundle, StringComparer.OrdinalIgnoreCase))
@@ -334,7 +337,7 @@ public static class PluginBundleEndpoints
         // reason (#3401) — separate it from a module set that is genuinely unusable.
         var publication = PublishedBundleCatalogue.SealedPublicationOf(directory, Log(http));
         if (publication.Bundles is null)
-            return BeingRepublished(http, identity, source, publication.TornReason!);
+            return BeingRepublished(http, identity, source, directory, publication.TornReason!);
         var reading = PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));
         if (reading.Modules is null)
             return Results.Json(
@@ -361,7 +364,7 @@ public static class PluginBundleEndpoints
             return NothingPublished(identity, source);
         var publication = PublishedBundleCatalogue.SealedPublicationOf(directory, Log(http));
         if (publication.Bundles is null)
-            return BeingRepublished(http, identity, source, publication.TornReason!);
+            return BeingRepublished(http, identity, source, directory, publication.TornReason!);
         if (HeldGeneration(http) is { } held && held != publication.Generation)
             return GenerationMoved(held, publication.Generation!);
         var reading = PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -339,6 +339,8 @@ public static class PluginBundleEndpoints
         if (publication.Bundles is null)
             return BeingRepublished(http, identity, source, directory, publication.TornReason!);
         var reading = PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));
+        if (reading.PublicationUnavailable)
+            return BeingRepublished(http, identity, source, directory, reading.Refusal!);
         if (reading.Modules is null)
             return Results.Json(
                 new { error = $"{reading.Refusal} — source '{source}', framework identity '{identity}'" },
@@ -368,6 +370,8 @@ public static class PluginBundleEndpoints
         if (HeldGeneration(http) is { } held && held != publication.Generation)
             return GenerationMoved(held, publication.Generation!);
         var reading = PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));
+        if (reading.PublicationUnavailable)
+            return BeingRepublished(http, identity, source, directory, reading.Refusal!);
         if (reading.Modules is null || !reading.Modules.Contains(bundle, StringComparer.OrdinalIgnoreCase))
             return NoSuchBundle();
         var path = Path.Combine(

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -70,6 +70,13 @@ distinction is the whole point — before it, all three were `404`:
 | `503` + `Retry-After` | the publication exists and is **being replaced right now** | wait it out; it is self-healing |
 | `412` | the caller pinned a generation and the publication has since moved | **re-read the publication that now applies** |
 
+The seal's file open decides whether it is present (#3876). A separate `File.Exists` observation
+cannot protect a later read: a publisher can remove the seal between those two operations. The
+catalogue's seal readers therefore handle `FileNotFoundException` and `DirectoryNotFoundException`
+at the read and report an absent seal. Other I/O failures still surface. An existing source without
+a seal gets `503` with `Retry-After`; an absent source directory gets `404`. Tests remove the seal
+or its parent after observing it, and exercise all four publication routes over HTTP.
+
 🚨 **A `404` for a name the index just listed used to be the *only* signal for all of this, and it
 named the wrong thing.** The route re-evaluates the seal on every request, so a `404` on
 `Export.zip` was equally consistent with *some other* bundle having gone absent a moment earlier —

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -75,7 +75,10 @@ cannot protect a later read: a publisher can remove the seal between those two o
 catalogue's seal readers therefore handle `FileNotFoundException` and `DirectoryNotFoundException`
 at the read and report an absent seal. Other I/O failures still surface. An existing source without
 a seal gets `503` with `Retry-After`; an absent source directory gets `404`. Tests remove the seal
-or its parent after observing it, and exercise all four publication routes over HTTP.
+or its parent at the read operation, after an existence check could have observed it. HTTP tests
+also remove it between the module routes' first and second catalogue reads. A structured
+`ModuleSetReading.PublicationUnavailable` result preserves the transient response on that second
+read, distinct from a sealed publication with no module index. All four routes are exercised.
 
 🚨 **A `404` for a name the index just listed used to be the *only* signal for all of this, and it
 named the wrong thing.** The route re-evaluates the seal on every request, so a `404` on

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-publication-updates-return-a-retry-response.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-publication-updates-return-a-retry-response.md
@@ -1,0 +1,17 @@
+---
+Name: Publication updates return a retry response
+Category: Fix
+Description: A plugin build reading a publication during an update now receives the retry response instead of an unexpected server error when the publication seal disappears.
+Icon: ArrowSyncCheckmark
+Order: -20260910
+---
+
+# Publication updates return a retry response
+
+A publication update briefly removes its completion marker while replacing the stored bundles.
+A build reading at that moment could receive an unexpected server error because the marker
+disappeared between the presence check and the file read.
+
+The read now handles that removal directly. The registry returns its existing retry response
+while the publication is being replaced, so the consuming build can wait for the completed set.
+A publication that has been removed entirely still returns a missing-publication response.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -681,14 +681,15 @@ public static class PublishedBundleCatalogue
         var directory = ShippedPrebuiltBundles.PublicationDirectoryOf(sourceDirectory, logger);
         var sentinel = Path.Combine(
             directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
-        if (!File.Exists(sentinel))
+        var lines = ReadSealLines(sentinel);
+        if (lines is null)
             return new SealedPublicationReading(
                 null, null,
                 "the publication is being republished right now (no completion sentinel) — the "
                 + "publisher removes it before uploading and restores it last, so this is a "
                 + "transient window, not a missing publication") { Directory = directory };
 
-        var listed = File.ReadAllLines(sentinel)
+        var listed = lines
             .Select(line => line.Trim())
             .Where(line => line.Length > 0)
             .ToList();
@@ -722,6 +723,21 @@ public static class PublishedBundleCatalogue
     private static IReadOnlyList<string>? CompleteBundlesOf(string sourceDirectory, ILogger? logger)
         => CompletePublicationOf(sourceDirectory, logger).Bundles;
 
+    // The publisher removes the seal before replacing a publication. File.Exists followed by
+    // ReadAllLines races that removal (#3876): only the open can decide whether it is readable.
+    // Other I/O failures must still surface; they do not establish an absent seal.
+    internal static string[]? ReadSealLines(string sentinel)
+    {
+        try
+        {
+            return File.ReadAllLines(sentinel);
+        }
+        catch (Exception error) when (error is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return null;
+        }
+    }
+
     /// <summary>
     /// The same reading as <see cref="CompleteBundlesOf"/>, plus the directory the bytes are
     /// actually in — the generation this source's pointer names, or the source directory itself
@@ -735,7 +751,8 @@ public static class PublishedBundleCatalogue
         var directory = ShippedPrebuiltBundles.PublicationDirectoryOf(sourceDirectory, logger);
         var sentinel = Path.Combine(
             directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
-        if (!File.Exists(sentinel))
+        var lines = ReadSealLines(sentinel);
+        if (lines is null)
         {
             logger?.LogInformation(
                 "ReleaseAvailability: {SourceDirectory} carries no {Sentinel} — the publication "
@@ -744,7 +761,7 @@ public static class PublishedBundleCatalogue
             return (directory, null);
         }
 
-        var listed = File.ReadAllLines(sentinel)
+        var listed = lines
             .Select(line => line.Trim())
             .Where(line => line.Length > 0)
             .ToList();
@@ -791,10 +808,7 @@ public static class PublishedBundleCatalogue
         var sentinel = Path.Combine(
             ShippedPrebuiltBundles.PublicationDirectoryOf(sourceDirectory),
             ShippedPrebuiltBundles.CompletionSentinelFileName);
-        if (!File.Exists(sentinel))
-            return null;
-        return File.ReadAllLines(sentinel)
-            .Select(line => line.Trim())
+        return ReadSealLines(sentinel)?.Select(line => line.Trim())
             .Where(line => line.Length > 0)
             .ToList();
     }

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -726,11 +726,11 @@ public static class PublishedBundleCatalogue
     // The publisher removes the seal before replacing a publication. File.Exists followed by
     // ReadAllLines races that removal (#3876): only the open can decide whether it is readable.
     // Other I/O failures must still surface; they do not establish an absent seal.
-    internal static string[]? ReadSealLines(string sentinel)
+    internal static string[]? ReadSealLines(string sentinel, Func<string, string[]>? readLines = null)
     {
         try
         {
-            return File.ReadAllLines(sentinel);
+            return (readLines ?? File.ReadAllLines)(sentinel);
         }
         catch (Exception error) when (error is FileNotFoundException or DirectoryNotFoundException)
         {
@@ -869,7 +869,8 @@ public static class PublishedBundleCatalogue
         // bytes are in; the module set is `<publication>/modules`, never `<source>/modules`.
         var (publication, complete) = CompletePublicationOf(sourceDirectory, logger);
         if (complete is null)
-            return new(null, "no sealed publication") { Directory = publication };
+            return new(null, "no sealed publication")
+            { Directory = publication, PublicationUnavailable = true };
         var directory = Path.Combine(publication, ModulesDirectoryName);
         var index = Path.Combine(directory, ModulesIndexFileName);
         if (!File.Exists(index))
@@ -907,6 +908,10 @@ public static class PublishedBundleCatalogue
 /// <c>null</c> with the reason a consumer must not compose from it.</summary>
 public sealed record ModuleSetReading(IReadOnlyList<string>? Modules, string? Refusal)
 {
+    /// <summary>The publication itself is unsealed or torn, rather than a sealed publication
+    /// with no usable module index. HTTP readers preserve the transient publication response.</summary>
+    public bool PublicationUnavailable { get; init; }
+
     /// <summary>
     /// 🚨 The directory the module bundles are actually IN (#3461) — the generation this source's
     /// <c>_current</c> pointer names, or the source directory itself in the flat layout. Compose

--- a/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
+++ b/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
@@ -290,6 +290,45 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
         }
     }
 
+    [Fact(Timeout = 120_000)]
+    public async Task RemovedSealAndRemovedIdentity_HaveDistinctAnswersOnEveryPublicationRoute()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-prebuilt-removed-" + Guid.NewGuid().ToString("N"));
+        var directory = Path.Combine(root, Identity, Source);
+        Directory.CreateDirectory(directory);
+        try
+        {
+            WriteBundle(Path.Combine(directory, "Store.zip"), "Store");
+            var seal = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            File.WriteAllText(seal, "Store.zip\n");
+            var key = await RegisterInstance(Granted, $"{Source}/*");
+            await using var app = await StartHost(root);
+            var route = $"/api/plugins/bundles/prebuilt/{Identity}/{Source}";
+            Assert.Equal(HttpStatusCode.OK, (await Get(app, route, key)).StatusCode);
+
+            File.Delete(seal);
+            string[] suffixes = ["", "/Store.zip", "/modules", "/modules/ai.module.nupkg"];
+            foreach (var suffix in suffixes)
+            {
+                using var response = await Get(app, route + suffix, key);
+                Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                Assert.Equal(TimeSpan.FromSeconds(30), response.Headers.RetryAfter?.Delta);
+            }
+
+            Directory.Delete(Path.Combine(root, Identity), recursive: true);
+            foreach (var suffix in suffixes)
+            {
+                using var response = await Get(app, route + suffix, key);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                Assert.Null(response.Headers.RetryAfter);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static async Task<HttpResponseMessage> Get(
         WebApplication app, string route, string key, string? ifMatch = null)
     {

--- a/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
+++ b/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
@@ -205,7 +205,7 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
             .Register("owner", "Owner", "owner@test.com", instanceId, instanceId)
             .Select(r => r.RawKey).FirstAsync().Timeout(TimeSpan.FromSeconds(60)).Await();
 
-    private async Task<WebApplication> StartHost(string publishedRoot)
+    private async Task<WebApplication> StartHost(string publishedRoot, Action? beforePublicationRead = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -216,6 +216,8 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
         builder.Services.AddSingleton<IMessageHub>(Mesh);
         builder.Services.AddSingleton(new InstanceRegistryAuthenticator(
             Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>()));
+        if (beforePublicationRead is not null)
+            builder.Services.AddSingleton<ILoggerFactory>(new PublicationReadLoggerFactory(beforePublicationRead));
         var app = builder.Build();
         app.MapPluginBundles();
         await app.StartAsync();
@@ -290,7 +292,7 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
         }
     }
 
-    [Fact(Timeout = 120_000)]
+    [HubFact]
     public async Task RemovedSealAndRemovedIdentity_HaveDistinctAnswersOnEveryPublicationRoute()
     {
         var root = Path.Combine(Path.GetTempPath(), "mw-prebuilt-removed-" + Guid.NewGuid().ToString("N"));
@@ -312,7 +314,7 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
             {
                 using var response = await Get(app, route + suffix, key);
                 Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
-                Assert.Equal(TimeSpan.FromSeconds(30), response.Headers.RetryAfter?.Delta);
+                Assert.Equal("30", response.Headers.RetryAfter?.ToString());
             }
 
             Directory.Delete(Path.Combine(root, Identity), recursive: true);
@@ -327,6 +329,68 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Theory]
+    [InlineData("/modules", false)]
+    [InlineData("/modules/ai.module.nupkg", false)]
+    [InlineData("/modules", true)]
+    [InlineData("/modules/ai.module.nupkg", true)]
+    public async Task PublicationRemovedBetweenTheTwoModuleReads_PreservesItsStatus(
+        string suffix, bool removeDirectory)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-prebuilt-between-" + Guid.NewGuid().ToString("N"));
+        var directory = Path.Combine(root, Identity, Source);
+        Directory.CreateDirectory(directory);
+        try
+        {
+            WriteBundle(Path.Combine(directory, "Store.zip"), "Store");
+            var seal = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            File.WriteAllText(seal, "Store.zip\n");
+            var key = await RegisterInstance(Granted, $"{Source}/*");
+            var reads = 0;
+            // Authentication obtains the first logger; each catalogue read obtains the next.
+            // This existing boundary lets the real HTTP handler finish its first sealed read
+            // before removal at the second catalogue read (third logger), with no production hook.
+            await using var app = await StartHost(root, () =>
+            {
+                if (++reads != 3)
+                    return;
+                Assert.True(File.Exists(seal));
+                if (removeDirectory)
+                    Directory.Delete(Path.Combine(root, Identity), recursive: true);
+                else
+                    File.Delete(seal);
+            });
+            using var response = await Get(
+                app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}" + suffix, key);
+            Assert.Equal(3, reads);
+            Assert.Equal(removeDirectory ? HttpStatusCode.NotFound : HttpStatusCode.ServiceUnavailable,
+                response.StatusCode);
+            if (removeDirectory)
+                Assert.Null(response.Headers.RetryAfter);
+            else
+                Assert.Equal("30", response.Headers.RetryAfter?.ToString());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class PublicationReadLoggerFactory(Action beforeRead) : ILoggerFactory
+    {
+        private readonly ILoggerFactory inner = LoggerFactory.Create(_ => { });
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            if (categoryName == typeof(PluginBundleEndpoints).FullName)
+                beforeRead();
+            return inner.CreateLogger(categoryName);
+        }
+
+        public void AddProvider(ILoggerProvider provider) => inner.AddProvider(provider);
+        public void Dispose() => inner.Dispose();
     }
 
     private static async Task<HttpResponseMessage> Get(

--- a/test/Memex.Portal.Shared.Test/PublicationSealReadTest.cs
+++ b/test/Memex.Portal.Shared.Test/PublicationSealReadTest.cs
@@ -20,14 +20,21 @@ public class PublicationSealReadTest : IDisposable
         File.WriteAllText(seal, "Store.zip\n");
         Assert.True(File.Exists(seal));
 
-        // Deterministic interleaving: the old reader's existence observation has already happened.
-        // The publisher now removes the seal, or retention removes its parent, before the open.
-        if (removeDirectory)
-            Directory.Delete(Path.Combine(root, "identity"), recursive: true);
-        else
-            File.Delete(seal);
-
-        Assert.Null(PublishedBundleCatalogue.ReadSealLines(seal));
+        // Remove at the filesystem operation, not before entering the reader. Even a reader
+        // that reinstates File.Exists observes a present seal before this operation removes it.
+        var opened = false;
+        var lines = PublishedBundleCatalogue.ReadSealLines(seal, path =>
+        {
+            Assert.True(File.Exists(path));
+            opened = true;
+            if (removeDirectory)
+                Directory.Delete(Path.Combine(root, "identity"), recursive: true);
+            else
+                File.Delete(path);
+            return File.ReadAllLines(path);
+        });
+        Assert.True(opened);
+        Assert.Null(lines);
         Assert.Null(PublishedBundleCatalogue.SealedPublicationOf(directory).Bundles);
         Assert.Null(PublishedBundleCatalogue.SealedBundlesOf(directory));
     }

--- a/test/Memex.Portal.Shared.Test/PublicationSealReadTest.cs
+++ b/test/Memex.Portal.Shared.Test/PublicationSealReadTest.cs
@@ -1,0 +1,67 @@
+using MeshWeaver.Hosting;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>Missing seals are decided by the file open, including removal after observation.</summary>
+public class PublicationSealReadTest : IDisposable
+{
+    private readonly string root = Path.Combine(Path.GetTempPath(), "mw-seal-read-" + Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ASealRemovedAfterObservation_IsAbsentAtTheOpen(bool removeDirectory)
+    {
+        var directory = Path.Combine(root, "identity", "plugins");
+        Directory.CreateDirectory(directory);
+        var seal = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        File.WriteAllText(seal, "Store.zip\n");
+        Assert.True(File.Exists(seal));
+
+        // Deterministic interleaving: the old reader's existence observation has already happened.
+        // The publisher now removes the seal, or retention removes its parent, before the open.
+        if (removeDirectory)
+            Directory.Delete(Path.Combine(root, "identity"), recursive: true);
+        else
+            File.Delete(seal);
+
+        Assert.Null(PublishedBundleCatalogue.ReadSealLines(seal));
+        Assert.Null(PublishedBundleCatalogue.SealedPublicationOf(directory).Bundles);
+        Assert.Null(PublishedBundleCatalogue.SealedBundlesOf(directory));
+    }
+
+    [Fact]
+    public void AReadableSeal_PreservesItsListing()
+    {
+        Directory.CreateDirectory(root);
+        var seal = Path.Combine(root, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        File.WriteAllText(seal, " Store.zip \n\nEdu.zip\n");
+        File.WriteAllText(Path.Combine(root, "Store.zip"), "store");
+        File.WriteAllText(Path.Combine(root, "Edu.zip"), "education");
+
+        var lines = PublishedBundleCatalogue.ReadSealLines(seal);
+        Assert.NotNull(lines);
+        Assert.Equal([" Store.zip ", "", "Edu.zip"], lines);
+        Assert.Equal(["Store.zip", "Edu.zip"], PublishedBundleCatalogue.SealedPublicationOf(root).Bundles);
+        Assert.Equal(["Store.zip", "Edu.zip"], PublishedBundleCatalogue.SealedBundlesOf(root));
+    }
+
+    [Fact]
+    public void AnUnreadableExistingSeal_IsNotReportedAsAbsent()
+    {
+        Directory.CreateDirectory(root);
+        var seal = Path.Combine(root, ShippedPrebuiltBundles.CompletionSentinelFileName);
+        File.WriteAllText(seal, "Store.zip\n");
+        using var held = File.Open(seal, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        Assert.Throws<IOException>(() => PublishedBundleCatalogue.ReadSealLines(seal));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+            Directory.Delete(root, recursive: true);
+    }
+}


### PR DESCRIPTION
A publication can remove `_complete` after the catalogue's presence check but before its file open. That throws an unhandled 500 in the prebuilt bundle/module routes. Manufacturing PR #75 hit this exact failure in run 34418872053 at 23:54:29Z, matching the identity and timestamp recorded in #3876.

The catalogue now decides absence at the file read and handles only FileNotFoundException and DirectoryNotFoundException. All three seal-reading paths use that operation. Other I/O failures still surface. All four prebuilt HTTP routes retain 503 with Retry-After for an existing source being republished and return 404 if the source directory has disappeared. The existing authorization decisions and generation checks are unchanged.

Validation:
- Release builds with CIRun and warnings as errors: zero warnings and errors for the portal test project, its production dependencies, and documentation tests.
- 34 focused tests pass with no skips: deterministic removal at the file-read operation, a readable seal, non-missing I/O failure, all four real HTTP routes, removal between the module routes' two reads, existing generation behavior, and catalogue denominator consumers.
- Two independent negative controls: restoring File.Exists followed by the unguarded read makes the injected removal cases fail with FileNotFoundException/DirectoryNotFoundException (2 fail, 4 HTTP controls pass). Removing the structured transient-publication classification makes both HTTP module routes return 404 instead of 503 after removal between reads (2 fail, 4 controls pass).
- 13 documentation checks pass, including the exact timeout ratchet that failed the first CI run. Retry-After is asserted as its wire header value; the guard and its baseline are unchanged. The updated sealed-read contract and Fix entry in What's New validate.

Refs #3876. Keep the issue open until the supported publication reaches the affected production registry and the HTTP behavior is verified there. This does not change stale-build execution policy or complete the separate publication-writer/retention work.
