### PR TITLE
fix(ci): a caller must grant what its lane demands — the check that would have caught #3933

### DIFF
--- a/.github/scripts/check-workflow-permission-pairing.py
+++ b/.github/scripts/check-workflow-permission-pairing.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""check-workflow-permission-pairing.py — a caller grants every permission the lane it calls demands.
+
+(The name on this first line is load-bearing: node-repo-validate.yml fetches this file at
+platform-ref and refuses a body whose first 400 bytes do not name it — the same shape as
+check-workflow-timeouts.py and compile-check.py.)
+
+WHY THIS EXISTS (measured 2026-09-10, a five-hour fleet-wide outage)
+-------------------------------------------------------------------
+A called workflow's job can NEVER hold a permission its caller did not grant. So a job-level
+`permissions:` block inside a `workflow_call` workflow is not a grant — it is a HARD REQUIREMENT
+imposed on every caller, in every repository, including repositories the lane's own repo cannot see.
+
+MeshWeaver#3933 added `permissions: {contents: read, id-token: write}` to three jobs of
+node-repo-module-pack.yml so core's CD could authenticate to ACR over OIDC, and updated core's own
+caller in the same commit. It updated no satellite. From 2026-09-10T18:59:37Z every run of
+MeshWeaver.Plugins' `Plugin Catalog CI` — main, every PR, every trigger — ended `startup_failure`
+with ZERO jobs.
+
+🚨 THE SYMPTOM IS AN ABSENCE, WHICH IS WHY IT COST FIVE HOURS. There is no permission error. The run
+graph is rejected before a job is scheduled, so NO check-run is published at all — and under classic
+branch protection an ABSENT required context blocks forever rather than passing (see
+Doc/Architecture/ReadingCiSignals). The repo could not merge anything, including the two-line fix
+for the thing that broke it. Same class as "a new REQUIRED input on a reusable workflow is a silent
+startup_failure", one permission-shaped step sideways.
+
+THE RULE
+--------
+For every job in this repository that `uses:` a reusable workflow whose definition this checkout can
+read, the caller's effective permissions must be a SUPERSET of every job-level `permissions:` the
+called workflow declares.
+
+Effective permissions of a caller job = its own `permissions:` if it has one, else the workflow-level
+`permissions:`, else GitHub's default — which this check treats as UNKNOWN and reports, because a
+default that happens to be permissive today is not a pairing.
+
+WHERE IT RUNS
+-------------
+Core runs it on itself (its own `main-cd.yml` calls the same lanes). Every satellite runs it through
+node-repo-validate.yml against the platform checkout at its own platform-ref, which is the run that
+matters: that is the moment a satellite's caller meets the lane version it is about to call, and the
+only place the pair is visible at all.
+
+WHAT IT DELIBERATELY DOES NOT DO
+--------------------------------
+It does not forbid job-level permissions in a reusable lane. Measured on core 2026-09-11: eleven of
+twelve `workflow_call` workflows declare them, and `node-repo-gate` and `node-repo-publish-bake` both
+demand `id-token: write` with all twelve of their fleet callers correctly paired. Demanding a
+permission is legitimate; demanding it without pairing the callers is the defect.
+"""
+from __future__ import annotations
+import argparse, os, sys, glob
+try:
+    import yaml
+except ImportError:
+    print("check-workflow-permission-pairing: PyYAML is required", file=sys.stderr)
+    sys.exit(2)
+
+# 🚨 An absent `permissions:` does NOT grant nothing — the job inherits the repository/organisation
+# default. GitHub's RESTRICTED default (the recommended setting, and the floor of the permissive one)
+# is contents/packages/metadata read. Treating absence as "grants nothing" makes this check fire on
+# every ordinary caller of a lane that merely wants `contents: read`, and a guard that fires on
+# working lanes gets muted — which is how the next real one goes unnoticed. Measured while writing
+# this: against a real satellite it produced 1 true finding and 2 false ones before this floor was
+# added.
+#
+# What the default can NEVER provide is `id-token`, which always requires an explicit grant — and
+# that is precisely the scope the 2026-09-10 outage turned on. Anything at `write` beyond the floor
+# is likewise not safe to assume.
+DEFAULT_FLOOR = {"contents": "read", "packages": "read", "metadata": "read"}
+
+
+def _load(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except Exception as exc:                                    # noqa: BLE001 - reported, not raised
+        return exc
+
+
+def _perm_map(value) -> dict | None:
+    """A `permissions:` value as a dict. `read-all`/`write-all` are blanket grants; None means absent."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return {"*": value}                                     # read-all / write-all satisfy anything
+    if isinstance(value, dict):
+        return {str(k): str(v) for k, v in value.items()}
+    return None
+
+
+def _satisfies(granted: dict | None, demanded: dict) -> list[str]:
+    """Which demanded scopes the grant does not cover. `write` is required where `write` is demanded."""
+    if granted is None:
+        # inherits the repo/org default — satisfied only up to the floor above
+        return sorted(k for k, v in demanded.items()
+                      if DEFAULT_FLOOR.get(k) is None or (v == "write" and DEFAULT_FLOOR[k] != "write"))
+    if "*" in granted:
+        return [] if granted["*"] == "write-all" else [k for k, v in demanded.items() if v == "write"]
+    missing = []
+    for scope, level in demanded.items():
+        have = granted.get(scope)
+        if have is None or (level == "write" and have != "write"):
+            missing.append(scope)
+    return sorted(missing)
+
+
+def _local_lane_path(uses: str, root: str) -> str | None:
+    """The lane's definition inside THIS checkout, when `uses:` names one we can read."""
+    ref = uses.split("@", 1)[0]
+    if ref.startswith("./"):
+        return os.path.join(root, ref[2:])
+    # owner/repo/.github/workflows/x.yml — readable only if it is this platform checkout's own lane
+    parts = ref.split("/")
+    if len(parts) >= 4 and parts[2] == ".github" and parts[3] == "workflows":
+        candidate = os.path.join(root, ".github", "workflows", parts[-1])
+        return candidate if os.path.isfile(candidate) else None
+    return None
+
+
+def check(root: str, platform_root: str | None) -> tuple[list[str], int]:
+    problems: list[str] = []
+    pairs = 0
+    for wf_path in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.yml"))):
+        doc = _load(wf_path)
+        if isinstance(doc, Exception) or not isinstance(doc, dict):
+            continue
+        wf_default = _perm_map(doc.get("permissions"))
+        for job_name, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            uses = str(job.get("uses") or "")
+            if not uses:
+                continue
+            lane_path = _local_lane_path(uses, root)
+            if lane_path is None and platform_root:
+                lane_path = _local_lane_path(uses, platform_root)
+            if lane_path is None or not os.path.isfile(lane_path):
+                continue                                        # a lane we cannot read says nothing
+            lane = _load(lane_path)
+            if isinstance(lane, Exception) or not isinstance(lane, dict):
+                problems.append(f"{os.path.basename(wf_path)}: job '{job_name}' calls "
+                                f"{os.path.basename(lane_path)}, which does not parse: {lane}")
+                continue
+            granted = _perm_map(job.get("permissions"))
+            if granted is None:
+                granted = wf_default
+            for lane_job, lane_def in (lane.get("jobs") or {}).items():
+                if not isinstance(lane_def, dict):
+                    continue
+                demanded = _perm_map(lane_def.get("permissions"))
+                if not demanded or "*" in demanded:
+                    continue
+                pairs += 1
+                missing = _satisfies(granted, demanded)
+                if missing:
+                    problems.append(
+                        f"{os.path.basename(wf_path)}: job '{job_name}' calls "
+                        f"{os.path.basename(lane_path)}, whose job '{lane_job}' demands "
+                        f"{demanded} — this caller grants "
+                        f"{granted if granted is not None else 'only the inherited default (no explicit block)'}, "
+                        f"missing: {', '.join(missing)}.\n"
+                        f"      A called job can never hold a permission its caller did not grant, so "
+                        f"this run is rejected before ANY job is scheduled: `startup_failure`, zero "
+                        f"jobs, and NO check-run published — which blocks forever under classic "
+                        f"protection rather than failing visibly (MeshWeaver#3933, five hours dark)."
+                    )
+    return problems, pairs
+
+
+def self_test() -> int:
+    """The check must FAIL on the 2026-09-10 shape and PASS on the paired one. A guard that cannot
+    fail is not a guard (AGENTS.md)."""
+    unpaired = _satisfies({"contents": "read", "actions": "read"},
+                          {"contents": "read", "id-token": "write"})
+    paired = _satisfies({"contents": "read", "actions": "read", "id-token": "write"},
+                        {"contents": "read", "id-token": "write"})
+    blanket = _satisfies({"*": "write-all"}, {"id-token": "write"})
+    absent = _satisfies(None, {"contents": "read"})
+    weaker = _satisfies({"contents": "read"}, {"contents": "write"})
+    cases = [
+        ("the 2026-09-10 outage shape is caught", unpaired == ["id-token"]),
+        ("a correctly paired caller passes", paired == []),
+        ("write-all satisfies anything", blanket == []),
+        ("an absent block still covers the default floor", absent == []),
+        ("an absent block does NOT cover id-token", _satisfies(None, {"id-token": "write"}) == ["id-token"]),
+        ("an absent block does NOT cover a write beyond the floor",
+         _satisfies(None, {"contents": "write"}) == ["contents"]),
+        ("read does not satisfy a write demand", weaker == ["contents"]),
+    ]
+    bad = [name for name, ok in cases if not ok]
+    for name, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}")
+    return 1 if bad else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".", help="repository to check (its callers)")
+    ap.add_argument("--platform-root", default=None,
+                    help="platform checkout at platform-ref, where the shared lanes live")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    problems, pairs = check(args.root, args.platform_root)
+    # 🚨 The DENOMINATOR is printed on every run, green or red. A check pointed at the wrong root
+    # resolves no lanes, reports zero problems, and ticks exactly like a clean measurement.
+    print(f"check-workflow-permission-pairing: {pairs} caller/lane permission pair(s) resolved, "
+          f"{len(problems)} violation(s), root={os.path.abspath(args.root)}")
+    if pairs == 0:
+        print("  NOTE: zero pairs resolved — either this repo calls no lane whose definition is "
+              "readable here, or --root/--platform-root is wrong. Zero is not a pass.")
+    for p in problems:
+        print(f"::error::{p}")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1976,6 +1976,10 @@ jobs:
       run: python3 .github/scripts/check-workflow-timeouts.py --self-test
     - name: "Every job is capped at 45 minutes"
       run: python3 .github/scripts/check-workflow-timeouts.py --root .
+    - name: "A caller grants what its lane demands — the gate can fail (self-test)"
+      run: python3 .github/scripts/check-workflow-permission-pairing.py --self-test
+    - name: "Core's own callers grant every permission their lanes demand"
+      run: python3 .github/scripts/check-workflow-permission-pairing.py --root .
 
     # 🚨 `yaml.safe_load` accepts a DUPLICATE MAPPING KEY silently and keeps the LAST one — and
     # every guard in this fleet, the one directly above included, reads workflows through it. So a

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -120,7 +120,34 @@ jobs:
           gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-abbreviated-shas.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-abbreviated-shas.py" \
             || { echo "::error::could not fetch .github/scripts/check-abbreviated-shas.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
           head -c 400 "$RUNNER_TEMP/check-abbreviated-shas.py" | grep -q "check-abbreviated-shas" || { echo "::error::the fetched check-abbreviated-shas.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-permission-pairing.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-permission-pairing.py" \
+            || { echo "::error::could not fetch .github/scripts/check-workflow-permission-pairing.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/check-workflow-permission-pairing.py" | grep -q "check-workflow-permission-pairing" || { echo "::error::the fetched check-workflow-permission-pairing.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
+          # 🚨 The pairing guard needs the LANE DEFINITIONS, not just the script: the defect is a
+          # relation between this repo's caller and the lane it is about to call, and neither half
+          # alone shows it. Fetch every shared lane at the same ref into a platform root. A fetch
+          # that fails exits RED — a lane we cannot read would make the check silently vacuous,
+          # which is the failure mode it exists to prevent (AGENTS.md — a gate never tests its own
+          # inputs).
+          mkdir -p "$RUNNER_TEMP/platform/.github/workflows"
+          for lane in node-repo-validate node-repo-compile-check node-repo-gate node-repo-module-pack \
+                      node-repo-module-publish node-repo-publish-bake node-repo-tag-modules \
+                      node-repo-platform-canary node-repo-platform-ref-bump node-repo-supersede; do
+            gh api "repos/Systemorph/MeshWeaver/contents/.github/workflows/${lane}.yml?ref=${SCRIPTS_REF}" --jq .content \
+              | base64 -d > "$RUNNER_TEMP/platform/.github/workflows/${lane}.yml" \
+              || { echo "::error::could not fetch .github/workflows/${lane}.yml at ${SCRIPTS_REF} — the permission-pairing guard cannot read the lane this repo calls, and a guard that cannot read its subject must not pass"; exit 1; }
+          done
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
+      - name: "A caller grants what its lane demands — the gate can fail (self-test)"
+        run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --self-test
+      # 🚨 MeshWeaver#3933 added `id-token: write` to three jobs of the module-pack lane and paired
+      # only core's own caller. Every satellite run became `startup_failure` with ZERO jobs — no
+      # permission error, no check-run, and under classic protection an ABSENT required context
+      # blocks forever. MeshWeaver.Plugins was dark for five hours and could not merge the two-line
+      # fix for the thing that broke it. This is the check that would have caught it, and this is
+      # the only place it CAN be caught: the caller lives here, the lane lives there.
+      - name: "This repo's callers grant every permission their platform lanes demand"
+        run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --root . --platform-root "$RUNNER_TEMP/platform"
       - name: "Every job is capped at 45 minutes — the gate can fail (self-test)"
         run: python3 "$RUNNER_TEMP/check-workflow-timeouts.py" --self-test
       - name: "Every job in this repo's workflows is capped at 45 minutes"

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -349,6 +349,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [In-Mesh Build and Test](InMeshBuildAndTest)
 - [Orleans Test Routing Pattern](OrleansTestRoutingPattern)
 - [Reading CI Signals](ReadingCiSignals)
+- [Workflow Permission Pairing](WorkflowPermissionPairing) — a job-level `permissions:` in a shared lane is a requirement on every caller; an unpaired one is `startup_failure` with zero jobs
 
 ### Deployment & ops
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/WorkflowPermissionPairing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WorkflowPermissionPairing.md
@@ -1,0 +1,78 @@
+# A caller grants what its lane demands
+
+🚨 **A job-level `permissions:` block inside a `workflow_call` workflow is not a grant. It is a
+requirement imposed on every caller, in every repository — including repositories the lane's own repo
+cannot see.**
+
+A called workflow's job can never hold a permission its caller did not grant. So adding
+`permissions:` to a shared lane silently makes it a precondition fleet-wide, and a caller that does
+not meet it does not get a permission error.
+
+## What it looks like when it goes wrong
+
+**The run graph is rejected before a single job is scheduled.** `startup_failure`, **zero jobs**, and
+therefore **no check-run published at all**. Under classic branch protection an *absent* required
+context blocks forever rather than passing (see [Reading CI Signals](../ReadingCiSignals)), so the
+repository cannot merge anything — including the fix for the thing that broke it.
+
+There is no error text naming the permission. The symptom is an absence.
+
+## The incident this is written from (2026-09-10)
+
+MeshWeaver#3933 added `permissions: {contents: read, id-token: write}` to three jobs of
+`node-repo-module-pack.yml`, so core's CD could authenticate to ACR over OIDC without a long-lived
+credential. It updated core's own caller in the same commit, and **no satellite**.
+
+| | |
+|---|---|
+| 18:54:37Z | run resolves core `@main` = `756d6d99e` (pre-#3933) → jobs ran |
+| **18:59:37Z** | run resolves `d540b0dca` → **0 jobs** |
+| 18:59Z → 23:5xZ | MeshWeaver.Plugins dark: main, every PR, every trigger |
+| — | MeshWeaver.SocialMedia had the identical gap, unfired only because its lane had not run |
+
+`id-token` is used only on the opt-in `acr-login: oidc` path; the default is `basic`. So every
+satellite was made to require a permission for a code path none of them take.
+
+Fixed by MeshWeaver#3968, which removed the job-level blocks and restored caller inheritance.
+
+## The rule, and the guard
+
+For every job in a repository that `uses:` a shared lane, the caller's effective permissions must be
+a **superset** of every job-level `permissions:` that lane declares.
+
+`.github/scripts/check-workflow-permission-pairing.py` enforces it. Core runs it on itself;
+**every satellite runs it through `node-repo-validate.yml`** against the lane definitions fetched at
+its own `platform-ref` — which is the only place the pair is visible at all, because the caller lives
+in one repository and the lane in another.
+
+### Two things the guard deliberately gets right
+
+**It does not ban job-level permissions in a lane.** Measured on core 2026-09-11: eleven of twelve
+`workflow_call` workflows declare them, and `node-repo-gate` and `node-repo-publish-bake` both demand
+`id-token: write` with **all twelve** of their fleet callers correctly paired. Demanding a permission
+is legitimate; demanding it without pairing the callers is the defect.
+
+**An absent `permissions:` block is not "grants nothing".** The job inherits the repository default,
+whose floor is `contents`/`packages`/`metadata: read`. The first version of this guard treated
+absence as zero and produced, against a real satellite, **one true finding and two false ones** — and
+a guard that fires on working lanes gets muted, which is how the next real one goes unnoticed. What
+the default can *never* provide is `id-token`, which always needs an explicit grant — and that is
+exactly the scope this incident turned on.
+
+### Verified in three directions, on real repositories
+
+| | |
+|---|---|
+| satellite at its pre-fix commit + the demanding lane | **1 violation** — the incident, and nothing else |
+| the same satellite after its fix | **0** — the positive control |
+| core against itself | **0** — correct; core's own caller *was* paired |
+
+The denominator (`N caller/lane permission pair(s) resolved`) prints on every run, green or red, so a
+check pointed at the wrong root cannot tick like a clean measurement. Zero pairs says so explicitly.
+
+## Related
+
+- [Reading CI Signals](../ReadingCiSignals) — why an absent required context is not a skipped one.
+- [Cross-Repo Pair Gate](../CrossRepoPairGate) — the same family: a change whose other half lives in
+  a repository this one cannot see. A new **required input** on a reusable workflow is the other
+  known instance of this exact shape.


### PR DESCRIPTION
The check that would have caught #3933 five hours earlier — and would have stopped MeshWeaver.SocialMedia going the same way.

## The defect class

A job-level `permissions:` block inside a `workflow_call` workflow is **not a grant**. A called workflow's job can never hold a permission its caller did not grant, so the block is a **requirement imposed on every caller, in every repository** — including repositories the lane's own repo cannot see.

🚨 **And the symptom is an absence, which is why it cost five hours.** No permission error. GitHub rejects the run graph before scheduling anything: `startup_failure`, **zero jobs**, therefore **no check-run published** — and under classic protection an absent required context blocks forever rather than failing visibly. The repo could not merge anything, *including the two-line fix for what broke it*.

Measured boundary, with a positive control:

```
18:54:37Z   run resolves core @main = 756d6d99e (pre-#3933)   -> jobs ran
18:59:37Z   run resolves d540b0dca                             -> 0 jobs
18:59Z → 23:5xZ   MeshWeaver.Plugins dark: main, every PR, every trigger
```

`id-token` is used only on the opt-in `acr-login: oidc` path — the default is `basic` — so every satellite was made to require a permission for a code path none of them take.

## The guard

`check-workflow-permission-pairing.py` asserts a caller's effective permissions are a **superset** of every job-level `permissions:` the lane declares.

Core runs it on itself; **every satellite runs it through `node-repo-validate.yml`** against lane definitions fetched at its own `platform-ref`. That is the only place the pair is visible at all — the caller lives in one repository, the lane in another. A lane that cannot be fetched exits **red**: a guard that cannot read its subject must not pass.

## Two things it deliberately gets right — both of which my first draft got wrong

**It does not ban job-level permissions in a lane.** I nearly wrote that rule; measuring first killed it. On core today, **11 of 12** `workflow_call` workflows declare them, and `node-repo-gate` and `node-repo-publish-bake` both demand `id-token: write` with **all twelve** of their fleet callers correctly paired. Demanding a permission is legitimate; demanding it *unpaired* is the defect.

**An absent `permissions:` block is not "grants nothing".** The job inherits the repository default, floor `contents`/`packages`/`metadata: read`. The first version assumed zero and produced, against a real satellite, **one true finding and two false ones**. That version would have been *worse than no guard* — a check that fires on working lanes gets muted, and then the next real one goes unnoticed. What the default can never supply is `id-token`, which is exactly the scope this incident turned on.

## Verified in three directions, on real repositories

| | |
|---|---|
| satellite at its pre-fix commit + the demanding lane | **1 violation** — the incident, and nothing else |
| the same satellite after its fix | **0** — the positive control |
| core against itself | **0** — correct, core's own caller *was* paired in #3933 |

`--self-test` covers **7** cases including the default-floor asymmetry, so the script proves it still discriminates with no repository to point at.

The denominator (`N caller/lane permission pair(s) resolved`) prints on every run, green or red, and zero pairs says so explicitly — a check pointed at the wrong root must not tick like a clean measurement.

## Local verification

| | |
|---|---|
| `check-workflow-timeouts` | 84 jobs, **0 violations** |
| `check-workflow-yaml-keys` | 34 files, **0** |
| `check-pr-secret-preflight` | 2 reachable, 2 asserted, **0** |
| `check-workflow-permission-pairing` | 2 pairs resolved, **0** |
| `MeshWeaver.Documentation` + `.Test`, `-c Release -warnaserror` | `0 Error(s)` |
| `MeshWeaver.Documentation.Test` | **374/374** incl. link integrity + topic map |

Doc: `Doc/Architecture/WorkflowPermissionPairing`, indexed in the topic map and linked from the CrossRepoPairGate family — a new **required input** on a reusable workflow is the other known instance of this exact shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
