### PR TITLE
docs: Timeout DOES manufacture a termination — fix the over-correction from #3919

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -467,8 +467,11 @@ subscriber cannot fail to answer:
 🚨 **None of this bounds a source that NEVER terminates.** `DetachedReplyOutcome.Of` is about the
 three terminations Rx *delivers*; the fourth outcome — never emits, never completes, the section
 "The FOURTH outcome" above — reaches no arm at all, and `Of` cannot rescue it, because every
-operator it applies **reacts** to a termination and none **manufactures** one. The operator that
-manufactures one is `Timeout`, and it is separately present where the source can starve:
+operator it applies is **notification-driven**: `Take(1)` synthesises a completion but only *after
+a value*, `Catch` substitutes a sequence but only *after a fault*, `DefaultIfEmpty` fires only *on
+a completion*. From a source that has produced nothing, none of them can fire. The one
+**clock**-driven operator is `Timeout`, which is why it — and only it — can terminate a silent
+source; it is separately present where the source can starve:
 `InnerCreateVerdictBound` on the inner create, `NodeOpForwardTimeout` inside the no-op probe.
 Compose `Of` **around** that bound and both properties hold — the timeout supplies liveness, `Of`
 turns whichever termination arrives into an answer. Totality and liveness are different properties;

--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -466,10 +466,13 @@ subscriber cannot fail to answer:
 
 🚨 **None of this bounds a source that NEVER terminates.** `DetachedReplyOutcome.Of` is about the
 three terminations Rx *delivers*; the fourth outcome — never emits, never completes, the section
-"The FOURTH outcome" above — reaches no arm at all, and no composition over the source can invent
-one. A liveness bound stays the leg's own responsibility and is separately present where the
-source can starve: `InnerCreateVerdictBound` on the inner create, `NodeOpForwardTimeout` inside the
-no-op probe. Totality and liveness are different properties; this section is about the first.
+"The FOURTH outcome" above — reaches no arm at all, and `Of` cannot rescue it, because every
+operator it applies **reacts** to a termination and none **manufactures** one. The operator that
+manufactures one is `Timeout`, and it is separately present where the source can starve:
+`InnerCreateVerdictBound` on the inner create, `NodeOpForwardTimeout` inside the no-op probe.
+Compose `Of` **around** that bound and both properties hold — the timeout supplies liveness, `Of`
+turns whichever termination arrives into an answer. Totality and liveness are different properties;
+this section is about the first.
 
 ### #3674: the no-op probe is the one that was actually silent, and it is a RE-INSTALL
 

--- a/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
+++ b/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
@@ -29,12 +29,16 @@ namespace MeshWeaver.Mesh;
 /// <para>🚨 <b>TOTALITY IS NOT LIVENESS, and this type gives only the first.</b> A source that
 /// never emits AND never completes — <c>Observable.Never</c>, a request whose response is lost, the
 /// starvation shape behind <see href="https://github.com/Systemorph/MeshWeaver/issues/2742">#2742</see>
-/// — reaches no arm at all, and no composition OVER a source can invent a termination it never
-/// produces. Read the guarantee strictly: <i>if the source terminates, exactly one outcome is
-/// emitted.</i> A leg whose source can starve still owes its own <c>Timeout</c>, exactly as
-/// <c>DispatchInnerCreate</c> (<c>InnerCreateVerdictBound</c>) and the no-op probe
-/// (<c>NodeOpForwardTimeout</c>) carry one — and composing through this type neither adds nor
-/// excuses that bound. See <c>Doc/Architecture/WriteVerdictTotality</c> → "The FOURTH outcome".</para>
+/// — reaches no arm at all, and <c>Of</c> cannot rescue it: every operator it applies
+/// (<c>Take(1)</c>, <c>Select</c>, <c>Catch</c>, <c>DefaultIfEmpty</c>) reacts to a termination and
+/// none MANUFACTURES one. Read the guarantee strictly: <i>if the source terminates, exactly one
+/// outcome is emitted.</i> The operator that DOES manufacture a termination is <c>Timeout</c> — it
+/// is a composition over the source too, and it is the right tool here — so a leg whose source can
+/// starve still owes its own, exactly as <c>DispatchInnerCreate</c>
+/// (<c>InnerCreateVerdictBound</c>) and the no-op probe (<c>NodeOpForwardTimeout</c>) carry one.
+/// Compose <c>Of</c> AROUND that bound and both properties hold; composing through this type alone
+/// neither adds nor excuses it. See <c>Doc/Architecture/WriteVerdictTotality</c> → "The FOURTH
+/// outcome".</para>
 ///
 /// <para>🚨 <b>Empty is NOT a value.</b> <c>DefaultIfEmpty()</c> on the source itself would emit
 /// <c>default(T)</c> — <c>null</c> for a reference type — which the value arm then reads as a real
@@ -65,8 +69,10 @@ internal static class DetachedReplyOutcome
     /// <summary>
     /// <c>value → HasValue</c>, <c>fault → Error</c>, <c>completed empty → CompletedEmpty</c> — one
     /// emission for each of the three terminations Rx delivers, so a subscriber cannot fail to
-    /// answer a source that TERMINATES. It adds no deadline: a source that never terminates still
-    /// reaches nobody, and bounding that is the caller's own job (see the type's remarks).
+    /// answer a source that TERMINATES. <b>It adds no deadline</b> — none of its operators
+    /// manufactures a termination, they only react to one — so a source that never terminates still
+    /// reaches nobody. Bounding that is a <c>Timeout</c> the caller composes UNDER this (see the
+    /// type's remarks).
     ///
     /// <para><c>Take(1)</c> comes FIRST so the outcome is the source's own first terminal: a
     /// source that emits and then faults has already answered, and its late fault must not

--- a/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
+++ b/src/MeshWeaver.Mesh.Contract/DetachedReplyOutcome.cs
@@ -29,12 +29,15 @@ namespace MeshWeaver.Mesh;
 /// <para>🚨 <b>TOTALITY IS NOT LIVENESS, and this type gives only the first.</b> A source that
 /// never emits AND never completes — <c>Observable.Never</c>, a request whose response is lost, the
 /// starvation shape behind <see href="https://github.com/Systemorph/MeshWeaver/issues/2742">#2742</see>
-/// — reaches no arm at all, and <c>Of</c> cannot rescue it: every operator it applies
-/// (<c>Take(1)</c>, <c>Select</c>, <c>Catch</c>, <c>DefaultIfEmpty</c>) reacts to a termination and
-/// none MANUFACTURES one. Read the guarantee strictly: <i>if the source terminates, exactly one
-/// outcome is emitted.</i> The operator that DOES manufacture a termination is <c>Timeout</c> — it
-/// is a composition over the source too, and it is the right tool here — so a leg whose source can
-/// starve still owes its own, exactly as <c>DispatchInnerCreate</c>
+/// — reaches no arm at all, and <c>Of</c> cannot rescue it. Every operator it applies is
+/// NOTIFICATION-DRIVEN: each one needs an upstream notification before it can do anything.
+/// <c>Take(1)</c> does synthesise a completion — but only <i>after a value</i>; <c>Catch</c> does
+/// substitute a sequence — but only <i>after a fault</i>; <c>DefaultIfEmpty</c> fires only <i>on a
+/// completion</i>. From a source that has produced NOTHING, none of them can fire at all. Read the
+/// guarantee strictly: <i>if the source terminates, exactly one outcome is emitted.</i>
+/// <c>Timeout</c> is the exception, and the reason is the useful part — it is CLOCK-driven, so it
+/// is the one composition that can terminate a silent source. A leg whose source can starve
+/// therefore still owes its own, exactly as <c>DispatchInnerCreate</c>
 /// (<c>InnerCreateVerdictBound</c>) and the no-op probe (<c>NodeOpForwardTimeout</c>) carry one.
 /// Compose <c>Of</c> AROUND that bound and both properties hold; composing through this type alone
 /// neither adds nor excuses it. See <c>Doc/Architecture/WriteVerdictTotality</c> → "The FOURTH
@@ -69,10 +72,10 @@ internal static class DetachedReplyOutcome
     /// <summary>
     /// <c>value → HasValue</c>, <c>fault → Error</c>, <c>completed empty → CompletedEmpty</c> — one
     /// emission for each of the three terminations Rx delivers, so a subscriber cannot fail to
-    /// answer a source that TERMINATES. <b>It adds no deadline</b> — none of its operators
-    /// manufactures a termination, they only react to one — so a source that never terminates still
-    /// reaches nobody. Bounding that is a <c>Timeout</c> the caller composes UNDER this (see the
-    /// type's remarks).
+    /// answer a source that TERMINATES. <b>It adds no deadline</b> — every operator it applies is
+    /// notification-driven, so none of them can fire while the source is silent — and a source that
+    /// never terminates therefore still reaches nobody. Bounding that needs the one CLOCK-driven
+    /// operator, a <c>Timeout</c> the caller composes UNDER this (see the type's remarks).
     ///
     /// <para><c>Take(1)</c> comes FIRST so the outcome is the source's own first terminal: a
     /// source that emits and then faults has already answered, and its late fault must not


### PR DESCRIPTION
Follow-up to #3919 (merged). Documentation only.

🚨 **Opened as a DRAFT on purpose.** `auto-arm.yml` arms every non-draft PR, and both previous PRs in this chain were enqueued *before* the Copilot review landed — a queued branch cannot be updated, so each round of review had to become another PR. Draft is the documented opt-out. It will be marked ready once review has landed and been addressed, which is where this loop stops.

## The over-correction

#3919 replaced one overbroad claim with another. It said:

> no composition over the source can invent a termination it never produces

**That is false, and self-contradicting two sentences later** — the very same paragraph names `Timeout` as what supplies liveness, and `Timeout` *is* a composition over a source that manufactures an `OnError` when the source is silent. Copilot flagged it at all three sites.

## The fix, stated positively

The limitation is specific to `DetachedReplyOutcome.Of`, and now the **reason** is given rather than the claim merely narrowed:

> every operator `Of` applies — `Take(1)`, `Select`, `Catch`, `DefaultIfEmpty` — **reacts** to a termination; none **manufactures** one.

`Timeout` manufactures one, which is exactly what makes it the right tool for the fourth outcome. So the guidance is now actionable instead of merely cautionary:

> Compose `Of` **around** a `Timeout` and both properties hold — the timeout supplies liveness, `Of` turns whichever termination arrives into an answer.

which is, not by accident, what `DispatchInnerCreate` (`.Take(1).Timeout(InnerCreateVerdictBound)`) and the no-op probe (`.Timeout(NodeOpForwardTimeout)`) already do.

Applied at the three sites named: the type's remarks, the `Of` summary, and the doc page's caveat.

## Verification

`Mesh.Contract`, `Documentation`, `Documentation.Test` each `0 Error(s)` in Release with `-warnaserror`; `DocumentationLinkIntegrityTest` green.

Chain: #3915 (the fix, merged) → #3919 (narrowed two overclaims, merged) → this. Related: #3917 (the pre-existing i18n gap in the upsert failure surface), #3674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
