### PR TITLE
fix: the speculative pre-flight can say "I did not check" (#3888)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
@@ -196,25 +196,75 @@ internal sealed class MeshNodeLanguageService : IMeshLanguageService
                 _ => Observable.Return<IReadOnlyList<CompletionEntry>>(Array.Empty<CompletionEntry>()),
             });
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// 🚨 The EDITOR's overload, and it deliberately degrades to an empty list when nothing was
+    /// checked — Monaco's contract is "no diagnostics means no squiggles", and painting squiggles
+    /// computed under the wrong language rules is worse than painting none. It is DERIVED from
+    /// <see cref="CheckSpeculativeOutcome"/> rather than written twice, so the two can never
+    /// disagree about what a given path produces: the only difference is that this one drops the
+    /// status. Anything rendering a VERDICT must call the outcome overload (#3888).
+    /// </remarks>
     public IObservable<IReadOnlyList<DiagnosticInfo>> CheckSpeculative(
         string nodeTypePath, string sourcePath, string proposedCode)
-        => ResolveNode(nodeTypePath)
-            .SelectMany(node => Environment(node, nodeTypePath) switch
-            {
-                CompletionEnvironment.NodeType => compilationService.GetCompilationInputsAsync(node!)
-                    .SelectMany(inputs => inputs is null
-                        ? Observable.Return<IReadOnlyList<DiagnosticInfo>>(Array.Empty<DiagnosticInfo>())
-                        : _ioPool.Run(ct =>
-                            speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct))),
-                // A non-NodeType owner that EXISTS → a standalone script Code node: diagnose in
-                // the script environment so lesson cells get live squiggles too (this used to
-                // fall through to a compilation that parses a cell as REGULAR C#, reporting the
-                // spurious "top-level statements must be in an executable" on every cell).
-                CompletionEnvironment.Script => _ioPool.Run(ct => GetScriptDiagnosticsAsync(proposedCode, ct)),
-                // Owner unresolvable → no honest environment to diagnose in; stay silent rather
-                // than paint squiggles computed under the wrong language rules.
-                _ => Observable.Return<IReadOnlyList<DiagnosticInfo>>(Array.Empty<DiagnosticInfo>()),
-            });
+        => CheckSpeculativeOutcome(nodeTypePath, sourcePath, proposedCode)
+            .Select(outcome => outcome.Diagnostics);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// 🚨 Reads <see cref="ResolveNodeOutcome"/>, not <see cref="ResolveNode"/>. The distinction was
+    /// never missing from the framework — the read underneath already separates Present / Absent /
+    /// Unavailable — it was discarded here, and discarding it is what made an unresolvable NodeType
+    /// answer byte-identically to a clean one, which <c>lsp_check_node</c> then rendered as
+    /// <c>{"ok":true,"diagnostics":[]}</c> for source that was not C# at all (#3888). Same shape,
+    /// same fix, as <see cref="GetDiagnostics"/> under #1592/#1618.
+    /// </remarks>
+    public IObservable<NodeDiagnosticsOutcome> CheckSpeculativeOutcome(
+        string nodeTypePath, string sourcePath, string proposedCode)
+        => ResolveNodeOutcome(nodeTypePath)
+            .SelectMany(outcome => outcome.Node is { } node
+                ? SpeculativeFor(node, nodeTypePath, sourcePath, proposedCode)
+                : Observable.Return(outcome.Status switch
+                {
+                    // Genuinely not there, or its delete is in flight — either way the proposed
+                    // source was never compiled against anything.
+                    NodeReadStatus.Absent or NodeReadStatus.DeleteInProgress =>
+                        NodeDiagnosticsOutcome.Absent,
+                    // 🚨 The owner did not answer inside the budget, the read faulted, or a
+                    // delivery-level denial came back as a failure. Precisely when a pre-flight
+                    // most needs to refuse, and precisely where it used to be most confidently
+                    // green.
+                    _ => NodeDiagnosticsOutcome.Unavailable(outcome.Failure),
+                }));
+
+    // The speculative half, given an already-resolved node. Environment() cannot answer Unknown
+    // for a non-null node, so the two arms below are the whole space.
+    private IObservable<NodeDiagnosticsOutcome> SpeculativeFor(
+        MeshNode node, string nodeTypePath, string sourcePath, string proposedCode)
+        => Environment(node, nodeTypePath) switch
+        {
+            CompletionEnvironment.NodeType => compilationService.GetCompilationInputsAsync(node)
+                .SelectMany(inputs => inputs is null
+                    // 🚨 The honest reading of a nullable contract, and NOT reachable today — said
+                    // plainly rather than pinned by a test that could never fail. Reaching it needs
+                    // GetCompilationInputsAsync to answer null, which it does for exactly one shape
+                    // (a node whose NodeType is unset), and such a node is classified as Script
+                    // above, so it never gets here. #3888 listed this as one of two silent branches
+                    // and could not say which produced the live observation; it can only have been
+                    // the unresolvable-owner one. The arm stays because mapping a null to Compiled
+                    // is precisely the defect — if the nullable contract ever gains a second cause,
+                    // this says "nothing was compiled" rather than inventing a clean bill.
+                    ? Observable.Return(NodeDiagnosticsOutcome.NotCompilable)
+                    : _ioPool.Run(ct =>
+                            speculativeCompilation.GetDiagnosticsAsync(inputs, sourcePath, proposedCode, ct))
+                        .Select(NodeDiagnosticsOutcome.Compiled)),
+            // A non-NodeType owner that EXISTS → a standalone script Code node: diagnose in
+            // the script environment so lesson cells get live squiggles too (this used to
+            // fall through to a compilation that parses a cell as REGULAR C#, reporting the
+            // spurious "top-level statements must be in an executable" on every cell).
+            _ => _ioPool.Run(ct => GetScriptDiagnosticsAsync(proposedCode, ct))
+                .Select(NodeDiagnosticsOutcome.Compiled),
+        };
 
     /// <summary>Which language environment a Code node's text belongs to.</summary>
     private enum CompletionEnvironment

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -1,7 +1,7 @@
 ---
 Name: Controls That Cannot Fail
 Category: Architecture
-Description: A control whose green is guaranteed by construction is not a control. Twelve measured instances — a test, a detector, an identity anchor, a preflight, a watcher, a CD verdict, a git idiom that answers the wrong question, a generator whose failure mode is a success line, and a guard handed an input that could not fail — and the one question that catches them all.
+Description: A control whose green is guaranteed by construction is not a control. Thirteen measured instances — a test, a detector, an identity anchor, a preflight, a watcher, a CD verdict, a git idiom that answers the wrong question, a generator whose failure mode is a success line, a guard handed an input that could not fail, and a probe whose defect had already been fixed in its sibling method — and the one question that catches them all.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 12h8"/><path d="M12 8v8" opacity="0.25"/></svg>
 ---
 
@@ -50,8 +50,9 @@ instances. The family is larger, and it is worth recognising by shape.
 | **An input the OPERATOR supplies** | `--is-ancestor <commit I chose> <candidate>` where the commit chosen is the branch's own tip | the check is sound; the value handed to it cannot make it print anything but PASS |
 | **An observer that becomes the load** | several sessions polling the same PRs until the shared credential 403s | the watch removes the ability to observe; `/rate_limit` still reports a healthy quota |
 | **A remedy written for reads, applied to a write** | "retry the failed call" after a timeout on `gh pr create` | a lost response is not a lost request; the blind retry creates the second one |
+| **One contract serving two consumers with opposite needs** | `[]` from a speculative compile: *no squiggles* to an editor, *approved* to a tool rendering `{ok}` | the code is right for one caller, so reviewing it on its own terms confirms it |
 
-## Twelve measured instances
+## Thirteen measured instances
 
 The first six were found in a single day, across tests, CI, publication and ops. Instances 7 and 8
 were found **while writing this page** — one by its author, one by the session that supplied instances
@@ -679,6 +680,51 @@ Classify the operation *before* choosing the recovery, and note which of the thr
 about: whether the request was sent, whether it was applied, and whether the operation is safe to
 repeat. Most transport errors answer only the first, and only sometimes.
 
+### 13. The same defect, fixed in one method and left in its sibling — two months apart
+
+The instrument was `lsp_check_node`, the pre-flight the `/code` skill's whole edit loop is built on
+(*"edit a source file in your head → `lsp_check_node` → if diagnostics, fix → repeat → only then
+patch + compile"*). Measured on `memex.systemorph.com`, 2026-09-10:
+
+```
+lsp_check_node  nodeTypePath: @BinaryClickerV2/BinaryToggle
+                proposedCode: "this is definitely not valid C# ###"
+→ {"ok":true,"diagnostics":[]}
+```
+
+That second call **is** the second half of the diagnostic, run by accident: a probe handed a subject
+broken on purpose — text that cannot parse as C# at all — and it still returned clean. The NodeType
+sat in a partition that identity had no read grant on, so nothing was ever compiled; the empty list
+was "I could not look", spelled exactly like "I looked and it is fine".
+
+**What makes this one worth its own instance is not the defect. It is that the defect had already
+been found, understood, written up and fixed — in the method next door.** #1592/#1618 gave
+`GetDiagnostics` a `NodeDiagnosticsOutcome` for precisely this reason, and the type's own XML doc
+says it in bold: *"An empty diagnostic list is not evidence of health."* `CheckSpeculative`, four
+lines away in the same class, kept returning a bare list. Nothing carried the fix across, because
+nothing had named the CLASS the two methods share.
+
+The reason it survived a careful reading is subtler than an oversight, and it is the general lesson:
+
+> **One return type was serving two consumers whose needs are opposite.** The Monaco editor wants
+> silence when the owner cannot be resolved — a squiggle computed under the wrong language rules is
+> worse than no squiggle. The MCP tool renders a **verdict**, where silence reads as *approved*. The
+> code comment said *"stay silent rather than paint squiggles computed under the wrong language
+> rules"*, and it was **right for one caller and wrong for the other** — so reviewing the method on
+> its own terms could only ever confirm it.
+
+The fix is two surfaces rather than one compromise: `CheckSpeculative` (the editor's, silent by
+contract) and `CheckSpeculativeOutcome` (everyone rendering a verdict), the first derived from the
+second so they cannot drift. Full account: [Language Services](/Doc/Architecture/LanguageServices)
+→ *An empty diagnostic list is not evidence of health*.
+
+**Two transferable rules.** When you fix an instrument that cannot fail, ask *which other callers of
+this data have the same shape* — a sibling method, a second tool over the same service, the other
+overload — because the fix travels with the CLASS, not with the call site. And when a "silent on
+error" contract looks correct, ask **whose** contract it is: if two consumers read the same value
+and one of them renders it as a verdict, silence is not a shared default, it is a defect for one of
+them.
+
 ## What the whole family has in common
 
 Instances 9, 10 and 11 were found on one day, alongside a watcher reading a `startup_failure` (a
@@ -794,4 +840,5 @@ carries its own control arm is that thesis applied to itself.
 - [Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) — a gate that sees two of seven break shapes, and says so.
 - [Orleans Test Routing Pattern](/Doc/Architecture/OrleansTestRoutingPattern) — the pod-hub claim, and why reachability cannot stand in for it.
 - [Transitional Allow Entries](/Doc/Architecture/TransitionalAllowEntries) — in force only in the change that adds them, which is why instance 12's hardcoded set expires.
+- [Language Services](/Doc/Architecture/LanguageServices) — instance 13 in full: why one return type could not serve both the editor and the pre-flight tool.
 - [Writing Tests](/Doc/Architecture/WritingTests) — the golden rules these controls are expressed against.

--- a/src/MeshWeaver.Documentation/Data/Architecture/LanguageServices.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LanguageServices.md
@@ -38,7 +38,7 @@ Behind all three sits one `IMeshLanguageService` interface with one in-process i
   <line x1="645" y1="72" x2="422" y2="128" stroke="#90a4ae" stroke-width="1.5" marker-end="url(#arr)"/>
   <rect x="175" y="130" width="410" height="68" rx="10" fill="#37474f"/>
   <text x="380" y="154" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#fff">IMeshLanguageService</text>
-  <text x="380" y="172" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#cfd8dc">GetDiagnostics · GetHover · GetCompletions · CheckSpeculative</text>
+  <text x="380" y="172" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#cfd8dc">GetDiagnostics · GetHover · GetCompletions · CheckSpeculative(Outcome)</text>
   <text x="380" y="188" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#90a4ae">all return IObservable&lt;T&gt;</text>
   <line x1="380" y1="198" x2="380" y2="230" stroke="#90a4ae" stroke-width="1.5" marker-end="url(#arr)"/>
   <rect x="175" y="232" width="410" height="72" rx="10" fill="#455a64"/>
@@ -60,7 +60,7 @@ Behind all three sits one `IMeshLanguageService` interface with one in-process i
    ┌──────────────────────────────────────────────────────┐
    │       IMeshLanguageService (Mesh.Contract)           │
    │   GetDiagnostics / GetHover / GetCompletions /       │
-   │   CheckSpeculative                                   │
+   │   CheckSpeculative / CheckSpeculativeOutcome         │
    │   — all return IObservable<T>                        │
    └────────────────────────┬─────────────────────────────┘
                             │
@@ -106,7 +106,40 @@ Two tools are exposed via `McpMeshPlugin` for external MCP clients (`lsp_check_n
 
 **Position convention.** All positions are **0-based line/character** (LSP convention). Monaco's 1-based coordinates are converted at the JS bridge.
 
-**`{ok: true}` semantics.** This means there are no `Error`-severity diagnostics — warnings alone don't fail the check, mirroring how a real `Compile` succeeds with warnings.
+**`{ok: true}` semantics.** This means Roslyn ran **and** there are no `Error`-severity diagnostics — warnings alone don't fail the check, mirroring how a real `Compile` succeeds with warnings. Both halves are load-bearing; the section below is why.
+
+## An empty diagnostic list is not evidence of health
+
+🚨 **A verification step that cannot fail is not a verification step**, and this surface has now produced that defect twice — the second time in the method next door to the one that was fixed.
+
+`[]` is what a clean compile looks like. It is *also* what "I could not resolve that path" looks like, and what "the owning hub never answered" looks like. Nothing in an `IReadOnlyList<DiagnosticInfo>` separates them, so a tool rendering `ok = !diagnostics.Any(Error)` reports a **clean bill of health for a check that never ran**.
+
+| | Fixed in | The symptom |
+|---|---|---|
+| `GetDiagnostics` | #1592 / #1618 | `lsp_diagnostics_for_node @Edu/DefinitelyNotARealNodeType` → `{"ok":true,"diagnostics":[]}`; the mandated pre-prod sweep reported all-green over stale paths having verified nothing |
+| `CheckSpeculative` | #3888 | `lsp_check_node` on a NodeType in a partition the caller cannot read → `{"ok":true,"diagnostics":[]}` — **including for `proposedCode` that is not C# at all**; the `/code` edit loop's pre-flight blessed every proposed edit against every path it could not reach |
+
+**Why one fix did not cover the other, and why it looked reasonable at the time.** One return type was serving two consumers whose needs are *opposite*:
+
+- the **Monaco editor** wants silence when the owner cannot be resolved — a squiggle computed under the wrong language rules is worse than no squiggle;
+- the **`lsp_check_node` tool** renders a **verdict**, and silence there reads as *approved*.
+
+The comment in the code said "stay silent rather than paint squiggles computed under the wrong language rules". That is correct — for one of the two callers. The compromise return type made it wrong for the other, invisibly.
+
+**The shape of the fix: two surfaces, not one compromise.**
+
+| Method | Returns | For |
+|---|---|---|
+| `CheckSpeculative` | `IReadOnlyList<DiagnosticInfo>` | the **editor**. Deliberately silent when nothing was checked — Monaco's contract is "no diagnostics means no squiggles" |
+| `CheckSpeculativeOutcome` | `NodeDiagnosticsOutcome` | **every caller that renders a verdict** — the MCP tool, the agent plugin, any pre-flight gate |
+
+`NodeDiagnosticsOutcome` carries `Compiled` / `Absent` / `NotCompilable` / `Unavailable` plus `IsClean` (false for every status that did not actually compile) and `DescribeProblem(path)` (the reason, with the path in it, so a sweep's output says *which* entry could not be checked). The list overload is **derived from** the outcome overload — `CheckSpeculativeOutcome(...).Select(o => o.Diagnostics)` — so the two can never drift apart about what a given path produces; the only difference is that one drops the status.
+
+The interface member carries a **default implementation that answers `Unavailable`**, deliberately fail-closed. It exists so an addition cannot oblige every implementer at once (an addition's core half lands first — see [Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate)), and an implementation that has not supplied one has genuinely not checked anything. Mapping the list onto `Compiled` in the default would have re-created the defect for every implementer that never noticed the member appear.
+
+> **What #3888 also corrected about its own reading of the code.** The issue named *two* silent branches and could not say which produced the live observation. It can only have been the unresolvable-owner one: the other — `GetCompilationInputsAsync` answering `null` — is unreachable from the speculative path, because that method refuses exactly one shape (a node whose `NodeType` is unset) and such a node is classified as a **script** here, never as a NodeType. The `NotCompilable` mapping stays as the honest reading of a nullable contract, and the test suite says so rather than pinning a branch that could never fail.
+
+The controls live in `test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs` and run **in both directions**: an unresolvable path must not read clean, *and* a real NodeType must still compile its proposal and report errors when the proposal is broken. A fix that made everything fail would be no better than one that made everything pass. See [Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail).
 
 ## The /code Pre-Flight Loop
 
@@ -174,14 +207,15 @@ The following capabilities were considered but are not yet implemented:
 | Concern | File |
 |---|---|
 | Interface + DTOs | `src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs` |
-| In-process implementation | `src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs` |
-| Speculative compile + `#r` handling | `src/MeshWeaver.Graph/Configuration/SpeculativeCompilation.cs` |
+| In-process implementation | `src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs` |
+| Speculative compile + `#r` handling | `src/MeshWeaver.Compiler/SpeculativeCompilation.cs` |
 | `CompilationInputs` (shared with emit path) | `src/MeshWeaver.Graph/Configuration/CompilationInputs.cs` |
-| `GetCompilationInputsAsync` (the per-file pipeline) | `src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs` |
+| `GetCompilationInputsAsync` (the per-file pipeline) | `src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs` |
 | DI registration | `src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs` (`AddGraph`) |
 | Agent plugin | `src/MeshWeaver.AI/Plugins/LspPlugin.cs` |
 | MCP tools | `src/MeshWeaver.Mcp/McpMeshPlugin.cs` (the `Lsp*` methods) |
 | Monaco wiring | `src/MeshWeaver.Blazor/Components/Monaco/MonacoEditorView.razor[.js]`, `CodeEditorView.razor` |
 | Editor opt-in | `src/MeshWeaver.Layout/CodeEditorControl.cs` (`LanguageServer` property) |
 | Edit-view opt-in | `src/MeshWeaver.Graph/CodeLayoutAreas.cs` (`Edit` area) |
-| Integration tests | `test/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs` |
+| Integration tests | `MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/MeshNodeLanguageServiceTest.cs` |
+| The pre-flight's honesty controls | `test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs` |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-code-preflight-can-no-longer-approve-code-it-never-checked.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-code-preflight-can-no-longer-approve-code-it-never-checked.md
@@ -1,0 +1,54 @@
+---
+Name: The code assistant's pre-flight can no longer approve code it never looked at
+Category: Fix
+Description: Before an assistant edits the source of a type, it asks the compiler whether the proposed text is valid. When it could not reach that type at all — a wrong path, a space you have no access to, an area that did not answer — the check reported "no problems found", which is indistinguishable from a clean bill. It now says it could not check, and names why.
+Icon: Wrench
+Order: -20260910
+---
+
+# The code assistant's pre-flight can no longer approve code it never looked at
+
+When an assistant proposes a change to the source code of a type, it does not simply write the file
+and hope. It first asks the compiler: *given everything else this type is built from, would this
+text compile?* Answers come back as a list of problems, and an empty list means "go ahead".
+
+**An empty list also meant "I could not look."** Those two answers were spelled the same way.
+
+## What went wrong
+
+Asking about a type the check could not reach — a path with a typo in it, a type that had been
+renamed, a space the asker has no access to, or an area that simply did not answer in time — came
+back as *no problems found*. Not "not found". Not "I could not check". A clean bill of health, from
+a check that had never run.
+
+The result was measured deliberately, and it is the clearest possible statement of the problem: the
+check was handed text that is not valid code in any language, against a type it could not reach, and
+it still answered **no problems found**.
+
+A verification step that cannot report a failure is not a verification step. Here it sat at the
+front of the assistant's edit loop — propose, check, fix, repeat — so for any type it could not
+reach, every proposal passed on the first try.
+
+## What changes
+
+The check now distinguishes four answers instead of two, and only the first can be read as approval:
+
+- **Checked** — the compiler really ran. An empty problem list here, and only here, means the
+  proposed source is clean.
+- **Not found** — nothing exists at that path. Renamed, mistyped, deleted, or somewhere this
+  replica does not hold.
+- **Nothing to compile** — the path is real, but it is not a kind of node that has source code.
+- **Could not be checked** — the owning area did not answer, or the read failed. This is the one
+  that used to look greenest, and it says nothing at all about the code.
+
+The last three come back explicitly as *not approved*, with a sentence naming the path that could
+not be checked, so the assistant reports the real obstacle instead of proceeding on a phantom
+approval.
+
+## What is deliberately unchanged
+
+The live squiggles in the portal's code editor keep their silence. There, "I could not resolve the
+owner" genuinely should draw nothing: red underlines computed under the wrong assumptions are worse
+than no underlines at all. What was wrong was never the silence — it was that a tool rendering a
+verdict was reading the same silence as a yes. The editor and the verdict now have separate answers
+rather than one shared compromise.

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshLanguageService.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+
 namespace MeshWeaver.Mesh.Services.LanguageServer;
 
 /// <summary>
@@ -92,11 +94,62 @@ public interface IMeshLanguageService
     /// <c>MetadataReference</c> set so per-check cost is just parse + bind + diagnose
     /// (~200–500ms for typical NodeTypes; no NuGet resolution, no emit).
     /// </para>
+    ///
+    /// <para>🚨 <b>This overload is the EDITOR's contract, and its empty list is not a verdict.</b>
+    /// Monaco wants silence when the owner cannot be resolved — squiggles computed under the wrong
+    /// language rules are worse than none — so a path that resolves to NOTHING answers exactly what
+    /// a clean compile answers. A caller that RENDERS a verdict (<c>lsp_check_node</c>'s
+    /// <c>{ok, diagnostics}</c>, any pre-flight gate) must call
+    /// <see cref="CheckSpeculativeOutcome"/> instead: it carries the same diagnostics plus the
+    /// status that says whether anything was checked at all (Systemorph/MeshWeaver#3888).</para>
     /// </summary>
+    /// <param name="nodeTypePath">Path of the NodeType whose compilation hosts the source.</param>
+    /// <param name="sourcePath">Path of the Code MeshNode to substitute; added as a new file when absent.</param>
+    /// <param name="proposedCode">The proposed full source text for that file.</param>
     IObservable<IReadOnlyList<DiagnosticInfo>> CheckSpeculative(
         string nodeTypePath,
         string sourcePath,
         string proposedCode);
+
+    /// <summary>
+    /// The INTERROGABLE form of <see cref="CheckSpeculative"/> — the same speculative compile,
+    /// returning a <see cref="NodeDiagnosticsOutcome"/> so "I did not check" is a distinct answer
+    /// from "I checked and it is clean". Every caller that renders a VERDICT uses this one.
+    ///
+    /// <para>🚨 <b>Why it exists.</b> <see cref="CheckSpeculative"/> can only express diagnostics,
+    /// and two of its branches produce an empty list without compiling anything: an unresolvable
+    /// owner, and a node with no compilation inputs. The <c>lsp_check_node</c> tool renders that
+    /// list as <c>{"ok":true,"diagnostics":[]}</c> — so the <c>/code</c> skill's pre-flight blessed
+    /// a NodeType it could not resolve, for proposed text that was not even C#, on
+    /// <c>memex.systemorph.com</c> on 2026-09-10 (Systemorph/MeshWeaver#3888). That is the same
+    /// defect <see cref="GetDiagnostics"/> carried until #1592/#1618, left in the sibling method
+    /// because ONE return type was serving two consumers with opposite needs — the editor, for
+    /// which silence is right, and the tool, for which silence reads as approval.</para>
+    ///
+    /// <para>Read <see cref="NodeDiagnosticsOutcome.Status"/>, or
+    /// <see cref="NodeDiagnosticsOutcome.IsClean"/>, which is false for every status that did not
+    /// actually compile. <see cref="NodeDiagnosticsOutcome.DescribeProblem"/> writes the reason with
+    /// the path in it.</para>
+    ///
+    /// <para>🚨 The DEFAULT implementation answers
+    /// <see cref="NodeDiagnosticsStatus.Unavailable"/> — deliberately fail-CLOSED. It exists so a
+    /// new member cannot oblige every implementer at once (an addition's core half lands FIRST; see
+    /// <c>Doc/Architecture/CrossRepoPairGate</c>), and an implementation that has not supplied one
+    /// has genuinely not checked anything. Mapping <see cref="CheckSpeculative"/>'s list onto
+    /// <see cref="NodeDiagnosticsStatus.Compiled"/> here would re-create #3888 for every
+    /// implementer that never noticed the member appear.</para>
+    /// </summary>
+    /// <param name="nodeTypePath">Path of the NodeType whose compilation hosts the source.</param>
+    /// <param name="sourcePath">Path of the Code MeshNode to substitute; added as a new file when absent.</param>
+    /// <param name="proposedCode">The proposed full source text for that file.</param>
+    /// <returns>The outcome — diagnostics when, and only when, something was actually compiled.</returns>
+    IObservable<NodeDiagnosticsOutcome> CheckSpeculativeOutcome(
+        string nodeTypePath,
+        string sourcePath,
+        string proposedCode)
+        => Observable.Return(NodeDiagnosticsOutcome.Unavailable(new NotSupportedException(
+            $"{GetType().Name} does not implement CheckSpeculativeOutcome, so the speculative "
+            + "check was never run. This is NOT evidence that the proposed source compiles.")));
 
     /// <summary>
     /// Remembers that this user accepted <paramref name="label"/> while <paramref name="prefix"/>

--- a/test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Services.LanguageServer;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// Issue #3888 — the speculative pre-flight could not fail.
+///
+/// <para><b>What it did.</b> On <c>memex.systemorph.com</c>, 2026-09-10, as a global admin:
+/// <c>lsp_check_node @BinaryClickerV2/BinaryToggle</c> with <c>proposedCode</c> =
+/// <c>"this is definitely not valid C# ###"</c> answered <c>{"ok":true,"diagnostics":[]}</c>. Not a
+/// wrong verdict about the code — no verdict at all, wearing the costume of a clean one. The
+/// NodeType lives in a partition that identity has no read grant on, so nothing was ever compiled;
+/// <c>CheckSpeculative</c> mapped BOTH of its no-answer branches (owner unresolvable, and no
+/// compilation inputs) to <c>Array.Empty&lt;DiagnosticInfo&gt;()</c>, which is byte-identical to
+/// what a clean compile produces.</para>
+///
+/// <para><b>Why it is the worst shape available.</b> The <c>/code</c> skill's edit loop is built on
+/// this call — <i>"edit a Source/*.cs file in your head → lsp_check_node → if diagnostics, fix →
+/// repeat → only then patch + compile"</i> — so a probe that cannot fail blesses every proposed
+/// edit against every path it cannot reach. AGENTS.md states the rule absolutely: <i>"A
+/// verification step that cannot fail is not a verification step"</i>, and <i>"ok:false with a
+/// status other than Compiled … is a sweep FAILURE, not a pass — that entry was never
+/// checked."</i></para>
+///
+/// <para><b>The same defect, already fixed next door.</b> #1592/#1618 gave
+/// <see cref="IMeshLanguageService.GetDiagnostics"/> a <see cref="NodeDiagnosticsOutcome"/> for
+/// exactly this reason. It was left in the sibling method because ONE return type served two
+/// consumers with OPPOSITE needs: the Monaco editor, for which silence is right (squiggles computed
+/// under the wrong language rules are worse than none), and the MCP/agent tool, for which silence
+/// is rendered as <c>ok:true</c> and therefore reads as approval. The fix is not to make the editor
+/// noisy — it is to let the instrument SAY which of the two it is doing, via
+/// <see cref="IMeshLanguageService.CheckSpeculativeOutcome"/>.</para>
+///
+/// <para>🚨 <b>Both directions are pinned here on purpose.</b> A fix that made every check answer
+/// "not checked" would satisfy the negative cases alone and be no better than the bug. So
+/// <see cref="ARealNodeTypeStillCompilesTheProposal_CleanReadsClean"/> and
+/// <see cref="ARealNodeTypeStillCompilesTheProposal_BrokenReadsBroken"/> hold the other end: the
+/// substituted source really is compiled, and its verdict really does follow the code.</para>
+/// </summary>
+public class SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>The measured payload, verbatim: text that cannot parse as C# at all.</summary>
+    private const string NotEvenCSharp = "this is definitely not valid C# ###";
+
+    private IMeshLanguageService LanguageService =>
+        Mesh.ServiceProvider.GetRequiredService<IMeshLanguageService>();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    // ─────────────────────────────── the negative controls: it must be able to refuse
+
+    /// <summary>
+    /// The reported case, verbatim in shape: a NodeType path that resolves to nothing, and a
+    /// proposal that is not C#. The check must NOT come back clean.
+    /// </summary>
+    [Fact]
+    public async Task AnInventedNodeTypePathIsAbsent_NotClean()
+    {
+        var path = $"type/DefinitelyNotARealNodeType{Guid.NewGuid():N}";
+
+        var outcome = await LanguageService
+            .CheckSpeculativeOutcome(path, $"{path}/Source/Probe.cs", NotEvenCSharp)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        outcome.Status.Should().Be(NodeDiagnosticsStatus.Absent,
+            "nothing resolved at the path, so the proposed source was never compiled against "
+            + "anything — reporting that as a clean pre-flight is how the /code loop came to bless "
+            + "text that is not even C# (#3888)");
+        outcome.IsClean.Should().BeFalse(
+            "IsClean is the one flag a terse caller reads, and lsp_check_node renders it as ok; it "
+            + "must be false for every status that did not actually compile");
+        outcome.Diagnostics.Should().BeEmpty(
+            "emptiness is still the payload — what changed is that it is no longer the ANSWER");
+    }
+
+    /// <summary>
+    /// The reason has to survive to the caller, or a refusal is just a different unreadable green:
+    /// the message must name the path that could not be checked.
+    /// </summary>
+    [Fact]
+    public async Task TheRefusalNamesThePathThatCouldNotBeChecked()
+    {
+        var path = $"type/Missing{Guid.NewGuid():N}";
+
+        var outcome = await LanguageService
+            .CheckSpeculativeOutcome(path, $"{path}/Source/Probe.cs", NotEvenCSharp)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        var problem = outcome.DescribeProblem(path);
+        problem.Should().NotBeNull(
+            "a non-Compiled status without a reason hands the caller a bare 'no' it cannot act on");
+        problem!.Should().Contain(path,
+            "the agent asked about one path and gets one line back; the line has to identify it");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The measurement that corrected the issue's own reading of the code.</b> #3888 named TWO
+    /// silent branches and said which one produced the live observation was "not established". It is
+    /// now: it can only be the unresolvable-owner branch, because the other one — the
+    /// <c>inputs is null</c> arm — is <b>unreachable from the speculative path</b>. Reaching it
+    /// requires <c>GetCompilationInputsAsync</c> to answer null, which it does for exactly one
+    /// shape, a node whose <c>NodeType</c> is unset; and a node whose <c>NodeType</c> is unset is
+    /// classified as SCRIPT here, never as NodeType, so it never asks for compilation inputs at all.
+    ///
+    /// <para>This case pins what such a node ACTUALLY does, which is the opposite of a silent
+    /// branch: it is compiled — as a script, which is what the kernel would really run that text as
+    /// — so it is genuinely checked, and the verdict follows the code. Written as a control in both
+    /// directions for that arm, so it cannot pass by the arm doing nothing.</para>
+    ///
+    /// <para>The <c>NotCompilable</c> mapping stays in the implementation as the honest reading of a
+    /// nullable contract — the alternative is mapping a null to <c>Compiled</c>, which IS the defect
+    /// — but nothing here pretends to pin it. A test asserting an unreachable branch would be one
+    /// more control that cannot fail.</para>
+    /// </summary>
+    [Fact]
+    public async Task ANodeThatIsNotANodeTypeIsGenuinelyCheckedAsAScript()
+    {
+        var id = $"NoTypeNode{Guid.NewGuid():N}";
+        var path = $"type/{id}";
+        await MeshService.CreateNode(new MeshNode(id, "type")
+        {
+            Name = "A node with no NodeType",
+            Content = new CodeConfiguration { Code = "not code", Language = "markdown" },
+            State = MeshNodeState.Active,
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var broken = await LanguageService
+            .CheckSpeculativeOutcome(path, $"{path}/Source/Probe.cs", NotEvenCSharp)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        broken.Status.Should().Be(NodeDiagnosticsStatus.Compiled,
+            "the owner exists, so the kernel's script environment is the honest one to diagnose in "
+            + "— something really was compiled");
+        broken.Diagnostics.Should().Contain(d => d.Severity == DiagnosticSeverity.Error,
+            "text that cannot parse must produce Roslyn errors even on the script arm");
+        broken.IsClean.Should().BeFalse();
+
+        var clean = await LanguageService
+            .CheckSpeculativeOutcome(path, $"{path}/Source/Probe.cs", "var probe = 1 + 1;")
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        clean.Status.Should().Be(NodeDiagnosticsStatus.Compiled);
+        clean.IsClean.Should().BeTrue(
+            "the other direction: valid script text must still read clean, or this arm would be "
+            + "refusing everything rather than checking anything — got: {0}",
+            string.Join("; ", clean.Diagnostics.Select(d => $"{d.Id} {d.Severity} {d.Message}")));
+    }
+
+    // ─────────────────────────── the positive controls: it must still actually check
+
+    /// <summary>
+    /// 🚨 The control that stops the fix from passing by making everything fail. A real NodeType
+    /// with a clean proposed source must still read <see cref="NodeDiagnosticsStatus.Compiled"/>
+    /// and clean — an instrument that refuses everything is exactly as useless as one that blesses
+    /// everything.
+    /// </summary>
+    [Fact]
+    public async Task ARealNodeTypeStillCompilesTheProposal_CleanReadsClean()
+    {
+        var (typePath, sourcePath, typeName) = await ANodeTypeWithOneSource();
+
+        var outcome = await LanguageService
+            .CheckSpeculativeOutcome(
+                typePath, sourcePath,
+                $"public record {typeName} {{ public string Title {{ get; init; }} = string.Empty; }}")
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        outcome.Status.Should().Be(NodeDiagnosticsStatus.Compiled,
+            "the NodeType resolved and Roslyn answered — this is the ONE status whose empty "
+            + "diagnostics list means clean");
+        outcome.Diagnostics.Should().NotContain(d => d.Severity == DiagnosticSeverity.Error,
+            "clean source must still read clean — got: {0}",
+            string.Join("; ", outcome.Diagnostics.Select(d => $"{d.Id} {d.Severity} {d.Message}")));
+        outcome.IsClean.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The other half of the positive control: the substituted source is genuinely COMPILED, so a
+    /// broken proposal against a resolvable NodeType comes back Compiled-with-errors. Without this,
+    /// the suite could not tell "the checker works" from "the checker resolves paths and stops".
+    /// </summary>
+    [Fact]
+    public async Task ARealNodeTypeStillCompilesTheProposal_BrokenReadsBroken()
+    {
+        var (typePath, sourcePath, _) = await ANodeTypeWithOneSource();
+
+        var outcome = await LanguageService
+            .CheckSpeculativeOutcome(typePath, sourcePath, NotEvenCSharp)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        outcome.Status.Should().Be(NodeDiagnosticsStatus.Compiled,
+            "the path resolved and Roslyn ran — the failure is in the CODE, not in the lookup");
+        outcome.Diagnostics.Should().Contain(d => d.Severity == DiagnosticSeverity.Error,
+            "text that cannot parse as C# must produce Roslyn errors; a check that answers empty "
+            + "here is the #3888 defect wearing a resolvable path");
+        outcome.IsClean.Should().BeFalse();
+    }
+
+    // ────────────────────────────────────── the split is deliberate, and stays
+
+    /// <summary>
+    /// The editor's overload keeps its silence. This is not an oversight being tolerated: Monaco's
+    /// contract is "no diagnostics means no squiggles", and a squiggle computed under the wrong
+    /// language rules is worse than none. Pinning it here says the two overloads differ ON PURPOSE
+    /// — so a later reader cannot "fix" the list overload and quietly paint phantom errors into
+    /// every editor whose NodeType read was slow.
+    /// </summary>
+    [Fact]
+    public async Task TheEditorOverloadStaysSilentForAPathItCannotResolve()
+    {
+        var path = $"type/DefinitelyNotARealNodeType{Guid.NewGuid():N}";
+
+        var diagnostics = await LanguageService
+            .CheckSpeculative(path, $"{path}/Source/Probe.cs", NotEvenCSharp)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        diagnostics.Should().BeEmpty(
+            "the list overload is the EDITOR's contract and cannot carry a status; that is exactly "
+            + "why a caller rendering a verdict must use CheckSpeculativeOutcome instead");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────── fixtures
+
+    /// <summary>A real NodeType with one real source file — the subject of the positive controls.</summary>
+    private async Task<(string TypePath, string SourcePath, string TypeName)> ANodeTypeWithOneSource()
+    {
+        var id = $"CleanType{Guid.NewGuid():N}";
+        var typePath = $"type/{id}";
+
+        await MeshService.CreateNode(MeshNode.FromPath(typePath) with
+        {
+            Name = id,
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = $"config => config.WithContentType<{id}>()"
+            },
+            State = MeshNodeState.Active,
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        await MeshService.CreateNode(new MeshNode($"{id}.cs", $"{typePath}/Source")
+        {
+            NodeType = "Code",
+            Name = $"{id}.cs",
+            Content = new CodeConfiguration
+            {
+                Code = $"public record {id} {{ public string Id {{ get; init; }} = string.Empty; }}",
+                Language = "csharp"
+            },
+            State = MeshNodeState.Active,
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        return (typePath, $"{typePath}/Source/{id}.cs", id);
+    }
+}


### PR DESCRIPTION
Refs #3888 — **deliberately not `Fixes`.** This is the platform half. The `{ok:true}` a reader
of #3888 can reproduce is rendered in `MeshWeaver.Plugins`, so closing the issue on this merge
would be the issue-tracker version of the very defect being fixed: a green that reports
something was completed when only part of it was. #3888 stays open until the dependent half
(below) lands.

## The defect

`lsp_check_node` — the pre-flight the `/code` skill's whole edit loop is built on — answered a clean
bill of health for a NodeType it could not resolve. Measured on `memex.systemorph.com`, 2026-09-10:

```
lsp_check_node  nodeTypePath: @BinaryClickerV2/BinaryToggle
                proposedCode: "this is definitely not valid C# ###"
→ {"ok":true,"diagnostics":[]}
```

`IMeshLanguageService.CheckSpeculative` returns a bare `IReadOnlyList<DiagnosticInfo>`. An empty list
is what a clean compile looks like — and it is equally what *"I could not resolve that path"* looks
like. The tool renders `ok = !diagnostics.Any(Error)`, so **"I did not check" was rendered as
approved**, for any path the caller cannot reach and for any text at all.

This is the same defect #1592/#1618 fixed **next door** on `GetDiagnostics`, whose
`NodeDiagnosticsOutcome` XML doc already says it in bold: *"An empty diagnostic list is not evidence
of health."* It survived in the sibling method because ONE return type was serving two consumers
whose needs are **opposite**:

- the **Monaco editor** wants silence when the owner cannot be resolved — a squiggle computed under
  the wrong language rules is worse than none;
- the **MCP / agent tool** renders a **verdict**, where silence reads as *approved*.

The code comment (*"stay silent rather than paint squiggles computed under the wrong language
rules"*) was right for one caller and wrong for the other, so reviewing the method on its own terms
could only ever confirm it.

## The fix: two surfaces, not one compromise

| Method | Returns | For |
|---|---|---|
| `CheckSpeculative` | `IReadOnlyList<DiagnosticInfo>` | the **editor** — deliberately silent, contract unchanged |
| `CheckSpeculativeOutcome` | `NodeDiagnosticsOutcome` | **every caller that renders a verdict** |

`NodeDiagnosticsOutcome` (the type #1618 already introduced, reused rather than reinvented) carries
`Compiled` / `Absent` / `NotCompilable` / `Unavailable`, plus `IsClean` — false for every status that
did not actually compile — and `DescribeProblem(path)`, which names the path that could not be
checked.

The list overload is now **derived from** the outcome overload
(`CheckSpeculativeOutcome(...).Select(o => o.Diagnostics)`), so the two can never drift apart about
what a given path produces; the only difference is that one drops the status.

The interface member carries a **default implementation answering `Unavailable`** — deliberately
fail-closed. It keeps the addition from obliging every implementer at once (an addition's core half
lands first), and an implementation that has not supplied one has genuinely not checked anything.
Mapping the list onto `Compiled` in the default would have re-created this exact defect for every
implementer that never noticed the member appear.

## What this corrected about the issue's own reading of the code

#3888 named **two** silent branches and said which one produced the live observation was "not
established". It is now: it can only have been the unresolvable-owner one. The other —
`GetCompilationInputsAsync` answering `null` — is **unreachable from the speculative path**: that
method refuses exactly one shape (a node whose `NodeType` is unset), and such a node is classified as
a **script** here, never as a NodeType, so it never asks for compilation inputs at all. The
`NotCompilable` mapping stays as the honest reading of a nullable contract, and the test suite says
so in prose rather than pinning a branch that could never fail.

One latent bug went with it: the old `node!` in the NodeType arm dereferenced a null node whenever
the read failed but a workspace was cached, throwing an NRE out of the editor's callback. That path
now answers `Unavailable` (verdict) / empty (editor).

## The control, in both directions

`test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs`
— 6 cases, real `MonolithMeshTestBase`, no mocking.

**Negative** — run with `CheckSpeculativeOutcome` reverted to the pre-fix semantics (every no-answer
mapped to `Compiled(empty)`), the two negative controls go RED and the four positive ones stay green:

```
Failed  AnInventedNodeTypePathIsAbsent_NotClean
  Expected value to be Absent because nothing resolved at the path, so the proposed source was
  never compiled against anything — reporting that as a clean pre-flight is how the /code loop
  came to bless text that is not even C# (#3888), but found Compiled.

Failed  TheRefusalNamesThePathThatCouldNotBeChecked
  Expected value not to be <null> because a non-Compiled status without a reason hands the caller
  a bare 'no' it cannot act on.

Failed! - Failed: 2, Passed: 4, Total: 6
```

**Positive** — a real NodeType still compiles its proposal, and the verdict follows the code: a clean
proposal reads `Compiled` + `IsClean`, a broken one reads `Compiled` + errors. Plus the script arm in
both directions, and one case pinning that the editor overload's silence is deliberate and stays.
With the fix in place: `Passed! - Failed: 0, Passed: 6, Total: 6`.

## The dependent half (not in this PR, by design)

The `{ok, diagnostics}` rendering lives in `MeshWeaver.Plugins` and compiles against a pinned core
commit, so it lands after the pin moves — the standard inverted ordering for an addition. Two call
sites switch from `CheckSpeculative` to `CheckSpeculativeOutcome` and render a non-`Compiled` status
as `ok:false` + `status` + `DescribeProblem`, exactly as `LspDiagnosticsForNode` already does two
methods below:

- `src/MeshWeaver.Mcp/McpMeshPlugin.cs` → `LspCheckNode`
- `src/MeshWeaver.AI/Plugins/LspPlugin.cs` → `LspCheckNode`

(`src/MeshWeaver.Blazor.Views/Components/Monaco/CodeEditorView.razor` keeps calling the list overload
— that is the consumer the silence is for. `MeshWeaver.AI.Test`'s `FakeLanguageService` needs an
override of the new member so the cancellation test still parks.)

## Local verification

- `dotnet build src/MeshWeaver.Mesh.Contract -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
- `dotnet build src/MeshWeaver.Compiler.Pipeline -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
- `dotnet build src/MeshWeaver.Graph -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
- `dotnet build src/MeshWeaver.Documentation -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
- `dotnet build test/MeshWeaver.Compiler.Pipeline.Test -c Release -warnaserror` → `0 Error(s)`
- `MeshWeaver.Documentation.Test` (link integrity, embeds, topic map, timeout ratchet) → 18 passed
- `check-type-forwards.py`: 0 public types removed, 1 member added; implementer obligations
  455 → 455, i.e. the default implementation obliges nobody.

## Docs (work products conserved)

- `Doc/Architecture/LanguageServices` → new section *An empty diagnostic list is not evidence of
  health*: the two-consumer split, the table of both occurrences, and why the fix travels with the
  class rather than the call site.
- `Doc/Architecture/ControlsThatCannotFail` → instance 13, *the same defect, fixed in one method and
  left in its sibling*, plus a new shape row.
- What's New entry, `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
