### PR TITLE
Retain registry errors when image-set verification fails (#3882)

### DIFF
--- a/.github/scripts/check-image-set.sh
+++ b/.github/scripts/check-image-set.sh
@@ -90,8 +90,8 @@ while [ $# -gt 0 ]; do
     --pointers)
       CHECK_POINTERS=1
       # Deliberately tolerant of an EMPTY value here: an unresolved version is reported below,
-      # AFTER the per-sha diagnostics, so a run whose image leg died still gets "<repo>:<sha> is
-      # MISSING" as its headline instead of a usage message about a flag.
+      # AFTER the per-sha diagnostics, so a run whose image leg died still gets "<repo>:<sha>
+      # could not be verified" as its headline instead of a usage message about a flag.
       if [ $# -ge 2 ]; then POINTER_VERSION="$2"; shift 2; else shift; fi
       ;;
     --*) echo "::error::check-image-set.sh: unknown option '$1'"; usage; exit 1 ;;

--- a/.github/scripts/check-image-set.sh
+++ b/.github/scripts/check-image-set.sh
@@ -3,7 +3,7 @@
 # Is the COMPLETE deployment image set present in ACR for one commit?
 #
 #   .github/scripts/check-image-set.sh <short-sha> [<plugins-short-sha>] [--pointers <version>]
-#   exit 0 = complete   exit 1 = something is missing / malformed
+#   exit 0 = complete   exit 1 = something is missing / malformed / could not be verified
 #
 # 🚨 THE SECOND ARGUMENT IS WHAT MAKES THE IDENTITY HONEST (MeshWeaver#2622). The portal HOSTS
 # live in MeshWeaver.Plugins, so a merge THERE that edits a file shipping in the image — an
@@ -114,8 +114,8 @@ fi
 REGISTRY="${ACR_NAME:-meshweaver}"
 
 # Reads manifests through ARM (an `az login` is enough — `az acr login` is for docker push creds).
-# `az acr manifest show` is an Azure-CLI PREVIEW command group (it prints a warning on stderr,
-# discarded here). If it is ever withdrawn, the equivalent is
+# `az acr manifest show` is an Azure-CLI PREVIEW command group. --only-show-errors suppresses
+# its preview warning while retaining registry failures. If it is ever withdrawn, the equivalent is
 # `docker buildx imagetools inspect --raw <acr>/<repo>:<tag>` after `az acr login`.
 fail=0
 summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$1" >> "$GITHUB_STEP_SUMMARY"; return 0; }
@@ -140,9 +140,12 @@ REPOS="memex-portal-ai memex-migration mw-plugin-test"
 # nothing would be gained by letting the two answers drift apart.
 #   assert_index <repo> <tag> <what-a-miss-means>
 assert_index() {
-  local repo="$1" tag="$2" consequence="$3" m arches
-  if ! m=$(az acr manifest show --registry "$REGISTRY" --name "$repo:$tag" -o json 2>/dev/null); then
-    report "$repo:$tag is MISSING from ACR — $consequence"
+  local repo="$1" tag="$2" requirement="$3" m arches status
+  if m=$(az acr manifest show --registry "$REGISTRY" --name "$repo:$tag" -o json --only-show-errors); then
+    :
+  else
+    status=$?
+    report "$repo:$tag could not be verified in ACR (az exit $status) — see the registry diagnostic above. $requirement"
     return 1
   fi
   arches=$(printf '%s' "$m" | jq -r '[(.manifests // [])[] | select(.platform.os == "linux") | .platform.architecture] | sort | join(",")')
@@ -155,7 +158,7 @@ assert_index() {
 }
 
 for repo in $REPOS; do
-  assert_index "$repo" "$SHA" "main $SHA has an INCOMPLETE image set" || true
+  assert_index "$repo" "$SHA" "Commit $SHA requires all three images." || true
 done
 
 # 🚨 memex-portal-next is NOT checked here any more: its sources and its build lane moved to
@@ -170,10 +173,11 @@ done
 # the one place the answer may narrow, and it narrows only for callers that opted in.
 if [ -n "$PLUGINS_SHA" ]; then
   pair="$SHA-p$PLUGINS_SHA"
-  if az acr manifest show --registry "$REGISTRY" --name "memex-portal-ai:$pair" -o json >/dev/null 2>&1; then
+  if az acr manifest show --registry "$REGISTRY" --name "memex-portal-ai:$pair" -o json --only-show-errors >/dev/null; then
     ok "memex-portal-ai:$pair — built from plugins $PLUGINS_SHA"
   else
-    report "memex-portal-ai:$pair is MISSING — the published portal image was NOT built from the current plugins HEAD ($PLUGINS_SHA). The portal hosts live in MeshWeaver.Plugins, so a merge there ships in the image while core's sha does not move (#2622). The reconciler will rebuild."
+    status=$?
+    report "memex-portal-ai:$pair could not be verified in ACR (az exit $status) — see the registry diagnostic above. The pair tag must identify the image built from plugins $PLUGINS_SHA (#2622)."
   fi
 fi
 
@@ -196,28 +200,28 @@ fi
 #                   `latest`; see the header. Do not generalise this line into the loop.
 #
 # No `if:` on a variable and no tolerated failure anywhere in here: a pointer that cannot be checked
-# is reported RED naming what is missing, exactly like one that is missing. A gate that can decline
+# is reported RED naming the failed read, exactly like one that is missing. A gate that can decline
 # to run is indistinguishable from one that passed.
 if [ "$CHECK_POINTERS" -eq 1 ]; then
   summary "### Pointers"
   for repo in $REPOS; do
     assert_index "$repo" main \
-      "the promotion's moving pointer is not on every repository of the set. Phase B writes \`main\` on all three; a set where only one half carries it is exactly MeshWeaver#3670 (Doc/Architecture/ImageTagContract)." || true
+      "Phase B must publish \`main\` on all three repositories (Doc/Architecture/ImageTagContract)." || true
   done
   assert_index mw-plugin-test latest \
-    "the satellites resolve this tag as \`vars.MW_TEST_IMAGE\`, so their CI cannot pull a tester. Phase B writes it beside \`mw-plugin-test:main\`." || true
+    "Satellites resolve this tag as \`vars.MW_TEST_IMAGE\`; phase B must publish it beside \`mw-plugin-test:main\`." || true
   if [ -z "$POINTER_VERSION" ]; then
     report "--pointers was given an EMPTY version, so the set's immutable pointer could not be asserted. The caller must pass the version this run promoted (every leg's \$(Version), e.g. 3.0.0-ci.8079). An empty value means the leg that computes it never ran — the set is not promoted."
   else
     for repo in $REPOS; do
       assert_index "$repo" "$POINTER_VERSION" \
-        "the promoted set is ASYMMETRIC: $POINTER_VERSION does not resolve on every repository. The portal's is phase C, the arming write SelfUpdateHostedService acts on; the other two are phase A." || true
+        "Version $POINTER_VERSION must resolve on every repository. The portal's is phase C; the other two are phase A." || true
     done
   fi
 fi
 
 if [ "$fail" -ne 0 ]; then
-  echo "::error::main $SHA does NOT have a complete image set — see the errors above: an image is missing or malformed, or a pointer the promotion publishes does not resolve on every repository of the set. Every self-updating install stays on the previous image until a CD run publishes all of them, and a consumer naming a missing pointer cannot resolve anything at all."
+  echo "::error::The complete image set for main $SHA could not be verified — see the errors above for missing or malformed images, or failed registry reads. A failed read does not establish that an image is absent; this gate remains red until the complete set is verified."
   exit 1
 fi
 echo "All images exist in ACR for $SHA${PLUGINS_SHA:+ (built from plugins $PLUGINS_SHA)}${POINTER_VERSION:+, and every promoted pointer resolves ($POINTER_VERSION)}."

--- a/.github/scripts/test-check-image-set.py
+++ b/.github/scripts/test-check-image-set.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Run the real image-set checker against registry success and failure responses."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check-image-set.sh")
+INDEX = {"manifests": [
+    {"platform": {"os": "linux", "architecture": architecture}}
+    for architecture in ("amd64", "arm64")
+]}
+
+
+class ImageSetTests(unittest.TestCase):
+    def check(self, failed_tag="", diagnostic="", exit_code=0, index=INDEX):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            az = root / "az"
+            az.write_text("""#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+tag = sys.argv[sys.argv.index('--name') + 1]
+with Path(os.environ['CALLS']).open('a') as log:
+    log.write(tag + '\\n')
+if tag == os.environ['FAILED_TAG']:
+    print(os.environ['DIAGNOSTIC'], file=sys.stderr)
+    sys.exit(int(os.environ['EXIT_CODE']))
+print(os.environ['INDEX'])
+""")
+            az.chmod(0o755)
+            env = {**os.environ, "PATH": str(root) + os.pathsep + os.environ["PATH"],
+                   "FAILED_TAG": failed_tag, "DIAGNOSTIC": diagnostic,
+                   "EXIT_CODE": str(exit_code), "INDEX": json.dumps(index),
+                   "CALLS": str(root / "calls"), "GITHUB_STEP_SUMMARY": str(root / "summary")}
+            result = subprocess.run(["bash", str(SCRIPT), "abcdef1", "1234567", "--pointers", "3.0.0-ci.42"],
+                                    capture_output=True, text=True, env=env, timeout=15)
+            calls = (root / "calls").read_text().splitlines()
+            return result, calls
+
+    def test_full_set_checks_every_identity_and_pointer(self):
+        result, calls = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertEqual(len(calls), 11)
+        self.assertEqual(len(set(calls)), 11)
+        self.assertIn("All images exist", result.stdout)
+
+    def test_registry_errors_remain_red_and_keep_the_actual_diagnostic(self):
+        for tag in ("memex-migration:main", "memex-portal-ai:abcdef1-p1234567"):
+            for code, diagnostic in ((3, "ERROR: MANIFEST_UNKNOWN: tag does not exist"),
+                                     (1, "ERROR: response status 503 Service Unavailable"),
+                                     (2, "ERROR: registry operation was refused")):
+                with self.subTest(tag=tag, code=code):
+                    result, calls = self.check(tag, diagnostic, code)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(diagnostic, result.stderr)
+                    self.assertIn(f"az exit {code}", result.stdout)
+                    self.assertNotIn("is MISSING", result.stdout)
+                    self.assertNotIn("was NOT built", result.stdout)
+                    self.assertEqual(calls.count(tag), 1, "a failed read must not be retried")
+                    self.assertEqual(len(calls), 11, "a failed read must not hide later checks")
+
+    def test_single_architecture_still_fails(self):
+        result, _ = self.check(index={"manifests": INDEX["manifests"][:1]})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not a linux amd64+arm64 image index", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-check-image-set.py
+++ b/.github/scripts/test-check-image-set.py
@@ -13,6 +13,13 @@ INDEX = {"manifests": [
     {"platform": {"os": "linux", "architecture": architecture}}
     for architecture in ("amd64", "arm64")
 ]}
+EXPECTED_TAGS = {
+    "memex-portal-ai:abcdef1", "memex-migration:abcdef1", "mw-plugin-test:abcdef1",
+    "memex-portal-ai:abcdef1-p1234567",
+    "memex-portal-ai:main", "memex-migration:main", "mw-plugin-test:main",
+    "mw-plugin-test:latest",
+    "memex-portal-ai:3.0.0-ci.42", "memex-migration:3.0.0-ci.42", "mw-plugin-test:3.0.0-ci.42",
+}
 
 
 class ImageSetTests(unittest.TestCase):
@@ -45,7 +52,7 @@ print(os.environ['INDEX'])
         result, calls = self.check()
         self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
         self.assertEqual(len(calls), 11)
-        self.assertEqual(len(set(calls)), 11)
+        self.assertEqual(set(calls), EXPECTED_TAGS)
         self.assertIn("All images exist", result.stdout)
 
     def test_registry_errors_remain_red_and_keep_the_actual_diagnostic(self):
@@ -62,6 +69,7 @@ print(os.environ['INDEX'])
                     self.assertNotIn("was NOT built", result.stdout)
                     self.assertEqual(calls.count(tag), 1, "a failed read must not be retried")
                     self.assertEqual(len(calls), 11, "a failed read must not hide later checks")
+                    self.assertEqual(set(calls), EXPECTED_TAGS)
 
     def test_single_architecture_still_fails(self):
         result, _ = self.check(index={"manifests": INDEX["manifests"][:1]})

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1949,6 +1949,9 @@ jobs:
     - name: "Prove the gate is non-vacuous (self-test)"
       run: python3 .github/scripts/check-workflow-shell.py --self-test
 
+    - name: "Image-set reads retain registry failures"
+      run: python3 .github/scripts/test-check-image-set.py
+
     # 🚨 This repo's .github/scripts/compile-check.py is the CANONICAL NodeType gate: every node
     # repo's lane fetches it from here at the pinned platform ref and runs it instead of its own
     # copy (node-repo-compile-check.yml). So a defect in its import-scope parser reds satellites

--- a/src/MeshWeaver.Documentation/Data/Architecture/ImageTagContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ImageTagContract.md
@@ -151,8 +151,9 @@ supposed to produce.**
 
 There is no skip-trapdoor in any of it: nothing is conditioned on whether a variable is set, nothing
 carries `continue-on-error`, and an empty version reaching the flag is reported RED — after the
-per-image diagnostics, so a run whose image leg died still leads with *"`<repo>:<sha>` is MISSING"*
-rather than with a message about a flag.
+per-image diagnostics, so a run whose image leg died first names the image that could not be
+verified, its registry error and the command's exit status, rather than leading with a message
+about a flag. The registry's own diagnostic distinguishes an absent tag from a failed read.
 
 ## The general lesson
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ImageTagContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ImageTagContract.md
@@ -96,6 +96,26 @@ The satellite side was repaired separately — MeshWeaver.Reinsurance now resolv
 
 ## The gate: pointer symmetry, asserted at promotion time
 
+### A failed registry read is not proof of an absent image (#3882)
+
+CD run 8239 pushed `memex-migration:main` at 02:55:08 UTC on September 10, 2026.
+Its verifier reported that tag missing at 02:58:31, but a subsequent registry read returned
+the promoted digest with the same 02:55:08 last-update timestamp and both Linux architectures.
+The checker had discarded the command's error output and called every nonzero exit "MISSING".
+Those observations do not establish a deletion or explain the original read failure.
+
+The checker now retains the registry error and reports the command's exit status for both
+image-index reads and the core/plugins pair tag. It suppresses only Azure CLI's preview warning
+with `--only-show-errors`. Failed reads still fail the gate, are not retried, and do not skip
+the remaining image checks. Use the retained error to investigate the failed operation before
+attributing it to retention, changing registry configuration, or rebuilding an existing image.
+
+The executable regression exercises the real shell checker against successful multi-architecture
+responses, single-architecture responses, missing tags, unavailable reads and refused operations.
+It verifies that all eleven requested identities and pointers are attempted once.
+
+### Required pointers
+
 `check-image-set.sh` takes `--pointers <version>` and, when given it, asserts that **every named
 pointer the promotion publishes resolves — as a `linux/amd64 + linux/arm64` image index — on every
 repository the promotion publishes it to**:


### PR DESCRIPTION
CD 8239 reported `memex-migration:main` missing when its registry read failed. The tag subsequently resolved to the exact promoted digest, with a last-update timestamp before the failed check. The verifier discarded the diagnostic needed to explain that read failure.

Keep Azure CLI error output and include its exit status for image-index and core/plugins pair-tag reads. Suppress only the CLI preview warning, and report an unverified set without asserting that an image was deleted or built from the wrong source. All failures still fail the gate; no retries, permissions, publication ordering or image checks change.

Validation: the executable shell regression failed on all six lost-error scenarios before the correction and now passes, including successful eleven-tag enumeration and single-architecture rejection. It verifies each failed read happens once and later checks still execute. Wired into CI's existing shell job. Shellcheck, actionlint, workflow timeout/YAML/secret guards and diff checks pass. Embedded documentation and dependencies build Release with CIRun and warnings-as-errors: zero warnings/errors. A read-only run of the corrected checker against actual set8239 verified all eleven identities/pointers successfully.

Related to #3882; deliberately does not close it or claim the original registry failure's cause is solved. The incident evidence and diagnostic contract are recorded in Doc/Architecture/ImageTagContract.

No What's New entry: internal CI diagnostics with no product behavior change.