### PR TITLE
fix: the Unavailable arm gets a control that can fail (Copilot review on #3912)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
@@ -224,18 +224,42 @@ internal sealed class MeshNodeLanguageService : IMeshLanguageService
         => ResolveNodeOutcome(nodeTypePath)
             .SelectMany(outcome => outcome.Node is { } node
                 ? SpeculativeFor(node, nodeTypePath, sourcePath, proposedCode)
-                : Observable.Return(outcome.Status switch
-                {
-                    // Genuinely not there, or its delete is in flight — either way the proposed
-                    // source was never compiled against anything.
-                    NodeReadStatus.Absent or NodeReadStatus.DeleteInProgress =>
-                        NodeDiagnosticsOutcome.Absent,
-                    // 🚨 The owner did not answer inside the budget, the read faulted, or a
-                    // delivery-level denial came back as a failure. Precisely when a pre-flight
-                    // most needs to refuse, and precisely where it used to be most confidently
-                    // green.
-                    _ => NodeDiagnosticsOutcome.Unavailable(outcome.Failure),
-                }));
+                : Observable.Return(NothingWasChecked(outcome)));
+
+    /// <summary>
+    /// The no-answer mapping: what a read that produced no node means for a pre-flight VERDICT.
+    /// Extracted so a test can drive it over every <see cref="NodeReadStatus"/> directly — the
+    /// wedged-owner arm cannot be arranged on demand against a live mesh, and an arm no control can
+    /// reach is exactly how a regression putting it back on <see cref="NodeDiagnosticsStatus.Compiled"/>
+    /// would leave the suite green. Same idiom as <see cref="CanReuseWorkspace"/>: the WHOLE
+    /// decision, not a fragment of it.
+    ///
+    /// <para>🚨 The invariant is not "Absent here and Unavailable there" — it is that <b>no</b>
+    /// status reachable with a null node may produce <see cref="NodeDiagnosticsStatus.Compiled"/>,
+    /// including a status added later. That is what
+    /// <c>NoReadThatProducedNoNodeMayReadAsCompiled</c> pins, over the live enum.</para>
+    /// </summary>
+    /// <param name="outcome">The read that produced no node.</param>
+    internal static NodeDiagnosticsOutcome NothingWasChecked(NodeReadOutcome outcome)
+        => outcome.Status switch
+        {
+            // Genuinely not there, its delete is in flight, or a read validator HID it — a filtered
+            // node is invisible to the reader by contract, which is how #3888's live case (a
+            // NodeType in a partition the caller held no grant on) reached this arm. Either way the
+            // proposed source was never compiled against anything.
+            NodeReadStatus.Absent or NodeReadStatus.DeleteInProgress => NodeDiagnosticsOutcome.Absent,
+            // 🚨 The owner did not answer inside the budget, the read faulted, or the payload could
+            // not be materialised. Precisely when a pre-flight most needs to refuse, and precisely
+            // where it used to be most confidently green. `Present` cannot honestly land here (the
+            // caller took the other branch on a non-null node), and if it ever did — a Present
+            // outcome with no node is a contradiction — Unavailable is the fail-closed reading.
+            //
+            // 🚨 A DELIVERY-level RLS denial does NOT arrive here: GetMeshNodeOutcome rides a raw
+            // GetDataRequest whose NACK surfaces as OnError (DeliveryFailureException), which the
+            // tool boundary converts into the same {ok:false} shape (#2554). Two different routes,
+            // both refusing; neither may read as clean.
+            _ => NodeDiagnosticsOutcome.Unavailable(outcome.Failure),
+        };
 
     // The speculative half, given an already-resolved node. Environment() cannot answer Unknown
     // for a non-null node, so the two arms below are the whole space.

--- a/src/MeshWeaver.Documentation/Data/Architecture/LanguageServices.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LanguageServices.md
@@ -114,7 +114,7 @@ Two tools are exposed via `McpMeshPlugin` for external MCP clients (`lsp_check_n
 
 `[]` is what a clean compile looks like. It is *also* what "I could not resolve that path" looks like, and what "the owning hub never answered" looks like. Nothing in an `IReadOnlyList<DiagnosticInfo>` separates them, so a tool rendering `ok = !diagnostics.Any(Error)` reports a **clean bill of health for a check that never ran**.
 
-| | Fixed in | The symptom |
+| Method | Fixed in | The symptom |
 |---|---|---|
 | `GetDiagnostics` | #1592 / #1618 | `lsp_diagnostics_for_node @Edu/DefinitelyNotARealNodeType` → `{"ok":true,"diagnostics":[]}`; the mandated pre-prod sweep reported all-green over stale paths having verified nothing |
 | `CheckSpeculative` | #3888 | `lsp_check_node` on a NodeType in a partition the caller cannot read → `{"ok":true,"diagnostics":[]}` — **including for `proposedCode` that is not C# at all**; the `/code` edit loop's pre-flight blessed every proposed edit against every path it could not reach |
@@ -140,6 +140,17 @@ The interface member carries a **default implementation that answers `Unavailabl
 > **What #3888 also corrected about its own reading of the code.** The issue named *two* silent branches and could not say which produced the live observation. It can only have been the unresolvable-owner one: the other — `GetCompilationInputsAsync` answering `null` — is unreachable from the speculative path, because that method refuses exactly one shape (a node whose `NodeType` is unset) and such a node is classified as a **script** here, never as a NodeType. The `NotCompilable` mapping stays as the honest reading of a nullable contract, and the test suite says so rather than pinning a branch that could never fail.
 
 The controls live in `test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs` and run **in both directions**: an unresolvable path must not read clean, *and* a real NodeType must still compile its proposal and report errors when the proposal is broken. A fix that made everything fail would be no better than one that made everything pass. See [Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail).
+
+> **One arm no live-mesh test can reach — and what to do about it.** The wedged-owner case
+> (`NodeReadStatus.Unavailable`) cannot be arranged on demand: the read's budget is 15 s and the
+> outcome depends on an owner that will not answer. An arm with no control is precisely where a
+> regression would put `Compiled` back unnoticed, so the mapping is **extracted** —
+> `MeshNodeLanguageService.NothingWasChecked(NodeReadOutcome)`, the whole decision rather than a
+> fragment, the same idiom as `CanReuseWorkspace` — and driven directly over
+> `Enum.GetValues<NodeReadStatus>()`. The invariant that gets asserted is deliberately stronger than
+> per-value equality: **no** read that produced no node may render as `Compiled`, *including a status
+> added later*. A per-value test would go silent on a new status; enumerating the enum makes the next
+> one arrive as a red instead of as a hole.
 
 ## The /code Pre-Flight Loop
 

--- a/test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest.cs
@@ -19,10 +19,12 @@ namespace MeshWeaver.Compiler.Pipeline.Test;
 /// <c>lsp_check_node @BinaryClickerV2/BinaryToggle</c> with <c>proposedCode</c> =
 /// <c>"this is definitely not valid C# ###"</c> answered <c>{"ok":true,"diagnostics":[]}</c>. Not a
 /// wrong verdict about the code — no verdict at all, wearing the costume of a clean one. The
-/// NodeType lives in a partition that identity has no read grant on, so nothing was ever compiled;
-/// <c>CheckSpeculative</c> mapped BOTH of its no-answer branches (owner unresolvable, and no
-/// compilation inputs) to <c>Array.Empty&lt;DiagnosticInfo&gt;()</c>, which is byte-identical to
-/// what a clean compile produces.</para>
+/// NodeType lives in a partition that identity has no read grant on — a read validator HIDES such a
+/// node, and a filtered node is invisible to the reader by contract — so nothing was ever compiled,
+/// and <c>CheckSpeculative</c> mapped that to <c>Array.Empty&lt;DiagnosticInfo&gt;()</c>, which is
+/// byte-identical to what a clean compile produces. (The issue listed a second silent branch, "no
+/// compilation inputs". It is unreachable from this path — see
+/// <see cref="ANodeThatIsNotANodeTypeIsGenuinelyCheckedAsAScript"/>.)</para>
 ///
 /// <para><b>Why it is the worst shape available.</b> The <c>/code</c> skill's edit loop is built on
 /// this call — <i>"edit a Source/*.cs file in your head → lsp_check_node → if diagnostics, fix →
@@ -205,6 +207,71 @@ public class SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest(ITestOutput
             "text that cannot parse as C# must produce Roslyn errors; a check that answers empty "
             + "here is the #3888 defect wearing a resolvable path");
         outcome.IsClean.Should().BeFalse();
+    }
+
+    // ───────────────── the arm no live mesh can arrange: a read that did not answer
+
+    /// <summary>
+    /// 🚨 <b>The arm a live-mesh test cannot reach, and therefore the one a regression would put
+    /// back on <c>Compiled</c> unnoticed</b> (Copilot review on #3912). A wedged per-node hub is not
+    /// something a monolith test can arrange on demand — the read's budget is 15 s and the outcome
+    /// depends on an owner that will not answer — so the mapping is driven directly instead, over
+    /// the LIVE enum.
+    ///
+    /// <para>The assertion is deliberately stronger than "Unavailable maps to Unavailable": <b>no</b>
+    /// read that produced no node may read as compiled, <i>including a
+    /// <see cref="NodeReadStatus"/> added later</i>. A per-value test would go silent on a new
+    /// status; enumerating the enum makes the next one arrive as a red instead of as a hole.</para>
+    /// </summary>
+    [Fact]
+    public void NoReadThatProducedNoNodeMayReadAsCompiled()
+    {
+        foreach (var status in Enum.GetValues<NodeReadStatus>())
+        {
+            var mapped = MeshNodeLanguageService.NothingWasChecked(
+                new NodeReadOutcome { Status = status, Failure = new TimeoutException("owner silent") });
+
+            mapped.Status.Should().NotBe(NodeDiagnosticsStatus.Compiled,
+                "a read that produced no node compiled nothing, so status {0} must not render as a "
+                + "verdict about the proposed source", status);
+            mapped.IsClean.Should().BeFalse(
+                "IsClean is what lsp_check_node renders as ok; status {0} must not read as approval",
+                status);
+        }
+    }
+
+    /// <summary>
+    /// The wedged-owner arm specifically, and that the CAUSE survives to the caller — a refusal
+    /// naming neither the path nor the reason is only a differently-shaped dead end.
+    /// </summary>
+    [Fact]
+    public void AnOwnerThatDidNotAnswerIsUnavailable_AndTheReasonSurvives()
+    {
+        var failure = new TimeoutException("the owning hub did not answer within the budget");
+
+        var mapped = MeshNodeLanguageService.NothingWasChecked(NodeReadOutcome.Unavailable(failure));
+
+        mapped.Status.Should().Be(NodeDiagnosticsStatus.Unavailable,
+            "a hub that did not answer is not a hub that answered 'fine' — this is the case that "
+            + "makes the pre-flight a gate rather than a nicety");
+        mapped.IsClean.Should().BeFalse();
+        mapped.Failure.Should().BeSameAs(failure, "the cause is what makes the refusal actionable");
+        mapped.DescribeProblem("type/Wedged")!.Should().Contain("type/Wedged");
+        mapped.DescribeProblem("type/Wedged")!.Should().Contain(failure.Message);
+    }
+
+    /// <summary>
+    /// And the OTHER direction of the same mapping, so it cannot pass by answering `Unavailable` to
+    /// everything: a delete in flight is <see cref="NodeDiagnosticsStatus.Absent"/>, because the
+    /// next authoritative answer for that path is "gone" and never "here again".
+    /// </summary>
+    [Fact]
+    public void ADeleteInFlightReadsAbsent_NotUnavailable()
+    {
+        MeshNodeLanguageService.NothingWasChecked(NodeReadOutcome.DeleteInProgress)
+            .Status.Should().Be(NodeDiagnosticsStatus.Absent,
+                "the node is on its way out — 'the read failed' would send the caller retrying "
+                + "something that is deliberately disappearing");
     }
 
     // ────────────────────────────────────── the split is deliberate, and stays


### PR DESCRIPTION
Follow-up to #3912 (Refs #3888), acting on the Copilot review it received. The branch was already in
the merge queue when the review landed, and a queued branch cannot be pushed to — so this is the
same change set's second commit, carried on its own PR rather than dequeued out from under the group
behind it.

## The finding, which is the right one to catch on this change of all changes

> Please add a deterministic test for the `NodeReadStatus.Unavailable` arm … The six new cases cover
> Absent and Compiled/Script, so a regression that maps an unavailable read back to `Compiled` would
> still leave the suite green — the fail-closed guarantee this change is meant to provide.

Correct. #3912 fixed an instrument that could not fail, and shipped **one arm of its own fix with no
control on it**. A wedged owner is the case that made the outcome type worth having in the first
place (#1592: memex-cloud went 2 h 20 m with per-node hubs not answering, and every diagnostics probe
in that window would have read clean), and it was the one arm nothing could have caught going back.

## Why no live-mesh test could reach it

`GetMeshNodeOutcome`'s budget is 15 s and `Unavailable` depends on an owner that will not answer —
not something a `MonolithMeshTestBase` can arrange on demand, and the suite's `methodTimeout` is
30 s. An arm no control can reach is precisely where a regression puts `Compiled` back unnoticed.

So the mapping is **extracted** — `MeshNodeLanguageService.NothingWasChecked(NodeReadOutcome)`, the
WHOLE decision rather than a fragment, the same idiom as `CanReuseWorkspace` three methods below —
and driven directly.

## The controls

| Test | What it pins |
|---|---|
| `NoReadThatProducedNoNodeMayReadAsCompiled` | over `Enum.GetValues<NodeReadStatus>()`: **no** status may render as `Compiled` or `IsClean`, *including one added later* |
| `AnOwnerThatDidNotAnswerIsUnavailable_AndTheReasonSurvives` | the arm itself, plus that the cause reaches `DescribeProblem` — a refusal naming neither path nor reason is only a differently-shaped dead end |
| `ADeleteInFlightReadsAbsent_NotUnavailable` | the other direction, so the mapping cannot pass by answering `Unavailable` to everything |

Enumerating the enum rather than testing per value is deliberate: a per-value test goes **silent** on
a new `NodeReadStatus`, which is the same failure shape as the bug — the next status arrives as a red
instead of as a hole.

**Falsified on purpose.** With the `_` arm returning `Compiled(empty)`, the two new negative controls
go red and 7 of 9 stay green:

```
Failed  NoReadThatProducedNoNodeMayReadAsCompiled
  Did not expect value to be Compiled because a read that produced no node compiled nothing,
  so status Present must not render as a verdict about the proposed source.

Failed  AnOwnerThatDidNotAnswerIsUnavailable_AndTheReasonSurvives
  Expected value to be Unavailable because a hub that did not answer is not a hub that answered
  'fine' — this is the case that makes the pre-flight a gate rather than a nicety, but found Compiled.

Failed! - Failed: 2, Passed: 7, Total: 9
```

Restored: `Passed! - Failed: 0, Passed: 9, Total: 9`.

## The review's second half was a correction to the COMMENT, and it was also right

> `GetMeshNodeOutcome` surfaces Unauthorized via `OnError` and RLS-hidden nodes as `Absent`, so the
> test should target a status that actually reaches this switch (or adjust the comment/contract
> accordingly).

#3912's comment said the `Unavailable` arm covers "a delivery-level denial". It does not. A
delivery-level RLS denial rides a raw `GetDataRequest` whose NACK surfaces as `OnError`
(`DeliveryFailureException`) and is caught at the tool boundary (#2554) — it never reaches this
switch. What *does* reach it via access control is a read validator **hiding** the node: a filtered
node is invisible to the reader by contract, which lands on `Absent`, and that is how #3888's live
case — a NodeType in a partition the caller held no grant on — got there. Both routes now say so
where they are, so the next reader is not sent looking for a denial in the wrong arm.

## Local verification

- `dotnet build src/MeshWeaver.Compiler.Pipeline -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
- `dotnet build test/MeshWeaver.Compiler.Pipeline.Test -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
- `SpeculativeCheckCannotAnswerGreenForAnUncheckedNodeTest` → 9 passed (2 red under the sabotage above)
- `MeshWeaver.Documentation.Test` link/embed/topic/timeout guards → 18 passed

`Doc/Architecture/LanguageServices` records the general point: **an arm no live test can reach is not
an excuse, it is an instruction to extract the decision** and assert the invariant over the enum
rather than over the values you happened to think of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
