### PR TITLE
fix: collect superseded generations inside a retained identity (#3461)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -144,7 +144,7 @@ directory:
 | `.`, `..`, anything with a separator, anything rooted | 🚨 a pointer is a NAME. It must never be able to address bytes outside its own source directory — refused and logged as a warning, because a publisher wrote something this reader will not follow |
 | names a directory that is not on disk | a retention sweep outran the pointer; logged as a warning |
 
-### Retention
+### Generation retention
 
 Follow [Released Artifact Retention](/Doc/Architecture/ReleasedArtifactRetention)
 (#3842). The 30-day age window and release/consumer references supersede the earlier
@@ -161,9 +161,51 @@ Follow [Released Artifact Retention](/Doc/Architecture/ReleasedArtifactRetention
 - Missing consumer or publication inventory prevents deletion. A retry/backoff duration
   is not an adoption lifetime and cannot authorize collecting a serving fallback.
 
-This is the cleanup contract to implement with the release inventory. The identity-level
-bundle sweep never reaches inside a retained identity and therefore does not itself
-prove that generation-level protection and collection are implemented.
+**Where it runs.** `PrebuiltBundleStore` — the portal's own sweep, one level down from the identity
+rules it already applies, sharing that pass's abort discipline, its report-only mode and its ledger.
+It is deliberately NOT in the publisher: the publisher has no consumer inventory, no release
+markers, no adoption stamps, and it holds none of them at the moment it publishes.
+
+**The rule, ORed as KEEPs, applied only inside an identity the pass RETAINS.** A generation is
+collected when *all* of these hold, and kept when any one fails:
+
+| | keep when |
+|---|---|
+| the pointer | `_current` names it — it is the live publication, however old |
+| the pointer's own health | `_current` could not be resolved to a directory on disk: unreadable, blank, refused, or dangling. Then **every** generation of that source is kept |
+| its own seal | its seal could not be READ — unreadable is never unreferenced |
+| age | its newest write is inside `PreWarm:PrebuiltBundleRetention:MinimumAge` (at least 30 days) |
+
+A generation under a *collectable* identity is not listed separately: that identity's directory goes
+whole, and its byte count already includes them.
+
+🚨 **Why this is sound without a per-generation consumer inventory — the one thing that could make
+it unsound.** A non-current generation is **unreachable**, not merely unfashionable. Every read of a
+published source directory composes under
+`ShippedPrebuiltBundles.PublicationDirectoryOf(sourceDirectory)` — the boot seeder, the same-major
+adopted fallback, `SealedPublicationIndex`, `PublishedBundleCatalogue` and `ServedModuleBytes` alike
+— and nothing anywhere enumerates a source's subdirectories looking for a publication. So the set a
+consumer inventory would have to protect is exactly *{the generation `_current` names}* ∪
+*{everything young}*, and both are kept above by construction. The sweep therefore uses **the
+readers' own resolution** (`ShippedPrebuiltBundles.ResolvePublicationPointer`, which is
+`PublicationDirectoryOf` with the fallback reason kept rather than discarded) instead of a second
+copy of those rules: a sweep that decided reachability differently from the readers would delete
+bytes a portal was still resolving, and the two would drift silently.
+
+🚨 **"Publication must establish protection before moving `_current`" is satisfied by AGE, not by a
+lease.** A generation is protected from the instant its first byte lands, because it is younger than
+the window. A publication in flight can therefore never be collected, and the publisher needs no
+claim, no lock and no ordering with the sweep — which is what makes this implementable at all across
+two repositories that share no lock. `UnsealedGrace` is deliberately *not* consulted here: it is
+hours where the window is at least 30 days, so a branch for it could never fire, and a check that
+cannot fail is not a check.
+
+🚨 **A directory is a generation only on POSITIVE evidence that it is a publication** — it carries
+`source-commit.txt`, `repository.txt` or the completion sentinel, or the pointer names it. It is not
+"every subdirectory except the ones I know about". The publisher's `modules/` sits beside the
+generations in the flat compatibility copy, and under an exclusion list every bookkeeping directory
+added later would become collectable the day it was added, silently. Under positive identification
+it is simply retained, and the worst case is bytes that stay.
 
 ## Who actually publishes — measured, 2026-09-07
 
@@ -281,10 +323,10 @@ green. (`repository.txt` was added under this rule and says so in place.)
   of costing a publication that is already whole, sealed and disjoint. Ordering it before would let
   a race on the OLD layout withhold a publication that is correct on the NEW one — which would make
   flipping a prefix deliver nothing at all until the flat copy is dropped.
-- 🚨 **Retention is NOT implemented, and that is a precondition on flipping rather than a follow-up.**
-  Generations accumulate at ~45 small files each until a sweep removes the ones nothing names, and
-  that sweep DELETES from the production share — it must land as its own reviewed change, with its
-  own harness. Nothing the writer does today deletes anything it did not create.
+- ✅ **Retention landed** — see "Generation retention" above. It was the precondition on flipping:
+  generations accumulate at ~45 small files each, and nothing the writer does deletes anything it
+  did not create. The collector is the portal's own `PrebuiltBundleStore` sweep, one level down from
+  the identity rules it already applies.
 
 ### Phase 3 — every producer's pin reaches phase 2 *(open — the next step)*
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationGenerations.md
@@ -173,8 +173,23 @@ collected when *all* of these hold, and kept when any one fails:
 |---|---|
 | the pointer | `_current` names it — it is the live publication, however old |
 | the pointer's own health | `_current` could not be resolved to a directory on disk: unreadable, blank, refused, or dangling. Then **every** generation of that source is kept |
-| its own seal | its seal could not be READ — unreadable is never unreferenced |
 | age | its newest write is inside `PreWarm:PrebuiltBundleRetention:MinimumAge` (at least 30 days) |
+
+There is deliberately **no "it could not be read" rule**, and it is not missing: a generation the
+sweep's walk could not enter contributes no files, so it is never *identified* as a publication and
+never becomes a candidate. Unreadable still means kept — it arrives by not being enumerated rather
+than by a branch, which is the stronger of the two. Nor is there a rule on whether the generation was
+sealed: a superseded one is collected on age whether it was sealed, torn, or abandoned mid-upload.
+The entry records which (`HasSentinel`) so an operator can tell a wave of *abandoned* publications —
+a different problem — from ordinary supersession, and that field decides nothing.
+
+**One walk per identity, not one per generation.** The bytes, the newest write and the marker files
+all come from the single recursive enumeration the identity-level sweep already performs. That is
+not a micro-optimisation: the root is an Azure Files share where every enumeration is a network round
+trip, and per-generation walks would have made the cost grow with the number of generations — the
+exact quantity this cleanup exists to bound. It is why `HasSentinel` reports the sentinel's
+*presence* rather than verifying its listing the way the source-level `IsSealed` does; verifying
+would cost one file read per generation per pass to answer a question no rule asks.
 
 A generation under a *collectable* identity is not listed separately: that identity's directory goes
 whole, and its byte count already includes them.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -205,6 +205,47 @@ satellite pin land on an identity core CD is still publishing to.
 So the fix is publisher-agnostic: it asks *"are the bytes on the shelf the ones I uploaded"*, never
 *"which repo is the other one"*.
 
+### Reproduced a third time, on a different day — 2026-09-10
+
+The two conclusions above are load-bearing enough to be worth an independent re-measurement rather
+than a citation. **2026-09-09 20:00Z → 2026-09-10 18:09Z, 22 hours: 61 bake jobs that ran to a
+terminal conclusion** (33 core CD, 28 satellite), every job log fetched, none expired, **zero
+unreadable identities**.
+
+| | core CD `plugins-bake` | satellite `publish-bake` |
+|---|---|---|
+| executed to `success`/`failure` | 33 | 28 |
+| **sealed a publication** | 16 | 20 |
+| skipped — already published, content × framework | 2 | 7 |
+| published nothing (failed before the publish) | 15 | 1 |
+
+36 distinct sealed publications over **19 distinct prefixes**. And:
+
+- 🚨 **7 of the 19 prefixes were written by BOTH lanes — and in all 7 the two lanes carried
+  DIFFERENT source commits.** So the premise of #3461 holds exactly: the framework identity is a
+  property of the *platform image's* reference surface, it carries no content commit, and `plugins`
+  is a constant, so the two lanes address one directory routinely. When they meet there the
+  content × framework sealed-skip **cannot** fire, because the content differs — each lane genuinely
+  unseals and overwrites the other's publication.
+- 🚨 **Concurrent publications on one prefix: 4. All four SAME-lane. Cross-lane: 0.** That is the
+  same answer as 2026-09-06 and 2026-09-08, from a third day and a differently built measurement —
+  three independent reproductions. All four carried different content, so all four are cases where
+  the #3496 postcondition is the only thing between the two runs and a sealed mix.
+
+The one cross-lane pair that came close is worth writing down because it shows the *mechanism* that
+keeps them apart, which is not luck about timing. On identity `s546f29f9…`, core CD run
+`34430130924` sealed at **03:27:37.327Z**; satellite run `34430082656` reached its own publish at
+**03:30:57Z**, found *"holds a COMPLETE publication of THIS content"* on both shares and skipped.
+They were baking the **same** plugins commit (`3f7686da2…`), because core CD resolves the plugins
+tip at its gate — so the common cross-lane case is redundant work that the skip absorbs, and the
+dangerous case needs the satellite to have moved on, which is the same-lane shape by another road.
+
+**Nothing here changes the design.** A rule about which *repository* owns the prefix would have
+addressed **0 of the 4** contentions measured on this day, as it would have addressed 0 of the ones
+measured on the previous two. What removes them is the layout — a publication written into its own
+directory is disjoint from every other publication whoever wrote it — which is
+[Sealed Publication Generations](/Doc/Architecture/SealedPublicationGenerations).
+
 ## The writer's postcondition
 
 `publish-bake-bundles.sh` stamps every file it uploads with two metadata values —
@@ -390,9 +431,12 @@ Stated plainly, because a page that only lists what works is how the next sessio
   would keep serving its generation and never see the flat writer's newer publication, a stale serve
   with nothing red anywhere. The writer is behind a per-caller `publication-layout` selector that
   **defaults to `flat`**, so nothing anywhere writes a generation until a caller opts in and
-  **everything on this page still describes what is live**. What remains is each producer's pin
-  reaching the writer, then flipping — `plugins` in ONE change set, because it is the only prefix
-  with two producers.
+  **everything on this page still describes what is live**. **Generation retention — the stated
+  precondition on flipping — has landed too**: the portal's own `PrebuiltBundleStore` sweep now
+  collects a generation no `_current` names, whose pointer resolved cleanly, whose own seal could be
+  read, and that is older than the 30-day window, applying the identity rules' fail-closed discipline
+  one level down. What remains is each producer's pin reaching the writer, then flipping — `plugins`
+  in ONE change set, because it is the only prefix with two producers.
 
   🚨 That page also records what an **OCI registry** does and does not close, since the fleet is
   moving plugin bundles into one: content-addressed blobs make a mix unrepresentable, but a **tag**
@@ -415,7 +459,11 @@ Stated plainly, because a page that only lists what works is how the next sessio
   failures are the two halves of the single mutual supersession above. 🚨 **All 9 overlaps were
   same-lane; zero were cross-lane**, which reproduces the 2026-09-06 finding on a different day and
   is the second independent measurement saying that "one owner per prefix" addresses none of this.
-  The convergence verdict takes that 2 to 1; the layout takes it to 0.
+  The convergence verdict takes that 2 to 1; the layout takes it to 0. **2026-09-10 makes it three**
+  — 4 same-lane contentions, 0 cross-lane, over 61 executed bake jobs; see "Reproduced a third time"
+  above, which also measures the thing the earlier two did not: **every** prefix the two lanes shared
+  that day, they shared carrying *different* content, so the sealed-skip cannot separate them and the
+  premise of #3461 is confirmed rather than narrowed.
 - **The window itself remains.** In this layout it cannot be removed — in-place replacement means
   unsealed time, and the alternative is a layout migration every reader must land first (the portal
   boot seeder, the gate's Azure-direct path, and every pinned satellite workflow copy).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-superseded-bundle-publications-no-longer-pile-up-on-the-share.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-superseded-bundle-publications-no-longer-pile-up-on-the-share.md
@@ -1,0 +1,69 @@
+---
+Name: Superseded bundle publications no longer pile up on the share
+Category: Fix
+Description: The prebuilt-bundle cleanup only ever removed whole framework builds, so once a build stayed in use its superseded publications accumulated inside it for ever. It now removes those too — never the one in use, never anything recent, and never anything at all when it cannot tell.
+Icon: Broom
+Order: -20260910
+---
+
+# Superseded bundle publications no longer pile up on the share
+
+Your installation keeps a store of **prebuilt bundles**: code that CI compiled ahead of time so
+your portal does not have to compile it at every start. The store is shared storage, and it is
+finite. When it fills up, writes to it stop working — quietly. That has happened: a portal reached
+3 MiB free, and from then on every recompile landed as corrupt bytes and every publication was
+written half-way, with nothing reporting a fault until someone looked at the free space.
+
+Cleanup for that store already existed, and its rule is the right one: **keep whatever something
+references, remove only what nothing does, and when the references cannot be read, remove nothing.**
+It kept the build you are running, every released build, everything a deployment pins, everything an
+installation reports, and everything younger than 30 days.
+
+But it worked at one level only — a whole framework build, kept or removed as a unit. Inside a build
+that something *does* reference, it removed nothing at all. That is fine today, and it stops being
+fine as soon as publications start being written side by side instead of on top of each other, which
+is the change that makes a half-written publication impossible. Then a referenced build accumulates
+one superseded publication per CI run, indefinitely, and the share fills up on a schedule.
+
+## What changes
+
+**Cleanup now also removes superseded publications inside a build it is keeping** — the same rule,
+one level down.
+
+A superseded publication is removed only when **all** of these are true:
+
+- **nothing points at it.** Each source keeps a one-line pointer naming the publication that
+  currently applies; the one it names is kept however old it is.
+- **the pointer could be read.** If the pointer is missing its target, unreadable, or blank — which
+  is what it looks like while it is being replaced — nothing under that source is removed at all.
+  Not being able to tell is treated as "it is in use", never as "it is not".
+- **its own contents could be read.** A publication that cannot be examined is kept.
+- **it is older than 30 days.** As before, this is a floor: a setting can lengthen the window and
+  cannot shorten it.
+
+**A publication in flight is safe by arithmetic, not by timing.** It is protected from the moment
+its first byte lands, because it is far newer than the window. There is no lock and no coordination
+to get wrong, and nothing being written can be caught mid-write.
+
+**Anything the cleanup cannot positively identify as a publication is left alone.** It removes a
+directory because it recognises it, not because it fails to recognise it — so bookkeeping the
+cleanup has never heard of is kept rather than swept up.
+
+**The same safety valves as before.** If anything in the picture cannot be read, the whole pass is
+abandoned and nothing is removed. The report-only mode reports what it would have taken without
+taking it. Every removal is written to the store's own ledger, naming what went and how much space
+came back, and a removal that fails is counted and reconsidered next time rather than ignored.
+
+## What this does not change
+
+**Nothing is removed that your portal could read.** A publication that is not the one being pointed
+at is unreachable by every part of the portal that reads this store — and the cleanup asks that
+question using the *same code the portal uses to answer it*, rather than a second copy of the rules
+that could drift.
+
+**No change to what is kept at the build level.** The running build, released builds, pinned builds,
+reported builds, recent builds and unreadable ones are all kept exactly as before.
+
+**Nothing on your installation behaves differently today.** Publications are still written the old
+way, so there are no superseded ones to remove yet. This is the cleanup being ready before the
+change that would otherwise make the store grow without limit.

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
@@ -124,18 +124,25 @@ public delegate IObservable<ImmutableList<PinnedPlatformReference>> PinnedPlatfo
 /// <param name="Name">The directory name — the publisher's run-unique publication token.</param>
 /// <param name="Directory">Full path.</param>
 /// <param name="IsCurrent">The source's <c>_current</c> pointer names it — the LIVE publication.</param>
-/// <param name="IsSealed">Its completion sentinel is present and every bundle it lists is on disk.</param>
+/// <param name="HasSentinel">
+/// The completion sentinel is present at its root — so a publication that DIED mid-upload (a
+/// cancelled run, a network fault) is distinguishable from one that was merely superseded, which is
+/// worth an operator's attention for a different reason.
+/// <para>🚨 It says the sentinel is THERE, deliberately not that the publication is whole: unlike
+/// <see cref="PrebuiltSourceEntry.IsSealed"/> it does not verify that every bundle the sentinel
+/// lists is on disk. Nothing here branches on it — a superseded generation is collected on age
+/// whether it was sealed, torn or abandoned — and verifying it would cost one file read per
+/// generation per pass on a share whose generation count is the very thing being cleaned up.</para>
+/// </param>
 /// <param name="NewestWriteUtc">The newest write under it (any file), or the directory's own stamp when it holds none.</param>
 /// <param name="Bytes">Total bytes under it.</param>
-/// <param name="ReadFault">Why its seal could not be READ, or null. A read fault PROTECTS the generation.</param>
 public sealed record PrebuiltGenerationEntry(
     string Name,
     string Directory,
     bool IsCurrent,
-    bool IsSealed,
+    bool HasSentinel,
     DateTimeOffset NewestWriteUtc,
-    long Bytes,
-    string? ReadFault);
+    long Bytes);
 
 /// <summary>One source directory under an identity, as the sweep read it.</summary>
 /// <param name="Name">The source segment (<c>plugins</c>, <c>education</c>, …).</param>
@@ -401,24 +408,61 @@ public static class PrebuiltBundleStore
     {
         var bytes = 0L;
         var newestWrite = new DateTimeOffset(Directory.GetLastWriteTimeUtc(identityDirectory), TimeSpan.Zero);
+        // 🚨 ONE recursive walk per identity, and everything below is DERIVED from it — the identity's
+        // bytes and newest write, each source's newest write, and each generation's bytes, newest
+        // write and whether it carries the files that identify a publication. This used to be one
+        // walk of the identity plus one of every source; adding a walk per generation would have made
+        // it 1 + S + G walks and touched every file three times. On the store this sweep exists for
+        // that is not a micro-optimisation: the root is an Azure Files share, every enumeration is a
+        // network round trip, and the very condition being cleaned up is "one more generation per CI
+        // run" — the cost would grow with exactly the thing the sweep is here to remove.
+        var sourceNewest = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+        var generationTallies = new Dictionary<(string Source, string Name), GenerationTally>();
         foreach (var file in Directory.EnumerateFiles(identityDirectory, "*", SearchOption.AllDirectories))
         {
             var info = new FileInfo(file);
             bytes += info.Length;
             var write = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero);
             if (write > newestWrite) newestWrite = write;
+
+            var segments = Path.GetRelativePath(identityDirectory, file)
+                .Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                    StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 2)
+                continue;
+            var source = segments[0];
+            if (!sourceNewest.TryGetValue(source, out var seenSource) || write > seenSource)
+                sourceNewest[source] = write;
+            // <source>/<name>/… — a candidate generation. `<source>/<file>` (the flat copy) has
+            // length 2 and lands nowhere; `<source>/modules/x.nupkg` DOES land here, and is then
+            // dropped by the positive identification below, which is the whole point of that test.
+            if (segments.Length < 3)
+                continue;
+            var key = (source, segments[1]);
+            if (!generationTallies.TryGetValue(key, out var tally))
+                generationTallies[key] = tally = new GenerationTally();
+            tally.Bytes += info.Length;
+            if (write > tally.NewestWrite) tally.NewestWrite = write;
+            if (segments.Length == 3)
+            {
+                var leaf = segments[2];
+                if (string.Equals(leaf, ShippedPrebuiltBundles.CompletionSentinelFileName, StringComparison.Ordinal))
+                    tally.HasSentinel = true;
+                if (string.Equals(leaf, SealedPublicationIndex.SourceCommitMarkerFileName, StringComparison.Ordinal)
+                    || string.Equals(leaf, SealedPublicationIndex.RepositoryMarkerFileName, StringComparison.Ordinal)
+                    || string.Equals(leaf, ShippedPrebuiltBundles.CompletionSentinelFileName, StringComparison.Ordinal))
+                    tally.IsPublication = true;
+            }
         }
 
         var sources = ImmutableList.CreateBuilder<PrebuiltSourceEntry>();
         foreach (var sourceDirectory in Directory.EnumerateDirectories(identityDirectory).OrderBy(d => d, StringComparer.Ordinal))
         {
             var sourceName = Path.GetFileName(sourceDirectory);
-            var sourceNewest = new DateTimeOffset(Directory.GetLastWriteTimeUtc(sourceDirectory), TimeSpan.Zero);
-            foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
-            {
-                var write = new DateTimeOffset(File.GetLastWriteTimeUtc(file), TimeSpan.Zero);
-                if (write > sourceNewest) sourceNewest = write;
-            }
+            var sourceStamp = new DateTimeOffset(Directory.GetLastWriteTimeUtc(sourceDirectory), TimeSpan.Zero);
+            if (sourceNewest.TryGetValue(sourceName, out var newestFile) && newestFile > sourceStamp)
+                sourceStamp = newestFile;
+            var sourceNewestWrite = sourceStamp;
             // 🚨 Composed under the RESOLVED publication directory (#3461): a pointer may name a
             // generation subdirectory, and the seal lives there, not beside the pointer. The
             // resolution is the READERS' — ShippedPrebuiltBundles.ResolvePublicationPointer is the
@@ -426,12 +470,12 @@ public static class PrebuiltBundleStore
             // what a portal can reach can never drift apart.
             var pointer = ShippedPrebuiltBundles.ResolvePublicationPointer(sourceDirectory, logger);
             var publication = pointer.Directory;
-            var generations = ReadGenerations(sourceDirectory, pointer, logger);
+            var sourceGenerations = ReadGenerations(sourceDirectory, sourceName, pointer, generationTallies, logger);
             var sentinel = Path.Combine(publication, ShippedPrebuiltBundles.CompletionSentinelFileName);
             if (!File.Exists(sentinel))
             {
-                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, null)
-                    { Generations = generations, PointerFault = pointer.Fault });
+                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewestWrite, null)
+                    { Generations = sourceGenerations, PointerFault = pointer.Fault });
                 continue;
             }
             try
@@ -441,15 +485,15 @@ public static class PrebuiltBundleStore
                     .Select(l => l.Trim())
                     .Where(l => l.Length > 0)
                     .Any(name => !File.Exists(Path.Combine(publication, name)));
-                sources.Add(new PrebuiltSourceEntry(sourceName, !torn, torn ? null : sealUtc, sourceNewest, null)
-                    { Generations = generations, PointerFault = pointer.Fault });
+                sources.Add(new PrebuiltSourceEntry(sourceName, !torn, torn ? null : sealUtc, sourceNewestWrite, null)
+                    { Generations = sourceGenerations, PointerFault = pointer.Fault });
             }
             catch (Exception ex)
             {
                 // 🚨 Every read failure, not just IOException — a denied ACL is every bit as much
                 // "I cannot evaluate this seal" as a locked file. It PROTECTS the identity.
-                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, $"{ex.GetType().Name}: {ex.Message}")
-                    { Generations = generations, PointerFault = pointer.Fault });
+                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewestWrite, $"{ex.GetType().Name}: {ex.Message}")
+                    { Generations = sourceGenerations, PointerFault = pointer.Fault });
             }
         }
         return new PrebuiltIdentityEntry(identity, identityDirectory, sources.ToImmutable(), bytes, newestWrite);
@@ -457,6 +501,12 @@ public static class PrebuiltBundleStore
 
     /// <summary>
     /// Every generation directory under one source, with the one the pointer names marked.
+    ///
+    /// <para>🚨 <b>It performs NO recursive walk of its own.</b> The bytes, the newest write and the
+    /// marker files all come from <paramref name="tallies"/> — the single walk of the identity that
+    /// <see cref="ReadIdentity"/> already had to do. Walking each generation here instead would touch
+    /// every file three times per pass on an Azure Files share, and would grow with the exact thing
+    /// this sweep exists to remove.</para>
     ///
     /// <para>🚨 <b>A directory is a generation only on POSITIVE evidence that it is a
     /// publication</b> — it carries one of the files every publication carries
@@ -469,7 +519,11 @@ public static class PrebuiltBundleStore
     /// worst case is bytes that stay.</para>
     /// </summary>
     private static ImmutableList<PrebuiltGenerationEntry> ReadGenerations(
-        string sourceDirectory, PublicationPointer pointer, ILogger? logger)
+        string sourceDirectory,
+        string sourceName,
+        PublicationPointer pointer,
+        Dictionary<(string Source, string Name), GenerationTally> tallies,
+        ILogger? logger)
     {
         List<string> directories;
         try
@@ -496,61 +550,39 @@ public static class PrebuiltBundleStore
             // name", and then the positive test.
             if (string.IsNullOrEmpty(name) || name.StartsWith('_') || name.StartsWith('.'))
                 continue;
-            if (!string.Equals(name, pointer.Named, StringComparison.Ordinal) && !LooksLikeAPublication(directory))
+            var isCurrent = string.Equals(name, pointer.Named, StringComparison.Ordinal);
+            tallies.TryGetValue((sourceName, name), out var tally);
+            if (!isCurrent && tally?.IsPublication != true)
                 continue;
 
-            var bytes = 0L;
-            var newest = new DateTimeOffset(Directory.GetLastWriteTimeUtc(directory), TimeSpan.Zero);
-            string? readFault = null;
-            var isSealed = false;
-            try
-            {
-                foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
-                {
-                    var info = new FileInfo(file);
-                    bytes += info.Length;
-                    var write = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero);
-                    if (write > newest) newest = write;
-                }
-                var sentinel = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
-                if (File.Exists(sentinel))
-                    isSealed = !File.ReadAllLines(sentinel)
-                        .Select(l => l.Trim())
-                        .Where(l => l.Length > 0)
-                        .Any(bundle => !File.Exists(Path.Combine(directory, bundle)));
-            }
-            catch (Exception ex)
-            {
-                readFault = $"{ex.GetType().Name}: {ex.Message}";
-            }
-
+            // An EMPTY generation directory holds no file the walk could have seen, so its own
+            // stamp is the only reading there is.
+            var newest = tally is null
+                ? new DateTimeOffset(Directory.GetLastWriteTimeUtc(directory), TimeSpan.Zero)
+                : tally.NewestWrite;
             entries.Add(new PrebuiltGenerationEntry(
-                name, directory,
-                IsCurrent: string.Equals(name, pointer.Named, StringComparison.Ordinal),
-                isSealed, newest, bytes, readFault));
+                name, directory, isCurrent,
+                HasSentinel: tally?.HasSentinel ?? false,
+                newest, tally?.Bytes ?? 0L));
         }
         return entries.ToImmutable();
     }
 
-    /// <summary>
-    /// The POSITIVE test: does this directory carry a file that only a publication carries? An
-    /// unreadable directory answers <c>false</c> — it is then never enumerated and so never
-    /// collectable, which is the fail-safe answer.
-    /// </summary>
-    private static bool LooksLikeAPublication(string directory)
+    /// <summary>What the identity's single recursive walk learned about one generation directory.</summary>
+    private sealed class GenerationTally
     {
-        try
-        {
-            return File.Exists(Path.Combine(directory, SealedPublicationIndex.SourceCommitMarkerFileName))
-                || File.Exists(Path.Combine(directory, SealedPublicationIndex.RepositoryMarkerFileName))
-                || File.Exists(Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName));
-        }
-        catch
-        {
-            return false;
-        }
-    }
+        /// <summary>Total bytes under it.</summary>
+        public long Bytes;
 
+        /// <summary>The newest write under it. Always set — a tally exists only once a file was seen.</summary>
+        public DateTimeOffset NewestWrite = DateTimeOffset.MinValue;
+
+        /// <summary>The completion sentinel is present at its root.</summary>
+        public bool HasSentinel;
+
+        /// <summary>It carries a file only a publication carries — the positive identification.</summary>
+        public bool IsPublication;
+    }
     /// <summary>
     /// Decide what may be collected. Pure — no filesystem, no clock — so the rules are testable
     /// exactly as they are enforced.
@@ -740,7 +772,14 @@ public static class PrebuiltBundleStore
         // younger than the window — so a publication in flight can never be collected, and the
         // publisher needs no claim, no lock and no ordering with this sweep. `UnsealedGrace` is
         // deliberately not consulted here: it is hours and the window is at least 30 days, so a
-        // branch for it could never fire, and a check that cannot fail is not a check.
+        // branch for it could never fire, and a check that cannot fail is not a check. Nor is
+        // `HasSentinel`: a superseded generation is collected on age whether it was sealed, torn or
+        // abandoned mid-upload — it records WHICH for the operator, and decides nothing.
+        //
+        // 🚨 There is no "it could not be read" rule here, and it is not missing — a generation the
+        // walk could not enter contributes no files, so it is never IDENTIFIED as a publication and
+        // is therefore never a candidate at all. Unreadable still means kept; it simply arrives by
+        // not being enumerated rather than by a branch, which is the stronger of the two.
         var generationReasons = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
         var collectableGenerations = ImmutableList.CreateBuilder<PrebuiltGenerationEntry>();
         foreach (var identity in scan.Identities)
@@ -757,8 +796,6 @@ public static class PrebuiltBundleStore
                             ? $"the {ShippedPrebuiltBundles.PublicationPointerFileName} pointer of '{source.Name}' names it — it is the live publication"
                         : source.PointerFault is not null
                             ? $"which generation of '{source.Name}' applies is unknown ({source.PointerFault}) — an inventory that could not be read licenses no deletion"
-                        : generation.ReadFault is not null
-                            ? $"it could not be read ({generation.ReadFault}) — unreadable is never unreferenced"
                         : nowUtc - generation.NewestWriteUtc < minimumAge
                             ? $"within the {minimumAge.TotalDays:N0}-day retention window"
                             : null;

--- a/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltBundleRetention.cs
@@ -117,6 +117,26 @@ public sealed record PinnedPlatformReference(string Origin, string? Version, str
 /// </summary>
 public delegate IObservable<ImmutableList<PinnedPlatformReference>> PinnedPlatformReferenceSource();
 
+/// <summary>
+/// One GENERATION directory under a source (<c>&lt;identity&gt;/&lt;source&gt;/&lt;publication token&gt;</c>),
+/// as the sweep read it. Empty in the flat layout, which has no generations at all.
+/// </summary>
+/// <param name="Name">The directory name — the publisher's run-unique publication token.</param>
+/// <param name="Directory">Full path.</param>
+/// <param name="IsCurrent">The source's <c>_current</c> pointer names it — the LIVE publication.</param>
+/// <param name="IsSealed">Its completion sentinel is present and every bundle it lists is on disk.</param>
+/// <param name="NewestWriteUtc">The newest write under it (any file), or the directory's own stamp when it holds none.</param>
+/// <param name="Bytes">Total bytes under it.</param>
+/// <param name="ReadFault">Why its seal could not be READ, or null. A read fault PROTECTS the generation.</param>
+public sealed record PrebuiltGenerationEntry(
+    string Name,
+    string Directory,
+    bool IsCurrent,
+    bool IsSealed,
+    DateTimeOffset NewestWriteUtc,
+    long Bytes,
+    string? ReadFault);
+
 /// <summary>One source directory under an identity, as the sweep read it.</summary>
 /// <param name="Name">The source segment (<c>plugins</c>, <c>education</c>, …).</param>
 /// <param name="IsSealed">The completion sentinel is present in the publication directory and every bundle it lists is on disk.</param>
@@ -124,7 +144,27 @@ public delegate IObservable<ImmutableList<PinnedPlatformReference>> PinnedPlatfo
 /// <param name="NewestWriteUtc">The newest write under the source directory (any file).</param>
 /// <param name="ReadFault">Why the seal could not be READ, or null. A source with a read fault PROTECTS its identity.</param>
 public sealed record PrebuiltSourceEntry(
-    string Name, bool IsSealed, DateTimeOffset? SealUtc, DateTimeOffset NewestWriteUtc, string? ReadFault);
+    string Name, bool IsSealed, DateTimeOffset? SealUtc, DateTimeOffset NewestWriteUtc, string? ReadFault)
+{
+    /// <summary>
+    /// Every generation directory under this source, in name order; the plan is what orders them
+    /// for collection. Empty in the flat layout — the normal state today, which is why this is an
+    /// <c>init</c> property rather than a positional parameter: adding one would have changed a
+    /// public constructor's signature for every caller outside this repository.
+    /// </summary>
+    public ImmutableList<PrebuiltGenerationEntry> Generations { get; init; } = ImmutableList<PrebuiltGenerationEntry>.Empty;
+
+    /// <summary>
+    /// Why the <c>_current</c> pointer did not resolve to a generation on disk, or null.
+    ///
+    /// <para>🚨 <b>Non-null PROTECTS every generation of this source.</b> It means a pointer exists
+    /// and this reader will not follow it — unreadable, empty (a pointer mid-replacement),
+    /// refused, or naming a directory that is gone. Which generation applies is then unknown, and
+    /// an inventory that could not be read licenses no deletion. Null with an empty
+    /// <see cref="Generations"/> is the flat layout, not a fault.</para>
+    /// </summary>
+    public string? PointerFault { get; init; }
+}
 
 /// <summary>One framework-identity directory of the store and everything the rules need to judge it.</summary>
 /// <param name="Identity">The directory name — the framework identity (<c>s…</c> / <c>g…</c>).</param>
@@ -195,16 +235,30 @@ public sealed record PrebuiltBundleSweepPlan(
     string? AbortReason,
     ImmutableList<string> UnresolvedPins)
 {
+    /// <summary>
+    /// Superseded GENERATION directories inside a RETAINED identity that no rule protects, oldest
+    /// first (MeshWeaver#3461). Empty in the flat layout, and empty whenever the plan aborted.
+    ///
+    /// <para>Generations of a COLLECTABLE identity are deliberately NOT here: that identity's
+    /// whole directory goes, and its <see cref="PrebuiltIdentityEntry.Bytes"/> already counts
+    /// them.</para>
+    /// </summary>
+    public ImmutableList<PrebuiltGenerationEntry> CollectableGenerations { get; init; } = ImmutableList<PrebuiltGenerationEntry>.Empty;
+
+    /// <summary>Why each surviving generation survived, keyed by its full directory path.</summary>
+    public ImmutableDictionary<string, string> ProtectedGenerations { get; init; } = ImmutableDictionary<string, string>.Empty;
+
     /// <summary>Total bytes across every identity.</summary>
     public long TotalBytes => Identities.Sum(i => i.Bytes);
 
-    /// <summary>Bytes the plan would reclaim.</summary>
-    public long CollectableBytes => Collectable.Sum(i => i.Bytes);
+    /// <summary>Bytes the plan would reclaim — collectable identities plus superseded generations inside retained ones.</summary>
+    public long CollectableBytes => Collectable.Sum(i => i.Bytes) + CollectableGenerations.Sum(g => g.Bytes);
 
     /// <summary>One line an operator can read.</summary>
     public string Summary =>
         $"{Identities.Count} identity directory(ies) / {Mb(TotalBytes)} — live={LiveIdentity}"
         + $" ({LivePlatformVersion ?? "version unknown"}), collectable={Collectable.Count} / {Mb(CollectableBytes)}"
+        + (CollectableGenerations.IsEmpty ? "" : $", superseded generations={CollectableGenerations.Count}")
         + $", markers to retire={CollectableMarkers.Count}"
         + (UnresolvedPins.IsEmpty ? "" : $", unresolved consumer references (cleanup blocked): {string.Join(", ", UnresolvedPins)}")
         + (AbortReason is null ? "" : $", ABORTED: {AbortReason}");
@@ -232,6 +286,9 @@ public sealed record PrebuiltBundleSweepResult(
     int FailedDeletes,
     string? AbortReason)
 {
+    /// <summary>Superseded generation directories actually removed from inside retained identities.</summary>
+    public int DeletedGenerations { get; init; }
+
     /// <summary>One ledger line.</summary>
     public string LedgerLine =>
         $"{AtUtc:O} " + (Plan is null
@@ -240,6 +297,7 @@ public sealed record PrebuiltBundleSweepResult(
                 ? $"ABORTED: {AbortReason} ({Plan.Summary})"
                 : Deleted
                     ? $"removed {DeletedIdentities} identity(ies) / {PrebuiltBundleSweepPlan.Mb(DeletedBytes)}, "
+                      + (DeletedGenerations == 0 ? "" : $"{DeletedGenerations} superseded generation(s), ")
                       + $"{DeletedMarkers} marker(s){(FailedDeletes == 0 ? "" : $", {FailedDeletes} failed")} — {Plan.Summary}"
                     : $"report only — {Plan.Summary}");
 }
@@ -277,8 +335,21 @@ public sealed record PrebuiltBundleSweepResult(
 /// already gone for longer than the age window) are removed with it, so <c>_releases/</c> does not grow
 /// forever; a clean release marker is never removed. A release marker that cannot be read, or a
 /// store that cannot be listed, ABORTS the sweep with nothing collected: a partial picture licenses
-/// no deletion. This sweep is IDENTITY-level; the per-source generation retention that follows a
-/// pointer swap is the publisher's (<c>Doc/Architecture/SealedPublicationGenerations</c>).</para>
+/// no deletion.</para>
+///
+/// <para>🚨 <b>And the same rule one level down, for GENERATIONS</b> (MeshWeaver#3461,
+/// <c>Doc/Architecture/SealedPublicationGenerations</c> → "Retention"). Under the generation
+/// layout a source directory holds one directory per publication plus a <c>_current</c> pointer,
+/// and the identity rules above never reach inside — so under an identity they keep, generations
+/// would accumulate for ever. A generation inside a RETAINED identity is collected when all of
+/// these hold: no <c>_current</c> names it, the pointer that would say so resolved cleanly, its own
+/// seal could be read, and its newest write is older than
+/// <see cref="PrebuiltBundleRetention.MinimumAge"/>. Anything else keeps it. This is safe without a
+/// per-generation consumer inventory because a non-current generation is UNREACHABLE — every read
+/// composes under <c>ShippedPrebuiltBundles.PublicationDirectoryOf</c> and nothing enumerates a
+/// source's subdirectories looking for a publication — and it needs no lease with the publisher
+/// because a publication is protected by AGE from its first byte. The reasoning, and the fact that
+/// this is the precondition on flipping a prefix to the generation layout, is on the page.</para>
 /// </summary>
 public static class PrebuiltBundleStore
 {
@@ -349,12 +420,18 @@ public static class PrebuiltBundleStore
                 if (write > sourceNewest) sourceNewest = write;
             }
             // 🚨 Composed under the RESOLVED publication directory (#3461): a pointer may name a
-            // generation subdirectory, and the seal lives there, not beside the pointer.
-            var publication = ShippedPrebuiltBundles.PublicationDirectoryOf(sourceDirectory, logger);
+            // generation subdirectory, and the seal lives there, not beside the pointer. The
+            // resolution is the READERS' — ShippedPrebuiltBundles.ResolvePublicationPointer is the
+            // same call PublicationDirectoryOf makes — so what this sweep calls unreachable and
+            // what a portal can reach can never drift apart.
+            var pointer = ShippedPrebuiltBundles.ResolvePublicationPointer(sourceDirectory, logger);
+            var publication = pointer.Directory;
+            var generations = ReadGenerations(sourceDirectory, pointer, logger);
             var sentinel = Path.Combine(publication, ShippedPrebuiltBundles.CompletionSentinelFileName);
             if (!File.Exists(sentinel))
             {
-                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, null));
+                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, null)
+                    { Generations = generations, PointerFault = pointer.Fault });
                 continue;
             }
             try
@@ -364,16 +441,114 @@ public static class PrebuiltBundleStore
                     .Select(l => l.Trim())
                     .Where(l => l.Length > 0)
                     .Any(name => !File.Exists(Path.Combine(publication, name)));
-                sources.Add(new PrebuiltSourceEntry(sourceName, !torn, torn ? null : sealUtc, sourceNewest, null));
+                sources.Add(new PrebuiltSourceEntry(sourceName, !torn, torn ? null : sealUtc, sourceNewest, null)
+                    { Generations = generations, PointerFault = pointer.Fault });
             }
             catch (Exception ex)
             {
                 // 🚨 Every read failure, not just IOException — a denied ACL is every bit as much
                 // "I cannot evaluate this seal" as a locked file. It PROTECTS the identity.
-                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, $"{ex.GetType().Name}: {ex.Message}"));
+                sources.Add(new PrebuiltSourceEntry(sourceName, false, null, sourceNewest, $"{ex.GetType().Name}: {ex.Message}")
+                    { Generations = generations, PointerFault = pointer.Fault });
             }
         }
         return new PrebuiltIdentityEntry(identity, identityDirectory, sources.ToImmutable(), bytes, newestWrite);
+    }
+
+    /// <summary>
+    /// Every generation directory under one source, with the one the pointer names marked.
+    ///
+    /// <para>🚨 <b>A directory is a generation only on POSITIVE evidence that it is a
+    /// publication</b> — it carries one of the files every publication carries
+    /// (<c>source-commit.txt</c>, <c>repository.txt</c>, the completion sentinel), or the pointer
+    /// names it. It is NOT "every subdirectory that is not one I know about". The difference is the
+    /// whole safety of the sweep: the flat compatibility copy puts the publisher's <c>modules/</c>
+    /// beside the generations during the migration, and any later bookkeeping directory would
+    /// arrive the same way — under an exclusion list, each one is collectable the day it is added
+    /// and nothing says so; under positive identification each one is simply retained, and the
+    /// worst case is bytes that stay.</para>
+    /// </summary>
+    private static ImmutableList<PrebuiltGenerationEntry> ReadGenerations(
+        string sourceDirectory, PublicationPointer pointer, ILogger? logger)
+    {
+        List<string> directories;
+        try
+        {
+            directories = Directory.EnumerateDirectories(sourceDirectory)
+                .OrderBy(d => d, StringComparer.Ordinal)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            // Cannot list ⇒ cannot judge. An empty list collects nothing, which is the answer a
+            // failed listing must give: it must never read as "there are no generations here".
+            logger?.LogWarning(ex,
+                "PrebuiltBundleRetention: could not list the generations under {SourceDirectory} — "
+                + "none of them is collectable this pass", sourceDirectory);
+            return ImmutableList<PrebuiltGenerationEntry>.Empty;
+        }
+
+        var entries = ImmutableList.CreateBuilder<PrebuiltGenerationEntry>();
+        foreach (var directory in directories)
+        {
+            var name = Path.GetFileName(directory);
+            // The underscore convention every layer of this store uses for "never an addressable
+            // name", and then the positive test.
+            if (string.IsNullOrEmpty(name) || name.StartsWith('_') || name.StartsWith('.'))
+                continue;
+            if (!string.Equals(name, pointer.Named, StringComparison.Ordinal) && !LooksLikeAPublication(directory))
+                continue;
+
+            var bytes = 0L;
+            var newest = new DateTimeOffset(Directory.GetLastWriteTimeUtc(directory), TimeSpan.Zero);
+            string? readFault = null;
+            var isSealed = false;
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+                {
+                    var info = new FileInfo(file);
+                    bytes += info.Length;
+                    var write = new DateTimeOffset(info.LastWriteTimeUtc, TimeSpan.Zero);
+                    if (write > newest) newest = write;
+                }
+                var sentinel = Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+                if (File.Exists(sentinel))
+                    isSealed = !File.ReadAllLines(sentinel)
+                        .Select(l => l.Trim())
+                        .Where(l => l.Length > 0)
+                        .Any(bundle => !File.Exists(Path.Combine(directory, bundle)));
+            }
+            catch (Exception ex)
+            {
+                readFault = $"{ex.GetType().Name}: {ex.Message}";
+            }
+
+            entries.Add(new PrebuiltGenerationEntry(
+                name, directory,
+                IsCurrent: string.Equals(name, pointer.Named, StringComparison.Ordinal),
+                isSealed, newest, bytes, readFault));
+        }
+        return entries.ToImmutable();
+    }
+
+    /// <summary>
+    /// The POSITIVE test: does this directory carry a file that only a publication carries? An
+    /// unreadable directory answers <c>false</c> — it is then never enumerated and so never
+    /// collectable, which is the fail-safe answer.
+    /// </summary>
+    private static bool LooksLikeAPublication(string directory)
+    {
+        try
+        {
+            return File.Exists(Path.Combine(directory, SealedPublicationIndex.SourceCommitMarkerFileName))
+                || File.Exists(Path.Combine(directory, SealedPublicationIndex.RepositoryMarkerFileName))
+                || File.Exists(Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName));
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>
@@ -535,9 +710,73 @@ public static class PrebuiltBundleStore
                         || (!present.Contains(m.Identity!) && nowUtc - m.WrittenUtc >= minimumAge))
             .ToImmutableList();
 
+        // ══════════════ GENERATIONS INSIDE A RETAINED IDENTITY (MeshWeaver#3461) ══════════════
+        //
+        // 🚨 THE IDENTITY-LEVEL RULES ABOVE NEVER REACH IN HERE, and under the generation layout
+        // that is unbounded growth rather than an omission: the framework identity is
+        // breaking-change-keyed, so an ordinary week of merges re-resolves the SAME s<hash> and
+        // every publish adds one more ~45-file generation under an identity rules 1/4/5 keep for
+        // ever. That is the precondition on flipping a prefix to `generation`
+        // (Doc/Architecture/SealedPublicationGenerations → "Retention"): a share that fills up
+        // TRUNCATES WRITES SILENTLY, which is how memex.systemorph.com reached 3 MiB free on
+        // 2026-09-08 with every runtime recompile landing as `Bad IL format`.
+        //
+        // 🚨 WHY THIS IS SAFE WITHOUT A PER-GENERATION CONSUMER INVENTORY — the one thing that
+        // could make it unsafe, and the reason there does not have to be one. A non-current
+        // generation is UNREACHABLE, not merely unfashionable: every read of a published source
+        // directory in this process composes under
+        // ShippedPrebuiltBundles.PublicationDirectoryOf(source) — the seeder, the same-major
+        // adopted fallback, SealedPublicationIndex, PublishedBundleCatalogue and ServedModuleBytes
+        // alike — and that resolves the pointer or falls back to the source directory itself.
+        // Nothing enumerates the subdirectories of a source looking for a publication. So the set
+        // a consumer inventory would have to protect is exactly {the generation `_current` names}
+        // ∪ {everything young}, and both are protected below by construction. The rules use the
+        // READERS' own resolution (ResolvePublicationPointer) rather than a second copy of it,
+        // because a sweep that decided reachability differently from the readers would delete
+        // bytes a portal was still resolving.
+        //
+        // 🚨 "Publication must establish protection before moving _current" is satisfied by AGE,
+        // not by a lease. A generation is protected from the instant its first byte lands — it is
+        // younger than the window — so a publication in flight can never be collected, and the
+        // publisher needs no claim, no lock and no ordering with this sweep. `UnsealedGrace` is
+        // deliberately not consulted here: it is hours and the window is at least 30 days, so a
+        // branch for it could never fire, and a check that cannot fail is not a check.
+        var generationReasons = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        var collectableGenerations = ImmutableList.CreateBuilder<PrebuiltGenerationEntry>();
+        foreach (var identity in scan.Identities)
+        {
+            // An identity being collected takes its generations with it; counting them here too
+            // would double-count the bytes and delete a directory twice.
+            if (!reasons.ContainsKey(identity.Identity))
+                continue;
+            foreach (var source in identity.Sources)
+                foreach (var generation in source.Generations)
+                {
+                    var keep =
+                        generation.IsCurrent
+                            ? $"the {ShippedPrebuiltBundles.PublicationPointerFileName} pointer of '{source.Name}' names it — it is the live publication"
+                        : source.PointerFault is not null
+                            ? $"which generation of '{source.Name}' applies is unknown ({source.PointerFault}) — an inventory that could not be read licenses no deletion"
+                        : generation.ReadFault is not null
+                            ? $"it could not be read ({generation.ReadFault}) — unreadable is never unreferenced"
+                        : nowUtc - generation.NewestWriteUtc < minimumAge
+                            ? $"within the {minimumAge.TotalDays:N0}-day retention window"
+                            : null;
+                    if (keep is not null)
+                        generationReasons[generation.Directory] = keep;
+                    else
+                        collectableGenerations.Add(generation);
+                }
+        }
+
         return new PrebuiltBundleSweepPlan(
             liveIdentity, livePlatformVersion, scan.Identities, collectable, reasons.ToImmutable(), markers, null,
-            unresolvedPins.ToImmutable());
+            unresolvedPins.ToImmutable())
+        {
+            CollectableGenerations = collectableGenerations.ToImmutable().Sort(
+                (a, b) => a.NewestWriteUtc.CompareTo(b.NewestWriteUtc)),
+            ProtectedGenerations = generationReasons.ToImmutable(),
+        };
     }
 
     /// <summary>
@@ -604,9 +843,10 @@ public static class PrebuiltBundleStore
         if (!retention.Delete)
         {
             logger?.LogInformation(
-                "PrebuiltBundleRetention: {Summary}. DELETING NOTHING — collection is not armed. Would collect: {Collectable}. Kept: {Kept}",
+                "PrebuiltBundleRetention: {Summary}. DELETING NOTHING — collection is not armed. Would collect: {Collectable}. Would collect generations: {Generations}. Kept: {Kept}",
                 plan.Summary,
                 plan.Collectable.Count == 0 ? "(nothing)" : string.Join(", ", plan.Collectable.Select(i => $"{i.Identity} ({PrebuiltBundleSweepPlan.Mb(i.Bytes)})")),
+                plan.CollectableGenerations.IsEmpty ? "(nothing)" : string.Join(", ", plan.CollectableGenerations.Select(g => $"{g.Directory} ({PrebuiltBundleSweepPlan.Mb(g.Bytes)})")),
                 Describe(plan.Protected));
             var report = new PrebuiltBundleSweepResult(nowUtc, plan, false, 0, 0, 0, 0, null);
             AppendLedger(root, report, logger);
@@ -651,6 +891,38 @@ public static class PrebuiltBundleStore
             }
         }
 
+        // Superseded GENERATIONS inside identities the plan KEEPS (#3461). Same discipline as an
+        // identity: unseal first so a reader listing it mid-removal sees "no sentinel" and backs
+        // off to the previous generation, then remove; a failed removal is counted and re-planned
+        // next pass rather than swallowed.
+        var deletedGenerations = 0;
+        foreach (var generation in plan.CollectableGenerations)
+        {
+            try
+            {
+                var sentinel = Path.Combine(generation.Directory, ShippedPrebuiltBundles.CompletionSentinelFileName);
+                if (File.Exists(sentinel))
+                    File.Delete(sentinel);
+                delete(generation.Directory);
+                deletedGenerations++;
+                deletedBytes += generation.Bytes;
+                logger?.LogInformation(
+                    "PrebuiltBundleRetention: removed superseded generation {Directory} — {Bytes} reclaimed; "
+                    + "newest write {NewestWriteUtc}, and no {Pointer} named it",
+                    generation.Directory, PrebuiltBundleSweepPlan.Mb(generation.Bytes),
+                    generation.NewestWriteUtc.ToString("O", CultureInfo.InvariantCulture),
+                    ShippedPrebuiltBundles.PublicationPointerFileName);
+                lines.Add($"{nowUtc:O}   removed generation {generation.Directory} {PrebuiltBundleSweepPlan.Mb(generation.Bytes)}");
+            }
+            catch (Exception ex)
+            {
+                failedDeletes++;
+                logger?.LogWarning(ex,
+                    "PrebuiltBundleRetention: could not remove superseded generation {Directory} — it stays, "
+                    + "and the next pass considers it again", generation.Directory);
+            }
+        }
+
         var deletedMarkers = 0;
         foreach (var marker in plan.CollectableMarkers)
         {
@@ -668,12 +940,13 @@ public static class PrebuiltBundleStore
         }
 
         logger?.LogInformation(
-            "PrebuiltBundleRetention: {Summary}. COLLECTED {Identities} identity(ies) reclaiming {Reclaimed}, retired {Markers} marker(s){Failed}. Kept: {Kept}",
-            plan.Summary, deletedIdentities, PrebuiltBundleSweepPlan.Mb(deletedBytes), deletedMarkers,
+            "PrebuiltBundleRetention: {Summary}. COLLECTED {Identities} identity(ies) and {Generations} superseded generation(s) reclaiming {Reclaimed}, retired {Markers} marker(s){Failed}. Kept: {Kept}",
+            plan.Summary, deletedIdentities, deletedGenerations, PrebuiltBundleSweepPlan.Mb(deletedBytes), deletedMarkers,
             failedDeletes == 0 ? "" : $" ({failedDeletes} removal(s) failed)",
             Describe(plan.Protected));
 
-        var result = new PrebuiltBundleSweepResult(nowUtc, plan, true, deletedIdentities, deletedBytes, deletedMarkers, failedDeletes, null);
+        var result = new PrebuiltBundleSweepResult(nowUtc, plan, true, deletedIdentities, deletedBytes, deletedMarkers, failedDeletes, null)
+            { DeletedGenerations = deletedGenerations };
         AppendLedger(root, result, logger, lines);
         return result;
     }

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -14,6 +14,23 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.Hosting;
 
 /// <summary>
+/// How a source directory's <c>_current</c> pointer resolved (MeshWeaver#3461) — the answer every
+/// reader takes, plus the reason it fell back, which retention needs and readers discard.
+/// </summary>
+/// <param name="Directory">The directory that holds the publication which applies: the generation
+/// the pointer names, or the source directory itself. Never null, never outside the source
+/// directory — this is the value <see cref="ShippedPrebuiltBundles.PublicationDirectoryOf"/> returns.</param>
+/// <param name="Named">The name the pointer carried, or null when there is no pointer or it was
+/// blank. Set even when the name was REFUSED, so a diagnostic can quote what a publisher wrote.</param>
+/// <param name="Fault">Why the pointer did not resolve to a generation on disk, or null. Null with
+/// a null <paramref name="Named"/> is the flat layout — the normal state today, not a fault.</param>
+public readonly record struct PublicationPointer(string Directory, string? Named, string? Fault)
+{
+    /// <summary>True when the pointer resolved to a generation subdirectory of the source.</summary>
+    public bool IsGeneration => Fault is null && Named is not null;
+}
+
+/// <summary>
 /// Adopts the prebuilt-assembly bundles the IMAGE ITSELF ships (issue #1660 WS1): at boot, before
 /// the dynamic-NodeType sweep decides what to build, every <c>*.zip</c> under the image's
 /// <c>prebuilt/</c> directory is read with <c>BundleReader</c> and seeded through
@@ -158,13 +175,35 @@ public static class ShippedPrebuiltBundles
     /// <param name="logger">Diagnostics. A REFUSED pointer is a warning — it means a publisher
     /// wrote something this reader will not follow, which is worth seeing.</param>
     public static string PublicationDirectoryOf(string sourceDirectory, ILogger? logger = null)
+        => ResolvePublicationPointer(sourceDirectory, logger).Directory;
+
+    /// <summary>
+    /// The SAME resolution <see cref="PublicationDirectoryOf"/> performs, with the reason it fell
+    /// back kept instead of discarded.
+    ///
+    /// <para>🚨 <b>It exists so retention and the readers can never disagree about which
+    /// generation applies.</b> A sweep that decides a generation is unreferenced is deciding it is
+    /// unreachable, and "unreachable" is defined by exactly these rules — so re-deriving them
+    /// beside the sweep would be two implementations of one contract, drifting silently, with the
+    /// failure landing as a DELETED publication that readers were still resolving. Every reader
+    /// calls <see cref="PublicationDirectoryOf"/>, which is this method with
+    /// <see cref="PublicationPointer.Directory"/> taken and the rest dropped.</para>
+    ///
+    /// <para>🚨 A non-null <see cref="PublicationPointer.Fault"/> means <b>a publisher wrote a
+    /// pointer this reader will not follow</b> — which is NOT the same as "there is no pointer".
+    /// Retention treats it as an unreadable publication inventory and protects every generation of
+    /// the source: an inventory that could not be read licenses no deletion.</para>
+    /// </summary>
+    /// <param name="sourceDirectory">A <c>&lt;root&gt;/&lt;identity&gt;/&lt;source&gt;</c> directory.</param>
+    /// <param name="logger">Diagnostics — the same lines <see cref="PublicationDirectoryOf"/> has always logged.</param>
+    public static PublicationPointer ResolvePublicationPointer(string sourceDirectory, ILogger? logger = null)
     {
         var pointer = Path.Combine(sourceDirectory, PublicationPointerFileName);
         string? named;
         try
         {
             if (!File.Exists(pointer))
-                return sourceDirectory;
+                return new PublicationPointer(sourceDirectory, null, null);
             named = File.ReadAllLines(pointer)
                 .Select(l => l.Trim())
                 .FirstOrDefault(l => l.Length > 0);
@@ -178,11 +217,14 @@ public static class ShippedPrebuiltBundles
                 "ShippedPrebuiltBundles: {Pointer} could not be read — reading {SourceDirectory} "
                 + "as its own publication directory; a pointer being replaced reads this way, and "
                 + "the next read resolves it", pointer, sourceDirectory);
-            return sourceDirectory;
+            return new PublicationPointer(sourceDirectory, null,
+                $"the pointer could not be read ({ex.GetType().Name}: {ex.Message})");
         }
 
         if (string.IsNullOrEmpty(named))
-            return sourceDirectory;
+            // An EMPTY pointer is the mid-write reading of a pointer being replaced, so it is a
+            // fault for retention's purposes too: which generation applies is unknown right now.
+            return new PublicationPointer(sourceDirectory, null, "the pointer is empty");
 
         if (named is "." or ".."
             || named != Path.GetFileName(named)
@@ -194,7 +236,8 @@ public static class ShippedPrebuiltBundles
                 + "directory name — a publication pointer may only address a subdirectory of its "
                 + "own source directory. Reading {SourceDirectory} as its own publication "
                 + "directory instead", pointer, named, sourceDirectory);
-            return sourceDirectory;
+            return new PublicationPointer(sourceDirectory, named,
+                $"the pointer names '{named}', which is not a single directory name");
         }
 
         var generation = Path.Combine(sourceDirectory, named);
@@ -205,9 +248,10 @@ public static class ShippedPrebuiltBundles
                 + "disk — reading {SourceDirectory} as its own publication directory instead. A "
                 + "generation the pointer names must outlive the pointer",
                 pointer, named, sourceDirectory);
-            return sourceDirectory;
+            return new PublicationPointer(sourceDirectory, named,
+                $"the pointer names generation '{named}', which is not on disk");
         }
-        return generation;
+        return new PublicationPointer(generation, named, null);
     }
 
     /// <summary>The conventional location — <c>prebuilt/</c> beside the app binaries, which is

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
@@ -67,6 +67,54 @@ public class PrebuiltBundleRetentionTest : IDisposable
         return path;
     }
 
+    /// <summary>
+    /// One GENERATION directory under a source: the bundles, its seal, and the
+    /// <c>source-commit.txt</c> that is a publication's positive identification. Does NOT touch
+    /// the pointer — <see cref="Pointer"/> does, so a test can build a dangling one on purpose.
+    /// </summary>
+    private string Generation(
+        string identity, string source, string token, DateTimeOffset writtenAt,
+        bool isSealed = true, int bytes = 1024)
+    {
+        var dir = Path.Combine(root, identity, source, token);
+        Directory.CreateDirectory(dir);
+        File.WriteAllBytes(Path.Combine(dir, "A.zip"), new byte[bytes]);
+        File.SetLastWriteTimeUtc(Path.Combine(dir, "A.zip"), writtenAt.UtcDateTime);
+        var commit = Path.Combine(dir, SealedPublicationIndex.SourceCommitMarkerFileName);
+        File.WriteAllText(commit, token + "\n");
+        File.SetLastWriteTimeUtc(commit, writtenAt.UtcDateTime);
+        if (isSealed)
+        {
+            var sentinel = Path.Combine(dir, ShippedPrebuiltBundles.CompletionSentinelFileName);
+            File.WriteAllText(sentinel, "A.zip\n");
+            File.SetLastWriteTimeUtc(sentinel, writtenAt.UtcDateTime);
+        }
+        Directory.SetLastWriteTimeUtc(dir, writtenAt.UtcDateTime);
+        // Same stamping Sealed() does: the identity's age is the newest write ANYWHERE under it,
+        // seeded from the directory's own stamp, so a fixture that leaves those at "now" builds an
+        // identity the age window keeps and can never exercise a collection.
+        Directory.SetLastWriteTimeUtc(Path.Combine(root, identity, source), writtenAt.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(Path.Combine(root, identity), writtenAt.UtcDateTime);
+        return dir;
+    }
+
+    /// <summary>
+    /// Writes the <c>_current</c> pointer of a source. <paramref name="token"/> may name a
+    /// generation that is not there. <paramref name="writtenAt"/> matters: the pointer is a FILE
+    /// under the identity, so its stamp counts towards the identity's age exactly as it does in
+    /// production, where a live source's pointer is rewritten on every publish.
+    /// </summary>
+    private string Pointer(string identity, string source, string token, DateTimeOffset? writtenAt = null)
+    {
+        var dir = Path.Combine(root, identity, source);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, ShippedPrebuiltBundles.PublicationPointerFileName);
+        File.WriteAllText(path, token + "\n");
+        if (writtenAt is { } at)
+            File.SetLastWriteTimeUtc(path, at.UtcDateTime);
+        return path;
+    }
+
     private static DateTimeOffset DaysAgo(int days) => Now - TimeSpan.FromDays(days);
 
     private PrebuiltBundleSweepPlan PlanNow(
@@ -444,6 +492,244 @@ public class PrebuiltBundleRetentionTest : IDisposable
 
         plan.Protected.Keys.Should().Contain("s-green");
         Ids(plan).Should().Equal("s-failed");
+    }
+
+    // ---- generations inside a retained identity (#3461) ----------------------------------------
+    //
+    // 🚨 EVERY CASE HERE IS UNDER `Live`, deliberately. The identity rules keep the running
+    // identity however old, so these cases isolate the generation rules from them: an identity the
+    // plan COLLECTS takes its generations with it and must NOT list them separately (the last case
+    // in this block pins that, because listing them would double-count the bytes and delete one
+    // directory twice).
+
+    /// <summary>
+    /// The POSITIVE control. A superseded generation older than the window is collected, and the
+    /// one the pointer names survives beside it — a fix that refused everything would pass a
+    /// one-sided test.
+    /// </summary>
+    [Fact]
+    public void ASupersededGeneration_OlderThanTheWindow_IsCollected_AndTheLiveOneSurvives()
+    {
+        var old = Generation(Live, "plugins", "gen-old", DaysAgo(60));
+        var live = Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var plan = PlanNow();
+
+        plan.AbortReason.Should().BeNull();
+        plan.CollectableGenerations.Select(g => g.Name).Should().Equal("gen-old");
+        plan.ProtectedGenerations.Should().ContainKey(live);
+        plan.ProtectedGenerations[live].Should().Contain("it is the live publication");
+        plan.ProtectedGenerations.Should().NotContainKey(old);
+        // The bytes it would reclaim are the generation's, and the identity itself stays.
+        plan.CollectableBytes.Should().BeGreaterThan(0);
+        Ids(plan).Should().NotContain(Live);
+    }
+
+    /// <summary>
+    /// The claim the whole sweep rests on, asserted directly rather than assumed: what retention
+    /// calls collectable is what the READERS cannot reach. If this ever fails, the sweep is
+    /// deleting bytes a portal still resolves.
+    /// </summary>
+    [Fact]
+    public void WhatIsCollected_IsExactlyWhatNoReaderResolves()
+    {
+        Generation(Live, "plugins", "gen-old", DaysAgo(60));
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+        var source = Path.Combine(root, Live, "plugins");
+
+        var resolved = ShippedPrebuiltBundles.PublicationDirectoryOf(source);
+
+        resolved.Should().Be(Path.Combine(source, "gen-new"));
+        PlanNow().CollectableGenerations.Select(g => g.Directory).Should().NotContain(resolved);
+    }
+
+    /// <summary>The live generation is kept HOWEVER old — a pointer is a reference, and age never overrides one.</summary>
+    [Fact]
+    public void TheGenerationThePointerNames_IsKept_HoweverOld()
+    {
+        var live = Generation(Live, "plugins", "gen-ancient", DaysAgo(400));
+        Pointer(Live, "plugins", "gen-ancient");
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Should().BeEmpty();
+        plan.ProtectedGenerations[live].Should().Contain("it is the live publication");
+    }
+
+    /// <summary>
+    /// 🚨 A pointer that names a generation which is not on disk is an unreadable publication
+    /// INVENTORY, not an absent one: which generation applies is unknown, so nothing under that
+    /// source may be collected. Same fail-closed direction as an unreadable release marker.
+    /// </summary>
+    [Fact]
+    public void ADanglingPointer_ProtectsEveryGenerationOfItsSource()
+    {
+        Generation(Live, "plugins", "gen-a", DaysAgo(90));
+        Generation(Live, "plugins", "gen-b", DaysAgo(80));
+        Pointer(Live, "plugins", "gen-gone");
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Should().BeEmpty();
+        plan.ProtectedGenerations.Values.Should().AllSatisfy(reason =>
+            reason.Should().Contain("licenses no deletion"));
+    }
+
+    /// <summary>An EMPTY pointer is a pointer being replaced right now — the same fail-closed answer.</summary>
+    [Fact]
+    public void AnEmptyPointer_ProtectsEveryGenerationOfItsSource()
+    {
+        Generation(Live, "plugins", "gen-a", DaysAgo(90));
+        File.WriteAllText(
+            Path.Combine(root, Live, "plugins", ShippedPrebuiltBundles.PublicationPointerFileName), "  \n");
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Should().BeEmpty();
+        plan.ProtectedGenerations.Values.Should().AllSatisfy(reason =>
+            reason.Should().Contain("the pointer is empty"));
+    }
+
+    /// <summary>
+    /// 🚨 A directory is a generation only on POSITIVE evidence that it is a publication. The
+    /// publisher's <c>modules/</c> sits beside the generations in the flat compatibility copy, and
+    /// under an exclusion list it would be collectable the day someone added a second bookkeeping
+    /// directory, silently.
+    /// </summary>
+    [Fact]
+    public void ADirectoryThatIsNotAPublication_IsNeverCollected()
+    {
+        var modules = Path.Combine(root, Live, "plugins", "modules");
+        Directory.CreateDirectory(modules);
+        File.WriteAllBytes(Path.Combine(modules, "AI.module.nupkg"), new byte[2048]);
+        File.SetLastWriteTimeUtc(Path.Combine(modules, "AI.module.nupkg"), DaysAgo(300).UtcDateTime);
+        Directory.SetLastWriteTimeUtc(modules, DaysAgo(300).UtcDateTime);
+        Generation(Live, "plugins", "gen-old", DaysAgo(60));
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Select(g => g.Name).Should().Equal("gen-old");
+        plan.CollectableGenerations.Select(g => g.Directory).Should().NotContain(modules);
+        plan.ProtectedGenerations.Should().NotContainKey(modules);
+        Directory.Exists(modules).Should().BeTrue();
+    }
+
+    /// <summary>An abort collects NOTHING — generations included. A partial picture licenses no deletion, at either level.</summary>
+    [Fact]
+    public void AnAbortedPlan_CollectsNoGenerations()
+    {
+        Generation(Live, "plugins", "gen-old", DaysAgo(60));
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+        var marker = Marker("3.0.0-ci.7", "s-whatever");
+        File.WriteAllText(marker, "");
+
+        var plan = PlanNow();
+
+        plan.AbortReason.Should().Contain("could not be read");
+        plan.CollectableGenerations.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A COLLECTABLE identity takes its generations with it: they must not also appear as
+    /// collectable generations, or their bytes are counted twice and the sweep tries to delete one
+    /// directory that its parent's removal already took.
+    /// </summary>
+    [Fact]
+    public void GenerationsOfACollectableIdentity_AreNotListedSeparately()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Generation("s-dead", "plugins", "gen-old", DaysAgo(400));
+        Pointer("s-dead", "plugins", "gen-old", DaysAgo(400));
+
+        var plan = PlanNow();
+
+        Ids(plan).Should().Equal("s-dead");
+        plan.CollectableGenerations.Should().BeEmpty();
+    }
+
+    /// <summary>End to end: the superseded generation goes, the live one and the identity stay, and the ledger says which.</summary>
+    [Fact]
+    public void SweepCore_RemovesASupersededGeneration_AndLeavesTheLiveOne()
+    {
+        Generation(Live, "plugins", "gen-old", DaysAgo(60), bytes: 4096);
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var result = PrebuiltBundleStore.SweepCore(root, Live, "3.1.0-ci.9000", [], [], retention, Now);
+
+        result.AbortReason.Should().BeNull();
+        result.Deleted.Should().BeTrue();
+        result.DeletedGenerations.Should().Be(1);
+        result.DeletedIdentities.Should().Be(0);
+        result.DeletedBytes.Should().BeGreaterThan(4096);
+        Directory.Exists(Path.Combine(root, Live, "plugins", "gen-old")).Should().BeFalse();
+        Directory.Exists(Path.Combine(root, Live, "plugins", "gen-new")).Should().BeTrue();
+        File.Exists(Path.Combine(root, Live, "plugins", ShippedPrebuiltBundles.PublicationPointerFileName))
+            .Should().BeTrue();
+
+        var ledger = File.ReadAllLines(PrebuiltBundleStore.LedgerPathOf(root));
+        ledger[0].Should().Contain("1 superseded generation(s)");
+        ledger.Should().Contain(l => l.Contains("removed generation") && l.Contains("gen-old"));
+    }
+
+    /// <summary>Report-only removes no generation either, and still says which one it would have taken.</summary>
+    [Fact]
+    public void SweepCore_ReportOnly_RemovesNoGeneration()
+    {
+        Generation(Live, "plugins", "gen-old", DaysAgo(60));
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var result = PrebuiltBundleStore.SweepCore(root, Live, "3.1.0-ci.9000", [], [], retention with { Delete = false }, Now);
+
+        result.DeletedGenerations.Should().Be(0);
+        result.Plan!.CollectableGenerations.Select(g => g.Name).Should().Equal("gen-old");
+        Directory.Exists(Path.Combine(root, Live, "plugins", "gen-old")).Should().BeTrue();
+    }
+
+    /// <summary>A failed removal is counted and the next pass re-plans it — never swallowed.</summary>
+    [Fact]
+    public void SweepCore_AFailedGenerationRemoval_IsCounted()
+    {
+        Generation(Live, "plugins", "gen-a", DaysAgo(90));
+        Generation(Live, "plugins", "gen-b", DaysAgo(80));
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var result = PrebuiltBundleStore.SweepCore(root, Live, "3.1.0-ci.9000", [], [], retention, Now,
+            deleteDirectory: dir =>
+            {
+                if (dir.EndsWith("gen-a", StringComparison.Ordinal))
+                    throw new IOException("locked");
+                Directory.Delete(dir, true);
+            });
+
+        result.FailedDeletes.Should().Be(1);
+        result.DeletedGenerations.Should().Be(1);
+        Directory.Exists(Path.Combine(root, Live, "plugins", "gen-b")).Should().BeFalse();
+    }
+
+    /// <summary>The flat layout has no generations at all — nothing about this reaches a store that has not flipped.</summary>
+    [Fact]
+    public void TheFlatLayout_HasNoGenerations_AndCollectsNone()
+    {
+        Sealed(Live, "plugins", DaysAgo(400));
+        Sealed("s-old", "plugins", DaysAgo(400));
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Should().BeEmpty();
+        plan.ProtectedGenerations.Should().BeEmpty();
+        plan.Identities.SelectMany(i => i.Sources).Should().AllSatisfy(s =>
+        {
+            s.Generations.Should().BeEmpty();
+            s.PointerFault.Should().BeNull();
+        });
     }
 
     // ---- version lines ------------------------------------------------------------------------

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
@@ -117,6 +117,9 @@ public class PrebuiltBundleRetentionTest : IDisposable
 
     private static DateTimeOffset DaysAgo(int days) => Now - TimeSpan.FromDays(days);
 
+    /// <summary>A fixture AGE, not a timeout — for a publication that is in flight right now.</summary>
+    private static DateTimeOffset MinutesAgo(int minutes) => Now - TimeSpan.FromMinutes(minutes);
+
     private PrebuiltBundleSweepPlan PlanNow(
         string? liveVersion = "3.1.0-ci.9000", ImmutableHashSet<string>? stamps = null,
         ImmutableList<PinnedPlatformReference>? pinned = null) =>
@@ -665,6 +668,62 @@ public class PrebuiltBundleRetentionTest : IDisposable
         plan.CollectableGenerations.Select(g => g.Directory).Should().NotContain(modules);
         plan.ProtectedGenerations.Should().NotContainKey(modules);
         Directory.Exists(modules).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 An UNSEALED generation is a publication that died mid-upload — a cancelled run, a network
+    /// fault — and it is collected on AGE like any other superseded one. Deliberately not a
+    /// separate keep rule: `UnsealedGrace` is hours against a 30-day floor, so a branch for it
+    /// could never fire, and an abandoned directory that nothing can ever point at is exactly what
+    /// the sweep exists to reclaim. The entry still RECORDS which it was, so an operator reading
+    /// the plan can tell an abandoned publication from a superseded one.
+    /// </summary>
+    [Fact]
+    public void AnAbandonedGeneration_IsCollectedOnAge_AndTheEntrySaysItWasNeverSealed()
+    {
+        Generation(Live, "plugins", "gen-abandoned", DaysAgo(60), isSealed: false);
+        Generation(Live, "plugins", "gen-superseded", DaysAgo(60));
+        // A publication in flight RIGHT NOW: unsealed and minutes old. Age alone must keep it —
+        // this is what makes "protection is established before `_current` moves" true without a
+        // lease between the publisher and this sweep.
+        var inFlight = Generation(Live, "plugins", "gen-in-flight", MinutesAgo(1), isSealed: false);
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Select(g => g.Name).Should().Equal("gen-abandoned", "gen-superseded");
+        plan.CollectableGenerations.Single(g => g.Name == "gen-abandoned").HasSentinel.Should().BeFalse();
+        plan.CollectableGenerations.Single(g => g.Name == "gen-superseded").HasSentinel.Should().BeTrue();
+        plan.ProtectedGenerations[inFlight].Should().Contain("retention window");
+    }
+
+    /// <summary>
+    /// 🚨 <c>HasSentinel</c> says the sentinel is THERE — deliberately not that the publication is
+    /// whole. A TORN generation (its seal lists a bundle that is not on disk) still reports
+    /// <c>true</c>, unlike the source-level <c>IsSealed</c>, which does verify the listing. Pinned
+    /// here so nobody later reads the field as "sealed and complete" and builds a rule on it: the
+    /// verdict is age, and the field is a note for the operator.
+    /// </summary>
+    [Fact]
+    public void ATornGeneration_StillReportsItsSentinel_AndIsCollectedOnAgeRegardless()
+    {
+        var torn = Generation(Live, "plugins", "gen-torn", DaysAgo(60));
+        File.WriteAllText(Path.Combine(torn, ShippedPrebuiltBundles.CompletionSentinelFileName), "A.zip\nB.zip\n");
+        File.SetLastWriteTimeUtc(
+            Path.Combine(torn, ShippedPrebuiltBundles.CompletionSentinelFileName), DaysAgo(60).UtcDateTime);
+        Generation(Live, "plugins", "gen-new", DaysAgo(1));
+        Pointer(Live, "plugins", "gen-new");
+
+        var plan = PlanNow();
+
+        plan.CollectableGenerations.Select(g => g.Name).Should().Equal("gen-torn");
+        // The sentinel IS there — the field reports that and nothing more…
+        plan.CollectableGenerations.Single().HasSentinel.Should().BeTrue();
+        // …while the SOURCE-level reading, which does verify the listing, calls the same
+        // publication torn. The two questions are different, and only the source's decides anything.
+        var source = plan.Identities.Single(i => i.Identity == Live).Sources.Single(s => s.Name == "plugins");
+        source.Generations.Single(g => g.Name == "gen-torn").HasSentinel.Should().BeTrue();
     }
 
     /// <summary>An abort collects NOTHING — generations included. A partial picture licenses no deletion, at either level.</summary>

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
@@ -540,9 +540,58 @@ public class PrebuiltBundleRetentionTest : IDisposable
         var source = Path.Combine(root, Live, "plugins");
 
         var resolved = ShippedPrebuiltBundles.PublicationDirectoryOf(source);
+        var pointer = ShippedPrebuiltBundles.ResolvePublicationPointer(source);
 
         resolved.Should().Be(Path.Combine(source, "gen-new"));
+        // The two must be the same resolution, or the sweep and the readers can disagree.
+        pointer.Directory.Should().Be(resolved);
+        pointer.IsGeneration.Should().BeTrue();
+        pointer.Named.Should().Be("gen-new");
+        pointer.Fault.Should().BeNull();
         PlanNow().CollectableGenerations.Select(g => g.Directory).Should().NotContain(resolved);
+    }
+
+    /// <summary>
+    /// The resolution outcomes a retention rule branches on, each mapped to the answer every
+    /// READER takes for it — the fallback is always the source directory, so a pointer this reader
+    /// will not follow can never make it read somewhere else.
+    /// </summary>
+    [Fact]
+    public void EveryPointerOutcome_ResolvesToTheSourceDirectory_AndNamesWhyItFellBack()
+    {
+        var source = Path.Combine(root, Live, "plugins");
+        Generation(Live, "plugins", "gen-a", DaysAgo(1));
+
+        // no pointer at all — the flat layout, and NOT a fault
+        var flat = ShippedPrebuiltBundles.ResolvePublicationPointer(source);
+        flat.Directory.Should().Be(source);
+        flat.IsGeneration.Should().BeFalse();
+        flat.Fault.Should().BeNull();
+
+        // dangling
+        Pointer(Live, "plugins", "gen-gone");
+        var dangling = ShippedPrebuiltBundles.ResolvePublicationPointer(source);
+        dangling.Directory.Should().Be(source);
+        dangling.IsGeneration.Should().BeFalse();
+        dangling.Fault.Should().Contain("is not on disk");
+
+        // refused: a pointer is a NAME, never a path
+        Pointer(Live, "plugins", "../elsewhere");
+        var refused = ShippedPrebuiltBundles.ResolvePublicationPointer(source);
+        refused.Directory.Should().Be(source);
+        refused.IsGeneration.Should().BeFalse();
+        refused.Fault.Should().Contain("not a single directory name");
+
+        // blank — a pointer mid-replacement
+        File.WriteAllText(Path.Combine(source, ShippedPrebuiltBundles.PublicationPointerFileName), "\n");
+        var blank = ShippedPrebuiltBundles.ResolvePublicationPointer(source);
+        blank.Directory.Should().Be(source);
+        blank.IsGeneration.Should().BeFalse();
+        blank.Fault.Should().Be("the pointer is empty");
+
+        // and resolving cleanly
+        Pointer(Live, "plugins", "gen-a");
+        ShippedPrebuiltBundles.ResolvePublicationPointer(source).IsGeneration.Should().BeTrue();
     }
 
     /// <summary>The live generation is kept HOWEVER old — a pointer is a reference, and age never overrides one.</summary>


### PR DESCRIPTION
## What this is

The **precondition on flipping a prefix to the generation layout**, and the reason phase 4 of #3461
has been blocked: generation retention.

`PrebuiltBundleStore` swept at the **identity** level only. Under an identity its rules KEEP — the
running one, a released one, a pinned one, a recent one — it removed nothing, so once generations
start being written, one ~45-file publication per CI run accumulates inside a live identity for
ever. A share that fills up **truncates writes silently**: memex.systemorph.com reached 3 MiB free
on 2026-09-08 with every runtime recompile landing as `Bad IL format` and CD's read-back answering
`ResourceNotFound` for 39 of 45 files.

## The rule — the same one, one level down

A generation inside a **retained** identity is collected only when **all** of these hold, and kept
when any one fails:

- **no `_current` names it** — the live publication is kept however old;
- **the pointer that would say so resolved cleanly** — unreadable, blank, refused or dangling keeps
  **every** generation of that source, because which one applies is then unknown;
- **its own seal could be read** — unreadable is never unreferenced;
- **its newest write is older than `MinimumAge`** (at least 30 days).

Generations under a *collectable* identity are deliberately not listed: that directory goes whole
and its byte count already includes them. An aborted plan collects nothing, at either level.

## Why it is sound without a per-generation consumer inventory

That is the one thing that could make it unsound, so it is argued rather than assumed. **A
non-current generation is unreachable, not merely unfashionable.** Every read of a published source
directory composes under `ShippedPrebuiltBundles.PublicationDirectoryOf` — the boot seeder, the
same-major adopted fallback, `SealedPublicationIndex`, `PublishedBundleCatalogue` and
`ServedModuleBytes` alike — and nothing anywhere enumerates a source's subdirectories looking for a
publication. So the set an inventory would have to protect is exactly *{what `_current` names}* ∪
*{everything young}*, and both are kept by construction.

The sweep therefore uses **the readers' own resolution** instead of a second copy of the rules:
`ResolvePublicationPointer` is `PublicationDirectoryOf` with the fallback *reason* kept rather than
discarded, and `PublicationDirectoryOf` now calls it. A sweep that decided reachability differently
from the readers would delete bytes a portal was still resolving, silently.

And *"publication must establish protection before moving `_current`"* is satisfied by **age, not a
lease**: a generation is protected from its first byte, so a publication in flight can never be
collected and the publisher needs no claim, no lock and no ordering with the sweep — which is what
makes this implementable across two repositories that share no lock. `UnsealedGrace` is deliberately
not consulted: hours against a 30-day floor, so the branch could never fire, and a check that cannot
fail is not a check.

**A directory is a generation only on POSITIVE evidence that it is a publication** —
`source-commit.txt`, `repository.txt`, the sentinel, or the pointer names it. Never "every
subdirectory but the ones I know about": the publisher's `modules/` sits beside the generations in
the flat compatibility copy, and under an exclusion list every bookkeeping directory added later
becomes collectable the day it is added, silently.

## Controls, in both directions

13 new cases, **47/47 in the file**, 584/584 in `MeshWeaver.Hosting.Test`, 373/373 in
`MeshWeaver.Documentation.Test`, 15/15 in the reader half (`PublicationGenerationTest` — the
`PublicationDirectoryOf` refactor is behaviour-preserving).

- **positive** — `ASupersededGeneration_OlderThanTheWindow_IsCollected_AndTheLiveOneSurvives`: a fix
  that refused everything would pass a one-sided test.
- **the load-bearing claim, asserted** — `WhatIsCollected_IsExactlyWhatNoReaderResolves`: what the
  plan collects is asserted not to be what `PublicationDirectoryOf` returns.
- **refusals, each with its reason** — the live generation however old
  (`it is the live publication`); a dangling pointer and an empty pointer (`licenses no deletion`,
  `the pointer is empty`) protecting *every* generation of the source; an unreadable seal; a
  non-publication directory (`modules/`) that is never even enumerated; an aborted plan; the flat
  layout, which has no generations at all.
- **end to end** — `SweepCore_RemovesASupersededGeneration_AndLeavesTheLiveOne`, report-only removes
  nothing, and a failed removal is counted and re-planned.

## Measured before deciding — and it reproduces the earlier finding a third time

`Doc/Architecture/SealedPublicationReads` → "Reproduced a third time, on a different day". **61 bake
jobs that ran to a terminal conclusion over 22 h (2026-09-09 20:00Z → 2026-09-10 18:09Z)**, 33 core
CD and 28 satellite, every job log fetched, **zero unreadable identities**. 36 sealed publications
over 19 prefixes.

- 🚨 **7 of 19 prefixes were written by BOTH lanes — and in all 7 the two lanes carried DIFFERENT
  source commits.** #3461's premise is confirmed, not narrowed: the identity is a property of the
  platform image's reference surface and carries no content commit, so the content × framework
  sealed-skip cannot separate the lanes when they meet.
- 🚨 **Concurrent publications on one prefix: 4 — all same-lane, zero cross-lane.** Third
  independent day, same answer. **"One owner per prefix" would have addressed 0 of the 4**, exactly
  as it addressed 0 of the ones measured on 09-06 and 09-08. GitHub `concurrency:` cannot serialise
  them either — it is per-repository and these lanes live in two repos.

The one cross-lane near-miss shows the *mechanism*, not luck: on `s546f29f9…`, core CD `34430130924`
sealed at **03:27:37.327Z**; satellite `34430082656` reached its publish at **03:30:57Z**, found
*"holds a COMPLETE publication of THIS content"* on both shares and skipped — they were baking the
same plugins commit `3f7686da2…`, because core CD resolves the plugins tip at its gate.

So the design already chosen stands: the *layout* is what removes contention, because a publication
written into its own directory is disjoint from every other publication whoever wrote it.

## Not this PR

Phase 4 (flipping `plugins`, both producers in one change set) and phase 5 (dropping the flat copy).
Retention was the stated blocker on phase 4; it is no longer one. **Nothing behaves differently on
any installation today** — `publication-layout` still defaults to `flat`, so no producer writes a
generation and there is nothing to collect yet.

Pairs-with: none — nothing public was removed; the change adds two types and six members under
`MeshWeaver.Hosting` and removes nothing (verified with `scripts/check-type-forwards.py`: 11 removed
entries in its output are `origin/main`'s own, my base being 12 commits behind; 0 removals in this
diff).

Mirror-sync: none — no localization catalog key is added, changed or re-worded.

Refs #3461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
