### PR TITLE
Give the click-to-edit form's inputs an accessible name (#3863)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/GUI/Editor.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/Editor.md
@@ -250,6 +250,56 @@ Each property becomes a named area inside the `EditorControl`. The reactive over
 
 ---
 
+# Accessible names
+
+A generated field paints its caption **outside** the input, and both generated forms do it
+differently:
+
+| Form | Where the caption is painted | What names the input |
+|---|---|---|
+| `Edit<T>()` / `EditorControl` | the `PropertySkin`'s `<dt>` | a `<label for>` the renderer targets at the input's id, **plus** `aria-label` |
+| The node editor's click-to-edit form (`MapToToggleableControl`) | a **sibling** `LabelControl` above the field | `aria-label` only — a `FluentLabel` carries no `for`, and there is no id to point it at |
+
+In both the control itself is created with **no `Label`**, so the caption is not drawn twice. That is
+deliberate, and it costs the input its accessible name unless something puts one back.
+
+So the generators set **`AriaLabel`** on every generated **input** — every `IFormControl`: text,
+multi-line text, number, date, checkbox, switch, select, combobox, listbox, radio group, mesh-node
+picker. It is read from the same source the visible caption comes from — `[Display(Name = …)]`, then
+`[DisplayName(…)]`, then the property name word-split — so the two can never disagree, which is what
+WCAG's *label in name* asks for.
+
+```csharp
+public record Assessment
+{
+    [DisplayName("1. What topics do you want to cover?")]
+    [UiControl<TextAreaControl>]
+    public string Topics { get; init; } = null!;
+}
+// renders: <dt><label for="property-…">1. What topics …</label></dt>
+//          <dd><fluent-text-area id="property-…" aria-label="1. What topics …"> …
+```
+
+🚨 **`aria-label` is not decoration on top of `<label for>`.** A Fluent input is a web component that
+keeps its real `<input>` inside a **shadow root**, and the generated form used to emit
+`<label for="topics">` pointing at an element that could not exist: the caption was visible, the
+textbox was unnamed, and `getByRole('textbox', { name: question })` matched nothing
+(MeshWeaver#3863). `aria-label` sits on the host element, needs no id plumbing, and is the only one
+of the two the click-to-edit form can use at all.
+
+Setting `Label` yourself still works and still renders a second, visible caption — use it for a
+control you compose by hand, not for a field the editor generates. A control that carries its own
+`Label` is left alone: the Fluent host paints its own associated label, and an `aria-label` would
+only shadow it.
+
+**One generated surface is NOT covered**, and it is named here rather than left to be rediscovered
+from a symptom: a `[Markdown]` / `[UiControl<MarkdownEditorControl>]` property. `MarkdownEditorControl`
+is not an `IFormControl` — it is a composite editor with its own toolbar and its own view, so its
+accessible name is an `aria-labelledby` question about that composite, not an `aria-label` on one
+input.
+
+---
+
 # See Also
 
 - [Property Attributes](../Attributes) — every supported attribute in detail

--- a/src/MeshWeaver.Documentation/Data/GUI/Editor.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/Editor.md
@@ -265,9 +265,21 @@ deliberate, and it costs the input its accessible name unless something puts one
 
 So the generators set **`AriaLabel`** on every generated **input** — every `IFormControl`: text,
 multi-line text, number, date, checkbox, switch, select, combobox, listbox, radio group, mesh-node
-picker. It is read from the same source the visible caption comes from — `[Display(Name = …)]`, then
-`[DisplayName(…)]`, then the property name word-split — so the two can never disagree, which is what
-WCAG's *label in name* asks for.
+picker.
+
+**Each form reads it from the same helper its own caption comes from**, so within a form the
+accessible name and the visible term can never disagree — which is what WCAG's *label in name* asks
+for. The two helpers do not resolve the caption the same way, and that predates this:
+
+| Form | caption helper | resolution order |
+|---|---|---|
+| `Edit<T>()` | `GetEditorLabel` | `[Display(Name = …)]` → `[DisplayName(…)]` → the property name word-split |
+| click-to-edit | `GetToggleableDisplayName` | `[Display(Name = …)]` → the viewer-localized `[Description]` / `[Translation]` → the property name word-split |
+
+🚨 So `[DisplayName("…")]` names an `Edit<T>()` field and does **not** name a click-to-edit one, which
+falls through to the wordified property name. That divergence is stated here rather than smoothed
+over: it is a question about the visible CAPTION, not about the accessible name, and changing it
+would re-word every click-to-edit caption in the portal.
 
 ```csharp
 public record Assessment
@@ -276,8 +288,8 @@ public record Assessment
     [UiControl<TextAreaControl>]
     public string Topics { get; init; } = null!;
 }
-// renders: <dt><label for="property-…">1. What topics …</label></dt>
-//          <dd><fluent-text-area id="property-…" aria-label="1. What topics …"> …
+// Edit<T>() renders: <dt><label for="property-…">1. What topics …</label></dt>
+//                    <dd><fluent-text-area id="property-…" aria-label="1. What topics …"> …
 ```
 
 🚨 **`aria-label` is not decoration on top of `<label for>`.** A Fluent input is a web component that

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-generated-form-fields-announce-their-question.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-generated-form-fields-announce-their-question.md
@@ -1,7 +1,7 @@
 ---
 Name: Generated form fields announce their question
 Category: Fix
-Description: Every input a generated editor produces now carries its question as an accessible name, so screen readers and keyboard users hear the field they are in.
+Description: A generated form field now carries its question as an accessible name, so a screen reader says which question you are answering.
 Icon: AccessibilityCheckmark
 Order: -20260910
 ---
@@ -11,6 +11,8 @@ inside it — the `Edit` form as the term of a definition list, the node editor'
 a caption above the value. The input itself was left with no accessible name, so a screen reader
 announced it as a bare "textbox" and gave no way to tell one question from the next.
 
-Every generated input now carries its question as its accessible name, read from the same
-`[Display(Name = …)]` / `[DisplayName(…)]` the visible caption comes from, so the two can never
-drift apart. Fields you compose by hand with an explicit label are unchanged.
+Generated form fields — text, multi-line text, number, date, checkbox, switch, and the option and
+mesh-node pickers — now carry their question as an accessible name, read from the same declaration
+the visible caption is read from, so the two can never drift apart. Fields you compose by hand with
+an explicit label are unchanged, and a property rendered as a full markdown editor is not covered
+yet: that editor is a composite with its own toolbar, and naming it is a different question.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-generated-form-fields-announce-their-question.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-generated-form-fields-announce-their-question.md
@@ -1,0 +1,16 @@
+---
+Name: Generated form fields announce their question
+Category: Fix
+Description: Every input a generated editor produces now carries its question as an accessible name, so screen readers and keyboard users hear the field they are in.
+Icon: AccessibilityCheckmark
+Order: -20260910
+---
+
+A field the platform generates from your type paints its question beside the input rather than
+inside it — the `Edit` form as the term of a definition list, the node editor's click-to-edit form as
+a caption above the value. The input itself was left with no accessible name, so a screen reader
+announced it as a bare "textbox" and gave no way to tell one question from the next.
+
+Every generated input now carries its question as its accessible name, read from the same
+`[Display(Name = …)]` / `[DisplayName(…)]` the visible caption comes from, so the two can never
+drift apart. Fields you compose by hand with an explicit label are unchanged.

--- a/src/MeshWeaver.Layout/DateTimeControl.cs
+++ b/src/MeshWeaver.Layout/DateTimeControl.cs
@@ -67,8 +67,8 @@ public record DateTimeControl(object Data) : FormControlBase<DateTimeControl>(Da
     /// </summary>
     public object? PopupHorizontalPosition { get; init; }
 
-    /// <summary>
-    /// Gets or initializes the ARIA label for accessibility.
-    /// </summary>
-    public object? AriaLabel { get; init; }
+    // NB: AriaLabel used to be declared here. It moved UP to FormControlBase (MeshWeaver#3863) so
+    // that EVERY form control can carry an accessible name, not just this one — it is still
+    // readable and settable on DateTimeControl exactly as before, by inheritance. Re-declaring it
+    // here would shadow the base property and give the record two backing fields.
 }

--- a/src/MeshWeaver.Layout/EditorExtensions.cs
+++ b/src/MeshWeaver.Layout/EditorExtensions.cs
@@ -590,13 +590,13 @@ public static class EditorExtensions
         if (dimensionAttribute != null)
         {
             if (dimensionAttribute.Options is not null)
-                return editor.WithView((host, _) => RenderListControl(host, Controls.Select, jsonPointerReference, dimensionAttribute.Options), skinConfiguration);
+                return editor.WithView((host, _) => RenderListControl(host, Controls.Select, jsonPointerReference, dimensionAttribute.Options).WithAriaLabel(propertySkinLabel), skinConfiguration);
             return editor.WithView((host, ctx) =>
             {
                 var id = Guid.NewGuid().AsString();
                 host.RegisterForDisposal(ctx.Area,
                     GetStream(host, dimensionAttribute).Subscribe(x => host.UpdateData(id, x)));
-                return RenderListControl(host, Controls.Select, jsonPointerReference, id);
+                return RenderListControl(host, Controls.Select, jsonPointerReference, id).WithAriaLabel(propertySkinLabel);
             }, skinConfiguration);
         }
 
@@ -666,6 +666,25 @@ public static class EditorExtensions
     private static JsonPointerReference GetJsonPointerReference(PropertyInfo propertyInfo) =>
         new(propertyInfo.Name.ToCamelCase()!);
 
+    /// <summary>
+    /// Gives <paramref name="control"/> the accessible name <paramref name="accessibleName"/> when
+    /// it is an input — the one place the generated editors express "this input is named by the
+    /// caption beside it" (MeshWeaver#3863).
+    ///
+    /// <para>A control that is not an <see cref="IFormControl"/> is returned unchanged: a composite
+    /// (the <c>[ContentItem]</c> text-field + Browse row, a collection section, the markdown editor)
+    /// has no single input to name, and a <see cref="LabelControl"/> read-only view is not an input
+    /// at all. Those surfaces are named where they are built, or recorded as not yet named in
+    /// Doc/GUI/Editor — never silently skipped here.</para>
+    /// </summary>
+    private static UiControl WithAccessibleName(UiControl control, object? accessibleName)
+        => accessibleName is null || control is not IFormControl formControl
+            ? control
+            : (UiControl)formControl.WithAriaLabel(accessibleName);
+
+    private static IFormControl WithAccessibleName(IFormControl control, object? accessibleName)
+        => accessibleName is null ? control : control.WithAriaLabel(accessibleName);
+
 
     private static UiControl RenderControl(
         LayoutAreaHost host,
@@ -675,10 +694,29 @@ public static class EditorExtensions
         JsonPointerReference reference,
         object? parameter = null)
     {
+        // 🚨 The ACCESSIBLE name, and it is NOT the same thing as `label` (MeshWeaver#3863).
+        // On the skinned path `label` is deliberately null so the caption is not painted twice —
+        // the PropertySkin renders it as the surrounding <dt>. That left the input with no
+        // accessible name at all: `getByRole('textbox', { name: question })` matched nothing.
+        // Read from GetEditorLabel() — the SAME single source the PropertySkin's own label comes
+        // from — so the accessible name and the visible term can never disagree (WCAG
+        // label-in-name). When `label` IS set the Fluent host paints its own associated <label>,
+        // so an aria-label would only shadow it: leave it alone.
+        var ariaLabel = label is null ? propertyInfo.GetEditorLabel() : null;
+
         if (BasicControls.TryGetValue(controlType, out var factory))
-            return (UiControl)((IFormControl)factory.Invoke(reference, propertyInfo, parameter!)).WithLabel(label!);
+            return (UiControl)WithAccessibleName(
+                ((IFormControl)factory.Invoke(reference, propertyInfo, parameter!)).WithLabel(label!),
+                ariaLabel);
         if (ListControls.TryGetValue(controlType, out var factory2))
-            return (UiControl)((IListControl)factory2.Invoke(host, propertyInfo, reference, parameter!)).WithLabel(label!);
+            return (UiControl)WithAccessibleName(
+                ((IListControl)factory2.Invoke(host, propertyInfo, reference, parameter!)).WithLabel(label!),
+                ariaLabel);
+        // 🚨 NOT covered, and deliberately so rather than by oversight. A SpecialControl is not an
+        // IFormControl — MarkdownEditorControl is a composite editor with its own toolbar and its
+        // own Blazor view, so its accessible name is an aria-labelledby/region question about that
+        // composite, not an aria-label on a single input, and guessing at it here would ship an
+        // unmeasured answer. Recorded in Doc/GUI/Editor.
         if (SpecialControls.TryGetValue(controlType, out var specialFactory))
             return specialFactory.Invoke(propertyInfo, reference);
 
@@ -1314,7 +1352,8 @@ public static class EditorExtensions
         else if (property.GetCustomAttribute<ContentItemAttribute>() is { } contentItemAttr
                  && propType == typeof(string))
         {
-            editCtrl = CreateContentItemControl(host, jsonPointer, dataId, editStateId, isRequired, isToggleable, contentItemAttr.Collection);
+            editCtrl = CreateContentItemControl(host, jsonPointer, dataId, editStateId, isRequired, isToggleable, contentItemAttr.Collection,
+                GetToggleableDisplayName(property, host));
         }
         else if (property.GetCustomAttribute<DimensionAttribute>() is { } dimAttr)
         {
@@ -1382,6 +1421,14 @@ public static class EditorExtensions
                 : textCtrl;
         }
 
+        // 🚨 The accessible name for the CLICK-TO-EDIT form (MeshWeaver#3863). Here the caption is
+        // painted as a SIBLING LabelControl above the input (MapToToggleableControl) — a FluentLabel
+        // that carries no `for`, with no id to point it at — so without this the field renders as a
+        // bare `textbox` with no accessible name at all, exactly as the skinned path did. Read from
+        // GetToggleableDisplayName, the SAME single source that caption comes from, so the two can
+        // never drift apart (WCAG label-in-name).
+        editCtrl = WithAccessibleName(editCtrl, GetToggleableDisplayName(property, host));
+
         // Apply style from UiControlAttribute if present, otherwise no default constraints
         var attrStyle = property.GetCustomAttribute<UiControlAttribute>()?.Style;
         editCtrl = editCtrl with
@@ -1410,13 +1457,17 @@ public static class EditorExtensions
         string editStateId,
         bool isRequired,
         bool isToggleable,
-        string collection)
+        string collection,
+        string accessibleName)
     {
         var textCtrl = new TextFieldControl(jsonPointer)
         {
             Required = isRequired,
             Immediate = true,
-            DataContext = LayoutAreaReference.GetDataPointer(dataId)
+            DataContext = LayoutAreaReference.GetDataPointer(dataId),
+            // The row is a composite (field + Browse), so BuildEditControl's blanket naming cannot
+            // reach the input — name it here instead of leaving it unnamed (MeshWeaver#3863).
+            AriaLabel = accessibleName
         };
 
         var browseButton = Controls.Button(host.Localize("ui.browse"))

--- a/src/MeshWeaver.Layout/FormControlBase.cs
+++ b/src/MeshWeaver.Layout/FormControlBase.cs
@@ -29,6 +29,24 @@ public abstract record FormControlBase <TControl>(object Data)
         => WithLabel(label);
 
     /// <summary>
+    /// The accessible name rendered as <c>aria-label</c> on the underlying input. See
+    /// <see cref="IFormControl.AriaLabel"/> for why a form control needs one in addition to
+    /// <see cref="Label"/>.
+    /// </summary>
+    public object? AriaLabel { get; init; }
+
+    /// <summary>
+    /// Sets the accessible name (<c>aria-label</c>) of the control.
+    /// </summary>
+    /// <param name="ariaLabel">The accessible name, or a binding expression resolving to one.</param>
+    /// <returns>A new instance of the control with the specified accessible name.</returns>
+    public TControl WithAriaLabel(object ariaLabel)
+        => This with { AriaLabel = ariaLabel };
+
+    IFormControl IFormControl.WithAriaLabel(object ariaLabel)
+        => WithAriaLabel(ariaLabel);
+
+    /// <summary>
     /// Whether the number field is disabled.
     /// </summary>
     public object? Disabled { get; init; }

--- a/src/MeshWeaver.Layout/IFormControl.cs
+++ b/src/MeshWeaver.Layout/IFormControl.cs
@@ -23,6 +23,38 @@ public interface IFormControl : IUiControl
     IFormControl WithLabel(object label);
 
     /// <summary>
+    /// Accessible name for the control, rendered as <c>aria-label</c> on the underlying input.
+    ///
+    /// <para>
+    /// 🚨 This is NOT a second visible label — it exists because the visible one frequently lives
+    /// OUTSIDE the control. A generated editor field paints its caption in the surrounding
+    /// <see cref="PropertySkin"/> (a <c>&lt;dt&gt;</c>), and the click-to-edit form
+    /// (<c>MapToToggleableControl</c>) paints it as a SIBLING <see cref="LabelControl"/>; both
+    /// deliberately leave <see cref="Label"/> null so the caption is not drawn twice. The input is
+    /// then left with no accessible name at all. An HTML <c>&lt;label for&gt;</c> does not always
+    /// rescue it either — a sibling <c>FluentLabel</c> carries no <c>for</c>, and there is no id to
+    /// point it at — which is why <c>getByRole('textbox', { name })</c> matched nothing
+    /// (MeshWeaver#3863). <c>aria-label</c> sits on the host element and needs no id plumbing.
+    /// </para>
+    /// </summary>
+    object? AriaLabel => null;
+
+    /// <summary>
+    /// Returns a copy of the control carrying <paramref name="ariaLabel"/> as its accessible name.
+    /// </summary>
+    /// <param name="ariaLabel">The accessible name, or a binding expression resolving to one.</param>
+    /// <returns>A new instance of the form control with the specified accessible name.</returns>
+    /// <remarks>
+    /// The default implementation returns the control unchanged — a form control that carries no
+    /// accessible name of its own. <see cref="FormControlBase{TControl}"/>, which every control in
+    /// this repository derives from, overrides both this and <see cref="AriaLabel"/> with the real
+    /// record copy. The default exists so that adding this member cannot oblige an out-of-repo
+    /// implementer to write code before it can compile — see the
+    /// <c>Interface additions (implementers declared)</c> gate.
+    /// </remarks>
+    IFormControl WithAriaLabel(object ariaLabel) => this;
+
+    /// <summary>
     /// Whether the form control is disabled.
     /// </summary>
     object? Disabled { get; init; }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -488,6 +488,7 @@
   "comments.add": "Kommentar hinzufügen",
   "comments.placeholder": "Kommentar schreiben…",
   "ui.icon": "Symbol",
+  "ui.numericInput": "Zahleneingabe",
   "ui.submit": "Absenden",
   "ui.open": "Öffnen",
   "ui.readOnlyContent": "Schreibgeschützter Inhalt",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -488,6 +488,7 @@
   "comments.add": "Add comment",
   "comments.placeholder": "Write your comment...",
   "ui.icon": "Icon",
+  "ui.numericInput": "Numeric input",
   "ui.submit": "Submit",
   "ui.open": "Open",
   "ui.readOnlyContent": "Read-only content",

--- a/test/MeshWeaver.Layout.Test/EditorTest.cs
+++ b/test/MeshWeaver.Layout.Test/EditorTest.cs
@@ -275,6 +275,95 @@ public class EditorTest(ITestOutputHelper output) : HubTestBase(output)
     }
 
 
+    #region Accessible names (#3863)
+
+    /// <summary>
+    /// The shape MeshWeaver#3863 was reported on: an assessment form whose questions are declared
+    /// with <see cref="DisplayNameAttribute"/> and rendered through an explicit
+    /// <c>[UiControl&lt;TextAreaControl&gt;]</c>.
+    /// </summary>
+    private record AssessmentForm
+    {
+        [DisplayName("1. What topics do you want to cover?")]
+        [Description("The learner's own words")]
+        [UiControl<TextAreaControl>]
+        public string Topics { get; init; } = null!;
+
+        [DisplayName("2. How much time can you invest each week?")]
+        [Description("Hours per week")]
+        public string Commitment { get; init; } = null!;
+    }
+
+    private UiControl? AssessmentEditor(LayoutAreaHost host, RenderingContext ctx) =>
+        host.Hub.Edit(new AssessmentForm(), "assessment");
+
+    /// <summary>
+    /// The generated input must carry the question as its ACCESSIBLE name, and must still NOT carry
+    /// it as a visible <c>Label</c>.
+    ///
+    /// <para>
+    /// Both halves matter and they pull against each other, which is exactly how #3863 was created:
+    /// <c>MapToControl</c> passes <c>label = null</c> to the control on purpose, because the caption
+    /// is already painted by the surrounding <see cref="PropertySkin"/> (the <c>&lt;dt&gt;</c>) and
+    /// setting it twice would render it twice. The consequence nobody accounted for is that the
+    /// input was then left with NO accessible name at all — Playwright's
+    /// <c>getByRole('textbox', { name: question })</c> matched nothing on a live portal.
+    /// </para>
+    ///
+    /// <para>
+    /// 🚨 This asserts the VIEW MODEL, which is all core can see: core ships no renderer. It is the
+    /// INPUT to the accessibility guarantee, not the guarantee — the markup control lives beside the
+    /// Blazor views in MeshWeaver.Plugins (<c>PropertyViewLabelTest</c>), where a real
+    /// <c>HtmlRenderer</c> asserts the <c>aria-label</c> actually emitted. Read the two together.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task GeneratedFieldsCarryTheirQuestionAsAccessibleName()
+    {
+        var host = GetHost();
+        var workspace = host.GetWorkspace();
+        var area = workspace.GetStream(new LayoutAreaReference(nameof(AssessmentEditor)));
+
+        var control = await area
+            .GetControlStream(nameof(AssessmentEditor))
+            .Should().Within(10.Seconds()).Match(x => x is not null);
+
+        var editor = control.Should().BeOfType<EditorControl>().Subject;
+        editor.Areas.Should().HaveCount(2);
+
+        foreach (var namedArea in editor.Areas)
+        {
+            var skin = namedArea.Skins.OfType<PropertySkin>().Should().ContainSingle().Subject;
+            skin.Label.Should().BeOfType<string>();
+            var question = (string)skin.Label!;
+
+            var field = await area
+                .GetControlStream(namedArea.Area.ToString()!)
+                .Should().Within(10.Seconds()).Match(x => x is not null);
+
+            field.Should().BeAssignableTo<IFormControl>();
+            var formControl = (IFormControl)field!;
+
+            // The accessible name — absent before #3863, which is what left the textbox unnamed.
+            formControl.AriaLabel.Should().Be(question,
+                "the generated input must expose the question as its accessible name (#3863)");
+
+            // …and NOT a second visible label: the caption is the PropertySkin's <dt>.
+            formControl.Label.Should().BeNull(
+                "the visible caption is rendered by the PropertySkin, so duplicating it on the control would paint it twice");
+        }
+
+        // The declared control type is honoured — this is the exact shape reported on the portal.
+        var topics = await area
+            .GetControlStream(editor.Areas.First().Area.ToString()!)
+            .Should().Within(10.Seconds()).Match(x => x is not null);
+        topics.Should().BeOfType<TextAreaControl>()
+            .Which.AriaLabel.Should().Be("1. What topics do you want to cover?");
+    }
+
+    #endregion
+
+
     protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
     {
         return base.ConfigureHost(configuration).AddLayout(layout => layout
@@ -282,6 +371,7 @@ public class EditorTest(ITestOutputHelper output) : HubTestBase(output)
             .WithView(nameof(EditorWithResult), EditorWithResult)
             .WithView(nameof(EditorWithDelayedResult), EditorWithDelayedResult)
             .WithView(nameof(EditorWithListFormProperties), EditorWithListFormProperties)
+            .WithView(nameof(AssessmentEditor), AssessmentEditor)
         ).AddData(data => data
             .AddSource(source =>
                 source.WithType<MyDimension>(type => type.WithInitialData(Dimensions))));

--- a/test/MeshWeaver.Layout.Test/MapToToggleableControlTest.cs
+++ b/test/MeshWeaver.Layout.Test/MapToToggleableControlTest.cs
@@ -221,6 +221,63 @@ public class MapToToggleableControlTest(ITestOutputHelper output) : HubTestBase(
     }
 
     /// <summary>
+    /// 🚨 The click-to-edit input must carry its caption as an ACCESSIBLE name (MeshWeaver#3863).
+    ///
+    /// <para>
+    /// This form paints the caption as a SIBLING <see cref="LabelControl"/> above the field — a
+    /// <c>FluentLabel</c> that carries no <c>for</c>, with no id to point it at — and the input
+    /// itself was created with no <c>Label</c> and no <c>AriaLabel</c>. So the field rendered as a
+    /// bare <c>textbox</c> with no name: exactly the defect reported against the skinned editor,
+    /// on the OTHER generated form. The assertion is that the name on the input is the SAME string
+    /// as the sibling caption, because both are read from <c>GetToggleableDisplayName</c> and so
+    /// cannot drift (WCAG label-in-name).
+    /// </para>
+    ///
+    /// <para>
+    /// 🚨 View-model level, which is all core can see — core ships no renderer. The markup control
+    /// is in MeshWeaver.Plugins beside the Blazor views, where an <c>HtmlRenderer</c> asserts the
+    /// <c>aria-label</c> that is actually emitted.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task ClickToEditInput_IsNamedByItsCaption()
+    {
+        var client = GetClient();
+        var workspace = client.GetWorkspace();
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(),
+            new LayoutAreaReference(DataBindingTestView));
+
+        var control = await stream
+            .GetControlStream(DataBindingTestView)
+            .Should().Within(10.Seconds()).Match(x => x is not null);
+
+        var stack = control.Should().BeOfType<StackControl>().Subject;
+
+        // The visible caption: the first area is the sibling label this form paints by hand.
+        var captionAreaId = stack.Areas.First().Area.ToString()!;
+        var caption = await stream
+            .GetControlStream(captionAreaId)
+            .Should().Within(5.Seconds()).Match(x => x is LabelControl);
+        var captionText = caption.Should().BeOfType<LabelControl>().Subject.Data.Should().BeOfType<string>().Subject;
+
+        var reactiveAreaId = stack.Areas.Skip(1).First().Area.ToString()!;
+        var editControlStream = stream
+            .GetControlStream(reactiveAreaId)
+            .Where(x => x is TextFieldControl);
+
+        client.Post(new ClickedEvent(reactiveAreaId, stream.StreamId), o => o.WithTarget(CreateHostAddress()));
+
+        var editControl = await editControlStream.Should().Within(5.Seconds()).Emit();
+        var textField = editControl.Should().BeOfType<TextFieldControl>().Subject;
+
+        textField.AriaLabel.Should().Be(captionText,
+            "the click-to-edit input is named only by the caption beside it, which carries no <label for> to associate with (#3863)");
+        textField.Label.Should().BeNull(
+            "the caption is already painted as a sibling label, so a second visible one would duplicate it");
+    }
+
+    /// <summary>
     /// Test that blur on edit control switches back to readonly mode.
     /// </summary>
     [Fact]


### PR DESCRIPTION
Fixes #3863 — **core half**. Pairs with a **MeshWeaver.Plugins** pull request opened alongside this one, which carries the renderer and the markup control (linked in a comment below).

## Re-measured first: the reported surface is fixed, the OTHER generated form is not

The instance in the issue — the `Edit` macro / `EditorControl` / `PropertySkin` path, questions as
`<dt>` of a definition list — was fixed by MeshWeaver.Plugins#1578 (merged 2026-09-10 02:35Z). Its
`PropertyView` now mints a per-instance id, points `<label for>` at it, and cascades the question
down to the input as an `aria-label`. Measured on `origin/main` of that repo: nine input kinds
covered by `PropertyViewLabelTest`.

**The node editor's OTHER generated form was left exactly as #3863 described it.**
`EditorExtensions.MapToToggleableControl` — what `EditLayoutArea.BuildPropertyForm` builds for
`Edit`/`Overview` on a mesh node — paints the caption as a **sibling** `LabelControl`:

```csharp
return Controls.Stack
    .WithView(Controls.Label(displayName).WithStyle("font-weight: 600; …"))
    .WithView((h, _) => editStateStream.Select(isEditing => isEditing && isEditable
        ? BuildEditControl(h, property, dataId, editStateId, isToggleable, boundDataContext)
        : BuildReadonlyControl(…)));
```

There is no `PropertySkin`, so the merged cascade never reaches it; there is no `<label for>`,
because a `FluentLabel` emits none and there is no id to point one at; and `BuildEditControl` created
the input with no `Label` (the caption is already painted) and nothing else. So every field of the
node Edit form renders as a bare `textbox` with **no accessible name at all** — the same defect, on
the more central form. The Plugins suite already records the shape:
`StandaloneInput_DoesNotAcquireAnEmptyAccessibleName` asserts an input outside `PropertyView` carries
no name.

`aria-label` is the only channel that reaches it: it needs no id plumbing and, unlike `<label for>`,
it survives the Fluent web component's shadow root.

## What this half changes

* **`IFormControl` gains `AriaLabel` and `WithAriaLabel(object)`, both with default implementations**
  (`null` / return-unchanged) so no out-of-repo implementer is obliged to write code before it can
  compile. `FormControlBase<TControl>` carries the real record copy, so every form control can hold
  an accessible name — exactly as `DataGridControl.WithAriaLabel` already does for grids.
* **`DateTimeControl.AriaLabel` moves UP to `FormControlBase`** — it was the only control that had
  one. Still readable and settable on `DateTimeControl` by inheritance; re-declaring it there would
  shadow the base property and give the record two backing fields.
* **`MapToToggleableControl` → `BuildEditControl` names its input** from `GetToggleableDisplayName`,
  the SAME single source the sibling caption is read from, so the accessible name and the visible
  caption cannot drift (WCAG *label in name*). The `[ContentItem]` field+Browse row is a composite,
  so its text field is named where the row is built rather than skipped silently.
* **`RenderControl` names the skinned path too**, from `GetEditorLabel()` — belt and braces with the
  renderer cascade, and the channel that reaches views the cascade does not (the mesh-node picker).
  A control that carries its own visible `Label` is left alone: the Fluent host paints an associated
  label of its own, and an `aria-label` would only shadow it.
* **`ui.numericInput`** replaces the hard-coded English `aria-label="Numeric input"` fallback the
  number field emits (Plugins side). An `aria-label` is a user-visible string.
* **`Doc/GUI/Editor`** gains an "Accessible names" section: the table of which form names its input
  how, why it is `aria-label` and not `<label for>`, and the one surface still uncovered.

**Scope, stated narrowly on purpose.** The guarantee is over `IFormControl`. A `[Markdown]` /
`[UiControl<MarkdownEditorControl>]` property is NOT covered and is recorded as such in
`Doc/GUI/Editor` and at the code site: `MarkdownEditorControl` is not an `IFormControl`, it is a
composite editor with its own toolbar and view, so its accessible name is an `aria-labelledby`
question about that composite, not an `aria-label` on one input. Guessing at it here would ship an
unmeasured answer.

## Control — both directions, and it fails without the fix

Two view-model tests drive the REAL generators through a real layout area:

| test | what it drives |
|---|---|
| `EditorTest.GeneratedFieldsCarryTheirQuestionAsAccessibleName` | `hub.Edit(new AssessmentForm())` — the exact `[DisplayName]` + `[UiControl<TextAreaControl>]` shape from the issue |
| `MapToToggleableControlTest.ClickToEditInput_IsNamedByItsCaption` | the click-to-edit form: click into edit mode, then compare the input's name with the sibling caption's own text |

Reverting `src/MeshWeaver.Layout/EditorExtensions.cs` to `main` and rebuilding fails both:

```
Failed MeshWeaver.Layout.Test.EditorTest.GeneratedFieldsCarryTheirQuestionAsAccessibleName
  Expected value to be "1. What topics do you want to cover?" because the generated input must
  expose the question as its accessible name (#3863), but found <null>.
Failed MeshWeaver.Layout.Test.MapToToggleableControlTest.ClickToEditInput_IsNamedByItsCaption
  Expected value to be "Title" because the click-to-edit input is named only by the caption beside
  it, which carries no <label for> to associate with (#3863), but found <null>.
Failed!  - Failed: 2, Passed: 0
```

With the fix: `Passed! - Failed: 0, Passed: 476` over the whole `MeshWeaver.Layout.Test` project.

🚨 **These assert the VIEW MODEL, which is all core can see — core ships no renderer.** They are the
INPUT to the accessibility guarantee, not the guarantee. The markup control is in the Plugins half:
a real `HtmlRenderer` over the real dispatch chain, asserting the `aria-label` the Fluent host
actually emits, in both directions. Both tests say so in their own doc comments so neither is ever
read as more than it is.

## Ordering

Nothing here is observable on its own — the rendered `aria-label` comes from the Blazor views in
MeshWeaver.Plugins. Per AGENTS.md the core half lands FIRST, and the Plugins half is open alongside
it with the browser-level regression the issue asks for.

Local verification (Release, warnings-as-errors, one project per invocation): MeshWeaver.Layout,
MeshWeaver.Messaging.Hub, MeshWeaver.Documentation, MeshWeaver.Layout.Test,
MeshWeaver.Documentation.Test, MeshWeaver.Messaging.Hub.Test — all `0 Warning(s) 0 Error(s)`;
`DocumentationLinkIntegrityTest` and `LocalizationTest` (58) green.

Pairs-with: none — nothing left the public surface. DateTimeControl.AriaLabel was not deleted, it moved UP to its base class FormControlBase, so every existing read, object-initializer write and `with` expression on DateTimeControl still compiles unchanged by inheritance — including in-mesh C#, which the compiler cannot see. The detector reports the move as a member removal because it compares declaration sites, not effective surfaces.

Implementers: IFormControl.AriaLabel, IFormControl.WithAriaLabel — both ship with default implementations (`=> null` and `=> this`), so no implementer is obliged to write code. Checked in this repo: FormControlBase<TControl> is the only implementer of IFormControl and it now carries the real record copy; searched MeshWeaver.Plugins for `: IFormControl` and `IFormControl,` and found no other implementer, only consumers (FormComponentBase<,,> binds the interface, never implements it).

Mirror-sync: npm run sync:i18n -- --ref <this PR's merge sha> — this adds one key, `ui.numericInput`, so the Plugins react/RN catalog mirror goes stale on merge and nothing reds to say so. Handed over on the paired MeshWeaver.Plugins pull request opened alongside this one, which consumes the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
