### PR TITLE
fix: stop re-keying a slash-bearing node id — SanitizeNodeId split one node across two PK rows (#3894)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -106,6 +106,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Update Queue Ownership](UpdateQueueOwnership) — one published queue per path, retained until accepted work settles
 - [Request via Stream Update](RequestViaStreamUpdate)
 - [Data Access Patterns](DataAccessPatterns)
+- [Node Identity and Path Keying](NodeIdentityAndPathKeying) — `(namespace, id)` is the key and `path` is derived, so splitting a path positionally leaves the path identical while re-keying the node into a second row
 - [Workspace References](WorkspaceReferences)
 - [Content Chunk Navigation](ContentChunkNavigation)
 - [Moving Nodes](MovingNodes) — a move relocates the node and everything that belongs to it, or it refuses

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeIdentityAndPathKeying.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeIdentityAndPathKeying.md
@@ -1,0 +1,131 @@
+---
+NodeType: Markdown
+Name: "Node Identity — (namespace, id) is the key, path is derived"
+Abstract: "A node's identity is the (namespace, id) pair; path is a GENERATED column derived from it. Writes upsert on the key, reads and deletes address the path — so moving a slash between namespace and id leaves the path identical while changing the key, which inserts a duplicate row instead of updating. An id may contain '/', and re-keying one is data loss."
+Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#5e35b1'/><path d='M6 8h12M6 12h12M6 16h7' stroke='white' stroke-width='2' stroke-linecap='round'/><circle cx='17.5' cy='16' r='2.5' fill='none' stroke='white' stroke-width='1.6'/></svg>"
+Authors:
+  - "Roland Buergi"
+Tags:
+  - "Architecture"
+  - "Data"
+  - "Identity"
+  - "Postgres"
+---
+
+A mesh node's identity is the pair **`(namespace, id)`**. Its **`path` is derived**, not stored
+independently — in Postgres it is literally a generated column:
+
+```sql
+CREATE TABLE IF NOT EXISTS mesh_nodes (
+    namespace       TEXT        NOT NULL DEFAULT '',
+    id              TEXT        NOT NULL,
+    path            TEXT        GENERATED ALWAYS AS (
+                        CASE WHEN namespace = '' THEN id ELSE namespace || '/' || id END
+                    ) STORED,
+    ...
+    PRIMARY KEY (namespace, id)
+);
+```
+
+Two consequences follow, and together they are the whole of this page.
+
+## An id MAY contain a slash
+
+There is **no constraint anywhere forbidding it**. Every `mesh_nodes` DDL — the three Postgres
+variants, the satellite-table script, `mesh_node_history`, and the SQLite adapter — declares plain
+`id TEXT NOT NULL`. A repo-wide sweep for a SQL `CHECK` constraint across both `src/` trees finds
+none at all.
+
+Slash-bearing ids are not an accident to be tolerated; several node families depend on them. **Every
+`LanguageModel` node's id is the provider's wire id** — `z-ai/glm-5.3`, `anthropic/claude-opus-5`,
+`openai/gpt-5.2` — because that string is what the provider's API expects and what the model is
+known by. The Postgres adapter states the rule in its own words (issue #2212):
+
+> 🚨 THERE IS NO POSITIONAL (namespace, id) SPLIT OF A PATH — an id may contain '/'.
+
+## Splitting a path positionally is path-invariant and key-destroying
+
+Because `path` is `namespace || '/' || id`, **moving a slash from the id into the namespace leaves
+the path byte-identical while changing the primary key.** These two rows have the same path and
+different identities:
+
+| namespace | id | generated path |
+|---|---|---|
+| `Provider/OpenRouter` | `z-ai/glm-5.3` | `Provider/OpenRouter/z-ai/glm-5.3` |
+| `Provider/OpenRouter/z-ai` | `glm-5.3` | `Provider/OpenRouter/z-ai/glm-5.3` |
+
+That invariance is what makes the corruption invisible: every path-addressed read, every log line,
+every URL keeps reading the same. Nothing looks wrong.
+
+## The read/write asymmetry that turns it into data loss
+
+The two sides of the adapter address rows differently, and both are correct in isolation:
+
+- **Writes upsert on the KEY** — `INSERT … ON CONFLICT (namespace, id) DO UPDATE SET …`
+- **Reads and deletes address the PATH** — `SELECT … WHERE path = $1`, `DELETE … WHERE path = $1`
+
+So a write carrying a re-keyed `(namespace, id)` finds **no conflict** and **INSERTs a second row**
+whose generated path collides with the first. From that moment:
+
+1. A read `WHERE path = $1` matches **two** rows and resolves an arbitrary one — not reliably the
+   same one twice.
+2. The versions table (PK `(namespace, id, version)`) holds **two independent chains**, so a node
+   with a long history can read back as having none.
+3. A delete `WHERE path = $1` removes **BOTH** rows. One delete, and the node is gone.
+
+## What went wrong (#3894)
+
+`MeshOperations.SanitizeNodeId` split a slash-bearing id at its LAST slash and moved the prefix into
+the namespace, on the stated premise that *"the DB has a CHECK constraint blocking slashes in id"*.
+That premise was false, and had presumably always been false. `Create` and `Update` both ran through
+it, so **no MCP write could address a flat-keyed slash-id node** — every write minted a duplicate.
+
+On the production portal this split `Provider/OpenRouter` + `z-ai/glm-5.3` across two rows on
+2026-09-09; the following morning the node was gone from the model list entirely. The MCP `create`
+tool's own documentation stated the same false rule (*"id — the node's own slug, NO slashes"*), so
+an agent following its instructions produced the duplicate by hand.
+
+Both writes reported *"did not land within the confirmation window"* — a **true** negative: the
+confirmation reads the flat-keyed path while the write had gone to a different primary key.
+
+`Patch` was never affected. It reads the existing node and writes `existing with { … }`, so it
+inherits that node's keying by construction — which is why the split could not be reproduced through
+`patch` alone.
+
+## The rules
+
+- **Never split a path positionally into `(namespace, id)`.** Not in an adapter, not in a tool, not
+  in a "normalisation" step. The decomposition the caller holds is the correct one.
+- **Address a row by `path`.** It is the only decomposition-free way to name a row, it is what the
+  caller actually has, and it is indexed.
+- **A write to an existing node carries back the SAME `(namespace, id)` it was read with.** Re-deriving
+  identity from the path on the way in is how a duplicate gets created.
+- **Never "tidy" an id.** Store it verbatim, slashes included.
+
+## The adjacent failure: a cached miss that outlives its invalidation
+
+Worth knowing when a node "does not exist" right after you created it. A negative read is cached by
+the **storm breaker inside `MeshNodeStreamCache`** (`_negative`, keyed by path) — not by the per-node
+hub, and not by the unrelated `MessageStormBreaker`, which is a per-hub *rate* breaker with no path
+negative. An open window fast-fails **reads and writes alike**, and `MeshOperations.Get` reports it
+as `Not found`, indistinguishable from genuine absence and produced without ever reaching the owner.
+
+A create at that path **does** clear it: the post-commit `MeshChangeEvent.Created` publish reaches
+`MeshNodeStreamCache.OnMeshChange` → `ResetFailureState(path)`, which drops the negative entry and
+evicts a faulted read entry. That behaviour is pinned by a test.
+
+The gap is a race, not a missing mechanism (tracked as **#3954**): `RecordNegative` writes `_negative[path]` unconditionally,
+with no epoch or claim guard. A `NotFound` minted by a read that subscribed *before* the create can
+therefore land *after* the `Created` broadcast has already reset the state, re-arming a window of up
+to five minutes that nothing then evicts until it expires — or until another change event for that
+path arrives. A `recycle` publishes exactly such an event, which is why recycling clears the symptom.
+`PathResolutionService` guards the identical race with its `_pendingFills` claims; the stream cache
+has no counterpart.
+
+## See also
+
+- [CQRS — Queries, Reads, Writes, Operations](/Doc/Architecture/CqrsAndContentAccess) — why a point
+  read of a maybe-absent path is a defect, and what to use instead.
+- [Postgres Schema Architecture](/Doc/Architecture/PostgresSchemaArchitecture) — one schema per
+  partition, and why `namespace` keeps its partition prefix.
+- [Data Access Patterns](/Doc/Architecture/DataAccessPatterns) — the read/write API table.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-node-whose-name-contains-a-slash-stops-disappearing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-node-whose-name-contains-a-slash-stops-disappearing.md
@@ -1,0 +1,38 @@
+---
+Name: Nodes whose id contains a slash stop disappearing when you edit them
+Category: Fix
+Description: Editing a node whose id contains a slash — every language model, whose id is the provider's own identifier — quietly filed a second copy of it instead of changing the original. Both copies answered to the same address, and deleting either removed both. Edits now change the node you edited.
+Icon: Warning
+Order: -20260910
+---
+
+# Nodes whose id contains a slash stop disappearing when you edit them
+
+Most nodes have a simple name at the end of their address: a page called `PricingTool` sitting in a
+folder called `ACME/Projects`. Some do not. A language model's name is the identifier its provider
+publishes — `z-ai/glm-5.3`, `anthropic/claude-opus-5`, `openai/gpt-5.2` — and that name has a slash
+in the middle of it. The platform has always stored those exactly as written.
+
+Editing one through the assistant did something else. Before saving, the platform "tidied" the name
+by cutting it at its last slash and moving the first part into the folder — turning the model
+`z-ai/glm-5.3` in folder `Provider/OpenRouter` into a model `glm-5.3` in a folder
+`Provider/OpenRouter/z-ai`. The full address reads the same either way, so nothing looked wrong. But
+the platform files nodes under the name-and-folder pair, not the address, so the edit was not
+recognised as a change to the existing node: it filed a **second** node beside the first.
+
+From then on the two were indistinguishable from outside. Both answered to the same address, so
+reading it returned one of them — not reliably the same one. Each carried its own separate history,
+so a node with a long edit history appeared to have none. And because removing a node works by
+address, deleting either one removed both.
+
+That is what happened to a model on the production portal on 9 September: two edits filed two extra
+copies, and the following morning the model was gone from the model list entirely. It was restored
+by hand, and this fix removes the cause.
+
+The tidying step is gone. A node's id is now stored exactly as you give it, slashes included, and an
+edit changes the node you edited. The assistant's guidance changed to match: it used to be told that
+an id must never contain a slash, which was simply not true, and following that instruction was one
+way to produce the duplicate by hand. It is now told to keep an existing node's id and folder exactly
+as it read them.
+
+Nothing changes for ordinary nodes. An id with no slash in it is stored the way it always was.

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -1588,7 +1588,7 @@ public class MeshOperations
             if (meshNode == null)
                 return Observable.Return("Invalid node: deserialized to null.");
 
-            meshNode = SanitizeNodeId(meshNode);
+            // 🚨 The id is written AS GIVEN — slashes included. See NormalizeNamespace's note.
             meshNode = NormalizeNamespace(meshNode);
 
             var identityError = ValidateNodeIdentity(meshNode, "create");
@@ -1665,7 +1665,8 @@ public class MeshOperations
                     continue;
                 }
 
-                var meshNode = NormalizeNamespace(SanitizeNodeId(rawNode));
+                // 🚨 The id is written AS GIVEN — slashes included. See NormalizeNamespace's note.
+                var meshNode = NormalizeNamespace(rawNode);
 
                 var identityError = ValidateNodeIdentity(meshNode, "update");
                 if (identityError != null)
@@ -2286,9 +2287,16 @@ public class MeshOperations
     private static string? ValidateNodeIdentity(MeshNode node, string operation)
     {
         if (string.IsNullOrWhiteSpace(node.Id))
-            return $"Error: cannot {operation}: 'id' is not set. The id is the node's own slug — the final path segment, " +
-                   "no slashes (e.g. \"PricingTool\"). Put the parent path in 'namespace' (e.g. \"ACME/Projects\"); " +
-                   "the node's path is derived as {namespace}/{id}.";
+            // 🚨 "no slashes" was a FALSE rule (#3894): an id may contain '/', and several node
+            // families rely on it (every LanguageModel id is the provider's wire id, e.g.
+            // "z-ai/glm-5.3"). Say what the id IS — the remainder of the path below the namespace
+            // — rather than forbidding a separator the store accepts and the keying depends on.
+            return $"Error: cannot {operation}: 'id' is not set. The id is the node's own key below its " +
+                   "namespace — usually the final path segment (e.g. \"PricingTool\"), but it MAY contain " +
+                   "slashes where that is the node's real key (e.g. \"z-ai/glm-5.3\"). Put the parent path in " +
+                   "'namespace' (e.g. \"ACME/Projects\"); the node's path is derived as {namespace}/{id}. " +
+                   "When a node already exists, keep its 'id' and 'namespace' EXACTLY as read back — " +
+                   "re-splitting a path across the two changes the node's identity and creates a duplicate.";
 
         if (string.IsNullOrWhiteSpace(node.NodeType))
             return $"Error: cannot {operation} '{node.Path}': 'nodeType' is not set. Every node must declare a nodeType — " +
@@ -2316,6 +2324,24 @@ public class MeshOperations
     /// path arguments: strips a leading '@' / '/' and surrounding whitespace. Models routinely
     /// copy the namespace out of an absolute reference ("@/ACME/Projects") — that intent is
     /// unambiguous, so fix it instead of failing the write.
+    ///
+    /// <para>🚨 THE NAMESPACE IS NORMALISED; THE ID IS NOT TOUCHED. An id may contain '/', and
+    /// re-keying one is DATA LOSS — do not reintroduce a "SanitizeNodeId" here or anywhere else
+    /// (issue #3894, the mirror of the adapter's own "THERE IS NO POSITIONAL (namespace, id) SPLIT
+    /// OF A PATH" note, issue #2212).</para>
+    ///
+    /// <para>Until #3894 this pair ran behind a <c>SanitizeNodeId</c> that split a slash-bearing id
+    /// at its LAST slash, on the stated premise that "the DB has a CHECK constraint blocking
+    /// slashes in id". There is no such constraint — every <c>mesh_nodes</c> DDL declares plain
+    /// <c>id TEXT NOT NULL</c>. What the split actually did was re-key the node: the PRIMARY KEY is
+    /// <c>(namespace, id)</c> while <c>path</c> is a GENERATED column, and moving a slash across
+    /// the two leaves <c>path</c> IDENTICAL while changing the key. Writes upsert
+    /// <c>ON CONFLICT (namespace, id)</c>, so the re-keyed write found no conflict and INSERTED a
+    /// SECOND row at the same path; reads and deletes address <c>WHERE path = $1</c>, so the read
+    /// then resolved an arbitrary one of the two and a delete removed BOTH. That is how
+    /// <c>Provider/OpenRouter</c> + <c>z-ai/glm-5.3</c> — a LanguageModel node whose id is the
+    /// provider's wire id, like every one of its siblings — was split across two rows and then
+    /// vanished from production.</para>
     /// </summary>
     private static MeshNode NormalizeNamespace(MeshNode node)
     {
@@ -2327,29 +2353,6 @@ public class MeshOperations
         // WithNamespace, not `with { Namespace = … }`: MainNode is a STORED default and would keep
         // the un-normalised "@/ACME/Projects/x" while Path became "ACME/Projects/x" (#2939).
         return normalized == ns ? node : node.WithNamespace(normalized);
-    }
-
-    /// <summary>
-    /// Sanitizes a MeshNode's Id: if the Id contains slashes, splits it into proper Id + Namespace.
-    /// This prevents duplicate rows in the DB (the DB has a CHECK constraint blocking slashes in id).
-    /// </summary>
-    private MeshNode SanitizeNodeId(MeshNode node)
-    {
-        if (string.IsNullOrEmpty(node.Id) || !node.Id.Contains('/'))
-            return node;
-
-        var lastSlash = node.Id.LastIndexOf('/');
-        var ns = node.Id[..lastSlash];
-        var id = node.Id[(lastSlash + 1)..];
-
-        if (!string.IsNullOrEmpty(node.Namespace))
-            ns = $"{node.Namespace}/{ns}";
-
-        logger.LogWarning("SanitizeNodeId: Fixed slash in id. Was id='{OldId}', now id='{NewId}' namespace='{Namespace}'",
-            node.Id, id, ns);
-
-        // WithPath keeps MainNode on the node's own (new) path when it was never set explicitly.
-        return node.WithPath(id, ns);
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/SlashBearingNodeIdKeyingTest.cs
+++ b/test/Memex.Portal.Shared.Test/SlashBearingNodeIdKeyingTest.cs
@@ -1,0 +1,321 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Content of a keying-probe node. Shaped after a real <c>LanguageModel</c> node (the family whose
+/// ids carry the provider's slash) so the write verbs exercise the same typed-content path they do
+/// in production — <c>Update</c> REFUSES a node with null content, so a content-less probe would
+/// never reach the keying logic this test is about.
+/// </summary>
+public record LanguageModelProbeContent
+{
+    /// <summary>The provider endpoint the model is served from.</summary>
+    public string? Endpoint { get; init; }
+
+    /// <summary>Display ordering among sibling models.</summary>
+    public int Order { get; init; }
+}
+
+/// <summary>
+/// #3894: an MCP write to a node whose <see cref="MeshNode.Id"/> CONTAINS A SLASH re-keyed it.
+///
+/// <para><b>The defect.</b> <c>MeshOperations.SanitizeNodeId</c> split a slash-bearing id at its
+/// LAST slash and moved the prefix into the namespace, on the stated premise that "the DB has a
+/// CHECK constraint blocking slashes in id". There is no such constraint — every <c>mesh_nodes</c>
+/// DDL declares plain <c>id TEXT NOT NULL</c>. What the split actually did was change the node's
+/// IDENTITY while leaving its PATH untouched, because <c>path</c> is a GENERATED column
+/// (<c>namespace || '/' || id</c>) and moving a slash across the two is path-invariant.</para>
+///
+/// <para><b>Why that is data loss.</b> The primary key is <c>(namespace, id)</c>, and writes upsert
+/// <c>ON CONFLICT (namespace, id)</c> — so a re-keyed write found NO conflict and INSERTED a SECOND
+/// row carrying the same generated path. Reads and deletes address <c>WHERE path = $1</c>, so the
+/// read then resolved an arbitrary one of the two rows and a delete removed BOTH. On production
+/// this split <c>Provider/OpenRouter</c> + <c>z-ai/glm-5.3</c> — a LanguageModel node whose id is
+/// the provider's wire id, exactly like its eleven siblings — across two rows, after which it
+/// vanished. Slash-bearing ids are not an accident; the Postgres adapter says so in its own words
+/// ("THERE IS NO POSITIONAL (namespace, id) SPLIT OF A PATH — an id may contain '/'", #2212).</para>
+///
+/// <para>🚨 <b>What this test can and cannot observe, stated honestly.</b> The monolith's
+/// <c>InMemoryStorageAdapter</c> holds nodes in a PATH-KEYED dictionary, so the duplicate ROW
+/// cannot manifest here — the second write simply overwrites the first entry. What IS observable,
+/// and what this test asserts, is the node's <c>Namespace</c>/<c>Id</c> pair, which IS the Postgres
+/// primary key: if identity survives a write, the upsert targets the same PK and there is one row;
+/// if it is re-keyed, Postgres inserts a second. Asserting the keying is therefore the faithful
+/// in-memory expression of "ONE row with the ORIGINAL keying", not a weaker substitute.</para>
+///
+/// <para>Every case drives the REAL MCP verb (<c>MeshOperations.Create</c> / <c>Update</c> /
+/// <c>Patch</c>) against a REAL monolith mesh, and the update case reproduces the operator sequence
+/// from the incident exactly: read the node back, change one field, write the whole node again.</para>
+/// </summary>
+public class SlashBearingNodeIdKeyingTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The node type the probe nodes carry — registered below so the create path
+    /// (which rejects an unregistered NodeType outright) accepts them.</summary>
+    private const string ProbeNodeType = "LanguageModelKeyingProbe";
+
+    /// <summary>The partition root both provider namespaces live under.</summary>
+    private const string PartitionRoot = "Provider";
+
+    // ── the incident's own shape: an id that legitimately contains a slash ──
+    private const string SlashNamespace = "Provider/OpenRouter";
+    private const string SlashId = "z-ai/glm-5.3";
+    private const string SlashPath = $"{SlashNamespace}/{SlashId}";
+
+    // ── the positive control: an ordinary, slash-free id ──
+    private const string PlainNamespace = "Provider/OpenAI";
+    private const string PlainId = "gpt-5-2";
+    private const string PlainPath = $"{PlainNamespace}/{PlainId}";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(new MeshNode(ProbeNodeType)
+            {
+                Name = "Language Model Keying Probe",
+                IsSatelliteType = false,
+                HubConfiguration = config => config
+                    .AddMeshDataSource(source => source
+                        .WithContentType<LanguageModelProbeContent>()),
+            })
+            .ConfigureHub(config => config
+                .WithType<LanguageModelProbeContent>(nameof(LanguageModelProbeContent)));
+
+    /// <summary>
+    /// 🚨 THE TWIN THE ISSUE ASKS FOR. Patch a slash-id node through
+    /// <c>MeshOperations.Patch</c> and assert it is still ONE node under its ORIGINAL
+    /// <c>(namespace, id)</c>, on a single version chain.
+    ///
+    /// <para>This case is a REGRESSION GUARD rather than a discriminating repro, and saying so is
+    /// part of the test: <c>Patch</c> never called the sanitiser. It reads the existing node and
+    /// writes <c>existing with { … }</c>, so it inherits that node's keying by construction — which
+    /// is exactly why the issue's own follow-up comment could not reproduce the split through
+    /// <c>patch</c> alone. The invariant is pinned here so a future refactor that routes <c>Patch</c>
+    /// through a shared "normalise the node" step cannot silently acquire the defect.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)] // literal: an attribute argument must be a constant. Dominates TestTimeouts.Convergence.
+    public async Task Patch_OnASlashBearingId_KeepsTheOriginalKeying_AndOneVersionChain()
+    {
+        var seeded = await SeedProbe(SlashId, SlashNamespace, "GLM 5.3");
+
+        var result = await Operations()
+            .Patch(SlashPath, """{"name":"GLM 5.3 (patched)"}""")
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Patch tool returned: {result}");
+        result.Should().NotContain("Error:",
+            "patching the display name of an existing node is an applicable change and must not be refused");
+
+        var after = await ReadNodeOnce(SlashPath);
+
+        after.Name.Should().Be("GLM 5.3 (patched)",
+            "the tool reported success, so the caller's own field must actually have landed");
+        after.Namespace.Should().Be(SlashNamespace,
+            "the namespace is half the (namespace, id) PRIMARY KEY — a patch must address the existing "
+            + "row, never mint a new identity at the same path");
+        after.Id.Should().Be(SlashId,
+            "the id is the other half of the PRIMARY KEY and it legitimately contains a slash "
+            + "(a LanguageModel id is the provider's wire id); re-keying it to 'glm-5.3' under "
+            + "namespace 'Provider/OpenRouter/z-ai' leaves the generated path identical while "
+            + "INSERTING a second row — the #3894 data loss");
+        after.Path.Should().Be(SlashPath,
+            "the path is generated from the keying and must be unchanged either way");
+        after.Version.Should().BeGreaterThan(seeded.Version,
+            "the write must ADVANCE the existing node's version chain — a re-keyed write would start "
+            + "a second chain at version 1 instead, which is how one path came to hold two 'version 1' rows");
+    }
+
+    /// <summary>
+    /// The DISCRIMINATING repro for <c>update</c> — this is the verb the sanitiser ran on, and this
+    /// case fails on the pre-#3894 code. It reproduces the operator sequence from the incident
+    /// literally: read the node back, change one field, write the WHOLE node again (which is what an
+    /// MCP client does, and which carries the node's own slash-bearing id straight back in).
+    /// </summary>
+    [Fact(Timeout = 120_000)] // literal: an attribute argument must be a constant. Dominates TestTimeouts.Convergence.
+    public async Task Update_OnASlashBearingId_KeepsTheOriginalKeying_AndOneVersionChain()
+    {
+        var seeded = await SeedProbe(SlashId, SlashNamespace, "GLM 5.3");
+
+        var result = await Operations()
+            .Update(SerializeAsUpdateBatch(seeded with { Name = "GLM 5.3 (updated)" }))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Update tool returned: {result}");
+        result.Should().NotContain("Error:",
+            "writing back a node that was just read, with one field changed, must not be refused");
+
+        var after = await ReadNodeOnce(SlashPath);
+
+        after.Name.Should().Be("GLM 5.3 (updated)",
+            "the tool reported success, so the caller's own field must actually have landed");
+        after.Namespace.Should().Be(SlashNamespace,
+            "update must write back the SAME (namespace, id) the caller read — SanitizeNodeId used to "
+            + "move 'z-ai' out of the id and into the namespace here, producing "
+            + "'Provider/OpenRouter/z-ai' and a second PRIMARY KEY at an unchanged path");
+        after.Id.Should().Be(SlashId,
+            "the id must survive the round trip verbatim, slash included — this is the exact "
+            + "re-keying that split the production node across two rows (#3894)");
+        after.Path.Should().Be(SlashPath,
+            "the path is generated from the keying and is invariant under the split, which is "
+            + "precisely why the corruption was invisible to every path-addressed read");
+        after.Version.Should().BeGreaterThan(seeded.Version,
+            "the write must ADVANCE the existing node's version chain rather than start a second one");
+    }
+
+    /// <summary>
+    /// The DISCRIMINATING repro for <c>create</c> — the other verb the sanitiser ran on. A caller
+    /// that creates a node at a slash-bearing id must get a node keyed the way it asked, not one
+    /// silently re-keyed to a namespace that does not match its siblings.
+    /// </summary>
+    [Fact(Timeout = 120_000)] // literal: an attribute argument must be a constant. Dominates TestTimeouts.Convergence.
+    public async Task Create_WithASlashBearingId_StoresItUnderTheKeyingItWasGiven()
+    {
+        await SeedPartitionRoot();
+
+        var result = await Operations()
+            .Create(NodeJson(SlashId, SlashNamespace, "GLM 5.3"))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Create tool returned: {result}");
+        result.Should().NotContain("Error:",
+            "an id containing a slash is legitimate — every LanguageModel id is the provider's wire id");
+
+        var created = await ReadNodeOnce(SlashPath);
+
+        created.Namespace.Should().Be(SlashNamespace,
+            "the node must be created under the namespace the caller gave, not one the platform "
+            + "invented by splitting the id at its last slash");
+        created.Id.Should().Be(SlashId,
+            "the id must be stored verbatim; storing 'glm-5.3' instead makes this node key "
+            + "differently from its eleven seeded siblings and makes it unaddressable by the "
+            + "identity its creator holds (#3894)");
+        created.Path.Should().Be(SlashPath,
+            "the generated path must match what the caller asked for");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL, in the other direction: an ORDINARY, slash-free id must still be
+    /// keyed exactly as before through both write verbs. Without this the keying fix could pass by
+    /// disabling identity handling altogether — a test that only checks "nothing was rewritten"
+    /// cannot tell a correct writer from one that writes nothing at all.
+    /// </summary>
+    [Fact(Timeout = 120_000)] // literal: an attribute argument must be a constant. Dominates TestTimeouts.Convergence.
+    public async Task Create_ThenUpdate_WithAnOrdinaryId_StillKeysAndLandsExactlyAsBefore()
+    {
+        await SeedPartitionRoot();
+
+        var createResult = await Operations()
+            .Create(NodeJson(PlainId, PlainNamespace, "GPT 5.2"))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Create tool returned: {createResult}");
+        createResult.Should().NotContain("Error:",
+            "an ordinary slash-free id is the common case and must keep working unchanged");
+
+        var created = await ReadNodeOnce(PlainPath);
+        created.Namespace.Should().Be(PlainNamespace,
+            "an ordinary id must still be keyed by the namespace it was given — the fix removes a "
+            + "wrong rewrite, it does not stop the platform keying nodes at all");
+        created.Id.Should().Be(PlainId,
+            "an ordinary id must be stored verbatim, exactly as it always was");
+        created.Path.Should().Be(PlainPath,
+            "the generated path must match what the caller asked for");
+
+        var updateResult = await Operations()
+            .Update(SerializeAsUpdateBatch(created with { Name = "GPT 5.2 (updated)" }))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Update tool returned: {updateResult}");
+        updateResult.Should().NotContain("Error:",
+            "writing back an ordinary node with one field changed must not be refused");
+
+        var updated = await ReadNodeOnce(PlainPath);
+        updated.Name.Should().Be("GPT 5.2 (updated)",
+            "the tool reported success, so the caller's own field must actually have landed");
+        updated.Namespace.Should().Be(PlainNamespace,
+            "an ordinary id must round-trip through update with its keying intact");
+        updated.Id.Should().Be(PlainId,
+            "an ordinary id must round-trip through update verbatim");
+        updated.Version.Should().BeGreaterThan(created.Version,
+            "the update must advance the SAME version chain, proving the write addressed the "
+            + "existing row rather than creating a parallel one");
+    }
+
+    // ── helpers ──
+
+    private MeshOperations Operations() => new(Mesh);
+
+    /// <summary>The MCP <c>create</c> payload for one probe node — the JSON an agent actually sends.</summary>
+    // $$$ / {{{…}}}: the payload itself contains literal `{` and `}}`, so the interpolation
+    // delimiters have to be longer than any brace run in the JSON (CS9007 otherwise).
+    private static string NodeJson(string id, string ns, string name)
+        => $$$"""
+            {"id":{{{JsonSerializer.Serialize(id)}}},"namespace":{{{JsonSerializer.Serialize(ns)}}},
+             "nodeType":"{{{ProbeNodeType}}}","name":{{{JsonSerializer.Serialize(name)}}},
+             "content":{"endpoint":"https://example.invalid/v1","order":1}}
+            """;
+
+    /// <summary>
+    /// The MCP <c>update</c> payload: the node serialised with the mesh's OWN options and wrapped in
+    /// the array the tool takes. This is deliberately a re-serialisation of a node that was READ
+    /// back — the operator sequence from the incident — so the slash-bearing id travels into the
+    /// write exactly as a real client would carry it.
+    /// </summary>
+    private string SerializeAsUpdateBatch(MeshNode node)
+        => $"[{JsonSerializer.Serialize(node, Mesh.JsonSerializerOptions)}]";
+
+    /// <summary>
+    /// Seeds the top-level <c>Provider</c> partition root as System. A top-level node IS a partition
+    /// root, so <c>PartitionWriteGuardValidator</c> refuses a non-System caller creating one whose
+    /// NodeType does not own a partition — see <see cref="MonolithMeshTestBase.SeedTopLevel"/>.
+    /// </summary>
+    private Task<MeshNode> SeedPartitionRoot()
+        => SeedTopLevel(new MeshNode(PartitionRoot)
+        {
+            Name = "Providers",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        });
+
+    /// <summary>Seeds one probe node under <see cref="PartitionRoot"/> and returns it as stored.</summary>
+    private async Task<MeshNode> SeedProbe(string id, string ns, string name)
+    {
+        await SeedPartitionRoot();
+        await SeedTopLevel(new MeshNode(id, ns)
+        {
+            NodeType = ProbeNodeType,
+            Name = name,
+            State = MeshNodeState.Active,
+            // Content must be non-null: Update refuses a null-content node outright, so a
+            // content-less probe would never reach the keying logic under test.
+            Content = new LanguageModelProbeContent { Endpoint = "https://example.invalid/v1", Order = 1 },
+        });
+        return await ReadNodeOnce($"{ns}/{id}");
+    }
+
+    /// <summary>
+    /// One authoritative read off the shared per-node stream handle — the same primitive an MCP
+    /// <c>get</c> uses, and the only read that is live rather than eventually consistent.
+    /// </summary>
+    private Task<MeshNode> ReadNodeOnce(string path)
+        => Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(node => node is not null)
+            .Select(node => node!)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await(TestContext.Current.CancellationToken);
+}


### PR DESCRIPTION
Fixes #3894.

Pairs-with: none — the only removed member, MeshOperations.SanitizeNodeId, was **private**. No public top-level type or public member leaves src/ in this diff, so nothing outside core could have referenced it.

## The defect

`MeshOperations.SanitizeNodeId` split a slash-bearing id at its LAST slash and moved the prefix into the namespace, on the stated premise that *"the DB has a CHECK constraint blocking slashes in id"*.

**That premise is false, and I verified it in the schema rather than trusting the comment.** Every `mesh_nodes` DDL declares plain `id TEXT NOT NULL` — the three Postgres variants (`PostgreSqlSchemaInitializer.cs:1433 / 2299 / 2712`), the satellite-table script, `mesh_node_history`, and the SQLite adapter (which keys on `path` outright). A regex sweep for a SQL `CHECK` constraint across both `src/` trees returns only English prose, no constraint.

What the split actually did was **re-key the node**. The PRIMARY KEY is `(namespace, id)` and `path` is a GENERATED column, so moving a slash across the two leaves `path` **byte-identical** while changing the key:

| namespace | id | generated path |
|---|---|---|
| `Provider/OpenRouter` | `z-ai/glm-5.3` | `Provider/OpenRouter/z-ai/glm-5.3` |
| `Provider/OpenRouter/z-ai` | `glm-5.3` | `Provider/OpenRouter/z-ai/glm-5.3` |

The two sides of the adapter then disagree, and that is what turns it into data loss:

- **Writes** upsert on the KEY — `INSERT … ON CONFLICT (namespace, id) DO UPDATE`
- **Reads and deletes** address the PATH — `WHERE path = $1`

So the re-keyed write found no conflict and **INSERTed a second row** at the same path; a read then resolved an arbitrary one of the two, and a delete removed **both**. That is how `Provider/OpenRouter` + `z-ai/glm-5.3` — a LanguageModel node whose id is the provider's wire id, like every one of its eleven siblings — was split across two rows on prod and then vanished.

## What changed

- Deleted `SanitizeNodeId` and **both** call sites — `Create` (L1591) and `Update` (L1668). `NormalizeNamespace` carries a do-not-reintroduce note mirroring the adapter's own #2212 comment.
- Corrected the false *"no slashes"* rule in `ValidateNodeIdentity`'s missing-id error, and told the caller to keep an existing node's id/namespace exactly as read back.

**`Patch` never called the sanitiser** — it writes `existing with { … }` and inherits the stored keying by construction. That is why the issue's own follow-up comment could not reproduce the split through `patch`, and the test suite pins it as a regression guard rather than claiming it as a repro.

## Control, measured in both directions

`test/Memex.Portal.Shared.Test/SlashBearingNodeIdKeyingTest.cs` drives the real MCP verbs against a real monolith mesh. Measured on the **pre-fix** code, two cases fail with the exact re-keying:

```
Update_OnASlashBearingId_KeepsTheOriginalKeying_AndOneVersionChain [FAIL]
  Expected value to be "Provider/OpenRouter" because update must write back the SAME
  (namespace, id) the caller read … but found "Provider/OpenRouter/z-ai".

Create_WithASlashBearingId_StoresItUnderTheKeyingItWasGiven [FAIL]
  Expected value to be "Provider/OpenRouter" because the node must be created under the
  namespace the caller gave … but found "Provider/OpenRouter/z-ai".
```

while the `Patch` twin and the **ordinary slash-free id positive control** pass — so the fix cannot pass by disabling keying altogether. On this branch all four pass.

The monolith's `InMemoryStorageAdapter` is **path-keyed**, so the duplicate ROW cannot manifest there. The tests therefore assert the `(namespace, id)` pair, which *is* the Postgres primary key, and the test's own doc comment says so plainly rather than claiming more than it checks.

## Asks I did NOT do, with evidence

**Delete auditing already exists.** `MeshExtensions.cs:2548` already logs at Information, per node (the handler is re-entered per descendant):

```
[DeleteNode] start path={Path} recursive={Recursive} confirmWarnings={Confirm} deletedBy={DeletedBy}
```

The issue's *"Loki has no delete line"* was withdrawn in its own follow-up comment as a wrong-namespace read (`{namespace="memex"}` for an instance that is `memex-cloud`). Adding a second line would have been duplicate Information volume for no gain — and `MeshExtensions.cs` is held by #3947 besides.

**Create-side cache invalidation already exists.** The cached miss is `MeshNodeStreamCache._negative` — the **storm breaker** — not the per-node hub (`MonolithRoutingService.streams` is positive-only; `MessageHubGrain`'s replayed error dies with the activation it immediately deactivates) and not the class literally named `MessageStormBreaker` (a per-hub *rate* breaker with no path negative). A create at that path already invalidates it: `WriteAndPublishCreated` → `MeshChangeEvent.Created` → `OnMeshChange` → `ResetFailureState(path)`, pinned by `MeshNodeStreamCacheRecycleResetTest.CreateAfterFailureEra_ClearsBreakerAndFaultedEntry_ViaChangeFeed`.

The residual defect is a **race**, not a missing mechanism: `RecordNegative` writes unconditionally, so a `NotFound` from a read that subscribed *before* the create can land *after* the invalidation and re-arm the window — which is exactly why `recycle` (which publishes another change event) cleared it. Filed as **#3954** rather than bundled here: it is a distinct root cause in the hottest read/write path and deserves its own change and tests. No timer, sweeper or retry was added.

## Left for the Plugins half

The MCP `create` tool's own `id — the node's own slug, NO slashes` text lives in MeshWeaver.Plugins at `src/MeshWeaver.Mcp/McpMeshPlugin.cs:339` and needs the same correction. It is model-facing guidance, not enforcement, so core's fix stands alone — but an agent following that text still produces the duplicate by hand.

## Verification

- `dotnet build src/MeshWeaver.Mesh.Operations -c Release -warnaserror` → `0 Error(s)`
- `dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` → `0 Error(s)`
- `SlashBearingNodeIdKeyingTest` → 4 passed, 0 failed (and 2 failed on the reverted fix, above)
- `DocumentationLinkIntegrityTest` → passed

Work products conserved: `Doc/Architecture/NodeIdentityAndPathKeying` + a What's New entry (`Category: Fix` — a user can notice a node that stops vanishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
