### PR TITLE
fix(#3954): invalidation wins over a late cached miss

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeIdentityAndPathKeying.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeIdentityAndPathKeying.md
@@ -114,13 +114,18 @@ A create at that path **does** clear it: the post-commit `MeshChangeEvent.Create
 `MeshNodeStreamCache.OnMeshChange` → `ResetFailureState(path)`, which drops the negative entry and
 evicts a faulted read entry. That behaviour is pinned by a test.
 
-The gap is a race, not a missing mechanism (tracked as **#3954**): `RecordNegative` writes `_negative[path]` unconditionally,
-with no epoch or claim guard. A `NotFound` minted by a read that subscribed *before* the create can
-therefore land *after* the `Created` broadcast has already reset the state, re-arming a window of up
-to five minutes that nothing then evicts until it expires — or until another change event for that
-path arrives. A `recycle` publishes exactly such an event, which is why recycling clears the symptom.
-`PathResolutionService` guards the identical race with its `_pendingFills` claims; the stream cache
-has no counterpart.
+The remaining race was fixed in **#3954**. Every read/write that can conclude `NotFound` now claims
+the path *before* opening its owner round-trip. A change event revokes the current claim before it
+clears the negative entry. When an older `NotFound` lands, `RecordNegative` checks that exact claim
+both before and after attempting the dictionary write; readers also refuse an entry whose claim is
+no longer current. The two checks close both interleavings, including an invalidation between the
+first check and the write itself.
+
+Claims are not a second permanent path cache: a successful or transient probe removes its claim,
+while a genuine miss keeps one only for the lifetime of the existing negative entry. Natural
+re-probes replace the claim and keep the established exponential backoff; no timer, retry, or
+sweeper was added. This mirrors `PathResolutionService._pendingFills`: invalidation is authoritative
+over work that began in the older failure era.
 
 ## See also
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeIdentityAndPathKeying.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeIdentityAndPathKeying.md
@@ -115,16 +115,18 @@ A create at that path **does** clear it: the post-commit `MeshChangeEvent.Create
 evicts a faulted read entry. That behaviour is pinned by a test.
 
 The remaining race was fixed in **#3954**. Every read/write that can conclude `NotFound` now claims
-the path *before* opening its owner round-trip. A change event revokes the current claim before it
-clears the negative entry. When an older `NotFound` lands, `RecordNegative` checks that exact claim
-both before and after attempting the dictionary write; readers also refuse an entry whose claim is
-no longer current. The two checks close both interleavings, including an invalidation between the
-first check and the write itself.
+the path *before* opening its owner round-trip. A change event revokes the current claim and clears
+only the negative entry belonging to that exact generation. Publication is a pair-exact
+compare-and-swap: an older probe cannot overwrite a newer probe's genuine miss, and its retraction
+cannot remove that newer entry either. Readers and writers also refuse an entry whose claim is no
+longer current, so a stale verdict cannot fast-fail even during the small interval before its owner
+retracts it.
 
 Claims are not a second permanent path cache: a successful or transient probe removes its claim,
-while a genuine miss keeps one only for the lifetime of the existing negative entry. Natural
-re-probes replace the claim and keep the established exponential backoff; no timer, retry, or
-sweeper was added. This mirrors `PathResolutionService._pendingFills`: invalidation is authoritative
+and teardown removes a pending probe that never reached a terminal, while a genuine miss keeps one
+only for the lifetime of the existing negative entry. Natural re-probes replace the claim and keep
+the established exponential backoff; no timer, retry, or sweeper was added. This mirrors
+`PathResolutionService._pendingFills`: invalidation is authoritative
 over work that began in the older failure era.
 
 ## See also

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-created-node-no-longer-stays-not-found-until-restart.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-a-created-node-no-longer-stays-not-found-until-restart.md
@@ -1,0 +1,12 @@
+---
+Name: A created node no longer stays “not found” until restart
+Category: Fix
+Description: A delayed response from an older read can no longer hide a node that was created while that read was in flight.
+Icon: Sparkle
+Order: -20260910
+---
+
+When a node is created while an earlier lookup is still finishing, the older “not found” response
+can no longer overwrite the newer state. Reads and updates now recover as soon as the creation is
+published instead of continuing to report the node as missing until the cache expires or the portal
+is restarted.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -327,8 +327,15 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// this rather than against the absence of a log line, because "it did not error" and "it did
     /// not suppress the write the form is about to make" are different claims.</para>
     /// </summary>
-    internal bool IsStormWindowOpen(string path) =>
-        _negative.TryGetValue(path, out var negative) && negative.OpenUntil > DateTimeOffset.UtcNow;
+    internal bool IsStormWindowOpen(string path)
+    {
+        if (!_negative.TryGetValue(path, out var negative))
+            return false;
+        if (IsCurrentNegative(path, negative))
+            return negative.OpenUntil > DateTimeOffset.UtcNow;
+        _negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, negative));
+        return false;
+    }
 
     // 🚨 STORM BREAKER / negative cache. A read whose owner answers NotFound /
     // DeliveryFailure (the node does not exist) caches that FAILURE here with an
@@ -357,6 +364,20 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // StormFailThreshold logs ONE "[STORM-BREAKER] suppressing" warning so the storm is
     // visible in Grafana/Loki without the per-failure log flood.
     private readonly ConcurrentDictionary<string, NegativeEntry> _negative = new();
+    // A read/write that can conclude "missing" claims the path BEFORE it opens its owner
+    // round-trip. ResetFailureState invalidates the current claim, so a NotFound already in
+    // flight cannot re-arm _negative after the authoritative change event has cleared it.
+    // Successful/transient probes remove their claim; a missing result keeps it only for the
+    // lifetime of the negative entry, so this registry has the same bounded cardinality as the
+    // in-flight probes + _negative rather than growing once per path ever seen (#3954).
+    private sealed class NegativeProbeClaim(int priorFailCount)
+    {
+        private int invalidated;
+        public int PriorFailCount { get; } = priorFailCount;
+        public bool IsValid => Volatile.Read(ref invalidated) == 0;
+        public void Invalidate() => Interlocked.Exchange(ref invalidated, 1);
+    }
+    private readonly ConcurrentDictionary<string, NegativeProbeClaim> _negativeClaims = new();
     // Reprobing: set true by the FIRST read past OpenUntil — that read drops the stale errored
     // entry and lets a fresh probe hydrate. Subsequent reads while that probe is IN FLIGHT must
     // NOT re-evict it (repeatedly tearing a still-hydrating entry down before it can resolve is a
@@ -364,7 +385,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // a fresh window; FailCount is carried across the reprobe so a genuinely-missing node still
     // backs off further when the fresh probe re-errors.
     private sealed record NegativeEntry(Exception Error, int FailCount, DateTimeOffset OpenUntil,
-        bool Reprobing = false);
+        bool Reprobing = false, NegativeProbeClaim? Claim = null);
     private static readonly TimeSpan StormBaseCooldown = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan StormMaxCooldown = TimeSpan.FromMinutes(5);
     private const int StormFailThreshold = 5;
@@ -816,6 +837,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// </summary>
     internal void ResetFailureState(string path)
     {
+        InvalidateNegativeProbe(path);
         if (_negative.TryRemove(path, out var cleared))
         {
             // One line when a genuinely-suppressed storm is lifted (mirrors the
@@ -1013,6 +1035,9 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // 5. Storm-breaker negative cache — drop the cached failure windows so
         //    nothing roots the disposed mesh's exceptions/identities.
         _negative.Clear();
+        foreach (var claim in _negativeClaims.Values)
+            claim.Invalidate();
+        _negativeClaims.Clear();
         _transientStreaks.Clear();
 
 
@@ -1044,8 +1069,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
 
     private Entry CreateEntry(string p)
     {
+        logger.LogDebug("MeshNodeStreamCache: opening shared stream for {Path}", p);
+        var negativeClaim = BeginNegativeProbe(p);
+        try
         {
-            logger.LogDebug("MeshNodeStreamCache: opening shared stream for {Path}", p);
             // 🚨 Bypass the cache when opening our OWN upstream — otherwise
             // GetMeshNodeStream(workspace, path) auto-redirects back into the
             // cache and we'd recurse forever waiting for ourselves. Use the
@@ -1159,13 +1186,18 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     if (node is not null)
                     {
                         _negative.TryRemove(p, out _);
+                        CompleteNegativeProbe(p, negativeClaim);
                         _transientStreaks.TryRemove(p, out _);
                     }
                 },
                 ex =>
                 {
                     entry.MarkFaulted();
-                    if (IsMissingNodeFailure(ex)) RecordNegative(p, ex);
+                    if (IsMissingNodeFailure(ex))
+                    {
+                        if (!TryRecordNegative(p, ex, negativeClaim))
+                            CompleteNegativeProbe(p, negativeClaim);
+                    }
                     // Everything that is NOT a genuine missing node stays out of the negative
                     // cache (the node exists — see IsTransientOwnerFailure), but a STREAK of
                     // failures is the poisoned-activation loop; record it so re-probes back off
@@ -1184,10 +1216,20 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     // first TransientGraceFailures faults of ANY class, then bounds a persistent
                     // one at ≤ TransientMaxCooldown. A successful read or a change-feed
                     // invalidation clears it immediately, exactly as before.
-                    else RecordTransient(p, ex);
-                });
+                    else
+                    {
+                        CompleteNegativeProbe(p, negativeClaim);
+                        RecordTransient(p, ex);
+                    }
+                },
+                () => CompleteNegativeProbe(p, negativeClaim));
             disposal.Add(bookkeeping);
             return entry;
+        }
+        catch
+        {
+            CompleteNegativeProbe(p, negativeClaim);
+            throw;
         }
     }
 
@@ -1455,16 +1497,40 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// history (a compile-error era's worth of consecutive activation failures)
     /// deterministically instead of waiting out real backoff windows.
     /// </summary>
-    internal void RecordNegative(string path, Exception error)
+    internal void RecordNegative(string path, Exception error) =>
+        TryRecordNegative(path, error, claim: null);
+
+    /// <summary>
+    /// Production negative-cache admission. A claimed result is accepted only while the exact
+    /// claim captured before its owner round-trip is still current. The post-write re-check closes
+    /// the other interleaving: invalidation can land between the first check and the dictionary
+    /// write, in which case the pair-exact removal retracts the stale entry. Readers also validate
+    /// the claim, so even that short-lived entry can never fast-fail a caller (#3954).
+    /// </summary>
+    private bool TryRecordNegative(string path, Exception error, NegativeProbeClaim? claim)
     {
-        var priorFails = _negative.TryGetValue(path, out var existing) ? existing.FailCount : 0;
+        if (claim is not null && !ClaimStillHeld(path, claim))
+            return false;
+        var priorFails = Math.Max(
+            _negative.TryGetValue(path, out var existing) ? existing.FailCount : 0,
+            claim?.PriorFailCount ?? 0);
         var failCount = priorFails + 1;
         // 2^(n-1) capped at 20 shifts (~12 days) before the Min — StormMaxCooldown
         // is the real ceiling; the cap just keeps the intermediate from overflowing.
         var backoffTicks = Math.Min(
             StormBaseCooldown.Ticks * (1L << Math.Min(failCount - 1, 20)),
             StormMaxCooldown.Ticks);
-        _negative[path] = new NegativeEntry(error, failCount, DateTimeOffset.UtcNow + TimeSpan.FromTicks(backoffTicks));
+        var recorded = new NegativeEntry(
+            error,
+            failCount,
+            DateTimeOffset.UtcNow + TimeSpan.FromTicks(backoffTicks),
+            Claim: claim);
+        _negative[path] = recorded;
+        if (claim is not null && !ClaimStillHeld(path, claim))
+        {
+            _negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, recorded));
+            return false;
+        }
         if (failCount == StormFailThreshold)
             logger.LogWarning(
                 "[STORM-BREAKER] Suppressing re-probe of '{Path}' after {FailCount} consecutive access failures: {Error}. "
@@ -1472,6 +1538,58 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 + "not exist is a defect — read optional nodes via GetQuery (empty-on-absent), not GetMeshNodeStream(exactPath); "
                 + "bring a new node into being with CreateNode, not Update.",
                 path, failCount, error.Message);
+        return true;
+    }
+
+    private NegativeProbeClaim BeginNegativeProbe(string path)
+    {
+        while (true)
+        {
+            if (!_negativeClaims.TryGetValue(path, out var current))
+            {
+                // Claim-less entries exist only through the internal deterministic test seam.
+                // Preserve their grown backoff when a real re-probe follows one.
+                var prior = _negative.TryGetValue(path, out var unclaimed)
+                    && unclaimed.Claim is null
+                    ? unclaimed.FailCount
+                    : 0;
+                var claim = new NegativeProbeClaim(prior);
+                if (_negativeClaims.TryAdd(path, claim))
+                    return claim;
+                continue;
+            }
+            var priorFailCount = _negative.TryGetValue(path, out var existing)
+                                 && ReferenceEquals(existing.Claim, current)
+                ? existing.FailCount
+                : 0;
+            var replacement = new NegativeProbeClaim(priorFailCount);
+            if (!_negativeClaims.TryUpdate(path, replacement, current))
+                continue;
+            current.Invalidate();
+            return replacement;
+        }
+    }
+
+    private bool ClaimStillHeld(string path, NegativeProbeClaim claim) =>
+        claim.IsValid
+        && _negativeClaims.TryGetValue(path, out var current)
+        && ReferenceEquals(current, claim);
+
+    private bool IsCurrentNegative(string path, NegativeEntry negative) =>
+        negative.Claim is null || ClaimStillHeld(path, negative.Claim);
+
+    private void CompleteNegativeProbe(string path, NegativeProbeClaim claim)
+    {
+        if (_negativeClaims.TryRemove(new KeyValuePair<string, NegativeProbeClaim>(path, claim)))
+            claim.Invalidate();
+    }
+
+    private void InvalidateNegativeProbe(string path)
+    {
+        if (!_negativeClaims.TryGetValue(path, out var claim))
+            return;
+        claim.Invalidate();
+        _negativeClaims.TryRemove(new KeyValuePair<string, NegativeProbeClaim>(path, claim));
     }
 
     /// <summary>
@@ -1731,9 +1849,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         //      identical exception while the backoff grew. See EvictFaultedEntry (#1202).
         if (_negative.TryGetValue(path, out var neg))
         {
-            if (neg.OpenUntil > DateTimeOffset.UtcNow)
+            if (!IsCurrentNegative(path, neg))
+                _negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, neg));
+            else if (neg.OpenUntil > DateTimeOffset.UtcNow)
                 return Observable.Throw<MeshNode>(neg.Error);
-            if (!neg.Reprobing && _negative.TryUpdate(path, neg with { Reprobing = true }, neg))
+            else if (!neg.Reprobing && _negative.TryUpdate(path, neg with { Reprobing = true }, neg))
                 EvictFaultedEntry(path, "storm-breaker");
         }
 
@@ -1927,6 +2047,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // path can never storm the mesh from either direction. Only a real CreateNode brings a
         // non-existent node into being — an Update can't.
         if (_negative.TryGetValue(path, out var negWrite)
+            && IsCurrentNegative(path, negWrite)
             && negWrite.OpenUntil > DateTimeOffset.UtcNow
             && IsMissingNodeFailure(negWrite.Error))
             return Observable.Throw<MeshNode>(negWrite.Error);
@@ -2093,6 +2214,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 using var callerScope = req.Caller is not null && accessService is not null
                     ? accessService.SwitchAccessContext(req.Caller)
                     : null;
+                var negativeClaim = BeginNegativeProbe(path);
 
                 // 🚨 Consume the predecessor's locally-computed state from this queue owner. Taken
                 // (and REMOVED) here rather than read in place so it can only ever inform the single
@@ -2168,8 +2290,11 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 _inflightWrites[inflight] = 0;
                 queue.Inflight.Add(inflight);
                 var sawLocalEmit = false;
+                var keepNegativeClaim = 0;
                 void Settle()
                 {
+                    if (Volatile.Read(ref keepNegativeClaim) == 0)
+                        CompleteNegativeProbe(path, negativeClaim);
                     _inflightWrites.TryRemove(inflight, out _);
                     queue.Inflight.Remove(inflight);
                     try { inflight.Dispose(); } catch { /* best-effort */ }
@@ -2182,6 +2307,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                             path, req.Seq, (DateTimeOffset.UtcNow - req.EnteredAt).TotalMilliseconds);
                         // A successful write proves the owner is live ⇒ clear any storm-breaker
                         // window so reads/writes re-probe normally.
+                        InvalidateNegativeProbe(path);
                         _negative.TryRemove(path, out _);
                         // Write activity refreshes the read entry's idle window — GetEntry
                         // pinned it at write START; touching again on each terminal keeps
@@ -2202,8 +2328,9 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                         // instead of re-enqueueing doomed PatchDataRequests against a hub that can't
                         // activate. Only missing-node failures record (not RLS denial / transient),
                         // so a legitimately-existing node is never falsely suppressed.
-                        if (IsMissingNodeFailure(ex))
-                            RecordNegative(path, ex);
+                        if (IsMissingNodeFailure(ex)
+                            && TryRecordNegative(path, ex, negativeClaim))
+                            Volatile.Write(ref keepNegativeClaim, 1);
                         entry.Touch();
                         // 🚨 A Conflict NACK is the owner PRESCRIBING the remedy: "re-read and
                         // re-apply". This queue re-invokes the caller's mutation on the CURRENT
@@ -2999,6 +3126,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// </summary>
     public void Invalidate(string path)
     {
+        InvalidateNegativeProbe(path);
         _negative.TryRemove(path, out _);
         if (_streams.TryRemove(path, out var lazyEntry))
         {

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -370,7 +370,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // Successful/transient probes remove their claim; a missing result keeps it only for the
     // lifetime of the negative entry, so this registry has the same bounded cardinality as the
     // in-flight probes + _negative rather than growing once per path ever seen (#3954).
-    private sealed class NegativeProbeClaim(int priorFailCount)
+    internal sealed class NegativeProbeClaim(int priorFailCount)
     {
         private int invalidated;
         public int PriorFailCount { get; } = priorFailCount;
@@ -837,8 +837,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// </summary>
     internal void ResetFailureState(string path)
     {
-        InvalidateNegativeProbe(path);
-        if (_negative.TryRemove(path, out var cleared))
+        var invalidatedClaim = InvalidateNegativeProbe(path);
+        if (TryRemoveNegativeGeneration(path, invalidatedClaim, out var cleared))
         {
             // One line when a genuinely-suppressed storm is lifted (mirrors the
             // single "[STORM-BREAKER] suppressing" warning); routine clears stay at Debug.
@@ -1034,10 +1034,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
 
         // 5. Storm-breaker negative cache — drop the cached failure windows so
         //    nothing roots the disposed mesh's exceptions/identities.
-        _negative.Clear();
         foreach (var claim in _negativeClaims.Values)
             claim.Invalidate();
         _negativeClaims.Clear();
+        _negative.Clear();
         _transientStreaks.Clear();
 
 
@@ -1185,7 +1185,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 {
                     if (node is not null)
                     {
-                        _negative.TryRemove(p, out _);
+                        TryRemoveNegativeGeneration(p, negativeClaim, out _);
                         CompleteNegativeProbe(p, negativeClaim);
                         _transientStreaks.TryRemove(p, out _);
                     }
@@ -1224,6 +1224,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                 },
                 () => CompleteNegativeProbe(p, negativeClaim));
             disposal.Add(bookkeeping);
+            disposal.Add(System.Reactive.Disposables.Disposable.Create(
+                () => CompleteNegativeProbeUnlessRetained(p, negativeClaim)));
             return entry;
         }
         catch
@@ -1507,41 +1509,98 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// write, in which case the pair-exact removal retracts the stale entry. Readers also validate
     /// the claim, so even that short-lived entry can never fast-fail a caller (#3954).
     /// </summary>
-    private bool TryRecordNegative(string path, Exception error, NegativeProbeClaim? claim)
+    private bool TryRecordNegative(string path, Exception error, NegativeProbeClaim? claim) =>
+        TryRecordNegative(path, error, claim, afterClaimCheck: null);
+
+    /// <summary>Test seam for the one CAS interleaving that cannot be held from outside the
+    /// dictionary: <paramref name="afterClaimCheck"/> runs after the final claim check and after
+    /// the expected dictionary pair was captured, immediately before publication.</summary>
+    internal bool TryRecordNegativeForTest(
+        string path,
+        Exception error,
+        NegativeProbeClaim claim,
+        Action afterClaimCheck) =>
+        TryRecordNegative(path, error, claim, afterClaimCheck);
+
+    /// <summary>The write-side admission stays a named seam so its independent use of the claim
+    /// protocol is pinned without having to substitute a mesh owner.</summary>
+    private bool TryRecordWriteNegative(string path, Exception error, NegativeProbeClaim claim) =>
+        IsMissingNodeFailure(error) && TryRecordNegative(path, error, claim);
+
+    internal bool TryRecordWriteNegativeForTest(
+        string path, Exception error, NegativeProbeClaim claim) =>
+        TryRecordWriteNegative(path, error, claim);
+
+    private bool TryRecordNegative(
+        string path,
+        Exception error,
+        NegativeProbeClaim? claim,
+        Action? afterClaimCheck)
     {
-        if (claim is not null && !ClaimStillHeld(path, claim))
-            return false;
-        var priorFails = Math.Max(
-            _negative.TryGetValue(path, out var existing) ? existing.FailCount : 0,
-            claim?.PriorFailCount ?? 0);
-        var failCount = priorFails + 1;
-        // 2^(n-1) capped at 20 shifts (~12 days) before the Min — StormMaxCooldown
-        // is the real ceiling; the cap just keeps the intermediate from overflowing.
-        var backoffTicks = Math.Min(
-            StormBaseCooldown.Ticks * (1L << Math.Min(failCount - 1, 20)),
-            StormMaxCooldown.Ticks);
-        var recorded = new NegativeEntry(
-            error,
-            failCount,
-            DateTimeOffset.UtcNow + TimeSpan.FromTicks(backoffTicks),
-            Claim: claim);
-        _negative[path] = recorded;
-        if (claim is not null && !ClaimStillHeld(path, claim))
+        while (true)
         {
-            _negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, recorded));
-            return false;
+            if (claim is not null && !ClaimStillHeld(path, claim))
+                return false;
+
+            var hasExisting = _negative.TryGetValue(path, out var existing);
+            if (hasExisting && existing!.Claim is not null
+                && !ReferenceEquals(existing.Claim, claim))
+            {
+                // A stale claimed entry is dead state and may be removed pair-exact. A CURRENT
+                // different claim means this caller is stale (or is the claim-less test seam) and
+                // must never overwrite the current probe's verdict.
+                if (!IsCurrentNegative(path, existing))
+                {
+                    _negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, existing));
+                    continue;
+                }
+                return false;
+            }
+
+            var priorFails = Math.Max(hasExisting ? existing!.FailCount : 0, claim?.PriorFailCount ?? 0);
+            var failCount = priorFails + 1;
+            // 2^(n-1) capped at 20 shifts (~12 days) before the Min — StormMaxCooldown
+            // is the real ceiling; the cap just keeps the intermediate from overflowing.
+            var backoffTicks = Math.Min(
+                StormBaseCooldown.Ticks * (1L << Math.Min(failCount - 1, 20)),
+                StormMaxCooldown.Ticks);
+            var recorded = new NegativeEntry(
+                error,
+                failCount,
+                DateTimeOffset.UtcNow + TimeSpan.FromTicks(backoffTicks),
+                Claim: claim);
+
+            if (claim is not null && !ClaimStillHeld(path, claim))
+                return false;
+
+            // Test-only rendezvous; production always passes null. It holds the exact race:
+            // another probe can replace this claim and publish between validation and CAS.
+            afterClaimCheck?.Invoke();
+            afterClaimCheck = null;
+
+            var published = hasExisting
+                ? _negative.TryUpdate(path, recorded, existing!)
+                : _negative.TryAdd(path, recorded);
+            if (!published)
+                continue;
+
+            if (claim is not null && !ClaimStillHeld(path, claim))
+            {
+                _negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, recorded));
+                return false;
+            }
+            if (failCount == StormFailThreshold)
+                logger.LogWarning(
+                    "[STORM-BREAKER] Suppressing re-probe of '{Path}' after {FailCount} consecutive access failures: {Error}. "
+                    + "Reads AND writes fast-fail until the backoff window elapses. A point node-access to a node that does "
+                    + "not exist is a defect — read optional nodes via GetQuery (empty-on-absent), not GetMeshNodeStream(exactPath); "
+                    + "bring a new node into being with CreateNode, not Update.",
+                    path, failCount, error.Message);
+            return true;
         }
-        if (failCount == StormFailThreshold)
-            logger.LogWarning(
-                "[STORM-BREAKER] Suppressing re-probe of '{Path}' after {FailCount} consecutive access failures: {Error}. "
-                + "Reads AND writes fast-fail until the backoff window elapses. A point node-access to a node that does "
-                + "not exist is a defect — read optional nodes via GetQuery (empty-on-absent), not GetMeshNodeStream(exactPath); "
-                + "bring a new node into being with CreateNode, not Update.",
-                path, failCount, error.Message);
-        return true;
     }
 
-    private NegativeProbeClaim BeginNegativeProbe(string path)
+    internal NegativeProbeClaim BeginNegativeProbe(string path)
     {
         while (true)
         {
@@ -1584,13 +1643,70 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             claim.Invalidate();
     }
 
-    private void InvalidateNegativeProbe(string path)
+    private void CompleteNegativeProbeUnlessRetained(string path, NegativeProbeClaim claim)
+    {
+        if (_negative.TryGetValue(path, out var negative)
+            && ReferenceEquals(negative.Claim, claim)
+            && ClaimStillHeld(path, claim))
+            return;
+        CompleteNegativeProbe(path, claim);
+    }
+
+    internal NegativeProbeClaim? InvalidateNegativeProbe(string path)
     {
         if (!_negativeClaims.TryGetValue(path, out var claim))
-            return;
+            return null;
         claim.Invalidate();
         _negativeClaims.TryRemove(new KeyValuePair<string, NegativeProbeClaim>(path, claim));
+        return claim;
     }
+
+    private bool TryRemoveNegativeGeneration(
+        string path,
+        NegativeProbeClaim? invalidatedClaim,
+        out NegativeEntry removed)
+    {
+        while (_negative.TryGetValue(path, out var candidate))
+        {
+            // A claimed entry from a replacement probe began after this invalidation. Never let a
+            // path-only clear erase that newer genuine miss and its backoff (#3954 review).
+            if (candidate.Claim is not null
+                && !ReferenceEquals(candidate.Claim, invalidatedClaim))
+            {
+                if (IsCurrentNegative(path, candidate))
+                {
+                    removed = null!;
+                    return false;
+                }
+                // It belongs to an already-invalidated generation. Removing that dead pair is
+                // safe and prevents an explicit clear from leaving stale state merely because
+                // its claim had already been detached by another terminal path.
+                if (_negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, candidate)))
+                {
+                    removed = candidate;
+                    return true;
+                }
+                continue;
+            }
+            if (_negative.TryRemove(new KeyValuePair<string, NegativeEntry>(path, candidate)))
+            {
+                removed = candidate;
+                return true;
+            }
+        }
+        removed = null!;
+        return false;
+    }
+
+    internal bool TryRemoveNegativeGenerationForTest(string path, NegativeProbeClaim? invalidatedClaim) =>
+        TryRemoveNegativeGeneration(path, invalidatedClaim, out _);
+
+    internal Exception? CurrentNegativeErrorForTest(string path) =>
+        _negative.TryGetValue(path, out var negative) && IsCurrentNegative(path, negative)
+            ? negative.Error
+            : null;
+
+    internal bool HasNegativeProbeClaimForTest(string path) => _negativeClaims.ContainsKey(path);
 
     /// <summary>
     /// Records an owner fault that is NOT a genuine missing node — the transient class
@@ -2307,8 +2423,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                             path, req.Seq, (DateTimeOffset.UtcNow - req.EnteredAt).TotalMilliseconds);
                         // A successful write proves the owner is live ⇒ clear any storm-breaker
                         // window so reads/writes re-probe normally.
-                        InvalidateNegativeProbe(path);
-                        _negative.TryRemove(path, out _);
+                        var invalidatedClaim = InvalidateNegativeProbe(path);
+                        TryRemoveNegativeGeneration(path, invalidatedClaim, out _);
                         // Write activity refreshes the read entry's idle window — GetEntry
                         // pinned it at write START; touching again on each terminal keeps
                         // an in-flight write's upstream out of the idle sweep's reach.
@@ -2328,8 +2444,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                         // instead of re-enqueueing doomed PatchDataRequests against a hub that can't
                         // activate. Only missing-node failures record (not RLS denial / transient),
                         // so a legitimately-existing node is never falsely suppressed.
-                        if (IsMissingNodeFailure(ex)
-                            && TryRecordNegative(path, ex, negativeClaim))
+                        if (TryRecordWriteNegative(path, ex, negativeClaim))
                             Volatile.Write(ref keepNegativeClaim, 1);
                         entry.Touch();
                         // 🚨 A Conflict NACK is the owner PRESCRIBING the remedy: "re-read and
@@ -3126,8 +3241,8 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// </summary>
     public void Invalidate(string path)
     {
-        InvalidateNegativeProbe(path);
-        _negative.TryRemove(path, out _);
+        var invalidatedClaim = InvalidateNegativeProbe(path);
+        TryRemoveNegativeGeneration(path, invalidatedClaim, out _);
         if (_streams.TryRemove(path, out var lazyEntry))
         {
             // Dispose the upstream SubscribeRequest so it doesn't dangle in

--- a/test/MeshWeaver.Hosting.Test/NegativeCacheInvalidationRaceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/NegativeCacheInvalidationRaceTest.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Regression guard for issue #3954: a missing-node verdict that was already in flight when a
+/// write invalidated the path must not re-open the negative-cache window after that invalidation.
+/// </summary>
+public class NegativeCacheInvalidationRaceTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    /// <summary>
+    /// Owns one throwaway path and parks its first request before returning the authoritative
+    /// routing NotFound. The producer-to-test signal is an <see cref="AsyncSubject{T}"/>; the
+    /// release into the deliberately parked routing callback is the sanctioned bounded
+    /// <see cref="SpinWait.SpinUntil(Func{bool},TimeSpan)"/> shape and is always opened by the
+    /// test's <c>finally</c>.
+    /// </summary>
+    private sealed class HeldMissingOwner : IDisposable
+    {
+        private readonly IDisposable registration;
+        private readonly AsyncSubject<Unit> requestEntered = new();
+        private int release;
+        private int gateTimedOut;
+
+        public HeldMissingOwner(IMessageHub mesh, IRoutingService routing, string path)
+        {
+            var access = mesh.ServiceProvider.GetService<AccessService>();
+            SyncDelivery answer = delivery =>
+            {
+                if (delivery.Message is DeliveryFailure
+                    || delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
+                    return delivery.Processed();
+
+                requestEntered.OnNext(Unit.Default);
+                requestEntered.OnCompleted();
+                if (!SpinWait.SpinUntil(
+                        () => Volatile.Read(ref release) == 1,
+                        TestTimeouts.Convergence))
+                    Volatile.Write(ref gateTimedOut, 1);
+
+                var message = $"No node found at '{path}'. Closest ancestor is 'TestData'.";
+                using (delivery.AccessContext is null ? access?.ImpersonateAsSystem() : null)
+                    mesh.Post(
+                        new DeliveryFailure(delivery)
+                        {
+                            ErrorType = ErrorType.NotFound,
+                            Message = message,
+                        },
+                        options => options.ResponseFor(delivery));
+                return delivery.FailedAndNacked(message);
+            };
+            registration = routing.RegisterStream(new Address(path), answer);
+        }
+
+        public IObservable<Unit> RequestEntered => requestEntered;
+        public bool GateTimedOut => Volatile.Read(ref gateTimedOut) != 0;
+        public void Release() => Volatile.Write(ref release, 1);
+        public void Dispose() => registration.Dispose();
+    }
+
+    private async Task<string> CreateNodeAsync()
+    {
+        var path = $"{TestPartition}/negative-race-{Guid.NewGuid():N}";
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Original",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        await NodeFactory.CreateNode(node).Should().Within(TestTimeouts.Convergence).Emit();
+        return path;
+    }
+
+    private void PublishAuthoritativeChange(string path)
+    {
+        var segments = path.Split('/');
+        Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>().Publish(new MeshChangeEvent(
+            Namespace: string.Join("/", segments[..^1]),
+            Id: segments[^1],
+            Path: path,
+            Kind: MeshChangeKind.Created,
+            NodeType: MeshNode.NodeTypePath,
+            Version: 1,
+            Timestamp: DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>
+    /// Control arm: the claim guard must not disable the storm breaker. When no authoritative
+    /// change supersedes the probe, the same NotFound still opens its normal backoff window.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task MissingVerdictWithoutInvalidation_StillOpensTheNegativeWindow()
+    {
+        var path = await CreateNodeAsync();
+        using var owner = new HeldMissingOwner(
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IRoutingService>(),
+            path);
+        owner.Release();
+
+        var failure = await Cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(TestTimeouts.Convergence).Match(
+                notification => notification.Kind == NotificationKind.OnError,
+                "the owner must return the genuine missing-node verdict used by the subject arm");
+
+        MeshNodeStreamCache.IsMissingNodeFailure(failure.Exception!).Should().BeTrue();
+        owner.GateTimedOut.Should().BeFalse();
+        Cache.IsStormWindowOpen(path).Should().BeTrue(
+            "without a newer change event, a genuine missing path must retain storm backoff");
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task MissingVerdictThatLandsAfterInvalidation_DoesNotRearmTheNegativeWindow()
+    {
+        var path = await CreateNodeAsync();
+        using var owner = new HeldMissingOwner(
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IRoutingService>(),
+            path);
+
+        var terminal = Cache.GetStream(path, Mesh.JsonSerializerOptions).Materialize().Replay();
+        using var connection = terminal.Connect();
+        try
+        {
+            await owner.RequestEntered.Should().Within(TestTimeouts.Convergence).Emit(
+                "the NotFound must already be in flight before the invalidation, or the race is not held");
+
+            PublishAuthoritativeChange(path);
+            owner.Release();
+
+            var failure = await terminal.Should().Within(TestTimeouts.Convergence).Match(
+                notification => notification.Kind == NotificationKind.OnError,
+                "the held owner must deliver its pre-invalidation NotFound after the change event");
+            MeshNodeStreamCache.IsMissingNodeFailure(failure.Exception!).Should().BeTrue(
+                "the delayed verdict must be exactly the failure class that normally opens the negative window");
+            owner.GateTimedOut.Should().BeFalse(
+                "the test must release the parked verdict; a self-expired gate proves no ordering");
+            Cache.IsStormWindowOpen(path).Should().BeFalse(
+                "the change event is authoritative over a missing verdict minted in the older failure era");
+        }
+        finally
+        {
+            owner.Release();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/NegativeCacheInvalidationRaceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/NegativeCacheInvalidationRaceTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
@@ -35,7 +36,7 @@ public class NegativeCacheInvalidationRaceTest(ITestOutputHelper output) : Monol
     /// </summary>
     private sealed class HeldMissingOwner : IDisposable
     {
-        private readonly IDisposable registration;
+        private IDisposable? registration;
         private readonly AsyncSubject<Unit> requestEntered = new();
         private int release;
         private int gateTimedOut;
@@ -73,7 +74,8 @@ public class NegativeCacheInvalidationRaceTest(ITestOutputHelper output) : Monol
         public IObservable<Unit> RequestEntered => requestEntered;
         public bool GateTimedOut => Volatile.Read(ref gateTimedOut) != 0;
         public void Release() => Volatile.Write(ref release, 1);
-        public void Dispose() => registration.Dispose();
+        public void RestoreRealOwner() => Interlocked.Exchange(ref registration, null)?.Dispose();
+        public void Dispose() => RestoreRealOwner();
     }
 
     private async Task<string> CreateNodeAsync()
@@ -154,8 +156,134 @@ public class NegativeCacheInvalidationRaceTest(ITestOutputHelper output) : Monol
                 "the delayed verdict must be exactly the failure class that normally opens the negative window");
             owner.GateTimedOut.Should().BeFalse(
                 "the test must release the parked verdict; a self-expired gate proves no ordering");
+
+            // Do NOT call IsStormWindowOpen first: that diagnostic helper rejects and removes a
+            // stale-claim entry itself. The real read and write surfaces must both recover without
+            // help from the diagnostic seam.
+            owner.RestoreRealOwner();
+            var recovered = await Cache.GetStream(path, Mesh.JsonSerializerOptions)
+                .Take(1).Timeout(TestTimeouts.Convergence).Await();
+            recovered.Path.Should().Be(path);
+            var updated = await Cache.Update(
+                    path,
+                    node => node with { Name = "Recovered after stale read verdict" },
+                    Mesh.JsonSerializerOptions)
+                .Take(1).Timeout(TestTimeouts.Convergence).Await();
+            updated.Name.Should().Be("Recovered after stale read verdict");
             Cache.IsStormWindowOpen(path).Should().BeFalse(
                 "the change event is authoritative over a missing verdict minted in the older failure era");
+        }
+        finally
+        {
+            owner.Release();
+        }
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task WriteMissingVerdictThatLandsAfterInvalidation_DoesNotRearmOrFastFailTheNextWrite()
+    {
+        var path = await CreateNodeAsync();
+        var writeClaim = Cache.BeginNegativeProbe(path);
+        PublishAuthoritativeChange(path);
+        var lateMissing = new InvalidOperationException(
+            $"No node found at '{path}'. Closest ancestor is 'TestData'.");
+
+        Cache.TryRecordWriteNegativeForTest(path, lateMissing, writeClaim).Should().BeFalse(
+            "the exact claim captured before the write's owner round-trip was invalidated by the change");
+
+        // Exercise the real write fast-fail guard before IsStormWindowOpen gets a chance to clean
+        // stale state. A mistakenly admitted old write verdict would fail this synchronously.
+        var updated = await Cache.Update(
+                path,
+                node => node with { Name = "write recovered" },
+                Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(TestTimeouts.Convergence).Await();
+        updated.Name.Should().Be("write recovered");
+        Cache.IsStormWindowOpen(path).Should().BeFalse();
+    }
+
+    /// <summary>Holds the review's exact critical interleaving: the old claim has passed its last
+    /// validation and captured the dictionary pair; a replacement then publishes before the old
+    /// caller executes its CAS. The replacement must remain present.</summary>
+    [Fact(Timeout = 240_000)]
+    public async Task OlderProbeCannotOverwriteOrRemoveANewerProbesNegativeEntry()
+    {
+        var path = $"{TestPartition}/negative-cas-{Guid.NewGuid():N}";
+        var oldClaim = Cache.BeginNegativeProbe(path);
+        var oldError = new InvalidOperationException("old missing verdict");
+        var newError = new InvalidOperationException("new missing verdict");
+        var oldReachedPublish = new AsyncSubject<Unit>();
+        var oldResult = new AsyncSubject<bool>();
+        var releaseOld = 0;
+
+        Observable.Start(
+                () => Cache.TryRecordNegativeForTest(path, oldError, oldClaim, () =>
+                {
+                    oldReachedPublish.OnNext(Unit.Default);
+                    oldReachedPublish.OnCompleted();
+                    SpinWait.SpinUntil(
+                        () => Volatile.Read(ref releaseOld) == 1,
+                        TestTimeouts.Convergence);
+                }),
+                TaskPoolScheduler.Default)
+            .Subscribe(oldResult);
+
+        try
+        {
+            await oldReachedPublish.Should().Within(TestTimeouts.Convergence).Emit(
+                "the old probe must be parked after validation and before publication");
+            var newClaim = Cache.BeginNegativeProbe(path);
+            Cache.TryRecordNegativeForTest(path, newError, newClaim, static () => { }).Should().BeTrue();
+
+            Volatile.Write(ref releaseOld, 1);
+            (await oldResult.Should().Within(TestTimeouts.Convergence).Emit()).Should().BeFalse(
+                "the stale claim lost publication ownership");
+            Cache.CurrentNegativeErrorForTest(path).Should().BeSameAs(newError,
+                "the stale writer must neither overwrite nor pair-remove the newer entry");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseOld, 1);
+            Cache.Invalidate(path);
+        }
+    }
+
+    [Fact]
+    public void PairExactClearCannotDeleteAReplacementProbesNegativeEntry()
+    {
+        var path = $"{TestPartition}/negative-clear-{Guid.NewGuid():N}";
+        var oldClaim = Cache.BeginNegativeProbe(path);
+        Cache.TryRecordNegativeForTest(
+            path, new InvalidOperationException("old"), oldClaim, static () => { }).Should().BeTrue();
+        var invalidated = Cache.InvalidateNegativeProbe(path);
+        var newClaim = Cache.BeginNegativeProbe(path);
+        var newError = new InvalidOperationException("new");
+        Cache.TryRecordNegativeForTest(path, newError, newClaim, static () => { }).Should().BeTrue();
+
+        Cache.TryRemoveNegativeGenerationForTest(path, invalidated).Should().BeFalse(
+            "ResetFailureState and Invalidate may clear only the generation they invalidated");
+        Cache.CurrentNegativeErrorForTest(path).Should().BeSameAs(newError);
+        Cache.Invalidate(path);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task TeardownOfAPendingReadReleasesItsNegativeProbeClaim()
+    {
+        var path = await CreateNodeAsync();
+        using var owner = new HeldMissingOwner(
+            Mesh,
+            Mesh.ServiceProvider.GetRequiredService<IRoutingService>(),
+            path);
+        using var subscriber = Cache.GetStream(path, Mesh.JsonSerializerOptions).Subscribe(_ => { }, _ => { });
+        try
+        {
+            await owner.RequestEntered.Should().Within(TestTimeouts.Convergence).Emit();
+            Cache.HasNegativeProbeClaimForTest(path).Should().BeTrue();
+            subscriber.Dispose();
+            Cache.ReleaseIfUnwatched(path).Should().BeTrue(
+                "the final-subscriber path is the teardown that can win before an owner terminal");
+            Cache.HasNegativeProbeClaimForTest(path).Should().BeFalse(
+                "a pending hydration with no negative entry retains no claim after teardown");
         }
         finally
         {


### PR DESCRIPTION
## Root cause

A read or update could begin before a create/change invalidated the path, then deliver its NotFound afterward. RecordNegative wrote the delayed verdict unconditionally, reopening the storm-breaker window after the authoritative invalidation had already cleared it. Reads and writes then fast-failed a path that existed until another change or process recycle.

## Fix

- claim each owner probe before it can produce a missing-node verdict
- revoke the current claim before change-feed and explicit invalidation clear failure state
- admit a negative only if the exact claim survives checks both before and after the cache write
- make read/write fast-fail paths reject even a briefly visible stale claim
- retain the established exponential backoff for genuine unsuperseded misses

No retry, timer, sweeper, wider timeout, or replacement stream is introduced. Claims are removed after successful/transient probes and otherwise have the same bounded cardinality as the existing negative cache.

## Evidence

- deterministic red-before: the late NotFound reopened the window in 615 ms
- fixed race + positive control: 2/2 passed
- MeshWeaver.Hosting.Test: 592/592 passed
- MeshWeaver.Documentation.Test: 374/374 passed
- Plugins MeshNodeStreamCacheRecycleResetTest against this core: 2/2 passed
- Release warnings-as-errors builds: MeshWeaver.Hosting, MeshWeaver.Hosting.Test, MeshWeaver.Documentation, MeshWeaver.Documentation.Test

Fixes #3954