### PR TITLE
fix(#3962): the divergent-build guard cites the harm that survives — the refusal is unchanged

### DIFF
--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -1099,7 +1099,7 @@ jobs:
           echo "module set: $COPIES MeshWeaver.* assembly file(s) across $MODULE_COUNT bundle(s), $NAMES distinct name(s), $SHARED carried by more than one bundle, $DIVERGED carried at more than one BUILD"
           if [ "$DIVERGED" -ne 0 ]; then
             while IFS= read -r dupe; do
-              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
+              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first and the loser's bytes are never in memory, so callers compiled against the loser silently run the winner (MeshWeaver#3732). Since MeshWeaver#3934 a dependency record expresses a FLOOR rather than an exact build, so the adoption decline that used to accompany this no longer fires for same-version copies — the loader coin toss is the harm that remains, and it is why a torn publication is refused HERE, at the one place every copy is in one hand."
               awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
             echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1144,7 +1144,7 @@ jobs:
           echo "module set: $COPIES MeshWeaver.* assembly file(s) across $MODULE_COUNT bundle(s), $NAMES distinct name(s), $SHARED carried by more than one bundle, $DIVERGED carried at more than one BUILD"
           if [ "$DIVERGED" -ne 0 ]; then
             while IFS= read -r dupe; do
-              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first, and the other's NodeTypes are declined at adoption (MeshWeaver#3732)."
+              echo "::error::$dupe reaches this mesh as more than one build — the loader keeps whichever it sees first and the loser's bytes are never in memory, so callers compiled against the loser silently run the winner (MeshWeaver#3732). Since MeshWeaver#3934 a dependency record expresses a FLOOR rather than an exact build, so the adoption decline that used to accompany this no longer fires for same-version copies — the loader coin toss is the harm that remains, and it is why a torn publication is refused HERE, at the one place every copy is in one hand."
               awk -v n="$dupe" '$1 == n {printf "          sealed %s %s %s\n", substr($2, 1, 16), ($4 == "declared" ? "as the declared module of" : "as a sibling riding"), $3}' "$DIGESTS" | sort -u
             done < <(awk '{if (!seen[$1 SUBSEP $2]++) d[$1]++} END {for (k in d) if (d[k] > 1) print k}' "$DIGESTS" | sort)
             echo "::error::the composed module set carries $DIVERGED assembly name(s) at more than one build. The bake would stamp every NodeType against whichever copy it loaded first, and every consumer that loaded another would decline them. Build the whole set in ONE compilation, or stop the divergent copy riding — Doc/Architecture/ModuleOwnedSiblingsRide."

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -114,11 +114,24 @@ trap"), so two copies under one simple name are **one assembly identity**: `Asse
 the already-loaded one and ignores the second path. Whichever copy loads first wins the process, and
 the loser's bytes are never in memory.
 
-What that costs when the copies differ is exactly the `#3175` incident:
-`NodeTypeCompilationHelpers.ModuleMvidsOf` reports the MVID of the assembly that actually loaded, so
-every NodeType whose dependency record named the other build is declined at adoption —
-*"dependency record mismatch — 'MeshWeaver.Markdown.Collaboration' built against mvid:A, live is
-mvid:B"* — and the view renders empty.
+What that costs when the copies differ is a **behaviour** hazard first: every caller compiled against
+the loser silently runs the winner, and nothing anywhere reports it. Where the two builds differ in
+more than their MVID — a partially updated lane, a half-landed source change, two commits reaching
+two `build-workspace` calls — that is a process running code its callers were not built against.
+
+🚨 **The adoption decline that used to be quoted here is no longer the harm, and must not be cited as
+it.** Until #3934 a dependency record named an exact build, so `NodeTypeCompilationHelpers.ModuleMvidsOf`
+reporting the MVID of the assembly that actually loaded declined every NodeType whose record named the
+other one — *"dependency record mismatch — 'MeshWeaver.Markdown.Collaboration' built against mvid:A,
+live is mvid:B"*, and the view rendered empty (the `#3175` incident). #3946 replaced the pin with a
+FLOOR, so for same-version copies — the only case the composed-set guard has ever actually fired on —
+that decline no longer happens. A floor still declines a live copy genuinely **below** it.
+
+The record was therefore only ever a **proxy**: it never detected the loader coin toss, it merely
+fired on the same input. Removing the proxy makes the composed-set refusal **more** load-bearing, not
+less — see [Module Adoption Policy](../ModuleAdoptionPolicy) → "What the platform roll gates on",
+which states the rule independently of any mechanism: two builds of one platform assembly in one
+identity is a torn publication, and torn publications are refused whole.
 
 ### 🚨 The copies do NOT agree, and the reason is structural (#3732)
 


### PR DESCRIPTION
Closes #3962.

## What changed

The composed-set guard's error message, at both call sites, plus the doc passage it quoted. **The refusal itself is unchanged.**

Old:

> `$dupe` reaches this mesh as more than one build — the loader keeps whichever it sees first, **and the other's NodeTypes are declined at adoption** (MeshWeaver#3732).

New:

> `$dupe` reaches this mesh as more than one build — the loader keeps whichever it sees first **and the loser's bytes are never in memory, so callers compiled against the loser silently run the winner** (MeshWeaver#3732). Since MeshWeaver#3934 a dependency record expresses a FLOOR rather than an exact build, so the adoption decline that used to accompany this no longer fires for same-version copies — the loader coin toss is the harm that remains, and it is why a torn publication is refused HERE, at the one place every copy is in one hand.

## Why the sentence had to change

The message gave two reasons. #3946 falsified the second, conditionally:

- *"the loader keeps whichever it sees first"* — **untouched**. #3946 changes neither which copy `Assembly.LoadFrom` returns nor which one the bake host stamps records against.
- *"the other's NodeTypes are declined at adoption"* — this is exactly the decline #3946 removes, and it removes it **precisely for same-version copies, which is the only case this guard has ever actually fired on**. A floor still declines a live copy genuinely *below* it.

A control whose cited consequence has been fixed elsewhere reads as stale to the next person who checks it — and the tempting next move is to relax it.

## 🚨 Why the refusal stays

1. **The record was only ever a PROXY.** It never *detected* the loader coin toss; it fired on the same input. Where two builds differ in more than their MVID — a partially updated lane, a half-landed source change, two commits reaching two `build-workspace` calls — the process silently runs one copy and every caller compiled against the other gets behaviour it was not built against, with nothing reporting it. Removing the proxy makes the composed-set assertion **more** load-bearing, not less.
2. **This is the only reading taken where every copy is in one hand.** A consumer holds one copy and cannot see a second by construction. The downstream checks (`ArtifactsForIdentity`, `ReleaseAvailability`) can see both and #3946 kept them firing under floors — but both are *after* the seal, and a torn publication that reaches the shelf has already cost something.
3. **It is stated policy independent of the mechanism** — `Doc/Architecture/ModuleAdoptionPolicy` → "What the platform roll gates on": two builds of one platform assembly in one identity is a torn publication, and torn publications are refused whole.

Practical argument too: the producer remedy is in flight (#3933 merged; Plugins#1614 outstanding). Relaxing the guard now would remove the pressure to finish it and would hide the *next* divergence, which may not be the benign same-version kind.

## Deliberately NOT done

Narrowing the refusal to "only when the copies differ in a way the floor cannot absorb." That trades a definite refusal on the fleet's upstream for a prediction about the consumer — and the copies-differ case is exactly where the loader hazard is real.

## Verified

| | |
|---|---|
| both call sites rewritten and identical | `node-repo-gate.yml:1102`, `node-repo-publish-bake.yml:1147` |
| stale clause remaining | **0** occurrences in either file |
| YAML parses | node-repo-gate 3 jobs · node-repo-publish-bake 2 jobs |
| `check-workflow-timeouts.py` | 84 jobs checked, **0 violations** |
| `MeshWeaver.Documentation` Release `-warnaserror` | `0 Error(s)`, `0 Warning(s)` |
| `MeshWeaver.Documentation.Test` | **374/374**, incl. `DocumentationLinkIntegrityTest` |

No behaviour change, so no What's New entry — the only observable difference is what a CI log says when the guard fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
