### PR TITLE
docs(#3201): retiring an inline env entry has no API action, and the audit that finds it has no remedy

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -103,10 +103,20 @@ A shadowed secret is the worst version of this: the shadowed copy is inert, and 
 in use sits in plaintext on the Deployment spec, in no committed source, readable by anything that
 can `get deploy`.
 
-That is live on `memex` today (MeshWeaver#3201): `PluginCatalog__RegistryToken` exists both in
-`secret/memex-portal-secrets` and as an inline entry, and **the two values differ** — so the portal
-authenticates to the plugin registry with the plaintext copy while the secret's copy goes unused. It
-also means the obvious cleanup is wrong: deleting the inline entry does not restore the status quo.
+That was live on `memex` as measured 2026-09-03 (MeshWeaver#3201): `PluginCatalog__RegistryToken`
+existed both in `secret/memex-portal-secrets` and as an inline entry, and **the two values differed**
+— so the portal authenticated to the plugin registry with the plaintext copy while the secret's copy
+went unused. It also meant the obvious cleanup was wrong: deleting the inline entry did not restore
+the status quo.
+
+🚨 **The divergence half of that is CLOSED; the shadow half is not.** Re-measured in-cluster
+2026-09-08T01:03Z: both portals now have a Key Vault-synced copy
+(`memex-portal-keyvault` / `memexcloud-portal-keyvault`), and on each one the inline value and the
+vault copy are **EQUAL** — `Systemorph/Memex#180` promoted each instance's *in-use* token verbatim
+rather than picking a winner, so removing the inline entry is now a no-op in value terms. What
+remains is the plaintext inline entry itself, on both pod specs, still outranking every `envFrom`.
+Nothing in a repository can remove it — see
+[DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Step 2 has NO API action"*.
 
 ### A credential shadow can be two PRINCIPALS, not two values
 
@@ -380,6 +390,14 @@ the run's own log; the owned/never-owned split and the value probes are read-onl
 | 5 | **Cluster-only, never owned** | **22** | live-edited settings the chart had no key for until MeshWeaver#3199 — AI providers, `LogWatch__*`, `Speech__*`, `Commerce__BaseUrl`, `Features__Ai__Clis__*`, `Portal__ReactAppUrl` | put them on the `Hosting/Deployment` record — `Systemorph/Memex#148` |
 | 6 | **Committed, never deployed** | **5** | memex-cloud's overlay carries `PreWarm__{BatchBake,BuildProtocol,DynamicTypes,GateReadiness}: "true"` and `probes.startup.failureThreshold: 1080`; live runs the shipped defaults | a deploy, not a cleanup — this is `deploy-drift`'s class surfacing here |
 | 7 | **Ruled inert** | **2** | the memex liveness/readiness `initialDelaySeconds` — see above; the chart is authoritative | nothing; do not "fix" it |
+
+🚨 **Group 2 has moved since this snapshot and the row is no longer current.** *"neither portal has
+a Key Vault entry at all"* stopped being true on 2026-09-06 for `memex` and by 2026-09-08 for
+`memex-cloud`: `Systemorph/Memex#180` declared a chart-owned `keyVaultSecrets` class on both, and
+re-measured 2026-09-08T01:03Z the inline value and the vault copy are **EQUAL** on each portal. The
+table stays as it was measured; read this line with it. The remaining act — delete the inline entry
+— has no repository half and no operator action
+([DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Step 2 has NO API action"*).
 
 Zero `COLLIDES` and zero `CHART-ONLY` — as on 2026-09-03, which is the only other run since #3168
 introduced those two classes, so "consecutive" is a two-run claim and nothing more. The `EMAIL__*`

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -225,7 +225,8 @@ this page that has no such action.** Four sources say so, and they agree — mea
 **So the audit names the drift and nothing can repair it.** `kubectl -n <ns> set env
 deployment/<name> <KEY>-` remains the only instrument. Read that under rule 2 of
 OperatingFromThePortal: an audit finding with no remedy is **a gap to file against the Hosting
-package**, not a recipe to promote back into a procedure. The remedy the record's shape already
+package**, not a recipe to promote back into a procedure — filed as
+[MeshWeaver.Plugins#1593](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1593). The remedy the record's shape already
 anticipates is the one that does not exist — `InlineEnvOverride.RetiredBy` names what retires an
 entry, and no code reads it.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -193,6 +193,48 @@ the pod template, which creates a new ReplicaSet and supersedes an in-flight rol
 `kubectl rollout status` first and hold if a deploy is already in progress — a cleanup that ejects a
 release roll costs more than the shadow it clears.
 
+### 🚨 Step 2 has NO API action — the audit finds it, and no remedy can act on it
+
+Under the 2026-09-08 operating directive every operation is a `Hosting/InstanceAction` the control
+instance's operator executes in-cluster, and a cluster command is break-glass
+([OperatingFromThePortal](/Doc/Architecture/OperatingFromThePortal)). **Step 2 is the one act on
+this page that has no such action.** Four sources say so, and they agree — measured 2026-09-10:
+
+- **The chart cannot render it away, because the chart never rendered it.**
+  `deploy/helm/templates/memex-portal/deployment.yaml` emits exactly **five** inline `env:` entries
+  on the portal container — four `DOTNET_Dbg*`/`DOTNET_CreateDumpDiagnostics` crash-dump variables
+  and, when `selfUpdate.azureClientId` is set, `AZURE_CLIENT_ID` — and exactly **two** on a gate
+  sidecar (`MESH_GRPC_URL`, `MESH_GATE_ADDRESS`). There is no values-driven inline-env list anywhere
+  in the chart: every configurable key reaches the pod through `envFrom`. So **no values edit, in
+  any overlay or on any record, can delete an inline entry — nothing in a repository created one.**
+  The one committed JSON patch in the fleet, `deployments/aks/memex-cloud/portal-patch.json`, adds
+  volumes, mounts, an `envFrom` source, `resources` and a `nodeSelector`, and touches
+  `/containers/0/env` not at all.
+- **The record cannot delete it either, and that is the contract.** `InlineEnvOverride` is
+  declarative: recording an entry does not create one and *dropping it does not delete one*.
+- **`Reconcile` cannot.** Its only configuration remedy is `RepairRemedy.ReapplyRecord` — re-render
+  values from the record and run `hosting-deploy`, which is a `helm upgrade`. Three-way merge
+  removes only what helm previously OWNED, so a live-only inline entry survives it; that is the same
+  measurement (helm v3.21.1 and v4.2.4, positive control) this page already rests on.
+- **`Audit` sees it exactly, twice.** `hosting-audit` reports the key under `envLiveOnly` (an env
+  name on the live portal container that no manifest renders) *and* under `plainSecretEntries` (a
+  name matching `token|secret|key|password` carried as a plain value). The operator's own test suite
+  asserts the finding by its literal name,
+  `env:memex-portal:PluginCatalog__RegistryToken`.
+
+**So the audit names the drift and nothing can repair it.** `kubectl -n <ns> set env
+deployment/<name> <KEY>-` remains the only instrument. Read that under rule 2 of
+OperatingFromThePortal: an audit finding with no remedy is **a gap to file against the Hosting
+package**, not a recipe to promote back into a procedure. The remedy the record's shape already
+anticipates is the one that does not exist — `InlineEnvOverride.RetiredBy` names what retires an
+entry, and no code reads it.
+
+**Why this matters more than one duplicated variable.** MeshWeaver#3201 has outlived three merged
+PRs. Every deferral until 2026-09-08 was about *rollout timing* — a fleet freeze, then the newly
+armed readiness gate (#3404, #3395), then the bake-gate stall (#3663). All three closed by
+2026-09-08. What is left is not a schedule and not a risk: the last step's instrument is the one the
+operating model withdrew, and the entry's `retiredBy` therefore has no lane to travel.
+
 ## What else the record gained
 
 - **`gates`** — the language gate sidecars (`python`, `node`, `pandas`). The chart has been able to

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -90,6 +90,25 @@ and how to reconcile it in the same session. Do not re-derive that list here —
 3. **Is it a measurement in a war story?** Leave it — it is the reason the rule on the page exists.
    Do not run it to "check"; ask the API question the page's rule now points at.
 
+### The one WRITE with no action kind: retiring an inline `env:` entry
+
+Rule 1 has exactly one known miss, and it is a write rather than a read. **Nothing can remove an
+inline `env:` entry from a Deployment.** The chart never rendered one (it emits five fixed portal
+entries and two per gate sidecar, and no values-driven list), the record's `inlineEnv` is
+declarative by contract — *dropping an entry does not delete one* — and `Reconcile`'s only
+configuration remedy, `ReapplyRecord`, is a `helm upgrade`, whose three-way merge removes only what
+helm previously owned. `Audit` detects the drift precisely, under `envLiveOnly` and
+`plainSecretEntries`, so the finding is reported and no remedy can act on it.
+
+The record already carries the intent: `InlineEnvOverride.RetiredBy` names what retires an entry,
+and no code reads it. **The gap is a `RetireInlineEnv` remedy** that removes the keys a record marks
+retired, ordered after `ReapplyRecord` so the key has a declared home before the shadow goes — the
+two-step in
+[DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Retiring a shadow takes two steps"*,
+with the equality precondition that page states. Until it exists, `kubectl set env deploy/<name>
+<KEY>-` is break-glass and the live worked example (MeshWeaver#3201, a plugin-registry credential in
+plaintext on two portals' pod specs) stays open on the instrument, not on the analysis.
+
 ## Related rules decided the same day
 
 - **The Deployment record is the ONE input.** Aspire and Helm render from it; the image receives

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -101,7 +101,8 @@ helm previously owned. `Audit` detects the drift precisely, under `envLiveOnly` 
 `plainSecretEntries`, so the finding is reported and no remedy can act on it.
 
 The record already carries the intent: `InlineEnvOverride.RetiredBy` names what retires an entry,
-and no code reads it. **The gap is a `RetireInlineEnv` remedy** that removes the keys a record marks
+and no code reads it. **The gap is a `RetireInlineEnv` remedy** (filed as
+[MeshWeaver.Plugins#1593](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1593)) that removes the keys a record marks
 retired, ordered after `ReapplyRecord` so the key has a declared home before the shadow goes — the
 two-step in
 [DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Retiring a shadow takes two steps"*,


### PR DESCRIPTION
Doc-only. Records the finding that keeps Systemorph/MeshWeaver#3201 open after three merged PRs (#3383, #3447, #3668).

## What was measured

The issue's remaining subject is the inline `env: PluginCatalog__RegistryToken` on both portals' Deployment specs. The question nobody had answered from source was **is that entry chart-rendered or imperative** — because the two have completely different fixes. Established from chart source, 2026-09-10:

| claim | evidence |
|---|---|
| the chart renders **no** values-driven inline env | `deploy/helm/templates/memex-portal/deployment.yaml` emits exactly five inline entries on the portal container (four `DOTNET_Dbg*`/`DOTNET_CreateDumpDiagnostics`, plus `AZURE_CLIENT_ID` when `selfUpdate.azureClientId` is set) and exactly two on a gate sidecar. Every configurable key reaches the pod through `envFrom`. |
| no committed patch adds one | `deployments/aks/memex-cloud/portal-patch.json` adds volumes, mounts, an `envFrom` source, `resources` and a `nodeSelector`; it touches `/containers/0/env` not at all. `memex` has no patch file. |
| the record cannot delete one | `InlineEnvOverride` is declarative by contract — recording an entry does not create one and dropping it does not delete one. |
| `Reconcile` cannot | its only configuration remedy is `RepairRemedy.ReapplyRecord` = `hosting-deploy` = `helm upgrade`, whose three-way merge removes only what helm previously owned. |
| `Audit` **can see it**, twice | `hosting-audit` reports it under `envLiveOnly` and under `plainSecretEntries`; `deploy/aks/operator/test/run-tests.sh` asserts the finding by its literal name. |

**So the entry is imperative, the audit names it, and no remedy can act on it.** `kubectl set env deploy/<name> <KEY>-` is the only instrument, and under the 2026-09-08 operating directive that is break-glass. The record already carries the intent (`InlineEnvOverride.RetiredBy`) and no code reads it.

## Why this is worth a page rather than another issue comment

Every deferral of #3201 until 2026-09-08 was about rollout timing — the fleet freeze, then the newly armed readiness gate (#3404, #3395), then the bake-gate stall (#3663). **All three are now closed.** What remains is not a schedule and not a risk; it is a missing remedy, and that is a durable class-level finding rather than an instance's status.

## Changes

- `DeploymentEnvLayers.md` — new subsection under the two-step: *"Step 2 has NO API action — the audit finds it, and no remedy can act on it"*, with the four sources above.
- `OperatingFromThePortal.md` — the one known miss in rule 1, and it is a WRITE rather than a read; names the gap as a `RetireInlineEnv` remedy driven by the record's `retiredBy`.
- `ChartDriftSemantics.md` — date-qualifies two claims about this key that stopped being true on 2026-09-06/08: both portals now DO have a Key Vault entry, and the inline and vault copies are EQUAL on each. The dated audit-run table stays as measured, with a correction note beside it rather than an edit inside it.

## Ordering safety, for the record

Removing the inline entry is now a no-op in value terms — measured in-cluster 2026-09-08T01:03Z, inline and vault-synced are EQUAL (len 47) on both portals — and a value survives on each: `memex` falls through to `memex-portal-keyvault` (last in `envFrom`, so it outranks the third, different copy in `memex-portal-secrets`); `memex-cloud` falls through to `memexcloud-portal-keyvault`, its only source. The legacy key is still read (`PluginCatalogOptions.RegistryToken`, via `InstanceAutoRegistrationService`, `InstanceConsentService`, `RegistryUpdateReconciler`), so leaving it unset would not have been safe — it will not be.

No token value was read, printed or stored anywhere in this work; nothing was mutated on any cluster and no cluster command was run.

Paired config half: Systemorph/Memex (record + overlay status notes).

Refs #3201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
