### PR TITLE
fix(#3876): the serve and the module index open decide absence — no more 500 on a replaced publication

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -310,14 +310,20 @@ public static class PluginBundleEndpoints
             return BeingRepublished(http, identity, source, directory, reading.TornReason!);
         if (HeldGeneration(http) is { } held && held != reading.Generation)
             return GenerationMoved(held, reading.Generation!);
-        if (!reading.Bundles.Contains(bundle, StringComparer.OrdinalIgnoreCase))
+        // 🚨 The SEAL's own spelling, never the request's (#3876). The match is
+        // case-INSENSITIVE while the share is not, so composing the requested name served
+        // `store.zip` out of a publication that sealed `Store.zip` — an open that fails on Linux
+        // for a permanent client mistake, which would now wear the transient answer and have that
+        // caller retry for ever. The listing verified THIS name present; serve THIS name.
+        if (reading.Bundles.FirstOrDefault(
+                name => name.Equals(bundle, StringComparison.OrdinalIgnoreCase)) is not { } sealedName)
             return NoSuchBundle();
         // 🚨 #3461: the bytes come from the directory the READING resolved — the generation this
         // source's `_current` names, or the source directory in the flat layout. Composing under
         // `directory` here would serve the flat publication's bytes under the generation this
         // response's ETag pins, which is precisely the mix the generation exists to prevent.
-        var path = Path.Combine(reading.Directory ?? directory, bundle);
-        return Results.File(path, "application/zip", fileDownloadName: bundle);
+        var path = Path.Combine(reading.Directory ?? directory, sealedName);
+        return SealedBytes(http, identity, source, directory, path, sealedName);
     }
 
     /// <summary>The module bundles the sealed publication composed — its NodeType assemblies'
@@ -372,11 +378,63 @@ public static class PluginBundleEndpoints
         var reading = PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));
         if (reading.PublicationUnavailable)
             return BeingRepublished(http, identity, source, directory, reading.Refusal!);
-        if (reading.Modules is null || !reading.Modules.Contains(bundle, StringComparer.OrdinalIgnoreCase))
+        // The index's own spelling, for the reason given on the bundle route above (#3876).
+        if (reading.Modules?.FirstOrDefault(
+                name => name.Equals(bundle, StringComparison.OrdinalIgnoreCase)) is not { } sealedName)
             return NoSuchBundle();
         var path = Path.Combine(
-            reading.Directory ?? directory, PublishedBundleCatalogue.ModulesDirectoryName, bundle);
-        return Results.File(path, "application/zip", fileDownloadName: bundle);
+            reading.Directory ?? directory, PublishedBundleCatalogue.ModulesDirectoryName, sealedName);
+        return SealedBytes(http, identity, source, directory, path, sealedName);
+    }
+
+    /// <summary>
+    /// 🚨 #3876 — THE serve, and the OPEN is what decides. <c>Results.File(path, …)</c> resolves the
+    /// path again when the RESULT executes, which is after the handler has returned: the seal read
+    /// that listed this name (and stat'ed it present) is by then several steps in the past, and the
+    /// publisher replaces a publication several times an hour during a release while retention
+    /// removes whole identity directories. A file that went away in between threw
+    /// <see cref="FileNotFoundException"/> — or <see cref="DirectoryNotFoundException"/>, which is
+    /// what a removed parent throws on Linux — out of result execution, past every handler, to
+    /// <c>ExceptionHandlerMiddleware</c>: a 500 for a condition this route has had a correct answer
+    /// for since #3401. The listing check upstream cannot close it; only the open can.
+    ///
+    /// <para>Opening HERE and handing the result an already-open handle also removes the window
+    /// rather than merely reporting it: on POSIX the bytes stay readable through an open descriptor
+    /// after the directory entry is gone, so a publication replaced mid-response is served whole
+    /// from the generation the ETag pins instead of being torn across two. The share is opened
+    /// <see cref="FileShare.Delete"/> so the publisher is never blocked by a read in flight.</para>
+    ///
+    /// <para>🚨 Only ABSENCE is classified, exactly as
+    /// <c>ShippedPrebuiltBundles.ReadSealLines</c> does it. A file that is present but unreadable —
+    /// denied, locked, a share fault — is NOT a republish window, and must keep surfacing: dressing
+    /// a permanent fault as "come back in thirty seconds" would have every consumer retry forever
+    /// against a publication that will never be readable.</para>
+    /// </summary>
+    private static IResult SealedBytes(
+        HttpContext http, string identity, string source, string directory, string path, string bundle)
+    {
+        // Obtained before the open so the vanishing can be REPORTED — this is the event the
+        // incident behind #3876 was filed from, and a 503 with nothing in the log behind it is not
+        // something the next reader can act on.
+        var logger = Log(http);
+        FileStream bytes;
+        try
+        {
+            bytes = new FileStream(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        }
+        catch (Exception error) when (error is FileNotFoundException or DirectoryNotFoundException)
+        {
+            logger?.LogInformation(error,
+                "PrebuiltPublication: '{Bundle}' was listed by the seal read a moment ago and was gone at "
+                + "the open — source '{Source}', framework identity '{Identity}'. The publication is "
+                + "being replaced or reclaimed; answering transiently rather than 500",
+                bundle, source, identity);
+            return BeingRepublished(http, identity, source, directory,
+                $"the publication's bytes moved while it was being served — '{bundle}' is listed by "
+                + "the seal that was read a moment ago and was gone at the open");
+        }
+        return Results.File(bytes, "application/zip", fileDownloadName: bundle);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -80,6 +80,43 @@ also remove it between the module routes' first and second catalogue reads. A st
 `ModuleSetReading.PublicationUnavailable` result preserves the transient response on that second
 read, distinct from a sealed publication with no module index. All four routes are exercised.
 
+🚨 **An existence check leading an open is the DEFECT SHAPE, not the `_complete` file.** Fixing the
+seal readers left two more `File.Exists`-then-open pairs on the very same routes, each throwing the
+same unhandled `FileNotFoundException` from a slightly different frame — which is why the incident
+kept recurring after it had twice been "fixed". Both are now closed:
+
+- **The module set's own seal.** `SealedModulesOf` probed `modules/_index` and then read it
+  unguarded. That index is written strictly *before* `_complete`, so the removal that takes one
+  takes the other. An index absent **at the open** is now discriminated by re-reading the seal, and
+  the ordering is what makes that sound: the publisher unseals first and retention unseals before
+  removing an identity, so a seal that *still reads* means the publication is intact and simply has
+  no module set — it **predates module sealing**, permanent, `404`, republish the source — while a
+  seal that has gone too means the publication is **being replaced right now**, which sets
+  `PublicationUnavailable` and rides the existing transient mapping. The two answers are opposite,
+  and collapsing either into the other is the bug.
+- **The serve itself.** `Results.File(path, …)` resolves the path *again* when the result executes,
+  after the handler has returned — so the listing that stat'ed the file present is several steps in
+  the past, and a file removed in between threw out of result execution, past every handler. The
+  open now happens **in the handler**, and the already-open handle is what the response streams:
+  on POSIX the bytes stay readable through a descriptor after the directory entry is gone, so a
+  publication replaced mid-response is served whole from the generation its `ETag` pins rather than
+  merely being reported as torn. The share is opened `FileShare.Delete` so a read in flight never
+  blocks the publisher.
+
+Both route their failure into the **same** discrimination the seal readers use — source directory
+present ⇒ `503` + `Retry-After`, identity directory gone ⇒ `404` — so there is one mapping, not
+three. The probe that decides it is `Directory.Exists`, which is **total**: it returns `false` for
+every failure rather than throwing, so the race where the directory is removed between the failed
+open and the probe answers `404` (the correct answer for a removed identity) and can never produce
+a `500`. In the opposite order — present at the probe, removed after — the caller gets `503` and
+its next read gets `404`; the consumer contract is built to re-read, so that converges.
+
+🚨 **The bytes are served under the SEAL's spelling, never the request's.** The name match is
+case-insensitive and the share is not, so composing the requested name served `store.zip` out of a
+publication that sealed `Store.zip`: an open that fails on Linux for a permanent client mistake,
+which would now wear the transient answer and have that caller retry for ever. The listing verified
+one exact name present; that is the name the response opens.
+
 🚨 **The BOOT SEEDER reads the same seal, and it is the reader with no status to return.**
 `ShippedPrebuiltBundles.CompletePublishedBundlesOf` walks every source under one identity and skips
 an unsealed one deliberately — the sweep compiles it instead. It kept the racing `File.Exists`

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-downloading-a-plugin-bundle-mid-update-returns-the-retry-response-too.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-downloading-a-plugin-bundle-mid-update-returns-the-retry-response-too.md
@@ -1,0 +1,32 @@
+---
+Name: Downloading a plugin bundle mid-update returns the retry response too
+Category: Fix
+Description: The bundle and module downloads themselves — and the module set's own listing — now answer a publication that is being replaced with the retry response, closing the last places a build could still receive an unexpected server error.
+Icon: ArrowSyncCheckmark
+Order: -20260910
+---
+
+# Downloading a plugin bundle mid-update returns the retry response too
+
+A publication update briefly removes the files it is replacing, and a build reading through that
+moment must be told to come back — not handed an unexpected server error. That was fixed for the
+publication's completion marker, but two places on the same routes still read a file without
+allowing for its removal, and each produced the same unexpected error from a slightly different
+step. Both are now closed.
+
+**The download itself.** The registry checked that a bundle was listed and present, then opened it
+again to send the bytes — and by then the publication may have been replaced or removed. The file
+is now opened while the request is still being decided, and the already-open file is what the
+response sends, so a download that started before an update is delivered whole from the version it
+began with rather than failing part-way.
+
+**The module set's own listing.** The list of module packages a publication shipped was read the
+same way the completion marker used to be, with the same outcome. It now distinguishes the two
+cases that need opposite answers: a publication that never shipped a module set still reports that
+permanently, so the fix is to republish it, while one whose listing vanished because the
+publication is being replaced returns the retry response like everything else.
+
+A related detail: a download is now served under the name the publication itself sealed. Names were
+matched ignoring case, but the storage does not ignore case, so asking for `store.zip` when the
+publication sealed `Store.zip` used to fail on the server. That is a permanent mistake by the
+caller, and it now reads as one.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -858,8 +858,27 @@ public static class PublishedBundleCatalogue
     /// <c>publish-bake-bundles.sh</c> does on its next run), or when the index names a bundle
     /// that is absent or not a bare name. It is EMPTY, not null, when the bake composed nothing —
     /// a reader can tell "composed nothing" from "predates module sealing".</para>
+    ///
+    /// <para>🚨 An index that is absent AT THE OPEN having been there a moment ago is the
+    /// republish window, not a publication that predates module sealing, and it sets
+    /// <see cref="ModuleSetReading.PublicationUnavailable"/> so the HTTP readers keep answering
+    /// 503 + <c>Retry-After</c> (or 404 once the identity directory itself is gone) rather than
+    /// telling a satellite gate to give up (#3876).</para>
     /// </summary>
     public static ModuleSetReading SealedModulesOf(string sourceDirectory, ILogger? logger = null)
+        => ReadModuleSet(sourceDirectory, logger, null);
+
+    // Internal for the ModuleIndexRemovedMidRead pin (InternalsVisibleTo): the index has to go away
+    // AT the open, which is the only way to exercise that race deterministically — the same seam,
+    // for the same reason, as ShippedPrebuiltBundles.ReadSealLines' own `readLines` (#3885).
+    //
+    // 🚨 A distinct NAME rather than an overload of SealedModulesOf. An added overload makes every
+    // bare `<see cref="SealedModulesOf"/>` ambiguous — CS0419, an ERROR under the -warnaserror this
+    // repo and every dependent build with, and one no cross-repo gate can see (it is not a removal
+    // and not an interface addition). It reddened this very file on the first build, and a satellite
+    // holding the same bare cref would have found out only when it moved its platform pin.
+    internal static ModuleSetReading ReadModuleSet(
+        string sourceDirectory, ILogger? logger, Func<string, string[]>? readIndex)
     {
         // 🚨 #3461: one resolution, handed back on the reading. `publication` is the directory the
         // bytes are in; the module set is `<publication>/modules`, never `<source>/modules`.
@@ -869,8 +888,40 @@ public static class PublishedBundleCatalogue
             { Directory = publication, PublicationUnavailable = true };
         var directory = Path.Combine(publication, ModulesDirectoryName);
         var index = Path.Combine(directory, ModulesIndexFileName);
-        if (!File.Exists(index))
+        // 🚨 #3876: the OPEN decides absence here too. `File.Exists(index)` leading an unguarded
+        // `File.ReadAllLines(index)` is the same racing pair the seal readers shed — the publisher
+        // replaces a publication several times an hour during a release and retention removes whole
+        // identity directories, so the index observed by the probe was gone by the time the read
+        // opened it, and the FileNotFoundException (or DirectoryNotFoundException, which is what a
+        // removed parent throws) reached ExceptionHandlerMiddleware as a 500 on the module routes.
+        var lines = ReadSealLines(index, readIndex);
+        if (lines is null)
         {
+            // 🚨 Absent at the open has TWO causes needing OPPOSITE answers, and the SEAL tells
+            // them apart — no second probe of the same file, which is what made the race. The
+            // publisher writes `modules/_index` strictly BEFORE `_complete` and removes `_complete`
+            // FIRST when it replaces or reclaims a publication, so:
+            //   • the seal still reads  ⇒ this publication is intact and simply has no module set:
+            //     it predates module sealing. PERMANENT — the caller must republish the source.
+            //   • the seal has gone too ⇒ the publication is being replaced (or reclaimed) right
+            //     now. TRANSIENT — PublicationUnavailable, which the HTTP readers turn into
+            //     503 + Retry-After while the directory is there and 404 once it is not.
+            // Collapsing the second into the first would tell a satellite gate to give up on a
+            // publication that is ninety seconds from existing.
+            var sentinel = Path.Combine(
+                publication, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            if (ReadSealLines(sentinel) is null)
+            {
+                logger?.LogInformation(
+                    "ReleaseAvailability: {SourceDirectory} lost its {Modules}/{Index} and its seal "
+                    + "while this read was in flight — the publication is being replaced or "
+                    + "reclaimed right now, which is transient; a consumer re-reads it",
+                    publication, ModulesDirectoryName, ModulesIndexFileName);
+                return new(null,
+                    $"the publication is being replaced right now — its {ModulesDirectoryName}/{ModulesIndexFileName} "
+                    + "and its completion sentinel both went away while this read was in flight")
+                { Directory = publication, PublicationUnavailable = true };
+            }
             logger?.LogInformation(
                 "ReleaseAvailability: {SourceDirectory} is sealed but carries no {Modules}/{Index} — "
                 + "it predates module sealing, so a consumer cannot compose from it until it is republished",
@@ -880,7 +931,7 @@ public static class PublishedBundleCatalogue
                 + "it predates module sealing; republish the source under a platform that seals module sets")
             { Directory = publication };
         }
-        var listed = File.ReadAllLines(index)
+        var listed = lines
             .Select(line => line.Trim())
             .Where(line => line.Length > 0)
             .ToList();

--- a/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
+++ b/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
@@ -378,6 +378,176 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
         }
     }
 
+    /// <summary>
+    /// 🚨 #3876, the LAST unguarded open on these routes. The seal read lists a name and stats it
+    /// present; <c>Results.File(path, …)</c> then resolves that path AGAIN when the result executes,
+    /// after the handler has returned. The publisher replaces a publication several times an hour
+    /// during a release and retention removes whole identity directories, so a file that went away
+    /// in between threw <see cref="FileNotFoundException"/> (or
+    /// <see cref="DirectoryNotFoundException"/> from a removed parent, which is what Linux raises)
+    /// out of result execution to <c>ExceptionHandlerMiddleware</c> — a 500 for a condition this
+    /// route has had a correct answer for since #3401. The open now happens in the handler, and the
+    /// SAME discrimination decides: the source directory is still there ⇒ transient, 503 +
+    /// <c>Retry-After</c>; the identity directory is gone ⇒ permanent, 404.
+    ///
+    /// <para>Three directions, because a fix that answered 404 for everything would pass a
+    /// two-case test: the healthy publication must still serve its BYTES — the positive control,
+    /// asserted first, on the very route the removal then hits.</para>
+    /// </summary>
+    /// <param name="suffix">The byte route under the publication.</param>
+    /// <param name="openRead">Which <c>PluginBundleEndpoints</c> logger the open sits behind —
+    /// authentication takes the first, each catalogue read the next, and the serve the last. It is
+    /// asserted exactly, so an ordinal that drifts fails LOUDLY instead of removing nothing.</param>
+    /// <param name="removeIdentity">Whether the identity directory goes, or only the bytes.</param>
+    [Theory]
+    [InlineData("/Store.zip", 3, false)]
+    [InlineData("/Store.zip", 3, true)]
+    [InlineData("/modules/ai.module.nupkg", 4, false)]
+    [InlineData("/modules/ai.module.nupkg", 4, true)]
+    public async Task BytesRemovedBetweenTheSealReadAndTheOpen_AreTransientOrNotFound_NeverA500(
+        string suffix, int openRead, bool removeIdentity)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-prebuilt-serve-" + Guid.NewGuid().ToString("N"));
+        var directory = Path.Combine(root, Identity, Source);
+        var modules = Path.Combine(directory, PublishedBundleCatalogue.ModulesDirectoryName);
+        Directory.CreateDirectory(modules);
+        try
+        {
+            WriteBundle(Path.Combine(directory, "Store.zip"), "Store");
+            var seal = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            File.WriteAllText(seal, "Store.zip\n");
+            WriteBundle(Path.Combine(modules, "ai.module.nupkg"), "AI");
+            File.WriteAllText(
+                Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName), "ai.module.nupkg\n");
+            var bytes = Path.Combine(
+                directory, suffix.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+
+            var key = await RegisterInstance(Granted, $"{Source}/*");
+            var armed = false;
+            var reads = 0;
+            await using var app = await StartHost(root, () =>
+            {
+                if (!armed || ++reads != openRead)
+                    return;
+                Assert.True(File.Exists(seal),
+                    "the seal must still be readable here — this test removes the BYTES after the "
+                    + "seal read has listed them, which is the race; a seal already gone would be "
+                    + "the older, already-fixed condition instead");
+                if (removeIdentity)
+                    Directory.Delete(Path.Combine(root, Identity), recursive: true);
+                else
+                    File.Delete(bytes);
+            });
+            var route = $"/api/plugins/bundles/prebuilt/{Identity}/{Source}";
+
+            // POSITIVE CONTROL, on the same route the removal then hits: a healthy sealed
+            // publication still serves its bytes, with no Retry-After.
+            using (var healthy = await Get(app, route + suffix, key))
+            {
+                Assert.Equal(HttpStatusCode.OK, healthy.StatusCode);
+                Assert.True((await healthy.Content.ReadAsByteArrayAsync()).Length > 0,
+                    "a healthy sealed publication must serve the bundle's BYTES");
+                Assert.Null(healthy.Headers.RetryAfter);
+            }
+
+            armed = true;
+            using var response = await Get(app, route + suffix, key);
+            Assert.Equal(openRead, reads);
+            Assert.NotEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            if (removeIdentity)
+            {
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                Assert.Null(response.Headers.RetryAfter);
+            }
+            else
+            {
+                Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                Assert.Equal("30", response.Headers.RetryAfter?.ToString());
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* the test may have removed it */ }
+        }
+    }
+
+    /// <summary>
+    /// 🚨 #3876 on the module set's OWN seal. <c>File.Exists(modules/_index)</c> leading an
+    /// unguarded <c>File.ReadAllLines(modules/_index)</c> is the same racing pair the
+    /// <c>_complete</c> readers shed in #3877/#3885, and it threw the same unhandled exception onto
+    /// the same two module routes. The open now decides, and the discrimination is the point: an
+    /// index absent at the open needs the OPPOSITE answer depending on WHY.
+    ///
+    /// <para>Three directions. (1) The index is gone at the open and the seal has gone with it —
+    /// the publisher unseals FIRST and retention unseals before it removes an identity, so this is
+    /// a publication being replaced right now: <c>PublicationUnavailable</c>, which the HTTP
+    /// readers already turn into 503 + <c>Retry-After</c> while the directory is there and 404 once
+    /// it is not (<see cref="RemovedSealAndRemovedIdentity_HaveDistinctAnswersOnEveryPublicationRoute"/>
+    /// pins that mapping). (2) The index was never there and the seal reads fine — the publication
+    /// predates module sealing, which is PERMANENT and must stay a 404 that says to republish;
+    /// collapsing either into the other is the defect. (3) A healthy publication still yields its
+    /// module set.</para>
+    /// </summary>
+    /// <param name="removeDirectory">Whether the whole <c>modules</c> directory goes at the open
+    /// (<see cref="DirectoryNotFoundException"/>) or only the index
+    /// (<see cref="FileNotFoundException"/>) — a removed parent raises neither the same exception
+    /// nor the same message, and both must classify.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AModuleIndexRemovedAtTheOpen_IsTransient_NotAPublicationThatPredatesModuleSealing(
+        bool removeDirectory)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-prebuilt-index-" + Guid.NewGuid().ToString("N"));
+        var directory = Path.Combine(root, Identity, Source);
+        var modules = Path.Combine(directory, PublishedBundleCatalogue.ModulesDirectoryName);
+        Directory.CreateDirectory(modules);
+        try
+        {
+            WriteBundle(Path.Combine(directory, "Store.zip"), "Store");
+            var seal = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            File.WriteAllText(seal, "Store.zip\n");
+            WriteBundle(Path.Combine(modules, "ai.module.nupkg"), "AI");
+            var index = Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName);
+            File.WriteAllText(index, "ai.module.nupkg\n");
+
+            // POSITIVE CONTROL: healthy, so a reading that refused everything could not pass.
+            var healthy = PublishedBundleCatalogue.SealedModulesOf(directory);
+            Assert.Equal(["ai.module.nupkg"], healthy.Modules);
+            Assert.False(healthy.PublicationUnavailable);
+
+            // 1. gone AT THE OPEN, seal gone with it — the publisher's own order — is TRANSIENT.
+            var removedAtTheOpen = PublishedBundleCatalogue.ReadModuleSet(directory, null, path =>
+            {
+                if (removeDirectory)
+                    Directory.Delete(modules, recursive: true);
+                else
+                    File.Delete(index);
+                File.Delete(seal);
+                return File.ReadAllLines(path);
+            });
+            Assert.Null(removedAtTheOpen.Modules);
+            Assert.True(removedAtTheOpen.PublicationUnavailable,
+                "an index that was there for the seal read and gone at the open is a publication "
+                + "being replaced — 503 + Retry-After, never 'republish the source'");
+            Assert.Contains("being replaced right now", removedAtTheOpen.Refusal);
+
+            // 2. never there, seal intact — PERMANENT, and it must keep saying so.
+            File.WriteAllText(seal, "Store.zip\n");
+            Directory.CreateDirectory(modules);
+            var predates = PublishedBundleCatalogue.SealedModulesOf(directory);
+            Assert.Null(predates.Modules);
+            Assert.False(predates.PublicationUnavailable,
+                "a sealed publication that simply carries no module set is a permanent 404 telling "
+                + "the caller to republish — it must not wear the transient answer");
+            Assert.Contains("predates module sealing", predates.Refusal);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* the test may have removed it */ }
+        }
+    }
+
     private sealed class PublicationReadLoggerFactory(Action beforeRead) : ILoggerFactory
     {
         private readonly ILoggerFactory inner = LoggerFactory.Create(_ => { });


### PR DESCRIPTION
Closes the last two unguarded opens on the prebuilt bundle/module routes, both of which still
answered an absent publication with an unhandled `FileNotFoundException` → 500 after #3877 and
#3885 had fixed the four `_complete` readers. Refs #3876.

## The defect shape is an existence check leading an open — not the `_complete` file

#3877/#3885 removed that pair from every reader of `_complete`. Two more survived on the very same
routes, each throwing the same exception from a different frame, which is why the incident kept
recurring after it had twice been "fixed":

1. **`PublishedBundleCatalogue.SealedModulesOf`** probed `modules/_index` with `File.Exists` and
   then read it with an unguarded `File.ReadAllLines`. That index is written strictly *before*
   `_complete`, so the removal that takes one takes the other → 500 on `PrebuiltModuleSet` and
   `PrebuiltModule`.
2. **The serve itself.** `Results.File(path, …)` resolves the path *again* when the result
   executes, after the handler has returned — so the seal read that listed the name and stat'ed it
   present is several steps in the past. A file removed in between threw out of result execution,
   past every handler, to `ExceptionHandlerMiddleware` → 500 on `PrebuiltBundle` and
   `PrebuiltModule`.

## How the two absent-seal conditions are discriminated, and the probe/open race

Both failures route into the **one** mapping that already existed, rather than a fourth answer:
`BeingRepublished(...)` → source directory still present ⇒ **503 + `Retry-After: 30`**; identity
directory gone ⇒ **404**.

The probe that decides it is `Directory.Exists`, which is **total** — it returns `false` for every
failure rather than throwing. So the race where the directory is removed *between* the failed open
and the probe answers 404, which is the correct answer for a removed identity, and can never
produce a 500. In the opposite order — present at the probe, removed just after — the caller gets
503 and its next read gets 404; the consumer contract (`node-repo-gate.yml`,
`compose-sealed-modules.sh`, `memex build plugin`) is built to re-read, so that converges.

For the module index the discrimination is not a second probe of the same file (that is what made
the race) but a re-read of the **seal**, and the publisher's own ordering is what makes it sound:
`modules/_index` is written before `_complete`, and `_complete` is removed *first* on both replace
and reclaim. Seal still reads ⇒ the publication is intact and simply has no module set: it
**predates module sealing**, permanent, 404, republish the source. Seal gone too ⇒ **being replaced
right now**, transient, `PublicationUnavailable`, which rides the mapping above.

Only ABSENCE is classified, exactly as `ShippedPrebuiltBundles.ReadSealLines` does it — a file
present but unreadable (denied, locked, a share fault) keeps surfacing, because dressing a
permanent fault as "come back in thirty seconds" would have every consumer retry for ever.

Opening in the handler also *removes* the window rather than reporting it: on POSIX the bytes stay
readable through an open descriptor after the directory entry is gone, so a publication replaced
mid-response is delivered whole from the generation its `ETag` pins. Cost: the response streams
instead of using `sendfile`. Correctness wins; these are CI-gate downloads.

**Also fixed:** the bytes are served under the SEAL's spelling, never the request's. The name match
is case-insensitive and the share is not, so `store.zip` against a publication that sealed
`Store.zip` opened a path that does not exist on Linux — a permanent client mistake that would now
have worn the transient answer and retried for ever.

## Control, in three directions

`BytesRemovedBetweenTheSealReadAndTheOpen_AreTransientOrNotFound_NeverA500` — a Theory over both
byte routes × {bytes removed, identity removed}, driven through the **real HTTP routes**:

- **positive control first, on the very route the removal then hits** —
  `Assert.Equal(HttpStatusCode.OK, healthy.StatusCode)` and
  `Assert.True((await healthy.Content.ReadAsByteArrayAsync()).Length > 0, "a healthy sealed publication must serve the bundle's BYTES")`
  plus `Assert.Null(healthy.Headers.RetryAfter)`;
- **absent bytes, source directory present** — `Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode)`
  and `Assert.Equal("30", response.Headers.RetryAfter?.ToString())`;
- **identity directory gone** — `Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)` and
  `Assert.Null(response.Headers.RetryAfter)`;
- and `Assert.NotEqual(HttpStatusCode.InternalServerError, response.StatusCode)` on every leg.

The removal fires at the logger ordinal the open sits behind, and `Assert.Equal(openRead, reads)`
asserts that ordinal exactly — an ordinal that drifts fails LOUDLY instead of removing nothing and
passing vacuously.

`AModuleIndexRemovedAtTheOpen_IsTransient_NotAPublicationThatPredatesModuleSealing` — the same
three directions at the catalogue: healthy set (`Assert.Equal(["ai.module.nupkg"], healthy.Modules)`),
removed at the open (`Assert.True(removedAtTheOpen.PublicationUnavailable, …)` +
`Assert.Contains("being replaced right now", …)`), never there
(`Assert.False(predates.PublicationUnavailable, …)` + `Assert.Contains("predates module sealing", …)`),
over both `FileNotFoundException` and `DirectoryNotFoundException`.

**Negative control.** With the two production changes reverted and the project rebuilt: **6 failed,
0 passed** — `System.IO.FileNotFoundException : Could not find file '…/plugins/Store.zip'`,
`'…/plugins/modules/ai.module.nupkg'`, `'…/plugins/modules/_index'` and
`System.IO.DirectoryNotFoundException : Could not find a part of the path '…/modules/_index'`, each
with `at Interop.ThrowExceptionForIoErrno(...)` — the exact top frame the incident samples carry.
Restored: 14/14 green.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation:
  `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, `MeshWeaver.Documentation`,
  `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test` — **0 Error(s), 0 Warning(s)** each.
- `Memex.Portal.Shared.Test`: 14/14 on `PrebuiltPublicationTest`; full project green.
- `MeshWeaver.Documentation.Test`: **373 passed**, including `DocumentationLinkIntegrityTest`.

## Notes

The internal seam is named `ReadModuleSet`, deliberately **not** an overload of `SealedModulesOf`:
an added overload makes every bare `<see cref="SealedModulesOf"/>` ambiguous — CS0419, an error
under `-warnaserror`, and one no cross-repo gate can see. It reddened this file on the first build,
and a satellite holding the same bare cref would have found out only when it moved its platform pin.

#3876 stays OPEN — its own bar is production verification of the route behaviour through a real
mid-replace window, which needs a rolled portal and is not assertable from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
