### PR TITLE
feat(ea): Teams send scopes, and a grant consented for a smaller scope set reads as NotConnected

### DIFF
--- a/.claude/skills/teams/SKILL.md
+++ b/.claude/skills/teams/SKILL.md
@@ -11,9 +11,10 @@ allowed-tools:
 # /teams — reading and sending Teams on a user's behalf
 
 **Measured 2026-09-09** by asking the Executive Assistant on memex "can you see my Teams channels,
-in particular PartnerRe ESL?": it answered no, and it was right. Nothing in the fleet can enumerate
-a user's teams or read a channel. This skill records what exists, what the ask needs, and the one
-wall that no scope can climb.
+in particular PartnerRe ESL?": it answered no, and it was right — then. Since Mail 1.5/1.6 (read,
+2026-09-09/10) and Mail 1.7 (post, 2026-09-10) the EA reads a user's own-tenant teams, channels and
+chats, and posts to them where the deployment sets `Teams:AgentSend=Send`. This skill records what
+exists, what the ask needs, and the one wall that no scope can climb.
 
 ## What exists: a bot, not a reader
 
@@ -25,18 +26,29 @@ can answer in a conversation the bot is part of and nothing else. On memex it is
 (`Teams:Enabled=false`, zero `TeamsConversation` nodes).
 
 The Executive Assistant (`src/MeshWeaver.Mail.MicrosoftGraph/ExecutiveAssistantPlugin.cs`) has
-mail and calendar tools only. Its credential is the delegated one minted by the EA consent link,
+mail, calendar and Teams tools. Its credential is the delegated one minted by the EA consent link,
 and that credential is the seam everything below hangs on.
 
 ## The seam: the EA consent link IS a delegated Graph token
 
 `{BaseUrl}/auth/ea/connect` sends the user through Microsoft's authorize endpoint with
-`prompt=consent` and the scope string in `EaGraphAuth.Scopes` — **Memex repo**,
-`Memex.Portal.Shared/Authentication/EaGraphAuth.cs`:
+`prompt=consent` and the scope string in `EaGraphAuth.Scopes` — **this repo**,
+`memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs`:
 
 ```
-Mail.ReadWrite Mail.Send Calendars.ReadWrite offline_access
+Mail.ReadWrite Mail.Send Calendars.ReadWrite
+Team.ReadBasic.All Channel.ReadBasic.All ChannelMessage.Read.All Chat.Read
+ChannelMessage.Send ChatMessage.Send offline_access
 ```
+
+🚨 **Widening that string invalidates every stored grant.** Entra refuses to redeem a refresh token
+for scopes the user never consented to (400 `invalid_grant`), and the consent controller's fast path
+bounces a user whose credential node exists straight back — so on 2026-09-10 the read scopes landed,
+the reconnect link "just brought me in", and every Teams call kept failing. `EaGraphAuth.Classify`
+now compares the credential's stored `Scopes` with the constant and reports a mismatch as
+`NotConnected`, which hands the user the link AND makes `/auth/ea/connect` run the dialog. Do not
+add a scope without that classification in place; `?force=true` on the connect link is the manual
+escape hatch for a portal that predates it.
 
 Add Teams scopes to that string and every user reconnects once; from then on the same
 `GraphServiceClient` the plugin already builds reaches `/me/joinedTeams`, `/teams/{id}/channels`,
@@ -66,21 +78,25 @@ before adding a scope — a tenant's consent policy can make any of them admin-o
 before the user sees a screen.
 
 🚨 **Teams has no draft state.** Mail is DraftOnly by design (`Email:AgentSend`, the human presses
-Send); a Teams send is immediate and irreversible. A send tool needs the same gate — a
-`Teams:AgentSend` mode defaulting to a preview page the human confirms, the shape `PrepareMailing`
-already has — and the sending tools must never be handed to the model in the default mode, exactly
-as `SendMail`/`ReplyToMail` are not.
+Send); a Teams post is immediate and irreversible. The gate is the same shape: `Teams:AgentSend`
+defaults to `Off`, in which `PostChannelMessage` / `ReplyToChannelMessage` / `SendChatMessage` are
+never handed to the model (and refuse by name when reached directly); `Send` hands them over, with
+no per-message confirmation — the boundary `Email:AgentSend=Send` has too. The scopes are consented
+regardless of the mode, so flipping the mode later costs nobody a reconnect. memex-cloud runs
+`Teams__AgentSend: "Send"` (Memex values); memex.systemorph.com does not.
 
-### The three pieces to write
+### The three pieces (built 2026-09-09/10)
 
-1. **Memex repo:** the scopes in `EaGraphAuth.Scopes`, and the delegated permissions on the app
-   registration (Roland's Entra tenant for the Systemorph portals).
-2. **Plugins repo:** tools on `ExecutiveAssistantPlugin` — `ListTeams`, `ListChannels`,
-   `ReadChannelMessages`, `ListChats`, `ReadChat`, and (gated) `SendChannelMessage` /
-   `SendChatMessage`; the plugin's `ClientAsync()` already yields the delegated
-   `GraphServiceClient`. Model-facing `[Description]`s stay English.
-3. **Plugins repo:** `src/MeshWeaver.AI/Data/Agent/ExecutiveAssistant.md` names the new surface,
-   or the agent will keep answering "I have no Teams tool" from its instructions.
+1. **This repo:** the scopes in `EaGraphAuth.Scopes` plus the stale-grant classification above; the
+   delegated permissions on the app registration (Roland's Entra tenant for the Systemorph portals)
+   are optional under dynamic consent except the admin-restricted `ChannelMessage.Read.All`.
+2. **Plugins repo:** the tools on `ExecutiveAssistantPlugin` — read: `ListTeams`, `ListChannels`,
+   `ReadChannelMessages`, `ListChats`, `ReadChat` (every mode); post: `PostChannelMessage`,
+   `ReplyToChannelMessage`, `SendChatMessage` (`Teams:AgentSend=Send` only). 🚨 A tool exists for
+   the model only when `CreateTools()` LISTS it — Mail 1.5 shipped the read methods without listing
+   them and the EA answered "not in my toolset" (Plugins#1611).
+3. **Plugins repo:** `src/MeshWeaver.AI/Data/Agent/ExecutiveAssistant.md` names the surface, or the
+   agent keeps answering "I have no Teams tool" from its instructions.
 
 ## 🚨 The wall: "PartnerRe ESL" lives in PartnerRe's tenant
 

--- a/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
@@ -92,7 +92,11 @@ public sealed class EaConsentController(
         // forcing Microsoft's dialog (BuildConsentUrl carries prompt=consent) on a user whose
         // grant is stored — visiting the connect link twice used to re-prompt every time and read
         // as "my consent is not saved". ?force=true still runs the full consent deliberately
-        // (scope additions, credential rotation, a revoked grant the stored token hides).
+        // (credential rotation, a revoked grant the stored token hides). A SCOPE ADDITION needs no
+        // force: EaGraphAuth classifies a grant consented for a smaller scope set than the build's
+        // as NotConnected, so this fast path is not taken for it — which is what ended the
+        // 2026-09-10 loop where the read scopes had landed, the reconnect link bounced a
+        // "connected" user straight back, and every Teams call kept failing on the refused refresh.
         // Sanitised BEFORE either use: the fast path redirects to it directly, and the consent
         // path round-trips it through the IdP as `state` and redirects to it on the way back —
         // so an unsanitised value is an open redirect on both routes, not just the visible one.

--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -61,21 +61,32 @@ public sealed class EaGraphAuth(
     /// <summary>
     /// Delegated scopes the EA needs (space-separated, Graph v2 form).
     ///
-    /// <para><b>Teams, read-only (2026-09-09).</b> <c>Team.ReadBasic.All</c> lists the user's teams,
-    /// <c>Channel.ReadBasic.All</c> a team's channels, <c>ChannelMessage.Read.All</c> a channel's
-    /// messages, <c>Chat.Read</c> the user's chats — the surface the Executive Assistant's
-    /// <c>ListTeams</c> / <c>ListChannels</c> / <c>ReadChannelMessages</c> / <c>ListChats</c> /
-    /// <c>ReadChat</c> tools (MeshWeaver.Plugins) call. Deliberately NO send scope: Teams has no
-    /// draft state, so a send would be immediate and irreversible, and the EA's mail contract is
-    /// draft-by-default; sending gets its own gate and its own consent when it is built.</para>
+    /// <para><b>Teams (read 2026-09-09, send 2026-09-10).</b> <c>Team.ReadBasic.All</c> lists the
+    /// user's teams, <c>Channel.ReadBasic.All</c> a team's channels, <c>ChannelMessage.Read.All</c>
+    /// a channel's messages, <c>Chat.Read</c> the user's chats — the surface the Executive
+    /// Assistant's <c>ListTeams</c> / <c>ListChannels</c> / <c>ReadChannelMessages</c> /
+    /// <c>ListChats</c> / <c>ReadChat</c> tools (MeshWeaver.Plugins) call.
+    /// <c>ChannelMessage.Send</c> and <c>ChatMessage.Send</c> let the same grant POST to a channel
+    /// or a chat as the user — Teams has no draft state, so those posts are immediate and
+    /// irreversible, which is why the plugin hands the posting tools to the model ONLY where the
+    /// deployment says so (<c>Teams:AgentSend=Send</c>, mirroring <c>Email:AgentSend</c>). The
+    /// scope is consented here regardless: consent is per grant, and a user should not have to
+    /// reconnect a second time on the day the deployment turns posting on.</para>
     ///
     /// <para><b>Consent.</b> The v2 authorize endpoint consents to whatever <c>scope</c> asks for
     /// (dynamic consent), so these need not be pre-listed on the app registration — but
     /// <c>ChannelMessage.Read.All</c> is admin-restricted: a non-admin user sees "Need admin
     /// approval" until a tenant admin has consented once (Entra → Enterprise applications → the
-    /// sign-in app → Permissions → Grant admin consent). Every user who connected BEFORE this
-    /// change holds a grant without these scopes and must reconnect once via
-    /// <c>{BaseUrl}/auth/ea/connect</c>; the plugin says so on the 403 it gets until then.</para>
+    /// sign-in app → Permissions → Grant admin consent). 🚨 <b>Widening this string invalidates
+    /// every stored grant</b>: Entra refuses to redeem a refresh token for scopes the user never
+    /// consented to (400 <c>invalid_grant</c>), so a grant minted under the previous string answers
+    /// nothing until the user reconnects. That is why <see cref="Classify(MeshNode?, IMessageHub)"/>
+    /// compares the stored <see cref="EaCredential.Scopes"/> with THIS string and reports a mismatch
+    /// as <see cref="EaConnection.NotConnected"/> — the one state that hands the user the consent
+    /// link AND makes <c>/auth/ea/connect</c> run the dialog instead of bouncing a "connected" user
+    /// straight back (measured 2026-09-10: the read scopes landed, the user clicked the link, the
+    /// controller saw a stored credential and skipped consent, and every Teams call kept failing on
+    /// the refused refresh).</para>
     ///
     /// <para><b>Tenant boundary.</b> A grant is minted by the user's HOME tenant. A team the user
     /// reaches as a guest of another company's tenant is not visible on it — <c>/me/joinedTeams</c>
@@ -86,6 +97,7 @@ public sealed class EaGraphAuth(
         "https://graph.microsoft.com/Calendars.ReadWrite " +
         "https://graph.microsoft.com/Team.ReadBasic.All https://graph.microsoft.com/Channel.ReadBasic.All " +
         "https://graph.microsoft.com/ChannelMessage.Read.All https://graph.microsoft.com/Chat.Read " +
+        "https://graph.microsoft.com/ChannelMessage.Send https://graph.microsoft.com/ChatMessage.Send " +
         "offline_access";
 
     /// <summary>
@@ -432,10 +444,25 @@ public sealed class EaGraphAuth(
                 $"the credential node at {node.Path} exists but its content could not be read as an "
                 + $"{nameof(EaCredential)}"));
 
-        return new CredentialRead(node, cred,
-            string.IsNullOrEmpty(cred.RefreshTokenEncrypted)
-                ? EaGraphAccess.NotConnected("the stored credential carries no refresh token")
-                : EaGraphAccess.Connected());
+        if (string.IsNullOrEmpty(cred.RefreshTokenEncrypted))
+            return new CredentialRead(node, cred,
+                EaGraphAccess.NotConnected("the stored credential carries no refresh token"));
+
+        // 🚨 A grant is only as wide as the consent that minted it. When THIS build asks for more
+        // than the stored grant covers, Entra refuses to redeem the refresh token (400
+        // invalid_grant) — so "connected" would be a lie every Teams call disproves, and the
+        // consent controller, trusting it, would bounce the user's reconnect straight back
+        // without ever showing the dialog. NotConnected is the truthful answer: the read
+        // COMPLETED and found a credential that cannot serve this build. The mailbox side of that
+        // grant still works, and the diagnostic says so, so the message is "reconnect once",
+        // never "you never connected". Compared as the exact string the consent stored: the
+        // constant is the only writer, so any difference IS a scope-set change.
+        if (!string.Equals(cred.Scopes, Scopes, StringComparison.Ordinal))
+            return new CredentialRead(node, cred, EaGraphAccess.NotConnected(
+                "the stored grant was consented for an earlier scope set; this build needs more "
+                + "(Teams), so a reconnect is required — the mailbox connection itself is intact"));
+
+        return new CredentialRead(node, cred, EaGraphAccess.Connected());
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/AI/ExecutiveAssistant.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ExecutiveAssistant.md
@@ -51,7 +51,7 @@ The EA agent declares the `Mesh` + `ExecutiveAssistant` plugins. The `ExecutiveA
 | Mail | `ListInbox`, `SearchMail`, `ReadMail`, `DraftMail`, `DraftReply`, `GetDraft`, `UpdateDraft`, `DiscardDraft` — and `SendMail`, `ReplyToMail` **only where the deployment opted in**, see below |
 | Mailings | `PrepareMailing` — one subject and body template merged per recipient into personal mails, saved as a page the person reviews; **never sends** — see below |
 | Calendar | `ListEvents`, `GetEvent`, `CreateEvent` (book + invite attendees), `UpdateEvent`, `CancelEvent` |
-| Teams (read-only) | `ListTeams`, `ListChannels`, `ReadChannelMessages`, `ListChats`, `ReadChat` — the user's own organisation's teams and chats; no send tool, see below |
+| Teams | `ListTeams`, `ListChannels`, `ReadChannelMessages`, `ListChats`, `ReadChat` — the user's own organisation's teams and chats; and `PostChannelMessage`, `ReplyToChannelMessage`, `SendChatMessage` **only where the deployment opted in** (`Teams:AgentSend=Send`), see below |
 
 Example asks: *"Book 30 min with Alice next Tuesday afternoon and invite her"*, *"reply to the vendor that
 we accept"*, *"clear my Friday"*, *"email me when an approval needs me"* (the last manages your
@@ -149,25 +149,34 @@ knowing before anyone edits them:
 | `UpdateDraft` | the patch carries **only** `subject`, `body`, `toRecipients`, `ccRecipients` — the four fields Graph documents as *"Updatable only if **isDraft** = true"*. A patch that arrives after the send is rejected by the **server**, atomically. `importance`, `categories`, `flag` and `isRead` *are* updatable on a sent message; adding one would remove that backstop silently, so the field set is pinned by a test. |
 | `DiscardDraft` | nothing beyond the re-read. `DELETE /me/messages/{id}` deletes whatever it is given, draft or sent — which is why this tool's guard is the only thing between "discard that draft" and destroying a delivered message. |
 
-### Teams is read-only, on the same grant — and a guest team is out of reach
+### Teams rides the same grant — reading always, posting where the deployment says so
 
 The Teams tools run on the same delegated grant as mail and calendar (`EaGraphAuth.Scopes` carries
 `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Read.All`, `Chat.Read` since
-2026-09-09). Two consequences the agent states rather than hides:
+2026-09-09, and `ChannelMessage.Send`, `ChatMessage.Send` since 2026-09-10). Three consequences the
+agent states rather than hides:
 
-- **A grant minted before those scopes existed answers 403.** The mailbox still works; only the
-  Teams consent is missing. The tool answers with the connect link (`{BaseUrl}/auth/ea/connect`)
-  and the agent hands it on — one reconnect, a few seconds — instead of reporting Teams as
-  unavailable. `ChannelMessage.Read.All` is admin-restricted: a non-admin sees "Need admin approval"
-  until a tenant admin has consented once.
+- **A grant consented for an earlier, smaller scope set cannot serve this build.** Entra refuses to
+  redeem such a refresh token for the wider set, so the credential read classifies it as
+  *not connected* with a diagnostic that says the mailbox side is intact. The tool answers with the
+  connect link (`{BaseUrl}/auth/ea/connect`), the agent hands it on — one reconnect, a few seconds —
+  and the connect endpoint runs Microsoft's dialog for that user instead of bouncing a "connected"
+  one straight back (the 2026-09-10 loop; see
+  [ExecutiveAssistantCredentialReads](/Doc/Architecture/ExecutiveAssistantCredentialReads)).
+  `ChannelMessage.Read.All` is admin-restricted: a non-admin sees "Need admin approval" until a
+  tenant admin has consented once.
 - **A team the user joined as a guest of another organisation is not visible.** The grant is the
   user's home tenant's; `/me/joinedTeams` omits guest teams and their channels answer 403/404. No
   scope changes that. The agent says so rather than reporting the team as missing. Reading such a
   team needs the other organisation's cooperation — see the repository's `/teams` skill.
-
-There is deliberately **no Teams send tool**: Teams has no draft state, so a send would be immediate
-and irreversible, against this agent's draft-by-default contract. Sending gets its own gate
-(`Teams:AgentSend`, mirroring `Email:AgentSend`) and its own consent when it is built.
+- **Posting is immediate.** Teams has no draft state, so `PostChannelMessage`,
+  `ReplyToChannelMessage` and `SendChatMessage` go out the moment the model calls them. The gate is
+  the same shape as mail's: **`Teams:AgentSend`** defaults to `Off`, in which the posting tools are
+  never handed to the model at all (and refuse by name if reached directly); a deployment sets
+  `Teams:AgentSend=Send` to hand them over. The scopes are consented either way, so turning posting
+  on later does not cost every user a second reconnect. In `Send` mode there is no per-message
+  confirmation — the same boundary `Email:AgentSend=Send` has, and the same approval-gate work
+  closes both.
 
 ### Editing an event is READ then PATCH, never cancel-and-recreate
 
@@ -207,7 +216,7 @@ The EA reuses the portal's **sign-in** app registration (the `Authentication:Mic
 
 1. Add the **delegated** Microsoft Graph permissions: `Mail.ReadWrite`, `Mail.Send`,
    `Calendars.ReadWrite`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`, `ChannelMessage.Read.All`,
-   `Chat.Read`, `offline_access`.
+   `Chat.Read`, `ChannelMessage.Send`, `ChatMessage.Send`, `offline_access`.
 2. Add the redirect URI **`{BaseUrl}/auth/ea/callback`** (e.g. `https://portal.example.com/auth/ea/callback`).
 3. No admin pre-consent is required for mail and calendar — each user consents for themselves on
    first use (that's the point). `ChannelMessage.Read.All` is the one exception: it is

--- a/src/MeshWeaver.Documentation/Data/Architecture/ExecutiveAssistantCredentialReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ExecutiveAssistantCredentialReads.md
@@ -118,6 +118,20 @@ public sealed record EaGraphAccess(
 `Undetermined` always carries a `Diagnostic`, because an undetermined state with nothing to say is
 indistinguishable from the swallow it replaces.
 
+### A grant is only as wide as its consent
+
+`NotConnected` has a second cause besides an absent node, added 2026-09-10: a credential whose
+stored `Scopes` differ from the build's `EaGraphAuth.Scopes`. The constant is the only writer of
+that field, so any difference is a scope-set change — and Entra refuses to redeem a refresh token
+for scopes the user never consented to (400 `invalid_grant`). Calling such a grant "connected" was
+a lie every Teams call disproved, and it closed a loop nobody could leave: the plugin reported the
+refused refresh as undetermined, the user clicked the reconnect link, and the consent controller —
+reading the same credential as connected — bounced them back without ever showing the dialog.
+Classified as `NotConnected`, the same value both hands the user the consent link and makes
+`/auth/ea/connect` run consent; the diagnostic says the mailbox side is intact, so the plugin's
+sentence is "reconnect once", never "you never connected". The token endpoint is not asked at all
+(`AStaleGrant_IsNotOfferedToTheTokenEndpoint` counts the calls).
+
 ### What a caller must do with `Undetermined`
 
 Say so. "I could not check your mailbox connection just now" is the honest sentence, and it is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-executive-assistant-can-post-to-teams-and-a-widened-consent-reconnects-cleanly.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-executive-assistant-can-post-to-teams-and-a-widened-consent-reconnects-cleanly.md
@@ -1,0 +1,22 @@
+---
+Name: The Executive Assistant can post to Teams, and a widened consent reconnects cleanly
+Category: Feature
+Description: The assistant's Microsoft connection now carries the permissions to post to your Teams channels and chats, and a connection granted before new permissions were added takes you through the consent dialog again instead of bouncing you back.
+Icon: Sparkle
+Order: -20260910
+---
+
+# The Executive Assistant can post to Teams, and a widened consent reconnects cleanly
+
+The consent the Executive Assistant asks for when you connect your Microsoft account now includes
+posting to Teams channels and chats, next to reading them. Whether the assistant may actually post
+is a decision each installation makes (`Teams:AgentSend`); the permission is asked for once so that
+turning posting on later does not send everybody through the consent dialog again.
+
+Adding a permission also used to leave existing connections in a loop: Microsoft refuses to renew a
+connection for more than it was granted, the assistant said it could not check your mailbox, and the
+reconnect link — seeing a stored connection — bounced you straight back without ever showing the
+dialog. A connection granted for fewer permissions than the current version needs is now recognised
+as one that has to be renewed: the assistant hands you the reconnect link, and the link runs the
+dialog. Your mailbox and calendar keep working throughout; only the new permissions are missing
+until you reconnect.

--- a/test/Memex.Portal.Shared.Test/EaCredentialReadTest.cs
+++ b/test/Memex.Portal.Shared.Test/EaCredentialReadTest.cs
@@ -44,6 +44,17 @@ public class EaCredentialReadTest(ITestOutputHelper output) : MonolithMeshTestBa
 {
     private const string ConnectedUser = "ea-connected-user";
     private const string NeverConnectedUser = "ea-never-connected-user";
+    private const string StaleGrantUser = "ea-stale-grant-user";
+
+    /// <summary>
+    /// The scope string every grant minted before 2026-09-09 was consented for — mail and
+    /// calendar only. A credential carrying it is exactly the production shape of 2026-09-10: the
+    /// Teams scopes landed, the user's stored grant predates them, and Entra refuses to redeem the
+    /// refresh token for the wider set.
+    /// </summary>
+    private const string PreTeamsScopes =
+        "https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send " +
+        "https://graph.microsoft.com/Calendars.ReadWrite offline_access";
 
     /// <summary>An arbitrary, valid AES-256 key: the protector is real, only the key source is local.</summary>
     private sealed class FixedMasterKey : IMasterKeyProvider
@@ -71,6 +82,16 @@ public class EaCredentialReadTest(ITestOutputHelper output) : MonolithMeshTestBa
                     Scopes = EaGraphAuth.Scopes,
                     AcquiredAt = DateTimeOffset.UtcNow,
                 }
+            })
+            .AddMeshNodes(EaGraphAuth.NewCredentialNode(StaleGrantUser) with
+            {
+                Content = new EaCredential
+                {
+                    UserObjectId = StaleGrantUser,
+                    RefreshTokenEncrypted = "enc:v1:seeded-for-the-stale-grant-test",
+                    Scopes = PreTeamsScopes,
+                    AcquiredAt = DateTimeOffset.UtcNow.AddDays(-30),
+                }
             });
 
     /// <summary>
@@ -79,7 +100,7 @@ public class EaCredentialReadTest(ITestOutputHelper output) : MonolithMeshTestBa
     /// <c>budget</c> are reachable — so the undetermined branch can be reached deterministically
     /// instead of waited for.
     /// </summary>
-    private EaGraphAuth NewAuth(TimeSpan? readTimeout = null) => new(
+    private EaGraphAuth NewAuth(TimeSpan? readTimeout = null, HttpMessageHandler? tokenEndpoint = null) => new(
         Mesh.ServiceProvider,
         new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -87,14 +108,30 @@ public class EaCredentialReadTest(ITestOutputHelper output) : MonolithMeshTestBa
             ["Authentication:Microsoft:ClientSecret"] = "test-secret",
         }).Build(),
         new ProviderKeyProtector(new FixedMasterKey()),
-        // Never used: every test here exercises GetConnection, which reads the node and posts
-        // nothing. A handler that throws would be reached only by a regression that started
-        // calling the token endpoint from a pure connection check.
-        new HttpClient(),
+        // Unused by the GetConnection tests, which read the node and post nothing. The one test
+        // that calls GetAccessToken passes a handler that RECORDS, so "the token endpoint was not
+        // asked" is a measured zero rather than the absence of a network.
+        tokenEndpoint is null ? new HttpClient() : new HttpClient(tokenEndpoint),
         Mesh.ServiceProvider.GetRequiredService<ILogger<EaGraphAuth>>())
     {
         CredentialReadTimeout = readTimeout ?? TimeSpan.FromSeconds(10),
     };
+
+    /// <summary>Counts token-endpoint calls; answers every one of them as Entra would refuse a stale grant.</summary>
+    private sealed class RecordingTokenEndpoint : HttpMessageHandler
+    {
+        private int calls;
+        public int Calls => Volatile.Read(ref calls);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref calls);
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":"invalid_grant","error_description":"AADSTS65001: consent required"}"""),
+            });
+        }
+    }
 
     // ── The mechanism ────────────────────────────────────────────────────────────────────────────
 
@@ -207,6 +244,62 @@ public class EaCredentialReadTest(ITestOutputHelper output) : MonolithMeshTestBa
         access.Connection.Should().Be(EaConnection.NotConnected,
             "an absent credential is a completed read with a negative answer, and the consent link "
             + "is the correct response to it");
+    }
+
+    // ── A grant is only as wide as its consent ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 2026-09-10, on memex-cloud. The Teams scopes were added to <see cref="EaGraphAuth.Scopes"/>;
+    /// the user's stored grant predated them; Entra refused every refresh-token redemption for the
+    /// wider set (400 <c>invalid_grant</c>); the plugin reported the connection as undetermined; the
+    /// user clicked the reconnect link; and the consent controller — reading the SAME credential as
+    /// "connected" — bounced them straight back without ever showing Microsoft's dialog. Nothing in
+    /// that loop could end it, because the classification called a grant that cannot serve this
+    /// build "connected".
+    ///
+    /// <para>The truthful answer is <see cref="EaConnection.NotConnected"/>: the read completed and
+    /// found a credential consented for a smaller scope set. That one value both hands the user the
+    /// consent link and makes <c>/auth/ea/connect</c> run the dialog. The diagnostic must say the
+    /// mailbox side is intact, so the plugin's sentence is "reconnect once", never "you never
+    /// connected".</para>
+    /// </summary>
+    [Fact]
+    public async Task AGrantConsentedForASmallerScopeSet_ReadsAsNotConnected_SoTheReconnectRunsConsent()
+    {
+        var stale = await NewAuth().GetConnection(StaleGrantUser)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var current = await NewAuth().GetConnection(ConnectedUser)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        Output.WriteLine($"stale-grant verdict: {stale}");
+
+        stale.Connection.Should().Be(EaConnection.NotConnected,
+            "a credential consented for fewer scopes than this build asks for cannot mint a token, "
+            + "and NotConnected is the one state that makes the connect link run the consent dialog "
+            + "instead of bouncing a 'connected' user back");
+        stale.Diagnostic.Should().Contain("reconnect",
+            "the user must be told what to do, and it is not 'connect for the first time'");
+        current.Connection.Should().Be(EaConnection.Connected,
+            "the positive control: the same read on a grant consented for THIS build's scopes");
+    }
+
+    /// <summary>
+    /// The token endpoint is never asked to redeem a grant the classification already knows it will
+    /// refuse. A recorded zero, not an assumed one: the handler counts.
+    /// </summary>
+    [Fact]
+    public async Task AStaleGrant_IsNotOfferedToTheTokenEndpoint()
+    {
+        var endpoint = new RecordingTokenEndpoint();
+
+        var access = await NewAuth(tokenEndpoint: endpoint).GetAccessToken(StaleGrantUser)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        access.Connection.Should().Be(EaConnection.NotConnected);
+        access.AccessToken.Should().BeNull();
+        endpoint.Calls.Should().Be(0,
+            "redeeming a refresh token for scopes it was never consented for is the 400 Entra "
+            + "answered all day on 2026-09-10; the classification exists so that call is not made");
     }
 
     /// <summary>


### PR DESCRIPTION
## What

- `EaGraphAuth.Scopes` gains `ChannelMessage.Send` and `ChatMessage.Send`. The Executive Assistant's posting tools (Plugins Mail 1.7, gated on `Teams:AgentSend`) run on the same delegated grant; consenting the scope now means flipping the mode later costs nobody a second reconnect.
- `EaGraphAuth.Classify` compares the stored `EaCredential.Scopes` with the build's constant. A mismatch is **`NotConnected`** with a diagnostic saying the mailbox side is intact.

## Why the second half

Widening the scope string invalidates every stored grant: Entra refuses to redeem a refresh token for scopes the user never consented to (400 `invalid_grant`). Measured on memex-cloud today (Plugins#1615): the plugin reported the refused refresh as *undetermined*, the user clicked the reconnect link, and `EaConsentController.Connect` — reading the same credential as *connected* — bounced them straight back without ever showing Microsoft's dialog. Nothing in that loop could end it.

`NotConnected` is the one value that both hands the user the consent link and makes `/auth/ea/connect` run consent. The token endpoint is no longer asked for a grant the classification already knows it will refuse.

## Tests

`EaCredentialReadTest` (real monolith mesh): a seeded credential carrying the pre-Teams scope string reads as `NotConnected` with a "reconnect" diagnostic while the current-scope credential stays `Connected`; `GetAccessToken` on the stale grant makes **zero** token-endpoint calls (a recording handler counts them).

Locally: `Memex.Portal.Shared` and its test project build Release `-warnaserror` clean; 15/15 in the EA test classes pass.

## Docs

`Doc/AI/ExecutiveAssistant` (Teams section rewritten, Azure setup scopes), `Doc/Architecture/ExecutiveAssistantCredentialReads` (the second `NotConnected` cause), `.claude/skills/teams` (what is built, the scope-widening trap), What's New entry.

Pairs-with: none — no public type or member removed; adds no interface member.

Follow-ups: Plugins Mail 1.7 (`PostChannelMessage` / `ReplyToChannelMessage` / `SendChatMessage`), Memex pin + `Teams__AgentSend` on memex-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
