### PR TITLE
Record that #3653's GUI question is answered (docs + publish-packages header)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,31 +35,39 @@ name: Publish the surviving NuGet packages
 # The moment either grows a dependency on a MeshWeaver framework assembly, this lane is wrong and
 # must take its bytes from a sealed set instead.
 #
-# ──────────────────── THE TEMPLATE IS BLOCKED ON A PRODUCT DECISION, NOT ON WIRING ────────────────
-# MeshWeaver.MemexTemplate is a survivor by decision but is NOT published here yet, because
-# publishing it today would publish PRIVATE SOURCE to public nuget.org. Measured 2026-09-07:
+# ──────────────────── THE GUI QUESTION IS ANSWERED; THE WIRING IS NOT BUILT ───────────────────
+# MeshWeaver.MemexTemplate is a survivor by decision and is still NOT published here — but the
+# reason has changed, and the old one no longer holds. What was measured on 2026-09-07:
 #
-#   • generate-memex-template.cs REFUSES to generate without `--with-gui`: the two shipped hosts
-#     reference Memex.Portal.Gui unconditionally, so a template without it cannot build.
+#   • generate-memex-template.cs REFUSED to generate without `--with-gui`: the two shipped hosts
+#     referenced Memex.Portal.Gui unconditionally, so a template without it could not build.
 #   • Memex.Portal.Gui lives ONLY in Systemorph/MeshWeaver.Plugins, which is PRIVATE. Core holds
 #     zero .razor files and no MeshWeaver.Blazor* project — the GUI has fully left the public repo.
-#   • The published 3.0.0-rc7 template contains NO Memex.Portal.Gui, so shipping it now would be a
-#     NEW public exposure, not a restoration of prior behaviour.
+#   • The published 3.0.0-rc7 template contains NO Memex.Portal.Gui, so shipping it WITH the GUI
+#     would be a NEW public exposure, not a restoration of prior behaviour.
 #   • A nupkg cannot be recalled. Unlisting hides a version from search; it stays downloadable by
 #     exact version for ever (verified against this very registry).
 #
-# There IS a standing decision to include the GUI (2026-08-26) but its stated premise — "the UI is
-# public in core today" — has since expired with the move. So the template's publish step is
-# deliberately absent rather than written and disabled: a step that exists but never runs is the
-# skip-trapdoor this repository forbids, and one that runs would ship the source.
+# 🚨 The FIRST bullet is HISTORY: issue #3653 was decided the other way — make the GUI optional in
+# the hosts — and Systemorph/MeshWeaver.Plugins#1591 landed it. Both hosts now reference
+# Memex.Portal.Gui from a CONDITIONED ItemGroup and compile without it, the generator drops an
+# optional project it is not shipping (refusing by name if the reference is unconditional), and
+# `dotnet pack tools/MeshWeaver.MemexTemplate.Pack` succeeds with no `--with-gui` and no
+# Memex.Portal.Gui in the nupkg. So there IS a GUI-less template to publish, and publishing it
+# does not publish the GUI.
 #
-# 🚨 DO NOT add the template here until the GUI question is answered (issue #3653). When it is, the step needs:
-# a Plugins checkout with a MINTED App token (never a stored PAT — the predecessor
+# What is still missing is this lane's own wiring, and it is a real task, not a formality. Adding
+# the step needs: a Plugins checkout with a MINTED App token (never a stored PAT — the predecessor
 # publish-github.yml carried secrets.GH_PAT and is deleted), `-p:Version=X.Y.Z` (that project
 # inherits no props and would otherwise stamp 1.0.0), `-p:MeshWeaverRoot=` (the generator copies
 # two projects and three assets from core and can run in NEITHER repo alone), and an answer to
 # WHICH Plugins commit a core tag pairs with — no pairing artefact exists, so record the resolved
-# sha in the summary at minimum.
+# sha in the summary at minimum. Note also that the scaffolded solution is a HEADLESS mesh host
+# (no Blazor shell), which the generated README states; publishing it is a product call about what
+# `dotnet new meshweaver-memex` should hand a newcomer, not a packaging one.
+#
+# Until that step exists the template's publish is ABSENT rather than written-and-disabled: a step
+# that exists but never runs is the skip-trapdoor this repository forbids.
 #
 # 🛡️ NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"): `preflight` asserts every
 # secret and fails RED naming what to provision; `publish` needs it and runs unconditionally. There
@@ -178,7 +186,7 @@ jobs:
           {
             echo "### Publishing MeshWeaver ${{ steps.version.outputs.version }}"
             echo "- core: \`${GITHUB_SHA}\`"
-            echo "- \`MeshWeaver.MemexTemplate\` is NOT published by this lane — see the header."
+            echo "- \`MeshWeaver.MemexTemplate\` is NOT published by this lane — the step is not built yet; see the header."
           } >> "$GITHUB_STEP_SUMMARY"
 
       # PublicRelease=true is what makes $(Version) the clean $(PlatformVersion) rather than
@@ -284,6 +292,6 @@ jobs:
             echo "### Published to nuget.org"
             echo "- \`MeshWeaver.Aspire.Hosting.Memex\` ${{ steps.version.outputs.version }}"
             echo ""
-            echo "\`MeshWeaver.MemexTemplate\` was NOT published — it is blocked on the GUI"
+            echo "\`MeshWeaver.MemexTemplate\` was NOT published — this lane has no step for it yet (the GUI question is answered; see the header)"
             echo "decision recorded in Doc/Architecture/NuGetPackageRetirement."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src/MeshWeaver.Documentation/Data/Architecture/NuGetPackageRetirement.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NuGetPackageRetirement.md
@@ -39,30 +39,41 @@ what THIS tree packs, and one survivor is in another repository — invisible to
 construction. That gap has already cost one wrong unlist: an earlier sweep run from this repository
 could not see the template's project and retired it.
 
-### 🛑 The template is a survivor that cannot ship yet
+### 🛑 The template is a survivor that has not shipped yet
 
 `MeshWeaver.MemexTemplate` last published `3.0.0-rc7`; all seven of its versions read
 `listed: false`, so a versionless `dotnet new install MeshWeaver.MemexTemplate` cannot resolve it.
-One cause was mechanical and is fixed — its pack target never passed the generator the platform
-checkout it requires, so `dotnet pack` on it could not succeed at all. The other is **a product
-decision that is not made**, and it blocks publication. Measured 2026-09-07:
+Two causes, both now cleared, and one piece of wiring that is still not built.
+
+**Cause 1 — mechanical, fixed.** Its pack target never passed the generator the platform checkout
+it requires, so `dotnet pack` on it could not succeed at all.
+
+**Cause 2 — the GUI, decided 2026-09-10.** Measured 2026-09-07:
 
 | Fact | Consequence |
 |---|---|
-| `generate-memex-template.cs` **refuses** to generate without `--with-gui` — the two shipped hosts reference `Memex.Portal.Gui` unconditionally | there is no GUI-less template to publish |
-| `Memex.Portal.Gui` lives **only** in MeshWeaver.Plugins, which is **private**. Core holds zero `.razor` files and no `MeshWeaver.Blazor*` project | publishing the template publishes private source |
-| The published `3.0.0-rc7` package contains **no** `Memex.Portal.Gui` | shipping it now is a NEW exposure, not a restoration |
-| A nupkg cannot be recalled — unlisting hides a version from search but it stays downloadable by exact version for ever | the exposure is irreversible |
+| `generate-memex-template.cs` **refused** to generate without `--with-gui` — the two shipped hosts referenced `Memex.Portal.Gui` unconditionally | there was no GUI-less template to publish |
+| `Memex.Portal.Gui` lives **only** in MeshWeaver.Plugins, which is **private**. Core holds zero `.razor` files and no `MeshWeaver.Blazor*` project | publishing the template WITH it publishes private source |
+| The published `3.0.0-rc7` package contains **no** `Memex.Portal.Gui` | shipping it with the GUI is a NEW exposure, not a restoration |
+| A nupkg cannot be recalled — unlisting hides a version from search but it stays downloadable by exact version for ever | that exposure would be irreversible |
 
-There *is* a standing decision to include the GUI (2026-08-26), but its stated premise — *"the UI
+There *was* a standing decision to include the GUI (2026-08-26), but its stated premise — *"the UI
 is public in core today, the move is what would make it private"* — **expired when the move
-happened.** So `publish-packages.yml` publishes the Aspire integration only, and the template's
-step is **absent rather than written-and-disabled**: a step that exists but never runs is the
-skip-trapdoor this repository forbids, and one that runs would ship the source. Tracked in
-[#3653](https://github.com/Systemorph/MeshWeaver/issues/3653).
+happened.** [#3653](https://github.com/Systemorph/MeshWeaver/issues/3653) was therefore decided the
+other way: **make the GUI optional in the hosts**, landed by
+[MeshWeaver.Plugins#1591](https://github.com/Systemorph/MeshWeaver.Plugins/pull/1591). Both hosts
+reference `Memex.Portal.Gui` from a conditioned ItemGroup and compile without it; the generator
+drops an optional project it is not shipping and refuses by name if the reference is unconditional;
+`dotnet pack` on the template now succeeds with no `--with-gui` and no `Memex.Portal.Gui` in the
+nupkg. **Nothing private ships, and the first row above is history.** The scaffolded solution is a
+headless mesh host — no Blazor shell — which the generated README states rather than promising a UI
+the package cannot contain. Full reasoning: `Hosting/OptionalPortalGui` in MeshWeaver.Plugins.
 
-Either answer unblocks it — publish the GUI source deliberately, or change the hosts so a GUI-less
-template builds. Neither is a packaging decision.
+**What is left is this lane's wiring**, and it is a real task. `publish-packages.yml` publishes the
+Aspire integration only; the template's step is **absent rather than written-and-disabled** (a step
+that exists but never runs is the skip-trapdoor this repository forbids). Building it needs a
+Plugins checkout with a minted App token, `-p:Version=`, `-p:MeshWeaverRoot=`, and an answer to
+which Plugins commit a core tag pairs with — see that workflow's header.
 
 Everything else was a *library*, and a MeshWeaver library package has had no consumer for months:
 in-mesh source compiles against the platform **image**, module bundles carry their own closures, and

--- a/src/MeshWeaver.Documentation/Data/Architecture/ProjectTemplates.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ProjectTemplates.md
@@ -37,12 +37,24 @@ takes the platform checkout as `--core`:
 ```bash
 # from a MeshWeaver.Plugins checkout, with a MeshWeaver checkout alongside
 dotnet run tools/generate-memex-template.cs -- <version> . dist/templates \
-    --core ../MeshWeaver --with-gui
+    --core ../MeshWeaver
 dotnet new install dist/templates/                  # or install the produced .nupkg
 ```
 
-`--with-gui` includes `Memex.Portal.Gui`, which carries the portal's pages and the dev-login
-screen — without it the scaffolded app builds but has no UI.
+🚨 **The published package has no GUI, and that is deliberate.** `Memex.Portal.Gui` carries the
+portal's pages, the dev-login screen and the whole portal composition, and it lives only in the
+private MeshWeaver.Plugins repository — so copying it into a package published to public nuget.org
+would publish private source irreversibly. Both hosts therefore reference it from a *conditioned*
+ItemGroup and compile without it
+([#3653](https://github.com/Systemorph/MeshWeaver/issues/3653)), and the generator drops the
+reference it is not shipping. What the flagless command above scaffolds is a **headless mesh
+host**: it composes the mesh, mounts module static assets and module endpoints, and answers the
+health probes — no pages, no authentication schemes, no MCP/SignalR/gRPC-web. The generated
+README says so.
+
+`--with-gui` still exists and still copies `Memex.Portal.Gui`, for generating a template inside the
+private repository. **It must never be passed by a lane that publishes**, and the generator's own
+message says why.
 
 ### 2. Scaffold a New Project
 


### PR DESCRIPTION
Follow-up to Systemorph/MeshWeaver.Plugins#1591, which implements the decision in #3653: **the GUI is optional in the hosts**.

Three places in this repository assert the premise that #3653 has now retired — *"generate-memex-template.cs refuses to generate without `--with-gui`, so there is no GUI-less template to publish"*. That is no longer true, and prose that asserts a blocker which has been cleared sends the next reader down a path that no longer exists.

## What changed (documentation and one workflow header — no behaviour)

- **`.github/workflows/publish-packages.yml`** — the header block said *"THE TEMPLATE IS BLOCKED ON A PRODUCT DECISION, NOT ON WIRING"* and *"DO NOT add the template here until the GUI question is answered (issue #3653)"*. The question **is** answered, so the block now separates what is history (the generator's refusal) from what still holds (the GUI is private; a nupkg cannot be recalled) and from **what is actually missing: this lane's own wiring** — the Plugins checkout with a minted App token, `-p:Version=`, `-p:MeshWeaverRoot=`, and the unanswered core-tag↔Plugins-commit pairing. The two summary lines that told the reader the template "is blocked on the GUI" now say the step is not built yet.
- **`Doc/Architecture/NuGetPackageRetirement`** — the *"survivor that cannot ship yet"* section becomes *"has not shipped yet"*: cause 1 (mechanical) fixed, cause 2 (the GUI) decided, and the remaining wiring named. The measured 2026-09-07 table is kept, in the past tense, because it is the evidence for why the answer went the way it did.
- **`Doc/Architecture/ProjectTemplates`** — the Quick Start told a reader to build the template **with** `--with-gui`, which is exactly what must never reach a publishing lane. The flagless command is now the documented one, with what it actually scaffolds (a headless mesh host — no pages, no auth schemes, no MCP/SignalR/gRPC-web) stated instead of implied.

**No publish step is added.** Publishing `MeshWeaver.MemexTemplate` to nuget.org is irreversible and is a separate, deliberate act with the wiring above behind it; this PR only stops the repository from documenting a blocker that is gone.

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → `Build succeeded. 0 Error(s)` (the docs are embedded resources, so this is a real build, not `--no-build` over a stale asset).
- `DocumentationLinkIntegrityTest` → `Passed! Failed: 0, Passed: 1`.
- `publish-packages.yml` still parses (`yaml.safe_load` → jobs `preflight`, `publish`); only comments and two `echo` lines changed, and both jobs keep their literal `timeout-minutes`.

The design itself is recorded where the code lives — `Hosting/OptionalPortalGui` in MeshWeaver.Plugins.

Pairs-with: none — documentation and workflow comments only; this diff removes no public type or member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
