### PR TITLE
fix(#3477): the phantom guard asks the write path's OWN no-op question, and the test observes the write's contract

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md
@@ -177,11 +177,15 @@ cases those are in two places of its own:
   a re-parsed `JsonElement` …, or a content record holding collections (compared by reference) all
   read as 'changed' while the persisted JSON is byte-identical"*.
 
-And the mixed pair is what this path always has. `UpdateRemote` runs on the **cache hub**, whose
-mirror content is a `JsonElement` because — in `MeshNode.Equals`'s own words — that hub *"does not
-know domain types"*; the caller's lambda produces a **typed** content. So every such write fails gate
-1 by construction and is decided at gate 2, which is precisely where the phantom guard was not
-looking.
+And a mixed pair is what this comparison gets **whenever the content type resolves**. `UpdateQueued`
+wraps the caller's lambda as `update(EnsureTypedContent(node, …))`, so the lambda's **output** carries
+typed content while `current` — the raw mirror emission it is compared against — still carries the
+`JsonElement`. Gate 1 therefore cannot fire, and gate 2 decides, which is precisely where the phantom
+guard was not looking.
+
+When the type does **not** resolve, `EnsureTypedContent` degrades back to a `JsonElement`, both sides
+stay untyped, and `JsonElement.DeepEquals` settles it at gate 1. So gate 2 is the resolved-type case
+— the ordinary one — not literally every write.
 
 The fix is to ask the write path's own question once:
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PhantomBaseAfterOwnerDisposal.md
@@ -126,6 +126,142 @@ bounded below the 45 s the test waited:
 Exactly one terminal is both silent and leaves storage unchanged, and it is the one that requires the
 mirror to already carry the marker. That is the reading; the code that produces it is above.
 
+### 🚨 A correction to that elimination: the bounds compose ADDITIVELY
+
+The table above reads every terminal's deadline from a **common origin** — the NACK — and concludes
+that all of them fall inside the 45 s the test waited. They do not. The re-attempt's bounds are
+**sequential**, and the same page of `LatePatchResponseRegistry` says so about its own window: *"The
+owner-side paths were enumerated as ALTERNATIVES, taking their maximum; in
+`ApplyMeshNodePatchInTurn` they compose ADDITIVELY."* The re-attempt is the same shape:
+
+```
+BaseStateWaitBound (30 s, from SUBSCRIBE)  →  post  →  WriteVerdictBound (31 s, from the POST)
+                                              └─ plus GetMeshNode's 10 s when the base is a phantom
+```
+
+So `VERDICT_TIMEOUT` is due at *(base-read latency) + 31 s*, not at 31 s. A re-attempt whose base
+arrives after 14 s produces its first Warning at 45 s or later — **outside the window the test was
+watching**. The region from T+30 to T+61 is therefore silent BY DESIGN, and the failing observation
+sat inside it.
+
+That does not make the phantom reading wrong; it makes the sighting **under-determined**. It is
+consistent with two things, and this page's change closes the first while the observation contract
+described below closes the second:
+
+1. the re-attempt settled silently against a phantom base (this page), or
+2. the re-attempt had simply not reached any terminal yet, and the test stopped watching first.
+
+## The residual: the write path has TWO no-write exits, and #3633 guarded ONE
+
+`UpdateRemote` decides not to post a patch in two separate places:
+
+| # | gate | where | logs |
+|---|---|---|---|
+| 1 | `IsRecordNoOp(current, updated)` | before anything is serialised | `NO-OP … contentType=…` (Debug; Warning only for a raw `JsonElement`) |
+| 2 | `ComputeMergePatchDiff(...).Count == 0` | after serialisation | `NO-OP … diff empty after serialisation` (Debug) |
+
+Both post nothing, both complete the caller as a **success**, both are Debug. They are one decision
+wearing two coats — and `ReattemptBaseSource`'s phantom test was originally written at its call site
+as **gate 1 alone**. A phantom base that fails record equality but serialises identically therefore
+walked straight past the guard and out through gate 2, into precisely the silent loss the guard
+exists to refuse.
+
+**That pair is not contrived — it is the cache hub's ordinary shape.** Gate 2 exists because "a
+rebuilt-but-identical content slips past the record-Equals check above", and `MeshNode` says which
+cases those are in two places of its own:
+
+- `MeshNode.ContentEquals` compares two `JsonElement`s structurally, but a **MIXED** pair — one
+  `JsonElement`, one typed — is `false` by construction, and says so: *"no `JsonSerializerOptions` is
+  available here to bridge representations"*.
+- `MeshNode.SerializedEquals` enumerates the same witnesses: *"a rebuilt-but-identical typed content,
+  a re-parsed `JsonElement` …, or a content record holding collections (compared by reference) all
+  read as 'changed' while the persisted JSON is byte-identical"*.
+
+And the mixed pair is what this path always has. `UpdateRemote` runs on the **cache hub**, whose
+mirror content is a `JsonElement` because — in `MeshNode.Equals`'s own words — that hub *"does not
+know domain types"*; the caller's lambda produces a **typed** content. So every such write fails gate
+1 by construction and is decided at gate 2, which is precisely where the phantom guard was not
+looking.
+
+The fix is to ask the write path's own question once:
+
+```csharp
+internal static bool PostsNothing(MeshNode current, MeshNode updated, JsonSerializerOptions o)
+    => IsRecordNoOp(current, updated)
+       || ComputeMergePatchDiff(ToJsonObject(current, o), ToJsonObject(updated, o)).Count == 0;
+```
+
+`UpdateRemote` passes `PostsNothing` as `baseAlreadyCarriesTheWrite`, and spells both of its own
+gates through the same helpers, so the guard and the decision cannot drift apart again. The extra
+serialisation is paid **only where the guard runs at all** — a re-attempt whose owner said the write
+never applied — never on a first attempt, a `Conflict` re-attempt, or a write that yields a real
+diff.
+
+## The second half: observing a write through its own contract
+
+The sighting that opened #3477 could not name its own cause, and that was a property of the
+**instrument**, not of the race. Three defects, all in the test:
+
+1. **It waited on a proxy before the contract.** The ground truth was `storage.Read(path)` reaching
+   the marker; the caller's terminal — the only wait with a bound and a diagnosis of its own — was
+   checked *afterwards*. So when `UpdateRemote` was about to report `OwnerUnreachable` with the
+   `corr=` request trail, the test had already failed with `System.TimeoutException : The operation
+   has timed out.` and thrown the explanation away. This is #2819 restated: *anything waiting on a
+   write must bound itself STRICTLY ABOVE the framework's bound, so the framework's terminal wins and
+   names the cause.*
+2. **The decisive bound was a hand-written `45.Seconds()`** — not CI-scaled while every other wait in
+   the same test was `TestTimeouts.Convergence`, and below what one re-enqueue may legitimately cost
+   before the framework gives up (see the additive arithmetic above).
+3. **`[Fact(Timeout = 90_000)]` was BELOW the inner waits on a runner.** `TestTimeouts.Convergence`
+   is 108 s at the CI factor, so on CI xunit killed the test before any inner wait could report.
+   That is not hypothetical: core merge-queue run `34332482683` (2026-09-09, shard 4) failed
+   `LateNackReenqueueCorrelationTest` as a bare *"Test execution timed out after 90000
+   milliseconds"* — no assertion, no named wait — and #3477 has been unable to attribute that
+   sighting since. `TestTimeouts` exists to prevent exactly this: *"the inner bound must be strictly
+   less than the outer one, and that is why both live here."*
+
+The corrected order asserts the caller's terminal first and durable storage second, which is also a
+**strictly stronger** claim than the old poll made: on the owner the ack FOLLOWS the flush
+(`PATCH_MERGE_STAMPED → PATCH_ECHO_SEEN → Flush → ack`), so once the caller holds a success the store
+already holds the value. A phantom success — the write reported saved while no store holds it, which
+is the class this test exists to refuse — now fails on the storage assertion and **says so**, instead
+of hiding inside an anonymous timeout.
+
+🚨 **`TestTimeoutLiteralRatchetGuard` does not see either literal.** It is deliberately narrow — it
+counts `30.Seconds()`, `TimeSpan.FromSeconds(30)` and `Timeout = 30_000` — so a test carrying a
+*different* guessed number is invisible to it. Both of this issue's sightings were that shape
+(`45.Seconds()`, `Timeout = 90_000`), and there are ~700 `Timeout = <literal>` sites in core's test
+tree, so widening the ratchet is a fleet-scale change rather than part of this fix. When you write
+one, write the standard comment beside it: the constant must DOMINATE `TestTimeouts.TestMilliseconds`
+(216 s at the CI factor), because an attribute argument cannot be a property.
+
+## 🚨 Still open: `WriteVerdictBound` is not the bound it says it is
+
+`LatePatchResponseRegistry.WriteVerdictBound` documents itself as *"the outer bound on a
+caller-visible mesh WRITE: the instant `UpdateRemote` gives up and reports `OwnerUnreachable`"*, and
+`TestTimeouts.Convergence` derives from it so that every waiter in the fleet dominates it by
+construction. **For a write that re-enqueues, it is false.** Each attempt arms its own deadline from
+its own post, `MaxOwnerDisposingReenqueues` is 2, and each attempt also pays a base read outside that
+deadline — so the true worst case before a caller sees any terminal is
+
+```
+3 attempts x (BaseStateWaitBound 30 s + GetMeshNode 10 s + WriteVerdictBound 31 s) ≈ 213 s
+```
+
+against a published 31 s. Nothing in this change alters that; the two candidate fixes are a
+maintainer decision, not an implementation detail:
+
+- **Mint the deadline ONCE per write** (at attempt 0's entry) and thread the remaining budget into
+  every re-attempt, exactly as `correlationId` is threaded. The published bound becomes true, and a
+  NACK arriving late in the budget makes the re-attempt fail fast rather than land — a write that
+  would have landed at 90 s is now refused at 31 s with a diagnosis.
+- **Publish the composite bound** instead. Honest, but `TestTimeouts.Convergence` then becomes ~218 s
+  locally and ~654 s on CI, which inflates every convergence wait in the fleet to buy a bound almost
+  nothing needs.
+
+The first is the better shape; it changes caller-visible behaviour on the slow path, so it is stated
+here rather than smuggled in.
+
 🚨 The corroboration is that `ClassifyPatchException`'s own remarks already predicted the shape
 without naming the mechanism: *"Routing more faults here makes that class MORE likely, not less, and
 it is silent when it happens."* The faults it routes are the post-echo ones.
@@ -153,7 +289,16 @@ no cluster, no scheduler and no wall clock are involved:
   for a durable write);
 - a mirror that is behind ⇒ the mirror is used and the authoritative read is **never subscribed**;
 - an ordinary write ⇒ untouched, even when its lambda is a legitimate no-op;
-- an authoritative read that cannot answer ⇒ raises, never falls back.
+- an authoritative read that cannot answer ⇒ raises, never falls back;
+- 🚨 a phantom mirror holding the value as **untyped JSON** against a lambda producing it **typed**
+  ⇒ still rebases on the owner. That case also asserts that the pre-#3477 predicate (`IsRecordNoOp`
+  alone) does **not** see it, so it is a positive control on the gap rather than a restatement of the
+  fix.
+
+🚨 The cases call `MeshNodeStreamHandle.PostsNothing` — the predicate `UpdateRemote` itself passes —
+rather than a local copy of it. An earlier version of this file spelled the record comparison out in
+the test, so the production guard could be narrowed without a single case going red: a test asserting
+a rule nothing under test was using.
 
 🚨 It was falsified by planting the pre-fix behaviour (`=> mirrorBase`, unconditionally) and watching
 it go red. It is deliberately **not** verified by re-running `LateNackReenqueueTest` hoping to catch

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-retried-write-checks-the-owner-before-calling-itself-a-no-op.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-retried-write-checks-the-owner-before-calling-itself-a-no-op.md
@@ -1,0 +1,23 @@
+---
+Name: A retried write checks the owner before calling itself a no-op
+Category: Fix
+Description: When a node's owner reports that an update never applied, the retry now asks the owner what it holds in every case where it would otherwise have posted nothing — closing the last route by which a write could be reported saved while no store held it.
+Icon: CheckCircle
+Order: -20260910
+---
+
+# A retried write checks the owner before calling itself a no-op
+
+An update to a node held by another part of the mesh can be answered with "that never applied"
+while the shutting-down owner has already told every reader about it. The retry then saw its own
+value already present, decided there was nothing to write, and reported success — for a change that
+reached no store.
+
+That was closed for one form of "nothing to write". A second form remained: when the value was
+rebuilt rather than reused, it compared as different and only turned out to be identical once
+written out. Both forms now ask the owner what it actually holds. If the owner has the value the
+success is real; if it does not, the retry writes it.
+
+The [phantom-base investigation](/Doc/Architecture/PhantomBaseAfterOwnerDisposal) records the
+mechanism, why a mirror can never answer the question on its own, and what a test must observe for a
+lost write to be reported as one.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -471,6 +471,65 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             + "that read produced no state. The write did NOT land; re-issue it."))));
             });
 
+    /// <summary>
+    /// 🚨 "Does this base make the write a no-op?" — asked in ONE place, because it is asked
+    /// TWICE and the two askers had drifted (issue #3477).
+    ///
+    /// <para><b>The write path decides not to post in two separate places.</b> First
+    /// <see cref="IsRecordNoOp"/>, on the records, before anything is serialised. Then — for a
+    /// lambda whose output is NOT record-equal — again on the SERIALISED merge patch:
+    /// <c>if (patch.Count == 0)</c>, <c>NO-OP … diff empty after serialisation</c>. Both exits
+    /// post no <c>PatchDataRequest</c>, complete the caller as a SUCCESS, and log at
+    /// <c>LogDebug</c>. They are one decision wearing two coats.</para>
+    ///
+    /// <para><b>#3633 guarded only the first coat.</b> <see cref="ReattemptBaseSource"/>'s phantom
+    /// test was written inline at its call site as the record comparison alone, so a phantom base
+    /// that is not record-equal to <c>update(base)</c> but serialises identically walked straight
+    /// past the guard and out through the second exit — into exactly the silent success #3633
+    /// exists to refuse: nothing posted, storage untouched, the caller told the marker was saved,
+    /// not one line above Debug.</para>
+    ///
+    /// <para><b>That pair is not contrived — it is this path's ordinary shape.</b>
+    /// <c>MeshNode.ContentEquals</c> compares two <c>JsonElement</c>s structurally, but a MIXED
+    /// pair — one <c>JsonElement</c>, one typed — is <c>false</c> by construction, and says why:
+    /// "no <c>JsonSerializerOptions</c> is available here to bridge representations". The mirror
+    /// <c>UpdateRemote</c> reads lives on the CACHE hub, which (in <c>MeshNode.Equals</c>'s own
+    /// words) "does not know domain types", so its content IS a <c>JsonElement</c>, while the
+    /// caller's lambda produces a TYPED content. Every such write therefore fails gate 1 by
+    /// construction and is decided at gate 2 — the gate the phantom test was not looking at.
+    /// <c>MeshNode.SerializedEquals</c> enumerates the same witnesses.</para>
+    ///
+    /// <para>So the guard now asks the write path's OWN question, through the write path's own
+    /// serialisation and diff. The extra serialisation is paid only where the guard runs at all —
+    /// a re-attempt whose owner said the write never applied — never on a first attempt, a
+    /// CONFLICT re-attempt, or any write that yields a real diff.</para>
+    /// </summary>
+    /// <param name="current">The candidate base.</param>
+    /// <param name="updated">What the caller's lambda produced from it.</param>
+    /// <param name="jsonOptions">The hub's serializer options — the same ones the write path uses,
+    /// so the diff computed here is the diff that would have been posted.</param>
+    internal static bool PostsNothing(MeshNode current, MeshNode updated, JsonSerializerOptions jsonOptions)
+        => IsRecordNoOp(current, updated)
+            || ComputeMergePatchDiff(
+                ToJsonObject(current, jsonOptions),
+                ToJsonObject(updated, jsonOptions)).Count == 0;
+
+    /// <summary>
+    /// The write path's FIRST no-write gate: a lambda that returned the node unchanged. Named so
+    /// that <see cref="PostsNothing"/> and the write path cannot spell it differently.
+    /// </summary>
+    internal static bool IsRecordNoOp(MeshNode current, MeshNode updated)
+        => ReferenceEquals(updated, current) || Equals(updated, current);
+
+    /// <summary>
+    /// The write path's serialisation of a node for the merge diff — one spelling, so
+    /// <see cref="PostsNothing"/> measures what would actually be posted.
+    /// </summary>
+    internal static System.Text.Json.Nodes.JsonObject ToJsonObject(
+        MeshNode node, JsonSerializerOptions jsonOptions)
+        => JsonSerializer.SerializeToNode(node, jsonOptions) as System.Text.Json.Nodes.JsonObject
+            ?? new System.Text.Json.Nodes.JsonObject();
+
     internal MeshNodeStreamHandle(IWorkspace workspace, string? path = null,
         IMeshNodeStreamCache? cache = null, bool bypassCache = false)
     {
@@ -1788,11 +1847,13 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // aside for a still-shutting-down activation, so what answers is the fresh one.
                     Observable.Defer(() => MeshNodeStreamExtensions
                         .GetMeshNode(_workspace.Hub, _path!)),
+                    // 🚨 The write path's OWN no-write decision, not a re-spelling of half of it.
+                    // This used to be the record comparison alone, which is only the FIRST of the
+                    // two exits that post nothing; the second — an empty patch after serialisation
+                    // — walked past the guard into the very silent success it exists to refuse.
+                    // See PostsNothing.
                     baseAlreadyCarriesTheWrite: node =>
-                    {
-                        var candidate = update(node);
-                        return ReferenceEquals(candidate, node) || Equals(candidate, node);
-                    },
+                        PostsNothing(node, update(node), _workspace.Hub.JsonSerializerOptions),
                     path: _path!,
                     onPhantomBase: () => diagLogger?.LogWarning(
                         "[UpdateRemote] PHANTOM_BASE hub={Hub} target={Path} attempt={Attempt} corr={Corr} — "
@@ -1818,7 +1879,10 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                         try
                         {
                             var updated = update(current);
-                            if (ReferenceEquals(updated, current) || Equals(updated, current))
+                            // 🚨 Gate ONE of two. The other is `patch.Count == 0` below. Both are
+                            // spelled through the helpers PostsNothing composes, so the phantom
+                            // guard above and this decision cannot drift apart again (#3477).
+                            if (IsRecordNoOp(current, updated))
                             {
                                 // A lambda that returns the node unchanged is a legitimate
                                 // no-op (an identical upsert, a guard `return node`, a
@@ -1853,12 +1917,8 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             }
 
                             var jsonOpts = _workspace.Hub.JsonSerializerOptions;
-                            var currentNode = System.Text.Json.JsonSerializer
-                                .SerializeToNode(current, jsonOpts) as System.Text.Json.Nodes.JsonObject
-                                ?? new System.Text.Json.Nodes.JsonObject();
-                            var updatedNode = System.Text.Json.JsonSerializer
-                                .SerializeToNode(updated, jsonOpts) as System.Text.Json.Nodes.JsonObject
-                                ?? new System.Text.Json.Nodes.JsonObject();
+                            var currentNode = ToJsonObject(current, jsonOpts);
+                            var updatedNode = ToJsonObject(updated, jsonOpts);
                             // 🚨 Diff the lambda's ACTUAL output FIRST — before the audit stamp
                             // below. The stamp used to run first, so a lambda that changed
                             // NOTHING (a rebuilt-but-identical content slips past the
@@ -1868,6 +1928,14 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // change earns the audit stamp and the send.
                             var patch = ComputeMergePatchDiff(currentNode, updatedNode);
 
+                            // 🚨 Gate TWO of two, and the one #3633's phantom guard could not see:
+                            // reached precisely when a "rebuilt-but-identical content slips past
+                            // the record-Equals check above" — which on THIS hub is every write,
+                            // because the cache mirror's content is untyped JSON and the caller's
+                            // lambda yields a typed value, a pair MeshNode.ContentEquals refuses
+                            // outright. PostsNothing now covers both gates, so a re-attempt whose
+                            // owner said the write never applied can no longer exit here against a
+                            // phantom base (#3477).
                             if (patch.Count == 0)
                             {
                                 diagLogger?.LogDebug(

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -420,10 +420,18 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// mode. The authoritative read is paid only in the ambiguous case, which is the case that was
     /// losing the write.</para>
     ///
-    /// <para><paramref name="baseAlreadyCarriesTheWrite"/> runs the caller's lambda against the
-    /// candidate base and discards the result; the lambda is a pure state transform by contract
-    /// (the re-enqueue machinery already re-runs it once per attempt), so evaluating it a second
-    /// time on the SAME base cannot change what is written.</para>
+    /// <para>The phantom test runs the caller's lambda against the candidate base and discards the
+    /// result; the lambda is a pure state transform by contract (the re-enqueue machinery already
+    /// re-runs it once per attempt), so evaluating it a second time on the SAME base cannot change
+    /// what is written.</para>
+    ///
+    /// <para>🚨 <b>The predicate is COMPUTED here, not injected.</b> It used to be a
+    /// <c>Func&lt;MeshNode, bool&gt;</c> parameter, which made the seam un-pinnable: a test could
+    /// supply <see cref="PostsNothing"/> and stay green while the production call site regressed to
+    /// half of it — which is exactly how #3633's guard came to cover only one of the write path's
+    /// two no-write exits. Taking <paramref name="update"/> and
+    /// <paramref name="jsonOptions"/> instead means there is one predicate and no way to pass a
+    /// different one.</para>
     ///
     /// <para>Static, with both bases as seams, so the rule is asserted deterministically — no hub,
     /// no cluster, no wall clock.</para>
@@ -434,8 +442,9 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// <param name="mirrorBase">The composed mirror read every other write uses.</param>
     /// <param name="authoritativeBase">A read served by the OWNER, subscribed only when the mirror
     /// base turns out to be a phantom.</param>
-    /// <param name="baseAlreadyCarriesTheWrite">Whether the caller's lambda is a no-op against the
-    /// candidate base — i.e. whether the base already contains the write the owner just refused.</param>
+    /// <param name="update">The caller's update lambda — the same one the write path applies.</param>
+    /// <param name="jsonOptions">The hub's serializer options, so <see cref="PostsNothing"/>
+    /// measures the diff that would actually be posted.</param>
     /// <param name="path">The node being written, for the refusal message.</param>
     /// <param name="onPhantomBase">Called when the mirror base is discarded for the authoritative
     /// one, so the swap is nameable in a log rather than invisible.</param>
@@ -443,14 +452,16 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
         bool ownerSaidNeverApplied,
         IObservable<MeshNode> mirrorBase,
         IObservable<MeshNode?> authoritativeBase,
-        Func<MeshNode, bool> baseAlreadyCarriesTheWrite,
+        Func<MeshNode, MeshNode> update,
+        JsonSerializerOptions jsonOptions,
         string path,
         Action? onPhantomBase = null)
         => !ownerSaidNeverApplied
             ? mirrorBase
             : mirrorBase.SelectMany(node =>
             {
-                if (!baseAlreadyCarriesTheWrite(node))
+                // 🚨 The write path's OWN no-write decision — both gates, never half of them.
+                if (!PostsNothing(node, update(node), jsonOptions))
                     return Observable.Return(node);
                 onPhantomBase?.Invoke();
                 // 🚨 TOTALITY, the same rule RequireBaseState applies to the mirror read (#3001),
@@ -489,14 +500,17 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// exists to refuse: nothing posted, storage untouched, the caller told the marker was saved,
     /// not one line above Debug.</para>
     ///
-    /// <para><b>That pair is not contrived — it is this path's ordinary shape.</b>
-    /// <c>MeshNode.ContentEquals</c> compares two <c>JsonElement</c>s structurally, but a MIXED
-    /// pair — one <c>JsonElement</c>, one typed — is <c>false</c> by construction, and says why:
-    /// "no <c>JsonSerializerOptions</c> is available here to bridge representations". The mirror
-    /// <c>UpdateRemote</c> reads lives on the CACHE hub, which (in <c>MeshNode.Equals</c>'s own
-    /// words) "does not know domain types", so its content IS a <c>JsonElement</c>, while the
-    /// caller's lambda produces a TYPED content. Every such write therefore fails gate 1 by
-    /// construction and is decided at gate 2 — the gate the phantom test was not looking at.
+    /// <para><b>That pair is not contrived — it is this path's ordinary shape whenever the content
+    /// type RESOLVES.</b> <c>MeshNode.ContentEquals</c> compares two <c>JsonElement</c>s
+    /// structurally, but a MIXED pair — one <c>JsonElement</c>, one typed — is <c>false</c> by
+    /// construction, and says why: "no <c>JsonSerializerOptions</c> is available here to bridge
+    /// representations". And a mixed pair is what this comparison gets: <c>UpdateQueued</c> wraps
+    /// the caller's lambda as <c>update(EnsureTypedContent(node, …))</c>, so the lambda's OUTPUT
+    /// carries typed content while <c>current</c> — the raw mirror emission it is compared against —
+    /// still carries the <c>JsonElement</c>. Gate 1 therefore cannot fire, and gate 2 decides.
+    /// (When the type does NOT resolve, <c>EnsureTypedContent</c> degrades back to a
+    /// <c>JsonElement</c>, both sides stay untyped, and <c>JsonElement.DeepEquals</c> settles it at
+    /// gate 1 — so gate 2 is the RESOLVED-type case, which is the ordinary one.)
     /// <c>MeshNode.SerializedEquals</c> enumerates the same witnesses.</para>
     ///
     /// <para>So the guard now asks the write path's OWN question, through the write path's own
@@ -1847,13 +1861,14 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // aside for a still-shutting-down activation, so what answers is the fresh one.
                     Observable.Defer(() => MeshNodeStreamExtensions
                         .GetMeshNode(_workspace.Hub, _path!)),
-                    // 🚨 The write path's OWN no-write decision, not a re-spelling of half of it.
-                    // This used to be the record comparison alone, which is only the FIRST of the
-                    // two exits that post nothing; the second — an empty patch after serialisation
-                    // — walked past the guard into the very silent success it exists to refuse.
-                    // See PostsNothing.
-                    baseAlreadyCarriesTheWrite: node =>
-                        PostsNothing(node, update(node), _workspace.Hub.JsonSerializerOptions),
+                    // 🚨 The lambda and the options, NOT a predicate — ReattemptBaseSource computes
+                    // the no-write decision itself (PostsNothing), so this call site cannot supply
+                    // half of it. It used to pass the record comparison alone, which is only the
+                    // FIRST of the two exits that post nothing; the second — an empty patch after
+                    // serialisation — walked past the guard into the very silent success it exists
+                    // to refuse.
+                    update,
+                    _workspace.Hub.JsonSerializerOptions,
                     path: _path!,
                     onPhantomBase: () => diagLogger?.LogWarning(
                         "[UpdateRemote] PHANTOM_BASE hub={Hub} target={Path} attempt={Attempt} corr={Corr} — "
@@ -1930,12 +1945,13 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
 
                             // 🚨 Gate TWO of two, and the one #3633's phantom guard could not see:
                             // reached precisely when a "rebuilt-but-identical content slips past
-                            // the record-Equals check above" — which on THIS hub is every write,
-                            // because the cache mirror's content is untyped JSON and the caller's
-                            // lambda yields a typed value, a pair MeshNode.ContentEquals refuses
-                            // outright. PostsNothing now covers both gates, so a re-attempt whose
-                            // owner said the write never applied can no longer exit here against a
-                            // phantom base (#3477).
+                            // the record-Equals check above" — which is every write whose content
+                            // type RESOLVES, because UpdateQueued wraps the lambda as
+                            // update(EnsureTypedContent(node, …)) so `updated` is typed while
+                            // `current` is still the raw mirror's JsonElement, a pair
+                            // MeshNode.ContentEquals refuses outright. PostsNothing now covers both
+                            // gates, so a re-attempt whose owner said the write never applied can no
+                            // longer exit here against a phantom base (#3477).
                             if (patch.Count == 0)
                             {
                                 diagLogger?.LogDebug(

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueCorrelationTest.cs
@@ -55,7 +55,18 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
                         filter: null));
                 }));
 
-    [Fact(Timeout = 90_000)]
+    // 240_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant, so
+    // the property cannot be written here. The value must still DOMINATE it — 216 s at the CI
+    // factor (Convergence 108 s x OuterMargin 2) — or the xunit kill pre-empts the inner wait and
+    // the failure cannot say what it was waiting for.
+    //
+    // 🚨 It was 90_000, and EVERY wait below is TestTimeouts.Convergence, which is 108 s on a
+    // runner. So on CI this test could never report which wait failed — the xunit kill always won.
+    // That is not a hypothetical: core merge-queue run 34332482683 (2026-09-09, shard 4) failed it
+    // as a bare "Test execution timed out after 90000 milliseconds", no assertion and no named
+    // wait, and #3477 has been unable to attribute that sighting since. An outer bound below the
+    // inner one is the exact defect TestTimeouts exists to prevent.
+    [Fact(Timeout = 240_000)]
     public async Task AReenqueuedAttemptInheritsTheCorrelationIdOfTheNackThatCausedIt()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -70,7 +81,7 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
             .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
             .Where(n => n is not null)
-            .FirstAsync().Timeout(10.Seconds()).Await(ct);
+            .FirstAsync().Timeout(TestTimeouts.Quick).Await(ct);
 
         var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
         Assert.NotNull(nodeHub);
@@ -109,7 +120,7 @@ public class LateNackReenqueueCorrelationTest(ITestOutputHelper output) : Monoli
 
         try
         {
-            await gateEntered.Should().Within(10.Seconds()).Emit(
+            await gateEntered.Should().Within(TestTimeouts.Quick).Emit(
                 "the gated turn must be running before the cross-hub write");
 
             captured.Clear();

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
@@ -51,8 +51,17 @@ namespace MeshWeaver.Graph.Test;
 /// commit's own ack, dispatched to the armed watch; the OwnerDisposing NACK and its re-enqueue
 /// remain the safety net for a merge the owner could not run at all (a post refused by an
 /// already-closing sync hub, a store that completes before the echo). Both paths end in the same
-/// ground truth this test asserts. Without the late watch either verdict is dropped and the
-/// storage poll times out at the pre-write state.</para>
+/// ground truth this test asserts. Without the late watch either verdict is dropped, the caller is
+/// never settled, and durable storage stays at the pre-write state.</para>
+///
+/// <para>🚨 The two assertions are in this order ON PURPOSE — #3477. The CALLER'S TERMINAL is the
+/// only wait here with a contract of its own (<c>UpdateRemote</c> settles every write inside its
+/// own bound and says why), so it is waited on FIRST and durable storage is checked second. The old
+/// order polled storage for a hand-written 45 s — below what one re-enqueue may legitimately cost,
+/// and inside a region that is silent by design — so the failure could only ever read "The
+/// operation has timed out.", with the write's own diagnosis discarded unread. The new order also
+/// makes the claim STRONGER: the owner acks only after its durable flush, so a write reported
+/// committed while no store holds it fails on the storage assertion and says so.</para>
 ///
 /// <para>🚨 Since #2661 the caller is NOT completed at the 2 s bound — a bound expiring is not
 /// a commit, so the write's terminal is the owner's verdict wherever it arrives. Here that
@@ -62,7 +71,17 @@ namespace MeshWeaver.Graph.Test;
 /// </summary>
 public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    [Fact(Timeout = 90_000)]
+    // 240_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant, so
+    // the property cannot be written here. The value must still DOMINATE it — 216 s at the CI
+    // factor (Convergence 108 s x OuterMargin 2) — or the xunit kill pre-empts the inner wait and
+    // the failure cannot say what it was waiting for.
+    //
+    // 🚨 It was 90_000, which is BELOW TestTimeouts.Convergence on a runner (108 s), so every
+    // internal wait in this test was killed anonymously before it could report. That is exactly the
+    // defect TestTimeouts exists to prevent, and it is what the 2026-09-09 sighting of this test's
+    // sibling looked like: "Test execution timed out after 90000 milliseconds", no assertion, no
+    // named wait (#3477).
+    [Fact(Timeout = 240_000)]
     public async Task LateOwnerDisposingNack_AfterOptimisticEmit_ReenqueuesAndLands()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -77,7 +96,7 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
             .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
             .Where(n => n is not null)
-            .FirstAsync().Timeout(10.Seconds()).Await(ct);
+            .FirstAsync().Timeout(TestTimeouts.Quick).Await(ct);
 
         var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
         nodeHub.Should().NotBeNull();
@@ -110,7 +129,7 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
         }), _ => { });
         try
         {
-            await gateEntered.Should().Within(10.Seconds()).Emit(
+            await gateEntered.Should().Within(TestTimeouts.Quick).Emit(
                 "the gated turn must be running on the primary stream's executor before the write");
 
             // Cross-hub cache write — the production mirror path (UpdateRemote via the
@@ -138,7 +157,7 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
             // Fence: the patch handler has provably run on the owner (registered the
             // disposal NACK) before the dispose below.
             await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
-                .Should().Within(10.Seconds()).Emit();
+                .Should().Within(TestTimeouts.Quick).Emit();
 
             // Dispose the owner AFTER the caller's response bound has expired — its
             // OwnerDisposing NACK (posted from the ShutDown-phase disposal action) is
@@ -147,26 +166,44 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
             nodeHub!.Dispose();
             Output.WriteLine($"[dispose] owner per-node hub disposal invoked for {path}");
 
-            // Ground truth: the write eventually lands in durable storage. Without the
-            // late-NACK re-enqueue the store stays frozen at 'initial' (the parked merge
-            // turn died with the sync hub; nobody re-applies) and this poll times out —
-            // the WaitForPersistedBeyond signature of the TwoSilo failure.
-            var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
-                .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
-                .Where(n => n is not null && n.Name == marker)
-                .FirstAsync().Timeout(45.Seconds()).Await(ct);
-            persisted!.Name.Should().Be(marker,
-                "a write whose owner NACKed OwnerDisposing must be re-enqueued and applied on "
-                + "the fresh activation — never silently lost");
-
+            // 🚨 THE CALLER'S TERMINAL IS WAITED ON FIRST, and that ordering is the point.
             // #2661: the re-attempt's verdict is the CALLER's verdict. Chaining it back is what
-            // makes "saved" mean the owner committed, on the late path as much as the early one.
+            // makes "saved" mean the owner committed, on the late path as much as the early one —
+            // and it is the only wait here with a CONTRACT of its own: UpdateRemote settles every
+            // write inside its own bound and says why (VERDICT_TIMEOUT / OwnerUnreachable, carrying
+            // the corr= trail of every attempt). TestTimeouts.Convergence derives from that bound
+            // precisely so this assertion dominates it.
+            //
+            // 🚨 The old order asked durable storage FIRST, for a hand-written 45 s. Storage is a
+            // PROXY with no bound of its own, 45 s is below what one re-enqueue may legitimately
+            // cost before the framework itself gives up (BaseStateWaitBound 30 s, then
+            // WriteVerdictBound 31 s measured from the RE-ATTEMPT's post — additive, not
+            // alternatives), and it is not CI-scaled while every other wait in this test is. So the
+            // window closed inside a region that is silent BY DESIGN and the failure could only ever
+            // read "System.TimeoutException : The operation has timed out." — which is verbatim what
+            // #3477 recorded, with the write's own diagnosis discarded unread.
             await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
                 .Where(_ => callerTerminal is not null || callerError is not null)
                 .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
             callerError.Should().BeNull("the re-enqueued attempt landed, so the caller must see a success");
             callerTerminal!.Name.Should().Be(marker,
                 "the caller's terminal is the verdict of the attempt that actually committed");
+
+            // Ground truth, and now a STRICTLY STRONGER claim than the old poll made. On the owner
+            // the ack FOLLOWS the durable flush (PATCH_MERGE_STAMPED → PATCH_ECHO_SEEN →
+            // IPostCommitFlush.Flush → ack), so the instant the caller holds a success the value is
+            // already in the store. Without the late-NACK re-enqueue the store stays frozen at
+            // 'initial' (the parked merge turn died with the sync hub; nobody re-applies) — and a
+            // PHANTOM success, the write reported saved while no store anywhere holds it, fails
+            // HERE and says so, instead of hiding inside an anonymous storage timeout.
+            var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+                .Where(n => n is not null && n.Name == marker)
+                .FirstAsync().Timeout(TestTimeouts.Quick).Await(ct);
+            persisted!.Name.Should().Be(marker,
+                "a write whose owner NACKed OwnerDisposing must be re-enqueued and applied on "
+                + "the fresh activation — never silently lost, and never reported to the caller as "
+                + "committed while durable storage still holds the pre-write state");
         }
         finally
         {

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
@@ -140,11 +140,21 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
             // cannot give is what would hang.
             var marker = $"post-nack-{Guid.NewGuid():N}"[..24];
             var workspace = Mesh.GetWorkspace();
+            // 🚨 VOLATILE both ways. These are written on whatever thread carries the owner's
+            // verdict — the cache hub's action block — and read by the interval poller below on a
+            // scheduler thread. A plain field gives the reader no guarantee of ever observing the
+            // write, so the poll could time out on a caller that HAD been settled and lose exactly
+            // the diagnosis this test exists to surface. (Polling, rather than awaiting the write
+            // observable, is deliberate: awaiting resumes the continuation INLINE on the signalling
+            // thread — see LateNackReenqueueCorrelationTest.CapturingLoggerProvider.FirstMatching
+            // for the 90 s wedge that produced.)
             MeshNode? callerTerminal = null;
             Exception? callerError = null;
             using var writeSub = workspace.GetMeshNodeStream(path)
                 .Update(n => n with { Name = marker })
-                .Subscribe(n => callerTerminal = n, ex => callerError = ex);
+                .Subscribe(
+                    n => Volatile.Write(ref callerTerminal, n),
+                    ex => Volatile.Write(ref callerError, ex));
             Output.WriteLine($"[write] patch posted with marker {marker}; owner merge is parked");
 
             // Fence on the patch actually being in flight before the dispose below — the armed
@@ -182,11 +192,27 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
             // window closed inside a region that is silent BY DESIGN and the failure could only ever
             // read "System.TimeoutException : The operation has timed out." — which is verbatim what
             // #3477 recorded, with the write's own diagnosis discarded unread.
-            await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
-                .Where(_ => callerTerminal is not null || callerError is not null)
-                .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
-            callerError.Should().BeNull("the re-enqueued attempt landed, so the caller must see a success");
-            callerTerminal!.Name.Should().Be(marker,
+            // 🚨 The bound is TURNED INTO A VALUE, never allowed to throw. A bare
+            // `.Timeout(...)` raises an anonymous TimeoutException before any assertion runs — the
+            // very defect this reordering exists to remove — so the elapsed bound becomes `false`
+            // and the assertion below carries the diagnosis instead.
+            var settled = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .Where(_ => Volatile.Read(ref callerTerminal) is not null
+                    || Volatile.Read(ref callerError) is not null)
+                .Select(_ => true)
+                .Take(1)
+                .Timeout(TestTimeouts.Convergence, Observable.Return(false))
+                .FirstAsync().Await(ct);
+            settled.Should().BeTrue(
+                "the write must reach a terminal, and TestTimeouts.Convergence dominates the bound "
+                + "UpdateRemote PUBLISHES (LatePatchResponseRegistry.WriteVerdictBound). 🚨 If THIS "
+                + "is what failed, the write is unbounded rather than merely slow: a re-enqueue "
+                + "chain arms a fresh deadline per attempt and pays a base read outside it, so its "
+                + "composite worst case exceeds the published bound — the open defect recorded in "
+                + "Doc/Architecture/PhantomBaseAfterOwnerDisposal, not a number to widen here");
+            Volatile.Read(ref callerError).Should().BeNull(
+                "the re-enqueued attempt landed, so the caller must see a success");
+            Volatile.Read(ref callerTerminal)!.Name.Should().Be(marker,
                 "the caller's terminal is the verdict of the attempt that actually committed");
 
             // Ground truth, and now a STRICTLY STRONGER claim than the old poll made. On the owner
@@ -196,10 +222,20 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
             // 'initial' (the parked merge turn died with the sync hub; nobody re-applies) — and a
             // PHANTOM success, the write reported saved while no store anywhere holds it, fails
             // HERE and says so, instead of hiding inside an anonymous storage timeout.
+            // 🚨 Same rule as above: the bound becomes a NULL, not a TimeoutException, so the
+            // phantom — a caller told "committed" while no store holds the value — is reported by
+            // the assertion that names it rather than by an anonymous timeout.
             var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
                 .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
                 .Where(n => n is not null && n.Name == marker)
-                .FirstAsync().Timeout(TestTimeouts.Quick).Await(ct);
+                .Take(1)
+                .Timeout(TestTimeouts.Quick, Observable.Return<MeshNode?>(null))
+                .FirstAsync().Await(ct);
+            persisted.Should().NotBeNull(
+                "the caller has just been handed a SUCCESS, and on the owner the ack follows the "
+                + "durable flush — so a store that does not carry the marker means the write was "
+                + "reported saved while it is in no store at all: #3477's silent loss, caught here "
+                + "instead of hiding inside a timeout");
             persisted!.Name.Should().Be(marker,
                 "a write whose owner NACKed OwnerDisposing must be re-enqueued and applied on "
                 + "the fresh activation — never silently lost, and never reported to the caller as "

--- a/test/MeshWeaver.Graph.Test/ReattemptBaseIsAuthoritativeTest.cs
+++ b/test/MeshWeaver.Graph.Test/ReattemptBaseIsAuthoritativeTest.cs
@@ -56,17 +56,15 @@ public class ReattemptBaseIsAuthoritativeTest
 
     private static MeshNode Update(MeshNode node) => node with { Name = Marker };
 
-    private static readonly JsonSerializerOptions JsonOptions = new();
-
     /// <summary>
-    /// 🚨 PRODUCTION's predicate, not a local re-implementation of it. An earlier version of this
-    /// file spelled the record comparison out here, so the guard could be narrowed in
-    /// <c>UpdateRemote</c> without a single case going red — a test asserting a rule nothing under
-    /// test was using. <see cref="MeshNodeStreamHandle.PostsNothing"/> is the one the write path
-    /// calls, so narrowing it now fails <see cref="NeverAppliedReattempt_WhoseMirrorCarriesAPhantomThatIsNotRecordEqual_StillRebasesOnTheOwner"/>.
+    /// 🚨 These cases hand <see cref="MeshNodeStreamHandle.ReattemptBaseSource"/> the caller's
+    /// LAMBDA, never a predicate — the seam computes the no-write decision itself
+    /// (<see cref="MeshNodeStreamHandle.PostsNothing"/>), so there is no way for this test to
+    /// supply one rule while the production call site uses another. An earlier version of this file
+    /// injected the predicate and spelled the record comparison out locally, which is exactly how a
+    /// guard covering only ONE of the write path's two no-write exits stayed green (#3477).
     /// </summary>
-    private static bool AlreadyCarriesTheWrite(MeshNode node) =>
-        MeshNodeStreamHandle.PostsNothing(node, Update(node), JsonOptions);
+    private static readonly JsonSerializerOptions JsonOptions = new();
 
     /// <summary>A typed content payload — what a caller's lambda produces, against a mirror that
     /// holds the same value as untyped JSON.</summary>
@@ -108,7 +106,8 @@ public class ReattemptBaseIsAuthoritativeTest
             ownerSaidNeverApplied: true,
             mirrorBase: Observable.Return(Phantom),
             authoritativeBase: Observable.Return<MeshNode?>(OwnerState),
-            baseAlreadyCarriesTheWrite: AlreadyCarriesTheWrite,
+            update: Update,
+            jsonOptions: JsonOptions,
             path: Path,
             onPhantomBase: () => phantomNoted++));
 
@@ -157,8 +156,13 @@ public class ReattemptBaseIsAuthoritativeTest
     {
         // The cache hub's mirror carries UNTYPED content; the caller's lambda produces a TYPED
         // value. ContentEquals refuses that mixed pair outright, and the two serialise identically.
+        // 🚨 The mirror's JSON is produced by the SAME serializer the diff uses, so the two sides
+        // are byte-identical under WHATEVER options are supplied — hub options included, with their
+        // naming policy and polymorphic discriminator. A hand-written literal here would pin only
+        // the default options and could disagree with production (which is how the mirror gets its
+        // value in the first place: the owner serialised it with the hub's own options).
         static JsonElement Mirrored() =>
-            JsonDocument.Parse("""{"Text":"unchanged"}""").RootElement.Clone();
+            JsonSerializer.SerializeToElement<object>(new Payload("unchanged"), JsonOptions);
         static MeshNode UpdateRebuildingContent(MeshNode node) =>
             node with { Name = Marker, Content = new Payload("unchanged") };
 
@@ -176,8 +180,8 @@ public class ReattemptBaseIsAuthoritativeTest
             ownerSaidNeverApplied: true,
             mirrorBase: Observable.Return(phantom),
             authoritativeBase: Observable.Return<MeshNode?>(owned),
-            baseAlreadyCarriesTheWrite: node =>
-                MeshNodeStreamHandle.PostsNothing(node, UpdateRebuildingContent(node), JsonOptions),
+            update: UpdateRebuildingContent,
+            jsonOptions: JsonOptions,
             path: Path,
             onPhantomBase: () => phantomNoted++));
 
@@ -208,7 +212,8 @@ public class ReattemptBaseIsAuthoritativeTest
             ownerSaidNeverApplied: true,
             mirrorBase: Observable.Return(Phantom),
             authoritativeBase: Observable.Return<MeshNode?>(new MeshNode(Path) { Name = Marker, Version = 5 }),
-            baseAlreadyCarriesTheWrite: AlreadyCarriesTheWrite,
+            update: Update,
+            jsonOptions: JsonOptions,
             path: Path));
 
         observed.Error.Should().BeNull();
@@ -236,7 +241,8 @@ public class ReattemptBaseIsAuthoritativeTest
             ownerSaidNeverApplied: true,
             mirrorBase: Observable.Return(new MeshNode(Path) { Name = "initial", Version = 4 }),
             authoritativeBase: authoritative,
-            baseAlreadyCarriesTheWrite: AlreadyCarriesTheWrite,
+            update: Update,
+            jsonOptions: JsonOptions,
             path: Path));
 
         observed.Values.Should().ContainSingle().Which.Name.Should().Be("initial");
@@ -265,7 +271,8 @@ public class ReattemptBaseIsAuthoritativeTest
             ownerSaidNeverApplied: false,
             mirrorBase: Observable.Return(Phantom),
             authoritativeBase: authoritative,
-            baseAlreadyCarriesTheWrite: AlreadyCarriesTheWrite,
+            update: Update,
+            jsonOptions: JsonOptions,
             path: Path));
 
         observed.Values.Should().ContainSingle().Which.Name.Should().Be(Marker);
@@ -299,7 +306,8 @@ public class ReattemptBaseIsAuthoritativeTest
             ownerSaidNeverApplied: true,
             mirrorBase: Observable.Return(Phantom),
             authoritativeBase: authoritative,
-            baseAlreadyCarriesTheWrite: AlreadyCarriesTheWrite,
+            update: Update,
+            jsonOptions: JsonOptions,
             path: Path));
 
         observed.Values.Should().BeEmpty("there was no trustworthy state to diff against");

--- a/test/MeshWeaver.Graph.Test/ReattemptBaseIsAuthoritativeTest.cs
+++ b/test/MeshWeaver.Graph.Test/ReattemptBaseIsAuthoritativeTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Text.Json;
 using MeshWeaver.Mesh;
 using Xunit;
 
@@ -55,11 +56,21 @@ public class ReattemptBaseIsAuthoritativeTest
 
     private static MeshNode Update(MeshNode node) => node with { Name = Marker };
 
-    private static bool AlreadyCarriesTheWrite(MeshNode node)
-    {
-        var candidate = Update(node);
-        return ReferenceEquals(candidate, node) || Equals(candidate, node);
-    }
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
+    /// <summary>
+    /// 🚨 PRODUCTION's predicate, not a local re-implementation of it. An earlier version of this
+    /// file spelled the record comparison out here, so the guard could be narrowed in
+    /// <c>UpdateRemote</c> without a single case going red — a test asserting a rule nothing under
+    /// test was using. <see cref="MeshNodeStreamHandle.PostsNothing"/> is the one the write path
+    /// calls, so narrowing it now fails <see cref="NeverAppliedReattempt_WhoseMirrorCarriesAPhantomThatIsNotRecordEqual_StillRebasesOnTheOwner"/>.
+    /// </summary>
+    private static bool AlreadyCarriesTheWrite(MeshNode node) =>
+        MeshNodeStreamHandle.PostsNothing(node, Update(node), JsonOptions);
+
+    /// <summary>A typed content payload — what a caller's lambda produces, against a mirror that
+    /// holds the same value as untyped JSON.</summary>
+    private sealed record Payload(string Text);
 
     /// <summary>What a subscriber actually observed — all three Rx terminations, separately.</summary>
     private sealed record Observed(IReadOnlyList<MeshNode> Values, Exception? Error, bool Completed);
@@ -110,6 +121,78 @@ public class ReattemptBaseIsAuthoritativeTest
                 + "against that phantom produces an EMPTY patch, posts nothing, and reports the "
                 + "write as saved when it is in no store at all — #3477's silent loss.");
         phantomNoted.Should().Be(1, "the swap must be nameable in the log, not invisible");
+    }
+
+    /// <summary>
+    /// 🚨 THE RESIDUAL #3633 LEFT OPEN — the same phantom, reached through the write path's OTHER
+    /// no-write exit.
+    ///
+    /// <para><c>UpdateRemote</c> decides not to post a patch in TWO places: the record comparison
+    /// (<c>IsRecordNoOp</c>), and — for a lambda whose output is not record-equal — the SERIALISED
+    /// merge patch coming out empty (<c>NO-OP … diff empty after serialisation</c>). Both post
+    /// nothing, both complete the caller as a SUCCESS, both log at Debug. #3633's phantom guard was
+    /// written as the record comparison alone, so a phantom base that fails record equality but
+    /// serialises identically walked past the guard and out through the second exit — into exactly
+    /// the silent loss the guard exists to refuse.</para>
+    ///
+    /// <para><b>Not a contrived pair — it is the cache hub's ordinary shape.</b>
+    /// <c>MeshNode.ContentEquals</c> compares two <c>JsonElement</c>s structurally, but a MIXED
+    /// pair — one <c>JsonElement</c>, one typed — is <c>false</c> by construction, and says so:
+    /// "no JsonSerializerOptions is available here to bridge representations". The mirror
+    /// <c>UpdateRemote</c> reads lives on the cache hub, "whose hub does not know domain types",
+    /// so its content IS a <c>JsonElement</c>; the caller's lambda produces a TYPED content. Every
+    /// such write is not record-equal and serialises identically when the value has not changed —
+    /// which is exactly what the write path's own comment predicts ("a rebuilt-but-identical
+    /// content slips past the record-Equals check above") and why gate 2 exists at all.
+    /// <c>MeshNode.SerializedEquals</c> documents the same three witnesses.</para>
+    ///
+    /// <para><b>Falsified.</b> Narrowing <c>PostsNothing</c> back to the record comparison alone
+    /// (the pre-#3477 predicate) turns this case red on the BEHAVIOUR assertion, measured:
+    /// <c>Expected value to be "initial" … but found "post-nack-4b7556aa5983"</c> — the re-attempt
+    /// diffing against the phantom, which is the loss itself. The first assertion states why the old
+    /// guard cannot see it; the last states why the write path would nevertheless post nothing.</para>
+    /// </summary>
+    [Fact]
+    public void NeverAppliedReattempt_WhoseMirrorCarriesAPhantomThatIsNotRecordEqual_StillRebasesOnTheOwner()
+    {
+        // The cache hub's mirror carries UNTYPED content; the caller's lambda produces a TYPED
+        // value. ContentEquals refuses that mixed pair outright, and the two serialise identically.
+        static JsonElement Mirrored() =>
+            JsonDocument.Parse("""{"Text":"unchanged"}""").RootElement.Clone();
+        static MeshNode UpdateRebuildingContent(MeshNode node) =>
+            node with { Name = Marker, Content = new Payload("unchanged") };
+
+        var phantom = new MeshNode(Path) { Name = Marker, Version = 5, Content = Mirrored() };
+        var owned = new MeshNode(Path) { Name = "initial", Version = 4, Content = Mirrored() };
+
+        // The two halves of the gap, stated before the behaviour: gate 1 does not see this base,
+        // and the write path would nevertheless post nothing against it.
+        MeshNodeStreamHandle.IsRecordNoOp(phantom, UpdateRebuildingContent(phantom)).Should().BeFalse(
+            "the pre-#3477 guard was this comparison alone, and it does NOT see this phantom — an "
+            + "untyped mirror value and a typed one are never record-equal, whatever they hold");
+
+        var phantomNoted = 0;
+        var observed = Watch(MeshNodeStreamHandle.ReattemptBaseSource(
+            ownerSaidNeverApplied: true,
+            mirrorBase: Observable.Return(phantom),
+            authoritativeBase: Observable.Return<MeshNode?>(owned),
+            baseAlreadyCarriesTheWrite: node =>
+                MeshNodeStreamHandle.PostsNothing(node, UpdateRebuildingContent(node), JsonOptions),
+            path: Path,
+            onPhantomBase: () => phantomNoted++));
+
+        observed.Error.Should().BeNull();
+        observed.Values.Should().ContainSingle().Which.Name.Should().Be("initial",
+            "the owner has just stated it does not hold this write, and the mirror base would have "
+            + "produced an empty patch — posting nothing and reporting success for a write that is "
+            + "in no store at all. #3633 closed that exit for a record-equal no-op; this is the "
+            + "same exit one gate later (#3477)");
+        phantomNoted.Should().Be(1, "the swap must be nameable in the log, not invisible");
+        MeshNodeStreamHandle.PostsNothing(phantom, UpdateRebuildingContent(phantom), JsonOptions)
+            .Should().BeTrue(
+                "…and this is WHY: the write path would post NOTHING against this base, because the "
+                + "serialised merge patch is empty. That — not record equality — is the only "
+                + "measure that decides whether a PatchDataRequest is sent");
     }
 
     /// <summary>


### PR DESCRIPTION
Closes the residual of #3477 in the write path, and fixes the instrument that has kept every sighting
of it unattributable.

## Which of the three candidates it was

Both of the ones that matter, and the evidence separates them:

| candidate | verdict |
|---|---|
| the production re-enqueue path is wrong | **yes** — one no-write exit was still unguarded (below) |
| the test observes the wrong signal | **yes** — it polled a proxy on a bound below the framework's own, and its `[Fact(Timeout)]` sat below its inner waits |
| the harness/fixture races | **no evidence either way** — nothing in the two CI transcripts distinguishes it, and the local statistical repro produced 0 failures in 4 full-assembly runs on the pre-fix binary, so it neither supports nor excludes this. Not pursued; if a sighting survives this change, it is the first candidate to revisit |

## 1. Production: the write path has TWO no-write exits; #3633 guarded ONE

`UpdateRemote` decides not to post a patch in two places:

| # | gate | logs |
|---|---|---|
| 1 | `ReferenceEquals(updated, current) \|\| Equals(updated, current)` | `NO-OP … contentType=…` (Debug) |
| 2 | `ComputeMergePatchDiff(...).Count == 0` | `NO-OP … diff empty after serialisation` (Debug) |

Both post nothing, both complete the caller as a **success**, both are Debug — one decision wearing
two coats. #3633's phantom guard (`ReattemptBaseSource`) was written inline at its call site as **gate
1 alone**, so a phantom base that fails record equality but serialises identically walked past it and
out through gate 2, into exactly the silent loss the guard exists to refuse.

**That pair is this path's ordinary shape, not a contrived one.** `MeshNode.ContentEquals` compares
two `JsonElement`s structurally but refuses a MIXED pair — one `JsonElement`, one typed — outright,
and says why: *"no `JsonSerializerOptions` is available here to bridge representations"*. The mirror
`UpdateRemote` reads lives on the **cache hub**, which in `MeshNode.Equals`'s own words *"does not
know domain types"*, so its content **is** a `JsonElement` while the caller's lambda yields a **typed**
content. Every such write fails gate 1 by construction and is decided at gate 2.

The fix asks the write path's own question once, and both gates are now spelled through the same
helpers so they cannot drift apart again:

```csharp
internal static bool PostsNothing(MeshNode current, MeshNode updated, JsonSerializerOptions o)
    => IsRecordNoOp(current, updated)
       || ComputeMergePatchDiff(ToJsonObject(current, o), ToJsonObject(updated, o)).Count == 0;
```

The extra serialisation is paid **only where the guard runs at all** — a re-attempt whose owner said
the write never applied. A first attempt, a `Conflict` re-attempt and any write yielding a real diff
are byte-for-byte the path they were.

## 2. The instrument: the tests could not report their own failure

Three defects, all in the tests, all arithmetic rather than opinion:

1. **`LateNackReenqueueTest` waited on the proxy before the contract.** Ground truth was
   `storage.Read(path)` reaching the marker; the caller's terminal — the only wait with a bound and a
   diagnosis of its own — was checked *afterwards*. So the framework's `OwnerUnreachable` + `corr=`
   request trail was always discarded in favour of `System.TimeoutException : The operation has timed
   out.`, which is verbatim what #3477 recorded. #2819's rule restated.
2. **The decisive bound was a hand-written `45.Seconds()`** — not CI-scaled while every other wait in
   the same test was `TestTimeouts.Convergence`, and below what one re-enqueue may legitimately cost.
   The issue's elimination table read every terminal's deadline from a common origin; they compose
   **additively** (`BaseStateWaitBound` 30 s from subscribe, then `WriteVerdictBound` 31 s from the
   *post*), so T+30…T+61 is silent **by design** and the 45 s window sat inside it.
3. **`[Fact(Timeout = 90_000)]` was BELOW the inner waits on a runner** (`TestTimeouts.Convergence` is
   108 s at the CI factor), so xunit killed both tests anonymously before any inner wait could report.
   Core merge-queue run `34332482683` (2026-09-09, shard 4) is an instance: *"Test execution timed out
   after 90000 milliseconds"*, no assertion, no named wait.

The corrected order asserts the caller's terminal first and durable storage second, which is a
**strictly stronger** claim: the owner acks only after its flush, so once the caller holds a success
the store already holds the value — and a phantom success now fails on the storage assertion and says
so, instead of hiding inside an anonymous timeout.

## Control, both directions

**Deterministic, at the seam.** `ReattemptBaseIsAuthoritativeTest` gains a case whose phantom holds the
value as untyped JSON against a lambda producing it typed. It asserts first that the pre-#3477
predicate does *not* see that base (a positive control on the gap), then the behaviour.

- **RED with the pre-fix predicate planted** (`PostsNothing => IsRecordNoOp(current, updated)`):
  `Expected value to be "initial" because the owner has just stated it does not hold this write … but
  found "post-nack-4b7556aa5983".`
- **GREEN restored**: 17/17 over `ReattemptBaseIsAuthoritativeTest`, `LateNackReenqueueTest`,
  `LateNackReenqueueCorrelationTest`, `WriteBaseStateTotalityTest`, `BaseReadBoundIsReachableTest`,
  `UpsertAnswersWhenTheOwnerGoesAwayTest`; full `MeshWeaver.Graph.Test` and
  `MeshWeaver.Documentation.Test` green.
- The cases now call `MeshNodeStreamHandle.PostsNothing` — the predicate `UpdateRemote` itself passes
  — instead of a local copy, so the production guard can no longer be narrowed without a case going
  red.

**Statistical, honestly reported.** The 1/330 race did **not** reproduce here: 4 full-assembly
`MeshWeaver.Graph.Test` runs (1506 tests each, `DOTNET_PROCESSOR_COUNT=2`, load 6–29) on the *pre-fix*
binary, 0 failures. At this rate a clean streak is close to no evidence, which is exactly why the fix
is pinned at the seam and not by a green run.

## 🚨 Still open — a maintainer decision, not part of this change

`LatePatchResponseRegistry.WriteVerdictBound` documents itself as *"the outer bound on a caller-visible
mesh WRITE"*, and `TestTimeouts.Convergence` derives from it so every waiter in the fleet dominates it
by construction. **For a write that re-enqueues it is false**: each attempt arms its own deadline from
its own post, `MaxOwnerDisposingReenqueues` is 2, and each attempt also pays a base read *outside* that
deadline — worst case ≈ 3 × (30 + 10 + 31) ≈ 213 s against a published 31 s. The two candidate fixes
(mint the deadline once per write and thread the remaining budget through re-attempts, vs. publish the
composite bound) are written up in the doc page; the first changes caller-visible behaviour on the slow
path, so it is stated rather than smuggled in.

## 🚨 Plugins twin: port obligation

`test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs` is one test kept in two files; Plugins'
`TeardownTwinParityTest` compares its copy against core's body **at `MW_PLATFORM_REF`**. It reddens in
the **pin bump**, not here — the copy in
`MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs` must carry this body
in the same change that moves the pin past this commit. That Plugins copy is the one that actually
failed in #3477's original sighting, so it keeps the `45.Seconds()` / `Timeout = 90_000` defects until
that port lands.

Doc: `Doc/Architecture/PhantomBaseAfterOwnerDisposal` — extended with the second exit, the additive-bounds
correction to the original elimination, the observation contract, and the open bound question.

Refs #3477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
