### PR TITLE
Fingerprint mounted package sources from their content (#3880)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-mounted-source-content-version.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-mounted-source-content-version.md
@@ -1,0 +1,9 @@
+---
+Name: Mounted source fingerprints detect content edits
+Category: Fix
+Description: Mounted package source fingerprints now detect edits even when the file size stays the same.
+Icon: FolderSync
+Order: -20260910
+---
+
+Mounted package sources now include file contents in their fingerprints. Editing text or replacing an image with the same byte length changes the source fingerprint used as the version of packages without a declared release version. Unchanged files keep their fingerprint.

--- a/src/MeshWeaver.PluginCatalog/PackageSources.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageSources.cs
@@ -293,11 +293,17 @@ public static class PackageSources
                 // Skip dot-directories (.git, .github, …) — infrastructure, not repo content.
                 if (relative.Split('/').Any(seg => seg.StartsWith('.')))
                     continue;
-                var info = new FileInfo(path);
-                hash.Append(relative).Append(':').Append(info.Length).Append(';');
-                files.Add(IsProbablyText(relative)
+                var file = IsProbablyText(relative)
                     ? new RepoFile(relative, File.ReadAllText(path))
-                    : new RepoFile(relative, "", File.ReadAllBytes(path)));
+                    : new RepoFile(relative, "", File.ReadAllBytes(path));
+                // Hash the payload we actually return, not its size or timestamp: equal-length
+                // edits must move the source version too. Reading once also keeps the fingerprint
+                // and the returned snapshot about the same bytes if the checkout changes mid-read.
+                var contentHash = Convert.ToHexString(
+                    System.Security.Cryptography.SHA256.HashData(file.Bytes));
+                hash.Append(relative.Length).Append(':').Append(relative)
+                    .Append(':').Append(contentHash).Append(';');
+                files.Add(file);
             }
 
             var sha = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(

--- a/test/Memex.Portal.Shared.Test/LocalSourceContentVersionTest.cs
+++ b/test/Memex.Portal.Shared.Test/LocalSourceContentVersionTest.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
@@ -34,21 +35,21 @@ public class LocalSourceContentVersionTest(ITestOutputHelper output) : MonolithM
             var source = PackageSources.FromRepo(Mesh, root, "", nodeRepo: PackageSources.IsNodeRepoFormat("node-repo"));
             Assert.NotNull(source);
 
-            var first = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
-            var unchanged = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            var first = (await source.ListPackages("HEAD").Should().Within(TestTimeouts.Quick).Emit()).Single();
+            var unchanged = (await source.ListPackages("HEAD").Should().Within(TestTimeouts.Quick).Emit()).Single();
             unchanged.Version.Should().Be(first.Version, "an unchanged source must keep its version");
 
             // Keep both the byte count and timestamp: neither is evidence of equal content.
             var modified = File.GetLastWriteTimeUtc(path);
             File.WriteAllBytes(path, [68, 69, 70]);
             File.SetLastWriteTimeUtc(path, modified);
-            var edited = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            var edited = (await source.ListPackages("HEAD").Should().Within(TestTimeouts.Quick).Emit()).Single();
             edited.Version.Should().NotBe(first.Version, "a mounted source version must identify its content, including equal-length edits");
 
             // Infrastructure outside the package payload must not move the advertised version.
             Directory.CreateDirectory(Path.Combine(root, ".git"));
             File.WriteAllText(Path.Combine(root, ".git", "HEAD"), "ref: refs/heads/elsewhere");
-            var infrastructureOnly = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            var infrastructureOnly = (await source.ListPackages("HEAD").Should().Within(TestTimeouts.Quick).Emit()).Single();
             infrastructureOnly.Version.Should().Be(edited.Version);
         }
         finally

--- a/test/Memex.Portal.Shared.Test/LocalSourceContentVersionTest.cs
+++ b/test/Memex.Portal.Shared.Test/LocalSourceContentVersionTest.cs
@@ -1,0 +1,59 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+public class LocalSourceContentVersionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        ConfigureMeshBase(builder).AddPluginCatalog();
+
+    [Theory(Timeout = 120_000)]
+    [InlineData("Page.md")]
+    [InlineData("icon.png")]
+    public async Task EqualLengthContentEdits_ChangeTheListedVersion(string fileName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-local-content-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Widget"));
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "Widget", "index.json"),
+                """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget."}}""");
+            var path = Path.Combine(root, "Widget", fileName);
+            File.WriteAllBytes(path, [65, 66, 67]);
+            var source = PackageSources.FromRepo(Mesh, root, "", nodeRepo: PackageSources.IsNodeRepoFormat("node-repo"));
+            Assert.NotNull(source);
+
+            var first = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            var unchanged = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            unchanged.Version.Should().Be(first.Version, "an unchanged source must keep its version");
+
+            // Keep both the byte count and timestamp: neither is evidence of equal content.
+            var modified = File.GetLastWriteTimeUtc(path);
+            File.WriteAllBytes(path, [68, 69, 70]);
+            File.SetLastWriteTimeUtc(path, modified);
+            var edited = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            edited.Version.Should().NotBe(first.Version, "a mounted source version must identify its content, including equal-length edits");
+
+            // Infrastructure outside the package payload must not move the advertised version.
+            Directory.CreateDirectory(Path.Combine(root, ".git"));
+            File.WriteAllText(Path.Combine(root, ".git", "HEAD"), "ref: refs/heads/elsewhere");
+            var infrastructureOnly = (await source.ListPackages("HEAD").Should().Within(30.Seconds()).Emit()).Single();
+            infrastructureOnly.Version.Should().Be(edited.Version);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Mounted node-repo snapshots hash filenames and byte counts, so replacing `ABC` with `DEF` leaves their advertised source version unchanged. Hash the already-read text or binary payload as well, keeping one disk read per file and the existing `local-` ref format. Declared package release versions retain their existing precedence.

Addresses #3880, found while investigating Systemorph/MeshWeaver.Plugins#1563. This does not enable the mounted Store feed or choose its visibility policy. Keep #3880 open until publication and affected mounted-source behavior are verified.

Validation:
- Deterministic negative control against unchanged core: both real-mesh Markdown and PNG cases fail when content changes with the same byte count and timestamp.
- With the correction: all four focused tests pass, including unchanged/dot-directory controls and the existing mounted reconciliation and fetched-source seed tests; zero skips.
- Core solution builds in Release with CIRun and warnings-as-errors: zero warnings, zero errors.
- All 368 documentation/repository guards pass, including the timeout-literal ratchet. The four focused regressions pass after adopting TestTimeouts.Quick. A user-facing Fix entry documents the corrected source fingerprint.

No public API removal, authentication change, filesystem visibility expansion, or second file read.
