### PR TITLE
Record the mounted-source fingerprint contract, with the control #3881 deferred (#3880)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -320,6 +320,48 @@ The file-level diff is available with **no extra fetch**: the installed side is 
 the install record (`InstalledFiles`, written by `WriteInstalledRecord`), and the candidate side
 rides in on the catalog entry (`ManifestFiles`, kept when the source parses `manifest.lock`).
 
+### 🚨 A manifest-less package advertises its SNAPSHOT REF — so the ref must be content-derived (#3880)
+
+The comparison above needs a `moduleVersion`, and a package that ships no `manifest.lock` has none.
+Both the card and the install then fall back to `PackageManifest.Version`, which
+`NodeRepoPackageSource.ListPackages` takes from the snapshot's `CommitSha`:
+
+> no `manifest.lock` ⇒ the source's **snapshot ref** *is* the module's content identity
+
+For a repo fetched over git that ref is a real commit sha, so content identity comes for free. A
+**mounted working tree** has no commit to read — the local checkout a `memex-local` self-registry
+serves, and the tree a `LocalCheckout` source reconciles on every boot — so
+`PackageSources.LocalDirectoryFetch` synthesises the ref, and whatever it hashes *is* that identity.
+
+It hashed each file's relative path and its `FileInfo.Length`. Any edit preserving the byte count —
+`ABC` → `DEF` in a Markdown page, a PNG swapped for another of the same size — left the advertised
+version identical, so the catalog card read "up to date" and the boot reconcile short-circuited.
+The portal quietly stopped mirroring the tree it exists to mirror. Nothing was logged, because from
+every consumer's point of view "nothing changed" was correctly derived from the evidence it was
+given.
+
+The fingerprint now hashes the bytes the snapshot actually returns (`RepoFile.Bytes` — already read
+to build the payload, so there is no second filesystem read), keeping the `local-<sha>` ref format,
+the dot-directory skip and the declared-release-version precedence.
+
+Verified by reverting the fix under `LocalSourceContentVersionTest` (2026-09-10): with the
+length-only hash restored, both the Markdown and the PNG case fail with
+
+```text
+Did not expect value to be "local-26ab574df588" because a mounted source version must
+identify its content, including equal-length edits.
+```
+
+and both pass with the content hash, while the unchanged-tree and `.git`-only controls hold either
+way — so the test discriminates rather than merely passing.
+
+**The general rule: a fingerprint that gates adoption is computed over the bytes it certifies, never
+over metadata that merely correlates with them.** Length and mtime are both preserved by an ordinary
+edit, so neither is evidence of equal content. It is the same reason
+[`PartitionSourceFingerprint`](/Doc/Architecture/StaticRepoImport) hashes serialised node content for
+an unversioned partition instead of a version number, and why `ModuleLandingService.GenerationIdOf`
+appends each file's bytes and not only its length.
+
 ## 🚨 Reminder by default; unattended on opt-in — seeded per deployment
 
 The **platform default is explicit opt-in**: a changed module raises a `Notification` satellite on


### PR DESCRIPTION
Closes #3880.

The code fix for #3880 already merged as #3881, which deliberately left the issue open: *"Keep #3880 open until publication and affected mounted-source behavior are verified."* This PR carries that verification and commits the finding, which until now lived only in a What's New blurb and a PR body.

## What was actually wrong

`PackageSources.LocalDirectoryFetch` built a mounted checkout's snapshot ref from each file's relative path and `FileInfo.Length`. That ref is not cosmetic: a package with no `manifest.lock` has no `moduleVersion`, so both `CatalogLayoutAreas` comparisons fall back to `PackageManifest.Version`, which `NodeRepoPackageSource.ListPackages` takes from the snapshot's `CommitSha`. A repo fetched over git supplies a real commit sha there; a **mounted working tree has no commit to read**, so the synthesised ref *is* the module's content identity.

So any edit preserving the byte count left the advertised version identical — the catalog card read "up to date" and the boot reconcile short-circuited. The portal quietly stopped mirroring the tree it exists to mirror, with nothing logged, because every consumer derived "nothing changed" correctly from the evidence it was given.

## Verification (the part #3881 deferred)

Control run against `LocalSourceContentVersionTest`, Release, this worktree:

| src/ state | result |
|---|---|
| fix reverted (`FileInfo.Length` hash restored) | **2 failed**, exit 1 |
| fix present | **2 passed** |

Failing assertion text, both parameterisations:

```text
MeshWeaver.Reactive.Assertions.AssertionException : Did not expect value to be
"local-26ab574df588" because a mounted source version must identify its content,
including equal-length edits.      (fileName: "Page.md")

... "local-4f2ae79a74bf" ...                                (fileName: "icon.png")
```

The unchanged-tree and dot-directory controls hold in **both** directions, so the test discriminates rather than merely passing — it is not vacuous.

Affected mounted-source behaviour, with the fix in place: **21 passed / 0 failed / 0 skipped** across `LocalSourceContentVersionTest`, `MountedCheckoutReassertsOnEveryBootTest`, `LocalCheckoutPredicateTest`, `UndeclaredCatalogFormatIsDetectedTest` and `InstallTimePrebuiltAdoptionTest`. Documentation guards: **368 passed / 0 failed**, including `DocumentationLinkIntegrityTest`. Both touched projects build `-c Release -warnaserror` with `0 Warning(s), 0 Error(s)`.

## Sweep for the same defect shape

Checked every other fingerprint on this path; none repeats it. `ModuleLandingService.GenerationIdOf` appends each file's bytes (the length is only injective framing), and `PartitionSourceFingerprint` / `NodeTypeSourceFingerprint` hash serialised node content. The page states the general rule so the next one is recognisable: **a fingerprint that gates adoption is computed over the bytes it certifies, never over metadata that merely correlates with them.**

No What's New entry — #3881 already shipped one (`Category: Fix`) for this fix, and a docs-only change adds no user-visible behaviour of its own. Docs-only diff: no public surface removed, no interface member added, no i18n catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
