### PR TITLE
fix: say when an installed package's declared module has no binary here

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-package-whose-module-never-lands-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-package-whose-module-never-lands-says-so.md
@@ -1,0 +1,14 @@
+---
+nodeType: WhatsNew
+Name: A package whose module never lands now says so
+Category: Fix
+Description: An installed package that declares a compiled module whose assembly is not on this installation is named once at boot, instead of reporting a clean install while half of it is missing.
+Icon: Sparkle
+Order: -20260910
+---
+
+# A package whose module never lands now says so
+
+A package that declares a compiled module arrives in two halves: its nodes come with the package, and its layout areas and node types come only with the module. Installing the first half and not the second lost the second in silence. Every surface read clean — the package was installed, the install record named the module, the boot reconcile reported it up to date, and its guide page rendered. Only the areas were absent, and nothing anywhere said why. On a course that is the certificate: a learner could finish, receive a correct certificate, and find no way to export it.
+
+Boot now names those packages once, with the module each one declares and what is missing because of it. The check asks the boot loader's own question — the same resolution the module loader uses, then the activation record — so a bundle that has landed and is only waiting for a restart is not reported as absent. It is a warning and never a refusal: a portal that will not start cannot be given the module it is missing.

--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Hosting.Persistence.Parsers;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -78,12 +79,71 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                         .Do(_ => logger?.LogInformation(
                             "[PackageRepair] reconciled declared access + install hooks for {Count} "
                             + "installed partition(s)", records.Count)))
+                .Do(_ => ReportDeclaredModulesWithNoBinary(records, logger))
                 .SelectMany(_ => VerifyCompleteness(records, logger)))
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex, "[PackageRepair] repair pass failed"));
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// 🚨 <b>Say when an installed package's DECLARED MODULE has no binary here — the half of a
+    /// mixed package that goes missing in total silence (Systemorph/MeshWeaver.Plugins#1597).</b>
+    ///
+    /// <para>The sibling of the <c>[InstallCompleteness]</c> lines below, asking the same question
+    /// about the OTHER half of the package. Those verdicts count the NODES an install owed the
+    /// mesh; a package that also declares <c>content.module</c> owes it a compiled assembly too,
+    /// and nothing counted that. So the record read up to date, the guide page rendered, and every
+    /// layout area the module serves answered <i>Area not found</i> — measured on a
+    /// <c>memex-local</c> self-registry install where <c>Export</c> was installed and
+    /// <c>MeshWeaver.Markdown.Export.dll</c> was in neither <c>/app</c> nor <c>/app/modules</c>,
+    /// because a mounted checkout can never land a module BINARY (Systemorph/MeshWeaver#2417).</para>
+    ///
+    /// <para><b>The probe is the boot loader's own resolution</b>, not a re-derivation:
+    /// <see cref="MeshBuilder.ResolveModulePath(string,string?)"/> (landed root → image
+    /// <c>modules/</c> → app closure) and then the activation sidecar, so a bundle that HAS landed
+    /// as a generation and is merely waiting for a restart is not reported as absent. A report that
+    /// fired on the normal minutes after an install would be one nobody reads by the second week.</para>
+    ///
+    /// <para>🚨 <b>One line, warning, never a failure.</b> It cannot fail the boot: a portal that
+    /// will not start cannot be given the module it is missing — the same deadlock
+    /// <see cref="ModuleLoadReport"/> refuses to create, and the reason <c>Modules:Required</c> is
+    /// the wrong home for this (a required module that cannot land fails readiness and the portal
+    /// never serves at all).</para>
+    /// </summary>
+    private void ReportDeclaredModulesWithNoBinary(
+        IReadOnlyList<InstalledRecord> records, ILogger? logger)
+    {
+        // 🚨 No configuration ⇒ no module root ⇒ nothing is KNOWN, and the report says nothing
+        // rather than clearing every package. Same rule as the null probe on BinaryAbsent.
+        if (hub.ServiceProvider.GetService<IConfiguration>() is not { } configuration)
+            return;
+
+        var moduleRoot = ModuleRoot.Resolve(configuration);
+        var activation = ModuleActivationSidecar.Read(moduleRoot);
+        var landed = activation.Entries
+            .ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+
+        var absent = ModuleDelivery.BinaryAbsent(
+            records.Select(record => record.Manifest),
+            module => File.Exists(MeshBuilder.ResolveModulePath($"{module}.dll", moduleRoot))
+                || (landed.TryGetValue(module, out var entry)
+                    && ModuleActivationBoot.LandedModuleDllExists(moduleRoot, entry)));
+
+        if (absent.IsEmpty)
+            return;
+
+        logger?.LogWarning(
+            "[PackageRepair] {Count} installed package(s) declare a compiled module whose assembly "
+            + "is not on this installation: [{Packages}]. Their NODES are installed and their pages "
+            + "render; every layout area and node type the module serves is ABSENT, and the install "
+            + "record says the package is up to date. Nothing here can produce the bytes — a mounted "
+            + "checkout never lands a module binary (MeshWeaver#2417). Install the package from a "
+            + "registry that serves its bundle, or ship the module in the image (a MeshModuleClosure "
+            + "row AND a Modules:Assemblies entry — the two move together or neither works).",
+            absent.Count, string.Join(", ", absent.Select(u => u.Describe())));
     }
 
     /// <summary>

--- a/src/MeshWeaver.PluginCatalog/ModuleDelivery.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleDelivery.cs
@@ -101,6 +101,64 @@ public static class ModuleDelivery
     }
 
     /// <summary>
+    /// 🚨 <b>The install records whose declared module HAS NO BINARY on this installation — the
+    /// half of a mixed package that can go missing in total silence
+    /// (Systemorph/MeshWeaver.Plugins#1597).</b>
+    ///
+    /// <para><b>Why <see cref="NotOffered"/> does not cover it.</b> That answers whether the
+    /// REGISTRY offered the package, and offering is not delivering. A self-registry install offers
+    /// its own checkout perfectly well and still cannot produce a module: a mounted checkout can
+    /// never land a module BINARY (Systemorph/MeshWeaver#2417). So the unreported state is the next
+    /// one along — offered, installed, its nodes present, and no lane here able to produce the
+    /// bytes its layout areas and node types live in.</para>
+    ///
+    /// <para><b>What that costs, measured.</b> On a <c>memex-local</c> self-registry install
+    /// (platform 3.0.0-ci.8118) the <c>Export</c> package was installed, <c>Export/Guide</c>
+    /// rendered, and <c>get @Export/Guide/area/ExportPdf</c> answered <i>Area not found</i>; the
+    /// node menu carried no Export group at all and <c>MeshWeaver.Markdown.Export.dll</c> was in
+    /// neither <c>/app</c> nor <c>/app/modules</c>. The package reported a clean install throughout.
+    /// It is invisible until someone tries to export, which on a course is the CERTIFICATE — the one
+    /// artefact a learner is meant to keep.</para>
+    ///
+    /// <para>🚨 <b>It REPORTS. It never refuses.</b> The same discipline
+    /// <see cref="ModuleLoadReport"/> keeps and for the same reason: a portal that will not boot
+    /// cannot be given the fix for whatever is wrong with it. Nor is it an entitlement verdict or a
+    /// fault — which modules a deployment SHOULD carry is a policy question this does not answer.
+    /// Making the shortfall visible is the whole deliverable.</para>
+    ///
+    /// <para>Pure and total, like <see cref="NotOffered"/>: the caller supplies the probe, so the
+    /// rule is testable with no filesystem, no registry and no host.</para>
+    /// </summary>
+    /// <param name="installedRecords">This installation's install records (<c>Plugins/*</c>).
+    /// Nulls — an unreadable record's content — and records with no id are skipped.</param>
+    /// <param name="moduleBinaryExists">Whether a module's ENTRY ASSEMBLY resolves through any lane
+    /// this installation has: the app closure, the image's <c>modules/</c> seed, or a landed
+    /// generation. 🚨 Null means NOTHING IS KNOWN, and the answer is then empty rather than "every
+    /// package is fine" — a probe that cannot be consulted must not clear anything.</param>
+    public static ImmutableList<UndeliveredModule> BinaryAbsent(
+        IEnumerable<PackageManifest?>? installedRecords,
+        Func<string, bool>? moduleBinaryExists)
+    {
+        if (moduleBinaryExists is null)
+            return [];
+
+        return (installedRecords ?? [])
+            // 🚨 A content-only record is not probed AT ALL, not merely excluded from the result.
+            // Its whole delivery is the content lane, so there are no module bytes to be missing —
+            // and probing for a module no record declares would put a name in the log that nothing
+            // ever claimed. Most installed packages are content-only, so naming them would bury the
+            // ones that really have lost half of themselves.
+            .Where(record => record is not null
+                && !string.IsNullOrWhiteSpace(record.Id)
+                && !string.IsNullOrWhiteSpace(record.Module))
+            .Where(record => !moduleBinaryExists(record!.Module!))
+            .Select(record => new UndeliveredModule(
+                record!.Id, record.Name, record.Module, record.ModuleVersion))
+            .OrderBy(u => u.PackageId, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableList();
+    }
+
+    /// <summary>
     /// The packages NO configured registry offers — the consumer-wide verdict a surface renders as
     /// <b>not delivered</b>, read off the ledger <see cref="RegistryUpdateReconciler"/> owns.
     ///

--- a/test/Memex.Portal.Shared.Test/DeclaredModuleWithNoBinaryIsReportedTest.cs
+++ b/test/Memex.Portal.Shared.Test/DeclaredModuleWithNoBinaryIsReportedTest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A MIXED PACKAGE WHOSE MODULE NEVER LANDS MUST SAY SO — never report a clean install
+/// (Systemorph/MeshWeaver.Plugins#1597).</b>
+///
+/// <para>A package that declares <c>content.module</c> arrives in two halves: its NODES come with
+/// the package, its layout areas and node types come only with the compiled module. Installing the
+/// first half and not the second is a SILENT and TOTAL loss of the second, and every surface reads
+/// clean: the package is <c>preInstalled</c>, its install record names the module, the boot
+/// reconcile reports it up to date, its guide page renders, and only the areas are absent.</para>
+///
+/// <para>Measured on a <c>memex-local</c> self-registry install, platform 3.0.0-ci.8118: the
+/// <c>Export</c> package was installed and <c>Export/Guide</c> rendered, while
+/// <c>get @Export/Guide/area/ExportPdf</c> answered <i>Area not found</i> and the node menu carried
+/// no Export group at all. <c>MeshWeaver.Markdown.Export.dll</c> was in neither <c>/app</c> nor
+/// <c>/app/modules</c>, and a mounted checkout can never land a module BINARY
+/// (Systemorph/MeshWeaver#2417). Walking a course to completion issues a correct certificate that
+/// cannot then be exported — and nothing anywhere says why.</para>
+///
+/// <para><see cref="ModuleDelivery.NotOffered"/> does not cover this and cannot: it answers whether
+/// the REGISTRY offered the package, and a self-registry install offers its own checkout perfectly
+/// well. The unreported state is the next one along — offered, installed, and the binary still has
+/// no lane that can produce it here.</para>
+///
+/// <para>🚨 This REPORTS. It never refuses, and it is not an entitlement verdict — the same
+/// discipline <see cref="ModuleLoadReport"/> keeps, and for the same reason: a portal that will not
+/// boot cannot be given the fix for whatever is wrong with it. Which modules a deployment SHOULD
+/// carry is a policy question this does not answer; making the shortfall visible is the whole
+/// deliverable.</para>
+/// </summary>
+public class DeclaredModuleWithNoBinaryIsReportedTest
+{
+    private static PackageManifest Package(string id, string? module, string? version = null) =>
+        new() { Id = id, Name = id, Module = module, ModuleVersion = version };
+
+    /// <summary>Present exactly for the modules named here; absent for everything else.</summary>
+    private static Func<string, bool> Present(params string[] modules)
+    {
+        var set = modules.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return set.Contains;
+    }
+
+    [Fact]
+    public void ADeclaredModuleWithNoBinaryOnThisInstallationIsNamed()
+    {
+        var absent = ModuleDelivery.BinaryAbsent(
+            [Package("Export", "MeshWeaver.Markdown.Export", "1.3")],
+            Present());
+
+        var only = Assert.Single(absent);
+        Assert.Equal("Export", only.PackageId);
+        Assert.Equal("MeshWeaver.Markdown.Export", only.Module);
+        // The claimed identity rides along, because that is what makes the shape legible: the
+        // record says 1.3 while there is no assembly at all.
+        Assert.Equal("1.3", only.InstalledModuleVersion);
+        Assert.Contains("MeshWeaver.Markdown.Export", only.Describe(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AModuleWhoseBinaryIsHereIsNotNamed()
+    {
+        Assert.Empty(ModuleDelivery.BinaryAbsent(
+            [Package("Mcp", "MeshWeaver.Mcp")],
+            Present("MeshWeaver.Mcp")));
+    }
+
+    /// <summary>
+    /// 🚨 The negative that keeps this usable. Most installed packages are content-only, and naming
+    /// them would bury the ones that have actually lost half of themselves — the annotation-on-every
+    /// -green-run failure this repo has met before.
+    /// </summary>
+    [Fact]
+    public void AContentOnlyPackageIsNeverNamed_AndIsNeverEvenProbed()
+    {
+        var probed = new List<string>();
+        var absent = ModuleDelivery.BinaryAbsent(
+            [Package("Northwind", null), Package("Chess", "   ")],
+            module => { probed.Add(module); return false; });
+
+        Assert.Empty(absent);
+        // Probing the filesystem for a module nobody declared would put a name in the log that no
+        // install record ever claimed.
+        Assert.Empty(probed);
+    }
+
+    [Fact]
+    public void EveryDeclaredModuleIsProbedExactlyOnce()
+    {
+        var probed = new List<string>();
+        ModuleDelivery.BinaryAbsent(
+            [Package("Export", "MeshWeaver.Markdown.Export"), Package("Voice", "MeshWeaver.Speech")],
+            module => { probed.Add(module); return false; });
+
+        Assert.Equal(["MeshWeaver.Markdown.Export", "MeshWeaver.Speech"], probed.Order());
+        Assert.Equal(2, probed.Count);
+    }
+
+    /// <summary>Ordered and case-insensitive on the package id — the same comparison every other
+    /// install-record lookup on this path uses, so two readings never disagree on order.</summary>
+    [Fact]
+    public void TheReportIsOrderedByPackageId()
+    {
+        var absent = ModuleDelivery.BinaryAbsent(
+            [Package("voice", "MeshWeaver.Speech"), Package("Export", "MeshWeaver.Markdown.Export")],
+            Present());
+
+        Assert.Equal(["Export", "voice"], absent.Select(u => u.PackageId));
+    }
+
+    /// <summary>An unreadable record's content arrives as null, and a record with no id is not a
+    /// record. Neither may take down a boot-time report.</summary>
+    [Fact]
+    public void NullsAndIdlessRecordsAreSkipped_AndNullInputIsEmpty()
+    {
+        Assert.Empty(ModuleDelivery.BinaryAbsent(null, Present()));
+        Assert.Empty(ModuleDelivery.BinaryAbsent(
+            [null, Package("", "MeshWeaver.Markdown.Export")], Present()));
+    }
+
+    /// <summary>🚨 A probe that cannot be consulted must not silently answer "everything is fine".
+    /// No probe means nothing is known, and the report says nothing rather than clearing every
+    /// package.</summary>
+    [Fact]
+    public void WithNoProbeNothingIsClaimed()
+    {
+        Assert.Empty(ModuleDelivery.BinaryAbsent(
+            [Package("Export", "MeshWeaver.Markdown.Export")], null));
+    }
+}


### PR DESCRIPTION
Addresses the reporting half of Systemorph/MeshWeaver.Plugins#1597.

A package that declares `content.module` arrives in two halves: its **nodes** come with the package, its **layout areas and node types** come only with the compiled module. Installing the first half and not the second was a silent and total loss of the second — the install record read up to date, the guide page rendered, and every area the module serves answered *Area not found*.

Measured on a `memex-local` self-registry install (platform `3.0.0-ci.8118`): `Export` was installed and `Export/Guide` rendered, while `MeshWeaver.Markdown.Export.dll` was in neither `/app` nor `/app/modules`, because a mounted checkout can never land a module **binary** (#2417). Walking a course to completion issues a correct certificate that cannot then be exported.

## Why `NotOffered` cannot cover it

`ModuleDelivery.NotOffered` answers whether the **registry offered** the package. A self-registry install offers its own checkout perfectly well and still lands no binary. The unreported state is the next one along — offered, installed, its nodes present, and no lane here able to produce the bytes. `BinaryAbsent` is its sibling, in the same file, same shape: pure, total, caller supplies the probe.

## Where it is reported

`InstalledPackageRepairService`, beside the `[InstallCompleteness]` verdicts that already say *"the install record says this package is up to date; the mesh disagrees"*. Those count the **nodes** an install owed the mesh; a package that also declares a module owes it an assembly, and nothing counted that.

The probe is the boot loader's own resolution — `MeshBuilder.ResolveModulePath` (landed root -> image `modules/` -> app closure), then the activation sidecar — so a bundle that **has** landed and is merely waiting for a restart is not named. A report that fired on the normal minutes after an install is one nobody reads by the second week.

## What it deliberately does not do

1. **It never refuses.** A portal that will not boot cannot be given the module it is missing — the same deadlock `ModuleLoadReport` refuses to create, and the reason `Modules:Required` is the wrong home: a required module that cannot land fails readiness and the portal never serves at all.
2. **Content-only packages are never named, and never even probed.** Most installed packages are content-only; naming them would bury the ones that really have lost half of themselves.
3. **It is not a policy verdict.** Whether `MeshWeaver.Markdown.Export` should also ship in the image is a separate decision, left on Plugins#1597 with its measured cost.

## Verification

- `test/Memex.Portal.Shared.Test` — **1254 passed, 0 failed**, including the 7 new cases and the existing `UndeliveredModuleIsRecordedTest`.
- Red first: `CS0117: 'ModuleDelivery' does not contain a definition for 'BinaryAbsent'` x7.
- `dotnet build MeshWeaver.slnx -c Release -warnaserror` — clean.

`Pairs-with: none` — the diff removes no public type and no public member; it adds one static method and one private method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FHnXTQ8XrfKZ2x3ijkFXv
