### PR TITLE
Record what a registry does NOT deliver — an installed module package the registry declines no longer reads as up to date (Plugins#1584)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -229,6 +229,56 @@ to reconcile. The change is that a catalog open now *is* a reconcile when one is
 line had always claimed and the code had never done. (The safety net above reads the feed too, and a
 successful read from it drains a pending registry through this same path — one pass, not two.)
 
+### 🚨 A package the registry does NOT offer is recorded as NOT DELIVERED (Plugins#1584)
+
+Both lanes above iterate **the packages the registry serves** and intersect them with this
+installation's install records. That is right for everything the registry carries — and it means a
+package installed *here* that the registry does **not** carry is neither "up to date" nor "failed".
+It is *absent from both loops*, and absence used to produce no log line, no ledger entry and no card
+state anywhere.
+
+The shape that made this expensive, measured on memex 2026-09-10:
+
+| What was true | What every surface said |
+|---|---|
+| The registry answered its feed with **45 manifests**; `Mail` was not among them | — |
+| `Mail/index.json` declares `tier: personal`; the instance's catalog grant covers the baseline plan, so the registry declined it (`the registry … does not offer a package 'Mail' to this instance`) | — |
+| The package's **content** kept arriving through the instance's own git source, and the install record advanced to `1.5.0` an hour earlier | *installed, version 1.5.0, up to date* |
+| The loaded assembly `MeshWeaver.Mail.MicrosoftGraph` was written **eleven days** earlier | *no module activation pending* — and correctly so: nothing had landed, so nothing was waiting on a restart |
+
+A feature that ships as a module change in such a package therefore cannot reach the deployment by
+merge + roll + restart. Only content moves. An Executive Assistant thread asked for the Teams tools
+that shipped in that module's 1.5 and had none.
+
+**The mechanism fix is to make the absence an answer.** After the content and module lanes, a full
+feed pass lists this installation's install records once and records, on the same ledger entry, the
+installed packages that declare a `module` and which *this registry did not offer*
+(`RegistryReconcileEntry.UndeliveredModules`, one `UndeliveredModule` per package carrying the
+module name and the content identity the record claims). One Warning line names them and points at
+the ledger; `ModuleDelivery.NotDeliveredByAnyRegistry` intersects the entries so a surface can say
+*not delivered* honestly on an installation with several registries — a package one registry serves
+is delivered, whatever the others carry.
+
+Three properties are load-bearing:
+
+- **Absence is evidence only after a SUCCESSFUL, COMPLETE read.** The lane runs from
+  `ReconcileFromFeed`, i.e. the boot pass, a drained deferral or the safety net — never from the
+  per-package broadcast drain, whose "packages" is the one package the registry named and which
+  would call every other installed module undelivered.
+- **`null` is not an empty list.** A listing that fails records *not determined*, not *none*: an
+  inventory that could not be read is not an empty inventory, and reading the first as the second is
+  a gate that never ran painted the colour of one that passed.
+- **It is not an entitlement verdict, and not a fault.** A consumer cannot tell "your grant does not
+  cover this" from "this registry never carried it", and nothing here is broken — the package is
+  simply not delivered from this registry. The remedy is the registry operator's: grant the
+  instance the plan, tier the package differently, or point the installation at a registry that
+  carries it.
+
+What this deliberately does **not** do: fall back to the image's `modules/` seed or to an in-mesh
+compile when the registry has no bundle. That changes what an installation *runs* and belongs with
+the adoption policy ([Module Adoption Policy](/Doc/Architecture/ModuleAdoptionPolicy)), not with
+the reconcile's bookkeeping; the honest first step is that the state stops being invisible.
+
 ## Why a node and not a call
 
 The producer is `MeshWeaver.GitSync` (it owns webhook signature verification, payload parsing and

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-package-the-registry-does-not-serve-no-longer-reads-as-up-to-date.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-package-the-registry-does-not-serve-no-longer-reads-as-up-to-date.md
@@ -1,0 +1,46 @@
+---
+Name: A package the registry does not serve no longer reads as up to date
+Category: Fix
+Description: An installed package whose module the registry does not offer was invisible to both lanes of the update reconcile — its content kept advancing while its module bytes stayed on the generation the deployment was first seeded with, and every surface read "installed, up to date". The reconcile now records what a registry does NOT deliver on its own ledger, names it in one Warning, and distinguishes "not offered" from "could not tell".
+Icon: PlugConnected
+Order: -20260910
+---
+
+# A package the registry does not serve no longer reads as up to date
+
+On 2026-09-10 at 02:40Z `memex` was running `MeshWeaver.Mail.MicrosoftGraph` from an assembly
+written on **2026-08-30** — eleven days earlier — on an image built from the very commit that
+shipped that module's 1.5. The package's install record said `version 1.5.0`, `installedAtUtc`
+one hour before the measurement, with the 1.5 file hashes; the health check said no module
+activation was pending, correctly, because nothing had landed and so nothing was waiting on a
+restart. Every surface read *installed, up to date*. An Executive Assistant thread asked for the
+Teams tools that shipped in that module and had none.
+
+**Why nothing advanced.** Both lanes of the registry reconcile — the content lane and the module
+lane — iterate the packages the **registry serves** and intersect them with this installation's
+install records. The registry answered its feed with 45 manifests and `Mail` was not among them:
+the package declares `tier: personal` and the instance's catalog grant covers the baseline plan, so
+the registry declined it (its own maintenance task says so in as many words — *the registry does
+not offer a package 'Mail' to this instance*). A package the registry does not serve is therefore
+neither up to date nor failed. It is **absent from both loops**, and absence produced no log line,
+no ledger entry and no card state anywhere, while the package's content kept arriving through the
+instance's own git source and its install record kept advancing.
+
+**The absence is now an answer.** After the content and module lanes, a full feed pass lists the
+install records once and records on the reconcile ledger
+(`Plugins/_RegistryReconcileLedger`) which installed packages declare a module that *this registry
+did not offer* — the package, the module whose bytes are not arriving, and the content identity the
+record claims. One Warning names them and points at the ledger;
+`ModuleDelivery.NotDeliveredByAnyRegistry` intersects the per-registry entries, so on an
+installation with several registries a package one of them serves is still delivered.
+
+Three things it deliberately does not do. It does not treat a **failed** listing as an empty one —
+that records *not determined*, never *none*. It does not run from the per-package broadcast drain,
+whose one named package would make every other installed module look undelivered. And it is not an
+entitlement verdict or a fault: a consumer cannot tell "your grant does not cover this" from "this
+registry never carried it", and the remedy belongs to whoever runs the registry — grant the
+instance the plan, tier the package differently, or point it at a registry that carries it.
+
+The mechanism is written up in
+[Plugin Update on Green Build](/Doc/Architecture/PluginUpdateOnGreenBuild) → "A package the
+registry does NOT offer is recorded as NOT DELIVERED".

--- a/src/MeshWeaver.PluginCatalog/ModuleDelivery.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleDelivery.cs
@@ -1,0 +1,180 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// One package this installation HAS INSTALLED, whose install record declares a compiled module,
+/// and which the registry DID NOT OFFER at the ref a successful feed read was made against.
+///
+/// <para>Its content moves — a consumer's own git source keeps landing new files and the install
+/// record advances — while its module bytes stay on whatever generation the deployment was first
+/// seeded with, because the module funnel only ever considers packages the registry serves.</para>
+/// </summary>
+/// <param name="PackageId">The install record's id, which is the package id.</param>
+/// <param name="Name">The package's display name, when the record carries one.</param>
+/// <param name="Module">The module assembly the record declares
+/// (<see cref="PackageManifest.Module"/>) — the bytes that are not being delivered.</param>
+/// <param name="InstalledModuleVersion">The content identity the record claims is installed. It is
+/// what makes the shape legible: the record says 1.5 while the loaded assembly is whatever the
+/// last delivered generation was.</param>
+public sealed record UndeliveredModule(
+    string PackageId,
+    string? Name,
+    string? Module,
+    string? InstalledModuleVersion)
+{
+    /// <summary>One line for a log or a ledger reader.</summary>
+    public string Describe() =>
+        $"{PackageId}"
+        + (string.IsNullOrWhiteSpace(Module) ? "" : $" (module {Module})");
+}
+
+/// <summary>
+/// 🚨 <b>Whether a consumer's installed modules can be DELIVERED at all — the question the module
+/// funnel never asked (Systemorph/MeshWeaver.Plugins#1584).</b>
+///
+/// <para><b>The defect.</b> <see cref="RegistryUpdateReconciler"/>'s module lane iterates the
+/// packages the REGISTRY SERVES, intersects them with this installation's install records, and
+/// adopts what is newer. A package installed HERE that the registry does NOT serve is therefore
+/// not "up to date" and not "failed" — it is <i>absent from the loop</i>, and absence produced no
+/// log line, no ledger entry and no card state anywhere. Measured on memex 2026-09-10: the
+/// registry offered 45 manifests and <c>Mail</c> was not among them (its
+/// <c>index.json</c> declares <c>tier: personal</c>, the instance's catalog grant covers the
+/// baseline plan), so <c>MeshWeaver.Mail.MicrosoftGraph</c> loaded an assembly written eleven days
+/// earlier while the install record read <c>version 1.5.0</c>, installed an hour ago, and every
+/// dashboard read "installed, up to date".</para>
+///
+/// <para><b>Absence of an offer is EVIDENCE, once the feed read succeeded.</b> That is the whole
+/// reason this can be stated at all, and the reason it is computed from a completed read rather
+/// than from a timeout: a registry that answered its feed in full and did not list a package has
+/// declined it — the entitlement anchor's own vocabulary (see
+/// <see cref="EntitlementDecision"/>) — and a decline the consumer cannot see is indistinguishable
+/// from delivery. A read that FAILED says nothing, and the caller must record "not determined"
+/// rather than an empty list; the two are separate states on
+/// <see cref="RegistryReconcileEntry.UndeliveredModules"/> for exactly that reason.</para>
+///
+/// <para><b>What this does NOT claim.</b> It is not an entitlement verdict — a registry may omit a
+/// package for any reason, and the consumer cannot tell "your grant does not cover it" from "this
+/// registry never carried it". It is not a fault either: nothing here is broken, the package is
+/// simply not delivered from this registry, and the remedy (grant the plan, tier the package,
+/// point at a registry that carries it) lives with whoever runs the registry. And it says nothing
+/// about a package the registry DOES offer whose bundle is missing or built for another framework
+/// identity — that lands in <see cref="PluginBundleClient.AdoptModule"/>, which logs its own
+/// verdict.</para>
+///
+/// <para>Pure and total: the caller supplies both sides, so the rule is testable with no registry,
+/// no mesh and no host.</para>
+/// </summary>
+public static class ModuleDelivery
+{
+    /// <summary>
+    /// The install records that declare a module and whose package the registry did not offer.
+    ///
+    /// <para>A record with no <see cref="PackageManifest.Module"/> is content-only: its whole
+    /// delivery is the content lane, which the reconcile already covers, so it is never reported
+    /// here. Matching is ORDINAL-IGNORE-CASE on the package id, the same comparison every other
+    /// install-record lookup on this path uses.</para>
+    /// </summary>
+    /// <param name="installedRecords">This installation's install records
+    /// (<c>Plugins/*</c>). Nulls — an unreadable record's content — are skipped.</param>
+    /// <param name="servedPackages">The packages the registry answered its feed with. An EMPTY
+    /// feed from a successful read means the registry offers this instance nothing, and every
+    /// installed module package is then undelivered, which is the honest answer.</param>
+    public static ImmutableList<UndeliveredModule> NotOffered(
+        IEnumerable<PackageManifest?>? installedRecords,
+        IEnumerable<PackageManifest?>? servedPackages)
+    {
+        var offered = (servedPackages ?? [])
+            .Where(pkg => pkg is not null && !string.IsNullOrWhiteSpace(pkg.Id))
+            .Select(pkg => pkg!.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return (installedRecords ?? [])
+            .Where(record => record is not null
+                && !string.IsNullOrWhiteSpace(record.Id)
+                && !string.IsNullOrWhiteSpace(record.Module)
+                && !offered.Contains(record.Id))
+            .Select(record => new UndeliveredModule(
+                record!.Id, record.Name, record.Module, record.ModuleVersion))
+            .OrderBy(u => u.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableList();
+    }
+
+    /// <summary>
+    /// The packages NO configured registry offers — the consumer-wide verdict a surface renders as
+    /// <b>not delivered</b>, read off the ledger <see cref="RegistryUpdateReconciler"/> owns.
+    ///
+    /// <para>🚨 <b>Only DETERMINED entries vote.</b> An entry whose
+    /// <see cref="RegistryReconcileEntry.UndeliveredModules"/> is null never read its feed
+    /// successfully in this process, so it has nothing to say — counting it as "offers nothing"
+    /// would turn one unreachable registry into a mesh-wide "not delivered" alarm, and counting it
+    /// as "offers everything" would silence a real one. With no determined entry at all the answer
+    /// is EMPTY: nothing is known, which is not the same as nothing being undelivered, and the
+    /// caller distinguishes them with <see cref="AnyRegistryDetermined"/>.</para>
+    ///
+    /// <para>An intersection, not a union: several registries are alternatives, so a package one of
+    /// them serves is delivered, whatever the others do or do not carry.</para>
+    /// </summary>
+    /// <param name="ledger">The reconcile ledger, or null.</param>
+    public static ImmutableList<UndeliveredModule> NotDeliveredByAnyRegistry(
+        RegistryReconcileLedger? ledger)
+    {
+        var determined = (ledger?.Registries ?? [])
+            .Where(entry => entry.UndeliveredModules is not null)
+            .ToList();
+        if (determined.Count == 0)
+            return [];
+
+        var undeliveredEverywhere = determined
+            .Select(entry => entry.UndeliveredModules!
+                .Select(u => u.PackageId)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase))
+            .Aggregate((left, right) =>
+            {
+                left.IntersectWith(right);
+                return left;
+            });
+
+        return determined[0].UndeliveredModules!
+            .Where(u => undeliveredEverywhere.Contains(u.PackageId))
+            .OrderBy(u => u.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableList();
+    }
+
+    /// <summary>Whether ANY configured registry answered its feed in this process — the denominator
+    /// behind <see cref="NotDeliveredByAnyRegistry"/>, so an empty result can be read as "nothing
+    /// undelivered" rather than as "nothing known".</summary>
+    /// <param name="ledger">The reconcile ledger, or null.</param>
+    public static bool AnyRegistryDetermined(RegistryReconcileLedger? ledger) =>
+        (ledger?.Registries ?? []).Any(entry => entry.UndeliveredModules is not null);
+
+    /// <summary>
+    /// The line a reconcile logs when a registry declined installed module packages — naming the
+    /// packages, what it means for them, and where the remedy lives. One line, never one per
+    /// package: this is true on every boot for as long as the grant stands.
+    /// </summary>
+    /// <param name="undelivered">What the registry did not offer.</param>
+    /// <param name="registryName">The registry's display name.</param>
+    /// <param name="maxNamed">How many packages are named before the line truncates.</param>
+    public static string Describe(
+        IReadOnlyCollection<UndeliveredModule> undelivered, string registryName, int maxNamed = 10)
+    {
+        ArgumentNullException.ThrowIfNull(undelivered);
+        if (undelivered.Count == 0)
+            return $"{registryName} offers every installed module package of this installation";
+
+        var named = undelivered
+            .OrderBy(u => u.PackageId, StringComparer.OrdinalIgnoreCase)
+            .Take(Math.Max(1, maxNamed))
+            .Select(u => u.Describe())
+            .ToArray();
+
+        return $"{registryName} does NOT offer {undelivered.Count} installed package(s) that "
+            + "declare a module, so their module bytes are NOT DELIVERED here and can never "
+            + "advance from this registry — the content lane keeps moving and the install record "
+            + "keeps advancing, which is what makes them read as installed and up to date: "
+            + string.Join(", ", named)
+            + (undelivered.Count > named.Length ? $", …(+{undelivered.Count - named.Length})" : "")
+            + ". Check the instance's catalog grant on the registry, or the packages' tier.";
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -253,6 +253,12 @@ public static class PluginCatalogConfigurationExtensions
             .WithType(typeof(ModuleDiscovery), nameof(ModuleDiscovery))
             .WithType(typeof(DefaultInstallLedger), nameof(DefaultInstallLedger))
             .WithType(typeof(RegistryReconcileLedger), nameof(RegistryReconcileLedger))
+            // The ledger's own parts. Both were auto-registered under their short names, which
+            // WORKS and logs a Warning on every write — and the auto route is a short-name gamble
+            // across namespaces, where an explicit registration is the documented contract. They
+            // are named here for the same reason ModuleInventoryContent below is.
+            .WithType(typeof(RegistryReconcileEntry), nameof(RegistryReconcileEntry))
+            .WithType(typeof(UndeliveredModule), nameof(UndeliveredModule))
             // 🚨 The module-inventory record every instance writes about ITSELF, and it was the one
             // type on this surface that was never registered (#3625). DeploymentReportService
             // stamped a hand-written discriminator, "ModuleInventoryContent", that named NO CLR

--- a/src/MeshWeaver.PluginCatalog/RegistryReconcileLedger.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryReconcileLedger.cs
@@ -71,4 +71,18 @@ public record RegistryReconcileEntry
     /// <summary><see cref="ViaBoot"/>, <see cref="ViaFeedRead"/>, <see cref="ViaBroadcast"/> or
     /// <see cref="ViaSafetyNet"/>.</summary>
     public string? LastReconciledVia { get; init; }
+
+    /// <summary>
+    /// 🚨 The installed packages that declare a compiled module and which THIS registry did not
+    /// OFFER at <see cref="Ref"/> — so the module funnel never considers them and their bytes can
+    /// never advance from here (Systemorph/MeshWeaver.Plugins#1584). See <see cref="ModuleDelivery"/>
+    /// for what this does and does not claim.
+    ///
+    /// <para>🚨 <b><c>null</c> is NOT an empty list.</b> Null means this process has no successful
+    /// feed read from this registry to answer the question from; an EMPTY list means the registry
+    /// answered in full and offers every installed module package. Reading the first as the second
+    /// is a gate that never ran painted the colour of one that passed — the same distinction
+    /// <see cref="Pending"/> exists to draw, one question further along.</para>
+    /// </summary>
+    public ImmutableList<UndeliveredModule>? UndeliveredModules { get; init; }
 }

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -687,14 +687,98 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
             // for a new framework MVID has unchanged content, and this lane is what heals it after
             // an image roll.
             .SelectMany(_ => ReconcileModules(bundles, name, packages))
-            .Do(_ => Mark(registry, entry => entry with
+            // The DELIVERY lane (Plugins#1584): the two lanes above only ever visit packages the
+            // registry SERVES, so a package installed here that it does not serve is not "up to
+            // date" and not "failed" — it is absent from both loops, and absence said nothing.
+            // This is where the absence becomes an answer.
+            .SelectMany(_ => UndeliveredModules(name, packages))
+            // ONE mark, so the delivery verdict and the completion it belongs to land in the SAME
+            // ledger snapshot: a reader can never see a reconcile that just finished carrying the
+            // previous pass's verdict.
+            .Do(undelivered => Mark(registry, entry => entry with
             {
                 Pending = false,
                 PendingSince = null,
                 LastFault = null,
                 LastReconciledAt = DateTimeOffset.UtcNow,
                 LastReconciledVia = via,
-            }));
+                UndeliveredModules = undelivered,
+            }))
+            .Select(_ => Unit.Default);
+    }
+
+    /// <summary>How long the delivery lane's ONE install-record listing may take. Bounded for the
+    /// same reason every other read on this path is: a wedged listing must cost this, never the
+    /// reconcile that has already done its work.</summary>
+    private static readonly TimeSpan InstallRecordListingBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// 🚨 <b>Records which installed modules this registry does NOT deliver (Plugins#1584).</b>
+    ///
+    /// <para>Measured on memex 2026-09-10: the registry answered its feed with 45 manifests,
+    /// <c>Mail</c> was not among them (the package declares <c>tier: personal</c> and the
+    /// instance's catalog grant covers the baseline plan), and so the module funnel never
+    /// considered it. <c>MeshWeaver.Mail.MicrosoftGraph</c> went on loading an assembly written
+    /// eleven days earlier while the package's CONTENT arrived through the instance's own git
+    /// source and the install record advanced to 1.5 — "installed, up to date, eleven days old",
+    /// with nothing anywhere able to say otherwise. A feature that ships as a module change in
+    /// such a package cannot reach the deployment by merge + roll + restart, and nobody could see
+    /// why.</para>
+    ///
+    /// <para><b>Only reached from a FULL feed read</b> — <see cref="ReconcileFromFeed"/>, i.e. the
+    /// boot pass, a drained deferral or the safety net. Never from the per-package broadcast lane
+    /// (<see cref="ReconcileModule"/>), whose "packages" is the ONE package the registry named: a
+    /// delivery verdict computed there would call every other installed module undelivered.</para>
+    ///
+    /// <para>🚨 <b>An inventory that could not be read is not an empty inventory</b> — the lesson
+    /// the Store's own refresh task states in as many words. A listing that fails yields
+    /// <c>null</c> (not determined) rather than an empty list, so nothing downstream can read
+    /// "I could not look" as "everything is delivered". The lane never faults: a delivery REPORT
+    /// that failed must not withhold a reconcile that already landed content and modules.</para>
+    /// </summary>
+    /// <returns>What this registry does not deliver, or <c>null</c> when the install records could
+    /// not be listed. The caller records it on the ledger in the same mark that closes the pass.</returns>
+    private IObservable<ImmutableList<UndeliveredModule>?> UndeliveredModules(
+        string name,
+        IReadOnlyList<PackageManifest> packages)
+    {
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return<ImmutableList<UndeliveredModule>?>(null);
+        var access = hub.ServiceProvider.GetService<AccessService>();
+
+        // A SET listing is the sanctioned use of Query (CqrsAndContentAccess): no single node's
+        // content is read through it, and a stale entry can only under-report — which costs a
+        // signal, where over-reporting would print a "not delivered" on a package that is fine.
+        var query = $"path:{PackageInstaller.InstalledPartition} scope:children "
+            + $"nodeType:{PackageInstaller.PackageNodeType}";
+        // RunAsSystem, never Observable.Using (#1790): impersonation is an AsyncLocal store/restore
+        // pair, and Observable.Using splits the two across threads — exactly as WriteLedger does.
+        return access.RunAsSystem(() => meshService.Query<MeshNode>(MeshQueryRequest.FromQuery(query)))
+            .Take(1)
+            .Timeout(InstallRecordListingBudget)
+            .Select(change => ModuleDelivery.NotOffered(
+                change.Items.Select(n => n.ContentAs<PackageManifest>(hub.JsonSerializerOptions)),
+                packages))
+            .Do(undelivered =>
+            {
+                if (!undelivered.IsEmpty)
+                    // Warning, and ONE line for the whole registry: this stays true on every pass
+                    // for as long as the grant does, so a line per package would be a repeated
+                    // flood of the same fact.
+                    logger.LogWarning(
+                        "[RegistryUpdate] {Report} Recorded on {Ledger}.",
+                        ModuleDelivery.Describe(undelivered, name), LedgerPath);
+            })
+            .Select(undelivered => (ImmutableList<UndeliveredModule>?)undelivered)
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "[RegistryUpdate] could not list this installation's install records, so which "
+                    + "of them {Name} does not deliver is NOT DETERMINED this pass — recorded as "
+                    + "unknown rather than as none. Cause: {Cause}", name, ex.Message);
+                return Observable.Return<ImmutableList<UndeliveredModule>?>(null);
+            });
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/UndeliveredModuleIsRecordedTest.cs
+++ b/test/Memex.Portal.Shared.Test/UndeliveredModuleIsRecordedTest.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A store-installed module the registry does NOT OFFER must be recorded as not delivered —
+/// never left reading as installed and up to date (Systemorph/MeshWeaver.Plugins#1584).</b>
+///
+/// <para>Both lanes of <see cref="RegistryUpdateReconciler"/>'s reconcile iterate the packages the
+/// REGISTRY SERVES and intersect them with this installation's install records. A package
+/// installed here that the registry does not serve is therefore not "up to date" and not "failed"
+/// — it is absent from both loops, and absence produced no log line, no ledger entry and no card
+/// state anywhere.</para>
+///
+/// <para>Measured on memex 2026-09-10: the registry answered its feed with 45 manifests and
+/// <c>Mail</c> was not among them — the package declares <c>tier: personal</c> while the instance's
+/// catalog grant covers the baseline plan, so the registry's own maintenance task answered "the
+/// registry does not offer a package 'Mail' to this instance". The CONTENT kept arriving through
+/// the instance's own git source and the install record advanced to 1.5.0 an hour before the
+/// measurement, while <c>MeshWeaver.Mail.MicrosoftGraph</c> went on loading an assembly written
+/// eleven days earlier and every dashboard read "installed, up to date". An Executive Assistant
+/// thread asked for the Teams tools that shipped in 1.5 and had none.</para>
+///
+/// <para>This fixture pins the mechanism against the REAL reconciler, the REAL
+/// <see cref="RegistryPackageSource"/> HTTP path and a registry that answers exactly as memex's
+/// did — a full, successful feed that simply does not list the package:</para>
+/// <list type="number">
+///   <item>The undelivered package is named on the ledger node the reconciler owns, carrying the
+///   module whose bytes are not arriving and the content identity the record claims.</item>
+///   <item>A package the registry DOES offer is not named — being served is what delivery is.</item>
+///   <item>A CONTENT-ONLY installed package the registry does not offer is not named either: it
+///   declares no module, so there are no module bytes to deliver and calling it undelivered would
+///   be an alarm nobody can act on.</item>
+///   <item>The consumer-wide verdict (<see cref="ModuleDelivery.NotDeliveredByAnyRegistry"/>) reads
+///   the same answer off the ledger, with <see cref="ModuleDelivery.AnyRegistryDetermined"/> as its
+///   denominator — so an empty result can be read as "nothing undelivered" instead of "nothing
+///   known".</item>
+/// </list>
+/// </summary>
+public class UndeliveredModuleIsRecordedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RegistryUrl = "http://registry.delivery.test";
+    private const string RegistryName = "Delivery Test Registry";
+    private const string Token = "mwi_undelivered_module_test";
+
+    /// <summary>Installed here, declares a module, and the registry SERVES it — delivered.</summary>
+    private const string ServedPackageId = "DeliveredPkg";
+
+    /// <summary>Installed here, declares a module, and the registry does NOT serve it. The
+    /// <c>Mail</c> shape: content moves, module bytes do not.</summary>
+    private const string DeclinedPackageId = "DeclinedPkg";
+    private const string DeclinedModule = "MeshWeaver.Delivery.Declined";
+    private const string DeclinedModuleVersion = "mv-declined-1f5";
+
+    /// <summary>Installed here, NOT served, and declares no module — nothing to deliver.</summary>
+    private const string ContentOnlyPackageId = "ContentOnlyPkg";
+
+    private readonly FakeRegistry registry = new();
+
+    private System.Text.Json.JsonSerializerOptions Json => Mesh.JsonSerializerOptions;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            // The registry, as RegistryPackageSource reaches it: through the named HttpClient the
+            // catalog wires. Nothing between the reconciler and the wire is replaced.
+            .ConfigureServices(s => s.AddSingleton<IHttpClientFactory>(new FakeRegistryClientFactory(registry)));
+
+    [Fact]
+    public async Task AFullFeedThatOmitsAnInstalledModulePackage_RecordsItAsNotDelivered()
+    {
+        await SeedInstallRecord(ServedPackageId, module: "MeshWeaver.Delivery.Served",
+            moduleVersion: "mv-served-9e4");
+        await SeedInstallRecord(DeclinedPackageId, module: DeclinedModule,
+            moduleVersion: DeclinedModuleVersion);
+        await SeedInstallRecord(ContentOnlyPackageId, module: null, moduleVersion: "mv-content-3b2");
+
+        // 🚨 A SUCCESSFUL, COMPLETE feed that simply does not list the other two packages — the
+        // entitlement decline as a consumer sees it. Nothing here is an error: the registry
+        // answered in full, which is precisely what makes the absence evidence rather than noise.
+        registry.Serve(HttpStatusCode.OK, [ServedManifest()]);
+
+        var reconciler = Mesh.ServiceProvider.GetRequiredService<RegistryUpdateReconciler>();
+        var reference = new PluginRegistryReference { Name = RegistryName, Url = RegistryUrl, Token = Token };
+        await reconciler.ReconcileRegistry(reference, _ => TimeSpan.Zero).Timeout(TestTimeouts.Convergence);
+
+        // ── The reconcile completed, and it recorded WHAT IT DOES NOT DELIVER ───────────────────
+        var entries = await LedgerEntries()
+            .Where(es => es.Any(e => e.Url == RegistryUrl && e.LastReconciledAt is not null))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        var entry = entries.Single(e => e.Url == RegistryUrl);
+        Assert.Equal(RegistryReconcileEntry.ViaBoot, entry.LastReconciledVia);
+
+        // 🚨 null would mean "not determined". The feed read succeeded, so the question IS answered.
+        Assert.NotNull(entry.UndeliveredModules);
+        var undelivered = Assert.Single(entry.UndeliveredModules!);
+        Assert.Equal(DeclinedPackageId, undelivered.PackageId);
+        // The module whose bytes are not arriving, and the identity the record claims is installed
+        // — the pair that makes "installed 1.5, running an eleven-day-old assembly" legible.
+        Assert.Equal(DeclinedModule, undelivered.Module);
+        Assert.Equal(DeclinedModuleVersion, undelivered.InstalledModuleVersion);
+
+        // A package the registry serves is delivered; a content-only package has nothing to deliver.
+        Assert.DoesNotContain(entry.UndeliveredModules!, u => u.PackageId == ServedPackageId);
+        Assert.DoesNotContain(entry.UndeliveredModules!, u => u.PackageId == ContentOnlyPackageId);
+
+        // ── The consumer-wide verdict reads the same answer, with its denominator ───────────────
+        var ledger = new RegistryReconcileLedger { Registries = [.. entries] };
+        Assert.True(ModuleDelivery.AnyRegistryDetermined(ledger));
+        Assert.Equal(
+            [DeclinedPackageId],
+            ModuleDelivery.NotDeliveredByAnyRegistry(ledger).Select(u => u.PackageId));
+    }
+
+    private async Task SeedInstallRecord(string id, string? module, string moduleVersion)
+    {
+        var manifest = new PackageManifest
+        {
+            Id = id,
+            Name = $"{id} display name",
+            Version = "1.5.0",
+            ModuleVersion = moduleVersion,
+            Module = module,
+            TargetPartition = id,
+            AutoUpdate = false,
+        };
+        var record = MeshNode.FromPath($"{PackageInstaller.InstalledPartition}/{id}") with
+        {
+            NodeType = PackageInstaller.PackageNodeType,
+            Name = manifest.Name,
+            State = MeshNodeState.Active,
+            Content = manifest,
+        };
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        await access.RunAsSystem(() => NodeFactory.CreateOrUpdateNode(record))
+            .Timeout(TestTimeouts.Convergence);
+    }
+
+    /// <summary>The one package the registry offers — at the SAME module content identity the
+    /// install record carries, so the content lane has nothing to say and the only thing this test
+    /// observes is the delivery verdict.</summary>
+    private static PackageManifest ServedManifest() => new()
+    {
+        Id = ServedPackageId,
+        Name = $"{ServedPackageId} display name",
+        Version = "1.5.0",
+        ModuleVersion = "mv-served-9e4",
+        Module = "MeshWeaver.Delivery.Served",
+        TargetPartition = ServedPackageId,
+    };
+
+    // The ledger, read LIVE through a children query (a query never storms on a node that does not
+    // exist yet, and it re-emits on every write), flattened to its registry entries.
+    private IObservable<IReadOnlyList<RegistryReconcileEntry>> LedgerEntries() =>
+        Mesh.GetWorkspace()
+            .GetQuery("ledger|delivery",
+                $"path:{PackageInstaller.InstalledPartition} scope:children nodeType:{RegistryUpdateReconciler.LedgerNodeType}")
+            .Select(ns => (IReadOnlyList<RegistryReconcileEntry>)(ns ?? [])
+                .Select(n => n.ContentAs<RegistryReconcileLedger>(Json))
+                .Where(l => l is not null)
+                .SelectMany(l => l!.Registries)
+                .ToList());
+
+    /// <summary>A registry that answers every request with the status and list payload the test
+    /// set. The undelivered package is absent from that payload — that IS the decline.</summary>
+    private sealed class FakeRegistry : HttpMessageHandler
+    {
+        private volatile HttpStatusCode status = HttpStatusCode.ServiceUnavailable;
+        private volatile string body = "";
+        private int attempts;
+
+        public int Attempts => Volatile.Read(ref attempts);
+
+        public void Serve(HttpStatusCode code, IReadOnlyList<PackageManifest> packages)
+        {
+            // Body before status: a reader that sees the new status sees the body it belongs to.
+            body = PluginRegistryPayloads.List(packages);
+            status = code;
+        }
+
+        // HttpMessageHandler's contract is Task-shaped; nothing here bridges an observable.
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref attempts);
+            var current = status;
+            var content = current == HttpStatusCode.OK ? body : "{\"error\":\"unavailable\"}";
+            return Task.FromResult(new HttpResponseMessage(current)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FakeRegistryClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
Fixes the mechanism defect named in Systemorph/MeshWeaver.Plugins#1584 (comment, 03:06Z): *"a package the registry declines should show as **not delivered** on the consumer, not as installed."*

## The defect

Both lanes of `RegistryUpdateReconciler`'s reconcile — the content lane (`PackageUpdateReconciler.ReconcileInstalled`) and the module lane (`ReconcileModules`) — iterate **the packages the registry serves** and intersect them with this installation's install records. A package installed *here* that the registry does **not** serve is therefore neither "up to date" nor "failed": it is **absent from both loops**, and absence produced no log line, no ledger entry and no card state anywhere.

Measured on memex 2026-09-10 (the issue's own measurement):

| What was true | What every surface said |
|---|---|
| The registry answered its feed with **45 manifests**; `Mail` was not among them | — |
| `Mail/index.json` declares `tier: personal`; the instance's grant covers the baseline plan, so the registry declined it — its own maintenance task answers *"the registry does not offer a package 'Mail' to this instance"* | — |
| The package's **content** kept arriving through the instance's own git source; the install record advanced to `1.5.0` an hour earlier | *installed, version 1.5.0, up to date* |
| The loaded `MeshWeaver.Mail.MicrosoftGraph` was written **eleven days** earlier | `pending_module_activation` green — and correctly so: nothing had landed, so nothing was waiting on a restart |

A feature that ships as a module change in such a package cannot reach the deployment by merge + roll + restart. Only content moves.

## The fix

After the content and module lanes, a **full** feed pass lists this installation's install records once and records, in the **same ledger mark that closes the pass**, the installed packages that declare a `module` and which *this registry did not offer*: `RegistryReconcileEntry.UndeliveredModules`, one `UndeliveredModule` per package carrying the module name and the content identity the record claims. One Warning names them and points at `Plugins/_RegistryReconcileLedger`. `ModuleDelivery.NotDeliveredByAnyRegistry` intersects the per-registry entries — a package one registry serves is delivered, whatever the others carry — with `AnyRegistryDetermined` as its denominator.

Three properties are load-bearing:

- **Absence is evidence only after a SUCCESSFUL, COMPLETE read.** The lane runs from `ReconcileFromFeed` (boot / drained deferral / safety net), never from the per-package broadcast drain, whose "packages" is the one package the registry named and which would call every other installed module undelivered.
- **`null` is not an empty list.** A listing that fails records *not determined*, not *none* — an inventory that could not be read is not an empty inventory, the same distinction `Pending` draws one question earlier.
- **It is not an entitlement verdict and not a fault.** A consumer cannot tell "your grant does not cover this" from "this registry never carried it"; the remedy (grant the plan, tier the package, point at another registry) is the registry operator's, and the issue records it as such.

Deliberately **not** done here: falling back to the image's `modules/` seed or an in-mesh compile when the registry has no bundle. That changes what an installation *runs* and belongs with the adoption policy, not with the reconcile's bookkeeping.

Also registers `RegistryReconcileEntry` and `UndeliveredModule` explicitly on the type registry — the first was auto-registered under its short name and logged a Warning on every ledger write.

## Test and control

`UndeliveredModuleIsRecordedTest` drives the **real** reconciler over the **real** `RegistryPackageSource` HTTP path against a registry that answers a full, successful feed omitting the package. It pins all four cases: the declined module package is named with its module and installed identity; a served package is not; a content-only package is not; and the consumer-wide verdict reads the same answer off the ledger.

**Control (measured against the final code):** with `RegistryUpdateReconciler.cs` reverted to `origin/main` — the ledger field, the classifier and the test kept — the project rebuilds clean and the test **FAILS** at `Assert.NotNull(entry.UndeliveredModules)`: the reconcile completes (`LastReconciledAt` set, `LastReconciledVia = boot`) and records nothing at all about delivery. Restoring the lane and rebuilding, it passes.

Local verification, Release + `-warnaserror`, one project per invocation: `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `MeshWeaver.Compiler.Pipeline.Test`, `MeshWeaver.Documentation.Test` — all `0 Warning(s), 0 Error(s)`. Tests: the 289 `Registry|Reconcil|Module|Install` tests of `Memex.Portal.Shared.Test` pass, and all 368 of `MeshWeaver.Documentation.Test` (doc-link integrity included).

**This is compiled C# in `src/` only — no in-mesh (`Source/*.cs`) node sources are touched**, so `dotnet build` really does cover it. No files under investigation on MeshWeaver#3732 (`ShippedPrebuiltBundles.cs`, `PrebuiltAssemblySeeder.cs`, `NodeTypeCompilationHelpers.cs`) are touched.

Work product committed: [Plugin Update on Green Build](src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md) gains "A package the registry does NOT offer is recorded as NOT DELIVERED", plus a What's New entry.

Pairs-with: none — nothing public is removed or renamed; this adds two types and one property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
