### PR TITLE
Gate pod-hub claims on silo readiness

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -140,10 +140,12 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     ///
     /// <para>🚨 <b>What it governs, and what it must never govern.</b> It selects the pod-hub
     /// claim's TERMINAL and the level of the line that reports one — see
-    /// <see cref="AttachPodHub"/>. It does NOT gate whether the claim is attempted: a routing
-    /// service built on a bare container (several fixtures do exactly that) must still make the
-    /// call, or the gate that stops a SHUTTING-DOWN silo from claiming would be indistinguishable
-    /// from a gate that stopped claiming altogether.</para>
+    /// <see cref="AttachPodHub"/>. It does NOT decide readiness: every host orders the claim on
+    /// <see cref="OrleansStreamingReadiness"/>, and once that signal opens this flag decides whether
+    /// a failed claim can ever converge locally. A routing service built on a bare container
+    /// (several fixtures do exactly that) must therefore still make the call after its test opens
+    /// readiness, or the gate that stops a SHUTTING-DOWN silo from claiming would be
+    /// indistinguishable from a gate that stopped claiming altogether.</para>
     ///
     /// <para>Settable as a test seam, exactly like <see cref="AttachBackoff"/>: instance state,
     /// never static, so a unit test can pin the silo policy without standing up a silo.</para>
@@ -297,8 +299,9 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     private readonly IClusterMembershipFeed? membershipFeed;
 
     /// <summary>
-    /// When a pod-hub claim for <paramref name="addressPath"/> must be (re-)asserted: once
-    /// immediately, and then once per cluster membership change.
+    /// When a pod-hub claim for <paramref name="addressPath"/> must be (re-)asserted: once the
+    /// Orleans lifecycle reaches <see cref="ServiceLifecycleStage.Active"/>, and then once per
+    /// cluster membership change.
     ///
     /// <para>🚨 <b>The membership change is the EVENT that can invalidate the claim, not a poll.</b>
     /// The claim publishes an address→silo mapping into Orleans' own grain directory, and that
@@ -311,18 +314,36 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     /// re-publishes its client routing table to every silo on every membership change, and for the
     /// same reason.</para>
     ///
-    /// <para>Where there is no feed the sequence is a single immediate emission, i.e. exactly the
-    /// behaviour that existed before: assert once, never re-assert.</para>
+    /// <para>🚨 <b>The readiness ordering is the fix for #3983/#3984.</b> The old immediate
+    /// emission ran while eager <c>mesh/{id}</c> and <c>cache/{id}</c> hubs were being registered,
+    /// before this silo — and sometimes before ANY silo — advertised <c>IPodHubGrain</c>. Orleans
+    /// then failed placement with <c>Known nodes with grain type: none</c>. One logical claim was
+    /// visible twice in production: Orleans.Messaging logged every internal placement attempt
+    /// (#3983), while Polly logged the exhausted call (#3984). This gate removes the invalid call
+    /// rather than classifying or retrying it.</para>
+    ///
+    /// <para><c>ObserveOn</c> is load-bearing. <see cref="OrleansStreamingReadiness.Ready"/>
+    /// is completed on Orleans' lifecycle thread; invoking <c>Attach</c> inline there would make the
+    /// lifecycle wait on a cluster call whose placement depends on that lifecycle finishing. The
+    /// first claim is therefore scheduled away from that thread, just like the sibling stream
+    /// subscription's <c>ConfigureAwait(false)</c> continuation.</para>
+    ///
+    /// <para>Where there is no feed the post-readiness sequence is a single emission: assert once,
+    /// never re-assert.</para>
     /// </summary>
     /// <param name="addressPath">The address being claimed — used only for the trace line.</param>
     /// <returns>The trigger sequence the claim subscribes to.</returns>
     private IObservable<long> ClaimTriggers(string addressPath) =>
-        membershipFeed is null
-            ? Observable.Return(0L)
-            : membershipFeed.Changes
-                .Do(seq => OrleansRouteTrace.Write(
-                    $"OrleansRoutingService.AttachPodHub REASSERT addr={addressPath} membershipChange={seq}"))
-                .StartWith(0L);
+        Observable.Defer(() =>
+            serviceProvider.GetRequiredService<OrleansStreamingReadiness>().Ready
+                .Take(1)
+                .ObserveOn(Scheduler.Default)
+                .SelectMany(_ => membershipFeed is null
+                    ? Observable.Return(0L)
+                    : membershipFeed.Changes
+                        .Do(seq => OrleansRouteTrace.Write(
+                            $"OrleansRoutingService.AttachPodHub REASSERT addr={addressPath} membershipChange={seq}"))
+                        .StartWith(0L)));
 
     /// <summary>
     /// Routes a message delivery to its target. Locally registered streams are invoked
@@ -896,6 +917,11 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         // two transports run side by side for one release, and a hub the grain cannot reach still
         // falls back to the stream. See Doc/Architecture/PodHubDeliveryRollPlan.
         //
+        // The claim is ORDERED on the same Active-stage readiness signal as the stream subscription
+        // below. Eager hubs are registered before the silo advertises its grain types; touching
+        // IPodHubGrain in that window produced #3983/#3984's "Known nodes with grain type: none"
+        // burst. The local route above is already live, so waiting changes no local behaviour.
+        //
         // This is a NO-OP outside a silo: an Orleans CLIENT process cannot host a grain, so Attach
         // never lands locally, the retries give up, and that hub keeps the stream permanently. That
         // is correct rather than degraded — and it is why the fallback is not a temporary scaffold.
@@ -1200,10 +1226,11 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     /// Claims <paramref name="address"/> for THIS process, so the rest of the cluster can deliver to
     /// it with a directed grain call instead of a stream publish (#1742).
     ///
-    /// <para>Synchronous to the caller and best-effort by construction: <c>RegisterStream</c>'s local
-    /// route is already live, and a claim that has not landed yet simply leaves this hub on the
-    /// stream — the transport it has always used. So a failure here degrades, it never blocks; the
-    /// returned disposable releases the claim.</para>
+    /// <para>Registration is synchronous to the caller and best-effort by construction:
+    /// <c>RegisterStream</c>'s local route is already live, while the cluster claim begins after
+    /// readiness. A claim that has not landed yet simply leaves this hub on the stream — the
+    /// transport it has always used. So a failure here degrades, it never blocks; the returned
+    /// disposable releases a claim that was actually attempted.</para>
     ///
     /// <para>🚨 <b>The claim's lifetime is DERIVED, never a counter</b> — the #2426 rule, applied
     /// here because a bounded claim was #1742's stated open residual: six attempts over ≈3 s and
@@ -1266,12 +1293,59 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         var budgetWarned = false;
         var recoveryLogged = false;
         var landedOnce = 0;
+        // Claim/dispose handshake. Disposal can race the synchronous interval between selecting a
+        // grain and actually invoking Attach(): it must neither Detach a claim that was never made
+        // nor Detach first and let that already-reserved Attach run afterwards. The STARTING state
+        // hands release ownership to the thread making the Attach call; that thread invokes Attach
+        // first and only then honours a concurrent disposal request.
+        const int WaitingForFirstAttempt = 0;
+        const int StartingAttempt = 1;
+        const int AttachWasInvoked = 2;
+        const int DisposedBeforeAnyAttempt = 3;
+        const int DisposeRequestedWhileStarting = 4;
+        const int DisposedAfterAttempt = 5;
+        var claimState = 0;
         var attach = new SingleAssignmentDisposable();
         // Armed BEFORE the claim is subscribed, so there is no window in which the claim could
         // terminate unobserved. AsyncSubject: it completes once and replays that completion to
         // whoever asks afterwards, so an observer arriving late still sees the terminal.
         var settled = podHubClaimSettled[address] = new AsyncSubject<Unit>();
         inFlight.Add(attach);
+
+        void ReleaseClaim(IPodHubGrain? selectedGrain = null)
+        {
+            // Fire-and-forget: teardown is best-effort, and an activation that outlives its owner is
+            // recovered anyway — Deliver on a silo with no local route steps aside (see PodHubGrain).
+            // Wrapped because this runs during teardown, where the cluster client may already be
+            // gone: releasing a claim that nobody can hear is a no-op, never a throw out of Dispose.
+            try
+            {
+                // 🚨 THE INVARIANT, at the site that violated it. A "goodbye" that has to CREATE the
+                // activation it says goodbye to is not a release — IPodHubGrain is
+                // [PreferLocalPlacement], so once the previous activation has gone this call places a
+                // brand-new one on the very silo that is shutting down, purely to tell it nothing.
+                // There is also nothing to release: every activation in this process is going away
+                // with it. Skipping is the whole correct behaviour, not a degradation.
+                var grain = selectedGrain ?? GrainWhileRunning<IPodHubGrain>(addressPath);
+                if (grain is null)
+                {
+                    logger.LogDebug(
+                        "Pod-hub claim for {Address} not released — the host has begun stopping, so the "
+                        + "activation is going away regardless and announcing it would only create one.",
+                        addressPath);
+                    return;
+                }
+
+                grain.Detach().ToObservable()
+                    .Subscribe(
+                        _ => { },
+                        ex => logger.LogDebug(ex, "Failed to release the pod-hub claim for {Address}", addressPath));
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Failed to release the pod-hub claim for {Address}", addressPath);
+            }
+        }
 
         // ONE ROUND of the claim: ask, retry the bounce, and complete when it lands. Composed per
         // subscription so its retry state is genuinely per-round.
@@ -1284,21 +1358,63 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             return Observable
                 .Defer(() =>
                 {
-                    // Inside the Defer on purpose: RetryWhen re-subscribes, so a claim that is still
-                    // bouncing between pods when shutdown begins stops asking instead of spending its
-                    // remaining attempts placing an activation on the silo that is leaving.
-                    var grain = GrainWhileRunning<IPodHubGrain>(addressPath);
-                    if (grain is null)
-                    {
-                        logger.LogDebug(
-                            "Pod-hub claim for {Address} not attempted — the host has begun stopping, and "
-                            + "claiming an address for a process that is going away would only place a new "
-                            + "activation on the silo that is leaving.",
-                            addressPath);
+                    var previousState = Interlocked.CompareExchange(
+                        ref claimState, StartingAttempt, WaitingForFirstAttempt);
+                    if (previousState == AttachWasInvoked)
+                        previousState = Interlocked.CompareExchange(
+                            ref claimState, StartingAttempt, AttachWasInvoked);
+                    if (previousState >= DisposedBeforeAnyAttempt || previousState == StartingAttempt)
                         return Observable.Empty<bool>();
-                    }
 
-                    return grain.Attach().ToObservable();
+                    var hadEarlierAttempt = previousState == AttachWasInvoked;
+
+                    IPodHubGrain? grain = null;
+                    var attachCallEntered = false;
+                    try
+                    {
+                        // Inside the Defer on purpose: RetryWhen re-subscribes, so a claim that is still
+                        // bouncing between pods when shutdown begins stops asking instead of spending its
+                        // remaining attempts placing an activation on the silo that is leaving.
+                        grain = GrainWhileRunning<IPodHubGrain>(addressPath);
+                        if (grain is null)
+                        {
+                            logger.LogDebug(
+                                "Pod-hub claim for {Address} not attempted — the host has begun stopping, and "
+                                + "claiming an address for a process that is going away would only place a new "
+                                + "activation on the silo that is leaving.",
+                                addressPath);
+                            return Observable.Empty<bool>();
+                        }
+
+                        // The call itself is inside the handshake. If disposal changes STARTING to
+                        // DISPOSE_REQUESTED while this synchronous invocation is in progress, the
+                        // finally below becomes the sole release owner and therefore Detach cannot
+                        // overtake Attach.
+                        attachCallEntered = true;
+                        return grain.Attach().ToObservable();
+                    }
+                    finally
+                    {
+                        // Restore the retryable stable state even when GetGrain/Attach throws. A
+                        // failed first call was still INVOKED and must count as a claim for teardown:
+                        // the remote runtime may have accepted it before surfacing the exception.
+                        var stableState = attachCallEntered || hadEarlierAttempt
+                            ? AttachWasInvoked
+                            : WaitingForFirstAttempt;
+                        var stateAfterInvocation = Interlocked.CompareExchange(
+                            ref claimState, stableState, StartingAttempt);
+                        if (stateAfterInvocation == DisposeRequestedWhileStarting)
+                        {
+                            var anyAttempt = attachCallEntered || hadEarlierAttempt;
+                            Interlocked.Exchange(
+                                ref claimState,
+                                anyAttempt ? DisposedAfterAttempt : DisposedBeforeAnyAttempt);
+                            if (attachCallEntered)
+                                ReleaseClaim(grain);
+                            else if (hadEarlierAttempt)
+                                ReleaseClaim();
+                        }
+                    }
                 })
                 // `false` is "landed on a silo that is not the owner". Turning it into an error is what
                 // lets the retry policy below express "bounce off the old activation and try again"
@@ -1400,40 +1516,40 @@ public class OrleansRoutingService : IRoutingService, IDisposable
 
         return Disposable.Create(() =>
         {
+            var releaseHere = false;
+            var endedBeforeAnyAttempt = false;
+            while (true)
+            {
+                var state = Volatile.Read(ref claimState);
+                var next = state switch
+                {
+                    WaitingForFirstAttempt => DisposedBeforeAnyAttempt,
+                    StartingAttempt => DisposeRequestedWhileStarting,
+                    AttachWasInvoked => DisposedAfterAttempt,
+                    _ => state
+                };
+                if (next == state || Interlocked.CompareExchange(ref claimState, next, state) == state)
+                {
+                    endedBeforeAnyAttempt = state == WaitingForFirstAttempt;
+                    releaseHere = state == AttachWasInvoked;
+                    break;
+                }
+            }
             inFlight.Remove(attach);
             podHubClaimSettled.TryRemove(address, out _);
             attach.Dispose();
-            // Fire-and-forget: teardown is best-effort, and an activation that outlives its owner is
-            // recovered anyway — Deliver on a silo with no local route steps aside (see PodHubGrain).
-            // Wrapped because this runs during teardown, where the cluster client may already be
-            // gone: releasing a claim that nobody can hear is a no-op, never a throw out of Dispose.
-            try
+            if (endedBeforeAnyAttempt)
             {
-                // 🚨 THE INVARIANT, at the site that violated it. A "goodbye" that has to CREATE the
-                // activation it says goodbye to is not a release — IPodHubGrain is
-                // [PreferLocalPlacement], so once the previous activation has gone this call places a
-                // brand-new one on the very silo that is shutting down, purely to tell it nothing.
-                // There is also nothing to release: every activation in this process is going away
-                // with it. Skipping is the whole correct behaviour, not a degradation.
-                var grain = GrainWhileRunning<IPodHubGrain>(addressPath);
-                if (grain is null)
-                {
-                    logger.LogDebug(
-                        "Pod-hub claim for {Address} not released — the host has begun stopping, so the "
-                        + "activation is going away regardless and announcing it would only create one.",
-                        addressPath);
-                    return;
-                }
-
-                grain.Detach().ToObservable()
-                    .Subscribe(
-                        _ => { },
-                        ex => logger.LogDebug(ex, "Failed to release the pod-hub claim for {Address}", addressPath));
+                logger.LogDebug(
+                    "Pod-hub claim for {Address} not released — its registration ended before Orleans "
+                    + "reached Active, so no claim was ever attempted.",
+                    addressPath);
+                return;
             }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex, "Failed to release the pod-hub claim for {Address}", addressPath);
-            }
+            // StartingAttempt handed release ownership to the Attach caller; terminal states have
+            // already been handled. Only a fully-invoked claim is released on this disposing thread.
+            if (releaseHere)
+                ReleaseClaim();
         });
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PodHubClaimReassertion.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PodHubClaimReassertion.md
@@ -140,7 +140,7 @@ So the claim is now re-asserted on **every cluster membership change** —
 `IClusterMembershipFeed`, fed on the silo by Orleans' own `ISiloStatusListener`:
 
 ```
-ClaimTriggers()            // immediately, then once per membership change
+ClaimTriggers()            // after Active, then once per membership change
     .Select(_ => ClaimOnce())
     .Switch()              // exactly one claim in flight per address, ever
     .Subscribe(…)
@@ -194,13 +194,15 @@ measurement, and it is stated here rather than glossed. A stronger form (the own
 unreachability directly) has no seam today: the refusal is raised on a silo that does not know who
 the owner is.
 
-The claim's placement during **silo startup** is also not ordered on readiness. `RegisterStream`
-orders its Orleans *stream* subscription on `OrleansStreamingReadiness` (lifecycle stage `Active`)
-and issues the pod-hub claim immediately, unordered — which is why the eagerly-registered
-`mesh/{meshId}` and `cache/{meshId}` hubs burn their whole initial budget in a window where
-prefer-local provably cannot place locally. The membership change that fires when the silo reaches
-`Active` now repairs that, so the fault is closed; the wasted burst and its per-pod startup `Warning`
-remain, and closing *those* is a separate, smaller change.
+The claim's placement during **silo startup** is now ordered on the same
+`OrleansStreamingReadiness` signal as the stream subscription (lifecycle stage `Active`). Before
+#3983/#3984, `RegisterStream` issued the pod-hub claim immediately, unordered. The eagerly-registered
+`mesh/{meshId}` and `cache/{meshId}` hubs therefore called `IPodHubGrain.Attach` before this silo —
+and sometimes before any silo — advertised the grain type. Orleans rejected the invalid placement
+with `Known nodes with grain type: none`; its per-attempt logger produced #3983 while the exhausted
+Polly call produced #3984. The claim now waits for `Active` and then moves off the lifecycle thread
+before touching the grain factory. The membership-change re-assertion remains the repair for a
+mapping lost after startup.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-pod-hubs-wait-for-the-cluster.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-pod-hubs-wait-for-the-cluster.md
@@ -1,0 +1,19 @@
+---
+Name: Pod hubs wait for the cluster before announcing themselves
+Category: Fix
+Description: A portal starting several hubs at once could try to announce them before its cluster was ready, producing a burst of routing errors. The announcements now begin only after the portal is an active cluster member.
+Icon: Checkmark
+Order: -20260911
+---
+
+# Pod hubs wait for the cluster before announcing themselves
+
+Some of the portal's central message hubs are created very early during startup. They used to
+announce themselves to the cluster immediately, even though the starting portal had not yet become
+an active cluster member. During a rolling update that could leave no active portal able to accept
+the announcement, producing a burst of routing errors and a short interval in which those hubs
+could not be reached from another portal.
+
+Those announcements now wait for the same lifecycle milestone as the portal's other cluster
+routing setup. Once the portal is active, both routing paths start normally. A hub removed before
+that point no longer sends a redundant withdrawal for an announcement it never made.

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansStreamingReadinessGateTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansStreamingReadinessGateTest.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Connection.Orleans;
@@ -16,27 +18,34 @@ using MeshWeaver.Fixture;
 namespace MeshWeaver.Hosting.Orleans.Test;
 
 /// <summary>
-/// Pins the #1129 root fix: <c>OrleansRoutingService.RegisterStream</c> must NOT touch the
-/// Orleans stream provider before the Orleans lifecycle reports streaming usable
+/// Pins the #1129 and #3983/#3984 root fixes: <c>OrleansRoutingService.RegisterStream</c> must NOT
+/// touch either the Orleans stream provider or the pod-hub grain before the Orleans lifecycle
+/// reports the silo usable
 /// (<see cref="OrleansStreamingReadiness"/>, completed at <c>ServiceLifecycleStage.Active</c>).
 /// <c>GetStream</c> on a <c>PersistentStreamProvider</c> whose lifecycle Init has not run yet
 /// NREs from deep inside Orleans — the eagerly-created cache/mesh hubs lost exactly that race
 /// on every memex pod boot (2 Error-level NREs per boot), papered over by a poll-retry loop.
-/// Deterministic unit test, no cluster: the stream provider is a recording probe — REACHING it
-/// is the observable, so both directions of the gate are assertable.
+/// #3983/#3984 were the same invalid early <c>IPodHubGrain.Attach</c> calls seen through Orleans'
+/// per-attempt logger and Polly's exhausted-call logger: no active silo advertised the grain type
+/// yet. Deterministic unit test, no cluster: both dependencies are recording probes — REACHING one
+/// is the observable, so both directions of the gate are asserted without polling or sleeping.
 /// </summary>
 public class OrleansStreamingReadinessGateTest
 {
     private sealed class RecordingStreamProvider : IStreamProvider
     {
+        private readonly ISubject<Unit> touches =
+            Subject.Synchronize(new ReplaySubject<Unit>(bufferSize: 1));
         private int getStreamCalls;
         public int GetStreamCalls => Volatile.Read(ref getStreamCalls);
+        public IObservable<Unit> Touches => touches.AsObservable();
         public string Name => StreamProviders.Memory;
         public bool IsRewindable => false;
 
         public IAsyncStream<T> GetStream<T>(StreamId streamId)
         {
             Interlocked.Increment(ref getStreamCalls);
+            touches.OnNext(Unit.Default);
             // Any touch BEFORE readiness would have been the #1129 NRE; the gate must make this
             // unreachable until the lifecycle observer has run. The throw keeps the fake minimal —
             // the attach-success path is covered by the real-cluster routing tests.
@@ -45,19 +54,18 @@ public class OrleansStreamingReadinessGateTest
     }
 
     [Fact]
-    public async Task RegisterStream_TouchesStreamProvider_OnlyAfterLifecycleReportsReady()
+    public async Task RegisterStream_TouchesOrleans_OnlyAfterLifecycleReportsReady()
     {
         var provider = new RecordingStreamProvider();
+        var grainFactory = new RecordingGrainFactory();
         var readiness = new OrleansStreamingReadiness();
         var services = new ServiceCollection();
         services.AddSingleton(readiness);
         services.AddKeyedSingleton<IStreamProvider>(StreamProviders.Memory, provider);
         await using var sp = services.BuildServiceProvider();
 
-        // grainFactory is deliberately null — RegisterStream never places grains, so reaching it
-        // would throw and fail the test (the same probe technique as the shutdown-classification test).
         using var routing = new OrleansRoutingService(
-            null!,
+            grainFactory,
             sp,
             NullLogger<OrleansRoutingService>.Instance);
 
@@ -65,24 +73,165 @@ public class OrleansStreamingReadinessGateTest
             AddressExtensions.CreateMeshAddress("streaming-gate-test"),
             (d, _) => Observable.Return(d));
 
-        // Negative control: the gate must HOLD while the lifecycle has not reported ready.
-        // (Sanctioned "confirm nothing happened" wait — there is no positive signal to filter for.)
-        await Task.Delay(500);
-        provider.GetStreamCalls.Should().Be(0,
-            "the stream provider must never be touched before the Orleans lifecycle reaches Active — " +
-            "that touch is the #1129 NRE");
+        // Negative controls: there is no positive "still not ready" signal, so NotEmit is the
+        // sanctioned bounded assertion for exactly this direction. Both recorders replay, which
+        // means an invalid touch made before the assertion subscribed cannot slip past it.
+        await provider.Touches.Should().NotEmit(
+            within: TimeSpan.FromMilliseconds(300),
+            because: "the stream provider must never be touched before Active — that is #1129's NRE");
+        await grainFactory.Requests
+            .Where(t => t == typeof(IPodHubGrain))
+            .Should().NotEmit(
+                within: TimeSpan.FromMilliseconds(300),
+                because: "the pod-hub claim must never ask Orleans for placement before Active — "
+                    + "that is #3983/#3984's 'Known nodes with grain type: none' burst");
 
         // Open the gate exactly the way Orleans does: the lifecycle observer's OnStart at Active.
         await ((ILifecycleObserver)readiness).OnStart(CancellationToken.None);
 
-        // The attach must now reach the provider (poll the recorded call, never a fixed sleep).
-        var calls = await Observable.Interval(TimeSpan.FromMilliseconds(50))
-            .StartWith(0L)
-            .Select(_ => provider.GetStreamCalls)
-            .Where(c => c > 0)
-            .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(10))
-            .Await();
-        calls.Should().Be(1, "after readiness the subscription attaches exactly once — no retry loop");
+        // Positive controls: after Active both independent Orleans legs must actually run. A
+        // one-sided test would let a "fix" disable cross-process routing altogether.
+        await provider.Touches.Should().Within(TimeSpan.FromSeconds(10)).Emit(
+            "after readiness the stream subscription must attach");
+        await grainFactory.Requests
+            .Where(t => t == typeof(IPodHubGrain))
+            .Should().Within(TimeSpan.FromSeconds(10)).Emit(
+                "after readiness the silo must claim the locally registered hub");
+        provider.GetStreamCalls.Should().Be(1,
+            "after readiness the subscription attaches exactly once — no retry loop");
+    }
+
+    /// <summary>
+    /// The early-disposal half of the same ordering. A registration that ends before Active never
+    /// made a claim, so releasing it must not create a pod-hub activation merely to detach it.
+    /// </summary>
+    [Fact]
+    public async Task RegistrationDisposedBeforeReady_NeverTouchesOrleans()
+    {
+        var provider = new RecordingStreamProvider();
+        var grainFactory = new RecordingGrainFactory();
+        var services = new ServiceCollection();
+        services.AddSingleton(new OrleansStreamingReadiness());
+        services.AddKeyedSingleton<IStreamProvider>(StreamProviders.Memory, provider);
+        await using var sp = services.BuildServiceProvider();
+        using var routing = new OrleansRoutingService(
+            grainFactory, sp, NullLogger<OrleansRoutingService>.Instance);
+
+        var registration = routing.RegisterStream(
+            AddressExtensions.CreateMeshAddress("disposed-before-ready"),
+            (d, _) => Observable.Return(d));
+        registration.Dispose();
+
+        await provider.Touches.Should().NotEmit(
+            within: TimeSpan.FromMilliseconds(300),
+            because: "a cancelled pre-readiness stream attach must never reach the provider");
+        await grainFactory.Requests.Should().NotEmit(
+            within: TimeSpan.FromMilliseconds(300),
+            because: "a never-made claim has nothing to detach, and Detach would itself ask Orleans "
+                + "to place a pod-hub grain before any compatible silo exists");
+    }
+
+    /// <summary>
+    /// Disposal can land after the claim has reserved its attempt but while the grain factory is
+    /// still selecting the target. The release must be handed to the claim caller so <c>Detach</c>
+    /// cannot overtake the <c>Attach</c> that was already committed to run.
+    /// </summary>
+    [Fact]
+    public async Task DisposalDuringGrainSelection_AttachesBeforeItDetaches()
+    {
+        IDisposable? registration = null;
+        var provider = new RecordingStreamProvider();
+        var readiness = new OrleansStreamingReadiness();
+        var grainFactory = new RecordingGrainFactory(() => registration!.Dispose());
+        var services = new ServiceCollection();
+        services.AddSingleton(readiness);
+        services.AddKeyedSingleton<IStreamProvider>(StreamProviders.Memory, provider);
+        await using var sp = services.BuildServiceProvider();
+        using var routing = new OrleansRoutingService(
+            grainFactory, sp, NullLogger<OrleansRoutingService>.Instance);
+
+        registration = routing.RegisterStream(
+            AddressExtensions.CreateMeshAddress("disposed-during-grain-selection"),
+            (d, _) => Observable.Return(d));
+
+        await ((ILifecycleObserver)readiness).OnStart(CancellationToken.None);
+
+        var operations = await grainFactory.Operations
+            .Buffer(2)
+            .Where(buffer => buffer.Count == 2)
+            .Should().Within(TimeSpan.FromSeconds(10)).Emit(
+                "the disposal fired inside the first GetGrain call, so the reserved claim must both "
+                + "attach and release without leaking either operation");
+        operations.Should().Equal(["attach", "detach"]);
+    }
+
+    /// <summary>
+    /// Records the exact grain interface requested by the router. Every unused overload throws, so
+    /// a new production call shape makes the test fail loudly instead of passing without evidence.
+    /// </summary>
+    private sealed class RecordingGrainFactory(Action? onFirstPodHubRequest = null) : IGrainFactory
+    {
+        private readonly ISubject<Type> requests =
+            Subject.Synchronize(new ReplaySubject<Type>(bufferSize: 1));
+        private readonly ISubject<string> operations =
+            Subject.Synchronize(new ReplaySubject<string>(bufferSize: 2));
+        private int firstRequest;
+
+        public IObservable<Type> Requests => requests.AsObservable();
+        public IObservable<string> Operations => operations.AsObservable();
+
+        public TGrainInterface GetGrain<TGrainInterface>(
+            string primaryKey, string? grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithStringKey
+        {
+            requests.OnNext(typeof(TGrainInterface));
+            if (typeof(TGrainInterface) == typeof(IPodHubGrain))
+            {
+                if (Interlocked.Exchange(ref firstRequest, 1) == 0)
+                    onFirstPodHubRequest?.Invoke();
+                return (TGrainInterface)(object)new StubPodHubGrain(operations);
+            }
+            throw new NotSupportedException($"Unexpected grain interface {typeof(TGrainInterface)}");
+        }
+
+        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string? grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithGuidKey => throw new NotSupportedException();
+        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string? grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithIntegerKey => throw new NotSupportedException();
+        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string? grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithGuidCompoundKey => throw new NotSupportedException();
+        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string? grainClassNamePrefix = null)
+            where TGrainInterface : IGrainWithIntegerCompoundKey => throw new NotSupportedException();
+        public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj)
+            where TGrainObserverInterface : IGrainObserver => throw new NotSupportedException();
+        public void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj)
+            where TGrainObserverInterface : IGrainObserver => throw new NotSupportedException();
+        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey) => throw new NotSupportedException();
+        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey) => throw new NotSupportedException();
+        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey) => throw new NotSupportedException();
+        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension) => throw new NotSupportedException();
+        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension) => throw new NotSupportedException();
+        public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId)
+            where TGrainInterface : IAddressable => throw new NotSupportedException();
+        public IAddressable GetGrain(GrainId grainId) => throw new NotSupportedException();
+        public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType) => throw new NotSupportedException();
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix) => throw new NotSupportedException();
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey) => throw new NotSupportedException();
+    }
+
+    private sealed class StubPodHubGrain(ISubject<string> operations) : IPodHubGrain
+    {
+        public Task<bool> Attach()
+        {
+            operations.OnNext("attach");
+            return Task.FromResult(true);
+        }
+
+        public Task Detach()
+        {
+            operations.OnNext("detach");
+            return Task.CompletedTask;
+        }
+        public Task<IMessageDelivery> Deliver(IMessageDelivery delivery) => Task.FromResult(delivery);
     }
 }

--- a/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimLifetimeTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimLifetimeTest.cs
@@ -58,16 +58,21 @@ public class PodHubClaimLifetimeTest
     private static IObservable<IMessageDelivery> Ignore(IMessageDelivery d, CancellationToken _) =>
         Observable.Return(d);
 
-    private static Microsoft.Extensions.DependencyInjection.ServiceProvider Services(
+    private static async Task<Microsoft.Extensions.DependencyInjection.ServiceProvider> Services(
         IHostApplicationLifetime? lifetime = null)
     {
+        var readiness = new OrleansStreamingReadiness();
         var services = new ServiceCollection();
-        // Registered but never fired: the stream attach then stays parked on the #1129 readiness
-        // gate, so this test needs no stream provider and touches none.
-        services.AddSingleton(new OrleansStreamingReadiness());
+        services.AddSingleton(readiness);
         if (lifetime is not null)
             services.AddSingleton(lifetime);
-        return services.BuildServiceProvider();
+        var provider = services.BuildServiceProvider();
+        // These tests exercise the claim's post-startup lifetime policy. Open the same Active-stage
+        // gate production opens first; the dedicated readiness test pins that nothing is touched
+        // before it. The absent stream provider is reported by the sibling attach path and is not
+        // the subject here.
+        await ((ILifecycleObserver)readiness).OnStart(TestContext.Current.CancellationToken);
+        return provider;
     }
 
     private static OrleansRoutingService Router(
@@ -123,7 +128,7 @@ public class PodHubClaimLifetimeTest
     {
         var factory = new RefusingGrainFactory();
         var logger = new RecordingLogger();
-        await using var sp = Services();
+        await using var sp = await Services();
         using var routing = Router(factory, sp, logger, canHostGrains: true);
 
         using var registration = routing.RegisterStream(Hub, Ignore);
@@ -161,7 +166,7 @@ public class PodHubClaimLifetimeTest
     {
         var factory = new RefusingGrainFactory();
         var logger = new RecordingLogger();
-        await using var sp = Services();
+        await using var sp = await Services();
         using var routing = Router(factory, sp, logger, canHostGrains: false);
 
         using var registration = routing.RegisterStream(Hub, Ignore);
@@ -188,7 +193,7 @@ public class PodHubClaimLifetimeTest
     public async Task DisposingTheRegistration_EndsTheClaim()
     {
         var factory = new RefusingGrainFactory();
-        await using var sp = Services();
+        await using var sp = await Services();
         using var routing = Router(factory, sp, new RecordingLogger(), canHostGrains: true);
 
         var registration = routing.RegisterStream(Hub, Ignore);
@@ -219,7 +224,7 @@ public class PodHubClaimLifetimeTest
         // fires ApplicationStopping regardless, and that token is the signal under test.
         var lifetime = new HostBuilder().Build().Services.GetRequiredService<IHostApplicationLifetime>();
         var factory = new RefusingGrainFactory();
-        await using var sp = Services(lifetime);
+        await using var sp = await Services(lifetime);
         using var routing = Router(factory, sp, new RecordingLogger(), canHostGrains: true);
 
         using var registration = routing.RegisterStream(Hub, Ignore);

--- a/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimReassertionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimReassertionTest.cs
@@ -62,16 +62,20 @@ public class PodHubClaimReassertionTest
     private static IObservable<IMessageDelivery> Ignore(IMessageDelivery d, CancellationToken _) =>
         Observable.Return(d);
 
-    private static Microsoft.Extensions.DependencyInjection.ServiceProvider Services(
+    private static async Task<Microsoft.Extensions.DependencyInjection.ServiceProvider> Services(
         IClusterMembershipFeed? feed)
     {
+        var readiness = new OrleansStreamingReadiness();
         var services = new ServiceCollection();
-        // Registered but never fired: the stream attach then stays parked on the #1129 readiness
-        // gate, so this test needs no stream provider and touches none.
-        services.AddSingleton(new OrleansStreamingReadiness());
+        services.AddSingleton(readiness);
         if (feed is not null)
             services.AddSingleton(feed);
-        return services.BuildServiceProvider();
+        var provider = services.BuildServiceProvider();
+        // The re-assertion policy begins only after the initial Active-stage readiness event. The
+        // readiness test owns the pre-Active direction; these tests own what membership changes do
+        // to a live claim afterwards.
+        await ((ILifecycleObserver)readiness).OnStart(TestContext.Current.CancellationToken);
+        return provider;
     }
 
     private static OrleansRoutingService Router(
@@ -119,11 +123,12 @@ public class PodHubClaimReassertionTest
     {
         var feed = new TestMembershipFeed();
         var factory = new AcceptingGrainFactory();
-        await using var sp = Services(feed);
+        await using var sp = await Services(feed);
         using var routing = Router(factory, sp, new RecordingLogger());
 
         using var registration = routing.RegisterStream(Hub, Ignore);
-        await WaitForAttaches(factory, 1, "the initial claim must still be made immediately");
+        await WaitForAttaches(factory, 1,
+            "the initial claim must be made as soon as the already-open readiness gate permits it");
 
         feed.PushChange();
         await WaitForAttaches(factory, 2,
@@ -148,7 +153,7 @@ public class PodHubClaimReassertionTest
         var feed = new TestMembershipFeed();
         var factory = new AcceptingGrainFactory();
         var logger = new RecordingLogger();
-        await using var sp = Services(feed);
+        await using var sp = await Services(feed);
         using var routing = Router(factory, sp, logger);
 
         using var registration = routing.RegisterStream(Hub, Ignore);
@@ -182,7 +187,7 @@ public class PodHubClaimReassertionTest
     {
         var feed = new TestMembershipFeed();
         var factory = new AcceptingGrainFactory();
-        await using var sp = Services(feed);
+        await using var sp = await Services(feed);
         using var routing = Router(factory, sp, new RecordingLogger());
 
         var registration = routing.RegisterStream(Hub, Ignore);
@@ -215,11 +220,12 @@ public class PodHubClaimReassertionTest
     public async Task WithNoMembershipFeed_TheClaimIsAssertedExactlyOnce()
     {
         var factory = new AcceptingGrainFactory();
-        await using var sp = Services(feed: null);
+        await using var sp = await Services(feed: null);
         using var routing = Router(factory, sp, new RecordingLogger());
 
         using var registration = routing.RegisterStream(Hub, Ignore);
-        await WaitForAttaches(factory, 1, "the initial claim is made with or without a feed");
+        await WaitForAttaches(factory, 1,
+            "after readiness, the initial claim is made with or without a feed");
 
         await Task.Delay(400);
         factory.AttachCalls.Should().Be(1,

--- a/test/MeshWeaver.Hosting.Orleans.Test/SiloShutdownActivationGateTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/SiloShutdownActivationGateTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -107,12 +108,17 @@ public class SiloShutdownActivationGateTest : TestBase
     /// that is a brand-new activation on the silo that is leaving.</para>
     /// </summary>
     [Fact]
-    public void HostStopping_TheGoodbyeAnnouncement_NeverAsksOrleansForAnActivation()
+    public async Task HostStopping_TheGoodbyeAnnouncement_NeverAsksOrleansForAnActivation()
     {
         var factory = new RecordingGrainFactory();
         var routing = CreateRouter(factory);
 
         var registration = routing.RegisterStream(SenderAddress, Ignore);
+        var settled = routing.PodHubClaimSettled(SenderAddress)
+                      ?? throw new InvalidOperationException("the claim readiness seam was not registered");
+        await ((ILifecycleObserver)readiness).OnStart(TestContext.Current.CancellationToken);
+        await settled.Should().Within(TimeSpan.FromSeconds(10)).Emit(
+            "precondition: the healthy host must claim the address after Orleans reaches Active");
         factory.Requests.Should().NotBeEmpty("the claim must be made while the host is healthy");
 
         lifetime.StopApplication();
@@ -134,12 +140,17 @@ public class SiloShutdownActivationGateTest : TestBase
     /// no activation stranded on the pod it left.
     /// </summary>
     [Fact]
-    public void HostRunning_TheGoodbyeAnnouncement_StillReachesOrleans()
+    public async Task HostRunning_TheGoodbyeAnnouncement_StillReachesOrleans()
     {
         var factory = new RecordingGrainFactory();
         var routing = CreateRouter(factory);
 
         var registration = routing.RegisterStream(SenderAddress, Ignore);
+        var settled = routing.PodHubClaimSettled(SenderAddress)
+                      ?? throw new InvalidOperationException("the claim readiness seam was not registered");
+        await ((ILifecycleObserver)readiness).OnStart(TestContext.Current.CancellationToken);
+        await settled.Should().Within(TimeSpan.FromSeconds(10)).Emit(
+            "precondition: the healthy host must claim the address after Orleans reaches Active");
         factory.Clear();
 
         registration.Dispose();
@@ -156,7 +167,7 @@ public class SiloShutdownActivationGateTest : TestBase
     /// began spent its remaining attempts doing exactly that.
     /// </summary>
     [Fact]
-    public void HostStopping_ThePodHubClaim_NeverAsksOrleansForAnActivation()
+    public async Task HostStopping_ThePodHubClaim_NeverAsksOrleansForAnActivation()
     {
         var factory = new RecordingGrainFactory();
         var routing = CreateRouter(factory);
@@ -164,10 +175,12 @@ public class SiloShutdownActivationGateTest : TestBase
         lifetime.StopApplication();
 
         using var registration = routing.RegisterStream(SenderAddress, Ignore);
+        await ((ILifecycleObserver)readiness).OnStart(TestContext.Current.CancellationToken);
 
-        factory.Requests.Should().BeEmpty(
-            "claiming an address for a process that is shutting down only places an activation on "
-            + "the silo that is leaving");
+        await factory.RequestStream.Should().NotEmit(
+            within: TimeSpan.FromMilliseconds(300),
+            because: "claiming an address for a process that is shutting down only places an "
+                + "activation on the silo that is leaving");
     }
 
     /// <summary>
@@ -176,17 +189,19 @@ public class SiloShutdownActivationGateTest : TestBase
     /// is what makes a hub reachable by directed grain call at all (#1742).
     /// </summary>
     [Fact]
-    public void HostRunning_ThePodHubClaim_StillReachesOrleans()
+    public async Task HostRunning_ThePodHubClaim_StillReachesOrleans()
     {
         var factory = new RecordingGrainFactory();
         var routing = CreateRouter(factory);
 
         using var registration = routing.RegisterStream(SenderAddress, Ignore);
+        await ((ILifecycleObserver)readiness).OnStart(TestContext.Current.CancellationToken);
 
-        factory.Requests.Should().Contain(
-            r => r.Interface == typeof(IPodHubGrain) && r.Key == SenderAddress.ToString(),
-            "a healthy silo must still claim its addresses — a gate that refuses everything would "
-            + "pass the shutdown assertions above and break the portal");
+        await factory.RequestStream
+            .Where(r => r.Interface == typeof(IPodHubGrain) && r.Key == SenderAddress.ToString())
+            .Should().Within(TimeSpan.FromSeconds(10)).Emit(
+                "a healthy silo must still claim its addresses — a gate that refuses everything "
+                + "would pass the shutdown assertions above and break the portal");
     }
 
     /// <summary>
@@ -242,15 +257,20 @@ public class SiloShutdownActivationGateTest : TestBase
     private sealed class RecordingGrainFactory : IGrainFactory
     {
         private readonly ConcurrentQueue<GrainRequest> requests = new();
+        private readonly ISubject<GrainRequest> requestStream =
+            Subject.Synchronize(new ReplaySubject<GrainRequest>(bufferSize: 1));
 
         public IReadOnlyList<GrainRequest> Requests => requests.ToArray();
+        public IObservable<GrainRequest> RequestStream => requestStream.AsObservable();
 
         public void Clear() => requests.Clear();
 
         public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string? grainClassNamePrefix = null)
             where TGrainInterface : IGrainWithStringKey
         {
-            requests.Enqueue(new GrainRequest(typeof(TGrainInterface), primaryKey));
+            var request = new GrainRequest(typeof(TGrainInterface), primaryKey);
+            requests.Enqueue(request);
+            requestStream.OnNext(request);
             if (typeof(TGrainInterface) == typeof(IPodHubGrain))
                 return (TGrainInterface)(object)new StubPodHubGrain();
             if (typeof(TGrainInterface) == typeof(IRoutingGrain))


### PR DESCRIPTION
Fixes #3983.
Fixes #3984.

## Root cause

`RegisterStream` ordered the Orleans stream subscription on lifecycle `Active`, but started the sibling pod-hub claim immediately. Eager `mesh/{id}` and `cache/{id}` registrations therefore called `IPodHubGrain.Attach` before any active silo advertised that grain type.

The two incidents are the same calls seen at two levels: five exhausted `Attach` placements in Polly produced the 34 Orleans.Messaging per-attempt failures in the identical 65-second, two-pod window.

## Fix

- Order the initial pod-hub claim on `OrleansStreamingReadiness`, then schedule it away from the lifecycle thread.
- Preserve membership-change re-assertion after startup.
- Do not send `Detach` when a registration is disposed before any claim was attempted.
- Pin both negative and positive ordering with recording probes; no polling or sleeps.
- Update the architecture note and user-facing change entry.

## Local verification

- Focused readiness/claim/shutdown tests: 16 passed, 0 failed.
- Full `MeshWeaver.Hosting.Orleans.Test` under the CI locale: 255 passed, 0 failed.
- `MeshWeaver.Documentation.Test`: 374 passed, 0 failed.
- Release warnings-as-errors builds: `MeshWeaver.Connection.Orleans`, `MeshWeaver.Hosting.Orleans`, `MeshWeaver.Documentation`, and `MeshWeaver.Hosting.Orleans.Test` all completed with 0 warnings and 0 errors.
