### PR TITLE
fix: a dependency record's module entry is a FLOOR, not an MVID pin (#3934)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -2736,16 +2736,20 @@ internal static class NodeTypeCompilationHelpers
 
     /// <summary>
     /// The surface-id resolver over THIS mesh's environment (process surface manifest + the
-    /// mesh's installed modules) — see <see cref="Compiler.CompiledDependencies.CreateIdResolver"/>.
+    /// mesh's installed modules) — see <c>CompiledDependencies.CreateIdResolver</c>.
     /// </summary>
-    internal static Func<string, string?> DependencyIdResolverOf(IMessageHub hub) =>
-        Compiler.CompiledDependencies.CreateIdResolver(
+    internal static Func<string, string?> DependencyIdResolverOf(IMessageHub hub)
+    {
+        var versions = ModuleVersionsOf(hub);
+        return Compiler.CompiledDependencies.CreateIdResolver(
             FrameworkBuildIdentity.ProcessSurfacePairs,
             ModuleMvidsOf(hub),
-            FrameworkBuildIdentity.ProcessImplMvidOf);
+            FrameworkBuildIdentity.ProcessImplMvidOf,
+            name => versions.TryGetValue(name, out var version) ? version : null);
+    }
 
-    /// <summary>Installed module simple name → implementation MVID ("N"), for the resolver's
-    /// exact-build module ids.</summary>
+    /// <summary>Installed module simple name → implementation MVID ("N"), the resolver's fallback
+    /// module id for a module that states no version (#3934).</summary>
     internal static IReadOnlyDictionary<string, string> ModuleMvidsOf(IMessageHub hub)
     {
         var modules = hub.ServiceProvider.GetServices<InstalledModuleAssembly>();
@@ -2755,6 +2759,25 @@ internal static class NodeTypeCompilationHelpers
             var name = module.Assembly.GetName().Name;
             if (!string.IsNullOrEmpty(name))
                 map[name] = module.Assembly.ManifestModule.ModuleVersionId.ToString("N");
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Installed module simple name → its ORDERED build version (#3934), for the resolver's
+    /// <c>min:</c> floor ids. Modules carrying no version stamp are simply absent from the map and
+    /// resolve their MVID instead — an environment that cannot state a version has no floor to
+    /// offer, and inconclusive stays on the rebuild side.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> ModuleVersionsOf(IMessageHub hub)
+    {
+        var modules = hub.ServiceProvider.GetServices<InstalledModuleAssembly>();
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var module in modules)
+        {
+            var name = module.Assembly.GetName().Name;
+            if (!string.IsNullOrEmpty(name) && module.Version is { Length: > 0 } version)
+                map[name] = version;
         }
         return map;
     }

--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -515,16 +515,22 @@ public static class PrebuiltAssemblySeeder
         // PLATFORM surface matches; this proves the MODULE/toolchain bindings do too — the store
         // key cannot see either, so an unvalidated adopt would suppress a needed rebuild exactly
         // like a framework mismatch would.
+        // 🚨 #3934 — the DECLINE NAMES ITS OWN SHAPE. A module entry is a FLOOR, so "the record did
+        // not validate" now has three distinguishable causes with three different remedies, and a
+        // fixed sentence for all three is what left three investigations across three repos unable
+        // to tell an ordinary framework roll from a module drift (Doc/Architecture/DependencyRecordFloor).
+        // FloorNotMet says "land a newer module"; NotChecked says "nothing was established here",
+        // which is never a clean bill and is exactly as declining as a drift.
         if (dependencies is not null
-            && CompiledDependencies.FindMismatch(
+            && CompiledDependencies.Validate(
                 dependencies,
                 NodeTypeCompilationHelpers.DependencyIdResolverOf(hub),
-                NodeTypeCompilationHelpers.ProcessToolchainId) is { } dependencyMismatch)
+                NodeTypeCompilationHelpers.ProcessToolchainId) is { IsSatisfied: false } outcome)
         {
             logger?.LogInformation(
-                "Prebuilt assembly for {NodeTypePath} DECLINED: dependency record mismatch — "
+                "Prebuilt assembly for {NodeTypePath} DECLINED: dependency record {Status} — "
                 + "{Mismatch} — compiling instead",
-                nodeTypePath, dependencyMismatch);
+                nodeTypePath, outcome.Status, outcome.Problem);
             return Observable.Return(SeedOutcome.DeclinedDependencies);
         }
 

--- a/src/MeshWeaver.Compiler/CompiledDependencies.cs
+++ b/src/MeshWeaver.Compiler/CompiledDependencies.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Text;
+using MeshWeaver.Plugin.Packaging;
 
 namespace MeshWeaver.Compiler;
 
@@ -21,11 +22,24 @@ namespace MeshWeaver.Compiler;
 ///
 /// <para><b>Surface-id schemes:</b> a platform assembly resolves its REFERENCE-ASSEMBLY hash from
 /// the process's surface manifest (<c>ref:&lt;sha&gt;</c> — moves only on a breaking surface
-/// change, the same oracle the framework identity uses); an installed module resolves its
-/// implementation MVID (<c>mvid:&lt;id&gt;</c> — modules pin by exact build, matching the bundle
-/// lane's strict-MVID gate); a platform assembly with no manifest pair falls back to its
-/// loaded/on-disk MVID. The scheme prefix keeps the two from ever comparing equal by accident.
-/// The reserved <see cref="ToolchainKey"/> entry carries the toolchain's identity
+/// change, the same oracle the framework identity uses); an installed module resolves a
+/// <b>FLOOR</b> over its build version (<c>min:&lt;version&gt;</c> — "I need at least this",
+/// satisfied by anything at or above it, #3934), falling back to its implementation MVID
+/// (<c>mvid:&lt;id&gt;</c>) only when no version can be read; a platform assembly with no manifest
+/// pair falls back to its loaded/on-disk MVID. The scheme prefix keeps them from ever comparing
+/// equal by accident.</para>
+///
+/// <para>🚨 <b>Why a module is a FLOOR and a platform assembly is not.</b> Platform assemblies are
+/// compared by API SURFACE, so a rebuild with an unchanged API compares equal and adopts. Modules
+/// were compared by raw MVID — which moves on every compilation BY CONSTRUCTION, including a
+/// rebuild of identical source — so every NodeType binding a module was declined whenever the
+/// module was rebuilt anywhere. There is no incompatibility to protect against: MeshWeaver
+/// assemblies bind by a fleet-synchronised <c>AssemblyVersion</c>, so two builds of one module name
+/// are ONE assembly identity and <c>Assembly.LoadFrom</c> returns the already-loaded copy. The
+/// measured cost of the pin, and the outage it produced, are on
+/// <c>Doc/Architecture/DependencyRecordFloor</c>.</para>
+///
+/// <para>The reserved <see cref="ToolchainKey"/> entry carries the toolchain's identity
 /// (the <see cref="FrameworkBuildIdentity.FullMvidAssemblies"/> closure members' MVIDs): the
 /// emitted code never REFERENCES the toolchain, but its generated input was shaped by it, so a
 /// record cannot claim validity across a toolchain change.</para>
@@ -41,6 +55,30 @@ public static class CompiledDependencies
 
     /// <summary>Scheme prefix for an implementation MVID.</summary>
     public const string MvidScheme = "mvid:";
+
+    /// <summary>
+    /// 🚨 Scheme prefix for a module's VERSION FLOOR (#3934) — <c>min:&lt;version&gt;</c>, meaning
+    /// "the bytes were built against this module at version X, and any build at or above X will
+    /// serve them". The ONE relaxation this scheme expresses, stated so it cannot spread:
+    ///
+    /// <list type="bullet">
+    /// <item><description>It applies to MODULE entries only. A platform <c>ref:</c> surface, a
+    /// platform fallback <c>mvid:</c>, <see cref="AbsentId"/> and both reserved <c>!</c> keys are
+    /// compared by ORDINAL EQUALITY exactly as before — <see cref="Satisfies"/> is the only place
+    /// the floor is applied, and it refuses to compare across schemes.</description></item>
+    /// <item><description>It does NOT loosen the toolchain proxy (<see cref="ToolchainKey"/>) or
+    /// the direct content-key observation (<see cref="ContentKey"/>). A module rebuild no longer
+    /// moves a record's module entry, which is precisely why it also stops moving the content key
+    /// — see <see cref="LiveContentKeyOf"/>, which folds a SATISFIED entry at its recorded value.
+    /// The toolchain entry still decides every case the content key cannot answer.</description>
+    /// </item>
+    /// <item><description>It is not a claim about compatibility that anything AUTHORS. The floor
+    /// is the version of the module the producer actually compiled against — a measured fact, not
+    /// a hand-written <c>minMeshVersion</c> claim, which <c>Doc/Architecture/ModuleAdoptionPolicy</c>
+    /// rule R2 rightly refuses to let decide anything.</description></item>
+    /// </list>
+    /// </summary>
+    public const string MinVersionScheme = "min:";
 
     /// <summary>Recorded when a name is in scope but nothing resolves an id for it — absence is
     /// part of the record, never silently skipped (two environments with different presence sets
@@ -103,7 +141,7 @@ public static class CompiledDependencies
     /// </summary>
     /// <param name="referencedSimpleNames">The emitted assembly's AssemblyRef simple names
     /// (<c>Assembly.GetReferencedAssemblies()</c> on the compiled output).</param>
-    /// <param name="idOf">The surface-id resolver (see <see cref="CreateIdResolver"/>) —
+    /// <param name="idOf">The surface-id resolver (see <c>CreateIdResolver</c>) —
     /// null = out of scope (System/TPA), excluded from the record.</param>
     /// <param name="toolchainId">The producing process's toolchain id
     /// (<see cref="ComputeToolchainId"/>).</param>
@@ -146,12 +184,29 @@ public static class CompiledDependencies
     /// provably compatible.
     /// </summary>
     /// <param name="record">The stamped record.</param>
-    /// <param name="liveIdOf">The live surface-id resolver (<see cref="CreateIdResolver"/>).</param>
+    /// <param name="liveIdOf">The live surface-id resolver (<c>CreateIdResolver</c>).</param>
     /// <param name="liveToolchainId">The live toolchain id (<see cref="ComputeToolchainId"/>).</param>
     /// <param name="liveContentKey">The content key the caller computed by REGENERATING this
     /// type's compile input (<see cref="GeneratedInputIdentity"/>), or null when it did not — see
     /// <see cref="ContentKey"/>.</param>
     public static string? FindMismatch(
+        IReadOnlyDictionary<string, string> record,
+        Func<string, string?> liveIdOf,
+        string liveToolchainId,
+        string? liveContentKey = null)
+        => Validate(record, liveIdOf, liveToolchainId, liveContentKey).Problem;
+
+    /// <summary>
+    /// <see cref="FindMismatch"/> answering WHICH outcome (#3934) — drifted, below a recorded
+    /// floor, or not checked at all. <see cref="FindMismatch"/> is a projection of this
+    /// (<see cref="DependencyRecordOutcome.Problem"/>), so the two can never disagree.
+    /// </summary>
+    /// <param name="record">The stamped record.</param>
+    /// <param name="liveIdOf">The live surface-id resolver (<c>CreateIdResolver</c>).</param>
+    /// <param name="liveToolchainId">The live toolchain id (<see cref="ComputeToolchainId"/>).</param>
+    /// <param name="liveContentKey">The content key the caller computed by REGENERATING this
+    /// type's compile input, or null when it did not — see <see cref="ContentKey"/>.</param>
+    public static DependencyRecordOutcome Validate(
         IReadOnlyDictionary<string, string> record,
         Func<string, string?> liveIdOf,
         string liveToolchainId,
@@ -184,11 +239,27 @@ public static class CompiledDependencies
     /// rebuild side.</para>
     /// </summary>
     /// <param name="record">The stamped record.</param>
-    /// <param name="liveIdOf">The live surface-id resolver (<see cref="CreateIdResolver"/>).</param>
+    /// <param name="liveIdOf">The live surface-id resolver (<c>CreateIdResolver</c>).</param>
     /// <param name="liveToolchainId">The live toolchain id (<see cref="ComputeToolchainId"/>).</param>
     /// <param name="liveContentKey">The content key the caller computed by REGENERATING this
     /// type's compile input — <see cref="LiveContentKeyOf"/>. Null when it did not.</param>
     public static string? FindMismatchAfterReevaluation(
+        IReadOnlyDictionary<string, string> record,
+        Func<string, string?> liveIdOf,
+        string liveToolchainId,
+        string? liveContentKey)
+        => ValidateAfterReevaluation(record, liveIdOf, liveToolchainId, liveContentKey).Problem;
+
+    /// <summary>
+    /// <see cref="FindMismatchAfterReevaluation"/> answering WHICH outcome (#3934).
+    /// <see cref="FindMismatchAfterReevaluation"/> is a projection of this.
+    /// </summary>
+    /// <param name="record">The stamped record.</param>
+    /// <param name="liveIdOf">The live surface-id resolver (<c>CreateIdResolver</c>).</param>
+    /// <param name="liveToolchainId">The live toolchain id (<see cref="ComputeToolchainId"/>).</param>
+    /// <param name="liveContentKey">The content key the caller computed by REGENERATING this
+    /// type's compile input — <see cref="LiveContentKeyOf"/>. Null when it did not.</param>
+    public static DependencyRecordOutcome ValidateAfterReevaluation(
         IReadOnlyDictionary<string, string> record,
         Func<string, string?> liveIdOf,
         string liveToolchainId,
@@ -202,7 +273,7 @@ public static class CompiledDependencies
         return Compare(record, liveIdOf, liveToolchainId, liveContentKey, demoteToolchain: proven);
     }
 
-    private static string? Compare(
+    private static DependencyRecordOutcome Compare(
         IReadOnlyDictionary<string, string> record,
         Func<string, string?> liveIdOf,
         string liveToolchainId,
@@ -218,8 +289,10 @@ public static class CompiledDependencies
         // always carries it; anything else (an empty or hand-assembled record) declines and the
         // type compiles, the always-safe direction.
         if (!record.ContainsKey(ToolchainKey))
-            return $"the record carries no '{ToolchainKey}' entry, so it cannot invalidate on "
-                + "toolchain changes and is not trusted";
+            return DependencyRecordOutcome.NotChecked(
+                entry: null,
+                $"the record carries no '{ToolchainKey}' entry, so it cannot invalidate on "
+                + "toolchain changes and is not trusted");
 
         foreach (var (name, stamped) in record)
         {
@@ -247,10 +320,74 @@ public static class CompiledDependencies
             }
             else
                 live = liveIdOf(name) ?? AbsentId;
-            if (!string.Equals(stamped, live, StringComparison.Ordinal))
-                return $"'{name}' built against {stamped}, live is {live}";
+            if (Classify(name, stamped, live) is { } problem)
+                return problem;
         }
-        return null;
+        return DependencyRecordOutcome.Satisfied;
+    }
+
+    /// <summary>
+    /// 🚨 THE ONE COMPARISON (#3934): whether a live id SATISFIES a stamped one. Ordinal equality
+    /// everywhere, plus exactly one relaxation — two <see cref="MinVersionScheme"/> values compare
+    /// as SemVer with <see cref="NuGetVersionComparer"/>, and the live side satisfies the stamped
+    /// one when it is at or above it.
+    ///
+    /// <para>🚨 It refuses to compare ACROSS schemes, and that refusal is the safety property. A
+    /// recorded floor against an environment that can only report an MVID is not "satisfied by
+    /// default" and not "drifted" — it is UNCOMPARABLE, which <see cref="Classify"/> reports as
+    /// <see cref="DependencyRecordStatus.NotChecked"/> and every consumer treats as rebuild. The
+    /// comparer lives in <c>MeshWeaver.Plugin.Packaging</c> and is used verbatim rather than
+    /// re-implemented: two call sites computing the same version fold differently either never
+    /// converge or never fire, and both are silent (<c>check-module-platform-floor.py</c>).</para>
+    /// </summary>
+    /// <param name="stamped">The recorded id.</param>
+    /// <param name="live">The live id.</param>
+    public static bool Satisfies(string stamped, string live)
+    {
+        if (string.Equals(stamped, live, StringComparison.Ordinal))
+            return true;
+        if (!IsFloor(stamped) || !IsFloor(live))
+            return false;
+        return NuGetVersionComparer.Instance.Compare(VersionOf(live), VersionOf(stamped)) >= 0;
+    }
+
+    /// <summary>True for a <see cref="MinVersionScheme"/> id.</summary>
+    private static bool IsFloor(string id) =>
+        id.StartsWith(MinVersionScheme, StringComparison.Ordinal);
+
+    /// <summary>The version text of a <see cref="MinVersionScheme"/> id.</summary>
+    private static string VersionOf(string id) => id[MinVersionScheme.Length..];
+
+    /// <summary>
+    /// The per-entry verdict: null when the entry holds, else the outcome naming WHY it does not.
+    /// The three non-satisfied shapes are deliberately distinct — a floor that is genuinely below
+    /// is a different fact, with a different remedy, from a surface that moved and from an entry
+    /// nothing could compare.
+    /// </summary>
+    private static DependencyRecordOutcome? Classify(string name, string stamped, string live)
+    {
+        if (Satisfies(stamped, live))
+            return null;
+        if (IsFloor(stamped) && IsFloor(live))
+            // Compared, and genuinely below. The remedy names itself: land a newer module.
+            return DependencyRecordOutcome.FloorNotMet(name,
+                $"'{name}' needs at least {VersionOf(stamped)} — this environment has "
+                + $"{VersionOf(live)}, below the recorded floor");
+        if ((IsFloor(stamped) || IsFloor(live))
+            && !string.Equals(live, AbsentId, StringComparison.Ordinal)
+            && !string.Equals(stamped, AbsentId, StringComparison.Ordinal))
+            // 🚨 One side records a floor and the other cannot express one (a legacy record's
+            // exact-build pin, an environment that reads no version off the module, a module the
+            // platform now ships as a ref: surface). Nothing was established either way.
+            //
+            // 🚨 AbsentId is deliberately NOT in here. "The name is in scope and nothing resolves
+            // it" is a MEASURED fact about this environment — the build binds something that is
+            // not here — so it is a drift with a definite answer, not an inability to compare.
+            return DependencyRecordOutcome.NotChecked(name,
+                $"'{name}' recorded {stamped} and this environment reports {live} — the two cannot "
+                + "be compared, so nothing was checked and the build is not adopted");
+        // The pre-#3934 sentence, byte-for-byte: every exact-id entry still reports exactly this.
+        return DependencyRecordOutcome.Drifted(name, $"'{name}' built against {stamped}, live is {live}");
     }
 
     /// <summary>
@@ -272,7 +409,7 @@ public static class CompiledDependencies
     /// treat it as "rebuild", never as "match".</para>
     /// </summary>
     /// <param name="record">The stamped record.</param>
-    /// <param name="liveIdOf">The live surface-id resolver (<see cref="CreateIdResolver"/>).</param>
+    /// <param name="liveIdOf">The live surface-id resolver (<c>CreateIdResolver</c>).</param>
     /// <param name="liveGeneratedInputDigest">The stage-1 digest
     /// (<see cref="GeneratedInputIdentity.OfGeneratedInput"/>) of the compile input as REGENERATED
     /// now, or null when the caller did not regenerate.</param>
@@ -288,8 +425,20 @@ public static class CompiledDependencies
         return GeneratedInputIdentity.Combine(
             liveGeneratedInputDigest,
             record.Where(pair => !IsReservedKey(pair.Key))
-                .Select(pair => new KeyValuePair<string, string>(
-                    pair.Key, liveIdOf(pair.Key) ?? AbsentId)));
+                .Select(pair =>
+                {
+                    var live = liveIdOf(pair.Key) ?? AbsentId;
+                    // 🚨 FOLD A SATISFIED ENTRY AT ITS RECORDED VALUE (#3934). The key's assembly
+                    // half asks "does every entry the build binds still HOLD here" — and under
+                    // floor semantics holding is satisfaction, not identity. Folding the live
+                    // value verbatim would make a module rebuilt ABOVE the floor move the key, so
+                    // the toolchain demotion this key exists to license would be lost on exactly
+                    // the environments the floor was added for. It cannot widen anything: a
+                    // non-satisfying entry folds its LIVE value (so the key differs and nothing is
+                    // demoted), and Compare re-checks every entry independently afterwards.
+                    return new KeyValuePair<string, string>(
+                        pair.Key, Satisfies(pair.Value, live) ? pair.Value : live);
+                }));
     }
 
     /// <summary>
@@ -322,6 +471,23 @@ public static class CompiledDependencies
         key.StartsWith('!');
 
     /// <summary>
+    /// True for an id in the MODULE lane — <see cref="MinVersionScheme"/> (a floor) or
+    /// <see cref="MvidScheme"/> (the exact pin a version-less module still resolves). The ONE
+    /// predicate for "this entry names a module rather than a platform surface", so a reader that
+    /// enumerates a record's module entries cannot silently stop seeing half of them when a
+    /// producer starts stating versions (#3934).
+    ///
+    /// <para>🚨 <see cref="MvidScheme"/> is deliberately included even though it is ALSO the
+    /// platform fallback for a manifest-less assembly: that ambiguity predates the floor, every
+    /// reader already lived with it, and narrowing it here would change what those readers see for
+    /// a reason unrelated to this change.</para>
+    /// </summary>
+    /// <param name="id">A record entry's value.</param>
+    public static bool IsModuleLaneId(string id) =>
+        id.StartsWith(MinVersionScheme, StringComparison.Ordinal)
+        || id.StartsWith(MvidScheme, StringComparison.Ordinal);
+
+    /// <summary>
     /// The surface-id resolver over one environment: installed modules FIRST (exact-build MVID —
     /// a module name wins even when it starts with <c>MeshWeaver.</c>, because modules pin by
     /// build), then platform assemblies (<c>MeshWeaver.*</c>: manifest ref-asm hash, else
@@ -339,10 +505,40 @@ public static class CompiledDependencies
         IReadOnlyDictionary<string, string> surfaceByName,
         IReadOnlyDictionary<string, string> moduleMvidByName,
         Func<string, string?> implMvidOf)
+        => CreateIdResolver(surfaceByName, moduleMvidByName, implMvidOf, static _ => null);
+
+    /// <summary>
+    /// <see cref="CreateIdResolver(IReadOnlyDictionary{string, string}, IReadOnlyDictionary{string, string}, Func{string, string})"/>
+    /// with the module lane resolving a VERSION FLOOR (#3934) instead of an exact build.
+    ///
+    /// <para>A module name that <paramref name="moduleVersionOf"/> answers resolves
+    /// <c>min:&lt;version&gt;</c>; a module it cannot answer for falls back to
+    /// <c>mvid:&lt;id&gt;</c> — the pre-#3934 exact pin — because an environment that cannot state
+    /// a version has no floor to offer and INCONCLUSIVE must stay on the rebuild side. The
+    /// three-argument overload is exactly this one with a resolver that answers nothing, which is
+    /// the honest reading of a caller that has no version to give.</para>
+    ///
+    /// <para>🚨 Producer and consumer must resolve the version the SAME way, or a floor is
+    /// compared against a value nobody else computes — <c>InstalledModuleAssembly.Version</c> is
+    /// the one reader, and both the portal (<c>NodeTypeCompilationHelpers</c>) and the bake host
+    /// (<c>mw-plugin-test</c>) go through it.</para>
+    /// </summary>
+    /// <param name="surfaceByName">The process's surface-manifest pairs.</param>
+    /// <param name="moduleMvidByName">Installed module assembly simple name → MVID ("N").</param>
+    /// <param name="implMvidOf">Fallback MVID resolution for manifest-less platform assemblies.</param>
+    /// <param name="moduleVersionOf">Installed module assembly simple name → its build version
+    /// (<c>InstalledModuleAssembly.Version</c>), or null when none can be read.</param>
+    public static Func<string, string?> CreateIdResolver(
+        IReadOnlyDictionary<string, string> surfaceByName,
+        IReadOnlyDictionary<string, string> moduleMvidByName,
+        Func<string, string?> implMvidOf,
+        Func<string, string?> moduleVersionOf)
         => name =>
         {
             if (moduleMvidByName.TryGetValue(name, out var moduleMvid))
-                return MvidScheme + moduleMvid;
+                return moduleVersionOf(name) is { Length: > 0 } version
+                    ? MinVersionScheme + version
+                    : MvidScheme + moduleMvid;
             if (!name.StartsWith("MeshWeaver.", StringComparison.Ordinal))
                 return null;
             if (surfaceByName.TryGetValue(name, out var surface))

--- a/src/MeshWeaver.Compiler/ContentKeyReevaluation.cs
+++ b/src/MeshWeaver.Compiler/ContentKeyReevaluation.cs
@@ -70,7 +70,7 @@ public static class ContentKeyReevaluation
     /// <param name="record">The build's stamped dependency record
     /// (<c>NodeTypeDefinition.CompiledDependencies</c>), or null when none was stamped.</param>
     /// <param name="liveIdOf">The live surface-id resolver
-    /// (<see cref="CompiledDependencies.CreateIdResolver"/>), or null when this environment cannot
+    /// (<c>CompiledDependencies.CreateIdResolver</c>), or null when this environment cannot
     /// resolve one — which is itself inconclusive.</param>
     /// <param name="liveToolchainId">The live toolchain id
     /// (<see cref="CompiledDependencies.ComputeToolchainId"/>).</param>

--- a/src/MeshWeaver.Compiler/DependencyRecordOutcome.cs
+++ b/src/MeshWeaver.Compiler/DependencyRecordOutcome.cs
@@ -1,0 +1,111 @@
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// What comparing a stamped <see cref="CompiledDependencies"/> record against a live environment
+/// ESTABLISHED — the distinction a <c>string?</c> "first mismatch" cannot carry.
+///
+/// <para>🚨 <b>"Not null" is not evidence of drift.</b> Before #3934 every non-match produced one
+/// sentence and one action (rebuild), so "this environment has a DIFFERENT build of a module the
+/// type binds" and "this environment cannot compare that entry at all" were indistinguishable in
+/// the log, on the bake probe and on the status row. The measured cost is on
+/// <c>Doc/Architecture/DependencyRecordFloor</c>: <c>SocialMedia/Post</c> served nothing for a
+/// whole day while its NodeType read <c>compilationStatus: Ok</c>, and three investigations across
+/// three repos could not tell an ordinary framework roll from a module drift.</para>
+///
+/// <para>Modelled deliberately on
+/// <c>MeshWeaver.Mesh.Services.LanguageServer.NodeDiagnosticsOutcome</c> (#3912/#3916) rather than
+/// inventing a second way to say "I could not check": one status, one sentence, and the
+/// no-answer status can never read as the healthy one.</para>
+/// </summary>
+public enum DependencyRecordStatus
+{
+    /// <summary>
+    /// Every entry was compared and every entry holds — an exact id still resolves identically,
+    /// and every recorded FLOOR is met by this environment. The ONLY status that licenses adopting
+    /// the stamped build.
+    /// </summary>
+    Satisfied,
+
+    /// <summary>
+    /// An entry was compared and does NOT hold: an exact id (a platform <c>ref:</c> surface, the
+    /// reserved <c>!toolchain</c>/<c>!input</c> entries, a module pinned by build) resolves to
+    /// something else here, or the name resolves to nothing at all. The bytes bind something this
+    /// environment does not present.
+    /// </summary>
+    Drifted,
+
+    /// <summary>
+    /// A module entry recorded a FLOOR and this environment is BELOW it (#3934). Distinct from
+    /// <see cref="Drifted"/> because the remedy is different and namable: the deployment is
+    /// carrying an OLDER module than the build requires, so land a newer one — nothing about the
+    /// platform surface moved.
+    /// </summary>
+    FloorNotMet,
+
+    /// <summary>
+    /// 🚨 NOTHING WAS CHECKED, and this is never evidence of health. Either the record is not
+    /// trustworthy at all (no reserved <c>!toolchain</c> entry, so it could never invalidate), or a
+    /// stamped entry and its live counterpart are expressed in schemes that cannot be compared —
+    /// a recorded floor against an environment that can only report an MVID, or a legacy
+    /// exact-build pin against an environment that reports a version. Every such case takes the
+    /// REBUILD side, exactly as an inconclusive content key does: a false mismatch costs one
+    /// rebuild, a false match serves stale bytes.
+    /// </summary>
+    NotChecked,
+}
+
+/// <summary>
+/// The outcome of validating a stamped dependency record against one live environment:
+/// <see cref="Status"/>, the entry that decided it, and the one-line sentence every log, decline
+/// reason and status row prints.
+///
+/// <para><see cref="CompiledDependencies.FindMismatch"/> and
+/// <see cref="CompiledDependencies.FindMismatchAfterReevaluation"/> are DERIVED from this — they
+/// return <see cref="Problem"/> — so the string form and the status form can never disagree about
+/// what a given record produces. Same idiom as <c>CheckSpeculative</c> over
+/// <c>CheckSpeculativeOutcome</c> (#3888).</para>
+/// </summary>
+public sealed record DependencyRecordOutcome
+{
+    /// <summary>What the comparison established.</summary>
+    public required DependencyRecordStatus Status { get; init; }
+
+    /// <summary>The record key that decided the outcome — an assembly simple name, or one of the
+    /// reserved <c>!</c> keys. Null for <see cref="DependencyRecordStatus.Satisfied"/> and for the
+    /// untrusted-record case, which is a property of the record rather than of one entry.</summary>
+    public string? Entry { get; init; }
+
+    /// <summary>The one-line description, for logs and decline reasons. 🚨 Null EXACTLY when
+    /// <see cref="Status"/> is <see cref="DependencyRecordStatus.Satisfied"/> — which is what lets
+    /// the legacy string API be a projection of this record rather than a second
+    /// implementation.</summary>
+    public string? Problem { get; init; }
+
+    /// <summary>True only for <see cref="DependencyRecordStatus.Satisfied"/>. 🚨 False for every
+    /// other status INCLUDING <see cref="DependencyRecordStatus.NotChecked"/>, so a caller that
+    /// reads only this flag still cannot mistake "no answer" for "compatible".</summary>
+    public bool IsSatisfied => Status == DependencyRecordStatus.Satisfied;
+
+    /// <summary>The satisfied outcome — the singleton, since it carries nothing (a constant, not a
+    /// cache).</summary>
+    public static DependencyRecordOutcome Satisfied { get; } =
+        new() { Status = DependencyRecordStatus.Satisfied };
+
+    /// <summary>An entry was compared and does not hold.</summary>
+    /// <param name="entry">The record key.</param>
+    /// <param name="problem">The sentence naming both sides.</param>
+    public static DependencyRecordOutcome Drifted(string entry, string problem) =>
+        new() { Status = DependencyRecordStatus.Drifted, Entry = entry, Problem = problem };
+
+    /// <summary>A recorded floor is not met here.</summary>
+    /// <param name="entry">The module's assembly simple name.</param>
+    /// <param name="problem">The sentence naming the floor and what this environment has.</param>
+    public static DependencyRecordOutcome FloorNotMet(string entry, string problem) =>
+        new() { Status = DependencyRecordStatus.FloorNotMet, Entry = entry, Problem = problem };
+
+    /// <summary>Nothing was checked — never a clean bill.</summary>
+    /// <param name="entry">The record key, or null when the whole record is untrusted.</param>
+    /// <param name="problem">The sentence saying what could not be compared.</param>
+    public static DependencyRecordOutcome NotChecked(string? entry, string problem) =>
+        new() { Status = DependencyRecordStatus.NotChecked, Entry = entry, Problem = problem };
+}

--- a/src/MeshWeaver.Compiler/MeshWeaver.Compiler.csproj
+++ b/src/MeshWeaver.Compiler/MeshWeaver.Compiler.csproj
@@ -46,6 +46,15 @@
   <ItemGroup>
     <ProjectReference Include="..\MeshWeaver.ContentCollections\MeshWeaver.ContentCollections.csproj" />
     <ProjectReference Include="..\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
+    <!-- 🚨 #3934 — NuGetVersionComparer, the ONE version fold in the repo. A module entry of a
+         dependency record is a FLOOR (min:<version>), so the toolchain has to ORDER versions, and
+         re-implementing that ordering here is the failure check-module-platform-floor.py's own
+         header warns about ("two call sites computing the same fold differently either never
+         converge or never fire, and both are silent"). MeshWeaver.Plugin.Packaging is a leaf with
+         no project references of its own, so this closes no cycle; the consequence — it joins
+         FrameworkBuildIdentity.FullMvidAssemblies, so a body change to the comparer rebakes
+         content — is CORRECT, because the comparer now decides which builds are adopted. -->
+    <ProjectReference Include="..\MeshWeaver.Plugin.Packaging\MeshWeaver.Plugin.Packaging.csproj" />
     <ProjectReference Include="..\MeshWeaver.NuGet\MeshWeaver.NuGet.csproj" />
   </ItemGroup>
 

--- a/src/MeshWeaver.Compiler/NodeSetCompiler.cs
+++ b/src/MeshWeaver.Compiler/NodeSetCompiler.cs
@@ -207,7 +207,7 @@ public static class NodeSetCompiler
     /// <param name="references">The metadata references to compile against —
     /// <see cref="CompileReferences.Default"/> composed with the deployment's installed modules.</param>
     /// <param name="dependencyIdOf">The surface-id resolver for the dependency record
-    /// (<see cref="CompiledDependencies.CreateIdResolver"/> over the PRODUCING environment).</param>
+    /// (<c>CompiledDependencies.CreateIdResolver</c> over the PRODUCING environment).</param>
     /// <param name="toolchainId">This process's toolchain id
     /// (<see cref="CompiledDependencies.ComputeToolchainId"/>).</param>
     /// <param name="outputDirectory">Directory the DLL/PDB are written into. Created if absent.</param>

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -233,6 +233,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Emit Reference Capture](EmitReferenceCapture) — bounded, opt-in CI evidence for runtime compiler failures
 - [Graph / Compiler Layering](GraphCompilerLayering) — the four assemblies, the cycle, and the full-MVID size rule
 - [Toolchain Re-evaluation Lane](ToolchainReevaluationLane) — why a toolchain change stopped rebaking the world
+- [The Dependency Record Floor](DependencyRecordFloor) — a record's module entry says "I need at least X", not "I need exactly this build"; the MVID pin that could not converge because Roslyn hashes absolute source paths, the two-replica recompile ping-pong it produced, and the four things the floor deliberately does not relax
 - [Producer Determinism of the Dependency Record](ProducerDeterminismOfTheDependencyRecord) — the same content must stamp the same record however the producer reached its bytes; the disk-cache hit that shipped a weaker guard, and why the digest is persisted beside the bytes rather than recomputed
 - [Rebake Waves](RebakeWaves) — why a roll rebakes the world anyway, and what one rebake writes
 - [Source-Set Establishment](SourceSetEstablishment) — a resolved source set of ZERO is ambiguous, and only the type's own persisted snapshot tells "owns no Code" from "the discovery pass came back short"; the boot that resolved 91 fewer Code nodes than its neighbours and held a portal out of rotation for the startup probe's full three hours

--- a/src/MeshWeaver.Documentation/Data/Architecture/DependencyRecordFloor.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DependencyRecordFloor.md
@@ -1,0 +1,201 @@
+---
+Name: The Dependency Record Floor
+Category: Architecture
+Description: A compiled NodeType's dependency record states a FLOOR over each module it binds — "I need at least X" — not the module's MVID. The decision (#3934), why an MVID pin could never converge, what the floor deliberately does not relax, and the outage that measured it.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18"/><path d="M6 21V9l6-5 6 5v12"/><path d="M3 13h18"/></svg>
+---
+
+# The Dependency Record Floor
+
+**Platform owner's decision, 2026-09-10 ([#3934](https://github.com/Systemorph/MeshWeaver/issues/3934)),
+in four clauses:**
+
+1. **There is no incompatibility.** Two builds of one module assembly link fine — `AssemblyVersion`
+   is synchronised fleet-wide, so `Assembly.LoadFrom` returns the already-loaded copy and ignores
+   the second path. Nothing throws.
+2. **It is a floor, not a pin.** A record says *"I need at least X"* and accepts anything at or
+   above.
+3. **It must never recompile.** A moved MVID is not a reason to rebuild a NodeType at runtime.
+4. **It must not crash.** If a floor genuinely is not met, that must be visible — never a silent
+   fallback that drops the type's views.
+
+This page is the authority on how a module entry of a
+[dependency record](../NodeTypeCompilation) is written and compared. Where another page describes a
+module entry as an exact build, it is describing the mechanism this replaced.
+
+## What the record carried before, and why it could not converge
+
+`CompiledDependencies.CreateIdResolver` resolved each referenced assembly to a *surface id*:
+
+| lane | id | compared |
+|---|---|---|
+| platform assembly | `ref:<surface-hash>` | exactly — but the hash moves only on a **surface** change, so a rebuild with an unchanged API adopts |
+| installed module | `mvid:<guid>` | exactly — and the MVID moves on **every compilation**, by construction |
+
+That asymmetry is the whole defect. A platform rebuild of identical source compares equal; a
+*module* rebuild of identical source compares unequal, and every NodeType binding that module is
+declined at adoption.
+
+**It is not fixable by making the producers agree.** Roslyn's deterministic MVID also hashes the
+**absolute source paths**, and neither core nor MeshWeaver.Plugins sets `DeterministicSourcePaths`,
+`PathMap` or `ContinuousIntegrationBuild`. Measured 2026-09-10: the same commit, the same
+properties, and the same emitted `InformationalVersion`, compiled at `$GITHUB_WORKSPACE` and at
+`/repo` inside the image, produced `dace9bf7-…` and `202e6e4f-…`. So byte-equality is a property of
+the *lane*, not of the source — see
+[Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide), which now records that its earlier
+"agreement is cheaper than exclusivity" remedy treats the symptom.
+
+### The outage it produced
+
+Measured on `memex.meshweaver.cloud`, 2026-09-10. One pod held
+`MeshWeaver.Markdown.Collaboration` in 15 copies and **three builds** — the three independent
+compilations a MeshWeaver.Plugins publication is composed from. The bake host loaded whichever copy
+arrived first and stamped *that* MVID into every record; the pods loaded a different one.
+
+* `PrebuiltAssemblySeeder` declined 22 of 272 entries at that identity, across 3 module names, on
+  **one** entry each: `mvid:798f92a0…` recorded, `mvid:825581836a…` live, with all eight `ref:`
+  surfaces and `!toolchain` agreeing. For the `socialmedia` bundle it was **all six** declines.
+* A declined bundle means the content compiles **in-portal**, which sets
+  `latestAssemblyCollection: "local"` — documented by `FileSystemAssemblyStore` as *"the bytes live
+  in the local filesystem cache only; cross-silo readers must recompile"*. memex runs 2 replicas, so
+  the type was dark on whichever pod lacked the bytes.
+* Each replica then declined the other's stamp, recompiled, and stamped its own —
+  `v2031 → v2050 → v2053`, two `compiledModulesHash` values alternating with
+  `currentSourceFingerprint` constant, two forced re-activations recompiling **2 seconds apart**
+  with identical inputs.
+* Net effect: `/Posts/SavThankYou` returned **HTTP 200 rendering nothing**. Every view
+  `SocialMedia/Post` declares — `Preview`, `Write`, `PostCard` — was absent for the whole day, while
+  the NodeType's own record read `compilationStatus: Ok` throughout. An instance `recycle` was
+  measured not to fix it.
+
+## The floor
+
+A module now resolves **`min:<version>`**, where the version is the module assembly's
+`AssemblyInformationalVersion` with the `+<sha>` build metadata stripped —
+`InstalledModuleAssembly.Version`, the one reader, which both the portal's resolver
+(`NodeTypeCompilationHelpers.DependencyIdResolverOf`) and the bake host's (`mw-plugin-test`'s
+`BakeHost`) go through so a floor is never compared against a value nobody else computes.
+
+**A live id satisfies a stamped one when it is at or above it**, ordered by
+`NuGetVersionComparer` — the repo's one SemVer fold, used verbatim rather than re-implemented
+(`MeshWeaver.Compiler` now references `MeshWeaver.Plugin.Packaging` for it). String order is wrong
+here in a way that silently picks an old build: as text `3.0.0-ci.900` sorts above
+`3.0.0-ci.3758`.
+
+```text
+recorded          live              verdict
+min:3.0.0         min:3.0.0         Satisfied      ← the SavThankYou case: same version, moved MVID
+min:3.0.0-ci.900  min:3.0.0-ci.3758 Satisfied      ← numeric, not textual
+min:1.6.0         min:1.5.0         FloorNotMet    ← below; land a newer module
+min:3.0.0         mvid:798f92a0…    NotChecked     ← incomparable; declines
+mvid:798f92a0…    min:3.0.0         NotChecked     ← a legacy record, once; declines
+min:3.0.0         absent            Drifted        ← the module is not here at all
+```
+
+**A module that states no version keeps the exact `mvid:` pin.** An environment that cannot read a
+version has no floor to offer, and inconclusive stays on the rebuild side — the same rule the
+content key follows. The three-argument `CreateIdResolver` overload is exactly the four-argument one
+with a version resolver that answers nothing.
+
+### Where the version comes from, and what that makes the floor mean today
+
+Core's `Directory.Build.props` pins `InformationalVersion` to `$(PlatformVersion)` under `CIRun`
+(plus the SDK's `+<SourceRevisionId>`), and MeshWeaver.Plugins carries the same pin
+(Plugins#1604 — `$(AssemblyVersion)`, or the platform's version string where it is readable). So a
+module built anywhere in one platform line carries **one** ordered value, e.g. `3.0.0`, whichever
+lane compiled it. `NuGetVersionComparer` treats `3.0.0.0` and `3.0.0` as equal, so the two shapes
+the Plugins props can emit agree.
+
+That is exactly what clause 1 asks for: every build of a line satisfies every record of that line,
+and the floor still orders across lines and across a module that versions independently of the
+platform.
+
+## What the floor deliberately does NOT relax
+
+The relaxation lives in exactly one function, `CompiledDependencies.Satisfies`, and it **refuses to
+compare across schemes**. Everything below is ordinal equality, exactly as before:
+
+* **`!toolchain`** — the toolchain PROXY ("the toolchain moved, so the bytes MIGHT be stale") still
+  invalidates every record on a toolchain change. A module floor met with room to spare licenses
+  nothing about it.
+* **`!input`** — the direct observation ("the input that produced these bytes hashed to X") is
+  still exact. A regenerated input that hashes differently is not excusable by any version.
+* **`ref:` platform surfaces** — still exact, and a `min:` never compares to a `ref:`. That
+  refusal is what keeps [#3175](../ModuleBuildArchitecture)'s one-producer rule intact: a module the
+  platform host *also* ships resolves `ref:` on a portal and `min:` in the bake, which now reports
+  *NotChecked* rather than quietly matching.
+* **`absent`** — a build that binds something this environment does not have is a drift with a
+  definite answer, and stays one.
+
+**The demotion the content key licenses survives the floor.** `LiveContentKeyOf` folds a
+**satisfied** entry at its *recorded* value rather than its live one — the key's assembly half asks
+"does every entry still hold", and under floor semantics holding is satisfaction. Folding the live
+value would make a module rebuilt *above* the floor move the key, reintroducing the same
+invalidation one layer down. It cannot widen anything: a non-satisfying entry folds its live value,
+so the key differs and nothing is demoted, and the comparison re-checks every entry independently
+afterwards. See [The Toolchain Re-evaluation Lane](../ToolchainReevaluationLane).
+
+## Clause 4: an unmet floor is visible, and never a silent default
+
+Two changes, both about a verdict that could not previously be read.
+
+**The comparison answers WHICH outcome.** `CompiledDependencies.Validate` returns a
+`DependencyRecordOutcome` — `Satisfied` / `Drifted` / `FloorNotMet` / `NotChecked` — modelled on
+`NodeDiagnosticsOutcome` ([Language Services](../LanguageServices), #3912/#3916) rather than
+inventing a second way to say *"I could not check"*. `FindMismatch` is a **projection** of it
+(`outcome.Problem`), so the string form and the status form cannot disagree. `IsSatisfied` is false
+for `NotChecked` too, so a caller reading only the flag still cannot mistake "no answer" for
+"compatible". Every reader — the prebuilt seeder's decline, `HasUsableBuild`, its stale twin, the
+bake probe's `ClassifyDetailed`, the stale-build kickoff — goes through that one comparison, so the
+floor is honoured and named everywhere or nowhere.
+
+**A recorded build whose bytes this process cannot resolve now overlays a diagnosis.** That branch
+used to bind the **default configuration**: the instance activated, served the generic areas, and
+every area the type declares was simply missing — which is precisely what a reader saw at
+`/Posts/SavThankYou`, with nothing on the page, in the node, or in a recycle to name the cause. It
+now takes the same `AssemblyUnavailable` overlay the pinned-release branch beside it already used,
+with the same version-gated self-heal, and keeps the fail-fast contract: the overlay sets an
+`UnhandledMessageNack`, so a typed request the missing assembly would have handled gets a terminal
+`DeliveryFailure` naming the NodeType instead of being silently ignored.
+
+## Controls
+
+`DependencyRecordFloorTest` runs both directions, because a test that only proves the new
+acceptance would also pass for "adopt everything":
+
+* the falsification arm — the old `mvid:` pin **declined** the moved-build case, asserted verbatim,
+  so the acceptance test says something about what changed;
+* a record **below** its floor still declines, with the exact sentence
+  `'X' needs at least 1.6.0 — this environment has 1.5.0, below the recorded floor`;
+* `!toolchain`, `!input`, `ref:` and `absent` each have their own arm proving they did not move;
+* `LiveContentKeyOf` reproduces the stamped key when a module moved **above** its floor and does not
+  when it moved **below** it;
+* every adopt-time reader (`HasUsableBuild`, `HasStaleFrameworkBuild`, `Classify`,
+  `ClassifyDetailed`) is exercised on both sides of one floor.
+
+## What this does not close
+
+**The producer still composes a publication from more than one compilation.** The floor makes a
+consumer stop caring, which is the point — but the sealed-set assertions
+([Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide) → "The producer asserts it") still refuse a
+set carrying one assembly name at two builds, and should: a torn publication is a real defect even
+when nothing declines it downstream. Merging MeshWeaver.Plugins' `floor` and `rest` `module-pack`
+calls into one workspace remains the remedy at source.
+
+**The registry does not yet answer "the latest version compatible with this platform".** The
+resolution model recorded on #3934 inverts today's direction — a consumer asks and the registry
+supplies, rather than a producer stamping an identity a consumer must match. That is an
+architectural change to how every instance obtains modules and is not implemented here; the floor is
+the consumer half that stops a divergent producer from being fatal in the meantime.
+
+**A version string still decides nothing about whether a module LOADS.**
+[Module Adoption Policy](../ModuleAdoptionPolicy) rule R2 is unchanged: loadability is measured by
+the link probe and the load, never declared. The floor is not a `minMeshVersion`-style claim an
+author writes — it is the version of the module the producer actually compiled against, recorded
+automatically, and it governs only whether a *prebuilt NodeType assembly* is reused.
+
+See also: [Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide) ·
+[Module Adoption Policy](../ModuleAdoptionPolicy) ·
+[NodeType Compilation](../NodeTypeCompilation) ·
+[The Toolchain Re-evaluation Lane](../ToolchainReevaluationLane) ·
+[Controls That Cannot Fail](../ControlsThatCannotFail)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleAdoptionPolicy.md
@@ -155,7 +155,7 @@ All four steps are implemented: 1 is [#3661](https://github.com/Systemorph/MeshW
 
 ## What stays exactly as it is
 
-- The **content bake identity rule**: a NodeType assembly adopts only for the identity it was baked against. Wrong bytes are worse than no bytes.
+- The **content bake identity rule**: a NodeType assembly adopts only for the identity it was baked against. Wrong bytes are worse than no bytes. 🚨 The per-type DEPENDENCY RECORD beneath it changed on 2026-09-10 and this rule did not: a module entry is now a FLOOR over the module's version rather than its MVID, so a module REBUILD stops declining a bundle while a genuinely older module still does — [The Dependency Record Floor](../DependencyRecordFloor). That is the same instinct as R2 one layer down (a different build is not evidence of incompatibility), and it relaxes nothing about the framework identity, the toolchain entry or the content key.
 - The **seal**: a publication is real when `_complete` is written last and every listed file exists; a torn publication is refused whole (#3461, #3401).
 - **Never roll back unattended**: an older served version is never adopted over a newer landed one (`SkipOlder`).
 - **Never swap a module in a running process**: a new generation loads at the next restart; the policy makes that restart happen (step 3), it does not make the swap live.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -94,6 +94,15 @@ conflict is unfixable by agreement — one producer must go.
 Module-vs-module is `mvid:` on **both** sides. Identical bytes compare **equal**. The conflict is
 fixable by agreement, and agreement is cheaper than exclusivity.
 
+🚨 **That last sentence was the wrong remedy, and #3934 replaced it.** "Agreement" here means every
+producer of every copy emitting byte-identical output *forever*, and the section below measures why
+that is unsatisfiable: Roslyn's deterministic MVID hashes the absolute source paths, so two lanes
+compiling one file at two paths fork the MVID with identical properties. The CONSUMER half is the
+fix — a module entry of a dependency record is now a **floor** (`min:<version>`), so a moved build
+is not a mismatch at all. See [The Dependency Record Floor](../DependencyRecordFloor); everything
+below about *why the copies diverge*, and the producer-side refusals, stands unchanged and is still
+the right verdict for a torn publication.
+
 ## The invariant that replaces it
 
 > **One assembly name, one framework identity, one build — across every copy in the sealed set,
@@ -270,6 +279,7 @@ and still disagree with each other. See
 two ways to close it (the seal composes the registry's bytes, or the instance adopts module bytes
 for its identity from the sealed publication).
 
-See also: [Module Closure Accounting](../ModuleClosureAccounting) ·
+See also: [The Dependency Record Floor](../DependencyRecordFloor) ·
+[Module Closure Accounting](../ModuleClosureAccounting) ·
 [Module Build Architecture](../ModuleBuildArchitecture) ·
 [Candidate Release Protocol](../CandidateReleaseProtocol) · [Release Gates](../ReleaseGates)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-rebuilt-module-no-longer-makes-a-pages-views-disappear.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-rebuilt-module-no-longer-makes-a-pages-views-disappear.md
@@ -1,0 +1,61 @@
+---
+Name: A rebuilt module no longer makes a page's views disappear
+Category: Fix
+Description: A page could return successfully and render nothing — every view its type declares simply absent — because a module it uses had been rebuilt. The rebuild is no longer treated as an incompatibility, and a page that genuinely cannot load its code now says so instead of coming up empty.
+Icon: Checkmark
+Order: -20260910
+---
+
+# A rebuilt module no longer makes a page's views disappear
+
+Some pages came up **blank**. Not an error page and not a slow one: the page loaded, reported
+success, and every view its type defines — the preview, the editor, the card — was simply *not
+there*. Anything generic still rendered, so the page looked like it worked and had nothing on it.
+
+Nothing was broken in the content. The type reported itself as **compiled and healthy** the entire
+time. A restart did not help, and neither did opening it again on another day.
+
+The cause was upstream and invisible from the page: a shared building block had been **compiled more
+than once**. Compiling the very same code twice produces two builds that are, byte for byte,
+different — that is simply how compilation works — and the platform was treating "a different build"
+as "a different, possibly incompatible thing". So a page's compiled views were refused, rebuilt
+locally on whichever server happened to serve you, and then refused again by the other server. The
+two never agreed, and while they disagreed the views were nowhere.
+
+On a portal running two servers this could persist for a full day.
+
+## What changes
+
+**A rebuild is no longer treated as an incompatibility.** A page's compiled views now record *"I
+need this building block at version X or newer"* rather than *"I need this exact build of it"*. Two
+builds of one building block work together — they always did — so the views are simply used, and the
+tug-of-war has nothing left to be about.
+
+**Nothing gets rebuilt at page-open time for this reason any more.** That rebuilding was the whole
+mechanism behind the blank page, and it is gone.
+
+**A version that really is too old still refuses, and says which one.** The check did not become
+"accept anything": if your installation genuinely carries an older building block than a page's
+views were built for, the views are refused exactly as before, and the reason now names the block
+and both versions instead of a single generic sentence.
+
+**A page that cannot load its code shows a diagnosis instead of coming up empty.** Where the
+platform knows a page has compiled views but cannot find them on the server answering you, it now
+renders the same *"this could not be loaded"* card the rest of the platform uses, with the reason —
+and it repairs itself and reloads the page as soon as the views become available. Previously it
+silently fell back to a bare page, which is what made this look like "the feature was never there"
+rather than "something went wrong".
+
+## What this does not change
+
+**Nothing else about how a page's code is validated has loosened.** A page's views are still refused
+when the platform itself has moved underneath them, when their source has changed, or when they
+reference something this installation does not have at all. Only the "which build of the module"
+question — the one where both answers were always fine — stopped refusing.
+
+**Installing and updating modules works exactly as it did.** Whether a module *loads* is still
+decided by measuring it against the running platform, never by comparing version strings.
+
+**"I could not check" is never read as "this is fine".** Where the two sides cannot be compared at
+all, the views are refused and the page's code is rebuilt — the safe direction — rather than being
+accepted on the assumption that silence means agreement.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1281,41 +1281,48 @@ internal static class NodeTypeEnrichmentHelpers
                         if (recompileAttempts >= MaxRecompileAttempts)
                         {
                             logger?.LogWarning(
-                                "EnrichWithNodeType: latest assembly for {NodeType} still not found in store after {Attempts} recompile attempt(s) (collection={Coll}, version={Version}) — falling back to default config",
+                                "EnrichWithNodeType: latest assembly for {NodeType} still not found in store after {Attempts} recompile attempt(s) (collection={Coll}, version={Version}) — overlaying the assembly-unavailable diagnosis",
                                 nodeType, recompileAttempts, def.LatestAssemblyCollection, compileVersion);
-                            // 🚨 The SECOND sticky class (memex two-pod evidence,
-                            // 2026-07-26): this silent default-config fallback is
-                            // cached for the grain's lifetime exactly like the
-                            // error overlay — an instance on a pod whose local
-                            // store lacks the type's bytes serves only generic
-                            // areas until a manual recycle (and each recycle
-                            // re-rolls placement). Attach the same self-heal
-                            // watcher. The version gate is MANDATORY here, not
-                            // optional: HasUsableBuild is already TRUE in this
-                            // state (only the byte resolution missed), so an
-                            // ungated watcher would fire on the replayed current
-                            // state and hot-loop the recycle. Gated, the instance
-                            // self-recycles once per NodeType write — when the
-                            // compile eventually lands on this pod, re-enrichment
-                            // resolves the bytes and heals.
+                            // 🚨 #3934 CLAUSE 4 — A DIAGNOSIS, NEVER A SILENT DEFAULT.
+                            // This branch used to bind the DEFAULT configuration here: the
+                            // instance activated, served the generic areas, and every area the
+                            // type declares was simply absent. Measured on memex 2026-09-10,
+                            // that is what a reader saw at /Posts/SavThankYou — an HTTP 200
+                            // rendering "Area not found" for Preview, Write and PostCard, while
+                            // the NodeType's own record read compilationStatus: Ok. There is
+                            // nothing in that page, in the node, or in a recycle that names the
+                            // cause, which is why it cost a day.
                             //
-                            // Only wrap when a hub configuration will actually be
-                            // composed (the node's own, or the mesh default the
-                            // factory adds underneath). With NEITHER, the null
-                            // HubConfiguration must survive: routing/grain key
-                            // the fail-fast NACK-fallback hub on it, and that
-                            // hub's DeactivateOnIdle already retries on next
-                            // access — wrapping would swap fail-fast for a bare
-                            // hub that Ignores typed requests (the park class).
-                            var fallback = ApplyEntry(
-                                node, localAssemblyPath: null, hubConfig: null,
-                                nodeType, meshConfiguration);
+                            // The state is EXACTLY the one the pinned-release branch above
+                            // already overlays — a build is recorded, and this process cannot
+                            // resolve its bytes — so it takes the same OverlayCause and the same
+                            // self-heal. It also keeps the fail-fast contract the old comment
+                            // was protecting: WithCompilationErrorOverlay Sets an
+                            // UnhandledMessageNack, so a typed request the missing assembly
+                            // would have handled gets a terminal DeliveryFailure naming this
+                            // NodeType instead of parking — strictly better than the bare
+                            // default config, which Ignores it.
+                            //
+                            // The version gate on the self-heal stays MANDATORY: HasUsableBuild
+                            // is already TRUE in this state (only the byte resolution missed),
+                            // so an ungated watcher would fire on the replayed current state and
+                            // hot-loop the recycle. Gated, the instance self-recycles once per
+                            // NodeType write — when the compile eventually lands on this pod,
+                            // re-enrichment resolves the bytes and heals.
+                            var (storeMissIntro, storeMissCta, storeMissGuidance) =
+                                OverlayCopy(OverlayCause.AssemblyUnavailable);
                             return Observable.Return(
-                                fallback.HubConfiguration is null
-                                && meshConfiguration.DefaultNodeHubConfiguration is null
-                                    ? fallback
-                                    : WithOverlaySelfHeal(
-                                        fallback, meshHub, nodeType, typeNode.Version, logger));
+                                WithOverlaySelfHeal(
+                                    WithCompilationErrorOverlay(node, nodeType,
+                                        $"The compiled assembly for '{nodeType}' is recorded "
+                                        + $"(collection={def.LatestAssemblyCollection}, "
+                                        + $"version={compileVersion}) but could not be resolved in "
+                                        + "this process's assembly store.",
+                                        guidance: storeMissGuidance,
+                                        intro: storeMissIntro,
+                                        callToAction: storeMissCta,
+                                        activityPath: def.LastCompilationActivityPath),
+                                    meshHub, nodeType, typeNode.Version, logger));
                         }
                         return TriggerRecompileAndRetry(
                             node, nodeType, meshConfiguration, compilationService, meshHub,

--- a/src/MeshWeaver.Mesh.Contract/InstalledModuleAssembly.cs
+++ b/src/MeshWeaver.Mesh.Contract/InstalledModuleAssembly.cs
@@ -20,4 +20,38 @@ public sealed record InstalledModuleAssembly(Assembly Assembly)
 {
     /// <summary>The assembly's MVID — the per-build identity the bake fingerprint hashes.</summary>
     public Guid Mvid => Assembly.ManifestModule.ModuleVersionId;
+
+    /// <summary>
+    /// 🚨 THE ONE READER of a module build's ORDERED version (#3934): its
+    /// <see cref="AssemblyInformationalVersionAttribute"/> with the <c>+gitSha</c> build metadata
+    /// stripped, or null when the assembly carries no stamp.
+    ///
+    /// <para><b>What it is for.</b> A compiled NodeType's dependency record states a FLOOR over
+    /// this value — <c>min:&lt;version&gt;</c> — instead of the module's MVID, which moves on
+    /// every compilation by construction and therefore declined every prebuilt bundle whenever a
+    /// module was rebuilt anywhere (<c>Doc/Architecture/DependencyRecordFloor</c>). Producer and
+    /// consumer must derive it identically or a floor is compared against a value nobody else
+    /// computes, so both the portal's resolver and the bake host's go through this property.</para>
+    ///
+    /// <para>🚨 <b>Null is not a version, and never reads as one.</b> An unstamped module resolves
+    /// its MVID instead, i.e. the pre-#3934 exact pin — inconclusive stays on the rebuild side.
+    /// The metadata is stripped for the same reason <c>ModulePlatformFloor.RunningVersion</c>
+    /// strips it: SemVer ignores it for ordering, and dropping it keeps a decline sentence
+    /// readable.</para>
+    /// </summary>
+    public string? Version => VersionOf(Assembly);
+
+    /// <summary>The pure half, so a producer holding a bare <see cref="Assembly"/> resolves the
+    /// identical value.</summary>
+    /// <param name="assembly">The module assembly.</param>
+    public static string? VersionOf(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        var version = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+        var plus = version.IndexOf('+');
+        return plus < 0 ? version : version[..plus];
+    }
 }

--- a/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
+++ b/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
@@ -371,8 +371,13 @@ public static class ReleaseAvailability
         {
             foreach (var (name, id) in record.Dependencies.OrderBy(d => d.Key, StringComparer.Ordinal))
             {
-                if (name.StartsWith('!')
-                    || !id.StartsWith(CompiledDependencies.MvidScheme, StringComparison.Ordinal))
+                // 🚨 THE MODULE LANE, not one spelling of it (#3934). A module entry is now a
+                // FLOOR (min:<version>) wherever the module states a version, and falls back to
+                // mvid: only where it does not — so a predicate that matched mvid: alone would
+                // have stopped seeing most module entries the day producers started stating
+                // versions, and this gate would have gone quietly green over a torn publication.
+                // That is the one failure mode a roll gate may not have.
+                if (name.StartsWith('!') || !CompiledDependencies.IsModuleLaneId(id))
                     continue;
 
                 var set = artifacts.Modules;
@@ -396,7 +401,16 @@ public static class ReleaseAvailability
                         + "the other's NodeTypes are declined at adoption; the set is inconsistent and "
                         + "nothing rolls");
 
-                if (set.MvidByModule.TryGetValue(name, out var sealedMvid)
+                // 🚨 THE ONE CHECK THE FLOOR RETIRES, and only for a floor-shaped id (#3934):
+                // "the bundle and the module are two BUILDS" stopped being a refusal the moment a
+                // record stopped naming a build. An instance no longer declines that at adoption,
+                // so a gate holding a roll for it would be refusing on a fact nothing downstream
+                // acts on. The two checks above — the set could not be read, and the set carries
+                // one name at two builds — are untouched and still fire for every module entry,
+                // floor or pin: a torn publication is refused whole, exactly as
+                // Doc/Architecture/ModuleAdoptionPolicy requires.
+                if (id.StartsWith(CompiledDependencies.MvidScheme, StringComparison.Ordinal)
+                    && set.MvidByModule.TryGetValue(name, out var sealedMvid)
                     && !string.Equals(sealedMvid, id, StringComparison.Ordinal))
                     return new PackageAvailability(
                         package.Name,

--- a/src/MeshWeaver.PluginCatalog/ServedModuleBytes.cs
+++ b/src/MeshWeaver.PluginCatalog/ServedModuleBytes.cs
@@ -63,6 +63,17 @@ public static class ServedModuleBytes
     /// The build the assemblies in this bundle say they need for one module: the single
     /// <c>mvid:</c> id their dependency records agree on, or a named
     /// <see cref="RecordedModuleId.Disagreement"/> when they do not.
+    ///
+    /// <para>🚨 <b>A <c>min:</c> FLOOR entry contributes nothing here, deliberately (#3934), and
+    /// that is not a reader that stopped seeing its input.</b> This selection exists to serve the
+    /// EXACT build a record names, because naming another one used to decline every NodeType in the
+    /// bundle. A floor names no build — anything at or above it serves — so there is nothing to
+    /// select by, and "no id recorded" is the honest answer: the shelf's bytes are served, exactly
+    /// as for a bundle that predates records. The consumer's own floor check is then what decides,
+    /// and it declines with a sentence naming both versions if the shelf really is behind. What is
+    /// lost is only the DIVERGENCE report for floor-shaped records; extending the selection to
+    /// "the newest sealed build at or above the floor" is the registry-resolves-compatibility model
+    /// recorded on #3934 and is not built.</para>
     /// </summary>
     /// <param name="dependencyRecords">Each served assembly's <c>CompiledDependencies</c> record
     /// (null entries — an assembly recorded before records existed — simply contribute nothing).</param>

--- a/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
@@ -455,6 +455,83 @@ public class SealedSetConsistencyTest
         Assert.True(verdict.IsUpdatable, verdict.HoldReason);
     }
 
+    // ── #3934: a module entry is a FLOOR, and this gate must not go quiet on it ──────────────────
+    //
+    // A record's module entry is now `min:<version>` wherever the module states a version. The
+    // predicate that enumerates module entries therefore had to widen, and the risk of the change
+    // is entirely in one direction: a gate that silently stops seeing its input reports GREEN over
+    // a torn publication, which is the one failure a roll gate may not have. Both surviving checks
+    // are pinned on the floor shape, and the one that is deliberately RETIRED is pinned too, so a
+    // future reader can tell "retired on purpose" from "quietly stopped firing".
+
+    /// <summary>🚨 A floor-shaped record must STILL be held by a set carrying one name at two
+    /// builds. If the module-lane predicate had stayed <c>mvid:</c>-only, this would answer
+    /// AVAILABLE over a publication the loader resolves by coin toss.</summary>
+    [Fact]
+    public void AFloorShapedRecord_IsStillHeldByASealedSetConflict()
+    {
+        var conflict = $"module {Module}: source 'plugins' sealed mvid:aaaa, source 'socialmedia' sealed mvid:bbbb";
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = new SealedModuleSet(
+                ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal),
+                [conflict],
+                null),
+            DependencyRecords = [Record(Module, CompiledDependencies.MinVersionScheme + "3.0.0")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.False(verdict.IsUpdatable);
+        var package = Assert.Single(verdict.Packages);
+        Assert.Equal(PackageAvailabilityKind.SealedSetInconsistent, package.Kind);
+        Assert.Contains(conflict, package.Reason!, StringComparison.Ordinal);
+    }
+
+    /// <summary>🚨 And an unreadable set is still INDETERMINATE for a floor-shaped record — "I
+    /// could not check" is not clearance, floor or pin.</summary>
+    [Fact]
+    public void AFloorShapedRecord_IsStillIndeterminateWhenTheSetCannotBeRead()
+    {
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = null,
+            DependencyRecords = [Record(Module, CompiledDependencies.MinVersionScheme + "3.0.0")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.True(verdict.IsIndeterminate);
+        Assert.Equal(PackageAvailabilityKind.Indeterminate, Assert.Single(verdict.Packages).Kind);
+    }
+
+    /// <summary>
+    /// 🚨 THE ONE CHECK THE FLOOR RETIRES, pinned so nobody has to guess whether it was retired or
+    /// merely broken. "The sealed set carries a DIFFERENT build of this module" was a hold because
+    /// an instance declined that at adoption; under a floor it does not, so holding a whole fleet's
+    /// roll for it would be refusing on a fact nothing downstream acts on.
+    ///
+    /// <para>Its falsification arm is <see cref="ABundleBuiltAgainstAnotherBuildOfTheSealedModule_IsHeld_NamingBothBuilds"/>:
+    /// the same set, an <c>mvid:</c>-shaped record, still held.</para>
+    /// </summary>
+    [Fact]
+    public void AFloorShapedRecord_IsNotHeldMerelyBecauseTheSealedBuildDiffers()
+    {
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = new SealedModuleSet(
+                ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal)
+                    .Add(Module, "mvid:whatever-this-wave-produced"),
+                [],
+                null),
+            DependencyRecords = [Record(Module, CompiledDependencies.MinVersionScheme + "3.0.0")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+    }
+
     // ── fixtures ────────────────────────────────────────────────────────────────────────────────
 
     private static ReleaseTarget Target => new(Version, Identity);

--- a/test/MeshWeaver.Compiler.Pipeline.Test/DependencyRecordFloorTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/DependencyRecordFloorTest.cs
@@ -1,0 +1,343 @@
+#pragma warning disable CS1591
+
+using System.Collections.Immutable;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins the MODULE FLOOR (#3934): a dependency record's module entry says "I need at least X",
+/// not "I need exactly this build".
+///
+/// <para><b>The measured defect.</b> <c>CreateIdResolver</c> resolved a module as
+/// <c>mvid:&lt;guid&gt;</c> — an exact build — and an MVID moves on every compilation BY
+/// CONSTRUCTION, including a rebuild of identical source from a different absolute path. So a
+/// publication composed from more than one Roslyn workspace carried two builds of one module name,
+/// and every NodeType binding it was declined at adoption on both replicas, each recompiled
+/// locally into <c>latestAssemblyCollection: "local"</c>, and each invalidated the other. Measured
+/// on memex 2026-09-10: <c>SocialMedia/Post</c> lost <c>Preview</c>, <c>Write</c> and
+/// <c>PostCard</c>, <c>/Posts/SavThankYou</c> returned HTTP 200 rendering nothing all day, and the
+/// NodeType's own record read <c>compilationStatus: Ok</c> throughout.</para>
+///
+/// <para><b>Both directions are controlled here, deliberately.</b> A test that only proves the new
+/// acceptance is not a control — "accept everything" would pass it. Every relaxation test below is
+/// paired with the falsification arm that must still DECLINE, and the four things the floor
+/// deliberately does NOT relax (the toolchain proxy, the content key, platform surfaces, and an
+/// absent dependency) each have their own arm.</para>
+/// </summary>
+public class DependencyRecordFloorTest
+{
+    private const string Toolchain = "mvid:toolchain-1";
+    private const string Collab = "MeshWeaver.Markdown.Collaboration";
+
+    private static Func<string, string?> Resolver(params (string Name, string Id)[] pairs)
+        => name => pairs.FirstOrDefault(p => p.Name == name).Id;
+
+    private static ImmutableSortedDictionary<string, string> RecordBinding(
+        string name, string id, string toolchain = Toolchain, string? digest = null)
+        => CompiledDependencies.Compute([name], Resolver((name, id)), toolchain, digest);
+
+    // ── The resolver: what a module's id IS now ─────────────────────────────────────────────────
+
+    [Fact]
+    public void IdResolver_AModuleWithAVersionResolvesAFloor_WithoutOneItStillPinsTheBuild()
+    {
+        var resolver = CompiledDependencies.CreateIdResolver(
+            surfaceByName: new Dictionary<string, string>(),
+            moduleMvidByName: new Dictionary<string, string>
+            {
+                [Collab] = "798f92a0",
+                ["Legacy.Module"] = "deadbeef",
+            },
+            implMvidOf: _ => null,
+            moduleVersionOf: name => name == Collab ? "3.0.0" : null);
+
+        resolver(Collab).Should().Be("min:3.0.0",
+            "a module that states a version records a FLOOR over it");
+        resolver("Legacy.Module").Should().Be("mvid:deadbeef",
+            "a module that states no version has no floor to offer, so the exact pin stays — "
+            + "inconclusive takes the rebuild side");
+    }
+
+    [Fact]
+    public void IdResolver_TheThreeArgumentOverloadIsTheNoVersionCase()
+    {
+        // The pre-#3934 overload is not a second notion of a module id: it is this one with a
+        // version resolver that answers nothing. A caller that cannot state a version must not
+        // silently acquire a floor.
+        var legacy = CompiledDependencies.CreateIdResolver(
+            surfaceByName: new Dictionary<string, string>(),
+            moduleMvidByName: new Dictionary<string, string> { [Collab] = "798f92a0" },
+            implMvidOf: _ => null);
+
+        legacy(Collab).Should().Be("mvid:798f92a0");
+    }
+
+    // ── THE RELAXATION, and its falsification arm ───────────────────────────────────────────────
+
+    [Fact]
+    public void AMovedBuildAtTheSameVersion_NowAdopts_WhereTheMvidPinDeclined()
+    {
+        // THE SavThankYou SHAPE, exactly: one module name, two builds from two workspaces of one
+        // publication, therefore the same version and different MVIDs.
+        var pinned = RecordBinding(Collab, "mvid:798f92a0");
+        CompiledDependencies.FindMismatch(pinned, Resolver((Collab, "mvid:825581836a")), Toolchain)
+            .Should().Be($"'{Collab}' built against mvid:798f92a0, live is mvid:825581836a",
+                "the CONTROL that the old rule declined this — without it the test below proves "
+                + "nothing about what changed");
+
+        var floored = RecordBinding(Collab, "min:3.0.0");
+        CompiledDependencies.Validate(floored, Resolver((Collab, "min:3.0.0")), Toolchain)
+            .Should().Be(DependencyRecordOutcome.Satisfied,
+                "two builds of one module assembly link fine — AssemblyVersion is synchronised "
+                + "fleet-wide, so Assembly.LoadFrom returns the already-loaded copy");
+    }
+
+    [Fact]
+    public void AHigherLiveVersionSatisfiesTheFloor_AndOrdersNumerically()
+    {
+        var floored = RecordBinding(Collab, "min:3.0.0-ci.900");
+
+        CompiledDependencies.FindMismatch(floored, Resolver((Collab, "min:3.0.0-ci.3758")), Toolchain)
+            .Should().BeNull("ci.3758 is ABOVE ci.900 — SemVer, never string order");
+        CompiledDependencies.FindMismatch(floored, Resolver((Collab, "min:3.0.0")), Toolchain)
+            .Should().BeNull("a clean version outranks a prerelease of the same core");
+        CompiledDependencies.FindMismatch(floored, Resolver((Collab, "min:3.0.0+abc123")), Toolchain)
+            .Should().BeNull("build metadata is ignored for ordering, per SemVer");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL. If this passed with the floor removed — i.e. if any module entry
+    /// were accepted — the whole change would be "adopt everything", which is a different and much
+    /// worse bug than the one it replaces.
+    /// </summary>
+    [Fact]
+    public void ARecordBelowItsFloor_StillDeclines_AndTheSentenceNamesBothSides()
+    {
+        var floored = RecordBinding(Collab, "min:1.6.0");
+        var outcome = CompiledDependencies.Validate(
+            floored, Resolver((Collab, "min:1.5.0")), Toolchain);
+
+        outcome.Status.Should().Be(DependencyRecordStatus.FloorNotMet);
+        outcome.Entry.Should().Be(Collab);
+        outcome.Problem.Should().Be(
+            $"'{Collab}' needs at least 1.6.0 — this environment has 1.5.0, below the recorded floor");
+        outcome.IsSatisfied.Should().BeFalse();
+        CompiledDependencies.FindMismatch(floored, Resolver((Collab, "min:1.5.0")), Toolchain)
+            .Should().Be(outcome.Problem, "the string API is a projection of the outcome, never a "
+                + "second implementation that could disagree with it");
+    }
+
+    [Fact]
+    public void AMajorVersionBelowTheFloorDeclines_SoTheOrderIsRealAndNotAPrefixMatch()
+    {
+        var floored = RecordBinding(Collab, "min:3.0.0");
+        CompiledDependencies.Validate(floored, Resolver((Collab, "min:2.9.9")), Toolchain)
+            .Status.Should().Be(DependencyRecordStatus.FloorNotMet);
+    }
+
+    // ── Nothing was checked is NEVER a clean bill ───────────────────────────────────────────────
+
+    [Fact]
+    public void AFloorAgainstAnEnvironmentThatReportsAnMvid_IsNotChecked_NotSatisfied()
+    {
+        var floored = RecordBinding(Collab, "min:3.0.0");
+        var outcome = CompiledDependencies.Validate(
+            floored, Resolver((Collab, "mvid:798f92a0")), Toolchain);
+
+        outcome.Status.Should().Be(DependencyRecordStatus.NotChecked);
+        outcome.IsSatisfied.Should().BeFalse("a status that established nothing must never read as "
+            + "compatible — the whole reason the outcome carries a status at all");
+        outcome.Problem.Should().Be(
+            $"'{Collab}' recorded min:3.0.0 and this environment reports mvid:798f92a0 — the two "
+            + "cannot be compared, so nothing was checked and the build is not adopted");
+    }
+
+    [Fact]
+    public void ALegacyExactPinAgainstAVersionedEnvironment_IsAlsoNotChecked()
+    {
+        // The other direction, which is what every record stamped before #3934 hits once. It takes
+        // the rebuild side, exactly like an inconclusive content key.
+        var pinned = RecordBinding(Collab, "mvid:798f92a0");
+        CompiledDependencies.Validate(pinned, Resolver((Collab, "min:3.0.0")), Toolchain)
+            .Status.Should().Be(DependencyRecordStatus.NotChecked);
+    }
+
+    [Fact]
+    public void AModuleTheEnvironmentDoesNotHaveAtAll_IsDrift_NotAnUnmetFloor()
+    {
+        // 'absent' is a measured fact about this environment, not an incomparable scheme: the
+        // build binds something that is not here.
+        var floored = RecordBinding(Collab, "min:3.0.0");
+        var outcome = CompiledDependencies.Validate(floored, Resolver(), Toolchain);
+
+        outcome.Status.Should().Be(DependencyRecordStatus.Drifted,
+            "'nothing resolves this name here' is a measured fact with a definite answer, not an "
+            + "inability to compare — a floor must not launder it into 'nothing was checked'");
+        outcome.Problem.Should().Be(
+            $"'{Collab}' built against min:3.0.0, live is {CompiledDependencies.AbsentId}");
+    }
+
+    [Fact]
+    public void AnUntrustedRecordIsNotCheckedRatherThanDrifted()
+    {
+        var handAssembled = ImmutableSortedDictionary<string, string>.Empty
+            .Add(Collab, "min:3.0.0");
+        var outcome = CompiledDependencies.Validate(
+            handAssembled, Resolver((Collab, "min:3.0.0")), Toolchain);
+
+        outcome.Status.Should().Be(DependencyRecordStatus.NotChecked);
+        outcome.Entry.Should().BeNull("the whole record is untrusted, not one entry of it");
+        outcome.Problem.Should().Contain(CompiledDependencies.ToolchainKey);
+    }
+
+    // ── WHAT THE FLOOR DOES NOT RELAX ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheToolchainProxyIsStillExact()
+    {
+        var record = RecordBinding(Collab, "min:3.0.0");
+        var outcome = CompiledDependencies.Validate(
+            record, Resolver((Collab, "min:9.9.9")), "mvid:toolchain-2");
+
+        outcome.Status.Should().Be(DependencyRecordStatus.Drifted);
+        outcome.Entry.Should().Be(CompiledDependencies.ToolchainKey,
+            "a module floor met with room to spare does not license a toolchain change");
+    }
+
+    [Fact]
+    public void APlatformSurfaceIsStillExact_AFloorNeverAppliesToRefAsmIds()
+    {
+        var record = RecordBinding("MeshWeaver.Layout", "ref:aaa");
+        CompiledDependencies.Validate(record, Resolver(("MeshWeaver.Layout", "ref:bbb")), Toolchain)
+            .Status.Should().Be(DependencyRecordStatus.Drifted);
+
+        // …and the scheme prefixes still never compare across lanes, floor or not.
+        CompiledDependencies.Satisfies("ref:aaa", "min:9.9.9").Should().BeFalse();
+        CompiledDependencies.Satisfies("min:1.0.0", "ref:aaa").Should().BeFalse();
+        CompiledDependencies.Satisfies("mvid:a", "min:9.9.9").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheContentKeyIsStillExact()
+    {
+        var record = CompiledDependencies.Compute(
+            [Collab], Resolver((Collab, "min:3.0.0")), Toolchain, "g-input-1");
+        record.Should().ContainKey(CompiledDependencies.ContentKey);
+
+        CompiledDependencies.FindMismatch(
+                record, Resolver((Collab, "min:3.0.0")), Toolchain, "i-something-else")
+            .Should().Contain(CompiledDependencies.ContentKey,
+                "a regenerated input that hashes differently is a direct observation, and no "
+                + "version floor can excuse it");
+    }
+
+    // ── The content key keeps its meaning under floors ──────────────────────────────────────────
+
+    [Fact]
+    public void LiveContentKeyOf_ReproducesTheStampedKey_WhenAModuleMovedABOVEItsFloor()
+    {
+        // The demotion the content key licenses (#1976) must survive the floor. Folding the LIVE
+        // value verbatim would move the key on every module rebuild — reintroducing exactly the
+        // invalidation #3934 removes, one layer down.
+        var record = CompiledDependencies.Compute(
+            [Collab], Resolver((Collab, "min:3.0.0")), Toolchain, "g-input-1");
+        var stamped = record[CompiledDependencies.ContentKey];
+
+        CompiledDependencies.LiveContentKeyOf(
+                record, Resolver((Collab, "min:3.0.1")), "g-input-1")
+            .Should().Be(stamped, "the entry still HOLDS, so the key must still reproduce");
+
+        CompiledDependencies.FindMismatchAfterReevaluation(
+                record, Resolver((Collab, "min:3.0.1")), "mvid:toolchain-LATER",
+                CompiledDependencies.LiveContentKeyOf(
+                    record, Resolver((Collab, "min:3.0.1")), "g-input-1"))
+            .Should().BeNull("the regenerated input proved the toolchain move irrelevant, and the "
+                + "module is at or above its floor");
+    }
+
+    [Fact]
+    public void LiveContentKeyOf_DoesNotReproduceIt_WhenTheModuleIsBELOWTheFloor()
+    {
+        var record = CompiledDependencies.Compute(
+            [Collab], Resolver((Collab, "min:3.0.0")), Toolchain, "g-input-1");
+        var stamped = record[CompiledDependencies.ContentKey];
+
+        CompiledDependencies.LiveContentKeyOf(
+                record, Resolver((Collab, "min:2.0.0")), "g-input-1")
+            .Should().NotBe(stamped, "a non-satisfying entry folds its LIVE value, so nothing is "
+                + "demoted and the toolchain entry keeps deciding");
+
+        CompiledDependencies.FindMismatchAfterReevaluation(
+                record, Resolver((Collab, "min:2.0.0")), "mvid:toolchain-LATER",
+                CompiledDependencies.LiveContentKeyOf(
+                    record, Resolver((Collab, "min:2.0.0")), "g-input-1"))
+            .Should().NotBeNull();
+    }
+
+    // ── The adopt-time judges every reader goes through ─────────────────────────────────────────
+
+    private static NodeTypeDefinition UsableDef(ImmutableSortedDictionary<string, string> record)
+        => new()
+        {
+            LatestAssemblyCollection = "prebuilt",
+            LatestAssemblyPath = "x/v1-abc.dll",
+            CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+            CompiledDependencies = record,
+            LastCompiledVersion = 1,
+        };
+
+    private static readonly MeshNode Node = new("SocialMedia/Post", "Post");
+
+    [Fact]
+    public void EveryReaderHonoursTheFloor_AndEveryReaderStillDeclinesBelowIt()
+    {
+        var record = RecordBinding(Collab, "min:1.6.0");
+        var above = new NodeTypeCompilationHelpers.BuildGuards(
+            ModulesHash: "irrelevant-once-a-record-exists",
+            DependencyIdOf: Resolver((Collab, "min:1.7.0")),
+            ToolchainId: Toolchain);
+        var below = above with { DependencyIdOf = Resolver((Collab, "min:1.5.0")) };
+
+        // HasUsableBuild + its stale twin — the pair the per-instance activation reads.
+        NodeTypeCompilationHelpers.HasUsableBuild(Node, UsableDef(record), above)
+            .Should().BeTrue("a module ABOVE the floor is not a reason to rebuild");
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(UsableDef(record), above)
+            .Should().BeFalse();
+
+        NodeTypeCompilationHelpers.HasUsableBuild(Node, UsableDef(record), below)
+            .Should().BeFalse("a module BELOW the floor must still decline");
+        NodeTypeCompilationHelpers.HasStaleFrameworkBuild(UsableDef(record), below)
+            .Should().BeTrue("the stale twin must re-drive the compile for the same condition");
+
+        // The bake probe / sweep — the same record, the same answer.
+        NodeTypeBakeStatus.Classify(
+                UsableDef(record), storeHasBytes: true,
+                NodeTypeCompilationHelpers.FrameworkVersion,
+                above.DependencyIdOf, Toolchain)
+            .Should().Be(BakeState.Baked);
+        NodeTypeBakeStatus.Classify(
+                UsableDef(record), storeHasBytes: true,
+                NodeTypeCompilationHelpers.FrameworkVersion,
+                below.DependencyIdOf, Toolchain)
+            .Should().Be(BakeState.DependencyStale);
+    }
+
+    [Fact]
+    public void TheBakeProbeReportsTheFloorSentence_NotAFixedOne()
+    {
+        var record = RecordBinding(Collab, "min:1.6.0");
+        var (state, mismatch) = NodeTypeBakeStatus.ClassifyDetailed(
+            UsableDef(record), storeHasBytes: true,
+            NodeTypeCompilationHelpers.FrameworkVersion,
+            Resolver((Collab, "min:1.5.0")), Toolchain);
+
+        state.Should().Be(BakeState.DependencyStale);
+        mismatch.Should().Be(
+            $"'{Collab}' needs at least 1.6.0 — this environment has 1.5.0, below the recorded floor");
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/FrameworkBuildIdentityTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/FrameworkBuildIdentityTest.cs
@@ -155,6 +155,21 @@ public class FrameworkBuildIdentityTest
             "MeshWeaver.Mesh.Contract",
             "MeshWeaver.Messaging.Contract",
             "MeshWeaver.Messaging.Hub",
+            // 🚨 WIDENED DELIBERATELY (#3934), and this is the reason the ratchet asks for. A
+            // dependency record's MODULE entry is now a FLOOR (min:<version>), so the toolchain has
+            // to ORDER versions, and the repo has exactly one version fold — NuGetVersionComparer,
+            // which lives here. Re-implementing it inside MeshWeaver.Compiler is the failure
+            // check-module-platform-floor.py's own header warns about ("two call sites computing
+            // the same fold differently either never converge or never fire, and both are silent"),
+            // so MeshWeaver.Compiler references the assembly that owns it.
+            //
+            // The cost was measured before taking it: MeshWeaver.Plugin.Packaging is a LEAF (zero
+            // ProjectReferences of its own, so it pulls no subtree in behind it) at 3 commits/60d,
+            // against a union already carrying MeshWeaver.Mesh.Contract (190/30d) and
+            // MeshWeaver.Messaging.Hub (135/30d). And the membership is CORRECT rather than merely
+            // cheap: the comparer now decides which prebuilt builds are adopted, which is precisely
+            // the property this set exists to invalidate on.
+            "MeshWeaver.Plugin.Packaging",
             "MeshWeaver.Reflection",
             "MeshWeaver.ServiceProvider",
             "MeshWeaver.ShortGuid",

--- a/tools/MeshWeaver.PluginTester/BakeHost.cs
+++ b/tools/MeshWeaver.PluginTester/BakeHost.cs
@@ -117,8 +117,10 @@ internal sealed class BakeHost
             return null;
         return $"module(s) {string.Join(", ", shipped)} are composed with --module AND shipped by the "
                + $"platform host at '{appDirectory}' — two builds of one assembly name in one bake. "
-               + "The records this bake would write name the module's build (mvid:…) while a portal "
-               + "carrying the name in its app closure resolves the platform's (ref:…), so every "
+               + "The records this bake would write name the MODULE lane (min:… — a version floor, "
+               + "or mvid:… when the module states no version) while a portal carrying the name in "
+               + "its app closure resolves the PLATFORM's (ref:…). The two schemes never compare, "
+               + "floor or not (#3934), so every "
                + "NodeType binding it would be DECLINED at adoption (\"dependency record mismatch\"). "
                + "A module has exactly one producer: remove the assembly from the platform host's "
                + "closure (it is a module, landed from the registry) or stop composing it (#3175).";
@@ -139,7 +141,8 @@ internal sealed class BakeHost
             IdOf = CompiledDependencies.CreateIdResolver(
                 FrameworkBuildIdentity.ProcessSurfacePairs,
                 TreeBake.ModuleMvidsOf(modules),
-                FrameworkBuildIdentity.ProcessImplMvidOf),
+                FrameworkBuildIdentity.ProcessImplMvidOf,
+                TreeBake.ModuleVersionResolverOf(modules)),
             ToolchainId = CompiledDependencies.ComputeToolchainId(FrameworkBuildIdentity.ProcessImplMvidOf),
             References = CompileReferences.ComposeWithModules(modules),
             Description =
@@ -263,7 +266,9 @@ internal sealed class BakeHost
         {
             FrameworkIdentity = identity,
             AppDirectory = app,
-            IdOf = CompiledDependencies.CreateIdResolver(pairs, TreeBake.ModuleMvidsOf(modules), HostMvidOf),
+            IdOf = CompiledDependencies.CreateIdResolver(
+                pairs, TreeBake.ModuleMvidsOf(modules), HostMvidOf,
+                TreeBake.ModuleVersionResolverOf(modules)),
             ToolchainId = CompiledDependencies.ComputeToolchainId(HostMvidOf),
             References = references,
             Description =

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -347,6 +347,36 @@ public static class TreeBake
         return map;
     }
 
+    /// <summary>
+    /// Installed module simple name → its ORDERED build version (#3934), for the resolver's
+    /// <c>min:</c> floor ids. Deliberately the same projection the mesh makes
+    /// (<c>NodeTypeCompilationHelpers.ModuleVersionsOf</c>), reading the same
+    /// <see cref="InstalledModuleAssembly.Version"/> — a producer that derived the floor
+    /// differently would stamp a value no consumer computes, and every bundle would be declined
+    /// for a reason nobody could name.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> ModuleVersionsOf(
+        IReadOnlyList<InstalledModuleAssembly> modules)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var module in modules)
+        {
+            var name = module.Assembly.GetName().Name;
+            if (!string.IsNullOrEmpty(name) && module.Version is { Length: > 0 } version)
+                map[name] = version;
+        }
+        return map;
+    }
+
+    /// <summary>The bake host's floor resolver over <paramref name="modules"/> — the exact shape
+    /// <c>NodeTypeCompilationHelpers.DependencyIdResolverOf</c> builds on a live mesh.</summary>
+    internal static Func<string, string?> ModuleVersionResolverOf(
+        IReadOnlyList<InstalledModuleAssembly> modules)
+    {
+        var versions = ModuleVersionsOf(modules);
+        return name => versions.TryGetValue(name, out var version) ? version : null;
+    }
+
     private static Report BakeAll(
         Options options,
         ImmutableArray<TreeNodeLoader.TreeNode> treeNodes,


### PR DESCRIPTION
Implements #3934 — the platform owner's decision, not a proposal: a dependency record's module entry states a **floor**, not an MVID pin.

## The chain this dissolves, measured on memex 2026-09-10

`CompiledDependencies.CreateIdResolver` resolved a module to `mvid:<guid>` — an exact build, checked first. An MVID moves on **every** compilation by construction, and Roslyn's deterministic MVID also hashes the **absolute source paths**, so two `build-workspace` lanes of one publication compiling identical source at `$GITHUB_WORKSPACE` and `/repo` fork it with byte-identical version attributes. No producer agreement can fix that.

- `PrebuiltAssemblySeeder` declined **22 of 272** entries at one identity, across 3 module names, on **one** entry each: `MeshWeaver.Markdown.Collaboration` recorded `mvid:798f92a0…`, live `mvid:825581836a…`, with all eight `ref:` surfaces and `!toolchain` agreeing. `socialmedia` was 20/26, **all six** declines that one assembly.
- A declined bundle compiles in-portal → `latestAssemblyCollection: "local"`, which `FileSystemAssemblyStore` documents as *"the bytes live in the local filesystem cache only; cross-silo readers must recompile"*. memex runs 2 replicas, so each declined the other's stamp and recompiled — two forced re-activations **2 seconds apart** with identical inputs.
- Net: `https://memex.meshweaver.cloud/Posts/SavThankYou` returned **HTTP 200 rendering nothing** for the whole day — `Preview`, `Write`, `PostCard` all absent — while the NodeType read `compilationStatus: Ok`. `recycle` was measured not to fix it.

## What the floor is, and how a consumer compares it

A module resolves **`min:<version>`** over `InstalledModuleAssembly.Version` — its `AssemblyInformationalVersion` with `+<sha>` stripped. That is the **one reader**, and both the portal's resolver (`NodeTypeCompilationHelpers.DependencyIdResolverOf`) and the bake host's (`mw-plugin-test`'s `BakeHost.InProcess` / `ResolveDirectory`) go through it, so a floor is never compared against a value nobody else computes.

`CompiledDependencies.Satisfies` is **the** comparison: ordinal equality, plus exactly one relaxation — two `min:` values order by `NuGetVersionComparer`, and live at-or-above stamped satisfies. `MeshWeaver.Compiler` now references `MeshWeaver.Plugin.Packaging` for that comparer rather than re-implementing the fold (`check-module-platform-floor.py`'s own header: *"two call sites computing the same fold differently either never converge or never fire, and both are silent"*). A module stating **no** version keeps the exact `mvid:` pin — an environment that cannot state a version has no floor to offer, and inconclusive stays on the rebuild side.

Relation to what already exists: this is the same instinct as `ModuleAdoptionPolicy` R2 (*"a different build commit or MVID is not evidence of incompatibility"*) one layer down, and unlike `minMeshVersion` it is **measured, not authored** — the version of the module the producer actually compiled against. `ModuleVersionCompatibility`'s same-MAJOR stale-but-serving rule is a different question (may an already-adopted build keep serving over moved source) and is untouched.

## Every reader changed

| reader | change |
|---|---|
| `CompiledDependencies.Compare` (the one comparison behind `FindMismatch`, `FindMismatchAfterReevaluation`, `Validate`, `ValidateAfterReevaluation`) | floor semantics for `min:`; everything else ordinal |
| `LiveContentKeyOf` | folds a **satisfied** entry at its RECORDED value, so the #1976 toolchain demotion survives a module rebuilt above its floor |
| `CreateIdResolver` | new 4-arg overload taking `moduleVersionOf`; the 3-arg one delegates with "no version" (kept, so no public removal) |
| `PrebuiltAssemblySeeder.SeedDetailed` | declines on `Validate(...)` and logs the **status** plus the sentence |
| `NodeTypeCompilationHelpers` — `HasUsableBuild`, `HasStaleFrameworkBuild`, the stale-build kickoff | via the same comparison; new `ModuleVersionsOf` |
| `NodeTypeBakeStatus.Classify` / `ClassifyDetailed` (bake probe + sweep) | via the same comparison; the mismatch string now names the floor |
| `mw-plugin-test` `TreeBake` / `BakeHost` (producer) | `ModuleVersionsOf` / `ModuleVersionResolverOf`; `ShippedByHostProblem`'s wording |
| `ReleaseAvailability.SealedSetProblem` (roll gate) | enumerates the module lane by the new `IsModuleLaneId` so it **keeps firing** on floors |
| `ServedModuleBytes.RecordedFor` (registry #3244) | a floor names no build, so it selects nothing and the shelf is served — stated in the doc comment rather than left as silence |

## What I deliberately did NOT relax

- **`!toolchain`** — the PROXY still invalidates every record on a toolchain change. A module floor met with room to spare licenses nothing there.
- **`!input`** — the direct observation is still exact.
- **`ref:` platform surfaces** and **`absent`** — still ordinal. `min:` never compares to `ref:`, which keeps #3175's one-producer rule intact: the bake reports *NotChecked* rather than quietly matching.
- **The sealed-set consistency gate** — "the set carries one name at two builds" and "the set could not be read" still hold a roll for every module entry, floor or pin. Only the *exact-build* comparison retires, and only for a floor-shaped id, because an instance no longer declines that at adoption.
- **`ModuleVersionCompatibility`**, the framework identity, `PrebuiltAssemblySeeder.DeclineReason` (framework MVID equality), and R2's link probe: untouched.

## Clause 4 — an unmet floor is visible

`Validate` answers a `DependencyRecordOutcome` (`Satisfied` / `Drifted` / `FloorNotMet` / `NotChecked`) modelled on `NodeDiagnosticsOutcome` (#3912/#3916) — not a fourth way to say "I could not check". `FindMismatch` is a **projection** of it, so the string and status forms cannot disagree, and `IsSatisfied` is false for `NotChecked`.

And the silent-default path is gone: a recorded build whose bytes this process cannot resolve now overlays the existing `AssemblyUnavailable` diagnosis — the same one the pinned-release branch beside it already used, with the same version-gated self-heal — instead of binding the default configuration and rendering "Area not found". The overlay keeps the fail-fast contract (`UnhandledMessageNack`), so a typed request gets a terminal `DeliveryFailure` naming the NodeType rather than being ignored.

## Controls, both directions

`DependencyRecordFloorTest` — a test that only proved acceptance would also pass for "adopt everything", so every relaxation arm is paired:

- **falsification arm** (the old rule declined it, asserted verbatim):
  `'MeshWeaver.Markdown.Collaboration' built against mvid:798f92a0, live is mvid:825581836a`
- **positive control** — a record BELOW its floor still declines, exact text:
  `'MeshWeaver.Markdown.Collaboration' needs at least 1.6.0 — this environment has 1.5.0, below the recorded floor`
- `min:3.0.0` vs a moved build at the same version answers `DependencyRecordOutcome.Satisfied`
- separate arms proving `!toolchain`, `!input`, `ref:` and `absent` did not move
- `LiveContentKeyOf` reproduces the stamped key when a module moved **above** its floor, and does not when **below**
- every adopt-time reader exercised on both sides of one floor; `ClassifyDetailed` asserted to report the floor sentence
- `SealedSetConsistencyTest` gains three arms: a floor-shaped record is still held by a set conflict, still Indeterminate on an unreadable set, and **not** held merely because the sealed build differs (the one retired check, pinned so "retired" is distinguishable from "quietly stopped firing")

`FullMvidAssemblies` gains `MeshWeaver.Plugin.Packaging` — its ratchet caught it, which is what it is for. Cost measured before taking it: a LEAF (zero `ProjectReference`s, so it pulls no subtree behind it) at 3 commits/60d, against a union already carrying `Mesh.Contract` (190/30d) and `Messaging.Hub` (135/30d); and the membership is *correct*, not merely cheap, since the comparer now decides which builds are adopted.

## Would a portal now adopt the bundle that produced the SavThankYou outage?

**Yes.** All three builds of `MeshWeaver.Markdown.Collaboration` in that publication carry one `InformationalVersion` (core pins it to `$(PlatformVersion)` under `CIRun`; Plugins#1604 carries the same pin), so record and live both resolve `min:3.0.0`, `Satisfies` answers true, and the bundle is adopted instead of declined. Nothing then sets `latestAssemblyCollection: "local"`, so neither replica compiles, neither invalidates the other, and the type's declared views register.

## Verification

Release + `-warnaserror`, one project per invocation, all `0 Error(s)`: MeshWeaver.Compiler, Compiler.Pipeline, Graph, PluginCatalog, Hosting, Documentation, PluginTester, and the test projects Compiler.Pipeline.Test, Graph.Test, Memex.Portal.Shared.Test, PluginTester.Test, Hosting.Test, Hosting.Orleans.Test.

Tests: Compiler.Pipeline.Test **839 passed**, Graph.Test **1516 passed**, PluginTester.Test **361 passed**, Memex.Portal.Shared.Test sealed-set/release filter **58 passed**, Hosting.Test `PrebuiltAdoptionPolicyTest` **14 passed**, `DocumentationLinkIntegrityTest` **passed**.

Doc: `Doc/Architecture/DependencyRecordFloor`, cross-linked from `ModuleOwnedSiblingsRide` (whose "agreement is cheaper than exclusivity" remedy this replaces) and `ModuleAdoptionPolicy`. What's New entry, `Category: Fix`.

Pairs-with: none — nothing public was removed. The diff adds public surface only (`MinVersionScheme`, `Satisfies`, `IsModuleLaneId`, `Validate`, `ValidateAfterReevaluation`, `DependencyRecordOutcome`, `InstalledModuleAssembly.Version`); the pre-existing `CreateIdResolver`, `FindMismatch` and `FindMismatchAfterReevaluation` signatures are all kept, and the only external caller found — `MeshWeaver.Plugins`' `ShippedPrebuiltBundlesTest`, which calls the 3-arg `CreateIdResolver` positionally with an empty module map — is unaffected, as is its `mvid:some-other-build` decline assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
