### PR TITLE
chart: render Email__AgentSend and Teams__AgentSend so an overlay can open the assistant's send gates

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -914,3 +914,11 @@ data:
   # makes the action report itself UNAVAILABLE rather than silently drop a message — so this
   # key is what turns Forward on, and an untemplated key here would ship the feature inert.
   Email__Inbound__ForwardAddress: "{{ .Values.config.memex_portal.Email__Inbound__ForwardAddress | default "" }}"
+  # ---- What the Executive Assistant may SEND on a person's behalf (MeshWeaver.Plugins, Mail
+  # module). Both default to the safe mode in the module itself — DraftOnly for mail, Off for
+  # Teams posting — and ONLY the literal word "Send" opens either gate (a typo, "true", "1"
+  # stay closed). Rendered here so an overlay can turn one on per environment; before this line
+  # existed the key reached no container and the feature shipped inert (config-key-coverage).
+  # Independent of each other: Teams posting does not widen mail sending, nor the reverse.
+  Email__AgentSend: "{{ .Values.config.memex_portal.Email__AgentSend | default "" }}"
+  Teams__AgentSend: "{{ .Values.config.memex_portal.Teams__AgentSend | default "" }}"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1027,6 +1027,11 @@ config:
     # /api/email webhook rejects mismatches. Global (same across envs is fine —
     # each deployment validates against its own configured value).
     Email__SubscriptionClientState: "meshweaver-emailhook-7f3c9a21e84b46d2b1c05e9af6d3"
+    # ---- What the Executive Assistant may SEND as the user (Mail module, MeshWeaver.Plugins).
+    # Empty = the module's safe default (mail: DraftOnly; Teams posting: Off). The ONLY value
+    # that opens a gate is the word "Send". Set per environment in the overlay.
+    Email__AgentSend: ""
+    Teams__AgentSend: ""
     # ---- GitHub App identity (non-secret half) --------------------------------
     # The App's client id, and which installation to use when the App is installed on more
     # than one account. The PEM key is the secret half (secrets.memex_portal.GitHub__App__


### PR DESCRIPTION
## What

The Executive Assistant's two send gates (`Email:AgentSend`, `Teams:AgentSend`; Mail module in MeshWeaver.Plugins, Teams half in Plugins#1628) are read from configuration, but the chart rendered neither key into the portal ConfigMap. An overlay setting one reached no container and the feature shipped inert — which the Memex repo's `config-key-coverage` gate caught on the memex-cloud overlay that turns Teams posting on.

Both keys now render with an empty default (the module's safe mode: DraftOnly / Off); only the literal word `Send` opens a gate. Defaults added to `values.yaml`.

## Verified locally

- `deploy/aks/scripts/check-values-are-read.sh` — chart values (121 keys / 3 files) and the memex-cloud overlay (103 keys): all read.
- `deploy/aks/scripts/check-chart-invariants.sh` — 7/7 combinations self-consistent.
- Memex `config-key-coverage` against this chart: 0 rendered-nowhere keys.

Chart-only; no `src/` change. Pairs-with: none — no public type or member removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
