### PR TITLE
Module registry hand-over waits for the full source validation verdict (#3878)

### DIFF
--- a/.github/scripts/module-publication.py
+++ b/.github/scripts/module-publication.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""module-publication.py — the module registry HAND-OVER, downstream of the FULL source verdict.
+
+(The name on this first line is load-bearing: the publication lane fetches this file at the
+platform pin and refuses a body whose first 400 bytes do not name it.)
+
+WHY THIS EXISTS (MeshWeaver#3878, requirement 3 of #3842: "a red or cancelled source build must
+not become visible to portals")
+------------------------------------------------------------------------------------------------
+`node-repo-module-pack.yml` used to POST each module bundle to the live registry INSIDE its own
+matrix leg, right after that module's own suite. Everything else that validates the source — a
+sibling module's suite, the portal-host shards, the NodeType compile-check, the Tests-area gate —
+runs BESIDE or AFTER that leg, so a module was already being served to every installation while
+the run that produced it was still deciding whether the source was any good. Making the pack job
+`needs:` those gates is not available: they consume the `modules-floor` artifacts, so the edge
+would be a cycle.
+
+So the hand-over MOVES. `pack` keeps building, uploading and testing — everything a downstream
+gate consumes stays exactly where it was, at the same point in the run — and STAGES the bytes it
+would have published. This script is what runs afterwards, in a job the caller wires `needs:` on
+its whole validation set, and it is deliberately built so that "the validation did not run" and
+"the validation passed" can never look the same:
+
+  verdict       Every job in the caller's `needs:` context must be present with result `success`.
+                FAILED, SKIPPED, CANCELLED, MISSING and UNKNOWN are all refusals, each naming the
+                job and what it actually said. An empty needs context is a refusal too — a
+                publication that waited for nothing is the defect, not the base case.
+  check-caller  The caller's own workflow file, read at the caller's commit: the publishing job
+                must `needs:` (transitively) every job it declares required, must carry no status
+                function in its `if:` (`always()`/`!cancelled()` re-open the door the verdict
+                closes), must hand this lane the WHOLE needs context rather than a curated
+                literal, and must account for every other job in the workflow — covered, or
+                declared unrelated with a reason. This is the half `verdict` cannot see: a
+                dependency dropped from `needs:` AND from `required-jobs` is invisible at runtime.
+  publish       The staged evidence is matched against the selection before ONE byte is POSTed:
+                exactly one publication record per selected module, stamped with THIS call's lane,
+                naming the bytes by sha256 and the framework identity read back off those bytes.
+                A missing, foreign-lane or substituted record refuses the WHOLE publication — the
+                registry is left untouched rather than half-served. Only then does the hand-over
+                run, and only a 2xx from the registry records `Published` in the build ledger.
+
+USAGE
+  module-publication.py verdict --verdicts @needs.json --required "validate compile-check"
+  module-publication.py check-caller --workflow .github/workflows/ci.yml \\
+        --uses node-repo-module-publish.yml --required "validate compile-check" \\
+        --unrelated "auto-arm: arms auto-merge, validates nothing"
+  module-publication.py publish --staged DIR --lane L --declared @modules.json \\
+        --selected "MeshWeaver.AI" --registry https://memex.meshweaver.cloud --source Plugins
+  module-publication.py --self-test
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+GOOD = "success"
+#: The four expression functions that re-open a job GitHub would otherwise have skipped. A
+#: publishing job must run under the DEFAULT rule (every `needs:` succeeded) and nothing else —
+#: `if: ${{ !cancelled() }}` on a publisher is the same defect as `continue-on-error` on a gate's
+#: input step: it makes "a dependency failed" indistinguishable from "everything was fine".
+STATUS_FUNCS = ("always", "cancelled", "failure", "success")
+#: The caller must hand over its WHOLE needs context, verbatim. A curated object literal would let
+#: the caller answer the verdict question with a value it chose rather than one GitHub computed.
+VERDICTS_EXPR = "${{ toJSON(needs) }}"
+HTTP_TIMEOUT_S = 300
+PUBLISH_TOKEN_ENV = "MW_PUBLISH_TOKEN"
+
+
+def die(msg: str, code: int = 1):
+    print(f"::error::{msg}", file=sys.stderr, flush=True)
+    sys.exit(code)
+
+
+def names(raw: str | None) -> list[str]:
+    return [n for n in re.split(r"[,\s]+", raw or "") if n]
+
+
+def load_json_arg(raw: str):
+    if raw.startswith("@"):
+        return json.loads(Path(raw[1:]).read_text(encoding="utf-8"))
+    return json.loads(raw)
+
+
+def summarise(lines: list[str]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ══════════════════════════════════ verdict ══════════════════════════════════
+def verdict(verdicts_raw: str, required_raw: str) -> int:
+    """Every dependency succeeded — asserted, out loud, naming whatever did not."""
+    try:
+        ctx = load_json_arg(verdicts_raw)
+    except Exception as exc:  # noqa: BLE001 — the message has to name the input, not the traceback
+        die(f"the verdicts input is not JSON ({exc}). It must be `{VERDICTS_EXPR}` — a publication "
+            "that cannot read its dependencies' results must never proceed as if they had passed.")
+    if not isinstance(ctx, dict):
+        die(f"the verdicts input parsed as {type(ctx).__name__}, not an object. Pass "
+            f"`{VERDICTS_EXPR}` unchanged.")
+    required = names(required_raw)
+    if not required:
+        die("required-jobs is EMPTY. A publication lane that names no required validation job "
+            "asserts nothing — 'every required job passed' would be vacuously true. Name the jobs "
+            "whose verdict entitles this run to publish.")
+    if not ctx:
+        die("the needs context is EMPTY — this publishing job depends on nothing, so it cannot be "
+            "waiting for any validation and would hand bundles to the registry the moment the run "
+            "starts. Give the job a `needs:` covering the validation set (MeshWeaver#3878).")
+
+    problems: list[str] = []
+    rows: list[tuple[str, str, str]] = []
+    for job in sorted(set(list(ctx) + required)):
+        entry = ctx.get(job)
+        mark = "required" if job in required else "extra"
+        if entry is None:
+            rows.append((job, "MISSING", mark))
+            problems.append(
+                f"required validation job `{job}` is NOT among this job's `needs:` — it never "
+                "reported to this publication, and an absent verdict is not a positive one. Add it "
+                "to `needs:` (or stop declaring it required and say why).")
+            continue
+        result = entry.get("result") if isinstance(entry, dict) else None
+        if not isinstance(result, str) or not result:
+            rows.append((job, "UNKNOWN", mark))
+            problems.append(
+                f"job `{job}` reported no readable result ({json.dumps(entry)[:120]}). A verdict "
+                "this lane cannot read must never resolve to 'it passed'.")
+            continue
+        rows.append((job, result, mark))
+        if result != GOOD:
+            problems.append(
+                f"job `{job}` reported `{result}`, not `success` — the source validation did not "
+                "reach a positive verdict, so nothing may be handed to the registry. "
+                + ("A SKIPPED dependency is the trap this check exists for: GitHub paints it with "
+                   "the same tick as a passed one." if result == "skipped" else
+                   "Read that job; this publication is refusing, not failing."))
+
+    width = max((len(j) for j, _, _ in rows), default=8)
+    print(f"{len(rows)} dependency verdict(s), {len(required)} of them declared required:")
+    for job, result, mark in rows:
+        tick = "ok " if result == GOOD else "RED"
+        print(f"  {tick} {job.ljust(width)}  {result}  ({mark})")
+
+    lines = ["### Source validation verdict", "",
+             "| job | result | |", "|---|---|---|"]
+    lines += [f"| `{j}` | {r} | {'required' if m == 'required' else '—'} |" for j, r, m in rows]
+    if problems:
+        lines += ["", "**REFUSED — nothing was handed to the registry:**", ""]
+        lines += [f"- {p}" for p in problems]
+    else:
+        lines += ["", f"All {len(rows)} dependencies reported `success`. The hand-over may proceed."]
+    summarise(lines)
+
+    for p in problems:
+        print(f"::error title=Publication refused::{p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+# ══════════════════════════════════ check-caller ══════════════════════════════════
+def _job_graph(jobs: dict) -> dict[str, set[str]]:
+    graph: dict[str, set[str]] = {}
+    for jid, job in jobs.items():
+        need = (job or {}).get("needs") or []
+        if isinstance(need, str):
+            need = [need]
+        graph[jid] = {n for n in need if isinstance(n, str)}
+    return graph
+
+
+def _ancestors(graph: dict[str, set[str]], start: str) -> set[str]:
+    seen: set[str] = set()
+    stack = list(graph.get(start, ()))
+    while stack:
+        n = stack.pop()
+        if n in seen:
+            continue
+        seen.add(n)
+        stack.extend(graph.get(n, ()))
+    return seen
+
+
+def _descendants(graph: dict[str, set[str]], start: str) -> set[str]:
+    seen: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for jid, need in graph.items():
+            if jid in seen or jid == start:
+                continue
+            if need & (seen | {start}):
+                seen.add(jid)
+                changed = True
+    return seen
+
+
+def _status_function_in(expr) -> str | None:
+    if not isinstance(expr, str):
+        return None
+    for fn in STATUS_FUNCS:
+        if re.search(rf"\b{fn}\s*\(", expr):
+            return fn
+    return None
+
+
+def check_caller(workflow: Path, uses_suffix: str, required_raw: str, unrelated_raw: str) -> int:
+    try:
+        import yaml
+    except ImportError:
+        die("module-publication.py check-caller needs PyYAML (pip install pyyaml)")
+    if not workflow.is_file():
+        die(f"the caller's workflow file `{workflow}` does not exist. This lane reads the caller's "
+            "own graph to prove the publishing job actually waits for the validation set; a file it "
+            "cannot read is a check that did not run, which must never pass.")
+    try:
+        doc = yaml.safe_load(workflow.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        die(f"`{workflow}` does not parse as YAML ({exc}) — a caller graph this lane cannot read is "
+            "a check that did not run.")
+    jobs = doc.get("jobs") or {}
+    if not isinstance(jobs, dict) or not jobs:
+        die(f"`{workflow}` declares no jobs — nothing here can be the publishing job.")
+
+    publishers = [jid for jid, job in jobs.items()
+                  if isinstance((job or {}).get("uses"), str)
+                  and uses_suffix in job["uses"].split("@")[0]]
+    print(f"{workflow}: {len(jobs)} job(s); {len(publishers)} of them call `{uses_suffix}`")
+    if not publishers:
+        die(f"no job in `{workflow}` calls `{uses_suffix}` — this lane is running, so one does. "
+            "Either `github.workflow_ref` named the wrong file or the caller reaches this lane "
+            "through an indirection this check cannot follow; refusing rather than passing on an "
+            "empty denominator.")
+
+    required = names(required_raw)
+    unrelated: dict[str, str] = {}
+    for entry in re.split(r"[\n;]+", unrelated_raw or ""):
+        entry = entry.strip()
+        if not entry:
+            continue
+        job, _, reason = entry.partition(":")
+        unrelated[job.strip()] = reason.strip()
+
+    graph = _job_graph(jobs)
+    problems: list[str] = []
+    for pub in publishers:
+        job = jobs[pub] or {}
+        anc = _ancestors(graph, pub)
+        desc = _descendants(graph, pub)
+        if not graph.get(pub):
+            problems.append(f"`{pub}` has no `needs:` — it would publish the moment the run starts.")
+        fn = _status_function_in(job.get("if"))
+        if fn:
+            problems.append(
+                f"`{pub}`'s `if:` uses the status function `{fn}()`, which makes the job run even "
+                "when a dependency FAILED, was CANCELLED or was SKIPPED — exactly the door this "
+                "lane exists to close. A publishing job runs under GitHub's default rule (every "
+                "`needs:` succeeded) or not at all; its `if:` may gate the EVENT and nothing else "
+                f"(got: {job.get('if')!r}).")
+        if job.get("continue-on-error") in (True, "true"):
+            problems.append(f"`{pub}` carries `continue-on-error` — a publication whose failure "
+                            "does not red the run is a publication nobody is told about.")
+        with_ = job.get("with") or {}
+        got = str(with_.get("verdicts", "")).strip()
+        if re.sub(r"\s+", "", got) != re.sub(r"\s+", "", VERDICTS_EXPR):
+            problems.append(
+                f"`{pub}` passes `verdicts: {got or '<nothing>'}` — it must pass `{VERDICTS_EXPR}` "
+                "verbatim, so the verdict check reads what GitHub computed rather than a value the "
+                "caller curated.")
+        for name in required:
+            if name not in jobs:
+                problems.append(f"`{pub}` declares `{name}` required, but `{workflow}` has no such job.")
+            elif name not in anc:
+                problems.append(
+                    f"`{pub}` declares `{name}` required but does not depend on it (not in `needs:`, "
+                    "directly or transitively) — it would publish while that job is still running.")
+        for name in sorted(set(jobs) - anc - desc - {pub} - set(unrelated)):
+            problems.append(
+                f"job `{name}` can still fail AFTER `{pub}` has handed the bundles over: it is "
+                "neither upstream of the publication nor declared unrelated. Add it to `needs:`, or "
+                "name it in `unrelated-jobs` with the reason it validates no source.")
+        for name in sorted(set(unrelated) - set(jobs)):
+            problems.append(f"`unrelated-jobs` names `{name}`, which `{workflow}` no longer has — a "
+                            "stale exemption hides the job that replaced it.")
+        print(f"  `{pub}`: waits for {len(anc)} job(s) — {', '.join(sorted(anc)) or '<none>'}")
+        if unrelated:
+            print(f"  `{pub}`: declared unrelated — " + "; ".join(
+                f"{k} ({v or 'NO REASON GIVEN'})" for k, v in sorted(unrelated.items())))
+    for p in problems:
+        print(f"::error title=Publication gate::{p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+# ══════════════════════════════════ publish ══════════════════════════════════
+REQUIRED_RECORD_FIELDS = ("lane", "package", "module", "version", "frameworkIdentity")
+
+
+def _read_records(staged: Path) -> tuple[dict[str, dict], list[str]]:
+    records: dict[str, dict] = {}
+    problems: list[str] = []
+    for path in sorted(staged.rglob("*.publication.json")):
+        try:
+            rec = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"staged record `{path.name}` is not readable JSON ({exc}) — refusing "
+                            "to publish a set whose evidence this lane could not check.")
+            continue
+        module = rec.get("module")
+        if not isinstance(module, str) or not module:
+            problems.append(f"staged record `{path.name}` names no module.")
+            continue
+        if module in records:
+            problems.append(f"two staged records claim `{module}` — the staged set is ambiguous, so "
+                            "there is no such thing as 'the exact validated bytes' for it.")
+            continue
+        rec["_dir"] = str(path.parent)
+        records[module] = rec
+    return records, problems
+
+
+def publish(a: argparse.Namespace) -> int:
+    staged = Path(a.staged)
+    lane = (a.lane or "").strip()
+    if not lane:
+        die("the lane key is empty — every staged record carries the lane of the call that produced "
+            "it, and artifacts are RUN-WIDE, so without it a sibling call's bundles could answer "
+            "this publication (Plugins#1077). Refusing.")
+    declared = {e["module"] for e in load_json_arg(a.declared)} if a.declared else set()
+    selected = names(a.selected)
+    if not staged.is_dir():
+        # 🚨 The ONE shape in which "nothing was staged" is not a finding, and it is positive
+        # evidence rather than an absence: the pack call's OWN selection output says it chose zero
+        # modules (a narrowed run whose diff reached none of them), so there is nothing this
+        # publication could be missing. Every other empty is a refusal below.
+        if not selected:
+            print(f"the pack call `{lane}` selected ZERO modules — nothing was packed, nothing was "
+                  "staged, and nothing is owed to the registry.")
+            summarise(["### Module publication", "",
+                       f"The pack call `{lane}` selected **zero** modules on this run; nothing was "
+                       "handed over."])
+            return 0
+        die(f"the staged directory `{staged}` does not exist — the pack lane staged nothing for this "
+            f"call, yet {len(selected)} module(s) were selected and validated ({', '.join(selected)}). "
+            "That is a missing input, never an empty one.")
+
+    records, problems = _read_records(staged)
+
+    foreign = sorted(m for m, r in records.items() if r.get("lane") != lane)
+    for m in foreign:
+        problems.append(
+            f"staged record for `{m}` is stamped lane `{records[m].get('lane')}`, not `{lane}` — it "
+            "belongs to another call of the pack lane in this run. A publication may only hand over "
+            "bytes its OWN validated call produced.")
+    unexpected = sorted(m for m in records if declared and m not in declared)
+    for m in unexpected:
+        problems.append(f"staged record for `{m}` is not in this call's declared matrix — set aside, "
+                        "never published.")
+    mine = {m: r for m, r in records.items() if m not in foreign and m not in unexpected}
+
+    for m in selected:
+        if m not in mine:
+            problems.append(
+                f"`{m}` was SELECTED and validated by this run, but no staged publication record "
+                "reached this lane. Its pack leg either never ran or never staged — and 'nothing "
+                "was staged' must never publish as quietly as 'everything was staged'.")
+
+    plan: list[dict] = []
+    for m in sorted(mine):
+        rec = mine[m]
+        missing = [f for f in REQUIRED_RECORD_FIELDS if not rec.get(f)]
+        if "owed" not in rec:
+            missing.append("owed")
+        if missing:
+            problems.append(f"staged record for `{m}` states no {', '.join(missing)}.")
+            continue
+        if selected and m not in selected:
+            problems.append(f"staged record for `{m}` was produced by this lane but the selection "
+                            "does not name it — the two disagree about what this run validated.")
+            continue
+        if not rec.get("owed"):
+            print(f"  -- {m}@{rec['version']}: no hand-over owed — "
+                  f"{rec.get('reason') or 'no reason recorded'}")
+            continue
+        bundle_meta = rec.get("bundle") or {}
+        name, want = bundle_meta.get("name"), bundle_meta.get("sha256")
+        if not name or not want:
+            problems.append(f"staged record for `{m}` owes a hand-over but names no bundle bytes "
+                            "(bundle.name / bundle.sha256).")
+            continue
+        path = Path(rec["_dir"]) / name
+        if not path.is_file():
+            problems.append(f"`{m}` owes a hand-over and its record names `{name}`, which is NOT in "
+                            "the staged artifact. The bytes the validation covered are missing; "
+                            "publishing anything else would publish something nobody validated.")
+            continue
+        got = sha256_file(path)
+        if got != want:
+            problems.append(f"`{m}`'s staged bytes are NOT the validated bytes: the record says "
+                            f"sha256 {want}, the artifact is {got}. Substituted or truncated — "
+                            "refusing the whole publication.")
+            continue
+        try:
+            with zipfile.ZipFile(path) as zf:
+                manifest = json.loads(zf.read("meshweaver/manifest.json"))
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"cannot read meshweaver/manifest.json out of `{m}`'s staged bundle "
+                            f"({exc}) — 'could not check' must never render as 'checked'.")
+            continue
+        identity = str(manifest.get("frameworkMvid") or "").strip()
+        if not identity:
+            problems.append(f"`{m}`'s staged bundle states no framework identity — the registry "
+                            "would shelve a null and every consumer would answer 'up to date, "
+                            "identity could not be checked' for ever (#3154/#3211).")
+            continue
+        if identity != rec["frameworkIdentity"]:
+            problems.append(f"`{m}`'s record was written against framework identity "
+                            f"{rec['frameworkIdentity']} and the staged bytes state {identity}.")
+            continue
+        assembly = (manifest.get("module") or {}).get("assemblyName")
+        if assembly != m:
+            problems.append(f"`{m}`'s staged bundle declares module `{assembly}`.")
+            continue
+        plan.append({"module": m, "package": rec["package"], "version": rec["version"],
+                     "path": path, "identity": identity, "sha256": got,
+                     "ledgerKey": (rec.get("ledger") or {}).get("key") or ""})
+
+    if problems:
+        for p in problems:
+            print(f"::error title=Publication refused::{p}", file=sys.stderr)
+        summarise(["### Module publication REFUSED", "",
+                   "The registry was left untouched — not one byte was handed over.", ""]
+                  + [f"- {p}" for p in problems])
+        return 1
+
+    if not plan:
+        print("nothing owes a hand-over in this call: "
+              f"{len(mine)} staged record(s), {len(selected)} selected, 0 to publish.")
+        summarise(["### Module publication", "",
+                   f"{len(mine)} staged record(s) accounted for; **none owed a hand-over** "
+                   "(the build ledger already serves these keys, or the selection was empty)."])
+        return 0
+
+    token = os.environ.get(PUBLISH_TOKEN_ENV, "")
+    if not token and not a.dry_run:
+        die(f"a hand-over is owed for {len(plan)} module(s) but {PUBLISH_TOKEN_ENV} is empty — the "
+            "registry would never receive them and this job would have reported success.")
+
+    print(f"handing over {len(plan)} module bundle(s) to {a.registry} as source `{a.source}`:")
+    failed: list[str] = []
+    published: list[dict] = []
+    for item in plan:
+        url = (f"{a.registry.rstrip('/')}/api/plugins/bundles/{item['package']}"
+               f"?version={item['version']}&packagePath={a.source}/{item['package']}")
+        print(f"  -> {item['module']}@{item['version']} ({item['sha256'][:12]}…, built against "
+              f"{item['identity']}) to {url}")
+        if a.dry_run:
+            published.append(item)
+            continue
+        req = urllib.request.Request(url, data=item["path"].read_bytes(), method="POST", headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/octet-stream",
+        })
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+                body = resp.read(4096).decode("utf-8", "replace")
+                print(f"     registry answered {resp.status}: {body}")
+        except urllib.error.HTTPError as exc:
+            body = exc.read(4096).decode("utf-8", "replace")
+            failed.append(f"registry refused `{item['module']}@{item['version']}` (HTTP "
+                          f"{exc.code}): {body}")
+            continue
+        except Exception as exc:  # noqa: BLE001 — a transport failure is a refusal, never a pass
+            failed.append(f"could not reach the registry for `{item['module']}@{item['version']}`: {exc}")
+            continue
+        published.append(item)
+        # 🚨 AFTER the 2xx, never before: a staged artifact is not a Published ledger record, and a
+        # failed hand-over must not be recorded as one (#3878, repair contract 4).
+        if a.ledger == "required" and item["ledgerKey"] and a.ledger_script:
+            rc = subprocess.run([sys.executable, a.ledger_script, "record", "--key", item["ledgerKey"],
+                                 "--status", "Published"], check=False).returncode
+            if rc != 0:
+                print(f"::warning::the build ledger did not record `{item['module']}` as Published "
+                      f"(exit {rc}); the bundle IS served — the ledger may cost a duplicate build, "
+                      "never a green.")
+
+    lines = ["### Module publication", "",
+             f"Source `{a.source}` → {a.registry}", ""]
+    lines += [f"- `{i['module']}@{i['version']}` — sha256 `{i['sha256'][:16]}…`, framework "
+              f"`{i['identity']}`" for i in published]
+    if failed:
+        lines += ["", "**Refused by the registry:**", ""] + [f"- {f}" for f in failed]
+    summarise(lines)
+    for f in failed:
+        print(f"::error title=Publication failed::{f}", file=sys.stderr)
+    print(f"published {len(published)} of {len(plan)} module bundle(s)")
+    return 1 if failed else 0
+
+
+# ══════════════════════════════════ self-test ══════════════════════════════════
+def self_test() -> int:  # noqa: C901 — a table of cases reads better than a dozen helpers
+    import io
+    import contextlib
+    import tempfile
+
+    failures: list[str] = []
+
+    def check(label: str, ok: bool, detail: str = ""):
+        print(("  ok   " if ok else "  FAIL ") + label + (f" — {detail}" if detail and not ok else ""))
+        if not ok:
+            failures.append(label)
+
+    def run(fn, *args, **kwargs) -> tuple[int, str]:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+            try:
+                rc = fn(*args, **kwargs)
+            except SystemExit as exc:
+                rc = exc.code if isinstance(exc.code, int) else 1
+        return rc, buf.getvalue()
+
+    print("== verdict")
+    green = json.dumps({"validate": {"result": "success"}, "gate": {"result": "success"}})
+    rc, out = run(verdict, green, "validate gate")
+    check("every dependency success publishes", rc == 0, out)
+    for bad in ("failure", "cancelled", "skipped"):
+        rc, out = run(verdict, json.dumps({"validate": {"result": "success"},
+                                           "gate": {"result": bad}}), "validate gate")
+        check(f"a `{bad}` dependency refuses", rc == 1 and "gate" in out, out)
+    rc, out = run(verdict, json.dumps({"validate": {"result": "success"}}), "validate gate")
+    check("a required job MISSING from needs refuses", rc == 1 and "not among" in out.lower() or
+          rc == 1 and "NOT among" in out, out)
+    rc, out = run(verdict, json.dumps({"validate": {}}), "validate")
+    check("a dependency with no readable result refuses", rc == 1, out)
+    rc, out = run(verdict, "{}", "validate")
+    check("an EMPTY needs context refuses", rc == 1, out)
+    rc, out = run(verdict, green, "")
+    check("an empty required-jobs list refuses", rc == 1, out)
+    rc, out = run(verdict, "not json", "validate")
+    check("unreadable verdicts refuse", rc == 1, out)
+
+    print("== check-caller")
+    good_caller = """
+name: ci
+on: { push: { branches: [main] } }
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps: [{ run: echo }]
+  modules:
+    needs: [validate]
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@abc
+  gate:
+    needs: [modules]
+    runs-on: ubuntu-latest
+    steps: [{ run: echo }]
+  publish:
+    needs: [validate, modules, gate]
+    if: github.event_name == 'push'
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-publish.yml@abc
+    with:
+      verdicts: ${{ toJSON(needs) }}
+      required-jobs: validate modules gate
+  summary:
+    needs: [publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps: [{ run: echo }]
+"""
+    with tempfile.TemporaryDirectory() as td:
+        wf = Path(td) / "ci.yml"
+
+        def caller(text: str, required="validate modules gate", unrelated=""):
+            wf.write_text(text, encoding="utf-8")
+            return run(check_caller, wf, "node-repo-module-publish.yml", required, unrelated)
+
+        rc, out = caller(good_caller)
+        check("a caller that waits for its whole graph passes", rc == 0, out)
+
+        # MUTATION 1 — a required dependency dropped from `needs:` (and from nothing else).
+        rc, out = caller(good_caller.replace("needs: [validate, modules, gate]",
+                                             "needs: [validate, modules]"))
+        check("MUTATION: a dropped `needs:` entry is caught", rc == 1 and "gate" in out, out)
+
+        # MUTATION 1b — dropped from BOTH `needs:` and `required-jobs`: invisible at runtime, which
+        # is exactly why this static half exists.
+        rc, out = caller(good_caller.replace("needs: [validate, modules, gate]",
+                                             "needs: [validate, modules]")
+                                    .replace("required-jobs: validate modules gate",
+                                             "required-jobs: validate modules"),
+                         required="validate modules")
+        check("MUTATION: a dependency dropped from needs AND required-jobs is caught",
+              rc == 1 and "still fail AFTER" in out, out)
+
+        # MUTATION 2 — a status function re-opens the door the verdict closes.
+        for expr in ("${{ always() }}", "${{ !cancelled() }}", "${{ success() || failure() }}"):
+            rc, out = caller(good_caller.replace("if: github.event_name == 'push'", f"if: {expr}"))
+            check(f"MUTATION: `if: {expr}` on the publisher is caught", rc == 1 and "status function" in out, out)
+
+        # MUTATION 3 — the caller curates the verdicts instead of handing over the needs context.
+        rc, out = caller(good_caller.replace("verdicts: ${{ toJSON(needs) }}",
+                                             "verdicts: '{\"validate\":{\"result\":\"success\"}}'"))
+        check("MUTATION: a curated `verdicts` literal is caught", rc == 1 and "verbatim" in out, out)
+
+        rc, out = caller(good_caller.replace("    needs: [validate, modules, gate]\n", "", 1)
+                         .replace("required-jobs: validate modules gate", "required-jobs: validate"),
+                         required="validate")
+        check("a publisher with NO needs is caught", rc == 1, out)
+
+        rc, out = caller(good_caller, required="validate modules gate nonesuch")
+        check("a required job the workflow does not have is caught", rc == 1 and "nonesuch" in out, out)
+
+        rc, out = caller(good_caller, unrelated="ghost: retired last year")
+        check("a STALE unrelated-jobs entry is caught", rc == 1 and "ghost" in out, out)
+
+        rc, out = caller(good_caller.replace(
+            "  summary:\n    needs: [publish]\n", "  summary:\n"))
+        check("a job that is neither upstream nor declared unrelated is caught",
+              rc == 1 and "summary" in out, out)
+
+        rc, out = caller(good_caller.replace(
+            "  summary:\n    needs: [publish]\n", "  summary:\n"),
+            unrelated="summary: prints a table, validates no source")
+        check("…and passes once it is DECLARED unrelated with a reason", rc == 0, out)
+
+        rc, out = caller(good_caller.replace(
+            "node-repo-module-publish.yml@abc", "node-repo-tag-modules.yml@abc"))
+        check("a workflow with NO publishing job refuses (empty denominator)", rc == 1, out)
+
+    print("== publish")
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        def bundle(path: Path, module: str, identity: str = "mvid:aaaa"):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(path, "w") as zf:
+                zf.writestr("meshweaver/manifest.json", json.dumps(
+                    {"frameworkMvid": identity, "module": {"assemblyName": module}}))
+
+        def stage(dirname: str, module: str, lane: str = "L1", owed: bool = True,
+                  identity: str = "mvid:aaaa", sha: str | None = None, with_bytes: bool = True,
+                  version: str = "1.2.3"):
+            d = root / dirname
+            d.mkdir(parents=True, exist_ok=True)
+            name = f"{module}.module.nupkg"
+            if with_bytes:
+                bundle(d / name, module, identity)
+            rec = {"lane": lane, "package": module.split(".")[-1], "module": module,
+                   "version": version, "frameworkIdentity": identity, "owed": owed,
+                   "bundle": {"name": name,
+                              "sha256": sha or (sha256_file(d / name) if with_bytes else "0" * 64)},
+                   "ledger": {"key": ""}}
+            if not owed:
+                rec["reason"] = "the build ledger already serves this key"
+            (d / f"{module}.publication.json").write_text(json.dumps(rec), encoding="utf-8")
+            return d
+
+        def args(**kw):
+            base = dict(staged=str(root / "staged"), lane="L1",
+                        declared=json.dumps([{"module": "MeshWeaver.AI"}, {"module": "MeshWeaver.Mcp"}]),
+                        selected="MeshWeaver.AI", registry="https://registry.invalid",
+                        source="Plugins", ledger="off", ledger_script="", dry_run=True)
+            base.update(kw)
+            return argparse.Namespace(**base)
+
+        stage("staged", "MeshWeaver.AI")
+        rc, out = run(publish, args())
+        check("a whole, lane-stamped staged set publishes", rc == 0 and "MeshWeaver.AI@1.2.3" in out, out)
+
+        rc, out = run(publish, args(selected="MeshWeaver.AI MeshWeaver.Mcp"))
+        check("a SELECTED module with no staged record refuses", rc == 1 and "MeshWeaver.Mcp" in out, out)
+
+        stage("foreign", "MeshWeaver.Mcp", lane="L2")
+        rc, out = run(publish, args(staged=str(root / "foreign"), selected="MeshWeaver.Mcp"))
+        check("a FOREIGN-lane record refuses", rc == 1 and "another call" in out, out)
+
+        stage("swapped", "MeshWeaver.AI", sha="f" * 64)
+        rc, out = run(publish, args(staged=str(root / "swapped")))
+        check("SUBSTITUTED bytes refuse", rc == 1 and "not the validated bytes" in out.lower()
+              or rc == 1 and "NOT the validated bytes" in out, out)
+
+        stage("gone", "MeshWeaver.AI", with_bytes=False)
+        rc, out = run(publish, args(staged=str(root / "gone")))
+        check("a record whose bytes are MISSING refuses", rc == 1 and "NOT in" in out, out)
+
+        d = stage("noidentity", "MeshWeaver.AI", identity="")
+        bundle(d / "MeshWeaver.AI.module.nupkg", "MeshWeaver.AI", identity="")
+        rec = json.loads((d / "MeshWeaver.AI.publication.json").read_text())
+        rec["frameworkIdentity"] = "mvid:aaaa"
+        rec["bundle"]["sha256"] = sha256_file(d / "MeshWeaver.AI.module.nupkg")
+        (d / "MeshWeaver.AI.publication.json").write_text(json.dumps(rec), encoding="utf-8")
+        rc, out = run(publish, args(staged=str(d)))
+        check("bytes stating NO framework identity refuse", rc == 1 and "framework identity" in out, out)
+
+        stage("notowed", "MeshWeaver.AI", owed=False)
+        rc, out = run(publish, args(staged=str(root / "notowed")))
+        check("a record that owes no hand-over is accounted for, not published",
+              rc == 0 and "no hand-over owed" in out, out)
+
+        rc, out = run(publish, args(lane=""))
+        check("an EMPTY lane refuses", rc == 1, out)
+        rc, out = run(publish, args(staged=str(root / "never-staged")))
+        check("a missing staged directory refuses when modules WERE selected", rc == 1, out)
+        rc, out = run(publish, args(staged=str(root / "never-staged"), selected=""))
+        check("…but a call whose selection was EMPTY says so and publishes nothing",
+              rc == 0 and "ZERO" in out, out)
+
+        stage("undeclared", "MeshWeaver.Other")
+        rc, out = run(publish, args(staged=str(root / "undeclared"), selected="MeshWeaver.Other"))
+        check("a record outside the declared matrix refuses", rc == 1 and "declared matrix" in out, out)
+
+    print()
+    if failures:
+        print(f"::error::{len(failures)} self-test case(s) FAILED: " + "; ".join(failures))
+        return 1
+    print("module-publication.py self-test: all cases pass")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("command", nargs="?", choices=("verdict", "check-caller", "publish"))
+    p.add_argument("--verdicts", default="")
+    p.add_argument("--required", default="")
+    p.add_argument("--unrelated", default="")
+    p.add_argument("--workflow", default="")
+    p.add_argument("--uses", default="node-repo-module-publish.yml")
+    p.add_argument("--staged", default="")
+    p.add_argument("--lane", default="")
+    p.add_argument("--declared", default="")
+    p.add_argument("--selected", default="")
+    p.add_argument("--registry", default="")
+    p.add_argument("--source", default="")
+    p.add_argument("--ledger", default="off")
+    p.add_argument("--ledger-script", dest="ledger_script", default="")
+    p.add_argument("--dry-run", dest="dry_run", action="store_true")
+    p.add_argument("--self-test", dest="self_test", action="store_true")
+    a = p.parse_args()
+    if a.self_test:
+        return self_test()
+    if not a.command:
+        p.error("a command or --self-test is required")
+    if a.command == "verdict":
+        return verdict(a.verdicts, a.required)
+    if a.command == "check-caller":
+        if not a.workflow:
+            p.error("check-caller needs --workflow")
+        return check_caller(Path(a.workflow), a.uses, a.required, a.unrelated)
+    if a.command == "publish":
+        for needed in ("staged", "registry", "source"):
+            if not getattr(a, needed):
+                p.error(f"publish needs --{needed}")
+        return publish(a)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -213,9 +213,22 @@ def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
 
     if not errors:
         published = sorted(m for m, r in receipts.items() if r.get("published") is True)
-        notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built"
-                     + (f"; {len(published)} published to the registry" if published
-                        else "; nothing published (not a trunk/release run)"))
+        # 🚨 `staged` is a THIRD outcome, and it must not read as either of the other two
+        # (MeshWeaver#3878). Under `publish-mode: staged` the leg POSTed nothing — the bytes went
+        # to the caller's publication lane, which hands over only on a green validation set. Saying
+        # "nothing published" there would be true and misleading; saying "published" would be false.
+        staged = sorted(m for m, r in receipts.items() if r.get("publication") == "staged")
+        if published:
+            notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built; "
+                         f"{len(published)} published to the registry")
+        elif staged:
+            notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built; "
+                         f"{len(staged)} STAGED for the publication lane — nothing has reached the "
+                         "registry yet, and nothing will until every required validation job in "
+                         "the caller's run reports success (MeshWeaver#3878)")
+        else:
+            notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built; "
+                         "nothing published (not a trunk/release run)")
     return (1 if errors else 0), errors, notes
 
 

--- a/.github/scripts/test-module-publication.py
+++ b/.github/scripts/test-module-publication.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""EXECUTE the module publication lane's real steps against a stub registry. No credential, no cloud.
+
+WHY
+---
+MeshWeaver#3878: the module registry hand-over used to run INSIDE `node-repo-module-pack.yml`'s
+matrix leg, right after that module's own suite — while a sibling module's suite, the portal-host
+shards, the NodeType compile-check and the Tests-area gate were still running. A module was being
+served to every installation before the run that produced it had decided whether the source was
+any good, and a red twenty minutes later changed nothing about what portals had adopted.
+
+`node-repo-module-publish.yml` is where the hand-over went. Nothing on a core pull request calls
+it — it is a `workflow_call` lane a satellite invokes — so the first execution of an edit to it
+would otherwise be in a satellite's production publication. This harness executes it here.
+
+BOTH DIRECTIONS, which is the acceptance criterion #3878 states:
+  * green validation → the registry receives the EXACT staged bytes, once, at the right URL;
+  * a later sibling / source failure → the registry receives NOTHING, even though the module was
+    successfully packed and staged.
+
+HOW IT STAYS HONEST
+-------------------
+* The steps are EXTRACTED FROM THE WORKFLOW by their `id:`, never copied here. A copy passes while
+  the real thing rots. A step that cannot be found, or that grew a `${{ }}` expression this
+  harness cannot supply, FAILS the harness rather than reporting a pass for something it did not
+  run.
+* The registry is a real HTTP server on localhost that RECORDS every request. "The registry was
+  left untouched" is read off the request log, never off the script's own exit code.
+* The MUTATIONS are run against the real files: a required dependency removed from the caller's
+  `needs:`, and a status function added to the publishing job's `if:`. Both must be caught. A gate
+  that has never been shown to fire is not a gate.
+* `node-repo-module-pack.yml` is asserted structurally: under `publish-mode: staged` the in-leg
+  hand-over must be unable to fire, and the staging step must be its exact complement. Without
+  MeshWeaver#3878's change these assertions fail — which is the point.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PUBLISH_WORKFLOW = ROOT / ".github/workflows/node-repo-module-publish.yml"
+PACK_WORKFLOW = ROOT / ".github/workflows/node-repo-module-pack.yml"
+
+failures: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = ""):
+    print(("  ok   " if ok else "  FAIL ") + label + (f"\n         {detail}" if detail and not ok else ""))
+    if not ok:
+        failures.append(label)
+
+
+def die(msg: str):
+    print(f"::error::{msg}")
+    sys.exit(1)
+
+
+# ── extraction ──────────────────────────────────────────────────────────────────────────────
+def extract_step(workflow: Path, step_id: str) -> str:
+    import yaml
+
+    if not workflow.is_file():
+        die(f"{workflow} does not exist — the publication lane this harness executes is missing, so "
+            "there is nothing to prove. A harness must never report a pass for a lane it could not "
+            "find (MeshWeaver#3878).")
+    doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and step.get("id") == step_id:
+                body = step.get("run")
+                if not body:
+                    die(f"step id `{step_id}` in {workflow.name} has no `run:` — nothing to execute.")
+                if "${{" in body:
+                    die(f"step id `{step_id}`'s `run:` now contains a ${{{{ }}}} expression, which this "
+                        "harness cannot supply. It refuses to execute a body it would have to "
+                        "rewrite — pass the value through `env:` instead.")
+                return body
+    die(f"no step with `id: {step_id}` in {workflow.name}. It was renamed, moved or deleted — and "
+        "this harness will not report a pass for a step it could not find.")
+    return ""  # unreachable
+
+
+def run_step(body: str, env: dict[str, str], workspace: Path) -> subprocess.CompletedProcess:
+    e = dict(os.environ)
+    e.update(env)
+    e["RUNNER_TEMP"] = str(workspace / "_temp")
+    (workspace / "_temp").mkdir(exist_ok=True)
+    e["GITHUB_STEP_SUMMARY"] = str(workspace / "_temp" / "summary.md")
+    Path(e["GITHUB_STEP_SUMMARY"]).touch()
+    e.setdefault("GITHUB_REPOSITORY", "Systemorph/Acme")
+    e.setdefault("GITHUB_RUN_ID", "1000")
+    # Belt and braces: no live credential may reach a step this harness executes.
+    for cred in ("GH_TOKEN", "GITHUB_TOKEN", "MW_LEDGER_TOKEN"):
+        e[cred] = ""
+    return subprocess.run(["bash", "-c", body], cwd=workspace, env=e,
+                          capture_output=True, text=True)
+
+
+# ── the stub registry ───────────────────────────────────────────────────────────────────────
+class Registry:
+    """Records every request. 'The registry was left untouched' is read off THIS, never off an
+    exit code — an assertion about the absence of a side effect has to observe the side effect."""
+
+    def __init__(self, status: int = 200):
+        self.requests: list[dict] = []
+        self.status = status
+        log = self.requests
+        outer = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length)
+                log.append({"path": self.path, "body": body,
+                            "auth": self.headers.get("Authorization", "")})
+                self.send_response(outer.status)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"ok":true}')
+
+            def log_message(self, *args):  # silence
+                pass
+
+        self.server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self.server.server_port}"
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self.server.shutdown()
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────────────────────
+IDENTITY = "mvid:8f2c19a4b7de4c2f9a1e6b3d5c7f0a12"
+MODULES = [{"package": "AI", "module": "MeshWeaver.AI", "project": "src/MeshWeaver.AI/MeshWeaver.AI.csproj"}]
+LANE = "floor-0123456789ab"
+
+
+def stage_fixture(root: Path, lane: str = LANE, owed: bool = True) -> Path:
+    """What `node-repo-module-pack.yml`'s `stage` step uploads, laid out the way
+    download-artifact@v8 lays a `pattern:` download out: one directory per artifact."""
+    d = root / "staged" / f"module-publication-{lane}-MeshWeaver.AI"
+    d.mkdir(parents=True, exist_ok=True)
+    name = "MeshWeaver.Plugin.AI.3.1.0.module.nupkg"
+    bundle = d / name
+    with zipfile.ZipFile(bundle, "w") as zf:
+        zf.writestr("meshweaver/manifest.json", json.dumps(
+            {"frameworkMvid": IDENTITY,
+             "module": {"assemblyName": "MeshWeaver.AI", "assemblies": ["MeshWeaver.AI.dll"]}}))
+        zf.writestr("meshweaver/modules/MeshWeaver.AI.dll", b"\x4d\x5a" + b"stub" * 64)
+    import hashlib
+    sha = hashlib.sha256(bundle.read_bytes()).hexdigest()
+    (d / "MeshWeaver.AI.publication.json").write_text(json.dumps({
+        "lane": lane, "package": "AI", "module": "MeshWeaver.AI", "version": "3.1.0",
+        "registrySource": "Plugins", "frameworkIdentity": IDENTITY, "owed": owed,
+        "reason": "" if owed else "no hand-over owed: the ledger already serves this key",
+        "bundle": {"name": name, "sha256": sha, "size": bundle.stat().st_size},
+        "ledger": {"key": "", "decision": "build"},
+    }), encoding="utf-8")
+    return root / "staged"
+
+
+def workspace(root: Path) -> Path:
+    """The lane's layout: the platform checkout lives under `meshweaver/`."""
+    ws = root / "ws"
+    ws.mkdir(exist_ok=True)
+    link = ws / "meshweaver"
+    if not link.exists():
+        link.symlink_to(ROOT)
+    return ws
+
+
+CALLER_GOOD = """
+name: ci
+on: { push: { branches: [main] } }
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps: [{ run: echo }]
+  module-pack:
+    needs: [validate]
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@0123456789012345678901234567890123456789
+  compile-check:
+    needs: [module-pack]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps: [{ run: echo }]
+  publish-modules:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [validate, module-pack, compile-check]
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-publish.yml@0123456789012345678901234567890123456789
+    with:
+      verdicts: ${{ toJSON(needs) }}
+      required-jobs: validate module-pack compile-check
+      lane: ${{ needs.module-pack.outputs.lane }}
+      selected: ${{ needs.module-pack.outputs.selected }}
+      modules: '[]'
+      platform-ref: 0123456789012345678901234567890123456789
+"""
+
+
+def main() -> int:  # noqa: C901
+    verdict_body = extract_step(PUBLISH_WORKFLOW, "verdict")
+    caller_body = extract_step(PUBLISH_WORKFLOW, "caller-gate")
+    publish_body = extract_step(PUBLISH_WORKFLOW, "publish")
+    print(f"extracted 3 step(s) from {PUBLISH_WORKFLOW.name}\n")
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = workspace(root)
+        staged = stage_fixture(root)
+        registry = Registry()
+        try:
+            base = {
+                "LANE": LANE, "SELECTED": "MeshWeaver.AI",
+                "DECLARED": json.dumps(MODULES),
+                "REGISTRY": registry.url, "REGISTRY_SOURCE": "Plugins",
+                "LEDGER": "off", "MW_PUBLISH_TOKEN": "tok_test",
+            }
+
+            def do_publish(**over):
+                env = dict(base)
+                env.update(over)
+                # download-artifact@v8 puts the matched artifacts under $RUNNER_TEMP/staged; the
+                # fixture is copied there so the step's own path expression is what resolves it.
+                dest = ws / "_temp" / "staged"
+                if dest.exists():
+                    import shutil
+                    shutil.rmtree(dest)
+                if over.pop("_no_staged", False) is not True:
+                    import shutil
+                    (ws / "_temp").mkdir(exist_ok=True)
+                    shutil.copytree(staged, dest)
+                return run_step(publish_body, env, ws)
+
+            def do_verdict(verdicts: dict, required="validate module-pack compile-check"):
+                return run_step(verdict_body, {"VERDICTS": json.dumps(verdicts), "REQUIRED": required}, ws)
+
+            green = {"validate": {"result": "success"}, "module-pack": {"result": "success"},
+                     "compile-check": {"result": "success"}}
+
+            print("== DIRECTION 1: green validation publishes the exact validated bytes")
+            r = do_verdict(green)
+            check("the verdict step passes on an all-success needs context", r.returncode == 0,
+                  r.stdout + r.stderr)
+            r = do_publish()
+            check("the hand-over step runs and exits 0", r.returncode == 0, r.stdout + r.stderr)
+            check("the registry received exactly ONE request", len(registry.requests) == 1,
+                  json.dumps([q["path"] for q in registry.requests]))
+            if registry.requests:
+                q = registry.requests[0]
+                want = (staged / f"module-publication-{LANE}-MeshWeaver.AI"
+                        / "MeshWeaver.Plugin.AI.3.1.0.module.nupkg").read_bytes()
+                check("…carrying the EXACT staged bytes", q["body"] == want,
+                      f"{len(q['body'])} bytes received, {len(want)} staged")
+                check("…to /api/plugins/bundles/AI with the version and packagePath",
+                      q["path"] == "/api/plugins/bundles/AI?version=3.1.0&packagePath=Plugins/AI",
+                      q["path"])
+                check("…with the publish token as a bearer credential",
+                      q["auth"] == "Bearer tok_test", q["auth"])
+
+            print("\n== DIRECTION 2: a later sibling/source failure leaves the registry untouched")
+            for job, result in (("compile-check", "failure"), ("module-pack", "cancelled"),
+                                ("validate", "skipped")):
+                before = len(registry.requests)
+                ctx = dict(green)
+                ctx[job] = {"result": result}
+                r = do_verdict(ctx)
+                ran_publish = r.returncode == 0
+                check(f"a `{result}` {job} refuses BEFORE the hand-over — and names it",
+                      r.returncode == 1 and job in (r.stdout + r.stderr), r.stdout + r.stderr)
+                # GitHub would not run the later step at all; the harness models that literally.
+                if ran_publish:
+                    do_publish()
+                check(f"…and the registry received nothing more ({result} {job})",
+                      len(registry.requests) == before,
+                      f"{len(registry.requests) - before} extra request(s)")
+
+            before = len(registry.requests)
+            r = do_verdict({"validate": {"result": "success"}, "module-pack": {"result": "success"}})
+            check("a required job MISSING from `needs:` refuses (it never reported at all)",
+                  r.returncode == 1 and "compile-check" in (r.stdout + r.stderr), r.stdout + r.stderr)
+            r = do_verdict(green, required="")
+            check("an EMPTY required-jobs list refuses — it would assert nothing",
+                  r.returncode == 1, r.stdout + r.stderr)
+            r = do_verdict({}, required="validate")
+            check("an EMPTY needs context refuses — a publication that waited for nothing",
+                  r.returncode == 1, r.stdout + r.stderr)
+            check("nothing above reached the registry", len(registry.requests) == before)
+
+            print("\n== The staged evidence must be THIS call's, and unaltered")
+            before = len(registry.requests)
+            r = do_publish(LANE="rest-fedcba987654")
+            check("a FOREIGN lane's staged record refuses", r.returncode == 1,
+                  r.stdout + r.stderr)
+            r = do_publish(SELECTED="MeshWeaver.AI MeshWeaver.Mcp")
+            check("a SELECTED module with no staged record refuses (its leg never staged)",
+                  r.returncode == 1 and "MeshWeaver.Mcp" in (r.stdout + r.stderr), r.stdout + r.stderr)
+            swapped = staged / f"module-publication-{LANE}-MeshWeaver.AI" / "MeshWeaver.Plugin.AI.3.1.0.module.nupkg"
+            keep = swapped.read_bytes()
+            swapped.write_bytes(keep + b"tampered")
+            r = do_publish()
+            check("SUBSTITUTED bytes refuse — the sha256 on the record is the validated one",
+                  r.returncode == 1, r.stdout + r.stderr)
+            swapped.write_bytes(keep)
+            r = do_publish(MW_PUBLISH_TOKEN="")
+            check("an EMPTY publish token FAILS the job rather than publishing nothing quietly",
+                  r.returncode == 1, r.stdout + r.stderr)
+            check("none of those reached the registry", len(registry.requests) == before,
+                  f"{len(registry.requests) - before} extra request(s)")
+
+            print("\n== A registry refusal is a RED, and is not recorded as published")
+            refusing = Registry(status=409)
+            try:
+                r = do_publish(REGISTRY=refusing.url)
+                check("a non-2xx answer fails the job", r.returncode == 1, r.stdout + r.stderr)
+                check("…after actually asking the registry", len(refusing.requests) == 1)
+            finally:
+                refusing.close()
+
+            print("\n== MUTATIONS of the caller's graph (the half the runtime verdict cannot see)")
+            caller_dir = ws / "caller" / ".github" / "workflows"
+            caller_dir.mkdir(parents=True, exist_ok=True)
+            wf = caller_dir / "ci.yml"
+
+            def do_caller(text: str, required="validate module-pack compile-check", unrelated=""):
+                wf.write_text(text, encoding="utf-8")
+                return run_step(caller_body, {
+                    "WORKFLOW_REF": "Systemorph/Acme/.github/workflows/ci.yml@refs/heads/main",
+                    "REQUIRED": required, "UNRELATED": unrelated}, ws)
+
+            r = do_caller(CALLER_GOOD)
+            check("a caller that waits for its whole graph passes", r.returncode == 0,
+                  r.stdout + r.stderr)
+            r = do_caller(CALLER_GOOD.replace("needs: [validate, module-pack, compile-check]",
+                                              "needs: [validate, module-pack]"),
+                          required="validate module-pack")
+            check("MUTATION: a required dependency removed from `needs:` AND `required-jobs` is caught",
+                  r.returncode == 1 and "compile-check" in (r.stdout + r.stderr), r.stdout + r.stderr)
+            r = do_caller(CALLER_GOOD.replace(
+                "if: github.event_name == 'push' && github.ref == 'refs/heads/main'",
+                "if: ${{ !cancelled() }}"))
+            check("MUTATION: a status function on the publishing job's `if:` is caught",
+                  r.returncode == 1 and "status function" in (r.stdout + r.stderr), r.stdout + r.stderr)
+            r = do_caller(CALLER_GOOD.replace("verdicts: ${{ toJSON(needs) }}",
+                                              "verdicts: '{\"validate\":{\"result\":\"success\"}}'"))
+            check("MUTATION: a curated `verdicts` literal is caught", r.returncode == 1,
+                  r.stdout + r.stderr)
+        finally:
+            registry.close()
+
+    print("\n== node-repo-module-pack.yml stages instead of publishing under `publish-mode: staged`")
+    import yaml
+
+    pack = yaml.safe_load(PACK_WORKFLOW.read_text(encoding="utf-8"))
+    inputs = ((pack.get(True) or pack.get("on") or {}).get("workflow_call") or {}).get("inputs") or {}
+    check("the lane declares `publish-mode`", "publish-mode" in inputs)
+    check("…defaulting to `direct`, so an unconverted caller is unchanged",
+          (inputs.get("publish-mode") or {}).get("default") == "direct")
+    outs = ((pack.get(True) or pack.get("on") or {}).get("workflow_call") or {}).get("outputs") or {}
+    check("the lane publishes its `lane` key so one publication can only reach one call's evidence",
+          "lane" in outs)
+    check("…and its `selected` set, so a module that never staged is a NAMED refusal", "selected" in outs)
+
+    steps = {s.get("id") or s.get("name"): s for s in (pack["jobs"]["pack"]["steps"])}
+    handover = steps.get("publish")
+    stage = steps.get("stage")
+    check("the in-leg hand-over still exists (`direct` is untouched)", handover is not None)
+    check("…and cannot fire under `publish-mode: staged`",
+          handover is not None and "publish-mode == 'direct'" in str(handover.get("if")),
+          str(handover.get("if")) if handover else "")
+    check("a staging step exists as its exact complement", stage is not None
+          and "publish-mode == 'staged'" in str(stage.get("if")),
+          str(stage.get("if")) if stage else "")
+    check("…and it stages the SAME bytes the hand-over would have posted",
+          stage is not None and handover is not None
+          and str(stage.get("env", {}).get("BUNDLE")) == str(handover.get("env", {}).get("BUNDLE")))
+    ledger_published = [s for s in pack["jobs"]["pack"]["steps"] if s.get("name") == "Ledger — Published"]
+    check("a staged leg records NO `Published` ledger transition — a staged artifact is not a "
+          "publication", len(ledger_published) == 1
+          and "steps.publish.outcome == 'success'" in str(ledger_published[0].get("if")),
+          str(ledger_published[0].get("if")) if ledger_published else "")
+
+    pub = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+    job = pub["jobs"]["publish"]
+    check("the publication job carries NO `if:` of its own — a caller that weakened its gate is "
+          "caught by the verdict, never skipped past it", "if" not in job)
+    ids = [s.get("id") for s in job["steps"] if s.get("id")]
+    check("the verdict runs before the hand-over", ids.index("verdict") < ids.index("publish"))
+    check("…and so does the caller-graph check", ids.index("caller-gate") < ids.index("publish"))
+
+    print()
+    if failures:
+        print(f"::error::{len(failures)} case(s) FAILED: " + "; ".join(failures))
+        return 1
+    print("test-module-publication: both directions, the staged-evidence refusals, the caller "
+          "mutations and the pack lane's staged arm — all green")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2231,6 +2231,20 @@ jobs:
     - name: "Execute publish-bake-bundles.sh with two publishers on one prefix"
       run: python3 .github/scripts/test-publish-bake-overlap.py
 
+    # The MODULE registry hand-over (MeshWeaver#3878). `node-repo-module-publish.yml` is a
+    # `workflow_call` lane a SATELLITE invokes, so nothing on a core pull request runs it — the
+    # first execution of an edit to it would otherwise be a satellite's production publication,
+    # POSTing bytes to the live registry. Both of these run here, self-test first:
+    #   * the script's own cases — the verdict refusals (failed/skipped/cancelled/missing/unknown),
+    #     the caller-graph mutations, and the staged-evidence refusals;
+    #   * the harness, which EXTRACTS the lane's real steps by `id:` and executes them against a
+    #     stub registry that RECORDS every request — so "the registry was left untouched" is read
+    #     off the request log rather than off an exit code.
+    - name: "The module publication gate can refuse (self-test)"
+      run: python3 .github/scripts/module-publication.py --self-test
+    - name: "Execute the module publication lane against a stub registry"
+      run: python3 .github/scripts/test-module-publication.py
+
     # The gate and publish-bake lanes compose every external module into /ext/<Name>/ for the
     # tester container, and until #3514 they copied `meshweaver/modules/` alone — leaving a module
     # that LOADS and then 404s every static asset it ships (`meshweaver/moduleassets/`), announced

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -48,6 +48,39 @@ name: node-repo module pack
 #             || github.event_name == 'schedule' }}
 #     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
 #
+# ────────── WHERE the hand-over happens: `publish-mode` (MeshWeaver#3878) ──────────
+# 🚨 `publish: true` alone still POSTs from inside the matrix leg, and that is the defect #3878
+# names: the leg publishes right after its OWN suite, while a sibling module's suite, the
+# portal-host shards, the NodeType compile-check and the Tests-area gate are still running or have
+# not started. A red twenty minutes later changes nothing about what portals have already adopted.
+# Making this job `needs:` those gates is a CYCLE — they consume its artifacts.
+#
+# `publish-mode: staged` moves only the POST. The leg builds, uploads, tests and stages exactly the
+# bytes it would have published — plus a record naming them by sha256 and stating the framework
+# identity read back OFF them — as `module-publication-<lane>-<module>`. The caller then runs the
+# publication lane in a job wired to its whole validation set:
+#
+#   module-pack:
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@<pin>
+#     with: { publish: <trunk-only>, publish-mode: staged, … }
+#
+#   publish-modules:
+#     if: <the SAME trunk-only condition — and NO status function: this job runs under GitHub's
+#         default all-needs-succeeded rule or not at all>
+#     needs: [<every required validation job>, module-pack]
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-publish.yml@<pin>
+#     with:
+#       verdicts: ${{ toJSON(needs) }}
+#       required-jobs: <the same list, by name>
+#       lane:     ${{ needs.module-pack.outputs.lane }}
+#       selected: ${{ needs.module-pack.outputs.selected }}
+#       modules:  <the same JSON matrix this call was given>
+#       platform-ref: <the same pin>
+#     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
+#
+# One publication call per pack call: the lane key, the selection and the declared matrix all
+# belong to ONE call, and artifacts are RUN-WIDE (Plugins#1077).
+#
 # ─────────────────────────── Narrowing (the `select` job) ───────────────────────────
 # 🚨 "in plugins we only re-run concerned modules ⇒ we can estimate the required count and
 # validate it" · "all plugins should only re-build what changed" · "there is always a notion of
@@ -93,7 +126,10 @@ name: node-repo module pack
 #
 #   * `publish: true`  — the suite runs INLINE in `pack`, after the bundle upload and BEFORE the
 #     hand-over. That ordering buys exactly one property, and it is worth its cost here: a failing
-#     suite never publishes, and every installation reads what the registry serves.
+#     suite never publishes, and every installation reads what the registry serves. (Under
+#     `publish-mode: staged` the property is unchanged and stronger: the leg reds, so the caller's
+#     `uses:` job reds, so the publication lane's verdict refuses the whole hand-over — this
+#     module's AND its siblings'.)
 #   * `publish: false` — the hand-over step cannot fire at all (its own `if:` is `inputs.publish
 #     && …`), so the ordering protects nothing. The suite runs in the `tests` job, in PARALLEL
 #     with select → prepare → build-workspace → pack, and the lane finishes when the slower of the
@@ -260,6 +296,37 @@ on:
           FrameworkDeclined (#2088). See the caller contract at the top of this file.
         type: boolean
         default: false
+      publish-mode:
+        description: >
+          WHERE the live-registry hand-over happens, when `publish` is true. Both values are
+          printed in the log and the job summary on every run, so the two outcomes can never be
+          told apart only by what is missing.
+
+
+          `direct` — the DEFAULT, and what a caller that says nothing inherits: this leg POSTs the
+          bundle to the registry itself, right after its own suite. 🚨 Its cost is the one
+          MeshWeaver#3878 names: a SIBLING module's suite, the portal-host shards, the NodeType
+          compile-check and the Tests-area gate all run beside or after this leg, so the module is
+          already being served to every installation while the run is still deciding whether the
+          source is any good. Making this job `needs:` those gates is a cycle — they consume its
+          artifacts.
+
+
+          `staged` — this leg packs, uploads, tests and STAGES: the bytes it would have POSTed,
+          plus a publication record naming them by sha256 and stating the framework identity read
+          back off them, go up as `module-publication-<lane>-<module>`. Nothing reaches the
+          registry here. The caller then runs `node-repo-module-publish.yml` in a job that
+          `needs:` its whole validation set, and THAT lane hands over — refusing on any dependency
+          that failed, was skipped, was cancelled or is missing. A leg that owes no hand-over
+          (the build ledger already serves its key) stages a record saying so, so "not owed" and
+          "never staged" are distinguishable there.
+
+
+          Any other value — the empty string included — is RED. A flag that cannot be read must
+          never resolve to "publish anyway", and must never resolve to "publish nothing" either.
+        required: false
+        type: string
+        default: direct
       always-modules:
         description: >
           Comma-separated module names (entry assembly names from `modules`) that the caller's
@@ -499,6 +566,21 @@ on:
           bundles built`) still asserts the receipts AND the pack job's result, so a failed suite
           keeps the lane red wherever the lane itself is required.
         value: ${{ jobs.verify.outputs.bundles-built }}
+      lane:
+        description: >
+          THIS call's lane key — the artifact namespace every marker, receipt and staged
+          publication of this call is named with and stamped with. A caller wiring
+          `node-repo-module-publish.yml` (publish-mode: staged) passes it there, so the
+          publication can only ever reach evidence THIS call produced (artifacts are run-wide;
+          Plugins#1077). Empty when `select` did not succeed — and the publication lane refuses an
+          empty lane rather than falling back to a name-only match.
+        value: ${{ jobs.select.outputs.lane }}
+      selected:
+        description: >
+          The module names this call SELECTED, space-separated — the same list `verify` accounts
+          the receipts against. The publication lane requires a staged record for every one of
+          them, so "its leg never staged" cannot read like "there was nothing to stage".
+        value: ${{ jobs.select.outputs.selected }}
 
 jobs:
   # ─────────────────────── WHICH BUNDLES THIS DIFF CAN REACH ───────────────────────
@@ -542,6 +624,33 @@ jobs:
       # construction — there is no input a caller can forget. It is also stamped INTO every
       # marker and receipt this call drops, so the verifier can refuse a foreign lane's evidence
       # even if the names ever collide again.
+      # 🚨 READ THE FLAG FIRST, AND REFUSE AN UNREADABLE ONE. `publish-mode` decides whether this
+      # call's legs POST to the live registry or stage for the downstream publication lane
+      # (MeshWeaver#3878) — and a value neither arm recognises must never fall through to either.
+      # Falling through to `direct` would publish before the source verdict, which is the defect;
+      # falling through to `staged` would publish nothing at all while every step ticked green.
+      - name: Read the publication mode
+        env:
+          MODE: ${{ inputs.publish-mode }}
+          PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+          case "$MODE" in
+            direct|staged) ;;
+            *) echo "::error::inputs.publish-mode is '$MODE'. The only values are 'direct' (the default — this lane POSTs the bundle itself) and 'staged' (this lane stages the bytes and node-repo-module-publish.yml hands them over after the full source verdict, MeshWeaver#3878). A flag that cannot be read must NEVER resolve to either arm."; exit 1 ;;
+          esac
+          if [ "$PUBLISH" != "true" ]; then
+            echo "publish: false — no hand-over on this run, in either mode (publish-mode: $MODE)."
+          elif [ "$MODE" = "staged" ]; then
+            echo "publish-mode: staged — every leg stages its bundle as module-publication-<lane>-<module>; the registry hears nothing until the caller's node-repo-module-publish.yml job runs on a green validation set."
+          else
+            echo "publish-mode: direct — every leg POSTs its own bundle to the registry, BEFORE the run's sibling suites and gates have reported (MeshWeaver#3878)."
+          fi
+          {
+            echo "### Publication mode"
+            echo
+            echo "\`publish: $PUBLISH\`, \`publish-mode: $MODE\`."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: This call's lane key
         id: lane
         env:
@@ -2322,9 +2431,18 @@ jobs:
       # `need_publish`: the caller's `publish` AND, with the ledger on, "no earlier run published this
       # key" — a key the registry already serves at these bytes is not re-handed (Plugins#889: a push
       # publishes every module whose key has no Published record, and only those).
+      #
+      # 🚨 `publish-mode: direct` ONLY. This is the hand-over MeshWeaver#3878 moves: it fires while
+      # the run's sibling suites, the portal-host shards, the NodeType compile-check and the
+      # Tests-area gate are still running or have not started, so a red twenty minutes later
+      # changes nothing about what portals have already adopted. Under `staged` the two steps below
+      # take these exact bytes to the publication lane instead, and this step does not run — the
+      # two arms are mutually exclusive by construction, and the staged record RECORDS which arm
+      # owned the hand-over, so a bundle whose publication belongs to neither is not possible to
+      # produce quietly.
       - name: Hand the bundle to the registry
         id: publish
-        if: ${{ inputs.publish && steps.plan.outputs.need_publish == 'true' }}
+        if: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' }}
         env:
           TOKEN: ${{ secrets.publish-token }}
           REGISTRY: ${{ inputs.registry-url }}
@@ -2386,6 +2504,88 @@ jobs:
           set -euo pipefail
           python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Published
 
+      # ═════════ THE STAGED HAND-OVER — `publish-mode: staged` (MeshWeaver#3878) ═════════
+      # 🚨 The exact COMPLEMENT of the hand-over above, on the same input. Under `staged` this leg
+      # publishes NOTHING: it writes down what it WOULD have published — the bytes, named by their
+      # sha256, and the framework identity read back OFF those bytes — and takes both to the
+      # caller's `node-repo-module-publish.yml` job, which `needs:` the whole validation set. The
+      # registry hears nothing until every sibling suite, the portal-host shards, the compile-check
+      # and the Tests-area gate have reported `success`.
+      #
+      # 🚨 EVERY LEG STAGES, INCLUDING ONE THAT OWES NOTHING. A leg whose key the build ledger
+      # already serves has no hand-over to make — and if it simply staged nothing, "the registry
+      # already has these bytes" and "this leg never got here" would be the same absence at the
+      # publication lane. So it stages a record that SAYS so, with the reason, and the publication
+      # lane accounts for it instead of missing it. Same rule as the receipt below: positive
+      # evidence, never an inference from what is not there.
+      #
+      # 🚨 And NO ledger transition here. A staged artifact is not a `Published` record (#3878,
+      # repair contract 4): the ledger learns of a publication only from the lane that got a 2xx
+      # out of the registry, so a run that stages and then fails validation leaves a key that a
+      # later run will republish rather than one the fleet believes is already served.
+      - name: Stage the bundle for the publication lane
+        id: stage
+        if: ${{ inputs.publish && inputs.publish-mode == 'staged' }}
+        env:
+          LANE: ${{ needs.select.outputs.lane }}
+          PACKAGE: ${{ matrix.entry.package }}
+          MODULE: ${{ matrix.entry.module }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          REGISTRY_SOURCE: ${{ inputs.registry-source }}
+          OWED: ${{ steps.plan.outputs.need_publish }}
+          DECISION: ${{ steps.plan.outputs.decision }}
+          HOLDER: ${{ steps.plan.outputs.holder }}
+          LEDGER_KEY: ${{ steps.plan.outputs.key }}
+          # The same expression the receipt and the direct hand-over use: the build leg's packed
+          # bundle, or the artifact the reuse leg downloaded and sha256-verified against the ledger.
+          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/staged"
+          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so this staged publication could not be attributed to this call and the publication lane would refuse it anyway. Failing here, where it is readable."; exit 1; }
+          [ -n "${BUNDLE:-}" ] || { echo "::error::this leg produced no bundle path — neither the build nor the reuse leg recorded one, so there are no bytes to stage for $MODULE and none to read its framework identity off."; exit 1; }
+          # THE IDENTITY, OFF THE BYTES — never from a step output. The packer's exit code, the
+          # inspection's tick and the value inside the artifact are three different claims, and the
+          # publication lane compares this record against the THIRD one before it POSTs.
+          if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
+            echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to stage bytes whose manifest this lane could not check (#3211)"
+            exit 1
+          fi
+          identity="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
+          [ -n "$identity" ] || { echo "::error::REFUSING to stage $MODULE@$VERSION — the bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')). A registry that shelves a null advertises a null, and every consumer answers 'already landed — the identity could not be checked' on every reconcile, for ever (#3154/#3211). Repack with the platform's MeshWeaver.Compiler.dll as --graph-dll; if these bytes were REUSED, that run packed them before the identity was recorded — rebuild them."; exit 1; }
+          name="$(basename "$BUNDLE")"
+          sha="$(sha256sum "$BUNDLE" | cut -d' ' -f1)"
+          reason=""
+          if [ "$OWED" = "true" ]; then
+            cp "$BUNDLE" "$RUNNER_TEMP/staged/$name"
+            echo "staged $MODULE@$VERSION ($name, sha256 $sha, built against $identity) — the publication lane hands it over once this run's validation is green"
+          else
+            reason="no hand-over owed: the module build ledger already serves this key (decision '$DECISION'${HOLDER:+, holder $HOLDER})"
+            echo "staged $MODULE@$VERSION as NOT OWED — $reason"
+          fi
+          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" --arg v "$VERSION" \
+                --arg src "$REGISTRY_SOURCE" --arg fid "$identity" --arg n "$name" --arg s "$sha" \
+                --arg r "$reason" --arg lk "$LEDGER_KEY" --arg d "$DECISION" \
+                --argjson owed "$([ "$OWED" = "true" ] && echo true || echo false)" \
+                --argjson size "$(wc -c < "$BUNDLE" | tr -d ' ')" \
+             '{lane:$l, package:$p, module:$m, version:$v, registrySource:$src,
+               frameworkIdentity:$fid, owed:$owed, reason:$r,
+               bundle:{name:$n, sha256:$s, size:$size},
+               ledger:{key:$lk, decision:$d}}' \
+             > "$RUNNER_TEMP/staged/$MODULE.publication.json"
+          cat "$RUNNER_TEMP/staged/$MODULE.publication.json"
+      - name: Upload the staged publication
+        if: ${{ inputs.publish && inputs.publish-mode == 'staged' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-publication-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
+          path: ${{ runner.temp }}/staged
+          retention-days: 1
+          # An upload that found nothing means this leg staged nothing while reporting success —
+          # the publication lane would then name a SELECTED module with no record, which is the
+          # right verdict but the wrong place to discover it. Fail here, where the cause is.
+          if-no-files-found: error
+
       # ───────── THE LEDGER'S VERDICT WHEN THIS LEG DID NOT GET HERE — never a reason for red ─────────
       # `failure()`: the phase is read off the step outcomes, so the record says WHERE it failed and the
       # tolerance rule (compile blocks; a test failure blocks from the 2nd attempt; pack/publish never)
@@ -2402,6 +2602,10 @@ jobs:
           INSPECT_OUTCOME: ${{ steps.bundle.outcome }}
           TESTS_OUTCOME: ${{ steps.tests.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          # A staging failure is a PUBLISH-phase failure: the bytes exist and are tested, and what
+          # did not happen is the hand-over. Recording it as `pack` would tell a later run to
+          # rebuild something that is already built (MeshWeaver#3878).
+          STAGE_OUTCOME: ${{ steps.stage.outcome }}
           MODE: ${{ matrix.entry.build || 'sdk' }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
@@ -2410,12 +2614,12 @@ jobs:
           set -uo pipefail
           phase="pack"
           if   [ "$TESTS_OUTCOME" = "failure" ]; then phase="test"
-          elif [ "$PUBLISH_OUTCOME" = "failure" ]; then phase="publish"
+          elif [ "$PUBLISH_OUTCOME" = "failure" ] || [ "$STAGE_OUTCOME" = "failure" ]; then phase="publish"
           elif [ "$BUILD_OUTCOME" = "failure" ] && [ "$MODE" = "sdk" ]; then phase="compile"
           elif [ "$BUILD_OUTCOME" = "failure" ] || [ "$PACK_OUTCOME" = "failure" ] || [ "$INSPECT_OUTCOME" = "failure" ] || [ "$REUSED_OUTCOME" = "failure" ]; then phase="pack"
           fi
-          printf 'step outcomes — build:%s reused:%s pack:%s inspect:%s tests:%s publish:%s (%s)\n' \
-            "$BUILD_OUTCOME" "$REUSED_OUTCOME" "$PACK_OUTCOME" "$INSPECT_OUTCOME" "$TESTS_OUTCOME" "$PUBLISH_OUTCOME" "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$RUNNER_TEMP/failure.txt"
+          printf 'step outcomes — build:%s reused:%s pack:%s inspect:%s tests:%s publish:%s stage:%s (%s)\n' \
+            "$BUILD_OUTCOME" "$REUSED_OUTCOME" "$PACK_OUTCOME" "$INSPECT_OUTCOME" "$TESTS_OUTCOME" "$PUBLISH_OUTCOME" "$STAGE_OUTCOME" "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$RUNNER_TEMP/failure.txt"
           trx="$RUNNER_TEMP/trx/ledger.trx"
           trxarg=()
           if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
@@ -2449,7 +2653,18 @@ jobs:
           MODULE: ${{ matrix.entry.module }}
           VERSION: ${{ steps.identity.outputs.version }}
           COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
-          PUBLISHED: ${{ inputs.publish }}
+          # 🚨 "THIS LEG POSTED THE BUNDLE", not "this call was asked to publish". Under
+          # `publish-mode: staged` nothing reached the registry from here, and a receipt saying
+          # otherwise would make the lane's own report ("N published to the registry") a claim
+          # about something that has not happened yet.
+          PUBLISHED: ${{ inputs.publish && inputs.publish-mode == 'direct' }}
+          # 🚨 WHICH ARM OWNED THIS LEG'S HAND-OVER, written down rather than inferred from an
+          # `if:` nobody can read after the fact — the same discipline as `TESTS` below. `direct`:
+          # this leg POSTed the bundle itself. `staged`: it staged the bytes for the caller's
+          # publication lane, which hands over after the full source verdict (MeshWeaver#3878).
+          # `none`: this call does not publish at all. Two mutually exclusive conditions can BOTH
+          # be false; this is what makes that impossible to do quietly.
+          PUBLICATION: ${{ !inputs.publish && 'none' || inputs.publish-mode }}
           # 🚨 WHICH LANE OWNS THIS MODULE'S SUITE, written down rather than inferred from an `if:`
           # nobody can read after the fact. `none` — the selection says this entry owes no test run
           # (a floor-only entry, or a ledger record that already carries a verdict); `inline` — the
@@ -2471,6 +2686,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/receipts"
           [ -n "$LANE" ]  || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call."; exit 1; }
           [ -n "$TESTS" ] || { echo "::error::this leg recorded no owner for $MODULE's suite — a receipt that cannot say whether the suite ran here, ran in the tests lane, or was not owed leaves 'it ran nowhere' reading as green."; exit 1; }
+          [ -n "$PUBLICATION" ] || { echo "::error::this leg recorded no owner for $MODULE's hand-over — a receipt that cannot say whether the bundle was POSTed here, staged for the publication lane, or not published at all leaves 'it reached the registry from nowhere' reading as green (MeshWeaver#3878)."; exit 1; }
           # ───────── THE FRAMEWORK IDENTITY THIS BUNDLE STATES, ON THE RECEIPT (#3310) ─────────
           # 🚨 THE ONLY EVIDENCE THAT LETS `verify` SEE THE OUTCOME. #3293 and #3306 made the anchor
           # correct and their guards assert the lane's TEXT and the anchor's LOCATION — neither can
@@ -2491,10 +2707,10 @@ jobs:
           echo "$MODULE states framework identity $IDENTITY"
           jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
                 --arg v "$VERSION" --arg c "$COMPILER" --arg t "$TESTS" \
-                --argjson pub "$PUBLISHED" \
+                --argjson pub "$PUBLISHED" --arg pm "$PUBLICATION" \
                 --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
                 --arg fid "$IDENTITY" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}}' \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, publication:$pm, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}}' \
              > "$RUNNER_TEMP/receipts/$MODULE.json"
           cat "$RUNNER_TEMP/receipts/$MODULE.json"
       - name: Upload the receipt

--- a/.github/workflows/node-repo-module-publish.yml
+++ b/.github/workflows/node-repo-module-publish.yml
@@ -1,0 +1,283 @@
+name: node-repo module publish
+
+# THE MODULE REGISTRY HAND-OVER — downstream of the FULL source validation verdict.
+#
+# 🚨 WHY THIS IS A LANE OF ITS OWN (MeshWeaver#3878; requirement 3 of #3842, "a red or cancelled
+# source build must not become visible to portals").
+#
+# `node-repo-module-pack.yml` used to POST every module bundle to the live registry from INSIDE
+# its own matrix leg, immediately after that module's own suite. Everything else that validates
+# the source — a SIBLING module's suite, the portal-host shards, the NodeType compile-check, the
+# Tests-area gate — runs beside or after that leg. So a module was being served to every
+# installation while the run that produced it was still deciding whether the source was any good,
+# and a red twenty minutes later changed nothing about what portals had already adopted.
+#
+# Adding those gates to the pack job's `needs:` is not available: they CONSUME the pack lane's
+# artifacts (`modules-floor` is an input to compile-check and to the Tests-area gate), so the edge
+# is a cycle. The repair is therefore a MOVE, not a re-ordering:
+#
+#   pack (unchanged, same point in the run)      this lane (after everything)
+#   ─────────────────────────────────────       ────────────────────────────────────────
+#   build → upload artifact → built marker      verdict: every dependency reported `success`
+#   → tests → STAGE the bytes + a record        caller gate: the caller really waits for them
+#   → receipt                                   → validate the staged set → hand over → ledger
+#
+# Everything a downstream gate consumes still exists at exactly the moment it did before; only
+# the POST moved. `bundles-built`, the built markers, the receipts and the module suites are
+# untouched.
+#
+# ─────────────────────────── The no-skip-trapdoor posture ───────────────────────────
+# A hand-over that completes before its inputs are validated is the same defect class as a gate
+# that skips on missing input: "it did not run" and "it passed" must never be indistinguishable
+# (AGENTS.md). So this lane never asks whether something happens to be set, and it never lets an
+# absent answer read as a positive one:
+#
+#   * `verdicts` is `${{ toJSON(needs) }}` — the whole context, verbatim. FAILED, SKIPPED,
+#     CANCELLED, MISSING and UNKNOWN are each a refusal that NAMES the job and what it said. An
+#     empty needs context is a refusal too: a publication that waited for nothing is the defect.
+#   * The caller's own workflow file is read at the caller's commit and its graph is checked —
+#     the publishing job must transitively `needs:` every job it declares required, must carry no
+#     status function in its `if:` (`always()`/`!cancelled()` re-open the door the verdict closes),
+#     and must account for every OTHER job in the workflow: upstream, downstream, or named in
+#     `unrelated-jobs` with a reason. That is the half the runtime verdict cannot see — a
+#     dependency dropped from `needs:` AND from `required-jobs` is invisible at run time.
+#   * The staged set is matched against the SELECTION before one byte is POSTed: exactly one
+#     record per selected module, stamped with THIS call's lane, naming the bytes by sha256 and
+#     the framework identity read back off those bytes. Missing, foreign-lane or substituted
+#     evidence refuses the WHOLE publication — the registry is left untouched, never half-served.
+#   * A staged artifact is NOT a `Published` ledger record. The ledger transition is written after
+#     the registry's 2xx and never before, so a failed hand-over cannot be recorded as published.
+#
+# ─────────────────────────── Caller contract ───────────────────────────
+#   publish-modules:
+#     # Trunk-only, exactly like the pack call's `publish:` input — and NO status function: this
+#     # job must run under GitHub's default rule (every `needs:` succeeded) or not at all.
+#     if: >
+#       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+#       github.event_name == 'repository_dispatch' || github.event_name == 'schedule'
+#     needs: [preflight, validate, repo-gates, compile-check, test-repos, tests-ratchet,
+#             portal-hosts-gate, modules-floor, modules-rest]
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-publish.yml@<pin>
+#     with:
+#       verdicts: ${{ toJSON(needs) }}
+#       required-jobs: preflight validate repo-gates compile-check test-repos tests-ratchet portal-hosts-gate modules-floor
+#       lane:     ${{ needs.modules-floor.outputs.lane }}
+#       selected: ${{ needs.modules-floor.outputs.selected }}
+#       modules:  ${{ ... the same JSON the modules-floor call was given ... }}
+#       platform-ref: ${{ needs.platform-ref.outputs.sha }}
+#     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
+#
+# One call per pack call: the lane, the selection and the declared matrix all belong to ONE call
+# of the pack workflow (Plugins runs two — floor and rest), and mixing them would be exactly the
+# run-wide-artifact confusion the lane key exists to prevent (Plugins#1077).
+#
+# WHAT IS NOT IN SCOPE HERE, and must not be described as solved by it (#3878): atomic visibility
+# if the publication ITSELF fails or is cancelled part-way, every publisher's source provenance,
+# and last-green source selection remain #3842 and #3461. Core's own main-CD publishes a NodeType
+# and module set through `plugins-bake`; that separate path is untouched by this lane.
+
+on:
+  workflow_call:
+    inputs:
+      verdicts:
+        description: >
+          `${{ toJSON(needs) }}` — the calling job's WHOLE needs context, verbatim. Every entry
+          must carry `result: success`; anything else, and anything missing, refuses the
+          publication by name. A curated literal is refused by the caller gate: the point is to
+          read what GitHub computed, not what the caller chose to say.
+        required: true
+        type: string
+      required-jobs:
+        description: >
+          The validation jobs whose positive verdict entitles this run to publish, space- or
+          comma-separated. Each must exist in the caller's workflow AND be a (transitive)
+          dependency of the publishing job. An empty list is RED — it would assert nothing.
+        required: true
+        type: string
+      unrelated-jobs:
+        description: >
+          `name: reason` per line, for the caller's jobs that validate no source and therefore
+          need not precede the publication (an auto-merge armer, a summary job). Every job in the
+          caller's workflow that is neither upstream nor downstream of the publishing job must be
+          declared here — an omission is RED and names the job, so "we forgot it" and "it does not
+          matter" can never look the same. A name the workflow no longer has is RED too.
+        required: false
+        type: string
+        default: ''
+      lane:
+        description: >
+          The lane key of the pack call whose bundles this publishes — `needs.<pack
+          call>.outputs.lane`. Artifacts are RUN-WIDE and a repo may call the pack lane twice in
+          one run, so this is what makes the staged evidence attributable to ONE validated call.
+          Empty is RED.
+        required: true
+        type: string
+      selected:
+        description: >
+          The module names that pack call SELECTED (`needs.<pack call>.outputs.selected`). Every
+          one of them must have a staged publication record; a selected module with no record is
+          RED, because "its leg never staged" must not read like "there was nothing to stage".
+        required: true
+        type: string
+      modules:
+        description: >
+          The same JSON matrix the pack call was given. Used to set aside — and NAME — a staged
+          record from a call this publication does not speak for.
+        required: true
+        type: string
+      platform-ref:
+        description: The Systemorph/MeshWeaver commit this lane's scripts are fetched at (a pin, not a branch).
+        required: true
+        type: string
+      registry-url:
+        description: The registry that will serve these bundles onward.
+        required: false
+        type: string
+        default: https://memex.meshweaver.cloud
+      registry-source:
+        description: >
+          The registry SOURCE these packages belong to ("Plugins", "Education", …) — it stamps the
+          landed entry's packagePath, which is the key every PluginGrant and the bundle index match
+          on. An unstamped landing is servable to nobody.
+        required: false
+        type: string
+        default: Plugins
+      ledger:
+        description: >
+          `required` — record `Published` in the CI module build ledger after each accepted
+          hand-over (pass the same value the pack call was given, and the same `ledger-token`).
+          `off` — the default. Anything else is RED.
+        required: false
+        type: string
+        default: off
+    secrets:
+      publish-token:
+        description: >
+          The registry's Plugins:Registry:PublishToken. ASSERTED when a hand-over is owed — an
+          empty token fails the job rather than publishing nothing quietly.
+        required: false
+      ledger-token:
+        description: A `mw_` ApiToken of the registry portal's CI user for the module build ledger.
+        required: false
+
+jobs:
+  publish:
+    name: Hand the validated bundles to the registry
+    runs-on: ubuntu-latest
+    # A LITERAL, never an input: the fleet cap is 45 minutes for every job in every workflow
+    # (check-workflow-timeouts.py). This lane downloads a few megabytes and POSTs them.
+    timeout-minutes: 20
+    # 🚨 NO `if:` HERE, deliberately. The caller's job carries the trunk-only condition; this job
+    # must run whenever that one does, so that a caller who weakened its own gate is CAUGHT by the
+    # verdict step rather than quietly skipped past it.
+    permissions:
+      contents: read
+    steps:
+      - name: Check out Systemorph/MeshWeaver at the pinned ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: meshweaver
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Assert the tools this lane needs
+        env:
+          PLATFORM_REF: ${{ inputs.platform-ref }}
+        run: |
+          set -euo pipefail
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
+          head -c 400 meshweaver/.github/scripts/module-publication.py | grep -q "module-publication" \
+            || { echo "::error::meshweaver/.github/scripts/module-publication.py at ${PLATFORM_REF} does not look like the publisher"; exit 1; }
+
+      # 🚨 THE GATE ITSELF IS PROVEN BEFORE IT JUDGES ANYTHING. An unproven gate is no gate: every
+      # refusal below must be shown to FIRE on its defect and stay SILENT on its fix before its
+      # verdict on this run means anything. Same posture as check-workflow-shell.py's self-test.
+      - name: Prove the publication gate can refuse (self-test)
+        run: python3 meshweaver/.github/scripts/module-publication.py --self-test
+
+      # ─────────────── 1. THE VERDICT — before a token is read, before a byte moves ───────────────
+      - name: Every required validation job reported success
+        id: verdict
+        env:
+          VERDICTS: ${{ inputs.verdicts }}
+          REQUIRED: ${{ inputs.required-jobs }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$VERDICTS" > "$RUNNER_TEMP/verdicts.json"
+          python3 meshweaver/.github/scripts/module-publication.py verdict \
+            --verdicts "@$RUNNER_TEMP/verdicts.json" --required "$REQUIRED"
+
+      # ─────────────── 2. THE CALLER'S GRAPH — the half the verdict cannot see ───────────────
+      # A dependency dropped from `needs:` alone is caught above (its name is still in
+      # `required-jobs`, and a required job absent from the needs context is a refusal). A
+      # dependency dropped from BOTH is invisible at run time — so the caller's own workflow file
+      # is read, at the caller's commit, and its graph is asserted. `github.workflow_ref` names the
+      # top-level workflow of this run, which is the one that called this lane.
+      - name: Check out the caller's workflow at the commit being published
+        uses: actions/checkout@v7
+        with:
+          path: caller
+          persist-credentials: false
+      - name: The caller really waits for the validation set
+        id: caller-gate
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          REQUIRED: ${{ inputs.required-jobs }}
+          UNRELATED: ${{ inputs.unrelated-jobs }}
+        run: |
+          set -euo pipefail
+          # Systemorph/Repo/.github/workflows/ci.yml@refs/heads/main -> .github/workflows/ci.yml
+          path="${WORKFLOW_REF%@*}"
+          path="${path#*/}"; path="${path#*/}"
+          [ -n "$path" ] || { echo "::error::github.workflow_ref ('$WORKFLOW_REF') does not name a workflow file — this check cannot run, so it must not pass"; exit 1; }
+          echo "caller workflow: $path"
+          python3 meshweaver/.github/scripts/module-publication.py check-caller \
+            --workflow "caller/$path" \
+            --uses node-repo-module-publish.yml \
+            --required "$REQUIRED" --unrelated "$UNRELATED"
+
+      # ─────────────── 3. THE STAGED EVIDENCE ───────────────
+      # 🚨 SCOPED TO THIS CALL'S LANE, and `continue-on-error` is on the DOWNLOAD alone for one
+      # reason: a pattern that matches nothing must REACH the checker as zero evidence, which is a
+      # named refusal there, instead of dying here with "no artifacts found" and no module names.
+      # The step immediately after judges the result unconditionally — that is what keeps this from
+      # being a skip-trapdoor (`verify` in the pack lane collects its receipts the same way).
+      - name: Collect this call's staged publications
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: module-publication-${{ inputs.lane }}-*
+          path: ${{ runner.temp }}/staged
+
+      # ─────────────── 4. THE HAND-OVER ───────────────
+      - name: Hand the validated bundles to the registry
+        id: publish
+        env:
+          MW_PUBLISH_TOKEN: ${{ secrets.publish-token }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ inputs.lane }}
+          LANE: ${{ inputs.lane }}
+          SELECTED: ${{ inputs.selected }}
+          DECLARED: ${{ inputs.modules }}
+          REGISTRY: ${{ inputs.registry-url }}
+          REGISTRY_SOURCE: ${{ inputs.registry-source }}
+          LEDGER: ${{ inputs.ledger }}
+        run: |
+          set -euo pipefail
+          case "$LEDGER" in
+            off|required) ;;
+            *) echo "::error::inputs.ledger is '$LEDGER'. The only values are 'off' (the default) and 'required'."; exit 1 ;;
+          esac
+          printf '%s' "$DECLARED" > "$RUNNER_TEMP/declared.json"
+          python3 meshweaver/.github/scripts/module-publication.py publish \
+            --staged "$RUNNER_TEMP/staged" \
+            --lane "$LANE" \
+            --selected "$SELECTED" \
+            --declared "@$RUNNER_TEMP/declared.json" \
+            --registry "$REGISTRY" \
+            --source "$REGISTRY_SOURCE" \
+            --ledger "$LEDGER" \
+            --ledger-script meshweaver/.github/scripts/module-build-ledger.py

--- a/.github/workflows/node-repo-module-publish.yml
+++ b/.github/workflows/node-repo-module-publish.yml
@@ -79,12 +79,18 @@ name: node-repo module publish
 on:
   workflow_call:
     inputs:
+      # 🚨 NO `${{ … }}` IN A DESCRIPTION, here or in any other workflow_call metadata. GitHub
+      # evaluates expressions in these strings, `needs` is not a context that exists at workflow
+      # level, and the file is then INVALID — which for a reusable workflow means every caller
+      # reds. It does not announce itself either: the push produces one run named after the file
+      # path, `conclusion: failure`, with ZERO jobs and no log (measured on this file, run
+      # 34443383838). Write the expression without the braces, as below.
       verdicts:
         description: >
-          `${{ toJSON(needs) }}` — the calling job's WHOLE needs context, verbatim. Every entry
-          must carry `result: success`; anything else, and anything missing, refuses the
-          publication by name. A curated literal is refused by the caller gate: the point is to
-          read what GitHub computed, not what the caller chose to say.
+          The calling job's WHOLE needs context, verbatim — pass `toJSON(needs)` wrapped in the
+          usual expression braces. Every entry must carry `result: success`; anything else, and
+          anything missing, refuses the publication by name. A curated literal is refused by the
+          caller gate: the point is to read what GitHub computed, not what the caller chose to say.
         required: true
         type: string
       required-jobs:

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -272,6 +272,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [The Module Identity Anchor](ModuleIdentityAnchor)
 - [Module-Owned Siblings Ride](ModuleOwnedSiblingsRide)
 - [The Module Platform Link Gate](ModulePlatformLinkGate)
+- [The Module Publication Gate](ModulePublicationGate) — a bundle used to reach the live registry from inside its own pack leg, before the sibling suites, the portal-host shards, the compile-check and the Tests-area gate had reported; the hand-over moved downstream of the full source verdict, and what it refuses (failed, skipped, cancelled, missing, foreign-lane, substituted)
 - [Module Set Convergence](ModuleSetConvergence)
 - [Module Versioning](ModuleVersioning)
 - [Modules](Modules)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -906,8 +906,16 @@ producer of the same publication and is removed — a follow-up, not part of thi
 * **Self-hosted runners with a mounted git mirror + warm image store** (MeshWeaver#2926): bare
   mirror volume, `git worktree add` per run at the release ref, worktree deleted at job end.
 
+* **The hand-over waits for the full source verdict** — landed with MeshWeaver#3878. The POST to
+  the live registry moved out of the pack leg (where it fired while the run's sibling suites, the
+  portal-host shards, the NodeType compile-check and the Tests-area gate had not reported) into
+  `node-repo-module-publish.yml`, downstream of the caller's whole validation set. `pack` stages
+  under `publish-mode: staged` and everything a downstream gate consumes stays exactly where it
+  was — see [ModulePublicationGate](../ModulePublicationGate).
+
 See also: [ModuleClosureAccounting](../ModuleClosureAccounting) ·
 [ModuleOwnedSiblingsRide](../ModuleOwnedSiblingsRide) ·
+[ModulePublicationGate](../ModulePublicationGate) ·
 [ModuleVersioning](../ModuleVersioning) ·
 [NodeTypeCompilation](../NodeTypeCompilation) · [PluginBuildContract](../PluginBuildContract) ·
 [BuildProcess](../BuildProcess) · [InMeshBuildAndTest](../InMeshBuildAndTest).

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePublicationGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePublicationGate.md
@@ -1,0 +1,150 @@
+---
+Name: The Module Publication Gate
+Category: Architecture
+Description: A module bundle used to reach the live registry from inside its own pack leg, before the run's sibling suites, the portal-host shards, the NodeType compile-check and the Tests-area gate had reported. Why the fix is a MOVE and not a re-ordering, what the downstream publication lane refuses, and which halves of it a runtime verdict cannot see.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v6"/><path d="m9 5 3-3 3 3"/><rect x="3" y="8" width="18" height="6" rx="1"/><path d="M7 14v3a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-3"/><circle cx="12" cy="20" r="2"/></svg>
+---
+
+# The Module Publication Gate
+
+**A module bundle becomes visible to every installation the moment it is handed to the registry.
+So the hand-over may not happen until the run that produced it has finished deciding whether the
+source was any good.**
+
+Until MeshWeaver#3878 it did. `node-repo-module-pack.yml` POSTed each bundle from INSIDE its own
+matrix leg, immediately after that module's own suite — and everything else that validates the
+source runs beside or after that leg.
+
+## What the ordering actually was
+
+```
+ t=0                                                                              t=39 min
+ │ select → prepare → build-workspace                                                    │
+ │        ├─ pack (MeshWeaver.AI)     build → upload → tests → POST to the registry ◀── here
+ │        ├─ pack (MeshWeaver.Mcp)    build → upload → tests → POST                      │
+ │        └─ …                                                                           │
+ │ compile-check (every NodeType)          ────────────────────────────────▶ verdict     │
+ │ test-repos (the Tests-area gate)        ────────────────────────────────▶ verdict     │
+ │ portal-hosts (shards)                   ────────────────────────────────▶ verdict     │
+```
+
+The POST marked `◀── here` lands while three of the four validation lanes have not reported. A red
+twenty minutes later changes nothing about what portals have already adopted: a registry serves what
+it holds, and `ModuleUpdateDecision` on every installation reconciles against exactly that.
+
+## Why it is a MOVE, not a re-ordering
+
+The obvious repair — make `pack` depend on the gates — is not available. `modules-floor`'s bundle
+artifacts are the INPUT to `compile-check` and to the Tests-area gate, so the edge would close a
+cycle. Everything a downstream gate consumes has to keep existing at the moment it exists today.
+
+So only the POST moves:
+
+| | before | after |
+|---|---|---|
+| build, bundle upload, built marker | in `pack` | **unchanged, same point in the run** |
+| the module's own suite | in `pack` (publishing runs) | **unchanged** |
+| `bundles-built`, receipts, the identity checks | in `pack` / `verify` | **unchanged** |
+| the POST to the registry | in `pack` | in `node-repo-module-publish.yml`, downstream of everything |
+
+`publish-mode: staged` on the pack call is the switch. The leg writes down what it WOULD have
+published — the bytes, plus a record naming them by sha256 and stating the framework identity read
+back OFF those bytes — as `module-publication-<lane>-<module>`. The caller then runs the publication
+lane in a job wired to its whole validation set. `publish-mode: direct` is the default and is the
+behaviour every unconverted caller keeps.
+
+## What the publication lane refuses
+
+The house rule this sits next to is the one about gates: *"it did not run" and "it passed" must
+never be indistinguishable*. A hand-over that completes before its inputs are validated is the same
+defect class. So nothing in this lane asks whether something happens to be set, and no absent
+answer resolves to a positive one.
+
+### 1 · The verdict
+
+`verdicts: ${{ toJSON(needs) }}` — the calling job's whole needs context, verbatim. Every entry must
+carry `result: success`. Each of these is a refusal that NAMES the job and what it actually said:
+
+| what the dependency said | why it is refused |
+|---|---|
+| `failure` | the source validation reached a negative verdict |
+| `cancelled` | it reached none at all |
+| `skipped` | **the trap this exists for** — GitHub paints a skipped job with the same tick as a passed one |
+| absent from the context | a job named in `required-jobs` that is not in `needs:` never reported |
+| present with no readable `result` | a verdict this lane cannot read must never resolve to "it passed" |
+| an EMPTY needs context | a publication that waited for nothing is the defect, not the base case |
+| an EMPTY `required-jobs` | "every required job passed" would be vacuously true |
+
+### 2 · The caller's graph
+
+The verdict cannot see one mutation: a dependency removed from `needs:` **and** from
+`required-jobs` is invisible at run time — there is nothing left to be missing. So the lane checks
+out the caller's own repository at the commit being published, finds the job that calls it (via
+`github.workflow_ref`) and asserts its shape:
+
+* every `required-jobs` entry exists and is a transitive `needs:` ancestor;
+* the `if:` carries **no status function** — `always()`, `!cancelled()`, `success() || failure()`
+  each re-open the door the verdict closes, and a publishing job runs under GitHub's default
+  all-needs-succeeded rule or not at all. Gating the EVENT (trunk-only) is what an `if:` is for;
+* `verdicts` is the literal `${{ toJSON(needs) }}` — a curated object literal would let the caller
+  answer the verdict question with a value it chose;
+* no `continue-on-error`;
+* **every other job in the caller's workflow** is either upstream of the publication, downstream of
+  it, or named in `unrelated-jobs` with a reason. An omission is red and names the job, so "we
+  forgot it" and "it does not matter" cannot look the same. A `unrelated-jobs` entry the workflow no
+  longer has is red too — a stale exemption hides the job that replaced it.
+
+### 3 · The staged evidence
+
+Validated in full BEFORE one byte is POSTed, so a refusal leaves the registry untouched rather than
+half-served:
+
+* exactly one publication record per module, stamped with **this call's lane key**. Artifacts are
+  run-wide and a repo may call the pack lane twice in one run (Plugins: floor + rest), so a
+  foreign-lane record is set aside and named — the same failure `bundles-built` was fixed for;
+* every module in the pack call's own `selected` output has a record. A selected module with no
+  record is red: *its leg never staged* must not read like *there was nothing to stage*;
+* a record that owes no hand-over (the build ledger already serves the key) says so, with the
+  reason — so "not owed" and "never staged" stay distinguishable;
+* the bytes are re-hashed and compared to the sha256 on the record; the manifest's `frameworkMvid`
+  is read back out of the zip and compared to the identity the record states; the manifest's
+  `module.assemblyName` must be the module. Substituted, truncated or identity-less bytes refuse;
+* an empty publish token FAILS the job rather than publishing nothing quietly.
+
+### 4 · The ledger
+
+A staged artifact is **not** a `Published` ledger record. The `Published` transition is written only
+after the registry answers 2xx, and only by the lane that got that answer — so a run that stages and
+then fails validation leaves a key a later run will republish, rather than one the fleet believes is
+already served. Reuse and coalescing are otherwise untouched: see
+[Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture).
+
+## How the gate is proven
+
+`node-repo-module-publish.yml` is a `workflow_call` lane a satellite invokes; nothing on a core pull
+request runs it, so the first execution of an edit to it would otherwise be a satellite's production
+publication. Two things run in core CI instead, self-test first:
+
+* `module-publication.py --self-test` — the refusals above, each shown to fire on its defect and
+  stay silent on its fix, including the two mutations #3878 names: a required dependency removed
+  from the caller's `needs:`, and a status function added to the publishing job's `if:`.
+* `test-module-publication.py` — the harness EXTRACTS the lane's real steps by `id:` (never a copy;
+  a step it cannot find fails the harness) and executes them against a stub registry that RECORDS
+  every request. Both directions are asserted: a green validation set delivers the exact staged
+  bytes to `/api/plugins/bundles/<package>?version=…&packagePath=…`, and a later sibling failure
+  leaves the request log EMPTY even though the module packed and staged successfully. "The registry
+  was left untouched" is read off the log, never off an exit code.
+
+## What this does NOT solve
+
+Stated because #3878 says it must not be described as solved by moving one step:
+
+* **atomic visibility if the publication itself fails or is cancelled part-way** — the lane
+  validates the whole set before it POSTs, but the POSTs are still per module;
+* **every publisher's source provenance**, and **last-green source selection** — MeshWeaver#3842
+  and the generation work in #3461;
+* **core's own `plugins-bake`**, which publishes a NodeType and module set through a separate path.
+
+Related: [The Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) for the other family of
+"green here, red there" couplings, and [Reading CI Signals](/Doc/Architecture/ReadingCiSignals) for
+why a skipped required context counts as satisfied.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-module-bundles-wait-for-the-full-build-verdict.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-module-bundles-wait-for-the-full-build-verdict.md
@@ -1,0 +1,24 @@
+---
+Name: Module bundles wait for the full build verdict
+Category: Fix
+Description: A module bundle is no longer handed to the registry until every validation job in the run that produced it has reported success, so a build that goes red later cannot leave a module already served to installations.
+Icon: ShieldCheckmark
+Order: -20260910
+---
+
+# Module bundles wait for the full build verdict
+
+A module bundle used to be handed to the plugin registry from inside its own build step, right
+after that module's own tests. The rest of the run — the other modules' suites, the portal host
+tests, the node-type compilation check and the content gate — was still running or had not started.
+A failure in any of those changed nothing about the bundle: it was already being served, and every
+installation reconciling against the registry could adopt it.
+
+The hand-over now happens in its own step at the end of the run, and only when every required
+validation job has reported success. A job that failed, was cancelled, was skipped, or never
+reported at all each stops the hand-over and says which one it was — so a build that goes red for
+any reason leaves the registry exactly as it was.
+
+The bundles are still built, tested and made available to the rest of the run at the same moment
+they always were; only the publication moved. Nothing about how installations receive an already
+published module changes.


### PR DESCRIPTION
Fixes part of #3878. **Do not merge on green without a maintainer call** — see *What is still owed* below; the issue itself stays open until the Plugins caller adopts the lane and a production publication has been verified (requirement 6).

## The defect

`node-repo-module-pack.yml` POSTed each module bundle to the live registry from **inside its own matrix leg**, immediately after that module's own suite. Everything else that validates the source runs beside or after that leg:

```
 │ pack (MeshWeaver.AI)   build → upload → tests → POST to the registry ◀── here
 │ compile-check (every NodeType)   ──────────────────────────▶ verdict
 │ test-repos (Tests-area gate)     ──────────────────────────▶ verdict
 │ portal-hosts (shards)            ──────────────────────────▶ verdict
```

A red twenty minutes later changes nothing about what portals have already adopted. Making `pack` `needs:` those gates is not available — `modules-floor`'s artifacts are their **input**, so the edge closes a cycle.

## The repair: only the POST moves

| | before | after |
|---|---|---|
| build, bundle upload, built marker | in `pack` | **unchanged, same point in the run** |
| the module's own suite | in `pack` | **unchanged** |
| `bundles-built`, receipts, identity checks | `pack` / `verify` | **unchanged** |
| the POST to the registry | in `pack` | `node-repo-module-publish.yml`, downstream of everything |

* **`publish-mode`** (new pack input; `direct` is the default, so every unconverted caller is byte-for-byte unchanged). Under `staged`, the leg writes down what it would have published — the bytes plus a record naming them by sha256 and stating the framework identity read back **off** those bytes — as `module-publication-<lane>-<module>`. A leg that owes no hand-over (the ledger already serves its key) stages a record **saying so, with the reason**, so *not owed* and *never staged* stay distinguishable. An unreadable `publish-mode` is RED in `select`, never a fall-through to either arm.
* **New workflow outputs `lane` and `selected`**, so one publication can only reach one pack call's evidence (artifacts are run-wide — Plugins#1077).
* **`node-repo-module-publish.yml`** (new reusable lane) does the hand-over in a job the caller wires `needs:` on its whole validation set.

## What the publication lane refuses

Same house rule as a gate that may not skip on missing input: *"it did not run" and "it passed" must never be indistinguishable*.

**1 · the verdict** — `verdicts: ${{ toJSON(needs) }}`, the whole context verbatim. `failure`, `cancelled`, `skipped`, a `required-jobs` name **absent** from the context, a result it cannot read, an **empty** needs context and an **empty** `required-jobs` are each a refusal that names the job and what it said.

**2 · the caller's graph** — the half a runtime verdict cannot see: a dependency dropped from `needs:` *and* from `required-jobs` leaves nothing to be missing. So the lane checks out the caller's repo at the commit being published, finds its own calling job via `github.workflow_ref`, and asserts: `required-jobs` ⊆ transitive `needs:`; **no status function** in the `if:` (`always()` / `!cancelled()` / `success() || failure()` re-open the door the verdict closes — the `if:` may gate the *event*, nothing else); `verdicts` is the literal expression, not a curated one; no `continue-on-error`; and **every other job** in the caller's workflow is upstream, downstream, or declared in `unrelated-jobs` with a reason (a stale entry is RED too).

**3 · the staged evidence**, validated in full **before one byte is POSTed** so a refusal leaves the registry untouched rather than half-served: one record per selected module, stamped with **this call's lane**; every module in the pack call's own `selected` output has a record (*its leg never staged* must not read like *there was nothing to stage*); bytes re-hashed against the record; `frameworkMvid` read back out of the zip and compared; `module.assemblyName` must be the module; an empty publish token **fails** the job.

**4 · the ledger** — a staged artifact is **not** a `Published` record. The transition is written only after the registry answers 2xx, by the lane that got that answer, so a run that stages and then fails validation leaves a key a later run republishes.

## The control (a test that fails without the fix)

* `module-publication.py --self-test` — 33 cases, each shown to fire on its defect and stay silent on its fix, including the two mutations #3878 names by name: **a required dependency removed from the caller's `needs:`** (and the harder variant, removed from `needs:` *and* `required-jobs`), and **a status function added to the publishing job's `if:`**.
* `test-module-publication.py` — **extracts the lane's real steps by `id:`** (never a copy; a step it cannot find fails the harness) and executes them against a stub registry that **records every request**. Both directions per requirement 5: a green validation set delivers the exact staged bytes to `/api/plugins/bundles/AI?version=3.1.0&packagePath=Plugins/AI`; a later sibling/source failure leaves the request log **empty** even though the module packed and staged successfully. "The registry was left untouched" is read off the log, never off an exit code.

Verified by reverting, in this worktree:

| control | result |
|---|---|
| the publication lane deleted | `::error:: … the publication lane this harness executes is missing`, exit 1 |
| `node-repo-module-pack.yml` restored to `main` (publishes in-leg) | **7 cases FAIL** — `publish-mode` absent, `lane`/`selected` outputs absent, the hand-over's `if:` still `${{ inputs.publish && … }}` with no `direct` arm, no staging step |
| both restored | all cases green |

Also run: `check-workflow-timeouts` (84 jobs, 0 violations), `check-workflow-yaml-keys`, `check-workflow-shell`, `check-pr-secret-preflight`, `check-abbreviated-shas`, `node-repo-pack-verify.py --self-test`, and `MeshWeaver.Documentation.Test` — `dotnet build -c Release -warnaserror` clean (`0 Warning(s), 0 Error(s)`), **368 passed** including `DocumentationLinkIntegrityTest` and `ArchitectureTopicMapTest`.

## What is still owed (explicitly NOT solved here)

Stated because #3878 says this must not be described as solved by moving one step:

* **the Plugins caller adoption** — a paired PR in `Systemorph/MeshWeaver.Plugins` setting `publish-mode: staged` on `modules-floor`/`modules-rest` and adding the `publish-modules` job wired to its validation set. Core lands first (this is the mechanism); the issue closes when that has merged and a production publication has been verified.
* **atomic visibility if the publication itself fails or is cancelled part-way**, **every publisher's source provenance**, and **last-green source selection** — #3842 and #3461.
* **core's own `plugins-bake`**, which publishes a NodeType/module set through a separate path.

Doc (conserved work product): `Doc/Architecture/ModulePublicationGate`, linked from `ModuleBuildArchitecture` and the Architecture index; What's New entry `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
