### PR TITLE
Authorize a scoped build identity for portal compatibility checks

### DIFF
--- a/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
@@ -1,7 +1,11 @@
 using System.Reactive.Linq;
 using System.Text.Json;
 using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Data;
 using MeshWeaver.Messaging;
 using MeshWeaver.PluginCatalog;
 using Microsoft.AspNetCore.Builder;
@@ -24,7 +28,7 @@ namespace Memex.Portal.Shared.Api;
 /// of recomputing it. The portal's own poller calls the same
 /// <see cref="ReleaseAvailabilityService"/> in-process.</para>
 ///
-/// <para>🚨 <b>Auth is the instance key</b>, the same <c>mwi_</c> gate as the bundle routes, and it
+/// <para>🚨 <b>Auth is an instance key or a build granted <c>verify:combo</c></b>, the same <c>mwi_</c> gate as the bundle routes, and it
 /// fails CLOSED: the response names installed packages and the reasons a release is unsafe, which
 /// is deployment inventory, not public information.</para>
 ///
@@ -78,6 +82,12 @@ public static class ReleaseGateEndpoints
     /// </summary>
     public const string ComboRoute = "/api/plugins/combo";
 
+    /// <summary>Accepts one compatibility verdict from an explicitly trusted build.</summary>
+    public const string VerificationRoute = "/api/plugins/combo-verification";
+
+    /// <summary>The local resource named by a build's <c>verify:combo</c> grant.</summary>
+    public const string VerificationResource = "combo";
+
     /// <summary>Maps the instance-key-gated release gate. Call alongside <c>MapPluginBundles</c>.</summary>
     public static IEndpointRouteBuilder MapReleaseGate(this IEndpointRouteBuilder endpoints)
     {
@@ -88,6 +98,9 @@ public static class ReleaseGateEndpoints
                 Selection(http, current, ct))
             .AllowAnonymous();
         endpoints.MapGet(ComboRoute, (HttpContext http, CancellationToken ct) => Combo(http, ct))
+            .AllowAnonymous();
+        endpoints.MapPost(VerificationRoute, (HttpContext http, CancellationToken ct) =>
+                RecordVerification(http, ct))
             .AllowAnonymous();
         return endpoints;
     }
@@ -108,9 +121,9 @@ public static class ReleaseGateEndpoints
         return authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
             .SelectMany(outcome => outcome.IsUnavailable
                 ? Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger))
-                : outcome.Instance is null
+                : outcome.Instance is null && !CanVerify(outcome)
                     ? Observable.Return(Results.Json(
-                        new { error = "A registered instance key is required (Authorization: Bearer mwi_… or Basic)." },
+                        new { error = "A registered instance key or an authorized build identity is required." },
                         statusCode: StatusCodes.Status401Unauthorized))
                     : Choose(http, current))
             .FirstAsync()
@@ -175,9 +188,9 @@ public static class ReleaseGateEndpoints
         return authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
             .SelectMany(outcome => outcome.IsUnavailable
                 ? Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger))
-                : outcome.Instance is null
+                : outcome.Instance is null && !CanVerify(outcome)
                     ? Observable.Return(Results.Json(
-                        new { error = "A registered instance key is required (Authorization: Bearer mwi_… or Basic)." },
+                        new { error = "A registered instance key or an authorized build identity is required." },
                         statusCode: StatusCodes.Status401Unauthorized))
                     : Answer(http, version))
             .FirstAsync()
@@ -263,9 +276,9 @@ public static class ReleaseGateEndpoints
         return authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
             .SelectMany(outcome => outcome.IsUnavailable
                 ? Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger))
-                : outcome.Instance is null
+                : outcome.Instance is null && !CanVerify(outcome)
                     ? Observable.Return(Results.Json(
-                        new { error = "A registered instance key is required (Authorization: Bearer mwi_… or Basic)." },
+                        new { error = "A registered instance key or an authorized build identity is required." },
                         statusCode: StatusCodes.Status401Unauthorized))
                     : StateCombo(http, logger))
             .FirstAsync()
@@ -273,6 +286,79 @@ public static class ReleaseGateEndpoints
                 ex => logger?.LogWarning(ex,
                     "Instance combo read faulted after the response had already been sent"),
                 ct)!;
+    }
+
+    private static bool CanVerify(InstanceAuthResult outcome) =>
+        outcome.Build?.Allows(BuildVerbs.Verify, VerificationResource) == true;
+
+    private static Task<IResult> RecordVerification(HttpContext http, CancellationToken ct)
+    {
+        var logger = http.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ReleaseGateEndpoints));
+        return http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>()
+            .AuthenticateOutcome(http.Request.Headers.Authorization)
+            .SelectMany(outcome => outcome.IsUnavailable
+                ? Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger))
+                : !CanVerify(outcome)
+                    ? Observable.Return(Results.Json(
+                        new { error = "An authorized build identity is required." },
+                        statusCode: StatusCodes.Status401Unauthorized))
+                    : ReadAndRecordVerification(http, outcome.Build!, logger, ct))
+            .FirstAsync()
+            .ObserveCompletion(ex => logger?.LogWarning(ex,
+                "Combo verification recording failed after the response was sent"), ct)!;
+    }
+
+    private static IObservable<IResult> ReadAndRecordVerification(
+        HttpContext http, AuthenticatedBuild build, ILogger? logger, CancellationToken ct)
+    {
+        // Authenticate before reading the body or resolving any mesh service. The caller never
+        // becomes System: only the existing, narrowly scoped RecordVerification primitive writes.
+        var hub = http.RequestServices.GetRequiredService<IMessageHub>();
+        var pool = hub.ServiceProvider.GetRequiredService<IoPoolRegistry>().Get(IoPoolNames.Http);
+        return pool.Invoke(_ => http.Request.ReadFromJsonAsync<ComboVerification>(
+                InstanceComboAssembler.Json, ct).AsTask())
+            .SelectMany(verdict =>
+            {
+                if (verdict is null || string.IsNullOrWhiteSpace(verdict.CandidateTag)
+                    || verdict.VerifiedAt == default || !Enum.IsDefined(verdict.Verdict)
+                    || verdict.Modules is null || verdict.Caveats is null
+                    || verdict.Modules.Any(m => m is null || string.IsNullOrWhiteSpace(m.ModuleId)
+                        || !Enum.IsDefined(m.Outcome) || m.Failures is null)
+                    || verdict.Modules.Select(m => m.ModuleId).Distinct(StringComparer.OrdinalIgnoreCase)
+                        .Count() != verdict.Modules.Count
+                    || (verdict.Verdict == ComboVerdictKind.Green
+                        && (verdict.Modules.Count == 0 || string.IsNullOrWhiteSpace(verdict.ImageDigest)
+                            || string.IsNullOrWhiteSpace(verdict.VerifiedPlatform)
+                            || verdict.ComboReadAt == default
+                            || verdict.Modules.Any(m => m.Outcome != ModuleVerificationOutcome.Passed))))
+                    return Observable.Return(Results.BadRequest(new
+                        { error = "A complete, internally consistent combo verification is required." }));
+
+                var expected = JsonSerializer.Serialize(verdict, InstanceComboAssembler.Json);
+                return UpdatePolicyNodeType.RecordVerification(hub, verdict)
+                    // Update is optimistic across hubs. A 200 promises that the owning node has
+                    // recorded this exact verdict, so observe its reconciled state before replying.
+                    .SelectMany(_ => Observable.Create<IResult>(observer =>
+                    {
+                        using (AccessContextScope.AsSystem(hub.ServiceProvider.GetRequiredService<AccessService>()))
+                            return hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                                .Select(node => UpdatePolicyNodeType.Parse(node, hub.JsonSerializerOptions)
+                                    .VerificationFor(verdict.CandidateTag))
+                                .Where(recorded => JsonSerializer.Serialize(recorded,
+                                    InstanceComboAssembler.Json) == expected)
+                                .Take(1)
+                                .Select(_ => (IResult)Results.Ok(new
+                                    { recorded = true, candidateTag = verdict.CandidateTag }))
+                                .Subscribe(observer);
+                    }))
+                    .Timeout(TimeSpan.FromSeconds(30))
+                    .Do(_ => logger?.LogInformation(
+                        "Build {Repository} run {RunId} recorded combo verdict {Verdict} for {Candidate}",
+                        build.Repository, build.Claims.RunId, verdict.Verdict, verdict.CandidateTag));
+            })
+            .Catch<IResult, JsonException>(_ => Observable.Return(Results.BadRequest(new
+                { error = "The combo verification body is not valid JSON." })));
     }
 
     private static IObservable<IResult> StateCombo(HttpContext http, ILogger? logger) =>

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -1094,8 +1094,26 @@ verdict cache expires.
 
 ## Where a build principal is admitted
 
-Only the **prebuilt-publication routes** (`/api/plugins/bundles/prebuilt/…`), requiring
-`fetch:<source>`. A build is not an installation: it has no instance record, no plan and no
+The **prebuilt-publication routes** (`/api/plugins/bundles/prebuilt/…`) require
+`fetch:<source>`. The release-input routes (`GET /api/plugins/roll-target`,
+`GET /api/plugins/is-updatable`, and `GET /api/plugins/combo`) also admit a build explicitly
+granted `verify:combo`. `POST /api/plugins/combo-verification` accepts that build's off-portal
+verification result and records it through `UpdatePolicyNodeType.RecordVerification`. It accepts
+a `ComboVerification`, never a mesh path or a policy patch. The existing policy, including `None`,
+is preserved, and success is returned only after the node carries the recorded verdict.
+
+This is a system identity for the build process, not a user or a global-admin token. The grant
+is local to the portal whose configured OIDC audience the token must match. Provision
+`Admin/_BuildPrincipal/systemorph--meshweaver` for `Systemorph/MeshWeaver`, binding its immutable
+repository and owner IDs. Permit `verify` only for `workflow_run` and `workflow_dispatch`, both
+restricted to `refs/heads/main`; grant only `verify:combo`. This gives pull requests and other
+repositories no compatibility-check rights. Revocation applies on the next request.
+
+The verifier runs outside production; its grant does not install modules, apply an update, read
+arbitrary user content, edit access grants, or change update policy. Authentication outages still
+return 503, distinct from a refused credential.
+
+A build is not an installation: it has no instance record, no plan and no
 `PluginGrant`, so every other bundle route — which decides per package against exactly those — keeps
 refusing it with the same 401 as before. The narrowing is expressed once, in the group filter, so a
 route added later is refused by default rather than by remembering to.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-build-identity-compatibility-checks.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-build-identity-compatibility-checks.md
@@ -1,0 +1,17 @@
+---
+Name: Compatibility checks use a build identity
+Category: Feature
+Description: Trusted builds can read a portal's release inputs and record compatibility results without receiving an administrator credential or changing its update policy.
+Icon: ShieldCheckmark
+Order: -20260910
+---
+
+# Compatibility checks use a build identity
+
+A trusted build can use its short-lived GitHub identity to read a portal's release target and
+installed module inventory, run compatibility checks outside production, and record the result.
+The portal requires an explicit grant for these operations. The build receives no general access
+to user data or administrator settings.
+
+Recording a result preserves the chosen update policy, including disabled updates. A successful
+response confirms that the result is stored on the portal.

--- a/src/MeshWeaver.Mesh.Contract/Security/BuildPrincipal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/BuildPrincipal.cs
@@ -300,6 +300,10 @@ public static class BuildVerbs
 
     /// <summary>Write a source's bytes INTO this registry.</summary>
     public const string Publish = "publish";
+
+    /// <summary>Read this portal's release inputs and record an off-portal compatibility verdict.
+    /// The resource is <c>combo</c>; this grants no general mesh or update-policy access.</summary>
+    public const string Verify = "verify";
 }
 
 /// <summary>The control-plane verbs <see cref="BuildPrincipal.RequestedAction"/> accepts.</summary>

--- a/test/Memex.Portal.Shared.Test/BuildPrincipalAuthenticationTest.cs
+++ b/test/Memex.Portal.Shared.Test/BuildPrincipalAuthenticationTest.cs
@@ -4,6 +4,11 @@ using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.SelfUpdate;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,6 +69,7 @@ public class BuildPrincipalAuthenticationTest(ITestOutputHelper output) : Monoli
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
         => base.ConfigureMesh(builder)
             .AddPluginCatalog()
+            .AddUpdatePolicyType()
             .ConfigureServices(services => services
                 // The audience is the one deployment knob the build-principal leg has, and an
                 // unconfigured one refuses everything — so a test that wants the leg live has to
@@ -354,6 +360,121 @@ public class BuildPrincipalAuthenticationTest(ITestOutputHelper output) : Monoli
         }
     }
 
+    [Fact(Timeout = 240_000)]
+    public async Task ComboVerification_BuildCanReadAndRecord_WithoutChangingDisabledUpdates()
+    {
+        jwks = () => tokens.Jwks();
+        var principal = VerificationPrincipal();
+        await Grant(principal);
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        await access.RunAsSystem(() => Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .CreateOrUpdateNode(new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+            {
+                Name = "Update policy", NodeType = UpdatePolicyNodeType.NodeType,
+                State = MeshNodeState.Active,
+                Content = new UpdatePolicyContent { Policy = UpdatePolicyKind.None,
+                    LatestAvailableTag = "3.0.0-ci.123" },
+            })).Timeout(TestTimeouts.Convergence).Await();
+        await using var app = await StartHost(Path.GetTempPath());
+        var token = tokens.Mint(Audience, eventName: "workflow_run");
+        using var combo = await Get(app, ReleaseGateEndpoints.ComboRoute, token);
+        Assert.Equal(HttpStatusCode.OK, combo.StatusCode);
+        Assert.Contains("isComplete", await combo.Content.ReadAsStringAsync());
+
+        var verdict = new ComboVerification
+        {
+            CandidateTag = "3.0.0-ci.123", VerifiedAt = DateTimeOffset.UtcNow,
+            Verdict = ComboVerdictKind.NotVerifiable, Caveats = ["Test could not execute the candidate"],
+        };
+        using var recorded = await PostVerdict(app, token,
+            JsonSerializer.Serialize(verdict, InstanceComboAssembler.Json));
+        Assert.Equal(HttpStatusCode.OK, recorded.StatusCode);
+        Assert.Contains("\"recorded\":true", await recorded.Content.ReadAsStringAsync());
+        var policy = await access.RunAsSystem(() => Mesh.GetWorkspace()
+                .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                .Select(n => UpdatePolicyNodeType.Parse(n, Mesh.JsonSerializerOptions)))
+            .Where(c => c.VerificationFor(verdict.CandidateTag)?.VerifiedAt == verdict.VerifiedAt)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Equal(UpdatePolicyKind.None, policy.Policy);
+        Assert.Equal("3.0.0-ci.123", policy.LatestAvailableTag);
+        Assert.Equal(ComboVerdictKind.NotVerifiable, policy.VerificationFor(verdict.CandidateTag)!.Verdict);
+
+        // Revocation is observed on the very next request, including the write route.
+        await Grant(principal with { RequestedAction = BuildPrincipalActions.Revoke });
+        using var revoked = await PostVerdict(app, token, "{}");
+        Assert.Equal(HttpStatusCode.Unauthorized, revoked.StatusCode);
+    }
+
+    [Theory(Timeout = 240_000)]
+    [InlineData("scope")]
+    [InlineData("event")]
+    [InlineData("ref")]
+    [InlineData("repository")]
+    [InlineData("repositoryId")]
+    [InlineData("ownerId")]
+    [InlineData("audience")]
+    [InlineData("expired")]
+    public async Task ComboVerification_RefusesAChangedTrustInput(string changed)
+    {
+        jwks = () => tokens.Jwks();
+        var principal = VerificationPrincipal();
+        if (changed == "scope") principal = principal with { Scopes = ["fetch:plugins"] };
+        if (changed == "ownerId") principal = principal with { RepositoryOwnerId = "wrong-owner" };
+        await Grant(principal);
+        var token = tokens.Mint(changed == "audience" ? "https://another.portal.test" : Audience,
+            repository: changed == "repository" ? "Systemorph/AnotherRepo" : Repository,
+            repositoryId: changed == "repositoryId" ? "wrong-id" : "123456789",
+            eventName: changed == "event" ? "pull_request" : "workflow_dispatch",
+            gitRef: changed == "ref" ? "refs/heads/feature" : "refs/heads/main",
+            issuedAt: changed == "expired" ? DateTimeOffset.UtcNow.AddHours(-1) : null);
+        await using var app = await StartHost(Path.GetTempPath());
+        foreach (var route in new[] { ReleaseGateEndpoints.ComboRoute,
+                     ReleaseGateEndpoints.SelectRoute, ReleaseGateEndpoints.Route })
+        {
+            using var denied = await Get(app, route, token);
+            Assert.Equal(HttpStatusCode.Unauthorized, denied.StatusCode);
+        }
+        // Even malformed input must be refused as unauthorized, before the body is touched.
+        using var write = await PostVerdict(app, token, "not JSON");
+        Assert.Equal(HttpStatusCode.Unauthorized, write.StatusCode);
+    }
+
+    [Theory(Timeout = 240_000)]
+    [InlineData("null")]
+    [InlineData("{}")]
+    [InlineData("not JSON")]
+    [InlineData("{\"candidateTag\":\"3.0.0-ci.1\",\"verifiedAt\":\"2026-09-10T01:00:00Z\",\"verdict\":\"Green\"}")]
+    public async Task ComboVerification_RefusesAnInvalidOrEmptyGreenVerdict(string body)
+    {
+        jwks = () => tokens.Jwks();
+        await Grant(VerificationPrincipal());
+        await using var app = await StartHost(Path.GetTempPath());
+        using var response = await PostVerdict(app,
+            tokens.Mint(Audience, eventName: "workflow_run"), body);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static BuildPrincipal VerificationPrincipal() => Principal() with
+    {
+        RepositoryId = "123456789", RepositoryOwnerId = "9999", Scopes = ["verify:combo"],
+        Events = new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["workflow_run"] = [BuildVerbs.Verify], ["workflow_dispatch"] = [BuildVerbs.Verify],
+        },
+        EventRefs = new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["workflow_run"] = ["refs/heads/main"], ["workflow_dispatch"] = ["refs/heads/main"],
+        },
+    };
+
+    private static async Task<HttpResponseMessage> PostVerdict(WebApplication app, string token, string body)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, ReleaseGateEndpoints.VerificationRoute);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {token}");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        return await app.GetTestClient().SendAsync(request);
+    }
+
     private static void WriteBundle(string path)
     {
         using var zip = ZipFile.Open(path, ZipArchiveMode.Create);
@@ -372,8 +493,10 @@ public class BuildPrincipalAuthenticationTest(ITestOutputHelper output) : Monoli
         builder.Services.AddSingleton<IMessageHub>(Mesh);
         builder.Services.AddSingleton(new InstanceRegistryAuthenticator(
             Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>()));
+        builder.Services.AddSingleton(new InstanceComboReader(Mesh));
         var app = builder.Build();
         app.MapPluginBundles();
+        app.MapReleaseGate();
         await app.StartAsync();
         return app;
     }

--- a/test/Memex.Portal.Shared.Test/ReleaseGateAuthTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseGateAuthTest.cs
@@ -29,7 +29,7 @@ namespace Memex.Portal.Shared.Test;
 /// </summary>
 public class ReleaseGateAuthTest
 {
-    private static async Task<HttpResponseMessage> Get(string route, string? authorization)
+    private static async Task<HttpResponseMessage> Get(string route, string? authorization, HttpMethod? method = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -43,11 +43,18 @@ public class ReleaseGateAuthTest
         app.MapReleaseGate();
         await app.StartAsync();
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        using var request = new HttpRequestMessage(method ?? HttpMethod.Get, route);
         if (authorization is not null)
             request.Headers.TryAddWithoutValidation("Authorization", authorization);
 
         return await app.GetTestClient().SendAsync(request);
+    }
+
+    [Fact]
+    public async Task VerificationWriteAuthenticatesBeforeReadingTheBodyOrResolvingTheMesh()
+    {
+        using var response = await Get(ReleaseGateEndpoints.VerificationRoute, null, HttpMethod.Post);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
Compatibility verification currently needs a portal-wide administrator token to record results, while the existing GitHub OIDC build identity is rejected by the release-input routes. This change admits an explicitly granted `verify:combo` build to read the portal's release inputs and post a `ComboVerification` to `/api/plugins/combo-verification`.

The write calls the existing `RecordVerification` operation and acknowledges success only after the owning node carries the exact result. It preserves the existing update policy, including `None`. The build receives no generic mesh mutation, user-data access, or administrator role. Invalid or empty-green reports are rejected; authentication outages retain the existing 503 distinction.

Authorization for this scope was explicitly given by the maintainer. The dedicated `Systemorph/MeshWeaver` BuildPrincipal has been registered on both production portals with immutable repository/owner IDs, `verify:combo` only, and `workflow_run`/`workflow_dispatch` limited to `refs/heads/main`. Runtime audience configuration, caller wiring, and production route verification remain delivery work; registration alone does not establish that a build can use the routes.

Validation: Release build with `CIRun=true` and warnings as errors, zero warnings/errors. All 42 targeted real-mesh tests passed, covering authorized read/record, policy preservation, immediate revocation, repository/owner IDs, audience, event/ref, expired tokens, malformed verdicts, and unauthenticated requests. What's New and access-control documentation included.

Part of #3848. Runtime fleet discovery and removal of the static COMBO maps remain separate work; this PR does not close that issue.
