### PR TITLE
Restore the content key on a disk-cache hit (#3892)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -36,7 +36,10 @@ internal interface ICompilationCacheService
     /// <summary>
     /// Returns the path of the newest cached DLL for <paramref name="nodeName"/>
     /// whose write-time satisfies both the source-modified deadline and the
-    /// framework-DLL deadline. Returns null when no valid cache entry exists.
+    /// framework-DLL deadline, and whose artifact set is COMPLETE — DLL, PDB, the debug source
+    /// mirror when source debugging is on, and the generated-input digest the dependency record's
+    /// content key is restored from (<see cref="GeneratedInputDigestFile"/>, #3892). Returns null
+    /// when no valid cache entry exists.
     /// Use when you need the actual DLL path (not just whether the cache is
     /// valid) — e.g., to feed an ALC LoadContext without re-running Roslyn.
     /// </summary>
@@ -929,7 +932,10 @@ internal class CompilationCacheService(
     /// <summary>
     /// Returns the path of the newest cached DLL for <paramref name="nodeName"/>
     /// whose write-time satisfies both the source-modified deadline and the
-    /// framework-DLL deadline. Returns null when no valid cache entry exists.
+    /// framework-DLL deadline, and whose artifact set is COMPLETE — DLL, PDB, the debug source
+    /// mirror when source debugging is on, and the generated-input digest the dependency record's
+    /// content key is restored from (<see cref="GeneratedInputDigestFile"/>, #3892). Returns null
+    /// when no valid cache entry exists.
     ///
     /// <para>Layout: <c>CompileToDiskAsync</c> writes to
     /// <c>{cacheDir}/{nodeName}_{ticks_hex}/{nodeName}.dll</c> so V1 and V2
@@ -994,6 +1000,26 @@ internal class CompilationCacheService(
         if (_options.EnableSourceDebugging && !File.Exists(sourcePath))
         {
             logger.LogDebug("Cache miss for {NodeName}: Source not found at {SourcePath}", nodeName, sourcePath);
+            return null;
+        }
+
+        // 🚨 THE ARTIFACT SET INCLUDES ITS PROVENANCE (#3892). A cached assembly whose
+        // generated-input digest is not beside it cannot be stamped with the reserved '!input'
+        // CONTENT KEY entry, so reusing it would produce a dependency record WEAKER than the one a
+        // fresh compile of the same content produces — and that record is a PRODUCER artifact: it
+        // travels onto NodeTypeDefinition.CompiledDependencies and into every published bundle. Two
+        // publishes of identical content would then ship different guard strength depending on
+        // whether the baking machine's cache happened to be warm, with nothing downstream able to
+        // tell which it got. Refusing here is the same judgement the PDB check above makes — the
+        // entry is INCOMPLETE, so it is not a cache entry — and it costs at most ONE recompile per
+        // type, for artifacts published by a build that predates the sidecar (which the
+        // framework-timestamp check below usually invalidates anyway). See GeneratedInputDigestFile.
+        if (!GeneratedInputDigestFile.Exists(dllPath))
+        {
+            logger.LogDebug(
+                "Cache miss for {NodeName}: no generated-input digest beside {DllPath} — the "
+                + "artifact predates the sidecar, so its content key cannot be restored",
+                nodeName, dllPath);
             return null;
         }
 

--- a/src/MeshWeaver.Compiler.Pipeline/GeneratedInputDigestFile.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/GeneratedInputDigestFile.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// 🚨 THE PRODUCER-DETERMINISM HALF of the per-type CONTENT KEY (#3892): the stage-1
+/// generated-input digest, written BESIDE the bytes it describes so a disk-cache HIT can stamp the
+/// same dependency record a fresh compile stamps.
+///
+/// <para><b>The defect this closes.</b> <c>CompiledDependencies.Compute</c> writes the reserved
+/// <c>!input</c> entry only when the caller hands it a generated-input digest, and the digest was
+/// available at exactly one place — inside <c>CompileAsyncCore</c>, three statements before Roslyn.
+/// A disk-cache hit never enters that method, so it reached the stamp with <c>null</c> and produced
+/// a record WITHOUT the content key. Nothing failed: <c>FindMismatch</c> simply had nothing to
+/// compare and the toolchain entry still governed. But the stamp is a PRODUCER act — the record
+/// travels into <c>NodeTypeDefinition.CompiledDependencies</c> and from there into every published
+/// bundle — so whether a shipped artifact carried the ContentKey guard AT ALL depended on whether
+/// the baking machine happened to have a warm cache. Two publishes of identical content shipped
+/// records of different guard strength and no consumer could tell which it got; the weaker one
+/// silently never fires the check. That is the shape of #3768 / #3732, and it is what made
+/// <c>BakeEquivalenceTest</c> red only in a loaded CI shard.</para>
+///
+/// <para><b>Why the digest is PERSISTED and not RECOMPUTED.</b> Recomputing it at the hit site is
+/// affordable (the values are all available — <c>PrepareGeneratedSource</c> runs before any compile
+/// decision) but it answers a DIFFERENT question. The digest folds
+/// <c>EmitPipeline.OptionsFingerprint</c>, <c>GeneratedInputIdentity.CompilerIdentity</c> and the
+/// identities of the generator assemblies on disk — properties of the process doing the computing,
+/// not of the bytes. A recomputed digest therefore describes "what a compile RIGHT HERE would be
+/// fed", and stamping it onto bytes some other process emitted claims a content-key equality that
+/// was never established. Since <c>FindMismatchAfterReevaluation</c> DEMOTES the toolchain entry
+/// when the content key matches, that mis-stamp would let a build be adopted across the exact
+/// toolchain move the toolchain entry exists to catch. Reading the producing compile's own digest
+/// off the disk cannot say anything the producing compile did not.</para>
+///
+/// <para><b>Published atomically.</b> The file is written into <c>EmitToDiskWithRetry</c>'s STAGING
+/// directory, before the directory rename that publishes the artifact under the discovery glob — so
+/// a published cache entry carries the digest or does not exist, and a concurrent reader can never
+/// observe bytes whose digest has not landed yet. A write fault here fails the compile exactly as a
+/// lost DLL write does: an artifact whose provenance cannot be recorded is not published.</para>
+///
+/// <para>🚨 <b>Deliberately NOT in <c>MeshWeaver.Compiler</c>.</b> That assembly is a full-MVID
+/// toolchain ROOT (<c>FrameworkBuildIdentity.ToolchainRoots</c>): under deterministic builds ANY
+/// edit to it — a comment included — moves the framework identity, which invalidates every stamped
+/// dependency record and every published bundle's adoptability on every mesh, and recompiles every
+/// NodeType. The cache-directory layout is already split (the emit writes it, this pipeline reads
+/// it), so the sidecar lives on the pipeline side where the same fix costs nothing.</para>
+/// </summary>
+internal static class GeneratedInputDigestFile
+{
+    /// <summary>
+    /// The sidecar's extension. It sits beside <c>{nodeName}.dll</c> / <c>{nodeName}.pdb</c> in the
+    /// published <c>{cacheDir}/{nodeName}_{ticks}_{guid}/</c> directory.
+    /// </summary>
+    internal const string Extension = ".inputdigest";
+
+    /// <summary>The sidecar path for a cached assembly.</summary>
+    internal static string PathFor(string dllPath) => Path.ChangeExtension(dllPath, Extension);
+
+    /// <summary>Whether the artifact set at <paramref name="dllPath"/> carries its digest.</summary>
+    internal static bool Exists(string dllPath) => File.Exists(PathFor(dllPath));
+
+    /// <summary>
+    /// Writes the digest into a STAGING directory, beside the assembly the caller just emitted.
+    /// Throws on an IO fault — the caller (<c>EmitToDiskWithRetry</c>'s emit callback) discards the
+    /// staging directory and the compile fails, which is the same verdict a lost DLL write gets:
+    /// the artifact never enters the discovery namespace half-described.
+    /// </summary>
+    internal static void Write(string stagingDirectory, string nodeName, string digest)
+        => File.WriteAllText(Path.Combine(stagingDirectory, nodeName + Extension), digest);
+
+    /// <summary>
+    /// The digest recorded beside <paramref name="dllPath"/>, or null when there is none (an
+    /// artifact published by a build that predates the sidecar) or it cannot be read.
+    ///
+    /// <para>A read fault is LOGGED and answered as absent, never swallowed: the caller's response
+    /// is to recompile, which is correct for an artifact this process cannot describe — and it can
+    /// never be mistaken for a digest, because an absent digest is what the cache-validity check
+    /// already refuses.</para>
+    /// </summary>
+    internal static string? TryRead(string dllPath, ILogger logger)
+    {
+        var path = PathFor(dllPath);
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+            var digest = File.ReadAllText(path).Trim();
+            return digest.Length == 0 ? null : digest;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex,
+                "The generated-input digest at {DigestPath} could not be read — the cached assembly "
+                + "beside it cannot be stamped with a content key, so it is recompiled instead",
+                path);
+            return null;
+        }
+    }
+}

--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
@@ -290,12 +290,18 @@ internal class MeshNodeCompilationService(
 
     /// <summary>
     /// One compile attempt's outcome: the assembly path (null on failure), the CONTENT KEY digest
-    /// of the input that produced it (null when no compile ran — a disk-cache hit; the dependency
-    /// record then simply carries no content key), the <see cref="ActivityLog"/>, and — the point
+    /// of the input that produced it, the <see cref="ActivityLog"/>, and — the point
     /// of carrying it — the ONE source snapshot the attempt was taken against. Every downstream
     /// stage (<see cref="DiscoverSourceVersionSnapshot"/>, <see cref="BuildFailureDiagnostics"/>)
     /// reuses <c>Sources</c> instead of re-discovering; see
     /// <see cref="GetAssemblyLocationWithLog"/>.
+    ///
+    /// <para>🚨 The digest is present on BOTH ways of reaching bytes (#3892): a fresh emit takes it
+    /// three statements before Roslyn, and a disk-cache hit RESTORES the producing compile's own
+    /// from beside the assembly (<see cref="GeneratedInputDigestFile"/>). It used to be null on the
+    /// hit, which made the stamped dependency record — a PRODUCER artifact that ships inside
+    /// bundles — carry the reserved <c>!input</c> guard or not depending on whether this machine's
+    /// cache was warm. Null now means only "this attempt produced no assembly".</para>
     /// </summary>
     private readonly record struct CompileAttempt(
         string? Path, string? InputDigest, ActivityLog Log, IReadOnlyList<MeshNode> Sources);
@@ -425,15 +431,26 @@ internal class MeshNodeCompilationService(
                     if (cacheService.IsDiskCacheEnabled)
                     {
                         var cachedDllPath = cacheService.TryGetLatestCachedDllPath(nodeName, effectiveLastModified);
-                        if (cachedDllPath is not null)
+                        // 🚨 THE CONTENT KEY SURVIVES THE CACHE HIT (#3892). No compile runs here,
+                        // so the digest is RESTORED from beside the bytes rather than recomputed:
+                        // it is the digest of the compile that actually produced them, which is the
+                        // only thing this path is entitled to claim (a recomputed one would fold
+                        // THIS process's compiler and generator identities into a key describing
+                        // someone else's emit). TryGetLatestCachedDllPath already refused an
+                        // artifact without one, so a null here is a race — the directory went away
+                        // under us — and falls through to a fresh compile, which is the right
+                        // answer for bytes that are no longer there.
+                        var cachedInputDigest = cachedDllPath is null
+                            ? null
+                            : GeneratedInputDigestFile.TryRead(cachedDllPath, logger);
+                        if (cachedDllPath is not null && cachedInputDigest is not null)
                         {
                             logger.LogDebug(
                                 "Using cached assembly for {NodePath} at {DllPath} (effectiveLastModified={EffectiveLastModified})",
                                 node.Path, cachedDllPath, effectiveLastModified);
                             return Observable.Return(new CompileAttempt(
                                 cachedDllPath,
-                                // No compile ran, so there is no generated input to key on.
-                                null,
+                                cachedInputDigest,
                                 AppendInfo(log,
                                         $"Cache hit — returning {cachedDllPath} (effective LastModified={effectiveLastModified:O}).",
                                         "activity.compile.cacheHit",
@@ -1543,9 +1560,17 @@ internal class MeshNodeCompilationService(
     }
 
     /// <param name="generatedInputDigest">The stage-1 CONTENT KEY digest of the compile that
-    /// produced these bytes (#1707 slice 4), or null when no compile ran in this process — a
-    /// disk-cache hit or the assembly-hydration shortcut. Null simply leaves the record without a
-    /// content key; the toolchain entry still governs.</param>
+    /// produced these bytes (#1707 slice 4). A fresh emit takes it inline; a disk-cache hit
+    /// RESTORES it from beside the bytes (<see cref="GeneratedInputDigestFile"/>, #3892), so the
+    /// record this method stamps is the same either way — which matters because the record is a
+    /// PRODUCER artifact that travels into published bundles.
+    /// <para>It is still null on the ASSEMBLY-HYDRATION shortcut
+    /// (<see cref="GetConfigurationsFromExistingAssembly"/>), which loads bytes an
+    /// <c>IAssemblyStore</c> handed over with no local provenance. That path is a READER: its
+    /// result supplies a hub configuration and is never stamped onto a NodeType (it also carries
+    /// no <c>CompiledSources</c>, which is why stamping it would be catastrophic and nothing
+    /// does). Null simply leaves the record without a content key; the toolchain entry still
+    /// governs.</para></param>
     private NodeCompilationResult? CompileResultFromAssembly(
         MeshNode node, string assemblyLocation, ActivityLog log,
         ImmutableDictionary<string, long> compiledSources,
@@ -1955,8 +1980,22 @@ internal class MeshNodeCompilationService(
             var emitted = default(EmittedArtifact);
             actualPath = EmitPipeline.EmitToDiskWithRetry(
                 cacheService.CacheDirectory, nodeName, EmitPipeline.DiskEmitAttempts, logger,
-                releaseDir => emitted = EmitPipeline.EmitCompilationToDirectory(
-                    compilation, nodeName, node.Path, releaseDir, [], ct, _captureEmitFailure));
+                stagingDir =>
+                {
+                    emitted = EmitPipeline.EmitCompilationToDirectory(
+                        compilation, nodeName, node.Path, stagingDir, [], ct, _captureEmitFailure);
+                    // 🚨 The CONTENT KEY's stage-1 digest, recorded BESIDE the bytes it describes
+                    // (#3892) — written into the STAGING directory, so the atomic rename that
+                    // publishes the assembly publishes its provenance with it and a concurrent
+                    // reader can never see one without the other. A write fault propagates:
+                    // EmitToDiskWithRetry discards the staging directory and the compile fails,
+                    // which is the same verdict a lost DLL write gets. An artifact whose
+                    // provenance cannot be recorded is not published — that is what keeps the
+                    // dependency record identical whether these bytes are used now or restored
+                    // from the cache an hour later.
+                    GeneratedInputDigestFile.Write(stagingDir, nodeName, generatedInputDigest);
+                    return emitted;
+                });
             warnings = emitted.Warnings;
         }
         else

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -232,6 +232,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Emit Reference Capture](EmitReferenceCapture) — bounded, opt-in CI evidence for runtime compiler failures
 - [Graph / Compiler Layering](GraphCompilerLayering) — the four assemblies, the cycle, and the full-MVID size rule
 - [Toolchain Re-evaluation Lane](ToolchainReevaluationLane) — why a toolchain change stopped rebaking the world
+- [Producer Determinism of the Dependency Record](ProducerDeterminismOfTheDependencyRecord) — the same content must stamp the same record however the producer reached its bytes; the disk-cache hit that shipped a weaker guard, and why the digest is persisted beside the bytes rather than recomputed
 - [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes
 - [Source-Set Establishment](SourceSetEstablishment) — a resolved source set of ZERO is ambiguous, and only the type's own persisted snapshot tells "owns no Code" from "the discovery pass came back short"; the boot that resolved 91 fewer Code nodes than its neighbours and held a portal out of rotation for the startup probe's full three hours
 - [Install-Time Prebuilt Adoption](InstallTimePrebuiltAdoption) — the only lane that serves a package installed AFTER boot, and the four answers its zero must keep apart because a silent non-adoption reads exactly like a successful one

--- a/src/MeshWeaver.Documentation/Data/Architecture/ProducerDeterminismOfTheDependencyRecord.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ProducerDeterminismOfTheDependencyRecord.md
@@ -1,0 +1,150 @@
+---
+Name: Producer Determinism of the Dependency Record
+Category: Architecture
+Description: A NodeType's dependency record must not depend on how the producer reached its bytes. The disk-cache hit used to stamp a record without the `!input` content key, so a bundle's guard strength depended on whether the baking machine's cache was warm — and why the fix persists the digest instead of recomputing it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="6" rx="1"/><rect x="3" y="14" width="18" height="6" rx="1"/><path d="M7 7h.01"/><path d="M7 17h.01"/></svg>
+---
+
+# Producer Determinism of the Dependency Record
+
+Every dynamic NodeType compile stamps a **dependency record** — the sorted set of
+`referenced assembly → surface id` pairs read off the emitted assembly, plus two reserved entries:
+`!toolchain` (the producing toolchain's identity) and `!input` (the CONTENT KEY, the hash of the
+fully generated compilation input folded with the pruned reference surfaces). The record travels
+onto `NodeTypeDefinition.CompiledDependencies` and from there into every bundle baked from that
+type. See [Toolchain Re-evaluation Lane](../ToolchainReevaluationLane) for what the two entries decide.
+
+This page states one property of that record and the defect that violated it.
+
+## The property
+
+> **A producer stamps the same record for the same content, however it reached the bytes.**
+
+That is not a nicety. `!input` is what
+`CompiledDependencies.FindMismatchAfterReevaluation` uses to DEMOTE `!toolchain` from an
+invalidation unit to a trigger: when a consumer regenerates the input and the key matches, a
+toolchain move stops being a reason to rebuild. A record **without** `!input` degrades to the
+pre-content-key behaviour — nothing is wrong with it, `FindMismatch` simply has nothing to compare.
+
+The trouble is that a consumer cannot tell the two apart in any way that matters. A record with the
+key can answer the question directly; a record without it cannot, and it looks exactly like a record
+whose producer never had the key to give. If which one you get depends on the state of a machine,
+the guard's strength is a property of the build host rather than of the content — and the weaker one
+never fires the check it exists to make.
+
+## How it was violated (#3892)
+
+`CompiledDependencies.Compute` writes `!input` only when the caller hands it the stage-1
+generated-input digest, and that digest existed at exactly one place: inside
+`MeshNodeCompilationService.CompileAsyncCore`, three statements before Roslyn. So:
+
+| The producer reached the bytes by… | Digest in hand | `!input` in the record |
+|---|---|---|
+| a fresh Roslyn emit | yes | **yes** |
+| a **disk-cache hit** (before #3892) | no — the method never ran | **no** |
+| the assembly-hydration shortcut (`GetConfigurationsFromExistingAssembly`) | no | no |
+
+The cache-hit row is the defect. It is a full producer path — the compile watcher and the batch
+baker both stamp whatever `CompileAndGetConfigurations` returns, and `ApplyCompileSuccess` writes
+`result.CompiledDependencies ?? def.CompiledDependencies`, so a later cache-hit compile REPLACES a
+complete record with an incomplete one. Nothing throws, nothing logs, and the bundle is well formed.
+
+The hydration row is not a defect: that path is a READER. It loads bytes an `IAssemblyStore` handed
+over, supplies a hub configuration from them, and is never stamped onto a NodeType — it also carries
+no `CompiledSources`, which is why stamping it would be catastrophic and nothing does.
+
+### How it surfaced
+
+`BakeEquivalenceTest.MeshDrivenAndCompilerDrivenBakes_ProduceTheSameArtifacts` bakes one content set
+both ways and compares the two per-type records strictly. It went red on **one CI shard** and passed
+locally at both the merge base and the PR head: in that shard the mesh-driven bake had reached its
+bytes through a warm cache while the compiler-driven bake compiled fresh, so one record carried
+`!input` and the other did not. Everything else matched exactly.
+
+🚨 **Relaxing that assertion to compare "modulo `!input`" would have made the red go away and left
+the producer non-determinism exactly where it was.** The symptom was a strict comparison noticing a
+real difference — which is what it is for.
+
+## The fix: persist the digest, do not recompute it
+
+The stage-1 digest is written into the emit's **staging directory** as `{nodeName}.inputdigest`,
+beside `{nodeName}.dll` and `{nodeName}.pdb`, before the directory rename that publishes the
+artifact under the cache's discovery glob. A cache hit reads it back and stamps the record with it.
+
+Three properties follow from where it is written:
+
+- **Publication stays atomic.** The rename publishes bytes and provenance together, so no reader can
+  observe one without the other.
+- **A write fault fails the compile.** `EmitToDiskWithRetry` discards the staging directory and the
+  exception propagates — the same verdict a lost DLL write gets. An artifact whose provenance cannot
+  be recorded is not published.
+- **An artifact without one is not a cache entry.** `CompilationCacheService.TryGetLatestCachedDllPath`
+  refuses it, exactly as it already refuses a set with no PDB. That costs at most ONE recompile per
+  type, for artifacts published by a build predating the sidecar — and the framework-timestamp check
+  beside it usually invalidates those anyway.
+
+### Why not recompute the digest at the hit site?
+
+It is available: `GeneratedInputDigestOf(assemblyName, source, nugetAssemblyPaths)` is a pure
+function of values the pipeline already has there, and `RegenerateGeneratedInputDigest` exists to
+compute exactly this without compiling. Measured on this repo's own probe type — one source node,
+no `#r "nuget:"`, warm in-process mesh — regeneration costs **0.11–0.18 ms** against **0.023–0.14 ms**
+for the sidecar read, and both produce the identical `g…` digest. So cost is not the argument.
+
+**The argument is that a recomputed digest answers a different question.** The digest folds
+`EmitPipeline.OptionsFingerprint`, `GeneratedInputIdentity.CompilerIdentity` and the file identities
+of the **generator assemblies on disk** — properties of the process doing the computing, not of the
+bytes. Recomputing it describes *"what a compile RIGHT HERE would be fed"* and stamps that onto bytes
+some earlier process emitted.
+
+That difference is reachable. The cache's validity rules are source-mtime and framework-mtime; they
+do not see a `#r "nuget:"` resolving to a different generator version, and they do not see a process
+restart on the same image. In either case a recomputed key would claim an equality that was never
+established — and because a matching content key DEMOTES the toolchain entry, it would license an
+adoption across precisely the change the toolchain entry exists to catch. Reading the producing
+compile's own digest off the disk cannot say anything the producing compile did not.
+
+Cost, meanwhile, is *not* uniformly small for the recompute option: on a real mesh the same
+regeneration performs source discovery (measured ~0.25 s per query on memex, four queries per type)
+and, for any type declaring `#r "nuget:"`, a NuGet restore — network IO, on every cache hit, per
+type at boot.
+
+## Where the code lives
+
+| Concern | Where |
+|---|---|
+| The sidecar (name, write, read) | `src/MeshWeaver.Compiler.Pipeline/GeneratedInputDigestFile.cs` |
+| Written into the staging dir | `MeshNodeCompilationService.CompileAsyncCore`'s emit callback |
+| Restored on a cache hit | `MeshNodeCompilationService.GetAssemblyLocationWithLog` |
+| Refused when absent | `CompilationCacheService.TryGetLatestCachedDllPath` |
+| The control | `test/MeshWeaver.Compiler.Pipeline.Test/CacheHitStampsTheSameRecordTest.cs` |
+
+🚨 **None of it is in `MeshWeaver.Compiler`, and that is deliberate.** That assembly is a full-MVID
+toolchain root (`FrameworkBuildIdentity.ToolchainRoots`), so under deterministic builds ANY edit to
+it — a comment included — moves the framework identity, invalidates every stamped record and every
+published bundle's adoptability on every mesh, and rebakes every NodeType. The cache-directory layout
+is already split between the two assemblies (the emit writes the directory, the pipeline discovers
+it), so the sidecar lives on the pipeline side, where the same fix costs nothing. One consequence to
+know when reading the code: the `OPTIONAL` paragraph on `CompiledDependencies.ContentKey` still lists
+the disk-cache hit among the producers that carry no entry. That sentence is now narrower than
+reality and was left alone on purpose — correcting a comment there would rebake the fleet. See
+[Graph / Compiler Layering](../GraphCompilerLayering) for the size rule that makes this trade.
+
+## The control, in both directions
+
+A control for this cannot exercise only the fresh-compile path — that is the path that always
+worked. `CacheHitStampsTheSameRecordTest` compiles one type twice on a real Monolith mesh, handing
+both calls the same node objects and the same source snapshot so the ONLY variable is how the
+compiler reached the assembly, and it asserts the route before it asserts the record: the first
+call's activity must say *Compiled assembly written to* and the second must say *Cache hit*.
+
+Measured on the pre-fix code it fails at the record, having passed both route assertions:
+
+```text
+Expected dictionary to contain key "!input" because 🚨 the dependency record is a PRODUCER
+artifact: it is stamped onto the NodeType and ships inside every bundle baked from it …
+```
+
+and passes after. `CompilationCacheServiceTest.IsCacheValid_ReturnsFalse_WhenTheGeneratedInputDigestIsMissing`
+pins the other half — including a positive control that the same fabricated artifact set IS valid
+while the digest is present, so the refusal cannot pass for an unrelated reason.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-rebuilt-type-records-the-same-provenance-either-way.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-rebuilt-type-records-the-same-provenance-either-way.md
@@ -1,0 +1,45 @@
+---
+Name: A published type now records the same provenance whether or not the build machine had a warm cache
+Category: Fix
+Description: A compiled node type records what it was built from, and that record is what tells a later installation whether the shipped bytes still match. If the machine doing the building reused an assembly it had compiled earlier, part of that record was silently left out — so two publishes of identical content could ship different amounts of protection. They no longer can.
+Icon: Checkmark
+Order: -20260910
+---
+
+# A published type now records the same provenance whether or not the build machine had a warm cache
+
+When a node type is compiled, the platform records **what the bytes were built from**. That record
+is what a later installation checks before it decides to reuse those bytes instead of compiling the
+type again — and one part of it, the fingerprint of the exact compilation input, is the part that
+can answer the question directly rather than by proxy.
+
+It was only ever recorded when the machine actually ran the compiler. If that machine had built the
+same type a moment earlier and reused the assembly it already had — which is the normal, fast case
+— the fingerprint was left out. Nothing failed and nothing was logged: the record was still valid,
+just weaker, and the check it enables simply never ran for that build.
+
+The consequence is the part worth knowing: **two publishes of byte-identical content could ship
+different amounts of protection**, decided by nothing more than whether the build machine happened
+to have a warm cache. Nothing downstream could tell which one it had received.
+
+## What changes
+
+**The fingerprint is now written beside the assembly and read back with it.** A build records it
+once, at the moment it has it, and any later reuse of those bytes recovers the same value — so the
+record is a property of the content, not of the machine or the moment.
+
+**It is the producing build's own fingerprint, not a fresh guess.** The value is read from what was
+stored next to the bytes rather than recalculated later. Recalculating would describe the machine
+doing the recalculating, which is not the same claim — and getting that wrong would let a build be
+reused across exactly the kind of change the check exists to catch.
+
+**An assembly whose fingerprint is missing is rebuilt instead of reused.** Files left by an earlier
+version of the platform have no fingerprint beside them, so they are compiled once more. That is a
+single rebuild per node type, on the first run after updating, and usually it would have happened
+anyway.
+
+## What this does not change
+
+**Nothing about how types are compiled, published or installed.** The bytes, the assemblies and the
+bundles are exactly as before. What changed is that the record shipped alongside them no longer
+varies with the build machine's state.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/CacheHitStampsTheSameRecordTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/CacheHitStampsTheSameRecordTest.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Compiler;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🚨 <b>THE PRODUCER STAMPS ONE RECORD, however it reached the bytes</b> (#3892).
+///
+/// <para><b>The defect.</b> <c>CompiledDependencies.Compute</c> writes the reserved
+/// <c>!input</c> CONTENT KEY entry only when the caller hands it the stage-1 generated-input
+/// digest, and the digest existed at exactly one place: inside <c>CompileAsyncCore</c>, three
+/// statements before Roslyn. A DISK-CACHE HIT never enters that method, so it reached the stamp
+/// with <c>null</c> and produced a record WITHOUT the content key. Nothing threw:
+/// <c>FindMismatch</c> simply had nothing to compare and the toolchain entry still governed. But
+/// that record is a PRODUCER artifact — it is stamped onto
+/// <c>NodeTypeDefinition.CompiledDependencies</c> and travels from there into every published
+/// bundle — so whether a shipped artifact carried the guard AT ALL depended on whether the baking
+/// machine's cache happened to be warm. Two publishes of identical content shipped records of
+/// different strength and nothing downstream could tell which it got; the weaker one silently
+/// never fires the check.</para>
+///
+/// <para><b>Why this test and not the symptom.</b> The sighting was
+/// <c>BakeEquivalenceTest.MeshDrivenAndCompilerDrivenBakes_ProduceTheSameArtifacts</c> going red on
+/// ONE CI shard while passing everywhere else — the mesh bake had hit a warm cache, the
+/// compiler-driven bake had compiled fresh, and assertion 4 compared the two records strictly.
+/// Comparing "modulo <c>!input</c>" would have made that red go away and left the producer
+/// non-determinism exactly where it was. So the contract is asserted HERE, on the producer, at the
+/// one place the two ways of reaching bytes diverge.</para>
+///
+/// <para>🚨 <b>The control has to reach the bytes through the CACHE</b>, which is why the
+/// assertions below read the compile's own ActivityLog before they read the record: a run that
+/// compiled twice would satisfy every record assertion while proving nothing. The first call must
+/// say <i>Compiled assembly written to</i> and the second must say <i>Cache hit</i>, or the test
+/// fails on that alone.</para>
+///
+/// <para>Deterministic by construction: both calls are handed the SAME node objects and the SAME
+/// source snapshot (<c>sourcesOverride</c>, the authoritative point-in-time set the pipeline
+/// already accepts), so nothing about the input can differ between them and the ONLY variable left
+/// is how the compiler reached the assembly.</para>
+/// </summary>
+public class CacheHitStampsTheSameRecordTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string TypePath = "type/CacheHitContentKey";
+
+    /// <summary>The mesh's real compiler — registered by <c>AddGraph()</c>, as in every portal.</summary>
+    private IMeshNodeCompilationService Compiler =>
+        Mesh.ServiceProvider.GetRequiredService<IMeshNodeCompilationService>();
+
+    private static MeshNode TypeNode() => MeshNode.FromPath(TypePath) with
+    {
+        Name = "CacheHitContentKey",
+        NodeType = MeshNode.NodeTypePath,
+        State = MeshNodeState.Active,
+        // A REAL timestamp, so the cache's freshness comparison ("the DLL is newer than everything
+        // that went into it") is actually exercised rather than trivially satisfied by 0001-01-01.
+        LastModified = DateTimeOffset.UtcNow,
+        Content = new NodeTypeDefinition
+        {
+            Description = "a type whose bytes are produced once and then served from the cache",
+            Configuration = "config => config.WithContentType<CacheHitProbe>()",
+        },
+    };
+
+    private static IReadOnlyList<MeshNode> SourceNodes() =>
+    [
+        new MeshNode("probe", $"{TypePath}/Source")
+        {
+            NodeType = "Code",
+            Name = "probe",
+            State = MeshNodeState.Active,
+            LastModified = DateTimeOffset.UtcNow,
+            Content = new CodeConfiguration
+            {
+                Language = "csharp",
+                Code = """
+                    public record CacheHitProbe { public string Title { get; init; } = ""; }
+                    public static class CacheHitProbeApi { public static int TheAnswer() => 42; }
+                    """,
+            },
+        },
+    ];
+
+    private static string Transcript(NodeCompilationResult result) =>
+        string.Join(" | ", result.Log?.Messages.Select(m => m.Message) ?? []);
+
+    /// <summary>
+    /// The record as one comparable line — so a failure PRINTS both records side by side instead
+    /// of reporting that two dictionaries differ.
+    /// </summary>
+    private static string Render(ImmutableSortedDictionary<string, string>? record) =>
+        record is null
+            ? "(no record)"
+            : string.Join(", ", record.Select(entry => $"{entry.Key}={entry.Value}"));
+
+    [Fact(Timeout = 300_000)]
+    public async Task ARecordStampedFromTheDiskCache_CarriesTheSameContentKeyAsTheCompileThatProducedTheBytes()
+    {
+        // The same objects for both calls: identical content, identical timestamps, identical
+        // source set. Nothing but the route to the assembly can differ.
+        var typeNode = TypeNode();
+        var sources = SourceNodes();
+
+        var fresh = await Compiler.CompileAndGetConfigurations(typeNode, sources)
+            .Take(1)
+            .Should().Within(TestTimeouts.Convergence)
+            .Emit("the first compile must settle — everything below reads its result");
+        fresh.Should().NotBeNull();
+        fresh!.AssemblyLocation.Should().NotBeNullOrEmpty("Roslyn produced an assembly");
+
+        // ── THE CONTROL'S PRECONDITION: call 1 really did COMPILE ────────────────────────────────
+        Transcript(fresh).Should().Contain("Compiled assembly written to",
+            "this control only means something if the first call is a real emit and the second is a "
+            + "cache hit; a run that compiled twice would satisfy every assertion below while "
+            + $"exercising nothing. Transcript: {Transcript(fresh)}");
+
+        fresh.CompiledDependencies.Should().NotBeNull();
+        fresh.CompiledDependencies!.Should().ContainKey(CompiledDependencies.ContentKey,
+            "a fresh compile has the generated input in hand, so it always stamped the content key");
+
+        // ── THE SECOND CALL REACHES THE SAME BYTES THROUGH THE CACHE ─────────────────────────────
+        var warm = await Compiler.CompileAndGetConfigurations(typeNode, sources)
+            .Take(1)
+            .Should().Within(TestTimeouts.Convergence)
+            .Emit("the second call must settle");
+        warm.Should().NotBeNull();
+
+        Transcript(warm!).Should().Contain("Cache hit",
+            "the artifact call 1 published is newer than every source and newer than the framework, "
+            + "so call 2 MUST take the disk-cache branch — if it recompiled instead, this test is "
+            + $"measuring the wrong path. Transcript: {Transcript(warm!)}");
+        warm!.AssemblyLocation.Should().Be(fresh.AssemblyLocation,
+            "the cache hit serves the very bytes call 1 wrote");
+
+        // ── THE VERDICT ──────────────────────────────────────────────────────────────────────────
+        warm.CompiledDependencies.Should().NotBeNull();
+        warm.CompiledDependencies!.Should().ContainKey(CompiledDependencies.ContentKey,
+            "🚨 the dependency record is a PRODUCER artifact: it is stamped onto the NodeType and "
+            + "ships inside every bundle baked from it. Before #3892 a cache hit reached the stamp "
+            + "with no generated-input digest and produced a record WITHOUT the content key, so two "
+            + "publishes of identical content shipped different guard strength depending on whether "
+            + "the baking machine's cache was warm — and the weaker one simply never fires the "
+            + "check. The digest is now written beside the bytes at emit time and restored here, so "
+            + "the record does not depend on how the producer reached them");
+
+        Render(warm.CompiledDependencies).Should().Be(Render(fresh.CompiledDependencies),
+            "identical content compiled once and then served from the cache must stamp the IDENTICAL "
+            + "record — that equality is what BakeEquivalenceTest's assertion 4 compares between the "
+            + "mesh-driven and compiler-driven bakes, and it is the whole reason the record can be "
+            + "trusted as a per-type identity rather than a per-run one");
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/CompilationCacheServiceTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/CompilationCacheServiceTest.cs
@@ -162,9 +162,11 @@ public class CompilationCacheServiceTest : IDisposable
 
     /// <summary>
     /// Lays out the timestamped-subdir cache that <see cref="CompilationCacheService.TryGetLatestCachedDllPath"/>
-    /// expects: <c>{cacheDir}/{nodeName}_{ticks_hex}/{nodeName}.{dll,pdb}</c>
+    /// expects: <c>{cacheDir}/{nodeName}_{ticks_hex}/{nodeName}.{dll,pdb,inputdigest}</c>
     /// plus the flat <c>{cacheDir}/{nodeName}.cs</c> source mirror. Mirrors what
-    /// <see cref="MeshNodeCompilationService.CompileToDiskAsync"/> writes at runtime.
+    /// <see cref="MeshNodeCompilationService.CompileToDiskAsync"/> writes at runtime — including
+    /// the generated-input digest, which the emit publishes inside the same staged directory as
+    /// the assembly (#3892).
     /// </summary>
     private string CreateCacheArtifacts(string nodeName, DateTime? dllWriteTime = null)
     {
@@ -176,6 +178,7 @@ public class CompilationCacheServiceTest : IDisposable
         File.WriteAllText(dllPath, "dummy dll");
         File.WriteAllText(pdbPath, "dummy pdb");
         File.WriteAllText(sourcePath, "dummy source");
+        File.WriteAllText(GeneratedInputDigestFile.PathFor(dllPath), "gdummydigest");
         if (dllWriteTime is { } t)
             File.SetLastWriteTimeUtc(dllPath, t);
         return dllPath;
@@ -196,6 +199,34 @@ public class CompilationCacheServiceTest : IDisposable
 
         // Assert
         isValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 An artifact set WITHOUT its generated-input digest is INCOMPLETE, not merely undocumented
+    /// (#3892) — the same judgement the PDB check makes one line above it.
+    ///
+    /// <para>Reusing such an entry would stamp a dependency record with no <c>!input</c> content
+    /// key, while a fresh compile of the identical content stamps one. That record is a PRODUCER
+    /// artifact: it lands on the NodeType and ships inside every bundle baked from it, so the
+    /// guard's strength would depend on whether this machine's cache was warm. One recompile is
+    /// the price, and it is paid once per type, for artifacts a build that predates the sidecar
+    /// published.</para>
+    /// </summary>
+    [Fact]
+    public void IsCacheValid_ReturnsFalse_WhenTheGeneratedInputDigestIsMissing()
+    {
+        var nodeName = "digestless_cache";
+        var dllPath = CreateCacheArtifacts(nodeName);
+        _service.IsCacheValid(nodeName, DateTimeOffset.UtcNow.AddMinutes(-5)).Should().BeTrue(
+            "the positive control: with every artifact present this entry IS valid, so the "
+            + "assertion below cannot pass for some unrelated reason");
+
+        File.Delete(GeneratedInputDigestFile.PathFor(dllPath));
+
+        _service.IsCacheValid(nodeName, DateTimeOffset.UtcNow.AddMinutes(-5)).Should().BeFalse(
+            "bytes whose generated-input digest is not beside them cannot be stamped with a "
+            + "content key, so serving them would produce a WEAKER dependency record than a fresh "
+            + "compile of the same content — recompile instead");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #3892.

## The decision, and what decided it

The issue offers two resolutions. **(A)** relax `BakeEquivalenceTest`'s assertion 4 to compare
records modulo `!input`. **(B)** make the record complete however the producer reached its bytes.
This PR is **(B)**, and specifically the *persist* variant rather than the *recompute* variant.

(A) alone is a band-aid, for the reason in the issue comment: the dependency record is a **producer**
artifact. It is stamped onto `NodeTypeDefinition.CompiledDependencies` and travels into every bundle
baked from that type, so whether a published bundle carries the ContentKey guard at all depended on
whether the baking machine happened to have a warm disk cache. Two publishes of identical content
ship records of different guard strength, and nothing downstream can tell which it got — the weaker
one simply never fires the check. Relaxing the comparison hides that and leaves it live.

## Between the two forms of (B), the deciding argument is correctness, not cost

Recomputing the digest at the hit site is affordable — measured on a probe type (one source node,
no `#r "nuget:"`, warm in-process mesh) at **0.11–0.18 ms**, against **0.023–0.14 ms** for a sidecar
read, and both produce the identical `g…` value. So cost did not decide it.

What decided it is that a **recomputed digest answers a different question**. The digest folds
`EmitPipeline.OptionsFingerprint`, `GeneratedInputIdentity.CompilerIdentity` and the file identities
of the generator assemblies **on disk** — properties of the process doing the computing, not of the
bytes. Recomputing describes *"what a compile RIGHT HERE would be fed"* and stamps that onto bytes an
earlier process emitted. The cache's validity rules are source-mtime and framework-mtime; they do not
see a `#r "nuget:"` resolving to a different generator version, and they do not see a process restart
on the same image. And because a matching content key **DEMOTES** the toolchain entry
(`FindMismatchAfterReevaluation`), a mis-stamp would license an adoption across exactly the change
the toolchain entry exists to catch. Reading the producing compile's own digest off the disk cannot
say anything the producing compile did not.

For completeness on cost: recomputation is *not* uniformly cheap either. On a real mesh the same
regeneration performs source discovery (measured ~0.25 s per query on memex, four queries per type)
and, for any type declaring `#r "nuget:"`, a NuGet restore — network IO, on every cache hit, per type
at boot.

## What changes

- The stage-1 digest is written into the emit's **staging directory** as `{nodeName}.inputdigest`,
  before the rename that publishes the artifact — so publication stays atomic and no reader can see
  bytes without provenance. A write fault fails the compile, the same verdict a lost DLL write gets.
- A disk-cache hit **restores** it and stamps the record with it.
- An artifact with **no** digest beside it is refused as a cache entry — the same judgement
  `TryGetLatestCachedDllPath` already makes for a missing PDB. Cost: at most one recompile per type,
  for artifacts published by a build predating the sidecar, which the framework-timestamp check
  beside it usually invalidates anyway.

🚨 **Nothing lands in `MeshWeaver.Compiler`, deliberately.** That assembly is a full-MVID toolchain
root (`FrameworkBuildIdentity.ToolchainRoots`), so under deterministic builds even a comment there
moves the framework identity, invalidates every stamped record and every published bundle's
adoptability on every mesh, and rebakes every NodeType. The cache-directory layout was already split
across the two assemblies, so the sidecar lives on the pipeline side where the same fix costs
nothing. One consequence, called out in the doc page: the `OPTIONAL` paragraph on
`CompiledDependencies.ContentKey` still lists the disk-cache hit among the producers that carry no
entry. That sentence is now narrower than reality and was left alone on purpose — it is a stale
example list, not a stale contract, and correcting it would rebake the fleet.

## The control, in both directions

`test/MeshWeaver.Compiler.Pipeline.Test/CacheHitStampsTheSameRecordTest.cs` compiles ONE type twice
on a real Monolith mesh, handing both calls the same node objects and the same source snapshot so the
only variable is how the compiler reached the assembly. It asserts the **route** before the record —
call 1's activity must say *Compiled assembly written to*, call 2's must say *Cache hit* — so a run
that compiled twice cannot pass it vacuously.

**Before the fix** (src reverted, tests kept) it fails at the record, having passed both route
assertions:

```
Expected dictionary to contain key "!input" because 🚨 the dependency record is a PRODUCER
artifact: it is stamped onto the NodeType and ships inside every bundle baked from it. Before
#3892 a cache hit reached the stamp with no generated-input digest and produced a record WITHOUT
the content key …
```

and `CompilationCacheServiceTest.IsCacheValid_ReturnsFalse_WhenTheGeneratedInputDigestIsMissing`
fails with:

```
Expected value to be false because bytes whose generated-input digest is not beside them cannot be
stamped with a content key … but found True.
```

**After the fix** both pass. The cache-service test carries a positive control (the same fabricated
artifact set IS valid while the digest is present), so its refusal cannot pass for an unrelated
reason.

## Verified locally (Release, `-warnaserror`, `0 Error(s)` each)

| Suite | Result |
|---|---|
| `MeshWeaver.Compiler.Pipeline.Test` (full) | 787 / 787 |
| `MeshWeaver.Graph.Test` (full) | 1502 / 1502 |
| `MeshWeaver.Documentation.Test` (full — guards + link integrity) | 368 / 368 |
| `MeshWeaver.PluginTester.Test` → `BakeEquivalenceTest` | 2 / 2 |

## Work product

The finding is committed as `Doc/Architecture/ProducerDeterminismOfTheDependencyRecord`
(`src/MeshWeaver.Documentation/Data/Architecture/ProducerDeterminismOfTheDependencyRecord.md`),
linked from the Architecture index, with a What's New entry (`Category: Fix`).

Pairs-with: none — the diff removes no public type or member from `src/`; every change is an
addition, and the one new type (`GeneratedInputDigestFile`) is `internal` to
`MeshWeaver.Compiler.Pipeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
