### PR TITLE
fix: a detached upsert reply can no longer go silent on an empty completion (#3674)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -439,18 +439,67 @@ trails, six show `RECEIVED runLevel=Quiescing` at the issuing hub, i.e. the call
 the hub was `Started`), it is not fixed by this page's rule, and it is benign in every occurrence
 measured so far — the requester gets `HubDisposedBeforeResponseException`, which is a real answer.
 
-## The UPSERT lane is the same rule, one lane over — and only half of it is covered (#3510)
+## The UPSERT lane is the same rule, one lane over — and totality is now by CONSTRUCTION (#3510, #3674)
 
-`CreateOrUpdateNodeRequest` has three legs. Its READ leg reaches all of Rx's terminations already
-(#2454, `MeshExtensions`: *"THREE terminal states, not two"*). Its two WRITE legs subscribe with
-`onNext`/`onError` only:
+`CreateOrUpdateNodeRequest` is a **detached-reply** handler: it returns `Processed()` at once and
+owes its `CreateOrUpdateNodeResponse` from chains that outlive the turn. Every one of those chains
+is subject to the rule above, and for the same reason — the delivery trail records
+`HANDLER_ENTER … → HANDLER_EXIT state=Processed`, so a leg that answers nobody leaves a trail that
+looks completed and a caller that waits out its whole budget.
 
-| leg | trail stage | owner disposed under it |
+🚨 **"Covered" was asked of the wrong question, and the answer read as more than it was.** The
+earlier version of this table judged each leg by *"does it survive the owner being disposed under
+it?"* — a real question, pinned by a real test. But the leg that answers "yes" to that can still
+answer NOBODY when its source **completes empty**, which is a different termination reached by a
+different route. The legs are now composed through `DetachedReplyOutcome.Of`, which converts value /
+fault / empty into exactly one emission, so a leg cannot be silent whatever its source does:
+
+| leg | trail stage | its source's empty completion |
 |---|---|---|
-| update — `WriteThroughStream` | `UPSERT_WRITE_THROUGH_STREAM` | **covered.** The owner's `RegisterOwnerDisposingNack` mints `OwnerDisposing`, the writer re-enqueues against the fresh activation, the caller is answered `success=True` (pinned by `UpsertAnswersWhenTheOwnerGoesAwayTest`) |
-| create — `DispatchInnerCreate` | `UPSERT_READ absent → create` | **not covered.** No disposal-NACK registration, no `WriteVerdictBound` equivalent |
+| read — `gatedExisting` | `UPSERT_READ …` | posts a refusal naming the empty read (#2454). 🚨 Never `DefaultIfEmpty(null)`: the value arm reads `null` as "the node does not exist" and would turn a non-answer into a CREATE |
+| no-op probe — `SkipNoOpIfAuthorized` | `UPSERT_READ existing → no-op probe` | falls through to the write path. `GetEffectivePermissions` terminating without emitting is a documented outcome — half of what `HubPermissionExtensions` classifies as `Undetermined`, *"because it FAULTED, or because it terminated without ever emitting (#2742)"* — and against a two-arm `Subscribe` it posted nothing at all |
+| NodeType gate — `ApplyUpdateViaStream` | — | refuses, and says the probe produced no answer rather than "not registered" — a verdict and a non-verdict are not the same answer |
+| update — `WriteThroughStream` | `UPSERT_WRITE_THROUGH_STREAM` | posts a refusal naming the unconfirmed write. Disposal is separately covered: `RegisterOwnerDisposingNack` mints `OwnerDisposing`, the writer re-enqueues against the fresh activation, the caller is answered `success=True` (`UpsertAnswersWhenTheOwnerGoesAwayTest`) |
+| create — `DispatchInnerCreate` | `UPSERT_READ absent → create` | posts a refusal (`UPSERT_CREATE_COMPLETED_EMPTY`), and an `InnerCreateVerdictBound` bounds the no-answer case |
 
-🚨 **This gap is real, and it is NOT what failed the CD seals — measured 2026-09-07 on CD 7976.** The
+### #3674: the no-op probe is the one that was actually silent, and it is a RE-INSTALL
+
+[#3674](https://github.com/Systemorph/MeshWeaver/issues/3674) reported a
+`CreateOrUpdateNodeRequest` that reached *"a hub but no handler"*, followed by
+`ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this write` and a 31-second
+`VERDICT_TIMEOUT` — a write neither applied nor refused. Two of its own readings were later
+falsified in its thread: the `@` suffix in a request-fate entry names the hub that **recorded** the
+stage, not the delivery's target, so two of the three "not mine" verdicts were correct forwards; and
+the 8055-vs-8071 regression framing does not hold, because both commits carry the same code in the
+respect that matters. What survives every re-reading is the **shape** — the caller of a sanctioned
+lifecycle request received no terminal at all.
+
+The instance of that shape reachable with real machinery is the **no-op probe**. A re-install writes
+content identical to what is stored, which is exactly a no-op upsert, which is exactly the branch
+that asks `GetEffectivePermissions(path, requestedBy)` whether the caller could have written anyway.
+An empty completion there used to run neither arm: no `PostOk`, no write path, no log line.
+
+🚨 **That the reported failures took this branch is a FIT, not a measurement.** CD 7950's
+`[FAIL] Chess … idempotence: re-install failed` is an idempotent re-install, and a re-install is a
+no-op upsert — but no capture names the probe, because a leg that logs nothing leaves nothing to
+name it with. The claim this page makes is the narrow one: the branch was silent on an outcome its
+own source is documented to produce, and it is not any more.
+
+**Silence is handed to the write path, never resolved locally.** "No verdict" is not "denied" and
+certainly not "granted"; it is not an answer this optimisation may act on, so the optimisation steps
+aside and the owner stays the single authority on allow/deny — the same thing the probe's FAULT arm
+has always done. Answering "skipped" on an unproven authority would be a success-**without**-write,
+which is the one outcome worse than the silence.
+
+`UpsertAnswersWhenThePermissionProbeIsSilentTest` pins it, and the lever is the framework's own
+`WithPermissionEvaluator` seam narrowed to a single user id — not a mock: the create, the
+access-control pipeline and the cache's own write gate (which probes for the CALLER's identity) all
+run unchanged. Measured on this repo: without the fix the caller emits **nothing at all** for the
+full 36 s bound; with it, answered in 0.7 s.
+
+### The CREATE leg's history, and why closing it did not seal the bakes
+
+🚨 **This gap was real, and it was NOT what failed the CD seals — measured 2026-09-07 on CD 7976.** The
 one stale callback in that run's Hosting window took the **UPDATE** leg
 (`UPSERT_READ existing → update` → `UPSERT_WRITE_THROUGH_STREAM`) and resolved inside 35 s, and the
 eight-minute park that actually ran out the install's 600 s bound had **no pending callback anywhere**

--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -497,6 +497,34 @@ access-control pipeline and the cache's own write gate (which probes for the CAL
 run unchanged. Measured on this repo: without the fix the caller emits **nothing at all** for the
 full 36 s bound; with it, answered in 0.7 s.
 
+🚨 **And the reverted run reproduces #3674's reported artefact, not merely its symptom.** The
+capture below is from this repository's own test host with the fix backed out — the same
+`[STALE-CALLBACK] … CreateOrUpdateNodeRequest@portal/nodeops-…` line the issue quotes, and the same
+interleaved `ROUTED onTarget=False state=Forwarded` entries that were read there as *"forwarded by
+every hub, handled by none"*:
+
+```text
+[STALE-CALLBACK] client/…: 1 callback(s) pending > 30000ms:
+  …=CreateOrUpdateNodeRequest@portal/nodeops-…(35000ms)
+  AWAITING → POSTED target=portal/nodeops-… → RECEIVED@client/… → ENQUEUED@client/…
+  → RECEIVED@mesh/… → ENQUEUED@mesh/… → ROUTED onTarget=False state=Forwarded@client/…
+  → RECEIVED@portal/nodeops-… → ENQUEUED@portal/nodeops-…
+  → ROUTED onTarget=False state=Forwarded@mesh/…
+  → ROUTED onTarget=True state=Submitted@portal/nodeops-…
+  → HANDLER_ENTER@portal/nodeops-…
+  → UPSERT_READ existing → no-op probe@portal/nodeops-…
+  → HANDLER_EXIT state=Processed@portal/nodeops-…
+  ⇒ a handler was entered and no reply, completion or fault has been recorded since
+```
+
+**Read the two Forwarded lines against the two extra stages this trail carries.** The forwards are
+correct — `@` names the hub that RECORDED the stage, and both of those hubs correctly declined a
+delivery targeted at `portal/nodeops`. What names the defect is what follows on the target itself:
+`ROUTED onTarget=True`, `HANDLER_ENTER`, the leg's own stage, `HANDLER_EXIT state=Processed` — and
+then nothing. A trail that stops at a leg's stage is a leg that answered nobody, and it is
+distinguishable from a pump that never turned only by whether `HANDLER_ENTER` is present. That
+distinction is the reason each leg records a stage at all.
+
 ### The CREATE leg's history, and why closing it did not seal the bakes
 
 🚨 **This gap was real, and it was NOT what failed the CD seals — measured 2026-09-07 on CD 7976.** The

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-re-import-of-unchanged-content-can-no-longer-go-quiet.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-re-import-of-unchanged-content-can-no-longer-go-quiet.md
@@ -1,0 +1,54 @@
+---
+Name: A re-import of unchanged content can no longer go quiet
+Category: Fix
+Description: Saving something that had not actually changed could, in one narrow case, produce no answer at all — not a success, not a refusal, nothing. Whatever was waiting on it then sat there until its own patience ran out, with nothing anywhere saying why.
+Icon: Wrench
+Order: -20260910
+---
+
+# A re-import of unchanged content can no longer go quiet
+
+Re-installing an app, re-syncing a repository, re-running an import — these mostly write content
+that is already there, byte for byte. The platform notices that and skips the write, which is the
+right thing to do: an identical save that goes through anyway bumps a version, adds a history entry,
+and can look enough like a real edit to make a two-way sync start defending a copy nobody touched.
+
+Before skipping, it checks one thing: **could the person or process asking have written this
+anyway?** Skipping a write for someone who was not allowed to make it would be a success without a
+save — the worst of both answers — so the check exists to stop exactly that.
+
+## What was wrong
+
+That check could come back with **no answer at all**.
+
+Not "yes", not "no", not an error — simply nothing, which is a real and already-known outcome for a
+permission lookup. And nothing was precisely what happened next: the save was not skipped, the save
+was not attempted, no refusal was sent, and nothing was written to the log. The request that started
+it all had already been acknowledged as *received*, so from the outside everything looked normal
+until the caller's own patience ran out — a minute later, ten minutes later, depending on who was
+waiting.
+
+For a person, that is a save that appears to hang. For an automated install re-running to confirm it
+is repeatable, it is a step that stalls and then reports a failure naming a node rather than the
+thing that actually went wrong.
+
+## What changes
+
+**A non-answer is now treated as what it is: not an answer.** When the permission check produces no
+verdict, the platform stops trying to decide locally and simply performs the ordinary save, letting
+the node's owner rule on it the way it rules on every other write. That is already what happens when
+the check fails outright, so silence and failure now behave the same — which is the point, because
+they mean the same thing.
+
+Every other place the same request can hand its reply to background work was given the same
+treatment, so this class of silence is now closed by construction rather than by remembering to
+handle it: each one produces an outcome on every path, and an outcome always gets answered. Where the
+outcome is genuinely unknown, the answer says so, and says it is unknown — never "it did not happen",
+because a missing reply is not evidence that nothing was written.
+
+## What you will notice
+
+Almost always, nothing — the check answers normally and this never comes up. When it does not, a
+re-import or a save now finishes with a real result instead of going quiet, and if the outcome cannot
+be established you get a message that tells you so and tells you to check the node's state before
+retrying.

--- a/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
+++ b/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
@@ -1,0 +1,80 @@
+using System.Reactive.Linq;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// The single terminal of a source that a DETACHED REPLY depends on — value, fault, or
+/// <b>nothing at all</b>.
+///
+/// <para>🚨 <b>Why this type exists: a two-arm <c>Subscribe</c> is not total.</b> Rx has THREE
+/// terminal states, not two (MeshWeaver#2454). A handler that has already returned
+/// <c>Processed()</c> and owes its reply from a detached chain answers the caller from
+/// <c>onNext</c> and from <c>onError</c> — and says <b>nothing at all</b> when the source
+/// COMPLETES EMPTY. There is no fault to log, no value to post and no stage to record: the
+/// delivery trail ends at <c>HANDLER_EXIT state=Processed</c>, and the caller waits out its
+/// entire budget for a verdict that is never coming. That is the shape reported in
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/3674">#3674</see> — <i>"a write that
+/// is neither applied nor refused"</i> — and in
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/3510">#3510</see> before it.</para>
+///
+/// <para><b>Totality by construction, not by discipline.</b> Remembering to write a third arm at
+/// each site is exactly the discipline that failed: <c>MeshExtensions</c> states the rule twice in
+/// its own comments and still left the upsert's UPDATE leg on two arms. Composing through
+/// <c>DetachedReplyOutcome.Of</c> makes the source emit <b>exactly one</b> outcome on every path, so the
+/// site cannot be silent whatever the source does — and the leg becomes drivable without a mesh,
+/// which is what makes the empty-completion case testable at all (a live mesh cannot arrange it on
+/// demand — the same reason <c>PresentationScreenExtensions.LastKnownOnFault</c> is observable-in /
+/// observable-out).</para>
+///
+/// <para>🚨 <b>Empty is NOT a value.</b> <c>DefaultIfEmpty()</c> on the source itself would emit
+/// <c>default(T)</c> — <c>null</c> for a reference type — which the value arm then reads as a real
+/// answer (<c>MeshExtensions</c>' upsert read leg records why: an empty read turned into a
+/// <c>null</c> would be read as "the node does not exist" and become a CREATE). "Produced nothing"
+/// has to be its own outcome, and one the caller is told about.</para>
+/// </summary>
+/// <typeparam name="T">The source's value type.</typeparam>
+/// <param name="HasValue">True when the source emitted; <see cref="Value"/> is then its first emission.</param>
+/// <param name="Value">The source's first emission, when <paramref name="HasValue"/>.</param>
+/// <param name="Error">The source's fault, when it faulted before emitting.</param>
+internal readonly record struct DetachedReplyOutcome<T>(bool HasValue, T? Value, Exception? Error)
+{
+    /// <summary>
+    /// The source produced neither a value nor a fault — it completed empty. The caller MUST be
+    /// answered anyway, and the answer is a refusal that says the outcome is unknown, never a
+    /// success and never a silence.
+    /// </summary>
+    internal bool CompletedEmpty => !HasValue && Error is null;
+}
+
+/// <summary>
+/// Turns any source a detached reply hangs off into a source that emits EXACTLY ONE
+/// <see cref="DetachedReplyOutcome{T}"/> and completes. See that type for why.
+/// </summary>
+internal static class DetachedReplyOutcome
+{
+    /// <summary>
+    /// <c>value → HasValue</c>, <c>fault → Error</c>, <c>completed empty → CompletedEmpty</c> —
+    /// one emission on every path, so a subscriber cannot fail to answer.
+    ///
+    /// <para><c>Take(1)</c> comes FIRST so the outcome is the source's own first terminal: a
+    /// source that emits and then faults has already answered, and its late fault must not
+    /// overwrite the answer with a refusal. It also makes the outcome exactly-once for a source
+    /// that can emit more than once (the update queue's result subject replays, and
+    /// <c>UpdateRemote</c>'s late-verdict chain can re-emit), so a reply can never be posted
+    /// twice.</para>
+    ///
+    /// <para><c>Catch</c> is not swallow-and-continue: it does not resume the sequence, it
+    /// converts the fault into the one thing a detached reply can act on — a terminal the caller
+    /// is told about. The exception itself is carried through in
+    /// <see cref="DetachedReplyOutcome{T}.Error"/> and is the site's to log and report.</para>
+    /// </summary>
+    /// <typeparam name="T">The source's value type.</typeparam>
+    /// <param name="source">The source the detached reply hangs off.</param>
+    /// <returns>A source emitting exactly one outcome.</returns>
+    internal static IObservable<DetachedReplyOutcome<T>> Of<T>(IObservable<T> source)
+        => source
+            .Take(1)
+            .Select(value => new DetachedReplyOutcome<T>(true, value, null))
+            .Catch((Exception ex) => Observable.Return(new DetachedReplyOutcome<T>(false, default, ex)))
+            .DefaultIfEmpty(new DetachedReplyOutcome<T>(false, default, null));
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4821,21 +4821,32 @@ public static class MeshExtensions
         // content-confirmation oracle for callers the owner would have refused.
         void SkipNoOpIfAuthorized(MeshNode existing)
         {
-            (string.IsNullOrEmpty(requestedBy)
-                    ? Observable.Return(false)
-                    // 🚨 TakeDecisionOutsideGate, not a bare Take(1) — #899. Both branches of
-                    // the Subscribe below do real work (PostOk, or ApplyUpdateViaStream — a
-                    // cross-hub stream write that publishes). See
-                    // HubPermissionExtensions.TakeDecisionOutsideGate.
-                    : hub.GetEffectivePermissions(node.Path, requestedBy!)
-                        .TakeDecisionOutsideGate()
-                        .Timeout(NodeOpForwardTimeout)
-                        .Select(p => p.HasFlag(Permission.Update) || p.HasFlag(Permission.Sync))
-                        .Catch((Exception _) => Observable.Return(false)))
+            // 🚨 THREE terminal states, not two (MeshWeaver#2454 / #3674) — and on THIS leg the
+            // empty one is not a theoretical Rx corner, it is a documented outcome of the source.
+            // `GetEffectivePermissions` terminating without ever emitting is half of what
+            // HubPermissionExtensions classifies as `Undetermined` — "because it FAULTED, or
+            // because it terminated without ever emitting (issue #2742)". Against a two-arm
+            // Subscribe that is SILENCE: neither PostOk nor the write path runs, nothing is
+            // logged, the handler has already returned Processed(), and the caller waits out its
+            // whole budget for a verdict that is never coming. That is #3674's shape on the branch
+            // a RE-INSTALL takes (CD 7950: "[FAIL] Chess … idempotence: re-install failed"), since
+            // re-installing identical content is precisely a no-op upsert.
+            DetachedReplyOutcome.Of(
+                    string.IsNullOrEmpty(requestedBy)
+                        ? Observable.Return(false)
+                        // 🚨 TakeDecisionOutsideGate, not a bare Take(1) — #899. Both branches of
+                        // the Subscribe below do real work (PostOk, or ApplyUpdateViaStream — a
+                        // cross-hub stream write that publishes). See
+                        // HubPermissionExtensions.TakeDecisionOutsideGate.
+                        : hub.GetEffectivePermissions(node.Path, requestedBy!)
+                            .TakeDecisionOutsideGate()
+                            .Timeout(NodeOpForwardTimeout)
+                            .Select(p => p.HasFlag(Permission.Update) || p.HasFlag(Permission.Sync))
+                            .Catch((Exception _) => Observable.Return(false)))
                 .Subscribe(
-                    authorized =>
+                    outcome =>
                     {
-                        if (authorized)
+                        if (outcome is { HasValue: true, Value: true })
                         {
                             logger.LogDebug(
                                 "[CreateOrUpdate] no-op upsert for {Path}: identical to persisted state; skipped",
@@ -4843,19 +4854,31 @@ public static class MeshExtensions
                             PostOk(existing, isCreate: false,
                                 $"Node at '{node.Path}' unchanged — no-op upsert skipped",
                                 "activity.node.unchanged");
+                            return;
                         }
-                        else
-                            // Not (provably) authorized → the normal owner path stays the single
-                            // authority on allow/deny; it will refuse exactly as before.
-                            ApplyUpdateViaStream(existing, existing.NodeType);
-                    },
-                    ex =>
-                    {
-                        logger.LogDebug(ex,
-                            "[CreateOrUpdate] no-op permission probe failed for {Path}; taking the write path",
-                            node.Path);
+                        if (outcome.Error is { } probeError)
+                            logger.LogDebug(probeError,
+                                "[CreateOrUpdate] no-op permission probe failed for {Path}; taking the write path",
+                                node.Path);
+                        else if (outcome.CompletedEmpty)
+                            // A NON-VERDICT, not a denial. Treated exactly as the fault is: the
+                            // optimisation steps aside and the owner stays the single authority on
+                            // allow/deny. Answering "skipped" here would be a success-without-write
+                            // on unproven authority; answering nothing at all is what #3674 is.
+                            logger.LogWarning(
+                                "[CreateOrUpdate] the no-op permission probe for {Path} COMPLETED "
+                                + "without a verdict; taking the write path rather than leaving the "
+                                + "caller to wait out its budget (MeshWeaver#3674).",
+                                node.Path);
+                        // Not (provably) authorized → the normal owner path stays the single
+                        // authority on allow/deny; it will refuse exactly as before.
                         ApplyUpdateViaStream(existing, existing.NodeType);
-                    });
+                    },
+                    // The subscriber's OWN contract, never the probe's: the probe's fault arrives
+                    // as `Error` on the outcome above.
+                    ex => logger.LogWarning(ex,
+                        "[CreateOrUpdate] the no-op probe for {Path} threw while acting on its outcome",
+                        node.Path));
         }
 
         // 🚨 THE UPDATE-PATH NODETYPE GATE (issue #2993). The CREATE branch has always refused a
@@ -4893,13 +4916,52 @@ public static class MeshExtensions
                 return;
             }
 
-            NodeTypeResolution.Resolves(hub, node.NodeType)
+            // Total by construction, same rule and same reason as the write leg below
+            // (MeshWeaver#2454 / #3674): this subscription is on the handler's DETACHED reply path,
+            // so a probe that completed without an answer would post nothing at all and leave the
+            // caller to wait out its budget. `Resolves` ends in `IStorageAdapter.Exists`, whose
+            // implementations are free to complete empty — the routing proxy's is a request/response
+            // `Observe(...).Take(1)`, which is empty the moment the partition hub answers nothing.
+            DetachedReplyOutcome.Of(NodeTypeResolution.Resolves(hub, node.NodeType))
                 .Subscribe(
-                    resolves =>
+                    outcome =>
                     {
-                        if (resolves)
+                        if (outcome is { HasValue: true, Value: true })
                         {
                             WriteThroughStream(existing);
+                            return;
+                        }
+                        if (outcome.Error is { } probeError)
+                        {
+                            // 🚨 A VERDICT AND A NON-VERDICT ARE NOT THE SAME ANSWER. The probe
+                            // faulted, so we do NOT know whether the type exists — refuse (a write
+                            // here could strand the node permanently) but say which of the two it
+                            // is, and classify it as Unknown rather than InvalidNodeType so a
+                            // caller cannot read it as "go create that type".
+                            logger.LogWarning(probeError,
+                                "[CreateOrUpdate] {Path}: the NodeType existence probe for '{NodeType}' "
+                                + "faulted; refusing the update rather than risking a dangling type.",
+                                node.Path, node.NodeType);
+                            PostFail(
+                                NodeTypeResolution.ProbeFailedMessage(node.Path, node.NodeType!, probeError),
+                                NodeUpsertRejectionReason.Unknown);
+                            return;
+                        }
+                        if (outcome.CompletedEmpty)
+                        {
+                            // Silence is a non-verdict too, and by the same rule it is a refusal
+                            // that says so — never "not registered", which would send the caller
+                            // off to create a type that may well already exist.
+                            logger.LogWarning(
+                                "[CreateOrUpdate] {Path}: the NodeType existence probe for '{NodeType}' "
+                                + "COMPLETED without an answer; refusing the update rather than "
+                                + "risking a dangling type (MeshWeaver#3674).",
+                                node.Path, node.NodeType);
+                            PostFail(
+                                NodeTypeResolution.ProbeFailedMessage(node.Path, node.NodeType!,
+                                    new InvalidOperationException(
+                                        "the existence probe completed without producing an answer")),
+                                NodeUpsertRejectionReason.Unknown);
                             return;
                         }
                         logger.LogWarning(
@@ -4911,21 +4973,12 @@ public static class MeshExtensions
                             NodeTypeResolution.RejectionMessage(node.Path, node.NodeType!),
                             NodeUpsertRejectionReason.InvalidNodeType);
                     },
-                    ex =>
-                    {
-                        // 🚨 A VERDICT AND A NON-VERDICT ARE NOT THE SAME ANSWER. The probe faulted,
-                        // so we do NOT know whether the type exists — refuse (a write here could
-                        // strand the node permanently) but say which of the two it is, and classify
-                        // it as Unknown rather than InvalidNodeType so a caller cannot read it as
-                        // "go create that type".
-                        logger.LogWarning(ex,
-                            "[CreateOrUpdate] {Path}: the NodeType existence probe for '{NodeType}' "
-                            + "faulted; refusing the update rather than risking a dangling type.",
-                            node.Path, node.NodeType);
-                        PostFail(
-                            NodeTypeResolution.ProbeFailedMessage(node.Path, node.NodeType!, ex),
-                            NodeUpsertRejectionReason.Unknown);
-                    });
+                    // The subscriber's OWN contract, never the probe's: the probe's fault arrives
+                    // as `Error` on the outcome above, so anything reaching here is a throw out of
+                    // PostFail / WriteThroughStream.
+                    ex => logger.LogWarning(ex,
+                        "[CreateOrUpdate] the NodeType gate for {Path} threw while acting on its outcome",
+                        node.Path));
         }
 
         void WriteThroughStream(MeshNode existing)
@@ -4972,7 +5025,7 @@ public static class MeshExtensions
                 // mechanism anywhere able to restore it. Flooring on the row we JUST read makes
                 // the write forward by construction, so the repair lands on the first attempt.
                 // Content is untouched by this: it still comes from `live`.
-                hub.GetMeshNodeStream(node.Path)
+                var write = hub.GetMeshNodeStream(node.Path)
                     // 1b', on the MERGED node. The create path repairs a stale self-default MainNode
                     // before it is ever stored; the update path has to repair it AFTERWARDS, because
                     // the stale value lives on `live` and a full-instance source provably cannot move
@@ -4990,19 +5043,63 @@ public static class MeshExtensions
                             CreatedDate = live.CreatedDate == default ? existing.CreatedDate : live.CreatedDate,
                             CreatedBy = live.CreatedBy ?? existing.CreatedBy,
                         },
-                        upsertMeshConfig))
+                        upsertMeshConfig));
+
+                // 🚨 THREE terminal states, not two (MeshWeaver#2454 / #3674). This was the LAST
+                // two-arm subscription on the upsert's reply path — the read leg and
+                // DispatchInnerCreate above each grew a third arm; this one did not, and it is
+                // the leg an EXISTING node takes. An empty completion here is not hypothetical:
+                // `Update` on a cross-hub path is `IMeshNodeStreamCache.Update`, whose per-path
+                // queue forwards the write's own terminal to the caller's result subject, and its
+                // COMPLETE arm calls `req.Result.OnCompleted()` for "a write that completed
+                // without ever emitting" — MeshNodeStreamCache says so in that arm's own comment.
+                // Upstream, `UpdateRemote`'s late-NACK re-enqueue completes the caller through
+                // `ChainTerminal`, whose onCompleted arm can claim the terminal with no emission
+                // behind it. Both reach a two-arm Subscribe as SILENCE, and the handler has
+                // already returned Processed(), so the caller waits out its whole budget for a
+                // verdict that is never coming — #3674's "neither applied nor refused".
+                //
+                // Composed through DetachedReplyOutcome so exactly one outcome arrives on every
+                // path: totality is a property of the composition, not of remembering to write the
+                // arm. The onError arm below is the subscriber's OWN contract (a throw out of
+                // PostOk/PostFail), never the write's — the write's fault arrives as `Error` on
+                // the outcome.
+                DetachedReplyOutcome.Of(write)
                     .Subscribe(
-                        saved => PostOk(saved, isCreate: false, $"Updated node at '{node.Path}'",
-                            "activity.node.updated"),
-                        ex =>
+                        outcome =>
                         {
-                            logger.LogWarning(ex,
-                                "[CreateOrUpdate] inner UpdateNode faulted for {Path}", node.Path);
-                            PostFail($"Inner UpdateNode faulted: {ex.Message}",
-                                ex is UnauthorizedAccessException
-                                    ? NodeUpsertRejectionReason.Unauthorized
-                                    : NodeUpsertRejectionReason.Unknown);
-                        });
+                            if (outcome.HasValue)
+                            {
+                                PostOk(outcome.Value!, isCreate: false, $"Updated node at '{node.Path}'",
+                                    "activity.node.updated");
+                                return;
+                            }
+                            if (outcome.Error is { } ex)
+                            {
+                                logger.LogWarning(ex,
+                                    "[CreateOrUpdate] inner UpdateNode faulted for {Path}", node.Path);
+                                PostFail($"Inner UpdateNode faulted: {ex.Message}",
+                                    ex is UnauthorizedAccessException
+                                        ? NodeUpsertRejectionReason.Unauthorized
+                                        : NodeUpsertRejectionReason.Unknown);
+                                return;
+                            }
+                            hub.NoteRequestStage(request.Id, "UPSERT_UPDATE_COMPLETED_EMPTY");
+                            logger.LogWarning(
+                                "[CreateOrUpdate] the update write for {Path} COMPLETED without a "
+                                + "result and without a fault. Answering the caller with a refusal "
+                                + "rather than leaving it to wait out its budget (MeshWeaver#3674).",
+                                node.Path);
+                            PostFail(
+                                $"The update of '{node.Path}' completed without producing a result "
+                                + "or a fault, so the write is NOT confirmed. The outcome is "
+                                + "unknown: the owner may have committed it without acknowledging. "
+                                + "Check the node's state before retrying.",
+                                NodeUpsertRejectionReason.Unknown);
+                        },
+                        ex => logger.LogWarning(ex,
+                            "[CreateOrUpdate] the update reply for {Path} threw while being posted",
+                            node.Path));
             }
         }
 

--- a/test/MeshWeaver.Graph.Test/UpsertAnswersWhenThePermissionProbeIsSilentTest.cs
+++ b/test/MeshWeaver.Graph.Test/UpsertAnswersWhenThePermissionProbeIsSilentTest.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#3674 — an upsert whose reply hangs off a source that COMPLETES EMPTY answers nobody, and
+/// the caller waits out its entire budget.</b>
+///
+/// <para><b>What #3674 reported</b> is <c>CreateOrUpdateNodeRequest … ⇒ the delivery reached a hub
+/// but no handler</c>, then <c>ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this write</c>
+/// and <c>VERDICT_TIMEOUT … bound=31s</c> — a write that is neither applied nor refused. Its own
+/// thread later established that the routing reading was wrong (the <c>@</c> in a request-fate entry
+/// names the hub that RECORDED the stage, not the delivery's target, so two of the three "not mine"
+/// verdicts were correct forwards). What survives every re-reading is the SHAPE: the caller of a
+/// sanctioned lifecycle request got no terminal at all.</para>
+///
+/// <para><b>This test pins the one instance of that shape that is drivable with real machinery.</b>
+/// <c>HandleCreateOrUpdateNodeRequest</c> returns <c>Processed()</c> immediately and owes its reply
+/// from detached chains. Its no-op branch — the branch a RE-INSTALL takes, which is exactly what CD
+/// 7950's <c>[FAIL] Chess … idempotence: re-install failed</c> was doing — asks
+/// <c>hub.GetEffectivePermissions(path, requestedBy)</c> whether the caller could have written
+/// anyway. That probe <b>terminating without ever emitting is a known, tracked reality</b>: it is
+/// half of what <c>HubPermissionExtensions.CheckPermissionOutcome</c> classifies as
+/// <c>Undetermined</c>, <i>"because it FAULTED, or because it terminated without ever emitting
+/// (issue #2742)"</i>. Against a two-arm <c>Subscribe</c> that is SILENCE — neither
+/// <c>PostOk</c> nor the write path runs, no fault is logged, and the delivery trail simply stops.
+/// </para>
+///
+/// <para><b>The lever is the framework's own extension point, not a mock</b> —
+/// <c>MessageHubPermissionExtensions.WithPermissionEvaluator</c>, the documented
+/// "inject a custom evaluator (for tests / non-standard evaluators)" seam, the same one
+/// <c>MeshReadHub</c> and <c>SessionHubFactory</c> use in production. The evaluator here is
+/// <b>narrowed to one user id</b> and delegates everything else to the real
+/// <c>PermissionEvaluator</c>, so the create, the access-control pipeline and the cache's own write
+/// gate (which probes for the CALLER's identity, not <see cref="SilentProbeUser"/>) all run
+/// unchanged. Nothing is faked; one identity's answer is empty instead of a verdict.</para>
+///
+/// <para><b>What the fix does with silence.</b> The same thing the probe's FAULT arm has always
+/// done: fall through to the ordinary write path and let the owner stay the single authority on
+/// allow/deny. "No verdict" is not "denied" and it is certainly not "granted" — it is simply not an
+/// answer this optimisation may act on, so the optimisation steps aside.</para>
+/// </summary>
+public class UpsertAnswersWhenThePermissionProbeIsSilentTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The one identity whose effective-permission probe answers with an empty completion. Narrow
+    /// on purpose: every other identity — including the one the request itself carries — keeps the
+    /// real evaluator, so this test changes exactly one observable fact about the mesh.
+    /// </summary>
+    private const string SilentProbeUser = "3674-silent-probe-user";
+
+    private const string NodeId = "upsert-silent-probe";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            // Applied AFTER AddRowLevelSecurity so this delegate is the one the mesh hub carries —
+            // and the node-CRUD hub COPIES the mesh hub's delegate on creation (MeshExtensions'
+            // "INHERIT THE ROUTER'S PERMISSION EVALUATOR"), which is what puts it in front of the
+            // upsert handler running there.
+            .ConfigureHub(c => c.WithPermissionEvaluator(
+                (hub, nodePath, userId) => userId == SilentProbeUser
+                    ? Observable.Empty<Permission>()
+                    : PermissionEvaluator.GetEffectivePermissions(hub, nodePath, userId)));
+
+    /// <summary>
+    /// A no-op upsert (identical to the persisted node, so the no-op probe branch is taken) whose
+    /// permission probe completes without a verdict. The caller MUST be answered.
+    /// </summary>
+    [Fact]
+    public async Task NoOpUpsert_WhenThePermissionProbeCompletesWithoutAVerdict_StillAnswersTheCaller()
+    {
+        await NodeFactory.CreateNode(
+                new MeshNode(NodeId, TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        // Byte-identical to what was just created — Name, NodeType and a null Content — so
+        // IsNoOpUpsert is true and the handler takes SkipNoOpIfAuthorized. RequestedBy names the
+        // one identity whose probe is silent; the delivery's own AccessContext is untouched, which
+        // is what keeps the write path (and its access gate) working once the fix falls through
+        // to it.
+        var answer = await ObserveNodeOperation(
+                new CreateOrUpdateNodeRequest(
+                    new MeshNode(NodeId, TestPartition) { Name = "initial", NodeType = "Markdown" })
+                {
+                    RequestedBy = SilentProbeUser,
+                })
+            .Should().Within(TestTimeouts.Convergence).Emit(
+                "a CreateOrUpdateNodeRequest whose no-op permission probe completes without a "
+                + "verdict must still receive a terminal — a two-arm Subscribe posts nothing at "
+                + "all here, and the caller waits out its whole budget for a reply that is never "
+                + "coming (MeshWeaver#3674)");
+
+        // WHICH terminal is deliberately not over-specified: the fix hands silence to the ordinary
+        // write path, so the owner decides. What must never happen again is no terminal.
+        answer.Message.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Fixes #3674.

## The filed premise does not survive — the shape does

#3674 reads its trail as *"forwarded by the node hub, by the mesh hub and by the nodeops hub — each says 'not mine' — and no handler ever runs"*. Its own thread falsified that: the `@` in a request-fate entry names the hub that **RECORDED** the stage, not the delivery's target, so two of those three verdicts were correct forwards. The 8055-vs-8071 regression framing is falsified too — both commits carry the same code in the respect that matters, and a green control on racy code localises nothing.

**Re-measured today (2026-09-10):** the falsifying observation the thread was waiting for is still unavailable. MeshWeaver.Reinsurance's pin moved past the control (Reinsurance#184, merged 09-09 15:48Z) and its gate now resolves `3.0.0-ci.8261` / core `47d94201e` — but every `Reinsurance Plugins CI` run today dies **before** the render step, at `upstream 'plugins' has no SEALED publication … for framework identity s6c3644c091f6675035c9cfaf59453d21` (run 34467892111). `Ifrs17/AocConfiguration` has not been re-rendered on any platform ≥ 8071. Nothing here changes that; it is an upstream-publication blocker, not this defect.

What survives every re-reading is the **shape**, and it is the thing this PR fixes: *the caller of a sanctioned lifecycle request received no terminal at all* — the write was neither applied nor refused.

## Root cause

`HandleCreateOrUpdateNodeRequest` returns `Processed()` immediately and owes its `CreateOrUpdateNodeResponse` from chains that outlive the turn. **Three** of those chains subscribed with two of Rx's three terminations, so a source that **completes empty** ran neither arm — no reply, no fault, no log line, and a delivery trail reading `HANDLER_ENTER … → HANDLER_EXIT state=Processed` while the caller waits out its entire budget.

The reachable instance is the **no-op probe**, i.e. a **re-install**: identical content takes the no-op branch, which asks `hub.GetEffectivePermissions(path, requestedBy)` whether the caller could have written anyway. That probe **terminating without ever emitting is a documented outcome**, not an Rx corner — it is half of what `HubPermissionExtensions` classifies as `Undetermined`, *"because it FAULTED, or because it terminated without ever emitting (issue #2742)"*. CD 7950's `[FAIL] Chess … idempotence: re-install failed` is an idempotent re-install; that it took this branch is a **fit, not a measurement**, and the PR says so.

The file states the rule twice in its own comments (#2454, "THREE terminal states, not two") and still left three legs on two arms — which is why the fix is composition, not another remembered arm.

## The fix

`DetachedReplyOutcome.Of` maps value / fault / **empty** into **exactly one** emission, so a detached-reply leg cannot be silent whatever its source does — totality by construction.

| leg | what silence now does |
|---|---|
| no-op probe (`SkipNoOpIfAuthorized`) | falls through to the ordinary write path, exactly as the FAULT arm already did — a non-verdict is neither a denial nor a grant, and answering "skipped" on unproven authority would be a success **without** a write |
| NodeType gate (`ApplyUpdateViaStream`) | refuses and **says the probe produced no answer**, never "not registered" |
| update leg (`WriteThroughStream`) | refuses and says the write is **not confirmed** and the outcome unknown — a missing reply never proves rollback |

🚨 **No band-aid:** no bound moves, nothing is retried, nothing is swallowed, no watchdog is added. `Catch` here does not resume a sequence — it converts a fault into a terminal the caller is told about, and carries the exception through for the site to log. The only change is that a termination which previously reached no handler now reaches one.

## Control, both directions (Release, `-warnaserror`, full rebuild each way)

- **`src/` fix reverted, test kept** → RED in **36 s**:
  > `ObservableAssertionException : Expected the observable to emit a value within 36s because a CreateOrUpdateNodeRequest whose no-op permission probe completes without a verdict must still receive a terminal — a two-arm Subscribe posts nothing at all here, and the caller waits out its whole budget for a reply that is never coming (MeshWeaver#3674), but it did not. **The observable emitted nothing at all.**`
- **fix re-applied** → GREEN in **0.7 s**.

🚨 **The reverted run reproduces #3674's own artefact, not merely its symptom** — same `[STALE-CALLBACK] … CreateOrUpdateNodeRequest@portal/nodeops-…` line, same interleaved `ROUTED onTarget=False state=Forwarded` entries that were read there as "forwarded by every hub, handled by none":

```text
[STALE-CALLBACK] client/…: 1 callback(s) pending > 30000ms:
  …=CreateOrUpdateNodeRequest@portal/nodeops-…(35000ms)
  … → ROUTED onTarget=False state=Forwarded@client/…
  → RECEIVED@portal/nodeops-… → ENQUEUED@portal/nodeops-…
  → ROUTED onTarget=False state=Forwarded@mesh/…
  → ROUTED onTarget=True state=Submitted@portal/nodeops-…
  → HANDLER_ENTER@portal/nodeops-…
  → UPSERT_READ existing → no-op probe@portal/nodeops-…
  → HANDLER_EXIT state=Processed@portal/nodeops-…
  ⇒ a handler was entered and no reply, completion or fault has been recorded since
```

The forwards are **correct** (both hubs declined a delivery targeted at `portal/nodeops`). What names the defect is what follows on the target: `onTarget=True` → `HANDLER_ENTER` → the leg's stage → `HANDLER_EXIT state=Processed` → nothing. A trail stopping at a leg's stage is a leg that answered nobody; it is distinguishable from a pump that never turned only by whether `HANDLER_ENTER` is present.

`UpsertAnswersWhenThePermissionProbeIsSilentTest` uses the framework's own `WithPermissionEvaluator` seam **narrowed to one user id** — not a mock: the create, the access-control pipeline and the cache's own write gate (which probes for the CALLER's identity, not the probe id) all run unchanged.

Also green locally: `MeshWeaver.Graph.Test` upsert/create/dangling/release-wave filter (15/15), `MeshWeaver.Documentation.Test` in full (368/368, including `DocumentationLinkIntegrityTest` and `SubscribeErrorArmRatchetGuard`), and `Mesh.Contract` / `Hosting` / `Graph` / `Mesh.Operations` / `Documentation` each `0 Error(s)` in Release.

## Maintainer decision left

**#3674 should not be closed on this PR alone.** This closes one measured, reproducible instance of its shape. Two things it deliberately does **not** do, both still open:

1. **`portal/nodeops` enqueued the delivery and never took the turn** (#3674's own comment of 09-09, and #2543 / #3593). Nothing about assembly identity or handler selection is consulted before a turn starts, so a pump that does not turn is a separate defect — and the disposal-stall verdict from #3798 only prints for a hub that is stalled **while disposing**, never one merely stalled while alive. That gap is named in the thread and is not closed here.
2. **Whether the Reinsurance gate still reproduces** cannot be answered until its `upstream 'plugins'` publication is sealed for the current framework identity. Per the thread's own standing caution, a single green gate afterwards would confirm nothing; only a recurrence (falsifying) or a long clean run moves it.

Work product conserved: `Doc/Architecture/WriteVerdictTotality` gains the corrected per-leg table (the old one judged "covered" by *"does it survive the owner being disposed under it?"* — a leg can answer yes to that and still answer nobody on an empty completion), the #3674 section, and the honest fit-not-measurement caveat. What's New entry added, `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
