### PR TITLE
Fix reusable module workflow permission inheritance

### DIFF
--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -655,6 +655,8 @@ def module_pack_permission_problems(workflow_text: str) -> list[str]:
 
     doc = yaml.safe_load(workflow_text)
     problems = []
+    if "permissions" in doc:
+        problems.append("the called workflow declares permissions instead of inheriting its caller")
     for name in ("prepare", "build-workspace", "pack"):
         job = (doc.get("jobs") or {}).get(name) or {}
         if "permissions" in job:
@@ -736,6 +738,16 @@ def main() -> int:
     case("the permission guard catches a called job that tries to elevate basic callers",
          any(problem.startswith("prepare declares permissions") for problem in narrowed_problems),
          "the mutation passed with id-token: write inside the called workflow")
+    workflow_narrowed_module_pack = module_pack_text.replace(
+        "jobs:\n",
+        "permissions:\n  contents: read\n  id-token: write\njobs:\n",
+        1,
+    )
+    workflow_narrowed_problems = module_pack_permission_problems(workflow_narrowed_module_pack)
+    case("the permission guard catches a workflow-level attempt to elevate basic callers",
+         any(problem.startswith("the called workflow declares permissions")
+             for problem in workflow_narrowed_problems),
+         "the mutation passed with workflow-level id-token: write")
 
     base = {"RELEASE_VERSION": "", "BAKE_ONLY": "true", "SHORT_SHA": SHORT_SHA}
 

--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -39,6 +39,7 @@ import tempfile
 from pathlib import Path
 
 WORKFLOW = ".github/workflows/main-cd.yml"
+MODULE_PACK_WORKFLOW = ".github/workflows/node-repo-module-pack.yml"
 STEP_ID = "release"
 DECIDE_STEP_ID = "decide"
 VERDICT_STEP_ID = "verdict"
@@ -648,6 +649,21 @@ def plugin_module_build_problems(workflow_text: str) -> list[str]:
     return problems
 
 
+def module_pack_permission_problems(workflow_text: str) -> list[str]:
+    """OIDC is selected by the caller, so the called jobs must inherit its permission map."""
+    import yaml
+
+    doc = yaml.safe_load(workflow_text)
+    problems = []
+    for name in ("prepare", "build-workspace", "pack"):
+        job = (doc.get("jobs") or {}).get(name) or {}
+        if "permissions" in job:
+            problems.append(
+                f"{name} declares permissions instead of inheriting the caller's login mode"
+            )
+    return problems
+
+
 def main() -> int:
     root = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
     try:
@@ -705,6 +721,21 @@ def main() -> int:
     case("the plugin-module workspace guard fails when its image pin is absent",
          any("platform-image-digest" in problem for problem in digest_problems),
          "the mutation passed without a platform image digest")
+
+    module_pack_text = (root / MODULE_PACK_WORKFLOW).read_text()
+    permission_problems = module_pack_permission_problems(module_pack_text)
+    case("the reusable module jobs inherit the caller's basic-or-OIDC permission map",
+         not permission_problems, "; ".join(permission_problems))
+    narrowed_module_pack = module_pack_text.replace(
+        "    timeout-minutes: 45\n    # Deliberately inherit the caller's token permissions.",
+        "    timeout-minutes: 45\n    permissions:\n      contents: read\n      id-token: write\n"
+        "    # Deliberately inherit the caller's token permissions.",
+        1,
+    )
+    narrowed_problems = module_pack_permission_problems(narrowed_module_pack)
+    case("the permission guard catches a called job that tries to elevate basic callers",
+         any(problem.startswith("prepare declares permissions") for problem in narrowed_problems),
+         "the mutation passed with id-token: write inside the called workflow")
 
     base = {"RELEASE_VERSION": "", "BAKE_ONLY": "true", "SHORT_SHA": SHORT_SHA}
 

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -932,9 +932,11 @@ jobs:
     if: needs.select.result == 'success' && needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    permissions:
-      contents: read
-      id-token: write
+    # Deliberately inherit the caller's token permissions. `basic` callers grant only the reads
+    # they use; the platform CD's `oidc` caller additionally grants `id-token: write`. A called
+    # workflow may maintain or reduce the caller's permissions but cannot elevate them, so naming
+    # `id-token: write` here makes EVERY basic-auth caller fail workflow validation before a job
+    # exists — even though its Azure steps are correctly conditional.
     outputs:
       # The framework identity the PLATFORM host resolves for its /app — what every ledger record
       # and bundle is keyed to (the portal adopts, so the portal's identity is the honest one).
@@ -1181,9 +1183,8 @@ jobs:
     if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
+    # Inherit for the same reason as `prepare`: OIDC is a caller-selected capability, while basic
+    # callers must remain able to grant `actions: read` without also granting an identity token.
     steps:
       - name: Resolve the content repository's credential
         id: content-repo
@@ -1470,9 +1471,8 @@ jobs:
     needs: [select, prepare, build-workspace]
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    permissions:
-      contents: read
-      id-token: write
+    # Inherit the caller's least-privilege map; declaring OIDC here rejects basic-auth callers at
+    # graph creation time, before this job's `acr-login` mode can choose its conditional steps.
     # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
     # a matrix with no vectors, so an empty selection has to express itself as "this job does not
     # run". What makes it safe is that `verify` below runs UNCONDITIONALLY and asserts the pairing

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-module-builds-inherit-the-callers-login.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-module-builds-inherit-the-callers-login.md
@@ -1,0 +1,13 @@
+---
+Name: Module builds no longer stop before they start
+Category: Fix
+Description: Shared module checks once again start for repositories using registry credentials, while platform releases retain their short-lived workload identity.
+Icon: Checkmark
+Order: -20260910
+---
+
+# Module builds no longer stop before they start
+
+A shared module build now inherits the registry-login permissions chosen by its caller. Repositories
+using their existing registry credentials can start their checks normally, while the platform release
+continues to use its short-lived workload identity without giving that capability to every caller.


### PR DESCRIPTION
## What changed

- keep the OIDC choice at the caller boundary
- let reusable module jobs inherit the caller permission map
- reject both workflow-level and job-level permission overrides in the called module workflow
- add mutation controls for both forbidden shapes
- document the restored satellite checks

## Root cause

PR #3933 added conditional OIDC login steps, but also declared `id-token: write` inside three jobs of the called workflow. GitHub does not allow a reusable workflow to elevate the caller token, so every basic-auth satellite caller fails graph validation before creating any jobs. The OIDC core caller already grants the token; inheritance is the correct least-privilege contract.

The defect reproduced again after current main: MeshWeaver.Plugins#1634 run 34538991541 concluded `startup_failure` with zero jobs. That PR changes only generated localization catalogs, so the workflow graph is the failing subject rather than repository code or tests.

## Local and CI evidence

- `python3 .github/scripts/test-cd-steps.py`
- `python3 .github/scripts/test-module-publication.py`
- mutation controls for root- and job-level permission elevation
- workflow timeout and shell guards
- actionlint YAML and expression validation
- documentation Release build: 0 warnings, 0 errors
- documentation tests: 374 passed, 0 failed
- PR-head `MeshWeaver Build and Test`: success

Delivery remains serialized behind #3985; after this lands, MeshWeaver.Plugins#1634 will produce a fresh pull-request event against the corrected reusable workflow.
