### PR TITLE
Preserve input evidence when restamping an unchanged cached build (#3892)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -3169,7 +3169,26 @@ internal static class NodeTypeCompilationHelpers
         string? activityPath,
         string? releasePath,
         string? modulesHash = null)
-        => def with
+    {
+        var assemblyMvid = ServedBuildIdentity.OfFile(result.AssemblyLocation);
+        var dependencies = result.CompiledDependencies;
+        // A disk-cache load did not regenerate source, so its record has no !input. It must
+        // not erase evidence from the original emit of these SAME bytes. Require both the
+        // assembly identity and every other dependency entry to agree; carrying the key to
+        // different bytes or a changed dependency resolution would make an unproved claim.
+        if (dependencies is not null
+            && !dependencies.ContainsKey(CompiledDependencies.ContentKey)
+            && assemblyMvid is not null
+            && string.Equals(assemblyMvid, def.LatestAssemblyMvid, StringComparison.Ordinal)
+            && def.CompiledDependencies is { } previous
+            && previous.TryGetValue(CompiledDependencies.ContentKey, out var input)
+            && !string.IsNullOrEmpty(input)
+            && previous.Count == dependencies.Count + 1
+            && dependencies.All(kv => previous.TryGetValue(kv.Key, out var value)
+                && string.Equals(kv.Value, value, StringComparison.Ordinal)))
+            dependencies = dependencies.Add(CompiledDependencies.ContentKey, input);
+
+        return def with
         {
             DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
             CompilationStatus = CompilationStatus.Ok,
@@ -3232,7 +3251,7 @@ internal static class NodeTypeCompilationHelpers
             // only, nothing loaded); a producer with no readable file leaves the previous stamp
             // alone rather than erasing it, exactly as the other assembly fields do.
             LatestAssemblyMvid =
-                ServedBuildIdentity.OfFile(result.AssemblyLocation) ?? def.LatestAssemblyMvid,
+                assemblyMvid ?? def.LatestAssemblyMvid,
             // The framework the assembly bound against — HasUsableBuild compares this to the
             // live FrameworkVersion so a MeshWeaver redeploy forces a recompile instead of
             // loading an ABI-stale DLL.
@@ -3244,7 +3263,7 @@ internal static class NodeTypeCompilationHelpers
             // The per-type dependency record (#1707 slice 2) — read off the emitted assembly by
             // CompileResultFromAssembly and DECISIVE over the fingerprint above wherever present.
             // Preserved when the result carries none (e.g. a legacy producer), never erased.
-            CompiledDependencies = result.CompiledDependencies ?? def.CompiledDependencies,
+            CompiledDependencies = dependencies ?? def.CompiledDependencies,
             // Clear the consumed release-requester so a later System-only recompile doesn't
             // mis-attribute its release to a stale prior user.
             RequestedReleaseBy = null,
@@ -3263,6 +3282,7 @@ internal static class NodeTypeCompilationHelpers
             // THIS snapshot — which is how a needed rebuild gets suppressed. Consume it.
             RequestedSourceStampAt = null
         };
+    }
 
     /// <summary>
     /// The one-line summary of a FAILED compile for the node's

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-cache-preserves-build-evidence.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-cache-preserves-build-evidence.md
@@ -1,0 +1,11 @@
+---
+Name: Cached builds retain their compatibility evidence
+Category: Fix
+Description: Reloading an unchanged compiled module preserves its recorded input fingerprint.
+Icon: Sparkle
+Order: -20260910
+---
+
+# Cached builds retain their compatibility evidence
+
+Reloading an unchanged compiled module now preserves the input fingerprint recorded when it was built. The fingerprint is retained only when the assembly identity and its other dependency records still agree. This prevents a cache reload from discarding evidence used to check a module's compatibility.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/NodeTypeCompileStampTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/NodeTypeCompileStampTest.cs
@@ -136,6 +136,68 @@ public class NodeTypeCompileStampTest
             "an upload that did not happen has never failed a compile — that contract is unchanged");
     }
 
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void CacheReload_PreservesInputEvidenceOnlyForTheSameBuildAndDependencies(
+        bool sameBuild, bool changedDependency)
+    {
+        var assemblyPath = typeof(NodeTypeCompileStampTest).Assembly.Location;
+        var emitted = ImmutableSortedDictionary<string, string>.Empty
+            .Add(CompiledDependencies.ToolchainKey, "toolchain")
+            .Add("Dependency", "original")
+            .Add(CompiledDependencies.ContentKey, "generated-input-evidence");
+        var definition = PreviouslyBroken() with
+        {
+            LatestAssemblyMvid = sameBuild ? ServedBuildIdentity.OfFile(assemblyPath) : "other-build",
+            CompiledDependencies = emitted
+        };
+        var reloaded = emitted.Remove(CompiledDependencies.ContentKey);
+        if (changedDependency)
+            reloaded = reloaded.SetItem("Dependency", "changed");
+        var result = SuccessResult() with
+        {
+            AssemblyLocation = assemblyPath,
+            CompiledDependencies = reloaded
+        };
+
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            definition, result, 8, null, null);
+
+        Assert.Equal(sameBuild && !changedDependency,
+            stamped.CompiledDependencies!.ContainsKey(CompiledDependencies.ContentKey));
+        Assert.Equal(reloaded["Dependency"], stamped.CompiledDependencies["Dependency"]);
+        if (sameBuild && !changedDependency)
+            Assert.Equal(emitted[CompiledDependencies.ContentKey],
+                stamped.CompiledDependencies[CompiledDependencies.ContentKey]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("fresh-input-evidence")]
+    public void CacheReload_NeverInventsEvidenceOrReplacesAFreshDigest(string? freshInput)
+    {
+        var dependencyRecord = ImmutableSortedDictionary<string, string>.Empty
+            .Add(CompiledDependencies.ToolchainKey, "toolchain");
+        var definition = PreviouslyBroken() with
+        {
+            LatestAssemblyMvid = null,
+            CompiledDependencies = dependencyRecord.Add(CompiledDependencies.ContentKey, "old-evidence")
+        };
+        var result = SuccessResult() with
+        {
+            AssemblyLocation = typeof(NodeTypeCompileStampTest).Assembly.Location,
+            CompiledDependencies = freshInput is null ? dependencyRecord
+                : dependencyRecord.Add(CompiledDependencies.ContentKey, freshInput)
+        };
+
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            definition, result, 8, null, null);
+
+        Assert.Equal(result.CompiledDependencies, stamped.CompiledDependencies);
+    }
+
     // ---- ApplyCompileFailure ------------------------------------------------------------------
 
     [Fact]


### PR DESCRIPTION
A cache-load result can omit `!input` because it did not regenerate source. `ApplyCompileSuccess` previously replaced a complete dependency record with that result even when it described the same emitted assembly. This erased existing input evidence and is a concrete producer-side path to the mismatch reported by #3892 and blocking #3885.

Preserve the original input key only when the actual assembly MVID and every other dependency entry match. A different assembly, missing prior identity, changed dependencies, or a fresh emitted digest keeps the incoming result unchanged. The bake-equivalence assertion is unchanged; no cache reset or CI retry is used to conceal the failure.

Validation:
- Deterministic regression before the fix: one failure (same-build evidence erased), two negative controls passed.
- Final compile-stamp suite: 13 passed, including changed-build/dependency, missing-identity and fresh-digest controls.
- Full MeshWeaver.PluginTester.Test: 361 passed, including the unchanged bake-equivalence test.
- Release builds with CIRun=true and warnings-as-errors; portal dependent build: 0 warnings, 0 errors.

Refs #3892, #3885. Production verification remains outstanding; this does not add a fingerprint to legacy artifacts that never recorded one.
