### PR TITLE
docs: a declined bundle risks stale TYPES, not just a slower boot (Plugins#1585)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -86,6 +86,54 @@ the image rather than declared in a list — is
 copy that *does* load shadows the image copy, so the fallback never runs; and the sealed-set
 conflict below still HOLDS the roll for the whole fleet whatever one process does at boot.
 
+## A declined bundle risks stale TYPES, not just a slower boot
+
+The bullets above treat *no adopted bundle* as a cost paid in boot time, because the content then
+compiles in the mesh. Measured on 2026-09-10 (memex.systemorph.com, `3.0.0-ci.8238`, core
+`2287decb`, identity `s546f29f9…`) that is not the whole story: a module whose bundle is declined
+can keep serving **types built from source older than the source the instance has installed**,
+while every surface reports the package as installed, current and healthy.
+
+`MeshWeaver.AI` had gained `ModelDefinition.ReasoningEffort` (Plugins#1556, 09-09 12:41Z) and
+`ThreadMessage.Timing` (Plugins#1552, 11:59Z). The install record carried main's own file hashes —
+`src/MeshWeaver.AI/ModelDefinition.cs` = `89fd0a2264…`, byte-identical to `origin/main`, which
+declares the property — so the *sources* were current. The *types* were not: `get
+@…/schema/ModelDefinition` listed no `reasoningEffort`, and a `patch` setting it wrote a new node
+version with the property silently dropped. The instance's own health said why:
+
+```text
+bundle_adoption: Degraded — 25 adoption attempt(s), 0 assembly/assemblies adopted, 25 MISS(es) —
+content the registry was meant to serve is compiled here instead: AI: FrameworkDeclined
+(built against framework s72c27afab89c1007…, live framework is s546f29f90e235e61…)
+```
+
+The registry's bytes were therefore never in play. What served was the previously resolved build,
+kept alive by the same-MAJOR **stale-but-serving** rule recorded on
+[The Execute-Time Interlock](../ExecuteTimeInterlock) (#3844): a moved source fingerprint is
+deliberately *not* a refusal, so `1.5.0 → 1.5.1` kept the old build. That is why a Store
+`RefreshModules` re-land and two restarts each reloaded the identical generation and changed
+nothing. What finally let fresh types through was a new `{package}@{version}` shelf entry —
+`AI/index.json` 1.5 → 1.6 with **no source change** (Plugins#1586) — for which no previously
+adopted build existed. Two minutes after that merged the instance installed `AI 1.6.0`, and the
+property appeared on the served schema and survived a write.
+
+Three consequences worth carrying:
+
+- **"Installed, current version, sources current" is not "running these types."** The install
+  record describes the *content* lane. Which assembly answers `schema/<Type>` is the *module* lane,
+  and on a declined bundle the two can sit days apart with nothing red anywhere.
+- **Re-landing is not re-building.** `RefreshModules` re-lands content; it does not dislodge an
+  adopted build that the compatibility rule still accepts.
+- **A version bump is a delivery lever.** Where a stale adopted build is serving, moving
+  `{package}@{version}` is the supported way to force a fresh one — and it doubles as the
+  experiment that separates "the shelf holds stale bytes" from "an adopted build is being kept".
+
+🚨 **Do not read stale served types as the registry serving bad bytes.** The two are
+indistinguishable from the consumer: same `[ModuleLoad]` line, same generation directory, same
+mvid, and `[ModuleLoad]` never names the commit a bundle was built from. The discriminator is
+`bundle_adoption` on `/health` — `FrameworkDeclined` means the registry's copy was never adopted,
+so a fix aimed at the shelf would be aimed at bytes this instance never ran.
+
 ## What the platform roll gates on
 
 The self-updater and the CD post-promote gate select **the newest release on which no installed module is unloadable**. Concretely, per installed package: a build published for the target identity exists (it will be adopted), *or* the landed generation links against the target's surface, *or* neither can be shown — which is reported as *indeterminate*, never as clearance and never as a hold. Declared floors do not enter. A missing content bake does not enter (it is reported as "would compile at boot: …"). The sealed-set consistency check (#3175/#3221) stays: two builds of one platform assembly in one identity is a torn publication, and torn publications are refused whole.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -92,7 +92,7 @@ The bullets above treat *no adopted bundle* as a cost paid in boot time, because
 compiles in the mesh. Measured on 2026-09-10 (memex.systemorph.com, `3.0.0-ci.8238`, core
 `2287decb`, identity `s546f29f9…`) that is not the whole story: a module whose bundle is declined
 can keep serving **types built from source older than the source the instance has installed**,
-while every surface reports the package as installed, current and healthy.
+while the package's own install record reads installed, current and up to date.
 
 `MeshWeaver.AI` had gained `ModelDefinition.ReasoningEffort` (Plugins#1556, 09-09 12:41Z) and
 `ThreadMessage.Timing` (Plugins#1552, 11:59Z). The install record carried main's own file hashes —


### PR DESCRIPTION
Opened as a **draft on purpose** — draft is the documented `auto-arm` opt-out, so nothing can merge this while the finding is reviewed.

## Why

Re-measuring MeshWeaver.Plugins#1585 this morning showed the symptom is **already resolved**, and that the issue's own conclusion is wrong in a way worth recording.

#1585 reported that `ModelDefinition` served on memex lacked `reasoningEffort` (Plugins#1556) and that `ThreadMessage` lacked `timing` (Plugins#1552), and concluded (comment, 03:16Z) that *"the registry itself serves the stale bytes"* for `AI@1.5.1`.

The instance's own health falsifies that:

```text
bundle_adoption: Degraded — 25 adoption attempt(s), 0 assembly/assemblies adopted, 25 MISS(es) —
content the registry was meant to serve is compiled here instead: AI: FrameworkDeclined
(built against framework s72c27afab89c1007…, live framework is s546f29f90e235e61…)
```

The registry's AI bundle was **never adopted**, so its bytes were never in play. What served was the previously resolved build, kept alive by the same-MAJOR **stale-but-serving** rule #3844 introduced the evening before (in this portal's core, `2287decb`) — a moved source fingerprint is deliberately *not* a refusal. That is why a Store `RefreshModules` re-land and two restarts each reloaded the identical generation and changed nothing, and why the fix was a new `{package}@{version}` shelf entry (`AI/index.json` 1.5 → 1.6, **no source change**, Plugins#1586) for which no previously adopted build existed.

The layer matters: the model code was never at fault. `src/MeshWeaver.AI/ModelDefinition.cs` on Plugins `origin/main` hashes to `89fd0a2264…`, byte-identical to what the portal's install record claims, and declares `public string? ReasoningEffort { get; init; }` at line 177.

## What changed

One section on [Module Adoption Policy](src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md). The page already treats *no adopted bundle* as a cost paid in boot time ("the content compiles in the mesh… a missing bake is a cost, not a reason to hold a roll"). It adds the second consequence measured here — the **types** served can lag the **installed source** with nothing red on any surface — plus:

- the three consequences (installed-and-current ≠ running these types; re-landing is not re-building; a version bump is a delivery lever *and* the discriminating experiment);
- the discriminator, `bundle_adoption` on `/health`, because from the consumer a stale adopted build and a stale registry shelf are identical — same `[ModuleLoad]` line, same generation, same mvid, and `[ModuleLoad]` never names the commit a bundle was built from.

Documentation only. No code, no public surface, no in-mesh (`Source/*.cs`) node sources.

## Verification and control

`MeshWeaver.Documentation.Test`, Release + `-warnaserror`, one project per invocation: **0 Warning(s), 0 Error(s)**; full suite **368/368 passed**.

**Control (the gate is live, not vacuous):** with `../ExecuteTimeInterlock` changed to `../ExecuteTimeInterlockZZZ` and the project **REBUILT** (the doc is an embedded asset, so `--no-build` would have given a false verdict), `DocumentationLinkIntegrityTest` **fails**, exit 1, naming it:

```text
Doc/Architecture/ModuleAdoptionPolicy: (../ExecuteTimeInterlockZZZ) — resolves to
/Doc/Architecture/ExecuteTimeInterlockZZZ, which does not exist, but found 1 item(s).
Failed!  - Failed: 1, Passed: 0
```

Restored and rebuilt, it passes. The rebuild also confirms the embedded `.md` really does refresh, so the passing run is a real pass.

## Not done here

The residual class defect #1585 asks for — `[ModuleLoad]` naming the assembly a NodeType's content type actually resolves to, and a bundle manifest recording its built-from commit — is real and unaddressed, but it is a core change in the #3583/#3732 delivery area rather than anything in the model, and it deserves its own scoped issue rather than riding a docs commit.

Pairs-with: none — documentation only; no public type or member is removed or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
