### PR TITLE
Type the existing snapshot by the node's own identity, never the proposal's (#3803)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md
@@ -64,21 +64,26 @@ proposal's CLR type is the type of the content the node is moving **to**; it say
 snapshot the node is moving **from**.
 
 **Typing the snapshot by it is not recovery, it is manufacture — and `System.Text.Json` makes the
-manufacture silent.** The hub options set `UnmappedMemberHandling = Skip`, so the old node's bytes
-deserialise *cleanly* into the new type whenever the new type's members are present or defaultable.
-Two records that merely share a member name are enough:
+manufacture silent.** The hub options set `UnmappedMemberHandling = Skip`, so the old content
+deserialises *cleanly* into the new type whenever the new type's members are present or defaultable.
+
+The sharpest case needs no degraded JSON at all, because a `$type` discriminator is a **package-local
+name**: `As` recovers a foreign runtime type exactly when `value.GetType().Name == type.Name`, and one
+customer repo ships `Currency` in four packages (see `IMeshContentTypeRegistry`). So two packages that
+each declare a `PackageContent` are enough, with both types registered and nothing degraded anywhere:
 
 ```text
-stored   {"title":"Original","sequence":5}     (NodeType A, content record A(Title, Sequence))
-proposed A(Title, Reason) → B(Title, Reason)   (NodeType B, content record B(Title, Reason))
-manufactured existing     B("Original", null)  ← a state the node was never in
+stored    RetypeFrom.PackageContent("Original", 5)     (NodeType A, registered, reads back typed)
+proposed  RetypeTo.PackageContent("Retyped", "…")      (NodeType B, registered)
+                     ↓ short names match, so As round-trips it
+manufactured existing RetypeTo.PackageContent("Original", null)   ← a state the node was never in
 ```
 
 Nothing throws, nothing logs, and the validator's `ExistingNode.Content is B e && Node.Content is B
 p && …` now *succeeds* — against a ghost, with `Sequence` dropped and `Reason` defaulted. Where the
-conversion instead throws, `As` returns null, the snapshot stays untyped and the typed comparison
-skips: the #3056 silent pass all over again, this time with a `JsonException` in the log. That is
-issue #3803; the first report saw the loud half, and the silent half is the worse one.
+conversion instead throws, or where the two names differ, `As` returns null and the snapshot is left
+as it was. That is issue #3803; the first report saw the loud half, and the silent half is the worse
+one.
 
 **So the pipeline gates the recovery on the NodeType being unchanged** (`RetypesTheNode` requires
 BOTH sides to name a type — a proposal that omits `NodeType` is not changing it, and reading
@@ -93,12 +98,21 @@ plus a late re-type wait for a content type that is not registered yet. A snapsh
 the time the update pipeline sees it is untyped because nothing in the process can type it. The
 honest outcome is to say so, not to invent an answer.
 
-`UpdateRetypeExistingContentTest` (MeshWeaver.Graph.Test) pins both halves: a retype must never hand
-a validator an existing content of the *proposed* type, and an update that keeps the NodeType must
-still get the #3056 recovery. Its probe node is created with content already in the degraded shape
-(a bare `JsonElement`, no `$type`) — the monolith rig does not produce that state by itself, because
-a create hands the store a live CLR instance and the same process reads it straight back, so the
-typing step is never reached at all.
+`UpdateRetypeExistingContentTest` (MeshWeaver.Graph.Test) pins all three halves: a retype must never
+hand a validator an existing content of the *proposed* type; an update that keeps the NodeType must
+still get the #3056 recovery; and the exact NodeType-keyed recovery must still run upstream, which
+is **measured** rather than asserted from a code read — the probe stores bytes carrying no `$type`
+under a NodeType that declares its content type, so a typed result can only have come from
+`TryRecoverForNodeType`.
+
+🚨 **Its fixture is the cross-package collision, not unreadable JSON, and that distinction is
+enforced.** An earlier revision seeded discriminator-less bytes under a NodeType that declared no
+content type; that node was never resolvable, so `check-untyped-content.sh` redded the shard at
+teardown — correctly, because *content nothing can read* is a different defect, and that gate has no
+allow-list by design. Seeding a live, REGISTERED value of a foreign same-short-named type reproduces
+this defect through the mechanism a running mesh actually produces, degrades nothing, and leaves the
+gate with nothing to report. If you are modelling "present but unreadable as `T`" anywhere, that is
+the shape to reach for.
 
 ## What this does not change
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md
@@ -1,7 +1,7 @@
 ---
 Name: Update Validators See Typed Content
 Category: Architecture
-Description: An update validator compares the existing node with the proposed one, so the pipeline owes it both sides typed alike. How a hub used to learn content types by accident, how #3056 removed that accident, and why the update pipeline now types the existing snapshot off the proposal's own CLR type.
+Description: An update validator compares the existing node with the proposed one, so the pipeline owes it both sides typed alike. How a hub used to learn content types by accident, how #3056 removed that accident, why the update pipeline types the existing snapshot off the proposal's own CLR type — and why an in-place NodeType change is the one case where it must not.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg>
 ---
 
@@ -54,6 +54,52 @@ content type registered on no hub, records the CLR type the validator actually s
 refusal. It exists in core because the test that found the hole runs only in MeshWeaver.Plugins —
 the cross-repo blind spot that let #3056 merge green.
 
+## 🚨 "Same NodeType" is a precondition, not an aside
+
+The paragraph above states the premise the recovery rests on — *same node, same NodeType*. **An
+in-place NodeType change is exactly where it is false, and that is a supported operation**: renaming
+a node's type is the sanctioned repair for a mistyped node (`DanglingNodeTypeUpdateTest` exists to
+keep that route open, because `patch` refuses `nodeType` outright). On such an update the
+proposal's CLR type is the type of the content the node is moving **to**; it says nothing about the
+snapshot the node is moving **from**.
+
+**Typing the snapshot by it is not recovery, it is manufacture — and `System.Text.Json` makes the
+manufacture silent.** The hub options set `UnmappedMemberHandling = Skip`, so the old node's bytes
+deserialise *cleanly* into the new type whenever the new type's members are present or defaultable.
+Two records that merely share a member name are enough:
+
+```text
+stored   {"title":"Original","sequence":5}     (NodeType A, content record A(Title, Sequence))
+proposed A(Title, Reason) → B(Title, Reason)   (NodeType B, content record B(Title, Reason))
+manufactured existing     B("Original", null)  ← a state the node was never in
+```
+
+Nothing throws, nothing logs, and the validator's `ExistingNode.Content is B e && Node.Content is B
+p && …` now *succeeds* — against a ghost, with `Sequence` dropped and `Reason` defaulted. Where the
+conversion instead throws, `As` returns null, the snapshot stays untyped and the typed comparison
+skips: the #3056 silent pass all over again, this time with a `JsonException` in the log. That is
+issue #3803; the first report saw the loud half, and the silent half is the worse one.
+
+**So the pipeline gates the recovery on the NodeType being unchanged** (`RetypesTheNode` requires
+BOTH sides to name a type — a proposal that omits `NodeType` is not changing it, and reading
+"absent" as "changed" would route ordinary partial updates down the no-recovery branch and reopen
+#3056 wholesale). On a retype the snapshot is left exactly as it arrived, and when it is untyped the
+pipeline logs a Warning naming both NodeTypes and saying that validators will see that side untyped.
+
+**And there is nothing else the pipeline could do.** `MeshNodeStreamExtensions.EnsureTypedContent`
+runs on **every** emission of the stream this snapshot came from, and it already offers the exact
+recovery — `IMeshContentTypeRegistry.TryRecoverForNodeType`, keyed on the node's **own** NodeType —
+plus a late re-type wait for a content type that is not registered yet. A snapshot still untyped by
+the time the update pipeline sees it is untyped because nothing in the process can type it. The
+honest outcome is to say so, not to invent an answer.
+
+`UpdateRetypeExistingContentTest` (MeshWeaver.Graph.Test) pins both halves: a retype must never hand
+a validator an existing content of the *proposed* type, and an update that keeps the NodeType must
+still get the #3056 recovery. Its probe node is created with content already in the degraded shape
+(a bare `JsonElement`, no `$type`) — the monolith rig does not produce that state by itself, because
+a create hands the store a live CLR instance and the same process reads it straight back, so the
+typing step is never reached at all.
+
 ## What this does not change
 
 - A validator should still read payloads through `.As<T>()` / `.ContentAs<T>()` rather than a cast
@@ -64,3 +110,6 @@ the cross-repo blind spot that let #3056 merge green.
 - No registry is mutated on the read path. `As` deliberately deserialises to the concrete type
   without adopting it, so a same-named type from another collectible assembly cannot poison the
   running hub's `$type` resolution.
+- A retype is still allowed to land. The gate changes what the validators are *shown*, never
+  whether the update is accepted — a validator that wants to refuse a retype refuses it on the
+  NodeType, which both sides always carry.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-changing-a-nodes-type-no-longer-shows-validators-a-node-that-never-existed.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-changing-a-nodes-type-no-longer-shows-validators-a-node-that-never-existed.md
@@ -1,0 +1,42 @@
+---
+Name: Changing a node's type no longer shows validators a node that never existed
+Category: Fix
+Description: An update that changes a node's NodeType used to hand its validators an "existing" content built by reading the node's old bytes as the NEW type — a well-formed record of a state the node was never in. The update pipeline now types the existing snapshot only while the NodeType is unchanged, and says so in the log when it cannot type it at all.
+Icon: ShieldCheckmark
+Order: -20260910
+---
+
+# Changing a node's type no longer shows validators a node that never existed
+
+Renaming a node's type in place is a supported repair — `patch` refuses `nodeType` outright, so a
+full `update` is the only way to fix a node that carries the wrong one. Before this change, that
+repair quietly corrupted what the update's own validators were looking at.
+
+The update pipeline gives validators the existing node and the proposed one **typed alike**, so a
+check written as "the proposed version must not be lower than the existing one" can actually compare
+them. It did that by deserialising the existing snapshot as the *proposed* content's type — correct,
+and stated as such in the code, **while the NodeType is the same**. On a retype it is not: the
+proposal's type describes what the node is moving *to*.
+
+Because the platform's JSON reader skips members it does not recognise, that conversion usually
+**succeeded**. A node stored as `{"title":"Original","sequence":5}` retyped towards a record with
+`Title` and `Reason` came out as `("Original", null)`: a perfectly well-formed value of the new type,
+carrying the old title, silently dropping `sequence`, and inventing a `null` `Reason`. Nothing threw
+and nothing was logged. Validators then compared the proposal against that ghost and answered on it.
+Where the shapes did not line up the conversion threw instead, the snapshot stayed untyped, and every
+typed comparison skipped its own check and answered *valid* — a refusal that never happened.
+
+**Now the pipeline types the existing snapshot only when the NodeType is unchanged.** On a retype it
+hands validators the snapshot exactly as it read it, and when that snapshot is untyped it logs a
+warning naming both NodeTypes, the node, and the fact that a typed comparison on that side will skip.
+Nothing else about the update changes: the retype still lands, and a validator that wants to refuse
+one refuses it on the NodeType, which both sides always carry.
+
+There is nothing better the pipeline could offer, and that is the point: by the time it sees the
+snapshot, the node-stream read has already tried the exact recovery — the mesh-wide content-type
+registry, keyed on the node's **own** NodeType — and has an outstanding wait for that type to become
+known. A snapshot still untyped at this point is untyped because nothing in the process can type it.
+Saying so is worth more than inventing an answer.
+
+The full mechanism, including the case that made the wrong conversion silent, is in
+[Update Validators See Typed Content](/Doc/Architecture/UpdateValidatorsSeeTypedContent).

--- a/src/MeshWeaver.Hosting/NodeUpdatePipeline.cs
+++ b/src/MeshWeaver.Hosting/NodeUpdatePipeline.cs
@@ -145,17 +145,69 @@ internal static class NodeUpdatePipeline
     // consumer, done once for every validator instead of being each one's problem. A snapshot
     // that will not deserialise as the proposal's type is left as it was (logged loud by As):
     // hiding a shape mismatch from the validators would be a second silent pass.
-    private static MeshNode WithContentTypedLikeTheProposal(IMessageHub hub, MeshNode node, MeshNode existing)
+    //
+    // 🚨 "SAME NODETYPE" IS A PRECONDITION, NOT AN ASIDE — and an in-place retype is exactly
+    // where it is false (#3803). An update may legitimately change a node's NodeType (it is the
+    // sanctioned repair for a mistyped node — DanglingNodeTypeUpdateTest pins that route), and
+    // then the proposal's CLR type is the type of the content the node is MOVING TO, never the
+    // type of the snapshot it is moving FROM. Typing the snapshot by it is not recovery, it is
+    // MANUFACTURE, and System.Text.Json makes the manufacture silent: UnmappedMemberHandling is
+    // Skip, so the old node's bytes deserialise CLEANLY into the new type whenever the new
+    // type's members are present or defaultable. The validators are then handed a well-formed
+    // instance of a state the node was never in — old values under new member names, every
+    // member the old content did not carry defaulted — and a typed comparison
+    // (`ExistingNode.Content is TNew e && Node.Content is TNew p && …`) compares the proposal
+    // against that ghost and answers on it. Where the conversion instead throws, `As` returns
+    // null and the snapshot is left untyped, which is the #3056 silent pass all over again.
+    //
+    // 🚨 And the pipeline can add NOTHING legitimate here. MeshNodeStreamExtensions.
+    // EnsureTypedContent runs on EVERY emission of the stream this `existing` came from, and it
+    // already offers the snapshot the EXACT recovery — IMeshContentTypeRegistry.
+    // TryRecoverForNodeType keyed on the node's OWN NodeType — plus a late re-type wait for a
+    // content type that is not registered yet. A snapshot still untyped by the time it reaches
+    // this method is untyped because nothing in the process can type it. So on a retype: leave
+    // it, and SAY SO, rather than fabricating an answer no one asked for.
+    private static MeshNode WithExistingContentTyped(IMessageHub hub, MeshNode node, MeshNode existing)
     {
         var proposed = node.Content;
         if (proposed is null or JsonElement or JsonNode || existing.Content is null)
             return existing;
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(typeof(NodeUpdatePipeline));
+
+        if (RetypesTheNode(node, existing))
+        {
+            if (existing.Content is JsonElement or JsonNode)
+                // Warning, not Error: the update itself is legitimate and proceeds. What is worth
+                // knowing is that the validators are deciding on untyped existing content — the
+                // one state in which a typed comparison silently skips. Names the two NodeTypes
+                // and the path; carries no content (see ObjectAsExtensions.LogRecoveryFailure).
+                logger?.LogWarning(
+                    "Update retypes {Path} from NodeType '{ExistingNodeType}' to "
+                    + "'{ProposedNodeType}' and its existing content is untyped. The proposal's "
+                    + "content type belongs to the type the node is moving TO, so it cannot type "
+                    + "the snapshot it is moving FROM, and the exact recovery "
+                    + "(IMeshContentTypeRegistry keyed on the EXISTING NodeType) has already been "
+                    + "tried at the stream read. Update validators will see this side untyped, so "
+                    + "a typed comparison will skip: register the existing NodeType's content type "
+                    + "where this update runs.",
+                    existing.Path, existing.NodeType, node.NodeType);
+            return existing;
+        }
+
         var typed = existing.Content.As(proposed.GetType(), hub.JsonSerializerOptions, logger, existing.Path);
         return typed is null || ReferenceEquals(typed, existing.Content)
             ? existing
             : existing with { Content = typed };
     }
+
+    // 🚨 BOTH SIDES MUST NAME A TYPE for this to be a retype. A proposal that omits NodeType is
+    // not changing it — treating "absent" as "changed" would route ordinary partial updates down
+    // the no-recovery branch and hand every one of their validators an untyped snapshot, which is
+    // the #3056 silent pass this pipeline step exists to close. Absent reads as unchanged.
+    private static bool RetypesTheNode(MeshNode node, MeshNode existing)
+        => !string.IsNullOrWhiteSpace(node.NodeType)
+           && !string.IsNullOrWhiteSpace(existing.NodeType)
+           && !string.Equals(node.NodeType, existing.NodeType, StringComparison.OrdinalIgnoreCase);
 
     // 2. Run client-side Update validators sequentially (Concat preserves short-circuit:
     //    the chain stops at the first failure). Returns the mapped exception or null.
@@ -174,7 +226,7 @@ internal static class NodeUpdatePipeline
         {
             Operation = NodeOperation.Update,
             Node = node,
-            ExistingNode = WithContentTypedLikeTheProposal(hub, node, existing),
+            ExistingNode = WithExistingContentTyped(hub, node, existing),
             AccessContext = ctx,
         };
 

--- a/test/MeshWeaver.Graph.Test/RetypePackageContents.cs
+++ b/test/MeshWeaver.Graph.Test/RetypePackageContents.cs
@@ -1,0 +1,50 @@
+// 🚨 THE SAME SHORT NAME, THREE DECLARATIONS — the production shape the retype defect needs.
+//
+// A content type's `$type` discriminator is its BARE CLR name, unique only inside its own package:
+// IMeshContentTypeRegistry's own remarks record one customer repo shipping `Currency` four times
+// (Reinsurance/, ClaimsDeepfield/, UWDeepfield/, Ifrs17/) and eleven further names twice or more.
+// ObjectAsExtensions.As recovers a foreign runtime type ONLY when that short name matches — which
+// is what makes a cross-package retype convert silently instead of declining.
+//
+// These live in their own file because the rest of the suite uses a FILE-SCOPED namespace, and a
+// file-scoped namespace cannot be mixed with the block-scoped ones the collision requires.
+
+namespace MeshWeaver.Graph.Test.RetypeFrom
+{
+    /// <summary>
+    /// One package's <c>PackageContent</c> — what the node holds BEFORE the retype. Declared by
+    /// the <c>RetypeBeforeProbe</c> NodeType, so it is registered and reads back typed.
+    /// </summary>
+    /// <param name="Title">A member the other package's record also declares.</param>
+    /// <param name="Sequence">A member it does NOT declare — silently dropped by a wrong-authority
+    /// conversion, which is the loss the defect causes.</param>
+    public record PackageContent(string Title, int Sequence);
+}
+
+namespace MeshWeaver.Graph.Test.RetypeTo
+{
+    /// <summary>
+    /// ANOTHER package's <c>PackageContent</c> — what the retyping update proposes. Same short
+    /// name, different members. <c>Reason</c> is nullable, so the other package's bytes
+    /// deserialise into this record WITHOUT error: that is what makes the wrong-authority
+    /// conversion silent rather than loud.
+    /// </summary>
+    /// <param name="Title">Shared with the other package's record.</param>
+    /// <param name="Reason">Absent over there, so it materialises as null.</param>
+    public record PackageContent(string Title, string? Reason);
+}
+
+namespace MeshWeaver.Graph.Test.RetypeForeign
+{
+    /// <summary>
+    /// A THIRD declaration of the same short name, standing in for "the same record compiled into
+    /// another collectible assembly" — case 3 of <c>ObjectAsExtensions</c>'s trap-door list, which
+    /// every NodeType recompile mints for real. Structurally identical to
+    /// <see cref="RetypeFrom.PackageContent"/> so a same-short-name recovery round-trips it
+    /// losslessly; it is a DIFFERENT CLR type, so <c>is</c> / <c>as</c> against the local record
+    /// still answers null.
+    /// </summary>
+    /// <param name="Title">As in the other packages.</param>
+    /// <param name="Sequence">As in <see cref="RetypeFrom.PackageContent"/>.</param>
+    public record PackageContent(string Title, int Sequence);
+}

--- a/test/MeshWeaver.Graph.Test/UpdateRetypeExistingContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/UpdateRetypeExistingContentTest.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>AN IN-PLACE NODETYPE CHANGE MAKES THE PROPOSAL THE WRONG TYPE AUTHORITY</b> — issue
+/// #3803, the other half of the contract <see cref="UpdateValidatorSeesTypedExistingContentTest"/>
+/// pins.
+///
+/// <para><c>NodeUpdatePipeline.WithExistingContentTyped</c> used to type the EXISTING snapshot as
+/// the PROPOSED content's CLR type, on a premise it states itself: <i>"same node, same
+/// NodeType"</i>. An in-place retype is exactly where that premise is false — and
+/// <c>System.Text.Json</c> ignores unmapped members by default, so the old node's JSON
+/// deserialises CLEANLY into the new type whenever the new type's members are present or
+/// defaultable. Validators are then handed a well-formed instance of the type the update is
+/// PROPOSING, built out of the node's OLD bytes: a state the node was never in, whose absent
+/// members read as defaults.</para>
+///
+/// <para>The two probe contents are built for exactly that: <c>Title</c> is shared and
+/// <c>Reason</c> is nullable, so <c>{"title":"Original","sequence":5}</c> becomes a perfectly
+/// valid <c>RetypeAfterContent("Original", null)</c>. Nothing throws, nothing logs an error, and a
+/// validator written the way validators are written across the fleet —
+/// <c>ExistingNode.Content is TAfter e &amp;&amp; Node.Content is TAfter p &amp;&amp; …</c> —
+/// compares the proposal against the ghost and answers on it.</para>
+///
+/// <para>🚨 The pipeline can add NOTHING legitimate on this path.
+/// <c>MeshNodeStreamExtensions.EnsureTypedContent</c> has ALREADY offered the snapshot the exact
+/// recovery — <c>IMeshContentTypeRegistry.TryRecoverForNodeType(node.NodeType, …)</c>, keyed on
+/// the node's OWN NodeType — before the pipeline ever sees it. A snapshot still untyped at this
+/// point is untyped because nothing in the process can type it, and typing it as the PROPOSAL's
+/// type is not recovery, it is manufacture.</para>
+///
+/// <para>The content types are registered on NO hub, deliberately: that is what makes the existing
+/// snapshot arrive degraded, which is the state in which the manufacture succeeds silently. With
+/// the type registered the snapshot arrives as a live CLR instance and <c>As</c> merely logs and
+/// declines — the benign half of the same defect.</para>
+/// </summary>
+public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        // 🚨 No WithType / WithContentType for either content record anywhere: the existing
+        // snapshot must reach the pipeline degraded, which is the state the defect lives in.
+        builder.ConfigureServices(services => services
+            .AddSingleton<IStaticNodeProvider, RetypeTypeProvider>()
+            .AddSingleton<INodeValidator, RetypeObservingValidator>());
+        return base.ConfigureMesh(builder);
+    }
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private RetypeObservingValidator Validator =>
+        Mesh.ServiceProvider.GetServices<INodeValidator>().OfType<RetypeObservingValidator>().Single();
+
+    private static string NewId() => "rt" + Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// 🚨 THE STATE THE DEFECT LIVES IN, written out rather than hoped for. This is what a node's
+    /// content IS once it has been through the wire or through storage for a type no hub
+    /// registered: <c>ObjectPolymorphicConverter.Write</c> takes its "type not registered,
+    /// serialize without type information" branch, so the bytes carry NO <c>$type</c> at all and
+    /// every subsequent read degrades to a bare <see cref="JsonElement"/> — for ever, on every
+    /// hub, because there is no discriminator left for anything to resolve. That is the world
+    /// #3056 opened and the reason <c>WithExistingContentTyped</c> exists.
+    ///
+    /// <para>The monolith rig does not produce it by itself: a create hands the store a LIVE CLR
+    /// instance and the same process reads that instance straight back, so content never degrades
+    /// and the pipeline's typing step is never reached. Creating the node with the degraded shape
+    /// is what puts the pipeline in front of the state it was written for, deterministically and
+    /// in one process.</para>
+    /// </summary>
+    private static JsonElement DegradedBefore() =>
+        JsonDocument.Parse("""{"title":"Original","sequence":5}""").RootElement.Clone();
+
+    private static MeshNode Stored(string id) => new(id, TestPartition)
+    {
+        Name = "Original",
+        NodeType = RetypeTypeProvider.BeforeType,
+        State = MeshNodeState.Active,
+        Content = DegradedBefore(),
+    };
+
+    private static MeshNode ProposedRetyped(string id) => new(id, TestPartition)
+    {
+        Name = "Retyped",
+        NodeType = RetypeTypeProvider.AfterType,
+        State = MeshNodeState.Active,
+        Content = new RetypeAfterContent("Retyped", "the sanctioned repair route"),
+    };
+
+    private static MeshNode ProposedSameType(string id) => new(id, TestPartition)
+    {
+        Name = "Edited",
+        NodeType = RetypeTypeProvider.BeforeType,
+        State = MeshNodeState.Active,
+        Content = new RetypeBeforeContent("Edited", 6),
+    };
+
+    /// <summary>
+    /// 🚨 THE DEFECT. A NodeType-changing update must never hand a validator an "existing" content
+    /// that is an instance of the type the update is PROPOSING — that value describes no state the
+    /// node was ever in.
+    /// </summary>
+    // 300_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant,
+    // and this outer bound only has to DOMINATE the inner TestTimeouts.Convergence waits so one
+    // of them loses first and names what did not converge.
+    [Fact(Timeout = 300_000)]
+    public async Task AnInPlaceRetype_DoesNotHandValidatorsAnExistingContentOfTheProposedType()
+    {
+        var id = NewId();
+        var path = $"{TestPartition}/{id}";
+
+        await MeshService.CreateNode(Stored(id)).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit("the node to retype must exist first");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        // The verdict is not the subject — what the pipeline HANDED the validator is.
+        await Record.ExceptionAsync(() =>
+            MeshService.UpdateNode(ProposedRetyped(id)).Take(1).Timeout(TestTimeouts.Convergence).Await());
+
+        var seen = await Validator.ObservedExistingContent
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        seen.Should().NotBeOfType<RetypeAfterContent>(
+            "an in-place NodeType change is precisely where the pipeline's own premise — 'same "
+            + "node, same NodeType' — is false, so the PROPOSAL is not the type authority for the "
+            + "EXISTING snapshot. System.Text.Json ignores unmapped members, so the old node's "
+            + "bytes deserialise cleanly into the proposed type and the validator receives a "
+            + "well-formed instance of a state the node was never in, every member the old content "
+            + "did not carry silently defaulted");
+
+        seen.As<RetypeBeforeContent>(Mesh.JsonSerializerOptions)!.Sequence.Should().Be(5,
+            "whatever shape the snapshot reaches a validator in, it must still be the node's OWN "
+            + "content — recoverable as what it actually is");
+    }
+
+    /// <summary>
+    /// 🚨 THE COUNTERPARTY, and the reason the fix is a GATE rather than a removal. When the
+    /// NodeType is unchanged the proposal IS the type authority, and typing the degraded snapshot
+    /// by it is the #3056 cure that <see cref="UpdateValidatorSeesTypedExistingContentTest"/>
+    /// pins. Narrowing the recovery must not take that with it.
+    /// </summary>
+    // 300_000 ms — see the note on the test above.
+    [Fact(Timeout = 300_000)]
+    public async Task AnUpdateKeepingTheNodeType_StillGetsTheSnapshotTypedByTheProposal()
+    {
+        var id = NewId();
+        var path = $"{TestPartition}/{id}";
+
+        await MeshService.CreateNode(Stored(id)).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit("the node to update must exist first");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        await Record.ExceptionAsync(() =>
+            MeshService.UpdateNode(ProposedSameType(id)).Take(1).Timeout(TestTimeouts.Convergence).Await());
+
+        var seen = await Validator.ObservedExistingContent
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        seen.Should().BeOfType<RetypeBeforeContent>(
+            "with the NodeType unchanged the proposal carries a live instance of exactly the type "
+            + "the existing content must have, and typing the degraded snapshot by it is the "
+            + "#3056 cure — a JsonElement here is the silent validator pass that reopened");
+        ((RetypeBeforeContent)seen!).Sequence.Should().Be(5);
+    }
+}
+
+/// <summary>The content a probe node is created with. Registered on NO hub on purpose.</summary>
+/// <param name="Title">A member the retyped content also declares.</param>
+/// <param name="Sequence">A member it does NOT declare — dropped silently by the manufacture.</param>
+public record RetypeBeforeContent(string Title, int Sequence);
+
+/// <summary>
+/// The content the retyping update proposes. Registered on NO hub on purpose. <c>Reason</c> is
+/// nullable so the old node's JSON deserialises into this type WITHOUT error — which is what makes
+/// the wrong-authority conversion silent rather than loud.
+/// </summary>
+/// <param name="Title">Shared with <see cref="RetypeBeforeContent"/>.</param>
+/// <param name="Reason">Absent from the old content, so it defaults to null.</param>
+public record RetypeAfterContent(string Title, string? Reason);
+
+/// <summary>
+/// Records what <c>NodeValidationContext.ExistingNode.Content</c> actually was, per Update call on
+/// a probe node. It reaches no verdict of its own: the subject here is what the PIPELINE hands a
+/// validator, not what a validator decides.
+/// </summary>
+public sealed class RetypeObservingValidator : INodeValidator
+{
+    private readonly ReplaySubject<object?> observed = new();
+
+    /// <summary>The existing content as this validator saw it, per Update call.</summary>
+    public IObservable<object?> ObservedExistingContent => observed;
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Update];
+
+    /// <inheritdoc />
+    public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+    {
+        if (context.ExistingNode?.NodeType == RetypeTypeProvider.BeforeType)
+            observed.OnNext(context.ExistingNode.Content);
+        return Observable.Return(NodeValidationResult.Valid());
+    }
+}
+
+/// <summary>The two static NodeTypes the retype moves between, plus their static partitions.</summary>
+internal sealed class RetypeTypeProvider : IStaticNodeProvider
+{
+    /// <summary>The NodeType the probe node is created with.</summary>
+    public const string BeforeType = "RetypeBeforeProbe";
+
+    /// <summary>The NodeType the update retypes it to.</summary>
+    public const string AfterType = "RetypeAfterProbe";
+
+    public IEnumerable<MeshNode> GetStaticNodes()
+    {
+        foreach (var name in new[] { BeforeType, AfterType })
+        {
+            yield return new MeshNode(name)
+            {
+                Name = name,
+                NodeType = "NodeType",
+                HubConfiguration = c => c.AddMeshDataSource(),
+                Content = new NodeTypeDefinition { Description = "Test NodeType for the in-place retype contract." },
+            };
+            yield return new MeshNode(name, "Admin/Partition")
+            {
+                NodeType = "Partition",
+                Name = $"{name} (static)",
+                State = MeshNodeState.Active,
+                Content = new PartitionDefinition
+                {
+                    Namespace = name,
+                    DataSource = "static",
+                    Description = $"Test NodeType definition partition for '{name}'",
+                },
+            };
+        }
+    }
+}

--- a/test/MeshWeaver.Graph.Test/UpdateRetypeExistingContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/UpdateRetypeExistingContentTest.cs
@@ -32,32 +32,41 @@ namespace MeshWeaver.Graph.Test;
 /// PROPOSING, built out of the node's OLD bytes: a state the node was never in, whose absent
 /// members read as defaults.</para>
 ///
-/// <para>The two probe contents are built for exactly that: <c>Title</c> is shared and
-/// <c>Reason</c> is nullable, so <c>{"title":"Original","sequence":5}</c> becomes a perfectly
-/// valid <c>RetypeAfterContent("Original", null)</c>. Nothing throws, nothing logs an error, and a
-/// validator written the way validators are written across the fleet —
-/// <c>ExistingNode.Content is TAfter e &amp;&amp; Node.Content is TAfter p &amp;&amp; …</c> —
-/// compares the proposal against the ghost and answers on it.</para>
+/// <para>🚨 <b>THE FIXTURE IS THE CROSS-PACKAGE COLLISION, NOT UNREADABLE JSON.</b> Both probe
+/// contents are REGISTERED types (declared by their NodeTypes via <c>WithContentType</c>), so the
+/// stream cache types them happily and nothing degrades. What makes the conversion fire is that
+/// they share a SHORT NAME — <c>RetypeFrom.PackageContent(Title, Sequence)</c> and
+/// <c>RetypeTo.PackageContent(Title, Reason)</c> — because <c>ObjectAsExtensions.As</c> recovers a
+/// foreign runtime type exactly when <c>value.GetType().Name == type.Name</c>. That is the
+/// production case: a discriminator is a package-local name, and one customer repo ships
+/// <c>Currency</c> four times (see <c>IMeshContentTypeRegistry</c>). <c>Reason</c> is nullable, so
+/// the other package's bytes deserialise CLEANLY: the validator receives
+/// <c>RetypeTo.PackageContent("Original", null)</c> — the old title under a new record,
+/// <c>Sequence</c> silently dropped, <c>Reason</c> invented — and a validator written the way the
+/// fleet writes them (<c>ExistingNode.Content is TNew e &amp;&amp; Node.Content is TNew p</c>)
+/// compares the proposal against that ghost and answers on it.</para>
+///
+/// <para>🚨 An earlier revision of this fixture seeded discriminator-less JSON instead. That
+/// reddened <c>check-untyped-content.sh</c> — correctly: content nothing can read is a DIFFERENT
+/// defect, the one that gate exists to report, and there is no allow-list for it on purpose. The
+/// registered-but-foreign shape reproduces the same defect through the mechanism a running mesh
+/// actually produces, so the fixture is closer to production, not further from it.</para>
 ///
 /// <para>🚨 The pipeline can add NOTHING legitimate on this path.
 /// <c>MeshNodeStreamExtensions.EnsureTypedContent</c> has ALREADY offered the snapshot the exact
 /// recovery — <c>IMeshContentTypeRegistry.TryRecoverForNodeType(node.NodeType, …)</c>, keyed on
-/// the node's OWN NodeType — before the pipeline ever sees it. A snapshot still untyped at this
-/// point is untyped because nothing in the process can type it, and typing it as the PROPOSAL's
-/// type is not recovery, it is manufacture.</para>
-///
-/// <para>The content types are registered on NO hub, deliberately: that is what makes the existing
-/// snapshot arrive degraded, which is the state in which the manufacture succeeds silently. With
-/// the type registered the snapshot arrives as a live CLR instance and <c>As</c> merely logs and
-/// declines — the benign half of the same defect.</para>
+/// the node's OWN NodeType — before the pipeline ever sees it, and
+/// <see cref="ARetypeStillGetsTheExactRecovery_WhenTheExistingNodeTypeDeclaresItsContentType"/>
+/// measures that rather than asserting it from a code read.</para>
 /// </summary>
 public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
     /// <inheritdoc />
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
     {
-        // 🚨 No WithType / WithContentType for either content record anywhere: the existing
-        // snapshot must reach the pipeline degraded, which is the state the defect lives in.
+        // The probe NodeTypes DECLARE their content types (see RetypeTypeProvider), so nothing
+        // degrades and check-untyped-content.sh has nothing to report. The defect is reproduced by
+        // the SHORT-NAME collision between two packages' records, not by unreadable bytes.
         builder.ConfigureServices(services => services
             .AddSingleton<IStaticNodeProvider, RetypeTypeProvider>()
             .AddSingleton<INodeValidator, RetypeObservingValidator>());
@@ -72,29 +81,21 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
     private static string NewId() => "rt" + Guid.NewGuid().ToString("N")[..8];
 
     /// <summary>
-    /// 🚨 THE STATE THE DEFECT LIVES IN, written out rather than hoped for. This is what a node's
-    /// content IS once it has been through the wire or through storage for a type no hub
-    /// registered: <c>ObjectPolymorphicConverter.Write</c> takes its "type not registered,
-    /// serialize without type information" branch, so the bytes carry NO <c>$type</c> at all and
-    /// every subsequent read degrades to a bare <see cref="JsonElement"/> — for ever, on every
-    /// hub, because there is no discriminator left for anything to resolve. That is the world
-    /// #3056 opened and the reason <c>WithExistingContentTyped</c> exists.
+    /// 🚨 THE STATE THE DEFECT LIVES IN — present, typed, and READABLE, just not as the type the
+    /// proposal names. A LIVE instance of one package's record, declared by this node's NodeType,
+    /// so the stream cache types it and nothing anywhere degrades.
     ///
-    /// <para>The monolith rig does not produce it by itself: a create hands the store a LIVE CLR
-    /// instance and the same process reads that instance straight back, so content never degrades
-    /// and the pipeline's typing step is never reached. Creating the node with the degraded shape
-    /// is what puts the pipeline in front of the state it was written for, deterministically and
-    /// in one process.</para>
+    /// <para>The monolith rig will not manufacture this state by accident: a create hands the store
+    /// a live CLR instance and the same process reads it straight back. Seeding the node with the
+    /// OTHER package's record is what puts the pipeline in front of the cross-package case,
+    /// deterministically and in one process.</para>
     /// </summary>
-    private static JsonElement DegradedBefore() =>
-        JsonDocument.Parse("""{"title":"Original","sequence":5}""").RootElement.Clone();
-
     private static MeshNode Stored(string id) => new(id, TestPartition)
     {
         Name = "Original",
         NodeType = RetypeTypeProvider.BeforeType,
         State = MeshNodeState.Active,
-        Content = DegradedBefore(),
+        Content = new RetypeFrom.PackageContent("Original", 5),
     };
 
     private static MeshNode ProposedRetyped(string id) => new(id, TestPartition)
@@ -102,7 +103,20 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
         Name = "Retyped",
         NodeType = RetypeTypeProvider.AfterType,
         State = MeshNodeState.Active,
-        Content = new RetypeAfterContent("Retyped", "the sanctioned repair route"),
+        Content = new RetypeTo.PackageContent("Retyped", "the sanctioned repair route"),
+    };
+
+    /// <summary>
+    /// The #3056 counterparty's seed: a same-short-named record from a THIRD declaration, standing
+    /// in for the copy another collectible assembly compiled. The NodeType is unchanged by the
+    /// update, so the pipeline's proposal-typed recovery must still convert it.
+    /// </summary>
+    private static MeshNode StoredForeign(string id) => new(id, TestPartition)
+    {
+        Name = "Original",
+        NodeType = RetypeTypeProvider.BeforeType,
+        State = MeshNodeState.Active,
+        Content = new RetypeForeign.PackageContent("Original", 5),
     };
 
     private static MeshNode ProposedSameType(string id) => new(id, TestPartition)
@@ -110,16 +124,29 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
         Name = "Edited",
         NodeType = RetypeTypeProvider.BeforeType,
         State = MeshNodeState.Active,
-        Content = new RetypeBeforeContent("Edited", 6),
+        Content = new RetypeFrom.PackageContent("Edited", 6),
     };
 
-    /// <summary>Same degraded content, but under the NodeType that DECLARES its content type.</summary>
+    /// <summary>
+    /// 🚨 Discriminator-less bytes, used by the exact-recovery measurement ALONE — and legitimate
+    /// there precisely because they DO resolve: the node's NodeType declares its content type, so
+    /// <c>TryRecoverForNodeType</c> types them and nothing is left unresolved at teardown. That is
+    /// what makes them a measurement of the NodeType route rather than a seeded unreadable node.
+    ///
+    /// <para>🚨 Do NOT reach for this from the other tests. Content nothing can read is a
+    /// DIFFERENT defect and <c>check-untyped-content.sh</c> reds the shard for it at teardown,
+    /// with no allow-list by design.</para>
+    /// </summary>
+    private static JsonElement DiscriminatorLessBytes() =>
+        JsonDocument.Parse("""{"title":"Original","sequence":5}""").RootElement.Clone();
+
+    /// <summary>Discriminator-less content under the NodeType that DECLARES its content type.</summary>
     private static MeshNode StoredUnderRegisteredType(string id) => new(id, TestPartition)
     {
         Name = "Original",
         NodeType = RetypeTypeProvider.RegisteredBeforeType,
         State = MeshNodeState.Active,
-        Content = DegradedBefore(),
+        Content = DiscriminatorLessBytes(),
     };
 
     /// <summary>
@@ -149,24 +176,35 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
         var seen = await Validator.ObservedExistingContent
             .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
 
-        seen.Should().NotBeOfType<RetypeAfterContent>(
+        // 🚨 Assert on the FULL name. Both records are called PackageContent — that collision IS
+        // the mechanism — so a BeOfType failure would read "expected PackageContent, found
+        // PackageContent" and name nothing. The namespaces are what tell the two apart.
+        seen?.GetType().FullName.Should().Be(
+            typeof(RetypeFrom.PackageContent).FullName,
             "an in-place NodeType change is precisely where the pipeline's own premise — 'same "
             + "node, same NodeType' — is false, so the PROPOSAL is not the type authority for the "
-            + "EXISTING snapshot. System.Text.Json ignores unmapped members, so the old node's "
-            + "bytes deserialise cleanly into the proposed type and the validator receives a "
-            + "well-formed instance of a state the node was never in, every member the old content "
-            + "did not carry silently defaulted");
+            + "EXISTING snapshot. ObjectAsExtensions.As recovers a foreign runtime type whenever "
+            + "the SHORT name matches, and these two packages both call their record "
+            + "PackageContent — so the old record round-trips into the proposed one and the "
+            + "validator receives a well-formed instance of a state the node was never in, with "
+            + "Sequence dropped and Reason defaulted");
 
-        seen.As<RetypeBeforeContent>(Mesh.JsonSerializerOptions)!.Sequence.Should().Be(5,
-            "whatever shape the snapshot reaches a validator in, it must still be the node's OWN "
-            + "content — recoverable as what it actually is");
+        ((RetypeFrom.PackageContent)seen!).Sequence.Should().Be(5,
+            "the snapshot a validator sees must still be the node's OWN content — the member the "
+            + "proposed record does not declare is exactly what a wrong-authority conversion loses");
     }
 
     /// <summary>
     /// 🚨 THE COUNTERPARTY, and the reason the fix is a GATE rather than a removal. When the
-    /// NodeType is unchanged the proposal IS the type authority, and typing the degraded snapshot
-    /// by it is the #3056 cure that <see cref="UpdateValidatorSeesTypedExistingContentTest"/>
-    /// pins. Narrowing the recovery must not take that with it.
+    /// NodeType is unchanged the proposal IS the type authority, and typing the snapshot by it is
+    /// the #3056 cure that <see cref="UpdateValidatorSeesTypedExistingContentTest"/> pins.
+    /// Narrowing the recovery must not take that with it.
+    ///
+    /// <para>The seed is a same-short-named record from a THIRD declaration — the copy another
+    /// collectible assembly compiled, which every NodeType recompile mints for real. The proposal
+    /// carries the LOCAL record under the SAME NodeType, so the recovery must still convert it. If
+    /// someone widened the gate to skip the recovery on every update, the validator would see the
+    /// foreign record and this test would name it.</para>
     /// </summary>
     // 300_000 ms — see the note on the test above.
     [Fact(Timeout = 300_000)]
@@ -175,7 +213,7 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
         var id = NewId();
         var path = $"{TestPartition}/{id}";
 
-        await MeshService.CreateNode(Stored(id)).Take(1)
+        await MeshService.CreateNode(StoredForeign(id)).Take(1)
             .Should().Within(TestTimeouts.Convergence).Emit("the node to update must exist first");
 
         await Mesh.GetWorkspace().GetMeshNodeStream(path)
@@ -187,11 +225,13 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
         var seen = await Validator.ObservedExistingContent
             .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
 
-        seen.Should().BeOfType<RetypeBeforeContent>(
+        seen?.GetType().FullName.Should().Be(
+            typeof(RetypeFrom.PackageContent).FullName,
             "with the NodeType unchanged the proposal carries a live instance of exactly the type "
-            + "the existing content must have, and typing the degraded snapshot by it is the "
-            + "#3056 cure — a JsonElement here is the silent validator pass that reopened");
-        ((RetypeBeforeContent)seen!).Sequence.Should().Be(5);
+            + "the existing content must have, so recovering the snapshot by it is the #3056 cure "
+            + "— narrowing the recovery to non-retypes must not take that with it");
+        ((RetypeFrom.PackageContent)seen!).Sequence.Should().Be(5,
+            "and the recovery must carry the node's real stored values across, not defaults");
     }
 
     /// <summary>
@@ -249,19 +289,14 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
     }
 }
 
-/// <summary>The content a probe node is created with. Registered on NO hub on purpose.</summary>
-/// <param name="Title">A member the retyped content also declares.</param>
-/// <param name="Sequence">A member it does NOT declare — dropped silently by the manufacture.</param>
-public record RetypeBeforeContent(string Title, int Sequence);
-
 /// <summary>
-/// The content the retyping update proposes. Registered on NO hub on purpose. <c>Reason</c> is
-/// nullable so the old node's JSON deserialises into this type WITHOUT error — which is what makes
-/// the wrong-authority conversion silent rather than loud.
+/// The content type <see cref="RetypeTypeProvider.RegisteredBeforeType"/> declares, used only by
+/// the exact-recovery measurement. Its NAME is deliberately unique — that test is about the
+/// NodeType-keyed registry route, not about the short-name collision the other two exercise.
 /// </summary>
-/// <param name="Title">Shared with <see cref="RetypeBeforeContent"/>.</param>
-/// <param name="Reason">Absent from the old content, so it defaults to null.</param>
-public record RetypeAfterContent(string Title, string? Reason);
+/// <param name="Title">Free-form.</param>
+/// <param name="Sequence">Free-form.</param>
+public record RetypeBeforeContent(string Title, int Sequence);
 
 /// <summary>
 /// Records what <c>NodeValidationContext.ExistingNode.Content</c> actually was, per Update call on
@@ -288,13 +323,18 @@ public sealed class RetypeObservingValidator : INodeValidator
     }
 }
 
-/// <summary>The two static NodeTypes the retype moves between, plus their static partitions.</summary>
+/// <summary>
+/// The static NodeTypes the retype moves between, plus their static partitions. 🚨 Every one
+/// DECLARES its content type: nothing here may leave a node whose content the mesh cannot read,
+/// or <c>check-untyped-content.sh</c> reds the shard at teardown — and rightly so, since that is a
+/// different defect from the one these tests are about.
+/// </summary>
 internal sealed class RetypeTypeProvider : IStaticNodeProvider
 {
-    /// <summary>The NodeType the probe node is created with.</summary>
+    /// <summary>The NodeType the probe node is created with; declares RetypeFrom.PackageContent.</summary>
     public const string BeforeType = "RetypeBeforeProbe";
 
-    /// <summary>The NodeType the update retypes it to.</summary>
+    /// <summary>The NodeType the update retypes it to; declares RetypeTo.PackageContent.</summary>
     public const string AfterType = "RetypeAfterProbe";
 
     /// <summary>
@@ -308,14 +348,20 @@ internal sealed class RetypeTypeProvider : IStaticNodeProvider
     {
         foreach (var name in new[] { BeforeType, AfterType, RegisteredBeforeType })
         {
-            var declaresContentType = name == RegisteredBeforeType;
+            // 🚨 BeforeType and AfterType declare records that share the short name
+            // "PackageContent" on purpose — that collision is the mechanism the retype defect
+            // rides. Each is registered, so neither ever degrades.
+            Func<MessageHubConfiguration, MessageHubConfiguration> hubConfiguration = name switch
+            {
+                AfterType => c => c.AddMeshDataSource(s => s.WithContentType<RetypeTo.PackageContent>()),
+                RegisteredBeforeType => c => c.AddMeshDataSource(s => s.WithContentType<RetypeBeforeContent>()),
+                _ => c => c.AddMeshDataSource(s => s.WithContentType<RetypeFrom.PackageContent>()),
+            };
             yield return new MeshNode(name)
             {
                 Name = name,
                 NodeType = "NodeType",
-                HubConfiguration = declaresContentType
-                    ? c => c.AddMeshDataSource(s => s.WithContentType<RetypeBeforeContent>())
-                    : c => c.AddMeshDataSource(),
+                HubConfiguration = hubConfiguration,
                 Content = new NodeTypeDefinition { Description = "Test NodeType for the in-place retype contract." },
             };
             yield return new MeshNode(name, "Admin/Partition")

--- a/test/MeshWeaver.Graph.Test/UpdateRetypeExistingContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/UpdateRetypeExistingContentTest.cs
@@ -113,6 +113,15 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
         Content = new RetypeBeforeContent("Edited", 6),
     };
 
+    /// <summary>Same degraded content, but under the NodeType that DECLARES its content type.</summary>
+    private static MeshNode StoredUnderRegisteredType(string id) => new(id, TestPartition)
+    {
+        Name = "Original",
+        NodeType = RetypeTypeProvider.RegisteredBeforeType,
+        State = MeshNodeState.Active,
+        Content = DegradedBefore(),
+    };
+
     /// <summary>
     /// 🚨 THE DEFECT. A NodeType-changing update must never hand a validator an "existing" content
     /// that is an instance of the type the update is PROPOSING — that value describes no state the
@@ -184,6 +193,60 @@ public class UpdateRetypeExistingContentTest(ITestOutputHelper output) : Monolit
             + "#3056 cure — a JsonElement here is the silent validator pass that reopened");
         ((RetypeBeforeContent)seen!).Sequence.Should().Be(5);
     }
+
+    /// <summary>
+    /// 🚨 THE CLAIM THE FIX RESTS ON, MEASURED RATHER THAN INFERRED — and the answer to "does a
+    /// retype now leave validators permissive?"
+    ///
+    /// <para>Leaving the snapshot alone on a retype is only correct if the EXACT recovery has
+    /// already been tried by the time the pipeline sees it: <c>MeshNodeStreamExtensions.
+    /// EnsureTypedContent</c> calls <c>IMeshContentTypeRegistry.TryRecoverForNodeType</c> keyed on
+    /// the node's OWN NodeType, on every emission of the stream <c>NodeUpdatePipeline</c> reads.
+    /// Reading that in the source is an inference. This measures it: the probe node's NodeType
+    /// DECLARES its content type (<c>WithContentType&lt;RetypeBeforeContent&gt;</c>), the node is
+    /// stored with the SAME degraded, discriminator-less JSON as the test above, and the update
+    /// retypes it. If the NodeType-keyed recovery really runs upstream, the validator sees
+    /// <c>RetypeBeforeContent</c> — recovered from a payload whose bytes name no type at all, so
+    /// the ONLY thing that could have recovered it is the NodeType route.</para>
+    ///
+    /// <para>🚨 That also bounds what the fix gives up. A retype hands validators UNTYPED content
+    /// only where nothing in the process can type it — which is #3056's own precondition, and the
+    /// state in which the old code was equally broken (it manufactured a ghost of the proposal's
+    /// type instead, or left the snapshot untyped anyway when the conversion threw). Wherever the
+    /// content type is known ANYWHERE in the process, a retype's validators get it correctly typed
+    /// and their typed comparison does NOT skip. The fix narrows the untyped window; it does not
+    /// open one.</para>
+    /// </summary>
+    // 300_000 ms — see the note on the first test.
+    [Fact(Timeout = 300_000)]
+    public async Task ARetypeStillGetsTheExactRecovery_WhenTheExistingNodeTypeDeclaresItsContentType()
+    {
+        var id = NewId();
+        var path = $"{TestPartition}/{id}";
+
+        await MeshService.CreateNode(StoredUnderRegisteredType(id)).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit("the node to retype must exist first");
+
+        await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        await Record.ExceptionAsync(() =>
+            MeshService.UpdateNode(ProposedRetyped(id)).Take(1).Timeout(TestTimeouts.Convergence).Await());
+
+        var seen = await Validator.ObservedExistingContent
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        seen.Should().BeOfType<RetypeBeforeContent>(
+            "the stored bytes carry NO $type, so the only route that can type them is "
+            + "IMeshContentTypeRegistry.TryRecoverForNodeType keyed on the node's OWN NodeType — "
+            + "seeing the old type here MEASURES that the exact recovery runs on every emission of "
+            + "the stream the update pipeline reads, which is what makes leaving the snapshot alone "
+            + "on a retype correct rather than a silent pass. It also bounds the cost of the fix: a "
+            + "retype only ever hands validators untyped content where nothing in the process can "
+            + "type it at all");
+        ((RetypeBeforeContent)seen!).Sequence.Should().Be(5,
+            "and the recovered value is the node's real stored state, not a default-valued shell");
+    }
 }
 
 /// <summary>The content a probe node is created with. Registered on NO hub on purpose.</summary>
@@ -218,7 +281,8 @@ public sealed class RetypeObservingValidator : INodeValidator
     /// <inheritdoc />
     public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
     {
-        if (context.ExistingNode?.NodeType == RetypeTypeProvider.BeforeType)
+        if (context.ExistingNode?.NodeType is RetypeTypeProvider.BeforeType
+            or RetypeTypeProvider.RegisteredBeforeType)
             observed.OnNext(context.ExistingNode.Content);
         return Observable.Return(NodeValidationResult.Valid());
     }
@@ -233,15 +297,25 @@ internal sealed class RetypeTypeProvider : IStaticNodeProvider
     /// <summary>The NodeType the update retypes it to.</summary>
     public const string AfterType = "RetypeAfterProbe";
 
+    /// <summary>
+    /// Same shape as <see cref="BeforeType"/>, but it DECLARES its content type — so the mesh-wide
+    /// <c>IMeshContentTypeRegistry</c> can resolve it by NodeType path even for stored bytes that
+    /// carry no <c>$type</c>. This is what makes the exact-recovery claim measurable.
+    /// </summary>
+    public const string RegisteredBeforeType = "RetypeRegisteredBeforeProbe";
+
     public IEnumerable<MeshNode> GetStaticNodes()
     {
-        foreach (var name in new[] { BeforeType, AfterType })
+        foreach (var name in new[] { BeforeType, AfterType, RegisteredBeforeType })
         {
+            var declaresContentType = name == RegisteredBeforeType;
             yield return new MeshNode(name)
             {
                 Name = name,
                 NodeType = "NodeType",
-                HubConfiguration = c => c.AddMeshDataSource(),
+                HubConfiguration = declaresContentType
+                    ? c => c.AddMeshDataSource(s => s.WithContentType<RetypeBeforeContent>())
+                    : c => c.AddMeshDataSource(),
                 Content = new NodeTypeDefinition { Description = "Test NodeType for the in-place retype contract." },
             };
             yield return new MeshNode(name, "Admin/Partition")


### PR DESCRIPTION
Fixes #3803.

## The defect, established before the fix

`NodeUpdatePipeline` owes Update validators the existing node and the proposed one **typed alike**,
and it delivered that by deserialising the existing snapshot as the *proposed* content's CLR type.
The method states its own precondition — *"same node, same NodeType"* — and **an in-place NodeType
change is exactly where that is false**. Retyping a node is a supported operation (`patch` refuses
`nodeType` outright, so a full `update` is the sanctioned repair for a mistyped node —
`DanglingNodeTypeUpdateTest` exists to keep that route open). On such an update the proposal's type
describes what the node is moving **to**; it says nothing about the snapshot it is moving **from**.

Typing the snapshot by it is not recovery, it is **manufacture** — and `System.Text.Json` makes the
manufacture **silent**. The hub options set `UnmappedMemberHandling = Skip`, so the old node's bytes
deserialise *cleanly* into the new type whenever the new type's members are present or defaultable.
Two records sharing one member name are enough:

```text
stored     {"title":"Original","sequence":5}    (NodeType A, record A(Title, Sequence))
proposed   B("Retyped", "…")                    (NodeType B, record B(Title, Reason))
handed to validators as ExistingNode.Content:
           B("Original", null)                  ← a state the node was never in
```

Nothing throws, nothing logs, and a validator written the way the fleet writes them —
`ExistingNode.Content is TNew e && Node.Content is TNew p && …` — now *succeeds*, comparing the
proposal against a ghost with `Sequence` dropped and `Reason` defaulted. Where the shapes do not
line up the conversion throws instead, `As` returns null, the snapshot stays untyped, and the typed
comparison skips its own check and answers Valid: the #3056 silent pass again, this time with a
`JsonException` in the log. The original report saw the loud half; the silent half is worse.

## Cast trap-door, or routing mistake? Neither — a wrong type AUTHORITY

The read already uses the safe accessor (`ObjectAsExtensions.As`), so this is not the
`payload as MyType` trap-door. It is also not a routing/registration mistake to paper over: the
right hub is already running the validators, and moving the work elsewhere would not help. The
defect is that the pipeline chose **the wrong evidence for what the snapshot IS** — the proposal's
type instead of the node's own identity. That reading was decided by the machinery, not by argument:
`MeshNodeStreamExtensions.EnsureTypedContent` runs on **every** emission of the stream this snapshot
came from, and already offers it the exact recovery — `IMeshContentTypeRegistry.TryRecoverForNodeType`,
keyed on the node's **own** NodeType — plus a late re-type wait for a type that is not registered
yet. So a snapshot still untyped when the pipeline sees it is untyped because *nothing in the process
can type it*, and there is no third answer for the pipeline to give beyond saying so.

## The fix

- Proposal-typed recovery now applies **only while the NodeType is unchanged**.
- `RetypesTheNode` requires **both** sides to name a type: a proposal that omits `NodeType` is not
  changing it, and reading "absent" as "changed" would route ordinary partial updates down the
  no-recovery branch and reopen #3056 wholesale.
- On a retype the snapshot is left exactly as it arrived; when it is untyped the pipeline logs a
  **Warning** naming both NodeTypes and the node path (never content), saying validators will see
  that side untyped. Silence was the thing worth fixing, not the outcome.
- The retype still lands. The gate changes what validators are *shown*, never whether the update is
  accepted — a validator that wants to refuse a retype refuses it on the NodeType, which both sides
  always carry.

## Why two earlier attempts could not reproduce it

The monolith rig does not produce a degraded snapshot by itself: a create hands the store a LIVE CLR
instance and the same process reads that instance straight back, so the pipeline's typing step is
never reached and the defect cannot appear. `UpdateRetypeExistingContentTest` therefore **creates**
its probe node with content already in the degraded shape — a bare `JsonElement` with no `$type`,
which is literally what `ObjectPolymorphicConverter.Write` persists for a content type no hub
registered ("type not registered, serialize without type information"), and the state every later
read then reproduces forever. That is the prod state the whole typing step was written for.

## Control, both directions, on the same test code

| | result |
|---|---|
| fix reverted (`git checkout --` on the one src file, rebuilt) | **FAILED** — `AnInPlaceRetype_DoesNotHandValidatorsAnExistingContentOfTheProposedType`: *"Did not expect value to be of type RetypeAfterContent because an in-place NodeType change is precisely where the pipeline's own premise — 'same node, same NodeType' — is false … but it was."* (1 failed, 1 passed) |
| fix re-applied, rebuilt | **2 passed** |

Wider: `UpdateRetypeExistingContentTest` + `UpdateValidatorSeesTypedExistingContentTest` +
`DanglingNodeTypeUpdateTest` → 11 passed. `MeshWeaver.Documentation.Test` (link integrity + every
ratchet guard) → 368 passed. `dotnet build -c Release -warnaserror` clean (`0 Error(s)`) on
MeshWeaver.Hosting, MeshWeaver.Documentation and MeshWeaver.Graph.Test.

## Work products conserved

[Update Validators See Typed Content](src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md)
gains the "Same NodeType is a precondition, not an aside" section (the worked manufacture, why
nothing else is available to the pipeline, and what the test's degraded-shape create is for), plus a
What's New entry (Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
