### PR TITLE
fix(ci): compile platform plugin modules once

### DIFF
--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -605,6 +605,49 @@ def run_heal_cases(root, case) -> None:
     case("...and the heal comment is still written, so the delivery record survives",
          "gh issue comment 3176" in joined, f"calls={calls}")
 
+def plugin_module_build_problems(workflow_text: str) -> list[str]:
+    """The platform bake must have one compiler for every module it composes (#3732)."""
+    import yaml
+
+    doc = yaml.safe_load(workflow_text)
+    job = (doc.get("jobs") or {}).get("plugins-modules") or {}
+    inputs = job.get("with") or {}
+    raw = inputs.get("modules")
+    if not raw:
+        return ["plugins-modules has no module catalog"]
+    try:
+        entries = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        return [f"plugins-modules module catalog is not valid JSON: {exc}"]
+    if not entries:
+        return ["plugins-modules module catalog is empty"]
+    problems = []
+    accepts = []
+    for entry in entries:
+        module = entry.get("module") or "<unnamed>"
+        if entry.get("build") != "container":
+            problems.append(f"{module} does not use the shared container workspace")
+            continue
+        accept = entry.get("accept") or ""
+        accepts.append(accept)
+        if "targets" not in accept.split():
+            problems.append(f"{module} does not reuse the shared workspace targets")
+    if len(set(accepts)) > 1:
+        problems.append("plugins-modules container entries do not share one accept contract")
+    for name in ("platform-image", "platform-image-digest", "tester-image", "tester-image-digest"):
+        if not inputs.get(name):
+            problems.append(f"plugins-modules does not pass {name} to the container workspace")
+    if inputs.get("acr-login") != "oidc":
+        problems.append("plugins-modules does not select its available OIDC registry login")
+    secrets = job.get("secrets") or {}
+    for name in ("azure-client-id", "azure-tenant-id", "azure-subscription-id"):
+        if not secrets.get(name):
+            problems.append(f"plugins-modules does not pass {name}")
+    if (job.get("permissions") or {}).get("id-token") != "write":
+        problems.append("plugins-modules does not grant id-token: write for OIDC")
+    return problems
+
+
 def main() -> int:
     root = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
     try:
@@ -635,6 +678,33 @@ def main() -> int:
         if not ok:
             print(f"        {detail}")
             failures.append(name)
+
+    workflow_text = (root / WORKFLOW).read_text()
+    module_problems = plugin_module_build_problems(workflow_text)
+    case("every plugin module composed by CD reuses one container workspace",
+         not module_problems, "; ".join(module_problems))
+    mutated_workflow = workflow_text.replace('"build": "container"', '"build": "sdk"', 1)
+    mutation_problems = plugin_module_build_problems(mutated_workflow)
+    case("the plugin-module workspace guard fails when one entry leaves that workspace",
+         bool(mutation_problems), "the mutation passed having changed one producer")
+    divergent_accept = workflow_text.replace(
+        '"accept": "targets"', '"accept": "targets embedded-resource:build-output"', 1)
+    accept_problems = plugin_module_build_problems(divergent_accept)
+    case("the plugin-module workspace guard fails when one entry changes the accept contract",
+         any("one accept contract" in problem for problem in accept_problems),
+         "the mutation passed with divergent global-build acknowledgments")
+    missing_targets = workflow_text.replace(
+        '"accept": "targets"', '"accept": "embedded-resource:build-output"', 1)
+    targets_problems = plugin_module_build_problems(missing_targets)
+    case("the plugin-module workspace guard still requires target reuse",
+         any("workspace targets" in problem for problem in targets_problems),
+         "the mutation passed without the target-reuse contract")
+    missing_digest = workflow_text.replace(
+        "      platform-image-digest: ${{ needs.plugins-bake-image.outputs.platform_digest }}\n", "", 1)
+    digest_problems = plugin_module_build_problems(missing_digest)
+    case("the plugin-module workspace guard fails when its image pin is absent",
+         any("platform-image-digest" in problem for problem in digest_problems),
+         "the mutation passed without a platform image digest")
 
     base = {"RELEASE_VERSION": "", "BAKE_ONLY": "true", "SHORT_SHA": SHORT_SHA}
 

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2361,17 +2361,26 @@ jobs:
   # thing this section exists to guarantee, quietly not guaranteed.
   plugins-modules:
     name: "Plugins: pack the module bundles the bake composes"
-    needs: [preflight, gate, promote]
+    needs: [preflight, gate, promote, plugins-bake-image]
     if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/node-repo-module-pack.yml
     with:
       content-repository: Systemorph/MeshWeaver.Plugins
       content-ref: ${{ needs.gate.outputs.plugins_sha }}
       platform-ref: ${{ needs.gate.outputs.sha }}
+      platform-image: meshweaver.azurecr.io/memex-portal-ai
+      platform-image-digest: ${{ needs.plugins-bake-image.outputs.platform_digest }}
+      tester-image: meshweaver.azurecr.io/mw-plugin-test
+      tester-image-digest: ${{ needs.plugins-bake-image.outputs.digest }}
+      acr-login: oidc
       # The compose set the bake needs — the same set Plugins' own ci.yml passes as
-      # module-artifacts; the rest of the catalog is content, baked below.
+      # module-artifacts; the rest of the catalog is content, baked below. Every entry MUST use
+      # the container workspace: an SDK entry recompiles its transitive siblings separately, so
+      # the bake can receive byte-distinct copies of one assembly from the same source commit.
+      # The consistency gate then correctly refuses the whole publication (#3732).
       #
       # 🚨 THE SET IS "EVERY MODULE THE CONTENT BINDS", not "the two we started with". The bake
       # lane states the rule in its own input description: *"a repo whose NodeType source binds a
@@ -2393,10 +2402,10 @@ jobs:
       # avoid rebuilding these for the seal, but this repo holds no registry credential
       # (Doc/Architecture/ModuleBuildArchitecture → "What the gate still cannot see").
       modules: >-
-        [{"package": "AI", "module": "MeshWeaver.AI", "project": "src/MeshWeaver.AI/MeshWeaver.AI.csproj"},
-         {"package": "Essentials", "module": "MeshWeaver.Markdown.Collaboration", "project": "src/MeshWeaver.Markdown.Collaboration/MeshWeaver.Markdown.Collaboration.csproj"},
-         {"package": "Maps", "module": "MeshWeaver.Maps", "project": "src/MeshWeaver.Maps/MeshWeaver.Maps.csproj"},
-         {"package": "Stripe", "module": "MeshWeaver.Payments.Stripe", "project": "src/MeshWeaver.Payments.Stripe/MeshWeaver.Payments.Stripe.csproj"}]
+        [{"package": "AI", "module": "MeshWeaver.AI", "project": "src/MeshWeaver.AI/MeshWeaver.AI.csproj", "build": "container", "accept": "targets"},
+         {"package": "Essentials", "module": "MeshWeaver.Markdown.Collaboration", "project": "src/MeshWeaver.Markdown.Collaboration/MeshWeaver.Markdown.Collaboration.csproj", "build": "container", "accept": "targets"},
+         {"package": "Maps", "module": "MeshWeaver.Maps", "project": "src/MeshWeaver.Maps/MeshWeaver.Maps.csproj", "build": "container", "accept": "targets"},
+         {"package": "Stripe", "module": "MeshWeaver.Payments.Stripe", "project": "src/MeshWeaver.Payments.Stripe/MeshWeaver.Payments.Stripe.csproj", "build": "container", "accept": "targets"}]
       # Registry module PACKAGES are content-versioned and published by Plugins' own lane when a
       # package changes; a platform release changes no package content. The bundles packed here
       # are the bake's inputs (artifacts), nothing more.
@@ -2407,6 +2416,9 @@ jobs:
       # with Contents: Read, so it doubles as the content credential; preflight asserts it.
       content-app-id: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
       content-app-private-key: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   plugins-bake-image:
     name: "Plugins: resolve this run's tester + portal image digests"

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -189,7 +189,8 @@ name: node-repo module pack
 #     the generators the SDK would have supplied). The platform image ships no /app/mw-plugin-test
 #     and the tester image's /app is not the full reference surface, so the build runs the tester
 #     image against the platform image's extracted /app; both pins move together, from one CD wave.
-#   * the `acr-username`/`acr-password` secrets, to pull them.
+#   * registry authentication: the default `basic` mode uses `acr-username`/`acr-password`;
+#     `oidc` uses the three Azure workload-identity secrets. The mode is explicit and validated.
 #   * `accept` for every construct the evaluator refuses. MeshWeaver.Plugins' own
 #     `src/Directory.Build.props` carries a `<Target>` (the AssemblyVersion contract check), so its
 #     entries need at least `"accept": "targets"`.
@@ -436,6 +437,14 @@ on:
         type: string
         required: false
         default: ''
+      acr-login:
+        description: >
+          How digest-pinned platform images are pulled. `basic` (default) uses acr-username and
+          acr-password. `oidc` uses azure-client-id, azure-tenant-id and azure-subscription-id.
+          Any other value fails before a build; the workflow never guesses from secret presence.
+        type: string
+        required: false
+        default: basic
       registry-source:
         description: >
           The registry SOURCE these packages belong to ("Plugins", "Education", …) — it stamps the
@@ -539,6 +548,15 @@ on:
         required: false
       acr-password:
         description: Pull credential for platform-image's registry. Required when platform-image-digest is set.
+        required: false
+      azure-client-id:
+        description: Azure workload-identity client id. Required when acr-login is oidc.
+        required: false
+      azure-tenant-id:
+        description: Azure workload-identity tenant id. Required when acr-login is oidc.
+        required: false
+      azure-subscription-id:
+        description: Azure subscription id. Required when acr-login is oidc.
         required: false
       content-app-id:
         description: >-
@@ -914,6 +932,9 @@ jobs:
     if: needs.select.result == 'success' && needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       # The framework identity the PLATFORM host resolves for its /app — what every ledger record
       # and bundle is keyed to (the portal adopts, so the portal's identity is the honest one).
@@ -978,6 +999,34 @@ jobs:
         with:
           path: ${{ runner.temp }}/tester-app
           key: tester-app-${{ inputs.tester-image-digest }}
+      - name: The registry login mode must be explicit
+        env:
+          ACR_LOGIN: ${{ inputs.acr-login }}
+        run: |
+          case "$ACR_LOGIN" in
+            basic|oidc) echo "registry login: $ACR_LOGIN" ;;
+            *) echo "::error::acr-login must be 'basic' or 'oidc', got '$ACR_LOGIN'"; exit 1 ;;
+          esac
+      - name: Azure login for a cold image cache
+        if: >-
+          inputs.acr-login == 'oidc'
+          && inputs.platform-image-digest != ''
+          && (steps.image-cache.outputs.cache-hit != 'true'
+              || steps.refs-cache.outputs.cache-hit != 'true'
+              || (inputs.tester-image-digest != '' && steps.tester-cache.outputs.cache-hit != 'true'))
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+      - name: Log in to ACR with workload identity
+        if: >-
+          inputs.acr-login == 'oidc'
+          && inputs.platform-image-digest != ''
+          && (steps.image-cache.outputs.cache-hit != 'true'
+              || steps.refs-cache.outputs.cache-hit != 'true'
+              || (inputs.tester-image-digest != '' && steps.tester-cache.outputs.cache-hit != 'true'))
+        run: bash meshweaver/.github/scripts/acr-login.sh
       - name: Fill whichever cache is cold — the run's ONE trip to the registry
         if: >-
           inputs.platform-image-digest != ''
@@ -994,10 +1043,13 @@ jobs:
           TESTER_HIT: ${{ steps.tester-cache.outputs.cache-hit }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
+          ACR_LOGIN: ${{ inputs.acr-login }}
         run: |
           set -euo pipefail
-          [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::platform-image-digest is set but the acr-username/acr-password secrets are not passed — the cold caches cannot be filled"; exit 1; }
-          echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+          if [ "$ACR_LOGIN" = basic ]; then
+            [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::acr-login is basic but acr-username/acr-password were not passed — the cold caches cannot be filled"; exit 1; }
+            echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+          fi
           case "${IMAGE##*/}" in *:*) NOTAG="${IMAGE%:*}" ;; *) NOTAG="$IMAGE" ;; esac
           pinned="${NOTAG}@${DIGEST}"
           if [ "$IMAGE_HIT" != "true" ] || [ "$REFS_HIT" != "true" ]; then
@@ -1129,6 +1181,9 @@ jobs:
     if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Resolve the content repository's credential
         id: content-repo
@@ -1158,18 +1213,44 @@ jobs:
           repository: ${{ inputs.content-repository || github.repository }}
           ref: ${{ inputs.content-ref || github.sha }}
           token: ${{ steps.content-token.outputs.token || github.token }}
+      - name: Check out the ACR login helper
+        if: inputs.acr-login == 'oidc'
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: meshweaver
+          sparse-checkout: .github/scripts/acr-login.sh
       - name: Restore the platform image tarball (per-digest cache)
         if: ${{ inputs.platform-image-digest != '' }}
+        id: image-cache
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/platform-image
           key: platform-image-${{ inputs.platform-image-digest }}
       - name: Restore the tester app (per-digest cache)
         if: ${{ inputs.tester-image-digest != '' }}
+        id: tester-cache
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/tester-app
           key: tester-app-${{ inputs.tester-image-digest }}
+      - name: Azure login for registry fallback
+        if: >-
+          inputs.acr-login == 'oidc'
+          && ((inputs.platform-image-digest != '' && steps.image-cache.outputs.cache-hit != 'true')
+              || (inputs.tester-image-digest != '' && steps.tester-cache.outputs.cache-hit != 'true'))
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+      - name: Log in to ACR with workload identity
+        if: >-
+          inputs.acr-login == 'oidc'
+          && ((inputs.platform-image-digest != '' && steps.image-cache.outputs.cache-hit != 'true')
+              || (inputs.tester-image-digest != '' && steps.tester-cache.outputs.cache-hit != 'true'))
+        run: bash meshweaver/.github/scripts/acr-login.sh
       # 🚨 `build-modules`, not `modules`: the ledger handed some entries a reusable bundle, and those
       # are NOT compiled here. The postcondition below is fed the SAME list — one enumerator.
       - name: Build every selected container entry in ONE workspace
@@ -1183,6 +1264,7 @@ jobs:
           SUPERSEDED: ${{ inputs.superseded-image-assemblies }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
+          ACR_LOGIN: ${{ inputs.acr-login }}
         run: |
           set -euo pipefail
           mapfile -t projects < <(jq -r '.[] | select(.build == "container") | .project' <<< "$MODULES")
@@ -1215,17 +1297,21 @@ jobs:
             img="$(cat "$RUNNER_TEMP/platform-image/image-id.txt")"
             docker image inspect "$img" >/dev/null 2>&1 || { echo "::error::the cached tarball loaded but image id $img is absent — delete the platform-image-$DIGEST cache entry and rerun"; exit 1; }
           else
-            [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::image cache MISS and no acr credentials — the image cannot be fetched."; exit 1; }
+            if [ "$ACR_LOGIN" = basic ]; then
+              [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::image cache MISS and basic ACR credentials were not passed."; exit 1; }
+              echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+            fi
             echo "platform image: cache MISS for $DIGEST — pulling from ACR (same bytes, only slower)"
-            echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
             docker pull -q --platform linux/amd64 "$pinned"
             img="$pinned"
           fi
           tester_app="$RUNNER_TEMP/tester-app"
           if [ ! -f "$tester_app/mw-plugin-test.dll" ]; then
-            [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::tester cache MISS and no acr credentials."; exit 1; }
+            if [ "$ACR_LOGIN" = basic ]; then
+              [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::tester cache MISS and basic ACR credentials were not passed."; exit 1; }
+              echo "$ACR_PASSWORD" | docker login "${TESTER_IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+            fi
             echo "tester-app cache MISS for $TESTER_DIGEST — extracting once"
-            echo "$ACR_PASSWORD" | docker login "${TESTER_IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
             docker pull -q --platform linux/amd64 "$tester_pinned"
             rm -rf "$tester_app"
             tcid=$(docker create --platform linux/amd64 "$tester_pinned")
@@ -1384,6 +1470,9 @@ jobs:
     needs: [select, prepare, build-workspace]
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
     # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
     # a matrix with no vectors, so an empty selection has to express itself as "this job does not
     # run". What makes it safe is that `verify` below runs UNCONDITIONALLY and asserts the pairing
@@ -1648,6 +1737,16 @@ jobs:
         with:
           path: ${{ runner.temp }}/platform-refs
           key: platform-refs-${{ inputs.platform-image-digest }}
+      - name: Azure login for registry fallback
+        if: inputs.acr-login == 'oidc' && inputs.platform-image-digest != '' && steps.platform-cache.outputs.cache-hit != 'true'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+      - name: Log in to ACR with workload identity
+        if: inputs.acr-login == 'oidc' && inputs.platform-image-digest != '' && steps.platform-cache.outputs.cache-hit != 'true'
+        run: bash meshweaver/.github/scripts/acr-login.sh
       - name: Take the platform from the image (docker cp /app)
         if: inputs.platform-image-digest != '' && steps.platform-cache.outputs.cache-hit != 'true'
         env:
@@ -1655,11 +1754,14 @@ jobs:
           DIGEST: ${{ inputs.platform-image-digest }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
+          ACR_LOGIN: ${{ inputs.acr-login }}
         run: |
           set -euo pipefail
           [ -n "$IMAGE" ] || { echo "::error::platform-image-digest is set but platform-image is empty — name the image the digest belongs to"; exit 1; }
-          [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::platform-image-digest is set but the acr-username/acr-password secrets are not passed — the image cannot be pulled"; exit 1; }
-          echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+          if [ "$ACR_LOGIN" = basic ]; then
+            [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::platform-image-digest is set but basic ACR credentials were not passed — the image cannot be pulled"; exit 1; }
+            echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+          fi
           # 🚨 --platform linux/amd64 ALWAYS: framework identities are per-architecture build (the
           # ci.6469 manifest list resolves to s770d75c… on x64 and sfe27877f… on arm64), and the
           # bundles are sealed under the x64 identity the portals run. A multi-arch digest pulled on

--- a/src/MeshWeaver.Cli/README.md
+++ b/src/MeshWeaver.Cli/README.md
@@ -96,7 +96,8 @@ memex build project ../MeshWeaver.Plugins/src/MeshWeaver.Import \
 The `.csproj` is evaluated without MSBuild, and every reference comes from the image's `/app`, its
 `.deps.json` and the shared frameworks installed in it. `ProjectReference`s inside the source root
 are built first in dependency order; a `ProjectReference` pointing outside it resolves to the
-assembly the image already carries. See
+assembly the image already carries. Each dependent compiles against the full transitive output
+closure, matching the SDK rather than only exposing its direct project's assembly. See
 [In-Mesh Build and Test](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md).
 
 | option | meaning |

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -120,13 +120,18 @@ bundle that carries it. Both statements are true. **The conclusion drawn from th
 the gap is one word: re-keying makes the bundles **REBUILD**, and says nothing about their BYTES.
 
 **A publication is composed from several INDEPENDENT COMPILATIONS.** On `MeshWeaver.Plugins` there
-are three per push, and a sibling project is compiled once in each of them:
+were three per push, and a sibling project was compiled once in each of them:
 
 | compilation | what it is | which bundles it produced |
 |---|---|---|
 | the **floor** lane's `build-workspace` | one Roslyn workspace inside the pinned image, for the first `module-pack` call (`Essentials`, `AI`, `Maps`, `Stripe`) | the DECLARED `MeshWeaver.Markdown.Collaboration`, and its ride inside `MeshWeaver.AI` |
 | the **rest** lane's `build-workspace` | a second workspace, for the other `module-pack` call's `build: container` entries | its ride inside `Mcp`, `Teams`, `Mail.MicrosoftGraph`, `Observability`, `Notifications.Channels`, and the six `AI.*` providers |
 | the legacy **`sdk`** entries | `dotnet build <project> -p:Version=<that module's version>` per module, on the runner — and `-p:Version` is a GLOBAL property, so every transitively referenced sibling is rebuilt under it | its ride inside `MeshWeaver.Blazor.Chat` |
+
+With the paired MeshWeaver.Plugins change, the publication lane has **one** container workspace for
+the whole catalog. Core CD's four composed modules opt into that workspace explicitly, and
+`Northwind` and `Blazor.Chat` use it instead of rebuilding their shared siblings through the SDK
+path. The three rows above remain the measured failure, not the resulting topology.
 
 Measured on `memex.meshweaver.cloud`, 2026-09-10: **one pod held
 `MeshWeaver.Markdown.Collaboration` in 15 copies and THREE builds**, and the three groups match the
@@ -194,20 +199,24 @@ Two boundaries are deliberate:
   independently; it does not collapse to one identity. Judging it would hold every bundle in the
   fleet for a property that was never claimed.
 
-## What this does not close
+## How the divergence is removed
 
 **The assertions REFUSE the divergence; they do not remove the second compilation.** A repo whose
 publication is composed from more than one compilation now goes RED instead of shipping — which is
-the correct verdict for those bytes — but the way to stay green is a decision nobody has taken yet,
-and there are exactly two:
+the correct verdict for those bytes. There are exactly two structural ways to stay green; the first
+is the implemented choice and the second remains rejected:
 
 1. **One compilation per publication.** Every bundle of one publication is packed from ONE workspace
-   build. Today `MeshWeaver.Plugins` splits `module-pack` into a `floor` call and a `rest` call
-   (deliberately — the floor's four bundles are what the gates compose, Plugins#1438) and still has
-   FOUR legacy `sdk` entries (it had five until `Chat` was converted, below), each rebuilding its
-   siblings under its own `-p:Version`. Merging the two calls, or making the second reuse the
-   first's workspace output for shared siblings, is a lane change; converting the last `sdk` entries
-   is the standing direction anyway (maintainer, 2026-09-01: *"one global one and finish"*).
+   build. The paired `MeshWeaver.Plugins` change passes its whole module catalog through one
+   `module-pack` call;
+   entries that ride in-repo MeshWeaver siblings use that call's container workspace. Three legacy
+   `sdk` entries remain only because their non-MeshWeaver/private closure shapes require it, and the
+   lane guard names that reasoned set explicitly. Core CD follows the same rule for the four bundles
+   it composes during a platform release.
+   The shared compiler supplies each project with the full output closure of its in-repository
+   `ProjectReference` graph, just as the SDK does. Scheduling still follows direct edges, but a
+   dependent's Roslyn reference set is transitive; otherwise a valid chain such as Northwind
+   `Application → Model → Domain` builds its prerequisites and then fails to see `Domain` types.
    🚨 **A COMPILED-VERSION PIN DOES NOT REMOVE A PRODUCER, and this page said it did.** The claim
    here was that carrying core's #3022 pin into MeshWeaver.Plugins — core's own
    `Directory.Build.props` pins the COMPILED version attributes to the commit precisely so
@@ -233,8 +242,9 @@ and there are exactly two:
    reading of this page that promised one cost a session's work before the MVIDs were compared.
    `MeshWeaver.Blazor.Chat`, the one `sdk` entry that reaches `MeshWeaver.Markdown.Collaboration`,
    was therefore moved to `build: container` in MeshWeaver.Plugins' `.github/workflows/ci.yml`
-   (MeshWeaver#3732). That takes this assembly from THREE builds to **TWO**; the remaining two are
-   the `floor` and `rest` `build-workspace` calls, whose merge is the separate remedy above.
+   (MeshWeaver#3732). Merging the former `floor` and `rest` calls then took this assembly from TWO
+   builds to **ONE**. `Northwind`, the only remaining SDK entry that rode an in-repo module sibling
+   (`MeshWeaver.Maps`), moved into the same workspace in that change.
 🚦 **The refusal reaches a satellite only when that satellite MOVES ITS PIN, so the ordering is
 free.** Every node repo consumes these lanes at a full sha (`uses:
 Systemorph/MeshWeaver/.github/workflows/node-repo-publish-bake.yml@<40-char sha>`), and moving that

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-platform-releases-pack-plugin-modules-once.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-platform-releases-pack-plugin-modules-once.md
@@ -1,0 +1,23 @@
+---
+Name: Platform releases no longer fork plugin module builds
+Category: Fix
+Description: A platform release now compiles every plugin module it composes in one shared workspace, preventing byte-distinct copies of the same dependency from blocking publication and leaving pages empty.
+Icon: Checkmark
+Order: -20260910
+---
+
+# Platform releases no longer fork plugin module builds
+
+A platform release could compile related plugin modules separately even though they came from the
+same source commit. Shared dependencies then arrived in the publication with the same name but
+different binary identities. The safety gate correctly refused that publication, which stopped the
+release wave and left downstream updates waiting.
+
+The release now compiles all four composed plugin modules in one shared workspace and packages those
+exact outputs. One source commit therefore has one producer for each shared assembly, so the
+publication can be sealed and downstream updates can continue safely.
+
+The container compiler now also supplies each project with the full transitive output of its local
+project-reference graph, matching the .NET SDK. This keeps valid module chains such as Northwind's
+Application → Model → Domain buildable inside that one workspace instead of forcing a second
+compiler back into the release path.

--- a/test/MeshWeaver.PluginTester.Test/ProjectBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectBuildTest.cs
@@ -199,6 +199,46 @@ public class ProjectBuildTest : IDisposable
     }
 
     [Fact]
+    public async Task ATransitiveProjectReferenceIsInScopeForTheDependent()
+    {
+        // The SDK supplies Leaf to App through App -> Middle -> Leaf. Passing only Middle.dll to
+        // Roslyn is not equivalent: valid source that names Leaf's public types then fails CS0234.
+        Write("Directory.Build.props", "<Project><PropertyGroup /></Project>");
+        var app = Write("TransitiveApp/TransitiveApp.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+              <ItemGroup><ProjectReference Include="../TransitiveMiddle/TransitiveMiddle.csproj" /></ItemGroup>
+            </Project>
+            """);
+        Write("TransitiveApp/Uses.cs", "namespace TransitiveApp; public static class Uses { public static int N => TransitiveLeaf.Numbers.Answer; }");
+        Write("TransitiveMiddle/TransitiveMiddle.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+              <ItemGroup><ProjectReference Include="../TransitiveLeaf/TransitiveLeaf.csproj" /></ItemGroup>
+            </Project>
+            """);
+        Write("TransitiveMiddle/Marker.cs", "namespace TransitiveMiddle; public sealed class Marker;");
+        Write("TransitiveLeaf/TransitiveLeaf.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+            </Project>
+            """);
+        Write("TransitiveLeaf/Numbers.cs", "namespace TransitiveLeaf; public static class Numbers { public const int Answer = 42; }");
+
+        var report = await Build(OptionsFor(app));
+
+        report.FatalError.Should().BeNull();
+        report.ExitCode.Should().Be(0);
+        report.Projects.Should().HaveCount(3);
+        var leaf = report.Projects.Single(p => p.Result?.AssemblyName == "TransitiveLeaf");
+        var middle = report.Projects.Single(p => p.Result?.AssemblyName == "TransitiveMiddle");
+        var appResult = report.Projects.Single(p => p.Result?.AssemblyName == "TransitiveApp");
+        middle.Ready.Should().BeGreaterThanOrEqualTo(leaf.Finished);
+        appResult.Ready.Should().BeGreaterThanOrEqualTo(middle.Finished);
+        Assembly.LoadFrom(appResult.Result!.AssemblyPath!).GetType("TransitiveApp.Uses").Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task ACycleIsRefusedByNameBeforeAnythingIsCompiled()
     {
         Write("Directory.Build.props", "<Project><PropertyGroup /></Project>");

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -433,14 +433,31 @@ public static class ProjectBuild
             sink.Info($"module-libraries shelf: {shelf.PackageCount} package(s) from {shelf.Directory} "
                 + "(an additional library resolves here and RIDES the bundle with its deps.json-derived closure)");
 
+        // The SDK gives a dependent the whole transitive ProjectReference output set, not only
+        // the assemblies on its first edge. Keep the cascade's DIRECT edges as the scheduler — a
+        // direct dependency completing green proves its own dependencies completed green first —
+        // while retaining every finished output for the compiler reference set. Northwind's
+        // Application -> Model -> Domain chain is the production witness: Application names Domain
+        // types, and a direct-only reference set made valid SDK source fail with CS0234/CS0246.
+        var completedProjects = new ConcurrentDictionary<string, ProjectResult>(
+            StringComparer.OrdinalIgnoreCase);
         return Cascade.Run<ProjectResult>(
                 graph.Order,
                 id => graph.DependenciesOf(id),
-                (id, deps) =>
+                (id, _) =>
                 {
+                    var dependencyResults = InTreeClosure(graph, id)
+                        .Skip(1)
+                        .Select(dependency => completedProjects.TryGetValue(dependency, out var result)
+                            ? result
+                            : throw new InvalidOperationException(
+                                $"the dependency cascade started '{id}' before transitive dependency "
+                                + $"'{dependency}' recorded its result"))
+                        .ToArray();
                     var result = Compile(
                         graph.Models[id], graph, container, extraReferences, generators, shelf, options, sink, workRoot,
-                        deps.Where(d => d.Result is not null).Select(d => d.Result!).ToArray());
+                        dependencyResults);
+                    completedProjects[id] = result;
                     return (result, result.IsGreen);
                 },
                 options.MaxParallel,


### PR DESCRIPTION
## What

- Make core CD's four composed Plugins modules use the reusable module packer's single container workspace.
- Add explicit OIDC registry authentication to the reusable module packer so core can supply the promoted tester and portal images without introducing long-lived ACR credentials; cold caches authenticate once and warm caches make no registry login.
- Make the container compiler give every project the full transitive output closure of its local ProjectReference graph while retaining direct edges for scheduling.
- Add mutation-tested guards for compiler mode, uniform extensible accept contracts, target reuse, and required image pins.

Paired change: Systemorph/MeshWeaver.Plugins#1614 consolidates the Plugins repository's own two module-pack calls.

## Why

The platform release for 80b3b63a failed closed because AI and Essentials carried byte-distinct builds of MeshWeaver.Markdown.Collaboration. Both were compiled from the same Plugins commit, but each legacy SDK entry rebuilt its transitive siblings in a different checkout. Pinning version attributes cannot converge deterministic MVIDs across those source paths.

The first combined Plugins workspace then exposed a separate compiler defect: it scheduled Northwind Application → Model → Domain correctly but supplied Roslyn only the direct Model output, so valid source naming a Domain type failed with CS0234/CS0246. The SDK supplies that transitive reference set.

## Verification

- ProjectBuild regression: TransitiveApp → TransitiveMiddle → TransitiveLeaf compiles while App directly names a Leaf type
- MeshWeaver.PluginTester.Test: 362 passed, 0 failed, fresh TRX
- MeshWeaver.PluginTester and test project Release builds with warnings as errors: 0 warnings, 0 errors
- python3 .github/scripts/test-cd-steps.py: all cases passed, including compiler-mode, divergent-accept, missing-target-reuse, and missing-image-pin mutations
- workflow timeout, YAML-key, and PR-secret guards: 0 violations
- Documentation and Documentation.Test Release builds with warnings as errors: 0 warnings, 0 errors
- Documentation.Test: 368 passed, 0 failed, fresh TRX

Refs #3732.
