### PR TITLE
fix(security): respect descendant caps on inherited public reads

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -856,7 +856,8 @@ every evaluation:
 
 `PartitionAccessPolicy { Api = false }` is therefore meaningful in its own right: **"readable in a
 browser, not reachable through the API."** The public grant is ORed in *after* the cap so the page
-stays readable; the capability it confers is *not*, so the API surface closes.
+stays readable; the capability it confers is *not*, so the API surface closes. An inherited public
+grant is still subject to a deeper `Read = false` policy, as described below.
 
 ## 🚨 Why the mint-time role snapshot existed — and why trusting it was the bug
 
@@ -1199,6 +1200,52 @@ The predicate above used to carry a third term — `public_read_node_type OR …
 - **The shape was unsafe regardless of the type list.** Being an unconditional `OR` in front of the node fold, it short-circuited the longest-prefix resolution — i.e. it overrode DENY rows, which is precisely where store/course paywall gating lives. And `PermissionEvaluator` has no node-type-keyed term, so the SQL and evaluator paths would have diverged.
 
 **Declare public read with a mechanism both read paths honour instead:** a `PartitionAccessPolicy` `_Policy` node with `PublicRead = true` (issue #603 — projected as allow-`Read` rows for `Public`/`Anonymous` that *participate in* the prefix fold, so a deeper deny still wins), or a [`NodeTypeGate`](#type-declared-subtree-gates-nodetypegate) (issue #701) for a type that opens a short, explicitly listed set of surfaces on its own subtree.
+
+### Public policy grants and deeper read caps
+
+`PublicRead` follows scope order. At each scope, the evaluator first applies that policy's cap to
+the inherited public grant, then adds the scope's own public grant. This preserves the PostgreSQL
+projection's existing order: policy caps are projected first, public grants replace them at the
+same prefix, and a more specific prefix wins when reading a descendant.
+
+| Policies on the path | Read decision for a viewer without a role |
+|---|---|
+| Parent `PublicRead = true`; ordinary child | Allow |
+| Parent `PublicRead = true`; child `Read = false` | Deny at the child and below |
+| Same scope `PublicRead = true` and `Read = false` | Allow |
+| Parent public; child read cap; grandchild `PublicRead = true` | Allow at the grandchild and below |
+| `Read = true` alone | No grant |
+
+`BreaksInheritance` resets inherited roles and their caps; it does not make a child's explicit
+read cap ineffective against a public ancestor. Role denies continue to remove roles, while
+`PublicRead` remains a separate grant. This rule does not change the additive `NodeTypeGate`
+contract or the separate `Api` capability cap.
+
+**Regression evidence (2026-09-11).** On core baseline
+`3e731d947244b51b19f4c78b1114fc4273a9a840`, `PublicReadPolicyScopeTest` executed 14 cases against a
+real monolith mesh without the fixture's default Public Admin grant. Four failed: anonymous and
+signed-in reads through a deeper read cap, each with and without `BreaksInheritance`. The other ten
+controls passed. The correction caps the accumulated public grant at each scope before applying
+that scope's own `PublicRead`. Fixtures use invented subjects and scopes; no production records are
+part of the test. After the correction, all 14 cases and the seven existing
+`ApiTokenCapabilityFreshnessTest` cases passed (21 total). Both baseline and corrected builds used
+`dotnet build test/MeshWeaver.Graph.Test/MeshWeaver.Graph.Test.csproj -c Release -p:CIRun=true -warnaserror`
+and finished with zero warnings and errors. The corrected test selection was
+`FullyQualifiedName~PublicReadPolicyScopeTest|FullyQualifiedName~ApiTokenCapabilityFreshnessTest`.
+Two existing `RoutedApiTokenClampTest` cases also passed. Against the same corrected core, the
+Plugins `MeshWeaver.Security.Test` project at `8ee8a192` built with the same strict flags and passed
+33 existing cases selected by `PartitionAccessPolicyTests`, `StaticNamespacePolicyTests`,
+`NodeTypeGateTests`, `AnonymousGateTests` and `UserPublicReadTest`. These include a signed-in,
+unentitled viewer denied course content, public course surfaces and the entitled control.
+
+The baseline evaluator SHA-256 was
+`472c97c6d7419145178cff0e693bde17cad2e9d17d35ecbfb96bf222e1af3219`; this document's baseline SHA-256
+was `f67ad347c579f8bd483906fe7bcb4276d4fdd5f258491758154ab376ed35ad9b`. The SQL comparison used
+`MeshWeaver.Plugins` commit `39bd2e7ae0c2e1574ce44b26f3ef0b9938d98c04`,
+`PostgreSqlSchemaInitializer.cs` SHA-256
+`49515b4db3ffb27a5f6313577d239781447d10eb14087c1852a7b6d4162df026`. Its bulk and per-user
+projection both apply same-prefix public grants after policy denies. These are source receipts;
+the core regression does not execute PostgreSQL.
 
 ## AI tool call identity
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-private-subtrees-respect-their-read-policy.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-private-subtrees-respect-their-read-policy.md
@@ -1,0 +1,15 @@
+---
+Name: Private subtrees respect their read policy
+Category: Fix
+Description: A read restriction on a child now applies when opening it directly, even when its parent is public.
+Icon: Shield
+Order: -20260911
+---
+
+# Private subtrees respect their read policy
+
+A public page can contain a private subtree. Its read restriction now applies when someone opens
+a child directly, matching the existing policy precedence used by PostgreSQL listings.
+
+Ordinary public content stays readable. A public grant placed at the same scope as a read cap
+retains its existing precedence; a deeper read cap restricts inherited public access.

--- a/src/MeshWeaver.Mesh.Contract/Security/AccessAssignment.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AccessAssignment.cs
@@ -74,6 +74,9 @@ public record PartitionAccessPolicy
     /// When true, GRANTS Read to ALL users at this scope and below — a public-read
     /// override with precedence over the role-based grant computation (it is ORed in
     /// AFTER the per-user roles ∩ cap, so a user needs no role at this scope to read).
+    /// A deeper policy with <c>Read = false</c> suppresses this inherited grant; a
+    /// <c>PublicRead = true</c> at that deeper scope grants Read there again. At the
+    /// same scope, PublicRead retains precedence over the Read cap.
     /// This is the policy-driven way to publish a read-only catalog (e.g. the built-in
     /// Agent / Model / Documentation namespaces): the owning static node provider seeds
     /// one <c>_Policy</c> with <c>PublicRead = true</c> and the whole subtree becomes

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -695,10 +695,12 @@ internal static class PermissionEvaluator
                 roleIds = roleIds.Union(roles);
             if (policy is not null)
             {
-                permissionCap &= policy.GetPermissionCap();
-                // Public-read override: a policy with PublicRead grants Read to every
-                // user at this scope and below. Accumulated here, ORed in AFTER the
-                // per-user (roles ∩ cap) below — so it has precedence and needs no role.
+                var scopeCap = policy.GetPermissionCap();
+                permissionCap &= scopeCap;
+                // A deeper cap suppresses an inherited public grant, matching the SQL
+                // longest-prefix fold. Apply this scope's grant afterwards: PublicRead
+                // still overrides Read=false at the SAME scope and needs no role.
+                publicGrant &= scopeCap;
                 if (policy.PublicRead)
                     publicGrant |= Permission.Read;
             }

--- a/test/MeshWeaver.Graph.Test/PublicReadPolicyScopeTest.cs
+++ b/test/MeshWeaver.Graph.Test/PublicReadPolicyScopeTest.cs
@@ -1,0 +1,97 @@
+using System.Reactive.Linq;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>Public policy grants obey scope precedence, as the SQL prefix fold already does.</summary>
+public class PublicReadPolicyScopeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Reader = "scope-policy-reader";
+
+    // The usual test configuration grants Public Admin. That would invalidate these controls.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddMeshNodes(
+            new MeshNode("PublicPolicy") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("PublicPolicy", new PartitionAccessPolicy { PublicRead = true }),
+            new MeshNode("Page", "PublicPolicy") { NodeType = "Markdown" },
+            new MeshNode("Private", "PublicPolicy") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("PublicPolicy/Private", new PartitionAccessPolicy { Read = false }),
+            new MeshNode("Page", "PublicPolicy/Private") { NodeType = "Markdown" },
+            new MeshNode("Isolated", "PublicPolicy") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("PublicPolicy/Isolated",
+                new PartitionAccessPolicy { Read = false, BreaksInheritance = true }),
+            new MeshNode("Page", "PublicPolicy/Isolated") { NodeType = "Markdown" },
+            new MeshNode("Reopened", "PublicPolicy/Private") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("PublicPolicy/Private/Reopened",
+                new PartitionAccessPolicy { PublicRead = true }),
+            new MeshNode("Page", "PublicPolicy/Private/Reopened") { NodeType = "Markdown" },
+            new MeshNode("SameScope") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("SameScope", new PartitionAccessPolicy { PublicRead = true, Read = false }),
+            new MeshNode("Page", "SameScope") { NodeType = "Markdown" },
+            new MeshNode("CapOnly") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("CapOnly", new PartitionAccessPolicy { Read = true }),
+            new MeshNode("Page", "CapOnly") { NodeType = "Markdown" },
+            new MeshNode("RolePolicy") { NodeType = "Markdown" },
+            AssignmentNodeFactory.UserRole(Reader, "Viewer", "RolePolicy"),
+            new MeshNode("Page", "RolePolicy") { NodeType = "Markdown" },
+            new MeshNode("Capped", "RolePolicy") { NodeType = "Markdown" },
+            AssignmentNodeFactory.Policy("RolePolicy/Capped", new PartitionAccessPolicy { Read = false }),
+            new MeshNode("Page", "RolePolicy/Capped") { NodeType = "Markdown" },
+            new MeshNode("Denied", "RolePolicy") { NodeType = "Markdown" },
+            AssignmentNodeFactory.UserRole(Reader, "Viewer", "RolePolicy/Denied", denied: true),
+            new MeshNode("Page", "RolePolicy/Denied") { NodeType = "Markdown" });
+
+    private Task<Permission> Effective(string path, string subject)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var context = new AccessContext { ObjectId = subject, Name = subject };
+        access.SetContext(context);
+        access.SetHostIdentity(context);
+        // Assert the first decision, not a later matching answer that could hide an initial leak.
+        return Mesh.GetEffectivePermissions(path, subject)
+            .FirstAsync().Timeout(TestTimeouts.Quick).Await(TestContext.Current.CancellationToken);
+    }
+
+    [Theory(Timeout = 60_000)]
+    [InlineData("PublicPolicy/Page", WellKnownUsers.Anonymous, true)]
+    [InlineData("PublicPolicy/Page", Reader, true)]
+    [InlineData("PublicPolicy/Private/Page", WellKnownUsers.Anonymous, false)]
+    [InlineData("PublicPolicy/Private/Page", Reader, false)]
+    [InlineData("PublicPolicy/Isolated/Page", WellKnownUsers.Anonymous, false)]
+    [InlineData("PublicPolicy/Isolated/Page", Reader, false)]
+    [InlineData("PublicPolicy/Private/Reopened/Page", WellKnownUsers.Anonymous, true)]
+    [InlineData("PublicPolicy/Private/Reopened/Page", Reader, true)]
+    [InlineData("SameScope/Page", WellKnownUsers.Anonymous, true)]
+    [InlineData("SameScope/Page", Reader, true)]
+    [InlineData("CapOnly/Page", WellKnownUsers.Anonymous, false)]
+    [InlineData("CapOnly/Page", Reader, false)]
+    public async Task PublicRead_UsesTheMostSpecificPolicy(string path, string subject, bool readable)
+    {
+        (await Effective(path, subject)).HasFlag(Permission.Read).Should().Be(readable,
+            "a deeper cap suppresses an inherited public grant, while a grant at the same scope wins");
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task RoleGrantAndCap_KeepTheirExistingPermissionBits()
+    {
+        var granted = await Effective("RolePolicy/Page", Reader);
+        granted.HasFlag(Permission.Read | Permission.Execute | Permission.Api).Should().BeTrue();
+
+        var capped = await Effective("RolePolicy/Capped/Page", Reader);
+        capped.HasFlag(Permission.Read).Should().BeFalse();
+        capped.HasFlag(Permission.Execute | Permission.Api).Should().BeTrue();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task RoleDeny_StillRemovesTheInheritedRole()
+    {
+        (await Effective("RolePolicy/Denied/Page", Reader)).Should().Be(Permission.None);
+    }
+}


### PR DESCRIPTION
Direct reads could expose a private child when an ancestor policy granted public read. Apply each scope’s cap to inherited public grants before adding that scope’s own grant. This matches the existing PostgreSQL prefix precedence while preserving same-scope public grants, later explicit regrants and API capability caps.

Validation: four failing policy cases reproduced before the fix; 14 new scope cases, nine existing API cases, 33 existing security cases and six documentation checks passed with strict builds. Three matched-core Store source integration cases also passed on an isolated monolith, covering direct reads, queries, public content and entitled content. PostgreSQL source precedence was inspected; these new hosted cases use in-memory persistence.

The paired Store change, Systemorph/MeshWeaver.Plugins#1635, seeds the private policy before publishing grants or entitlement records. Release remains held pending the coordinated core/CD and coherent Store adoption checks. No production verification is claimed by this draft.

Local readiness: independently applied to core main `45306a33e9437f1b662450dc23c4dfa6d897fe41` after #3968, without conflicts. Every changed product, test and documentation file is byte-identical to the validated source commits. This source-only base refresh did not repeat runtime suites. The preceding #3985 delivery was reported sealed. This PR is staged as a draft for CI only; the current coordinated merge and release hold remains in force.

Mirror-sync: none — no UI catalog keys or localized values change.
