### PR TITLE
fix(#3432): a read shares one stream instead of minting a permanent sync hub per request

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -3413,7 +3413,10 @@ public static class DataExtensions
         GetDataRequest _)
     {
         var workspace = hub.GetWorkspace();
-        var stream = workspace.GetStream(reference, x => x.ReturnNullWhenNotPresent());
+        // 🚨 The SHARED stream, never `GetStream(reference, x => x.ReturnNullWhenNotPresent())`: a
+        // configured reduce is uncached, and every read then minted a permanent `sync/` hub on the
+        // owning node hub (#3432). See IWorkspace.GetNullableStream.
+        var stream = workspace.GetNullableStream(reference);
 
         if (stream == null)
             return Observable.Return(new GetDataResponse(null, 0));
@@ -3781,7 +3784,10 @@ public static class DataExtensions
         WorkspaceReference<TReference> reference)
     {
         var workspace = hub.GetWorkspace();
-        var stream = workspace.GetStream(reference, x => x.ReturnNullWhenNotPresent());
+        // 🚨 The SHARED stream, never `GetStream(reference, x => x.ReturnNullWhenNotPresent())`: a
+        // configured reduce is uncached, and every read then minted a permanent `sync/` hub on the
+        // owning node hub (#3432). See IWorkspace.GetNullableStream.
+        var stream = workspace.GetNullableStream(reference);
 
         if (stream == null)
             return Observable.Return(new GetDataResponse(null, 0)
@@ -4119,7 +4125,8 @@ public static class DataExtensions
                 "Entity ID must be specified for data deletion. Collection-level deletion is not supported."));
 
         var entityRef = new EntityReference(collection, entityId);
-        var stream = workspace.GetStream(entityRef, x => x.ReturnNullWhenNotPresent());
+        // Shared stream — see IWorkspace.GetNullableStream (#3432).
+        var stream = workspace.GetNullableStream(entityRef);
         if (stream == null)
             return Observable.Return(DeleteUnifiedReferenceResponse.Fail($"Entity not found: {collection}/{entityId}"));
 

--- a/src/MeshWeaver.Data/IWorkspace.cs
+++ b/src/MeshWeaver.Data/IWorkspace.cs
@@ -73,6 +73,29 @@ public interface IWorkspace : IDisposable
         WorkspaceReference<TReduced> reference,
         Func<StreamConfiguration<TReduced>, StreamConfiguration<TReduced>>? configuration = null);
 
+    /// <summary>
+    /// The SHARED local reduced stream for <paramref name="reference"/> that answers <c>null</c> when
+    /// the referenced state is absent — the READ path's stream.
+    ///
+    /// <para>🚨 Why this exists rather than <c>GetStream(reference, x =&gt; x.ReturnNullWhenNotPresent())</c>:
+    /// a caller-supplied configuration is treated as caller-SPECIFIC and therefore stays uncached, and
+    /// every uncached reduce constructs a <c>SynchronizationStream</c> with its own hosted
+    /// <c>sync/{id}</c> sub-hub (~390 KB) that is registered for disposal on its hub-lifetime parent —
+    /// i.e. one permanent hub per CALL. Null-when-absent is a CONSTANT, not a caller identity, so it
+    /// belongs in the cache key. Measured on memex.meshweaver.cloud 2026-09-10: six
+    /// <c>GetDataRequest</c>s against one node hub took it from 8 to 14 <c>sync/</c> hubs, 1:1
+    /// (Systemorph/MeshWeaver#3432). See <c>Doc/Architecture/ReadPathStreamMinting</c>.</para>
+    ///
+    /// <para>The default implementation forwards to the uncached overload so an implementer that has
+    /// no cache of its own keeps working unchanged.</para>
+    /// </summary>
+    /// <typeparam name="TReduced">The reduced value type produced by the reference.</typeparam>
+    /// <param name="reference">The reference describing the reduced view.</param>
+    /// <returns>The shared reduced synchronization stream, or null if the reference cannot be resolved.</returns>
+    ISynchronizationStream<TReduced>? GetNullableStream<TReduced>(
+        WorkspaceReference<TReduced> reference)
+        => GetStream(reference, x => x.ReturnNullWhenNotPresent());
+
     /// <summary>Subscribes to the collection of a given type owned by a remote hub.</summary>
     /// <typeparam name="TType">The entity type whose remote collection is observed.</typeparam>
     /// <param name="address">The address of the hub that owns the data.</param>

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -895,26 +895,57 @@ public class Workspace : IWorkspace
     // A caller-supplied `configuration` DOES make the stream caller-specific (client id,
     // subscriber, initialization callback, property bag), so those stay uncached — the same
     // split the remote cache draws by keying on the subscribing identity.
-    private readonly ConcurrentDictionary<WorkspaceReference, Lazy<ISynchronizationStream>> _localStreamCache = new();
+    //
+    // 🚨 WITH ONE EXCEPTION, and it was the whole of the READ path (Systemorph/MeshWeaver#3432).
+    // `ReturnNullWhenNotPresent` is a CONSTANT, not a caller identity: it names how the reduction
+    // answers an absent state and nothing else. The read handlers
+    // (`HandleGetDataRequest` → `GetDataResponseObservable`, `GetDataFromWorkspaceCore`,
+    // `DeleteUnifiedReference`) pass `x => x.ReturnNullWhenNotPresent()` and nothing else, so every
+    // read took the uncached branch above and minted a `sync/` hub that lives until the owning node
+    // hub dies. Measured on memex.meshweaver.cloud 2026-09-10: six `GetDataRequest`s against ONE
+    // node hub took it from 8 to 14 `sync/` hubs — one per read, 1:1 — while the replica gained
+    // ~16 `sync/` hubs a minute (≈985/h, ≈385 MB/h at the ~390 KB a hub retains). So the flag is
+    // part of the KEY (see <see cref="GetNullableStream{TReduced}"/>) and the read path shares one
+    // stream per reference, exactly like every other plain reduce.
+    // See Doc/Architecture/ReadPathStreamMinting.
+    private readonly ConcurrentDictionary<(WorkspaceReference Reference, bool NullReturn), Lazy<ISynchronizationStream>> _localStreamCache = new();
 
     /// <inheritdoc />
     public ISynchronizationStream<TReduced> GetStream<TReduced>(
         WorkspaceReference<TReduced> reference,
         Func<StreamConfiguration<TReduced>, StreamConfiguration<TReduced>>? configuration
         )
-    {
-        if (configuration is not null)
-            return ReduceLocalStream(reference, configuration);
+        => configuration is not null
+            ? ReduceLocalStream(reference, configuration)
+            : GetCachedStream(reference, nullReturn: false);
 
+    /// <inheritdoc />
+    public ISynchronizationStream<TReduced> GetNullableStream<TReduced>(
+        WorkspaceReference<TReduced> reference)
+        => GetCachedStream(reference, nullReturn: true);
+
+    /// <summary>
+    /// The SHARED reduced stream for (<paramref name="reference"/>, <paramref name="nullReturn"/>) —
+    /// built once and handed to every caller. See the <see cref="_localStreamCache"/> field note for
+    /// why a reduce is neither free nor collectable, and why the null-when-absent flag belongs in the
+    /// key rather than in a caller-specific configuration.
+    /// </summary>
+    private ISynchronizationStream<TReduced> GetCachedStream<TReduced>(
+        WorkspaceReference<TReduced> reference,
+        bool nullReturn)
+    {
+        var key = ((WorkspaceReference)reference, nullReturn);
         while (true)
         {
             // Constructed BEFORE the GetOrAdd so we can tell, by identity, whether the entry we
             // ended up with is the one we just made. That single bit is what bounds the loop
             // below — see the fall-through at the end.
             var mine = new Lazy<ISynchronizationStream>(
-                () => ReduceLocalStream(reference, null),
+                () => ReduceLocalStream(
+                    reference,
+                    nullReturn ? c => c.ReturnNullWhenNotPresent() : null),
                 LazyThreadSafetyMode.ExecutionAndPublication);
-            var lazy = _localStreamCache.GetOrAdd(reference, mine);
+            var lazy = _localStreamCache.GetOrAdd(key, mine);
 
             ISynchronizationStream stream;
             try
@@ -927,7 +958,7 @@ public class Workspace : IWorkspace
                 // failure (e.g. HubDisposingException from a hub that is winding down) would
                 // otherwise poison this reference for the workspace's life. Drop the faulted
                 // entry — only if it is still ours — and let the caller see the original fault.
-                Remove(reference, lazy);
+                Remove(key, lazy);
                 throw;
             }
 
@@ -937,7 +968,7 @@ public class Workspace : IWorkspace
             if (StreamLiveness.IsUsable(stream))
                 return (ISynchronizationStream<TReduced>)stream;
 
-            Remove(reference, lazy);
+            Remove(key, lazy);
 
             // 🚨 A FRESH reduce that is ALREADY unusable means the SOURCE is gone, not that the
             // cache entry went stale — and re-reducing can only mint another corpse. Retrying was
@@ -955,9 +986,11 @@ public class Workspace : IWorkspace
             // next turn install ours. Every turn removes one entry, so this cannot spin.
         }
 
-        void Remove(WorkspaceReference key, Lazy<ISynchronizationStream> entry) =>
-            ((ICollection<KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>>)_localStreamCache)
-                .Remove(new KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>(key, entry));
+        void Remove(
+            (WorkspaceReference Reference, bool NullReturn) entryKey,
+            Lazy<ISynchronizationStream> entry) =>
+            ((ICollection<KeyValuePair<(WorkspaceReference Reference, bool NullReturn), Lazy<ISynchronizationStream>>>)_localStreamCache)
+                .Remove(new KeyValuePair<(WorkspaceReference Reference, bool NullReturn), Lazy<ISynchronizationStream>>(entryKey, entry));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -119,6 +119,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Stream Liveness and the Hub Reference](StreamLivenessAndTheHubReference) — a stream outlived the hub it held, and the contract said it could not
 - [The sync/ Hub Population](SyncHubPopulation) — a `sync/` hub is one field of a stream and a subscription makes two of them; the only reaper of a Started one is an idle sweep the traffic keeps re-arming
 - [The Evicted-Stream Retention](EvictedStreamRetention) — a change-feed eviction parks a remote stream and `ReclaimIfUnheld` refuses to dispose one that carries no lease entry, so every unleased call site retains one stream, and two `sync/` hubs, per change event
+- [The Read Path Minted a Hub Per Read](ReadPathStreamMinting) — a live in-process census decomposed a replica's `sync/` hubs into their holders and pinned the growth on the read path: a constant configuration took `GetDataRequest` out of the stream cache, so every read left a permanent hub behind (six reads, six hubs, measured on the running portal)
 - [The Recursive-Delete Drain](RecursiveDeleteDrain) — the plan is a snapshot the removals may exceed, the completion check must include the ROOT, and the stage bound measures progress, not duration
 - [Business Rules & Calculations](BusinessRules)
 - [Data Versioning Strategies](DataVersioning)

--- a/src/MeshWeaver.Documentation/Data/Architecture/EvictedStreamRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EvictedStreamRetention.md
@@ -13,6 +13,18 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 if so what holds them.** This page answers it for one named mechanism, and the evidence is a
 controlled in-process experiment rather than a heap dump.
 
+🚨 **MEASURED AND RE-SCOPED, 2026-09-10 — read this before acting on the page below.** A live census
+of a production replica classified all 475 parked streams: **474 are `MeshNodeReference` streams
+holding a lease of 1** (the `leases != 0` branch, which is the correct one — released with their
+mesh-node cache entry), and **exactly 1** is the unleased `LayoutAreaReference` shape §3 predicts is
+"the volume case". The parked count was also FLAT (474/475/475) while the replica's `sync/` hub
+population grew by 120 in eight minutes, so this mechanism is real but is neither the bulk nor the
+growth of [#3432](https://github.com/Systemorph/MeshWeaver/issues/3432). The growth was pinned
+elsewhere, by experiment — see [The Read Path Minted a Hub Per Read](../ReadPathStreamMinting). 🚨 And
+do **not** apply §9's remedy to `ReclaimIfUnheld`'s predicate: the eviction parks a HEALTHY stream
+precisely because an undeclared reader may still be attached, so disposing on "no lease was ever
+declared" cuts live readers off silently.
+
 **The verdict is RETENTION, not a leak.** Nothing is created and forgotten. The streams are parked
 *deliberately*, by code that says so, and then the one routine that could release them structurally
 declines to — for a reason that is correct in general and wrong for the majority of call sites.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
@@ -1,0 +1,239 @@
+---
+Name: The Read Path Minted a Hub Per Read
+Category: Architecture
+Description: A live census of a production replica decomposed its 4,687 sync/ hubs into their holders, falsified the standing explanation, and pinned the growth on one line - a GetDataRequest resolved its stream through the uncached configured overload, so every read left a permanent sync/ hub on the owning node hub. Six reads, six hubs, measured on the running portal.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/><path d="M19 5l2-2"/><path d="M19 19l2 2"/></svg>
+---
+
+# The Read Path Minted a Hub Per Read
+
+[#3432](https://github.com/Systemorph/MeshWeaver/issues/3432) has carried the same title since it was
+filed: *population MEASURED, cause NOT established*. This page closes the cause, and it does so with a
+**controlled experiment on a running production replica** rather than another reading of `src/`.
+
+> **Six `GetDataRequest`s against one node hub took it from 8 to 14 `sync/` hubs.** One per read, 1:1,
+> permanent.
+
+It also **falsifies** the explanation that stood before it — not the population measurement, which was
+always solid, but the mechanism [The Evicted-Stream Retention](../EvictedStreamRetention) proposed.
+That is recorded here in full, because a wrong mechanism that survives is worse than no mechanism: the
+next session builds on it.
+
+## 1. The instrument: a live census, no heap dump
+
+Every previous attempt needed a `--type Heap` dump, and [Portal Heap Is Hubs](../PortalHeapIsHubs)
+measured what that costs — a **106 s** thread suspension against a **90 s** liveness budget, i.e. the
+replica restarts and the state being measured is destroyed. The freeze scales with the heap, so the
+measurement is self-defeating exactly where the population exists.
+
+It is not needed. A `Code` node running through the kernel executes **inside the portal process**, so
+it can walk the live hub tree and read the holders' own fields:
+
+- climb `Configuration.ParentHub` to the mesh root;
+- recurse `MessageHub.hostedHubs` (the same walk `MessageHub.LiveHubTree` does for the platform
+  meter), tallying `Address.Type == "sync"` per parent;
+- for each parent, resolve its `IWorkspace` and read `_remoteStreamCache`, `_evictedRemoteStreams`,
+  `_remoteStreamLeases`, `_clientSubscriptions`, `_localStreamCache` and each data source's `Streams`;
+- attribute a `sync/` hub to the stream that minted it by walking the hub's own `disposables`
+  composite to the closure that captured the stream (`RegisterForDisposal(_ => ReleaseHub())`), then
+  reading that stream's `Reference` and `Owner`.
+
+Read-only, bounded, and it runs in ~10 ms. It is the same class of instrument as the platform meter
+(#3488), one level finer.
+
+🚨 **A run lands on whichever replica hosts the activity hub.** Two runs are comparable only when the
+`pod` and `pid` printed by the census match; a differing pod is a different population, not a trend.
+
+## 2. The decomposition (memex.meshweaver.cloud, pod `…-sd7p4`, 2026-09-10 17:34Z)
+
+Uptime 89.8 min, working set 5,382 MiB, GC heap 2,396 MiB.
+
+```
+hubs=5362  sync=4687  parents=661
+cached=214  parked=475  subs=821  local=653  dsStreams=728
+explained=2891   residual=1796      (38 % held by NONE of the known holders)
+```
+
+| holder | count | what it is |
+|---|---:|---|
+| `_clientSubscriptions` | 821 | owner-side twins of live cross-hub subscriptions |
+| data-source `Streams` | 728 | one per data source per partition |
+| `_localStreamCache` | 653 | cached plain reduces |
+| `_evictedRemoteStreams` | 475 | change-feed-parked remote mirrors |
+| `_remoteStreamCache` | 214 | live remote mirrors |
+| **unaccounted** | **1796** | — |
+
+## 3. 🚨 What this falsifies
+
+[The Evicted-Stream Retention](../EvictedStreamRetention) concluded that the parked set is filled by
+**unleased** streams — *"`LayoutAreaReference` is the volume case"* — because `ReclaimIfUnheld`
+returns early when `_remoteStreamLeases.TryGetValue` is false. Classified on the live replica:
+
+```
+parked   474  MeshNodeReference   : lease == 1
+parked     1  LayoutAreaReference : no lease entry
+```
+
+**One of 475.** The parked set is dominated by the mesh-node cache's own mirrors, which *are* leased —
+they take the `leases != 0` branch, which is the branch that is **correct**, and they are released by
+the idle sweep when their cache entry is. The unleased mechanism is real, and it is 0.2 % of the
+parked set.
+
+The parked count was also **flat across three readings** (474 / 475 / 475) while the total grew by 120.
+It is not what grows, so it cannot be what #3432 is about.
+
+The [2026-09-09 comment](https://github.com/Systemorph/MeshWeaver/issues/3432#issuecomment-5599424759)
+on #3432 was therefore right on both counts, and its warning stands: do **not** change the
+`ReclaimIfUnheld` predicate. `EvictForPath` parks a HEALTHY stream precisely because an undeclared
+reader may still be attached; disposing on "nobody ever declared a lease" would cut live readers off
+silently, and would buy ~475 hubs for a correctness regression.
+
+## 4. Where the growth actually is
+
+Three readings on the same pod and pid:
+
+| UTC | uptime | `sync/` hubs |
+|---|---:|---:|
+| 17:30:48 | 85.9 min | 4,647 |
+| 17:34:41 | 89.8 min | 4,687 |
+| 17:38:07 | 93.2 min | 4,767 |
+
+**≈ +16 hubs/min ≈ +985/h ≈ +385 MB/h** at the ~390 KB a hub retains — the same order as the ~210 MB/h
+the issue reported on a 26 h replica. **Growing, not a high-water mark**, and the growth is in the
+residual.
+
+Attribution of the residual named it precisely. On this replica one node hub —
+`LocalSyncDemo/_Sync/party-1` — held **257** `sync/` hubs (229 → 237 → 243 → 257 over eight minutes),
+and **25 of 25 sampled** were streams with
+
+```
+MeshNodeReference  owner=ds/LocalSyncDemo/_Sync/party-1
+```
+
+while that data source's own `Streams` dictionary held **one**. Streams reduced from the data source's
+primary stream, retained by nothing that indexes them.
+
+## 5. The cause, and the controlled experiment that pins it
+
+`Workspace._localStreamCache` caches a **plain** reduce and deliberately does not cache a
+**configured** one. Its own field note says why, and says what a configuration means:
+
+> A caller-supplied `configuration` DOES make the stream caller-specific (client id, subscriber,
+> initialization callback, property bag), so those stay uncached.
+
+The read handlers passed a configuration that is **none of those things** — a constant:
+
+```csharp
+// DataExtensions.GetDataResponseObservable<TReference> — the GetDataRequest handler
+var stream = workspace.GetStream(reference, x => x.ReturnNullWhenNotPresent());
+```
+
+`ReturnNullWhenNotPresent` sets one `bool` on the configuration record. It says how the reduction
+answers an absent state; it identifies no caller. But it is *a* configuration, so every read took the
+uncached branch — and, as the same field note spells out, an uncached reduce constructs a
+`SynchronizationStream`, hence a hosted `sync/{id}` sub-hub with its own Autofac scope, `TypeRegistry`
+and `JsonSerializerOptions`, **registered for disposal on its hub-lifetime parent**. One permanent hub
+per read, released only when the owning node hub dies.
+
+The experiment, run in-process on the live replica against a node in the caller's own partition:
+
+```
+BEFORE 8 sync hubs under rbuergi/HubCensus0910
+  read 1: ok  now  9 sync hubs
+  read 2: ok  now 10 sync hubs
+  read 3: ok  now 11 sync hubs
+  read 4: ok  now 12 sync hubs
+  read 5: ok  now 13 sync hubs
+  read 6: ok  now 14 sync hubs
+AFTER 14 sync hubs (delta 6 for 6 reads)
+```
+
+Three call sites shared the defect: the `GetDataRequest` handler
+(`GetDataResponseObservable<TReference>`), the unified-reference read (`GetDataFromWorkspaceCore`) and
+`DeleteUnifiedReference`.
+
+## 6. The fix
+
+The flag belongs in the **cache key**, not in a caller-specific configuration. `_localStreamCache` is
+keyed `(WorkspaceReference Reference, bool NullReturn)`, and the read path resolves its stream through
+`IWorkspace.GetNullableStream`, which shares one stream per reference:
+
+```csharp
+public ISynchronizationStream<TReduced> GetStream<TReduced>(
+    WorkspaceReference<TReduced> reference,
+    Func<StreamConfiguration<TReduced>, StreamConfiguration<TReduced>>? configuration)
+    => configuration is not null
+        ? ReduceLocalStream(reference, configuration)      // genuinely caller-specific: unchanged
+        : GetCachedStream(reference, nullReturn: false);
+
+public ISynchronizationStream<TReduced> GetNullableStream<TReduced>(
+    WorkspaceReference<TReduced> reference)
+    => GetCachedStream(reference, nullReturn: true);
+```
+
+The interface member carries a **default implementation** forwarding to the uncached overload, so an
+implementer outside this repository keeps working unchanged.
+
+The population is now bounded by **distinct references per hub** instead of by reads. Nothing about the
+read's semantics changes: the stream still replays its current value to each new subscriber and still
+pushes every later change, which is what the handler's *"No `Take(1)`: updates flow continuously"*
+contract requires.
+
+🚨 **The new bound is never worse than the old one**, and that is the whole safety argument: distinct
+references ≤ calls, always. It is not always *tight* — a reference that carries a per-request unique
+field (an `EntityReference` for a one-shot delete, say) now caches one stream per distinct entity
+rather than one per call. That is strictly fewer, it is exactly what `_localStreamCache` has always
+done for a plain reduce, and where it matters the answer is a narrower reference, not a fresh stream.
+
+**Controls in both directions** — `test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs`:
+
+| arm | asserts |
+|---|---|
+| `ReadingTheSameReferenceRepeatedly_DoesNotMintASyncHubPerRead` | five reads of one reference add **0** `sync/` hubs to the owner (it fails with **+5** on the pre-fix call site) |
+| `AnUncachedConfiguredReduce_MintsOneSyncHubPerCall` | five genuinely-configured reduces add **5** — the counter can see growth, so the flat arm is not vacuous |
+| `TheSharedReadStream_StaysLive` | a write after the reads is visible to the next read — the shared stream is a live mirror, not a snapshot |
+
+### One behaviour DID change, and it is the better half of an existing contract
+
+`ReadDuringDisposalWindowTest` (#1470) pins what a read gets when its owner is tearing down. It warms
+the reference first, then reads it again inside the disposal window — and before this change the
+second read FAULTED, because building a fresh stream is refused once hosted-hub creation is frozen,
+which is what produced the transient `ShuttingDown` NACK. With a shared stream the warmed reference is
+now **answered from the live mirror, with the data**.
+
+That is not a weakening. What #1470 forbids is a fabricated `GetDataResponse{Error}` that
+`GetMeshNode` maps to *"this node does not exist"*; real data is its opposite. The contract now has two
+halves and both are pinned:
+
+| the read | answer |
+|---|---|
+| its stream already exists | SERVED from the live mirror — data, no error |
+| its stream would have to be BUILT in the frozen window | transient `ShuttingDown` NACK naming `HubDisposingException` |
+
+The NACK arm's reference is deliberately one the owner has never reduced, and the file says so — warm
+the same reference and that test would pass on a hub that refused nothing.
+
+## 7. 🚨 Still open, and named
+
+- **The rest of the residual.** The fix addresses the `GetDataRequest` path, which is where the
+  attribution landed. 1,796 unaccounted hubs on that replica were not attributed one by one, and the
+  census is the instrument for finishing that: re-run it after a deploy carrying this change and read
+  `residual` and its slope. Two readings on the same `pod`+`pid`, minutes apart, are the trend; one
+  reading is a snapshot of a moving target. The census used here survives as a `Code` node in the
+  author's own partition, but it is a scratch node — §1 is the recipe, and the recipe is the durable
+  form.
+- **`ContentCollection.GetMarkdown` has the same shape one layer down.** It calls
+  `markdownStream.Reduce(reference, c => c.ReturnNullWhenNotPresent())` — the stream-level *uncached*
+  reduce — once per call, while the cached sibling `ReduceShared` takes no configuration by design. Same
+  remedy (the flag in `sharedReduceCache`'s key), **not measured**, so not changed here.
+- **A `GetDataRequest` read is never unsubscribed.** `HandleGetDataRequest` registers its subscription
+  for disposal on the hub, and nothing else ends it, so an owner keeps posting responses to a caller
+  that stopped listening until the hub dies. That is a lifetime defect in its own right; it costs an
+  observer, not a hub, and it is untouched here.
+
+## Related
+
+- [The `sync/` Hub Population](../SyncHubPopulation) — the 1:1 stream↔hub identity this all rests on
+- [The Evicted-Stream Retention](../EvictedStreamRetention) — the mechanism §3 re-scopes to 1 of 475
+- [Portal Heap Is Hubs](../PortalHeapIsHubs) — the dumps, and why the dump is the wrong instrument
+- [Stream Liveness and the Hub Reference](../StreamLivenessAndTheHubReference) — #3321's `Dead` half

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
@@ -113,6 +113,32 @@ MeshNodeReference  owner=ds/LocalSyncDemo/_Sync/party-1
 while that data source's own `Streams` dictionary held **one**. Streams reduced from the data source's
 primary stream, retained by nothing that indexes them.
 
+## 4b. It is NOT [#3593](https://github.com/Systemorph/MeshWeaver/issues/3593) — measured, not assumed
+
+#3593 reports a mass event on one memex-cloud pod in which every affected hub was also a `sync/` hub
+also at `RunLevel=Started`, reading `Disposal=Pending`, `buffer=1`, `exec=0`: `Dispose()` HAD been
+called and the action block never dequeued the buffered `ShutdownRequest`, so teardown never started
+and *"each pending hub pins its stream, subscriptions and object graph until restart."* Same family,
+opposite mechanism — so the census asked the question directly rather than reasoning about it. Every
+`sync/` hub on the replica, classified by the same fields `MessageHub.AppendDiagnostics` prints
+(`disposalStarted`, `DisposalSignalled`, and `MessageService.GetQueueSnapshot()`):
+
+```
+CENSUS6  pod=…-f9lb5  upMin=123.5  sync=4649
+         withBufferedMessage=0  executingATurn=0  snapshotUnreadable=0
+   4648  Started  / Disposal=<not started>
+      1  Starting / Disposal=<not started>
+```
+
+**Zero `Pending`, zero buffered, zero executing, and the denominator is the whole population** —
+`snapshotUnreadable=0` means every one of the 4,649 was actually read, not skipped.
+
+So these hubs were **never asked to dispose**. Nothing is wedged, nothing is retained against a
+teardown in progress, and no pump is stuck: they are alive because the stream that owns each of them
+is alive and nothing ever released it. That is the opposite end of the lifecycle from #3593, and it
+rules the wedged-pump explanation out for this population rather than leaving it open. #3593 keeps its
+own defect and its own fix; nothing here should be filed under it.
+
 ## 5. The cause, and the controlled experiment that pins it
 
 `Workspace._localStreamCache` caches a **plain** reduce and deliberately does not cache a
@@ -237,3 +263,4 @@ the same reference and that test would pass on a hub that refused nothing.
 - [The Evicted-Stream Retention](../EvictedStreamRetention) — the mechanism §3 re-scopes to 1 of 475
 - [Portal Heap Is Hubs](../PortalHeapIsHubs) — the dumps, and why the dump is the wrong instrument
 - [Stream Liveness and the Hub Reference](../StreamLivenessAndTheHubReference) — #3321's `Dead` half
+- [Hub Disposal Model](../HubDisposalModel) — the state machine §4b's `Disposal=` reading comes from

--- a/src/MeshWeaver.Documentation/Data/Architecture/SyncHubPopulation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SyncHubPopulation.md
@@ -12,6 +12,11 @@ at `RunLevel=Started`** — about 2.7 GB of a 3.5 GB live heap (#3432). This pag
 about where they come from and what is supposed to take them away. It is a **narrowing, not a
 diagnosis**: the sections marked 🚨 NOT ESTABLISHED are still open.
 
+🚨 **The cause was established on 2026-09-10, by experiment on a live replica: the READ path minted one
+`sync/` hub per `GetDataRequest`.** See [The Read Path Minted a Hub Per Read](../ReadPathStreamMinting),
+which also carries the live census that decomposes the population into its holders — and re-scopes the
+evicted-stream mechanism to 1 parked stream in 475.
+
 ## 1. A `sync/` hub is not a population — it is one field of a stream
 
 `SynchronizationStream<T>`'s constructor mints exactly one, unconditionally, for every stream:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-reads-no-longer-leave-a-hub-behind.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-reads-no-longer-leave-a-hub-behind.md
@@ -1,0 +1,13 @@
+---
+Name: Reading data no longer leaves a hub behind
+Category: Fix
+Description: Repeated reads of the same data now share one stream instead of leaving a permanent hub behind on every request.
+Icon: Sparkle
+Order: -20260910
+---
+
+# Reading data no longer leaves a hub behind
+
+Every read of a node's data used to build its own private copy of the underlying stream, and that copy stayed alive for as long as the node was loaded. On a busy portal the copies accumulated: a replica gained roughly a thousand of them an hour, each holding a few hundred kilobytes, which is memory a running portal never gave back.
+
+Reads of the same data now share one stream. The read itself is unchanged — it answers with the same data, and later changes still reach whoever is listening — but the portal keeps one stream per view instead of one per request.

--- a/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
@@ -272,14 +272,14 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
                         .WithInitialData(new[] { new Item("1", "one") }))))
                 .WithPostingIdentity(PostingIdentity.System));
         owner.Should().NotBeNull();
-        await owner!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+        await owner!.Started.WaitAsync(TestTimeouts.Convergence, TestContext.Current.CancellationToken);
 
         var reference = new CollectionReference(nameof(Item));
 
         // WARM THE SAME REFERENCE — this is the difference from the test above, and the whole point.
         var warm = await host
             .Observe<GetDataResponse>(new GetDataRequest(reference), o => o.WithTarget(owner.Address))
-            .Should().Within(30.Seconds()).Emit();
+            .Should().Within(TestTimeouts.Convergence).Emit();
         warm.Message.Data.Should().NotBeNull("the warm read must land, or nothing is cached to serve from");
 
         // Same ordering discipline as above: occupy the block, enqueue DisposeRequest, then the read.
@@ -299,7 +299,7 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
 
         Volatile.Write(ref release, 1);
 
-        var answer = await answers.Should().Within(30.Seconds()).Emit();
+        var answer = await answers.Should().Within(TestTimeouts.Convergence).Emit();
         Output.WriteLine($"[TEST] answer: {answer} (owner IsShuttingDown={owner.IsShuttingDown}, RunLevel={owner.RunLevel})");
 
         owner.IsShuttingDown.Should().BeTrue(

--- a/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadDuringDisposalWindowTest.cs
@@ -120,11 +120,20 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
         owner.Should().NotBeNull();
         await owner!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
-        // The happy path first, so a later non-answer can never be blamed on the reference not
-        // resolving or the source not existing.
+        // The happy path first, so a later non-answer can never be blamed on the source not
+        // existing.
+        //
+        // 🚨 A DIFFERENT REFERENCE from the one read under test, and that is load-bearing since
+        // Systemorph/MeshWeaver#3432. The read path now resolves a SHARED stream per reference
+        // (IWorkspace.GetNullableStream), so warming the SAME reference here would leave a live
+        // mirror in the cache and the read below would be ANSWERED FROM IT instead of having to
+        // build a stream in the frozen window — this test would then pass on a hub that never
+        // refused anything. That answered case is real and is pinned by
+        // AWarmedReferenceIsAnsweredFromTheLiveMirror below; THIS test is about the read that
+        // genuinely FAULTS, so its reference must be one this owner has never reduced.
         var warm = await host
             .Observe<GetDataResponse>(
-                new GetDataRequest(new CollectionReference(nameof(Item))),
+                new GetDataRequest(new EntityReference(nameof(Item), "1")),
                 o => o.WithTarget(OwnerAddress))
             .Should().Within(30.Seconds()).Emit();
         warm.Message.Data.Should().NotBeNull("the read must work before the teardown, or this test proves nothing");
@@ -220,6 +229,92 @@ public class ReadDuringDisposalWindowTest(ITestOutputHelper output) : HubTestBas
         failure.Message.Should().NotContain("No node found",
             "that phrase turns a retryable stall into a PROVABLE absence "
             + "(MeshNodeStreamCache.IsMissingNodeFailure) — the exact confusion this NACK avoids");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The OTHER half of the same window, after Systemorph/MeshWeaver#3432.</b> A read whose
+    /// stream ALREADY EXISTS is answered from that live mirror — with the data — rather than
+    /// faulting because a fresh stream cannot be built.
+    ///
+    /// <para>This is not a weakening of the test above: what #1470 forbids is answering a teardown
+    /// with a fabricated <c>GetDataResponse{Error}</c> that reads as "this node does not exist".
+    /// Real data is the opposite of that. The two arms together state the whole contract — a read
+    /// that CAN be served is served, a read that cannot be built is NACKed transient — and they are
+    /// the reason the read path may share one stream per reference instead of minting a permanent
+    /// <c>sync/</c> hub per request.</para>
+    /// </summary>
+    [HubFact]
+    public async Task AWarmedReferenceIsAnsweredFromTheLiveMirror()
+    {
+        var host = GetHost();
+
+        var owner = host.GetHostedHub(
+            new Address("data-owner", "2"),
+            c => c.WithTypes(typeof(ParkRequest), typeof(Item))
+                .WithHandler<ParkRequest>((_, d) =>
+                {
+                    try
+                    {
+                        parked.OnNext(Unit.Default);
+                        parked.OnCompleted();
+                        SpinWait.SpinUntil(
+                            () => Volatile.Read(ref release) == 1, TestTimeouts.Convergence);
+                    }
+                    finally
+                    {
+                        Volatile.Write(ref release, 1);
+                    }
+                    return d.Processed();
+                })
+                .AddData(data => data.AddSource(source =>
+                    source.WithType<Item>(type => type
+                        .WithKey(i => i.Id)
+                        .WithInitialData(new[] { new Item("1", "one") }))))
+                .WithPostingIdentity(PostingIdentity.System));
+        owner.Should().NotBeNull();
+        await owner!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        var reference = new CollectionReference(nameof(Item));
+
+        // WARM THE SAME REFERENCE — this is the difference from the test above, and the whole point.
+        var warm = await host
+            .Observe<GetDataResponse>(new GetDataRequest(reference), o => o.WithTarget(owner.Address))
+            .Should().Within(30.Seconds()).Emit();
+        warm.Message.Data.Should().NotBeNull("the warm read must land, or nothing is cached to serve from");
+
+        // Same ordering discipline as above: occupy the block, enqueue DisposeRequest, then the read.
+        host.Post(new ParkRequest(), o => o.WithTarget(owner.Address));
+        await parked.Should().Within(TestTimeouts.Convergence).Emit(
+            "PRECONDITION: the park must OWN the action block before anything else is posted");
+
+        host.Post(new DisposeRequest(), o => o.WithTarget(owner.Address));
+
+        var answers = new AsyncSubject<object?>();
+        using var reading = host
+            .Observe<GetDataResponse>(new GetDataRequest(reference), o => o.WithTarget(owner.Address))
+            .Select(d => (object?)d.Message)
+            .Catch<object?, Exception>(ex => Observable.Return<object?>(ex))
+            .Take(1)
+            .Subscribe(answers);
+
+        Volatile.Write(ref release, 1);
+
+        var answer = await answers.Should().Within(30.Seconds()).Emit();
+        Output.WriteLine($"[TEST] answer: {answer} (owner IsShuttingDown={owner.IsShuttingDown}, RunLevel={owner.RunLevel})");
+
+        owner.IsShuttingDown.Should().BeTrue(
+            "the read must have been served inside the disposal window — that IS the condition "
+            + $"under test (RunLevel={owner.RunLevel})");
+
+        var response = answer.Should().BeOfType<GetDataResponse>(
+            "a read the owner can still serve from its live mirror is SERVED, not refused — the "
+            + "stream-creation refusal only applies when a stream has to be built").Which;
+        response.Error.Should().BeNull(
+            "🚨 an Error here is exactly #1470's fabricated absence — the failure this whole file "
+            + "exists to keep out");
+        response.Data.Should().NotBeNull(
+            "the answer carries the owner's actual data; a null payload is what GetMeshNode maps to "
+            + "'this node does not exist'");
     }
 
 }

--- a/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Data.TestDomain;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 <b>A READ must not mint a permanent hub.</b> Systemorph/MeshWeaver#3432.
+///
+/// <para><b>The mechanism.</b> <c>Workspace._localStreamCache</c> caches a plain reduce and
+/// deliberately does NOT cache a CONFIGURED one, because a caller-supplied configuration is
+/// caller-specific (client id, subscriber, init callback). The read handlers, however, supplied a
+/// CONSTANT — <c>x =&gt; x.ReturnNullWhenNotPresent()</c> — so every
+/// <c>GetDataRequest</c> took the uncached branch, and every uncached reduce constructs a
+/// <c>SynchronizationStream</c>, hence a hosted <c>sync/{id}</c> sub-hub with its own Autofac
+/// scope, <c>TypeRegistry</c> and <c>JsonSerializerOptions</c> (~390 KB), registered for disposal on
+/// its HUB-LIFETIME parent (the data source's <c>EntityStore</c> stream). One permanent hub per
+/// read, released only when the owning node hub dies.</para>
+///
+/// <para><b>Measured on production before the fix</b> (memex.meshweaver.cloud, 2026-09-10): six
+/// <c>GetDataRequest</c>s against ONE node hub took it from 8 to 14 <c>sync/</c> hubs — 1:1 — and the
+/// replica was gaining ~16 <c>sync/</c> hubs a minute (≈985/h, ≈385 MB/h). The fix keys the
+/// null-when-absent flag into the cache (<see cref="IWorkspace.GetNullableStream{TReduced}"/>) so the
+/// population is bounded by DISTINCT REFERENCES instead of by reads.</para>
+///
+/// <para>🚨 <b>Both directions are asserted.</b>
+/// <see cref="AnUncachedConfiguredReduce_MintsOneSyncHubPerCall"/> drives the OLD shape — the
+/// uncached configured overload — through the same counter and shows it grow, which is what makes
+/// the flat reading in <see cref="ReadingTheSameReferenceRepeatedly_DoesNotMintASyncHubPerRead"/>
+/// mean something: without it, "the count did not move" would also pass on a build where the counter
+/// is blind. The reads' own responses are the second control: a fix that bounded the population by
+/// breaking the read would fail on the data, not on the count.</para>
+/// </summary>
+public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>Reads driven per arm. Small on purpose — the defect is monotone, so a handful
+    /// separates "one hub per read" (grows with N) from "one hub per reference" (flat).</summary>
+    private const int Reads = 5;
+
+    /// <summary>Long enough that no heartbeat resubscribe fires during the measurement, so every
+    /// hub counted is one this test caused.</summary>
+    private static readonly TimeSpan LongHeartbeat = TimeSpan.FromMinutes(5);
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithServices(services => services
+                .Configure<SyncStreamOptions>(o => o.HeartbeatInterval = LongHeartbeat))
+            .AddData(data => data.AddSource(src => src
+                .WithType<BusinessUnit>(t => t.WithInitialData(TestData.BusinessUnits))));
+
+    /// <summary>
+    /// 🚨 <b>THE FIX.</b> Five <c>GetDataRequest</c>s for the SAME reference leave the owner's
+    /// <c>sync/</c> hub population where it was: the read path resolves the SHARED stream. Each read
+    /// still answers with the data — the fix must not buy a flat count with a broken read.
+    /// </summary>
+    [HubFact]
+    public async Task ReadingTheSameReferenceRepeatedly_DoesNotMintASyncHubPerRead()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var reference = new CollectionReference(nameof(BusinessUnit));
+
+        // The first read builds the shared stream — measure from AFTER it, so the baseline is the
+        // steady state and the assertion is about the reads that follow, not about the first one.
+        await ReadAsync(client, reference, "the first read must answer before the baseline is taken");
+        var baseline = LiveSyncHubs(host);
+
+        for (var i = 1; i <= Reads; i++)
+            await ReadAsync(client, reference, $"read {i} must still answer with the collection");
+
+        var grown = LiveSyncHubs(host) - baseline;
+        Output.WriteLine($"DIAG shared: reads={Reads} ownerSyncHubs=+{grown}");
+
+        grown.Should().Be(0,
+            $"the {Reads} reads all resolve the SAME (reference, null-when-absent) key, so the owner "
+            + "keeps ONE reduced stream and ONE sync/ hub for them — before #3432's fix each read "
+            + "took the uncached configured branch and left a permanent sync/ hub behind");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE POSITIVE CONTROL FOR LIVENESS.</b> Sharing one stream between reads must not turn
+    /// it into a frozen snapshot: a write landing after the reads is visible to the next read.
+    /// </summary>
+    [HubFact]
+    public async Task TheSharedReadStream_StaysLive()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var reference = new CollectionReference(nameof(BusinessUnit));
+
+        var before = await ReadAsync(client, reference, "the initial read must answer");
+        before.Instances.Should().HaveCount(TestData.BusinessUnits.Length);
+
+        await client.Observe(
+                DataChangeRequest.Update([new BusinessUnit("3", "Third")]),
+                o => o.WithTarget(CreateHostAddress()))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        var settled = await Observable.Interval(PollInterval).StartWith(0L)
+            .SelectMany(_ => ReadObservable(client, reference).Take(1))
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(c => c.Instances.Count == TestData.BusinessUnits.Length + 1,
+                "the shared read stream is LIVE — a write after the read is visible to the next one, "
+                + "so bounding the sync/ hub population did not freeze the mirror");
+
+        Output.WriteLine($"DIAG live: instances={settled.Instances.Count}");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE CONTROL IN THE OTHER DIRECTION — the counter can see growth.</b> The uncached
+    /// configured overload is what the read path used to call, and it is still the contract for a
+    /// genuinely caller-specific configuration. Five calls, five new <c>sync/</c> hubs. If this ever
+    /// goes flat, the counter has stopped measuring and the arm above is vacuous.
+    /// </summary>
+    [HubFact]
+    public async Task AnUncachedConfiguredReduce_MintsOneSyncHubPerCall()
+    {
+        var host = GetHost();
+        var workspace = host.ServiceProvider.GetRequiredService<IWorkspace>();
+        var reference = new CollectionReference(nameof(BusinessUnit));
+
+        await workspace.GetObservable<BusinessUnit>()
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(x => x.Count > 0, "the data source must have served its initial snapshot");
+
+        var baseline = LiveSyncHubs(host);
+        for (var i = 0; i < Reads; i++)
+            _ = workspace.GetStream(reference, x => x.WithClientId($"caller-{i}"));
+
+        var grown = LiveSyncHubs(host) - baseline;
+        Output.WriteLine($"DIAG uncached: calls={Reads} ownerSyncHubs=+{grown}");
+
+        grown.Should().Be(Reads,
+            "a CONFIGURED reduce is caller-specific and therefore uncached BY CONTRACT — each call "
+            + "constructs a SynchronizationStream and its sync/ hub. This is the metric proving the "
+            + "shared arm's flat reading is a real release and not a blind counter");
+    }
+
+    /// <summary>The poll interval for a convergence wait — not a timeout, so it is not a guessed
+    /// bound; the bound is <see cref="TestTimeouts.Convergence"/> on the wait itself.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>One <c>GetDataRequest</c> round trip, asserting the answer carries the collection —
+    /// the read's OWN positive control, so a flat hub count can never come from a broken read.</summary>
+    private async Task<InstanceCollection> ReadAsync(
+        IMessageHub client, CollectionReference reference, string because)
+    {
+        var delivery = await client
+            .Observe(new GetDataRequest(reference), o => o.WithTarget(CreateHostAddress()))
+            .Should().Within(TestTimeouts.Convergence).Emit(because);
+        var response = delivery.Message.Should().BeOfType<GetDataResponse>().Which;
+        response.Error.Should().BeNull(because);
+        return response.Data.Should().BeOfType<InstanceCollection>().Which;
+    }
+
+    /// <summary>The same read as an observable, for a convergence wait — no Task bridge inside an
+    /// Rx pipeline.</summary>
+    private IObservable<InstanceCollection> ReadObservable(
+        IMessageHub client, CollectionReference reference) =>
+        client.Observe(new GetDataRequest(reference), o => o.WithTarget(CreateHostAddress()))
+            .Select(d => (d.Message as GetDataResponse)?.Data as InstanceCollection)
+            .Where(c => c is not null)
+            .Select(c => c!);
+
+    /// <summary>
+    /// #3432's own metric, in-process: <c>SynchronizationStream</c>'s constructor mints exactly one
+    /// hosted <c>sync/{ClientId}</c> hub per stream, so the owner's hosted-hub collection filtered to
+    /// <see cref="SynchronizationAddress.AddressType"/> IS the count of streams it is keeping alive.
+    /// </summary>
+    private static int LiveSyncHubs(IMessageHub hub) =>
+        hub.ServiceProvider.GetRequiredService<HostedHubsCollection>()
+            .Hubs.Count(h => h.Address.Type == SynchronizationAddress.AddressType);
+}


### PR DESCRIPTION
Closes the cause of #3432 — *population MEASURED, cause NOT established* — by measurement on a running replica, and fixes it.

## What was measured

A read-only **in-process census** (a `Code` node runs inside the portal process, so it can walk the live hub tree and read the holders' own fields — no heap dump, no 106 s freeze, no replica restart). On `memex.meshweaver.cloud`, pod `…-sd7p4`, 2026-09-10:

```
hubs=5362  sync=4687  parents=661
cached=214  parked=475  subs=821  local=653  dsStreams=728
explained=2891   residual=1796
```

**Trend, three readings on the same pod and pid:** 4,647 (85.9 min) → 4,687 (89.8) → 4,767 (93.2) = **≈ +16 sync hubs/min ≈ +985/h ≈ +385 MB/h**. Growing, not a high-water mark — the same order as the ~210 MB/h the issue reported.

## What it falsifies

`Doc/Architecture/EvictedStreamRetention` proposed that the parked set is filled by **unleased** streams, *"`LayoutAreaReference` is the volume case"*. Classified live:

```
parked   474  MeshNodeReference   : lease == 1     <- the CORRECT branch
parked     1  LayoutAreaReference : no lease entry
```

One in 475 — and the parked count was **flat** (474/475/475) while the total grew by 120. That mechanism is real and is neither the bulk nor the growth. The 2026-09-09 comment on the issue was right: do NOT change the `ReclaimIfUnheld` predicate.

## The cause, pinned by experiment

`Workspace._localStreamCache` caches a plain reduce and deliberately not a configured one, because a configuration is caller-specific. The read handlers passed a **constant** — `x => x.ReturnNullWhenNotPresent()` — so every `GetDataRequest` took the uncached branch, and an uncached reduce constructs a `SynchronizationStream`, hence a hosted `sync/{id}` hub (~390 KB) registered for disposal on its **hub-lifetime** parent.

Run in-process against a node hub on the live replica:

```
BEFORE 8 sync hubs under rbuergi/HubCensus0910
  read 1..6: ok   9, 10, 11, 12, 13, 14
AFTER 14 sync hubs (delta 6 for 6 reads)
```

## The fix

The null-when-absent flag is a constant, so it belongs in the **cache key**. `_localStreamCache` is keyed `(WorkspaceReference, bool NullReturn)` and the read path resolves `IWorkspace.GetNullableStream`. The population is bounded by distinct references instead of by reads, and the bound is never worse than before: distinct references ≤ calls. The interface member carries a **default implementation** forwarding to the uncached overload.

## Controls, both directions

| arm | asserts |
|---|---|
| `ReadingTheSameReferenceRepeatedly_DoesNotMintASyncHubPerRead` | five reads add **0** hubs — verified to fail with **+5** by reverting the call site |
| `AnUncachedConfiguredReduce_MintsOneSyncHubPerCall` | five configured reduces still add **5** — the counter can see growth, so the flat arm is not vacuous |
| `TheSharedReadStream_StaysLive` | a write after the reads is visible to the next read — a live mirror, not a snapshot |

`ReadDuringDisposalWindowTest` gains its other half: a read whose stream already exists is now served from the live mirror inside the disposal window; a read whose stream would have to be BUILT there still gets the transient `ShuttingDown` NACK naming `HubDisposingException`. Real data is the opposite of #1470's fabricated absence, so both halves are pinned.

Local: `MeshWeaver.Data.Test` **500/500**, `DocumentationLinkIntegrityTest` green, every touched project `-c Release -warnaserror` with `0 Error(s)`.

Implementers: IWorkspace.GetNullableStream — added WITH a default implementation forwarding to the existing GetStream overload, so no implementer must change; the only implementer in the fleet is MeshWeaver.Data.Workspace (checked core and MeshWeaver.Plugins origin/main), which overrides it.

Doc: `Doc/Architecture/ReadPathStreamMinting` — the census recipe, the decomposition, the falsification, the experiment, and what is still open (the rest of the residual, the same shape one layer down in `ContentCollection.GetMarkdown`, and the read subscription that is never unsubscribed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
