### PR TITLE
fix(#3911): the loader says WHICH generation of a module is running

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -277,6 +277,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Module-Owned Siblings Ride](ModuleOwnedSiblingsRide)
 - [The Module Platform Link Gate](ModulePlatformLinkGate)
 - [The Module Publication Gate](ModulePublicationGate) — a bundle used to reach the live registry from inside its own pack leg, before the sibling suites, the portal-host shards, the compile-check and the Tests-area gate had reported; the hand-over moved downstream of the full source verdict, and what it refuses (failed, skipped, cancelled, missing, foreign-lane, substituted)
+- [Module Generation Substitution](ModuleGenerationSubstitution) — `Assembly.LoadFrom` does not promise to load the path it is handed: a byte-identical copy the load context already holds is returned instead, silently, so the loader recorded the generation it ASKED for while the process ran another; the three answers that replace two
 - [Module Set Convergence](ModuleSetConvergence)
 - [Module Versioning](ModuleVersioning)
 - [Modules](Modules)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleGenerationSubstitution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleGenerationSubstitution.md
@@ -1,0 +1,128 @@
+---
+Name: Module Generation Substitution
+Category: Architecture
+Description: Assembly.LoadFrom does not promise to load the path it is handed — it silently returns a copy the default load context already holds. What that did to the InstanceAction control plane, why nothing logged a word, and the three answers the loader now gives instead of two.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h9"/><path d="M4 12h16"/><path d="M4 17h9"/><path d="m16 4 4 3-4 3"/></svg>
+---
+
+# Module Generation Substitution
+
+> **The one sentence.** `Assembly.LoadFrom(path)` does not promise to load `path`. When the default
+> load context already holds an assembly of that identity, it returns **that** copy — same instance,
+> its own `Location`, no exception and no diagnostic — so a loader that records the path it *asked
+> for* is recording something nobody measured.
+
+This page is the finding behind [MeshWeaver#3911](https://github.com/Systemorph/MeshWeaver/issues/3911),
+where the `Hosting/InstanceAction` control plane on the control instance went silently dead after an
+activation restart and no log line anywhere named a cause.
+
+## What was measured
+
+Two copies of one assembly, three cases, .NET 10 on macOS, 2026-09-10:
+
+| The second `LoadFrom` is handed… | What happens |
+|---|---|
+| a copy carrying **different bytes** | throws `FileLoadException: Assembly with same name is already loaded` |
+| a **byte-identical** copy at another path | **returns the first copy, silently** — same instance, `Location` = the *first* path |
+| a copy of an assembly already loaded from `/app` | **returns the `/app` one, silently** |
+
+The throwing case was already handled: the loader catches it, records the generation as never
+loaded, and falls back to the previous one — with a `[MeshWeaver.Mesh.FallbackModule]` line on
+stderr. The **silent** case was handled nowhere, because nothing compared the path that was asked
+for with the path that arrived.
+
+## Why this happens in production, not just in a test process
+
+Four modules ship in the portal image as `MeshModuleClosure` **seeds** — `MeshWeaver.AI`,
+`MeshWeaver.Blazor.Chat`, `MeshWeaver.Markdown.Collaboration` and the MCP server — under
+`modules/<name>/`, so a self-registry install has *some* copy even with no registry to serve one.
+The registry then lands the same module again as a generation, `modules/<name>@<id>/`. Two paths,
+one assembly identity, and whichever a boot reaches first takes the name **for the whole process**.
+A landed generation that is byte-identical to the seed (a re-publish, or a seed cut from the same
+commit) is therefore substituted with nothing said.
+
+## The blast radius, and why it renews itself
+
+Every later reading of *"which generation is this process running"* is derived from the assembly the
+loader kept, and inherited the wrong answer without a comparison anywhere:
+
+- `InstalledModuleAssembly` — and therefore the in-mesh **compile reference set** and each
+  NodeType's stamped `compiledDependencies`;
+- `ModuleActivationStatus.LoadedModuleGenerations()` — the loaded-generation map;
+- the **module-set adoption** record, which claims *this replica runs this set*.
+
+The activation record names generation B; the process runs generation A; the derivation reads the
+difference as an ordinary pending update and prints **"restart to activate"**. The next boot
+resolves the same two paths the same way, so the prompt renews itself and no restart clears it —
+which is what left the control instance recycling with a control plane that could not be operated,
+and whose own restart is an `InstanceAction`.
+
+🚨 **The silence was the defect, not the substitution.** One copy per name in the default load
+context is a runtime constraint, not a bug. Not being able to *say which copy* is the bug.
+
+## The control that could not fail
+
+`ModuleLoadReport` was built for exactly this class of question (#2223: *say which copy of each
+module pack is actually loaded*), and its `Describe` carried the claim:
+
+> it reports the paths it is GIVEN — the same array that goes to `InstallAssemblies` — so the report
+> and the load can never disagree by construction.
+
+That makes the report agree with the **request**. It says nothing about the **load**, because the
+report is computed from files *before* anything is loaded and is never reconciled with what came
+back. It is the shape [Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail) calls
+*a writer whose failure mode is a success line*: the line prints the generation that was requested,
+whether or not that generation ever ran.
+
+The loader is the only place that holds both halves, so that is where the comparison now lives —
+`MeshBuilder.SubstitutedLocationOf`, one `Path.GetFullPath` comparison against
+`Assembly.Location`. An assembly with no readable location answers "cannot see", never a finding.
+
+## Three answers, never two
+
+A substituted load is recorded as a `FallbackModule` carrying **`RunsAlreadyLoadedCopy`** — the same
+record that already means *present, running, and behind*, so every surface that reads it (the boot
+stderr line, the Warning re-log, `RequiredModuleStatus`, the package card, the activation report,
+the adoption's running-generations map) names the state for free, and the report stops promising a
+restart that cannot clear it.
+
+The one place it must **not** be folded into the existing arms is the unloadable marker (#3650),
+which answers *do these bytes load on this platform build*. This boot never asked:
+
+| Verdict | Marker | Why the other two are wrong |
+|---|---|---|
+| **Unloadable** — measured, refused | written | — |
+| **Loaded** — measured, ran | cleared | — |
+| **Not measured** — never reached the loader | **untouched** | writing it makes the update reconcile permanently `SkipUnloadable` every rebuild of a version nobody executed; clearing it erases an earlier boot's real measurement |
+
+`ModuleActivationBoot.MeasuredLoadability.HeadNotMeasured` is that third answer, and
+`RecordMeasuredLoadability` neither writes nor clears on it — the same
+*"I did not check" is distinct from "I checked and it was clean"* discipline as
+`NodeDiagnosticsOutcome`.
+
+## What is NOT claimed
+
+- **Nothing here says those bytes are bad.** The head generation may be perfectly loadable; it
+  simply never got a turn. The reason string says only what happened.
+- **A restart is not promised, and not ruled out either.** Which of two paths a boot reaches first is
+  not something a status surface may predict, so this is never "restart required" — the same rule
+  the other fallback arms follow.
+- **`compiledDependencies` divergence across a module MVID is a separate question.** A substituted
+  load is byte-identical by construction (a different build throws instead), so it cannot by itself
+  move a stamped MVID. #3911's report pairs an MVID with a generation directory; that pairing was
+  not re-measurable after the pods rolled and is not asserted by this page.
+
+## Where the code is
+
+| Piece | File |
+|---|---|
+| The comparison | `MeshBuilder.SubstitutedLocationOf` (`src/MeshWeaver.Mesh.Contract/MeshBuilder.cs`) |
+| Who holds a taken name, for the refusal message | `MeshBuilder.WhereTheNameIsAlreadyHeld` |
+| The record arm | `FallbackModule.RunsAlreadyLoadedCopy` (`src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs`) |
+| The third marker answer | `ModuleActivationBoot.MeasuredLoadability.HeadNotMeasured` (`src/MeshWeaver.PluginCatalog/ModuleActivation.cs`) |
+| Repro through the real loader | `ConfiguredModuleActivationTest.WhenTheLoadContextAlreadyHoldsTheName_TheLoaderSaysWhichGenerationIsRunning` |
+| The marker's pure control | `ModuleUnloadableMarkerTest.ABootThatNeverReachedTheHeadsBytes_NeitherWritesNorClearsItsMarker` |
+
+See also: [Module Versioning](/Doc/Architecture/ModuleVersioning) ·
+[Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) ·
+[Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-your-installation-now-says-which-version-of-a-module-it-is-really-running.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-your-installation-now-says-which-version-of-a-module-it-is-really-running.md
@@ -1,0 +1,54 @@
+---
+Name: Your installation now says which version of a module it is really running
+Category: Fix
+Description: A module can be present in two places at once, and only one of them can actually run. Your installation used to report the one it asked for; now it reports the one it is running, and stops asking you to restart for something a restart cannot change.
+Icon: Checkmark
+Order: -20260910
+---
+
+# Your installation now says which version of a module it is really running
+
+A module can exist in **two places at once** on your installation: the copy that ships inside the
+platform image, and the copy the registry delivered. That is deliberate — the built-in copy is what
+lets a module work at all on an installation with no registry to serve one.
+
+But only **one** of them can actually run. Which one wins is decided the moment the module is first
+needed, and until now nothing checked the answer. Your installation recorded the version it *asked
+for* and carried on. If that was not the version it got, everything downstream inherited the wrong
+answer, and nothing anywhere said so.
+
+That happened on a live installation. It showed up as **"restart to activate"** that never went
+away: the restart ran, the same two copies were still there, the same one won, and the message came
+straight back. There was nothing in any log to explain it, and no way to tell from the outside
+whether an update had taken effect or not.
+
+## What changes
+
+**The module list now shows the version that is running, not the one that was requested.** Where
+the two differ you see both — *"running this one; that one was requested and never started"* —
+together with the reason. This is the same row your installation already uses for a module that is
+running an older version than the newest one installed, so nothing new has to be learned to read it.
+
+**"Restart required" is no longer shown when a restart cannot help.** As with a module held back for
+a newer platform, a prompt no restart can clear is worse than no prompt: it hides a real state
+behind an action that does nothing. The state is now named instead.
+
+**An update is no longer written off because it never got a turn.** Your installation keeps a note
+of module versions it has tried and found unrunnable, so it does not keep re-downloading them. A
+version that never actually started is a different thing from one that started and failed — it has
+not been judged at all, and it is no longer recorded as if it had. Without this, a perfectly good
+update could be skipped for good on the strength of a test that never ran.
+
+**When a module genuinely cannot load because another copy holds its place, the message says
+where.** Previously it named only the module. It now also names the file that is occupying the
+name — which is the copy your installation is actually running.
+
+## What this does not change
+
+**Nothing about which copy wins.** That is a property of how the platform loads code, not a setting,
+and this change does not alter it. What changed is that your installation can now *tell you* — and
+tells its own bookkeeping the truth as well.
+
+**Nothing is refused that used to work.** The module still loads, still registers, still serves its
+features. A readiness check stays healthy on it, and a module listed as required still counts as
+present. The only difference is that the version is now reported accurately.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -245,6 +245,22 @@ public record MeshBuilder
             if (newest.Loaded is not null)
             {
                 pending.Add(newest.Loaded);
+                // 🚨 The generation loaded — but not necessarily THIS one. When the default load
+                // context already held this identity, LoadFrom silently handed back that copy, and
+                // what runs is the generation at LoadedFrom. Recorded as a FallbackModule for the
+                // same reason the link-refusal fallbacks are: the module is present and running,
+                // one generation is in effect and another is not, and a surface that cannot say
+                // which reports a restart no restart can clear.
+                if (newest.LoadedFrom is { } already)
+                    fallbacks.Add(ReportFallback(new FallbackModule(
+                        newest.Loaded.Assembly.GetName().Name ?? Path.GetFileNameWithoutExtension(module.Location),
+                        module.Location, already,
+                        "this process had already loaded an assembly of that name, and the default "
+                        + "load context holds one copy per name")
+                    {
+                        Version = module.Version,
+                        RunsAlreadyLoadedCopy = true,
+                    }));
                 continue;
             }
 
@@ -276,11 +292,14 @@ public record MeshBuilder
                 if (retry.Loaded is not null)
                 {
                     pending.Add(retry.Loaded);
+                    // The row names the file that is RUNNING, which is the previous generation
+                    // unless the load context already held this identity elsewhere — then it is
+                    // that copy, and saying "previous" would name a generation nothing is running.
                     fallbacks.Add(ReportFallback(new FallbackModule(
-                        newest.Refused.Name, module.Location, previous, reason)
+                        newest.Refused.Name, module.Location, retry.LoadedFrom ?? previous, reason)
                     {
                         Version = module.Version,
-                        PreviousVersion = module.PreviousVersion,
+                        PreviousVersion = retry.LoadedFrom is null ? module.PreviousVersion : null,
                     }));
                     continue;
                 }
@@ -309,10 +328,19 @@ public record MeshBuilder
                 {
                     pending.Add(image.Loaded);
                     fallbacks.Add(ReportFallback(new FallbackModule(
-                        newest.Refused.Name, module.Location, baseline, reason)
+                        newest.Refused.Name, module.Location, image.LoadedFrom ?? baseline, reason)
                     {
                         Version = module.Version,
-                        RunsImageBaseline = true,
+                        // RunsImageBaseline only when the image copy is what actually loaded: a
+                        // substituted load runs neither the head nor the image, and stamping the
+                        // '@image' generation on it would record a generation nothing is running.
+                        //
+                        // 🚨 And NOT RunsAlreadyLoadedCopy, whatever was substituted here. That
+                        // flag means "the HEAD was never measured", which is false on this branch:
+                        // the head was measured and refused, and the unloadable marker it earns
+                        // must still be written. The substitution here decides only WHICH copy the
+                        // row names as running.
+                        RunsImageBaseline = image.LoadedFrom is null,
                     }));
                     continue;
                 }
@@ -480,8 +508,121 @@ public record MeshBuilder
     /// previous generation can be tried from: an assembly that loaded and then failed to
     /// materialise holds its simple name in the default load context, and a second assembly of
     /// that name cannot be loaded beside it.</param>
+    /// <param name="LoadedFrom">The file the loaded assembly ACTUALLY came from, when it is not
+    /// the one <see cref="TryLoad"/> was asked for (<see cref="SubstitutedLocationOf"/>); null
+    /// when the load did what it was asked, and always null when nothing loaded.</param>
     private sealed record LoadAttempt(
-        PendingModuleInstall? Loaded, IncompatibleModule? Refused, bool NeverLoaded);
+        PendingModuleInstall? Loaded, IncompatibleModule? Refused, bool NeverLoaded,
+        string? LoadedFrom = null);
+
+    /// <summary>
+    /// 🚨 <b>The file <paramref name="loaded"/> actually came from, when it is NOT the one that was
+    /// asked for — otherwise <c>null</c>. <c>Assembly.LoadFrom</c> does not promise to load the
+    /// path it is given, and this is the only thing that can tell.</b>
+    ///
+    /// <para><b>Measured, 2026-09-10.</b> <c>Assembly.LoadFrom</c> against a copy of an assembly the
+    /// default load context already holds returns THAT copy — same instance, its own
+    /// <see cref="Assembly.Location"/>, no exception, no diagnostic. (Only a copy carrying
+    /// DIFFERENT bytes throws <c>FileLoadException: Assembly with same name is already loaded</c>,
+    /// which the loader already handles as "never loaded" and falls back from.) So the silent
+    /// branch is exactly the one nothing was watching: a module the image ships as a
+    /// <c>MeshModuleClosure</c> SEED under <c>modules/&lt;name&gt;/</c> and the registry lands again
+    /// under <c>modules/&lt;name&gt;@&lt;generation&gt;/</c> binds whichever path was reached first,
+    /// and every later reading of "which generation is this process running" —
+    /// <see cref="InstalledModuleAssembly"/>, <c>ModuleActivationStatus.LoadedModuleGenerations</c>,
+    /// the per-NodeType dependency record, the module-set adoption — inherits the answer without
+    /// anyone comparing it to the one that was requested.</para>
+    ///
+    /// <para>🚨 <b>Why that silence is the defect and not the substitution.</b> The activation
+    /// record names the generation it landed; the process runs another; the derivation reads the
+    /// difference as an ordinary pending update and prints <i>restart to activate</i> — a prompt no
+    /// restart can clear, because the next boot resolves the same two paths the same way. Naming it
+    /// turns an invisible, self-renewing state into a <see cref="FallbackModule"/>: present,
+    /// running, and behind, which every status surface already knows how to say.</para>
+    ///
+    /// <para>🚨 <b>The comparison is over the GENERATION, not the path</b> — the containing
+    /// directory's leaf, the same identity <see cref="FallbackModule.Generation"/> and
+    /// <c>ModuleActivationStatus.LoadedModuleGenerations</c> use, so all three agree by
+    /// construction. A different PATH with the same leaf is the same generation reached twice, and
+    /// that is routine rather than a finding: every boot copies the generation WITH its leaf into
+    /// fresh process-local storage before loading (<c>ModuleGenerationPin</c>, #2509), so a second
+    /// boot in one process legitimately asks for a new path holding the generation already running.
+    /// Reporting that would put a row on every status surface saying a module runs the generation
+    /// it runs — noise, and an operator who learns to scroll past this line has lost the signal it
+    /// exists to carry. Case-INSENSITIVE, because a generation is <c>&lt;name&gt;@&lt;id&gt;</c> or
+    /// the seed's <c>&lt;name&gt;</c> and never two leaves differing only in case, while comparing
+    /// case-sensitively would invent a finding on a case-insensitive filesystem.</para>
+    ///
+    /// <para>An assembly with no readable location (loaded from bytes) answers <c>null</c>: "cannot
+    /// see" is never reported as a finding.</para>
+    /// </summary>
+    /// <param name="loaded">The assembly <c>Assembly.LoadFrom</c> returned.</param>
+    /// <param name="requestedLocation">The path it was asked to load.</param>
+    internal static string? SubstitutedLocationOf(Assembly loaded, string requestedLocation)
+    {
+        ArgumentNullException.ThrowIfNull(loaded);
+        if (string.IsNullOrWhiteSpace(requestedLocation))
+            return null;
+        string actual;
+        try
+        {
+            actual = loaded.Location;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+        if (string.IsNullOrEmpty(actual))
+            return null;
+        try
+        {
+            var actualGeneration = Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(actual)));
+            var requestedGeneration =
+                Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(requestedLocation)));
+            // An unreadable leaf on either side is "cannot see", not "they differ".
+            if (string.IsNullOrEmpty(actualGeneration) || string.IsNullOrEmpty(requestedGeneration))
+                return null;
+            return string.Equals(actualGeneration, requestedGeneration, StringComparison.OrdinalIgnoreCase)
+                ? null
+                : actual;
+        }
+        catch (Exception exception) when (exception is ArgumentException or PathTooLongException
+                                              or NotSupportedException or IOException
+                                              or System.Security.SecurityException)
+        {
+            // An unnormalisable path is "cannot see", never a finding — the same discipline
+            // ModuleLoadReport keeps for an unreadable DLL.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Where the simple name <paramref name="simpleName"/> is already held in this process, for the
+    /// refusal message when <c>Assembly.LoadFrom</c> answers <i>Assembly with same name is already
+    /// loaded</i>. That exception names the identity and never the holder, so on its own it tells an
+    /// operator nothing they can act on. Null when nothing of that name is loaded, or when the
+    /// holder has no readable location.
+    /// </summary>
+    private static string? WhereTheNameIsAlreadyHeld(string simpleName)
+    {
+        if (string.IsNullOrEmpty(simpleName))
+            return null;
+        foreach (var candidate in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (candidate.IsDynamic
+                || !string.Equals(candidate.GetName().Name, simpleName, StringComparison.Ordinal))
+                continue;
+            try
+            {
+                return string.IsNullOrEmpty(candidate.Location) ? null : candidate.Location;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+        }
+        return null;
+    }
 
     /// <summary>
     /// Probes one generation against <paramref name="surface"/> and loads it. Records a failure
@@ -502,8 +643,31 @@ public record MeshBuilder
         }
         catch (Exception exception)
         {
-            return new LoadAttempt(null, IncompatibleModule.From(location, exception), NeverLoaded: true);
+            // 🚨 The name-is-taken refusal ("Assembly with same name is already loaded") names the
+            // identity and never the holder, so on its own it cannot be acted on. Say WHERE the
+            // name is held — that path is the generation this process is actually running.
+            var refusal = IncompatibleModule.From(location, exception);
+            var holder = exception is FileLoadException
+                ? WhereTheNameIsAlreadyHeld(refusal.Name)
+                : null;
+            return new LoadAttempt(
+                null,
+                holder is null
+                    ? refusal
+                    : refusal with
+                    {
+                        Error = refusal.Error
+                            + $" — that name is already held in this process by '{holder}', "
+                            + "which is the generation running here.",
+                    },
+                NeverLoaded: true);
         }
+
+        // 🚨 LoadFrom does not promise to load the path it was given: an assembly of this identity
+        // already in the default load context is returned instead, silently. Measure it here — the
+        // one place that knows both what was asked for and what arrived — so nothing downstream has
+        // to take the requested path on trust. See SubstitutedLocationOf.
+        var substituted = SubstitutedLocationOf(assembly, location);
 
         try
         {
@@ -517,7 +681,8 @@ public record MeshBuilder
                     moduleAttributes.SelectMany(a => a.DefaultNodeHubConfigurations).ToArray(),
                     moduleAttributes.SelectMany(a => a.BuilderConfigurations).ToArray()),
                 null,
-                NeverLoaded: false);
+                NeverLoaded: false,
+                LoadedFrom: substituted);
         }
         catch (Exception exception)
         {

--- a/src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModuleInstallCandidate.cs
@@ -105,6 +105,34 @@ public sealed record FallbackModule(string Name, string Entry, string PreviousEn
     public bool RunsImageBaseline { get; init; }
 
     /// <summary>
+    /// True when the generation named by <see cref="Entry"/> never entered the process because the
+    /// default load context ALREADY HELD an assembly of that name, and
+    /// <see cref="PreviousEntry"/> is the copy it handed back instead (MeshWeaver#3911).
+    ///
+    /// <para>🚨 <b>This arm exists because nothing could previously observe it.</b>
+    /// <c>Assembly.LoadFrom</c> against a copy of an assembly the default context already holds
+    /// returns THAT copy — same instance, its own location, no exception and no diagnostic (only a
+    /// copy carrying DIFFERENT bytes throws, and that path already falls back). A module the image
+    /// ships as a <c>MeshModuleClosure</c> seed under <c>modules/&lt;name&gt;/</c> and the registry
+    /// lands again under <c>modules/&lt;name&gt;@&lt;generation&gt;/</c> is exactly that shape, so
+    /// the loader recorded the generation it ASKED for while the process ran the one it got.</para>
+    ///
+    /// <para>🚨 <b>And unlike the other two arms this one is about the PROCESS, not the bytes.</b>
+    /// The head generation is not claimed to be unloadable — nothing measured it — so the reason
+    /// says what actually happened and nothing more. It clears the same way the others do: on a
+    /// boot that reaches this generation first. Which of two paths a boot reaches first is not
+    /// something a status surface may promise, so this is still never "restart required".</para>
+    ///
+    /// <para>🚨 <b>It is therefore set ONLY when the HEAD's own load was substituted</b>, never on
+    /// a fallback whose head was measured and refused and whose REPLACEMENT was then substituted.
+    /// There the head's verdict is real and its unloadable marker must still be written; the
+    /// substitution decides only which copy <see cref="PreviousEntry"/> names. Confusing the two
+    /// would make a refused build look unexamined and stop the reconcile from ever ruling it out —
+    /// which is the mirror image of the mistake this flag exists to prevent.</para>
+    /// </summary>
+    public bool RunsAlreadyLoadedCopy { get; init; }
+
+    /// <summary>
     /// The stand-in "generation" recorded for a module that runs the image-shipped baseline —
     /// what <see cref="PreviousGeneration"/> answers, what the module-set adoption writes as the
     /// running generation, and what every status surface prints. Not a directory name by
@@ -128,11 +156,14 @@ public sealed record FallbackModule(string Name, string Entry, string PreviousEn
     /// re-logged as a Warning once the logging pipeline is up.
     /// </summary>
     public string Report() =>
-        RunsImageBaseline
-            ? $"'{Name}' runs the image-shipped baseline ({PreviousEntry}) because "
-              + $"{Label(Version, Generation)} cannot load here: {Reason}"
-            : $"'{Name}' runs its previous generation {Label(PreviousVersion, PreviousGeneration)} because "
-              + $"{Label(Version, Generation)} cannot load here: {Reason}";
+        RunsAlreadyLoadedCopy
+            ? $"'{Name}' runs the copy already loaded here ({PreviousEntry}) — "
+              + $"{Label(Version, Generation)} was requested and never entered the process: {Reason}"
+            : RunsImageBaseline
+                ? $"'{Name}' runs the image-shipped baseline ({PreviousEntry}) because "
+                  + $"{Label(Version, Generation)} cannot load here: {Reason}"
+                : $"'{Name}' runs its previous generation {Label(PreviousVersion, PreviousGeneration)} because "
+                  + $"{Label(Version, Generation)} cannot load here: {Reason}";
 
     /// <summary>
     /// The status-row sentence — "runs v1.2.3 (gen A); v1.3.0 (gen B) landed but does not load
@@ -141,10 +172,13 @@ public sealed record FallbackModule(string Name, string Entry, string PreviousEn
     /// card never read two different stories about one module.
     /// </summary>
     public string Describe() =>
-        (RunsImageBaseline
-            ? "runs the image-shipped baseline"
-            : $"runs {Label(PreviousVersion, PreviousGeneration)}")
-        + $"; {Label(Version, Generation)} landed but does not load here: {Reason}";
+        RunsAlreadyLoadedCopy
+            ? $"runs {Label(PreviousVersion, PreviousGeneration)}, the copy already loaded here; "
+              + $"{Label(Version, Generation)} was requested and never entered the process: {Reason}"
+            : (RunsImageBaseline
+                ? "runs the image-shipped baseline"
+                : $"runs {Label(PreviousVersion, PreviousGeneration)}")
+              + $"; {Label(Version, Generation)} landed but does not load here: {Reason}";
 
     private static string Label(string? version, string generation) =>
         string.IsNullOrWhiteSpace(version) ? $"({generation})" : $"v{version} ({generation})";

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -993,7 +993,28 @@ public static class ModuleActivationBoot
     /// (<see cref="IncompatibleModule"/>).</param>
     /// <param name="Reason">Why, when unloadable.</param>
     public sealed record MeasuredLoadability(
-        string Name, string Generation, string? FrameworkMvid, bool Unloadable, string? Reason);
+        string Name, string Generation, string? FrameworkMvid, bool Unloadable, string? Reason)
+    {
+        /// <summary>
+        /// 🚨 <b>The third answer: this boot did not MEASURE these bytes at all</b> (MeshWeaver#3911).
+        /// True when the loader fell back with <see cref="FallbackModule.RunsAlreadyLoadedCopy"/> —
+        /// the default load context already held an assembly of that name, so
+        /// <c>Assembly.LoadFrom</c> handed back that copy and the head generation never reached the
+        /// loader. <see cref="Unloadable"/> is false, and that is NOT the same as "it loaded".
+        ///
+        /// <para><b>Why it cannot collapse into either.</b> Recorded as unloadable it would write
+        /// the marker that makes the update reconcile permanently <c>SkipUnloadable</c> every
+        /// rebuild of that version — a verdict on bytes nobody executed. Recorded as loaded it
+        /// would CLEAR a marker an earlier boot wrote from a real measurement. So a boot that did
+        /// not look writes nothing and clears nothing, and the fallback record — on stderr, in the
+        /// log, and as a row on the activation report — is what says so out loud.</para>
+        ///
+        /// <para>An init property, not a fifth positional parameter: replacing a public record's
+        /// constructor is a binary break for a host compiled against the previous platform, which
+        /// is the incident <see cref="IncompatibleModule"/> exists for.</para>
+        /// </summary>
+        public bool HeadNotMeasured { get; init; }
+    }
 
     /// <summary>
     /// Reads the loader's records back onto the entries it was handed (#3650): for every enabled
@@ -1003,6 +1024,15 @@ public static class ModuleActivationBoot
     /// <see cref="IncompatibleModule"/> whose generation IS that directory says the head did not
     /// load; the absence of both says it did. A record naming another generation of the same
     /// module says nothing about this one. Pure.
+    ///
+    /// <para>🚨 <b>THREE answers, never two.</b> A fallback carrying
+    /// <see cref="FallbackModule.RunsAlreadyLoadedCopy"/> is the third: the head generation was
+    /// never handed to the loader, because the default load context already held that name, so
+    /// nothing about those bytes was measured. It comes back with
+    /// <see cref="MeasuredLoadability.HeadNotMeasured"/> and <see cref="MeasuredLoadability.Unloadable"/>
+    /// false, and <see cref="RecordMeasuredLoadability"/> neither writes nor clears its marker —
+    /// see that property for why collapsing it into either of the other two is wrong in a
+    /// different direction each way.</para>
     /// </summary>
     public static ImmutableList<MeasuredLoadability> MeasureLoadability(
         IEnumerable<ModuleActivationEntry> tried,
@@ -1026,10 +1056,14 @@ public static class ModuleActivationBoot
                     string.Equals(m.Name, entry.Name, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(GenerationOf(m.Entry), entry.Directory, StringComparison.Ordinal))
                 : null;
+            var notMeasured = fallback is { RunsAlreadyLoadedCopy: true };
             verdicts.Add(new MeasuredLoadability(
                 entry.Name, entry.Directory!, entry.FrameworkMvid,
-                Unloadable: fallback is not null || refused is not null,
-                Reason: fallback?.Reason ?? refused?.Error));
+                Unloadable: !notMeasured && (fallback is not null || refused is not null),
+                Reason: fallback?.Reason ?? refused?.Error)
+            {
+                HeadNotMeasured = notMeasured,
+            });
         }
         return verdicts.ToImmutable();
     }
@@ -1054,6 +1088,19 @@ public static class ModuleActivationBoot
         var transitions = ImmutableList.CreateBuilder<MeasuredLoadability>();
         foreach (var verdict in MeasureLoadability(tried, fallbacks, incompatible))
         {
+            // 🚨 A boot that did not look writes nothing and clears nothing (#3911). The marker
+            // answers "do these bytes load on this platform build"; this boot never asked, because
+            // the load context already held the name. Writing it would permanently SkipUnloadable
+            // every rebuild of a version nobody executed; clearing it would erase an earlier boot's
+            // real measurement. The FallbackModule record is what makes the state visible.
+            if (verdict.HeadNotMeasured)
+            {
+                onReport?.Invoke(
+                    $"module '{verdict.Name}': generation '{verdict.Generation}' was NOT measured this "
+                    + "boot — the load context already held that name, so its bytes never reached the "
+                    + "loader. The unloadable marker is left exactly as it was: " + verdict.Reason);
+                continue;
+            }
             var current = ModuleActivationSidecar.ReadUnloadable(baseDirectory, verdict.Name);
             try
             {

--- a/src/MeshWeaver.PluginCatalog/ModuleLoadReport.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLoadReport.cs
@@ -71,8 +71,18 @@ public static class ModuleLoadReport
 
     /// <summary>
     /// Describe what boot is about to load. Pure with respect to the caller's decision: it reports
-    /// the paths it is GIVEN — the same array that goes to <c>InstallAssemblies</c> — so the report
-    /// and the load can never disagree by construction.
+    /// the paths it is GIVEN — the same array that goes to <c>InstallAssemblies</c>.
+    ///
+    /// <para>🚨 <b>That makes the report and the REQUEST agree by construction; it does NOT make the
+    /// report and the LOAD agree, and reading it as though it did is how MeshWeaver#3911 stayed
+    /// invisible.</b> <c>Assembly.LoadFrom</c> does not promise to load the path it is handed: an
+    /// assembly of that identity already in the default load context is returned instead — same
+    /// instance, its own location, no exception (see
+    /// <c>MeshBuilder.SubstitutedLocationOf</c>). These lines are therefore a statement of intent
+    /// measured off FILES, and the loader is the only place that can compare them with what
+    /// arrived. It does, and records the difference as a <c>FallbackModule</c> carrying
+    /// <c>RunsAlreadyLoadedCopy</c>. Neither half is sufficient alone: this one names what was
+    /// asked for even when nothing loads, that one names what runs.</para>
     /// </summary>
     /// <param name="moduleRoot">The writable module root (<see cref="ModuleRoot.Resolve(string?)"/>).</param>
     /// <param name="resolved">Each effective module and the exact path it resolved to.</param>

--- a/test/Memex.Portal.Shared.Test/ModuleUnloadableMarkerTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleUnloadableMarkerTest.cs
@@ -155,4 +155,58 @@ public sealed class ModuleUnloadableMarkerTest : IDisposable
         Assert.Empty(ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [], [], _ => reports++));
         Assert.Equal(2, reports);
     }
+
+    /// <summary>
+    /// 🚨 <b>THE THIRD ANSWER (MeshWeaver#3911): a boot that did not LOOK writes nothing and clears
+    /// nothing.</b> When the default load context already held the module's simple name,
+    /// <c>Assembly.LoadFrom</c> handed back that copy and the head generation's bytes never reached
+    /// the loader — so this boot has no verdict on them.
+    ///
+    /// <para><b>Both collapses are wrong, in opposite directions, and each is asserted here.</b>
+    /// Reading the fallback as UNLOADABLE writes a marker that makes the update reconcile
+    /// permanently <c>SkipUnloadable</c> every rebuild of a version nobody executed; reading it as
+    /// LOADED clears a marker an earlier boot wrote from a real measurement. The two assertions
+    /// below are that pair — a not-measured boot over a clean sidecar leaves it clean, and over an
+    /// existing marker leaves the marker exactly as it found it.</para>
+    /// </summary>
+    [Fact]
+    public void ABootThatNeverReachedTheHeadsBytes_NeitherWritesNorClearsItsMarker()
+    {
+        WriteHead();
+        var tried = new[] { ReadEntry() };
+        var substituted = new FallbackModule(
+            Module, $"/pin/{Head}/{Module}.dll", $"/pin/{Previous}/{Module}.dll",
+            "this process had already loaded an assembly of that name")
+        {
+            RunsAlreadyLoadedCopy = true,
+        };
+
+        // The measurement says so in as many words: not unloadable, and not a measurement.
+        var verdict = Assert.Single(ModuleActivationBoot.MeasureLoadability([tried[0]], [substituted], []));
+        Assert.True(verdict.HeadNotMeasured);
+        Assert.False(verdict.Unloadable,
+            "nothing executed these bytes, so calling them unloadable would permanently skip every rebuild");
+
+        // Direction 1 — nothing to clear: the boot writes no marker.
+        var overClean = ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [substituted], []);
+        Assert.Empty(overClean);
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+
+        // Direction 2 — a marker a REAL measurement wrote survives untouched.
+        var measured = new FallbackModule(
+            Module, $"/pin/{Head}/{Module}.dll", $"/pin/{Previous}/{Module}.dll", "no type");
+        Assert.Single(ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [measured], []));
+        Assert.Equal(HeadMvid, ReadEntry().UnloadableFrameworkMvid);
+
+        var overMarked = ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [substituted], []);
+        Assert.Empty(overMarked);
+        Assert.Equal(HeadMvid, ReadEntry().UnloadableFrameworkMvid);
+
+        // 🚨 The negative control on the control: the SAME sidecar, the SAME entry, one boot that
+        // genuinely measured the head as loading — and the marker goes. Without this the two
+        // assertions above would also pass if RecordMeasuredLoadability had simply stopped
+        // clearing markers at all.
+        Assert.Single(ModuleActivationBoot.RecordMeasuredLoadability(root, tried, [], []));
+        Assert.Null(ReadEntry().UnloadableFrameworkMvid);
+    }
 }

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ConfiguredModuleActivationTest.cs
@@ -380,6 +380,10 @@ public class ConfiguredModuleActivationTest
         Assert.Equal(ModuleUpdateAction.SkipUpToDate, Decide(Rebuilt).Action);
 
         // ── 5. The boot loads the new head and CLEARS the marker ───────────────────────────────
+        // 🚨 This boot is handed a FRESH process-local pin of the same generation (ModuleGenerationPin
+        // copies per call), so LoadFrom hands back the copy loaded in step 1 — from a different
+        // path, but the SAME generation leaf, which is why no substitution is reported here
+        // (#3911). Same generation reached twice is routine; a different generation is the finding.
         var (afterwards, _) = Boot(deployment);
         Assert.Empty(afterwards.GetServices<FallbackModule>());
         Assert.Empty(afterwards.GetServices<IncompatibleModule>());
@@ -388,6 +392,169 @@ public class ConfiguredModuleActivationTest
         Assert.Equal(ModuleUpdateAction.SkipUpToDate, Decide(Rebuilt).Action);
         // The ordinary identity rule is back in charge: yet another build still lands.
         Assert.Equal(ModuleUpdateAction.Land, Decide(Loadable).Action);
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE repro of #3911, through the real loader.</b> <c>Assembly.LoadFrom</c> does not
+    /// promise to load the path it is handed: an assembly of that identity already in the default
+    /// load context is returned instead — same instance, its own location, NO exception (measured
+    /// 2026-09-10; only a copy carrying DIFFERENT bytes throws, and that path already falls back).
+    /// So a boot handed a generation whose name is already held runs a generation nobody asked for,
+    /// and before this the loader recorded the one it ASKED for.
+    ///
+    /// <para><b>The live shape.</b> Four modules ship as <c>MeshModuleClosure</c> SEEDS in the
+    /// portal image — MeshWeaver.AI among them — under <c>modules/&lt;name&gt;/</c>, and the registry
+    /// lands the same module again under <c>modules/&lt;name&gt;@&lt;generation&gt;/</c>. Whichever
+    /// path a boot reaches first takes the name for the whole process, and every later reading of
+    /// "which generation is running" — <see cref="InstalledModuleAssembly"/>, the loaded-generation
+    /// map, the per-NodeType dependency record, the module-set adoption — inherited the requested
+    /// answer rather than the real one. The activation report then read the difference as an
+    /// ordinary pending update and promised a restart that cannot clear it, which is what left the
+    /// control instance recycling on 2026-09-10 with nothing in any log naming a cause.</para>
+    ///
+    /// <para><b>The control runs in both directions here.</b> The first arrangement below is a
+    /// deployment whose landed generation is the only copy of its name: the loader is handed the
+    /// generation it then loads, and must report NOTHING. A detector that flagged every load would
+    /// satisfy every assertion in the second half and fail that one.</para>
+    /// </summary>
+    [Fact]
+    public async Task WhenTheLoadContextAlreadyHoldsTheName_TheLoaderSaysWhichGenerationIsRunning()
+    {
+        // ── The negative control: nothing else holds this name, so the loader loads what it asked
+        //    for and says nothing at all. Its own Deployment, because a module simple name can be
+        //    held only once per process and that is the whole subject here.
+        using (var undisturbed = new Deployment())
+        {
+            var landed = await Land(
+                undisturbed, ModuleBuiltAgainstThisPlatform(undisturbed.Module), "1.4.0");
+            var (clean, _) = Boot(undisturbed);
+            Assert.Empty(clean.GetServices<FallbackModule>());
+            Assert.Empty(clean.GetServices<IncompatibleModule>());
+            Assert.Equal(landed, Path.GetFileName(Path.GetDirectoryName(
+                Assert.Single(clean.GetServices<InstalledModuleAssembly>(),
+                        m => string.Equals(
+                            m.Assembly.GetName().Name, undisturbed.Module, StringComparison.Ordinal))
+                    .Assembly.Location)));
+        }
+
+        using var deployment = new Deployment();
+        var (asked, running, services) = await SubstitutedHead(deployment);
+
+        // The module is PRESENT — refusing it would take the module away over a diagnosis.
+        var installed = Assert.Single(services.GetServices<InstalledModuleAssembly>(),
+            m => string.Equals(m.Assembly.GetName().Name, deployment.Module, StringComparison.Ordinal));
+        Assert.Equal(running, Path.GetFileName(Path.GetDirectoryName(installed.Assembly.Location)));
+        Assert.Empty(services.GetServices<IncompatibleModule>());
+
+        // …and the loader now says WHICH generation that is, and which one it is not.
+        var fallback = Assert.Single(services.GetServices<FallbackModule>());
+        Assert.True(fallback.RunsAlreadyLoadedCopy);
+        Assert.False(fallback.RunsImageBaseline,
+            "the image copy was never TRIED — it was already loaded, which is a different fact");
+        Assert.Equal(deployment.Module, fallback.Name);
+        Assert.Equal(asked, fallback.Generation);
+        Assert.Equal(running, fallback.PreviousGeneration);
+        Assert.Equal("1.4.0", fallback.Version);
+        Assert.StartsWith(
+            $"'{deployment.Module}' runs the copy already loaded here (",
+            fallback.Report(), StringComparison.Ordinal);
+        Assert.Contains(
+            "was requested and never entered the process", fallback.Report(), StringComparison.Ordinal);
+        Assert.Contains(
+            "the default load context holds one copy per name",
+            fallback.Report(), StringComparison.Ordinal);
+
+        // 🚨 The adoption records the generation that RUNS, not the one that was asked for.
+        var index = ModuleSetStore.Read(deployment.Root);
+        Assert.Equal(running, index.RunningGenerations[deployment.Module]);
+
+        // 🚨 And the head's bytes were NOT measured, so NOTHING claims they are unloadable — that
+        // verdict would make the update reconcile skip every rebuild of 1.4.0 for good, on the
+        // strength of a test that never ran.
+        Assert.Null(ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module));
+        Assert.Null(Entry(deployment).UnloadableFrameworkMvid);
+    }
+
+    /// <summary>
+    /// The activation report NAMES the substituted generation and never calls it "restart
+    /// required" (#3911) — a restart resolves the same two paths, and the surface must not promise
+    /// what it cannot deliver. The blind reading at the end is the control: without the loader's
+    /// record the identical state reads as an ordinary pending update, which is precisely the
+    /// false prompt the control instance sat on for an hour with nothing else to go on.
+    /// </summary>
+    [Fact]
+    public async Task TheActivationReport_NamesASubstitutedGeneration_AndNeverCallsItRestartRequired()
+    {
+        using var deployment = new Deployment();
+        var (asked, running, services) = await SubstitutedHead(deployment);
+
+        var fallbacks = services.GetServices<FallbackModule>().ToArray();
+        // What the process actually runs — the generation the loader handed back, not the head.
+        var loaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { deployment.Module };
+        var generations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [deployment.Module] = running,
+        };
+
+        var report = new PendingModuleActivations(deployment.Root) { FallbackModules = fallbacks }
+            .Read(loaded, generations);
+
+        Assert.False(report.IsUndetermined, report.UndeterminedReason);
+        Assert.True(report.HasFallbacks);
+        var row = Assert.Single(report.Fallbacks);
+        Assert.Equal(asked, row.Generation);
+        Assert.Equal(running, row.PreviousGeneration);
+        Assert.Contains(
+            "was requested and never entered the process", row.Reason, StringComparison.Ordinal);
+        Assert.False(report.HasPending,
+            "a restart resolves the same two paths — the surface must not promise one that clears this");
+        Assert.False(report.HasQuarantined, "the module is running");
+
+        // 🚨 The control: strip the loader's record and the SAME state reads as a pending update.
+        var blind = new PendingModuleActivations(deployment.Root).Read(loaded, generations);
+        Assert.True(blind.HasPending,
+            "without the loader's record this is the invisible state #3911 was reported from");
+    }
+
+    /// <summary>
+    /// Arranges the #3911 state through the REAL landing service and the REAL loader, and returns
+    /// (the generation the last boot was ASKED for, the generation it is RUNNING, its services).
+    ///
+    /// <para><b>The production shape, exactly.</b> Four modules ship in the portal image as
+    /// <c>MeshModuleClosure</c> SEEDS — MeshWeaver.AI among them — at <c>modules/&lt;name&gt;/</c>,
+    /// so a self-registry install has a copy even with no registry to serve one; the registry then
+    /// lands the same build again at <c>modules/&lt;name&gt;@&lt;generation&gt;/</c>. Two paths, two
+    /// generation leaves, ONE assembly identity, identical bytes.</para>
+    ///
+    /// <para>It has to be identical bytes: a copy carrying DIFFERENT bytes is refused outright with
+    /// <c>Assembly with same name is already loaded</c> and takes the existing fallback chain, so
+    /// this is the ONLY shape that substitutes silently — which is exactly why nothing was watching
+    /// it.</para>
+    ///
+    /// <para>🚨 The explicit <c>Assembly.LoadFrom</c> of the seed stands in for whatever reaches
+    /// that path first on a portal (a sibling module's closure carries the same DLL; a boot that
+    /// ran before the landing did). It is not a stub — the CLR then does the real thing, and the
+    /// loader below is the real loader.</para>
+    /// </summary>
+    private static async Task<(string Asked, string Running, IServiceProvider Services)> SubstitutedHead(
+        Deployment deployment)
+    {
+        var build = ModuleBuiltAgainstThisPlatform(deployment.Module);
+        var seed = deployment.ShipInImage(build);
+        var running = Path.GetFileName(Path.GetDirectoryName(seed))!;
+        System.Reflection.Assembly.LoadFrom(seed);
+
+        var asked = await Land(deployment, build, "1.4.0");
+        Assert.NotEqual(running, asked);
+        Assert.Equal(asked, Entry(deployment).Directory);
+
+        // The mesh's set activates the landed generation — so the adoption below has something to
+        // be wrong about, which is the point: it must record what RUNS, not what the set names.
+        var proposed = await deployment.Landing.ProposeModuleSet().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Equal(asked, proposed!.Generations[deployment.Module]);
+
+        var (services, _) = Boot(deployment);
+        return (asked, running, services);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3911.

## Re-measured first

The issue's own diagnosis is a hypothesis, and two thirds of it did not survive re-measurement:

- **`ContentAs<T>` returning null across two collectible builds is already handled.** `ObjectAsExtensions.As<T>` recovers a same-short-named foreign type by a JSON round-trip and logs at Debug; the loud `LogError` is only for the genuinely unconvertible. That landed before the incident, so it is not what was silent.
- **`Hosting/InstanceAction` on the control instance reads `compilationStatus: Ok` today**, compiled 2026-09-10T12:02:06 — but `compiledDependencies["MeshWeaver.AI"]` is still `mvid:b1ba3029…`, the value the issue names as the PREVIOUS generation. That record is stamped from `InstalledModuleAssembly`, i.e. from the assembly the loader kept. So the divergence the issue reports is between what the loader RECORDED and what the activation entry NAMES — which is where I looked.

## What was actually measured

`Assembly.LoadFrom(path)` does not promise to load `path`. On .NET 10, 2026-09-10:

| the second `LoadFrom` is handed… | result |
|---|---|
| a copy with **different bytes** | throws `FileLoadException: Assembly with same name is already loaded` |
| a **byte-identical** copy at another path | **returns the first copy, silently** — same instance, `Location` = the *first* path |
| a copy of an already-loaded assembly | **returns the loaded one, silently** |

The throwing case was already handled (never-loaded ⇒ fallback chain ⇒ a `[MeshWeaver.Mesh.FallbackModule]` line). **The silent case was handled nowhere**, because nothing compared the path asked for with the path that arrived.

## Why it is the control plane's problem

Four modules ship in the portal image as `MeshModuleClosure` **seeds** at `modules/<name>/` — `MeshWeaver.AI` among them — and the registry lands the same build again at `modules/<name>@<generation>/`. Two paths, one identity. Whichever a boot reaches first takes the name for the whole process, and `InstalledModuleAssembly`, `LoadedModuleGenerations`, the in-mesh compile reference set, each NodeType's `compiledDependencies` and the module-set adoption all inherited the requested answer instead of the real one — with no log line anywhere. The activation report then reads the difference as an ordinary pending update and prints **"restart to activate"**, which the next boot renews.

🚨 The silence is the defect, not the substitution. One copy per name in the default load context is a runtime constraint. Not being able to *say which copy* is the bug.

## The control that could not fail

`ModuleLoadReport.Describe` carried: *"it reports the paths it is GIVEN … so the report and the load can never disagree by construction."* That makes it agree with the **request**. It is computed from files before anything loads and was never reconciled with what came back — a writer whose failure mode is a success line. Its doc is corrected and points at the reconciliation.

## The change

- **`MeshBuilder.SubstitutedLocationOf`** — the loader is the one place holding both halves, so the comparison lives there. It compares the **generation** (the containing directory's leaf — the same identity `FallbackModule.Generation` and `LoadedModuleGenerations` use), not the raw path, so a fresh per-boot `ModuleGenerationPin` copy of the generation already running is *not* reported. Unreadable on either side answers "cannot see", never a finding.
- **`FallbackModule.RunsAlreadyLoadedCopy`** — a substituted head is *present, running, and behind*, the record every status surface already reads. Set **only** when the HEAD's own load was substituted, never on a fallback whose head was measured and refused (there the head's verdict is real and its marker must still be written).
- **Three answers where the unloadable marker had two** — `MeasuredLoadability.HeadNotMeasured`; `RecordMeasuredLoadability` then neither writes nor clears. Unloadable would make the update reconcile permanently `SkipUnloadable` every rebuild of a version nobody executed; loaded would erase an earlier boot's real measurement.
- **The name-is-taken refusal now names the holder** — that file is the generation actually running.

## Control in both directions, with the assertion text

Positive — `ConfiguredModuleActivationTest.WhenTheLoadContextAlreadyHoldsTheName_TheLoaderSaysWhichGenerationIsRunning`, through the real landing service and the real loader:

```
Assert.True(fallback.RunsAlreadyLoadedCopy);
Assert.Equal(asked, fallback.Generation);
Assert.Equal(running, fallback.PreviousGeneration);
Assert.StartsWith($"'{deployment.Module}' runs the copy already loaded here (", fallback.Report(), …);
Assert.Equal(running, index.RunningGenerations[deployment.Module]);
Assert.Null(ModuleActivationSidecar.ReadUnloadable(deployment.Root, deployment.Module));
```

Negative, in the same test — an undisturbed deployment, so a detector that flagged every load fails here:

```
Assert.Empty(clean.GetServices<FallbackModule>());
Assert.Empty(clean.GetServices<IncompatibleModule>());
```

And `TheActivationReport_NamesASubstitutedGeneration_AndNeverCallsItRestartRequired`:

```
Assert.False(report.HasPending,
    "a restart resolves the same two paths — the surface must not promise one that clears this");
Assert.True(blind.HasPending,
    "without the loader's record this is the invisible state #3911 was reported from");
```

`ModuleUnloadableMarkerTest.ABootThatNeverReachedTheHeadsBytes_NeitherWritesNorClearsItsMarker` pins the third answer in both directions and carries its own negative control (a boot that DID measure still clears the marker).

**Run against the defect on purpose** (required, not inferred):
- comparison reverted to pre-fix (`substituted = null`) ⇒ both integration tests **FAIL** (`Failed: 2, Passed: 32`).
- `HeadNotMeasured` ignored ⇒ the marker test **FAILS** (`Failed: 1, Passed: 6`).

One existing assertion was green by construction and is now *explained* rather than changed: step 5 of the marker chain reaches the same generation through a fresh pin copy — a different PATH, the same GENERATION, which is routine.

## Verification

- `dotnet build -c Release -warnaserror` over the solution: **66 projects, `0 Warning(s)`, `0 Error(s)`**.
- `MeshWeaver.Compiler.Pipeline.Test`: **824 passed, 0 failed**.
- `ModuleUnloadableMarkerTest`: 7 passed. `DocumentationLinkIntegrityTest`: passed.

## Scope and what is not claimed

- Nothing says the substituted bytes are bad — they simply never got a turn; the reason string says only that.
- A restart is neither promised nor ruled out: which of two paths a boot reaches first is not something a status surface may predict.
- **The `compiledDependencies` MVID pairing in the issue body is not asserted.** A substituted load is byte-identical by construction (a different build throws instead), so it cannot by itself move a stamped MVID; that pairing was not re-measurable after the pods rolled.

Pairs-with: none — no public type or member is removed; the change adds two `init` properties and one internal method, and nothing outside core implements or overrides them.

Doc: `Doc/Architecture/ModuleGenerationSubstitution`, linked from the Architecture index. What's New: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
