### PR TITLE
fix: address the Copilot review on #3940 — immutable test constant, issue URL, scoped release note

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CopyCompleteness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CopyCompleteness.md
@@ -93,7 +93,7 @@ later.
 
 🚨 **The refusal states COUNTS and never the paths.** The shortfall is exactly the set the caller may
 not read, so naming it would turn a refusal into a disclosure surface — the same reason
-[#3890](https://github.com/Systemorph/MeshWeaver/pull/3890) closed the autocomplete drill-down, which
+[#3890](https://github.com/Systemorph/MeshWeaver/issues/3890) closed the autocomplete drill-down, which
 worked by naming other people's node titles. An `Incomplete` report DOES name its paths: every one of
 them came out of the caller's own enumeration, so it discloses nothing the caller cannot already see.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-copy-no-longer-half-lands-a-tree.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-copy-no-longer-half-lands-a-tree.md
@@ -8,9 +8,9 @@ Order: -20260910
 
 # A copy no longer half-lands a tree
 
-Copying a subtree — from the Copy dialog, from "copy to home", from an import, or through an agent's
-`copy` tool — used to report the number of nodes it managed to write, and that number said nothing
-about whether the copy was whole.
+Copying a subtree — from the Copy dialog, from "copy to home", or through an agent's or the CLI's
+`copy` command — used to report the number of nodes it managed to write, and that number said
+nothing about whether the copy was whole.
 
 Two things could make it short. If part of the source was **not visible to you** — a branch someone
 else has not shared, or the gated part of an installed package — the copy simply did not see those
@@ -31,3 +31,7 @@ folder. And it reports every node that did not land — the ones that were refus
 therefore never attempted — instead of naming one and staying silent about the rest.
 
 Copies that were already complete behave exactly as before, including the count they report.
+
+This covers the copy described above. Moving a node, importing an archive and installing a package
+each run on their own machinery and are unchanged — a move already refuses rather than relocating
+part of a subtree, and the other two are separate pipelines.

--- a/test/MeshWeaver.Graph.Test/ACopyThatCannotCompleteSaysSoTest.cs
+++ b/test/MeshWeaver.Graph.Test/ACopyThatCannotCompleteSaysSoTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -64,8 +65,12 @@ public class ACopyThatCannotCompleteSaysSoTest(ITestOutputHelper output) : Monol
     private const string RestrictedFolder = $"{SourceRoot}/Restricted";
     private const string RestrictedLeaf = $"{RestrictedFolder}/Beta";
 
-    /// <summary>The five content nodes a complete copy must produce.</summary>
-    private static readonly string[] SourcePaths =
+    /// <summary>
+    /// The five content nodes a complete copy must produce. <see cref="ImmutableArray{T}"/> rather
+    /// than an array: <c>static readonly</c> freezes only the reference, and a process-wide
+    /// collection whose elements one test could rewrite is the shape NoStaticState.md bans.
+    /// </summary>
+    private static readonly ImmutableArray<string> SourcePaths =
         [SourceRoot, SourceFolder, SourceLeaf, RestrictedFolder, RestrictedLeaf];
 
     /// <summary>


### PR DESCRIPTION
The three findings from the Copilot review on #3940. That PR was already in the merge queue when the
review landed, so its branch could not be updated — the fixes land here rather than by dequeuing a
shared resource for two doc edits and a test tidy.

- **`ACopyThatCannotCompleteSaysSoTest.SourcePaths` becomes an `ImmutableArray<string>`.**
  `static readonly` freezes only the reference; the array's elements stayed a process-wide mutable
  collection, which is exactly the shape `Doc/Architecture/NoStaticState` bans.
- **`Doc/Architecture/CopyCompleteness` linked `#3890` as `/pull/3890`.** It is an ISSUE
  (*"Autocomplete runs with useSecurityFilter:false and no caller identity…"*, verified over REST),
  so the link pointed at nothing. Now `/issues/3890`.
- **The What's New entry overstated the scope.** It said the fix covered "an import". It does not:
  `MeshOperations.Import` has its own manifest pipeline, `CopyNodeRequest`/`MoveNodeRequest` is
  separate and unchanged machinery, and a package install runs the PluginCatalog installer. Scoped to
  what actually routes through `NodeCopyHelper.CopyNodeTree` — the Copy dialog and copy-to-home (via
  the `Templates/Import/NodeCopy` template) and the agent/CLI `copy` command — and the entry now
  names the three surfaces that are deliberately untouched, so a reader cannot infer a guarantee that
  is not there.

No behaviour changes beyond the test's constant.

Verified: `dotnet build -c Release -warnaserror` `0 Error(s)` on `MeshWeaver.Graph.Test` and
`MeshWeaver.Documentation`; `ACopyThatCannotCompleteSaysSoTest` 6/6; `MeshWeaver.Documentation.Test`
373/373 (link integrity included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
