### PR TITLE
docs: what a green build costs a synced Space — one field is both the cheapness gate and the convergence guard

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -158,6 +158,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [DatabaseBackups](DatabaseBackups)
 - [Declarative export and import](DeclarativeImportExport)
 - [Syncing a Space with GitHub](GitHubSync)
+- [What a Green Build Costs a Synced Space](GitSyncTriggerCost) — one field decides whether a delivery is free or a full clone, and it is deliberately frozen while an import does not converge; so a source that cannot converge re-clones on every green build, at the source repository's CI cadence
 - [The Import Marker Records Convergence](ImportMarkerRecordsConvergence)
 - [Instance Sync — bi-directional space replication between MeshWeaver instances](InstanceSync)
 - [Managing Partition Sync (Admin Guide)](PartitionSyncGuide)

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -481,5 +481,6 @@ All GitHub HTTP and serialization run through the controlled I/O pool — see
 
 - [DataSyncSetup.md](/Doc/Architecture/DataSyncSetup) — the import-source model (platform content synced from a repo at a release tag).
 - [StaticRepoImport.md](/Doc/Architecture/StaticRepoImport) — the import mechanism reused here (fingerprint, activity lock, upsert, prune).
+- [What a Green Build Costs a Synced Space](/Doc/Architecture/GitSyncTriggerCost) — what one webhook delivery costs, the single field that makes it free, and why a source that never converges re-clones its repository on every green build.
 - [ControlledIoPooling.md](/Doc/Architecture/ControlledIoPooling) — why every GitHub HTTP call runs in the I/O pool.
 - [AccessControl.md](/Doc/Architecture/AccessControl) — credential encryption + the master key.

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -150,8 +150,9 @@ necessarily disarms the first:
 So the allow-list's stated invariant — *"a sync source already sitting on the built sha is skipped …
 so a scheduled re-verification triggers no import at all"* — holds for every source that converges
 and **for no source that does not**. On the converging sources the 15-minute probe costs nothing at
-all; on one that cannot converge, the same probe is a full clone of that repository, 96 times a day,
-on top of roughly three per merge.
+all; on one that cannot converge, the same probe is a full clone of that repository — 87 times in the
+measured 24 h (the cron offers 96; only the green runs are publish signals) — on top of roughly three
+per merge.
 
 None of the three freeze conditions resolves by itself:
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -1,0 +1,256 @@
+---
+Name: What a Green Build Costs a Synced Space
+Category: Architecture
+Description: A green build of a repository fans out to every Space that syncs it, and exactly one field decides whether a delivery is free or a full clone. That field is deliberately frozen whenever an import does not fully converge — so a source that cannot converge pays the full fetch on every delivery, and its retry cadence is set by the source repository's CI schedule rather than by anything about the source.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v6"/><path d="M12 15v6"/><circle cx="12" cy="12" r="3"/><path d="M4.2 6.6l2.8 2.2"/><path d="M17 15.2l2.8 2.2"/><path d="M4.2 17.4l2.8-2.2"/><path d="M17 8.8l2.8-2.2"/></svg>
+---
+
+# What a Green Build Costs a Synced Space
+
+[GitHub Sync](/Doc/Architecture/GitHubSync) keeps a Space current **without polling**: a green
+build of the repository is a webhook delivery, and the delivery imports. That page describes the
+feature. This page describes what one delivery **costs**, and the one field that decides it.
+
+The short version:
+
+> A delivery is free only when the source's `lastSyncCommitSha` already equals the built commit.
+> That field is held back — on purpose — whenever an import does not fully converge. So the
+> cheapness gate and the convergence guard are **the same field**, and a source that can never
+> converge is the source that re-clones its repository most often.
+
+## 1. What actually fires — a green build is not a merge
+
+`GitHubWebhookProcessor` acts on a `workflow_run` delivery when **both** guards pass: the run's
+`conclusion` is `success` **and** its `head_branch` is the repository's default branch, **and** the
+run's own trigger is in the publish-signal allow-list — `push`, `repository_dispatch`, `schedule`,
+`workflow_dispatch`. (A run triggered *by another workflow* — `event: workflow_run` — is not a
+publish signal and is ignored.) Every accepted delivery rewrites
+`Admin/_Build/{owner}.{repo}` ([`BuildCompletion`](/Doc/Architecture/SyncRefContract)) and then fans
+out to every sync source of that repository.
+
+**One merge is not one delivery.** Measured on `Systemorph/MeshWeaver` for the 24 h ending
+2026-09-10T17:35Z — 254 green publish-signal runs on `main`:
+
+| Workflow | Trigger | Runs |
+|---|---|---:|
+| Prod synthetic probe | `schedule` | 87 |
+| Chart Gate | `push` | 47 |
+| Hosting Operator | `push` | 47 |
+| MeshWeaver Build and Test | `push` | 46 |
+| Continuous Delivery (main) | `schedule` | 19 |
+| Arm credential / Shared rule blocks / Pinned image digests / Lock pinned image digests / Homebrew | `schedule`, `push` | 8 |
+
+`Admin/_Build/Systemorph.MeshWeaver` on `memex.meshweaver.cloud` read **version 4778** at
+2026-09-10T17:21Z, first written 2026-08-06T07:38:37Z — **4,775 recorded deliveries in 35 days**,
+256 of them in the last 24 h (10.7/h, one every 5.6 minutes). The version series matches the run
+census above, which is what makes the model checkable rather than inferred.
+
+Two consequences follow, and both are load-bearing:
+
+- **Three workflows go green on the same commit**, so a single merge produces roughly three
+  deliveries carrying the *same* `head_sha`.
+- **A third of the deliveries are a cron, and it builds nothing.** `Prod synthetic probe`
+  (`.github/workflows/prod-synthetic-probe.yml`) is `cron: "*/15 * * * *"` — it makes HTTP requests
+  to the live portals and asserts on the answers. It produces no artefact and touches no tree. But
+  it is a `schedule` run that goes green on the default branch, so it is a publish signal, and its
+  `head_sha` is whatever `main`'s tip happens to be — unchanged between merges.
+
+For a healthy source both are harmless, and the allow-list says so explicitly
+(`PublishSignalTriggers`):
+
+> **Widening this cannot cause churn.** A sync source already sitting on the built sha is skipped by
+> `SkipReason` ("already at this commit"), so a scheduled or dispatched re-verification of an
+> unchanged default branch triggers no import at all.
+
+That invariant is the design. Section 4 is about the sources for which it is **false**.
+
+## 2. The one gate that makes a delivery free
+
+`GitHubWebhookProcessor.SkipReason` is the complete list of reasons a source that *targets* the
+built repository is nevertheless left alone:
+
+| Skip reason | Meaning |
+|---|---|
+| `config content could not be read` | the `_GitSync` node's content did not deserialize |
+| `direction is ExportOnly` | the source refuses imports |
+| `branch 'X' != built branch 'Y'` | the build is not on the branch this source tracks |
+| **`already at this commit`** | **`lastSyncCommitSha == headSha`** |
+
+Only the last one is a *work* saving, and it is keyed on exactly one field. Deliveries two and three
+of a merge, and every cron tick until the next merge, are free **iff** the first delivery advanced
+`lastSyncCommitSha` to that commit.
+
+## 3. What a non-skipped delivery costs
+
+`GitHubSyncService.FetchAndImport` runs in this order:
+
+```text
+repoClient.Fetch(repoUrl, commitish, subdirectory, token)   ← git init + fetch --depth 1 + checkout
+      ↓                                                       into a fresh temp dir, then read the
+ParseSnapshot(snapshot, …)                                    whole worktree into RepoFiles
+      ↓                                                     ← every file materialised as a MeshNode
+repoClient.GetChangedPaths(baseSha …)                       ← the git diff — only now
+      ↓
+StaticRepoImporter.ImportSource(…, changedNodePaths)        ← the diff scopes THIS
+```
+
+🚨 **The git-diff scope is a WRITE scope, never a fetch scope.** It exists to stop a routine push
+re-materialising a whole partition into the live compiler (the memex-cloud loop of 2026-07-23), and
+it does that. It does not, and cannot, avoid the transfer: the diff is computed against
+`snapshot.CommitSha`, which only exists once the snapshot has been fetched. So **fetch + parse is
+the floor cost of any delivery that is not skipped** — and for a source with no `subdirectory`, that
+is the entire repository, every time.
+
+`IGitHubRepoClient` in production is `GitProtocolRepoClient`, so this is a real clone over the git
+protocol into a unique temp directory, not a REST tree walk:
+
+```text
+git init -q
+git fetch -q --depth 1 origin {commitish}
+git checkout -q --detach FETCH_HEAD
+ReadWorktree(tmp, prefix, pathFilter)          ← the subdirectory is applied HERE
+```
+
+🚨 **A `subdirectory` scopes what is PARSED, never what is TRANSFERRED.** There is no
+sparse-checkout and no partial-clone filter: the shallow pack is one exchange for the whole tree, and
+the prefix is a filter over the worktree afterwards (`GitProtocolRepoClient.Fetch`, "*the git
+protocol transfers the (shallow) pack in one exchange, so the filter is applied while reading the
+worktree*"). A source watching a four-file subdirectory therefore clones the entire repository on
+every non-skipped delivery, exactly like a source watching the root. What the subdirectory does save
+is the parse and the write fan-out — which is why a source with **no** subdirectory on a large repo
+is the expensive shape: every file in the repository becomes a `MeshNode` in memory.
+
+## 4. 🚨 The freeze: three ways `lastSyncCommitSha` stops advancing
+
+`GitHubSyncService.MayAdvanceBaseline` is the whole decision, and it is **correct**:
+
+```csharp
+result.Preserved == 0
+  && result.Failed == 0
+  && !string.Equals(result.Outcome, "Failed", StringComparison.OrdinalIgnoreCase)
+```
+
+Each clause is there because advancing past it lost data or lost content:
+
+| Clause | Why it holds the baseline |
+|---|---|
+| `Preserved > 0` | a two-way import kept server-newer nodes, so the mesh is AHEAD of the repo. Advancing makes the next diff overwrite the very edits two-way just protected (#675 / #677). |
+| `Failed > 0` | some node did not land. Advancing makes the miss PERMANENT — every later delivery answers `already at this commit` while the node is still absent (#2229 item C). |
+| `Outcome == "Failed"` | the whole import failed and carries no per-file tally to read. |
+
+Now put that beside section 2. **The gate that makes a delivery free and the guard that protects
+un-landed content are reading the same field**, so holding the field for the second reason
+necessarily disarms the first:
+
+> A source whose import does not fully converge pays a **full fetch + parse on every delivery**,
+> for as long as it does not converge — and the rate is the **source repository's CI cadence**, not
+> anything about the source. A cron probe that never changes the tip re-clones the repository just
+> as hard as a merge does.
+
+So the allow-list's stated invariant — *"a sync source already sitting on the built sha is skipped …
+so a scheduled re-verification triggers no import at all"* — holds for every source that converges
+and **for no source that does not**. On the converging sources the 15-minute probe costs nothing at
+all; on one that cannot converge, the same probe is a full clone of that repository, 96 times a day,
+on top of roughly three per merge.
+
+None of the three freeze conditions resolves by itself:
+
+- a **preserved** node stays preserved until someone commits it back or discards it;
+- a node **failed** on a content rule fails identically on the same bytes for ever;
+- an import that failed outright fails again until its cause is fixed.
+
+### Reading it off a live portal, read-only
+
+**The discriminator is `lastSyncedAt` far behind `lastSyncAttemptAt` with an outcome of
+`Imported`.** That pair says: a sync ran, it reported that it imported, and it still did not
+reconcile — which is `MayAdvanceBaseline` returning false, which holds `lastSyncCommitSha` too.
+
+> ⚠️ **Two things that look like this and are not.** A frozen `lastSyncedAt` beside outcome
+> `Skipped` is the sanctioned no-op (#677) — see *The three clocks* in
+> [GitHub Sync](/Doc/Architecture/GitHubSync). And a `lastSyncCommitSha` a few hours behind the
+> branch tip is normal: the webhook imports **at the commit the build proved**, not at the tip, so
+> the recorded sha is the last delivered green commit, not `HEAD`.
+
+Measured across all 67 readable `_GitSync` nodes on `memex.meshweaver.cloud` (search returned 67,
+`truncated:false`; 67 read, 0 unreadable), 2026-09-10T17:30–17:39Z:
+
+| Source | Repo / subdir | `lastSyncedAt` | `lastSyncAttemptAt` | Outcome | Gap |
+|---|---|---|---|---|---|
+| `Essentials/_GitSync` | Plugins / `Essentials` | 2026-08-10T07:23:48Z | 2026-09-10T16:10:01Z | `Imported` | **31 d** |
+| `Deployments/_GitSync` | Memex / `mesh/Deployments` | 2026-09-09T01:10:46Z | 2026-09-10T15:27:00Z | `Imported` | 1 d 14 h |
+
+`Essentials` sits on `lastSyncCommitSha: 709e7307…`, **436 commits behind** the repository's head,
+with at least 11 unimported files under `Essentials/`. Its 32 siblings on the same portal and the
+same repository — `Store`, `Publish`, `Hosting`, `Chess`, `BusinessRules`, … — all carried
+`f4570459…` with `lastSyncedAt` **equal to** `lastSyncAttemptAt`. Same repository, same webhook, same
+schedule; the difference is convergence.
+
+`Deployments/_GitSync` is the only source in the set carrying `twoWay: true`, i.e. the
+`Preserved > 0` arm — and the **independent** node of the same path on `memex.systemorph.com` reads
+`lastSyncedAt: 2026-08-19T20:06:37Z` against a `lastSyncAttemptAt` of 2026-09-10T15:27:00Z: **22
+days** of attempts that never reconciled. (The two portals hold two independent nodes here, not a
+replica and its lag — read both before concluding anything about either.)
+
+### The check
+
+1. `get @{Space}/_GitSync` and compare `lastSyncedAt` against `lastSyncAttemptAt`. Equal (or within
+   the same run) ⇒ converging, nothing to see. A gap of days with outcome `Imported` ⇒ frozen.
+2. Only then is the sha worth looking at — it tells you how much the freeze has cost:
+
+```bash
+gh api "repos/<owner>/<repo>/compare/<lastSyncCommitSha>...main" \
+  --jq '{ahead:.ahead_by, behind:.behind_by, files:(.files|length)}'
+```
+
+`behind_by: 0` confirms the recorded sha is still an ancestor (nothing was force-pushed away);
+`ahead_by` is how many commits of deliveries the source has been paying for without converging.
+
+## 5. What the content-addressed marker does and does not close
+
+[The import marker](/Doc/Architecture/ImportMarkerRecordsConvergence) narrows this a long way. When
+a pass refuses nodes and **every** refusal is a verdict about the content, the importer records
+`ImportedWithContentErrors`, stamps the fingerprint marker `Failed`, and the next pass at the same
+fingerprint short-circuits to `Skipped` — which carries `Failed == 0`, so the baseline finally
+advances and section 2's gate re-arms. That turns "every delivery" into "twice per new commit".
+
+Two limits are worth stating exactly:
+
+- **It engages after the fetch.** The marker id *is* the fingerprint of the parsed source, so the
+  repository has already been cloned and parsed by the time the short-circuit is reachable. The
+  saving is the write fan-out and the NodeType recompiles, not the transfer.
+- **It needs the pass to be ALL-deterministic.** `IsContentVerdict` is a deliberately short
+  allow-list — `InvalidPath`, `InvalidNodeType`, `ValidationFailed`, `Unauthorized` — and everything
+  else, including every unclassified infrastructure fault (`Unknown`: "Persistence read failed…",
+  "Inner CreateNode faulted…"), stays retryable, because getting *that* backwards freezes a healthy
+  partition out of the mesh (#3101). One `Unknown` among four hundred content verdicts keeps the
+  outcome `ImportedWithErrors`, keeps the marker `Warning`, and keeps the partition re-importing on
+  every delivery.
+
+## 6. The worst case is a misconfigured source
+
+A `_GitSync` is Space-scoped: its repository (or its `subdirectory`) is expected to hold that
+Space's **content tree**. Point one at a repository whose tree is *code* — a framework repo with no
+`subdirectory`, say — and the import can never come out clean:
+
+- a `samples/**` tree of sample partitions imports as nodes *under* the Space, and a partition-owning
+  type refused there answers `A 'Space' owns its partition, so it must be top-level` (`InvalidPath`);
+- content whose `$type` no registry resolves is refused by `ContentDiscriminatorValidator`
+  (`ValidationFailed`);
+- a file that maps to neither a NodeType nor content is refused as a bare node (`ValidationFailed`).
+
+Every one of those refusals is permanent, so the source never converges, so — by section 4 — it pays
+the full clone on **every** delivery of that repository, for ever. `Systemorph/Memex#237` is the
+live instance: a `MeshWeaver/_GitSync` on `memex.meshweaver.cloud` pointing at
+`https://github.com/Systemorph/MeshWeaver` with no subdirectory, 389 refused nodes per pass.
+
+**The fix for that shape is the configuration, not the engine**: give the source a `subdirectory`
+that really is a content tree, or delete the source. The engine's own share of the problem is the
+one section 4 states — that the cheapness gate has no way to say *"we have already looked at exactly
+these bytes for this source"* independently of *"the mesh is known to hold this commit"*.
+
+## See also
+
+- [Syncing a Space with GitHub](/Doc/Architecture/GitHubSync) — the feature, the three clocks, the webhook setup.
+- [The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence) — the content-addressed short-circuit and what may write it.
+- [Static Repo Import](/Doc/Architecture/StaticRepoImport) — fingerprint, activity lock, upsert, prune.
+- [Sync Ref Contract](/Doc/Architecture/SyncRefContract) — what a build completion records and who consumes it.

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -180,10 +180,10 @@ Measured across all 67 readable `_GitSync` nodes on `memex.meshweaver.cloud` (se
 | `Deployments/_GitSync` | Memex / `mesh/Deployments` | 2026-09-09T01:10:46Z | 2026-09-10T15:27:00Z | `Imported` | 1 d 14 h |
 
 `Essentials` sits on `lastSyncCommitSha: 709e7307…`, **436 commits behind** the repository's head,
-with at least 11 unimported files under `Essentials/`. Its 32 siblings on the same portal and the
-same repository — `Store`, `Publish`, `Hosting`, `Chess`, `BusinessRules`, … — all carried
-`f4570459…` with `lastSyncedAt` **equal to** `lastSyncAttemptAt`. Same repository, same webhook, same
-schedule; the difference is convergence.
+with at least 11 unimported files under `Essentials/`. It is the **only** one of the 34 sources on
+that repository off the shared baseline: its 33 siblings — `Store`, `Publish`, `Hosting`, `Chess`,
+`BusinessRules`, … — all carried `f4570459…` with `lastSyncedAt` **equal to** `lastSyncAttemptAt`.
+Same repository, same webhook, same schedule; the difference is convergence.
 
 `Deployments/_GitSync` is the only source in the set carrying `twoWay: true`, i.e. the
 `Preserved > 0` arm — and the **independent** node of the same path on `memex.systemorph.com` reads

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-space-that-never-finishes-syncing-re-downloads-its-repository-every-time.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-space-that-never-finishes-syncing-re-downloads-its-repository-every-time.md
@@ -1,0 +1,51 @@
+---
+Name: A Space that never finishes syncing re-downloads its repository every time
+Category: Feature
+Description: A green build of a repository imports into every Space that syncs it, and a Space already sitting on the built commit is skipped for free. But the field that earns that skip is deliberately held back whenever an import does not fully reconcile — so a Space that never reconciles is the one that re-clones the repository on every build, at the repository's CI cadence rather than its own. The cost model, the two-line check for a stuck source, and the measurements are now written down.
+Icon: DocumentBulletList
+Order: -20260910
+---
+
+A Space connected to GitHub stays current without polling: every green build of its repository is a
+webhook delivery, and the delivery imports. A Space that already sits on the built commit is skipped
+at no cost, which is what makes the arrangement affordable — most deliveries do nothing at all.
+
+That skip is earned by a single field on the sync source, `lastSyncCommitSha`. And the same field is
+deliberately **held back** whenever an import did not fully reconcile: when two-way protection kept
+server-newer nodes, when a node did not land, or when the import failed outright. Each of those
+holds exists because advancing past it once lost content. Together they mean something nobody had
+written down:
+
+> A sync source that never reconciles pays a **full download and parse of its whole repository on
+> every delivery**, for as long as it does not reconcile — and the rate is set by that
+> repository's CI schedule, not by anything about the Space.
+
+On `Systemorph/MeshWeaver` that schedule is 254 green publish signals in 24 hours (measured
+2026-09-10), 87 of them from a probe that runs every fifteen minutes and builds nothing. For the
+Spaces that reconcile, all 254 cost nothing. For one that does not, all 254 are a clone.
+
+## How to tell whether a source is stuck
+
+Open the Space's **GitHub Sync** settings, or `get @{Space}/_GitSync`, and compare two of the three
+clocks:
+
+- `lastSyncedAt` ≈ `lastSyncAttemptAt` → the source is reconciling. Nothing to do.
+- `lastSyncedAt` **days behind** `lastSyncAttemptAt`, with outcome `Imported` → it runs, it reports
+  that it imported, and it still has not reconciled. That is the stuck shape.
+
+A frozen `lastSyncedAt` beside outcome `Skipped` is *not* this — that is the sanctioned no-op, and a
+`lastSyncCommitSha` a few hours behind the branch tip is normal too, because a delivery imports at
+the commit the build proved rather than at the tip.
+
+Two live examples measured on 2026-09-10: `Essentials` last reconciled 2026-08-10 while attempting
+that same afternoon, 436 commits behind; `Deployments` on the staff portal last reconciled
+2026-08-19 while attempting the same afternoon. Both were reported as `Imported` every time.
+
+## What is now written down
+
+[What a Green Build Costs a Synced Space](/Doc/Architecture/GitSyncTriggerCost) carries the whole
+model: which workflow runs count as a publish signal, the four reasons a delivery is skipped, what a
+non-skipped delivery actually transfers (a shallow clone of the **entire** repository — a configured
+subdirectory filters what is parsed, never what is downloaded), the three ways the baseline freezes
+and why each one is correct on its own, what the content-addressed import marker already narrows,
+and the check above.


### PR DESCRIPTION
Docs only. Written while re-measuring the premise of `Systemorph/Memex#237` (*memex-cloud
re-imports the ENTIRE core repository on every green core build*), which turned out to rest on a
platform behaviour nothing had written down.

## The finding

`GitHubWebhookProcessor.SkipReason` makes a green-build delivery free for exactly one reason —
`lastSyncCommitSha == headSha` — and `GitHubSyncService.MayAdvanceBaseline` deliberately **holds**
that same field whenever an import did not fully converge (`Preserved > 0` — #675/#677;
`Failed > 0` — #2229 item C; outcome `Failed`). Each hold is correct on its own and has an incident
behind it. Together:

> A sync source that cannot converge pays a full `fetch --depth 1` of its **whole** repository plus a
> full parse on **every** publish-signal delivery, and the rate is the source repository's CI
> cadence, not anything about the source.

The trigger allow-list states the opposite as its justification (`PublishSignalTriggers`:
*"Widening this cannot cause churn. A sync source already sitting on the built sha is skipped by
`SkipReason` … so a scheduled or dispatched re-verification of an unchanged default branch triggers
no import at all"*). That invariant holds for every source that converges and for no source that
does not — and the ones that do not are the ones whose imports are most expensive.

Two things the code makes true that nothing said either:

- **The git-diff scope is a WRITE scope, never a fetch scope.** `FetchAndImport` must fetch first,
  because `GetChangedPaths` needs `snapshot.CommitSha`.
- **A configured `subdirectory` filters the worktree READ, not the transfer.** There is no
  sparse-checkout and no partial-clone filter, so a source watching a four-file subdirectory clones
  the entire repository on every non-skipped delivery.

## Measurements in the page (all read-only)

- `Systemorph/MeshWeaver` `main`, 24 h to 2026-09-10T17:35Z: **254 green publish-signal runs** — 87
  of them `Prod synthetic probe` (`cron: "*/15 * * * *"`, an HTTP probe that builds nothing, at a
  `head_sha` that does not move between merges), and **three** separate workflows green per push.
  `Admin/_Build/Systemorph.MeshWeaver` on memex.meshweaver.cloud read **version 4778** at
  2026-09-10T17:21Z, first written 2026-08-06T07:38:37Z — **4,775 deliveries in 35 days**.
- All **67 of 67** readable `_GitSync` nodes on memex.meshweaver.cloud (search `truncated:false`, 0
  unreadable), 17:30–17:39Z. `Essentials/_GitSync` last reconciled **2026-08-10T07:23:48Z** while
  attempting at 2026-09-10T16:10:01Z with outcome `Imported`, on a baseline **436 commits behind**
  (`behind_by: 0` — still an ancestor) with ≥11 unimported files under its own subdirectory. Its
  **32 siblings on the same repository** all carry the shared baseline with `lastSyncedAt` equal to
  `lastSyncAttemptAt`. The independent `Deployments/_GitSync` on memex.systemorph.com has been in the
  same state for **22 days**, and is the only source carrying `twoWay: true`.

The page also gives the read-only check (`lastSyncedAt` vs `lastSyncAttemptAt`, *then* the sha) and
names the two look-alikes that are **not** this: a frozen horizon beside outcome `Skipped` (the
sanctioned no-op, #677) and a sha behind the branch tip (normal — a delivery imports at the commit
the build proved, not at the tip).

## What is NOT in this PR, and why

The engine fix is filed as **#3945** rather than shipped. The sketch is to record the commit the
last *attempt* targeted, separately from the commit the mesh is known to hold, so the webhook can
skip *"we have already looked at exactly these bytes"* without touching the conservative baseline.
It is not shipped here because today's accidental retry-on-next-delivery is load-bearing for exactly
the failures `IsContentVerdict` refuses to call final (`Unknown` — a store blip, an inner-create
fault), so replacing it needs a bounded re-attempt of its own or a deliberate carve-out. That is a
design decision about a live fleet's sync engine, not a patch.

## Verification

```
dotnet build -c Release -warnaserror test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj
  → Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test test/MeshWeaver.Documentation.Test --no-build -c Release
  → Passed! Failed: 0, Passed: 373, Skipped: 0, Total: 373
```

Both new files confirmed present in the built `MeshWeaver.Documentation.dll` (the embedded-resource
false-pass trap), and `DocumentationLinkIntegrityTest` + `ArchitectureTopicMapTest` are among the
373.

Refs Systemorph/Memex#237, #3945, #675, #677, #2229, #3146, #3581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
