### PR TITLE
fix(ci): explain divergent module hazard accurately

### DIFF
--- a/.github/scripts/test-module-set-consistency.py
+++ b/.github/scripts/test-module-set-consistency.py
@@ -210,6 +210,8 @@ def case_divergent_is_refused(lane: str, body: str, tmp: Path) -> None:
     combined = result.stdout + result.stderr
     missing = [needle for needle in
                ("MeshWeaver.Shared reaches this mesh as more than one build",
+                "other copy's bytes never enter memory",
+                "A version floor can keep the affected NodeTypes adoptable",
                 "as a sibling riding",
                 "1 carried at more than one BUILD")
                if needle not in combined]

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -1102,7 +1102,7 @@ jobs:
               echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first and the other copy's bytes never enter memory, so callers compiled against the loser silently run the winner (MeshWeaver#3732)."
               awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
-            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. A version floor can keep the affected NodeTypes adoptable (MeshWeaver#3934), but cannot make the loader use both builds or prove their behavior agrees. Refusing here is the only point where every copy is visible. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
+            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. A version floor can keep the affected NodeTypes adoptable (MeshWeaver#3934), but cannot make the loader use both builds or prove their behaviour agrees. Refusing here is the only point where every copy is visible. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
             exit 1
           fi
           echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -1099,10 +1099,10 @@ jobs:
           echo "module set: $COPIES MeshWeaver.* assembly file(s) across $MODULE_COUNT bundle(s), $NAMES distinct name(s), $SHARED carried by more than one bundle, $DIVERGED carried at more than one BUILD"
           if [ "$DIVERGED" -ne 0 ]; then
             while IFS= read -r dupe; do
-              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
+              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first and the other copy's bytes never enter memory, so callers compiled against the loser silently run the winner (MeshWeaver#3732)."
               awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
-            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
+            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. A version floor can keep the affected NodeTypes adoptable (MeshWeaver#3934), but cannot make the loader use both builds or prove their behavior agrees. Refusing here is the only point where every copy is visible. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
             exit 1
           fi
           echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1147,7 +1147,7 @@ jobs:
               echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first and the other copy's bytes never enter memory, so callers compiled against the loser silently run the winner (MeshWeaver#3732)."
               awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
-            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. A version floor can keep the affected NodeTypes adoptable (MeshWeaver#3934), but cannot make the loader use both builds or prove their behavior agrees. Refusing here is the only point where every copy is visible. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
+            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. A version floor can keep the affected NodeTypes adoptable (MeshWeaver#3934), but cannot make the loader use both builds or prove their behaviour agrees. Refusing here is the only point where every copy is visible. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
             exit 1
           fi
           echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1144,10 +1144,10 @@ jobs:
           echo "module set: $COPIES MeshWeaver.* assembly file(s) across $MODULE_COUNT bundle(s), $NAMES distinct name(s), $SHARED carried by more than one bundle, $DIVERGED carried at more than one BUILD"
           if [ "$DIVERGED" -ne 0 ]; then
             while IFS= read -r dupe; do
-              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
+              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first and the other copy's bytes never enter memory, so callers compiled against the loser silently run the winner (MeshWeaver#3732)."
               awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
-            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
+            echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. A version floor can keep the affected NodeTypes adoptable (MeshWeaver#3934), but cannot make the loader use both builds or prove their behavior agrees. Refusing here is the only point where every copy is visible. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."
             exit 1
           fi
           echo "external modules: $MODULE_COUNT composed, $ASSET_MODULES of them carrying static web assets, $ASSET_FILES asset file(s) landed module-relative under /ext/<module>/"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -112,13 +112,15 @@ The hazard is real and worth an assertion. `MeshWeaver.*` assemblies bind by a s
 `AssemblyVersion` (see [Module Closure Accounting](../ModuleClosureAccounting) → "the same-identity
 trap"), so two copies under one simple name are **one assembly identity**: `Assembly.LoadFrom` returns
 the already-loaded one and ignores the second path. Whichever copy loads first wins the process, and
-the loser's bytes are never in memory.
+the loser's bytes are never in memory. Callers compiled against the loser silently run the winner,
+so load order decides behaviour whenever the builds differ.
 
-What that costs when the copies differ is exactly the `#3175` incident:
-`NodeTypeCompilationHelpers.ModuleMvidsOf` reports the MVID of the assembly that actually loaded, so
-every NodeType whose dependency record named the other build is declined at adoption —
-*"dependency record mismatch — 'MeshWeaver.Markdown.Collaboration' built against mvid:A, live is
-mvid:B"* — and the view renders empty.
+Before dependency records became version floors ([#3934](https://github.com/Systemorph/MeshWeaver/issues/3934)),
+that hazard also surfaced as the `#3175` adoption failure: a NodeType naming the losing build's MVID
+was declined. A floor now keeps same-version NodeTypes adoptable, but it cannot make the loader use
+both builds or prove that their behaviour agrees. The composed-set refusal is therefore more
+load-bearing, not less: this is the one point where every competing copy is visible. A genuinely
+older live version remains below the floor and is still declined.
 
 ### 🚨 The copies do NOT agree, and the reason is structural (#3732)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-divergent-build-refusal-names-loader-hazard.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-divergent-build-refusal-names-loader-hazard.md
@@ -1,0 +1,23 @@
+---
+Name: Divergent module builds report the loader hazard accurately
+Category: Fix
+Description: A rejected module publication now explains the load-order hazard that remains after dependency records became version floors, instead of claiming every duplicate build causes a NodeType adoption failure.
+Icon: Warning
+Order: -20260910
+---
+
+# Divergent module builds report the loader hazard accurately
+
+The publication gate still refuses two different builds of the same assembly in one sealed module
+set. That refusal is necessary because the runtime loads only the first copy it encounters; code
+compiled against the other copy silently runs the winner.
+
+Its diagnostic still named a different consequence: it said the losing copy's NodeTypes would be
+declined at adoption. Dependency records now state a version floor, so same-version rebuilds remain
+adoptable even though the loader hazard is unchanged.
+
+The gate now names the surviving hazard and explains why the version floor does not make two builds
+safe. Its regression test checks that both release lanes keep that explanation while still refusing
+the divergent publication and naming both producers.
+
+This fixes [#3962](https://github.com/Systemorph/MeshWeaver/issues/3962).


### PR DESCRIPTION
## What

- Keep the divergent-build refusal in both reusable publication lanes.
- Replace the stale “the other NodeTypes are declined” claim with the surviving loader hazard: only the first build enters memory, so callers compiled against the loser silently run the winner.
- Explain why version-floor adoption does not make two builds safe.
- Strengthen the real workflow regression so both lanes must emit the corrected explanation.

## Why

MeshWeaver#3934 changed module dependency records from exact MVID pins to version floors. Same-version duplicate builds can now remain adoptable, so the old diagnostic described a consequence that no longer necessarily occurs. The load-order hazard remains, and this is the only stage where every competing copy is visible.

## Verification

- python3 .github/scripts/test-module-set-consistency.py: 2 lanes × 7 cases passed, including both falsification arms
- workflow YAML-key guard: 34 workflows checked, 0 violations
- workflow timeout guard: 84 jobs checked, 0 violations
- actionlint YAML/expression validation: success
- MeshWeaver.Documentation Release build with warnings as errors: 0 warnings, 0 errors
- MeshWeaver.Documentation.Test Release build with warnings as errors: 0 warnings, 0 errors
- MeshWeaver.Documentation.Test: 374 passed, 0 failed, fresh TRX

Fixes #3962.