### PR TITLE
fix: a subtree copy refuses instead of half-landing, and says what did not land

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -109,6 +109,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Workspace References](WorkspaceReferences)
 - [Content Chunk Navigation](ContentChunkNavigation)
 - [Moving Nodes](MovingNodes) — a move relocates the node and everything that belongs to it, or it refuses
+- [Copy Completeness](CopyCompleteness) — a copy asserts a set equality it never established; the two readings that turn a short enumeration from a silence into a number, and why the failure stops instead of rolling back
 - [Moved-Node Redirects](NodeRedirects) — keeping links alive after a move
 - [MainNode and Rebasing](MainNodeRebasing) — a `with { Namespace = … }` copy un-lists a node with nothing logged
 - [Write Verdict Totality](WriteVerdictTotality) — a write whose base read ends empty answers nobody, and arms no deadline either

--- a/src/MeshWeaver.Documentation/Data/Architecture/CopyCompleteness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CopyCompleteness.md
@@ -1,0 +1,193 @@
+---
+Name: Copy Completeness
+Category: Architecture
+Description: A copy asserts a set equality it never established — that what it enumerated is the source, and that what it wrote is what it enumerated. Both shortfalls read as a count, so a subtree could half-land and report success. The two readings that turn a silence into a number, why the failure stops instead of rolling back, and the measurement that produced the orphan.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/><path d="M13 15h4" opacity="0.35"/></svg>
+---
+
+# Copy Completeness
+
+A copy is a **set** operation: after it, every node the source subtree holds must have a node at its
+target path. `NodeCopyHelper.CopyNodeTree` reported an `int` — the number of writes that succeeded —
+and nothing anywhere established either half of the equality that number was standing in for.
+
+> **A count cannot say which member of a set is missing.** It cannot say that the set enumerated was
+> not the source, and it cannot say that the set written was not the set enumerated. Both shortfalls
+> therefore arrive as a number, and a number reads as success.
+
+The consequence is the orphan recorded in [Missing Declared Sources](../MissingDeclaredSources):
+`rbuergi/OperationRequest` on memex.meshweaver.cloud, a NodeType whose entire `Source/` subtree is
+absent — `search 'namespace:rbuergi/OperationRequest scope:subtree'` → **0**, against **21** for the
+package it was copied from — which then took the identical doomed Roslyn compile on every pod boot
+for four days and reported three missing symbols that live in nodes nobody has.
+
+## What was measured
+
+Both halves reproduce deterministically on an in-memory mesh with row-level security on
+(`ACopyThatCannotCompleteSaysSoTest`). The subtree is a package root, a readable branch and a branch
+the copier holds a role DENY on; the copier can read the root and not that branch.
+
+```
+A. a descendant the caller may not read
+     subject-scoped enumeration = 5 of the 7 nodes the subtree holds
+     copy RETURNED count = 5                          <- reported success
+     …/Pkg/Restricted        ABSENT                   <- silently left behind
+     …/Pkg/Restricted/Beta   ABSENT
+
+B. one write refused in the middle
+     copy THREW "Copy of 'TestData/Pkg/Source' … failed"    <- names ONE of five paths
+     …/Pkg                   PRESENT
+     …/Pkg/Source            ABSENT
+     …/Pkg/Source/Alpha      PRESENT                  <- ORPHAN, under a parent that never landed
+     …/Pkg/Restricted        PRESENT
+     …/Pkg/Restricted/Beta   PRESENT
+```
+
+**Only A was silent.** B *did* raise — so "the copy reports success either way" is not what was
+wrong with it. What was wrong with B is that the exception named one of five paths, the merge
+cancelled the observation of siblings whose writes had already been POSTED and landed anyway, and
+the result was a target tree containing a node whose parent does not exist. Nobody could say which
+nodes were where.
+
+## The unit that replaces the count
+
+`NodeCopyOutcome` carries a `NodeCopyStatus` plus one `NodeCopyEntry` per enumerated node.
+`CopyNodeTree` — the count surface — is **derived** from it and errors on anything that is not
+`Copied`, so the two cannot drift. That two-surface shape is instance 13 of
+[Controls That Cannot Fail](../ControlsThatCannotFail): one return type serving a consumer who wants
+a number and a consumer who renders a verdict is a compromise that is wrong for one of them.
+
+| Status | Meaning |
+|---|---|
+| `Copied` | Every node the subtree holds has a node at its target path. The only success. |
+| `SourceNotFound` | Nothing resolved at the source path. Nothing written. |
+| `SourceNotFullyReadable` | The enumeration is short of what the subtree holds. **Refused before any write.** |
+| `CompletenessNotDetermined` | Whether it was short could not be established. **Refused before any write.** |
+| `Incomplete` | The writes ran and the target set is short. Every missing path is named. |
+
+`CompletenessNotDetermined` exists for the reason that page gives, and collapsing it into either
+neighbour re-creates the defect: *"I checked and it is short"* and *"I could not check"* must never
+share a shape.
+
+## 1. The enumeration's own completeness — the subtle half
+
+The subtree listing runs **as the caller**, and that is not negotiable: it is the read row-level
+security filters, and copying out from under it would let a caller duplicate rows they may not read
+into a place they control. (`HandleCopyNodeRequest` states the same rule for its satellite sweep:
+*"the cure is NOT to enumerate the copy from storage as well"*.)
+
+But then the listing's shortness is a fact about the **reader**, not about the subtree — and the two
+were the same value. An enumeration that returns `[root]` because the caller may not read the
+children is indistinguishable from a subtree that has none.
+
+**The size of the subtree is therefore read a second time, from the same query, as System.** That is
+the shape MeshWeaver.Plugins' installer already uses and for the identical reason — a gated package
+hides its children from a subject-scoped query. Sharing the query shape is load-bearing: the only
+thing that can differ between the two answers is what the identity is permitted to see, so the
+difference means only what it is being read to mean. Nothing from the System reading is ever copied;
+only its size is taken.
+
+A difference is a **refusal**, not a smaller copy. A subtree copied without part of itself is not a
+smaller copy — it is a broken one, and `rbuergi/OperationRequest` is what that looks like four days
+later.
+
+🚨 **The refusal states COUNTS and never the paths.** The shortfall is exactly the set the caller may
+not read, so naming it would turn a refusal into a disclosure surface — the same reason
+[#3890](https://github.com/Systemorph/MeshWeaver/pull/3890) closed the autocomplete drill-down, which
+worked by naming other people's node titles. An `Incomplete` report DOES name its paths: every one of
+them came out of the caller's own enumeration, so it discloses nothing the caller cannot already see.
+
+🚨 **And with no `AccessService` there is no second identity, so there is no answer.** Running the
+"System-scoped" read unimpersonated would compare a set with itself and pass by construction — a
+control whose green is guaranteed. That case is `CompletenessNotDetermined`, and it names what is
+missing rather than shrugging.
+
+## 2. Parents before children — a failure-atomicity fix, stated as one
+
+Nodes are written **level by level**, deepest last, with the batch size in flight *within* a level. A
+level that does not fully land **ends the descent**; everything below it is recorded as
+`NotAttempted`.
+
+**This is not a correctness fix for the happy path, and saying otherwise would be wrong.** Nothing in
+the platform requires a parent to exist: no handler, no validator, no router and no storage adapter
+probes one — Postgres has no foreign key, the in-memory adapter synthesises intermediate directory
+levels on purpose, and the `NextLevel` query planner deliberately *skips* empty intermediate
+segments. `HandleCopyNodeRequest` itself writes `A/B/C` before `A/B` routinely.
+
+What ordering buys is the shape of the FAILURE:
+
+- **The residue is a well-formed tree.** Every node that landed has every ancestor that landed with
+  it. On the unfixed helper, measurement B left a leaf under a folder that never arrived.
+- It honours what `IStorageAdapter.WriteMany` already states about ordering — *"callers order
+  parents before children on purpose … activating a child's per-node hub while its parent's is still
+  cold is the race that used to wedge installs"*.
+
+**The alternative that was considered and rejected: pruning only the failed node's own subtree.** It
+would carry a sibling branch further — in measurement B, `…/Restricted/Beta` is reported
+`NotAttempted` although its own parent landed. But the operation is already known to be incomplete at
+that point, and writing *more* nodes into a copy known to be broken buys nothing a caller can use
+while costing a residue that is harder to reason about. Stopping is simpler, is deterministic, and
+minimises what a failed copy leaves behind. The report names every stranded path either way, so
+nothing about the choice is silent.
+
+## 3. A post-condition over the ledger, not a re-read
+
+Every enumerated node ends with an entry saying what the owning hub **acknowledged**: `Created`,
+`Updated`, `SkippedExisting`, `Failed` or `NotAttempted`. The outcome is then a set comparison —
+covered against enumerated.
+
+Two details are deliberate:
+
+- **`SkippedExisting` counts as covered, and is not counted as copied.** The property a copy has to
+  guarantee is that the target path holds a node; a `force=false` skip satisfies it. The returned
+  count has always meant "writes that happened", and a skip is not one — so the number this operation
+  emits is unchanged for every copy that was already correct.
+- **`Failed` means NOT ACKNOWLEDGED, never "not written".** A delivery that faults after the request
+  left may well have landed. The report says what the copy was told, which is the only thing it
+  knows — the same distinction [`NodeReadOutcome`](../DenialIsAnAnswer) keeps between Absent and
+  Unavailable.
+
+The ledger is assembled from the write acknowledgements rather than by querying the target back,
+because a query is eventually consistent ([CQRS and Content Access](../CqrsAndContentAccess)) and
+would answer about a moment that is not this one.
+
+Collecting a per-node fault instead of letting it abort the merge is **not** a swallow: the fault is
+recorded, it ends the descent, and it makes the whole operation fail carrying the full inventory.
+What it removes is the merge cancelling the observation of siblings that had already been posted —
+which is precisely why one path in an exception used to be all anybody could name.
+
+## Why there is no rollback
+
+An all-or-nothing outcome was the obvious fourth candidate and it is **not implementable here**:
+
+- **There is no cross-partition transaction.** Each node is its own hub and its own row, possibly in
+  another schema. "Undo the copy" is N more writes, on the path where the code is least trustworthy.
+- **Under `force` a copy overwrites nodes it holds no before-image of.** A compensating delete could
+  not restore them; it would destroy them. That is strictly worse than a half-copy.
+- **The helper deleting a target is a known incident shape** — the race against the per-node hub's
+  disposal that produced *"GetNode returns null after force-overwrite"*.
+
+So the guarantee offered instead is: **all-or-nothing at the point of refusal** (§1 — nothing is
+written at all), and **a well-formed prefix plus a complete inventory** when a write fails (§2 + §3).
+
+## What is NOT fixed here
+
+- **`MeshExtensions.HandleCopyNodeRequest` still has the same enumeration shape.** Its completeness
+  guard (`RequireComplete`, a comparison against `IStorageAdapter.ListDescendantPaths`) is set only
+  by the Move leg, for the reason its own doc gives — a plain copy deletes nothing, so carrying less
+  loses nothing *at the source*. That reasoning covers data loss and not a half-landed target, so the
+  gap is real; closing it is a separate change, because a plain copy's denominator has to decide what
+  it does about satellites and `RequireComplete`'s does not (Move always carries them).
+- **A copy still writes no install record**, so [Install Completeness](../InstallCompleteness) — the
+  platform's one partial-install detector — cannot see a copy at all.
+- **The live orphan `rbuergi/OperationRequest` is untouched.** Deleting production data in someone's
+  partition is the maintainer's call.
+
+## Related
+
+- [Missing Declared Sources](../MissingDeclaredSources) — what a half-copied NodeType looks like from the compiler, four days later
+- [Controls That Cannot Fail](../ControlsThatCannotFail) — why "not determined" and "checked and clean" must never share a shape
+- [CQRS and Content Access](../CqrsAndContentAccess) — why the post-condition is built from acknowledgements rather than a read-back
+- [Access Control](../AccessControl) — the fold that decides what a subject-scoped enumeration returns
+- [Moving Nodes](../MovingNodes) — the sibling operation, whose completeness guard is wired and why
+- [Install Completeness](../InstallCompleteness) — the detector a copy is invisible to

--- a/src/MeshWeaver.Documentation/Data/Architecture/MissingDeclaredSources.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MissingDeclaredSources.md
@@ -177,10 +177,35 @@ packages hide children from subject-scoped queries, and a batch-shortfall post-c
 writes no install record, so `InstallCompleteness` — the platform's one partial-install detector —
 cannot see it either.
 
-**That is a separate defect with its own design decisions** (ordering, rollback semantics, the
-identity a subtree enumeration runs under) and is tracked on its own issue. This page's change makes
-its consequence *legible and cheap* instead of silent and repeated; it does not stop the half-copy
-from happening.
+**That was a separate defect with its own design decisions** (ordering, rollback semantics, the
+identity a subtree enumeration runs under). This page's change makes its consequence *legible and
+cheap* instead of silent and repeated; it does not stop the half-copy from happening.
+
+**`NodeCopyHelper.CopyNodeTree` is now fixed, and the design is
+[Copy Completeness](../CopyCompleteness).** Both halves were reproduced deterministically first, and
+only one of them was silent — which is worth recording, because the obvious framing is wrong:
+
+```
+A. a descendant the caller may not read
+     subject-scoped enumeration = 5 of the 7 nodes the subtree holds
+     copy RETURNED count = 5                     <- reported success
+     …/Pkg/Restricted   ABSENT                   <- silently left behind
+B. one write refused in the middle
+     copy THREW, naming ONE of five paths
+     …/Pkg/Source         ABSENT
+     …/Pkg/Source/Alpha   PRESENT                <- ORPHAN, under a parent that never landed
+```
+
+The copy now reads the subtree TWICE from the same query — as the caller, which is the read
+row-level security filters, and as System, which is what turns "the listing came back short" from a
+silence into a number — and refuses before writing anything when the two disagree, stating counts
+rather than the paths it cannot show. Writes then go level by level so a failure leaves a
+well-formed tree, and every enumerated node ends with an acknowledgement, so the report names what
+did not land instead of one path out of five.
+
+**`MeshExtensions.HandleCopyNodeRequest` still has the shape described above** — its
+`RequireComplete` guard remains wired only to Move — and a copy still writes no install record, so
+`InstallCompleteness` still cannot see one. Both are named as residuals on that page.
 
 ## Residuals, named rather than left to be rediscovered
 
@@ -204,3 +229,4 @@ from happening.
 - [Retiring a NodeType](../RetiringANodeType) — the deliberate version of "the sources are gone"
 - [Dangling NodeTypes](../DanglingNodeTypes) — the instance-side sibling: a node whose TYPE resolves to nothing
 - [Controls That Cannot Fail](../ControlsThatCannotFail) — why "not determined" and "checked and clean" must never share a shape
+- [Copy Completeness](../CopyCompleteness) — the copy that produced this orphan, and the two readings that stop it

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-copy-no-longer-half-lands-a-tree.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-copy-no-longer-half-lands-a-tree.md
@@ -1,0 +1,33 @@
+---
+Name: A copy no longer half-lands a tree
+Category: Fix
+Description: Copying a folder, package or node type could quietly leave part of it behind — and still report how many nodes it copied.
+Icon: Sparkle
+Order: -20260910
+---
+
+# A copy no longer half-lands a tree
+
+Copying a subtree — from the Copy dialog, from "copy to home", from an import, or through an agent's
+`copy` tool — used to report the number of nodes it managed to write, and that number said nothing
+about whether the copy was whole.
+
+Two things could make it short. If part of the source was **not visible to you** — a branch someone
+else has not shared, or the gated part of an installed package — the copy simply did not see those
+nodes, carried the rest, and reported success. And if one write in the middle was **refused**, the
+copy stopped there but the nodes already in flight landed anyway, so the result could contain a file
+sitting under a folder that never arrived. Either way you were handed something that looked like a
+finished copy and was not. One node type reached a personal workspace this way without any of its
+source files, and then failed to build every time the portal restarted, for four days, complaining
+about symbols that were simply missing.
+
+A copy now checks itself, before and after. Before it writes anything it establishes how big the
+source subtree really is — not just how much of it you can see — and if it cannot carry all of it, it
+**refuses and writes nothing at all**, telling you how many nodes would have been left behind rather
+than handing you a broken half. (It deliberately does not name those nodes: they are the ones you are
+not entitled to see.) It then writes parents before their children and stops descending at the first
+level that fails, so what does land is always a properly rooted tree, never a file under a missing
+folder. And it reports every node that did not land — the ones that were refused and the ones it
+therefore never attempted — instead of naming one and staying silent about the rest.
+
+Copies that were already complete behave exactly as before, including the count they report.

--- a/src/MeshWeaver.Graph/NodeCopyHelper.cs
+++ b/src/MeshWeaver.Graph/NodeCopyHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
@@ -10,46 +11,150 @@ namespace MeshWeaver.Graph;
 
 /// <summary>
 /// Helper for deep-copying a mesh node tree (source node + all descendants) to a target namespace.
+///
+/// <para>🚨 <b>A copy asserts a set equality, so it has to establish one.</b> This helper used to
+/// return a COUNT of writes that succeeded, and nothing anywhere established either half of the
+/// equality it was reporting on: that the set it ENUMERATED is the source subtree, or that the set
+/// it WROTE is the set it enumerated. Both shortfalls therefore read as success. The consequence is
+/// recorded in <c>Doc/Architecture/MissingDeclaredSources</c> — a NodeType that reached a user
+/// partition without its <c>Source/</c> subtree and then failed its compile on every pod boot for
+/// four days, reporting three missing symbols that live in nodes nobody has. The design is
+/// <c>Doc/Architecture/CopyCompleteness</c>.</para>
 /// </summary>
 public static class NodeCopyHelper
 {
-    /// <summary>Default per-batch concurrency for the parallel
+    /// <summary>Default per-level concurrency for the parallel
     /// <see cref="CreateOrUpdateNodeRequest"/> fan-out below. Bounded so a
     /// large subtree doesn't open every per-node hub at once on the
     /// receiving side.</summary>
     public const int DefaultBatchSize = 16;
 
     /// <summary>
-    /// Copies a node and all its descendants to a target namespace. The
-    /// source node's Id is preserved; paths are rewritten under the target
-    /// namespace. Returns an <see cref="IObservable{T}"/> that emits the
-    /// total count of upserted nodes (each <see cref="CreateOrUpdateNodeRequest"/>
-    /// that succeeds counts as 1, regardless of create-vs-update).
+    /// Opening words of the refusal a copy answers with when the caller cannot read the whole
+    /// source subtree. Spelled once so the producer and every reader cannot drift — the same
+    /// reasoning as <see cref="CopyNodeRequest.IncompleteCopyRefusal"/>, which is the sibling
+    /// marker on the <c>CopyNodeRequest</c> path.
+    /// </summary>
+    public const string IncompleteSourceRefusal =
+        "Refused: this caller cannot read the whole subtree";
+
+    /// <summary>
+    /// Opening words of the refusal a copy answers with when it could not establish whether its
+    /// enumeration was complete. Distinct from <see cref="IncompleteSourceRefusal"/> on purpose:
+    /// "I checked and it is short" and "I could not check" must never share a shape.
+    /// </summary>
+    public const string UndeterminedCompletenessRefusal =
+        "Refused: the copy cannot establish what the source subtree holds";
+
+    /// <summary>
+    /// Opening words of the report a copy answers with when the writes ran and the target set is
+    /// short of the enumerated set.
+    /// </summary>
+    public const string IncompleteCopyReport = "Incomplete copy of";
+
+    /// <summary>
+    /// Copies a node and all its descendants to a target namespace, and emits the number of nodes
+    /// WRITTEN — or errors, naming exactly what did not land. The source node's Id is preserved;
+    /// paths are rewritten under the target namespace.
     ///
-    /// <para><b>Reactive end-to-end</b> — no <c>await</c>, no
-    /// <c>Task.FromAsync</c>, no <c>ToTask</c>. Per-node upsert observables
-    /// are merged with concurrency <paramref name="batchSize"/> so
-    /// independent writes can run in parallel without exhausting the
-    /// receiving side. Permission checks live inside the
-    /// <see cref="CreateOrUpdateNodeRequest"/> handler — the helper just
-    /// dispatches.</para>
+    /// <para>This is the COUNT surface, derived from <see cref="CopyNodeTreeOutcome"/> so the two
+    /// cannot drift. It exists because a caller that only wants "how many" should not have to know
+    /// how a copy can fall short — but it can no longer emit a number for a copy that did:
+    /// anything other than <see cref="NodeCopyStatus.Copied"/> is an <c>OnError</c> carrying
+    /// <see cref="NodeCopyOutcome.Describe"/>. Use <see cref="CopyNodeTreeOutcome"/> where the
+    /// outcome is rendered as a verdict.</para>
+    /// </summary>
+    /// <param name="meshQuery">Reads the source subtree.</param>
+    /// <param name="nodeFactory">Unused: the per-node writes route through <paramref name="hub"/> to
+    /// its node-operation target. Kept because <c>Templates/NodeCopy.csx</c> — a mesh-hosted script
+    /// compiled at RUNTIME, which <c>dotnet build</c> cannot see — binds this overload
+    /// positionally.</param>
+    /// <param name="hub">Supplies the caller identity, the reply address and the node-operation
+    /// target. May be ANY hub — an MCP/REST session hub, a per-node UI hub, the mesh hub.</param>
+    /// <param name="sourcePath">The subtree root to copy.</param>
+    /// <param name="targetNamespace">The namespace the copy lands under; empty means the root.</param>
+    /// <param name="force">Overwrite an existing target node instead of leaving it alone.</param>
+    /// <param name="logger">Optional; resolved from <paramref name="hub"/> when omitted.</param>
+    /// <param name="batchSize">Per-level concurrency bound.</param>
+    /// <returns>A cold observable emitting the number of nodes written.</returns>
+    public static IObservable<int> CopyNodeTree(
+        IMeshService meshQuery,
+        IMeshService nodeFactory,
+        IMessageHub hub,
+        string sourcePath,
+        string targetNamespace,
+        bool force,
+        ILogger? logger = null,
+        int batchSize = DefaultBatchSize)
+        => CopyNodeTreeOutcome(
+                meshQuery, nodeFactory, hub, sourcePath, targetNamespace, force, logger, batchSize)
+            .SelectMany(outcome => outcome.IsComplete
+                ? Observable.Return(outcome.CopiedCount)
+                : Observable.Throw<int>(new InvalidOperationException(outcome.Describe())));
+
+    /// <summary>
+    /// Copies a node and all its descendants to a target namespace and reports what became of every
+    /// one of them.
+    ///
+    /// <para><b>The three things it establishes, in order.</b></para>
+    ///
+    /// <para><b>1. The enumeration's own completeness — before writing anything.</b> The subtree
+    /// listing runs AS THE CALLER, because that is the read row-level security filters and copying
+    /// out from under it would let a caller duplicate rows they may not read into a place they
+    /// control. But a listing that came back short BECAUSE of that filter is not an empty subtree,
+    /// and the two used to be the same value. The size of the subtree is therefore established a
+    /// second time, from the SAME query run as System — the shape MeshWeaver.Plugins' installer
+    /// already uses, for the same reason: a gated package hides its children from a subject-scoped
+    /// query. A difference is a REFUSAL, not a smaller copy.</para>
+    ///
+    /// <para><b>2. Parents before children.</b> Nodes are written level by level, deepest last,
+    /// with <paramref name="batchSize"/> in flight WITHIN a level. Nothing in the platform requires
+    /// a parent to exist — no handler, validator, router or storage adapter probes one — so this is
+    /// not a correctness fix for the happy path. It is what makes the FAILURE well-formed: a level
+    /// that does not land ends the descent, so a copy that stops leaves a prefix of the tree instead
+    /// of scattering children under parents that never arrived. It also honours what
+    /// <see cref="IStorageAdapter.WriteMany"/> states about ordering — "callers order parents before
+    /// children on purpose … activating a child's per-node hub while its parent's is still cold is
+    /// the race that used to wedge installs".</para>
+    ///
+    /// <para><b>3. A post-condition over the ledger, not a re-read.</b> Every enumerated node ends
+    /// with a <see cref="NodeCopyEntry"/> saying what the owning hub ACKNOWLEDGED. The outcome is
+    /// then a set comparison: covered vs enumerated. It is assembled from the write
+    /// acknowledgements rather than by querying the target back, because a query is eventually
+    /// consistent and would answer about a moment that is not this one.</para>
+    ///
+    /// <para><b>And deliberately NOT a rollback.</b> There is no cross-partition transaction here —
+    /// each node is its own hub and its own row, possibly in another schema — and under
+    /// <paramref name="force"/> a copy overwrites nodes it holds no before-image of, so a
+    /// compensating delete could not restore them and would destroy them instead. A compensating
+    /// delete is a second uncontrolled mutation on the path where the code is least trustworthy;
+    /// the guarantee offered instead is all-or-nothing at the point of REFUSAL (1), and a
+    /// well-formed prefix plus a complete inventory when a write fails (2 + 3).</para>
     ///
     /// <para><b>Routing</b> — every per-node request is targeted at
     /// <c>hub.NodeOperationTarget()</c>: the nearest ancestor that declared
     /// <c>WithNodeOperationExecution</c>, else the root mesh hub, where the node-operation
-    /// handlers are guaranteed to be registered. <paramref name="hub"/> may therefore be ANY
-    /// hub (an MCP/REST session hub, a per-node UI hub, the mesh hub itself); it
-    /// only supplies the caller identity and the reply address.</para>
+    /// handlers are guaranteed to be registered.</para>
     ///
-    /// <para><b>force semantics</b> are encoded in the upsert request: when
-    /// the target path already exists, the upsert handler applies the change
-    /// via <c>stream.Update</c> (requires Update permission) when
-    /// <paramref name="force"/> is <c>true</c> and skips otherwise. The
-    /// helper never deletes a target — that race against the per-node hub's
-    /// disposal was the cause of the previous "GetNode returns null after
-    /// force-overwrite" bug.</para>
+    /// <para><b>force semantics</b> are encoded in the request verb: <c>false</c> uses
+    /// <see cref="CreateNodeRequest"/> and records an existing target as
+    /// <see cref="NodeCopyDisposition.SkippedExisting"/>; <c>true</c> uses
+    /// <see cref="CreateOrUpdateNodeRequest"/>, which writes either way. The helper never deletes a
+    /// target — that race against the per-node hub's disposal was the cause of the previous
+    /// "GetNode returns null after force-overwrite" bug.</para>
     /// </summary>
-    public static IObservable<int> CopyNodeTree(
+    /// <param name="meshQuery">Reads the source subtree.</param>
+    /// <param name="nodeFactory">Unused: the per-node writes route through <paramref name="hub"/> to
+    /// its node-operation target.</param>
+    /// <param name="hub">Supplies the caller identity, the reply address and the node-operation
+    /// target.</param>
+    /// <param name="sourcePath">The subtree root to copy.</param>
+    /// <param name="targetNamespace">The namespace the copy lands under; empty means the root.</param>
+    /// <param name="force">Overwrite an existing target node instead of leaving it alone.</param>
+    /// <param name="logger">Optional; resolved from <paramref name="hub"/> when omitted.</param>
+    /// <param name="batchSize">Per-level concurrency bound.</param>
+    /// <returns>A cold observable emitting exactly one <see cref="NodeCopyOutcome"/>.</returns>
+    public static IObservable<NodeCopyOutcome> CopyNodeTreeOutcome(
         IMeshService meshQuery,
         IMeshService nodeFactory,
         IMessageHub hub,
@@ -63,13 +168,14 @@ public static class NodeCopyHelper
             ?.CreateLogger("MeshWeaver.Graph.NodeCopyHelper");
 
         // 🚨 Capture the caller's identity EAGERLY, at invocation (the click action / MCP tool /
-        // handler thread where AsyncLocal is still correct). The per-node CreateNodeRequest posts
-        // below fire from SelectMany continuations on the subtree-query's emission scheduler, where
-        // the AsyncLocal AccessContext is WIPED — so an un-stamped post would carry no identity and
-        // the PostPipeline would fail closed (only the root landing; recursive children erroring
-        // with "AccessContext must never be null … message=CreateNodeRequest" — the cross-partition
-        // copy bug). Stamp the captured context explicitly on every post, exactly as
-        // FanOutDeleteSubtree does for recursive deletes.
+        // handler thread where AsyncLocal is still correct). The per-node posts below fire from
+        // SelectMany continuations on the query's emission scheduler, where the AsyncLocal
+        // AccessContext is WIPED — so an un-stamped post would carry no identity and the
+        // PostPipeline would fail closed (only the root landing; recursive children erroring with
+        // "AccessContext must never be null … message=CreateNodeRequest" — the cross-partition copy
+        // bug). Stamp the captured context explicitly on every post, exactly as FanOutDeleteSubtree
+        // does for recursive deletes — and run the ENUMERATION under it too, so what the copy reads
+        // and what it writes are the same identity by construction rather than by scheduler luck.
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var callerAccessContext = accessService?.Context ?? accessService?.CircuitContext;
 
@@ -79,10 +185,8 @@ public static class NodeCopyHelper
         // MCP/REST session hub (portal/mcp-{user}-{session}, SessionHubResolver) used to register
         // only AddData — every per-node post bounced with "No handler found for message type
         // CreateNodeRequest" (memex 2026-07-13, MCP copy tool). NodeOperationTarget resolves to the
-        // nearest hub that declared WithNodeOperationExecution — that session hub now does, so an
-        // MCP copy no longer runs its fan-out on the router — and to the root mesh hub otherwise.
-        // Same routing contract as MeshService, whose comment pins the identical 2026-05-23 incident
-        // for un-walked child-hub writes.
+        // nearest hub that declared WithNodeOperationExecution — that session hub now does — and to
+        // the root mesh hub otherwise.
         var operationTarget = hub.NodeOperationTarget();
 
         // Shared post options for both verbs: route to that target and stamp the
@@ -93,107 +197,197 @@ public static class NodeCopyHelper
             return callerAccessContext is null ? o : o.WithAccessContext(callerAccessContext);
         }
 
-        // Single Query over the source subtree — emits source + every
-        // descendant in one go. Take(1) snapshots the listing for the copy
-        // operation; subsequent edits to the source don't follow.
-        var sourceSubtree = meshQuery
-            .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                $"path:{sourcePath} scope:subtree"))
+        // The namespace the source root lives in, derived from the path so the refusal messages
+        // below can name the target before any node has been read.
+        var sourceNamespace = MeshNode.FromPath(sourcePath).Namespace ?? "";
+        var targetRootPath = RemapPathFor(sourcePath, sourceNamespace, targetNamespace);
+
+        // 🚨 THE DENOMINATOR NEEDS A SECOND IDENTITY, AND WITHOUT ONE THERE IS NO ANSWER. With no
+        // AccessService there is nothing to run the System-scoped enumeration under, so the two
+        // readings would be the SAME read and the comparison would pass having compared a set with
+        // itself — a control whose green is guaranteed by construction
+        // (Doc/Architecture/ControlsThatCannotFail). Say "not determined" instead. Unreachable on a
+        // real mesh: every hosting path registers AccessService.
+        if (accessService is null)
+            return Observable.Return(NodeCopyOutcome.CompletenessNotDetermined(
+                sourcePath, targetRootPath,
+                "no AccessService is registered, so the subtree cannot be enumerated a second time "
+                + "as System and a short enumeration would be indistinguishable from a small subtree"));
+
+        // ONE query shape, read twice under two identities — the difference between the answers IS
+        // the completeness question, and sharing the shape is what makes the difference mean only
+        // that. Complete(): this is an ENUMERATION, not a page (IMeshQuery.Complete).
+        var subtreeQuery = MeshQueryRequest
+            .FromQuery($"path:{sourcePath} scope:subtree")
+            .Complete();
+
+        IObservable<IReadOnlyList<MeshNode>> Enumerate() => meshQuery
+            .Query<MeshNode>(subtreeQuery)
             .Take(1)
-            .Select(c => c.Items
+            .Select(c => (IReadOnlyList<MeshNode>)c.Items
                 .Where(n => !string.IsNullOrEmpty(n.Path))
                 .ToArray());
 
-        return sourceSubtree.SelectMany(allNodes =>
+        // AS THE CALLER — explicitly, not by ambient. This is the set that may be copied, and it is
+        // the read row-level security filters. Take(1) snapshots the listing; later edits to the
+        // source don't follow.
+        var callerView = accessService.RunAs(callerAccessContext, Enumerate);
+
+        return callerView.SelectMany(allNodes =>
         {
             var sourceNode = allNodes.FirstOrDefault(n =>
                 string.Equals(n.Path, sourcePath, StringComparison.Ordinal));
             if (sourceNode == null)
-                return Observable.Throw<int>(
-                    new InvalidOperationException($"Source node not found: {sourcePath}"));
+                return Observable.Return(
+                    NodeCopyOutcome.SourceNotFound(sourcePath, targetRootPath));
 
-            var sourceNamespace = sourceNode.Namespace ?? "";
+            var enumerated = allNodes
+                .Select(n => n.Path)
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
-            // Per-node copy observable factory. Two verbs by design:
-            //
-            //   force=false → CreateNodeRequest. Handler fails with
-            //                 NodeAlreadyExists when target is populated;
-            //                 helper maps that rejection to count=0 (skip).
-            //   force=true  → CreateOrUpdateNodeRequest. Handler always
-            //                 writes — Create on missing, Update on existing.
-            //
-            // CreateOrUpdateNodeRequest is the single upsert verb; "skip on
-            // exists" semantics live in the create-only path. No flag to
-            // mix the two — keeps each verb single-purpose.
-            IObservable<int> CopyOne(MeshNode node)
+            // AS SYSTEM — the same query, so the only thing that can differ is what the identity is
+            // permitted to see. SecurityService grants Permission.All to System unconditionally,
+            // and RunAsSystem seals the scope at both ends so neither the subscribing thread nor
+            // anything composed downstream inherits it (#1790/#1444). Nothing read here is ever
+            // COPIED: only the size of the set is taken from it.
+            return accessService.RunAsSystem(Enumerate).SelectMany(sourceNodes =>
             {
-                var newPath = RemapPath(node.Path, sourceNamespace, targetNamespace);
-                var copiedNode = MeshNode.FromPath(newPath) with
+                var hidden = sourceNodes.Count(n => !enumerated.Contains(n.Path));
+                if (hidden > 0)
                 {
-                    Name = node.Name,
-                    NodeType = node.NodeType,
-                    Icon = node.Icon,
-                    Category = node.Category,
-                    Content = node.Content,
-                    State = MeshNodeState.Active,
-                    PreRenderedHtml = node.PreRenderedHtml,
-                };
-                if (force)
-                {
-                    return hub
-                        .Observe<CreateOrUpdateNodeResponse>(
-                            new CreateOrUpdateNodeRequest(copiedNode),
-                            ConfigurePost)
-                        .FirstAsync()
-                        .Select(d => d.Message)
-                        .SelectMany(resp =>
-                        {
-                            if (resp.Success)
-                            {
-                                logger?.LogInformation(
-                                    "Copied {SourcePath} -> {TargetPath} ({Mode})",
-                                    node.Path, newPath, resp.WasCreated ? "created" : "updated");
-                                return Observable.Return(1);
-                            }
-                            return Observable.Throw<int>(new InvalidOperationException(
-                                $"Force-upsert of '{newPath}' failed: {resp.Error}"));
-                        });
+                    logger?.LogWarning(
+                        "Refusing copy {SourcePath} -> {TargetNamespace}: the subtree holds "
+                        + "{Held} node(s) and this caller can read {Readable}",
+                        sourcePath, targetNamespace, sourceNodes.Count, allNodes.Count);
+                    return Observable.Return(NodeCopyOutcome.SourceNotFullyReadable(
+                        sourcePath, targetRootPath, allNodes.Count, sourceNodes.Count));
                 }
-                return hub
-                    .Observe<CreateNodeResponse>(new CreateNodeRequest(copiedNode),
-                        ConfigurePost)
+
+                return WriteLevels(allNodes)
+                    .Select(entries => entries.All(e => e.Covered)
+                        ? NodeCopyOutcome.Copied(
+                            sourcePath, targetRootPath, entries, sourceNodes.Count)
+                        : NodeCopyOutcome.Incomplete(
+                            sourcePath, targetRootPath, entries, sourceNodes.Count));
+            });
+        });
+
+        // ---- the write, level by level -------------------------------------------------------
+
+        IObservable<ImmutableList<NodeCopyEntry>> WriteLevels(IReadOnlyList<MeshNode> allNodes)
+        {
+            // Depth is the segment count of the path, so a level holds only nodes whose ancestors
+            // are all in shallower levels. Same computation MeshOperations' import already orders
+            // by ("Parents first — deterministic, and lets a partition root land before children").
+            var levels = allNodes
+                .GroupBy(n => n.Path.Count(c => c == '/'))
+                .OrderBy(g => g.Key)
+                .Select(g => g.OrderBy(n => n.Path, StringComparer.Ordinal).ToImmutableList())
+                .ToImmutableList();
+
+            NodeCopyEntry NotAttempted(MeshNode node) => new(
+                node.Path,
+                RemapPathFor(node.Path, sourceNamespace, targetNamespace),
+                NodeCopyDisposition.NotAttempted);
+
+            IObservable<ImmutableList<NodeCopyEntry>> Descend(
+                int level, ImmutableList<NodeCopyEntry> ledger)
+            {
+                if (level >= levels.Count)
+                    return Observable.Return(ledger);
+
+                return levels[level]
+                    .Select(CopyOne)
+                    .ToObservable()
+                    .Merge(batchSize)
+                    .ToList()
+                    .SelectMany(written =>
+                    {
+                        var next = ledger.AddRange(written);
+                        if (!written.Any(e => e.Disposition == NodeCopyDisposition.Failed))
+                            return Descend(level + 1, next);
+
+                        // 🚨 Stop the descent. A child of a node that did not land is an orphan —
+                        // exactly the residue measured on the unfixed helper, where a leaf reached
+                        // the target under a folder that never did. Everything deeper is recorded
+                        // as NOT ATTEMPTED, which is a different fact from "failed" and is the half
+                        // nobody could see before.
+                        return Observable.Return(next.AddRange(
+                            levels.Skip(level + 1).SelectMany(l => l).Select(NotAttempted)));
+                    });
+            }
+
+            return Descend(0, []);
+        }
+
+        // ---- one node --------------------------------------------------------------------------
+
+        IObservable<NodeCopyEntry> CopyOne(MeshNode node)
+        {
+            var newPath = RemapPathFor(node.Path, sourceNamespace, targetNamespace);
+            var copiedNode = MeshNode.FromPath(newPath) with
+            {
+                Name = node.Name,
+                NodeType = node.NodeType,
+                Icon = node.Icon,
+                Category = node.Category,
+                Content = node.Content,
+                State = MeshNodeState.Active,
+                PreRenderedHtml = node.PreRenderedHtml,
+            };
+
+            NodeCopyEntry Entry(NodeCopyDisposition disposition, string? error = null) =>
+                new(node.Path, newPath, disposition) { Error = error };
+
+            var attempt = force
+                ? hub.Observe<CreateOrUpdateNodeResponse>(
+                        new CreateOrUpdateNodeRequest(copiedNode), ConfigurePost)
                     .FirstAsync()
                     .Select(d => d.Message)
-                    .SelectMany(resp =>
+                    .Select(resp =>
+                    {
+                        if (!resp.Success)
+                            return Entry(NodeCopyDisposition.Failed, resp.Error);
+                        logger?.LogInformation(
+                            "Copied {SourcePath} -> {TargetPath} ({Mode})",
+                            node.Path, newPath, resp.WasCreated ? "created" : "updated");
+                        return Entry(resp.WasCreated
+                            ? NodeCopyDisposition.Created
+                            : NodeCopyDisposition.Updated);
+                    })
+                : hub.Observe<CreateNodeResponse>(new CreateNodeRequest(copiedNode), ConfigurePost)
+                    .FirstAsync()
+                    .Select(d => d.Message)
+                    .Select(resp =>
                     {
                         if (resp.Success)
                         {
                             logger?.LogInformation(
                                 "Copied node {SourcePath} -> {TargetPath}", node.Path, newPath);
-                            return Observable.Return(1);
+                            return Entry(NodeCopyDisposition.Created);
                         }
                         if (resp.RejectionReason == NodeCreationRejectionReason.NodeAlreadyExists)
                         {
                             logger?.LogInformation(
                                 "Skipping existing node at {TargetPath}", newPath);
-                            return Observable.Return(0);
+                            return Entry(NodeCopyDisposition.SkippedExisting);
                         }
-                        return Observable.Throw<int>(new InvalidOperationException(
-                            $"Copy of '{node.Path}' to '{newPath}' failed: {resp.Error}"));
+                        return Entry(NodeCopyDisposition.Failed, resp.Error);
                     });
-            }
 
-            // Parallel batch with bounded concurrency. allNodes -> per-node
-            // observable -> Merge(batchSize) caps in-flight count.
-            return allNodes
-                .Select(CopyOne)
-                .ToObservable()
-                .Merge(batchSize)
-                .Sum();
-        });
+            // 🚨 NOT a swallow. The fault is RECORDED, it ends the descent, and it makes the whole
+            // operation fail carrying the full inventory. What it stops is the merge aborting on
+            // the first fault: that used to cancel the observation of every sibling already in
+            // flight — whose writes had been POSTED and landed anyway — so the one path in the
+            // exception was the only one anybody could name, and the fate of the rest was
+            // unknowable. Letting each node answer for itself is what makes the post-condition
+            // possible at all.
+            return attempt.Catch((Exception ex) =>
+                Observable.Return(Entry(NodeCopyDisposition.Failed, ex.Message)));
+        }
     }
 
-    private static string RemapPath(string path, string sourceNamespace, string targetNamespace)
+    private static string RemapPathFor(string path, string sourceNamespace, string targetNamespace)
     {
         string relativePart;
         if (string.IsNullOrEmpty(sourceNamespace))
@@ -203,10 +397,6 @@ public static class NodeCopyHelper
         else if (path.StartsWith(sourceNamespace + "/", StringComparison.Ordinal))
         {
             relativePart = path[(sourceNamespace.Length + 1)..];
-        }
-        else if (path == sourceNamespace)
-        {
-            relativePart = path;
         }
         else
         {

--- a/src/MeshWeaver.Graph/NodeCopyOutcome.cs
+++ b/src/MeshWeaver.Graph/NodeCopyOutcome.cs
@@ -1,0 +1,286 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// What became of ONE node of a subtree copy. The unit exists because a copy's only report used to
+/// be a COUNT, and a count cannot say which member of a set is missing.
+/// </summary>
+public enum NodeCopyDisposition
+{
+    /// <summary>No node existed at the target path; this copy created it.</summary>
+    Created,
+
+    /// <summary>A node existed at the target path and this copy (<c>force</c>) overwrote it.</summary>
+    Updated,
+
+    /// <summary>
+    /// A node already existed at the target path and <c>force</c> was not set, so the copy left it
+    /// alone. 🚨 This COUNTS AS COVERED and deliberately so: the target path holds a node, which is
+    /// the property a copy has to guarantee. It is not counted as COPIED — the count this operation
+    /// returns has always meant "writes that happened", and a skip is not one.
+    /// </summary>
+    SkippedExisting,
+
+    /// <summary>
+    /// The write was attempted and did not come back acknowledged — refused, rejected, or faulted.
+    ///
+    /// <para>🚨 "Not acknowledged" is not "not written", and the wording is load-bearing in the
+    /// same way <c>NodeReadOutcome</c>'s Unavailable is: a delivery that
+    /// faults after the request left may well have landed. The report says what the copy was TOLD,
+    /// which is the only thing it knows.</para>
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// Never attempted, because a node at a SHALLOWER level of the same copy did not land. Writing
+    /// it would produce a node under a parent that does not exist — the exact residue a failed copy
+    /// used to leave.
+    /// </summary>
+    NotAttempted,
+}
+
+/// <summary>One node of a subtree copy, and what became of it.</summary>
+/// <param name="SourcePath">Where it was read from.</param>
+/// <param name="TargetPath">Where it was to land.</param>
+/// <param name="Disposition">What happened.</param>
+public sealed record NodeCopyEntry(
+    string SourcePath, string TargetPath, NodeCopyDisposition Disposition)
+{
+    /// <summary>Why the write was not acknowledged; set only for
+    /// <see cref="NodeCopyDisposition.Failed"/>.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// True when the target path ends this copy holding a node — created, updated, or already
+    /// there. This is the predicate the post-condition is expressed in.
+    /// </summary>
+    public bool Covered =>
+        Disposition is NodeCopyDisposition.Created
+            or NodeCopyDisposition.Updated
+            or NodeCopyDisposition.SkippedExisting;
+
+    /// <summary>True when this copy performed a write. The returned count sums these.</summary>
+    public bool Written =>
+        Disposition is NodeCopyDisposition.Created or NodeCopyDisposition.Updated;
+}
+
+/// <summary>
+/// How a subtree copy ended — the distinction an <c>int</c> cannot carry, and the reason
+/// <c>rbuergi/OperationRequest</c> reached a user partition without its <c>Source/</c> subtree
+/// while the copy reported the count it managed. See
+/// <c>Doc/Architecture/CopyCompleteness</c>.
+/// </summary>
+public enum NodeCopyStatus
+{
+    /// <summary>
+    /// Every node the source subtree holds now has a node at its target path. The ONLY status a
+    /// caller may read as success.
+    /// </summary>
+    Copied,
+
+    /// <summary>Nothing resolved at the source path. Nothing was written.</summary>
+    SourceNotFound,
+
+    /// <summary>
+    /// The copy's own enumeration of the source came back SHORT of what the source holds: nodes
+    /// exist under it that this caller may not read, so a copy would silently leave them behind.
+    /// Refused before anything was written.
+    /// </summary>
+    SourceNotFullyReadable,
+
+    /// <summary>
+    /// Whether the enumeration was complete could NOT be established. 🚨 Not a success and not a
+    /// failure of the source — it is the "nothing was checked" answer, kept apart from
+    /// <see cref="Copied"/> for the reason <c>Doc/Architecture/ControlsThatCannotFail</c> gives:
+    /// a completeness check with nothing to check against would pass. Refused before anything was
+    /// written.
+    /// </summary>
+    CompletenessNotDetermined,
+
+    /// <summary>
+    /// The writes ran and the target set is short of the enumerated set. <see cref="NodeCopyOutcome.Shortfall"/>
+    /// names every path, whether it failed or was never attempted.
+    /// </summary>
+    Incomplete,
+}
+
+/// <summary>
+/// The outcome of copying a subtree — <see cref="Status"/> plus the per-node ledger it was decided
+/// from. Modelled on <c>NodeDiagnosticsOutcome</c>, and for the
+/// same reason: the operation underneath already distinguishes "carried everything" from "carried
+/// what it could see", and the count was discarding that distinction rather than lacking it.
+/// </summary>
+public sealed record NodeCopyOutcome
+{
+    /// <summary>What the copy established.</summary>
+    public required NodeCopyStatus Status { get; init; }
+
+    /// <summary>The subtree root that was copied.</summary>
+    public required string SourcePath { get; init; }
+
+    /// <summary>The path the subtree root was copied to.</summary>
+    public required string TargetPath { get; init; }
+
+    /// <summary>
+    /// One entry per node the copy enumerated. Empty for the statuses that refuse before writing —
+    /// there is no ledger because nothing was attempted.
+    /// </summary>
+    public ImmutableList<NodeCopyEntry> Entries { get; init; } = [];
+
+    /// <summary>How many nodes the caller's own enumeration of the source returned.</summary>
+    public int EnumeratedCount { get; init; }
+
+    /// <summary>
+    /// How many nodes the source subtree HOLDS, established independently of what the caller may
+    /// read. Equal to <see cref="EnumeratedCount"/> whenever the enumeration is complete; -1 when
+    /// it could not be established (<see cref="NodeCopyStatus.CompletenessNotDetermined"/>).
+    /// </summary>
+    public int SourceNodeCount { get; init; } = -1;
+
+    /// <summary>Why nothing could be established; set only for
+    /// <see cref="NodeCopyStatus.CompletenessNotDetermined"/> and
+    /// <see cref="NodeCopyStatus.SourceNotFound"/>.</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// True only for <see cref="NodeCopyStatus.Copied"/>, so a caller that reads nothing but this
+    /// flag still cannot mistake a refusal — or a shortfall — for a finished copy.
+    /// </summary>
+    public bool IsComplete => Status == NodeCopyStatus.Copied;
+
+    /// <summary>
+    /// Writes this copy performed. 🚨 Deliberately NOT the size of the subtree: a node already
+    /// present at its target under <c>force=false</c> is covered and not copied, which is what the
+    /// count has always meant.
+    /// </summary>
+    public int CopiedCount => Entries.Count(e => e.Written);
+
+    /// <summary>Every enumerated node whose target path does NOT hold a node — the post-condition's
+    /// difference, failures and never-attempted alike.</summary>
+    public ImmutableList<NodeCopyEntry> Shortfall =>
+        Entries.Where(e => !e.Covered).ToImmutableList();
+
+    /// <summary>The copy carried everything it enumerated, and the enumeration was complete.</summary>
+    /// <param name="sourcePath">The subtree root.</param>
+    /// <param name="targetPath">Where it landed.</param>
+    /// <param name="entries">The per-node ledger.</param>
+    /// <param name="sourceNodeCount">The independently established size of the source subtree.</param>
+    public static NodeCopyOutcome Copied(
+        string sourcePath, string targetPath,
+        ImmutableList<NodeCopyEntry> entries, int sourceNodeCount) =>
+        new()
+        {
+            Status = NodeCopyStatus.Copied,
+            SourcePath = sourcePath,
+            TargetPath = targetPath,
+            Entries = entries,
+            EnumeratedCount = entries.Count,
+            SourceNodeCount = sourceNodeCount,
+        };
+
+    /// <summary>The writes ran and the target set is short of the enumerated set.</summary>
+    /// <param name="sourcePath">The subtree root.</param>
+    /// <param name="targetPath">Where it was landing.</param>
+    /// <param name="entries">The per-node ledger.</param>
+    /// <param name="sourceNodeCount">The independently established size of the source subtree.</param>
+    public static NodeCopyOutcome Incomplete(
+        string sourcePath, string targetPath,
+        ImmutableList<NodeCopyEntry> entries, int sourceNodeCount) =>
+        new()
+        {
+            Status = NodeCopyStatus.Incomplete,
+            SourcePath = sourcePath,
+            TargetPath = targetPath,
+            Entries = entries,
+            EnumeratedCount = entries.Count,
+            SourceNodeCount = sourceNodeCount,
+        };
+
+    /// <summary>Nothing resolved at the source path.</summary>
+    /// <param name="sourcePath">The path that resolved to nothing.</param>
+    /// <param name="targetPath">Where the copy would have landed.</param>
+    public static NodeCopyOutcome SourceNotFound(string sourcePath, string targetPath) =>
+        new()
+        {
+            Status = NodeCopyStatus.SourceNotFound,
+            SourcePath = sourcePath,
+            TargetPath = targetPath,
+            Reason = $"Source node not found: {sourcePath}",
+        };
+
+    /// <summary>The enumeration is short of what the source holds. Nothing was written.</summary>
+    /// <param name="sourcePath">The subtree root.</param>
+    /// <param name="targetPath">Where the copy would have landed.</param>
+    /// <param name="enumeratedCount">What the caller could see.</param>
+    /// <param name="sourceNodeCount">What the subtree holds.</param>
+    public static NodeCopyOutcome SourceNotFullyReadable(
+        string sourcePath, string targetPath, int enumeratedCount, int sourceNodeCount) =>
+        new()
+        {
+            Status = NodeCopyStatus.SourceNotFullyReadable,
+            SourcePath = sourcePath,
+            TargetPath = targetPath,
+            EnumeratedCount = enumeratedCount,
+            SourceNodeCount = sourceNodeCount,
+        };
+
+    /// <summary>Completeness could not be established. Nothing was written.</summary>
+    /// <param name="sourcePath">The subtree root.</param>
+    /// <param name="targetPath">Where the copy would have landed.</param>
+    /// <param name="reason">What was missing, named so it can be provisioned.</param>
+    public static NodeCopyOutcome CompletenessNotDetermined(
+        string sourcePath, string targetPath, string reason) =>
+        new()
+        {
+            Status = NodeCopyStatus.CompletenessNotDetermined,
+            SourcePath = sourcePath,
+            TargetPath = targetPath,
+            Reason = reason,
+        };
+
+    /// <summary>
+    /// A human- and agent-readable account of a non-<see cref="NodeCopyStatus.Copied"/> outcome.
+    /// Null when the copy completed.
+    ///
+    /// <para>🚨 A <see cref="NodeCopyStatus.SourceNotFullyReadable"/> refusal states COUNTS and
+    /// never the paths it could not read. The shortfall is a permission fact about the READER, so
+    /// naming what it hides would turn a refusal into a disclosure surface — the same reason
+    /// #3890 closed the autocomplete drill-down. A
+    /// <see cref="NodeCopyStatus.Incomplete"/> report DOES name its paths: every one of them came
+    /// out of the caller's own enumeration, so it discloses nothing the caller cannot already
+    /// read.</para>
+    /// </summary>
+    public string? Describe() => Status switch
+    {
+        NodeCopyStatus.Copied => null,
+
+        NodeCopyStatus.SourceNotFound => Reason,
+
+        NodeCopyStatus.SourceNotFullyReadable =>
+            $"{NodeCopyHelper.IncompleteSourceRefusal} at '{SourcePath}': it holds {SourceNodeCount} "
+            + $"node(s) and this caller can read {EnumeratedCount}, so {SourceNodeCount - EnumeratedCount} "
+            + "would have been left behind. Nothing was written. A subtree copied without part of "
+            + "itself is not a smaller copy — it is a broken one, which is why this is a refusal "
+            + "rather than a partial result.",
+
+        NodeCopyStatus.CompletenessNotDetermined =>
+            $"{NodeCopyHelper.UndeterminedCompletenessRefusal} at '{SourcePath}': {Reason}. Nothing "
+            + "was written. This is NOT evidence that the subtree is short — it is the absence of "
+            + "evidence either way, and a copy that cannot establish what it is copying must say so.",
+
+        _ =>
+            $"{NodeCopyHelper.IncompleteCopyReport} '{SourcePath}' -> '{TargetPath}': "
+            + $"{EnumeratedCount} node(s) enumerated, {CopiedCount} written, "
+            + $"{Entries.Count(e => e.Disposition == NodeCopyDisposition.SkippedExisting)} already present, "
+            + $"{Shortfall.Count} did not land:"
+            + string.Concat(Shortfall.Select(e => Environment.NewLine
+                + (e.Disposition == NodeCopyDisposition.Failed
+                    ? $"  not acknowledged  {e.TargetPath} — {e.Error}"
+                    : $"  not attempted     {e.TargetPath} — a node above it did not land")))
+            + Environment.NewLine
+            + "What DID land is left in place: this copy may have overwritten nodes it holds no "
+            + "before-image of, so deleting them back would be a second uncontrolled mutation "
+            + "rather than a rollback.",
+    };
+}

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -3090,8 +3090,14 @@ public class MeshOperations
 
     /// <summary>
     /// Copies a node and all its descendants to a target namespace. Delegates to
-    /// <see cref="NodeCopyHelper.CopyNodeTree"/> — fully reactive pipeline (Query +
-    /// MeshNodeReference streams + CreateNode observables chained sequentially).
+    /// <see cref="NodeCopyHelper.CopyNodeTree"/> — fully reactive, no <c>await</c> anywhere.
+    ///
+    /// <para>🚨 The helper REFUSES rather than half-landing a tree: it establishes how big the
+    /// source subtree is independently of what this caller may read, and writes nothing at all when
+    /// the two disagree. A copy that ran and fell short reports every path that did not land. Both
+    /// arrive here as an <c>OnError</c> and are rendered as the <c>Error:</c> answer below —
+    /// deliberately, because a partial copy used to arrive as a COUNT. See
+    /// <c>Doc/Architecture/CopyCompleteness</c>.</para>
     /// </summary>
     public IObservable<string> Copy(string sourcePath, string targetNamespace, bool force = false)
     {

--- a/test/MeshWeaver.Graph.Test/ACopyThatCannotCompleteSaysSoTest.cs
+++ b/test/MeshWeaver.Graph.Test/ACopyThatCannotCompleteSaysSoTest.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A copy that carried less than the whole subtree reported the count it managed, and
+/// completed.</b> The consequence is recorded in
+/// <c>Doc/Architecture/MissingDeclaredSources</c>: <c>rbuergi/OperationRequest</c> on
+/// memex.meshweaver.cloud — a NodeType node whose entire <c>Source/</c> subtree is absent
+/// (<c>search 'namespace:rbuergi/OperationRequest scope:subtree'</c> → <b>0</b>, against
+/// <b>21</b> for the package it was copied from) — which then failed its compile on every pod
+/// boot for four days, reporting three missing symbols that live in nodes nobody has. The design
+/// is <c>Doc/Architecture/CopyCompleteness</c>.
+///
+/// <para><b>The defect, stated as a property.</b> A copy asserts a set equality it never
+/// establishes. <see cref="NodeCopyHelper.CopyNodeTree"/> returned a COUNT of writes that
+/// succeeded; nothing anywhere established (a) that the set it enumerated IS the source subtree,
+/// or (b) that the set it wrote IS the set it enumerated. Both are set comparisons, and a count
+/// can express neither.</para>
+///
+/// <para><b>Measured on the unfixed helper, on this fixture, 2026-09-10</b> — the two halves are
+/// different failures and only the first was silent:</para>
+/// <code>
+/// A. a descendant the caller may not read
+///      subject-scoped enumeration = 5 of the 7 nodes the subtree holds
+///      copy RETURNED count = 5                         &lt;- reported success
+///      …/Pkg/Restricted        ABSENT                  &lt;- silently left behind
+///      …/Pkg/Restricted/Beta   ABSENT
+/// B. one write refused in the middle
+///      copy THREW "Copy of 'TestData/Pkg/Source' … failed"   &lt;- names ONE of five paths
+///      …/Pkg/Source            ABSENT
+///      …/Pkg/Source/Alpha      PRESENT                 &lt;- ORPHAN under a parent that never landed
+/// </code>
+///
+/// <para><b>The controls, in both directions.</b>
+/// <see cref="AnUnreadableDescendantRefusesTheCopyInsteadOfHalfLandingIt"/> and
+/// <see cref="AFailedWriteStopsTheDescentAndNamesEverythingThatDidNotLand"/> are the two
+/// regressions; <see cref="AnOrdinaryCopyStillCarriesTheWholeSubtree"/> and
+/// <see cref="ACopyOfASubtreeTheCallerCanFullyReadStillSucceeds"/> are the controls a fix that
+/// simply refused everything could not pass — the second matters more, because it is the SAME
+/// restricted caller running the SAME completeness machinery and succeeding.
+/// <see cref="TheCopierReallyCannotReadTheRestrictedBranch"/> pins the premise the first rests on,
+/// in both directions, against the fold row-level security itself consults.</para>
+/// </summary>
+public class ACopyThatCannotCompleteSaysSoTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string PkgId = "Pkg";
+
+    /// <summary>The subtree being copied: a root, a readable branch and a restricted branch.</summary>
+    private const string SourceRoot = $"{TestPartition}/{PkgId}";
+    private const string SourceFolder = $"{SourceRoot}/Source";
+    private const string SourceLeaf = $"{SourceFolder}/Alpha";
+    private const string RestrictedFolder = $"{SourceRoot}/Restricted";
+    private const string RestrictedLeaf = $"{RestrictedFolder}/Beta";
+
+    /// <summary>The five content nodes a complete copy must produce.</summary>
+    private static readonly string[] SourcePaths =
+        [SourceRoot, SourceFolder, SourceLeaf, RestrictedFolder, RestrictedLeaf];
+
+    /// <summary>
+    /// One target namespace PER TEST. The mesh is rebuilt per test, but
+    /// <see cref="RefuseOneTargetPathValidator"/> is registered class-wide, so a shared target
+    /// would make it fire in the controls too.
+    /// </summary>
+    private const string UnreadableTarget = $"{TestPartition}/DstUnreadable";
+    private const string RefusedWriteTarget = $"{TestPartition}/DstRefusedWrite";
+    private const string AdminTarget = $"{TestPartition}/DstAdmin";
+    private const string RestrictedButCompleteTarget = $"{TestPartition}/DstRestricted";
+
+    /// <summary>
+    /// The path whose CREATE <see cref="RefuseOneTargetPathValidator"/> refuses. It is the FOLDER
+    /// of the readable branch, so its child is perfectly creatable — which is what makes the
+    /// descent measurable: on the unfixed helper that child landed under a parent that never did.
+    /// </summary>
+    private const string RefusedPath = $"{RefusedWriteTarget}/{PkgId}/Source";
+
+    /// <summary>
+    /// A signed-in caller who may read <see cref="SourceRoot"/> but NOT
+    /// <see cref="RestrictedFolder"/>, and who may create under the target namespaces. The exact
+    /// shape behind the production orphan: the copier could read the package node and not all of
+    /// what hangs off it.
+    /// </summary>
+    private static readonly AccessContext Copier = new()
+    {
+        ObjectId = "copier",
+        Name = "Copier",
+        Email = "copier@example.com",
+        Roles = [],
+    };
+
+    // 🚨 ConfigureMeshBase, not base.ConfigureMesh — the latter chains PublicAdminAccess(), which
+    // grants Public→Admin in every default partition. Under it the Copier would read the restricted
+    // branch outright, the refusal would never fire, and this suite would pass having measured
+    // nothing.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .ConfigureServices(services =>
+                services.AddScoped<INodeValidator, RefuseOneTargetPathValidator>())
+            .AddMeshNodes(
+                // Read over the package…
+                AssignmentNodeFactory.UserRole(Copier.ObjectId, roleId: "Viewer", scope: SourceRoot),
+                // …except this branch. A deny overrides the inherited grant for that role, and the
+                // Copier holds no other — which is a gated package's shape.
+                AssignmentNodeFactory.UserRole(
+                    Copier.ObjectId, roleId: "Viewer", scope: RestrictedFolder, denied: true),
+                // …and Create where each test's copy lands.
+                AssignmentNodeFactory.UserRole(Copier.ObjectId, roleId: "Admin", scope: UnreadableTarget),
+                AssignmentNodeFactory.UserRole(Copier.ObjectId, roleId: "Admin", scope: RefusedWriteTarget),
+                AssignmentNodeFactory.UserRole(
+                    Copier.ObjectId, roleId: "Admin", scope: RestrictedButCompleteTarget));
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    /// <summary>Creates the five source nodes as the test's own admin identity, parents first.</summary>
+    private async Task SeedSource()
+    {
+        foreach (var path in SourcePaths)
+            await NodeFactory
+                .CreateNode(MeshNode.FromPath(path) with
+                {
+                    Name = path, NodeType = "Markdown", State = MeshNodeState.Active,
+                })
+                .Should().Within(Budget).Emit($"the admin owns {TestPartition}");
+    }
+
+    /// <summary>
+    /// Switches the ambient viewer to <see cref="Copier"/> and CHECKS THE SWITCH TOOK — without it
+    /// a mis-wired identity hop would leave every assertion running as the test's admin, for whom
+    /// the whole subtree is readable and "the copy completed" is the correct answer.
+    /// </summary>
+    private void BecomeTheCopier()
+    {
+        Access.SetCircuitContext(Copier);
+        (Access.Context?.ObjectId ?? Access.CircuitContext?.ObjectId)
+            .Should().Be(Copier.ObjectId,
+                "every assertion below is about what THIS identity can copy");
+    }
+
+    private Task<MeshNode?> Read(string path, string because) =>
+        ReadNode(path).Should().Within(Budget).Emit(because);
+
+    private Task<NodeCopyOutcome> CopyOutcome(
+        string sourcePath, string targetNamespace, string because) =>
+        NodeCopyHelper
+            .CopyNodeTreeOutcome(MeshQuery, NodeFactory, Mesh, sourcePath, targetNamespace, force: false)
+            .Should().Within(Budget).Emit(because);
+
+    /// <summary>
+    /// The premise <see cref="AnUnreadableDescendantRefusesTheCopyInsteadOfHalfLandingIt"/> rests
+    /// on, measured against the same fold <c>RlsNodeValidator</c> consults for a Read — in BOTH
+    /// directions, so a fold that answered <c>false</c> for everybody would fail HERE rather than
+    /// silently validate the refusal.
+    /// </summary>
+    [Fact]
+    public async Task TheCopierReallyCannotReadTheRestrictedBranch()
+    {
+        await SeedSource();
+
+        (await Mesh.CheckPermission(SourceRoot, Copier.ObjectId, Permission.Read)
+                .Should().Within(Budget).Emit("the permission fold answers"))
+            .Should().BeTrue("the Copier holds a Viewer grant on the package root");
+
+        (await Mesh.CheckPermission(RestrictedFolder, Copier.ObjectId, Permission.Read)
+                .Should().Within(Budget).Emit("the permission fold answers"))
+            .Should().BeFalse("the deny at that scope overrides the inherited Viewer grant");
+
+        (await Mesh.CheckPermission(RestrictedFolder, TestUsers.Admin.ObjectId, Permission.Read)
+                .Should().Within(Budget).Emit("the permission fold answers"))
+            .Should().BeTrue(
+                "the branch is readable for the identity that owns it — a fold that denied "
+                + "everybody would make the assertion above meaningless");
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION, first half. The subtree enumeration runs AS THE CALLER, so the two
+    /// restricted nodes are simply not in it — and "the caller cannot read them" and "they are not
+    /// there" were the same value. On the unfixed helper this copy returned 5 and left the target
+    /// package without its Restricted branch, which IS the production orphan.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreadableDescendantRefusesTheCopyInsteadOfHalfLandingIt()
+    {
+        await SeedSource();
+        BecomeTheCopier();
+
+        var outcome = await CopyOutcome(SourceRoot, UnreadableTarget, "the copy answers");
+
+        outcome.Status.Should().Be(NodeCopyStatus.SourceNotFullyReadable,
+            "an enumeration that came back short because of permission is NOT an empty subtree, "
+            + "and a copy that cannot see all of its source must refuse rather than carry a part");
+        (outcome.SourceNodeCount - outcome.EnumeratedCount).Should().Be(2,
+            $"'{RestrictedFolder}' and '{RestrictedLeaf}' are held by the subtree and hidden from "
+            + "this caller — the System-scoped reading is what turns that into a number instead of "
+            + "a silence");
+        outcome.IsComplete.Should().BeFalse("a refusal is never a finished copy");
+        outcome.Entries.Should().BeEmpty("the refusal is established BEFORE anything is attempted");
+
+        outcome.Describe().Should().Contain(NodeCopyHelper.IncompleteSourceRefusal,
+            "the marker every reader of this refusal matches on");
+        outcome.Describe().Should().NotContain(RestrictedFolder,
+            "a shortfall is a permission fact about the READER — naming the paths it hides would "
+            + "turn a refusal into a disclosure surface (#3890)");
+
+        foreach (var relative in SourcePaths.Select(Relative))
+            (await Read($"{UnreadableTarget}/{relative}", $"{relative} is read back"))
+                .Should().BeNull(
+                    "nothing at all is written: a caller who cannot copy the whole subtree does "
+                    + "not get half of one");
+    }
+
+    /// <summary>
+    /// The COUNT surface is derived from the outcome, so it cannot answer with a number for a copy
+    /// that was refused. Separate from the test above because a derived surface quietly keeping the
+    /// old behaviour is exactly the drift the two-surface shape exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task TheCountSurfaceErrorsOnARefusalInsteadOfEmittingACount()
+    {
+        await SeedSource();
+        BecomeTheCopier();
+
+        var failure = await Assert.ThrowsAnyAsync<Exception>(() =>
+            NodeCopyHelper
+                .CopyNodeTree(MeshQuery, NodeFactory, Mesh, SourceRoot, UnreadableTarget, force: false)
+                .Should().Within(Budget).Emit("the count surface answers"));
+
+        failure.Message.Should().Contain(NodeCopyHelper.IncompleteSourceRefusal,
+            "the count surface propagates the outcome's own account rather than a number");
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION, second half. One refused write used to abort the merge: whatever was
+    /// already in flight landed, whatever had not started never did, and the single exception named
+    /// one path. Here the refused path is a FOLDER whose child is perfectly creatable — so on the
+    /// unfixed helper <c>…/Source/Alpha</c> landed under a <c>…/Source</c> that never existed.
+    /// </summary>
+    [Fact]
+    public async Task AFailedWriteStopsTheDescentAndNamesEverythingThatDidNotLand()
+    {
+        await SeedSource();
+
+        var outcome = await CopyOutcome(SourceRoot, RefusedWriteTarget, "the copy answers");
+
+        outcome.Status.Should().Be(NodeCopyStatus.Incomplete,
+            "a copy that did not carry everything it enumerated is not a copy");
+
+        outcome.Shortfall.Should().Contain(
+            e => e.TargetPath == RefusedPath && e.Disposition == NodeCopyDisposition.Failed,
+            "the write that was refused is named, with its reason");
+        outcome.Shortfall.Should().Contain(
+            e => e.TargetPath == $"{RefusedPath}/Alpha"
+                 && e.Disposition == NodeCopyDisposition.NotAttempted,
+            "AND every descendant it therefore never attempted — the half nobody could see before, "
+            + "reported as NOT ATTEMPTED rather than as a failure of its own");
+
+        (await Read($"{RefusedPath}/Alpha", "the would-be orphan is read back"))
+            .Should().BeNull(
+                "a child of a node that could not be written is an orphan; the descent stops at "
+                + "the level that failed instead of scattering it");
+
+        (await Read($"{RefusedWriteTarget}/{PkgId}", "the root is read back"))
+            .Should().NotBeNull(
+                "the levels that DID land stay — this copy may have overwritten nodes it holds no "
+                + "before-image of, so deleting them back would be a second uncontrolled mutation "
+                + "rather than a rollback");
+
+        outcome.Entries
+            .Where(e => e.Covered)
+            .Should().OnlyContain(
+                e => outcome.Entries
+                    .Where(a => e.TargetPath.StartsWith(a.TargetPath + "/", StringComparison.Ordinal))
+                    .All(a => a.Covered),
+                "the residue is a well-formed tree: every node that landed has every ancestor that "
+                + "landed with it, which is what writing level by level buys");
+    }
+
+    /// <summary>
+    /// The control for the identity that can read everything: an ordinary complete copy still
+    /// copies, and still counts what it copied. The expected count comes from the subtree itself
+    /// rather than a literal — the seeded access assignments are nodes of the subtree too, and a
+    /// complete copy carries them.
+    /// </summary>
+    [Fact]
+    public async Task AnOrdinaryCopyStillCarriesTheWholeSubtree()
+    {
+        await SeedSource();
+
+        var held = await MeshQuery
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{SourceRoot} scope:subtree").Complete())
+            .Take(1).Select(c => c.Items)
+            .Should().Within(Budget).Emit("the admin enumerates the whole subtree");
+
+        var outcome = await CopyOutcome(SourceRoot, AdminTarget, "the copy answers");
+
+        outcome.Status.Should().Be(NodeCopyStatus.Copied, "nothing is hidden from this caller");
+        outcome.IsComplete.Should().BeTrue("this is what a finished copy looks like");
+        outcome.Shortfall.Should().BeEmpty("every enumerated node landed");
+        outcome.CopiedCount.Should().Be(held.Count,
+            "a complete copy writes every node the source subtree holds");
+
+        foreach (var relative in SourcePaths.Select(Relative))
+            (await Read($"{AdminTarget}/{relative}", $"{relative} is read back"))
+                .Should().NotBeNull($"'{relative}' is part of the subtree that was copied");
+    }
+
+    /// <summary>
+    /// The control that matters most: the SAME restricted caller, copying a subtree it can read in
+    /// full, still succeeds. Without it a fix that refused every restricted caller — or every copy
+    /// — would pass the refusal tests and look correct.
+    /// </summary>
+    [Fact]
+    public async Task ACopyOfASubtreeTheCallerCanFullyReadStillSucceeds()
+    {
+        await SeedSource();
+        BecomeTheCopier();
+
+        var outcome = await CopyOutcome(
+            SourceFolder, RestrictedButCompleteTarget, "the copy answers");
+
+        outcome.Status.Should().Be(NodeCopyStatus.Copied,
+            "the whole of THIS subtree is readable to the Copier, so the completeness check has "
+            + "nothing to refuse");
+        outcome.CopiedCount.Should().Be(2, "the readable branch is a folder and one leaf");
+
+        (await Read($"{RestrictedButCompleteTarget}/Source/Alpha", "the leaf is read back"))
+            .Should().NotBeNull("a restricted caller can still copy what it can wholly read");
+    }
+
+    /// <summary>The path a source node lands at, relative to the target namespace.</summary>
+    private static string Relative(string sourcePath) =>
+        sourcePath[(TestPartition.Length + 1)..];
+
+    /// <summary>
+    /// Refuses the CREATE of exactly one path. A real <see cref="INodeValidator"/> registered in a
+    /// real mesh — the framework's own extension point, not a stand-in for one — because the
+    /// failure being reproduced is "one write in the middle of a subtree is refused" and it has to
+    /// happen at a path whose CHILD is still creatable. Stateless: it holds a constant.
+    /// </summary>
+    private sealed class RefuseOneTargetPathValidator : INodeValidator
+    {
+        public IReadOnlyCollection<NodeOperation> SupportedOperations { get; } =
+            [NodeOperation.Create];
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context) =>
+            Observable.Return(
+                string.Equals(context.Node?.Path, RefusedPath, StringComparison.Ordinal)
+                    ? NodeValidationResult.Invalid(
+                        $"refused by {nameof(RefuseOneTargetPathValidator)}")
+                    : NodeValidationResult.Valid());
+    }
+}


### PR DESCRIPTION
A copy could carry less than the whole subtree and report the count it managed. The consequence is
already recorded in `Doc/Architecture/MissingDeclaredSources` → *"Where the orphan came from"*:
`rbuergi/OperationRequest` on memex.meshweaver.cloud, a NodeType whose entire `Source/` subtree is
absent (`search 'namespace:rbuergi/OperationRequest scope:subtree'` → **0**, against **21** for the
package it was copied from), which then took the identical doomed Roslyn compile on every pod boot
for four days and reported three missing symbols that live in nodes nobody has.

## The defect, as a property

A copy asserts a **set equality** it never establishes: that the set it ENUMERATED is the source
subtree, and that the set it WROTE is the set it enumerated. `NodeCopyHelper.CopyNodeTree` returned
an `int`. A count can express neither, so both shortfalls arrive as a number and a number reads as
success.

## Reproduced first, deterministically — and one of the two framings was wrong

`ACopyThatCannotCompleteSaysSoTest` (in-memory mesh, RLS on, a copier with Viewer on the package root
and a role DENY on one branch). Measured on the unfixed helper:

```
A. a descendant the caller may not read
     subject-scoped enumeration = 5 of the 7 nodes the subtree holds
     copy RETURNED count = 5                          <- reported success
     …/Pkg/Restricted        ABSENT                   <- silently left behind
     …/Pkg/Restricted/Beta   ABSENT

B. one write refused in the middle
     copy THREW "Copy of 'TestData/Pkg/Source' … failed"    <- names ONE of five paths
     …/Pkg/Source            ABSENT
     …/Pkg/Source/Alpha      PRESENT                  <- ORPHAN, under a parent that never landed
```

**Only A was silent.** B *did* raise — so "both report success" is not what was wrong with it. What
was wrong with B is that the exception named one of five paths, the merge cancelled the observation
of siblings whose writes had already been posted and landed anyway, and the target ended up holding
a node whose parent does not exist.

## The four candidates, and which were adopted

| Candidate | Verdict |
|---|---|
| Make the enumeration's incompleteness visible | **Adopted — this is the root cause of the orphan** |
| A post-condition over what was written | **Adopted — the only honest completion signal** |
| Parent-before-child ordering | **Adopted, as a failure-atomicity fix and stated as one** |
| An all-or-nothing outcome (rollback) | **Rejected — it is not implementable and would have teeth** |

**Enumeration completeness.** The subtree listing runs AS THE CALLER and must: it is the read
row-level security filters, and enumerating out of storage instead would let a caller duplicate rows
they cannot read into a place they control. But its shortness is then a fact about the READER, and an
enumeration that returns `[root]` because the children are hidden was the same value as a subtree
that has none. The size is now read a **second time, from the same query, as System** — the shape
MeshWeaver.Plugins' installer already uses, for the identical reason (a gated package hides its
children from a subject-scoped query). Sharing the query shape is load-bearing: the only thing that
can differ between the two answers is what the identity may see. A difference **refuses before
writing anything**, stating COUNTS and never the paths — the shortfall is exactly the set the caller
may not read, so naming it would turn a refusal into a disclosure surface (#3890). With no
`AccessService` there is no second identity, so the answer is `CompletenessNotDetermined`, not a
comparison of a set with itself that would pass by construction.

**Post-condition.** Every enumerated node ends with a `NodeCopyEntry` saying what the owning hub
ACKNOWLEDGED (`Created` / `Updated` / `SkippedExisting` / `Failed` / `NotAttempted`); the outcome is
the set comparison over it. Built from acknowledgements rather than a read-back, because a query is
eventually consistent. `Failed` means *not acknowledged*, never *not written*. `SkippedExisting`
counts as covered and not as copied — so the number every already-correct copy returns is unchanged.

**Ordering.** Level by level, deepest last; a level that does not fully land ends the descent.
Nothing in the platform requires a parent to exist (no handler, validator, router or storage adapter
probes one — PG has no FK, and the `NextLevel` planner deliberately skips empty intermediates), so
this is *not* a happy-path correctness fix and the doc says so. What it buys is a well-formed
residue: every node that landed has every ancestor that landed with it.

**No rollback.** There is no cross-partition transaction here — each node is its own hub and its own
row, possibly in another schema — and under `force` a copy overwrites nodes it holds no before-image
of, so a compensating delete could not restore them, it would destroy them. The helper deleting a
target is also a known incident shape (the per-node-hub disposal race behind *"GetNode returns null
after force-overwrite"*). The guarantee offered instead: all-or-nothing at the point of refusal, and
a well-formed prefix plus a complete inventory when a write fails.

## Surfaces

`CopyNodeTreeOutcome` is the verdict surface; `CopyNodeTree` keeps its signature and is **derived**
from it, erroring on anything that is not `Copied` — the two-surface shape from
`Doc/Architecture/ControlsThatCannotFail` instance 13, so a consumer that renders a verdict and a
consumer that wants a number do not share one compromise. `Templates/NodeCopy.csx` binds the count
overload positionally at RUNTIME and is unchanged.

## Controls, in both directions

- `AnUnreadableDescendantRefusesTheCopyInsteadOfHalfLandingIt` — refuses, writes **nothing**, and the
  refusal does not name the hidden paths.
- `AFailedWriteStopsTheDescentAndNamesEverythingThatDidNotLand` — the would-be orphan is absent, the
  refused write and every never-attempted descendant are named, and the residue is asserted to be a
  well-formed tree.
- `TheCountSurfaceErrorsOnARefusalInsteadOfEmittingACount` — the derived surface cannot keep the old
  behaviour quietly.
- `AnOrdinaryCopyStillCarriesTheWholeSubtree` — an ordinary complete copy still copies, count and all
  (taken from the subtree's own size, not a literal).
- `ACopyOfASubtreeTheCallerCanFullyReadStillSucceeds` — **the same restricted caller**, running the
  same completeness machinery, succeeding. Without it a fix that refused everything would look right.
- `TheCopierReallyCannotReadTheRestrictedBranch` — the premise, in both directions, against the fold
  RLS itself consults.

## Not fixed here, named rather than left to be rediscovered

`MeshExtensions.HandleCopyNodeRequest` still has the same enumeration shape (its `RequireComplete`
guard is wired only to Move); a copy still writes no install record, so `InstallCompleteness` cannot
see one; and the live orphan `rbuergi/OperationRequest` is **untouched** — deleting production data
in someone's partition is the maintainer's call.

## Verification

`dotnet build -c Release -warnaserror`, `0 Error(s)`: `MeshWeaver.Graph`, `MeshWeaver.Mesh.Operations`,
`MeshWeaver.Documentation`, `MeshWeaver.Graph.Test`. `MeshWeaver.Documentation.Test` 368/368 green
(link integrity included). No issue is referenced: the tracker was cleared and the issue that recorded
this was closed 20 seconds after it was filed — the durable record is
`Doc/Architecture/CopyCompleteness`, linked from `Doc/Architecture/MissingDeclaredSources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
