### PR TITLE
fix(retention): prebuilt-bundle sweep is report-only, and its registration is now asserted (#3963)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -121,6 +121,26 @@ data:
          Empty renders harmlessly: the host skips blank values, and the seeding logs "no published
          bundle root configured" at debug and stays inert. */}}
   PreWarm__PrebuiltBundleRoot: "{{ .Values.config.memex_portal.PreWarm__PrebuiltBundleRoot }}"
+  {{- /* PreWarm__PrebuiltBundleRetention__Delete: ARMS DELETION in the retention sweep over the
+         store the key above mounts (PrebuiltBundleRetentionExtensions.DeleteConfigKey). The scan,
+         the plan and the ledger line happen either way; this key alone decides whether the pass
+         REMOVES anything.
+
+         🚨 THE CODE DEFAULT IS THE OPPOSITE. PrebuiltBundleRetention.Delete is `true`, so until
+         this line existed the sweep ran ARMED on every instance that mounts a bundle root — and
+         the knob to disarm it was UNREACHABLE, because this configmap enumerates keys explicitly
+         (see the PreWarm__PrebuiltBundleRoot note above): a values file, an overlay or a
+         Deployment record's extraPortalConfig setting it reached no container, silently. That is
+         the Memex#53 / #1660 WS3 shape again, this time on a knob whose omission DELETES.
+
+         🚨 What this sweep removes is bytes something is EXECUTING — the framework identity a
+         portal adopted, or the sealed publication a consumer pulls over the HTTP prebuilt
+         surface. It belongs to the AssemblyCache__Retention__Delete class below, never to the
+         armed-by-default Notifications one, and it carries the same rule: read one ledger line,
+         confirm the protected set covers every instance AND every CI gate that pins an older
+         platform build, then arm it. A first run that deletes on unexamined defaults is the one
+         mistake here that cannot be undone. See Doc/Architecture/PrebuiltBundleRetention. */}}
+  PreWarm__PrebuiltBundleRetention__Delete: "{{ .Values.config.memex_portal.PreWarm__PrebuiltBundleRetention__Delete | default "false" }}"
   # ---- Assembly-cache retention -------------------------------------------
   # The bake writes one WHOLE GENERATION of NodeType assemblies per image, because the store
   # keys every file by the MeshWeaver.Graph MVID and a CI build changes it on every publish.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -961,6 +961,13 @@ config:
     # Mount point of CI's published bake, consumed as <root>/<framework-identity>/<source>/*.zip.
     # Empty = the lane is inert and every dynamic type is compiled/lazily built as before.
     PreWarm__PrebuiltBundleRoot: ""
+    # Arms DELETION in the retention sweep over that store (the scan, the plan and the ledger
+    # line happen regardless). Off here deliberately, and note the CODE default is the opposite
+    # (PrebuiltBundleRetention.Delete = true) — THIS line is what makes the fleet report-only,
+    # which is why it must stay declared even though it looks like a no-op. Read one ledger line,
+    # confirm the protected set covers every instance and every CI gate that pins an older
+    # platform build, then arm it per instance. See Doc/Architecture/PrebuiltBundleRetention.
+    PreWarm__PrebuiltBundleRetention__Delete: "false"
     # Arms DELETION of framework generations nothing is running any more (the claim + the
     # report happen regardless). Off by default — see config.yaml for what is kept and why
     # this is a decision taken against a report rather than a default.

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -275,6 +275,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Sealed Publication Generations](SealedPublicationGenerations) — the layout that makes that mix UNREPRESENTABLE (a directory per publication plus a pointer swapped last), the reader contract, the retention rule, and the ordered migration that avoids a new-writer/old-writer half-state
 - [Install Completeness](InstallCompleteness) — what an install RECORD declares landed, compared against what is actually in the mesh; the comparison nothing made until #3485, and why only one of its five verdicts is a pass
 - [CI Content Bake](CiContentBake)
+- [Prebuilt Bundle Retention](PrebuiltBundleRetention) — the sweep that prunes what CI bakes: where it is registered (and why "zero callers" was measured twice and wrong both times), the deletion default that is `true` in code and `false` in the chart, the report that names its denominator, and the pinned satellite gate the protected set cannot see
 - [Deploying a plugin change — merging is not shipping](DeployingPluginChanges)
 - [Module Adoption Policy](ModuleAdoptionPolicy)
 - [Module Build Architecture](ModuleBuildArchitecture)

--- a/src/MeshWeaver.Documentation/Data/Architecture/PrebuiltBundleRetention.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PrebuiltBundleRetention.md
@@ -1,0 +1,165 @@
+---
+Name: Prebuilt Bundle Retention
+Category: Architecture
+Description: The sweep that prunes the CI-published prebuilt-bundle store — where it is registered and how to prove it, why its deletion default is off in the chart and on in the code, what the "unreferenced" predicate can and cannot see, and how to read the report before arming anything.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+---
+
+# Prebuilt Bundle Retention
+
+The prebuilt-bundle store is where CI's published NodeType bake lands on a portal's data volume —
+`<PreWarm:PrebuiltBundleRoot>/<framework-identity>/<source>/…`, one identity directory per platform
+build. It grows by one directory per CI build for ever, and on 2026-09-08 it filled
+memex.systemorph.com's 16 GiB `/data` to **3 MiB free**: 482 identity directories, 13 398 MiB. A full
+Azure Files share **truncates writes silently**, so every runtime recompile landed as `Bad IL format`
+and the bake read-back answered `ResourceNotFound` for 39 of 45 files, with nothing reporting a fault
+until somebody looked at the free space.
+
+`PrebuiltBundleRetentionHostedService` is the sweep written in response. This page is what a reader
+needs before touching it: where it is actually registered, why "it has zero callers" was measured
+twice and was wrong both times, which default arms deletion, and what the protected set does **not**
+cover.
+
+## Where it is registered — and the measurement that keeps getting this wrong
+
+The sweep is registered **once**, in the boot path both portal hosts call:
+
+```
+memex/Memex.Portal.Shared/MemexConfiguration.cs   →  ConfigureMemexMesh
+    builder.ConfigureServices(services => services.AddModuleGenerationsGc(moduleRoot));
+    builder.ConfigureServices(services => services.AddPrebuiltBundleRetention(configuration));
+```
+
+`MeshBuilder.ConfigureServices` runs against the **host** `IServiceCollection`
+(`MeshHostApplicationBuilder` is constructed as `base(x => x.Invoke(Host.Services), address)`), so
+`AddHostedService<PrebuiltBundleRetentionHostedService>()` lands on the generic host's roster and the
+service does start. `Memex.Portal.Distributed/Program.cs` and `Memex.Portal.Monolith/Program.cs` (in
+MeshWeaver.Plugins) both call `ConfigureMemexMesh`, and both reference
+`memex/Memex.Portal.Shared` by project.
+
+🚨 **`grep -rn AddPrebuiltBundleRetention src/ test/` returns one hit — its own declaration — and
+that is not an answer.** This repository has THREE roots that ship code: `src/`, `test/` and
+`memex/`. The registration lives in the third. Reported as "zero callers, never run" it produced an
+issue (#3963) whose entire premise was a denominator error, and the same sweep was repeated
+independently with the same restricted roots and the same conclusion. The sibling
+`AddAssemblyCacheRetention` reads as *registered* on the identical search only because its
+registration happens to be duplicated per host in MeshWeaver.Plugins — so using it as the "positive
+control" confirms the error rather than catching it.
+
+Two things follow, and both are now asserted rather than remembered:
+
+| Question | Instrument |
+|---|---|
+| Is the sweep on the hosted-service roster? | `PrebuiltBundleRetentionIsRegisteredTest` (Memex.Portal.Shared.Test) — drives the real `ConfigureMemexMesh` and asserts an `IHostedService` descriptor whose implementation type is the sweep. Its positive control is the sibling `AddModuleGenerationsGc` registration, asserted first, so a harness that reached no registration at all fails loudly instead of passing. |
+| Is deletion armed by omission? | `PrebuiltBundleRetentionArmingGuard` (MeshWeaver.Hosting.Test) — see below. |
+
+A registration test is not optional decoration here. The service ships with a test per keep rule, a
+ledger, a report-only mode and a documented discipline, and **all of it is inert on a host that never
+constructs it** — with no observable difference, because "found nothing to collect" and "never ran"
+both produce no deletion, no ledger line and no log. That is the shape of a CI gate that skips.
+
+## Deletion: the code says yes, the chart says no
+
+`PrebuiltBundleRetention.Delete` defaults to **`true`**. The chart now binds the disarming key with
+an explicit `default "false"`:
+
+```yaml
+# deploy/helm/templates/memex-portal/config.yaml
+PreWarm__PrebuiltBundleRetention__Delete: "{{ .Values.config.memex_portal.PreWarm__PrebuiltBundleRetention__Delete | default "false" }}"
+```
+
+Until that line existed the knob was **unreachable**. The portal ConfigMap template enumerates every
+key it renders explicitly — there is no catch-all `range` over `.Values.config` — so a values file,
+a deployment overlay, or a `Hosting/Deployment` record's `extraPortalConfig` setting
+`PreWarm__PrebuiltBundleRetention__Delete` reached no container, silently. It is the same silent-drop
+shape that left the CI-bake lane inert for months (#1660 WS3) and dropped twelve OpenRouter model
+keys (#2203) — except that here the omission does not disable a feature, it **deletes**.
+
+Measured on the live control instance 2026-09-10: both `memex` and `memex-cloud` carry
+`PreWarm__PrebuiltBundleRoot=/data/prebuilt-bundles` and **no** `…Delete` key anywhere — record,
+overlay, ConfigMap or inline env. `deploy/aks/values.aks.yaml` and
+`deploy/homebrew/share/values.local.defaults.yaml` mount the same root, so every AKS instance and
+every memex-local install was in the same state. The chart line disarms all of them at once.
+
+**The rule is the sibling's**, stated in `AssemblyCache__Retention__Delete`'s own comment: read one
+report, confirm the kept set matches your roll cadence, *then* arm it — a first run that deletes on
+unexamined defaults is the one mistake here that cannot be undone. This sweep belongs to that class,
+never to the armed-by-default `Notifications__Retention__Enabled` class: what it removes is bytes
+something is **executing**, not a stale pointer to a node that still exists.
+
+## What the report says, and why it names a count
+
+Every pass writes one line to `<root>/_retention/ledger.txt` and records the result on
+`PrebuiltBundleRetentionStatus`. The line leads with the **denominator**:
+
+```
+2026-09-10T02:15:00.0000000+00:00 report only — 482 identity directory(ies) / 13398.4 MB —
+live=s417d365 (3.0.0-ci.8238), collectable=3 / 61.2 MB, markers to retire=3
+```
+
+That shape is the point. `collectable=0` on a store of 482 and `collectable=0` on a store the pod
+cannot see are the same number and opposite facts, and a ledger that counted only *actions* would
+make a sweep aimed at an unmounted share indistinguishable from a clean one. A pass that could not
+scan at all writes `ABORTED before planning: …` instead, and a pass whose reference set was
+incomplete writes `ABORTED: …` with the plan's summary — both are failures, never passes.
+`TheReportNamesItsDenominator_SoAnUnexaminedStoreCannotReadAsACleanOne` pins the distinction.
+
+**Reading it today is break-glass.** `PrebuiltBundleRetentionStatus` is written and has no reader:
+the ledger is a file on the data volume and the log line is in Loki. Surfacing the last pass on the
+Fleet Console — or in the pod's health payload beside `nodetype_bake` — is the step that makes
+"read one report" something an operator can actually do, and it is not built yet.
+
+## What "unreferenced" protects — and the gap
+
+`PrebuiltBundleStore.Plan` keeps an identity when **any** of these holds:
+
+1. it is the framework identity this process runs;
+2. its seal could not be read (unreadable is never unreferenced);
+3. a **clean** — non-pre-release — `_releases` marker names it;
+4. a `PinnedPlatformReference` names it, or names a version whose marker names it;
+5. a NodeType record's `CompiledFrameworkVersion` adoption stamp names it;
+6. it is the newest sealed publication of a source on some represented platform major;
+7. it is inside the 30-day minimum-age window (floor-clamped; a recent marker counts too);
+8. a source is unsealed and the newest write is inside the unsealed grace (a seal may be in flight).
+
+Anything unreadable, and any pin that resolves to no marker, **aborts the whole pass** with nothing
+collected. The direction is right: incomplete licenses no deletion.
+
+🚨 **But rule 4's inventory is exactly two things** — `DeploymentPinnedReferences` reads
+`Hosting/Deployment` records' `pinnedImageTag`, and `Hosting/ModuleInventory` reports filed by
+*registered instances*. **A satellite CI gate pinned to an older platform build is neither.** A
+`MW_PLATFORM_REF` in MeshWeaver.Plugins, Reinsurance, SocialMedia, Manufacturing, Crm or Education is
+a value in a GitHub Actions workflow: it files no instance report, holds no Deployment record, and
+writes no adoption stamp into this mesh. Such an identity is therefore protected by rule 3 or rule 7
+and by nothing else — and satellite pins are `X.Y.Z-ci.<n>` **pre-releases**, so rule 3 does not
+apply. **Past 30 days, a satellite's pinned platform build is collectable.**
+
+That is precisely the #3876 failure mode (a pruned identity directory breaking a satellite gate) and
+the registry-side twin Memex#219 (*"ACR retention can delete a tag a committed overlay or a live
+workload references — twice now"*). Closing it means giving the satellites a first-class reference —
+a pin source that reads the fleet's `MW_PLATFORM_REF` values, or a report a satellite lane files the
+way an instance does. Until then, **arming deletion on the registry (memex-cloud) is the dangerous
+half**, because that is the store a satellite's gate pulls from over the HTTP prebuilt surface; the
+gap must be closed, or the arming scoped to instances no CI lane pulls from.
+
+## Rolling it out
+
+1. **Report-only, everywhere** — the chart default above. The sweep runs, plans and writes its
+   ledger line; nothing is removed. This is the state the platform ships in.
+2. **Read a real report** on memex and on memex-cloud, and confirm the protected set is what it
+   should be. Do not skip this by reasoning about the rules: the rules are unit-tested against a
+   temp tree, while what has never been checked on a live portal is whether the *reference inventory*
+   reads completely — `StampedIdentities()` throws with no mesh hub or `IMeshService`, and a
+   `PinnedPlatformReferenceSource` that errors aborts the pass. Either would abort every pass,
+   silently, exactly as an unregistered sweep would.
+3. **Close the satellite gap**, or scope the arming away from the registry.
+4. **Arm deletion per instance**, by setting `PreWarm__PrebuiltBundleRetention__Delete: "true"` in
+   that instance's record — which now reaches the container, because the chart renders the key.
+
+## Related
+
+- [Sealed Publication Generations](../SealedPublicationGenerations) — the generation layout inside a
+  retained identity, and the generation-level collection this sweep also performs
+- [CI Content Bake](../CiContentBake) — what publishes into this store
+- [Node Type Compilation](../NodeTypeCompilation) — the assembly-cache retention sibling on the same
+  volume

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-bundle-store-cleanup-now-reports-before-it-removes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-the-bundle-store-cleanup-now-reports-before-it-removes.md
@@ -1,0 +1,51 @@
+---
+Name: The bundle-store cleanup now reports before it removes anything
+Category: Fix
+Description: The cleanup for the store CI publishes into shipped with removal switched ON, and the switch that would turn it off reached no installation. It is now off everywhere, it writes what it would have removed — including how much it looked at — and turning it on is a decision you make per installation, after reading that.
+Icon: Checkmark
+Order: -20260910
+---
+
+# The bundle-store cleanup now reports before it removes anything
+
+Your installation keeps a store of the ready-built content that arrives with each platform build,
+one directory per build. It grows by one directory every time a build is published, and nothing used
+to remove any of them. On one installation that store quietly filled a 16 GB volume to **3 MB free**
+— and a full volume of that kind does not report an error, it silently truncates whatever is written
+next. What that looked like from the outside was content failing to load for no stated reason.
+
+The cleanup written for that has been running since. What was wrong is which way it was pointed.
+
+## What changes
+
+**Removal is off, everywhere.** The cleanup shipped with removal switched **on** by default, and the
+setting that would switch it off never reached an installation at all — it was accepted in a
+configuration file and then dropped on the way, with nothing reporting the drop. So every
+installation with this store mounted has been removing on defaults nobody had checked against that
+installation. It is now off by default, and the setting genuinely arrives.
+
+**It still runs, and it still writes down what it would have removed.** This is not the cleanup being
+disabled — the pass happens on every boot and daily after that, and it records its findings the same
+way. It simply does not remove anything until you say so.
+
+**The record says how much it looked at, not just how much it would remove.** "Nothing to remove out
+of 482 directories" and "nothing to remove because the store was not there" are the same number and
+opposite facts. The report now leads with the count it examined, so a cleanup pointed at the wrong
+place can no longer read as a cleanup that found nothing to do.
+
+**Turning removal on is now a per-installation decision** you make after reading a real report from
+that installation — the same rule the equivalent cleanup for compiled content already follows.
+
+## What this does not change
+
+**Nothing is removed by this change.** It removes strictly less than before: previously armed,
+now reporting only.
+
+**The store still needs pruning.** Turning removal on is the intended end state, and it is a
+deliberate step rather than a default — one taken against a report from your own installation, not
+against settings chosen elsewhere.
+
+**One protection is known to be missing**, and is called out rather than papered over: a build that
+is only referenced by an automated build check elsewhere is not yet visible to the cleanup as
+"in use". That has to be closed before removal is switched on for the installation those checks pull
+from.

--- a/test/Memex.Portal.Shared.Test/PrebuiltBundleRetentionIsRegisteredTest.cs
+++ b/test/Memex.Portal.Shared.Test/PrebuiltBundleRetentionIsRegisteredTest.cs
@@ -1,0 +1,109 @@
+using Memex.Portal.Shared;
+using MeshWeaver.Hosting;
+using MeshWeaver.Mesh;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #3963, pinned: the prebuilt-bundle retention sweep must be REGISTERED by the portal boot path.
+///
+/// <para>🚨 <b>A hosted service that exists, compiles and is tested proves nothing about whether it
+/// RUNS.</b> <c>PrebuiltBundleRetentionHostedService</c> ships with unit tests for every keep rule,
+/// a ledger, a report-only mode and a documented discipline — and all of that is inert on a
+/// deployment whose host never constructs it. Nothing anywhere reports the absence, because "the
+/// sweep found nothing to collect" and "the sweep never ran" produce the same observable: no
+/// deletion, no ledger line, no log. That is the same shape as a CI gate that skips.</para>
+///
+/// <para><b>Why the assertion is on the DESCRIPTOR, and on <c>IHostedService</c> specifically.</b>
+/// Registering the class as a plain singleton compiles, resolves, and never runs — the generic host
+/// only starts what is registered AS <c>IHostedService</c>. So the check is not "the type exists"
+/// and not "the type resolves": it is "the boot path put this implementation on the hosted-service
+/// roster". Removing the <c>AddPrebuiltBundleRetention</c> line from <c>ConfigureMemexMesh</c>, or
+/// downgrading it to a bare <c>AddSingleton</c>, fails this test.</para>
+///
+/// <para><b>The positive control.</b> The sibling collector of the same data volume
+/// (<c>AddModuleGenerationsGc</c>, registered two lines above it) is asserted in the SAME
+/// inspection. A harness that stopped reaching these registrations at all — a throwing boot path, a
+/// renamed extension, a configuration shape that returns early — would otherwise let the subject's
+/// absence read as a pass. Here it cannot: the control fails first and names itself.</para>
+///
+/// <para>🚨 This covers the REGISTRATION only. Whether the sweep then COLLECTS anything depends on
+/// <c>PreWarm:PrebuiltBundleRoot</c> being configured, and whether it DELETES depends on
+/// <c>PreWarm:PrebuiltBundleRetention:Delete</c> — whose code default is <c>true</c> and whose
+/// chart default is <c>false</c>. <c>PrebuiltBundleRetentionArmingGuard</c> in
+/// MeshWeaver.Hosting.Test holds that half. See Doc/Architecture/PrebuiltBundleRetention.</para>
+/// </summary>
+public class PrebuiltBundleRetentionIsRegisteredTest
+{
+    [Fact]
+    public void TheBootPath_PutsTheRetentionSweep_OnTheHostedServiceRoster()
+    {
+        var root = Directory.CreateTempSubdirectory("mw-3963-").FullName;
+        try
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Graph:Storage:Type"] = "FileSystem",
+                    ["Graph:Storage:BasePath"] = root,
+                    ["Modules:Root"] = root,
+                })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<IHostApplicationLifetime>(
+                new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance));
+
+            // The REAL boot path — the one both portal hosts call
+            // (Memex.Portal.Distributed/Program.cs, Memex.Portal.Monolith/Program.cs).
+            new MeshBuilder(configure => configure(services), new Address("mesh", "test"))
+                .ConfigureMemexMesh(configuration);
+
+            // ── The positive control, asserted FIRST so a harness that reached no registration at
+            //    all cannot let the subject's absence read as a pass. ────────────────────────────
+            Assert.True(
+                services.Any(d => d.ServiceType == typeof(ModuleGenerationsGcHostedService)),
+                "POSITIVE CONTROL FAILED: ConfigureMemexMesh did not register the sibling "
+                + "collector (AddModuleGenerationsGc) either, so this test observed NO boot-path "
+                + "registrations and can say nothing about the prebuilt-bundle sweep. Fix the "
+                + "harness — do not read this as the sweep being absent.");
+
+            // ── The subject. ──────────────────────────────────────────────────────────────────
+            Assert.True(
+                services.Any(d => d.ServiceType == typeof(IHostedService)
+                                  && d.ImplementationType == typeof(PrebuiltBundleRetentionHostedService)),
+                "ConfigureMemexMesh must register the prebuilt-bundle retention sweep as an "
+                + "IHostedService (services.AddPrebuiltBundleRetention(configuration), beside "
+                + "AddModuleGenerationsGc). It is registered NOWHERE else: the sibling collector of "
+                + "the same data volume is right there, so a deployment can mount "
+                + "PreWarm:PrebuiltBundleRoot and have nothing at all sweep it. A store nothing "
+                + "prunes filled memex.systemorph.com's 16 GiB /data to 3 MiB free on 2026-09-08, "
+                + "and a full Azure Files share TRUNCATES WRITES SILENTLY (#3963).");
+
+            // ── The rest of AddPrebuiltBundleRetention's contract: the policy the sweep reads and
+            //    the status row an operator reads back. Either missing and the service cannot be
+            //    constructed, which the host would surface only at StartAsync. ──────────────────
+            Assert.True(
+                services.Any(d => d.ServiceType == typeof(PrebuiltBundleRetention)),
+                "AddPrebuiltBundleRetention must register the PrebuiltBundleRetention policy read "
+                + "from configuration — without it the hosted service cannot be constructed.");
+            Assert.True(
+                services.Any(d => d.ServiceType == typeof(PrebuiltBundleRetentionStatus)),
+                "AddPrebuiltBundleRetention must register PrebuiltBundleRetentionStatus — it is "
+                + "where the last pass's result and fault are recorded for an operator to read.");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); }
+            catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionArmingGuard.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionArmingGuard.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using MeshWeaver.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// #3963: deletion in the prebuilt-bundle store is NEVER armed by omission.
+///
+/// <para><b>The defect this pins.</b> <see cref="PrebuiltBundleRetention.Delete"/> defaults to
+/// <c>true</c>, so an instance that mounts <c>PreWarm:PrebuiltBundleRoot</c> and says nothing else
+/// sweeps ARMED. Worse, the knob that would disarm it was unreachable: the portal ConfigMap
+/// template enumerates every key it renders EXPLICITLY — there is no catch-all range over
+/// <c>.Values.config</c> — so a values file, a deployment overlay or a Deployment record's
+/// <c>extraPortalConfig</c> setting <c>PreWarm__PrebuiltBundleRetention__Delete</c> reached no
+/// container, with nothing erroring anywhere. The same silent-drop shape cost the CI-bake lane
+/// months of inertness (#1660 WS3) and twelve OpenRouter model keys (#2203); here the omission does
+/// not merely disable a feature, it DELETES.</para>
+///
+/// <para><b>The invariant, stated so it survives either fix.</b> Deletion must be off unless
+/// somebody wrote it down. That holds if the CODE default is already <c>false</c>, or if the chart
+/// binds the key with an explicit <c>default "false"</c>. It does NOT hold when the code default is
+/// <c>true</c> and the chart is silent — which is exactly the state this guard was written for. So
+/// the guard reads the live default off the type rather than assuming it, and only then demands the
+/// chart line.</para>
+///
+/// <para>🚨 The guard follows <see cref="PrebuiltBundleRetentionExtensions.DeleteConfigKey"/>, not a
+/// copied string: renaming the config key moves the guard's subject with it instead of leaving a
+/// check that passes having verified nothing.</para>
+///
+/// <para>See Doc/Architecture/PrebuiltBundleRetention.</para>
+/// </summary>
+public class PrebuiltBundleRetentionArmingGuard
+{
+    /// <summary>The config key as it lands in the rendered ConfigMap (<c>:</c> ⇒ <c>__</c>).</summary>
+    private static string EnvKey =>
+        PrebuiltBundleRetentionExtensions.DeleteConfigKey.Replace(":", "__", StringComparison.Ordinal);
+
+    [Fact]
+    public void DeletionIsNeverArmedByOmission()
+    {
+        var root = FindRepoRoot();
+        var configMap = File.ReadAllText(
+            Path.Combine(root, "deploy", "helm", "templates", "memex-portal", "config.yaml"));
+
+        // Read the shipped default rather than assuming it — if the code default is ever flipped to
+        // false, the invariant is satisfied at the source and this guard says so instead of
+        // demanding a chart line that would then be redundant.
+        if (!PrebuiltBundleRetention.Default.Delete)
+            return;
+
+        // 🚨 BOUND, not merely mentioned. The template's explanatory `{{- /* ... */}}` comment
+        // blocks open with the very key they describe, and no '#'-stripping removes them — so a
+        // check satisfied by prose is not a check. Requiring the value binding is a shape a comment
+        // cannot accidentally have.
+        var binding = new Regex(
+            @"^\s*" + Regex.Escape(EnvKey) + @"\s*:\s*""\{\{(?<expr>.*?)\}\}""\s*$",
+            RegexOptions.Multiline);
+        var match = binding.Match(configMap);
+
+        Assert.True(match.Success,
+            $"PrebuiltBundleRetention.Delete defaults to TRUE in code, so {EnvKey} MUST be bound in "
+            + "deploy/helm/templates/memex-portal/config.yaml — otherwise every instance that mounts "
+            + "PreWarm__PrebuiltBundleRoot sweeps with deletion ARMED and the knob that would disarm "
+            + "it reaches no container (the configmap enumerates keys explicitly; a values file or a "
+            + "Deployment record's extraPortalConfig setting it is silently dropped). Add:\n"
+            + $"  {EnvKey}: \"{{{{ .Values.config.memex_portal.{EnvKey} | default \"false\" }}}}\"");
+
+        Assert.Contains("default \"false\"", match.Groups["expr"].Value, StringComparison.Ordinal);
+
+        // The chart's own default is the fleet's report-only setting; values.yaml states it so the
+        // deployed surface stays reviewable, and so EveryPreWarmKeyInValues_IsTemplatedInTheConfigMap
+        // keeps the two halves tied together.
+        var values = File.ReadAllLines(Path.Combine(root, "deploy", "helm", "values.yaml"))
+            .Select(l => l.Trim())
+            .Where(l => !l.StartsWith('#'))
+            .FirstOrDefault(l => l.StartsWith(EnvKey + ":", StringComparison.Ordinal));
+
+        Assert.True(values is not null,
+            $"deploy/helm/values.yaml must declare {EnvKey} under config.memex_portal — the chart "
+            + "default is what makes the fleet report-only, and an undeclared key makes that "
+            + "invisible to anyone reading the values file.");
+        Assert.Contains("\"false\"", values!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The report NAMES ITS DENOMINATOR, so a sweep that examined nothing cannot read as a sweep
+    /// that found nothing. This is the same distinction the rest of the fleet gets wrong: "0
+    /// collectable over 482 identities" and "0 collectable because the root was empty" are the same
+    /// number and opposite facts. Asserted here on the shipped format string, so a later reword that
+    /// dropped the count would be caught even though every rule test would still pass.
+    /// </summary>
+    [Fact]
+    public void TheSummaryFormat_LeadsWithTheCountExamined_NotWithTheCountCollected()
+    {
+        var empty = new PrebuiltBundleSweepPlan(
+            "s-live", "3.1.0-ci.9000", [], [], System.Collections.Immutable.ImmutableDictionary<string, string>.Empty,
+            [], null, []);
+
+        Assert.StartsWith("0 identity directory(ies)", empty.Summary, StringComparison.Ordinal);
+        Assert.Contains("collectable=0", empty.Summary, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "Could not locate the repository root (MeshWeaver.slnx).");
+        return dir!.FullName;
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PrebuiltBundleRetentionTest.cs
@@ -894,4 +894,52 @@ public class PrebuiltBundleRetentionTest : IDisposable
         read.Interval.Should().Be(TimeSpan.FromHours(6));
         read.UnsealedGrace.Should().Be(PrebuiltBundleRetention.Default.UnsealedGrace);
     }
+
+    /// <summary>
+    /// #3963 — the report states the DENOMINATOR, so "the sweep examined 482 identities and none
+    /// was collectable" can never be mistaken for "the sweep examined nothing".
+    ///
+    /// <para>Both read <c>collectable=0</c> and neither writes a removal line, so a ledger that
+    /// counted only ACTIONS would make a sweep pointed at the wrong directory — an unmounted share,
+    /// a typo'd root, a store the pod cannot see — indistinguishable from a clean one. That is this
+    /// fleet's recurring failure: a zero whose denominator nobody printed.</para>
+    ///
+    /// <para>The two halves are asserted against EACH OTHER, not merely against a substring: the
+    /// point is that the two situations produce DIFFERENT text.</para>
+    /// </summary>
+    [Fact]
+    public void TheReportNamesItsDenominator_SoAnUnexaminedStoreCannotReadAsACleanOne()
+    {
+        Sealed(Live, "plugins", DaysAgo(1));
+        Sealed("s-recent-a", "plugins", DaysAgo(2));
+        Sealed("s-recent-b", "plugins", DaysAgo(3));
+
+        var examined = PlanNow();
+
+        // Nothing is collectable here — every identity is inside the 30-day window — so the ONLY
+        // thing separating this from a sweep that saw an empty store is the count it prints.
+        examined.Collectable.Should().BeEmpty();
+        examined.Summary.Should().StartWith("3 identity directory(ies)");
+        examined.Summary.Should().Contain("collectable=0");
+
+        var emptyRoot = Path.Combine(Path.GetTempPath(), $"mw-prebuilt-empty-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(emptyRoot);
+        try
+        {
+            var unexamined = PrebuiltBundleStore.Plan(
+                Live, "3.1.0-ci.9000", PrebuiltBundleStore.Scan(emptyRoot), [], [], retention, Now);
+
+            unexamined.Collectable.Should().BeEmpty();
+            unexamined.Summary.Should().StartWith("0 identity directory(ies)");
+            unexamined.Summary.Should().Contain("collectable=0");
+
+            examined.Summary.Should().NotBe(unexamined.Summary,
+                "a sweep that examined 3 identities and one that examined none must not produce "
+                + "the same report — otherwise a sweep pointed at the wrong root reads as clean");
+        }
+        finally
+        {
+            try { Directory.Delete(emptyRoot, recursive: true); } catch { /* best effort */ }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3963 — but not as filed. **The premise is falsified, and the real defect points the other way.**

## The zero-callers finding does NOT hold

`AddPrebuiltBundleRetention` has a caller, on `main`, since the commit that created the service:

```
memex/Memex.Portal.Shared/MemexConfiguration.cs:259   (e2fb5f03b, 2026-09-08)
    builder.ConfigureServices(services => services.AddPrebuiltBundleRetention(configuration));
```

It sits inside `ConfigureMemexMesh` — unconditionally, two lines below its sibling `AddModuleGenerationsGc` — and **both** portal hosts call it (`Memex.Portal.Distributed/Program.cs:392`, `Memex.Portal.Monolith/Program.cs:79`), both referencing `memex/Memex.Portal.Shared` by project. `MeshHostApplicationBuilder` is constructed as `base(x => x.Invoke(Host.Services), address)`, so `MeshBuilder.ConfigureServices` runs against the **host** `IServiceCollection` and `AddHostedService<…>` really does reach the generic host's roster.

The issue's measurement was `grep -rn AddPrebuiltBundleRetention src/ test/`. This repo has **three** roots that ship code — `src/`, `test/` and `memex/` — and the registration is in the third. Using `AddAssemblyCacheRetention` as the positive control confirmed the error rather than catching it: that one reads as *registered* on the same restricted search only because it happens to be duplicated per host in MeshWeaver.Plugins.

## The real defect: deletion was armed, and could not be turned off

`PrebuiltBundleRetention.Delete` defaults to **`true`**, and `PreWarm__PrebuiltBundleRetention__Delete` was templated **nowhere**. The portal ConfigMap enumerates every key explicitly — no catch-all `range` over `.Values.config` — so a values file, a deployment overlay or a `Hosting/Deployment` record's `extraPortalConfig` setting it reached no container, silently. Same silent-drop shape as #1660 WS3 and #2203, except this omission *deletes*.

Measured read-only on the live control instance, 2026-09-10:

| instance | `PreWarm__PrebuiltBundleRoot` | `…Retention__Delete` |
|---|---|---|
| `memex` (record v75) | `/data/prebuilt-bundles` (extraPortalConfig **and** inlineEnv) | absent everywhere ⇒ **true** |
| `memex-cloud` | `/data/prebuilt-bundles` | absent everywhere ⇒ **true** |

`deploy/aks/values.aks.yaml:276` and `deploy/homebrew/share/values.local.defaults.yaml:60` mount the same root, so every AKS instance and every memex-local install was in the same state.

## What this changes

**This change deletes nothing.** It removes strictly less than before: previously armed, now report-only.

* `deploy/helm/templates/memex-portal/config.yaml` — bind `PreWarm__PrebuiltBundleRetention__Delete` with an explicit `| default "false"`, mirroring `AssemblyCache__Retention__Delete`. This both disarms the fleet and makes the knob reachable for the first time.
* `deploy/helm/values.yaml` — declare it, so the reviewable surface says so and the existing `EveryPreWarmKeyInValues_IsTemplatedInTheConfigMap` guard keeps the halves tied.

The sweep still runs on every boot and daily after, still plans, still writes its ledger line. Arming becomes a per-instance decision taken against a real report — the rule the sibling's own comment already states.

## The controls, in both directions

**1. The registration is asserted — `PrebuiltBundleRetentionIsRegisteredTest` (Memex.Portal.Shared.Test).** Drives the real `ConfigureMemexMesh` and asserts an `IHostedService` **descriptor** whose implementation type is the sweep — not that the type exists, not that it resolves: registering it as a plain `AddSingleton` compiles, resolves and never runs. The sibling `AddModuleGenerationsGc` registration is asserted **first** as the positive control, so a harness that reached no registration at all fails naming itself instead of letting the subject's absence read as a pass.

Verified by removing line 259 and rebuilding:

```
FAILED: ConfigureMemexMesh must register the prebuilt-bundle retention sweep as an
IHostedService (services.AddPrebuiltBundleRetention(configuration), beside
AddModuleGenerationsGc). It is registered NOWHERE else: ...
Failed!  - Failed: 1, Passed: 0
```
…with the positive control still passing. Restored, `Passed! - Failed: 0, Passed: 1`.

**2. Deletion is never armed by omission — `PrebuiltBundleRetentionArmingGuard` (MeshWeaver.Hosting.Test).** Reads the shipped default off `PrebuiltBundleRetention.Default.Delete` rather than assuming it, and only then requires the chart binding, following `PrebuiltBundleRetentionExtensions.DeleteConfigKey` rather than a copied string. Proven non-vacuous against two mutations: binding line removed ⇒ no match; `default "false"` flipped to `"true"` ⇒ match but assertion fails.

**3. The report names its denominator.** `TheReportNamesItsDenominator_SoAnUnexaminedStoreCannotReadAsACleanOne` asserts a populated store reads `3 identity directory(ies) … collectable=0` while an empty one reads `0 identity directory(ies) … collectable=0`, and that the two strings **differ** — so a sweep aimed at an unmounted share can never read as a clean one.

## The gap this does NOT close, named

`DeploymentPinnedReferences` builds the protected pin set from exactly two things: `Hosting/Deployment` records' `pinnedImageTag`, and `Hosting/ModuleInventory` reports filed by *registered instances*. **A satellite CI gate pinned to an older platform build is neither** — an `MW_PLATFORM_REF` in Plugins/Reinsurance/SocialMedia/Manufacturing/Crm/Education files no report, holds no record and writes no adoption stamp into this mesh. Such an identity is protected only by rule 3 (a **clean**, non-pre-release `_releases` marker) or rule 7 (the 30-day window) — and satellite pins are `X.Y.Z-ci.<n>` pre-releases, so rule 3 never applies. **Past 30 days, a satellite's pinned platform build is collectable.** That is the #3876 / Memex#219 shape exactly, and it is why arming on the registry (memex-cloud) is the dangerous half. Written up in the doc page with what closing it needs.

Also noted rather than fixed: `PrebuiltBundleRetentionStatus` is written and has **no reader**, so "read one report" is break-glass today (a file on the data volume, or Loki).

## Work product

`Doc/Architecture/PrebuiltBundleRetention` — registration and how to prove it, the two-way default, the report format, the eight keep rules and the gap, and the four-step rollout. Listed in `Data/Architecture.md`; `ArchitectureTopicMapTest` + `DocumentationLinkIntegrityTest` green.

## Verification

`dotnet build -c Release -warnaserror`, `0 Error(s)` / `0 Warning(s)`: `MeshWeaver.Hosting.Test`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`.
Tests: Hosting.Test `~PrebuiltBundleRetention` 53/53; Shared.Test registration control 1/1; Documentation.Test topic-map + link-integrity + `PlatformBakeLaneGuard` + `TestTimeoutLiteralRatchetGuard` + What's New 21/21.

No public type or member removed; no public interface member added; no i18n catalog key touched. No `TimeSpan` timeout literal added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
