### PR TITLE
docs: totality is not liveness — narrow two overclaims from #3915 (Copilot review)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -451,8 +451,10 @@ looks completed and a caller that waits out its whole budget.
 earlier version of this table judged each leg by *"does it survive the owner being disposed under
 it?"* — a real question, pinned by a real test. But the leg that answers "yes" to that can still
 answer NOBODY when its source **completes empty**, which is a different termination reached by a
-different route. The legs are now composed through `DetachedReplyOutcome.Of`, which converts value /
-fault / empty into exactly one emission, so a leg cannot be silent whatever its source does:
+different route. **Every leg now handles all three of Rx's terminations** — the read leg and the
+inner create by their own explicit third arm, the other three by composing through
+`DetachedReplyOutcome.Of`, which converts value / fault / empty into exactly one emission so the
+subscriber cannot fail to answer:
 
 | leg | trail stage | its source's empty completion |
 |---|---|---|
@@ -461,6 +463,13 @@ fault / empty into exactly one emission, so a leg cannot be silent whatever its 
 | NodeType gate — `ApplyUpdateViaStream` | — | refuses, and says the probe produced no answer rather than "not registered" — a verdict and a non-verdict are not the same answer |
 | update — `WriteThroughStream` | `UPSERT_WRITE_THROUGH_STREAM` | posts a refusal naming the unconfirmed write. Disposal is separately covered: `RegisterOwnerDisposingNack` mints `OwnerDisposing`, the writer re-enqueues against the fresh activation, the caller is answered `success=True` (`UpsertAnswersWhenTheOwnerGoesAwayTest`) |
 | create — `DispatchInnerCreate` | `UPSERT_READ absent → create` | posts a refusal (`UPSERT_CREATE_COMPLETED_EMPTY`), and an `InnerCreateVerdictBound` bounds the no-answer case |
+
+🚨 **None of this bounds a source that NEVER terminates.** `DetachedReplyOutcome.Of` is about the
+three terminations Rx *delivers*; the fourth outcome — never emits, never completes, the section
+"The FOURTH outcome" above — reaches no arm at all, and no composition over the source can invent
+one. A liveness bound stays the leg's own responsibility and is separately present where the
+source can starve: `InnerCreateVerdictBound` on the inner create, `NodeOpForwardTimeout` inside the
+no-op probe. Totality and liveness are different properties; this section is about the first.
 
 ### #3674: the no-op probe is the one that was actually silent, and it is a RE-INSTALL
 

--- a/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
+++ b/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
@@ -19,12 +19,22 @@ namespace MeshWeaver.Mesh;
 ///
 /// <para><b>Totality by construction, not by discipline.</b> Remembering to write a third arm at
 /// each site is exactly the discipline that failed: <c>MeshExtensions</c> states the rule twice in
-/// its own comments and still left the upsert's UPDATE leg on two arms. Composing through
-/// <c>DetachedReplyOutcome.Of</c> makes the source emit <b>exactly one</b> outcome on every path, so the
-/// site cannot be silent whatever the source does — and the leg becomes drivable without a mesh,
-/// which is what makes the empty-completion case testable at all (a live mesh cannot arrange it on
-/// demand — the same reason <c>PresentationScreenExtensions.LastKnownOnFault</c> is observable-in /
-/// observable-out).</para>
+/// its own comments and still left three of its upsert legs on two arms. Composing through
+/// <c>DetachedReplyOutcome.Of</c> turns each of the three terminations Rx DELIVERS into exactly one
+/// outcome, so the site cannot be silent when its source terminates — and the leg becomes drivable
+/// without a mesh, which is what makes the empty-completion case testable at all (a live mesh
+/// cannot arrange it on demand — the same reason
+/// <c>PresentationScreenExtensions.LastKnownOnFault</c> is observable-in / observable-out).</para>
+///
+/// <para>🚨 <b>TOTALITY IS NOT LIVENESS, and this type gives only the first.</b> A source that
+/// never emits AND never completes — <c>Observable.Never</c>, a request whose response is lost, the
+/// starvation shape behind <see href="https://github.com/Systemorph/MeshWeaver/issues/2742">#2742</see>
+/// — reaches no arm at all, and no composition OVER a source can invent a termination it never
+/// produces. Read the guarantee strictly: <i>if the source terminates, exactly one outcome is
+/// emitted.</i> A leg whose source can starve still owes its own <c>Timeout</c>, exactly as
+/// <c>DispatchInnerCreate</c> (<c>InnerCreateVerdictBound</c>) and the no-op probe
+/// (<c>NodeOpForwardTimeout</c>) carry one — and composing through this type neither adds nor
+/// excuses that bound. See <c>Doc/Architecture/WriteVerdictTotality</c> → "The FOURTH outcome".</para>
 ///
 /// <para>🚨 <b>Empty is NOT a value.</b> <c>DefaultIfEmpty()</c> on the source itself would emit
 /// <c>default(T)</c> — <c>null</c> for a reference type — which the value arm then reads as a real
@@ -53,8 +63,10 @@ internal readonly record struct DetachedReplyOutcome<T>(bool HasValue, T? Value,
 internal static class DetachedReplyOutcome
 {
     /// <summary>
-    /// <c>value → HasValue</c>, <c>fault → Error</c>, <c>completed empty → CompletedEmpty</c> —
-    /// one emission on every path, so a subscriber cannot fail to answer.
+    /// <c>value → HasValue</c>, <c>fault → Error</c>, <c>completed empty → CompletedEmpty</c> — one
+    /// emission for each of the three terminations Rx delivers, so a subscriber cannot fail to
+    /// answer a source that TERMINATES. It adds no deadline: a source that never terminates still
+    /// reaches nobody, and bounding that is the caller's own job (see the type's remarks).
     ///
     /// <para><c>Take(1)</c> comes FIRST so the outcome is the source's own first terminal: a
     /// source that emits and then faults has already answered, and its late fault must not


### PR DESCRIPTION
Follow-up to #3915 (merged). Copilot found **two accuracy defects in what that change wrote about itself**; the fixes were ready but the PR had already been enqueued, and a queued branch cannot be updated. Documentation only — no behaviour change, no `src/` logic touched.

## 1. The doc claimed a construction that covers three of five legs

It said *"the legs are now composed through `DetachedReplyOutcome.Of`"*. The read leg and `DispatchInnerCreate` carry their own **explicit third arm** instead — only the no-op probe, the NodeType gate and the update leg use the helper. The per-leg table was already accurate; the introduction above it was not.

Reworded to the true claim: *"Every leg now handles all three of Rx's terminations — the read leg and the inner create by their own explicit third arm, the other three by composing through `DetachedReplyOutcome.Of`."*

## 2. 🚨 Totality is not liveness, and the summary conflated them

`DetachedReplyOutcome.Of`'s remarks promised one outcome *"on every path"* for *"any source"*. **That is false for the fourth outcome the very same doc page has a section about** — a source that never emits **and** never completes (`Observable.Never`, a lost response, the starvation shape behind #2742) reaches no arm at all, and no composition *over* a source can invent a termination it never produces.

The guarantee is now stated strictly:

> *if the source terminates, exactly one outcome is emitted.*

…with the #2742 shape named, and with the explicit statement that a leg whose source can starve **still owes its own `Timeout`** — pointing at the two that already carry one (`InnerCreateVerdictBound` on the inner create, `NodeOpForwardTimeout` inside the no-op probe) — and that composing through this type **neither adds nor excuses** that bound. The doc page carries the same caveat beside the table.

This is the more important of the two: a helper documented as making silence impossible is precisely the kind of standing claim a later reader stops checking.

## Not fixed here, and why

The same review found the upsert handler's **failure** surface English-only while its success surface is keyed. That is real, pre-existing and file-wide — `PostFail` has no key parameter and all **16** of its call sites pass literals — so keying only the three messages #3915 added would deepen the inconsistency rather than reduce it (German for "the probe produced no answer", English for "the probe faulted", in the same dialog). Filed with its scope written out as **#3917**, including the decision nobody has made about whether the wire field `*Response.Error` is itself localized.

## Verification

`Mesh.Contract`, `Documentation`, `Documentation.Test` each `0 Error(s)` in Release with `-warnaserror`; `DocumentationLinkIntegrityTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
