### PR TITLE
diag(#3510): a disposal names WHY, and a cascaded child names the teardown that took it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -256,14 +256,15 @@ mesh, which the attached recursive snapshot lists.
 
 ---
 
-## Who asked for the teardown
+## Who asked for the teardown, and why
 
-`[QUIESCE-START]` names the requester (#3510):
+`[QUIESCE-START]` names the requester **and the reason** (#3510):
 
 ```
-[QUIESCE-START] Hosting: requested by portal/installer (routed DisposeRequest); 4 pending callbacks …
-[QUIESCE-START] Hosting: requested by itself — a self-posted DisposeRequest (Hosting), i.e. a rebind or self-heal recycle; …
-[QUIESCE-START] Hosting: requested by a direct Dispose() (no routed DisposeRequest); …
+[QUIESCE-START] Hosting: requested by portal/nodeops-1 (routed DisposeRequest); why: PackageInstaller.SettleRetypedRoot: recycling the root 'Hosting' WHILE INSTALLING that package …; 4 pending callbacks …
+[QUIESCE-START] Hosting: requested by itself — a self-posted DisposeRequest (Hosting), i.e. a rebind or self-heal recycle; why: NodeType rebind: node 'Hosting' is now typed 'Store/Plugin' but its hub activated on '(none)'; …
+[QUIESCE-START] Hosting: requested by a direct Dispose() (no routed DisposeRequest); why: reason not stated by the caller; …
+[QUIESCE-START] Hosting/Admin/_Activity/compile-state: requested by a cascade from its owner Hosting; why: the owner's own teardown — Hosting was torn down by portal/nodeops-1 (routed DisposeRequest); why: PackageInstaller.SettleRetypedRoot: recycling the root 'Hosting' WHILE INSTALLING that package …
 ```
 
 **Why it was missing, and why the obvious source could not supply it.** `Dispose()` posts its
@@ -273,13 +274,41 @@ earlier: whether a `DisposeRequest` arrived over the bus at all, and from where.
 `HandleDispose`, where such a request is *honoured* (not merely received — the root-mesh refusal
 returns without disposing).
 
-**The three readings, and what each rules out:**
+**The four readings, and what each rules out:**
 
 | line says | means | rules out |
 |---|---|---|
 | a named sender | another hub asked — e.g. `PackageInstaller` posting to a package root | a recycle; a host teardown |
-| `itself — a self-posted DisposeRequest` | an automatic recycle: `NodeTypeRebindWatcher`, `WithOverlaySelfHeal` | an external actor |
-| `a direct Dispose() (no routed DisposeRequest)` | host teardown, an owner disposing its children, a `using` | **the whole message path** |
+| `itself — a self-posted DisposeRequest` | an automatic recycle: `NodeTypeRebindWatcher`, the stale-build convergence, `WithOverlaySelfHeal` | an external actor |
+| `a cascade from its owner <address>` | this hub went down because its OWNER did; the `why:` carries the owner's own attribution | this hub having been asked at all |
+| `a direct Dispose() (no routed DisposeRequest)` | host teardown or a `using` | **the whole message path** |
+
+### The `why:` field, and why WHO alone was not enough
+
+Three of core's recyclers post to their **own** hub — `NodeTypeRebindWatcher`, the stale-build
+convergence in `NodeTypeEnrichmentHelpers`, and `WithOverlaySelfHeal` — so the self-posted reading is
+**one word covering three states** ([Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail)).
+#3510's leading hypothesis was exactly *"which of those was it?"*, and the sender could never answer
+it. `DisposeRequest.Reason` closes that: the poster always knew, and now the request carries it.
+
+🚨 **An omission is REPORTED, never blank.** A `DisposeRequest` posted without a reason prints
+`why: reason not stated by the caller` (`DisposeRequest.ReasonNotStated`) — the same rule as
+`NodeDiagnosticsOutcome`: a field that simply disappears reads to the next person as *"there was
+nothing to report"*. One core poster is still unnamed at the time of writing —
+`MeshOperations.cs`'s recycle — and it is that token that says so.
+
+### The cascade reading is the one #3510 actually needed
+
+A hosted hub is torn down by `HostedHubsCollection.DisposeHubsReactive` calling `Dispose()` on it —
+a **direct** dispose, so before this every cascaded child printed the fourth line above: the same
+sentence a `using` produces. That is #3510's trail one level down. Its stranded writes were owed by
+those children (`Hosting/*/_Activity/compile-state`, `Hosting/_Access/Public_Access`), so the child's
+line is where a reader lands — and it attributed the teardown to nobody. The root recycle that took
+it was invisible from there.
+
+The child now names the cascade, its owner, **and the originating teardown**, which is propagated
+unchanged down the tree (so the string cannot grow with depth and a leaf still names the event that
+started it). One line, no second log to correlate against.
 
 🚨 The third is not an absence of information — it is the deduction #3510 could not make. That issue
 turned on one unknown: the Hosting root was disposed at 23:37:51Z *while its own 145-file install was
@@ -295,10 +324,74 @@ the one reading that must not be ambiguous.
 
 **This names the disposer; it does not stop the wedge.** #3510's other two Expectations — deferring a
 recycle while an install holds the root, or NACKing every in-flight write under it so the install
-fails in milliseconds with a name — are untouched. `QuiesceStartNamesTheAskerTest` pins all three
-readings, and the line is `Information`: a test asserting it must raise its own filter
+fails in milliseconds with a name — are untouched here. `QuiesceStartNamesTheAskerTest` pins all four
+readings plus both halves of the `why:` field, and the line is `Information`: a test asserting it must raise its own filter
 (`AddFilter("MeshWeaver", LogLevel.Information)`), because `TestBase` binds levels from
 `test/appsettings.json` and an Information line is otherwise dropped before any provider sees it.
+
+## Sighting 2026-09-10 — a verdict that was MINTED and still did not reach the waiter
+
+Recorded here because the evidence is a CI log that ages out, and because it is the *other* half of
+#3510's family: a caller owed a reply from an owner that has gone away.
+
+**Measured.** `MeshWeaver.Graph.Test.NackReachesTheWaiterDuringTeardownTest.OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller`
+failed on shard 4 of run
+[34513634943](https://github.com/Systemorph/MeshWeaver/actions/runs/34513634943)
+(PR #3956, 2026-09-10T18:29:17Z), `Graph.Test Total: 1519, Failed: 1`:
+
+```
+Did not expect collection {"3YOdHJMOHEKUFJlwHFjJmg"} to contain "3YOdHJMOHEKUFJlwHFjJmg"
+because the owner minted an OwnerDisposing NACK for this …
+  NackReachesTheWaiterDuringTeardownTest.cs(242,0)
+```
+
+Its own trace, in order:
+
+```
+[write]   patch posted with marker teardown-nack-d3197828e2; owner merge is parked
+[fence]   caller is armed on the late watch (request=3YOdHJMOHEKUFJlwHFjJmg)
+[dispose] mesh disposal invoked — parent is past DisposeHostedHubs
+[owner]   TestData/teardown-nack-node is Dead — its disposal registrants have run
+```
+
+**Not the diff, and not a catalogued flake.** #3956 touches `deploy/whisper/**` plus two doc pages
+and cannot reach `MeshWeaver.Graph.Test`; six sibling PRs built in the same window (#3952, #3957,
+#3955, #3959, #3947, #3946) have zero failing jobs; neither twin is in `.github/known-flakes.json`.
+
+### It is a DIFFERENT seam from #3510's, and the difference is where the verdict is
+
+| | #3510's trail | this sighting |
+|---|---|---|
+| the owner | **lives** — the ROOT under it is recycled | **dies** — it reaches `Dead` |
+| the verdict | **never minted**: `PATCH_MERGE_STAMPED → PATCH_ECHO_SEEN → (nothing)`, no bound armed, nobody owes one | minted by the ShutDown-phase registrant, per the assertion this test makes |
+| what the caller sees | `ADVANCE_WITHOUT_HANDOFF` at 5 s, then `OwnerUnreachable … no verdict within 31s` | silence, then the full 31 s budget |
+
+So they are two points on one lane, not one defect: #3510 is *nobody owns the answer*, this is *the
+answer exists and the waiter does not observe it*. Both surface identically to the caller, which is
+why the two get conflated on a first read.
+
+### 🚨 The one thing to check first on the next occurrence
+
+The test's precondition is `owner.RunLevel == Dead`, and its assertion message reads it as *"the
+owner is now terminally Dead, so its ShutDown-phase registrant has already run"*. **That implication
+holds on ONE of the three paths to `Dead`.** `HandleShutdownCore`'s ShutDown case sets `Dead` in the
+success path (after `DisposeImpl()`), **again in the `catch`**, and **again in the `finally`
+backstop** — so a `DisposeImpl()`/`messageService.Dispose()` that threw reaches `Dead` with the
+registrant's work incomplete, and the precondition is satisfied without the causal fact it stands
+for. That is the [Controls That Cannot Fail](/Doc/Architecture/ControlsThatCannotFail) shape *an
+input the operator supplies*, applied to a precondition instead of a check.
+
+This is stated as **the first hypothesis to eliminate, not as the cause** — the run carries no
+evidence of which path was taken, which is precisely the gap. The discriminator is one line: the
+`catch` logs `Error during shutdown of hub {address}` and the success path does not. Read that
+before reading anything else, and see [Teardown Verdicts Are Causal](/Doc/Architecture/TeardownVerdictsAreCausal)
+for why the precondition was made causal in the first place.
+
+🚨 **Both twins must move together.** `NackReachesTheWaiterDuringTeardownTest` and
+`LateNackReenqueueTest` are hand-synced with copies in MeshWeaver.Plugins, compared by that repo's
+`TeardownTwinParityTest` at `MW_PLATFORM_REF` — so it reddens in the PIN BUMP, not in core. A change
+to what either twin asserts is not done until the Plugins copy carries it (break shape 7; see
+[Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) → "Shape 7's worst form").
 
 ## What this page does not claim
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -329,6 +329,37 @@ readings plus both halves of the `why:` field, and the line is `Information`: a 
 (`AddFilter("MeshWeaver", LogLevel.Information)`), because `TestBase` binds levels from
 `test/appsettings.json` and an Information line is otherwise dropped before any provider sees it.
 
+### Where the `why:` is READ — the gate log already asks for it
+
+`PluginGateRunner` raises three categories to `Information` for exactly this question
+(`RecycleAttributionCategories`: `MeshWeaver.Graph.Configuration`,
+`MeshWeaver.PluginCatalog.PackageInstaller`, `MeshWeaver.Messaging.MessageHub`), because the gate
+otherwise runs at `Warning` and every candidate recycler announced itself into a sink with no
+listener. So the reason surfaces in the bake gate log with no further wiring — which is the one log
+where the six occurrences of #3510 were read.
+
+### The rebind hypothesis: possible by construction, excluded by measurement
+
+#3510's leading candidate was `NodeTypeRebindWatcher`. Read from code, it **can** fire against the
+root of the package currently installing, and that is worth stating plainly because two eliminations
+in the thread read as stronger than they are:
+
+- the watcher is armed on **every** instance hub at initialization (`WithInitialization` →
+  `RegisterForDisposal(Arm(...))`), package roots included;
+- `RequiresRebind` fires on any post-commit `Created`/`Updated` event for that node whose `NodeType`
+  differs from the one its hub bound — and the installer's placeholder dance **retypes the root**,
+  which is precisely such an event;
+- it posts at most ONE self-`DisposeRequest` (`Take(1)`), and skips a hub already `IsDisposing`.
+
+So "it cannot happen" is false. What is true is that it has **never been the observed disposer**:
+every measured occurrence carries `PackageInstaller`'s own recycle line at the disposal timestamp,
+and the two are separated by ORDERING — the rebind fires at the retype, in the WRITE stage; the
+installer's `SettleRetypedRoot` fires after the package's own adoption wave. They are also separated
+by TRANSPORT, which is the cheaper discriminator now that the line exists: the rebind posts to
+**itself**, and `SettleRetypedRoot` posts from the node-operation issuing hub, so one reads
+`requested by itself — a self-posted DisposeRequest` and the other `requested by portal/nodeops-… (routed
+DisposeRequest)`. With the reason attached, no ordering argument is needed at all.
+
 ## Sighting 2026-09-10 — a verdict that was MINTED and still did not reach the waiter
 
 Recorded here because the evidence is a CI log that ages out, and because it is the *other* half of

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-shutdown-log-says-why-and-what-went-with-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-shutdown-log-says-why-and-what-went-with-it.md
@@ -1,0 +1,48 @@
+---
+Name: The shutdown log says why, and what went down with it
+Category: Feature
+Description: A teardown now records the reason its caller gave, and anything torn down alongside it says whose teardown took it. Naming only the asker left the two questions that actually decide an investigation — which of several look-alike callers this was, and why a component nobody asked about disappeared — unanswerable from the log.
+Icon: PersonQuestionMark
+Order: -20260910
+---
+
+Last week the line that opens a shutdown started naming **what asked for it**. Working through the
+next occurrence showed that answer stops one question short, twice.
+
+## "It asked itself" describes three different things
+
+Several parts of the platform refresh themselves in place: when something is rebuilt, when a
+published build supersedes the one in use, when a stale overlay heals. All three ask *themselves* to
+shut down, so all three produced the same sentence — and the investigation this came from turned on
+telling them apart. It spent six occurrences and four failed publishes doing it by hand, from
+timings.
+
+Each of them has always known why it was recycling. The request simply had nowhere to carry it, so
+the reason stopped at the caller's own log and never reached the log of the thing going down. It
+does now, and the opening line prints it.
+
+**A caller that says nothing is reported as having said nothing.** The line reads *"reason not
+stated by the caller"* rather than quietly leaving the field out — a blank reads to the next person
+as "there was nothing to report", which is the one thing it must not mean.
+
+## Anything torn down alongside now names the teardown that took it
+
+When a component shuts down, everything it owns goes with it. Those pieces were shut down the
+ordinary way, so their own opening line said what an ordinary shutdown says: *nothing asked over the
+wire*. Indistinguishable from a routine, unrelated stop.
+
+That is exactly where the original incident had to be read. A package was installing 145 files; the
+component that owned them was torn down partway through; the pieces **it** owned went too, and the
+work waiting on those pieces was left unanswered until the install gave up ten minutes later. A
+reader lands on one of those pieces first — and it named nobody. The teardown that actually took it
+was invisible from there.
+
+Now each one says it went down with its owner, names the owner, **and carries the reason the owner
+was torn down for** — passed along unchanged however deep the ownership runs, so the piece at the
+bottom still names the event that started it. One line, instead of correlating two logs by
+timestamp.
+
+## What this does not do
+
+It still does not stop a shutdown from landing in the middle of an install. That remains open. What
+changes is that the next one can be read rather than reconstructed.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1864,8 +1864,18 @@ internal static class NodeTypeEnrichmentHelpers
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
                             instanceHub.Address.ToString(),
                             instanceHub.JsonSerializerOptions,
+                            // 🚨 Named, not anonymous (#3510): a self-posted DisposeRequest reads
+                            // as "a rebind or self-heal recycle" — three posters, one sentence —
+                            // and telling them apart cost that issue six occurrences.
                             recycle: () => instanceHub.Post(
-                                new DisposeRequest(), o => o.WithTarget(instanceHub.Address)),
+                                new DisposeRequest
+                                {
+                                    Reason = "Overlay self-heal: the instance is bound to an "
+                                             + $"overlay of NodeType '{nodeType}' that its own "
+                                             + "watcher found stale, so the hub is recycled to "
+                                             + "re-bind against the current build",
+                                },
+                                o => o.WithTarget(instanceHub.Address)),
                             reportStuck: () => ReportStuckOverlayToAdmins(instanceHub, nodeType, logger),
                             nodeType, typeVersionAtOverlay, logger,
                             guards: NodeTypeCompilationHelpers.GuardsOf(meshHub),
@@ -2119,7 +2129,16 @@ internal static class NodeTypeEnrichmentHelpers
                             "Stale-build convergence: NodeType '{NodeType}' published a new build ('{Published}' supersedes '{Bound}') — auto-recycling instance '{InstancePath}' ({ConfigKey}=true)",
                             nodeType, published, boundAssemblyPath, instanceHub.Address,
                             AutoRecycleConfigKey);
-                        instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                        // 🚨 Named (#3510) — see the rebind watcher: the three self-posting
+                        // recyclers were indistinguishable in the victim's own log.
+                        instanceHub.Post(
+                            new DisposeRequest
+                            {
+                                Reason = $"Stale-build convergence ({AutoRecycleConfigKey}=true): "
+                                         + $"NodeType '{nodeType}' published build '{published}', "
+                                         + $"superseding the bound '{boundAssemblyPath}'",
+                            },
+                            o => o.WithTarget(instanceHub.Address));
                         return;
                     }
 

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -152,7 +152,20 @@ internal static class NodeTypeRebindWatcher
                             "NodeType rebind: node '{Path}' is now typed '{NewNodeType}' but its hub activated on "
                             + "'{BoundNodeType}' — recycling so the next access binds the real type",
                             path, change.NodeType ?? "(none)", boundNodeType ?? "(none)");
-                        instanceHub.Post(new DisposeRequest(), o => o.WithTarget(instanceHub.Address));
+                        // 🚨 The reason rides along (#3510). This watcher was that issue's LEADING
+                        // hypothesis for six occurrences precisely because a self-posted
+                        // DisposeRequest renders as "requested by itself — a rebind or self-heal
+                        // recycle": one word covering this watcher, the stale-build convergence and
+                        // the overlay self-heal. Naming it here is what turns the next occurrence
+                        // into a read instead of an ordering argument.
+                        instanceHub.Post(
+                            new DisposeRequest
+                            {
+                                Reason = $"NodeType rebind: node '{path}' is now typed "
+                                         + $"'{change.NodeType ?? "(none)"}' but its hub activated on "
+                                         + $"'{boundNodeType ?? "(none)"}'",
+                            },
+                            o => o.WithTarget(instanceHub.Address));
                     }
                     catch (Exception ex)
                     {

--- a/src/MeshWeaver.Mesh.Contract/HubRecycleExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubRecycleExtensions.cs
@@ -51,13 +51,25 @@ public static class HubRecycleExtensions
     /// <param name="path">Path of the node whose hub is recycled.</param>
     /// <param name="budget">How long to wait for the address to answer again;
     /// <see cref="DefaultRecycleBudget"/> when omitted.</param>
+    /// <param name="reason">One sentence saying WHY, carried on the <see cref="DisposeRequest"/>
+    /// and printed by the target's <c>[QUIESCE-START]</c> (Systemorph/MeshWeaver#3510). Omitted, it
+    /// falls back to naming this API and the asking hub — which is still an answer, unlike the
+    /// blank it replaces.</param>
     /// <returns>The node as served by the re-activated address. Errors with
     /// <c>AddressRecyclingException</c> if the address is still recycling when the budget runs out.</returns>
     public static IObservable<MeshNode?> RecycleNode(
-        this IMessageHub hub, string path, TimeSpan? budget = null)
+        this IMessageHub hub, string path, TimeSpan? budget = null, string? reason = null)
         => Observable.Defer(() =>
         {
-            hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(path)));
+            hub.Post(
+                new DisposeRequest
+                {
+                    Reason = reason
+                             ?? $"HubRecycleExtensions.RecycleNode: {hub.Address} asked for this "
+                                + "address to be recycled and is waiting for a fresh activation to "
+                                + "answer",
+                },
+                o => o.WithTarget(new Address(path)));
             // The read is issued AFTER the dispose is posted, so it queues behind it at the target
             // and is answered by the reactivated hub (or NACKed ShuttingDown and re-probed until it
             // is). Deliberately NOT ReadTimeoutBehavior.EmitNull: "I could not tell" must reach the

--- a/src/MeshWeaver.Messaging.Contract/Events.cs
+++ b/src/MeshWeaver.Messaging.Contract/Events.cs
@@ -283,10 +283,38 @@ public enum ErrorType
 
 /// <summary>
 /// Request asking a hub to dispose itself and tear down its resources.
+///
+/// <para>🚨 <b>Carry a <see cref="Reason"/>.</b> A teardown that names only its sender answers half
+/// the question: Systemorph/MeshWeaver#3510 spent six occurrences and four bake seals establishing
+/// WHICH of several self-posting recyclers took a package root down mid-install, because
+/// <c>[QUIESCE-START]</c> could say <i>"requested by itself — a rebind or self-heal recycle"</i> and
+/// nothing more. That sentence is one word covering three states
+/// (<c>NodeTypeRebindWatcher</c>, the stale-build convergence, <c>WithOverlaySelfHeal</c>), which is
+/// the shape <see href="https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md">Controls That Cannot Fail</see>
+/// catalogues. The poster always knows why; only the log did not.</para>
 /// </summary>
 [SystemMessage]
 [CanBeIgnored]
-public record DisposeRequest;
+public record DisposeRequest
+{
+    /// <summary>
+    /// One sentence saying WHY this hub is being torn down, written by the code that posts the
+    /// request — <c>"NodeType rebind: 'X' is now typed 'A' but its hub activated on 'B'"</c>,
+    /// <c>"PackageInstaller: recycling the retyped root …"</c>.
+    ///
+    /// <para><c>null</c> means the poster did not say, and that is printed as
+    /// <see cref="ReasonNotStated"/> — a NAMED answer, never a blank. Same rule as
+    /// <c>NodeDiagnosticsOutcome</c>: an absent answer that renders as nothing reads to the next
+    /// person as "there was nothing to report".</para>
+    /// </summary>
+    public string? Reason { get; init; }
+
+    /// <summary>
+    /// What <c>[QUIESCE-START]</c> prints for a <see cref="DisposeRequest"/> whose poster supplied
+    /// no <see cref="Reason"/>. Spelled once so a log reader and a log QUERY agree on the token.
+    /// </summary>
+    public const string ReasonNotStated = "reason not stated by the caller";
+}
 /// <summary>
 /// Liveness probe requesting a <see cref="PingResponse"/> from the target hub.
 /// </summary>

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -28,6 +28,20 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
 
     private readonly ConcurrentDictionary<Address, IMessageHub> messageHubs = new(AddressComparer.Instance);
 
+    /// <summary>
+    /// 🚨 <b>Why the owner is going down, so its children can say so (#3510).</b> Set by the owning
+    /// <see cref="MessageHub"/> at construction and read once per teardown, inside
+    /// <see cref="DisposeHubsReactive"/>.
+    ///
+    /// <para>Children are torn down by a direct <c>Dispose()</c>, so without this every one of them
+    /// printed <c>[QUIESCE-START] … requested by a direct Dispose() (no routed DisposeRequest)</c> —
+    /// the same line a <c>using</c> and a host teardown produce. #3510's stranded writes were owed
+    /// by exactly these children: the reader who found them had no way, from the child's own line,
+    /// to learn that a root recycle had taken it. A <c>Func</c> rather than a value because the
+    /// owner's own attribution is settled a phase earlier than this one runs.</para>
+    /// </summary>
+    internal Func<string>? OwnerDisposalCause { get; set; }
+
     private readonly Subject<IMessageHub> _hubAdded = new();
     /// <summary>
     /// Emits each <see cref="IMessageHub"/> as it's added to this collection.
@@ -541,11 +555,16 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
         logger.LogDebug("Starting disposal of {count} hosted hubs: [{hubAddresses}]",
             hubs.Length, string.Join(", ", hubs.Select(h => h.Address.ToString())));
 
+        // Read ONCE for the whole wave: every child of this teardown shares one originating cause,
+        // and re-invoking per child would let the answer drift mid-teardown.
+        var originatingCause = ReadOwnerCause();
+
         var childCompletions = hubs.Select(h =>
         {
             var address = h.Address;
             try
             {
+                AttributeCascade(h, originatingCause);
                 h.Dispose();
             }
             catch (Exception ex)
@@ -600,6 +619,10 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
                 {
                     try
                     {
+                        // Attributed too: a hub that finished constructing after disposal began
+                        // still goes down BECAUSE its owner did, and a line that says otherwise
+                        // would be the one unattributed cascade in the tree.
+                        AttributeCascade(h, originatingCause);
                         h.Dispose();
                     }
                     catch (Exception ex)
@@ -640,6 +663,40 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
                     // Complete anyway — a faulted join must not block the owning hub's ShutDown.
                     SignalDone();
                 });
+    }
+
+    /// <summary>
+    /// The owner's own teardown attribution, or <c>null</c> when nobody installed one. Best-effort
+    /// by design — a diagnostic must never be able to fault the teardown it describes — and a
+    /// throw here degrades to the pre-#3510 reading (the child prints
+    /// <c>MessageHub.DirectDisposeSource</c>), never to a wrong one.
+    /// </summary>
+    private string? ReadOwnerCause()
+    {
+        try
+        {
+            return OwnerDisposalCause?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Could not read the disposal cause of host {Host} — its children's [QUIESCE-START] "
+                + "lines will not name the cascade", Host);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Tells <paramref name="hub"/> that it is going down because this collection's host is
+    /// (#3510), immediately before disposing it. A no-op when the cause is unknown, so an
+    /// unattributed cascade keeps reading as a direct dispose rather than acquiring a name it
+    /// cannot support.
+    /// </summary>
+    private void AttributeCascade(IMessageHub hub, string? originatingCause)
+    {
+        if (originatingCause is null || hub is not MessageHub concrete)
+            return;
+        concrete.NoteCascadeFrom(Host, originatingCause);
     }
 
     private void SignalDone()

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -131,11 +131,86 @@ public sealed class MessageHub : IMessageHub
     private volatile string? disposeRequestedBy;
 
     /// <summary>
+    /// WHY, as stated by whoever posted the <see cref="DisposeRequest"/> — <c>null</c> when they
+    /// did not say, which prints as <see cref="DisposeRequest.ReasonNotStated"/> rather than as
+    /// nothing. See <see cref="DisposeRequest.Reason"/> for why the sender alone is not enough.
+    /// </summary>
+    private volatile string? disposeReason;
+
+    /// <summary>
+    /// 🚨 <b>Set when this hub goes down because its OWNER is going down (#3510).</b> A hosted hub
+    /// is torn down by <c>HostedHubsCollection.DisposeHubsReactive</c> calling <c>Dispose()</c> on
+    /// it — a DIRECT dispose, so before this field existed every cascaded child printed
+    /// <see cref="DirectDisposeSource"/>, indistinguishable from a <c>using</c> and from host
+    /// teardown.
+    ///
+    /// <para>That indistinguishability IS #3510's wedge one level down. The issue's trail is
+    /// <i>"the Hosting root was disposed while its own 145-file install was in flight; its per-node
+    /// children went with it, and the writes they owed acks for were stranded"</i> — and the
+    /// stranded writes were owed by those CHILDREN, whose own <c>[QUIESCE-START]</c> lines
+    /// attributed their teardown to nobody. Reading the child told you nothing about the root.</para>
+    /// </summary>
+    private volatile string? cascadeOwner;
+
+    /// <summary>
+    /// The ORIGINATING teardown, propagated unchanged down a cascade, so a leaf hub's line names
+    /// the event that actually started it rather than only its immediate parent. Set together with
+    /// <see cref="cascadeOwner"/>.
+    /// </summary>
+    private volatile string? cascadeOrigin;
+
+    /// <summary>
     /// What <c>[QUIESCE-START]</c> prints when no routed <see cref="DisposeRequest"/> brought this
-    /// hub down — host teardown, an owner disposing its children, or a <c>using</c>. Spelled once so
+    /// hub down and no owner claimed the cascade — host teardown or a <c>using</c>. Spelled once so
     /// a log reader and a log QUERY agree on the token.
     /// </summary>
     internal const string DirectDisposeSource = "a direct Dispose() (no routed DisposeRequest)";
+
+    /// <summary>WHO — the first half of the <c>[QUIESCE-START]</c> attribution.</summary>
+    private string DisposalRequestedBy =>
+        cascadeOwner is { } owner
+            ? $"a cascade from its owner {owner}"
+            : disposeRequestedBy ?? DirectDisposeSource;
+
+    /// <summary>
+    /// WHY — the second half. Never empty: a poster that said nothing is reported as having said
+    /// nothing (<see cref="DisposeRequest.ReasonNotStated"/>), which is a different statement from
+    /// printing no reason at all.
+    /// </summary>
+    private string DisposalReason =>
+        cascadeOwner is not null
+            ? $"the owner's own teardown — {cascadeOrigin ?? DisposeRequest.ReasonNotStated}"
+            : disposeReason ?? DisposeRequest.ReasonNotStated;
+
+    /// <summary>
+    /// What this hub's hosted children are told when they go down with it. A hub that is itself
+    /// part of a cascade passes the ORIGIN along unchanged, so the chain names the event that
+    /// started it however deep the tree is — and the string cannot grow with depth.
+    /// </summary>
+    internal string DisposalOriginForChildren =>
+        cascadeOrigin
+        ?? $"{Address} was torn down by {disposeRequestedBy ?? DirectDisposeSource}; why: "
+           + (disposeReason ?? DisposeRequest.ReasonNotStated);
+
+    /// <summary>
+    /// Records that this hub is going down because <paramref name="owner"/> is (#3510). Called by
+    /// the owning <see cref="HostedHubsCollection"/> immediately before it disposes this hub.
+    ///
+    /// <para>FIRST CAUSE WINS: a child that had already been asked to recycle by name keeps that
+    /// attribution, because that request is what actually started its teardown — the owner's
+    /// cascade then arrives at a hub already going down. Idempotent, and safe from any thread; the
+    /// fields are only read when the Quiescing phase renders the line.</para>
+    /// </summary>
+    /// <param name="owner">The hub whose teardown is taking this one with it.</param>
+    /// <param name="originatingCause">The originating teardown, from
+    /// <see cref="DisposalOriginForChildren"/>.</param>
+    internal void NoteCascadeFrom(Address owner, string originatingCause)
+    {
+        if (disposeRequestedBy is not null || cascadeOwner is not null)
+            return;
+        cascadeOrigin = originatingCause;
+        cascadeOwner = owner.ToString();
+    }
 
     /// <summary>
     /// Disposal-health diagnostic: how many <see cref="ShutdownRequest"/> turns this hub
@@ -441,6 +516,10 @@ public sealed class MessageHub : IMessageHub
         InitializeTypes(this);
 
         this.hostedHubs = hostedHubs;
+        // 🚨 #3510: a child torn down with its owner must be able to say so. Installed here, at
+        // construction, because the collection disposes children a phase AFTER this hub's own
+        // attribution is settled — a value captured now would be the empty one.
+        hostedHubs.OwnerDisposalCause = () => DisposalOriginForChildren;
         ServiceProvider = serviceProvider;
         Configuration = configuration;
         unhandledNack = configuration.Get<UnhandledMessageNack>();
@@ -2745,9 +2824,9 @@ public sealed class MessageHub : IMessageHub
 
                 var initialPendingSnapshot = SnapshotPendingCallbacks();
                 TryLog(LogLevel.Information,
-                    "[QUIESCE-START] {Address}: requested by {RequestedBy}; {Count} pending callbacks "
-                    + "at dispose entry: {Pending}",
-                    Address, disposeRequestedBy ?? DirectDisposeSource,
+                    "[QUIESCE-START] {Address}: requested by {RequestedBy}; why: {Reason}; "
+                    + "{Count} pending callbacks at dispose entry: {Pending}",
+                    Address, DisposalRequestedBy, DisposalReason,
                     initialPendingSnapshot.Length, FormatPendingCallbacks(initialPendingSnapshot));
 
                 // CRITICAL: do the wait OFF the action block. The action block processes
@@ -3410,6 +3489,12 @@ public sealed class MessageHub : IMessageHub
         // which: a recycle this hub asked for, a teardown someone else asked for, or no message at
         // all. #3510's leading hypothesis is precisely the first, and the installer
         // (PackageInstaller posting to a package root) is the second.
+        // 🚨 WHO is only half of it. The self-posted reading below is ONE WORD COVERING THREE
+        // STATES — NodeTypeRebindWatcher, the stale-build convergence and WithOverlaySelfHeal all
+        // post to their own hub — and #3510's leading hypothesis was precisely "which of those
+        // was it?". The poster always knew; the request had nowhere to carry it. It does now, and
+        // an omission is reported as an omission rather than as silence.
+        disposeReason = request.Message.Reason;
         disposeRequestedBy = request.Sender is null
             ? "an unnamed sender (routed DisposeRequest)"
             : Equals(request.Sender, Address)

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1601,6 +1601,32 @@ public static class PackageInstaller
               + "cancel the work in flight beneath the root.";
     }
 
+    /// <summary>
+    /// 🚨 <b>What this recycle tells the hub it tears down (#3510).</b> Pure, so the sentence is
+    /// pinned without a mesh — and separate from the installer-side log line because the two are
+    /// read by different people: that one reaches whoever is looking at the install, this one
+    /// reaches whoever is looking at the ROOT's <c>[QUIESCE-START]</c>, or at one of the per-node
+    /// children the cascade takes with it.
+    ///
+    /// <para>The second reader is the one #3510 could not serve. Its trail — <i>"the Hosting root
+    /// was disposed at 23:37:51Z while its own 145-file install was in flight; its per-node
+    /// children went with it, and the writes they owed acks for were stranded"</i> — was assembled
+    /// over six occurrences and four lost bake seals, and attributing it took a full read of THIS
+    /// file plus an ordering argument, because every candidate recycler announces itself at
+    /// Information and none of them announced itself in the victim's log.</para>
+    ///
+    /// <para>Names the install explicitly ("while installing"), because that is the discriminator
+    /// the issue settled on: a root recycling under a reconcile is usually benign, and <i>"the
+    /// discriminator is not the count — it is whether the recycled root is the package currently
+    /// installing"</i>. A reader who greps one line now has that fact.</para>
+    /// </summary>
+    /// <param name="rootPath">The retyped root being recycled.</param>
+    /// <returns>The sentence carried on the <see cref="DisposeRequest"/>.</returns>
+    internal static string RetypedRootRecycleReason(string rootPath) =>
+        $"PackageInstaller.SettleRetypedRoot: recycling the root '{rootPath}' WHILE INSTALLING that "
+        + "package, now that this install has rebuilt its in-package NodeType — the hub re-activates "
+        + "against the package's own configuration instead of the placeholder binding";
+
     private static IObservable<Unit> SettleRetypedRoot(
         IMessageHub hub, string? rootPath, IReadOnlyCollection<MeshNode> nodes, int written,
         ILogger? logger)
@@ -1662,9 +1688,17 @@ public static class PackageInstaller
                     + "anything still pending at that bound is force-cancelled and surfaces to its "
                     + "issuer as HubDisposedBeforeResponseException.",
                     rootPath);
+                // 🚨 The reason travels WITH the request (#3510). The log line above says why to
+                // whoever reads the INSTALLER's log; the root's own [QUIESCE-START] — and, through
+                // the cascade, every per-node child that goes down with it, which is where #3510's
+                // stranded writes were owed — says why to whoever reads the HUB's. Those were two
+                // different readers on every occurrence of this issue, and only the first was
+                // served.
                 using (accessService?.ImpersonateAsSystem())
                     hub.NodeOperationIssuingHub()
-                        .Post(new DisposeRequest(), o => o.WithTarget(new Address(rootPath!)));
+                        .Post(
+                            new DisposeRequest { Reason = RetypedRootRecycleReason(rootPath!) },
+                            o => o.WithTarget(new Address(rootPath!)));
                 return WaitForRootReady(hub, rootPath!, logger);
             });
     }

--- a/test/Memex.Portal.Shared.Test/RetypedRootRecycleNeedsAJobTest.cs
+++ b/test/Memex.Portal.Shared.Test/RetypedRootRecycleNeedsAJobTest.cs
@@ -74,4 +74,31 @@ public class RetypedRootRecycleNeedsAJobTest
         Assert.Null(PackageInstaller.RecycleDeclineReason(rootPath, written: 0));
         Assert.Null(PackageInstaller.RecycleDeclineReason(rootPath, written: 5));
     }
+
+    /// <summary>
+    /// 🚨 <b>The recycle that DOES happen must announce itself IN THE VICTIM'S OWN LOG (#3510).</b>
+    ///
+    /// <para>The decline above is announced by the installer, to whoever is reading the install.
+    /// The recycle is read by somebody else entirely — whoever is looking at the root's
+    /// <c>[QUIESCE-START]</c>, or at one of the per-node children the cascade takes with it, which
+    /// is where #3510's stranded writes were owed. That reader had nothing: attributing CD 7950's
+    /// <c>Hosting</c> took a full read of <c>PackageInstaller</c> plus an ordering argument, because
+    /// every candidate recycler announces itself at Information and none of them announced itself
+    /// where the teardown was visible.</para>
+    ///
+    /// <para>The sentence must name the DISCRIMINATOR the issue settled on, verbatim: <i>"a root
+    /// recycling under a reconcile is usually benign … the discriminator is not the count — it is
+    /// whether the recycled root is the package currently installing"</i>. A reason saying only
+    /// "recycling a root" would satisfy a weaker test and leave the next reader exactly where #3510
+    /// left them.</para>
+    /// </summary>
+    [Fact]
+    public void TheRecycleThatProceeds_NamesTheInstallItIsRunningUnder()
+    {
+        var reason = PackageInstaller.RetypedRootRecycleReason("Hosting");
+
+        Assert.Contains("Hosting", reason);
+        Assert.Contains("SettleRetypedRoot", reason);
+        Assert.Contains("WHILE INSTALLING", reason);
+    }
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/QuiesceStartNamesTheAskerTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/QuiesceStartNamesTheAskerTest.cs
@@ -130,6 +130,132 @@ public class QuiesceStartNamesTheAskerTest : HubTestBase
         line.Should().NotContain("itself", "nothing asked; there is no requester to name");
     }
 
+    /// <summary>
+    /// 🚨 <b>WHO is only half the question (#3510).</b> The sender identifies the recycler only
+    /// when it is a DIFFERENT hub; the three automatic recyclers post to their OWN hub and render
+    /// as one sentence — "a rebind or self-heal recycle" — which is the
+    /// <see href="/Doc/Architecture/ControlsThatCannotFail">one word covering three states</see>
+    /// shape. The poster has always known why. Now the request carries it.
+    /// </summary>
+    [HubFact]
+    public async Task ADisposeRequestCarryingAReason_PrintsThatReason()
+    {
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "asked-with-reason"), c => c)!;
+        var asker = (MessageHub)Mesh.GetHostedHub(new Address("asker", "with-reason"), c => c)!;
+
+        asker.Post(
+            new DisposeRequest { Reason = "NodeType rebind: node 'X' is now typed 'A'" },
+            o => o.WithTarget(victim.Address));
+
+        var line = await QuiesceLineFor(victim);
+
+        line.Should().Contain("why: ",
+            "the line must have a WHY field at all — the whole residual of #3510 is that it did not");
+        line.Should().Contain("NodeType rebind: node 'X' is now typed 'A'",
+            "the poster's own sentence is the answer; a reader must not have to infer it from the "
+            + "sender the way #3510 had to infer it from ordering");
+        line.Should().NotContain(DisposeRequest.ReasonNotStated,
+            "a stated reason must never be reported as unstated");
+    }
+
+    /// <summary>
+    /// 🚨 The <c>NothingWasChecked</c> shape, one subsystem over: an unanswered question is a NAMED
+    /// answer, never a blank. A caller that said nothing is reported as having said nothing —
+    /// which is what tells the next reader to go and look at the poster, instead of reading an
+    /// empty field as "there was nothing to report".
+    ///
+    /// <para>This is also the NEGATIVE control on the test above: a formatter that invented a
+    /// plausible reason, or that silently dropped the field when there was none, would pass
+    /// <see cref="ADisposeRequestCarryingAReason_PrintsThatReason"/> and fail here.</para>
+    /// </summary>
+    [HubFact]
+    public async Task ADisposeRequestWithNoReason_SaysTheCallerDidNotStateOne()
+    {
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "asked-no-reason"), c => c)!;
+        var asker = (MessageHub)Mesh.GetHostedHub(new Address("asker", "no-reason"), c => c)!;
+
+        asker.Post(new DisposeRequest(), o => o.WithTarget(victim.Address));
+
+        var line = await QuiesceLineFor(victim);
+
+        line.Should().Contain(DisposeRequest.ReasonNotStated,
+            "an absent reason must be REPORTED as absent; a field that simply disappears reads to "
+            + "the next person as 'there was nothing to report'");
+        line.Should().Contain("asker/no-reason",
+            "the half that IS known must still be printed — a missing reason does not cost the "
+            + "sender");
+    }
+
+    /// <summary>
+    /// 🚨 <b>#3510's exact shape, one level down — and the reading nothing could produce.</b>
+    ///
+    /// <para>The issue's trail: <i>"The Hosting root hub was disposed at 23:37:51Z while its own
+    /// 145-file install was in flight. Its per-node children — the owners of
+    /// <c>Hosting/*/_Activity/compile-state</c> … — went with it"</i>, and the writes those
+    /// children owed acks for were stranded. The stranded writes were owed by the CHILDREN, so the
+    /// child's own <c>[QUIESCE-START]</c> is where a reader lands — and a hosted hub is torn down
+    /// by a plain <c>Dispose()</c> from <c>HostedHubsCollection</c>, so that line read
+    /// <c>requested by a direct Dispose() (no routed DisposeRequest)</c>: the same sentence a
+    /// <c>using</c> produces. The root recycle that actually took it was invisible from there.</para>
+    ///
+    /// <para>Now the child names the cascade AND the originating teardown, so one line answers
+    /// both halves without a second log to correlate against.</para>
+    /// </summary>
+    [HubFact]
+    public async Task AChildTornDownWithItsOwner_NamesTheCascadeAndTheOriginatingTeardown()
+    {
+        var root = (MessageHub)Mesh.GetHostedHub(new Address("root", "recycled-mid-install"), c => c)!;
+        var child = (MessageHub)((IMessageHub)root)
+            .GetHostedHub(new Address("child", "compile-state"), c => c)!;
+        var installer = (MessageHub)Mesh.GetHostedHub(new Address("installer", "packages"), c => c)!;
+
+        installer.Post(
+            new DisposeRequest
+            {
+                Reason = "PackageInstaller.SettleRetypedRoot: recycling the root WHILE INSTALLING "
+                         + "that package",
+            },
+            o => o.WithTarget(root.Address));
+
+        var line = await QuiesceLineFor(child);
+
+        line.Should().Contain("a cascade from its owner",
+            "a hub that goes down because its OWNER does must say so — this is the reading #3510 "
+            + "could not get from the child, which is where its stranded writes were owed");
+        line.Should().Contain("root/recycled-mid-install",
+            "and it must NAME the owner, so the reader can go to the right hub's line next");
+        line.Should().Contain("PackageInstaller.SettleRetypedRoot",
+            "the ORIGINATING teardown travels down the cascade — otherwise the child names its "
+            + "parent and the reader still has to correlate two logs to learn that an install "
+            + "recycled the root");
+        line.Should().NotContain("no routed DisposeRequest",
+            "a cascade is not a direct Dispose(), and reading it as one is exactly what cost "
+            + "#3510 six occurrences");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The negative control, in the other direction.</b> A change that stamped EVERY disposal
+    /// as a cascade would satisfy the test above while destroying the one reading #3510 already
+    /// had — the absence of a routed request, which rules the message path out. An ordinary hub
+    /// disposed on its own must still read as one.
+    /// </summary>
+    [HubFact]
+    public async Task AHubDisposedOnItsOwn_IsNotReportedAsACascade()
+    {
+        var lonely = (MessageHub)Mesh.GetHostedHub(new Address("lonely", "no-owner-teardown"), c => c)!;
+
+        lonely.Dispose();
+
+        var line = await QuiesceLineFor(lonely);
+
+        line.Should().NotContain("a cascade from its owner",
+            "nothing tore this hub down but the caller — claiming an owner did would be a "
+            + "confidently wrong attribution, which is worse than the blank it replaces");
+        line.Should().Contain("no routed DisposeRequest",
+            "the ABSENCE of a request must survive the change: it is what rules the message path "
+            + "out, and it is the one deduction #3510 could already make");
+    }
+
     private sealed class QuiesceLogCapture : ILoggerProvider
     {
         public ConcurrentQueue<string> Entries { get; } = new();


### PR DESCRIPTION
Closes nothing — **#3510 stays open.** This lands the Expectation that gates the others, not the wedge.

## What was already answered, and what still was not

#3821 made `[QUIESCE-START]` name **WHO** asked. Working the next occurrence showed that answer stops one question short, twice — and both gaps are exactly where #3510's investigation ran out of log.

**1. WHY was nowhere.** Three core recyclers post to their OWN hub — `NodeTypeRebindWatcher`, the stale-build convergence in `NodeTypeEnrichmentHelpers`, `WithOverlaySelfHeal` — so the self-posted reading is *one word covering three states*, the [Controls That Cannot Fail](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md) shape. Telling them apart is precisely what this issue spent six occurrences and four lost bake seals doing by hand, from timings. Every poster has always known why; `DisposeRequest` had nowhere to carry it. It does now.

An omission is **REPORTED**, never blank: `why: reason not stated by the caller` (`DisposeRequest.ReasonNotStated`). Same rule as `NodeDiagnosticsOutcome` — a field that simply disappears reads to the next person as "there was nothing to report". One core poster is still unnamed (`MeshOperations.cs`, held by another session this evening), and that token is what says so.

**2. A cascaded child named nobody — and that is this issue's own trail, one level down.** `HostedHubsCollection.DisposeHubsReactive` tears children down with a plain `Dispose()`, so every one of them printed `requested by a direct Dispose() (no routed DisposeRequest)`: the sentence a `using` produces. #3510's stranded writes were owed by exactly those children (`Hosting/*/_Activity/compile-state`, `Hosting/_Access/Public_Access`) — a reader lands on the child first, and the root recycle that took it was invisible from there.

A child now names the cascade, its owner, **and the originating teardown**, propagated unchanged down the tree so the string cannot grow with depth and a leaf still names the event that started it:

```
[QUIESCE-START] Hosting/Admin/_Activity/compile-state: requested by a cascade from its owner Hosting;
  why: the owner's own teardown — Hosting was torn down by portal/nodeops-1 (routed DisposeRequest);
  why: PackageInstaller.SettleRetypedRoot: recycling the root 'Hosting' WHILE INSTALLING that package …
```

`WHILE INSTALLING` is deliberate: it is the discriminator the issue settled on — *"a root recycling under a reconcile is usually benign … the discriminator is not the count — it is whether the recycled root is the package currently installing"*.

## Cost, stated

This is a logging decision and levels encode a production cost model, so: **no line is added and no level is changed.** `[QUIESCE-START]` gains one `why:` field, bounded by the disposal rate, against a defect that is currently unattributable by construction. Posters build one short string per teardown; the cascade costs two volatile writes per child.

## Controls, both directions — proven by breaking the subject, not by reasoning about it

With the two production edits neutralised and the suite **rebuilt** (the first attempt did not compile, so its `--no-build` pass was a stale binary — noted because that is the false-pass trap), exactly the two new assertions go red, and the pre-fix child line comes back verbatim in the failure text:

```
Expected "[QUIESCE-START] child/compile-state: requested by a direct Dispose() (no routed
DisposeRequest); why: reason not stated by the caller; 0 pending callbacks at dispose entry: <none>"
to contain "a cascade from its owner" because a hub that goes down because its OWNER does must say so
```

The other direction is two cases that stay **green** under that same neutralisation and must survive the change:

- `ADisposeRequestWithNoReason_SaysTheCallerDidNotStateOne` — a formatter that invented a plausible reason, or dropped the field when there was none, fails here.
- `AHubDisposedOnItsOwn_IsNotReportedAsACascade` — a change that stamped **every** disposal a cascade would satisfy the cascade test and destroy the one deduction #3510 could already make (an absent routed request rules the whole message path out).

## Gates — measured, not assumed

`check-type-forwards.py --base <merge base> --surface-json`: **0 removed, 2 added** (2099 public types / 13278 members at base, 2099 / 13280 at head), implementer obligations **455 → 455**. So no `Pairs-with:` and no `Implementers:` obligation, and `RecycleNode`'s new optional parameter does not register as a member removal (members are keyed by name). No i18n catalog change, so no `Mirror-sync:`.

## Teardown twins — no obligation created, and a sighting recorded

**This change does not alter what either hand-synced twin asserts**, adds no assertion to them and changes no NACK behaviour, so it creates no counterpart obligation in `MeshWeaver.Plugins` (whose copies are ported in Plugins#1626). Both twins were run locally against the changed binary and pass, **including** `NackReachesTheWaiterDuringTeardownTest.OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller` — the test that failed on shard 4 of run 34513634943 earlier today. One local pass on an unloaded machine is not a claim that that intermittency is resolved.

That sighting is instead **recorded as evidence** in `Doc/Architecture/DisposalStallVerdicts` with its date, run id and assertion text, because it is the other half of this issue's family and CI logs age out. It is a **different seam**: #3510's trail is *no verdict is ever minted* (`PATCH_MERGE_STAMPED → PATCH_ECHO_SEEN → nothing`, owner alive, root recycled); that one is *the verdict is minted and the waiter does not observe it*. Both look identical to the caller, which is why they get conflated. The page also names the first hypothesis to eliminate next time: the test's precondition is `RunLevel == Dead`, `HandleShutdownCore` reaches `Dead` on **three** paths (success, `catch`, `finally` backstop), and only the first guarantees the ShutDown-phase registrant ran — the discriminator is the `catch`'s `Error during shutdown of hub {address}` line.

## What this does NOT do

It does not stop a recycle landing in the middle of an install. #3510's other two Expectations — **defer the recycle while an install holds the root**, or **NACK every in-flight write under it** so the install fails in milliseconds with a name instead of running out a ten-minute bound — are untouched. It makes the next occurrence a read instead of a reconstruction.

## Verified

- `MeshWeaver.Messaging.Hub.Test` **409/409**, 2 m 19 s (the whole project — `MessageHub`/`HostedHubsCollection` are its subject)
- `QuiesceStartNamesTheAskerTest` **7/7** · `RetypedRootRecycleNeedsAJobTest` **6/6** · teardown twins **2/2**
- `DocumentationLinkIntegrityTest` + `ArchitectureTopicMapTest` **6/6**
- Every touched project: `dotnet build -c Release -warnaserror` → **0 Error(s), 0 Warning(s)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
