### PR TITLE
fix(#3432): make delete success visible to immediate reads

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -4097,7 +4097,8 @@ public static class DataExtensions
     /// <summary>
     /// Reactive delete for a <c>data:</c> path. Content-provider paths delete the file directly;
     /// entity paths read the entity once via <see cref="System.Reactive.Linq.Observable.Take{TSource}(IObservable{TSource}, int)"/>,
-    /// then issue a <see cref="DataChangeRequest"/> and observe the activity completion callback.
+    /// then issue a <see cref="DataChangeRequest"/> and report success after both the owner commit
+    /// and the shared read stream's absence frame.
     /// </summary>
     private static IObservable<DeleteUnifiedReferenceResponse> DeleteDataPath(
         IMessageHub hub,
@@ -4147,13 +4148,25 @@ public static class DataExtensions
                 };
 
                 return workspace.RequestChange(changeRequest)
-                    .Select(log =>
+                    .SelectMany(log =>
                     {
                         var response = new DataChangeResponse(hub.Version, log);
-                        return response.Status == DataChangeStatus.Committed
-                            ? DeleteUnifiedReferenceResponse.Ok()
-                            : DeleteUnifiedReferenceResponse.Fail(
-                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed");
+                        if (response.Status != DataChangeStatus.Committed)
+                            return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
+
+                        // RequestChange reports when the owning data-source stream has applied the
+                        // deletion. The shared read stream is a separate actor-backed reduction:
+                        // its null frame is posted from the source's turn and can still be queued
+                        // when the commit report arrives. A success response at that seam lets the
+                        // caller's immediate GetDataRequest replay the shared stream's OLD entity
+                        // before that queued frame lands. Wait on the exact read view this API
+                        // serves; no polling and no fresh stream/hub. Success now means a read made
+                        // after the response cannot observe the deleted entity (#3432 follow-up).
+                        return stream
+                            .Where(entity => entity.Value == null)
+                            .Take(1)
+                            .Select(_ => DeleteUnifiedReferenceResponse.Ok());
                     });
             });
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
@@ -218,6 +218,25 @@ done for a plain reduce, and where it matters the answer is a narrower reference
 | `ReadingTheSameReferenceRepeatedly_DoesNotMintASyncHubPerRead` | five reads of one reference add **0** `sync/` hubs to the owner (it fails with **+5** on the pre-fix call site) |
 | `AnUncachedConfiguredReduce_MintsOneSyncHubPerCall` | five genuinely-configured reduces add **5** — the counter can see growth, so the flat arm is not vacuous |
 | `TheSharedReadStream_StaysLive` | a write after the reads is visible to the next read — the shared stream is a live mirror, not a snapshot |
+| `UnifiedDelete_WaitsUntilTheSharedReadStreamCarriesAbsence` | a successful delete is withheld while the shared read actor is parked, even after the owner has committed; it answers only after the read view carries absence |
+
+### A shared stream makes its propagation boundary observable
+
+The data-source stream and a reduced read stream are separate actor-backed streams. Applying a change
+to the owner synchronously publishes a source frame, but forwarding that frame to the reduced stream
+posts work to the reduced stream's own hub. The owner's post-apply callback can therefore run while
+the read frame is still queued.
+
+This distinction did not matter when every read built a new reduction: a reduction built after the
+owner commit starts from the owner's latest replayed store. Once reads share the existing reduction,
+an immediate read can replay that reduction's previous value until its queued frame lands. The
+release gate exposed this as a successful `DeleteUnifiedReferenceRequest` followed immediately by a
+`GetDataRequest` that returned the deleted entity.
+
+The delete handler now waits reactively on the same shared entity stream until it carries `null`
+before reporting success. It does not poll and does not build a replacement stream. The resulting
+contract is precise: owner commit remains the storage boundary, while successful unified deletion is
+also the read-after-write boundary for the API's shared read view.
 
 ### One behaviour DID change, and it is the better half of an existing contract
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-delete-success-waits-for-the-read-view.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-delete-success-waits-for-the-read-view.md
@@ -1,0 +1,16 @@
+---
+Name: Deleted data stays gone on the next read
+Category: Fix
+Description: A successful delete now waits until the shared read view has applied the deletion, so an immediate follow-up read cannot return the removed item.
+Icon: Sparkle
+Order: -20260910
+---
+
+# Deleted data stays gone on the next read
+
+Deleting an item could report success just before the portal's shared read view had processed the
+same change. An immediate follow-up read could therefore briefly return the item that had just been
+deleted.
+
+The delete response now waits for that read view to carry the item's absence. Once deletion reports
+success, the next read agrees and the removed item stays gone.

--- a/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
 using MeshWeaver.Data.Serialization;
 using MeshWeaver.Data.TestDomain;
 using MeshWeaver.Fixture;
@@ -110,6 +113,85 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
                 + "so bounding the sync/ hub population did not freeze the mirror");
 
         Output.WriteLine($"DIAG live: instances={settled.Instances.Count}");
+    }
+
+    /// <summary>
+    /// A successful unified delete is a read-after-write boundary: once it answers, the shared
+    /// read stream must already carry absence. The data-source owner and its reduced read stream
+    /// are separate actors, so applying the owner store only QUEUES the reduced null frame. Before
+    /// the fix the handler answered at owner commit and an immediate read could replay the old
+    /// entity — the exact failure in the plugin release gate immediately after #3432's shared-read
+    /// change.
+    ///
+    /// This test parks the shared stream's actor after its initial entity arrived, then proves the
+    /// owner has applied the deletion while the read view cannot yet consume it. The delete reply
+    /// must remain absent until that actor is released. The park is the subject, so it uses the
+    /// repository's bounded SpinWait + finally release pattern; no sleeps, retries, or widened
+    /// production bounds.
+    /// </summary>
+    [HubFact]
+    public async Task UnifiedDelete_WaitsUntilTheSharedReadStreamCarriesAbsence()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var workspace = host.ServiceProvider.GetRequiredService<IWorkspace>();
+        var reference = new EntityReference(nameof(BusinessUnit), "1");
+        var readStream = workspace.GetNullableStream(reference)
+            ?? throw new InvalidOperationException("The BusinessUnit entity reference did not resolve to a stream.");
+
+        await readStream
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value is BusinessUnit { SystemName: "1" },
+                "the shared read stream must carry the entity before its actor is parked");
+
+        var blockerEntered = new AsyncSubject<System.Reactive.Unit>();
+        var releaseBlocker = 0;
+        readStream.Hub.InvokeAsync(
+            _ =>
+            {
+                blockerEntered.OnNext(System.Reactive.Unit.Default);
+                blockerEntered.OnCompleted();
+                if (!SpinWait.SpinUntil(
+                        () => Volatile.Read(ref releaseBlocker) == 1,
+                        TestTimeouts.Convergence))
+                    throw new TimeoutException("The test did not release the shared-read-stream actor.");
+                return Task.CompletedTask;
+            },
+            _ => Task.CompletedTask);
+
+        await blockerEntered.Should().Within(TestTimeouts.Quick)
+            .Emit("the shared stream actor must be occupied before the deletion is issued");
+
+        var answers = new ReplaySubject<DeleteUnifiedReferenceResponse>(1);
+        using var answerSubscription = client
+            .Observe(
+                new DeleteUnifiedReferenceRequest($"data:{nameof(BusinessUnit)}/1"),
+                o => o.WithTarget(CreateHostAddress()))
+            .Select(delivery => delivery.Message)
+            .Subscribe(answers);
+
+        try
+        {
+            var source = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+                .GetStreamForPartition(null)!;
+            await source
+                .Should().Within(TestTimeouts.Convergence)
+                .Match(item => item.Value?.GetCollection(nameof(BusinessUnit))?.Instances.ContainsKey("1") == false,
+                    "the owner must have applied the deletion while the shared read actor is still parked");
+
+            await answers.Should().NotEmit(TimeSpan.FromMilliseconds(300),
+                "owner commit alone is not enough: success must wait for the read view's queued null frame");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseBlocker, 1);
+        }
+
+        var answer = await answers.Should().Within(TestTimeouts.Convergence)
+            .Emit("releasing the shared read actor lets its null frame land and completes the delete");
+        answer.Success.Should().BeTrue();
+        readStream.Current?.Value.Should().BeNull(
+            "a successful delete response is now a read-after-write consistency boundary");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
@@ -146,6 +146,7 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
 
         var blockerEntered = new AsyncSubject<System.Reactive.Unit>();
         var releaseBlocker = 0;
+        Exception? blockerException = null;
         readStream.Hub.InvokeAsync(
             _ =>
             {
@@ -157,7 +158,12 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
                     throw new TimeoutException("The test did not release the shared-read-stream actor.");
                 return Task.CompletedTask;
             },
-            _ => Task.CompletedTask);
+            ex =>
+            {
+                Interlocked.CompareExchange(ref blockerException, ex, null);
+                Volatile.Write(ref releaseBlocker, 1);
+                return Task.CompletedTask;
+            });
 
         await blockerEntered.Should().Within(TestTimeouts.Quick)
             .Emit("the shared stream actor must be occupied before the deletion is issued");
@@ -189,6 +195,8 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
 
         var answer = await answers.Should().Within(TestTimeouts.Convergence)
             .Emit("releasing the shared read actor lets its null frame land and completes the delete");
+        Volatile.Read(ref blockerException).Should().BeNull(
+            "the parked actor turn must complete normally; swallowing a fault would make the ordering assertion vacuous");
         answer.Success.Should().BeTrue();
         readStream.Current?.Value.Should().BeNull(
             "a successful delete response is now a read-after-write consistency boundary");


### PR DESCRIPTION
## Root cause

The shared-read fix correctly stopped minting a synchronization hub per request, but it made the reduced read stream reuse its previous value. A unified delete reported success when the owning data-source stream committed; delivery of the resulting absence frame to the shared reduced stream was still queued on that stream actor. An immediate read could therefore replay the deleted entity.

## Fix

- after owner commit, wait reactively for the same shared entity stream to carry absence before reporting delete success
- add a deterministic actor-boundary regression that parks the shared read stream, proves the owner committed, and verifies no success escapes until the absence frame lands
- document the read-after-write contract and add the user-visible fix note

No polling, retry, delay, replacement stream, or new hub is introduced.

## Evidence

- regression with old behavior: failed in 228 ms because success escaped while the read actor was parked
- focused fixed regression: 1/1 passed in 566 ms
- MeshWeaver.Data.Test: 501/501 passed
- MeshWeaver.Documentation.Test: 374/374 passed
- MeshWeaver.AI.Test against this core: 1,941 passed, 3 skipped, 0 failed
- Release warnings-as-errors builds: MeshWeaver.Data, MeshWeaver.Data.Test, MeshWeaver.Documentation, MeshWeaver.Documentation.Test

Fixes #3971
Fixes #3979
Refs #3432