### PR TITLE
fix: refuse a module set carrying two builds of one assembly (#3732)

### DIFF
--- a/.github/scripts/test-module-set-consistency.py
+++ b/.github/scripts/test-module-set-consistency.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""EXECUTE the lanes' one-build-per-assembly-name assertion (MeshWeaver#3732).
+
+WHY
+---
+A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and 19 of
+MeshWeaver.Plugins' 37 bundles ride an assembly some OTHER package declares as its module
+(`Doc/Architecture/ModuleOwnedSiblingsRide`). That decision stands. It rests on ONE invariant:
+
+    one assembly name, one framework identity, ONE BUILD — across every copy in the set,
+    declared or riding.
+
+`MeshWeaver.*` assemblies bind by a strictly synchronised `AssemblyVersion`, so two copies under one
+simple name are ONE assembly identity: whichever loads first wins the process and the loser's bytes
+are never in memory. When the copies differ, the bake stamps every NodeType's dependency record
+against whichever copy IT loaded, and every portal that loaded another one declines all of them
+("dependency record mismatch — built against mvid:A, live is mvid:B"), falls back to a local
+compile, and — with two replicas holding two builds — recompiles in a ping-pong that never
+converges while the partition serves the default config.
+
+The design page believed re-keying preserved the invariant (`bake-scope.sh` and
+`module-build-key.py` fold a sibling's SOURCES into every bundle that carries it). Re-keying makes
+the bundles REBUILD; it says nothing about the bytes, and one publication is composed from SEVERAL
+independent compilations. Measured on memex 2026-09-10: ONE pod held
+`MeshWeaver.Markdown.Collaboration` in 15 copies and THREE builds, grouped exactly by which
+compilation produced them. So the invariant was asserted nowhere at the producer — only at the
+consumer, by `PublishedBundleCatalogue`, which turns it into `SealedSetInconsistent` and HOLDS the
+roll for the whole fleet, days later, on a portal.
+
+The lanes now assert it where every copy is first in one hand — the `ext-modules` composition, which
+is also where the damage is done. This harness EXECUTES that assertion.
+
+HOW IT STAYS HONEST
+-------------------
+* The step is EXTRACTED from the workflow by its `id:`, never copied here — a copy passes while the
+  real thing rots. BOTH lanes are extracted (they carry the same block on purpose, so the gate and
+  the bake cannot disagree) and finding fewer than both is RED.
+* The verdict is read off the step's EXIT STATUS and the bytes it composed, not off prose.
+* Every case prints the step's own DENOMINATOR line, and one case exists purely to check it: a
+  check aimed at an empty directory refuses nothing while ticking exactly like a clean measurement.
+* Both directions, on the same fixtures: divergent copies must go RED and name both producers;
+  IDENTICAL copies of the same shared sibling must go GREEN — a checker that flagged every duplicate
+  would fail there, and that is the whole decision the design page took.
+* TWO falsification arms that MUTATE THE REAL STEP:
+  - `strip`  — the assertion removed. The divergent case must then PASS. An assertion nobody has
+               watched fail is not an assertion.
+  - `blind`  — the assertion kept but pointed at an EMPTY directory. The divergent case must then
+               pass AND report `0 MeshWeaver.* assembly file(s)`, which is the shape a misdirected
+               check takes and the reason the denominator is printed at all.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# (workflow, step id) — the same block lives in both lanes and both are executed.
+LANES = [
+    (".github/workflows/node-repo-gate.yml", "ext-modules"),
+    (".github/workflows/node-repo-publish-bake.yml", "ext-modules"),
+]
+
+# The extraction and execution helpers are SHARED with the sibling harness rather than copied:
+# both run the same step, and a second copy of "how to extract it" is a second thing to rot.
+_spec = importlib.util.spec_from_file_location(
+    "module_asset_landing_harness", Path(__file__).with_name("test-module-asset-landing.py"))
+_harness = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_harness)
+
+extract_step = _harness.extract_step
+run_step = _harness.run_step
+ext_dir = _harness.ext_dir
+module_folder = _harness.module_folder
+
+FAILURES: list[str] = []
+
+
+def fail(message: str) -> None:
+    FAILURES.append(message)
+    print(f"  FAIL  {message}")
+
+
+def ok(message: str) -> None:
+    print(f"  ok    {message}")
+
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────────────────────
+def make_bundle(path: Path, module: str, rides: dict[str, bytes]) -> None:
+    """One module bundle in the shape `ModulePackCommand` writes: a manifest naming the entry
+    assembly, the entry DLL, and a FLAT closure beside it — which is where a riding sibling lives."""
+    folder = module_folder()
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("meshweaver/manifest.json", json.dumps({
+            "plugin": module.replace("MeshWeaver.", ""),
+            "version": "1.2.3",
+            "module": {"assemblyName": module},
+        }))
+        archive.writestr(f"{folder}/{module}.dll", b"MZ-entry-" + module.encode())
+        for name, content in rides.items():
+            archive.writestr(f"{folder}/{name}.dll", content)
+
+
+BUILD_A = b"MZ-MeshWeaver.Shared-compiled-by-workspace-floor"
+BUILD_B = b"MZ-MeshWeaver.Shared-compiled-by-workspace-rest\x00"
+
+
+def bundles(tmp: Path, case: str) -> list[Path]:
+    """The four fixtures, all built from ONE shape so the only variable is the sibling's BYTES."""
+    out = tmp / f"bundles-{case}"
+    out.mkdir()
+    if case == "divergent":
+        make_bundle(out / "alpha.module.nupkg", "MeshWeaver.Alpha", {"MeshWeaver.Shared": BUILD_A})
+        make_bundle(out / "beta.module.nupkg", "MeshWeaver.Beta", {"MeshWeaver.Shared": BUILD_B})
+    elif case == "declared-vs-riding":
+        make_bundle(out / "shared.module.nupkg", "MeshWeaver.Shared", {})
+        make_bundle(out / "beta.module.nupkg", "MeshWeaver.Beta", {"MeshWeaver.Shared": BUILD_B})
+    elif case == "agreeing":
+        make_bundle(out / "alpha.module.nupkg", "MeshWeaver.Alpha", {"MeshWeaver.Shared": BUILD_A})
+        make_bundle(out / "beta.module.nupkg", "MeshWeaver.Beta", {"MeshWeaver.Shared": BUILD_A})
+    elif case == "disjoint":
+        make_bundle(out / "alpha.module.nupkg", "MeshWeaver.Alpha", {})
+        make_bundle(out / "beta.module.nupkg", "MeshWeaver.Beta", {})
+    else:  # pragma: no cover - a typo in a case name must not silently test nothing
+        die(f"unknown fixture case '{case}'")
+    return sorted(out.iterdir())
+
+
+# ── mutating the real step ──────────────────────────────────────────────────────────────────
+MARKER = "ONE BUILD PER ASSEMBLY NAME"
+OPENER = 'if [ "$DIVERGED" -ne 0 ]; then'
+
+
+def block_bounds(body: str, lane: str) -> tuple[int, int]:
+    lines = body.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if MARKER in line)
+        opener = next(i for i, line in enumerate(lines) if OPENER in line)
+    except StopIteration:
+        die(f"{lane}: the module-set assertion is not in the step — every arm below would mutate "
+            "nothing and pass having tested nothing")
+    indent = len(lines[opener]) - len(lines[opener].lstrip())
+    closer = next((i for i in range(opener + 1, len(lines))
+                   if lines[i].strip() == "fi" and len(lines[i]) - len(lines[i].lstrip()) == indent),
+                  None)
+    if closer is None:
+        die(f"{lane}: cannot find the `fi` closing the module-set assertion")
+    return start, closer
+
+
+def strip_assertion(body: str, lane: str) -> str:
+    """The lane as it was before #3732: no assertion at all."""
+    start, closer = block_bounds(body, lane)
+    lines = body.splitlines()
+    out = "\n".join(lines[:start] + lines[closer + 1:])
+    if "DIVERGED" in out:
+        die(f"{lane}: the strip arm still mentions DIVERGED — it removed the wrong region")
+    return out
+
+
+def blind_assertion(body: str, lane: str) -> str:
+    """The assertion kept, pointed at an empty directory — what a misdirected check looks like."""
+    needle = 'done < <(find "$EXT" -mindepth 2 -maxdepth 2 -type f'
+    if needle not in body:
+        die(f"{lane}: the assertion's `find` is not in the step — the blind arm has nothing to aim "
+            "elsewhere")
+    return body.replace(
+        needle,
+        'mkdir -p "${RUNNER_TEMP:-/tmp}/nowhere"\n'
+        '          done < <(find "${RUNNER_TEMP:-/tmp}/nowhere" -mindepth 2 -maxdepth 2 -type f')
+
+
+# ── cases ───────────────────────────────────────────────────────────────────────────────────
+def summary_line(stdout: str) -> str:
+    for line in stdout.splitlines():
+        if line.startswith("module set: "):
+            return line
+    return ""
+
+
+def case_divergent_is_refused(lane: str, body: str, tmp: Path) -> None:
+    work = tmp / "divergent"
+    work.mkdir()
+    result = run_step(body, work, bundles(tmp, "divergent"))
+    line = summary_line(result.stdout)
+    print(f"        {line or '(no denominator line)'}")
+    if result.returncode == 0:
+        fail(f"{lane}: two DIFFERENT builds of MeshWeaver.Shared composed into one mesh and the "
+             f"step exited 0 — this is the publication that holds the fleet's rolls")
+        return
+    combined = result.stdout + result.stderr
+    missing = [needle for needle in
+               ("MeshWeaver.Shared reaches this mesh as more than one build",
+                "a RIDING sibling",
+                "1 carried at more than one BUILD")
+               if needle not in combined]
+    if missing:
+        fail(f"{lane}: the refusal does not say what is wrong — missing {missing}")
+        return
+    digests = {chunk.split()[1] for chunk in combined.splitlines() if "composed from module" in chunk}
+    if len(digests) != 2:
+        fail(f"{lane}: the refusal named {len(digests)} build(s); an operator needs BOTH to tell "
+             "which producer to change")
+        return
+    ok(f"{lane}: divergent copies are refused, naming both builds and both producers")
+
+
+def case_declared_vs_riding_is_labelled(lane: str, body: str, tmp: Path) -> None:
+    work = tmp / "declared"
+    work.mkdir()
+    result = run_step(body, work, bundles(tmp, "declared-vs-riding"))
+    combined = result.stdout + result.stderr
+    if result.returncode == 0:
+        fail(f"{lane}: a bundle riding a DIFFERENT build of another package's DECLARED module "
+             "passed — that is the exact shape measured on memex")
+        return
+    if "<- the DECLARED module" not in combined or "<- a RIDING sibling" not in combined:
+        fail(f"{lane}: the refusal does not distinguish the declared copy from the riding one, "
+             "which is the half that tells an operator which producer to change")
+        return
+    ok(f"{lane}: declared-vs-riding divergence is refused and each copy's ROLE is named")
+
+
+def case_agreeing_copies_pass(lane: str, body: str, tmp: Path) -> None:
+    work = tmp / "agreeing"
+    work.mkdir()
+    result = run_step(body, work, bundles(tmp, "agreeing"))
+    line = summary_line(result.stdout)
+    print(f"        {line or '(no denominator line)'}")
+    if result.returncode != 0:
+        fail(f"{lane}: two IDENTICAL copies of one riding sibling were refused. Riding is the "
+             "decision (ModuleOwnedSiblingsRide) and byte equality is the invariant — a check that "
+             f"refuses agreement refuses 19 of 37 bundles. stderr: {result.stderr.strip()[-400:]}")
+        return
+    if "1 carried by more than one module" not in line:
+        fail(f"{lane}: the step passed but its denominator does not show it SAW the shared copies "
+             f"({line!r}) — a check that looked at nothing passes the same way")
+        return
+    if "0 carried at more than one BUILD" not in line:
+        fail(f"{lane}: the denominator does not state the divergence count on the green path ({line!r})")
+        return
+    ok(f"{lane}: identical copies pass, and the denominator proves both were measured")
+
+
+def case_disjoint_reports_a_denominator(lane: str, body: str, tmp: Path) -> None:
+    work = tmp / "disjoint"
+    work.mkdir()
+    result = run_step(body, work, bundles(tmp, "disjoint"))
+    line = summary_line(result.stdout)
+    print(f"        {line or '(no denominator line)'}")
+    if result.returncode != 0:
+        fail(f"{lane}: a set with no shared sibling was refused: {result.stderr.strip()[-400:]}")
+        return
+    if not line.startswith("module set: 2 MeshWeaver.* assembly file(s)"):
+        fail(f"{lane}: the two composed entry assemblies are not in the denominator ({line!r}) — "
+             "the assertion is not reading the entries, so a module composed twice at two builds "
+             "would be invisible to it")
+        return
+    ok(f"{lane}: entry assemblies count too — the denominator is 2 with no riding sibling at all")
+
+
+def case_strip_arm_goes_green(lane: str, body: str, tmp: Path) -> None:
+    work = tmp / "strip"
+    work.mkdir()
+    result = run_step(strip_assertion(body, lane), work, bundles(tmp, "divergent"))
+    if result.returncode != 0:
+        fail(f"{lane}: with the assertion REMOVED the divergent set still failed "
+             f"({result.stderr.strip()[-300:]}) — something else is refusing it, so the positive "
+             "case above proves nothing about this block")
+        return
+    ok(f"{lane}: falsification arm `strip` — without the assertion the divergent set sails through")
+
+
+def case_blind_arm_shows_its_zero(lane: str, body: str, tmp: Path) -> None:
+    work = tmp / "blind"
+    work.mkdir()
+    result = run_step(blind_assertion(body, lane), work, bundles(tmp, "divergent"))
+    line = summary_line(result.stdout)
+    if result.returncode != 0:
+        fail(f"{lane}: the blind arm was expected to measure nothing and pass; it failed instead "
+             f"({result.stderr.strip()[-300:]})")
+        return
+    if not line.startswith("module set: 0 MeshWeaver.* assembly file(s)"):
+        fail(f"{lane}: a check aimed at an empty directory did not report a ZERO denominator "
+             f"({line!r}) — then nothing on the log distinguishes it from a clean measurement")
+        return
+    ok(f"{lane}: falsification arm `blind` — a misdirected check passes, and its ZERO is on the log")
+
+
+CASES = (
+    case_divergent_is_refused,
+    case_declared_vs_riding_is_labelled,
+    case_agreeing_copies_pass,
+    case_disjoint_reports_a_denominator,
+    case_strip_arm_goes_green,
+    case_blind_arm_shows_its_zero,
+)
+
+
+def main() -> int:
+    lanes = [(workflow, extract_step(workflow, step_id)) for workflow, step_id in LANES]
+    if len(lanes) != len(LANES):
+        die("not every lane was extracted")
+    for workflow, body in lanes:
+        lane = Path(workflow).name
+        print(f"{lane}:")
+        for case in CASES:
+            with tempfile.TemporaryDirectory() as raw:
+                case(lane, body, Path(raw))
+    if FAILURES:
+        print(f"\nFAILED — {len(FAILURES)} finding(s):")
+        for message in FAILURES:
+            print(f"  - {message}")
+        return 1
+    print(f"\nPASS — {len(lanes)} lane(s), {len(CASES)} case(s) each: divergent copies are refused "
+          "and named, identical copies pass and are counted, and BOTH falsification arms behave.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-module-set-consistency.py
+++ b/.github/scripts/test-module-set-consistency.py
@@ -96,7 +96,8 @@ def die(message: str) -> None:
 
 
 # ── fixtures ────────────────────────────────────────────────────────────────────────────────
-def make_bundle(path: Path, module: str, rides: dict[str, bytes]) -> None:
+def make_bundle(path: Path, module: str, rides: dict[str, bytes],
+                entry: bytes | None = None) -> None:
     """One module bundle in the shape `ModulePackCommand` writes: a manifest naming the entry
     assembly, the entry DLL, and a FLAT closure beside it — which is where a riding sibling lives."""
     folder = module_folder()
@@ -106,7 +107,7 @@ def make_bundle(path: Path, module: str, rides: dict[str, bytes]) -> None:
             "version": "1.2.3",
             "module": {"assemblyName": module},
         }))
-        archive.writestr(f"{folder}/{module}.dll", b"MZ-entry-" + module.encode())
+        archive.writestr(f"{folder}/{module}.dll", entry or b"MZ-entry-" + module.encode())
         for name, content in rides.items():
             archive.writestr(f"{folder}/{name}.dll", content)
 
@@ -128,6 +129,14 @@ def bundles(tmp: Path, case: str) -> list[Path]:
     elif case == "agreeing":
         make_bundle(out / "alpha.module.nupkg", "MeshWeaver.Alpha", {"MeshWeaver.Shared": BUILD_A})
         make_bundle(out / "beta.module.nupkg", "MeshWeaver.Beta", {"MeshWeaver.Shared": BUILD_A})
+    elif case == "same-entry-two-bundles":
+        # 🚨 The collision a scan of /ext CANNOT see: both bundles declare MeshWeaver.Alpha, so the
+        # landing loop merges them into ONE /ext/MeshWeaver.Alpha/ and the second `cp -R` overwrites
+        # the first. Only a reading taken per bundle, before the merge, has both copies.
+        make_bundle(out / "alpha-artifact.module.nupkg", "MeshWeaver.Alpha", {},
+                    entry=b"MZ-MeshWeaver.Alpha-from-this-run's-artifact")
+        make_bundle(out / "alpha-registry.bundle.zip", "MeshWeaver.Alpha", {},
+                    entry=b"MZ-MeshWeaver.Alpha-from-the-registry\x00")
     elif case == "disjoint":
         make_bundle(out / "alpha.module.nupkg", "MeshWeaver.Alpha", {})
         make_bundle(out / "beta.module.nupkg", "MeshWeaver.Beta", {})
@@ -137,7 +146,7 @@ def bundles(tmp: Path, case: str) -> list[Path]:
 
 
 # ── mutating the real step ──────────────────────────────────────────────────────────────────
-MARKER = "ONE BUILD PER ASSEMBLY NAME"
+MARKER = "THE VERDICT ON THE SET"
 OPENER = 'if [ "$DIVERGED" -ne 0 ]; then'
 
 
@@ -159,7 +168,7 @@ def block_bounds(body: str, lane: str) -> tuple[int, int]:
 
 
 def strip_assertion(body: str, lane: str) -> str:
-    """The lane as it was before #3732: no assertion at all."""
+    """The verdict block removed: the reading still runs, nothing decides on it."""
     start, closer = block_bounds(body, lane)
     lines = body.splitlines()
     out = "\n".join(lines[:start] + lines[closer + 1:])
@@ -170,14 +179,14 @@ def strip_assertion(body: str, lane: str) -> str:
 
 def blind_assertion(body: str, lane: str) -> str:
     """The assertion kept, pointed at an empty directory — what a misdirected check looks like."""
-    needle = 'done < <(find "$EXT" -mindepth 2 -maxdepth 2 -type f'
+    needle = 'done < <(find "$u/meshweaver/modules" -maxdepth 1 -type f'
     if needle not in body:
-        die(f"{lane}: the assertion's `find` is not in the step — the blind arm has nothing to aim "
+        die(f"{lane}: the reading's `find` is not in the step — the blind arm has nothing to aim "
             "elsewhere")
     return body.replace(
         needle,
         'mkdir -p "${RUNNER_TEMP:-/tmp}/nowhere"\n'
-        '          done < <(find "${RUNNER_TEMP:-/tmp}/nowhere" -mindepth 2 -maxdepth 2 -type f')
+        '              done < <(find "${RUNNER_TEMP:-/tmp}/nowhere" -maxdepth 1 -type f')
 
 
 # ── cases ───────────────────────────────────────────────────────────────────────────────────
@@ -201,13 +210,13 @@ def case_divergent_is_refused(lane: str, body: str, tmp: Path) -> None:
     combined = result.stdout + result.stderr
     missing = [needle for needle in
                ("MeshWeaver.Shared reaches this mesh as more than one build",
-                "a RIDING sibling",
+                "as a sibling riding",
                 "1 carried at more than one BUILD")
                if needle not in combined]
     if missing:
         fail(f"{lane}: the refusal does not say what is wrong — missing {missing}")
         return
-    digests = {chunk.split()[1] for chunk in combined.splitlines() if "composed from module" in chunk}
+    digests = {chunk.split()[1] for chunk in combined.splitlines() if chunk.strip().startswith("sealed ")}
     if len(digests) != 2:
         fail(f"{lane}: the refusal named {len(digests)} build(s); an operator needs BOTH to tell "
              "which producer to change")
@@ -224,11 +233,43 @@ def case_declared_vs_riding_is_labelled(lane: str, body: str, tmp: Path) -> None
         fail(f"{lane}: a bundle riding a DIFFERENT build of another package's DECLARED module "
              "passed — that is the exact shape measured on memex")
         return
-    if "<- the DECLARED module" not in combined or "<- a RIDING sibling" not in combined:
+    if ("as the declared module of" not in combined
+            or "as a sibling riding" not in combined):
         fail(f"{lane}: the refusal does not distinguish the declared copy from the riding one, "
              "which is the half that tells an operator which producer to change")
         return
     ok(f"{lane}: declared-vs-riding divergence is refused and each copy's ROLE is named")
+
+
+def case_same_entry_from_two_bundles_is_refused(lane: str, body: str, tmp: Path) -> None:
+    """🚨 The collision a scan of the COMPOSED directory cannot see.
+
+    Two bundles declaring the same `module.assemblyName` land in ONE `/ext/<name>/` and the second
+    `cp -R` overwrites the first — the lane's own notice calls the precedence between an artifact
+    bundle and a registry bundle an accident of glob order. So the reading has to be taken per
+    bundle, before the merge; a version of this check that scanned `/ext` afterwards passed here.
+    """
+    work = tmp / "same-entry"
+    work.mkdir()
+    result = run_step(body, work, bundles(tmp, "same-entry-two-bundles"))
+    line = summary_line(result.stdout)
+    print(f"        {line or '(no denominator line)'}")
+    combined = result.stdout + result.stderr
+    if result.returncode == 0:
+        fail(f"{lane}: two bundles declared MeshWeaver.Alpha at DIFFERENT builds and the step "
+             "exited 0 — the merge hid one of them, so the reading is being taken after the "
+             "collision instead of before it")
+        return
+    if "MeshWeaver.Alpha reaches this mesh as more than one build" not in combined:
+        fail(f"{lane}: the refusal does not name MeshWeaver.Alpha as the colliding entry")
+        return
+    named = {chunk.split()[-1] for chunk in combined.splitlines()
+             if chunk.strip().startswith("sealed ")}
+    if named != {"alpha-artifact.module.nupkg", "alpha-registry.bundle.zip"}:
+        fail(f"{lane}: the refusal names {sorted(named)} rather than both source bundles — an "
+             "operator cannot tell which producer to change")
+        return
+    ok(f"{lane}: two bundles declaring one module at two builds are refused, both bundles named")
 
 
 def case_agreeing_copies_pass(lane: str, body: str, tmp: Path) -> None:
@@ -242,7 +283,7 @@ def case_agreeing_copies_pass(lane: str, body: str, tmp: Path) -> None:
              "decision (ModuleOwnedSiblingsRide) and byte equality is the invariant — a check that "
              f"refuses agreement refuses 19 of 37 bundles. stderr: {result.stderr.strip()[-400:]}")
         return
-    if "1 carried by more than one module" not in line:
+    if "1 carried by more than one bundle" not in line:
         fail(f"{lane}: the step passed but its denominator does not show it SAW the shared copies "
              f"({line!r}) — a check that looked at nothing passes the same way")
         return
@@ -261,7 +302,7 @@ def case_disjoint_reports_a_denominator(lane: str, body: str, tmp: Path) -> None
     if result.returncode != 0:
         fail(f"{lane}: a set with no shared sibling was refused: {result.stderr.strip()[-400:]}")
         return
-    if not line.startswith("module set: 2 MeshWeaver.* assembly file(s)"):
+    if not line.startswith("module set: 2 MeshWeaver.* assembly file(s) across 2 bundle(s)"):
         fail(f"{lane}: the two composed entry assemblies are not in the denominator ({line!r}) — "
              "the assertion is not reading the entries, so a module composed twice at two builds "
              "would be invisible to it")
@@ -300,6 +341,7 @@ def case_blind_arm_shows_its_zero(lane: str, body: str, tmp: Path) -> None:
 CASES = (
     case_divergent_is_refused,
     case_declared_vs_riding_is_labelled,
+    case_same_entry_from_two_bundles_is_refused,
     case_agreeing_copies_pass,
     case_disjoint_reports_a_denominator,
     case_strip_arm_goes_green,

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2242,6 +2242,18 @@ jobs:
     - name: "Execute the lanes' external-module landing against real bundle shapes"
       run: python3 .github/scripts/test-module-asset-landing.py
 
+    # The same composition step now also asserts ONE BUILD PER ASSEMBLY NAME across the whole set
+    # (#3732). A module-owned MeshWeaver.* sibling RIDES every bundle that references it and 19 of
+    # MeshWeaver.Plugins' 37 ride an assembly another package DECLARES as its module — a decision,
+    # resting on the invariant that every copy is the same build. Nothing asserted it at the
+    # producer: measured on memex 2026-09-10, ONE pod held MeshWeaver.Markdown.Collaboration in 15
+    # copies and THREE builds, and the only thing that ever noticed was ReleaseAvailability, days
+    # later, as SealedSetInconsistent — a HOLD for the whole fleet. Same posture as the harness
+    # above: both lanes' step EXTRACTED by `id:` and executed, the verdict read off the exit status,
+    # and both directions covered — divergent copies RED, identical copies GREEN.
+    - name: "Execute the lanes' one-build-per-assembly-name assertion"
+      run: python3 .github/scripts/test-module-set-consistency.py
+
     # carry-forward-bundles.sh is the other half of that publication and had NO CI execution at
     # all: it runs only inside a node repo's publish lane, so the first execution of an edit was a
     # production publish. Its self-test covers the shrink refusals it has always owed and the

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -996,6 +996,38 @@ jobs:
           MODULE_COUNT=0
           ASSET_MODULES=0
           ASSET_FILES=0
+          # ───── ONE BUILD PER ASSEMBLY NAME, ACROSS THE WHOLE COMPOSED SET (MeshWeaver#3732) ─────
+          # 🚨 A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and some
+          # of those siblings are ANOTHER package's declared module (Doc/Architecture/
+          # ModuleOwnedSiblingsRide). That decision stands, and it rests on exactly ONE invariant:
+          # every copy of a name in the set is the SAME BUILD. `MeshWeaver.*` assemblies bind by a
+          # strictly synchronised AssemblyVersion, so the copies are ONE assembly identity — whichever
+          # this host loads FIRST wins the process, and every NodeType the bake compiles is stamped
+          # `mvid:` of THAT build. A portal that loaded another one declines every one of them at
+          # adoption ("dependency record mismatch — built against mvid:A, live is mvid:B"), falls back
+          # to a local compile, and with two replicas holding two builds ping-pongs between them for
+          # ever while the partition serves the default config and its pages render empty.
+          #
+          # 🚨 NOTHING ASSERTED THAT INVARIANT AT THE PRODUCER. The design page believed re-keying
+          # preserved it — bake-scope.sh and module-build-key.py fold a sibling's SOURCES into every
+          # bundle that carries it — but re-keying only makes those bundles REBUILD, and one
+          # publication is composed from SEVERAL independent compilations (MeshWeaver.Plugins: two
+          # `build-workspace` jobs, one per module-pack lane call, plus a
+          # `dotnet build -p:Version=<module version>` per legacy `sdk` entry). Same sources, three
+          # compilations, three MVIDs — measured on memex 2026-09-10, where ONE pod held
+          # MeshWeaver.Markdown.Collaboration in 15 copies and 3 builds, grouped exactly by which
+          # compilation produced them.
+          #
+          # This step is the first point where every copy is in ONE hand, and it is the point where
+          # the damage is done: what the bake loads becomes the record every consumer must match. So
+          # the assertion lives here, over the composed BYTES, and it is a REFUSAL — a publication
+          # carrying two builds of one name is what ReleaseAvailability later answers
+          # `SealedSetInconsistent` for, i.e. NOTHING ROLLS, for the whole fleet, until it is rebuilt.
+          digest_of() {
+            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+            else shasum -a 256 "$1" | cut -d' ' -f1; fi
+          }
+          DIGESTS="${RUNNER_TEMP:-/tmp}/ext-module-builds"; : > "$DIGESTS"
           for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do
             u="${RUNNER_TEMP:-/tmp}/unpack-$(basename "$b")"; rm -rf "$u"; mkdir -p "$u"
             unzip -o -q "$b" -d "$u"
@@ -1007,6 +1039,19 @@ jobs:
               name=$(basename "$1" .dll)
             fi
             test -f "$u/meshweaver/modules/$name.dll" || { echo "::error::$(basename "$b"): meshweaver/modules/$name.dll is missing from the bundle"; exit 1; }
+            # 🚨 DIGESTED FROM THIS BUNDLE'S OWN UNPACKED FOLDER, BEFORE THE MERGE — never from
+            # /ext afterwards. Two bundles that declare the same `module.assemblyName` land in the
+            # SAME /ext/<name>/ directory and the second `cp -R` OVERWRITES the first, so a scan of
+            # /ext cannot see a collision between an artifact bundle and a registry bundle — which
+            # is precisely the case this lane's own notice calls an accident of glob order
+            # (`*.nupkg` before `*.zip`, so a registry copy silently wins). Reading each bundle's own
+            # folder sees every input copy, and names the BUNDLE each one came from — the same
+            # wording `UpdatePolicy.heldReason` uses when the consumer finds it days later.
+            while IFS= read -r dll; do
+              simple="$(basename "$dll" .dll)"
+              printf '%s %s %s %s\n' "$simple" "$(digest_of "$dll")" "$(basename "$b")" \
+                "$(if [ "$simple" = "$name" ]; then echo declared; else echo riding; fi)" >> "$DIGESTS"
+            done < <(find "$u/meshweaver/modules" -maxdepth 1 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) | sort)
             mkdir -p "$EXT/$name"
             cp -R "$u"/meshweaver/modules/. "$EXT/$name/"
             # 🚨 A module bundle carries its STATIC WEB ASSETS separately from the flat closure,
@@ -1041,41 +1086,7 @@ jobs:
             echo "external module composed: $name ($(basename "$b")) — $assets static asset file(s)"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
-          # ───── ONE BUILD PER ASSEMBLY NAME, ACROSS THE WHOLE COMPOSED SET (MeshWeaver#3732) ─────
-          # 🚨 A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and some
-          # of those siblings are ANOTHER package's declared module (Doc/Architecture/
-          # ModuleOwnedSiblingsRide). That decision stands, and it rests on exactly ONE invariant:
-          # every copy of a name in the set is the SAME BUILD. `MeshWeaver.*` assemblies bind by a
-          # strictly synchronised AssemblyVersion, so the copies below are ONE assembly identity —
-          # whichever this host loads FIRST wins the process, and every NodeType the bake compiles is
-          # stamped `mvid:` of THAT build. A portal that loaded another one declines every one of them
-          # at adoption ("dependency record mismatch — built against mvid:A, live is mvid:B"), falls
-          # back to a local compile, and with two replicas holding two builds ping-pongs between them
-          # for ever while the partition serves the default config and its pages render empty.
-          #
-          # 🚨 NOTHING ASSERTED THAT INVARIANT AT THE PRODUCER. The design page believed re-keying
-          # preserved it — bake-scope.sh and module-build-key.py fold a sibling's SOURCES into every
-          # bundle that carries it — but re-keying only makes those bundles REBUILD, and one
-          # publication is composed from SEVERAL independent compilations (MeshWeaver.Plugins: two
-          # `build-workspace` jobs, one per module-pack lane call, plus a
-          # `dotnet build -p:Version=<module version>` per legacy `sdk` entry). Same sources, three
-          # compilations, three MVIDs — measured on memex 2026-09-10, where ONE pod held
-          # MeshWeaver.Markdown.Collaboration in 15 copies and 3 builds, grouped exactly by which
-          # compilation produced them.
-          #
-          # This step is the first point where every copy is in ONE hand, and it is the point where
-          # the damage is done: what the bake loads becomes the record every consumer must match. So
-          # the assertion lives here, over the composed BYTES, and it is a REFUSAL — a publication
-          # carrying two builds of one name is what ReleaseAvailability later answers
-          # `SealedSetInconsistent` for, i.e. NOTHING ROLLS, for the whole fleet, until it is rebuilt.
-          digest_of() {
-            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
-            else shasum -a 256 "$1" | cut -d' ' -f1; fi
-          }
-          DIGESTS="${RUNNER_TEMP:-/tmp}/ext-module-builds"; : > "$DIGESTS"
-          while IFS= read -r dll; do
-            printf '%s %s %s\n' "$(basename "$dll" .dll)" "$(digest_of "$dll")" "$(basename "$(dirname "$dll")")" >> "$DIGESTS"
-          done < <(find "$EXT" -mindepth 2 -maxdepth 2 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) | sort)
+          # ───── THE VERDICT ON THE SET (MeshWeaver#3732; the reading is collected above) ─────
           COPIES=$(awk 'END {print NR + 0}' "$DIGESTS")
           NAMES=$(awk '{print $1}' "$DIGESTS" | sort -u | awk 'END {print NR + 0}')
           SHARED=$(awk '{c[$1]++} END {n = 0; for (k in c) if (c[k] > 1) n++; print n}' "$DIGESTS")
@@ -1085,11 +1096,11 @@ jobs:
           # measurement, so the count that would expose it is never hidden. Zero is legitimate only
           # for a repo whose modules carry no `MeshWeaver.*` assembly at all; anywhere else it is the
           # wrong directory, and it is on the log.
-          echo "module set: $COPIES MeshWeaver.* assembly file(s) under /ext, $NAMES distinct name(s), $SHARED carried by more than one module, $DIVERGED carried at more than one BUILD"
+          echo "module set: $COPIES MeshWeaver.* assembly file(s) across $MODULE_COUNT bundle(s), $NAMES distinct name(s), $SHARED carried by more than one bundle, $DIVERGED carried at more than one BUILD"
           if [ "$DIVERGED" -ne 0 ]; then
             while IFS= read -r dupe; do
               echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
-              awk -v n="$dupe" '$1 == n {printf "          build %s  composed from module %s%s\n", substr($2, 1, 16), $3, ($3 == n ? "   <- the DECLARED module" : "   <- a RIDING sibling")}' "$DIGESTS" | sort -u
+              awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
             echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
             exit 1

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -1041,6 +1041,59 @@ jobs:
             echo "external module composed: $name ($(basename "$b")) — $assets static asset file(s)"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
+          # ───── ONE BUILD PER ASSEMBLY NAME, ACROSS THE WHOLE COMPOSED SET (MeshWeaver#3732) ─────
+          # 🚨 A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and some
+          # of those siblings are ANOTHER package's declared module (Doc/Architecture/
+          # ModuleOwnedSiblingsRide). That decision stands, and it rests on exactly ONE invariant:
+          # every copy of a name in the set is the SAME BUILD. `MeshWeaver.*` assemblies bind by a
+          # strictly synchronised AssemblyVersion, so the copies below are ONE assembly identity —
+          # whichever this host loads FIRST wins the process, and every NodeType the bake compiles is
+          # stamped `mvid:` of THAT build. A portal that loaded another one declines every one of them
+          # at adoption ("dependency record mismatch — built against mvid:A, live is mvid:B"), falls
+          # back to a local compile, and with two replicas holding two builds ping-pongs between them
+          # for ever while the partition serves the default config and its pages render empty.
+          #
+          # 🚨 NOTHING ASSERTED THAT INVARIANT AT THE PRODUCER. The design page believed re-keying
+          # preserved it — bake-scope.sh and module-build-key.py fold a sibling's SOURCES into every
+          # bundle that carries it — but re-keying only makes those bundles REBUILD, and one
+          # publication is composed from SEVERAL independent compilations (MeshWeaver.Plugins: two
+          # `build-workspace` jobs, one per module-pack lane call, plus a
+          # `dotnet build -p:Version=<module version>` per legacy `sdk` entry). Same sources, three
+          # compilations, three MVIDs — measured on memex 2026-09-10, where ONE pod held
+          # MeshWeaver.Markdown.Collaboration in 15 copies and 3 builds, grouped exactly by which
+          # compilation produced them.
+          #
+          # This step is the first point where every copy is in ONE hand, and it is the point where
+          # the damage is done: what the bake loads becomes the record every consumer must match. So
+          # the assertion lives here, over the composed BYTES, and it is a REFUSAL — a publication
+          # carrying two builds of one name is what ReleaseAvailability later answers
+          # `SealedSetInconsistent` for, i.e. NOTHING ROLLS, for the whole fleet, until it is rebuilt.
+          digest_of() {
+            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+            else shasum -a 256 "$1" | cut -d' ' -f1; fi
+          }
+          DIGESTS="${RUNNER_TEMP:-/tmp}/ext-module-builds"; : > "$DIGESTS"
+          while IFS= read -r dll; do
+            printf '%s %s %s\n' "$(basename "$dll" .dll)" "$(digest_of "$dll")" "$(basename "$(dirname "$dll")")" >> "$DIGESTS"
+          done < <(find "$EXT" -mindepth 2 -maxdepth 2 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) | sort)
+          COPIES=$(awk 'END {print NR + 0}' "$DIGESTS")
+          NAMES=$(awk '{print $1}' "$DIGESTS" | sort -u | awk 'END {print NR + 0}')
+          SHARED=$(awk '{c[$1]++} END {n = 0; for (k in c) if (c[k] > 1) n++; print n}' "$DIGESTS")
+          DIVERGED=$(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {n = 0; for (k in d) if (d[k] > 1) n++; print n}' "$DIGESTS")
+          # 🚨 The DENOMINATOR is printed on every run, green or red. A check pointed at an empty or
+          # wrong directory reports zero copies and refuses nothing while ticking exactly like a clean
+          # measurement, so the count that would expose it is never hidden. Zero is legitimate only
+          # for a repo whose modules carry no `MeshWeaver.*` assembly at all; anywhere else it is the
+          # wrong directory, and it is on the log.
+          echo "module set: $COPIES MeshWeaver.* assembly file(s) under /ext, $NAMES distinct name(s), $SHARED carried by more than one module, $DIVERGED carried at more than one BUILD"
+          if [ "$DIVERGED" -ne 0 ]; then
+            while IFS= read -r dupe; do
+              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
+              awk -v n="$dupe" '$1 == n {printf "          build %s  composed from module %s%s\n", substr($2, 1, 16), $3, ($3 == n ? "   <- the DECLARED module" : "   <- a RIDING sibling")}' "$DIGESTS" | sort -u
+            done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
+            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
+            exit 1
+          fi
           echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"
           echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
           echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1025,6 +1025,38 @@ jobs:
           MODULE_COUNT=0
           ASSET_MODULES=0
           ASSET_FILES=0
+          # ───── ONE BUILD PER ASSEMBLY NAME, ACROSS THE WHOLE COMPOSED SET (MeshWeaver#3732) ─────
+          # 🚨 A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and some
+          # of those siblings are ANOTHER package's declared module (Doc/Architecture/
+          # ModuleOwnedSiblingsRide). That decision stands, and it rests on exactly ONE invariant:
+          # every copy of a name in the set is the SAME BUILD. `MeshWeaver.*` assemblies bind by a
+          # strictly synchronised AssemblyVersion, so the copies are ONE assembly identity — whichever
+          # this host loads FIRST wins the process, and every NodeType the bake compiles is stamped
+          # `mvid:` of THAT build. A portal that loaded another one declines every one of them at
+          # adoption ("dependency record mismatch — built against mvid:A, live is mvid:B"), falls back
+          # to a local compile, and with two replicas holding two builds ping-pongs between them for
+          # ever while the partition serves the default config and its pages render empty.
+          #
+          # 🚨 NOTHING ASSERTED THAT INVARIANT AT THE PRODUCER. The design page believed re-keying
+          # preserved it — bake-scope.sh and module-build-key.py fold a sibling's SOURCES into every
+          # bundle that carries it — but re-keying only makes those bundles REBUILD, and one
+          # publication is composed from SEVERAL independent compilations (MeshWeaver.Plugins: two
+          # `build-workspace` jobs, one per module-pack lane call, plus a
+          # `dotnet build -p:Version=<module version>` per legacy `sdk` entry). Same sources, three
+          # compilations, three MVIDs — measured on memex 2026-09-10, where ONE pod held
+          # MeshWeaver.Markdown.Collaboration in 15 copies and 3 builds, grouped exactly by which
+          # compilation produced them.
+          #
+          # This step is the first point where every copy is in ONE hand, and it is the point where
+          # the damage is done: what the bake loads becomes the record every consumer must match. So
+          # the assertion lives here, over the composed BYTES, and it is a REFUSAL — a publication
+          # carrying two builds of one name is what ReleaseAvailability later answers
+          # `SealedSetInconsistent` for, i.e. NOTHING ROLLS, for the whole fleet, until it is rebuilt.
+          digest_of() {
+            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+            else shasum -a 256 "$1" | cut -d' ' -f1; fi
+          }
+          DIGESTS="${RUNNER_TEMP:-/tmp}/ext-module-builds"; : > "$DIGESTS"
           for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do
             u="${RUNNER_TEMP:-/tmp}/unpack-$(basename "$b")"; rm -rf "$u"; mkdir -p "$u"
             unzip -o -q "$b" -d "$u"
@@ -1036,6 +1068,19 @@ jobs:
               name=$(basename "$1" .dll)
             fi
             test -f "$u/meshweaver/modules/$name.dll" || { echo "::error::$(basename "$b"): meshweaver/modules/$name.dll is missing from the bundle"; exit 1; }
+            # 🚨 DIGESTED FROM THIS BUNDLE'S OWN UNPACKED FOLDER, BEFORE THE MERGE — never from
+            # /ext afterwards. Two bundles that declare the same `module.assemblyName` land in the
+            # SAME /ext/<name>/ directory and the second `cp -R` OVERWRITES the first, so a scan of
+            # /ext cannot see a collision between an artifact bundle and a registry bundle — which
+            # is precisely the case this lane's own notice calls an accident of glob order
+            # (`*.nupkg` before `*.zip`, so a registry copy silently wins). Reading each bundle's own
+            # folder sees every input copy, and names the BUNDLE each one came from — the same
+            # wording `UpdatePolicy.heldReason` uses when the consumer finds it days later.
+            while IFS= read -r dll; do
+              simple="$(basename "$dll" .dll)"
+              printf '%s %s %s %s\n' "$simple" "$(digest_of "$dll")" "$(basename "$b")" \
+                "$(if [ "$simple" = "$name" ]; then echo declared; else echo riding; fi)" >> "$DIGESTS"
+            done < <(find "$u/meshweaver/modules" -maxdepth 1 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) | sort)
             mkdir -p "$EXT/$name"
             cp -R "$u"/meshweaver/modules/. "$EXT/$name/"
             # 🚨 A module bundle carries its STATIC WEB ASSETS separately from the flat closure,
@@ -1086,41 +1131,7 @@ jobs:
             echo "sealing $name as module package '$pkg'"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
-          # ───── ONE BUILD PER ASSEMBLY NAME, ACROSS THE WHOLE COMPOSED SET (MeshWeaver#3732) ─────
-          # 🚨 A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and some
-          # of those siblings are ANOTHER package's declared module (Doc/Architecture/
-          # ModuleOwnedSiblingsRide). That decision stands, and it rests on exactly ONE invariant:
-          # every copy of a name in the set is the SAME BUILD. `MeshWeaver.*` assemblies bind by a
-          # strictly synchronised AssemblyVersion, so the copies below are ONE assembly identity —
-          # whichever this host loads FIRST wins the process, and every NodeType the bake compiles is
-          # stamped `mvid:` of THAT build. A portal that loaded another one declines every one of them
-          # at adoption ("dependency record mismatch — built against mvid:A, live is mvid:B"), falls
-          # back to a local compile, and with two replicas holding two builds ping-pongs between them
-          # for ever while the partition serves the default config and its pages render empty.
-          #
-          # 🚨 NOTHING ASSERTED THAT INVARIANT AT THE PRODUCER. The design page believed re-keying
-          # preserved it — bake-scope.sh and module-build-key.py fold a sibling's SOURCES into every
-          # bundle that carries it — but re-keying only makes those bundles REBUILD, and one
-          # publication is composed from SEVERAL independent compilations (MeshWeaver.Plugins: two
-          # `build-workspace` jobs, one per module-pack lane call, plus a
-          # `dotnet build -p:Version=<module version>` per legacy `sdk` entry). Same sources, three
-          # compilations, three MVIDs — measured on memex 2026-09-10, where ONE pod held
-          # MeshWeaver.Markdown.Collaboration in 15 copies and 3 builds, grouped exactly by which
-          # compilation produced them.
-          #
-          # This step is the first point where every copy is in ONE hand, and it is the point where
-          # the damage is done: what the bake loads becomes the record every consumer must match. So
-          # the assertion lives here, over the composed BYTES, and it is a REFUSAL — a publication
-          # carrying two builds of one name is what ReleaseAvailability later answers
-          # `SealedSetInconsistent` for, i.e. NOTHING ROLLS, for the whole fleet, until it is rebuilt.
-          digest_of() {
-            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
-            else shasum -a 256 "$1" | cut -d' ' -f1; fi
-          }
-          DIGESTS="${RUNNER_TEMP:-/tmp}/ext-module-builds"; : > "$DIGESTS"
-          while IFS= read -r dll; do
-            printf '%s %s %s\n' "$(basename "$dll" .dll)" "$(digest_of "$dll")" "$(basename "$(dirname "$dll")")" >> "$DIGESTS"
-          done < <(find "$EXT" -mindepth 2 -maxdepth 2 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) | sort)
+          # ───── THE VERDICT ON THE SET (MeshWeaver#3732; the reading is collected above) ─────
           COPIES=$(awk 'END {print NR + 0}' "$DIGESTS")
           NAMES=$(awk '{print $1}' "$DIGESTS" | sort -u | awk 'END {print NR + 0}')
           SHARED=$(awk '{c[$1]++} END {n = 0; for (k in c) if (c[k] > 1) n++; print n}' "$DIGESTS")
@@ -1130,11 +1141,11 @@ jobs:
           # measurement, so the count that would expose it is never hidden. Zero is legitimate only
           # for a repo whose modules carry no `MeshWeaver.*` assembly at all; anywhere else it is the
           # wrong directory, and it is on the log.
-          echo "module set: $COPIES MeshWeaver.* assembly file(s) under /ext, $NAMES distinct name(s), $SHARED carried by more than one module, $DIVERGED carried at more than one BUILD"
+          echo "module set: $COPIES MeshWeaver.* assembly file(s) across $MODULE_COUNT bundle(s), $NAMES distinct name(s), $SHARED carried by more than one bundle, $DIVERGED carried at more than one BUILD"
           if [ "$DIVERGED" -ne 0 ]; then
             while IFS= read -r dupe; do
               echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
-              awk -v n="$dupe" '$1 == n {printf "          build %s  composed from module %s%s\n", substr($2, 1, 16), $3, ($3 == n ? "   <- the DECLARED module" : "   <- a RIDING sibling")}' "$DIGESTS" | sort -u
+              awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
             echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
             exit 1

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1086,6 +1086,59 @@ jobs:
             echo "sealing $name as module package '$pkg'"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
+          # ───── ONE BUILD PER ASSEMBLY NAME, ACROSS THE WHOLE COMPOSED SET (MeshWeaver#3732) ─────
+          # 🚨 A module-owned `MeshWeaver.*` sibling RIDES every bundle that references it, and some
+          # of those siblings are ANOTHER package's declared module (Doc/Architecture/
+          # ModuleOwnedSiblingsRide). That decision stands, and it rests on exactly ONE invariant:
+          # every copy of a name in the set is the SAME BUILD. `MeshWeaver.*` assemblies bind by a
+          # strictly synchronised AssemblyVersion, so the copies below are ONE assembly identity —
+          # whichever this host loads FIRST wins the process, and every NodeType the bake compiles is
+          # stamped `mvid:` of THAT build. A portal that loaded another one declines every one of them
+          # at adoption ("dependency record mismatch — built against mvid:A, live is mvid:B"), falls
+          # back to a local compile, and with two replicas holding two builds ping-pongs between them
+          # for ever while the partition serves the default config and its pages render empty.
+          #
+          # 🚨 NOTHING ASSERTED THAT INVARIANT AT THE PRODUCER. The design page believed re-keying
+          # preserved it — bake-scope.sh and module-build-key.py fold a sibling's SOURCES into every
+          # bundle that carries it — but re-keying only makes those bundles REBUILD, and one
+          # publication is composed from SEVERAL independent compilations (MeshWeaver.Plugins: two
+          # `build-workspace` jobs, one per module-pack lane call, plus a
+          # `dotnet build -p:Version=<module version>` per legacy `sdk` entry). Same sources, three
+          # compilations, three MVIDs — measured on memex 2026-09-10, where ONE pod held
+          # MeshWeaver.Markdown.Collaboration in 15 copies and 3 builds, grouped exactly by which
+          # compilation produced them.
+          #
+          # This step is the first point where every copy is in ONE hand, and it is the point where
+          # the damage is done: what the bake loads becomes the record every consumer must match. So
+          # the assertion lives here, over the composed BYTES, and it is a REFUSAL — a publication
+          # carrying two builds of one name is what ReleaseAvailability later answers
+          # `SealedSetInconsistent` for, i.e. NOTHING ROLLS, for the whole fleet, until it is rebuilt.
+          digest_of() {
+            if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+            else shasum -a 256 "$1" | cut -d' ' -f1; fi
+          }
+          DIGESTS="${RUNNER_TEMP:-/tmp}/ext-module-builds"; : > "$DIGESTS"
+          while IFS= read -r dll; do
+            printf '%s %s %s\n' "$(basename "$dll" .dll)" "$(digest_of "$dll")" "$(basename "$(dirname "$dll")")" >> "$DIGESTS"
+          done < <(find "$EXT" -mindepth 2 -maxdepth 2 -type f \( -name 'MeshWeaver.*.dll' -o -name 'MeshWeaver.dll' \) | sort)
+          COPIES=$(awk 'END {print NR + 0}' "$DIGESTS")
+          NAMES=$(awk '{print $1}' "$DIGESTS" | sort -u | awk 'END {print NR + 0}')
+          SHARED=$(awk '{c[$1]++} END {n = 0; for (k in c) if (c[k] > 1) n++; print n}' "$DIGESTS")
+          DIVERGED=$(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {n = 0; for (k in d) if (d[k] > 1) n++; print n}' "$DIGESTS")
+          # 🚨 The DENOMINATOR is printed on every run, green or red. A check pointed at an empty or
+          # wrong directory reports zero copies and refuses nothing while ticking exactly like a clean
+          # measurement, so the count that would expose it is never hidden. Zero is legitimate only
+          # for a repo whose modules carry no `MeshWeaver.*` assembly at all; anywhere else it is the
+          # wrong directory, and it is on the log.
+          echo "module set: $COPIES MeshWeaver.* assembly file(s) under /ext, $NAMES distinct name(s), $SHARED carried by more than one module, $DIVERGED carried at more than one BUILD"
+          if [ "$DIVERGED" -ne 0 ]; then
+            while IFS= read -r dupe; do
+              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
+              awk -v n="$dupe" '$1 == n {printf "          build %s  composed from module %s%s\n", substr($2, 1, 16), $3, ($3 == n ? "   <- the DECLARED module" : "   <- a RIDING sibling")}' "$DIGESTS" | sort -u
+            done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
+            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
+            exit 1
+          fi
           echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"
           echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
           echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -152,15 +152,22 @@ Two consequences, both measured:
 ### The producer asserts it, where every copy is first in one hand
 
 The `ext-modules` composition step of `node-repo-gate.yml` and `node-repo-publish-bake.yml` digests
-every `MeshWeaver.*` assembly it composed under `/ext/<module>/`, groups them by simple name, and
-**refuses a set carrying one name at more than one build** — naming each copy's digest, the module
-folder it came from, and whether it is the DECLARED module or a RIDING sibling, which is the half
-that says which producer to change. It prints its denominator on every run, green or red (copies,
-distinct names, names carried by more than one module, names carried at more than one build), because
-a check pointed at the wrong directory refuses nothing while ticking exactly like a clean
-measurement. Identical copies PASS — that is the decision this page took, and
-`test-module-set-consistency.py` executes both directions plus two falsification arms against the
-lanes' own extracted shell.
+every `MeshWeaver.*` assembly of every bundle it composes, groups them by simple name, and **refuses
+a set carrying one name at more than one build** — naming each copy's digest, the BUNDLE it was
+sealed in, and whether it arrived as the DECLARED module or a RIDING sibling, which is the half that
+says which producer to change (the same wording `UpdatePolicy.heldReason` uses when the consumer
+finds it days later). It prints its denominator on every run, green or red, because a check pointed
+at the wrong directory refuses nothing while ticking exactly like a clean measurement. Identical
+copies PASS — that is the decision this page took, and `test-module-set-consistency.py` executes
+both directions plus two falsification arms against the lanes' own extracted shell.
+
+🚨 **The reading is taken per bundle, BEFORE the merge — never off the composed directory.** The
+landing loop copies each bundle's module folder into `/ext/<module.assemblyName>/`, so two bundles
+declaring the same entry assembly (an artifact bundle and a registry bundle — a precedence the lane's
+own notice calls an accident of glob order, `*.nupkg` before `*.zip`) land in ONE directory and the
+second `cp -R` overwrites the first. Measured against a scan of `/ext`: two bundles carrying
+`MeshWeaver.Alpha` at two builds reported **one** copy and passed. Reading each bundle's own unpacked
+folder has both, and the harness carries that case.
 
 That placement is not incidental: it is the first moment every copy is in one hand, **and** the
 moment the damage is done, since what the bake loads is what every consumer must then match.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -208,6 +208,18 @@ and there are exactly two:
    platform but leaves `InformationalVersion` at the SDK default, i.e. `$(Version)` — so on the
    `sdk` lane the host module's package version is still compiled into every sibling it rebuilds.
    Carrying #3022's pin across removes that producer without touching a lane.
+🚦 **The refusal reaches a satellite only when that satellite MOVES ITS PIN, so the ordering is
+free.** Every node repo consumes these lanes at a full sha (`uses:
+Systemorph/MeshWeaver/.github/workflows/node-repo-publish-bake.yml@<40-char sha>`), and moving that
+pin is a deliberate, reviewed act by each repo's own rule. So this assertion is INERT for
+MeshWeaver.Plugins and every other satellite until its pin bump — which is the moment to land the
+remedy below and the pin move together, rather than discovering the refusal on a publish that had
+nowhere to go. Measured 2026-09-10: on today's bytes the strip that #3751 added would keep the
+`MeshWeaver.Markdown.Collaboration` and `MeshWeaver.AI` rides out of the portal-pinned lane (the
+image seeds both), but `MeshWeaver.Maps` is seeded by nothing and is declared by the `floor` call
+while `Northwind` rides it from the `sdk` lane — two compilations, so that is where the refusal
+would first speak.
+
 2. **Stop the ride.** Argued and rejected above, and the argument still holds: `AI` `requires`
    `[Store]` while `Essentials` — which DECLARES `MeshWeaver.Markdown.Collaboration` — `requires`
    `[AI, …]`, so making `AI` resolve the sibling from `Essentials` is a package cycle. It becomes

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -111,11 +111,61 @@ every NodeType whose dependency record named the other build is declined at adop
 *"dependency record mismatch — 'MeshWeaver.Markdown.Collaboration' built against mvid:A, live is
 mvid:B"* — and the view renders empty.
 
-Today the copies agree by **accident**: `bake-scope.sh` classifies any change under `src/` as
-affecting ALL modules, and `module-build-key.py` folds each entry's whole in-repo `ProjectReference`
-closure into its content address, so a sibling's change re-keys every bundle that carries it. Both
-are correct and neither is the assertion — they are two mechanisms that happen to preserve the
-property. The assertion is:
+### 🚨 The copies do NOT agree, and the reason is structural (#3732)
+
+This page used to say the copies agree by **accident** — that `bake-scope.sh` classifies any change
+under `src/` as affecting ALL modules, and that `module-build-key.py` folds each entry's whole
+in-repo `ProjectReference` closure into its content address, so a sibling's change re-keys every
+bundle that carries it. Both statements are true. **The conclusion drawn from them was false**, and
+the gap is one word: re-keying makes the bundles **REBUILD**, and says nothing about their BYTES.
+
+**A publication is composed from several INDEPENDENT COMPILATIONS.** On `MeshWeaver.Plugins` there
+are three per push, and a sibling project is compiled once in each of them:
+
+| compilation | what it is | which bundles it produced |
+|---|---|---|
+| the **floor** lane's `build-workspace` | one Roslyn workspace inside the pinned image, for the first `module-pack` call (`Essentials`, `AI`, `Maps`, `Stripe`) | the DECLARED `MeshWeaver.Markdown.Collaboration`, and its ride inside `MeshWeaver.AI` |
+| the **rest** lane's `build-workspace` | a second workspace, for the other `module-pack` call's `build: container` entries | its ride inside `Mcp`, `Teams`, `Mail.MicrosoftGraph`, `Observability`, `Notifications.Channels`, and the six `AI.*` providers |
+| the legacy **`sdk`** entries | `dotnet build <project> -p:Version=<that module's version>` per module, on the runner — and `-p:Version` is a GLOBAL property, so every transitively referenced sibling is rebuilt under it | its ride inside `MeshWeaver.Blazor.Chat` |
+
+Measured on `memex.meshweaver.cloud`, 2026-09-10: **one pod held
+`MeshWeaver.Markdown.Collaboration` in 15 copies and THREE builds**, and the three groups match the
+three compilations entry for entry — 12 copies riding the `rest` lane's container modules, 2 sharing
+the `floor` lane's build (the declared module and its ride inside `MeshWeaver.AI`), 1 riding the one
+`sdk` module that reaches it. Nothing was stale, nothing had drifted: 14 rides + 1 declaration = 15
+copies, exactly as the closure rule intends, in as many builds as there were compilations.
+
+Two consequences, both measured:
+
+* **The bake host picks one by arrival order, and its pick becomes the contract.** The gate and bake
+  lanes compose every module into `/ext/<Name>/` and hand them all to one process, which loads the
+  first copy it sees and stamps `mvid:` of THAT build into every NodeType's dependency record. On
+  memex the bundles named a build (`798f92a0…`) that was on no pod at all.
+* **Two replicas holding two builds never converge.** Each declines the other's record
+  (`HasStaleFrameworkBuild`), recompiles locally, stamps its own — `v2031 → v2050 → v2053`,
+  alternating between two `compiledModulesHash` values with `currentSourceFingerprint` constant. Every
+  activation lands mid-ping-pong, exhausts `MaxRecompileAttempts` and falls to the default config, so
+  `SocialMedia/Post`'s views (`Preview`, `Write`, `PostCard`) were simply absent and
+  `/Posts/SavThankYou` rendered nothing. A recycle does not clear it; publishing the missing bundle
+  does not clear it either.
+
+### The producer asserts it, where every copy is first in one hand
+
+The `ext-modules` composition step of `node-repo-gate.yml` and `node-repo-publish-bake.yml` digests
+every `MeshWeaver.*` assembly it composed under `/ext/<module>/`, groups them by simple name, and
+**refuses a set carrying one name at more than one build** — naming each copy's digest, the module
+folder it came from, and whether it is the DECLARED module or a RIDING sibling, which is the half
+that says which producer to change. It prints its denominator on every run, green or red (copies,
+distinct names, names carried by more than one module, names carried at more than one build), because
+a check pointed at the wrong directory refuses nothing while ticking exactly like a clean
+measurement. Identical copies PASS — that is the decision this page took, and
+`test-module-set-consistency.py` executes both directions plus two falsification arms against the
+lanes' own extracted shell.
+
+That placement is not incidental: it is the first moment every copy is in one hand, **and** the
+moment the damage is done, since what the bake loads is what every consumer must then match.
+
+### The consumer asserts it again, and turns a violation into a HOLD
 
 **`PublishedBundleCatalogue.ArtifactsForIdentity` reads the MVID of every `MeshWeaver.*` assembly
 each sealed module bundle carries — entry and riding sibling alike — and any name carried at two
@@ -138,6 +188,40 @@ Two boundaries are deliberate:
   fleet for a property that was never claimed.
 
 ## What this does not close
+
+**The assertions REFUSE the divergence; they do not remove the second compilation.** A repo whose
+publication is composed from more than one compilation now goes RED instead of shipping — which is
+the correct verdict for those bytes — but the way to stay green is a decision nobody has taken yet,
+and there are exactly two:
+
+1. **One compilation per publication.** Every bundle of one publication is packed from ONE workspace
+   build. Today `MeshWeaver.Plugins` splits `module-pack` into a `floor` call and a `rest` call
+   (deliberately — the floor's four bundles are what the gates compose, Plugins#1438) and still has
+   five legacy `sdk` entries, each rebuilding its siblings under its own `-p:Version`. Merging the
+   two calls, or making the second reuse the first's workspace output for shared siblings, is a lane
+   change; converting the last `sdk` entries is the standing direction anyway (maintainer,
+   2026-09-01: *"one global one and finish"*).
+   🚨 One part of this is cheap and independent: core's own `Directory.Build.props` pins the
+   COMPILED version attributes to the commit precisely so `-p:Version=` cannot move an assembly's
+   MVID (#3022 — *"two publishes of one commit fork the identity and the bake goes inert"*).
+   MeshWeaver.Plugins' `src/Directory.Build.props` sets `AssemblyVersion`/`FileVersion` from the
+   platform but leaves `InformationalVersion` at the SDK default, i.e. `$(Version)` — so on the
+   `sdk` lane the host module's package version is still compiled into every sibling it rebuilds.
+   Carrying #3022's pin across removes that producer without touching a lane.
+2. **Stop the ride.** Argued and rejected above, and the argument still holds: `AI` `requires`
+   `[Store]` while `Essentials` — which DECLARES `MeshWeaver.Markdown.Collaboration` — `requires`
+   `[AI, …]`, so making `AI` resolve the sibling from `Essentials` is a package cycle. It becomes
+   available only if the assembly MOVES to a package `AI` already requires. That is a packaging
+   decision in MeshWeaver.Plugins, not a line edit here.
+
+🚨 **A host-measured witness cannot decide this.** [The Platform-Shipped Witness](../PlatformShippedWitness)
+drops a riding copy the platform host already ships, and its third reading —
+`<app>/modules/<Name>/<Name>.dll`, the seeded-module lane — happens to cover
+`MeshWeaver.Markdown.Collaboration` and `MeshWeaver.AI` **on the portal image**, because
+Plugins#1515 seeds them there. It does not cover them on `mw-plugin-test`, which is built from
+core and contains neither. One publication, two hosts, two answers, one seal: the duplicate is a
+property of the PUBLICATION and only a publication-level reading settles it. That is why the
+assertion above measures the composed set rather than the image.
 
 The **second producer in time** is untouched: an instance that installed a module from the registry's
 content-versioned package endpoint holds whatever *that* lane published last, while the sealed

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-page-can-no-longer-go-blank-because-one-add-on-was-built-twice.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-page-can-no-longer-go-blank-because-one-add-on-was-built-twice.md
@@ -1,0 +1,48 @@
+---
+Name: A page can no longer go blank because one add-on was built twice
+Category: Fix
+Description: A release could ship two different builds of the same shared component. Whichever one a server happened to load first won, everything compiled against the other was rejected, and the affected pages rendered nothing until the next release. Releases carrying that mixture are now refused when they are built.
+Icon: Checkmark
+Order: -20260910
+---
+
+# A page can no longer go blank because one add-on was built twice
+
+Some add-ons share a component with other add-ons. Until now, a release could be assembled out of
+several separate compilations, and each one produced its **own copy** of that shared component. The
+copies were built from identical source, so nothing looked wrong — but they were not the same file,
+and a server can only ever use one of them.
+
+Whichever copy the server loaded first won. Everything that had been compiled against one of the
+others was then rejected as "built against something else", and the pages behind it were left with
+no views to render. On a portal running two servers, each one could pick a different copy, and they
+took turns rebuilding and rejecting each other's work indefinitely.
+
+The visible result was a page that simply rendered **nothing** — no error, no warning, no banner.
+Reloading did not help. Restarting the affected area did not help. Publishing the missing content
+did not help either, because the content was never the problem.
+
+## What changes
+
+**A release that carries two different builds of one shared component is now refused as it is
+assembled.** The check happens where every copy is together for the first time, which is also the
+last moment before the mixture starts being written into everything else. Nothing ships in that
+state any more.
+
+**The refusal says which two producers to look at.** It names the component, both builds, and for
+each one whether it arrived as the add-on that *owns* that component or as a copy riding along with
+another add-on. That is what tells whoever is publishing which half to change.
+
+**Sharing a component is still completely normal.** More than half of the add-ons in the catalog
+carry a copy of something another add-on owns, and that stays exactly as it was. Only *disagreeing*
+copies are refused; identical ones pass, and the check reports how many it compared so that a check
+that quietly looked at nothing cannot pass for a clean one.
+
+## What this does not change
+
+**Nothing about how you install or update add-ons.** This is a check on how a release is built. If
+you never saw a blank page, nothing you do changes.
+
+**A portal that already carries the mixture still needs a new release.** The check prevents new ones
+from being published; an installation that already picked one up recovers when it takes the next
+release that passes.


### PR DESCRIPTION
Fixes the producer half of #3732 — and corrects the design page whose premise the live measurement falsifies.

## The mechanism, established

`MeshWeaver.Markdown.Collaboration` is the **declared module of package `Essentials`** *and* a transitive repo-local `ProjectReference` of `MeshWeaver.AI`, which 13 other module projects reference. `module-owned-platform.sh` marks it module-owned, so `DepsClosure` bundles it into every one of those bundles. That is the decision on record (`Doc/Architecture/ModuleOwnedSiblingsRide`), and it rests on ONE invariant: **every copy in a publication is the same build.**

**Nothing asserted that invariant at the producer.** The page believed re-keying preserved it — `bake-scope.sh` and `module-build-key.py` fold a sibling's SOURCES into every bundle that carries it. Re-keying makes the bundles **rebuild**; it says nothing about their BYTES. One publication is composed from **several independent compilations**: MeshWeaver.Plugins runs two `build-workspace` jobs (one per `module-pack` lane call — the 4-entry `floor` and the ~34-entry `rest`) plus a `dotnet build -p:Version=<module version>` per legacy `sdk` entry.

Measured on `memex.meshweaver.cloud` 2026-09-10 — ONE pod, **15 copies, 3 builds**, and the groups match the three compilations entry for entry:

| build | copies | riding | the compilation |
|---|---|---|---|
| `314a67c9…` | 12 | `Mail.MicrosoftGraph`, `AI.OpenAI`, `AI.AzureFoundry`, `Observability`, `AI.Anthropic`, `Teams`, `Notifications.Channels`, `AI.AppleIntelligence`, `AI.WebSearch`, `AI.Copilot`, `AI.ClaudeCode`, `Mcp` | all twelve are `"build": "container"` entries of the **rest** call |
| `82558183…` | 2 | `MeshWeaver.AI`, and the DECLARED module | both `AI` and `Essentials` are entries of the **floor** call |
| `767d94ea…` | 1 | `MeshWeaver.Blazor.Chat` | the one **`sdk`** entry that reaches `MeshWeaver.AI` |

14 rides + 1 declaration = 15, with no residual. The other four `sdk` entries (Northwind, Hosting.Instance, Publish, Testing) do not reach `MeshWeaver.AI`, which is why there is no fourth group.

**The issue's own hypothesis is half right.** "A downstream publication republishes its upstream's modules" (crm copying plugins) is a real, separate producer — but it is not this instance: `heldReason` names `source 'plugins'` on BOTH sides, and all 15 pod copies come from plugins bundles. "Image siblings" is `#3751`'s subject and is already handled *for the portal*. The dominant, unfixed producer is neither: a sibling that is itself a **declared module of the same publication**, compiled once per compilation.

## Why the fix is at the producer, not the consumer

Consumer determinism is falsified by the measurement, not merely rejected: the bundles were compiled against a **seventh** build (`798f92a0…`) that is on **no pod**. No tie-break over the copies present can make a dependency record match a build nothing holds. And arrival order deciding anything is itself the defect — the bake host picks one copy and its pick becomes the contract every consumer must match.

## What this adds

`node-repo-gate.yml` and `node-repo-publish-bake.yml` — the `ext-modules` composition step, the first point where every copy is in one hand **and** the point where the damage is done — now digest every `MeshWeaver.*` assembly under `/ext/<module>/`, group by simple name, and **refuse a set carrying one name at more than one build**, naming each copy's digest, its module folder, and whether it arrived as the DECLARED module or a RIDING sibling. Identical copies PASS: that is the decision the design page took, and 19 of 37 bundles depend on it. The denominator is printed on every run, green or red.

`test-module-set-consistency.py` EXTRACTS both lanes' step by `id:` and executes it — 6 cases × 2 lanes, all passing locally:

* divergent copies RED, naming both builds and both producers;
* declared-vs-riding divergence RED with each copy's ROLE labelled;
* **identical copies GREEN**, with `1 carried by more than one module` in the denominator proving the check saw them;
* entry assemblies counted (a module composed twice at two builds is visible);
* falsification arm `strip` — assertion removed ⇒ the divergent set sails through;
* falsification arm `blind` — assertion aimed at an empty directory ⇒ passes AND reports `0 MeshWeaver.* assembly file(s)`.

## What it does NOT do, and the decision that remains

It **refuses** the divergence; it does not remove the second compilation. Two ways to stay green, both decisions outside core, both written up on the page:

1. **One compilation per publication** — merge the two `module-pack` calls (they are split deliberately, Plugins#1438) and convert the last five `sdk` entries. 🚨 One part is cheap and independent: core's `Directory.Build.props` pins the compiled version attributes to the commit precisely so `-p:Version=` cannot move an MVID (#3022). MeshWeaver.Plugins' `src/Directory.Build.props` sets `AssemblyVersion`/`FileVersion` from the platform but leaves `InformationalVersion` at the SDK default `$(Version)` — so on the `sdk` lane the host module's package version is still compiled into every sibling it rebuilds. Carrying #3022's pin across removes that producer without touching a lane.
🚦 **This cannot red a satellite until that satellite moves its pin.** Both lanes are consumed at a full sha (`node-repo-{gate,publish-bake}.yml@174f5ab7…` in MeshWeaver.Plugins), and a pin move is a deliberate reviewed act there. So the assertion is inert everywhere until the pin bump — which is the moment to land remedy 1 and the pin move together. Measured: on today's bytes #3751's strip keeps the `Markdown.Collaboration` and `AI` rides out of the portal-pinned lane (the image seeds both), but `MeshWeaver.Maps` is seeded by nothing, is declared by the `floor` call and ridden by `Northwind` from the `sdk` lane — two compilations, so that is where the refusal would first speak.

2. **Stop the ride** — blocked by a package cycle: `AI` `requires: [Store]` while `Essentials`, which DECLARES `MeshWeaver.Markdown.Collaboration`, `requires: [AI, …]`. It becomes available only if the assembly MOVES to a package `AI` already requires. A packaging decision in MeshWeaver.Plugins.

Also recorded: a **host-measured** witness cannot settle this. `--platform-app`'s third reading (`<app>/modules/<Name>/<Name>.dll`) covers `Markdown.Collaboration` and `AI` on the *portal* image because Plugins#1515 seeds them, and covers neither on `mw-plugin-test`, which is built from core. One publication, two hosts, two answers, one seal — the duplicate is a property of the PUBLICATION.

## Verification

* `test-module-set-consistency.py` — 12/12 cases, both falsification arms behave.
* `test-module-asset-landing.py` (the sibling harness that executes the same step) — still 8/8.
* `check-workflow-shell.py` — `0 live` findings; `check-workflow-timeouts.py`, `check-workflow-yaml-keys.py`, `check-pr-secret-preflight.py`, `check-abbreviated-shas.py` — 0 violations.
* `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → `0 Error(s)`; `DocumentationLinkIntegrityTest` → `Passed! 1/1`.
* Live re-verification 2026-09-10 07:05Z: `SocialMedia/Post` is at v2078, still `latestAssemblyCollection: local`, `currentSourceFingerprint` still `c927425f384fbec5`, and its `MeshWeaver.Markdown.Collaboration` entry now reads a **fourth** value (`a0774e56…`); `@Posts/SavThankYou/area/Preview` still answers *"Area not found"* with only generic platform areas.

Refs #3732, #3768, #3583, #3221, #3751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
