### PR TITLE
fix: the bake sweep no longer rebuilds what this process just adopted (#3703)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeAdoptionRegistry.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeAdoptionRegistry.cs
@@ -1,14 +1,53 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
 
 namespace MeshWeaver.Graph.Configuration;
 
 /// <summary>
-/// Which NodeTypes have a PREBUILT ADOPTION in flight right now — the interlock that stops the
-/// first-build kickoff from racing (and throwing away) an adoption that is already under way.
+/// What THIS process stamped on a NodeType when it adopted prebuilt bytes for it — the record the
+/// adoption WROTE, plus the node version it was written over.
+/// </summary>
+/// <param name="NodeTypePath">The NodeType's mesh path.</param>
+/// <param name="ObservedVersion">The <see cref="MeshNode.Version"/> the adoption READ before its
+/// own write. The write bumps the node, so any snapshot at or below this version provably PREDATES
+/// the adoption, and any snapshot above it provably contains it (or something later still).</param>
+/// <param name="Definition">The definition the adoption stamped: live framework, the producer's
+/// validated dependency record, and the <c>LastCompiledVersion</c> the bytes were uploaded under.</param>
+/// <param name="At">When the stamp was written, for the log line that reports it.</param>
+public sealed record AdoptedStamp(
+    string NodeTypePath,
+    long ObservedVersion,
+    NodeTypeDefinition Definition,
+    DateTimeOffset At);
+
+/// <summary>
+/// The result of laying this process's own adoption stamps over an enumeration snapshot —
+/// see <see cref="NodeTypeAdoptionRegistry.OverlayOnto"/>.
+/// </summary>
+/// <param name="Definitions">The definitions to classify from.</param>
+/// <param name="Applied">The paths whose definition came from this process's own write because the
+/// snapshot provably predated it. 🚨 This is the count that makes an adoption report and a bake
+/// report commensurable — see <c>Doc/Architecture/AdoptionAndTheSweepCountDifferentThings</c>.</param>
+public sealed record AdoptionOverlay(
+    ImmutableDictionary<string, NodeTypeDefinition?> Definitions,
+    ImmutableList<string> Applied);
+
+/// <summary>
+/// What this process's PREBUILT ADOPTIONS are doing, in both tenses: which NodeTypes have one in
+/// flight RIGHT NOW (the interlock that stops the first-build kickoff from racing an adoption that
+/// is already under way), and which ones this process has already STAMPED (the ledger that stops
+/// the bake sweep from judging an adopted type off a projection that predates the stamp — #3703,
+/// <see cref="RecordAdopted"/>).
+///
+/// <para>Both halves close the same shape of race: a reader is about to decide something about a
+/// NodeType from information that is older than an adoption this process has made. The reservation
+/// closes it for the KICKOFF, which reads BEFORE the write; the ledger closes it for the SWEEP,
+/// which reads after the write but from a source that has not caught up.</para>
 ///
 /// <para><b>The race this closes, measured 2026-08-22.</b> Adopting a prebuilt assembly requires
 /// writing the NodeType's node, and that write goes through the type's OWN hub — so
@@ -109,6 +148,115 @@ public sealed class NodeTypeAdoptionRegistry
             // Subscribe callback on the emission thread" shape the compile watcher is explicitly
             // built to avoid.
             .ObserveOn(TaskPoolScheduler.Default));
+
+    // ---- The adoption LEDGER: what this process actually stamped -----------------------------
+
+    // Instance map on a mesh-scoped singleton, exactly like `reserved` above — never static, so its
+    // lifetime IS the mesh's and nothing bleeds across tests or partitions.
+    private readonly ConcurrentDictionary<string, AdoptedStamp> stamped =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Record that this process stamped <paramref name="definition"/> on
+    /// <paramref name="nodeTypePath"/>, over the node as it stood at
+    /// <paramref name="observedVersion"/>.
+    ///
+    /// <para>🚨 <b>Why the process has to remember this at all.</b> The bake sweep decides what to
+    /// compile from ONE mesh-wide enumeration (<c>Query&lt;MeshNode&gt;(…).Take(1)</c>), which is a
+    /// PROJECTION — eventually consistent, and therefore able to answer with records that predate
+    /// writes this same process has already made. On memex's 2026-09-08 00:31 cold boot the seeding
+    /// pass adopted 78 assemblies and the sweep ten seconds later classified 201 types
+    /// <c>FrameworkStale</c> from a snapshot that still carried the PREVIOUS framework's records
+    /// (#3703): 197 compiles instead of ~20, and the reachability that let a short source-discovery
+    /// pass turn four adopted <c>Doc/**</c> types into false regressions (#3663).</para>
+    ///
+    /// <para>Nothing in the classification can see that, because a stale projection and a genuinely
+    /// stale record are the SAME bytes. The process's own write is the one fact that distinguishes
+    /// them, and it was being thrown away — <c>SeedAll</c> emitted a count and nothing else.</para>
+    /// </summary>
+    /// <param name="nodeTypePath">The NodeType's mesh path.</param>
+    /// <param name="observedVersion">The node version the adoption read BEFORE its own write.</param>
+    /// <param name="definition">The definition the adoption stamped.</param>
+    public void RecordAdopted(string nodeTypePath, long observedVersion, NodeTypeDefinition definition)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(nodeTypePath);
+        ArgumentNullException.ThrowIfNull(definition);
+        var stamp = new AdoptedStamp(
+            nodeTypePath, observedVersion, definition, DateTimeOffset.UtcNow);
+        // Last writer wins on purpose: two bundles can carry the same node path, and the LATER
+        // adoption is the one whose bytes the store key now names.
+        stamped.AddOrUpdate(nodeTypePath, stamp, (_, _) => stamp);
+    }
+
+    /// <summary>Every stamp this process has written, as a snapshot.</summary>
+    public ImmutableDictionary<string, AdoptedStamp> AdoptedStamps =>
+        stamped.ToImmutableDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The stamp this process wrote for <paramref name="nodeTypePath"/> when a snapshot taken at
+    /// <paramref name="snapshotVersion"/> provably PREDATES it — otherwise null.
+    ///
+    /// <para>🚨 The ordering is a FACT, not a heuristic, and it is what keeps this from becoming a
+    /// stale serve. The adoption stamps the version it read and its own write BUMPS the node, so
+    /// <c>snapshotVersion &lt;= ObservedVersion</c> means the snapshot cannot contain that write,
+    /// while <c>snapshotVersion &gt; ObservedVersion</c> means it contains that write or something
+    /// LATER — an owner refusal (#2813), a recompile, a source change. In the second case the
+    /// snapshot is the newer evidence and it wins, so nothing here can outrank a record that has
+    /// moved on.</para>
+    /// </summary>
+    /// <param name="nodeTypePath">The NodeType's mesh path.</param>
+    /// <param name="snapshotVersion">The <see cref="MeshNode.Version"/> the enumeration observed.</param>
+    public AdoptedStamp? StampSuperseding(string nodeTypePath, long snapshotVersion) =>
+        stamped.TryGetValue(nodeTypePath, out var stamp) && snapshotVersion <= stamp.ObservedVersion
+            ? stamp
+            : null;
+
+    /// <summary>
+    /// Lay this process's own adoption stamps over an enumeration snapshot, so the bake sweep
+    /// classifies each type from the NEWER of the two — the projection, or the write this process
+    /// made and knows the projection has not seen.
+    ///
+    /// <para>Pure over its inputs plus the ledger: no hub, no mesh, no I/O, for the same reason
+    /// <see cref="NodeTypeBakeStatus.Classify"/> is — every case is unit-testable without a
+    /// fixture.</para>
+    ///
+    /// <para>A path absent from <paramref name="nodes"/> keeps its snapshot definition: with no
+    /// version to compare, the overlay cannot establish that the snapshot is older, and an overlay
+    /// that applied on faith would be exactly the unconditional trust this ordering rule exists to
+    /// refuse.</para>
+    /// </summary>
+    /// <param name="definitions">The enumeration snapshot's definitions, keyed by path.</param>
+    /// <param name="nodes">The same snapshot's nodes — the source of each observed version.</param>
+    public AdoptionOverlay OverlayOnto(
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IReadOnlyDictionary<string, MeshNode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        var applied = ImmutableList.CreateBuilder<string>();
+        var result = ImmutableDictionary.CreateBuilder<string, NodeTypeDefinition?>(
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (path, definition) in definitions)
+        {
+            if (nodes.TryGetValue(path, out var node)
+                && StampSuperseding(path, node.Version) is { } stamp)
+            {
+                result[path] = stamp.Definition;
+                applied.Add(path);
+            }
+            else
+            {
+                result[path] = definition;
+            }
+        }
+
+        // Ordered, so the line that reports the overlay is stable across boots and diffable.
+        return new AdoptionOverlay(
+            result.ToImmutable(),
+            [.. applied.Order(StringComparer.OrdinalIgnoreCase)]);
+    }
 
     private void Release(string nodeTypePath)
     {

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeBakeStatus.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeBakeStatus.cs
@@ -114,6 +114,27 @@ public sealed record NodeTypeBakeReport(
     public static NodeTypeBakeReport Empty(string frameworkVersion) =>
         new(ImmutableList<NodeTypeBakeEntry>.Empty, frameworkVersion);
 
+    /// <summary>
+    /// 🚨 <b>WHAT POPULATION THIS REPORT IS ABOUT — the half that was missing when two counters were
+    /// read as contradicting each other</b> (#3703).
+    ///
+    /// <para>How many <see cref="Entries"/> were classified from a definition THIS PROCESS wrote (a
+    /// prebuilt adoption) rather than from the mesh-wide enumeration snapshot, because the snapshot's
+    /// node version proves it predates that write. Zero on every steady-state boot.</para>
+    ///
+    /// <para><b>Why the report has to say this at all.</b> A bake report is NOT a census of the
+    /// assembly store, and reading it as one is the mistake #3703 was filed as. Every number here is
+    /// a statement about RECORDS: the store is consulted exactly once per type, at the version the
+    /// record names, so a record the reader has not caught up with makes the store unreachable for
+    /// that type no matter what bytes are on the share. The adoption pass's own summary — "78
+    /// prebuilt assembly(ies) … are backed by the assembly store" — counts BUNDLE ENTRIES whose
+    /// bytes are on the share. The two lines have different units, different populations and
+    /// different sources, and on memex's 2026-09-08 00:31 cold boot they printed 78 and 5 ten
+    /// seconds apart with nothing wrong on the share. Whenever this is non-zero, the sweep is saying
+    /// out loud that its input was behind.</para>
+    /// </summary>
+    public int ClassifiedFromLocalAdoption { get; init; }
+
     /// <summary>Every type is <see cref="BakeState.Baked"/> — the share is fully warm for this image.</summary>
     public bool IsComplete => Entries.All(e => !e.NeedsBake);
 
@@ -137,7 +158,14 @@ public sealed record NodeTypeBakeReport(
     public ImmutableList<NodeTypeBakeEntry> GateRelevant =>
         Entries.Where(e => e.NeedsBake && e.WasHealthy).ToImmutableList();
 
-    /// <summary>One-line summary for logs and the health-check payload.</summary>
+    /// <summary>
+    /// One-line summary for logs and the health-check payload.
+    ///
+    /// <para>🚨 Every count here is over RECORDS, not over the store — see
+    /// <see cref="ClassifiedFromLocalAdoption"/>, which is appended whenever the enumeration
+    /// snapshot was behind this process's own adoptions, so the line can never again be read as a
+    /// store census that disagrees with the adoption pass's.</para>
+    /// </summary>
     public string Summary =>
         $"framework={FrameworkVersion[..Math.Min(8, FrameworkVersion.Length)]} "
         + $"total={Entries.Count} baked={Entries.Count(e => !e.NeedsBake)} pending={Pending.Count}"
@@ -145,7 +173,10 @@ public sealed record NodeTypeBakeReport(
             .GroupBy(e => e.State)
             .Where(g => g.Key is not BakeState.Baked)
             .OrderBy(g => g.Key)
-            .Select(g => $" {g.Key.ToString().ToLowerInvariant()}={g.Count()}"));
+            .Select(g => $" {g.Key.ToString().ToLowerInvariant()}={g.Count()}"))
+        + (ClassifiedFromLocalAdoption > 0
+            ? $" fromlocaladoption={ClassifiedFromLocalAdoption}"
+            : string.Empty);
 }
 
 /// <summary>

--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -676,6 +676,12 @@ public static class PrebuiltAssemblySeeder
             // (the hub began leaving between the upload and the write), so the caller is told the
             // truth — "not adopted" — rather than the ADOPTED line below over a write that no-opped.
             var stamped = false;
+            // 🚨 #3703 — WHAT we stamped, captured on the same run that set `stamped`. The bake
+            // sweep decides what to compile from a mesh-wide enumeration, which is a PROJECTION and
+            // can answer with the record this write is replacing; this definition is the fact that
+            // outranks it. Captured rather than recomputed so it is BY CONSTRUCTION the record the
+            // owner received. See NodeTypeAdoptionRegistry.RecordAdopted.
+            NodeTypeDefinition? stampedDefinition = null;
 
             return store
                 .PutWithLocation(nodeTypePath, version, assemblyBytes, pdbBytes)
@@ -700,75 +706,83 @@ public static class PrebuiltAssemblySeeder
                         }
 
                         stamped = true;
-                        return current with
+                        var adopted = def with
                         {
-                            Content = def with
-                            {
-                                DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
-                                CompilationStatus = CompilationStatus.Ok,
-                                CompilationError = null,
-                                CompilationDiagnostics = null,
-                                LastCompileSucceededAt = DateTimeOffset.UtcNow,
-                                LastCompiledVersion = version,
-                                LatestAssemblyCollection = location.Collection,
-                                LatestAssemblyPath = location.ContentPath,
-                                // The adopted bytes' own identity (#2471), read from the image
-                                // in hand — no file, no load. An adopted build is exactly the
-                                // case where a path says least: several pods adopt the same
-                                // bundle under the same key, and a replica that later serves a
-                                // different build is invisible to a path comparison.
-                                LatestAssemblyMvid =
-                                    ServedBuildIdentity.OfBytes(assemblyBytes)
-                                    ?? def.LatestAssemblyMvid,
-                                CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
-                                // The adopted build retires any standing FAILURE verdict, so
-                                // the inputs it was formed from go with it (#1793) — exactly as
-                                // ApplyCompileSuccess does. A token left behind would describe a
-                                // verdict this node no longer holds.
-                                FailedBuildInputs = null,
-                                // 🚨 The source snapshot is stamped BY THE OWNER, not here
-                                // (#1834). The producer's own ticks are meaningless on this
-                                // mesh (the bake writes zeros), so adoption asserts "these
-                                // bytes correspond to the LIVE source set" — and only the
-                                // owner knows that set. This write is CROSS-HUB: the lambda
-                                // diffs against the MIRROR's snapshot, which predates the
-                                // first-activation write of CurrentSourceVersions that this
-                                // very subscribe triggers (InstallSourcesWatcher). Reading the
-                                // field here therefore stamped CompiledSources = null under a
-                                // non-empty CurrentSourceVersions — IsDirty — and the release
-                                // request PackageInstaller issues one step later recompiled
-                                // the type that had just been adopted. Requesting the stamp
-                                // instead has no ordering to lose: whichever of the two writes
-                                // lands second carries the owner's authoritative pair.
-                                RequestedSourceStampAt = DateTimeOffset.UtcNow,
-                                // 🚨 #2813 — WHAT the producer says these bytes were built
-                                // from. The owner checks it against its own live source set
-                                // when it fulfils the request above; it cannot be checked
-                                // here, for the same cross-hub reason the request exists.
-                                // Null (a legacy bundle) is carried as null, never as a
-                                // match: the owner then records AdoptedUnverified rather
-                                // than AdoptedVerified.
-                                AdoptedSourceFingerprint = sourceFingerprint,
-                                // #3583 — the module version these bytes were released at, for the
-                                // compatibility rule the owner applies when the source later moves.
-                                // Null from a producer that recorded none is carried as null: the
-                                // rule then answers UNKNOWN, which never refuses.
-                                AdoptedModuleVersion = moduleVersion,
-                                // The producer's dependency record (#1707 slice 2) — validated
-                                // above; stamped so ongoing validity checks judge the adopted
-                                // build like a locally-compiled one. Legacy bundles (null)
-                                // leave any prior stamp untouched.
-                                CompiledDependencies = dependencies is null
-                                    ? def.CompiledDependencies
-                                    : dependencies.ToImmutableSortedDictionary(
-                                        kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
-                            },
+                            DispatchedBuildInputs = null,   // terminal ⇒ no compile in flight (#3390)
+                            CompilationStatus = CompilationStatus.Ok,
+                            CompilationError = null,
+                            CompilationDiagnostics = null,
+                            LastCompileSucceededAt = DateTimeOffset.UtcNow,
+                            LastCompiledVersion = version,
+                            LatestAssemblyCollection = location.Collection,
+                            LatestAssemblyPath = location.ContentPath,
+                            // The adopted bytes' own identity (#2471), read from the image
+                            // in hand — no file, no load. An adopted build is exactly the
+                            // case where a path says least: several pods adopt the same
+                            // bundle under the same key, and a replica that later serves a
+                            // different build is invisible to a path comparison.
+                            LatestAssemblyMvid =
+                                ServedBuildIdentity.OfBytes(assemblyBytes)
+                                ?? def.LatestAssemblyMvid,
+                            CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+                            // The adopted build retires any standing FAILURE verdict, so
+                            // the inputs it was formed from go with it (#1793) — exactly as
+                            // ApplyCompileSuccess does. A token left behind would describe a
+                            // verdict this node no longer holds.
+                            FailedBuildInputs = null,
+                            // 🚨 The source snapshot is stamped BY THE OWNER, not here
+                            // (#1834). The producer's own ticks are meaningless on this
+                            // mesh (the bake writes zeros), so adoption asserts "these
+                            // bytes correspond to the LIVE source set" — and only the
+                            // owner knows that set. This write is CROSS-HUB: the lambda
+                            // diffs against the MIRROR's snapshot, which predates the
+                            // first-activation write of CurrentSourceVersions that this
+                            // very subscribe triggers (InstallSourcesWatcher). Reading the
+                            // field here therefore stamped CompiledSources = null under a
+                            // non-empty CurrentSourceVersions — IsDirty — and the release
+                            // request PackageInstaller issues one step later recompiled
+                            // the type that had just been adopted. Requesting the stamp
+                            // instead has no ordering to lose: whichever of the two writes
+                            // lands second carries the owner's authoritative pair.
+                            RequestedSourceStampAt = DateTimeOffset.UtcNow,
+                            // 🚨 #2813 — WHAT the producer says these bytes were built
+                            // from. The owner checks it against its own live source set
+                            // when it fulfils the request above; it cannot be checked
+                            // here, for the same cross-hub reason the request exists.
+                            // Null (a legacy bundle) is carried as null, never as a
+                            // match: the owner then records AdoptedUnverified rather
+                            // than AdoptedVerified.
+                            AdoptedSourceFingerprint = sourceFingerprint,
+                            // #3583 — the module version these bytes were released at, for the
+                            // compatibility rule the owner applies when the source later moves.
+                            // Null from a producer that recorded none is carried as null: the
+                            // rule then answers UNKNOWN, which never refuses.
+                            AdoptedModuleVersion = moduleVersion,
+                            // The producer's dependency record (#1707 slice 2) — validated
+                            // above; stamped so ongoing validity checks judge the adopted
+                            // build like a locally-compiled one. Legacy bundles (null)
+                            // leave any prior stamp untouched.
+                            CompiledDependencies = dependencies is null
+                                ? def.CompiledDependencies
+                                : dependencies.ToImmutableSortedDictionary(
+                                    kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
                         };
+                        stampedDefinition = adopted;
+                        return current with { Content = adopted };
                     }))
                 .Select(_ =>
                 {
                     if (!stamped)
                         return SeedOutcome.NotSeeded;
+                    // 🚨 #3703 — the ledger entry, written on the same branch as the ADOPTED line
+                    // and never without it. `version` is the node version the write went over, so
+                    // any later enumeration at or below it provably predates this stamp; anything
+                    // above it contains this write or something newer, and then the enumeration is
+                    // the better evidence. Absent registry (a host that registered none) simply
+                    // loses the optimisation — the sweep compiles, as it does today.
+                    if (stampedDefinition is { } written)
+                        hub.ServiceProvider.GetService<NodeTypeAdoptionRegistry>()
+                            ?.RecordAdopted(nodeTypePath, version, written);
                     logger?.LogInformation(
                         "Prebuilt assembly ADOPTED for {NodeTypePath} at version {Version} "
                         + "(framework {Framework}, module version {Module}) — no compile needed",

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -236,6 +236,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes
 - [Source-Set Establishment](SourceSetEstablishment) — a resolved source set of ZERO is ambiguous, and only the type's own persisted snapshot tells "owns no Code" from "the discovery pass came back short"; the boot that resolved 91 fewer Code nodes than its neighbours and held a portal out of rotation for the startup probe's full three hours
 - [Install-Time Prebuilt Adoption](InstallTimePrebuiltAdoption) — the only lane that serves a package installed AFTER boot, and the four answers its zero must keep apart because a silent non-adoption reads exactly like a successful one
+- [Adoption and the Sweep Count Different Things](AdoptionAndTheSweepCountDifferentThings) — the cold boot that adopted 78 prebuilt assemblies and then reported 5, with nothing wrong on the share: what each instrument counts, why the sweep could not see its own process's writes, and the node-version ordering that keeps the fix from becoming a stale serve
 - [Import Write Ordering](ImportWriteOrdering) — type before instance, and what a foreign type does
 - [Language Services](LanguageServices)
 - [Extensible Defaults](ExtensibleDefaults)

--- a/src/MeshWeaver.Documentation/Data/Architecture/AdoptionAndTheSweepCountDifferentThings.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AdoptionAndTheSweepCountDifferentThings.md
@@ -1,0 +1,168 @@
+---
+Name: Adoption and the Sweep Count Different Things
+Category: Architecture
+Description: A cold boot adopted 78 prebuilt assemblies and the bake sweep reported 5 ten seconds later. Neither number was wrong and neither was a census of the share — one counts bundle entries whose bytes landed, the other counts NodeTypes judged from an eventually-consistent record snapshot. What each instrument counts, why the sweep could not see its own process's writes, and the ordering rule that fixes it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h7v12H3z"/><path d="M14 10h7v8h-7z"/><path d="M10 12h4"/></svg>
+---
+
+# Adoption and the Sweep Count Different Things
+
+On memex, 2026-09-08, one cold boot printed these two lines ten seconds apart, from the same
+process, on the same framework identity:
+
+```
+00:31:08  ShippedPrebuiltBundles: 78 prebuilt assembly(ies) from 38 shipped bundle(s) …
+          are backed by the assembly store — 78 adopted now, 0 already current
+00:31:18  DynamicTypePreWarmer: 204 of 209 dynamic NodeType(s) need building … — 5 already
+          on the share.  framework=sb43f928 total=209 baked=5 pending=204 frameworkstale=201
+```
+
+It was filed as *"78 adopted, the sweep's store probe counts 5"*
+([#3703](https://github.com/Systemorph/MeshWeaver/issues/3703)) — the natural reading, and the
+wrong one. **The share was fine. Neither counter was lying. They were never the same
+population, and one of them was reading a projection its own process had already superseded.**
+
+The cost was real: 197 compiles instead of ~20, and it is what put four already-adopted `Doc/**`
+NodeTypes on the compile path where a short source-discovery pass could turn them into four false
+regressions and hold the portal out of rotation for three hours
+([#3663](https://github.com/Systemorph/MeshWeaver/issues/3663)).
+
+## What each instrument counts
+
+| | adoption line (`ShippedPrebuiltBundles`) | sweep line (`DynamicTypePreWarmer`) |
+|---|---|---|
+| **unit** | assemblies — **bundle entries** | **NodeTypes** |
+| **denominator** | entries across the bundles this mesh holds a NodeType for | the dynamic NodeTypes in ONE mesh-wide enumeration |
+| **source** | the bytes it wrote, plus the record patch it posted | a CQRS query snapshot of each type's record |
+| **claim** | "these bytes are on the assembly store" | "this type's RECORD names a live-framework build AND the store resolves bytes at the version that record names" |
+
+Two bundles may legitimately name one NodeType, so even the units do not convert. But the sharper
+point is the last row:
+
+> 🚨 **The bake report is not a census of the assembly store, and cannot be.** The store is asked
+> exactly ONE question per type — `TryGetAssemblyPath(typePath, definition.LastCompiledVersion)` —
+> and the key comes out of the **record**. A reader whose record snapshot is behind asks the wrong
+> key, gets a miss, and reports `FrameworkStale` no matter what is sitting on the volume.
+
+So `baked=5` and `frameworkstale=201` are both statements about **records**, filtered through one
+store lookup each. Reading either as "what the share holds" is a category error, and it is the
+error the issue's own title makes.
+
+## Why the sweep could not see its own process's writes
+
+The seeding pass writes each adopted type's record through
+`workspace.GetMeshNodeStream(path).Update(…)` — the authoritative mutation API, routed to the
+type's owning hub. The sweep then reads
+`meshService.Query<MeshNode>(MeshWideQuery.OfType(MeshNode.NodeTypePath)).Take(1)` — a CQRS read.
+
+Those are different sources with no ordering between them.
+[CQRS and Content Access](/Doc/Architecture/CqrsAndContentAccess) states the contract plainly:
+*"Queries route through a read-side index — a cached projection that is eventually consistent …
+that window is long enough to break any pattern that requires read-your-writes"*, and *"a query's
+answer for one path can be minutes old"*. On a cold boot the seeding pass issues 78 cross-hub
+patches in 35 seconds, and the enumeration ten seconds later is free to answer with the records
+those patches replaced.
+
+**And nothing in the classification can tell that apart from a genuinely stale record.** A record
+naming the previous framework because nobody has updated it, and a record naming the previous
+framework because the reader has not caught up, are the same bytes. `NodeTypeBakeStatus` is pure
+and correct on the input it is given; the input was behind.
+
+That is why the mitigations that suggest themselves are all wrong:
+
+| Tempting | Why it is not the fix |
+|---|---|
+| re-probe the store after the sweep starts | the store was never the problem; the key was |
+| wait / retry / sleep before enumerating | there is no bound to wait for — the projection's lag is unbounded by contract |
+| relax the classifier so a bytes-hit outranks the record | the record is what supplies the key, so there is no hit to outrank; and it would turn a real staleness into a stale serve |
+
+## The fix: classify from the newer of the two facts
+
+The process **knows** which records it wrote. That fact was being thrown away — the seeding pass
+emitted a count and nothing else.
+
+`NodeTypeAdoptionRegistry` — the mesh-scoped singleton that already existed to stop the first-build
+kickoff from racing an in-flight adoption — now also carries a **ledger** of completed ones:
+
+- `RecordAdopted(path, observedVersion, definition)` is called on the same branch that logs
+  `Prebuilt assembly ADOPTED …`, never without it. `observedVersion` is the `MeshNode.Version` the
+  adoption **read before its own write**.
+- `OverlayOnto(definitions, nodes)` lays those stamps over an enumeration snapshot, and returns
+  both the definitions to classify from and the list of paths it overrode.
+
+### The ordering rule is a fact, not a heuristic
+
+An adoption stamps the version it read, and its own write **bumps the node**. Therefore:
+
+| snapshot's `MeshNode.Version` | means | who wins |
+|---|---|---|
+| `<= observedVersion` | the snapshot **cannot** contain the adoption's write | the process's own stamp |
+| `> observedVersion` | the snapshot contains that write, or something after it — an owner refusal ([#2813](https://github.com/Systemorph/MeshWeaver/issues/2813)), a recompile, a source change | the snapshot, unchanged |
+| no node in the snapshot at all | nothing to compare | the snapshot, unchanged |
+
+The second row is what keeps this from becoming the stale serve the bake's conservatism exists to
+prevent, and it is pinned by a test that fails against an unconditional overlay:
+
+```
+Expected value to be NeverBuilt because the record the owner left is what decides; serving the
+adopted bytes over it would be exactly the stale serve #3703's fix must not introduce,
+but found Baked.
+```
+
+Nothing is retried, nothing waits, and no bound moved.
+
+## Making the two lines legible
+
+A fix that silently corrected the sweep's input would be the next version of the same defect — the
+operator reading a boot still could not tell whether the enumeration was behind. So all three
+statements now name their own population:
+
+- the adoption line says it counts **assemblies (bundle entries)**, and that the sweep's counts are
+  over **NodeTypes judged from their records**, so a difference between them is not a disagreement;
+- the sweep's line says `{Baked} need no build (record and share agree; … NOT a census of the
+  assembly store)` — it used to read *"already on the share"*, which is what invited the reading in
+  the first place;
+- `NodeTypeBakeReport.ClassifiedFromLocalAdoption` counts the entries classified from this
+  process's own write, and `Summary` appends `fromlocaladoption=N` whenever it is non-zero. A boot
+  where the enumeration was behind now **says so** in the same line that reports the verdict.
+
+## The second truncation, one level down
+
+The same population had a second way to shrink in silence. `DynamicTypesOf` selected the sweep's
+types with `n.Content is NodeTypeDefinition d` — a direct CLR pattern match on a payload that
+crossed a query boundary. A row whose `$type` the serving hub could not resolve degrades to a raw
+`JsonElement`, and such a NodeType **vanished**: out of `total=`, out of `baked=`, out of
+`pending=`, with nothing anywhere saying a type had been dropped. The report's denominator moved
+and the report read identically.
+
+The read is now `ContentAs<NodeTypeDefinition>` — which **recovers** the JSON case rather than
+dropping it — and whatever still will not type is counted and named by path in a warning. Excluded
+because checked (a static NodeType with no compilable source) and never checked at all are
+deliberately different states with different counters; collapsing them would be the same defect
+again. See [Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail).
+
+## The general rule
+
+> **Before comparing two numbers, make each one state its population, its unit and its source.**
+> Two instruments that disagree are only evidence of a defect once you have established they were
+> measuring the same thing — and an instrument that reads a projection must be able to say when its
+> input was superseded, or a stale read and a stale subject are indistinguishable from the outside.
+
+## Where the code is
+
+| Piece | File |
+|---|---|
+| the ledger + the ordering rule | `src/MeshWeaver.Compiler.Pipeline/NodeTypeAdoptionRegistry.cs` |
+| the stamp that feeds it | `src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs` (`Write`) |
+| the classification, unchanged | `src/MeshWeaver.Compiler.Pipeline/NodeTypeBakeStatus.cs` |
+| the overlay + the population report | `src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs` |
+| the adoption line | `src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs` |
+| controls | `test/MeshWeaver.Compiler.Pipeline.Test/AdoptedTypeIsNotJudgedFromAStaleSnapshotTest.cs`, `test/MeshWeaver.Hosting.Test/EnumerationSaysWhatItCouldNotTypeTest.cs` |
+
+## See also
+
+- [CQRS and Content Access](/Doc/Architecture/CqrsAndContentAccess) — why a query is never the
+  authoritative read for a node's content
+- [Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail) — the family this belongs to
+- [Install-Time Prebuilt Adoption](/Doc/Architecture/InstallTimePrebuiltAdoption) — the adoption lane
+- [NodeType Compilation](/Doc/Architecture/NodeTypeCompilation) — what the sweep is deciding about

--- a/src/MeshWeaver.Documentation/Data/Architecture/AdoptionAndTheSweepCountDifferentThings.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AdoptionAndTheSweepCountDifferentThings.md
@@ -48,6 +48,18 @@ So `baked=5` and `frameworkstale=201` are both statements about **records**, fil
 store lookup each. Reading either as "what the share holds" is a category error, and it is the
 error the issue's own title makes.
 
+### Why 5 and not 0 — the number that looked unexplainable
+
+#3703 closed its reading with *"what is left unexplained by all three is the **5**: not 0, not 78"*,
+and the answer is what turns this from a race into a defect. `baked=5` is over **all 209** types.
+The 78 the seeding pass had just adopted contributed **zero** of them; the 5 were types already
+current from an earlier boot. So the adoption's effect on the sweep was not *reduced* by a lag — it
+was **absent**, completely, for every type it touched.
+
+That matters because it rules out waiting. A probabilistic index lag would have shown up as *some*
+of the 78 landing; a total miss is a missing ordering, and the only thing that can supply an ordering
+between two sources is a fact one of them already holds.
+
 ## Why the sweep could not see its own process's writes
 
 The seeding pass writes each adopted type's record through

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -1,7 +1,7 @@
 ---
 Name: Controls That Cannot Fail
 Category: Architecture
-Description: A control whose green is guaranteed by construction is not a control. Thirteen measured instances — a test, a detector, an identity anchor, a preflight, a watcher, a CD verdict, a git idiom that answers the wrong question, a generator whose failure mode is a success line, a guard handed an input that could not fail, and a probe whose defect had already been fixed in its sibling method — and the one question that catches them all.
+Description: A control whose green is guaranteed by construction is not a control. Fourteen measured instances — a test, a detector, an identity anchor, a preflight, a watcher, a CD verdict, a git idiom that answers the wrong question, a generator whose failure mode is a success line, a guard handed an input that could not fail, a probe whose defect had already been fixed in its sibling method, and two counters over different populations printed as one measurement — and the one question that catches them all.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 12h8"/><path d="M12 8v8" opacity="0.25"/></svg>
 ---
 
@@ -50,9 +50,10 @@ instances. The family is larger, and it is worth recognising by shape.
 | **An input the OPERATOR supplies** | `--is-ancestor <commit I chose> <candidate>` where the commit chosen is the branch's own tip | the check is sound; the value handed to it cannot make it print anything but PASS |
 | **An observer that becomes the load** | several sessions polling the same PRs until the shared credential 403s | the watch removes the ability to observe; `/rate_limit` still reports a healthy quota |
 | **A remedy written for reads, applied to a write** | "retry the failed call" after a timeout on `gh pr create` | a lost response is not a lost request; the blind retry creates the second one |
+| **Two counters over different populations** | `78 adopted` beside `baked=5`, ten seconds apart | neither is wrong; the units, denominators and sources differ and nothing says so |
 | **One contract serving two consumers with opposite needs** | `[]` from a speculative compile: *no squiggles* to an editor, *approved* to a tool rendering `{ok}` | the code is right for one caller, so reviewing it on its own terms confirms it |
 
-## Thirteen measured instances
+## Fourteen measured instances
 
 The first six were found in a single day, across tests, CI, publication and ops. Instances 7 and 8
 were found **while writing this page** — one by its author, one by the session that supplied instances
@@ -724,6 +725,42 @@ overload — because the fix travels with the CLASS, not with the call site. And
 error" contract looks correct, ask **whose** contract it is: if two consumers read the same value
 and one of them renders it as a verdict, silence is not a shared default, it is a defect for one of
 them.
+
+### 14. Two counters over different populations, printed as if they were one measurement
+
+Not a control this time, but the same property one step over: an **instrument pair** whose readings
+were not comparable and whose lines did not say so. memex, 2026-09-08, one cold boot, ten seconds
+apart:
+
+```
+00:31:08  ShippedPrebuiltBundles: 78 prebuilt assembly(ies) … are backed by the assembly store
+00:31:18  DynamicTypePreWarmer:   204 of 209 … need building — 5 already on the share.
+```
+
+Filed as *"78 adopted, the sweep's store probe counts 5"*
+([#3703](https://github.com/Systemorph/MeshWeaver/issues/3703)) — which sends the next reader to the
+assembly store, where nothing is wrong. **78 counts BUNDLE ENTRIES whose bytes were written, in
+assemblies. 5 counts NODETYPES whose stored RECORD names a live-framework build and whose bytes
+resolve at the version that record names.** The store is asked exactly one question per type, keyed
+by the record — so the second number is not a census of the share at all, and the phrase *"already
+on the share"* was the whole misreading in four words.
+
+Underneath it sat the defect proper, and it is instance 5's shape: the sweep read a CQRS projection
+that its own process had superseded ten seconds earlier, and **a stale projection and a genuinely
+stale record are the same bytes** — the classification could not tell them apart, and reported
+`frameworkstale=201` with 197 needless compiles behind it.
+
+**Two fixes, and the second is the one this page is about.** The sweep now classifies from the newer
+of the two facts, ordered by `MeshNode.Version` rather than by hope. And every line names its own
+population: the adoption line says it counts assemblies, the sweep line says it is *"NOT a census of
+the assembly store"*, and the report carries `fromlocaladoption=N` so a boot whose input was behind
+says so in the same line that reports the verdict.
+
+> **A number that does not carry its population, its unit and its source is not a measurement, and
+> two of them side by side are an invitation to a false disagreement.** Before you treat two
+> instruments as contradicting each other, make each one state what it counted.
+
+Full account: [Adoption and the Sweep Count Different Things](/Doc/Architecture/AdoptionAndTheSweepCountDifferentThings).
 
 ## What the whole family has in common
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-cold-start-no-longer-rebuilds-what-it-just-adopted.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-cold-start-no-longer-rebuilds-what-it-just-adopted.md
@@ -1,0 +1,57 @@
+---
+Name: A cold start no longer rebuilds the content it has just adopted
+Category: Fix
+Description: A portal starting from cold takes ready-made builds out of the packages it ships, then works out what is left to compile. The second step was reading a catalogue that had not yet caught up with the first, so it rebuilt content whose finished build it had adopted seconds earlier — roughly 200 rebuilds instead of 20 on one measured start. It now consults what it has just done, and both counts say what they are counting.
+Icon: Rocket
+Order: -20260910
+---
+
+# A cold start no longer rebuilds the content it has just adopted
+
+A portal does not compile its content if it does not have to. Ready-made builds travel with the
+packages it ships, and the first thing a cold start does is adopt them. Only then does it work out
+what is still missing and compile that.
+
+On one measured start those two steps disagreed. Ten seconds apart, the same portal reported that it
+had adopted **78** ready-made builds, and then that only **5** of its 209 types were ready — so it
+compiled 197 of them. Nothing was wrong with the builds it had adopted. They were on disk, correct,
+and complete.
+
+## What went wrong
+
+The second step decides what to compile by reading a catalogue of every type and what each one was
+last built from. That catalogue is a summary kept slightly behind the real records — normally by
+milliseconds, occasionally by much longer — and the first step had just rewritten those records for
+78 types.
+
+So the portal asked a question it had already answered, got the answer from before its own work, and
+could not tell the difference. "This type's build is out of date" and "my copy of this type's
+information is out of date" looked identical.
+
+The cost was not only time. Content that never needed compiling ended up on the compile path, where
+a separate fault could turn four healthy pages into apparent failures and hold a portal out of
+service for three hours.
+
+## What changes
+
+The portal now remembers what it adopted during this start, and which version of each record it
+wrote over. When the catalogue's copy of a type is demonstrably older than that, the portal trusts
+what it did rather than what it is being told.
+
+The reverse case is deliberate too: if the catalogue's copy is *newer* — because something else
+changed the type after the adoption — the catalogue wins and the type is rebuilt. The portal only
+overrides information it can prove it has already superseded.
+
+## Both counts now say what they are counting
+
+The two numbers were never comparable, and nothing said so. **78** counted ready-made builds placed
+on disk. **5** counted types whose stored record and the disk agreed. Different things, different
+units, printed as if they were the same measurement.
+
+Each line now names its own population, and a start where the catalogue was behind says that out
+loud in the same line that reports the result — so the next person reading a start log is not left
+to guess which of two numbers to believe.
+
+Separately, a type whose stored information could not be read at all used to vanish from these
+counts entirely, with nothing to indicate it. Such a type is now recovered where possible and named
+where it is not, so the totals describe a group the portal can point at.

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -404,6 +404,12 @@ public static class DynamicTypePreWarmer
                     //
                     // 🚨 #3703 — the enumeration is a PROJECTION, and this process's own prebuilt
                     // adoptions may already have superseded it. Classify from the newer of the two.
+                    //
+                    // 🚨 The overlay moves DEFINITIONS and deliberately NOT `nodes`. A node carries
+                    // the VERSION the compiler's store upload keys on, and an overlaid definition on
+                    // a snapshot node would pair a fresh record with a stale version — strictly
+                    // worse than either. It costs nothing: an adopted type classifies Baked, so the
+                    // batch driver (which is the only consumer of `nodes`) never reaches it.
                     var overlay = OverlayThisProcessAdoptions(mesh, definitions, nodes, logger);
                     var classified = overlay.Definitions;
 

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
+using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
@@ -383,7 +384,9 @@ public static class DynamicTypePreWarmer
                 {
                     // The full nodes (not just their definitions): the batch driver feeds the
                     // compiler the enumerated MeshNode directly — no re-fetch, no activation.
-                    var (nodes, definitions) = DynamicTypesOf(change.Items);
+                    var dynamicTypes = DynamicTypesOf(
+                        change.Items, mesh.JsonSerializerOptions, logger);
+                    var (nodes, definitions) = (dynamicTypes.Nodes, dynamicTypes.Definitions);
 
                     // 🚨 ASK THE SHARE WHAT IS ACTUALLY THERE, before deciding what to build.
                     //
@@ -398,13 +401,23 @@ public static class DynamicTypePreWarmer
                     // which buys three properties at once: a cleared cache re-bakes by itself, an
                     // interrupted bake RESUMES (what already landed comes back Baked), and a second
                     // pod inherits the first pod's work instead of repeating it.
+                    //
+                    // 🚨 #3703 — the enumeration is a PROJECTION, and this process's own prebuilt
+                    // adoptions may already have superseded it. Classify from the newer of the two.
+                    var overlay = OverlayThisProcessAdoptions(mesh, definitions, nodes, logger);
+                    var classified = overlay.Definitions;
+
                     var store = ResolveAssemblyStore(mesh);
                     return NodeTypeBakeStatus
-                        .Probe(definitions, store, logger: logger,
+                        .Probe(classified, store, logger: logger,
                             liveDependencyIdOf: NodeTypeCompilationHelpers.DependencyIdResolverOf(mesh),
                             liveToolchainId: NodeTypeCompilationHelpers.ProcessToolchainId)
+                        .Select(report => report with
+                        {
+                            ClassifiedFromLocalAdoption = overlay.Applied.Count,
+                        })
                         .SelectMany(report => BakeOrFollow(
-                            mesh, workspace, accessService, definitions, nodes, store, report,
+                            mesh, workspace, accessService, classified, nodes, store, report,
                             budget, pacing, batchBake, buildProtocol, logger));
                 })
                 // 🚨 NO Catch HERE, AND NO LOG-AND-SWALLOW — DELIBERATELY.
@@ -430,29 +443,70 @@ public static class DynamicTypePreWarmer
     /// (<see cref="ProbeDynamicTypes"/>) so the two can never disagree about WHAT the mesh's
     /// dynamic types are — a drift there would make the adopt-only report describe a different
     /// population than the sweep it replaces.
+    ///
+    /// <para>🚨 <b>The typing is <c>ContentAs</c>, never <c>Content is NodeTypeDefinition</c>, and
+    /// a failure to type is COUNTED</b> (#3703). A query row's <c>Content</c> is deserialised by
+    /// whichever hub served it, so an unresolvable <c>$type</c> degrades to a raw
+    /// <c>JsonElement</c> and a pattern-match on the CLR type silently drops that NodeType from
+    /// this population — out of <c>total</c>, out of <c>baked</c>, out of <c>pending</c>, with
+    /// nothing to grep. That is the same defect this whole issue is about wearing a different hat:
+    /// an instrument that cannot say "I did not check". It can now, via
+    /// <see cref="DynamicTypes.Untyped"/>.</para>
     /// </summary>
-    private static (Dictionary<string, MeshNode> Nodes,
-        Dictionary<string, NodeTypeDefinition?> Definitions) DynamicTypesOf(
-        IEnumerable<MeshNode> items)
+    /// <param name="items">The enumeration snapshot.</param>
+    /// <param name="options">The mesh hub's serializer options — the registry that resolves the
+    /// content's <c>$type</c>.</param>
+    /// <param name="logger">Diagnostics; an unconvertible value is named by node path.</param>
+    internal static DynamicTypes DynamicTypesOf(
+        IEnumerable<MeshNode> items, JsonSerializerOptions options, ILogger? logger)
     {
-        var nodes = items
-            .Where(n => !string.IsNullOrEmpty(n.Path)
-                && n.State == MeshNodeState.Active
-                && n.Content is NodeTypeDefinition d
-                // Only DYNAMIC types have source to compile. Static/framework
-                // NodeTypes ship their assembly with the process — nothing to warm.
-                && HasCompilableSource(d))
-            .GroupBy(n => n.Path!, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(
-                g => g.Key,
-                g => g.First(),
-                StringComparer.OrdinalIgnoreCase);
-        var definitions = nodes.ToDictionary(
-            kvp => kvp.Key,
-            kvp => (NodeTypeDefinition?)kvp.Value.Content,
-            StringComparer.OrdinalIgnoreCase);
-        return (nodes, definitions);
+        var untyped = ImmutableList.CreateBuilder<string>();
+        var typed = items
+            .Where(n => !string.IsNullOrEmpty(n.Path) && n.State == MeshNodeState.Active)
+            .Select(n => (Node: n, Definition: n.ContentAs<NodeTypeDefinition>(options, logger)))
+            .Where(pair =>
+            {
+                if (pair.Definition is { } d)
+                    // Only DYNAMIC types have source to compile. Static/framework
+                    // NodeTypes ship their assembly with the process — nothing to warm.
+                    return HasCompilableSource(d);
+                if (pair.Node.Content is not null)
+                    untyped.Add(pair.Node.Path!);
+                return false;
+            })
+            .GroupBy(pair => pair.Node.Path!, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var nodes = typed.ToDictionary(
+            g => g.Key, g => g.First().Node, StringComparer.OrdinalIgnoreCase);
+        var definitions = typed.ToDictionary(
+            g => g.Key, g => g.First().Definition, StringComparer.OrdinalIgnoreCase);
+
+        if (untyped.Count > 0)
+            // Warning, not silence: a NodeType this pass could not type is a type NOTHING in the
+            // bake decides anything about, and the whole point of the report is that a number it
+            // prints is a number over a population it can name.
+            logger?.LogWarning(
+                "DynamicTypePreWarmer: {Count} node(s) matched the NodeType enumeration but their "
+                + "content did not resolve to a NodeTypeDefinition on this hub — they are NOT in "
+                + "this report's population and NOTHING decided anything about them (#3703). "
+                + "Unresolved: {Paths}",
+                untyped.Count, string.Join(", ", untyped.Order(StringComparer.OrdinalIgnoreCase)));
+
+        return new DynamicTypes(nodes, definitions, untyped.ToImmutable());
     }
+
+    /// <summary>
+    /// The dynamic NodeTypes an enumeration snapshot yielded, WITH what it could not read.
+    /// </summary>
+    /// <param name="Nodes">The nodes, keyed by path.</param>
+    /// <param name="Definitions">Their definitions, keyed by path.</param>
+    /// <param name="Untyped">Paths whose content this hub could not resolve to a
+    /// <see cref="NodeTypeDefinition"/> — checked by nothing, so named by this.</param>
+    internal sealed record DynamicTypes(
+        Dictionary<string, MeshNode> Nodes,
+        Dictionary<string, NodeTypeDefinition?> Definitions,
+        ImmutableList<string> Untyped);
 
     /// <summary>
     /// 🚨 ASKS, NEVER BUILDS — the adopt-only pass that every boot runs.
@@ -489,12 +543,23 @@ public static class DynamicTypePreWarmer
                 .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
                 .Take(1)
                 .Timeout(EnumerationBudget)
-                .SelectMany(change => NodeTypeBakeStatus.Probe(
-                    DynamicTypesOf(change.Items).Definitions,
-                    ResolveAssemblyStore(mesh),
-                    logger: logger,
-                    liveDependencyIdOf: NodeTypeCompilationHelpers.DependencyIdResolverOf(mesh),
-                    liveToolchainId: NodeTypeCompilationHelpers.ProcessToolchainId)));
+                .SelectMany(change =>
+                {
+                    var dynamicTypes = DynamicTypesOf(
+                        change.Items, mesh.JsonSerializerOptions, logger);
+                    var (nodes, definitions) = (dynamicTypes.Nodes, dynamicTypes.Definitions);
+                    var overlay = OverlayThisProcessAdoptions(mesh, definitions, nodes, logger);
+                    return NodeTypeBakeStatus.Probe(
+                            overlay.Definitions,
+                            ResolveAssemblyStore(mesh),
+                            logger: logger,
+                            liveDependencyIdOf: NodeTypeCompilationHelpers.DependencyIdResolverOf(mesh),
+                            liveToolchainId: NodeTypeCompilationHelpers.ProcessToolchainId)
+                        .Select(report => report with
+                        {
+                            ClassifiedFromLocalAdoption = overlay.Applied.Count,
+                        });
+                }));
     }
 
     /// <summary>
@@ -505,6 +570,61 @@ public static class DynamicTypePreWarmer
     /// </summary>
     private static IAssemblyStore ResolveAssemblyStore(IMessageHub mesh) =>
         mesh.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
+
+    /// <summary>
+    /// 🚨 <b>THE ENUMERATION IS A PROJECTION, AND THIS PROCESS MAY ALREADY HAVE SUPERSEDED IT</b>
+    /// (#3703).
+    ///
+    /// <para>The sweep decides what to compile from ONE mesh-wide
+    /// <c>Query&lt;MeshNode&gt;(…).Take(1)</c>. That is a CQRS read — eventually consistent, and
+    /// explicitly not the authoritative source for a node's content — while the prebuilt seeding
+    /// pass that runs immediately before it writes each adopted type's record through
+    /// <c>GetMeshNodeStream(path).Update(…)</c>, which IS authoritative. So the sweep can be handed
+    /// records that predate writes made seconds earlier by the same process, and nothing in the
+    /// classification can tell that apart from a genuinely stale record: both are the same
+    /// bytes.</para>
+    ///
+    /// <para><b>What that cost, measured.</b> memex, 2026-09-08 00:31 UTC, one cold boot: the
+    /// seeding pass reported <c>78 adopted now, 0 already current</c>, and ten seconds later the
+    /// sweep reported <c>baked=5 pending=204 frameworkstale=201</c> on the SAME framework identity —
+    /// 197 compiles instead of ~20. The two numbers were never comparable (see
+    /// <see cref="NodeTypeBakeReport.ClassifiedFromLocalAdoption"/>), and the compiles the
+    /// disagreement caused are what put four already-adopted <c>Doc/**</c> types on the compile path
+    /// where a short source-discovery pass could turn them into false regressions (#3663).</para>
+    ///
+    /// <para>The fix is neither a retry nor a wait: it is to classify each type from the NEWER of
+    /// the two facts. <see cref="NodeTypeAdoptionRegistry.OverlayOnto"/> applies the process's own
+    /// stamp only where the snapshot's <see cref="MeshNode.Version"/> proves the snapshot predates
+    /// it, so a record that has since moved on — an owner refusal, a recompile — always wins.</para>
+    /// </summary>
+    private static AdoptionOverlay OverlayThisProcessAdoptions(
+        IMessageHub mesh,
+        IReadOnlyDictionary<string, NodeTypeDefinition?> definitions,
+        IReadOnlyDictionary<string, MeshNode> nodes,
+        ILogger? logger)
+    {
+        var registry = mesh.ServiceProvider.GetService<NodeTypeAdoptionRegistry>();
+        if (registry is null)
+            return new AdoptionOverlay(
+                definitions.ToImmutableDictionary(
+                    kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase),
+                []);
+
+        var overlay = registry.OverlayOnto(definitions, nodes);
+        // 🚨 SAY IT. An instrument that silently corrected its own input would be the next version
+        // of the defect: the operator reading "197 compiles" needs to know the enumeration was
+        // behind, because a snapshot that is behind for 73 types on a 35-second seeding pass is a
+        // fact about this deployment's read path, not about its content.
+        if (!overlay.Applied.IsEmpty)
+            logger?.LogInformation(
+                "DynamicTypePreWarmer: the NodeType enumeration snapshot PREDATES this process's own "
+                + "prebuilt adoptions for {Count} type(s) — classifying those from the record this "
+                + "process wrote, not from the snapshot (#3703). A snapshot at or below the node "
+                + "version an adoption wrote over cannot contain that write; one above it wins and is "
+                + "used unchanged. Superseded: {Types}",
+                overlay.Applied.Count, string.Join(", ", overlay.Applied));
+        return overlay;
+    }
 
     /// <summary>
     /// 🚨 ONE PROCESS BAKES; the rest SUBSCRIBE TO THE GO.
@@ -637,9 +757,19 @@ public static class DynamicTypePreWarmer
                 + "{Missing} is not registered — falling back to the activation-driven sweep",
                 batchCompiler is null ? "IMeshNodeCompilationService" : "IMeshService");
 
+        // 🚨 THE UNITS ARE NODETYPES AND THE SOURCE IS THE RECORD (#3703). "already on the share"
+        // used to stand where "need no build" now does, and it invited exactly one misreading: that
+        // this number is a census of the assembly store, comparable with the adoption pass's "N
+        // prebuilt assembly(ies) … are backed by the assembly store". It never was. The store is
+        // asked ONE question per type — "bytes at the version this type's RECORD names?" — so this
+        // counts types whose record and the share agree, over the enumeration snapshot, in
+        // NodeTypes; the adoption line counts BUNDLE ENTRIES whose bytes were written, in
+        // assemblies. Two populations, two units, two sources.
         logger?.LogInformation(
             "DynamicTypePreWarmer: {Pending} of {Total} dynamic NodeType(s) need building "
-            + "(sequential, dependency order, {Mode}, perTypeBudget={Budget}) — {Baked} already on the share. "
+            + "(sequential, dependency order, {Mode}, perTypeBudget={Budget}) — {Baked} need no build "
+            + "(record and share agree; this is a count of NodeTypes judged from their records, NOT a "
+            + "census of the assembly store). "
             + "{Report}. Building: {Order}",
             pending.Count, order.Count, useBatch ? "batch direct-compile" : "activation-driven",
             budget, baked.Count, report.Summary,

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -907,12 +907,24 @@ public static class ShippedPrebuiltBundles
                                     .Aggregate(default(SeedTally), (total, one) => total + one)
                                     .Do(tally =>
                                     {
+                                        // 🚨 THE UNITS ARE BUNDLE ENTRIES (#3703). This counts
+                                        // ASSEMBLIES whose bytes are on the store — two bundles may
+                                        // legitimately name the same NodeType — and it says nothing
+                                        // about how many NodeTypes a later reader will find current,
+                                        // because that reader judges each type from its RECORD. The
+                                        // two were read as one population on memex's 2026-09-08
+                                        // 00:31 boot ("78 adopted" against the sweep's "baked=5"),
+                                        // so the line now names its own denominator.
                                         logger?.LogInformation(
                                             "ShippedPrebuiltBundles: {Covered} prebuilt assembly(ies) from "
                                             + "{Bundles} shipped bundle(s) under {Directory} are backed by "
                                             + "the assembly store — {Adopted} adopted now, {Current} already "
                                             + "current and skipped WITHOUT activating their NodeType hubs — "
-                                            + "in {Elapsed}",
+                                            + "in {Elapsed}. Counted in ASSEMBLIES (bundle entries — two "
+                                            + "bundles may name one NodeType); the bake sweep's counts are "
+                                            + "over NODETYPES judged from their records, so the two are not "
+                                            + "the same population and a difference between them is not a "
+                                            + "disagreement (#3703)",
                                             tally.Covered, bundles.Count, dir, tally.Adopted,
                                             tally.AlreadyCurrent, DateTimeOffset.UtcNow - startedAt);
                                         // 🚨 A mount that backed NOTHING needs its reason at the SAME level as

--- a/test/MeshWeaver.Compiler.Pipeline.Test/AdoptedTypeIsNotJudgedFromAStaleSnapshotTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/AdoptedTypeIsNotJudgedFromAStaleSnapshotTest.cs
@@ -1,0 +1,320 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>Two instruments, ten seconds apart, reported 78 and 5 about a mesh whose share was
+/// perfectly fine</b> — MeshWeaver#3703, memex, 2026-09-08 00:30–00:31 UTC, one cold boot:
+///
+/// <code>
+/// 00:31:08  ShippedPrebuiltBundles: 78 prebuilt assembly(ies) … are backed by the assembly store
+///                                   — 78 adopted now, 0 already current
+/// 00:31:18  DynamicTypePreWarmer:   204 of 209 … need building — 5 already on the share.
+///                                   framework=sb43f928 baked=5 pending=204 frameworkstale=201
+/// </code>
+///
+/// <para><b>Neither number was wrong, and they were never comparable.</b> The first counts BUNDLE
+/// ENTRIES whose bytes are on the store, in assemblies. The second counts NODETYPES whose RECORD,
+/// as it appeared in one mesh-wide <c>Query&lt;MeshNode&gt;(…).Take(1)</c>, names the live framework
+/// AND resolves bytes <i>at the version that record names</i>. The store is asked exactly ONE
+/// question per type, keyed by the record — so a reader whose record snapshot is behind cannot
+/// reach the bytes no matter what is on the share. "The sweep's store probe counts 5" was the
+/// wrong reading: the probe is not a census of the store, and this file is the pin that says so.</para>
+///
+/// <para><b>The real defect is an ORDERING one.</b> The prebuilt seeding pass writes each adopted
+/// type's record through <c>GetMeshNodeStream(path).Update(…)</c> — authoritative. The sweep then
+/// reads a CQRS projection, which is eventually consistent (<c>Doc/Architecture/CqrsAndContentAccess</c>:
+/// <i>"a query's answer for one path can be minutes old"</i>). So the sweep can be handed records
+/// this same process has already replaced, and no classification can tell that apart from a
+/// genuinely stale record — they are the same bytes. On that boot it cost 197 compiles instead of
+/// ~20, and it is what put four already-adopted <c>Doc/**</c> types on the compile path where a
+/// short source-discovery pass could turn them into false regressions (#3663).</para>
+///
+/// <para><b>The fix is neither a retry nor a wait.</b>
+/// <see cref="NodeTypeAdoptionRegistry.RecordAdopted"/> remembers what THIS process stamped and
+/// over which node version; <see cref="NodeTypeAdoptionRegistry.OverlayOnto"/> classifies each type
+/// from the NEWER of the two facts. The ordering is decided by <see cref="MeshNode.Version"/> and
+/// is a fact, not a heuristic: an adoption stamps the version it READ and its own write bumps the
+/// node, so a snapshot at or below that version cannot contain the write, and one above it contains
+/// the write or something later — an owner refusal, a recompile — and then the snapshot wins.</para>
+///
+/// <para>Pure: no hub, no mesh, no store beyond the in-memory one below — same split, and same
+/// reason, as <see cref="NodeTypeBakeStatus"/> itself.</para>
+/// </summary>
+public class AdoptedTypeIsNotJudgedFromAStaleSnapshotTest
+{
+    private const string Live = "sb43f9287dbd6922a7937bd24be103937";
+    private const string Previous = "sceaefc9a44d24f0d8e2a5c31f9048ab6";
+
+    /// <summary>The cheapest real instance from #3703's own "measurement that would settle it".</summary>
+    private const string Path = "Doc/DataMesh/SocialMedia/Profile";
+
+    private static NodeTypeDefinition Definition(string framework, long compiledVersion) => new()
+    {
+        Configuration = "config => config",
+        Sources = ["namespace:Source scope:subtree"],
+        CompilationStatus = CompilationStatus.Ok,
+        CompiledFrameworkVersion = framework,
+        LastCompiledVersion = compiledVersion,
+        LatestAssemblyCollection = "local",
+        LatestAssemblyPath = $"Doc_Profile/v{compiledVersion}-{framework[..8]}.dll",
+    };
+
+    /// <summary>
+    /// 🚨 THE CONTROL, in both directions, in one test — the first assertion IS the pre-fix
+    /// behaviour, so this file cannot go green by construction.
+    ///
+    /// <para>The stage is exactly #3703's boot: the adoption uploaded bytes under version 25 and
+    /// stamped the live framework; the enumeration snapshot still shows the node at version 25 with
+    /// the PREVIOUS framework's record naming version 24.</para>
+    /// </summary>
+    [Fact]
+    public void SnapshotOlderThanThisProcessAdoption_ClassifiesFromTheAdoption_NotTheSnapshot()
+    {
+        var store = new FakeStore();
+        // What the adoption actually put on the share: (path, 25).
+        store.Add(Path, 25);
+
+        var stale = Definition(Previous, compiledVersion: 24);
+        var snapshot = Node(version: 25, stale);
+
+        // --- the pre-fix reading: classify straight off the snapshot -----------------------------
+        // The store IS consulted — but at version 24, the only key the stale record offers — so it
+        // misses, and the type is rebuilt with correct live-framework bytes sitting on the volume.
+        Probe(store, (Path, stale)).Entries.Single().State
+            .Should().Be(
+                BakeState.FrameworkStale,
+                "the pre-#3703 sweep asks the store at the version the SNAPSHOT names, so a "
+                + "snapshot that predates this process's own adoption can never reach the bytes "
+                + "that adoption wrote — this is the 201-of-209 reading, reproduced");
+        store.Lookups.Should().ContainSingle().Which
+            .Should().Be(Key(Path, 24), "the miss is a key mismatch, never an absent byte");
+
+        // --- the fix: classify from the newer of the two facts -----------------------------------
+        var registry = new NodeTypeAdoptionRegistry();
+        registry.RecordAdopted(Path, observedVersion: 25, Definition(Live, compiledVersion: 25));
+
+        var overlay = registry.OverlayOnto(
+            Definitions((Path, stale)), Nodes((Path, snapshot)));
+
+        var report = Probed(NodeTypeBakeStatus.Probe(overlay.Definitions, store, Live));
+
+        report.Entries.Single().State.Should().Be(
+            BakeState.Baked,
+            "bytes compiled against the live framework exist for this type, and the record this "
+            + "process wrote is what names their key — recompiling it is the 197-instead-of-20 "
+            + "waste #3703 measured");
+        report.IsComplete.Should().BeTrue();
+
+        overlay.Applied.Should().Equal(
+            [Path],
+            "the snapshot's node version (25) is at or below the version the adoption wrote over "
+            + "(25), so it provably cannot contain that write");
+    }
+
+    /// <summary>
+    /// 🚨 THE REVERSE CONTROL — and the one that fails against an UNCONDITIONAL overlay.
+    ///
+    /// <para>The owner refused the adoption after it landed (#2813) and cleared the assembly
+    /// coordinates. That write bumped the node past the version the adoption wrote over, so the
+    /// snapshot is the NEWER evidence and the ledger must stand aside. Drop the
+    /// <c>snapshotVersion &lt;= ObservedVersion</c> guard from
+    /// <see cref="NodeTypeAdoptionRegistry.StampSuperseding"/> and this reports
+    /// <see cref="BakeState.Baked"/> over a record that no longer names any assembly — a stale
+    /// serve, which is the one outcome the bake's conservatism exists to prevent.</para>
+    /// </summary>
+    [Fact]
+    public void SnapshotNewerThanThisProcessAdoption_KeepsTheSnapshot_EvenWhenTheStoreHasBytes()
+    {
+        var store = new FakeStore();
+        store.Add(Path, 25);
+
+        var refused = new NodeTypeDefinition
+        {
+            Configuration = "config => config",
+            Sources = ["namespace:Source scope:subtree"],
+            // The owner's refusal cleared the coordinates the adoption had stamped.
+            CompilationStatus = CompilationStatus.Pending,
+        };
+        // 26 > the 25 the adoption wrote over: this snapshot contains that write, or something later.
+        var snapshot = Node(version: 26, refused);
+
+        var registry = new NodeTypeAdoptionRegistry();
+        registry.RecordAdopted(Path, observedVersion: 25, Definition(Live, compiledVersion: 25));
+
+        var overlay = registry.OverlayOnto(
+            Definitions((Path, refused)), Nodes((Path, snapshot)));
+
+        Probed(NodeTypeBakeStatus.Probe(overlay.Definitions, store, Live))
+            .Entries.Single().State
+            .Should().Be(
+                BakeState.NeverBuilt,
+                "the record the owner left is what decides; serving the adopted bytes over it "
+                + "would be exactly the stale serve #3703's fix must not introduce");
+
+        overlay.Applied.Should().BeEmpty(
+            "a snapshot ABOVE the version the adoption wrote over is the newer evidence, so the "
+            + "ledger must not outrank it");
+    }
+
+    /// <summary>
+    /// A type this process did NOT adopt is untouched, and a genuinely stale record still rebuilds.
+    /// Without this the first test would pass for a registry that overlays everything it is asked
+    /// about.
+    /// </summary>
+    [Fact]
+    public void ATypeThisProcessNeverAdopted_IsClassifiedFromTheSnapshotAsBefore()
+    {
+        var registry = new NodeTypeAdoptionRegistry();
+        registry.RecordAdopted("Other/Type", observedVersion: 25, Definition(Live, 25));
+
+        var stale = Definition(Previous, compiledVersion: 24);
+        var overlay = registry.OverlayOnto(
+            Definitions((Path, stale)), Nodes((Path, Node(version: 25, stale))));
+
+        overlay.Applied.Should().BeEmpty();
+        overlay.Definitions[Path].Should().BeSameAs(stale);
+        Probed(NodeTypeBakeStatus.Probe(overlay.Definitions, new FakeStore(), Live))
+            .Entries.Single().State.Should().Be(BakeState.FrameworkStale);
+    }
+
+    /// <summary>
+    /// A path the snapshot has no NODE for keeps its snapshot definition: with no version to
+    /// compare, the overlay cannot establish that the snapshot is older, and applying it on faith
+    /// would be the unconditional trust the ordering rule exists to refuse.
+    /// </summary>
+    [Fact]
+    public void NoNodeInTheSnapshot_MeansNoVersionToCompare_SoTheOverlayStandsAside()
+    {
+        var registry = new NodeTypeAdoptionRegistry();
+        registry.RecordAdopted(Path, observedVersion: 25, Definition(Live, 25));
+
+        var stale = Definition(Previous, compiledVersion: 24);
+        var overlay = registry.OverlayOnto(
+            Definitions((Path, stale)), new Dictionary<string, MeshNode>());
+
+        overlay.Applied.Should().BeEmpty();
+        overlay.Definitions[Path].Should().BeSameAs(stale);
+    }
+
+    /// <summary>The ledger's ordering boundary, stated as an equality rather than inferred.</summary>
+    [Theory]
+    [InlineData(24, true)]   // strictly older than the write ⇒ superseded
+    [InlineData(25, true)]   // the very version the write went over ⇒ superseded
+    [InlineData(26, false)]  // the write, or something after it ⇒ the snapshot wins
+    public void StampSuperseding_IsDecidedByTheNodeVersionTheAdoptionWroteOver(
+        long snapshotVersion, bool superseded)
+    {
+        var registry = new NodeTypeAdoptionRegistry();
+        registry.RecordAdopted(Path, observedVersion: 25, Definition(Live, 25));
+
+        (registry.StampSuperseding(Path, snapshotVersion) is not null)
+            .Should().Be(superseded);
+    }
+
+    /// <summary>
+    /// 🚨 THE REPORTING HALF — the outcome that makes two counters legible rather than
+    /// contradictory. A report that classified anything from this process's own write SAYS so, so
+    /// nobody reading the sweep's line can take it for a store census again.
+    /// </summary>
+    [Fact]
+    public void AReportThatUsedThisProcessAdoptions_SaysSo_AndOneThatDidNot_StaysSilent()
+    {
+        var report = new NodeTypeBakeReport(
+            [new NodeTypeBakeEntry(Path, BakeState.Baked)], Live);
+
+        report.Summary.Should().NotContain(
+            "fromlocaladoption",
+            "a steady-state boot classifies nothing from a local adoption, and a field that is "
+            + "always present carries no information");
+
+        (report with { ClassifiedFromLocalAdoption = 73 }).Summary
+            .Should().Contain(
+                "fromlocaladoption=73",
+                "when the enumeration was behind, the line that reports the verdict has to report "
+                + "that too — otherwise the next reader repeats #3703's reading");
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private static MeshNode Node(long version, NodeTypeDefinition definition) =>
+        new("Profile", "Doc/DataMesh/SocialMedia") { Version = version, Content = definition };
+
+    private static Dictionary<string, NodeTypeDefinition?> Definitions(
+        params (string Path, NodeTypeDefinition Definition)[] types) =>
+        types.ToDictionary(
+            t => t.Path, t => (NodeTypeDefinition?)t.Definition, StringComparer.OrdinalIgnoreCase);
+
+    private static Dictionary<string, MeshNode> Nodes(params (string Path, MeshNode Node)[] nodes) =>
+        nodes.ToDictionary(n => n.Path, n => n.Node, StringComparer.OrdinalIgnoreCase);
+
+    private static NodeTypeBakeReport Probe(
+        IAssemblyStore store, params (string Path, NodeTypeDefinition Definition)[] types) =>
+        Probed(NodeTypeBakeStatus.Probe(Definitions(types), store, Live));
+
+    /// <summary>
+    /// Subscribe and collect — never <c>.Wait()</c>, which parks the calling thread in a native wait
+    /// that xUnit's <c>methodTimeout</c> cannot abort, so a self-deadlock costs the whole shard and
+    /// reports <c>exit=124 TIMEOUT</c> with no test named (#2013).
+    ///
+    /// <para>Every source here is a <see cref="FakeStore"/> lookup composed of <c>Return</c> and
+    /// <c>Defer</c>, so the probe emits AND completes inside the <c>Subscribe</c> call. That makes
+    /// this stricter than a bounded await as well as safer: a probe that ever became asynchronous
+    /// fails loudly here instead of passing slowly. There is no timeout because there is nothing to
+    /// wait for.</para>
+    /// </summary>
+    private static NodeTypeBakeReport Probed(IObservable<NodeTypeBakeReport> probe)
+    {
+        NodeTypeBakeReport? emitted = null;
+        Exception? faulted = null;
+        using (probe.Subscribe(report => emitted = report, ex => faulted = ex))
+        {
+            // The subscription's whole life: a synchronous source has already terminated by here.
+        }
+
+        if (faulted is not null)
+            throw faulted;
+        return emitted ?? throw new InvalidOperationException(
+            "the probe did not emit synchronously — see the note on Probed");
+    }
+
+    private static string Key(string nodeTypePath, long version) =>
+        $"{nodeTypePath.Replace('/', '_')}_v{version}";
+
+    /// <summary>In-memory <see cref="IAssemblyStore"/> that records what was asked of it — the same
+    /// shape <c>NodeTypeBakeStatusTest</c> uses, so the two files stage the store identically.</summary>
+    private sealed class FakeStore : IAssemblyStore
+    {
+        private readonly HashSet<string> present = [];
+
+        public List<string> Lookups { get; } = [];
+
+        public void Add(string nodeTypePath, long version) => present.Add(Key(nodeTypePath, version));
+
+        public IObservable<string?> TryGetAssemblyPath(string nodeTypePath, long version) =>
+            Observable.Defer(() =>
+            {
+                var key = Key(nodeTypePath, version);
+                Lookups.Add(key);
+                return Observable.Return<string?>(
+                    present.Contains(key) ? $"/data/assembly-cache/{key}.dll" : null);
+            });
+
+        public IObservable<string> Put(
+            string nodeTypePath, long version, byte[] assemblyBytes, byte[]? pdbBytes)
+        {
+            present.Add(Key(nodeTypePath, version));
+            return Observable.Return($"/data/assembly-cache/{Key(nodeTypePath, version)}.dll");
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/EnumerationSaysWhatItCouldNotTypeTest.cs
+++ b/test/MeshWeaver.Hosting.Test/EnumerationSaysWhatItCouldNotTypeTest.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Reactive.Assertions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>The bake report's population could be TRUNCATED without anything saying so</b> —
+/// the second half of MeshWeaver#3703, and the same defect shape as the first.
+///
+/// <para><see cref="DynamicTypePreWarmer.DynamicTypesOf"/> used to select the sweep's population
+/// with <c>n.Content is NodeTypeDefinition d</c> — a direct CLR pattern match on a payload that
+/// crossed a query boundary. A query row's <c>Content</c> is deserialised by whichever hub served
+/// it, so an unresolvable <c>$type</c> degrades to a raw <c>JsonElement</c>
+/// (<c>Doc/Architecture/SyncedMeshNodeQueries</c>: <i>"a synced query built without the caller's
+/// options hands back raw JsonElement and every <c>is T</c> cast fails silently"</i>). Such a
+/// NodeType simply VANISHED from the sweep: out of <c>total=</c>, out of <c>baked=</c>, out of
+/// <c>pending=</c>. Nothing compiled it, nothing gated on it, and nothing anywhere said a type had
+/// been dropped — the report's denominator moved and the report read exactly the same.</para>
+///
+/// <para>#3703 is a case of two counters being compared across populations one of them could not
+/// name. A population that can silently shrink is the same failure one level down, so the read is
+/// now <c>ContentAs&lt;NodeTypeDefinition&gt;</c> — which RECOVERS the JSON case rather than
+/// dropping it — and whatever still will not type is COUNTED and logged by path. See
+/// <c>Doc/Architecture/ControlsThatCannotFail</c>: an instrument must be able to say "I did not
+/// check".</para>
+///
+/// <para>Pure — the function is a projection over an enumeration snapshot, so it needs no mesh.</para>
+/// </summary>
+public class EnumerationSaysWhatItCouldNotTypeTest
+{
+    private static NodeTypeDefinition Compilable => new()
+    {
+        Configuration = "config => config",
+        Sources = ["namespace:Source scope:subtree"],
+        CompilationStatus = CompilationStatus.Ok,
+    };
+
+    /// <summary>
+    /// 🚨 THE CONTROL. Content that arrived as JSON — the ordinary cross-hub shape — is RECOVERED
+    /// into the population instead of being dropped. Restore the
+    /// <c>n.Content is NodeTypeDefinition</c> match and this type is absent from both dictionaries
+    /// and from <c>Untyped</c> as well, i.e. gone without a trace, which is exactly what made the
+    /// truncation invisible.
+    /// </summary>
+    [Fact]
+    public void ContentThatArrivedAsJson_IsRecovered_NotSilentlyDropped()
+    {
+        var options = new JsonSerializerOptions();
+        var asJson = JsonSerializer.SerializeToElement(Compilable, options);
+
+        var result = DynamicTypePreWarmer.DynamicTypesOf(
+            [Node("Doc/Profile", asJson)], options, logger: null);
+
+        result.Definitions.Keys.Should().Equal(
+            ["Doc/Profile"],
+            "a NodeType whose content crossed a hub boundary as JSON is still a NodeType this "
+            + "sweep is responsible for");
+        result.Definitions["Doc/Profile"]!.Configuration.Should().Be("config => config");
+        result.Untyped.Should().BeEmpty("it typed — there is nothing unchecked here");
+    }
+
+    /// <summary>
+    /// 🚨 THE OTHER DIRECTION, and the one that makes the count able to fail. Content that CANNOT
+    /// be resolved is named rather than absorbed: the sweep decides nothing about it, and the
+    /// report says which types those were.
+    /// </summary>
+    [Fact]
+    public void ContentThatCannotBeResolved_IsNamed_SoNothingIsSilentlyUnchecked()
+    {
+        var options = new JsonSerializerOptions();
+        var unresolvable = JsonSerializer.SerializeToElement("this is not a definition", options);
+
+        var result = DynamicTypePreWarmer.DynamicTypesOf(
+            [Node("Doc/Profile", Compilable), Node("Doc/Broken", unresolvable)],
+            options, logger: null);
+
+        result.Definitions.Keys.Should().Equal(
+            ["Doc/Profile"], "only the type that resolved is in the population");
+        result.Untyped.Should().Equal(
+            ["Doc/Broken"],
+            "a type nothing decided anything about must be NAMED — a population that shrinks in "
+            + "silence is a denominator nobody can check (#3703)");
+    }
+
+    /// <summary>
+    /// A STATIC NodeType — one that ships its assembly with the process and has no source to
+    /// compile — is out of the population because it was CHECKED and answered "nothing to warm".
+    /// It must not land in <see cref="DynamicTypePreWarmer.DynamicTypes.Untyped"/>, or that count
+    /// would stop meaning "unchecked" and start meaning "excluded", which is the difference the
+    /// whole thing rests on.
+    /// </summary>
+    [Fact]
+    public void ATypeWithNoCompilableSource_IsExcluded_ButIsNotReportedAsUnchecked()
+    {
+        var options = new JsonSerializerOptions();
+        var result = DynamicTypePreWarmer.DynamicTypesOf(
+            [Node("Framework/Static", new NodeTypeDefinition())], options, logger: null);
+
+        result.Definitions.Should().BeEmpty();
+        result.Untyped.Should().BeEmpty(
+            "excluded-because-checked and unchecked are different states and must not share a "
+            + "counter");
+    }
+
+    /// <summary>A node with no content at all is not an unreadable one — nothing to recover, and
+    /// nothing to complain about.</summary>
+    [Fact]
+    public void ANodeWithNoContent_IsNotReportedAsUnchecked()
+    {
+        var result = DynamicTypePreWarmer.DynamicTypesOf(
+            [Node("Doc/Empty", content: null)], new JsonSerializerOptions(), logger: null);
+
+        result.Definitions.Should().BeEmpty();
+        result.Untyped.Should().BeEmpty();
+    }
+
+    /// <summary>A node the mesh has DELETED is out of scope for the sweep, as it always was.</summary>
+    [Fact]
+    public void AnInactiveNode_IsOutOfScope_AndNotReportedAsUnchecked()
+    {
+        var options = new JsonSerializerOptions();
+        var result = DynamicTypePreWarmer.DynamicTypesOf(
+            [Node("Doc/Profile", Compilable) with { State = MeshNodeState.Deleted }],
+            options, logger: null);
+
+        result.Definitions.Should().BeEmpty();
+        result.Untyped.Should().BeEmpty();
+    }
+
+    private static MeshNode Node(string path, object? content)
+    {
+        var slash = path.LastIndexOf('/');
+        return new MeshNode(path[(slash + 1)..], path[..slash]) { Content = content };
+    }
+}


### PR DESCRIPTION
## The premise of #3703 is wrong, and the defect underneath it is worse

The issue reads *"78 prebuilt assemblies adopted, the sweep's store probe counts 5"* — which sends
the reader to the assembly store. **Nothing was wrong with the store.** Both counters were right,
they were never the same population, and the sweep's number was computed from a projection this same
process had already superseded.

### What each instrument counts, with denominators

| | `ShippedPrebuiltBundles` → **78** | `DynamicTypePreWarmer` → **5** |
|---|---|---|
| unit | **assemblies** (bundle entries) | **NodeTypes** |
| denominator | entries across the 38 bundles this mesh holds a NodeType for | **209** dynamic NodeTypes in one mesh-wide enumeration |
| source | the bytes it wrote + the record patch it posted | a **CQRS query snapshot** of each type's record |
| claim | "these bytes are on the assembly store" | "this type's RECORD names a live-framework build **and** the store resolves bytes **at the version that record names**" |

Two bundles may name one NodeType, so the units do not even convert. But the load-bearing row is the
last one:

> 🚨 **The bake report is not a census of the assembly store and cannot be.** The store is asked
> exactly ONE question per type — `TryGetAssemblyPath(typePath, definition.LastCompiledVersion)` —
> and the key comes out of the **record**. A reader whose record snapshot is behind asks the wrong
> key, misses, and reports `FrameworkStale` whatever is on the volume.

So `baked=5` / `frameworkstale=201` are statements about **records**, each filtered through one store
lookup. `78` is a statement about **bytes**.

### Which of the three outcomes

**Outcome 2 and 1 together, not 3.** The adoption was *not* lost — the bytes were on the share and
the records did land (the control boot three hours later reports `77 already current`, `baked=189`).
So: the two lines measure different populations (a reporting defect), **and** the sweep's population
is judged from a source with no ordering against this process's own writes (an instrument defect
with a real 197-compiles-instead-of-~20 cost, and the reachability behind #3663).

### The mechanism, read off the code

- the seeding pass writes each adopted record through `GetMeshNodeStream(path).Update(…)` —
  authoritative, cross-hub, per type;
- the sweep reads `meshService.Query<MeshNode>(MeshWideQuery.OfType(…)).Take(1)` — a CQRS read.
  `Doc/Architecture/CqrsAndContentAccess`: *"a cached projection that is eventually consistent …
  long enough to break any pattern that requires read-your-writes"*, *"a query's answer for one path
  can be minutes old"*;
- nothing in `ClassifyDetailed` can tell a stale **projection** from a genuinely stale **record** —
  they are the same bytes.

Verified not to be the classifier: this repeats the finding in the issue's own third comment, and
`NodeTypeBakeStatus` is unchanged here except for the new report field.

## The fix — no retry, no wait, no bound moved

`NodeTypeAdoptionRegistry` already existed to stop the first-build kickoff racing an **in-flight**
adoption. It now also carries a ledger of **completed** ones — the same race, one tense later:

- `RecordAdopted(path, observedVersion, definition)` — called on the same branch that logs
  `Prebuilt assembly ADOPTED`, never without it. The definition is *captured* from the `Update`
  lambda, so it is by construction the record the owner received.
- `OverlayOnto(definitions, nodes)` — lays those stamps over an enumeration snapshot and reports
  which paths it overrode.

**The ordering is a fact, not a heuristic.** An adoption stamps the version it *read* and its own
write **bumps the node**:

| snapshot `MeshNode.Version` | means | wins |
|---|---|---|
| `<= observedVersion` | the snapshot cannot contain that write | the process's own stamp |
| `> observedVersion` | it contains that write, or something later (an owner refusal #2813, a recompile) | the snapshot |
| no node in the snapshot | nothing to compare | the snapshot |

Row 2 is what keeps this from becoming a stale serve, and it is pinned by a test that fails against
an unconditional overlay.

## Making the reporting honest

- the adoption line now says it counts **ASSEMBLIES (bundle entries)** and that the sweep counts
  **NODETYPES judged from records**, *"so the two are not the same population and a difference
  between them is not a disagreement"*;
- the sweep line reads `{Baked} need no build (record and share agree; … NOT a census of the
  assembly store)` — it used to say *"already on the share"*, which is the whole misreading in four
  words;
- `NodeTypeBakeReport.ClassifiedFromLocalAdoption`, surfaced in `Summary` as `fromlocaladoption=N`,
  so a boot whose enumeration was behind **says so in the line that reports the verdict**.

## The second truncation, one level down

`DynamicTypesOf` selected the sweep's population with `n.Content is NodeTypeDefinition d` — a direct
CLR match on a payload that crossed a query boundary. A row that degraded to a raw `JsonElement`
**vanished**: out of `total=`, out of `baked=`, out of `pending=`, with nothing to grep. The
denominator could move and the report read identically.

Now `ContentAs<NodeTypeDefinition>` (which **recovers** the JSON case) plus a counted, path-named
warning for whatever still will not type. Excluded-because-checked and never-checked stay separate
counters on purpose.

## Controls — both directions, each proven able to fail

`AdoptedTypeIsNotJudgedFromAStaleSnapshotTest` (8) · `EnumerationSaysWhatItCouldNotTypeTest` (5).
The forward case asserts the **pre-fix** verdict inside the same test, so it cannot go green by
construction. Each negative control was run by mutating the shipped code and captured verbatim:

**Overlay disabled** (`OverlayOnto` never applies):

```
Expected value to be Baked because bytes compiled against the live framework exist for this type,
and the record this process wrote is what names their key — recompiling it is the
197-instead-of-20 waste #3703 measured, but found FrameworkStale.
```

**Version guard removed** (an unconditional overlay — the stale-serve direction):

```
Expected value to be NeverBuilt because the record the owner left is what decides; serving the
adopted bytes over it would be exactly the stale serve #3703's fix must not introduce,
but found Baked.
```

**Direct cast restored** (the truncation direction):

```
Expected collection {} to equal {"Doc/Profile"} because a NodeType whose content crossed a hub
boundary as JSON is still a NodeType this sweep is responsible for.
```

## Work products committed

- **new** `Doc/Architecture/AdoptionAndTheSweepCountDifferentThings` — what each instrument counts,
  why the sweep could not see its own writes, the ordering rule, and the general rule
- instance **14** in `Doc/Architecture/ControlsThatCannotFail` (*"two counters over different
  populations, printed as if they were one measurement"*), plus the shapes-table row
- a What's New entry (`Category: Fix`)

## Verification

- `MeshWeaver.Compiler.Pipeline.Test` **809/809**
- `MeshWeaver.Documentation.Test` **368/368** (all ratchet guards + `DocumentationLinkIntegrityTest`)
- `MeshWeaver.Hosting.Test` **58/58** targeted (pre-warmer, adoption, prebuilt, seeding)
- `MeshWeaver.Compiler.Pipeline`, `MeshWeaver.Hosting`, `MeshWeaver.Graph`,
  `MeshWeaver.Hosting.Monolith` and both test projects: `-c Release -warnaserror`,
  **0 Error(s), 0 Warning(s)** each
- public surface: **0 removed, 7 added**; interface obligations **455 → 455** — no `Pairs-with:` and
  no `Implementers:` obligation. No i18n catalog change.

Closes #3703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
