### PR TITLE
fix(data): make unified update and delete read barriers causal

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -3948,8 +3948,8 @@ public static class DataExtensions
 
     /// <summary>
     /// Reactive update for a <c>data:</c> path. Content-provider paths write the file
-    /// directly; entity paths issue <see cref="DataChangeRequest"/> and observe the
-    /// <see cref="Activity"/> completion callback (no <see cref="TaskCompletionSource{TResult}"/>).
+    /// directly; entity paths issue <see cref="DataChangeRequest"/> and report success only after
+    /// both the owner commit and the shared read stream's matching frame.
     /// </summary>
     private static IObservable<UpdateUnifiedReferenceResponse> UpdateDataPath(
         IMessageHub hub,
@@ -3982,11 +3982,22 @@ public static class DataExtensions
         // path that addresses no data (UpdateUnifiedReferenceRequest_InvalidPath_ReturnsError).
         // A valid data collection is one a TypeSource projects; content collections
         // were already handled above.
-        var isKnownCollection = dataContext.TypeSources.Values
-            .Any(ts => string.Equals(ts.TypeDefinition.CollectionName, collection, StringComparison.OrdinalIgnoreCase));
-        if (!isKnownCollection)
+        var typeSource = dataContext.TypeSources.Values
+            .FirstOrDefault(ts => string.Equals(ts.TypeDefinition.CollectionName, collection, StringComparison.OrdinalIgnoreCase));
+        if (typeSource is null)
             return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
                 $"Unknown collection '{collection}': no registered data type source or content provider owns this path."));
+
+        var readId = (object?)entityId ?? typeSource.TypeDefinition.GetKey(content);
+        if (readId is null)
+            return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                $"Cannot determine the entity ID for collection '{collection}'."));
+
+        var stream = workspace.GetNullableStream(
+            new EntityReference(typeSource.TypeDefinition.CollectionName, readId));
+        if (stream is null)
+            return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                $"No readable data stream exists for {collection}/{readId}."));
 
         var changeRequest = new DataChangeRequest
         {
@@ -3994,15 +4005,53 @@ public static class DataExtensions
             ChangedBy = changedBy
         };
 
-        return workspace.RequestChange(changeRequest)
-            .Select(log =>
+        // RequestChange is eager. Observe the shared read stream BEFORE invoking it, otherwise a
+        // fast update can publish the only matching frame before the confirmation subscription is
+        // attached. Replay just that one post-baseline target frame so the owner commit and read
+        // actor may arrive in either order without a lost acknowledgement.
+        return stream.Take(1).SelectMany(initial =>
+        {
+            if (UnifiedContentEquals(initial.Value, content, hub))
+                return workspace.RequestChange(changeRequest).Select(ToResponse);
+
+            var visible = stream
+                .Where(item => item.Version > initial.Version
+                               && UnifiedContentEquals(item.Value, content, hub))
+                .Take(1)
+                .Replay(1);
+
+            return Observable.Using(
+                visible.Connect,
+                _ => workspace.RequestChange(changeRequest)
+                    .SelectMany(log =>
+                    {
+                        var response = new DataChangeResponse(hub.Version, log);
+                        return response.Status != DataChangeStatus.Committed
+                            ? Observable.Return(ToResponse(log))
+                            : visible.Select(_ => UpdateUnifiedReferenceResponse.Ok(response.Version));
+                    }));
+
+            UpdateUnifiedReferenceResponse ToResponse(ActivityLog log)
             {
                 var response = new DataChangeResponse(hub.Version, log);
                 return response.Status == DataChangeStatus.Committed
                     ? UpdateUnifiedReferenceResponse.Ok(response.Version)
                     : UpdateUnifiedReferenceResponse.Fail(
                         response.Log.Messages.LastOrDefault()?.Message ?? "Update failed");
-            });
+            }
+        });
+    }
+
+    private static bool UnifiedContentEquals(object? actual, object expected, IMessageHub hub)
+    {
+        if (actual is null)
+            return false;
+        if (Equals(actual, expected))
+            return true;
+
+        var actualNode = JsonSerializer.SerializeToNode(actual, actual.GetType(), hub.JsonSerializerOptions);
+        var expectedNode = JsonSerializer.SerializeToNode(expected, expected.GetType(), hub.JsonSerializerOptions);
+        return System.Text.Json.Nodes.JsonNode.DeepEquals(actualNode, expectedNode);
     }
 
     /// <summary>
@@ -4147,27 +4196,27 @@ public static class DataExtensions
                     ChangedBy = changedBy
                 };
 
-                return workspace.RequestChange(changeRequest)
-                    .SelectMany(log =>
-                    {
-                        var response = new DataChangeResponse(hub.Version, log);
-                        if (response.Status != DataChangeStatus.Committed)
-                            return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
-                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
+                // Subscribe before RequestChange: it writes eagerly, and a same-ID recreation can
+                // replace the shared stream's replay slot before the commit observable is consumed.
+                // Filtering by the baseline version makes this a post-request absence frame; the
+                // one-item replay preserves that causal acknowledgement across either ordering.
+                var absent = stream
+                    .Where(item => item.Version > entityValue.Version && item.Value is null)
+                    .Take(1)
+                    .Replay(1);
 
-                        // RequestChange reports when the owning data-source stream has applied the
-                        // deletion. The shared read stream is a separate actor-backed reduction:
-                        // its null frame is posted from the source's turn and can still be queued
-                        // when the commit report arrives. A success response at that seam lets the
-                        // caller's immediate GetDataRequest replay the shared stream's OLD entity
-                        // before that queued frame lands. Wait on the exact read view this API
-                        // serves; no polling and no fresh stream/hub. Success now means a read made
-                        // after the response cannot observe the deleted entity (#3432 follow-up).
-                        return stream
-                            .Where(entity => entity.Value == null)
-                            .Take(1)
-                            .Select(_ => DeleteUnifiedReferenceResponse.Ok());
-                    });
+                return Observable.Using(
+                    absent.Connect,
+                    _ => workspace.RequestChange(changeRequest)
+                        .SelectMany(log =>
+                        {
+                            var response = new DataChangeResponse(hub.Version, log);
+                            if (response.Status != DataChangeStatus.Committed)
+                                return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                                    response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
+
+                            return absent.Select(_ => DeleteUnifiedReferenceResponse.Ok());
+                        }));
             });
     }
 

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -3931,7 +3931,8 @@ public static class DataExtensions
         var (prefix, remainingPath) = ParseUnifiedPath(path);
         var observable = prefix switch
         {
-            "data" => UpdateDataPath(hub, remainingPath, request.Message.Content, request.Message.ChangedBy),
+            "data" => UpdateDataPath(hub, remainingPath, request.Message.Content,
+                request.Message.ChangedBy, request.AccessContext),
             "content" => UpdateContentPath(hub, remainingPath, request.Message.Content),
             "area" => Observable.Return(UpdateUnifiedReferenceResponse.Fail("Layout area updates are not supported via this API")),
             _ => Observable.Return(UpdateUnifiedReferenceResponse.Fail($"Unknown prefix: {prefix}"))
@@ -3955,7 +3956,8 @@ public static class DataExtensions
         IMessageHub hub,
         string? path,
         object content,
-        string? changedBy)
+        string? changedBy,
+        AccessContext? accessContext)
     {
         var (collection, entityId) = ParseDataPath(path);
 
@@ -3982,29 +3984,55 @@ public static class DataExtensions
         // path that addresses no data (UpdateUnifiedReferenceRequest_InvalidPath_ReturnsError).
         // A valid data collection is one a TypeSource projects; content collections
         // were already handled above.
-        var typeSource = dataContext.TypeSources.Values
+        var pathTypeSource = dataContext.TypeSources.Values
             .FirstOrDefault(ts => string.Equals(ts.TypeDefinition.CollectionName, collection, StringComparison.OrdinalIgnoreCase));
-        if (typeSource is null)
+        if (pathTypeSource is null)
             return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
-                $"Unknown collection '{collection}': no registered data type source or content provider owns this path."));
+                LocalizationCatalog.Get("unifiedData.error.unknownCollection", accessContext?.Locale, collection)));
 
-        var readId = (object?)entityId ?? typeSource.TypeDefinition.GetKey(content);
+        var contentCollection = content is EntityDeltaUpdate delta
+            ? delta.Collection
+            : dataContext.GetTypeSource(content.GetType())?.TypeDefinition.CollectionName;
+        if (!string.Equals(pathTypeSource.TypeDefinition.CollectionName, contentCollection,
+                StringComparison.OrdinalIgnoreCase))
+            return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                LocalizationCatalog.Get("unifiedData.error.collectionMismatch", accessContext?.Locale,
+                    pathTypeSource.TypeDefinition.CollectionName, contentCollection ?? content.GetType().Name)));
+
+        var contentId = content is EntityDeltaUpdate entityDelta
+            ? StandardReducers.ConvertKeyToProperType(
+                entityDelta.Id, pathTypeSource.TypeDefinition.CollectionName, hub.TypeRegistry)
+            : pathTypeSource.TypeDefinition.GetKey(content);
+        var pathId = entityId is null
+            ? null
+            : StandardReducers.ConvertKeyToProperType(
+                entityId, pathTypeSource.TypeDefinition.CollectionName, hub.TypeRegistry);
+        if (pathId is not null && !Equals(pathId, contentId))
+            return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                LocalizationCatalog.Get("unifiedData.error.entityIdMismatch", accessContext?.Locale,
+                    pathId, contentId)));
+
+        var readId = pathId ?? contentId;
         if (readId is null)
             return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
-                $"Cannot determine the entity ID for collection '{collection}'."));
+                LocalizationCatalog.Get("unifiedData.error.missingEntityId", accessContext?.Locale, collection)));
 
         var stream = workspace.GetNullableStream(
-            new EntityReference(typeSource.TypeDefinition.CollectionName, readId));
+            new EntityReference(pathTypeSource.TypeDefinition.CollectionName, readId));
         if (stream is null)
             return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
-                $"No readable data stream exists for {collection}/{readId}."));
+                LocalizationCatalog.Get("unifiedData.error.readStreamUnavailable", accessContext?.Locale,
+                    collection, readId)));
 
-        var partition = (typeSource as IPartitionedTypeSource)?.GetPartition(content);
-        var ownerStream = dataContext.DataSourcesByCollection[typeSource.TypeDefinition.CollectionName]
+        var partition = content is EntityDeltaUpdate partitionedDelta
+            ? partitionedDelta.Partition
+            : (pathTypeSource as IPartitionedTypeSource)?.GetPartition(content);
+        var ownerStream = dataContext.DataSourcesByCollection[pathTypeSource.TypeDefinition.CollectionName]
             .GetStreamForPartition(partition);
         if (ownerStream is null)
             return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
-                $"No owning data stream exists for {collection}/{readId}."));
+                LocalizationCatalog.Get("unifiedData.error.ownerStreamUnavailable", accessContext?.Locale,
+                    collection, readId)));
 
         var changeRequest = new DataChangeRequest
         {
@@ -4012,49 +4040,50 @@ public static class DataExtensions
             ChangedBy = changedBy
         };
 
-        // Warm the exact stream served by GetDataRequest before the eager owner write. A genuinely
-        // idempotent write needs no new read frame; otherwise the owner's committed version is the
-        // causal barrier — a same-value coincidence from an older frame is not sufficient.
-        return stream.Take(1).SelectMany(initial =>
-        {
-            if (UnifiedContentEquals(initial.Value, content, hub))
-                return workspace.RequestChange(changeRequest).Select(ToResponse);
+        // Warm the exact stream served by GetDataRequest before the owner write. The internal
+        // receipt distinguishes a value-changing write (whose new version is published) from a
+        // true no-op (whose owner-only adopted version is silent), so both branches wait for the
+        // precise version a shared read can actually observe.
+        return stream.Take(1)
+            .Select<ChangeItem<object>, ChangeItem<object>?>(item => item)
+            .DefaultIfEmpty(null)
+            .SelectMany(initial =>
+            {
+                if (initial is null)
+                    return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                        LocalizationCatalog.Get("unifiedData.error.readStreamEnded", accessContext?.Locale,
+                            collection, readId)));
 
-            return workspace.RequestChange(changeRequest)
-                .SelectMany(log =>
+                var access = hub.ServiceProvider.GetService<AccessService>();
+                return access.RunAs(accessContext, () => workspace.ChangeWithReceipt(changeRequest))
+                    .SelectMany(receipt =>
                 {
-                    var response = new DataChangeResponse(hub.Version, log);
+                    var response = new DataChangeResponse(hub.Version, receipt.Log);
                     if (response.Status != DataChangeStatus.Committed)
-                        return Observable.Return(ToResponse(log));
-                    if (ownerStream.Current is not { } ownerCommit)
+                        return Observable.Return(ToResponse(receipt.Log));
+                    if (receipt.VisibleVersions is not [var visibleVersion])
                         return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
-                            $"The owning data stream for {collection}/{readId} did not expose its committed version."));
+                            LocalizationCatalog.Get("unifiedData.error.ownerReceiptUnavailable",
+                                accessContext?.Locale, collection, readId)));
 
-                    return WaitForSharedReadVersion(stream, ownerCommit.Version)
-                        .Select(_ => UpdateUnifiedReferenceResponse.Ok(response.Version));
+                    return WaitForSharedReadVersion(stream, visibleVersion)
+                        .Select(_ => UpdateUnifiedReferenceResponse.Ok(response.Version))
+                        .DefaultIfEmpty(UpdateUnifiedReferenceResponse.Fail(
+                            LocalizationCatalog.Get("unifiedData.error.readBarrierEnded",
+                                accessContext?.Locale, collection, readId)));
                 });
 
-            UpdateUnifiedReferenceResponse ToResponse(ActivityLog log)
-            {
-                var response = new DataChangeResponse(hub.Version, log);
-                return response.Status == DataChangeStatus.Committed
-                    ? UpdateUnifiedReferenceResponse.Ok(response.Version)
-                    : UpdateUnifiedReferenceResponse.Fail(
-                        response.Log.Messages.LastOrDefault()?.Message ?? "Update failed");
-            }
-        });
-    }
-
-    private static bool UnifiedContentEquals(object? actual, object expected, IMessageHub hub)
-    {
-        if (actual is null)
-            return false;
-        if (Equals(actual, expected))
-            return true;
-
-        var actualNode = JsonSerializer.SerializeToNode(actual, actual.GetType(), hub.JsonSerializerOptions);
-        var expectedNode = JsonSerializer.SerializeToNode(expected, expected.GetType(), hub.JsonSerializerOptions);
-        return System.Text.Json.Nodes.JsonNode.DeepEquals(actualNode, expectedNode);
+                UpdateUnifiedReferenceResponse ToResponse(ActivityLog log)
+                {
+                    var response = new DataChangeResponse(hub.Version, log);
+                    if (response.Status == DataChangeStatus.Committed)
+                        return UpdateUnifiedReferenceResponse.Ok(response.Version);
+                    var message = response.Log.Messages.LastOrDefault();
+                    return UpdateUnifiedReferenceResponse.Fail(message is null
+                        ? LocalizationCatalog.Get("unifiedData.error.updateFailed", accessContext?.Locale)
+                        : message.Localize(accessContext?.Locale));
+                }
+            });
     }
 
     /// <summary>
@@ -4145,7 +4174,7 @@ public static class DataExtensions
         var (prefix, remainingPath) = ParseUnifiedPath(path);
         var observable = prefix switch
         {
-            "data" => DeleteDataPath(hub, remainingPath, request.Message.ChangedBy),
+            "data" => DeleteDataPath(hub, remainingPath, request.Message.ChangedBy, request.AccessContext),
             "content" => DeleteContentPath(hub, remainingPath),
             "area" => Observable.Return(DeleteUnifiedReferenceResponse.Fail("Layout area deletion is not supported via this API")),
             _ => Observable.Return(DeleteUnifiedReferenceResponse.Fail($"Unknown prefix: {prefix}"))
@@ -4169,7 +4198,8 @@ public static class DataExtensions
     private static IObservable<DeleteUnifiedReferenceResponse> DeleteDataPath(
         IMessageHub hub,
         string? path,
-        string? changedBy)
+        string? changedBy,
+        AccessContext? accessContext)
     {
         var (collection, entityId) = ParseDataPath(path);
 
@@ -4201,9 +4231,15 @@ public static class DataExtensions
         return stream
             .Timeout(TimeSpan.FromSeconds(30))
             .Take(1)
+            .Select<ChangeItem<object>, ChangeItem<object>?>(item => item)
+            .DefaultIfEmpty(null)
             .SelectMany(entityValue =>
             {
-                if (entityValue.Value == null)
+                if (entityValue is null)
+                    return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                        LocalizationCatalog.Get("unifiedData.error.readStreamEnded", accessContext?.Locale,
+                            collection, entityId)));
+                if (entityValue.Value is null)
                     return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
                         $"Entity not found: {collection}/{entityId}"));
 
@@ -4216,27 +4252,39 @@ public static class DataExtensions
                 var typeSource = dataContext.GetTypeSource(entityValue.Value.GetType());
                 if (typeSource is null)
                     return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
-                        $"No registered data type source owns {collection}/{entityId}."));
+                        LocalizationCatalog.Get("unifiedData.error.typeSourceUnavailable",
+                            accessContext?.Locale, collection, entityId)));
                 var partition = (typeSource as IPartitionedTypeSource)?.GetPartition(entityValue.Value);
                 var ownerStream = dataContext.DataSourcesByCollection[typeSource.TypeDefinition.CollectionName]
                     .GetStreamForPartition(partition);
                 if (ownerStream is null)
                     return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
-                        $"No owning data stream exists for {collection}/{entityId}."));
+                        LocalizationCatalog.Get("unifiedData.error.ownerStreamUnavailable", accessContext?.Locale,
+                            collection, entityId)));
 
-                return workspace.RequestChange(changeRequest)
-                    .SelectMany(log =>
+                var access = hub.ServiceProvider.GetService<AccessService>();
+                return access.RunAs(accessContext, () => workspace.ChangeWithReceipt(changeRequest))
+                    .SelectMany(receipt =>
                     {
-                        var response = new DataChangeResponse(hub.Version, log);
+                        var response = new DataChangeResponse(hub.Version, receipt.Log);
                         if (response.Status != DataChangeStatus.Committed)
+                        {
+                            var message = response.Log.Messages.LastOrDefault();
                             return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
-                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
-                        if (ownerStream.Current is not { } ownerCommit)
+                                message is null
+                                    ? LocalizationCatalog.Get("unifiedData.error.deleteFailed", accessContext?.Locale)
+                                    : message.Localize(accessContext?.Locale)));
+                        }
+                        if (receipt.VisibleVersions is not [var visibleVersion])
                             return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
-                                $"The owning data stream for {collection}/{entityId} did not expose its committed version."));
+                                LocalizationCatalog.Get("unifiedData.error.ownerReceiptUnavailable",
+                                    accessContext?.Locale, collection, entityId)));
 
-                        return WaitForSharedReadVersion(stream, ownerCommit.Version)
-                            .Select(_ => DeleteUnifiedReferenceResponse.Ok());
+                        return WaitForSharedReadVersion(stream, visibleVersion)
+                            .Select(_ => DeleteUnifiedReferenceResponse.Ok())
+                            .DefaultIfEmpty(DeleteUnifiedReferenceResponse.Fail(
+                                LocalizationCatalog.Get("unifiedData.error.readBarrierEnded",
+                                    accessContext?.Locale, collection, entityId)));
                     });
             });
     }

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -3999,37 +3999,40 @@ public static class DataExtensions
             return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
                 $"No readable data stream exists for {collection}/{readId}."));
 
+        var partition = (typeSource as IPartitionedTypeSource)?.GetPartition(content);
+        var ownerStream = dataContext.DataSourcesByCollection[typeSource.TypeDefinition.CollectionName]
+            .GetStreamForPartition(partition);
+        if (ownerStream is null)
+            return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                $"No owning data stream exists for {collection}/{readId}."));
+
         var changeRequest = new DataChangeRequest
         {
             Updates = [content],
             ChangedBy = changedBy
         };
 
-        // RequestChange is eager. Observe the shared read stream BEFORE invoking it, otherwise a
-        // fast update can publish the only matching frame before the confirmation subscription is
-        // attached. Replay just that one post-baseline target frame so the owner commit and read
-        // actor may arrive in either order without a lost acknowledgement.
+        // Warm the exact stream served by GetDataRequest before the eager owner write. A genuinely
+        // idempotent write needs no new read frame; otherwise the owner's committed version is the
+        // causal barrier — a same-value coincidence from an older frame is not sufficient.
         return stream.Take(1).SelectMany(initial =>
         {
             if (UnifiedContentEquals(initial.Value, content, hub))
                 return workspace.RequestChange(changeRequest).Select(ToResponse);
 
-            var visible = stream
-                .Where(item => item.Version > initial.Version
-                               && UnifiedContentEquals(item.Value, content, hub))
-                .Take(1)
-                .Replay(1);
+            return workspace.RequestChange(changeRequest)
+                .SelectMany(log =>
+                {
+                    var response = new DataChangeResponse(hub.Version, log);
+                    if (response.Status != DataChangeStatus.Committed)
+                        return Observable.Return(ToResponse(log));
+                    if (ownerStream.Current is not { } ownerCommit)
+                        return Observable.Return(UpdateUnifiedReferenceResponse.Fail(
+                            $"The owning data stream for {collection}/{readId} did not expose its committed version."));
 
-            return Observable.Using(
-                visible.Connect,
-                _ => workspace.RequestChange(changeRequest)
-                    .SelectMany(log =>
-                    {
-                        var response = new DataChangeResponse(hub.Version, log);
-                        return response.Status != DataChangeStatus.Committed
-                            ? Observable.Return(ToResponse(log))
-                            : visible.Select(_ => UpdateUnifiedReferenceResponse.Ok(response.Version));
-                    }));
+                    return WaitForSharedReadVersion(stream, ownerCommit.Version)
+                        .Select(_ => UpdateUnifiedReferenceResponse.Ok(response.Version));
+                });
 
             UpdateUnifiedReferenceResponse ToResponse(ActivityLog log)
             {
@@ -4053,6 +4056,20 @@ public static class DataExtensions
         var expectedNode = JsonSerializer.SerializeToNode(expected, expected.GetType(), hub.JsonSerializerOptions);
         return System.Text.Json.Nodes.JsonNode.DeepEquals(actualNode, expectedNode);
     }
+
+    /// <summary>
+    /// Waits until a shared read stream has applied the owner's committed version or a newer one.
+    /// The current snapshot is checked inside <see cref="Observable.Defer{TValue}(Func{IObservable{TValue}})"/>
+    /// and the stream itself replays its latest frame, so a frame landing between the check and the
+    /// subscription cannot be missed. A newer version is valid: it represents a later committed
+    /// write, never the stale state that preceded this operation.
+    /// </summary>
+    internal static IObservable<ChangeItem<object>> WaitForSharedReadVersion(
+        ISynchronizationStream<object> stream,
+        long committedVersion) =>
+        Observable.Defer(() => stream.Current is { } current && current.Version >= committedVersion
+            ? Observable.Return(current)
+            : stream.Where(item => item.Version >= committedVersion).Take(1));
 
     /// <summary>
     /// Reactive update for a <c>content:</c> path — parses collection/file and writes via the file provider.
@@ -4196,27 +4213,31 @@ public static class DataExtensions
                     ChangedBy = changedBy
                 };
 
-                // Subscribe before RequestChange: it writes eagerly, and a same-ID recreation can
-                // replace the shared stream's replay slot before the commit observable is consumed.
-                // Filtering by the baseline version makes this a post-request absence frame; the
-                // one-item replay preserves that causal acknowledgement across either ordering.
-                var absent = stream
-                    .Where(item => item.Version > entityValue.Version && item.Value is null)
-                    .Take(1)
-                    .Replay(1);
+                var typeSource = dataContext.GetTypeSource(entityValue.Value.GetType());
+                if (typeSource is null)
+                    return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                        $"No registered data type source owns {collection}/{entityId}."));
+                var partition = (typeSource as IPartitionedTypeSource)?.GetPartition(entityValue.Value);
+                var ownerStream = dataContext.DataSourcesByCollection[typeSource.TypeDefinition.CollectionName]
+                    .GetStreamForPartition(partition);
+                if (ownerStream is null)
+                    return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                        $"No owning data stream exists for {collection}/{entityId}."));
 
-                return Observable.Using(
-                    absent.Connect,
-                    _ => workspace.RequestChange(changeRequest)
-                        .SelectMany(log =>
-                        {
-                            var response = new DataChangeResponse(hub.Version, log);
-                            if (response.Status != DataChangeStatus.Committed)
-                                return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
-                                    response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
+                return workspace.RequestChange(changeRequest)
+                    .SelectMany(log =>
+                    {
+                        var response = new DataChangeResponse(hub.Version, log);
+                        if (response.Status != DataChangeStatus.Committed)
+                            return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                                response.Log.Messages.LastOrDefault()?.Message ?? "Delete failed"));
+                        if (ownerStream.Current is not { } ownerCommit)
+                            return Observable.Return(DeleteUnifiedReferenceResponse.Fail(
+                                $"The owning data stream for {collection}/{entityId} did not expose its committed version."));
 
-                            return absent.Select(_ => DeleteUnifiedReferenceResponse.Ok());
-                        }));
+                        return WaitForSharedReadVersion(stream, ownerCommit.Version)
+                            .Select(_ => DeleteUnifiedReferenceResponse.Ok());
+                    });
             });
     }
 

--- a/src/MeshWeaver.Data/StandardReducers.cs
+++ b/src/MeshWeaver.Data/StandardReducers.cs
@@ -174,7 +174,7 @@ public static class StandardReducers
     /// <summary>
     /// Converts a string key to the proper type based on the TypeDefinition for the collection.
     /// </summary>
-    private static object ConvertKeyToProperType(object id, string collection, ITypeRegistry typeRegistry)
+    internal static object ConvertKeyToProperType(object id, string collection, ITypeRegistry typeRegistry)
     {
         if (id is not string stringId)
             return id;

--- a/src/MeshWeaver.Data/WorkspaceOperations.cs
+++ b/src/MeshWeaver.Data/WorkspaceOperations.cs
@@ -38,7 +38,26 @@ public static class WorkspaceOperations
     /// <param name="workspace">The workspace to apply the change to.</param>
     /// <param name="change">The change request to validate and apply.</param>
     /// <returns>A single-emission observable carrying the finished <see cref="ActivityLog"/>.</returns>
-    public static IObservable<ActivityLog> Change(this IWorkspace workspace, DataChangeRequest change)
+    public static IObservable<ActivityLog> Change(this IWorkspace workspace, DataChangeRequest change) =>
+        workspace.ChangeCore(change, observePublishedVersions: false).Select(result => result.Log);
+
+    /// <summary>
+    /// Applies a data change and also reports the owner versions that can be observed by reduced
+    /// read streams. The receipt observes the owner's replay across the serialized apply turn, so
+    /// a value-changing patch reports its new frame while any number of value-equal patches retain
+    /// the last version that was actually published.
+    /// The public <see cref="Change(IWorkspace,DataChangeRequest)"/> surface deliberately projects
+    /// this back to the established <see cref="ActivityLog"/> contract.
+    /// </summary>
+    internal static IObservable<DataChangeReceipt> ChangeWithReceipt(
+        this IWorkspace workspace,
+        DataChangeRequest change) =>
+        workspace.ChangeCore(change, observePublishedVersions: true);
+
+    private static IObservable<DataChangeReceipt> ChangeCore(
+        this IWorkspace workspace,
+        DataChangeRequest change,
+        bool observePublishedVersions)
     {
         var logger = workspace.Hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
             .CreateLogger(typeof(WorkspaceOperations));
@@ -46,12 +65,18 @@ public static class WorkspaceOperations
 
         var (isValid, messages) = workspace.Validate(change, logger);
         if (!isValid)
-            return Observable.Return(Finish(workspace.Hub, messages));
+            return Observable.Return(new DataChangeReceipt(Finish(workspace.Hub, messages), []));
 
         logger.LogDebug("Update called: Creations={Creations}, Updates={Updates}, Deletions={Deletions}",
             change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
-        return workspace.UpdateStreams(change, messages, logger);
+        return workspace.UpdateStreams(change, messages, logger, observePublishedVersions);
     }
+
+    /// <summary>
+    /// Internal acknowledgement for callers that must establish a causal read boundary after a
+    /// write. <see cref="VisibleVersions"/> contains one version per affected owner stream.
+    /// </summary>
+    internal sealed record DataChangeReceipt(ActivityLog Log, IReadOnlyList<long> VisibleVersions);
 
     /// <summary>
     /// Runs the creation / update / deletion validators and folds every failure into log messages.
@@ -95,8 +120,8 @@ public static class WorkspaceOperations
         return (isValid, messages);
     }
 
-    private static IObservable<ActivityLog> UpdateStreams(this IWorkspace workspace, DataChangeRequest change,
-        ImmutableList<LogMessage> messages, ILogger logger)
+    private static IObservable<DataChangeReceipt> UpdateStreams(this IWorkspace workspace, DataChangeRequest change,
+        ImmutableList<LogMessage> messages, ILogger logger, bool observePublishedVersions)
     {
         logger.LogDebug("Updating streams for workspace {Address} with {Creations} creations, {Updates} updates, {Deletions} deletions", workspace.Hub.Address, change.Creations.Count(), change.Updates.Count(), change.Deletions.Count());
 
@@ -119,15 +144,20 @@ public static class WorkspaceOperations
         // ToArray() forces the writes NOW — Change is eager by contract; the observables only
         // report when each stream has applied its part.
         var applied = groups.Where(g => g.Key.DataSource is not null)
-            .Select(group => UpdateStream(change, group, logger))
+            .Select(group => UpdateStream(change, group, logger, observePublishedVersions))
             .ToArray();
 
         if (applied.Length == 0)
-            return Observable.Return(Finish(workspace.Hub, messages));
+            return Observable.Return(new DataChangeReceipt(Finish(workspace.Hub, messages), []));
 
         return applied.Merge()
-            .Aggregate(messages, (acc, streamMessages) => acc.AddRange(streamMessages))
-            .Select(all => Finish(workspace.Hub, all));
+            .ToArray()
+            .Select(results => new DataChangeReceipt(
+                Finish(workspace.Hub,
+                    results.Aggregate(messages, (acc, result) => acc.AddRange(result.Messages))),
+                results.Where(result => result.VisibleVersion is not null)
+                    .Select(result => result.VisibleVersion!.Value)
+                    .ToArray()));
     }
 
     /// <summary>
@@ -141,11 +171,12 @@ public static class WorkspaceOperations
     /// store still holds the pre-change state — ack-on-accept, the shape that raced read-after-write.
     /// The seam runs after the apply, in that same turn, so it costs no extra hub message.</para>
     /// </summary>
-    private static IObservable<ImmutableList<LogMessage>> UpdateStream(
+    private static IObservable<StreamApplyResult> UpdateStream(
         DataChangeRequest change,
         IGrouping<(IDataSource? DataSource, object? Partition), (object Instance, OperationType Op, ITypeSource?
             TypeSource, IDataSource? DataSource, object? Partition)> group,
-        ILogger logger)
+        ILogger logger,
+        bool observePublishedVersion)
     {
         var stream = group.Key.DataSource!.GetStreamForPartition(group.Key.Partition);
         if (stream is null)
@@ -160,7 +191,26 @@ public static class WorkspaceOperations
         if (!streamHub.Started.IsCompleted)
             throw new DataException($"Data source {group.Key.DataSource.Reference} for partition {group.Key.Partition} is not initialized.");
 
-        var applied = new AsyncSubject<ImmutableList<LogMessage>>();
+        var applied = new AsyncSubject<StreamApplyResult>();
+
+        // Observe the owner's replay BEFORE posting our update and keep that subscription through
+        // the serialized apply turn. SetCurrent publishes synchronously, so when `applied` runs the
+        // value below is exactly the last version an ordinary reduced stream could have received.
+        // It deliberately does not use Current.Version: value-equal patches adopt that clock
+        // silently, and after two no-ops even the preceding Current version was never published.
+        var lastPublishedVersion = long.MinValue;
+        Exception? publicationError = null;
+        var publicationEnded = 0;
+        var publicationSubscription = observePublishedVersion
+            ? stream.Subscribe(
+                item => Volatile.Write(ref lastPublishedVersion, item.Version),
+                ex =>
+                {
+                    Interlocked.Exchange(ref publicationError, ex);
+                    Volatile.Write(ref publicationEnded, 1);
+                },
+                () => Volatile.Write(ref publicationEnded, 1))
+            : null;
 
         // Synchronous update — the transform is pure in-memory; the stream's
         // handler serializes UpdateStreamRequests, so no retry logic is needed.
@@ -173,32 +223,57 @@ public static class WorkspaceOperations
             },
             ex =>
             {
+                publicationSubscription?.Dispose();
                 // The failure is REPORTED, never rethrown: every invocation of this callback is
                 // wrapped by the stream in a log-only try/catch, so a throw here could reach no
                 // caller — it only produced a secondary "exceptionCallback threw" ERROR. The log
                 // below is what the caller actually sees.
                 //
-                // A DISPOSED stream is the benign teardown marker the rest of the stream classifies
-                // as Debug-only ("stop the source"), so it stays a WARNING — which still commits
-                // (DataChangeResponse maps Warning → Committed) and keeps shutdown quiet. Any other
-                // failure is a real one and must surface as Failed rather than the silent
-                // "Succeeded" the sub-activity used to report.
+                // A disposed owner is normal during shutdown, but THIS requested write was not
+                // applied. Its activity result must therefore be Failed rather than Committed;
+                // otherwise a caller can acknowledge a mutation that never happened.
                 logger.LogError(ex, "Update of {Stream} failed", stream.StreamIdentity);
-                applied.OnNext([new LogMessage(
+                applied.OnNext(new StreamApplyResult([new LogMessage(
                     $"Update of {stream.StreamIdentity} failed: {ex.Message}",
-                    ex is ObjectDisposedException ? LogLevel.Warning : LogLevel.Error)
+                    LogLevel.Error)
                     .WithKey("activity.dataUpdate.streamUpdateFailed",
-                        ("stream", stream.StreamIdentity), ("error", ex.Message))]);
+                        ("stream", stream.StreamIdentity), ("error", ex.Message))], null));
                 applied.OnCompleted();
             },
             () =>
             {
-                applied.OnNext(streamMessages);
+                var ended = Volatile.Read(ref publicationEnded) == 1;
+                var error = Volatile.Read(ref publicationError);
+                var publishedVersion = Volatile.Read(ref lastPublishedVersion);
+                publicationSubscription?.Dispose();
+
+                if (!observePublishedVersion)
+                {
+                    applied.OnNext(new StreamApplyResult(streamMessages, null));
+                }
+                else if (ended)
+                {
+                    var reason = error?.Message ?? "the owner stream completed before its applied receipt";
+                    applied.OnNext(new StreamApplyResult(streamMessages.Add(new LogMessage(
+                            $"Update of {stream.StreamIdentity} failed: {reason}", LogLevel.Error)
+                        .WithKey("activity.dataUpdate.streamUpdateFailed",
+                            ("stream", stream.StreamIdentity), ("error", reason))), null));
+                }
+                else
+                {
+                    applied.OnNext(new StreamApplyResult(
+                        streamMessages,
+                        publishedVersion == long.MinValue ? null : publishedVersion));
+                }
                 applied.OnCompleted();
             }
         );
         return applied;
     }
+
+    private sealed record StreamApplyResult(
+        ImmutableList<LogMessage> Messages,
+        long? VisibleVersion);
 
     /// <summary>Finishes a data-update log: status is rolled up from the message levels.</summary>
     private static ActivityLog Finish(IMessageHub hub, ImmutableList<LogMessage> messages) =>
@@ -509,4 +584,3 @@ public static class WorkspaceOperations
 #pragma warning restore IDE0060
 
 }
-

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
@@ -219,6 +219,10 @@ done for a plain reduce, and where it matters the answer is a narrower reference
 | `AnUncachedConfiguredReduce_MintsOneSyncHubPerCall` | five genuinely-configured reduces add **5** — the counter can see growth, so the flat arm is not vacuous |
 | `TheSharedReadStream_StaysLive` | a write after the reads is visible to the next read — the shared stream is a live mirror, not a snapshot |
 | `UnifiedUpdate_WaitsUntilTheSharedReadStreamCarriesTheUpdate` | a successful update is withheld while the owner has committed but the shared read actor is parked on the old entity |
+| `UnifiedUpdate_OwnerNoOpUsesTheLastObservableVersion` | an idempotent owner write does not wait for its silently adopted, unpublished version; it fences on the last owner frame the shared read can observe |
+| `RepeatedNoOpReceiptTest.ASecondNoOpRetainsTheLastPublishedOwnerVersion` | consecutive idempotent writes keep the last actually emitted owner version instead of advancing the receipt through silent versions |
+| `UnifiedUpdate_InitiallyMatchingStaleReadStillNeedsItsOwnReadBoundary` | a cached value equal to the request is not mistaken for an owner no-op when an intervening owner frame is already queued |
+| `UnifiedUpdate_RejectsPathAndContentIdentityMismatchBeforeWriting` | a URL/payload key mismatch is refused before it can update one entity while waiting on another |
 | `UnifiedDelete_WaitsUntilTheSharedReadStreamCarriesAbsence` | a successful delete is withheld while the shared read actor is parked, even after the owner has committed; it answers only after the read view carries absence |
 | `UnifiedDelete_RetainsItsAbsenceAcknowledgementAcrossSameIdRecreation` | the read view reaches the delete's committed version before a later same-ID recreation becomes its newest state, so the delete still answers without mistaking the recreation for stale data |
 | `ReadVersionBarrier_AcceptsNewerStateAfterTheDeleteFrameWasReplaced` | a late barrier subscription completes from the newer recreation after the delete's exact null frame has been replaced in the shared one-item replay slot |
@@ -236,15 +240,26 @@ an immediate read can replay that reduction's previous value until its queued fr
 release gate exposed both directions: a successful `UpdateUnifiedReferenceRequest` followed by the
 old entity, and a successful `DeleteUnifiedReferenceRequest` followed by the deleted entity.
 
-Both handlers now warm the same shared entity stream **before** invoking the eager owner write. After
-commit they capture the owning stream's committed version and wait until the shared read stream has
-applied that version or a newer one. Checking the current snapshot inside a deferred subscription,
-then relying on the stream's own one-item replay, means the boundary cannot miss a frame that lands
-between those two operations. The version is the causal proof: a same-value older frame cannot release
-an update, while a legitimate same-ID recreation after a delete is accepted as newer state instead
-of leaving the delete waiting forever for a null that has already been replaced. There is no polling
-and no replacement stream. Owner commit remains the storage boundary; successful unified
-update/delete is also the causal read-view boundary for the API's shared read path.
+Both handlers now warm the same shared entity stream **before** invoking the owner write. The data
+change pipeline returns an internal receipt from the owner's serialized apply turn. A short-lived
+subscription observes the owner's replay from before the write through its post-apply callback, so a
+value-changing patch reports the new frame it published while any number of true no-ops retain the
+last version that was actually emitted. This cannot be derived from `Current.Version`: the stream
+adopts a no-op's new version silently, and after two no-ops even the preceding current version was
+never published. The handler waits until the shared read stream has applied the receipt's observable
+version or a newer one. This distinction is what makes both edges correct: equality with a stale
+cached read cannot bypass a real write, and an idempotent write cannot wait forever for a frame that
+by design does not exist.
+
+Checking the current snapshot inside a deferred subscription, then relying on the stream's own
+one-item replay, means the boundary cannot miss a frame that lands between those operations. A
+legitimate same-ID recreation after a delete is accepted as newer state instead of leaving the delete
+waiting forever for a null that has already been replaced. A URL/payload identity mismatch is rejected
+before mutation, the caller's access context is restored at the deferred write call, and stream
+completion in either read phase produces one explicit failure response instead of silent completion.
+There is no polling, retry, or replacement stream. The existing owner commit remains the in-memory
+mutation boundary; successful unified data-entity update/delete is also the causal read-view
+boundary for the API's shared read path.
 
 ### One behaviour DID change, and it is the better half of an existing contract
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
@@ -220,7 +220,8 @@ done for a plain reduce, and where it matters the answer is a narrower reference
 | `TheSharedReadStream_StaysLive` | a write after the reads is visible to the next read — the shared stream is a live mirror, not a snapshot |
 | `UnifiedUpdate_WaitsUntilTheSharedReadStreamCarriesTheUpdate` | a successful update is withheld while the owner has committed but the shared read actor is parked on the old entity |
 | `UnifiedDelete_WaitsUntilTheSharedReadStreamCarriesAbsence` | a successful delete is withheld while the shared read actor is parked, even after the owner has committed; it answers only after the read view carries absence |
-| `UnifiedDelete_RetainsItsAbsenceAcknowledgementAcrossSameIdRecreation` | the delete's pre-armed absence acknowledgement survives a legitimate same-ID recreation instead of waiting forever on a replaced replay slot |
+| `UnifiedDelete_RetainsItsAbsenceAcknowledgementAcrossSameIdRecreation` | the read view reaches the delete's committed version before a later same-ID recreation becomes its newest state, so the delete still answers without mistaking the recreation for stale data |
+| `ReadVersionBarrier_AcceptsNewerStateAfterTheDeleteFrameWasReplaced` | a late barrier subscription completes from the newer recreation after the delete's exact null frame has been replaced in the shared one-item replay slot |
 
 ### A shared stream makes its propagation boundary observable
 
@@ -235,14 +236,15 @@ an immediate read can replay that reduction's previous value until its queued fr
 release gate exposed both directions: a successful `UpdateUnifiedReferenceRequest` followed by the
 old entity, and a successful `DeleteUnifiedReferenceRequest` followed by the deleted entity.
 
-Both handlers now observe the same shared entity stream **before** invoking the eager owner write.
-They retain exactly one matching post-baseline frame and combine it with the commit result, so either
-side may arrive first without losing the acknowledgement. Update waits for the requested content;
-delete waits for absence. Pre-arming is load-bearing for delete: a legitimate same-ID recreation can
-otherwise replace the null in the stream's replay slot between owner commit and a late subscription,
-leaving an already committed request without a response. There is no polling and no replacement
-stream. Owner commit remains the storage boundary; successful unified update/delete is also the
-causal read-view boundary for the API's shared read path.
+Both handlers now warm the same shared entity stream **before** invoking the eager owner write. After
+commit they capture the owning stream's committed version and wait until the shared read stream has
+applied that version or a newer one. Checking the current snapshot inside a deferred subscription,
+then relying on the stream's own one-item replay, means the boundary cannot miss a frame that lands
+between those two operations. The version is the causal proof: a same-value older frame cannot release
+an update, while a legitimate same-ID recreation after a delete is accepted as newer state instead
+of leaving the delete waiting forever for a null that has already been replaced. There is no polling
+and no replacement stream. Owner commit remains the storage boundary; successful unified
+update/delete is also the causal read-view boundary for the API's shared read path.
 
 ### One behaviour DID change, and it is the better half of an existing contract
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadPathStreamMinting.md
@@ -218,7 +218,9 @@ done for a plain reduce, and where it matters the answer is a narrower reference
 | `ReadingTheSameReferenceRepeatedly_DoesNotMintASyncHubPerRead` | five reads of one reference add **0** `sync/` hubs to the owner (it fails with **+5** on the pre-fix call site) |
 | `AnUncachedConfiguredReduce_MintsOneSyncHubPerCall` | five genuinely-configured reduces add **5** — the counter can see growth, so the flat arm is not vacuous |
 | `TheSharedReadStream_StaysLive` | a write after the reads is visible to the next read — the shared stream is a live mirror, not a snapshot |
+| `UnifiedUpdate_WaitsUntilTheSharedReadStreamCarriesTheUpdate` | a successful update is withheld while the owner has committed but the shared read actor is parked on the old entity |
 | `UnifiedDelete_WaitsUntilTheSharedReadStreamCarriesAbsence` | a successful delete is withheld while the shared read actor is parked, even after the owner has committed; it answers only after the read view carries absence |
+| `UnifiedDelete_RetainsItsAbsenceAcknowledgementAcrossSameIdRecreation` | the delete's pre-armed absence acknowledgement survives a legitimate same-ID recreation instead of waiting forever on a replaced replay slot |
 
 ### A shared stream makes its propagation boundary observable
 
@@ -230,13 +232,17 @@ the read frame is still queued.
 This distinction did not matter when every read built a new reduction: a reduction built after the
 owner commit starts from the owner's latest replayed store. Once reads share the existing reduction,
 an immediate read can replay that reduction's previous value until its queued frame lands. The
-release gate exposed this as a successful `DeleteUnifiedReferenceRequest` followed immediately by a
-`GetDataRequest` that returned the deleted entity.
+release gate exposed both directions: a successful `UpdateUnifiedReferenceRequest` followed by the
+old entity, and a successful `DeleteUnifiedReferenceRequest` followed by the deleted entity.
 
-The delete handler now waits reactively on the same shared entity stream until it carries `null`
-before reporting success. It does not poll and does not build a replacement stream. The resulting
-contract is precise: owner commit remains the storage boundary, while successful unified deletion is
-also the read-after-write boundary for the API's shared read view.
+Both handlers now observe the same shared entity stream **before** invoking the eager owner write.
+They retain exactly one matching post-baseline frame and combine it with the commit result, so either
+side may arrive first without losing the acknowledgement. Update waits for the requested content;
+delete waits for absence. Pre-arming is load-bearing for delete: a legitimate same-ID recreation can
+otherwise replace the null in the stream's replay slot between owner commit and a late subscription,
+leaving an already committed request without a response. There is no polling and no replacement
+stream. Owner commit remains the storage boundary; successful unified update/delete is also the
+causal read-view boundary for the API's shared read path.
 
 ### One behaviour DID change, and it is the better half of an existing contract
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-delete-success-waits-for-the-read-view.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-delete-success-waits-for-the-read-view.md
@@ -1,16 +1,16 @@
 ---
-Name: Deleted data stays gone on the next read
+Name: Saved changes appear on the next read
 Category: Fix
-Description: A successful delete now waits until the shared read view has applied the deletion, so an immediate follow-up read cannot return the removed item.
+Description: Successful updates and deletes now wait for the shared read view, so an immediate follow-up read no longer replays stale data.
 Icon: Sparkle
 Order: -20260910
 ---
 
-# Deleted data stays gone on the next read
+# Saved changes appear on the next read
 
-Deleting an item could report success just before the portal's shared read view had processed the
-same change. An immediate follow-up read could therefore briefly return the item that had just been
-deleted.
+Updating or deleting an item could report success just before the portal's shared read view had
+processed the same change. An immediate follow-up read could therefore return the previous value or
+briefly return an item that had just been deleted.
 
-The delete response now waits for that read view to carry the item's absence. Once deletion reports
-success, the next read agrees and the removed item stays gone.
+Update and delete responses now wait for their matching change to reach that read view. Once the
+operation reports success, the next read no longer replays the state from before the operation.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-delete-success-waits-for-the-read-view.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-delete-success-waits-for-the-read-view.md
@@ -1,16 +1,17 @@
 ---
-Name: Saved changes appear on the next read
+Name: Saved data changes appear on the next read
 Category: Fix
-Description: Successful updates and deletes now wait for the shared read view, so an immediate follow-up read no longer replays stale data.
+Description: Successful data-entity updates and deletes now wait for the shared read view, so an immediate follow-up read no longer replays stale data.
 Icon: Sparkle
 Order: -20260910
 ---
 
-# Saved changes appear on the next read
+# Saved data changes appear on the next read
 
-Updating or deleting an item could report success just before the portal's shared read view had
+Updating or deleting a data entity could report success just before the portal's shared read view had
 processed the same change. An immediate follow-up read could therefore return the previous value or
 briefly return an item that had just been deleted.
 
-Update and delete responses now wait for their matching change to reach that read view. Once the
-operation reports success, the next read no longer replays the state from before the operation.
+Data-entity update and delete responses now wait for their matching change to reach that read view.
+Once the operation reports success, the next read no longer replays the state from before the
+operation. File-provider operations keep their existing provider-specific completion semantics.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1468,5 +1468,17 @@
   "setup.problem.noCompany": "Geben Sie die Organisation an, zu der diese Instanz gehört.",
   "setup.problem.noOwnerName": "Geben Sie den Namen der Person an, der diese Instanz gehört.",
   "setup.problem.noOwnerEmail": "Geben Sie eine gültige E-Mail-Adresse an — darüber erreicht die Registry die Eigentümerin oder den Eigentümer dieser Instanz.",
-  "setup.problem.noConsent": "Akzeptieren Sie die Datenschutzerklärung und die Plattform-Nutzungsbedingungen, um zu registrieren. Bis dahin wird nichts gesendet."
+  "setup.problem.noConsent": "Akzeptieren Sie die Datenschutzerklärung und die Plattform-Nutzungsbedingungen, um zu registrieren. Bis dahin wird nichts gesendet.",
+  "unifiedData.error.unknownCollection": "Unbekannte Sammlung '{0}': Keine registrierte Datenquelle und kein Inhaltsanbieter ist für diesen Pfad zuständig.",
+  "unifiedData.error.collectionMismatch": "Der Pfad verweist auf die Sammlung '{0}', der übermittelte Inhalt gehört jedoch zur Sammlung '{1}'.",
+  "unifiedData.error.entityIdMismatch": "Der Pfad verweist auf die Entität '{0}', der übermittelte Inhalt bezeichnet jedoch die Entität '{1}'.",
+  "unifiedData.error.missingEntityId": "Die Entitäts-ID für die Sammlung '{0}' konnte nicht bestimmt werden.",
+  "unifiedData.error.readStreamUnavailable": "Für {0}/{1} ist kein lesbarer Datenstrom verfügbar.",
+  "unifiedData.error.ownerStreamUnavailable": "Für {0}/{1} ist kein besitzender Datenstrom verfügbar.",
+  "unifiedData.error.typeSourceUnavailable": "Für {0}/{1} ist keine registrierte Datenquelle zuständig.",
+  "unifiedData.error.ownerReceiptUnavailable": "Der besitzende Datenstrom für {0}/{1} hat keine beobachtbare Commit-Version gemeldet.",
+  "unifiedData.error.readStreamEnded": "Der gemeinsame Lesedatenstrom für {0}/{1} endete, bevor er seinen aktuellen Zustand bereitstellte.",
+  "unifiedData.error.readBarrierEnded": "Der gemeinsame Lesedatenstrom für {0}/{1} endete, bevor er die bestätigte Version erreichte.",
+  "unifiedData.error.updateFailed": "Die Aktualisierung ist fehlgeschlagen.",
+  "unifiedData.error.deleteFailed": "Das Löschen ist fehlgeschlagen."
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1468,5 +1468,17 @@
   "setup.problem.noCompany": "Give the organisation this instance belongs to.",
   "setup.problem.noOwnerName": "Give the name of the person who owns this instance.",
   "setup.problem.noOwnerEmail": "Give a valid email address — it is how the registry reaches the owner about this instance.",
-  "setup.problem.noConsent": "Accept the privacy statement and the platform terms to register. Nothing is sent until you do."
+  "setup.problem.noConsent": "Accept the privacy statement and the platform terms to register. Nothing is sent until you do.",
+  "unifiedData.error.unknownCollection": "Unknown collection '{0}': no registered data type source or content provider owns this path.",
+  "unifiedData.error.collectionMismatch": "The path addresses collection '{0}', but the submitted content belongs to collection '{1}'.",
+  "unifiedData.error.entityIdMismatch": "The path addresses entity '{0}', but the submitted content identifies entity '{1}'.",
+  "unifiedData.error.missingEntityId": "Cannot determine the entity ID for collection '{0}'.",
+  "unifiedData.error.readStreamUnavailable": "No readable data stream exists for {0}/{1}.",
+  "unifiedData.error.ownerStreamUnavailable": "No owning data stream exists for {0}/{1}.",
+  "unifiedData.error.typeSourceUnavailable": "No registered data type source owns {0}/{1}.",
+  "unifiedData.error.ownerReceiptUnavailable": "The owning data stream for {0}/{1} did not report an observable commit version.",
+  "unifiedData.error.readStreamEnded": "The shared read stream for {0}/{1} ended before it exposed its current state.",
+  "unifiedData.error.readBarrierEnded": "The shared read stream for {0}/{1} ended before it reached the committed version.",
+  "unifiedData.error.updateFailed": "Update failed.",
+  "unifiedData.error.deleteFailed": "Delete failed."
 }

--- a/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
@@ -196,10 +196,10 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
     }
 
     /// <summary>
-    /// The delete acknowledgement is subscribed before the eager write. This pins the ordering in
-    /// which the delete's null frame is followed by a legitimate same-ID recreation before the
-    /// delete result is consumed; the committed delete must still answer instead of waiting forever
-    /// on a null frame that has already been replaced in the shared replay slot.
+    /// The read-version barrier survives the ordering in which the delete's null frame is followed
+    /// by a legitimate same-ID recreation before the delete result is consumed. The committed delete
+    /// must still answer once the read view reaches its version instead of waiting forever on a null
+    /// frame that has already been replaced in the shared replay slot.
     /// </summary>
     [HubFact]
     public async Task UnifiedDelete_RetainsItsAbsenceAcknowledgementAcrossSameIdRecreation()
@@ -263,11 +263,51 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
         }
 
         var answer = await answers.Should().Within(TestTimeouts.Convergence)
-            .Emit("the pre-armed absence observation retains the delete acknowledgement after recreation");
+            .Emit("the committed-version barrier retains the delete acknowledgement after recreation");
         answer.Success.Should().BeTrue();
         await readStream.Should().Within(TestTimeouts.Convergence)
             .Match(item => item.Value is BusinessUnit { DisplayName: "Recreated display" },
                 "the recreation remains the latest state after the delete acknowledgement");
+    }
+
+    /// <summary>
+    /// A late barrier subscriber must accept a newer frame after the exact delete frame has left the
+    /// shared stream's replay slot. This is the deterministic control for the race that a value-only
+    /// <c>Where(Value is null)</c> tail cannot survive.
+    /// </summary>
+    [HubFact]
+    public async Task ReadVersionBarrier_AcceptsNewerStateAfterTheDeleteFrameWasReplaced()
+    {
+        var workspace = GetHost().ServiceProvider.GetRequiredService<IWorkspace>();
+        var readStream = workspace.GetNullableStream(new EntityReference(nameof(BusinessUnit), "1"))
+                         ?? throw new InvalidOperationException(
+                             "The BusinessUnit entity reference did not resolve to a stream.");
+        var initial = await readStream.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value is BusinessUnit, "the initial entity must be visible");
+        var owner = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+            .GetStreamForPartition(null)!;
+
+        await workspace.RequestChange(new DataChangeRequest { Deletions = [initial.Value!] })
+            .Should().Within(TestTimeouts.Convergence).Emit("the delete must commit");
+        var deleteVersion = owner.Current?.Version
+                            ?? throw new InvalidOperationException("The owner did not expose the delete version.");
+        await readStream.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Version >= deleteVersion && item.Value is null,
+                "the shared stream must apply the delete before its replay slot is replaced");
+
+        await workspace.RequestChange(DataChangeRequest.Update(
+                [new BusinessUnit("1", "Recreated after delete")]))
+            .Should().Within(TestTimeouts.Convergence).Emit("the same ID must be recreated");
+        await readStream.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value is BusinessUnit { DisplayName: "Recreated after delete" },
+                "the recreation must replace the delete frame in the one-item replay slot");
+
+        var observed = await DataExtensions.WaitForSharedReadVersion(readStream, deleteVersion)
+            .Should().Within(TestTimeouts.Quick)
+            .Emit("a newer committed frame proves the read view crossed the delete boundary");
+        observed.Version.Should().BeGreaterThan(deleteVersion);
+        observed.Value.Should().BeOfType<BusinessUnit>()
+            .Which.DisplayName.Should().Be("Recreated after delete");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
@@ -116,6 +116,161 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
     }
 
     /// <summary>
+    /// A successful unified update is a read-after-write boundary. The owning data source and the
+    /// already-warmed shared read stream are separate actors, so the owner can commit while the
+    /// read actor still carries the old entity. The response must wait for that actor's matching
+    /// post-baseline frame.
+    /// </summary>
+    [HubFact]
+    public async Task UnifiedUpdate_WaitsUntilTheSharedReadStreamCarriesTheUpdate()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var workspace = host.ServiceProvider.GetRequiredService<IWorkspace>();
+        var readStream = workspace.GetNullableStream(new EntityReference(nameof(BusinessUnit), "1"))
+                         ?? throw new InvalidOperationException(
+                             "The BusinessUnit entity reference did not resolve to a stream.");
+
+        await readStream.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value is BusinessUnit { DisplayName: not "Updated display" },
+                "the shared read stream must carry the original entity before its actor is parked");
+
+        var blockerEntered = new AsyncSubject<System.Reactive.Unit>();
+        var releaseBlocker = 0;
+        Exception? blockerException = null;
+        readStream.Hub.InvokeAsync(
+            _ =>
+            {
+                blockerEntered.OnNext(System.Reactive.Unit.Default);
+                blockerEntered.OnCompleted();
+                if (!SpinWait.SpinUntil(
+                        () => Volatile.Read(ref releaseBlocker) == 1,
+                        TestTimeouts.Convergence))
+                    throw new TimeoutException("The test did not release the shared-read-stream actor.");
+                return Task.CompletedTask;
+            },
+            ex =>
+            {
+                Interlocked.CompareExchange(ref blockerException, ex, null);
+                Volatile.Write(ref releaseBlocker, 1);
+                return Task.CompletedTask;
+            });
+
+        await blockerEntered.Should().Within(TestTimeouts.Quick)
+            .Emit("the shared stream actor must be occupied before the update is issued");
+
+        var answers = new ReplaySubject<UpdateUnifiedReferenceResponse>(1);
+        using var answerSubscription = client
+            .Observe(
+                new UpdateUnifiedReferenceRequest(
+                    $"data:{nameof(BusinessUnit)}/1",
+                    new BusinessUnit("1", "Updated display")),
+                o => o.WithTarget(CreateHostAddress()))
+            .Select(delivery => delivery.Message)
+            .Subscribe(answers);
+
+        try
+        {
+            var source = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+                .GetStreamForPartition(null)!;
+            await source.Should().Within(TestTimeouts.Convergence).Match(item =>
+                    item.Value?.GetCollection(nameof(BusinessUnit))?.Instances.GetValueOrDefault("1")
+                        is BusinessUnit { DisplayName: "Updated display" },
+                "the owner must have applied the update while the shared read actor is still parked");
+
+            await answers.Should().NotEmit(TimeSpan.FromMilliseconds(300),
+                "owner commit alone is not enough: success must wait for the read view's queued update frame");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseBlocker, 1);
+        }
+
+        var answer = await answers.Should().Within(TestTimeouts.Convergence)
+            .Emit("releasing the shared read actor lets the matching frame land and completes the update");
+        Volatile.Read(ref blockerException).Should().BeNull(
+            "the parked actor turn must complete normally; swallowing a fault would make the ordering assertion vacuous");
+        answer.Success.Should().BeTrue();
+        readStream.Current?.Value.Should().BeOfType<BusinessUnit>()
+            .Which.DisplayName.Should().Be("Updated display");
+    }
+
+    /// <summary>
+    /// The delete acknowledgement is subscribed before the eager write. This pins the ordering in
+    /// which the delete's null frame is followed by a legitimate same-ID recreation before the
+    /// delete result is consumed; the committed delete must still answer instead of waiting forever
+    /// on a null frame that has already been replaced in the shared replay slot.
+    /// </summary>
+    [HubFact]
+    public async Task UnifiedDelete_RetainsItsAbsenceAcknowledgementAcrossSameIdRecreation()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var workspace = host.ServiceProvider.GetRequiredService<IWorkspace>();
+        var readStream = workspace.GetNullableStream(new EntityReference(nameof(BusinessUnit), "1"))
+                         ?? throw new InvalidOperationException(
+                             "The BusinessUnit entity reference did not resolve to a stream.");
+
+        await readStream.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value is BusinessUnit,
+                "the initial entity must be visible before the shared read actor is parked");
+
+        var blockerEntered = new AsyncSubject<System.Reactive.Unit>();
+        var releaseBlocker = 0;
+        readStream.Hub.InvokeAsync(() =>
+        {
+            blockerEntered.OnNext(System.Reactive.Unit.Default);
+            blockerEntered.OnCompleted();
+            if (!SpinWait.SpinUntil(
+                    () => Volatile.Read(ref releaseBlocker) == 1,
+                    TestTimeouts.Convergence))
+                throw new TimeoutException("The test did not release the shared-read-stream actor.");
+        });
+        await blockerEntered.Should().Within(TestTimeouts.Quick)
+            .Emit("the shared stream actor must be occupied before the delete is issued");
+
+        var answers = new ReplaySubject<DeleteUnifiedReferenceResponse>(1);
+        using var answerSubscription = client
+            .Observe(
+                new DeleteUnifiedReferenceRequest($"data:{nameof(BusinessUnit)}/1"),
+                o => o.WithTarget(CreateHostAddress()))
+            .Select(delivery => delivery.Message)
+            .Subscribe(answers);
+
+        try
+        {
+            var source = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+                .GetStreamForPartition(null)!;
+            await source.Should().Within(TestTimeouts.Convergence).Match(item =>
+                    item.Value?.GetCollection(nameof(BusinessUnit))?.Instances.ContainsKey("1") == false,
+                "the owner must apply the delete before the same ID is recreated");
+
+            await workspace.RequestChange(DataChangeRequest.Update(
+                    [new BusinessUnit("1", "Recreated display")]))
+                .Should().Within(TestTimeouts.Convergence)
+                .Emit("the owner must apply the legitimate same-ID recreation");
+            await source.Should().Within(TestTimeouts.Convergence).Match(item =>
+                    item.Value?.GetCollection(nameof(BusinessUnit))?.Instances.GetValueOrDefault("1")
+                        is BusinessUnit { DisplayName: "Recreated display" },
+                "both owner frames must be queued for the parked shared read actor");
+
+            await answers.Should().NotEmit(TimeSpan.FromMilliseconds(300),
+                "the delete response still waits for its own absence acknowledgement");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseBlocker, 1);
+        }
+
+        var answer = await answers.Should().Within(TestTimeouts.Convergence)
+            .Emit("the pre-armed absence observation retains the delete acknowledgement after recreation");
+        answer.Success.Should().BeTrue();
+        await readStream.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value is BusinessUnit { DisplayName: "Recreated display" },
+                "the recreation remains the latest state after the delete acknowledgement");
+    }
+
+    /// <summary>
     /// A successful unified delete is a read-after-write boundary: once it answers, the shared
     /// read stream must already carry absence. The data-source owner and its reduced read stream
     /// are separate actors, so applying the owner store only QUEUES the reduced null frame. Before

--- a/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
+++ b/test/MeshWeaver.Data.Test/ReadPathStreamMintingTest.cs
@@ -50,6 +50,172 @@ public class ReadPathStreamMintingTest(ITestOutputHelper output) : HubTestBase(o
     /// hub counted is one this test caused.</summary>
     private static readonly TimeSpan LongHeartbeat = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// A true owner no-op adopts a new version without publishing a value-equal frame. The write
+    /// receipt must therefore fence on the preceding observable owner version, not wait forever
+    /// for the silently adopted one.
+    /// </summary>
+    [HubFact]
+    public async Task UnifiedUpdate_OwnerNoOpUsesTheLastObservableVersion()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var workspace = host.ServiceProvider.GetRequiredService<IWorkspace>();
+        var read = workspace.GetNullableStream(new EntityReference(nameof(BusinessUnit), "1"))!;
+        await read.Should().Within(TestTimeouts.Convergence).Match(x => x.Value is BusinessUnit);
+
+        var entered = new AsyncSubject<System.Reactive.Unit>();
+        var release = 0;
+        var desired = new BusinessUnit("1", "Already committed by another writer");
+        read.Hub.InvokeAsync(() =>
+        {
+            entered.OnNext(System.Reactive.Unit.Default);
+            entered.OnCompleted();
+            if (!SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, TestTimeouts.Convergence))
+                throw new TimeoutException("The read actor hold was not released.");
+        });
+
+        var answers = new ReplaySubject<UpdateUnifiedReferenceResponse>(1);
+        try
+        {
+            await entered.Should().Within(TestTimeouts.Quick).Emit();
+            await workspace.RequestChange(DataChangeRequest.Update([desired]))
+                .Should().Within(TestTimeouts.Convergence)
+                .Emit("the owner already holds our target while the shared read is stale");
+            var owner = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+                .GetStreamForPartition(null)!;
+            var priorVersion = owner.Current!.Version;
+            using var observation = client.Observe(
+                    new UpdateUnifiedReferenceRequest($"data:{nameof(BusinessUnit)}/1", desired),
+                    o => o.WithTarget(CreateHostAddress()))
+                .Select(d => d.Message).Subscribe(answers);
+
+            await Observable.Interval(PollInterval).StartWith(0L)
+                .Select(_ => owner.Current!.Version)
+                .Should().Within(TestTimeouts.Convergence).Match(version => version > priorVersion,
+                    "the idempotent owner write adopts its next version silently");
+            await answers.Should().NotEmit(TimeSpan.FromMilliseconds(300),
+                "the shared read still has not crossed the last observable owner version");
+
+            Volatile.Write(ref release, 1);
+            await read.Should().Within(TestTimeouts.Convergence)
+                .Match(x => x.Value is BusinessUnit b && b == desired,
+                    "the earlier real change must reach the shared read view");
+            var response = await answers.Should().Within(TestTimeouts.Quick).Emit(
+                "the no-op must answer at the last version the shared read can observe");
+            response.Success.Should().BeTrue();
+        }
+        finally
+        {
+            Volatile.Write(ref release, 1);
+        }
+    }
+
+    /// <summary>
+    /// Equality with the cached read is not proof of an owner no-op: an intervening owner frame can
+    /// already be queued. The exact owner-side receipt must keep this update pending until its own
+    /// value-changing frame crosses the shared read actor.
+    /// </summary>
+    [HubFact]
+    public async Task UnifiedUpdate_InitiallyMatchingStaleReadStillNeedsItsOwnReadBoundary()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var workspace = host.ServiceProvider.GetRequiredService<IWorkspace>();
+        var read = workspace.GetNullableStream(new EntityReference(nameof(BusinessUnit), "1"))!;
+        var initial = await read.Should().Within(TestTimeouts.Convergence)
+            .Match(x => x.Value is BusinessUnit, "warm the real cached read stream");
+        var desired = (BusinessUnit)initial.Value!;
+        var firstEntered = new AsyncSubject<System.Reactive.Unit>();
+        var secondEntered = new AsyncSubject<System.Reactive.Unit>();
+        var releaseFirst = 0;
+        var releaseSecond = 0;
+        read.Hub.InvokeAsync(() =>
+        {
+            firstEntered.OnNext(System.Reactive.Unit.Default);
+            firstEntered.OnCompleted();
+            if (!SpinWait.SpinUntil(() => Volatile.Read(ref releaseFirst) == 1, TestTimeouts.Convergence))
+                throw new TimeoutException("The first read actor hold was not released.");
+        });
+
+        var answers = new ReplaySubject<UpdateUnifiedReferenceResponse>(1);
+        try
+        {
+            await firstEntered.Should().Within(TestTimeouts.Quick).Emit();
+            await workspace.RequestChange(DataChangeRequest.Update([new BusinessUnit("1", "Concurrent value")]))
+                .Should().Within(TestTimeouts.Convergence)
+                .Emit("the foreign write commits while the cached view still equals our desired value");
+            read.Hub.InvokeAsync(() =>
+            {
+                secondEntered.OnNext(System.Reactive.Unit.Default);
+                secondEntered.OnCompleted();
+                if (!SpinWait.SpinUntil(() => Volatile.Read(ref releaseSecond) == 1,
+                        TestTimeouts.Convergence))
+                    throw new TimeoutException("The second read actor hold was not released.");
+            });
+
+            using var observation = client.Observe(
+                    new UpdateUnifiedReferenceRequest($"data:{nameof(BusinessUnit)}/1", desired),
+                    o => o.WithTarget(CreateHostAddress()))
+                .Select(d => d.Message).Subscribe(answers);
+            var owner = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+                .GetStreamForPartition(null)!;
+            await owner.Should().Within(TestTimeouts.Convergence).Match(x =>
+                    x.Value?.GetCollection(nameof(BusinessUnit))?.Instances.GetValueOrDefault("1")
+                        is BusinessUnit b && b == desired,
+                "our own update has committed after the concurrent value");
+
+            Volatile.Write(ref releaseFirst, 1);
+            await secondEntered.Should().Within(TestTimeouts.Quick)
+                .Emit("the read actor applied the intervening write while our own frame remains queued");
+            ((BusinessUnit)read.Current!.Value!).DisplayName.Should().Be("Concurrent value");
+            await answers.Should().NotEmit(TimeSpan.FromMilliseconds(300),
+                "an initially matching stale read is not an acknowledgement for this update");
+
+            Volatile.Write(ref releaseSecond, 1);
+            var response = await answers.Should().Within(TestTimeouts.Convergence)
+                .Emit("the response must follow this update's own shared-read frame");
+            response.Success.Should().BeTrue();
+            ((BusinessUnit)read.Current!.Value!).DisplayName.Should().Be(desired.DisplayName);
+        }
+        finally
+        {
+            Volatile.Write(ref releaseFirst, 1);
+            Volatile.Write(ref releaseSecond, 1);
+        }
+    }
+
+    /// <summary>
+    /// The entity addressed by the URL and the entity carried by the payload are one target. A
+    /// mismatch must be rejected before the write instead of updating one entity while waiting on
+    /// another entity's read stream forever.
+    /// </summary>
+    [HubFact]
+    public async Task UnifiedUpdate_RejectsPathAndContentIdentityMismatchBeforeWriting()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var owner = host.GetWorkspace().DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+            .GetStreamForPartition(null)!;
+        var ownerState = await owner.Should().Within(TestTimeouts.Convergence)
+            .Match(item => item.Value?.GetCollection(nameof(BusinessUnit))?.Instances.ContainsKey("2") == true,
+                "the owner must expose the entity whose accidental mutation is the control");
+        var before = ownerState.Value!.GetCollection(nameof(BusinessUnit))!.Instances["2"];
+
+        var response = await client.Observe(
+                new UpdateUnifiedReferenceRequest(
+                    $"data:{nameof(BusinessUnit)}/1",
+                    new BusinessUnit("2", "Must not be written")),
+                o => o.WithTarget(CreateHostAddress()))
+            .Select(delivery => delivery.Message)
+            .Should().Within(TestTimeouts.Quick)
+            .Emit("a mismatched target must receive one explicit refusal instead of waiting forever");
+
+        response.Success.Should().BeFalse();
+        owner.Current!.Value!.GetCollection(nameof(BusinessUnit))!.Instances["2"]
+            .Should().Be(before, "the request is rejected before any differently keyed entity is changed");
+    }
+
     protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
         => base.ConfigureHost(configuration)
             .WithServices(services => services

--- a/test/MeshWeaver.Data.Test/RepeatedNoOpReceiptTest.cs
+++ b/test/MeshWeaver.Data.Test/RepeatedNoOpReceiptTest.cs
@@ -1,0 +1,56 @@
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data.TestDomain;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the owner-side causal receipt used by unified data writes. A synchronization stream adopts
+/// a value-equal patch's version without publishing it, so the receipt must retain the last frame a
+/// reduced read could actually have received across any number of consecutive no-ops.
+/// </summary>
+public class RepeatedNoOpReceiptTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(source => source
+                .WithType<BusinessUnit>(type => type.WithInitialData(TestData.BusinessUnits))));
+
+    [HubFact]
+    public async Task ASecondNoOpRetainsTheLastPublishedOwnerVersion()
+    {
+        var workspace = GetHost().ServiceProvider.GetRequiredService<IWorkspace>();
+        var read = workspace.GetNullableStream(new EntityReference(nameof(BusinessUnit), "1"))!;
+        var initial = await read.Should().Within(TestTimeouts.Convergence)
+            .Match(frame => frame.Value is BusinessUnit);
+        var desired = (BusinessUnit)initial.Value!;
+        var source = workspace.DataContext.DataSourcesByCollection[nameof(BusinessUnit)]
+            .GetStreamForPartition(null)!;
+        var originallyPublished = await source.Take(1).Should().Within(TestTimeouts.Quick).Emit();
+
+        var first = await workspace.ChangeWithReceipt(DataChangeRequest.Update([desired]))
+            .Should().Within(TestTimeouts.Quick).Emit("the first idempotent update still commits");
+        first.VisibleVersions.Should().ContainSingle().Which.Should().Be(originallyPublished.Version);
+        source.Current!.Version.Should().BeGreaterThan(originallyPublished.Version,
+            "the owner silently advances even though the value-equal patch was not published");
+
+        var second = await workspace.ChangeWithReceipt(DataChangeRequest.Update([desired]))
+            .Should().Within(TestTimeouts.Quick).Emit("the second idempotent update also commits");
+        var lastPublished = await source.Take(1).Should().Within(TestTimeouts.Quick).Emit();
+        lastPublished.Version.Should().Be(originallyPublished.Version,
+            "neither no-op emitted a replacement owner frame");
+        read.Current!.Version.Should().Be(originallyPublished.Version,
+            "the read has no later published owner frame to consume");
+        Output.WriteLine(
+            $"DIAG: first receipt={first.VisibleVersions[0]}, second receipt={second.VisibleVersions[0]}, "
+            + $"owner Current={source.Current!.Version}, last owner OnNext={lastPublished.Version}, "
+            + $"read={read.Current.Version}.");
+        second.VisibleVersions.Should().ContainSingle().Which.Should().Be(lastPublished.Version,
+            "the previous Current version can itself be an unpublished no-op; the receipt must "
+            + "reference a frame reduced reads can actually receive");
+    }
+}


### PR DESCRIPTION
## Root cause

#3976 fixed only the deletion symptom and waited for a value after owner commit. The full defect had several causal and lifecycle edges:

- UpdateUnifiedReferenceRequest could reply at owner commit while the existing shared read actor still retained the pre-update entity.
- Comparing the cached read value with the requested value mistook a stale coincidence for an owner no-op.
- A value-equal owner patch adopts a new version without publishing a frame; after consecutive no-ops, even the preceding Current version can be unpublished.
- A delete waiting specifically for null could be stranded when a legitimate same-ID recreation replaced that replay slot.
- A URL/payload key mismatch updated one entity while the acknowledgement watched another.
- Deferred writes could lose the inbound AccessContext, and an empty/completed read phase could terminate without posting a response.

The merge queue landed #3976 after it had been converted back to draft. This follow-up contains the correction that was deliberately excluded from that merge.

## Fix

- Warm the exact shared entity stream served by GetDataRequest before unified entity updates and deletes.
- Observe the owner stream's replay from before the write through its serialized post-apply callback and return that last actually published version in an internal receipt.
- Wait until the shared read stream reaches that published owner version or a newer one.
- Preserve the caller's AccessContext at the deferred write call site.
- Reject collection and entity-ID mismatches before mutation.
- Turn empty/completed baseline and barrier streams into one explicit localized failure response.
- Treat a rejected teardown-time owner write as failed, not committed.

This handles value-changing writes, any number of value-equal no-ops, and later same-ID recreation without polling, retry, delay, replacement streams, new hubs, or hand-rolled concurrency primitives. The ordinary RequestChange path does not pay for the receipt subscription; it is enabled only for the two unified entity operations that require the causal boundary.

## Evidence

Red controls on earlier #3976/#3985 heads:

- parked-read update returned while the shared read still held the old value
- initially matching stale read returned while an intervening owner frame was visible and this write remained queued
- URL/content key mismatch wrote one entity while waiting on another
- second consecutive no-op returned an unreachable unpublished owner version
- late delete confirmation missed its already-published boundary after same-ID recreation

Green on e01ce2b41:

- focused causal, repeated-no-op, identity, and recreation controls: 8/8
- MeshWeaver.Data.Test: 508/508
- MeshWeaver.Documentation.Test: 374/374
- MeshWeaver.Plugins MeshWeaver.AI.Test built against this exact core worktree: 1,941 passed, 3 expected skips, 0 failed
- strict Release warnings-as-errors builds: MeshWeaver.Data, MeshWeaver.Data.Test, MeshWeaver.Documentation, MeshWeaver.Documentation.Test, and the dependent MeshWeaver.AI.Test; all 0 warnings and 0 errors

Fixes #3971
Fixes #3979
Refs #3432
Refs #3976

Mirror-sync: MeshWeaver.Plugins runs `npm run sync:i18n -- --ref <merged core sha>` after this lands, tracked in #3985.
