### PR TITLE
Stop a non-converging sync source re-cloning its repository on every delivery (#3945)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -160,7 +160,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [DatabaseBackups](DatabaseBackups)
 - [Declarative export and import](DeclarativeImportExport)
 - [Syncing a Space with GitHub](GitHubSync)
-- [What a Green Build Costs a Synced Space](GitSyncTriggerCost) — one field decides whether a delivery is free or a full clone, and it is deliberately frozen while an import does not converge; so a source that cannot converge re-clones on every green build, at the source repository's CI cadence
+- [What a Green Build Costs a Synced Space](GitSyncTriggerCost) — one field decided whether a delivery was free or a full clone, and it is deliberately frozen while an import does not converge; the second, weaker pointer that makes a settled source free again, and why the skip needs the verdict to be FINAL and not merely recorded
 - [The Import Marker Records Convergence](ImportMarkerRecordsConvergence)
 - [Instance Sync — bi-directional space replication between MeshWeaver instances](InstanceSync)
 - [Managing Partition Sync (Admin Guide)](PartitionSyncGuide)

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -173,9 +173,9 @@ regardless — use it to deliberately discard local changes back to the reposito
 > Two-way generalizes this to *every* server-side edit (no explicit claim needed) as long as it
 > post-dates the last sync.
 
-### The three clocks on a sync source — and why they disagree on purpose
+### The four facts on a sync source — and why they disagree on purpose
 
-A sync source records **three separate facts**, and reading any one of them as the answer to
+A sync source records **four separate facts**, and reading any one of them as the answer to
 another's question is how an investigation goes wrong. They are deliberately independent:
 
 | Field | The question it answers | When it moves |
@@ -183,6 +183,7 @@ another's question is how an investigation goes wrong. They are deliberately ind
 | `lastSyncAttemptAt` + `lastSyncOutcome` | *When did a sync last RUN here, and what did it conclude?* | **Every** conclusion — an import, a no-op, one that preserved server-side edits, one that landed nothing. |
 | `lastSyncCommitSha` | *Which repo commit has this Space already got?* | Whenever the mesh genuinely reached that commit — **including** a no-op update, so a repo commit touching no node files does not leave the Space forever "behind". |
 | `lastSyncedAt` | *When were mesh and repo last RECONCILED?* — the two-way **conflict horizon** | Only on an import that really reconciled: **not** on a fingerprint-matched no-op, **not** when server-newer nodes were preserved, **not** when something failed to land. |
+| `lastAttemptedCommitSha` + `lastAttemptWasFinal` | *Have we already LOOKED at exactly these bytes, and could looking again change the answer?* | On every import conclusion; **cleared** by an export and by a hold. This is the pair that makes a green build free for a source that cannot converge — see [What a Green Build Costs a Synced Space](/Doc/Architecture/GitSyncTriggerCost). |
 
 The horizon is the one with teeth. Everything newer than it counts as a pending server-side change
 and is protected from overwrite and from the prune, so advancing it past uncommitted work disarms
@@ -198,6 +199,12 @@ sync"**.
 > the only way to date one was to compare node timestamps against image tags in a container
 > registry. `lastSyncAttemptAt` is that fact, and the settings tab now shows the three separately
 > instead of printing the horizon under the words *"Last synced"*.
+
+> 🚨 **And a frozen `lastSyncAttemptAt` is not necessarily a dead webhook.** A source whose last
+> attempt reached a FINAL verdict at a commit is deliberately skipped for every later delivery of
+> that same commit, so its recency stamp stops moving until the repository produces a new one.
+> The settings tab says so in as many words — *"this commit has a final verdict — the next new
+> commit re-attempts"* — precisely so the stopped clock cannot be read as a stopped delivery.
 
 Note that a node's own `lastModified` is **not** a substitute: `stream.Update` does not re-stamp
 it, so a node can be rewritten without its modification time moving.

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -405,8 +405,9 @@ repository's own CONTENT CI prove this tree"*. The discriminator for that is alr
 satellite, `dotnet-test.yml` in core). Keyed on that, the probe, the PR-updater, `Deployment Smoke`,
 `Arm credential`, `Chart Gate` and `Hosting Operator` all fall out under one rule, no repository
 loses its only signal, and the trigger allow-list can stay as wide as it is. That is a separate
-change with its own risk (a repository that declares the wrong workflow stops syncing silently), and
-it is filed as such.
+change with its own risk — a repository that declares the wrong workflow stops syncing silently,
+which is exactly MeshWeaver.Plugins#1194 recreated — and it is filed as #3978, together with the
+correctness finding above.
 
 ## See also
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -1,7 +1,7 @@
 ---
 Name: What a Green Build Costs a Synced Space
 Category: Architecture
-Description: A green build of a repository fans out to every Space that syncs it, and exactly one field decides whether a delivery is free or a full clone. That field is deliberately frozen whenever an import does not fully converge — so a source that cannot converge pays the full fetch on every delivery, and its retry cadence is set by the source repository's CI schedule rather than by anything about the source.
+Description: A green build of a repository fans out to every Space that syncs it, and for two years exactly one field decided whether a delivery was free or a full clone. That field is deliberately frozen whenever an import does not fully converge, so a source that could not converge paid the full fetch on every delivery at the source repository's CI cadence. The fix is a second, weaker pointer — and the reason it needs a FINAL verdict rather than merely a recorded one.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v6"/><path d="M12 15v6"/><circle cx="12" cy="12" r="3"/><path d="M4.2 6.6l2.8 2.2"/><path d="M17 15.2l2.8 2.2"/><path d="M4.2 17.4l2.8-2.2"/><path d="M17 8.8l2.8-2.2"/></svg>
 ---
 
@@ -13,10 +13,15 @@ feature. This page describes what one delivery **costs**, and the one field that
 
 The short version:
 
-> A delivery is free only when the source's `lastSyncCommitSha` already equals the built commit.
+> A delivery was free only when the source's `lastSyncCommitSha` already equalled the built commit.
 > That field is held back — on purpose — whenever an import does not fully converge. So the
-> cheapness gate and the convergence guard are **the same field**, and a source that can never
-> converge is the source that re-clones its repository most often.
+> cheapness gate and the convergence guard were **the same field**, and a source that could never
+> converge was the source that re-cloned its repository most often.
+>
+> §7 is the fix: a **second, weaker pointer** — *we have already looked at exactly these bytes* —
+> that never touches the conservative baseline. Its whole difficulty is that today's
+> re-clone-per-delivery is *also* the retry loop for transient failures, so the new skip has to
+> distinguish a verdict re-running cannot change from one that might.
 
 ## 1. What actually fires — a green build is not a merge
 
@@ -62,7 +67,12 @@ For a healthy source both are harmless, and the allow-list says so explicitly
 > `SkipReason` ("already at this commit"), so a scheduled or dispatched re-verification of an
 > unchanged default branch triggers no import at all.
 
-That invariant is the design. Section 4 is about the sources for which it is **false**.
+That invariant is the design. Section 4 is about the sources for which it was **false**, and §7
+about what makes it true again. 🚨 **Note what the fix is not: the trigger list is deliberately
+unchanged.** Dropping `schedule` would take out 87 of these 254 deliveries at a stroke — and it
+would be the same mistake the 2026-09-02 measurement corrected in the other direction, because a
+cron run is the only green verdict some repositories ever produce, and for a *converging* source
+those 87 deliveries already cost nothing. The trigger was never the defect.
 
 ## 2. The one gate that makes a delivery free
 
@@ -75,10 +85,12 @@ built repository is nevertheless left alone:
 | `direction is ExportOnly` | the source refuses imports |
 | `branch 'X' != built branch 'Y'` | the build is not on the branch this source tracks |
 | **`already at this commit`** | **`lastSyncCommitSha == headSha`** |
+| **`already attempted at this commit with a final verdict`** | **`lastAttemptedCommitSha == headSha` AND `lastAttemptWasFinal`** (§7) |
 
-Only the last one is a *work* saving, and it is keyed on exactly one field. Deliveries two and three
-of a merge, and every cron tick until the next merge, are free **iff** the first delivery advanced
-`lastSyncCommitSha` to that commit.
+Only the last two are a *work* saving. Until the second one existed the saving was keyed on exactly
+one field, so deliveries two and three of a merge, and every cron tick until the next merge, were
+free **iff** the first delivery advanced `lastSyncCommitSha` to that commit — and §4 is why, for
+some sources, it never did.
 
 ## 3. What a non-skipped delivery costs
 
@@ -147,6 +159,10 @@ necessarily disarms the first:
 > anything about the source. A cron probe that never changes the tip re-clones the repository just
 > as hard as a merge does.
 
+🚨 **None of the three clauses may be relaxed** — each is an incident, and the failure mode of
+relaxing one is silent data loss or silently-missing content, not a slow sync. The field stays
+exactly as conservative as it is; §7 adds a *different* field for the *different* question.
+
 So the allow-list's stated invariant — *"a sync source already sitting on the built sha is skipped …
 so a scheduled re-verification triggers no import at all"* — holds for every source that converges
 and **for no source that does not**. On the converging sources the 15-minute probe costs nothing at
@@ -160,6 +176,15 @@ None of the three freeze conditions resolves by itself:
 - a node **failed** on a content rule fails identically on the same bytes for ever;
 - an import that failed outright fails again until its cause is fixed.
 
+> ⚠️ **`MayAdvanceBaseline` and `StaticRepoImportResult.Converged` are not the same predicate**, and
+> the difference is `PruneRefused`. A run whose source listing came back truncated (#3589 / #3614)
+> is *not* `Converged` — the marker refuses to record it as such — but `MayAdvanceBaseline` does not
+> read that field, so such a run **does** advance `lastSyncCommitSha` and the source is skipped by
+> §2's first arm on every later delivery of that commit. That is pre-existing behaviour, deliberately
+> untouched here: closing it would make a source pay *more* clones, which is the opposite of this
+> page's subject. It is noted because a reader comparing the two predicates will otherwise assume
+> one of them is a typo.
+
 ### Reading it off a live portal, read-only
 
 **The discriminator is `lastSyncedAt` far behind `lastSyncAttemptAt` with an outcome of
@@ -167,7 +192,7 @@ None of the three freeze conditions resolves by itself:
 reconcile — which is `MayAdvanceBaseline` returning false, which holds `lastSyncCommitSha` too.
 
 > ⚠️ **Two things that look like this and are not.** A frozen `lastSyncedAt` beside outcome
-> `Skipped` is the sanctioned no-op (#677) — see *The three clocks* in
+> `Skipped` is the sanctioned no-op (#677) — see *The four facts* in
 > [GitHub Sync](/Doc/Architecture/GitHubSync). And a `lastSyncCommitSha` a few hours behind the
 > branch tip is normal: the webhook imports **at the commit the build proved**, not at the tip, so
 > the recorded sha is the last delivered green commit, not `HEAD`.
@@ -205,6 +230,12 @@ gh api "repos/<owner>/<repo>/compare/<lastSyncCommitSha>...main" \
 
 `behind_by: 0` confirms the recorded sha is still an ancestor (nothing was force-pushed away);
 `ahead_by` is how many commits of deliveries the source has been paying for without converging.
+
+Since §7 there is a third pair of fields to read, and for a settled source they are the ones that
+explain the frozen dates: `lastAttemptedCommitSha` (what the last attempt *looked at*) and
+`lastAttemptWasFinal` (whether looking again could change anything). The settings tab renders the
+second as *"this commit has a final verdict — the next new commit re-attempts"*, so a reader is not
+left to infer a stopped webhook from a stopped clock.
 
 ## 5. What the content-addressed marker does and does not close
 
@@ -245,13 +276,141 @@ live instance: a `MeshWeaver/_GitSync` on `memex.meshweaver.cloud` pointing at
 `https://github.com/Systemorph/MeshWeaver` with no subdirectory, 389 refused nodes per pass.
 
 **The fix for that shape is the configuration, not the engine**: give the source a `subdirectory`
-that really is a content tree, or delete the source. The engine's own share of the problem is the
-one section 4 states — that the cheapness gate has no way to say *"we have already looked at exactly
-these bytes for this source"* independently of *"the mesh is known to hold this commit"*.
+that really is a content tree, or delete the source. The engine's own share of the problem was the
+one section 4 states — that the cheapness gate had no way to say *"we have already looked at exactly
+these bytes for this source"* independently of *"the mesh is known to hold this commit"*. §7 is that
+sentence, given a field. It makes a misconfigured source cost **one** clone per new commit instead
+of one per delivery; it does not make the source correct, and the configuration is still the fix.
+
+## 7. The fix: two questions, two fields
+
+The engine had one field answering two questions that must be allowed to diverge:
+
+| Question | Who asks it | Field |
+|---|---|---|
+| *Is the mesh known to hold this commit's content?* | the two-way conflict guard, the diff base, the "up to date?" display | `lastSyncCommitSha` — **unchanged**, still held by `MayAdvanceBaseline` |
+| *Have we already looked at exactly these bytes?* | the webhook's cheapness gate | `lastAttemptedCommitSha` + `lastAttemptWasFinal` — **new** |
+
+`RecordSyncResult` writes the new pair on **every import conclusion**, in the same `stream.Update`
+patch as the recency stamp. `SkipReason` gains a fifth arm that fires only when *both* halves agree
+with the built commit. Nothing else moved: the baseline stays as conservative as #675 / #677 /
+#2229 item C need it to be, the next NEW commit still brings the source a full unscoped import, and
+the GUI's own **Update to latest** never consults `SkipReason` at all.
+
+### 🚨 Why "already attempted" is not enough on its own
+
+**Today's re-clone-per-delivery is also, accidentally, the retry loop** for exactly the failures the
+importer refuses to call final. `IsContentVerdict` is a short allow-list on purpose — `InvalidPath`,
+`InvalidNodeType`, `ValidationFailed`, `Unauthorized` — and everything else stays retryable, because
+getting *that* backwards freezes a healthy partition out of the mesh (#3101). A store that was
+briefly unreachable comes back as `Unknown` ("Persistence read failed…", "Inner CreateNode
+faulted…"); the next delivery is the only thing that retries it, and on a quiet repository the next
+commit is never.
+
+So a skip keyed on the sha alone would trade one bug for a worse one. The second half is
+`StaticRepoImportResult.VerdictIsFinal` — *would running again change the answer?* — which is a
+different question from `Converged` (*is the partition now equal to the source?*):
+
+| Outcome shape | `Converged` | `VerdictIsFinal` | Next delivery at the same commit |
+|---|---|---|---|
+| clean `Imported` | ✅ | ✅ | skipped by §2's **first** arm (the baseline advanced) |
+| `Preserved > 0`, nothing failed | ❌ | ✅ | **skipped by the new arm** — the same bytes meet the same server-newer nodes |
+| `ImportedWithContentErrors` (every failure a content verdict) | ❌ | ✅ | **skipped by the new arm** — the same bytes break the same rules |
+| `ImportedWithErrors` (one or more retryable failures) | ❌ | ❌ | **attempted** — a store blip may not recur |
+| outcome `Failed` (the whole import faulted) | ❌ | ❌ | **attempted** — no per-file tally to classify, and unknown means retryable |
+| `PruneRefused` (truncated listing) | ❌ | ❌ | attempted — though §4's aside notes the baseline advanced anyway |
+
+`Preserved > 0` is the row that matters most in practice: it is the arm both measured live sources
+sit on, and the one the import marker (§5) does nothing for. The preserve decision is taken against
+`lastSyncedAt`, which no re-import moves — so a preserved node is preserved identically on every
+pass until a person commits it back or discards it.
+
+### What clears the licence
+
+The pair is **written, never merged** — an older value must not survive a conclusion that set none,
+or a skip would be licensed for an attempt that never happened. Three things clear it:
+
+- **an export / commit-back**, because it advances the conflict horizon, which is what decides
+  *which* live nodes an import preserves — so any earlier "final at commit X" is stale;
+- **a hold** (the sealed-publication gate), because no attempt ran, and a seal arriving later is the
+  archetype of a condition that clears without the commit moving;
+- **a new commit**, trivially — the recorded sha stops matching.
+
+🚨 **What does NOT clear it, stated rather than hidden:** a mesh-side change at an unchanged commit —
+someone deleting the very node that was being preserved, say. The next green build still skips, and
+the source waits for the repository's next commit or for a human pressing **Update to latest**. That
+is the same contract `lastSyncCommitSha` has always had for the converging case, and it is the
+deliberate price of not re-cloning a repository ten times an hour to discover that nothing changed.
+
+### The controls
+
+`GreenBuildSkipsASettledSourceTest` measures both directions **on the clone itself** — the transfer
+is the cost, so an assertion on a decision function or on a log line would not be measuring it. The
+GitHub transport and one marked storage path are substituted; the webhook processor, the sync
+service, the importer and the node streams are real.
+
+- *A content verdict at this commit costs no second clone, and a new commit still does import* — a
+  nested `Space` refused with `InvalidPath`, then the same green build again (**no fetch**), then a
+  new sha (**fetch, at the commit that build proved**). It also pins `lastSyncCommitSha` still
+  `null`: the conservative baseline must not have moved.
+- *A failure that might not recur is still attempted at the same commit* — one node whose store
+  faults with the production connect-timeout shape, so the pass is `ImportedWithErrors` with
+  `VerdictIsFinal == false`; the same green build then **must** reach GitHub. This is the control
+  that could falsify the first: a fix that skips everything strands every self-healing source.
+
+## 8. Why the cron probe stays in the allow-list
+
+A third of core's deliveries come from one workflow that compiles nothing —
+`.github/workflows/prod-synthetic-probe.yml`, `cron: "*/15 * * * *"`, whose entire body is `curl`
+against the two live portals (no checkout, no restore, no compile, no artefact). Excluding it, or
+dropping `schedule` from `PublishSignalTriggers` altogether, looks like the cheapest possible win.
+It was measured, and it is not one.
+
+**The window (24 h to 2026-09-10T17:35Z, core `main`, green): 329 runs enumerated against a
+`total_count` of 329 — complete.** 254 are publish signals; 75 are `workflow_run`-triggered and
+already rejected. `schedule` accounts for 112 of the 254 (44 %), the probe alone for 87 (34 %).
+
+- **The probe publishes no commit that a push run did not already publish.** Its 87 runs cover 34
+  distinct `head_sha`s, and every one of them also carried a green `push` run of the content CI.
+  (One sha appeared to be probe-only until its push runs were found nine minutes before the window
+  opened — a window artefact, not a case.) So the probe's deliveries are *duplicates*: for a
+  converging source §2's first arm already answers them for free, and for a settled source §7's new
+  arm now does. **Excluding it saves nothing the engine fix does not already save.**
+- **No repository in the fleet depends on `schedule`.** All six satellites' content CI fires on
+  `push` *and* `repository_dispatch` *and* `schedule`; Memex's has no cron at all. Counting shas
+  whose only green content-CI run was a `schedule` run: 51 in the 30 days to 2026-09-10, **none on
+  or after 2026-09-01** (the satellites moved from `17,47 * * * *` polling to a daily `03:xx` cron
+  plus the `meshweaver-upstream-published` dispatch on 2026-08-29/30). Over the whole of September,
+  removing `schedule` would have widened exactly one repository's worst quiet stretch, by six hours.
+- **But it would not close the class.** A `push`-triggered run of a workflow that is *not* the
+  content CI is admitted exactly as readily as a cron: on core `192a60d84a36`, `Chart Gate` and
+  `Hosting Operator` both went green on `push` in the same second that `push MeshWeaver Build and
+  Test` **failed**. Narrowing the trigger set would suppress the loudest member of the class and
+  leave the rest — and it is the same shape of mistake as the pre-2026-09-02 `event == "push"` test,
+  which discarded `Systemorph/MeshWeaver.Reinsurance`'s three green `repository_dispatch` runs and
+  left `Underwriting/_GitSync` 38 h behind a merged main with every delivery answering 200 OK.
+
+🚨 **And the class has a correctness half, not only a cost half.** `Auto-update green armed PRs`
+(`cron: "*/10 * * * *"` in Reinsurance, SocialMedia and MeshWeaver.Crm) does nothing but call
+`gh api … /update-branch` on armed PRs — it checks out nothing — and in the 48 h to
+2026-09-10T19:36Z it recorded **20 green build completions for
+`MeshWeaver.Reinsurance@7d29a303`** and **40+ for `MeshWeaver.SocialMedia@07cc155e`**, both of them
+commits whose content CI had **failed**. That is a delivery authorising an import of a tree no build
+proved — the proposition `SyncRefContract` exists to guarantee.
+
+**The conclusion: the trigger event is a proxy for the wrong proposition.**
+`PublishSignalTriggers` answers *"how was this run started"*; what the record needs is *"did this
+repository's own CONTENT CI prove this tree"*. The discriminator for that is already in the payload —
+`workflow_run.name` / `.path` — and every repository has exactly one such workflow (`ci.yml` in each
+satellite, `dotnet-test.yml` in core). Keyed on that, the probe, the PR-updater, `Deployment Smoke`,
+`Arm credential`, `Chart Gate` and `Hosting Operator` all fall out under one rule, no repository
+loses its only signal, and the trigger allow-list can stay as wide as it is. That is a separate
+change with its own risk (a repository that declares the wrong workflow stops syncing silently), and
+it is filed as such.
 
 ## See also
 
-- [Syncing a Space with GitHub](/Doc/Architecture/GitHubSync) — the feature, the three clocks, the webhook setup.
+- [Syncing a Space with GitHub](/Doc/Architecture/GitHubSync) — the feature, the webhook setup, and the four facts — the horizon, the baseline, the recency stamp, and §7's attempt pair.
 - [The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence) — the content-addressed short-circuit and what may write it.
 - [Static Repo Import](/Doc/Architecture/StaticRepoImport) — fingerprint, activity lock, upsert, prune.
 - [Sync Ref Contract](/Doc/Architecture/SyncRefContract) — what a build completion records and who consumes it.

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -211,8 +211,17 @@ that repository off the shared baseline: its 33 siblings — `Store`, `Publish`,
 `BusinessRules`, … — all carried `f4570459…` with `lastSyncedAt` **equal to** `lastSyncAttemptAt`.
 Same repository, same webhook, same schedule; the difference is convergence.
 
+🚨 **Both are on the `Preserved > 0` arm, and it is worth naming HOW that is known**, because it is
+the arm §7's skip turns on. Read again 2026-09-10T19:41Z, `Essentials/_GitSync` was at version 378
+with `lastSyncAttemptAt` **30 minutes old** and `lastSyncOutcome: Imported` — and `Imported` means
+`Failed == 0` and the outcome is not `Failed`, so of `MayAdvanceBaseline`'s three clauses only
+`Preserved > 0` can be holding the baseline. By elimination, on live data. Note that it does **not**
+carry `twoWay`, so its preservation is the *bidirectional prune* protecting server-side additions
+(#604), not two-way overwrite protection — two different mechanisms feeding the same counter.
+
 `Deployments/_GitSync` is the only source in the set carrying `twoWay: true`, i.e. the
-`Preserved > 0` arm — and the **independent** node of the same path on `memex.systemorph.com` reads
+kept-not-overwritten half of the same arm — and the **independent** node of the same path on
+`memex.systemorph.com` reads
 `lastSyncedAt: 2026-08-19T20:06:37Z` against a `lastSyncAttemptAt` of 2026-09-10T15:27:00Z: **22
 days** of attempts that never reconciled. (The two portals hold two independent nodes here, not a
 replica and its lag — read both before concluding anything about either.)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-stuck-sync-stops-re-downloading-its-repository.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-stuck-sync-stops-re-downloading-its-repository.md
@@ -1,0 +1,33 @@
+---
+Name: A stuck sync stops re-downloading its repository
+Category: Fix
+Description: A GitHub-synced Space that cannot finish an import no longer re-downloads the whole repository on every green build of that repository — and the settings tab now says why it has stopped trying.
+Icon: ArrowSync
+Order: -20260910
+---
+
+A synced Space imports whenever the repository it tracks builds green. That delivery was free only
+when the Space had already fully reached the built commit — and a Space that *cannot* fully reach
+it (a node kept back because it was edited here, a file the mesh refuses) was, by exactly that
+rule, the one that never qualified. So it downloaded the entire repository again on every green
+build, at the repository's build cadence rather than at any rate of its own. On one live Space that
+had been running for a month; on a busy repository it is roughly ten downloads an hour, most of
+them for a commit that had already been looked at.
+
+Now the source remembers **which commit it last looked at** separately from **which commit it has
+actually got**. When the last attempt ended in a verdict that reading the same files again cannot
+change, later builds of that same commit are skipped outright — no download, no re-import. The next
+new commit still brings a full import, and **Update to latest** still works exactly as before.
+
+Sync sources that are healthy are unaffected: they were already skipping those deliveries.
+
+Two things a Space admin will notice on the **GitHub Sync** settings tab. Repeated import activity
+records stop piling up for a Space that is stuck. And when a source has settled, the line under the
+repository now reads *"this commit has a final verdict — the next new commit re-attempts"*, so a
+last-run time that has stopped moving reads as a deliberate skip rather than as a delivery that
+never arrived.
+
+Nothing was made less careful. A failure that might not happen again — a store that was briefly
+unreachable, an import that faulted outright — is still retried on the very next delivery, because
+freezing a Space out over a passing problem is the more expensive mistake. Only a verdict about the
+files themselves settles.

--- a/src/MeshWeaver.GitSync/GitHubSyncConfig.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfig.cs
@@ -170,6 +170,52 @@ public record GitHubSyncConfig
     public string? LastSyncOutcome { get; init; }
 
     /// <summary>
+    /// 🚨 <b>The commit the last IMPORT ATTEMPT targeted — which is NOT
+    /// <see cref="LastSyncCommitSha"/></b> (issue #3945). That field means "the mesh is known to
+    /// hold this commit's content" and is deliberately held back whenever an import did not fully
+    /// converge (<c>GitHubSyncService.MayAdvanceBaseline</c>); this one means only "we have already
+    /// looked at exactly these bytes". One field could not be both, which is why a source that can
+    /// never converge re-cloned its whole repository on every green build of the source repository
+    /// — at that repository's CI cadence, ~10/h on core.
+    ///
+    /// <para>Written on EVERY import conclusion, alongside
+    /// <see cref="LastAttemptWasFinal"/>. CLEARED (null) by an export/commit and by a hold, because
+    /// both change what a re-import would do: an export moves the conflict horizon, and a hold means
+    /// no attempt ran at all. Absent on a source that has never imported, and on one whose last
+    /// import predates this field — in both cases the next delivery attempts, which is the safe
+    /// direction.</para>
+    ///
+    /// <para>Set by the sync operation; not user-editable.</para>
+    /// </summary>
+    [Browsable(false)]
+    public string? LastAttemptedCommitSha { get; init; }
+
+    /// <summary>
+    /// 🚨 <b>Whether the attempt at <see cref="LastAttemptedCommitSha"/> reached a verdict that
+    /// re-attempting the SAME commit provably cannot change</b>
+    /// (<c>StaticRepoImportResult.VerdictIsFinal</c>) — the second half of the pair, and the half
+    /// that stops issue #3945's fix becoming a worse bug.
+    ///
+    /// <para>🚨 <b>Without it, the fix would strand every self-healing source.</b> Today's
+    /// re-clone-on-every-delivery is also, accidentally, the retry loop for the failures
+    /// <c>StaticRepoImporter.IsContentVerdict</c> deliberately refuses to call final — an
+    /// unreachable store, an owner that did not answer, a hub that went down mid-import. Skipping on
+    /// "same commit, already attempted" alone would make those wait for the next commit, which on an
+    /// idle repository is never. So the skip requires this flag too: a preserved node or an
+    /// all-content-verdict refusal settles (skip — the same bytes meet the same rules), while
+    /// <c>ImportedWithErrors</c>, a whole-import <c>Failed</c> and a truncated listing do not
+    /// (attempt — the next delivery may land it).</para>
+    ///
+    /// <para>🚨 <b>Never true without <see cref="LastAttemptedCommitSha"/>.</b> The two are written
+    /// in one <c>stream.Update</c> and mean nothing apart; <c>false</c> is the default and the safe
+    /// reading of an absent value.</para>
+    ///
+    /// <para>Set by the sync operation; not user-editable.</para>
+    /// </summary>
+    [Browsable(false)]
+    public bool LastAttemptWasFinal { get; init; }
+
+    /// <summary>
     /// WHY the last attempt did not move the source — the hold reason of the sealed-publication
     /// gate ("built at X, not sealed for this instance …"), or the reconciler's finding — so an
     /// operator reading the config sees the cause rather than only the outcome. Cleared by the

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -142,6 +142,11 @@ public sealed class GitHubSyncService
                         // Record the commit by MERGING only the last-sync fields atop the latest
                         // node content (stream.Update read-modify-write) — never a full-content write,
                         // so a concurrent repo-field edit in the GUI editor is not clobbered.
+                        // 🚨 The attempt pair (#3945) is left to its default — i.e. CLEARED. An
+                        // export advances the conflict horizon, and the horizon is what decides
+                        // which live nodes an import preserves, so any "final at commit X" verdict
+                        // an earlier import recorded is stale the moment this lands: the next green
+                        // build must attempt again rather than skip on it.
                         return repoClient.Push(request).SelectMany(result =>
                             RecordSyncResult(spacePath, CommittedOutcome, result.CommitSha,
                                     advanceHorizon: true, sourceId)
@@ -482,7 +487,16 @@ public sealed class GitHubSyncService
                                 // while the mesh still has instances) is drift the sync cannot close
                                 // by itself — it is stated on the config, where the settings tab and
                                 // the status surface read it, not only in the activity log.
-                                note: HeldNote(x.Result))
+                                note: HeldNote(x.Result),
+                                // 🚨 #3945 — the SECOND, weaker pointer, and the whole reason it is
+                                // a second one. "We have already looked at exactly these bytes" is
+                                // not "the mesh holds this commit", and one field answering both is
+                                // what made a source that cannot converge re-clone its entire
+                                // repository on every green build of the source repository. This one
+                                // is stamped whatever the outcome; whether it may LICENCE a skip is
+                                // the flag beside it, never this sha alone.
+                                attemptedCommitSha: x.CommitSha,
+                                attemptWasFinal: x.Result.VerdictIsFinal)
                             .Select(_ => x.Result);
                     });
             });
@@ -515,6 +529,17 @@ public sealed class GitHubSyncService
     /// <para>A "Skipped" (fingerprint-matched no-op) outcome is NOT judged here — it is allowed
     /// through to <c>RecordSyncResult</c> with <c>advanceHorizon: false</c>, which advances the SEEN commit only and deliberately
     /// leaves the conflict horizon alone.</para>
+    ///
+    /// <para>🚨 <b>This is NOT the question "would attempting again change anything" (#3945), and it
+    /// must never be relaxed into it.</b> Holding the baseline is what keeps un-landed content
+    /// reachable; but because <c>GitHubWebhookProcessor.SkipReason</c> also read this same field to
+    /// decide whether a delivery was FREE, holding it made every later green build of the source
+    /// repository pay a full clone — 10/h on core, for as long as the source did not converge. That
+    /// second question now has its own pair of fields
+    /// (<see cref="GitHubSyncConfig.LastAttemptedCommitSha"/> +
+    /// <see cref="GitHubSyncConfig.LastAttemptWasFinal"/>), fed by
+    /// <see cref="StaticRepoImportResult.VerdictIsFinal"/>, so this one can stay exactly as
+    /// conservative as #675 / #677 / #2229 item C need it to be.</para>
     /// </summary>
     /// <param name="result">The import outcome to judge.</param>
     /// <returns><c>true</c> when the mesh is genuinely in sync with the repo at this commit.</returns>
@@ -984,7 +1009,7 @@ public sealed class GitHubSyncService
     /// concurrent GUI edit of the repository fields is never clobbered, and re-writing an unchanged
     /// value costs nothing: the write travels as an RFC 7396 merge patch of what actually changed.
     ///
-    /// <para>🚨 <b>The three clocks are separate ON PURPOSE and must stay so.</b> Folding the horizon
+    /// <para>🚨 <b>The clocks are separate ON PURPOSE and must stay so.</b> Folding the horizon
     /// into the recency stamp is the one change that must never be made — it would advance the
     /// horizon on exactly the outcomes that suppress it (a fingerprint-matched no-op, an import that
     /// preserved server-newer nodes, one that landed nothing), moving it past pending uncommitted
@@ -1000,9 +1025,18 @@ public sealed class GitHubSyncService
     /// never landed.</param>
     /// <param name="advanceHorizon">Whether this outcome RECONCILED mesh and repo.</param>
     /// <param name="sourceId">The sync source (null = the primary).</param>
+    /// <param name="note">The hold reason / finding to state on the config, or null to clear it.</param>
+    /// <param name="attemptedCommitSha">The commit an IMPORT attempt actually read, or <c>null</c>
+    /// to CLEAR the attempt pair — which every non-import conclusion does, because an export moves
+    /// the conflict horizon (so an earlier verdict at that commit is stale) and a hold means no
+    /// attempt ran at all (#3945).</param>
+    /// <param name="attemptWasFinal">Whether that attempt's verdict is final at that commit
+    /// (<see cref="StaticRepoImportResult.VerdictIsFinal"/>). Meaningless without
+    /// <paramref name="attemptedCommitSha"/>, and written in the same patch as it.</param>
     private IObservable<MeshNode> RecordSyncResult(
         string spacePath, string outcome, string? seenCommitSha, bool advanceHorizon,
-        string? sourceId = null, string? note = null)
+        string? sourceId = null, string? note = null,
+        string? attemptedCommitSha = null, bool attemptWasFinal = false)
     {
         var now = DateTimeOffset.UtcNow;
         return hub.GetWorkspace().GetMeshNodeStream(ConfigPath(spacePath, sourceId)).Update(node =>
@@ -1019,6 +1053,17 @@ public sealed class GitHubSyncService
                     // A hold's reason, or cleared by an attempt that ran: the note describes the
                     // LAST attempt only, never an older one.
                     LastSyncNote = note,
+                    // 🚨 #3945 — ALWAYS written, never merged with what was already there. Unlike
+                    // the baseline above (`?? cur.…`, a HIGH-WATER MARK that only ever advances)
+                    // this pair describes the LAST ATTEMPT, so an older value surviving a conclusion
+                    // that set none would licence a skip for an attempt that never happened. The
+                    // RFC 7396 diff a cross-hub `stream.Update` ships emits a key present in the
+                    // stored node and absent from the new content as `null` — an RFC 7396 REMOVE —
+                    // so passing null here genuinely clears the stored value.
+                    LastAttemptedCommitSha = attemptedCommitSha,
+                    // Never true on its own: the flag is only ever read beside the sha, and a true
+                    // with no sha would be a licence attached to no commit.
+                    LastAttemptWasFinal = attemptedCommitSha is { Length: > 0 } && attemptWasFinal,
                 },
             };
         });
@@ -1032,6 +1077,11 @@ public sealed class GitHubSyncService
     /// Records that this source was HELD from advancing, and why — onto the config, so the reason
     /// is visible where the outcome is (2026-09-08: a source held for hours showed only
     /// <c>Skipped</c>). Moves nothing else: not the commit, not the horizon. Cold.
+    ///
+    /// <para>🚨 It also CLEARS the attempt pair (#3945), by leaving it at its default. A hold means
+    /// no import ran, and a seal that has not arrived yet is the archetype of a condition that
+    /// clears without the commit moving — so a hold must never leave a "final at this commit"
+    /// licence standing for the delivery that follows it.</para>
     /// </summary>
     public IObservable<MeshNode> RecordHold(string spacePath, string? sourceId, string reason)
         => RecordSyncResult(spacePath, HeldOutcome, seenCommitSha: null, advanceHorizon: false,

--- a/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncSettingsTab.cs
@@ -594,6 +594,13 @@ public static class GitHubSyncSettingsTab
                 ? Esc(LocalizationCatalog.Get("ui.gitSync.atCommit", locale))
                   + $" <span style=\"font-family:monospace;\">{Esc(sha)}</span>"
                 : null,
+            // 🚨 #3945 — a SETTLED source stops attempting, so without this line its recency stamp
+            // simply freezes and the reader has no way to tell "the webhook stopped arriving" from
+            // "the webhook arrives and is deliberately skipped". Rendered only in the settled state,
+            // which is exactly when the frozen dates need explaining.
+            cfg.LastAttemptWasFinal && cfg.LastAttemptedCommitSha is { Length: > 0 }
+                ? Esc(LocalizationCatalog.Get("ui.gitSync.settled", locale))
+                : null,
         };
         return $"<p style=\"{Style}\">{string.Join(" — ", parts.Where(x => x is not null))}</p>";
     }

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -262,7 +262,9 @@ public sealed class GitHubWebhookProcessor
     /// Every source of the repo is brought to the built commit; an unchanged subdirectory imports as
     /// a no-op. The <c>lastSyncCommitSha</c> check below is what keeps that cheap — it makes a re-run
     /// of an already-imported commit (a flake re-run, a manual re-dispatch) trigger nothing at all,
-    /// and now compares like with like: what the source RECORDS is the commit it was told to fetch.</para>
+    /// and now compares like with like: what the source RECORDS is the commit it was told to fetch.
+    /// 🚨 …and for a source whose import does NOT converge, that check never fires by construction,
+    /// which is why <see cref="SkipReason"/> carries a second, weaker one (#3945).</para>
     /// </summary>
     private IObservable<int> TriggerSyncForGreenBuild(RepoIdentity repo, string branch, string headSha)
         => MatchingBuildTargets(repo, branch, headSha).Select(targets =>
@@ -396,6 +398,32 @@ public sealed class GitHubWebhookProcessor
     /// Why a config that DOES target this repo is not being updated, or <c>null</c> when it is.
     /// The reason strings are log copy — a skipped Space must be traceable to the exact predicate
     /// that dropped it, never inferred from its absence.
+    ///
+    /// <para>🚨 <b>Issue #3945 — the last arm is the one that stops a non-converging source
+    /// re-cloning its whole repository on every green build.</b> Until it existed, exactly ONE
+    /// reason made a delivery free — <c>lastSyncCommitSha == headSha</c> — and that same field is
+    /// deliberately HELD by <c>GitHubSyncService.MayAdvanceBaseline</c> whenever an import did not
+    /// converge (#675 / #677 / #2229 item C). So the cheapness gate and the convergence guard were
+    /// one field, and a source that could never converge paid a full <c>git fetch --depth 1</c> of
+    /// its ENTIRE repository plus a full parse on every delivery, at the SOURCE repository's CI
+    /// cadence: measured 2026-09-10, <c>Essentials/_GitSync</c> on memex.meshweaver.cloud had been
+    /// doing that against MeshWeaver.Plugins since 2026-08-10 — 31 days, 436 commits — while its 33
+    /// siblings on the same repository, same webhook, same schedule, were skipped for free.</para>
+    ///
+    /// <para>🚨 <b>And why it is TWO conditions, not one.</b> Today's re-clone-on-every-delivery is
+    /// also, accidentally, the retry loop for the failures <c>StaticRepoImporter.IsContentVerdict</c>
+    /// deliberately refuses to call final — an unreachable store, an owner that did not answer, a
+    /// hub that went down mid-import. Skipping on "same commit, already attempted" ALONE would make
+    /// every one of those wait for the next commit, which on a quiet repository is never: a fix that
+    /// strands every self-healing source. So the skip also requires the recorded verdict to be FINAL
+    /// at that commit (<see cref="GitHubSyncConfig.LastAttemptWasFinal"/> ←
+    /// <see cref="StaticRepoImportResult.VerdictIsFinal"/>) — a preserved node or an
+    /// all-content-verdict refusal settles; <c>ImportedWithErrors</c>, a whole-import <c>Failed</c>
+    /// and a truncated listing do not.</para>
+    ///
+    /// <para>The baseline stays untouched, so nothing here weakens the guards above it: the next
+    /// NEW commit re-attempts the whole source unscoped, and the GUI's own "Update to latest"
+    /// (<c>GitHubSyncService.ReimportAtCommit</c>) never consults this predicate at all.</para>
     /// </summary>
     private static string? SkipReason(GitHubSyncConfig? cfg, string branch, string headSha)
         => cfg is null ? "config content could not be read"
@@ -404,6 +432,13 @@ public sealed class GitHubWebhookProcessor
                 ? $"branch '{cfg.Branch}' != built branch '{branch}'"
             : string.Equals(cfg.LastSyncCommitSha, headSha, StringComparison.OrdinalIgnoreCase)
                 ? "already at this commit"
+            // 🚨 Ordered AFTER "already at this commit" on purpose: a converged source keeps
+            // reporting the reason it has always reported, so this arm's appearance in a log is
+            // itself the signal that a source is settled-but-not-converged.
+            : cfg.LastAttemptWasFinal
+              && string.Equals(cfg.LastAttemptedCommitSha, headSha, StringComparison.OrdinalIgnoreCase)
+                ? $"already attempted at this commit with a final verdict ('{cfg.LastSyncOutcome}') — "
+                  + "re-reading the same bytes re-derives it; the next new commit re-attempts"
             : null;
 
     /// <summary>Maps a config node path (<c>{space}/_GitSync</c> or <c>{space}/_GitSync/{sourceId}</c>)
@@ -506,6 +541,20 @@ public sealed class GitHubWebhookProcessor
     /// <para><b>Widening this cannot cause churn.</b> A sync source already sitting on the built sha
     /// is skipped by <see cref="SkipReason"/> ("already at this commit"), so a scheduled or dispatched
     /// re-verification of an unchanged default branch triggers no import at all.</para>
+    ///
+    /// <para>🚨 <b>That claim was FALSE for two years for one class of source, and #3945 is what
+    /// makes it true again — the trigger set is deliberately NOT narrowed.</b> It rests on a source
+    /// being "already at the built sha", and <c>lastSyncCommitSha</c> is held back for every source
+    /// whose import does not converge, so a scheduled re-verification of an unchanged tip was a full
+    /// clone for exactly those sources: on <c>Systemorph/MeshWeaver</c> <c>main</c>, 87 of the 254
+    /// green publish-signal runs in the 24 h to 2026-09-10T17:35Z were <c>Prod synthetic probe</c>
+    /// (<c>cron: */15</c>), which builds nothing and never moves <c>head_sha</c> between merges.
+    /// <b>Dropping <c>schedule</c> would have been the wrong fix</b>: a cron run IS the only green
+    /// verdict some repositories ever produce (the exact shape of the 2026-09-02 measurement that
+    /// widened this list, where dropping <c>repository_dispatch</c> left <c>Underwriting/_GitSync</c>
+    /// 38 h behind with every delivery answering 200 OK), and for a CONVERGING source those 87
+    /// deliveries always were free. The defect was never the trigger; it was that the skip could not
+    /// say "we have already looked at exactly these bytes". <see cref="SkipReason"/>'s last arm can.</para>
     /// </summary>
     private static readonly ImmutableHashSet<string> PublishSignalTriggers =
         ImmutableHashSet.Create(

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -161,6 +161,60 @@ public sealed record StaticRepoImportResult(string Partition, string Fingerprint
         && Failed == 0
         && !PruneRefused
         && !string.Equals(Outcome, "Failed", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// 🚨 <b>Issue #3945 — is this run's verdict FINAL for the content it read?</b> True when every
+    /// reason this run did not converge is a property of THOSE BYTES, so a re-run against the same
+    /// content re-derives the identical verdict and can accomplish nothing.
+    ///
+    /// <para><b>Not the same question as <see cref="Converged"/>, and the difference is the point.</b>
+    /// <c>Converged</c> asks "is the partition now equal to the source?" — the question the
+    /// content-addressed marker answers, and the one <c>GitHubSyncService.MayAdvanceBaseline</c>
+    /// answers before it moves a sync source's baseline. This asks "would running again change the
+    /// answer?" A converged run is trivially final; a run that kept live nodes back
+    /// (<see cref="Preserved"/>) is NOT converged and IS final — the same bytes meet the same
+    /// server-newer nodes and are kept back again.</para>
+    ///
+    /// <para><b>Final — re-running provably cannot help:</b></para>
+    /// <list type="bullet">
+    ///   <item><see cref="Preserved"/> &gt; 0 with nothing failed — two-way conflict resolution kept
+    ///     server-newer nodes, or a bidirectional prune spared a server-side addition. Neither is a
+    ///     transient condition: the protection is measured against
+    ///     <c>GitHubSyncConfig.LastSyncedAt</c>, which no re-import moves.</item>
+    ///   <item><c>Outcome == "ImportedWithContentErrors"</c> — the fold above emits this literal
+    ///     only when EVERY per-node failure was an <c>IsContentVerdict</c> refusal, i.e. a rule
+    ///     these bytes break (#3146).</item>
+    /// </list>
+    ///
+    /// <para><b>NOT final — something outside the content may have changed by the next attempt:</b></para>
+    /// <list type="bullet">
+    ///   <item><c>Outcome == "ImportedWithErrors"</c> — at least one failure was NOT a content
+    ///     verdict. <c>Unknown</c> ("Persistence read failed…", "Inner CreateNode faulted…") and
+    ///     <c>PatchFailed</c> deliberately land here, and treating them as final is #3101 — a
+    ///     partition frozen out of the mesh over a store blip.</item>
+    ///   <item><c>Outcome == "Failed"</c> — the whole import faulted, carrying no per-file tally to
+    ///     classify. Unknown means retryable.</item>
+    ///   <item><see cref="PruneRefused"/> — the source listing came back truncated (#3589/#3614), so
+    ///     this run never saw the whole content its verdict would be about.</item>
+    /// </list>
+    ///
+    /// <para>🚨 <b>A caller may use this to skip WORK, never to record CONVERGENCE.</b> It says
+    /// nothing about whether the mesh holds this content; only <see cref="Converged"/> does.</para>
+    /// </summary>
+    public bool VerdictIsFinal =>
+        !PruneRefused
+        && !string.Equals(Outcome, "Failed", StringComparison.OrdinalIgnoreCase)
+        && (Failed == 0
+            || string.Equals(Outcome, ContentErrorsOutcome, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The <see cref="Outcome"/> literal a pass earns when it had failures and <b>every one</b> of
+    /// them was a content verdict (#3146) — the one outcome word that carries "re-reading these same
+    /// bytes re-derives this same refusal". Named here, beside <see cref="VerdictIsFinal"/> which
+    /// reads it and the fold in <c>StaticRepoImporter.Run</c> which writes it, so a re-wording
+    /// cannot silently split the two.
+    /// </summary>
+    public const string ContentErrorsOutcome = "ImportedWithContentErrors";
 }
 
 /// <summary>
@@ -1016,7 +1070,7 @@ public static class StaticRepoImporter
                                     // 🚨 #3146 — Failed, not Warning, and that is load-bearing: it is
                                     // the status the skip arm reads to stop re-running content that
                                     // provably cannot import at this fingerprint.
-                                    "ImportedWithContentErrors" => ActivityStatus.Failed,
+                                    StaticRepoImportResult.ContentErrorsOutcome => ActivityStatus.Failed,
                                     "Failed" => ActivityStatus.Failed,
                                     _ => ActivityStatus.Succeeded,
                                 },
@@ -1055,7 +1109,7 @@ public static class StaticRepoImporter
                 // fingerprint. Force still re-runs — that is its purpose.
                 if (policy?.Force != true
                     && existingLog is { Status: ActivityStatus.Failed }
-                    && MarkerOutcome(existingLog) == "ImportedWithContentErrors")
+                    && MarkerOutcome(existingLog) == StaticRepoImportResult.ContentErrorsOutcome)
                 {
                     logger?.LogWarning(
                         "[StaticRepoImport] {Partition} already FAILED at {Fingerprint} on content "
@@ -1983,7 +2037,7 @@ public static class StaticRepoImporter
                                 // retryable failure among them keeps the ordinary Warning, because
                                 // then a later pass genuinely might do better.
                                 failed > 0 && count.FailedDeterministic == failed
-                                    ? "ImportedWithContentErrors"
+                                    ? StaticRepoImportResult.ContentErrorsOutcome
                                 : failed > 0 ? "ImportedWithErrors"
                                     : blockedCreates.Count > 0 ? "ImportedWithBlockedCreates"
                                     : refusedContent.Count > 0 ? "ImportedWithRefusedContent" : "Imported",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -821,6 +821,7 @@
   "ui.gitSync.neverSynced": "Noch nicht synchronisiert.",
   "ui.gitSync.lastRun": "Letzter Synchronisierungslauf: {when} UTC",
   "ui.gitSync.atCommit": "bei Commit",
+  "ui.gitSync.settled": "dieser Commit hat ein endgültiges Ergebnis — der nächste neue Commit versucht es erneut",
   "ui.gitSync.outcome.Imported": "importiert",
   "ui.gitSync.outcome.ImportedWithErrors": "mit Fehlern importiert",
   "ui.gitSync.outcome.Skipped": "nichts zu importieren — dieser Inhalt liegt bereits vor",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -821,6 +821,7 @@
   "ui.gitSync.neverSynced": "Not synced yet.",
   "ui.gitSync.lastRun": "Last sync run: {when} UTC",
   "ui.gitSync.atCommit": "at commit",
+  "ui.gitSync.settled": "this commit has a final verdict — the next new commit re-attempts",
   "ui.gitSync.outcome.Imported": "imported",
   "ui.gitSync.outcome.ImportedWithErrors": "imported with errors",
   "ui.gitSync.outcome.Skipped": "nothing to import — already at this content",

--- a/test/MeshWeaver.Hosting.Test/GreenBuildSkipsASettledSourceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/GreenBuildSkipsASettledSourceTest.cs
@@ -1,0 +1,572 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Data.Common;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using MeshWeaver.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>A sync source that cannot converge re-cloned its WHOLE repository on every green build of
+/// that repository</b> (Systemorph/MeshWeaver#3945) — and the fix must not stop a source that could
+/// have healed itself from ever trying again.
+///
+/// <para><b>The mechanism.</b> Exactly one thing made a <c>workflow_run</c> delivery free:
+/// <c>GitHubWebhookProcessor.SkipReason</c>'s <c>lastSyncCommitSha == headSha</c>. And
+/// <c>GitHubSyncService.MayAdvanceBaseline</c> deliberately HOLDS that same field whenever an import
+/// did not fully converge — <c>Preserved &gt; 0</c> (#675 / #677), <c>Failed &gt; 0</c> (#2229
+/// item C), outcome <c>Failed</c>. So the cheapness gate and the convergence guard were ONE field,
+/// and holding it for the second reason necessarily disarmed the first.</para>
+///
+/// <para><b>Measured, 2026-09-10.</b> <c>Essentials/_GitSync</c> on memex.meshweaver.cloud had been
+/// paying a full <c>git fetch --depth 1</c> of MeshWeaver.Plugins plus a full parse on every green
+/// Plugins build since 2026-08-10 — 31 days, 436 commits behind — while its 33 siblings on the same
+/// repository, the same webhook and the same schedule were skipped for free. On core the same
+/// delivery rate is ~10/h (254 green publish-signal runs in 24 h, 87 of them a <c>*/15</c> cron
+/// probe that builds nothing and never moves <c>head_sha</c> between merges).</para>
+///
+/// <para><b>Why the second field is not simply "we already attempted this commit".</b> Today's
+/// re-clone-per-delivery is ALSO the retry loop for the failures
+/// <c>StaticRepoImporter.IsContentVerdict</c> refuses to call final — a store briefly unreachable,
+/// an owner that did not answer. Skipping on "same commit, already attempted" alone would make those
+/// wait for the next commit, which on a quiet repository is never: a fix that strands every
+/// self-healing source. The two tests below are that distinction, and the second is the one that
+/// could falsify the first.</para>
+///
+/// <para>Two seams are substituted, both IO boundaries and both with precedent: the GitHub transport
+/// (<see cref="IGitHubRepoClient"/>, as in <c>BuildTriggeredSyncPinsTheBuiltCommitTest</c>) and the
+/// storage adapter for ONE marked path (as in <c>CreateWhenTheStoreIsUnreachableTest</c>, which is
+/// where the production incident's own stack traces point). Everything between them is the real
+/// mesh: the real webhook processor, the real sync service, the real importer, the real node
+/// streams.</para>
+/// </summary>
+public class GreenBuildSkipsASettledSourceTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string RepoFullName = "test/settled-source";
+    private const string RepoUrl = $"https://github.com/{RepoFullName}";
+
+    /// <summary>Real-shaped 40-hex shas, so nothing downstream can mistake one for a branch name.</summary>
+    private const string BuiltSha = "3945000011112222333344445555666677778888";
+
+    private const string NextSha = "99990000aaaabbbbccccddddeeeeffff11112222";
+
+    /// <summary>A path segment whose storage READ/WRITE faults with the production connect-timeout
+    /// shape — the transient fault that must stay RETRYABLE (#3050 / #3051 / #3101).</summary>
+    private const string UnreachableMarker = "unreachable";
+
+    private readonly ScriptedRepoClient repoClient = new();
+
+    /// <summary>The DevLogin user the test base logs in — read directly, since
+    /// <c>AccessService.Context</c> is circuit-scoped and null on the test-method thread.</summary>
+    private static string UserId => TestUsers.Admin.ObjectId!;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGitHubSyncTypes()
+            .ConfigureServices(services =>
+            {
+                services.AddGitHubSyncServices();
+                // Last registration wins: the scripted client replaces the git/Octokit transport,
+                // so the whole loop runs offline and the CLONE is directly observable.
+                services.AddSingleton<IGitHubRepoClient>(repoClient);
+
+                // Wrap the LAST non-keyed IStorageAdapter — the production decorator chain's
+                // outermost layer — so the create handler's own read/write is what faults, exactly
+                // as in the incident. Path-gated, so it is inert for every test but the second.
+                var registered = services.Last(d => d.ServiceType == typeof(IStorageAdapter) && !d.IsKeyedService);
+                services.Remove(registered);
+                return services.AddSingleton<IStorageAdapter>(sp =>
+                    new PathFaultingStorageAdapter(Materialise(registered, sp)));
+            });
+
+    private GitHubSyncService Sync => Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
+
+    private GitHubCredentialService Credentials =>
+        Mesh.ServiceProvider.GetRequiredService<GitHubCredentialService>();
+
+    private GitHubWebhookProcessor Webhooks =>
+        Mesh.ServiceProvider.GetRequiredService<GitHubWebhookProcessor>();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  1. THE PIN — a content verdict at this commit costs no second clone
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>An import whose every refusal is a verdict about the BYTES must not be re-cloned at the
+    /// same commit — and a NEW commit must still be.</b>
+    ///
+    /// <para>The assertion is on the FETCH, not on a decision function or a log line, because the
+    /// whole cost this issue is about is the transfer: <c>FetchAndImport</c> fetches first and diffs
+    /// second (it has to — the diff is computed against <c>snapshot.CommitSha</c>), and a configured
+    /// subdirectory scopes the PARSE, never the transfer. Against the pre-fix code the second
+    /// delivery clones the repository again; against the fix it does not reach GitHub at all.</para>
+    ///
+    /// <para>The third step is the control that keeps the fix from being "never sync again": the
+    /// baseline is deliberately NOT advanced by this outcome, so the source is still behind, and the
+    /// next commit must still bring it a full unscoped import.</para>
+    /// </summary>
+    // 240_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant, and
+    // the inner waits below already carry the adaptive bound. This outer one only stops a WEDGE.
+    [Fact(Timeout = 240_000)]
+    public async Task AContentVerdictAtThisCommit_CostsNoSecondClone_AndANewCommitStillDoesImport()
+    {
+        var space = await Arrange("Cs");
+
+        // ── 1. A real import at BuiltSha whose every failure is a verdict about the content: a
+        //       nested Space, which the mesh's own rules refuse with InvalidPath ("A 'Space' owns
+        //       its partition, so it must be top-level") — one of the exact refusals memex-cloud
+        //       counted 425 of, per pass, 19 passes running (#3146).
+        repoClient.Sha = BuiltSha;
+        repoClient.Files = [Page("Lesson"), NestedSpace("Nested")];
+
+        var first = await Sync.ReimportAtCommit(space, BuiltSha, UserId)
+            .Timeout(TestTimeouts.Convergence * 2).Await();
+        Output.WriteLine($"import 1: outcome={first.Outcome} count={first.Count} failed={first.Failed}");
+
+        first.Outcome.Should().Be(StaticRepoImportResult.ContentErrorsOutcome,
+            "every failure in this pass must be a content verdict — if it is not, the source is not "
+            + "in the state this test is about and every assertion below measures something else");
+        first.VerdictIsFinal.Should().BeTrue(
+            "re-reading these same bytes re-derives this same refusal, so attempting the same "
+            + "commit again cannot accomplish anything");
+
+        var afterFirst = await ConfigWhen(space, c => c.LastAttemptedCommitSha is { Length: > 0 });
+        Output.WriteLine(
+            $"config: attempted={afterFirst.LastAttemptedCommitSha} final={afterFirst.LastAttemptWasFinal} "
+            + $"baseline={afterFirst.LastSyncCommitSha ?? "(none)"} outcome={afterFirst.LastSyncOutcome}");
+
+        afterFirst.LastAttemptedCommitSha.Should().Be(BuiltSha,
+            "the source has now LOOKED at exactly these bytes, and that fact needs a field of its own");
+        afterFirst.LastAttemptWasFinal.Should().BeTrue(
+            "the verdict is final at this commit, which is what licences the skip below");
+        afterFirst.LastSyncCommitSha.Should().BeNull(
+            "🚨 the CONSERVATIVE baseline must be untouched: a commit whose nodes did not all land "
+            + "is not 'seen', and advancing it here is the #2229 item C hole this fix must not "
+            + "reopen. The whole point is that the two questions now have two fields");
+
+        // The processor selects its candidates from an eventually-consistent QUERY, never from the
+        // node stream, so delivering the instant the stream shows the new content would race the
+        // index rather than measure the decision.
+        await QueryShows(space, c => c.LastAttemptedCommitSha == BuiltSha);
+
+        // ── 2. THE MEASURED SHAPE. The same green build arrives again — three workflows go green on
+        //       one merge, and a `*/15` cron probe re-delivers the unchanged tip 96 times a day.
+        var noSecondClone = repoClient.Fetches.Should().NotEmit(TestTimeouts.Quick,
+            "a delivery at a commit this source has already reached a FINAL verdict on must not "
+            + "reach GitHub at all — the clone is unconditional (fetch first, diff second) and a "
+            + "subdirectory scopes only the parse, so an attempt that can change nothing still "
+            + "transfers the whole repository (#3945)");
+
+        var again = await DeliverGreenBuild(BuiltSha);
+        again.Should().Be(1, "the build completion is still recorded — only the IMPORT is skipped");
+        await noSecondClone;
+
+        // ── 3. THE CONTROL THAT KEEPS THIS FROM BEING 'NEVER SYNC AGAIN'. The repository moves.
+        var newCommitClones = repoClient.Fetches.Should().Within(TestTimeouts.Convergence * 2)
+            .Emit("a source that is genuinely behind must still import: the skip is scoped to the "
+                + "ONE commit already judged, never to the source");
+
+        repoClient.Sha = NextSha;
+        await DeliverGreenBuild(NextSha);
+
+        (await newCommitClones).Should().Be(NextSha,
+            "and it must ask for the commit THAT BUILD proved, not the branch (MeshWeaver.Plugins#1430)");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    //  2. THE FALSIFIER — a failure that might not recur is still retried
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>The case that could falsify the one above, and the reason the skip needs TWO conditions
+    /// rather than "we already attempted this commit".</b>
+    ///
+    /// <para>A node whose store was briefly unreachable comes back as
+    /// <c>NodeUpsertRejectionReason.Unknown</c> — deliberately NOT in <c>IsContentVerdict</c>'s
+    /// allow-list, because calling a transient fault final is #3101: a partition frozen out of the
+    /// mesh until its content changes. One such failure among four hundred content verdicts keeps
+    /// the outcome <c>ImportedWithErrors</c>, and this source must keep being attempted — today the
+    /// only thing that retries it IS the next delivery, and on a quiet repository the next commit
+    /// is never.</para>
+    ///
+    /// <para>So the assertion is the exact opposite of the first test's, on the same instrument: the
+    /// delivery at the SAME commit must reach GitHub.</para>
+    /// </summary>
+    // 240_000 ms — see the note on the first test.
+    [Fact(Timeout = 240_000)]
+    public async Task AFailureThatMightNotRecur_IsStillAttemptedAtTheSameCommit()
+    {
+        var space = await Arrange("Rt");
+
+        // ── 1. One node lands; one faults because its store is unreachable. Not a rule about the
+        //       bytes — an outage, which the very same bytes may sail through next time.
+        repoClient.Sha = BuiltSha;
+        repoClient.Files = [Page("Lesson"), Page($"{UnreachableMarker}Blip")];
+
+        var first = await Sync.ReimportAtCommit(space, BuiltSha, UserId)
+            .Timeout(TestTimeouts.Convergence * 2).Await();
+        Output.WriteLine($"import 1: outcome={first.Outcome} count={first.Count} failed={first.Failed}");
+
+        first.Failed.Should().BeGreaterThan(0,
+            "the fault injection must actually have refused a node — if nothing failed, this test "
+            + "is measuring a clean import and proves nothing about the retryable arm");
+        first.Outcome.Should().NotBe(StaticRepoImportResult.ContentErrorsOutcome,
+            "a store that was briefly unreachable is NOT a verdict about the bytes: classifying it "
+            + "as one is #3101, a healthy partition frozen out of the mesh until its content changes");
+        first.VerdictIsFinal.Should().BeFalse(
+            "so re-running MIGHT do better, and the engine must say so rather than settle");
+
+        var afterFirst = await ConfigWhen(space, c => c.LastAttemptedCommitSha is { Length: > 0 });
+        Output.WriteLine(
+            $"config: attempted={afterFirst.LastAttemptedCommitSha} final={afterFirst.LastAttemptWasFinal} "
+            + $"baseline={afterFirst.LastSyncCommitSha ?? "(none)"} outcome={afterFirst.LastSyncOutcome}");
+
+        afterFirst.LastAttemptedCommitSha.Should().Be(BuiltSha,
+            "the source DID look at these bytes — recording that is not the same as licencing a skip");
+        afterFirst.LastAttemptWasFinal.Should().BeFalse(
+            "🚨 and this is the whole difference: the sha alone must never be the skip. A source "
+            + "whose last failure might not recur has to keep being attempted, or the fix strands "
+            + "every self-healing source until its repository happens to produce a new commit");
+        afterFirst.LastSyncCommitSha.Should().BeNull(
+            "the baseline is held for the same reason it always was — some node did not land (#2229 item C)");
+
+        await QueryShows(space, c => c.LastAttemptedCommitSha == BuiltSha);
+
+        // ── 2. THE POSITIVE CONTROL. The same green build arrives again and MUST be acted on.
+        var retried = repoClient.Fetches.Should().Within(TestTimeouts.Convergence * 2)
+            .Emit("a source whose last failure was NOT a verdict about the content must still be "
+                + "attempted at the same commit — the next delivery is the only thing that retries "
+                + "it, and a skip here would make a transient store fault permanent (#3101)");
+
+        await DeliverGreenBuild(BuiltSha);
+
+        (await retried).Should().Be(BuiltSha,
+            "at the commit that build proved, exactly as an ordinary delivery would");
+    }
+
+    // ── arrangement ──────────────────────────────────────────────────────────
+
+    /// <summary>A fresh Space with a sync source pointed at the fixture repository, and the
+    /// credential seeded for the identity the import will actually resolve — the config's CREATOR
+    /// (the activity-owner model), read off the node rather than assumed.</summary>
+    private async Task<string> Arrange(string prefix)
+    {
+        var space = prefix + Guid.NewGuid().ToString("N")[..8];
+        await NodeFactory.CreateNode(new MeshNode(space)
+        {
+            NodeType = "Space",
+            Name = "Settled source",
+            State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Timeout(TestTimeouts.Convergence).Await();
+
+        var configNode = await Sync
+            .SaveConfig(space, RepoUrl, "main", null,
+                createBranchIfMissing: false, createRepoIfMissing: false)
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        var syncOwner = configNode.CreatedBy is { Length: > 0 } creator ? creator : UserId;
+        Output.WriteLine($"sync config {configNode.Path} createdBy={syncOwner}");
+        await Credentials
+            .Save(syncOwner, new GitHubToken("ghp_test_token", null, "bearer", "repo", null), "octocat")
+            .Timeout(TestTimeouts.Convergence).Await();
+        return space;
+    }
+
+    /// <summary>
+    /// One verified green build of the default branch, delivered exactly as GitHub delivers it.
+    ///
+    /// <para>🚨 The webhook request is ANONYMOUS — its authorization is the verified HMAC signature.
+    /// Every ambient identity is dropped so the processor's own System impersonation is what carries
+    /// the lookups and the write, as it must on an access-gated portal.</para>
+    /// </summary>
+    private async Task<int> DeliverGreenBuild(string headSha)
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.ClearHostIdentity();
+        accessService.SetHostIdentity(null);
+        accessService.SetContext(null);
+        try
+        {
+            return await Webhooks.Process("workflow_run", GreenBuildPayload(headSha))
+                .Timeout(TestTimeouts.Convergence).Await();
+        }
+        finally
+        {
+            accessService.SetHostIdentity(new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
+        }
+    }
+
+    private static JsonElement GreenBuildPayload(string headSha) => JsonDocument.Parse($$"""
+        {
+          "action": "completed",
+          "repository": { "full_name": "{{RepoFullName}}", "default_branch": "main" },
+          "workflow_run": {
+            "conclusion": "success", "head_branch": "main", "head_sha": "{{headSha}}",
+            "id": 39450000001, "run_number": 3945, "name": "Content CI", "event": "push",
+            "updated_at": "2026-09-10T17:35:00Z"
+          }
+        }
+        """).RootElement;
+
+    /// <summary>A plain content page — it lands.</summary>
+    private static RepoFile Page(string id) =>
+        new($"{id}.md", $"---\nNodeType: Markdown\nName: {id}\n---\n\nThe {id} page.\n");
+
+    /// <summary>A nested <c>Space</c> — the mesh refuses it with <c>InvalidPath</c> ("A 'Space' owns
+    /// its partition, so it must be top-level"), a rule about these bytes that the same bytes break
+    /// identically on every later pass.</summary>
+    private static RepoFile NestedSpace(string id) =>
+        new($"{id}.md", $"---\nNodeType: Space\nName: {id}\n---\n\nA Space cannot live in here.\n");
+
+    // ── reading the source back ──────────────────────────────────────────────
+
+    /// <summary>
+    /// The sync config as the authoritative node stream reports it, once it satisfies
+    /// <paramref name="predicate"/> — never a query (eventually consistent, and this reads right
+    /// after a write), and never a bare first emission (the cache can replay the pre-write value).
+    /// </summary>
+    private async Task<GitHubSyncConfig> ConfigWhen(string space, Func<GitHubSyncConfig, bool> predicate)
+    {
+        var path = GitHubSyncService.ConfigPath(space);
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null
+                        && n.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions) is { } c
+                        && predicate(c))
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+        return node.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions)!;
+    }
+
+    /// <summary>
+    /// 🚨 Waits until the eventually-consistent QUERY — which is what the webhook processor selects
+    /// its candidates from, never the node stream — reports the config the stream already shows.
+    /// Without this the delivery would race the index and the test would measure the race rather
+    /// than the decision. (In production a stale index costs one extra clone, which is the very
+    /// thing this issue is about, so the race is real and is not the subject.)
+    /// </summary>
+    private Task QueryShows(string space, Func<GitHubSyncConfig, bool> predicate)
+        => Observable.Interval(50.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => MeshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{GitHubSyncService.ConfigPath(space)}"))
+                .Take(1))
+            .Where(c => c.Items.Any(n =>
+                n.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions) is { } cfg && predicate(cfg)))
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+
+    // ── the substituted IO boundaries ────────────────────────────────────────
+
+    /// <summary>
+    /// The GitHub transport reduced to the one question this test asks: WAS THE REPOSITORY CLONED,
+    /// and for which commit. Everything else throws, so a future caller that starts depending on
+    /// another operation is told rather than silently served a fake answer.
+    ///
+    /// <para>🚨 <see cref="Fetches"/> is HOT, not replaying. The negative control asserts that NO
+    /// clone follows a delivery, and a replaying subject would hand it the previous test step's
+    /// fetch and fail for the wrong reason.</para>
+    /// </summary>
+    private sealed class ScriptedRepoClient : IGitHubRepoClient
+    {
+        private readonly Subject<string> fetches = new();
+
+        /// <summary>Every commitish a fetch asks for, as it happens.</summary>
+        public IObservable<string> Fetches => fetches;
+
+        /// <summary>The commit the next fetch reports. Written by the test between deliveries.</summary>
+        public string Sha { get; set; } = BuiltSha;
+
+        /// <summary>The tree the next fetch returns.</summary>
+        public ImmutableList<RepoFile> Files { get; set; } = ImmutableList<RepoFile>.Empty;
+
+        public IObservable<RepoSnapshot> Fetch(
+            string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+            // Defer: the clone is what SUBSCRIBING costs, so the record has to be made there — a
+            // fetch composed and never subscribed transfers nothing and must count as nothing.
+            => Observable.Defer(() =>
+            {
+                fetches.OnNext(commitish);
+                return Observable.Return(new RepoSnapshot(Sha, Files.ToArray()));
+            });
+
+        // The default GetChangedPaths (null → full import) is deliberately inherited: a client with
+        // no compare support is the documented safe fallback, and these sources never advance their
+        // baseline anyway, so there is no base sha for a diff to be computed against.
+
+        public IObservable<GitHubPushResult> Push(GitHubPushRequest request) => NotUsed<GitHubPushResult>();
+
+        public IObservable<GitHubBranchResult> CreateBranch(GitHubCreateBranchRequest request)
+            => NotUsed<GitHubBranchResult>();
+
+        public IObservable<GitHubPullRequestInfo> OpenPullRequest(GitHubOpenPullRequestRequest request)
+            => NotUsed<GitHubPullRequestInfo>();
+
+        public IObservable<GitHubPullRequestInfo> GetPullRequestStatus(
+            string repositoryUrl, int number, string accessToken) => NotUsed<GitHubPullRequestInfo>();
+
+        public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+            string repositoryUrl, GitHubIssueState? state, string accessToken)
+            => NotUsed<IReadOnlyList<GitHubIssue>>();
+
+        public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken)
+            => NotUsed<GitHubIssue>();
+
+        public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request) => NotUsed<GitHubIssue>();
+
+        public IObservable<GitHubIssueComment> CommentIssue(
+            string repositoryUrl, int number, string body, string accessToken)
+            => NotUsed<GitHubIssueComment>();
+
+        public IObservable<GitHubIssue> SetIssueState(
+            string repositoryUrl, int number, GitHubIssueState state, string accessToken)
+            => NotUsed<GitHubIssue>();
+
+        public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+            string repositoryUrl, PullRequestStatus? state, string accessToken)
+            => NotUsed<IReadOnlyList<GitHubPullRequestSummary>>();
+
+        public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+            string repositoryUrl, int number, string accessToken) => NotUsed<GitHubPullRequestDetail>();
+
+        public IObservable<GitHubIssueComment> CommentPullRequest(
+            string repositoryUrl, int number, string body, string accessToken)
+            => NotUsed<GitHubIssueComment>();
+
+        public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request)
+            => NotUsed<GitHubMergeResult>();
+
+        private static IObservable<T> NotUsed<T>() => Observable.Throw<T>(
+            new NotSupportedException(
+                "GreenBuildSkipsASettledSourceTest's repo client answers only Fetch."));
+    }
+
+    /// <summary>
+    /// A driver exception core can construct: every ADO.NET provider derives its faults from
+    /// <see cref="DbException"/>. The verbatim incident shape — "Failed to connect …" wrapping a
+    /// connect timeout — which the create pipeline classifies as an outage, not a verdict
+    /// (#3050 / #3051), so the refusal reaches the importer as
+    /// <c>NodeUpsertRejectionReason.Unknown</c> and stays retryable.
+    /// </summary>
+    private sealed class FakeDbException(string message, Exception? inner = null)
+        : DbException(message, inner)
+    {
+        public override string? SqlState => null;
+    }
+
+    private static Exception? FaultFor(string path)
+        => path.Contains(UnreachableMarker, StringComparison.Ordinal)
+            ? new FakeDbException("Failed to connect to 10.42.18.4:5432",
+                new TimeoutException("Timeout during connection attempt"))
+            : null;
+
+    private static IStorageAdapter Materialise(ServiceDescriptor descriptor, IServiceProvider sp)
+        => descriptor.ImplementationFactory is { } factory
+            ? (IStorageAdapter)factory(sp)
+            : descriptor.ImplementationInstance as IStorageAdapter
+              ?? throw new InvalidOperationException(
+                  "The IStorageAdapter registration is neither a factory nor an instance, so this "
+                  + "test cannot wrap it. If the persistence registration lane changed, update this "
+                  + "hook — silently falling back to an unwrapped store would make the retryable-arm "
+                  + "assertions vacuous.");
+
+    /// <summary>
+    /// Makes the READ/WRITE surfaces fault for the ONE marked path; everything else forwards
+    /// untouched, so the mesh boots, the partition exists, and every unmarked node still lands.
+    ///
+    /// <para>Forwarding is exhaustive on purpose: <c>IStorageAdapter</c>'s doc-comments require a
+    /// decorator to forward <c>Changes</c>, <c>DeleteIfExists</c>, <c>WriteIfVersion</c>,
+    /// <c>ResolvePath</c> and <c>ListDescendantPaths</c>, or the behaviour they carry is silently
+    /// lost at the outermost decorator that falls back to the interface default.</para>
+    /// </summary>
+    private sealed class PathFaultingStorageAdapter(IStorageAdapter inner) : IStorageAdapter
+    {
+        private static IObservable<T> Fault<T>(Exception ex) => Observable.Throw<T>(ex);
+
+        public IObservable<DataChangeNotification> Changes => inner.Changes;
+
+        public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+            => FaultFor(path) is { } ex ? Fault<MeshNode?>(ex) : inner.Read(path, options);
+
+        public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+            => paths.Select(FaultFor).FirstOrDefault(e => e is not null) is { } ex
+                ? Fault<MeshNode>(ex)
+                : inner.ReadMany(paths, options);
+
+        public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+            => FaultFor(node.Path) is { } ex ? Fault<MeshNode?>(ex) : inner.Write(node, options);
+
+        public IObservable<IReadOnlyList<MeshNode>> WriteMany(
+            IReadOnlyCollection<MeshNode> nodes, JsonSerializerOptions options)
+            => nodes.Select(n => FaultFor(n.Path)).FirstOrDefault(e => e is not null) is { } ex
+                ? Fault<IReadOnlyList<MeshNode>>(ex)
+                : inner.WriteMany(nodes, options);
+
+        public IObservable<bool?> WriteIfVersion(MeshNode node, long expectedVersion, JsonSerializerOptions options)
+            => FaultFor(node.Path) is { } ex
+                ? Fault<bool?>(ex)
+                : inner.WriteIfVersion(node, expectedVersion, options);
+
+        public IObservable<bool> Exists(string path)
+            => FaultFor(path) is { } ex ? Fault<bool>(ex) : inner.Exists(path);
+
+        public IObservable<string> Delete(string path)
+            => FaultFor(path) is { } ex ? Fault<string>(ex) : inner.Delete(path);
+
+        public IObservable<bool> DeleteIfExists(string path)
+            => FaultFor(path) is { } ex ? Fault<bool>(ex) : inner.DeleteIfExists(path);
+
+        public IObservable<string?> FindDeleteBlockingProvider(string path)
+            => inner.FindDeleteBlockingProvider(path);
+
+        public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)>
+            ListChildPaths(string? parentPath) => inner.ListChildPaths(parentPath);
+
+        public IObservable<IReadOnlyCollection<string>> ListDescendantPaths(string rootPath)
+            => inner.ListDescendantPaths(rootPath);
+
+        public IObservable<(MeshNode? Node, int MatchedSegments)> FindBestPrefixMatch(
+            string fullPath, JsonSerializerOptions options) => inner.FindBestPrefixMatch(fullPath, options);
+
+        public IObservable<(MeshNode? Node, int MatchedSegments)> ResolvePath(
+            string fullPath, JsonSerializerOptions options) => inner.ResolvePath(fullPath, options);
+
+        public IObservable<IEnumerable<string>> ListPartitionSubPaths(string nodePath)
+            => inner.ListPartitionSubPaths(nodePath);
+
+        public IObservable<object> GetPartitionObjects(string nodePath, string? subPath, JsonSerializerOptions options)
+            => inner.GetPartitionObjects(nodePath, subPath, options);
+
+        public IObservable<System.Reactive.Unit> SavePartitionObjects(
+            string nodePath, string? subPath, IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+            => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+
+        public IObservable<System.Reactive.Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+            => inner.DeletePartitionObjects(nodePath, subPath);
+
+        public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+            => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+    }
+}


### PR DESCRIPTION
Fixes #3945.

## The defect, in one sentence

`GitHubWebhookProcessor.SkipReason` made a green-build delivery free for exactly one reason —
`lastSyncCommitSha == headSha` — and `GitHubSyncService.MayAdvanceBaseline` deliberately **holds**
that same field whenever an import did not converge (`Preserved > 0` #675/#677, `Failed > 0` #2229
item C, outcome `Failed`). **The cheapness gate and the convergence guard were the same field**, so
a source that could never converge paid a full `git fetch --depth 1` of its **entire** repository
plus a full parse on **every** delivery — at the source repository's CI cadence, not at any rate of
its own.

Measured 2026-09-10: `Essentials/_GitSync` on memex.meshweaver.cloud had been doing that against
MeshWeaver.Plugins since 2026-08-10 — **31 days, 436 commits** — while its 33 siblings on the same
repository, the same webhook and the same schedule were skipped for free. On core the delivery rate
is ~10/h (254 green publish-signal runs in 24 h).

## The fix — a second, weaker pointer

| Question | Field |
|---|---|
| *Is the mesh known to hold this commit's content?* | `lastSyncCommitSha` — **unchanged**, still held by `MayAdvanceBaseline` |
| *Have we already looked at exactly these bytes?* | `lastAttemptedCommitSha` + `lastAttemptWasFinal` — **new** |

- **`StaticRepoImportResult.VerdictIsFinal`** — *would running again at the same content change the
  answer?* Deliberately a different question from `Converged` (*is the partition now equal to the
  source?*). Final: `Preserved > 0` alone; `ImportedWithContentErrors` (every failure a content
  verdict). **Not** final: `ImportedWithErrors`, outcome `Failed`, `PruneRefused`.
- **The pair is written on every import conclusion and CLEARED** by an export (it advances the
  conflict horizon, which decides which nodes get preserved) and by a hold (no attempt ran, and a
  seal arriving later is the archetype of a condition that clears without the commit moving).
- **A fifth `SkipReason` arm** fires only when *both* halves match the built commit.

`lastSyncCommitSha` and `lastSyncedAt` keep their present semantics exactly, so #675 / #677 /
#2229 item C are untouched: the next NEW commit still brings a full unscoped import, and the GUI's
own **Update to latest** never consults `SkipReason` at all.

## Why the flag, and not the sha alone

Today's re-clone-per-delivery is *also*, accidentally, the retry loop for exactly the failures
`StaticRepoImporter.IsContentVerdict` refuses to call final. `Unknown` ("Persistence read failed…",
"Inner CreateNode faulted…") stays retryable because getting *that* backwards is #3101. Skipping on
"same commit, already attempted" alone would make a transient store fault permanent on any
repository quiet enough not to produce a new commit — a fix that strands every self-healing source.

## Controls, both end-to-end on the CLONE itself

The transfer is the cost (`FetchAndImport` fetches first and diffs second — it has to; a
`subdirectory` scopes the parse, never the transfer), so an assertion on a decision function or a
log line would not be measuring it. `GreenBuildSkipsASettledSourceTest` substitutes the GitHub
transport and one marked storage path; the webhook processor, the sync service, the importer and
the node streams are real.

- `AContentVerdictAtThisCommit_CostsNoSecondClone_AndANewCommitStillDoesImport` — a nested `Space`
  refused with `InvalidPath` → the same green build again **emits no fetch** → a new sha **does**
  fetch, at the commit that build proved. Also pins `lastSyncCommitSha` still `null`.
- `AFailureThatMightNotRecur_IsStillAttemptedAtTheSameCommit` — one node whose store faults with
  the production connect-timeout shape, so the pass is `ImportedWithErrors` with
  `VerdictIsFinal == false`; the same green build then **must** reach GitHub. This is the control
  that could falsify the first.

## The cron trigger — measured, and deliberately NOT narrowed

87 of core's 254 daily publish signals are `Prod synthetic probe`, a `*/15` cron whose entire body
is `curl` (no checkout, no compile). Excluding it, or dropping `schedule`, was measured and is not
the win it looks like:

- its 87 runs cover 34 distinct shas and **every one was already published by a green push run** —
  so excluding it saves nothing this PR's skip does not already save;
- **no repository in the fleet** gets its green default-branch signal only from `schedule` (all six
  satellites' content CI fires on push *and* `repository_dispatch` *and* `schedule`); over the whole
  of September, dropping it would have widened exactly one repository's worst quiet stretch, by 6 h;
- and it would not close the class: on core `192a60d84a36`, `Chart Gate` and `Hosting Operator`
  both went green on `push` in the same second that `push MeshWeaver Build and Test` **failed**.

The real discriminator is `workflow_run.name`/`.path` — *did this repository's own content CI prove
this tree* — which is a separate change with its own risk. §8 of the doc page carries the evidence
and a correctness finding that goes with it (a `*/10` PR-updater cron recorded 20+ green build
completions for commits whose content CI had failed).

## Documentation

`Doc/Architecture/GitSyncTriggerCost` §7 (the fix) and §8 (the trigger evidence);
`Doc/Architecture/GitHubSync`'s *three clocks* are now *four facts*. What's New entry
(`Category: Fix` — a Space admin sees the repeated import activity records stop, and the settings
tab now states why a settled source has stopped attempting).

Pairs-with: none — nothing public is removed; the diff only ADDS members (`StaticRepoImportResult.VerdictIsFinal`, `.ContentErrorsOutcome`, two `GitHubSyncConfig` properties, one optional-parameter pair on a private method).

Implementers: none — no member is added to a public interface or abstract class. The two new members land on `StaticRepoImportResult`, a sealed record, and on `GitHubSyncConfig`, a plain record with no implementers.

Mirror-sync: npm run sync:i18n -- --ref <this PR's merged core sha> — one key added (ui.gitSync.settled, en + de). Tracked on Systemorph/MeshWeaver#3596, which is the open issue for the pinned-mirror staleness this key joins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S25PJZbVeCbkWhCfMub9P7
