### PR TITLE
fix(#3903): a NodeType missing its own sources says so, and stops repeating a doomed compile

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
@@ -972,6 +972,37 @@ internal class MeshNodeCompilationService(
                         string.Join(", ", matchedCodePaths),
                         "activity.compile.discoveryMatched",
                         ("count", matchedCodePaths.Count), ("paths", string.Join(", ", matchedCodePaths)));
+
+                    // 🚨 …AND WHICH DECLARED QUERY MATCHED NOTHING (#3903). The line above is a
+                    // count over the UNION, so a type that draws on a shared library reports a
+                    // healthy-looking N while the query for its own Source subtree matched zero —
+                    // and Roslyn, handed a set short of what the type declares, then emits
+                    // completely genuine-looking CS0246/CS1061 about symbols nobody lost. That is
+                    // the same phantom-diagnostic failure SourceSnapshot exists to prevent (#1218),
+                    // reaching the compile through the one door it does not watch, and it is the
+                    // reader — not the compiler — who pays: on memex.meshweaver.cloud the three
+                    // unresolved names were hunted through module surfaces that never carried them.
+                    // Warning, not Info: this is the diagnosis, and it belongs above the noise.
+                    var unmatched = SourceCoverage.UnmatchedSourceQueries(
+                        ntDef?.Sources, selfPath, matchedCodePaths);
+                    if (unmatched is { Count: > 0 })
+                    {
+                        var declared = ntDef?.Sources is { Count: > 0 } s
+                            ? s.Count
+                            : CodeQueryResolver.DefaultSources.Count;
+                        // The query strings are the mesh query LANGUAGE, not prose — they ride as
+                        // written, exactly like activity.compile.sourceQuery above.
+                        var queries = string.Join(", ", unmatched);
+                        discoveryLog = AppendWarning(discoveryLog,
+                            $"{unmatched.Count} of {declared} DECLARED source quer(ies) for "
+                            + $"'{selfPath}' matched NO nodes: {queries}. The compile below runs "
+                            + "against a source set SHORT of what this NodeType declares — an "
+                            + "unresolved type or extension method is far more likely to be an "
+                            + "absent source NODE than an absent module.",
+                            "activity.compile.declaredQueryMatchedNone",
+                            ("count", unmatched.Count), ("declared", declared),
+                            ("path", selfPath), ("queries", queries));
+                    }
                 }
 
                 // 🚨 Compile on the ThreadPool via Task.Run, never inline and never the IoPool.

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -1012,7 +1012,7 @@ internal static class NodeTypeCompilationHelpers
         var redriveGivenUp = false;
         var failedVerdictKickoffSub = ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
-                && HasStaleFailureVerdict(def, guards.ModulesHash)
+                && HasStaleFailureVerdict(def, guards.ModulesHash, hubPath)
                 && !IsStaticOnlyNodeType(node, def))
             // Cheap dedupe so an unrelated field edit does not re-enter the body while the flip is
             // still in flight; correctness is the re-check inside the Update lambda, not this.
@@ -1095,20 +1095,42 @@ internal static class NodeTypeCompilationHelpers
                 // snapshot the re-drive is merely WAITING, not declining, and reporting that as
                 // "stuck" would cry wolf on every cold activation of a broken type.
                 && def.CurrentSourceVersions is not null
-                && !HasStaleFailureVerdict(def, guards.ModulesHash))
+                && !HasStaleFailureVerdict(def, guards.ModulesHash, hubPath))
             .Take(1)
             .Subscribe(
                 node =>
                 {
                     var def = (NodeTypeDefinition)node!.Content!;
-                    logger?.LogWarning(
-                        "NodeType {HubPath} is STUCK at {Status} with no compiled assembly: its verdict was "
-                        + "formed under the compile inputs that are live now ({Inputs}), so the automatic "
-                        + "re-drive correctly declines and nothing will retry it until the framework, the "
-                        + "installed modules or its sources change — or someone requests a build. Error: {Error}",
-                        hubPath, def.CompilationStatus,
-                        def.FailedBuildInputs ?? "(never stamped)",
-                        def.CompilationError ?? "(none recorded)");
+                    // 🚨 SAY WHICH KIND OF STUCK (#3903). "the framework, the installed modules or
+                    // its sources" is the right remedy list for a type whose code does not compile;
+                    // it is actively misleading for one whose own source nodes are ABSENT, because
+                    // two of the three can never help and the reader spends the investigation on
+                    // module surfaces. When the coverage says a declared query matched nothing, the
+                    // line names the query and narrows the remedy to the one thing that works.
+                    if (IsUnconvergableSourceFailure(def, hubPath))
+                        logger?.LogWarning(
+                            "NodeType {HubPath} is STUCK at {Status} with no compiled assembly, and it "
+                            + "CANNOT CONVERGE: {Missing} Nothing will retry it until those source nodes "
+                            + "exist (which re-drives it automatically) or someone requests a build — a "
+                            + "redeploy or a module update will not, because neither can supply a symbol "
+                            + "that lives in a node this mesh does not hold. Error: {Error}",
+                            hubPath, def.CompilationStatus,
+                            SourceCoverage.Describe(
+                                hubPath, def.FailedSourceQueries,
+                                def.Sources is { Count: > 0 }
+                                    ? def.Sources.Count
+                                    : CodeQueryResolver.DefaultSources.Count)
+                            ?? "(a declared source query matched no nodes)",
+                            def.CompilationError ?? "(none recorded)");
+                    else
+                        logger?.LogWarning(
+                            "NodeType {HubPath} is STUCK at {Status} with no compiled assembly: its verdict was "
+                            + "formed under the compile inputs that are live now ({Inputs}), so the automatic "
+                            + "re-drive correctly declines and nothing will retry it until the framework, the "
+                            + "installed modules or its sources change — or someone requests a build. Error: {Error}",
+                            hubPath, def.CompilationStatus,
+                            def.FailedBuildInputs ?? "(never stamped)",
+                            def.CompilationError ?? "(none recorded)");
                 },
                 ex => logger?.LogDebug(ex,
                     "Stuck-type diagnostic: own-stream subscription faulted for {HubPath}", hubPath));
@@ -2952,7 +2974,16 @@ internal static class NodeTypeCompilationHelpers
     /// disabling it, and a mesh that cannot answer the source query degrades to no re-drive rather
     /// than to a wrong verdict.</para>
     /// </summary>
-    internal static bool HasStaleFailureVerdict(NodeTypeDefinition def, string? modulesHash) =>
+    /// <param name="def">The definition to judge.</param>
+    /// <param name="modulesHash">The installed-module fingerprint half of the live compile inputs.</param>
+    /// <param name="nodeTypePath">
+    /// 🚨 The NodeType's own path, so <see cref="IsUnconvergableSourceFailure"/> can be asked
+    /// (#3903). Passing <c>null</c> makes that question unanswerable, and an unanswerable question
+    /// is answered NO — the re-drive then behaves exactly as it did before, which is the safe
+    /// direction: an extra attempt costs one compile, a wrongly-declined one strands a type.
+    /// </param>
+    internal static bool HasStaleFailureVerdict(
+        NodeTypeDefinition def, string? modulesHash, string? nodeTypePath = null) =>
         def.CompilationStatus is CompilationStatus.Error or CompilationStatus.Unavailable
         // NO usable build was ever recorded — the complement of HasStaleFrameworkBuild, which
         // owns every case where coordinates DO exist.
@@ -2960,6 +2991,11 @@ internal static class NodeTypeCompilationHelpers
         && string.IsNullOrEmpty(def.LatestAssemblyPath)
         // The source set must be ESTABLISHED before it can be compared — see above.
         && def.CurrentSourceVersions is not null
+        // 🚨 …and the failure must be one a fresh attempt could possibly answer differently
+        // (#3903). See IsUnconvergableSourceFailure: a compile whose missing symbols live in
+        // source nodes that are not on this mesh fails identically on every framework and every
+        // module set, so re-driving it on one of those is not a retry, it is a repetition.
+        && !IsUnconvergableSourceFailure(def, nodeTypePath)
         && (
             // 🚨 An UNAVAILABLE verdict is stale ON ITS OWN — the inputs are irrelevant, because the
             // inputs were never the reason (#1701). Unavailable records "we never found out": the
@@ -2977,6 +3013,54 @@ internal static class NodeTypeCompilationHelpers
                 def.FailedBuildInputs,
                 BuildInputsToken(modulesHash, def.CurrentSourceVersions),
                 StringComparison.Ordinal));
+
+    /// <summary>
+    /// 🚨 <b>THE compile that cannot converge</b> (issue #3903) — a standing <c>Error</c> on a type
+    /// whose own declared source queries still match NOTHING on this mesh, measured against the
+    /// LIVE source snapshot rather than against the stamp that recorded it.
+    ///
+    /// <para><b>Why this is a classification and not a retry cap.</b> The re-drive's whole premise
+    /// is that a verdict is worth re-forming when the INPUTS it was formed from have moved
+    /// (<see cref="NodeTypeDefinition.FailedBuildInputs"/>: framework, modules, sources). That
+    /// premise fails for exactly one shape: when the symbols Roslyn could not resolve are the ones
+    /// the type's own <c>Source/*</c> nodes define, and those nodes are not on this mesh, then no
+    /// framework identity and no module set can supply them — the ONLY input that can change the
+    /// answer is the source set. Re-driving on the other two is not a retry, it is the same
+    /// measurement taken again, and on memex.meshweaver.cloud it was taken on every pod boot for
+    /// four days while nothing named the cause.</para>
+    ///
+    /// <para><b>It converges by construction, and it cannot latch.</b> The question is re-asked
+    /// from <see cref="NodeTypeDefinition.CurrentSourceVersions"/> on every emission, so the
+    /// instant the missing nodes land the coverage is empty, this is false, the token comparison
+    /// takes over and the type is re-driven — sooner than before, because it no longer has to wait
+    /// for a framework change to be noticed. An explicit Compile / release request never consults
+    /// this at all.</para>
+    ///
+    /// <para>🚨 <b>Three conditions, each load-bearing:</b></para>
+    /// <list type="bullet">
+    ///   <item><c>Error</c>, never <see cref="CompilationStatus.Unavailable"/>. Unavailable means
+    ///     the compile reached NO verdict, so nothing was measured and there is nothing to decline
+    ///     repeating (#1701 — that branch is deliberately input-independent).</item>
+    ///   <item>A DECLARED source query matched nothing (<see cref="SourceCoverage"/>). Not "the
+    ///     snapshot is empty", which is <c>PreWarmStatus.NoSources</c>' condition and unreachable
+    ///     for any type that also draws on a shared library.</item>
+    ///   <item><see cref="NodeTypeDefinition.LastCompileSucceededAt"/> is set — the second witness
+    ///     that the sources were LOST rather than never present. A type that has never built cannot
+    ///     have lost anything: its failure may well be its own <c>Configuration</c>, and that one
+    ///     must keep earning its attempt on a new framework. Same discriminator, for the same
+    ///     reason, as <c>DynamicTypePreWarmer.ClassifyCompileFailure</c>.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="def">The definition to judge.</param>
+    /// <param name="nodeTypePath">The type's path; <c>null</c> makes the question unanswerable and
+    /// the answer is then NO — never a silent yes.</param>
+    internal static bool IsUnconvergableSourceFailure(
+        NodeTypeDefinition def, string? nodeTypePath) =>
+        def.CompilationStatus is CompilationStatus.Error
+        && def.LastCompileSucceededAt is not null
+        && SourceCoverage.UnmatchedSourceQueries(
+            def.Sources, nodeTypePath, def.CurrentSourceVersions?.Keys.ToList())
+            is { Count: > 0 };
 
     /// <summary>
     /// 🅿️ THE failed-verdict re-drive's COMMIT step (#2260) — the whole decision, including the
@@ -3023,7 +3107,7 @@ internal static class NodeTypeCompilationHelpers
             return curr;
         // Re-check against the state being committed — a genuine compile may have settled, or a
         // fresh terminal failure may have re-parked, between the outer Where and this write.
-        if (!HasStaleFailureVerdict(d, modulesHash)) return curr;
+        if (!HasStaleFailureVerdict(d, modulesHash, hubPath)) return curr;
         // 🅿️ Committing the flip — and ONLY now — claim the one-shot admission, so the compile
         // watcher's parked short-circuit lets this Pending emission through. The park itself is
         // never touched.
@@ -3276,6 +3360,11 @@ internal static class NodeTypeCompilationHelpers
             // had already had its automatic attempt under these inputs, and the type would sit
             // broken with nothing due to retry it.
             FailedBuildInputs = null,
+            // 🚨 …and so must the finding that explained it (#3903). A standing "these declared
+            // source queries matched nothing" describes a failure that no longer exists; left
+            // behind it would tell the next reader that a green type is missing its sources, and
+            // would let the re-drive decline for a type that is not even failing.
+            FailedSourceQueries = null,
             // 🚨 This compile just answered the question an adoption's stamp request was asking
             // (#1834), and answered it from the set it actually consumed. A request left standing
             // would let a later CurrentSourceVersions publication re-stamp CompiledSources over
@@ -3440,13 +3529,38 @@ internal static class NodeTypeCompilationHelpers
     /// <c>EnsureCompileDispatched</c> re-dispatches on the next request, and the bake gate files it
     /// as unevaluated rather than as an image regression (issue #1218).</para>
     /// </summary>
+    /// <param name="def">The definition being stamped.</param>
+    /// <param name="result">The compile result, when one was produced.</param>
+    /// <param name="error">The terminal exception, when the compile threw.</param>
+    /// <param name="activityPath">The compile activity, when one was created.</param>
+    /// <param name="modulesHash">The installed-module fingerprint half of the compile inputs.</param>
+    /// <param name="nodeTypePath">
+    /// 🚨 The NodeType's own path — the <c>$self</c> expansion root, and therefore what makes
+    /// <see cref="NodeTypeDefinition.FailedSourceQueries"/> computable (#3903). A <c>null</c> here
+    /// leaves that field NOT DETERMINED rather than empty: a stamp that could not measure the
+    /// coverage must never look like one that measured it and found nothing wrong.
+    /// </param>
     internal static NodeTypeDefinition ApplyCompileFailure(
         NodeTypeDefinition def,
         NodeCompilationResult? result,
         Exception? error,
         string? activityPath,
-        string? modulesHash = null)
-        => def with
+        string? modulesHash = null,
+        string? nodeTypePath = null)
+    {
+        // 🚨 Measured against the set the compile CONSUMED (the result's own snapshot when it
+        // resolved one, else the node's live one) — the same evidence FailedBuildInputs uses, so
+        // the two halves of the record describe the same compile.
+        var consumed = result?.CompiledSources ?? def.CurrentSourceVersions;
+        var unmatched = SourceCoverage.UnmatchedSourceQueries(
+            def.Sources, nodeTypePath, consumed?.Keys.ToList());
+        var declaredCount = def.Sources is { Count: > 0 }
+            ? def.Sources.Count
+            : CodeQueryResolver.DefaultSources.Count;
+        var missingSources = SourceCoverage.Describe(
+            nodeTypePath ?? "(unknown)", unmatched, declaredCount);
+
+        return def with
         {
             // 🚨 Terminal ⇒ no compile in flight (#3390). Missed by the first half of #3390
             // because the status here is a TERNARY, not the literal the guard matched on — the
@@ -3455,12 +3569,23 @@ internal static class NodeTypeCompilationHelpers
             CompilationStatus = IsAvailabilityNonVerdict(error)
                 ? CompilationStatus.Unavailable
                 : CompilationStatus.Error,
-            CompilationError = SummarizeCompileError(result, error),
+            // 🚨 The DIAGNOSIS LEADS (#3903). When a declared source query matched nothing, the
+            // Roslyn diagnostics below it are about a source set SHORT of what the type declares —
+            // and a reader who is not told that spends the investigation hunting the named symbols
+            // through module surfaces that never carried them (measured: rbuergi/OperationRequest,
+            // four days). Prefixed rather than replacing: the diagnostics are still the evidence.
+            CompilationError = missingSources is null
+                ? SummarizeCompileError(result, error)
+                : $"{missingSources}\n{SummarizeCompileError(result, error)}",
             CompilationDiagnostics = result?.Diagnostics is { Count: > 0 } ds
                 ? System.Collections.Immutable.ImmutableList.CreateRange(ds)
                 : null,
             LastCompilationActivityPath = activityPath,
             CompiledSources = null,
+            // 🚨 THE STRUCTURED HALF of the same finding — null when it could not be determined,
+            // EMPTY when every declared source query matched. See the property doc: those two must
+            // never collapse into each other.
+            FailedSourceQueries = unmatched,
             // 🚨 RECORD WHAT THE VERDICT WAS FORMED FROM (#1793). This is the one durable fact a
             // failure can leave behind — it writes no assembly coordinates and no framework stamp,
             // which is exactly why every automatic re-drive used to skip a never-compiled failure
@@ -3478,6 +3603,7 @@ internal static class NodeTypeCompilationHelpers
             // above), so the request goes with it — see ApplyCompileSuccess (#1834).
             RequestedSourceStampAt = null
         };
+    }
 
     /// <summary>
     /// Compile-and-write-back loop for one NodeType. Runs Roslyn via
@@ -4059,7 +4185,8 @@ internal static class NodeTypeCompilationHelpers
                         {
                             Content = ApplyCompileFailure(
                                 def, outcome.Result, outcome.Error, resolvedActivityPath,
-                                hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
+                                hub.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash,
+                                hubPath)
                         };
                     })
                     .Do(saved =>

--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompileState.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompileState.cs
@@ -119,6 +119,12 @@ public record NodeTypeCompileState
     /// <summary>See <see cref="NodeTypeDefinition.FailedBuildInputs"/>.</summary>
     public string? FailedBuildInputs { get; init; }
 
+    /// <summary>See <see cref="NodeTypeDefinition.FailedSourceQueries"/> — the declared source
+    /// queries that matched NOTHING when the standing failure was recorded (#3903). Mirrored for
+    /// the same reason as the token beside it, and with the same three-shape contract: <c>null</c>
+    /// is NOT DETERMINED, an empty list is "checked, every declared query matched".</summary>
+    public System.Collections.Immutable.ImmutableList<string>? FailedSourceQueries { get; init; }
+
     /// <summary>See <see cref="NodeTypeDefinition.AdoptedSourceFingerprint"/>.</summary>
     public string? AdoptedSourceFingerprint { get; init; }
 
@@ -170,6 +176,7 @@ public record NodeTypeCompileState
                 RequestedSourceStampAt = definition.RequestedSourceStampAt,
                 CompiledFrameworkVersion = definition.CompiledFrameworkVersion,
                 FailedBuildInputs = definition.FailedBuildInputs,
+                FailedSourceQueries = definition.FailedSourceQueries,
                 AdoptedSourceFingerprint = definition.AdoptedSourceFingerprint,
                 AdoptedModuleVersion = definition.AdoptedModuleVersion,
                 CurrentModuleVersion = definition.CurrentModuleVersion,
@@ -190,6 +197,7 @@ public record NodeTypeCompileState
         && CompiledSources is null && CurrentSourceVersions is null
         && RequestedSourceStampAt is null
         && CompiledFrameworkVersion is null && FailedBuildInputs is null
+        && FailedSourceQueries is null
         && AdoptedSourceFingerprint is null && AdoptedModuleVersion is null
         && CurrentModuleVersion is null
         && CurrentSourceFingerprint is null

--- a/src/MeshWeaver.Compiler/NodeSetQuery.cs
+++ b/src/MeshWeaver.Compiler/NodeSetQuery.cs
@@ -57,10 +57,39 @@ public static class NodeSetQuery
             if (nodeType is not null
                 && !string.Equals(node.NodeType, nodeType, StringComparison.OrdinalIgnoreCase))
                 return false;
+            return MatchesPathCore(node.Path, node.Namespace ?? string.Empty);
+        }
+
+        /// <summary>
+        /// The PATH/SCOPE half of the predicate evaluated against a BARE PATH — for a caller that
+        /// holds the paths a query matched but not the nodes themselves.
+        /// <see cref="SourceCoverage"/> is that caller: its evidence is
+        /// <c>NodeTypeDefinition.CurrentSourceVersions</c>, a path→version map.
+        ///
+        /// <para>🚨 The <c>nodeType:</c> constraint is deliberately IGNORED here, and the DIRECTION
+        /// of that omission is what makes it safe. Dropping a conjunct can only make a predicate
+        /// MORE permissive, so this overload can answer "matched something" where the full
+        /// predicate would have answered "matched nothing" — never the reverse. Every caller asks
+        /// only <i>"did this query match NOTHING?"</i>, and a more permissive predicate answering
+        /// "nothing" is proof that the stricter one did too. So the derived answer can UNDER-report
+        /// a missing source query and can never accuse one that was fine — the only asymmetry a
+        /// diagnosis is allowed to have.</para>
+        ///
+        /// <para>The namespace is derived from the path (everything before the last <c>/</c>),
+        /// which is the relation <c>MeshNode</c> itself maintains between the two.</para>
+        /// </summary>
+        /// <param name="nodePath">The node's full mesh path.</param>
+        public bool MatchesPath(string nodePath)
+        {
+            ArgumentNullException.ThrowIfNull(nodePath);
+            var slash = nodePath.LastIndexOf('/');
+            return MatchesPathCore(nodePath, slash < 0 ? string.Empty : nodePath[..slash]);
+        }
+
+        private bool MatchesPathCore(string nodePath, string nodeNamespace)
+        {
             if (path is null)
                 return true;
-            var nodePath = node.Path;
-            var nodeNamespace = node.Namespace ?? string.Empty;
             if (path.Length == 0)
                 return scope switch
                 {

--- a/src/MeshWeaver.Compiler/SourceCoverage.cs
+++ b/src/MeshWeaver.Compiler/SourceCoverage.cs
@@ -1,0 +1,155 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// 🚨 <b>Which of a NodeType's DECLARED source queries matched NOTHING</b> — the granularity
+/// <see cref="SourceSnapshot"/> is missing, and the reason a NodeType whose own <c>Source/</c>
+/// subtree is absent reports itself as broken C# instead of as missing content (issue #3903).
+///
+/// <para><b>The defect.</b> <see cref="SourceSnapshot"/> already establishes that a SHORT source
+/// set must never reach Roslyn as if it were the whole one: handed a set that is missing files,
+/// Roslyn emits a completely genuine-looking <c>CS0246</c>/<c>CS1061</c> about the author's code
+/// (#1218). But that mechanism measures emptiness on the MERGED set — the union of every expanded
+/// source and test query — and a NodeType that also draws on a shared library keeps a non-empty
+/// union even when the query for its OWN sources matches nothing at all. Measured on
+/// memex.meshweaver.cloud, 2026-09-10:</para>
+///
+/// <code>
+/// rbuergi/OperationRequest      compilationStatus: Error   since 2026-09-06, retried every boot
+///   sources: [ "namespace:Source scope:subtree",        ← matched 0 nodes
+///              "shared=@Store/Core/Source",             ← matched 41 between them
+///              "shared=@Store/Licensing/Source", … ]
+///   CS0246 'OperationRequestContent' could not be found
+///   CS1061 'MessageHubConfiguration' has no 'AddOperationRequestControlPlane'
+///   CS1061 'LayoutDefinition'        has no 'AddOperationRequestLayoutAreas'
+/// </code>
+///
+/// <para>All three unresolved symbols are the type's own <c>Source/*</c> nodes, which do not exist
+/// in that partition (<c>search 'namespace:rbuergi/OperationRequest scope:subtree'</c> → 0, against
+/// 21 under the package copy). The union was 41 nodes, so <c>PreWarmStatus.NoSources</c> could not
+/// fire and nothing anywhere said "one of your source queries matched nothing" — the reader was
+/// left hunting three symbols through module surfaces that never carried them.</para>
+///
+/// <para><b>The unit is the DECLARED ENTRY, not the expanded query</b>, and that is load-bearing.
+/// <see cref="CodeQueryResolver.Expand"/> turns one <c>@X</c> shorthand into TWO queries — a
+/// <c>path:X</c> exact match and a <c>namespace:X scope:subtree</c> folder match — of which the
+/// exact one is EXPECTED to match nothing whenever the folder node is not itself a Code node. Per
+/// QUERY, every <c>shared=@Lib/Source</c> entry in a healthy mesh would be reported as half
+/// missing. Per ENTRY — "did anything this line asks for exist?" — the answer is the one the author
+/// can act on.</para>
+///
+/// <para><b>🚨 Three answers, never two</b> (the <c>NodeDiagnosticsOutcome</c> rule: a status that
+/// says "nothing was checked" must not be readable as "checked and clean"):</para>
+/// <list type="bullet">
+///   <item><c>null</c> — NOT DETERMINED. No source snapshot to measure against, no NodeType path to
+///     expand <c>$self</c> against, or not one declared entry could be evaluated offline. Says
+///     nothing about the type's sources.</item>
+///   <item>EMPTY — determined, and every evaluable declared entry matched at least one node.</item>
+///   <item>NON-EMPTY — these declared entries answered and matched nothing.</item>
+/// </list>
+///
+/// <para><b>Why an entry may be inevaluable, and why that is not a failure.</b> The offline
+/// evaluator (<see cref="NodeSetQuery"/>) speaks the closed four-selector grammar
+/// <see cref="CodeQueryResolver.Expand"/> emits and REFUSES everything else rather than
+/// approximating it — free text routes to a vector index a pure function cannot reproduce. An entry
+/// it cannot parse simply does not contribute, in either direction: it is neither reported as
+/// missing nor counted as satisfied. Reporting one would be an accusation from evidence nobody has.
+/// </para>
+/// </summary>
+public static class SourceCoverage
+{
+    /// <summary>
+    /// The declared SOURCE entries of <paramref name="nodeTypePath"/> that answered and matched
+    /// none of <paramref name="matchedPaths"/>.
+    ///
+    /// <para>🚨 <b>Source entries only — never Tests.</b> The default test query
+    /// (<c>namespace:{path}/Test scope:subtree</c>) matches nothing for most NodeTypes in a real
+    /// mesh, by design: a type without tests is normal, not broken. Folding tests in would make
+    /// this fire on nearly the whole population and the signal would be worth nothing.</para>
+    /// </summary>
+    /// <param name="declaredSources">The NodeType's <c>Sources</c> as authored. Null/empty means
+    /// it uses <see cref="CodeQueryResolver.DefaultSources"/> — which is how very nearly every
+    /// NodeType is written, and exactly the population #1391 taught us not to exclude.</param>
+    /// <param name="nodeTypePath">The NodeType's mesh path — the <c>$self</c> expansion and the
+    /// rebase root for a bare <c>namespace:Source</c>.</param>
+    /// <param name="matchedPaths">The paths the compile's source snapshot actually resolved
+    /// (<c>NodeTypeDefinition.CurrentSourceVersions</c> / <c>CompiledSources</c> keys). A
+    /// <c>null</c> snapshot is "not established yet", NOT "nothing matched" — the same distinction
+    /// <c>NodeTypeCompilationHelpers.SourceToken</c> keeps.</param>
+    /// <returns>Null when nothing could be determined; otherwise the unmatched entries as
+    /// authored, in declaration order.</returns>
+    public static ImmutableList<string>? UnmatchedSourceQueries(
+        IReadOnlyList<string>? declaredSources,
+        string? nodeTypePath,
+        IReadOnlyCollection<string>? matchedPaths)
+    {
+        if (string.IsNullOrEmpty(nodeTypePath) || matchedPaths is null)
+            return null;
+
+        var entries = declaredSources is { Count: > 0 }
+            ? declaredSources
+            : CodeQueryResolver.DefaultSources;
+
+        var determined = 0;
+        var unmatched = ImmutableList.CreateBuilder<string>();
+
+        foreach (var entry in entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+
+            // One authored entry, every query it expands to. `evaluable` stays false until at
+            // least one expansion parses — an entry the offline evaluator cannot read contributes
+            // to neither side of the answer.
+            var evaluable = false;
+            var matched = false;
+            foreach (var query in CodeQueryResolver.Expand(entry, nodeTypePath))
+            {
+                if (!NodeSetQuery.TryParse(query, out var predicate, out _))
+                    continue;
+                evaluable = true;
+                if (matchedPaths.Any(predicate.MatchesPath))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!evaluable)
+                continue;
+            determined++;
+            if (!matched)
+                unmatched.Add(entry);
+        }
+
+        // 🚨 Not one entry could be evaluated ⇒ NOT DETERMINED, never "all clean". An empty list
+        // returned here would be indistinguishable from "every declared query matched", which is
+        // the exact shape a probe is forbidden to have.
+        return determined == 0 ? null : unmatched.ToImmutable();
+    }
+
+    /// <summary>
+    /// One line naming what <see cref="UnmatchedSourceQueries"/> found, for the compile's recorded
+    /// error and the operator log — or <c>null</c> when there is nothing to report.
+    ///
+    /// <para>Deliberately says what the reader should do with the diagnostics that follow it: a
+    /// missing type or extension method on a SHORT source set is far more likely to be an absent
+    /// source NODE than an absent module, and sending the reader to the module surfaces is the
+    /// cost this whole classification exists to avoid.</para>
+    /// </summary>
+    /// <param name="nodeTypePath">The NodeType the finding is about.</param>
+    /// <param name="unmatched">The unmatched declared entries.</param>
+    /// <param name="declaredCount">How many source entries the type declares in total.</param>
+    public static string? Describe(
+        string nodeTypePath, IReadOnlyList<string>? unmatched, int declaredCount) =>
+        unmatched is not { Count: > 0 }
+            ? null
+            : $"MISSING SOURCES: {unmatched.Count} of {declaredCount} declared source quer"
+              + $"{(declaredCount == 1 ? "y" : "ies")} for '{nodeTypePath}' matched NO nodes on "
+              + $"this mesh ({string.Join(", ", unmatched.Select(q => $"'{q}'"))}). The compile ran "
+              + "against a source set SHORT of what this NodeType declares, so an unresolved type "
+              + "or extension method below is far more likely to be an absent source NODE than an "
+              + "absent module. No framework or module change can supply it — restore the source "
+              + "nodes, or correct the query.";
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -235,6 +235,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Producer Determinism of the Dependency Record](ProducerDeterminismOfTheDependencyRecord) — the same content must stamp the same record however the producer reached its bytes; the disk-cache hit that shipped a weaker guard, and why the digest is persisted beside the bytes rather than recomputed
 - [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes
 - [Source-Set Establishment](SourceSetEstablishment) — a resolved source set of ZERO is ambiguous, and only the type's own persisted snapshot tells "owns no Code" from "the discovery pass came back short"; the boot that resolved 91 fewer Code nodes than its neighbours and held a portal out of rotation for the startup probe's full three hours
+- [Missing Declared Sources](MissingDeclaredSources) — emptiness measured on the UNION is invisible for any type that also draws on a shared library; the NodeType whose own Source subtree was gone, reported itself as broken C#, and had the identical doomed compile taken again on every boot for four days
 - [Install-Time Prebuilt Adoption](InstallTimePrebuiltAdoption) — the only lane that serves a package installed AFTER boot, and the four answers its zero must keep apart because a silent non-adoption reads exactly like a successful one
 - [Import Write Ordering](ImportWriteOrdering) — type before instance, and what a foreign type does
 - [Language Services](LanguageServices)

--- a/src/MeshWeaver.Documentation/Data/Architecture/MissingDeclaredSources.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MissingDeclaredSources.md
@@ -1,0 +1,206 @@
+---
+Name: Missing Declared Sources
+Category: Architecture
+Description: Emptiness measured on the UNION is invisible for any NodeType that also draws on a shared library — so a type whose own Source subtree was gone reported itself as broken C#, named three symbols that live in nodes nobody has, and had the identical doomed compile taken again on every pod boot for four days. The per-entry coverage that names it, and why declining to repeat it is a classification rather than a retry cap.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h7l2 2h9v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><line x1="9" y1="14" x2="15" y2="14"/><line x1="12" y1="3" x2="12" y2="7" opacity="0.35"/></svg>
+---
+
+# Missing Declared Sources
+
+A NodeType declares where its code lives. When one of those declarations matches **nothing**, the
+compile still runs — against a source set short of what the type asks for — and Roslyn, shown less
+than the whole, reports exactly what a broken program looks like.
+
+```
+rbuergi/OperationRequest      compilationStatus: Error   since 2026-09-06
+  CS0246  The type or namespace name 'OperationRequestContent' could not be found
+  CS1061  'MessageHubConfiguration' has no 'AddOperationRequestControlPlane'
+  CS1061  'LayoutDefinition'        has no 'AddOperationRequestLayoutAreas'
+```
+
+Every one of those three names is one of the type's **own** `Source/*` nodes, and that partition
+does not hold them:
+
+```
+search 'namespace:rbuergi/OperationRequest scope:subtree'    → 0
+search 'namespace:Essentials/OperationRequest scope:subtree' → 21   (14 Release + 5 Source + 2 Test)
+```
+
+Nothing said so. The reader was handed three missing symbols and went looking for them in module
+surfaces that never carried them — for four days, while every pod boot burned another Roslyn compile
+producing the identical diagnostics (issue #3903).
+
+## Why the existing mechanism could not see it
+
+[Source-Set Establishment](../SourceSetEstablishment) is the rule that a compile whose source set was
+not *established* is not a verdict about the code, and `PreWarmStatus.NoSources` is the rule that a
+source set which is established and **empty** is a fact about the mesh's CONTENT, not about the
+image. Both are right. Both measure the **union**.
+
+`rbuergi/OperationRequest` declares six source entries:
+
+```json
+"sources": [
+  "namespace:Source scope:subtree",       // its own Source subtree  → 0 nodes
+  "shared=@Store/Core/Source",            //
+  "shared=@Store/Licensing/Source",       //  41 nodes between them
+  "shared=@Store/Publishing/Source",      //
+  "shared=@Store/Coupon/Source",          //
+  "shared=@Store/Install/Source"          //
+]
+```
+
+The union is 41 nodes. It is established. It is not empty. Every emptiness test in the pipeline reads
+healthy, and the one query whose emptiness explains the failure is invisible to a count.
+
+> **Emptiness is a per-QUERY fact and it was being measured on the union.** For any NodeType that
+> composes — which is every type that reuses a library — that measurement cannot reach the case it
+> exists to catch.
+
+## The unit is the authored ENTRY, not the expanded query
+
+`CodeQueryResolver.Expand` turns one `@X` shorthand into **two** queries: a `path:X` exact match and
+a `namespace:X scope:subtree` folder match. The exact one matches nothing whenever the folder node is
+not itself a Code node — which is the normal, healthy case. Measured per query, every
+`shared=@Lib/Source` entry in the fleet would be reported as half missing and the signal would be
+worth nothing.
+
+So the unit is the line the author wrote: *did anything this entry asks for exist?* That is also the
+only unit anyone can act on.
+
+**Test entries are excluded.** The default `namespace:{path}/Test scope:subtree` matches nothing for
+most types in a real mesh, by design — a type without tests is normal, not broken.
+
+## Three answers, never two
+
+`SourceCoverage.UnmatchedSourceQueries` (in `MeshWeaver.Compiler`) is a pure function over the
+declared entries, the type's path and the paths its snapshot resolved. It answers in three shapes,
+and collapsing any two of them re-creates the defect
+[Controls That Cannot Fail](../ControlsThatCannotFail) is about:
+
+| Answer | Meaning |
+|---|---|
+| `null` | **NOT DETERMINED** — no established snapshot, no type path, or not one entry the offline evaluator could read. Says nothing about the sources. |
+| empty | Determined: every evaluable declared entry matched at least one node. |
+| non-empty | These declared entries answered and matched nothing. |
+
+An entry the evaluator refuses — free text, which routes to a vector index a pure function cannot
+reproduce — contributes to **neither** side. Reporting it would be an accusation from evidence
+nobody has; counting it as satisfied would be the "checked and clean" lie.
+
+The evaluation itself reuses `NodeSetQuery`, the mesh-free evaluator of the closed four-selector
+grammar the resolver emits, through a path-only overload that deliberately **ignores** the
+`nodeType:` conjunct. Dropping a conjunct can only make a predicate more permissive, so the derived
+answer can under-report a missing entry and can never accuse one that was fine.
+
+## What it changes
+
+### 1. The compile says which query matched nothing
+
+- **The activity log** gets a warning above the Roslyn output, keyed
+  (`activity.compile.declaredQueryMatchedNone`) and therefore translated, naming the entries and the
+  count.
+- **`NodeTypeDefinition.CompilationError`** leads with the diagnosis instead of leaving the reader
+  with three symbols and no direction. The Roslyn text is kept underneath: it is still the evidence,
+  it just is not the explanation.
+- **`NodeTypeDefinition.FailedSourceQueries`** carries the structured finding, as authored, so a
+  reader (or an agent) gets the answer as data rather than by parsing an error string, and the
+  compile-state satellite mirrors it. It is operational state: stripped on export, preserved from
+  the live node on every upsert, cleared by a success.
+
+### 2. The doomed compile is not taken again
+
+`PreWarmStatus.DeclaredSourcesMissing` is a **content verdict**, filed exactly like
+`PreWarmStatus.NoSources` and for the identical reason its own doc gives:
+
+> which nodes a mesh query matches is a property of the mesh, not of the framework being rolled out,
+> so no image caused it and no rollout can fix it
+
+so it never gates a rollout, and dependents inherit `UpstreamContentBroken` rather than the gating
+`UpstreamFailed`. And both drivers stop re-attempting it:
+
+- **The activation re-drive** (`HasStaleFailureVerdict` → `IsUnconvergableSourceFailure`) declines.
+  Its trigger is "the compile INPUTS moved", and a new framework or module set moved an input that
+  cannot change this answer.
+- **The batch bake**, which decides what to build from a store probe and maps a standing `Error` to
+  `BakeState.PreviouslyBroken` ⇒ `NeedsBake`, returns the classification without running Roslyn — but
+  only when **two independent witnesses agree**: the type's persisted snapshot *and* the set this
+  bake resolved for itself. The record alone would latch, because the sources watcher that maintains
+  it may never have run on a batch-baking pod; the resolved set alone would let a starved discovery
+  pass file itself as content drift (#1216). Either witness saying the sources are there compiles.
+
+🚨 **This is a classification, not a cap.** Three properties make the difference, and each one is a
+control in `ADoomedCompileIsClassifiedNotRepeatedTest`:
+
+1. **The first attempt always runs.** The condition requires a **standing** `Error` — a verdict this
+   deployment has already measured — so the coverage is never used to assert a failure nobody
+   observed. A type reaching this state compiles, fails honestly, records the finding, and only then
+   stops repeating a measurement whose inputs cannot have moved.
+2. **It converges instantly and by itself.** The decision is recomputed from the **live** snapshot on
+   every emission. The moment the missing nodes land, the coverage is empty and the type is
+   re-driven — sooner than before, because it no longer has to wait for a framework change to be
+   noticed. There is no field to clear and no budget to refund.
+3. **A second witness keeps the gate intact.** `LastCompileSucceededAt` must be set: the sources must
+   have been **lost**, not never present. A type that has never built cannot have lost anything — its
+   failure may be its own `Configuration`, and that one keeps earning its attempt and keeps refusing
+   readiness. Same discriminator, for the same reason, as `NoSources`.
+
+And it says so out loud. The stuck-type diagnostic no longer offers a remedy that cannot work:
+
+```
+NodeType rbuergi/OperationRequest is STUCK at Error with no compiled assembly, and it CANNOT
+CONVERGE: MISSING SOURCES: 1 of 6 declared source queries … matched NO nodes on this mesh
+('namespace:Source scope:subtree'). … Nothing will retry it until those source nodes exist
+(which re-drives it automatically) or someone requests a build — a redeploy or a module update
+will not, because neither can supply a symbol that lives in a node this mesh does not hold.
+```
+
+## Where the orphan came from — and what is NOT fixed here
+
+A NodeType definition reached a user partition without its `Source/**`. The copy is core's, and both
+implementations have the same shape:
+
+- `NodeCopyHelper.CopyNodeTree` (`src/MeshWeaver.Graph/NodeCopyHelper.cs`) — reached by the MCP
+  `copy` tool, the UI Copy / Import dialogs and "copy to home". It enumerates the source subtree **as
+  the caller**, then writes every node through `.Merge(16)` with **no parent-before-child ordering**,
+  **no rollback** on a failing child, and **no post-condition** comparing what landed against what
+  was enumerated. One failing child leaves everything already written in place and never attempts the
+  rest; a caller-scoped enumeration that returns only the root reports success.
+- `MeshExtensions.HandleCopyNodeRequest` writes the root strictly first, then the children as
+  independent creates, and its completeness guard (`RequireComplete`, which compares the enumeration
+  against `ListDescendantPaths` **before** writing anything) is set only by the Move leg. A plain copy
+  has none.
+
+Both are in **this repo**, not in MeshWeaver.Plugins — whose own installer solved these three
+problems explicitly (parents-before-children ordering, a System-scoped enumeration because gated
+packages hide children from subject-scoped queries, and a batch-shortfall post-condition). And a copy
+writes no install record, so `InstallCompleteness` — the platform's one partial-install detector —
+cannot see it either.
+
+**That is a separate defect with its own design decisions** (ordering, rollback semantics, the
+identity a subtree enumeration runs under) and is tracked on its own issue. This page's change makes
+its consequence *legible and cheap* instead of silent and repeated; it does not stop the half-copy
+from happening.
+
+## Residuals, named rather than left to be rediscovered
+
+- **The classification does not run for a type whose path is unknown.** Every production call site
+  passes it; the pure overloads without it fall back to the pre-#3903 behaviour, which is the safe
+  direction — an extra compile costs a compile, a wrongly declined one strands a type.
+- **A configuration-only type that legitimately owns no Code and is broken by an IMAGE change reads
+  as content-broken and does not gate.** Inherited knowingly from `NoSources`, whose doc concedes the
+  same case for the same reason, and bounded by the same second witness.
+- **`ApplyGateSettle` does not restamp the finding.** It settles a Pending flip that never ran Roslyn,
+  so the previous verdict's finding is still the true story — the same reasoning `ApplyCompileFailure`
+  applies to `BuildProvenance`.
+- **The `@@`-include closure is still not covered**, exactly as `NodeTypeSourceFingerprint` records:
+  an include pulls a Code node no source query matches, so it is in neither the snapshot nor this
+  coverage.
+
+## Related
+
+- [Source-Set Establishment](../SourceSetEstablishment) — the union-level rule this refines: a set that could not be established is not a verdict at all
+- [Node Type Compilation](../NodeTypeCompilation) — what a compile does, and what its status means
+- [Retiring a NodeType](../RetiringANodeType) — the deliberate version of "the sources are gone"
+- [Dangling NodeTypes](../DanglingNodeTypes) — the instance-side sibling: a node whose TYPE resolves to nothing
+- [Controls That Cannot Fail](../ControlsThatCannotFail) — why "not determined" and "checked and clean" must never share a shape

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-node-type-missing-its-own-code-now-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-node-type-missing-its-own-code-now-says-so.md
@@ -1,0 +1,59 @@
+---
+Name: A node type missing its own code now says so
+Category: Fix
+Description: A node type whose own code files are gone used to report itself as broken C#, naming types and methods that do not exist anywhere — and tried the same impossible compile again on every restart. It now names the missing code directly, and stops repeating an attempt that cannot succeed.
+Icon: Checkmark
+Order: -20260910
+---
+
+# A node type missing its own code now says so
+
+A node type points at the code files it is built from — usually its own `Source` folder, often a
+shared library as well. When **its own** files are missing but the shared ones are still there, the
+compiler was handed part of the picture and reported what it saw: unknown types and unknown methods,
+by name.
+
+Those names looked like a real programming error. They were not — every one of them was defined in a
+file that was simply not there. On a live portal one node type sat like that for four days while the
+names it reported were searched for in modules that never contained them, and every restart ran the
+same compile again and produced the same three messages.
+
+## What changes
+
+**The failure now leads with the actual cause.** The recorded error starts by naming which of the
+type's declared code locations found nothing, so the first line you read is *"this location is
+empty"* rather than *"this type does not exist"*. The compiler's own messages are still underneath —
+they are the evidence, they were just never the explanation.
+
+**The compile activity says the same thing while it happens**, in your language, above the compiler
+output — so you can see it on the run itself, not only afterwards on the record.
+
+**An attempt that cannot succeed is not repeated.** Missing code files are a fact about your content,
+not about the platform version, so no update and no restart can supply them. The first attempt still
+runs and still reports honestly; after that the type keeps serving its recorded error instead of
+spending a compile on it at every restart. The log says so plainly, and says what will actually help.
+
+**It fixes itself the moment the files come back.** The check is re-asked against what is really
+there each time, so restoring the code — by re-installing, re-copying, or creating it — starts a
+fresh compile on its own. Nothing has to be reset, cleared or pressed.
+
+**A missing file no longer holds up an update.** A type broken this way is now reported as a content
+problem rather than as a fault in the new platform version, so an installation is no longer kept out
+of service over code that is missing regardless of which version it runs.
+
+## What this does not change
+
+**Real compile errors still behave exactly as before.** A type whose code is all present and does not
+compile is still reported as broken, still retried when the platform or its modules change, and still
+holds back an update. Only the "the code is not here" case is separated out.
+
+**A type that has never compiled successfully is untouched.** If it never worked, nothing was lost —
+its failure may genuinely be its own configuration, so it keeps being retried and keeps being
+treated as a fault.
+
+**Empty test folders are still normal.** A node type with no tests is not reported as missing
+anything.
+
+**Copying a node type can still leave its code behind.** This change makes that situation obvious and
+cheap instead of silent and repeated; it does not yet prevent a partial copy. That is being fixed
+separately.

--- a/src/MeshWeaver.Graph.Contract/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph.Contract/NodeTypeDefinition.cs
@@ -860,6 +860,47 @@ public record NodeTypeDefinition
     public string? FailedBuildInputs { get; init; }
 
     /// <summary>
+    /// 🚨 The DECLARED SOURCE QUERIES that matched NOTHING when the standing failure verdict was
+    /// formed — the durable answer to "why does this compile name symbols nobody can find?"
+    /// (issue #3903).
+    ///
+    /// <para><b>The hole it closes.</b> <c>SourceSnapshot</c> already refuses to hand Roslyn a
+    /// source set it could not ESTABLISH, because a short set produces completely genuine-looking
+    /// <c>CS0246</c>/<c>CS1061</c> about code that is fine (#1218). But emptiness was measured on
+    /// the MERGED set — the union of every expanded source and test query — so a type that also
+    /// draws on a shared library keeps a non-empty union even when the query for its OWN sources
+    /// matches nothing. Measured on memex.meshweaver.cloud 2026-09-10:
+    /// <c>rbuergi/OperationRequest</c> had been failing since 2026-09-06 with three unresolved
+    /// symbols that are exactly its own three <c>Source/*</c> nodes — which do not exist in that
+    /// partition — while its snapshot held 41 nodes pulled in by five <c>shared=@Store/…</c>
+    /// entries. Nothing named the empty query, so the reader hunted three symbols through module
+    /// surfaces that never carried them.</para>
+    ///
+    /// <para><b>Three shapes, never two</b> — the <c>NodeDiagnosticsOutcome</c> rule that a status
+    /// meaning "nothing was checked" must not be readable as "checked and clean":</para>
+    /// <list type="bullet">
+    ///   <item><c>null</c> — NOT DETERMINED. No failure verdict stands (a success CLEARS this, like
+    ///     <see cref="FailedBuildInputs"/>), or the coverage could not be computed: no established
+    ///     source snapshot, or not one declared entry the offline evaluator could read. It never
+    ///     means "the declared sources were checked and all matched".</item>
+    ///   <item>EMPTY — determined: every evaluable declared source query matched at least one node,
+    ///     so the failure is about the CODE and the diagnostics mean what they say.</item>
+    ///   <item>NON-EMPTY — these declared entries answered and matched nothing, so the compile ran
+    ///     against a set SHORT of what the type declares.</item>
+    /// </list>
+    ///
+    /// <para><b>What it decides.</b> Nothing on its own — it is the REPORT. The re-drive and the
+    /// bake both recompute the coverage against the LIVE source set rather than trusting this
+    /// stamp, so restoring the missing nodes converges on the next pass without anyone clearing a
+    /// field. Entries are stored AS AUTHORED (the <c>name=</c> prefix included), so a reader can
+    /// find the offending line in <see cref="Sources"/> verbatim.</para>
+    ///
+    /// <para>🚨 Runtime state: never author it into a node file. <c>ShippedNodeTypeStateTest</c>
+    /// bans every member whose name starts <c>Failed</c>, and this is one of them.</para>
+    /// </summary>
+    public System.Collections.Immutable.ImmutableList<string>? FailedSourceQueries { get; init; }
+
+    /// <summary>
     /// The build-inputs token the in-flight compile was dispatched for, stamped by the RELEASE
     /// WATCHER on the commit where it flips <see cref="CompilationStatus"/> to Pending (#2544).
     ///

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -905,6 +905,7 @@ public static class BuildProtocolDriver
         && outcome.Status is not (PreWarmStatus.TimedOut
             or PreWarmStatus.UpstreamUnevaluated
             or PreWarmStatus.NoSources
+            or PreWarmStatus.DeclaredSourcesMissing
             or PreWarmStatus.UpstreamContentBroken);
 
     private sealed record OpenedChunk(

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -85,6 +85,32 @@ public enum PreWarmStatus
     /// </summary>
     NoSources,
     /// <summary>
+    /// 🚨 <see cref="NoSources"/> one granularity finer, and the shape <see cref="NoSources"/> can
+    /// never see (issue #3903): the source snapshot is NOT empty, but one of the type's DECLARED
+    /// source queries answered and matched NOTHING — its own <c>Source/</c> subtree is gone while
+    /// the <c>shared=@Lib/Source</c> entries beside it still resolve, so the union stays populated
+    /// and the emptiness that matters is invisible to a count.
+    ///
+    /// <para>The consequence is the phantom-diagnostic failure <c>SourceSnapshot</c> exists to
+    /// prevent, arriving through the one door it does not watch: Roslyn is handed a set that is
+    /// SHORT of what the type declares and emits completely genuine-looking <c>CS0246</c>/
+    /// <c>CS1061</c> about symbols the author never lost. Measured on memex.meshweaver.cloud —
+    /// <c>rbuergi/OperationRequest</c> failed from 2026-09-06 on three symbols that are exactly its
+    /// three absent <c>Source/*</c> nodes, against 41 sources pulled in by five <c>shared=</c>
+    /// entries, and the investigation went looking for them in module surfaces.</para>
+    ///
+    /// <para>A CONTENT verdict, like <see cref="NoSources"/> and for the identical reason: which
+    /// nodes a mesh query matches is a property of the mesh, not of the framework being rolled out,
+    /// so no image caused it and no rollout can fix it. Dependents inherit
+    /// <see cref="UpstreamContentBroken"/>, the gate files it under content-broken, and the batch
+    /// driver stops re-attempting the compile — see
+    /// <c>NodeTypeCompilationHelpers.IsUnconvergableSourceFailure</c> for why that is a
+    /// classification and not a retry cap, and for the second witness
+    /// (<see cref="NodeTypeDefinition.LastCompileSucceededAt"/>) that keeps a type which NEVER
+    /// built — whose failure may be its own configuration — gating exactly as before.</para>
+    /// </summary>
+    DeclaredSourcesMissing,
+    /// <summary>
     /// NOT ATTEMPTED, and content-broken one hop up: a NodeType this one draws sources from is
     /// <see cref="NoSources"/>-broken, so this type cannot build either — for the same
     /// content-not-image reason, which must propagate AS ITSELF rather than as a gating
@@ -787,6 +813,7 @@ public static class DynamicTypePreWarmer
                             if (o.Status is PreWarmStatus.TimedOut)
                                 unevaluated.Add(p);
                             else if (o.Status is PreWarmStatus.NoSources
+                                     or PreWarmStatus.DeclaredSourcesMissing
                                      or PreWarmStatus.Retired
                                      or PreWarmStatus.Removed)
                                 contentBroken.Add(p);
@@ -1059,13 +1086,33 @@ public static class DynamicTypePreWarmer
     /// a non-empty snapshot and keeps gating — pinned by
     /// <c>ClassifyCompileFailure_MatchedSources_StaysCompileError</c>.</para>
     /// </summary>
-    public static PreWarmStatus ClassifyCompileFailure(NodeTypeDefinition d) =>
+    /// <param name="d">The failed type's definition.</param>
+    /// <param name="nodeTypePath">
+    /// The type's path, so the <see cref="PreWarmStatus.DeclaredSourcesMissing"/> question can be
+    /// asked (#3903) — it needs the <c>$self</c> expansion root. 🚨 A <c>null</c> here leaves that
+    /// branch unreachable and the classification falls through to
+    /// <see cref="PreWarmStatus.CompileError"/>, i.e. it keeps GATING. Not being able to ask must
+    /// never buy a type the leniency the answer would have bought it.
+    /// </param>
+    public static PreWarmStatus ClassifyCompileFailure(
+        NodeTypeDefinition d, string? nodeTypePath = null) =>
         // A type its repository has retired (held for its remaining instances) is a content
         // verdict before anything else is asked: its sources were withdrawn on purpose.
         d.PendingRetirement is { Length: > 0 }
             ? PreWarmStatus.Retired
         : d.CurrentSourceVersions is { Count: 0 } && d.LastCompileSucceededAt is not null
             ? PreWarmStatus.NoSources
+        // 🚨 #3903 — the same content fact one granularity finer, and the branch that catches
+        // every COMPOSED type the one above cannot. The snapshot is non-empty (a `shared=` group
+        // still resolves) but a DECLARED source query matched nothing, so Roslyn was handed a set
+        // short of what the type declares and its CS0246/CS1061 are about symbols nobody lost.
+        // Guarded by the identical second witness: the sources must have been LOST, not never
+        // present, or a type broken in its own Configuration would stop gating.
+        : d.LastCompileSucceededAt is not null
+          && MeshWeaver.Compiler.SourceCoverage.UnmatchedSourceQueries(
+                 d.Sources, nodeTypePath, d.CurrentSourceVersions?.Keys.ToList())
+             is { Count: > 0 }
+            ? PreWarmStatus.DeclaredSourcesMissing
             : PreWarmStatus.CompileError;
 
     /// <summary>
@@ -1178,7 +1225,7 @@ public static class DynamicTypePreWarmer
     /// layer can say whether the source set was stable when the verdict was formed.
     /// </summary>
     internal static PreWarmOutcome FromFailedCompile(string typePath, NodeTypeDefinition d) =>
-        new(typePath, ClassifyCompileFailure(d), d.CompilationError)
+        new(typePath, ClassifyCompileFailure(d, typePath), d.CompilationError)
         {
             SourcesMovedDuringCompile = SourcesMovedDuringCompile(d)
         };

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -466,6 +466,7 @@ public sealed class DynamicTypePreWarmerHostedService(
                         // Broken by deleted CONTENT, not by this image — the gate files these
                         // under ContentBroken (never gating); the count keeps them visible here.
                         case PreWarmStatus.NoSources:
+                        case PreWarmStatus.DeclaredSourcesMissing:
                         case PreWarmStatus.UpstreamContentBroken: Interlocked.Increment(ref contentBroken); break;
                         default: Interlocked.Increment(ref faulted); break;
                     }

--- a/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBakeGate.cs
@@ -322,7 +322,9 @@ public sealed class NodeTypeBakeGateState : IMeshAdmissionAuthority
         // the same deploy-freeze rule as WasHealthyBeforeBake, arriving through content deletion
         // instead of an abandoned Error record. UpstreamContentBroken is the same condition one
         // hop downstream (the depth-1 rule, again).
-        if (outcome.Status is PreWarmStatus.NoSources or PreWarmStatus.UpstreamContentBroken)
+        if (outcome.Status is PreWarmStatus.NoSources
+                              or PreWarmStatus.DeclaredSourcesMissing
+                              or PreWarmStatus.UpstreamContentBroken)
         {
             contentBroken[outcome.TypePath] = $"{outcome.Status}: {outcome.Detail ?? "(no detail)"}";
             return false;

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -666,6 +666,60 @@ internal static class NodeTypeBatchBake
         ILogger? logger)
     {
         var typePath = typeNode.Path;
+
+        // 🚨 A COMPILE THAT CANNOT CONVERGE IS NOT ATTEMPTED AGAIN (issue #3903).
+        //
+        // This driver decides what to build from a STORE PROBE, not from the record
+        // (NodeTypeBakeStatus.ClassifyDetailed), and its first branch maps CompilationStatus.Error
+        // to BakeState.PreviouslyBroken ⇒ NeedsBake. That is right for a type broken by an image:
+        // a new image is exactly the input that could fix it, so it earns a fresh attempt on every
+        // boot. It is wrong for the one shape where no image can be the answer — a type whose own
+        // declared source query matches NOTHING on this mesh, so the symbols Roslyn cannot resolve
+        // live in nodes that are not here. Measured on memex.meshweaver.cloud: rbuergi/OperationRequest
+        // burned a full Roslyn compile on every pod boot from 2026-09-06, produced the identical
+        // CS0246/CS1061 every time, and nothing anywhere named the empty query.
+        //
+        // 🚨 THE FIRST ATTEMPT ALWAYS RUNS. The condition requires a STANDING Error — a verdict this
+        // deployment has already measured — so the coverage is never used to assert a failure
+        // nobody observed. A type reaching this state for the first time compiles, fails honestly,
+        // records the diagnosis (NodeTypeDefinition.FailedSourceQueries), and only THEN stops
+        // repeating a measurement whose inputs cannot have moved. That is memoisation of a
+        // deterministic function, not a retry cap: the coverage is recomputed from the LIVE source
+        // set on every boot, so restoring the nodes resumes normal baking with nothing to reset.
+        //
+        // 🚨 TWO INDEPENDENT WITNESSES, and the second is what stops the skip LATCHING (#1216's
+        // rule, applied in the direction that matters here). `IsUnconvergableSourceFailure` reads
+        // the record's CurrentSourceVersions, which the per-NodeType sources watcher maintains —
+        // and on a batch-baking pod that watcher may never have run, so the record alone could keep
+        // saying "missing" long after the nodes came back. THIS bake's own freshly-resolved set is
+        // the live witness. Both must agree before a compile is declined; either one saying the
+        // sources are there compiles, which is the safe direction (a needless compile costs a
+        // compile, a latched skip strands a type).
+        //
+        // Nothing is stamped here on purpose. The record already says Error with the same error and
+        // the same finding; re-writing it would move LastCompileStartedAt and make a compile that
+        // never ran look like one that did.
+        var standing = typeNode.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions, logger);
+        if (standing is not null
+            && NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(standing, typePath)
+            && SourceCoverage.UnmatchedSourceQueries(
+                   standing.Sources, typePath, sources.Select(s => s.Path).ToList())
+               is { Count: > 0 })
+        {
+            var detail = SourceCoverage.Describe(
+                typePath, standing.FailedSourceQueries,
+                standing.Sources is { Count: > 0 }
+                    ? standing.Sources.Count
+                    : CodeQueryResolver.DefaultSources.Count);
+            logger?.LogWarning(
+                "BatchBake: {TypePath} NOT ATTEMPTED — its standing compile failure cannot converge. "
+                + "{Detail} No image can change that, so this bake does not repeat it; restoring the "
+                + "source nodes re-drives the compile automatically.",
+                typePath, detail ?? "(a declared source query matched no nodes)");
+            return Observable.Return(new PreWarmOutcome(
+                typePath, PreWarmStatus.DeclaredSourcesMissing, detail));
+        }
+
         // PER-COMPILE cost, appended to the per-type line that already exists — no new log volume.
         // This is the measurement that answers "is compilation what eats the memory?" directly rather
         // than by elimination: one linked bake of 279 types left the pod at 2.5 GB, so the fleet is
@@ -834,7 +888,29 @@ internal static class NodeTypeBatchBake
                 // …and a type its REPOSITORY HAS RETIRED (held only for its remaining instances,
                 // NodeTypeDefinition.PendingRetirement) is a content verdict before any of that:
                 // its sources were withdrawn on purpose. Same first branch as ClassifyCompileFailure.
+                // …and #3903's sibling of NoSources, one granularity finer: the snapshot is NOT
+                // empty, but a DECLARED source query in it matched nothing — the shape a type that
+                // also draws on a shared library presents when its OWN Source subtree is gone, and
+                // the shape NoSources can never see because it measures the union. Same content-vs-
+                // image reasoning, same second witness (LastCompileSucceededAt: the sources were
+                // LOST, not never present), and measured against the set THIS bake resolved rather
+                // than against a stamp. Ordered after NoSources because a wholly empty set is the
+                // more specific statement.
                 var def = typeNode.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions);
+                // Both witnesses, exactly as the NoSources branch below takes them: this bake's own
+                // resolved set AND the type's persisted snapshot. A starved or truncated discovery
+                // pass also reports "matched nothing", and this classification does not gate — so a
+                // discovery bug that could reach it alone would quietly file itself as content
+                // drift. An absent persisted snapshot answers neither way and keeps the gating
+                // verdict.
+                var unmatched = def is null
+                    ? null
+                    : SourceCoverage.UnmatchedSourceQueries(
+                        def.Sources, typePath, sources.Select(s => s.Path).ToList());
+                var unmatchedOnRecord = def is null
+                    ? null
+                    : SourceCoverage.UnmatchedSourceQueries(
+                        def.Sources, typePath, def.CurrentSourceVersions?.Keys.ToList());
                 var status = def?.PendingRetirement is { Length: > 0 }
                     ? PreWarmStatus.Retired
                     : def is not null
@@ -842,6 +918,11 @@ internal static class NodeTypeBatchBake
                         && def.CurrentSourceVersions is { Count: 0 }
                         && def.LastCompileSucceededAt is not null
                     ? PreWarmStatus.NoSources
+                    : def is not null
+                        && unmatched is { Count: > 0 }
+                        && unmatchedOnRecord is { Count: > 0 }
+                        && def.LastCompileSucceededAt is not null
+                    ? PreWarmStatus.DeclaredSourcesMissing
                     : PreWarmStatus.CompileError;
                 return new PreWarmOutcome(
                     typePath, status, NodeTypeCompilationHelpers.SummarizeCompileError(result, error))
@@ -954,7 +1035,8 @@ internal static class NodeTypeBatchBake
                             mesh.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash)
                         : NodeTypeCompilationHelpers.ApplyCompileFailure(
                             def, result, error, activityPath: null,
-                            mesh.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash))
+                            mesh.ServiceProvider.GetService<InstalledModulesFingerprint>()?.Hash,
+                            typeNode.Path))
                     // The batch driver has no Pending→Compiling flip to stamp this at, and the
                     // shared field-set deliberately does not touch it (the activation path owns it
                     // there). Written here so a per-type duration is derivable FROM THE MESH on both

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -700,14 +700,18 @@ internal static class NodeTypeBatchBake
         // the same finding; re-writing it would move LastCompileStartedAt and make a compile that
         // never ran look like one that did.
         var standing = typeNode.ContentAs<NodeTypeDefinition>(mesh.JsonSerializerOptions, logger);
+        var standingUnmatched = standing is null
+            ? null
+            : SourceCoverage.UnmatchedSourceQueries(
+                standing.Sources, typePath, sources.Select(s => s.Path).ToList());
         if (standing is not null
-            && NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(standing, typePath)
-            && SourceCoverage.UnmatchedSourceQueries(
-                   standing.Sources, typePath, sources.Select(s => s.Path).ToList())
-               is { Count: > 0 })
+            && standingUnmatched is { Count: > 0 }
+            && NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(standing, typePath))
         {
+            // Reported from THIS pass's finding, not from the stamp: a failure recorded before
+            // #3903 carries no stamp at all, and the live answer is the one that is true now.
             var detail = SourceCoverage.Describe(
-                typePath, standing.FailedSourceQueries,
+                typePath, standingUnmatched,
                 standing.Sources is { Count: > 0 }
                     ? standing.Sources.Count
                     : CodeQueryResolver.DefaultSources.Count);

--- a/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
+++ b/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
@@ -94,6 +94,12 @@ public static class NodeTypeOperationalContent
         // happened to match this deployment's live inputs would SUPPRESS the one automatic retry a
         // never-compiled failure gets. Stripped on export, preserved from the live node on import.
         "failedBuildInputs",
+        // #3903 — the declared source queries that matched NOTHING when the standing failure was
+        // recorded. Operational for the same reason failedBuildInputs is: it is a measurement of
+        // THIS mesh's content (which nodes a query matches here), so an authored copy would assert
+        // a finding about a partition it was never taken on — and the empty list is the shape that
+        // reads as "checked, all present".
+        "failedSourceQueries",
     };
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1364,6 +1364,7 @@
   "activity.compile.sourceQuery": "Quell-Query: {query}",
   "activity.compile.discoveryMatchedNone": "Die Quellensuche für '{path}' fand 0 Code-Nodes — prüfen Sie, ob die Source-Code-Nodes existieren und die `Sources`-Liste des NodeType auf sie verweist.",
   "activity.compile.discoveryMatched": "Die Quellensuche fand {count} Code-Node(s): {paths}",
+  "activity.compile.declaredQueryMatchedNone": "{count} von {declared} DEKLARIERTEN Quellenabfragen f\u00fcr '{path}' fanden KEINE Nodes: {queries}. Die folgende Kompilierung l\u00e4uft gegen eine Quellenmenge, die WENIGER umfasst als dieser NodeType deklariert \u2014 ein nicht aufl\u00f6sbarer Typ oder eine fehlende Erweiterungsmethode ist weit eher ein fehlender Quell-NODE als ein fehlendes Modul.",
   "activity.compile.assemblyWritten": "Kompilierte Assembly nach {path} geschrieben.",
   "activity.compile.dllMissing": "Die Kompilierung war erfolgreich, aber unter {path} wurde keine DLL gefunden.",
   "activity.compile.assemblyInMemory": "Kompilierte Assembly im Arbeitsspeicher geladen ({path}).",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1364,6 +1364,7 @@
   "activity.compile.sourceQuery": "Source query: {query}",
   "activity.compile.discoveryMatchedNone": "Source discovery for '{path}' matched 0 Code nodes — check that the Source Code nodes exist and the NodeType's `Sources` list points at them.",
   "activity.compile.discoveryMatched": "Source discovery matched {count} Code node(s): {paths}",
+  "activity.compile.declaredQueryMatchedNone": "{count} of {declared} DECLARED source quer(ies) for '{path}' matched NO nodes: {queries}. The compile below runs against a source set SHORT of what this NodeType declares \u2014 an unresolved type or extension method is far more likely to be an absent source NODE than an absent module.",
   "activity.compile.assemblyWritten": "Compiled assembly written to {path}.",
   "activity.compile.dllMissing": "Compilation succeeded but DLL not found at {path}.",
   "activity.compile.assemblyInMemory": "Compiled assembly loaded in-memory ({path}).",

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ADoomedCompileIsClassifiedNotRepeatedTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ADoomedCompileIsClassifiedNotRepeatedTest.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+using MeshWeaver.Compiler;
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 Issue #3903 — <b>a NodeType whose own <c>Source/</c> subtree is absent must report THAT, and
+/// must not have the same doomed compile taken again on every boot.</b>
+///
+/// <para><b>The measurement this pins.</b> memex.meshweaver.cloud, 2026-09-10:
+/// <c>rbuergi/OperationRequest</c> had been at <c>compilationStatus: Error</c> since 2026-09-06,
+/// with <c>lastCompileStartedAt</c> moving on every pod boot, reporting</para>
+///
+/// <code>
+/// CS0246 The type or namespace name 'OperationRequestContent' could not be found
+/// CS1061 'MessageHubConfiguration' has no 'AddOperationRequestControlPlane'
+/// CS1061 'LayoutDefinition'        has no 'AddOperationRequestLayoutAreas'
+/// </code>
+///
+/// <para>All three names are its own three <c>Source/*</c> nodes, and
+/// <c>search 'namespace:rbuergi/OperationRequest scope:subtree'</c> returned <b>0</b> against 21
+/// under the package copy. Its snapshot nonetheless held <b>41</b> nodes, every one pulled in by a
+/// <c>shared=@Store/…</c> entry — so <c>PreWarmStatus.NoSources</c>, which asks whether the snapshot
+/// is EMPTY, could not fire, and nothing anywhere said "one of your declared source queries matched
+/// nothing". The investigation went looking for the three symbols in module surfaces that never
+/// carried them.</para>
+///
+/// <para><b>Both controls run here, on the same fixture.</b> The NEGATIVE control is that shape; the
+/// POSITIVE control is the identical type with its own source node present, which must still
+/// compile, still classify as an ordinary compile error, and still earn its automatic re-drive. A
+/// fix that "worked" by declining every re-drive would pass the first and fail the second.</para>
+///
+/// <para>🚨 <b>The pre-#3903 behaviour is re-measured on every run, not asserted from memory.</b>
+/// <c>HasStaleFailureVerdict</c> takes the type's path as an OPTIONAL argument, and without it the
+/// convergence question is unanswerable and answered NO — which is exactly what the predicate did
+/// before this change. Every test below calls both overloads on the same definition, so the
+/// baseline arm fails the moment the fix stops making a difference.</para>
+/// </summary>
+public class ADoomedCompileIsClassifiedNotRepeatedTest
+{
+    private const string TypePath = "rbuergi/OperationRequest";
+    private const string OwnSourceQuery = "namespace:Source scope:subtree";
+
+    /// <summary>The live node's <c>sources</c>, as read off memex.meshweaver.cloud 2026-09-10.</summary>
+    private static readonly ImmutableList<string> DeclaredSources = ImmutableList.Create(
+        OwnSourceQuery,
+        "shared=@Store/Core/Source",
+        "shared=@Store/Licensing/Source");
+
+    /// <summary>The <c>shared=</c> half of the live snapshot — real paths, shortened.</summary>
+    private static readonly ImmutableList<string> SharedOnly = ImmutableList.Create(
+        "Store/Core/Source/CoreContent",
+        "Store/Core/Source/MeshQueries",
+        "Store/Licensing/Source/LicenseTerms");
+
+    /// <summary>The same, plus the type's own source node — the world before it went missing.</summary>
+    private static readonly ImmutableList<string> SharedPlusOwn =
+        SharedOnly.Add($"{TypePath}/Source/OperationRequestContent");
+
+    private static ImmutableDictionary<string, long> Snapshot(IEnumerable<string> paths)
+    {
+        var map = ImmutableDictionary<string, long>.Empty;
+        var ticks = 1L;
+        foreach (var path in paths)
+            map = map.SetItem(path, ticks++);
+        return map;
+    }
+
+    /// <param name="sourcePaths">What the type's source discovery resolved.</param>
+    /// <param name="everCompiled">The second witness — whether the sources were LOST or never present.</param>
+    private static NodeTypeDefinition Failing(
+        IEnumerable<string> sourcePaths, bool everCompiled = true) => new()
+    {
+        Configuration =
+            "config => config.WithContentType<OperationRequestContent>().AddDefaultLayoutAreas()"
+            + ".AddOperationRequestControlPlane()",
+        Sources = DeclaredSources,
+        CompilationStatus = CompilationStatus.Error,
+        CompilationError = "CS0246 The type or namespace name 'OperationRequestContent' could not be found",
+        CurrentSourceVersions = Snapshot(sourcePaths),
+        // The verdict was formed on a DIFFERENT framework — i.e. this pod's boot is exactly the
+        // event that re-opened the attempt before #3903, on every image, for ever.
+        FailedBuildInputs = "fw=an0therfr4me;mod=mod-1;src=3:0000000000000000",
+        LastCompileSucceededAt = everCompiled
+            ? new DateTimeOffset(2026, 9, 6, 7, 8, 49, TimeSpan.Zero)
+            : null,
+    };
+
+    // ── The detector ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 NEGATIVE CONTROL — the live shape. The union is non-empty, so every existing emptiness
+    /// test reads healthy; the DECLARED entry for the type's own sources matched nothing.
+    /// </summary>
+    [Fact]
+    public void OwnSourceSubtreeAbsent_IsNamed_WhileTheUnionLooksHealthy()
+    {
+        var snapshot = Snapshot(SharedOnly);
+
+        snapshot.Should().NotBeEmpty(
+            "the whole point: PreWarmStatus.NoSources asks whether the SNAPSHOT is empty, and for a "
+            + "type that also draws on a shared library it never is — which is why the emptiness "
+            + "that matters was invisible for four days");
+
+        SourceCoverage.UnmatchedSourceQueries(DeclaredSources, TypePath, snapshot.Keys.ToList())
+            .Should().ContainSingle().Which.Should().Be(OwnSourceQuery,
+                "the type's own Source subtree resolved nothing while the shared= entries resolved, "
+                + "so the compile ran against a set SHORT of what the type declares");
+    }
+
+    /// <summary>
+    /// 🚨 POSITIVE CONTROL — the same type with its own source node present. Nothing is reported,
+    /// so the detector cannot pass by accusing everything.
+    /// </summary>
+    [Fact]
+    public void OwnSourcePresent_ReportsNothing()
+    {
+        SourceCoverage.UnmatchedSourceQueries(
+                DeclaredSources, TypePath, Snapshot(SharedPlusOwn).Keys.ToList())
+            .Should().BeEmpty(
+                "every declared entry matched — an EMPTY list is the 'checked, all present' answer "
+                + "and must stay distinguishable from the null one below");
+    }
+
+    /// <summary>
+    /// 🚨 The <c>@</c> shorthand's FALSE-ALARM control. <c>CodeQueryResolver.Expand</c> turns one
+    /// <c>shared=@Store/Core/Source</c> entry into TWO queries — a <c>path:</c> exact match and a
+    /// <c>namespace:… scope:subtree</c> folder match — and the exact one matches nothing whenever
+    /// the folder node is not itself a Code node, which is the normal case. Measured per QUERY, every
+    /// healthy shared entry in the fleet would be reported as half missing; the unit is therefore the
+    /// authored ENTRY.
+    /// </summary>
+    [Fact]
+    public void ASharedEntryWhoseFolderNodeIsNotCode_IsNotAccused()
+    {
+        // Only the subtree half of "@Store/Core/Source" matches: there is no Code node AT the
+        // folder path itself.
+        var snapshot = Snapshot(["Store/Core/Source/CoreContent", $"{TypePath}/Source/Own"]);
+
+        SourceCoverage.UnmatchedSourceQueries(DeclaredSources, TypePath, snapshot.Keys.ToList())
+            .Should().ContainSingle().Which.Should().Be("shared=@Store/Licensing/Source",
+                "only the entry that genuinely resolved nothing is named — the Store/Core entry "
+                + "matched through its subtree half and must not be accused because its path: half "
+                + "did not");
+    }
+
+    /// <summary>
+    /// 🚨 NOT DETERMINED is its own answer. An empty list means "checked, every declared query
+    /// matched"; null means "nothing was established". Collapsing them is the
+    /// <c>NodeDiagnosticsOutcome</c> defect (#3912) in a different costume.
+    /// </summary>
+    [Fact]
+    public void WithoutEvidence_TheAnswerIsNull_NeverEmpty()
+    {
+        SourceCoverage.UnmatchedSourceQueries(DeclaredSources, TypePath, matchedPaths: null)
+            .Should().BeNull("no source snapshot was established, so nothing was checked");
+
+        SourceCoverage.UnmatchedSourceQueries(DeclaredSources, nodeTypePath: null, [])
+            .Should().BeNull("without the type's path $self cannot be expanded, so no query is evaluable");
+
+        SourceCoverage.UnmatchedSourceQueries(["laptop pricing"], TypePath, [])
+            .Should().BeNull(
+                "a free-text query routes to the vector index, which a pure function cannot "
+                + "reproduce — an entry the offline evaluator refuses contributes to NEITHER side");
+
+        // …and one inevaluable entry does not silence an evaluable one.
+        SourceCoverage.UnmatchedSourceQueries(["laptop pricing", OwnSourceQuery], TypePath, [])
+            .Should().ContainSingle().Which.Should().Be(OwnSourceQuery);
+    }
+
+    // ── The report ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 NEGATIVE CONTROL — the durable record leads with the diagnosis instead of leaving the
+    /// reader with three symbols to hunt through module surfaces.
+    /// </summary>
+    [Fact]
+    public void AFailureOnAShortSourceSet_RecordsWhichQueryMatchedNothing()
+    {
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            Failing(SharedOnly), result: null,
+            new CompilationException(TypePath, "CS0246 'OperationRequestContent' could not be found"),
+            activityPath: null, modulesHash: "mod-1", nodeTypePath: TypePath);
+
+        stamped.FailedSourceQueries.Should().ContainSingle(
+                "the standing verdict must carry the finding that explains it — a reader who is "
+                + "not told the source set was short spends the investigation hunting the named "
+                + "symbols through module surfaces that never carried them")
+            .Which.Should().Be(OwnSourceQuery);
+        stamped.CompilationError.Should()
+            .Contain("MISSING SOURCES", "the diagnosis leads")
+            .And.Contain(OwnSourceQuery, "…and names the query the author can act on")
+            .And.Contain("CS0246", "…without discarding the evidence it explains");
+    }
+
+    /// <summary>🚨 POSITIVE CONTROL — an ordinary compile error is recorded exactly as before.</summary>
+    [Fact]
+    public void AnOrdinaryCompileError_IsRecordedUnchanged()
+    {
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            Failing(SharedPlusOwn), result: null,
+            new CompilationException(TypePath, "CS0103 The name 'Nope' does not exist"),
+            activityPath: null, modulesHash: "mod-1", nodeTypePath: TypePath);
+
+        stamped.FailedSourceQueries.Should().BeEmpty(
+            "determined, and every declared query matched — the failure is about the CODE");
+        stamped.CompilationError.Should().NotContain("MISSING SOURCES",
+            "a diagnosis that fires on a healthy source set is noise, and noise is how a real one "
+            + "stops being read");
+    }
+
+    /// <summary>
+    /// A stamp with no path could not measure the coverage, and must say so rather than record the
+    /// "checked, all present" shape.
+    /// </summary>
+    [Fact]
+    public void AFailureStampedWithoutThePath_LeavesTheFindingUndetermined()
+    {
+        NodeTypeCompilationHelpers.ApplyCompileFailure(
+                Failing(SharedOnly), result: null, new CompilationException(TypePath, "CS0246"),
+                activityPath: null, modulesHash: "mod-1")
+            .FailedSourceQueries.Should().BeNull(
+                "not determined — never an empty list, which reads as 'checked and clean'");
+    }
+
+    /// <summary>The finding describes a STANDING failure, so a success must take it with it.</summary>
+    [Fact]
+    public void ASuccess_ClearsTheFinding()
+    {
+        var failed = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            Failing(SharedOnly), result: null, new CompilationException(TypePath, "CS0246"),
+            activityPath: null, modulesHash: "mod-1", nodeTypePath: TypePath);
+        failed.FailedSourceQueries.Should().NotBeNull("the fixture must start from the state it clears");
+
+        NodeTypeCompilationHelpers.ApplyCompileSuccess(
+                failed, new NodeCompilationResult("/cache/T.dll", []),
+                currentNodeVersion: 2, activityPath: null, releasePath: null, modulesHash: "mod-1")
+            .FailedSourceQueries.Should().BeNull(
+                "a standing 'these queries matched nothing' describes a failure that no longer "
+                + "exists — left behind it would tell the next reader a green type is broken");
+    }
+
+    // ── The non-repetition ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 NEGATIVE CONTROL, and the behaviour change itself: a new framework no longer re-opens an
+    /// attempt at a compile whose missing symbols live in nodes this mesh does not hold. The
+    /// baseline arm re-measures the pre-#3903 answer on the SAME definition.
+    /// </summary>
+    [Fact]
+    public void ANewFramework_DoesNotReDriveACompileThatCannotConverge()
+    {
+        var doomed = Failing(SharedOnly);
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(doomed, "mod-1")
+            .Should().BeTrue(
+                "BASELINE — without the type's path the convergence question cannot be asked, which "
+                + "is exactly what this predicate did before #3903: the stamped token names another "
+                + "framework, so every boot bought another identical compile");
+
+        NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(doomed, TypePath)
+            .Should().BeTrue();
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(doomed, "mod-1", TypePath)
+            .Should().BeFalse(
+                "no framework and no module set can supply a symbol that lives in a source node "
+                + "this mesh does not hold, so re-driving on either is not a retry — it is the same "
+                + "measurement taken again");
+    }
+
+    /// <summary>
+    /// 🚨 POSITIVE CONTROL — the re-drive is intact. A type whose sources are all present and whose
+    /// verdict was formed on another framework still earns its one automatic attempt; #1793's whole
+    /// purpose survives.
+    /// </summary>
+    [Fact]
+    public void ANewFramework_StillReDrivesAnOrdinaryFailure()
+    {
+        var ordinary = Failing(SharedPlusOwn);
+
+        NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(ordinary, TypePath)
+            .Should().BeFalse("every declared query matched — this failure is about the code");
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(ordinary, "mod-1", TypePath)
+            .Should().BeTrue(
+                "a shipped fix must still reach the nodes it was written for (#1793) — a change "
+                + "that declined this one would be a mute, not a classification");
+    }
+
+    /// <summary>
+    /// 🚨 The SECOND WITNESS. A type that has NEVER built cannot have LOST its sources: its failure
+    /// may be its own Configuration, and that one must keep earning an attempt on a new framework —
+    /// the same discriminator, for the same reason, as <c>PreWarmStatus.NoSources</c>.
+    /// </summary>
+    [Fact]
+    public void ATypeThatNeverBuilt_IsStillReDriven()
+    {
+        var neverBuilt = Failing(SharedOnly, everCompiled: false);
+
+        SourceCoverage.UnmatchedSourceQueries(
+                DeclaredSources, TypePath, neverBuilt.CurrentSourceVersions!.Keys.ToList())
+            .Should().ContainSingle("the coverage says the same thing — only the witness differs");
+        NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(neverBuilt, TypePath)
+            .Should().BeFalse();
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(neverBuilt, "mod-1", TypePath)
+            .Should().BeTrue("nothing was lost, so nothing rules out that a new image is the answer");
+    }
+
+    /// <summary>
+    /// 🚨 IT CONVERGES. The decision is recomputed from the LIVE snapshot on every emission, so the
+    /// instant the missing nodes land the type is re-driven — with no field to clear and no budget
+    /// to refund. That is what makes this a classification rather than a cap.
+    /// </summary>
+    [Fact]
+    public void WhenTheSourcesComeBack_TheReDriveResumesImmediately()
+    {
+        var doomed = Failing(SharedOnly);
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(doomed, "mod-1", TypePath).Should().BeFalse();
+
+        var restored = doomed with { CurrentSourceVersions = Snapshot(SharedPlusOwn) };
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(restored, "mod-1", TypePath)
+            .Should().BeTrue(
+                "the same node, one source publication later — nothing had to notice that the "
+                + "framework changed, and nothing had to reset the standing finding");
+    }
+
+    /// <summary>
+    /// <see cref="CompilationStatus.Unavailable"/> means the compile reached NO verdict, so there is
+    /// nothing measured to decline repeating (#1701). It must keep its input-independent re-drive.
+    /// </summary>
+    [Fact]
+    public void AnUnavailableVerdict_IsNeverDeclined()
+    {
+        var unavailable = Failing(SharedOnly) with
+        {
+            CompilationStatus = CompilationStatus.Unavailable,
+            FailedBuildInputs = NodeTypeCompilationHelpers.BuildInputsToken(
+                "mod-1", Snapshot(SharedOnly)),
+        };
+
+        NodeTypeCompilationHelpers.IsUnconvergableSourceFailure(unavailable, TypePath)
+            .Should().BeFalse("nothing was established, so nothing is being repeated");
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(unavailable, "mod-1", TypePath)
+            .Should().BeTrue("'we never found out' is even less of a reason to stop asking");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/DeclaredSourcesMissingIsNotAnImageVerdictTest.cs
+++ b/test/MeshWeaver.Hosting.Test/DeclaredSourcesMissingIsNotAnImageVerdictTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 Issue #3903 — <b>a NodeType whose own declared source query matches NOTHING is broken by
+/// CONTENT, not by the image</b>, and the sweep must say which.
+///
+/// <para><c>PreWarmStatus.NoSources</c> already carries that rule for the degenerate case: "which
+/// nodes a mesh query matches is a property of the mesh, not of the framework being rolled out, so
+/// no image caused it and no rollout can fix it" — written after four <c>KmuBasics/*</c> types
+/// stalled memex-cloud's self-update for a day across two images (2026-08-10). But it asks whether
+/// the SNAPSHOT is empty, and for a type that also draws on a shared library the snapshot never is:
+/// <c>rbuergi/OperationRequest</c> held 41 sources from five <c>shared=@Store/…</c> entries while
+/// the entry for its own <c>Source/</c> subtree matched zero, and its three <c>CS0246</c>/
+/// <c>CS1061</c> — its own three absent source nodes — were filed as an image verdict on every pod
+/// boot from 2026-09-06.</para>
+///
+/// <para>🚨 <b>What must NOT change is that compile errors gate.</b> Both controls are here: the
+/// missing-sources shape does not gate and is NAMED, and an ordinary compile error on a
+/// previously-healthy type still refuses readiness. The second witness —
+/// <see cref="NodeTypeDefinition.LastCompileSucceededAt"/> — is what separates them, exactly as it
+/// does for <see cref="PreWarmStatus.NoSources"/>: a type that has NEVER built cannot have LOST
+/// anything, so its failure may be its own configuration and keeps gating.</para>
+/// </summary>
+public class DeclaredSourcesMissingIsNotAnImageVerdictTest
+{
+    private const string TypePath = "rbuergi/OperationRequest";
+    private const string OwnSourceQuery = "namespace:Source scope:subtree";
+
+    private static ImmutableDictionary<string, long> Snapshot(params string[] paths)
+    {
+        var map = ImmutableDictionary<string, long>.Empty;
+        var ticks = 1L;
+        foreach (var path in paths)
+            map = map.SetItem(path, ticks++);
+        return map;
+    }
+
+    /// <param name="ownSourcePresent">Whether the type's own <c>Source/</c> node resolved.</param>
+    /// <param name="everCompiled">The second witness: were the sources LOST, or never present?</param>
+    private static NodeTypeDefinition Failing(bool ownSourcePresent, bool everCompiled = true) => new()
+    {
+        Configuration = "config => config.WithContentType<OperationRequestContent>()",
+        Sources = ImmutableList.Create(OwnSourceQuery, "shared=@Store/Core/Source"),
+        CompilationStatus = CompilationStatus.Error,
+        CompilationError = "CS0246 The type or namespace name 'OperationRequestContent' could not be found",
+        CurrentSourceVersions = ownSourcePresent
+            ? Snapshot("Store/Core/Source/CoreContent", $"{TypePath}/Source/OperationRequestContent")
+            : Snapshot("Store/Core/Source/CoreContent"),
+        LastCompileSucceededAt = everCompiled
+            ? new DateTimeOffset(2026, 9, 6, 7, 8, 49, TimeSpan.Zero)
+            : null,
+    };
+
+    // ── The classification ──────────────────────────────────────────────────────────────────
+
+    /// <summary>🚨 NEGATIVE CONTROL — the live shape, classified as the content fact it is.</summary>
+    [Fact(Timeout = 60000)]
+    public void OwnSourceQueryMatchedNothing_IsAContentVerdict()
+    {
+        var def = Failing(ownSourcePresent: false);
+
+        def.CurrentSourceVersions.Should().NotBeEmpty(
+            "the union is populated by the shared= entries, which is exactly why NoSources cannot "
+            + "see this and why the emptiness that matters went unnamed for four days");
+
+        DynamicTypePreWarmer.ClassifyCompileFailure(def, TypePath)
+            .Should().Be(PreWarmStatus.DeclaredSourcesMissing);
+    }
+
+    /// <summary>
+    /// 🚨 POSITIVE CONTROL — sources all present. Roslyn's verdict is about the code and stays an
+    /// IMAGE verdict, so the classification cannot pass by reclassifying everything.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public void SourcesAllPresent_StaysACompileError()
+    {
+        DynamicTypePreWarmer.ClassifyCompileFailure(Failing(ownSourcePresent: true), TypePath)
+            .Should().Be(PreWarmStatus.CompileError,
+                "a type whose sources are still there and do not compile is this image's problem");
+    }
+
+    /// <summary>The second witness — a type that never built keeps gating.</summary>
+    [Fact(Timeout = 60000)]
+    public void ATypeThatNeverBuilt_StaysACompileError()
+    {
+        DynamicTypePreWarmer.ClassifyCompileFailure(
+                Failing(ownSourcePresent: false, everCompiled: false), TypePath)
+            .Should().Be(PreWarmStatus.CompileError,
+                "nothing was LOST — the failure may be the type's own Configuration, and that must "
+                + "keep refusing readiness and keep cascading UpstreamFailed to its dependents");
+    }
+
+    /// <summary>
+    /// 🚨 Not being able to ASK must never buy the leniency the answer would have bought. Without
+    /// the type's path the query cannot be expanded, and the classification falls back to the
+    /// gating verdict.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public void WithoutThePath_TheClassificationStaysGating()
+    {
+        DynamicTypePreWarmer.ClassifyCompileFailure(Failing(ownSourcePresent: false))
+            .Should().Be(PreWarmStatus.CompileError,
+                "an unanswerable question is answered in the direction that keeps the gate intact");
+    }
+
+    // ── The gate ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 NEGATIVE CONTROL — a rollout is never held on a failure no image caused and no image can
+    /// fix. Non-blocking must not mean invisible: the health payload names the type.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public void ADeclaredSourcesMissingOutcome_DoesNotGate_AndIsNamed()
+    {
+        var gate = new NodeTypeBakeGateState { GatesReadiness = true };
+        gate.MarkRunning("enumerating dynamic NodeTypes");
+
+        var watch = gate.MarkOutcome(new PreWarmOutcome(
+            TypePath, PreWarmStatus.DeclaredSourcesMissing,
+            $"MISSING SOURCES: 1 of 2 declared source queries matched NO nodes ('{OwnSourceQuery}')")
+        {
+            WasHealthyBeforeBake = true,
+        });
+
+        watch.Should().BeFalse("no image can bring the missing source nodes back, so there is no "
+            + "recovery for this pod to watch for");
+        gate.Regressions.Should().BeEmpty("this is a content fact, not an image verdict");
+        gate.ContentBroken.Keys.Should().Contain(TypePath);
+
+        gate.MarkComplete("baked in 00:01:00 — compiled=3 alreadyBaked=0");
+
+        gate.ReadinessGranted.Should().BeTrue();
+        gate.Detail.Should().Contain(TypePath,
+            "the pod serves, and says which type it is serving without");
+    }
+
+    /// <summary>🚨 POSITIVE CONTROL — the gate itself is untouched.</summary>
+    [Fact(Timeout = 60000)]
+    public void ACompileErrorOnAHealthyType_StillRefusesReadiness()
+    {
+        var gate = new NodeTypeBakeGateState { GatesReadiness = true };
+        gate.MarkRunning("enumerating dynamic NodeTypes");
+
+        gate.MarkOutcome(new PreWarmOutcome(TypePath, PreWarmStatus.CompileError, "CS0246")
+        {
+            WasHealthyBeforeBake = true,
+        }).Should().BeTrue();
+
+        gate.Phase.Should().Be(BakePhase.Regressed);
+        gate.ContentBroken.Should().BeEmpty();
+        gate.ReadinessGranted.Should().BeFalse(
+            "the classification changed; the gate did not");
+    }
+}


### PR DESCRIPTION
Fixes #3903.

## What was measured

memex.meshweaver.cloud, 2026-09-10. `rbuergi/OperationRequest` at `compilationStatus: Error` since 2026-09-06, `lastCompileStartedAt` moving on every pod boot:

```
CS0246  The type or namespace name 'OperationRequestContent' could not be found
CS1061  'MessageHubConfiguration' has no 'AddOperationRequestControlPlane'
CS1061  'LayoutDefinition'        has no 'AddOperationRequestLayoutAreas'
```

All three names are its own `Source/*` nodes, and the partition does not hold them (`namespace:rbuergi/OperationRequest scope:subtree` → 0, against 21 under `Essentials/OperationRequest`). Nothing named the empty query, so the investigation hunted three symbols through module surfaces that never carried them.

## The defect, and it is one granularity, not one type

`SourceSnapshot` already refuses to hand Roslyn a set it could not **establish**, because a short set produces genuine-looking phantom diagnostics (#1218). `PreWarmStatus.NoSources` already treats an established, **empty** set as a fact about the mesh's content rather than the image. Both are right; both measure the **union**.

This type declares one entry for its own `Source` subtree plus five `shared=@Store/…` entries. Its union was 41 nodes — established, non-empty — so every emptiness test in the pipeline read healthy while the one query whose emptiness explains the failure was invisible to a count.

> Emptiness is a per-QUERY fact and it was being measured on the union. For any NodeType that composes, that measurement cannot reach the case it exists to catch.

## What this changes

**Detection** — `SourceCoverage` (MeshWeaver.Compiler), a pure per-**entry** coverage over the declared source queries, evaluated offline through `NodeSetQuery` via a new path-only `Predicate` overload that deliberately ignores the `nodeType:` conjunct (more permissive ⇒ it can under-report a missing entry, never accuse one that was fine).

The unit is the **authored entry**, not the expanded query: `@X` emits a `path:` half that is *expected* to match nothing whenever the folder node is not itself Code, so per-query every healthy `shared=@Lib/Source` in the fleet would be reported half missing. Test entries are excluded — a type without tests is normal. Three answers, never two: `null` is NOT DETERMINED, empty is "checked, every declared query matched".

**The report** — a keyed (and therefore translated) warning on the compile activity above the Roslyn output; the diagnosis leading `CompilationError` with the Roslyn text kept underneath as the evidence it explains; and `NodeTypeDefinition.FailedSourceQueries` as the structured finding (operational state: stripped on export, preserved on upsert, mirrored to the compile-state satellite, cleared by a success).

**The non-repetition** — `PreWarmStatus.DeclaredSourcesMissing`, a CONTENT verdict filed exactly like `NoSources` (never gates a rollout; dependents inherit `UpstreamContentBroken`), and both drivers stop re-attempting: the activation re-drive through `IsUnconvergableSourceFailure`, and the batch bake by returning the classification without running Roslyn.

### Why this is a classification and not a retry cap

- **The first attempt always runs.** The condition requires a **standing** `Error` — a verdict this deployment already measured — so the coverage never asserts a failure nobody observed.
- **It converges by itself.** The decision is recomputed from the **live** source set on every emission: restoring the nodes re-drives the compile with no field to clear and no budget to refund, *sooner* than before, because it no longer has to wait for a framework change to be noticed.
- **A second witness keeps the gate intact.** `LastCompileSucceededAt` must be set — the sources must have been **lost**, not never present. A type that has never built keeps earning its attempt and keeps refusing readiness. Same discriminator, same reason, as `NoSources`.
- The batch bake additionally requires **two independent witnesses** (the record's snapshot and the set it resolved itself), so the skip can neither latch on a pod whose sources watcher never ran, nor be reached by a starved discovery pass (#1216).

The stuck-type diagnostic no longer offers a remedy that cannot work: it names the query and says a redeploy or module update will not help, because neither can supply a symbol that lives in a node this mesh does not hold.

## Controls, both directions

`ADoomedCompileIsClassifiedNotRepeatedTest` (13) and `DeclaredSourcesMissingIsNotAnImageVerdictTest` (7). The live shape is detected, recorded and declined; a type with its sources present still compiles, still classifies as a **gating** `CompileError`, and still earns its re-drive on a new framework. A `shared=@Lib/Source` entry whose `path:` half matched nothing is not accused. `Unavailable` is never declined. Each test re-measures the pre-#3903 answer on the same fixture — `HasStaleFailureVerdict` without the path is exactly the old predicate — rather than asserting it from memory.

Verified by mutation: reverting the three production lines fails 4 of 13, e.g.

```
Expected value to be false because no framework and no module set can supply a symbol
that lives in a source node this mesh does not hold, so re-driving on either is not a
retry — it is the same measurement taken again, but found True.
```

## Where the orphan came from

Core's subtree copy, not the Plugins installer: `NodeCopyHelper.CopyNodeTree` and `MeshExtensions.HandleCopyNodeRequest` both write root and children as independently-failing creates with no parent-before-child ordering, no rollback, a caller-scoped enumeration and no post-condition. Filed as #3927 with the full measurement. This change makes the consequence legible and cheap; it does not stop the half-copy. The live `rbuergi/OperationRequest` was **not** touched — read-only `get`/`search` throughout — and nothing references it (`search 'nodeType:rbuergi/OperationRequest'` → 0 instances).

## Verification

`dotnet build -c Release -warnaserror`, 0 Error(s): MeshWeaver.Compiler, MeshWeaver.Compiler.Pipeline, MeshWeaver.Hosting, and the four touched test projects.

- MeshWeaver.Compiler.Pipeline.Test — 814/814
- MeshWeaver.Documentation.Test — 368/368 (link integrity, topic map, What's New, the activity-log key ratchet)
- MeshWeaver.Hosting.Test pre-warm/gate suites — 44/44
- MeshWeaver.Graph.Test operational-content + shipped-state guards — 15/15
- MeshWeaver.Messaging.Hub.Test LocalizationTest — 58/58

`NodeTypeCompileStateTest.StateMembers_AreExactlyTheMaskedOperationalMembers` caught the satellite mirror before this was pushed; the field is mirrored.

Doc: Doc/Architecture/MissingDeclaredSources, listed in the topic map. What's New: Category Fix.

Mirror-sync: npm run sync:i18n -- --ref <this PR's merged core sha> — this adds one catalog key (activity.compile.declaredQueryMatchedNone) in en and de, so MeshWeaver.Plugins/clients/react/src/i18n needs the sync after merge; tracked on Systemorph/MeshWeaver#3903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
