### PR TITLE
fix(gitsync): restore returning sources and record evaluated roots

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -258,8 +258,8 @@ In the **distributed (Orleans/PG) portal, routing does not consult the in-memory
 A source can move **B → A → B** during a rollback or a change of sealed publication. The old
 `import-{B}` activity survives the A import because import history is outside the content prune.
 Its success is historical evidence. Before skipping, the importer reads the current
-`import-manifest` authoritatively and compares its source tokens with every requested node and the
-root. A mismatch clears any Git-diff scope and evaluates the full source with the existing conflict
+`import-manifest` authoritatively and compares its content tokens with every requested non-empty
+node path and the root. A mismatch clears any Git-diff scope and evaluates the full source with the existing conflict
 policy. The manifest remains the same path-to-token map; older maps without a root entry receive
 one incremental full pass before they can authorize a skip. The root is always recorded as evaluated:
 `EnsureRoot` runs independently of the child Git-diff scope. Retaining its previous token after a
@@ -282,7 +282,8 @@ absent. This is a bounded historical observation, not a claim about production a
 or replica turnover.
 
 `ReturningSourceConvergesTest` drives the real GitSync service and monolith importer, substituting
-only the GitHub I/O boundary. On unchanged core `f1a945d5`, all six cases fail: B → A → B returns `Skipped` (including
+only the GitHub I/O boundary. Its initial six-case matrix, before the scoped-root follow-up below,
+fails on unchanged core `f1a945d5`: B → A → B returns `Skipped` (including
 a root-only change); both same-SHA reconciliation cases restore the missing node but leave the
 existing source stale; an ordinary import whose recorded SHA is already B skips; and explicit
 reconciliation trusts a matching manifest despite measured live drift. The corrected regression
@@ -290,8 +291,8 @@ also verifies unchanged repeats and a person's two-way edit with its conflict ho
 concurrently importing different selected publications; durable delivery still requires the intended
 publication and actual final source fingerprints to agree.
 
-**Initial local validation:** the six-case regression is red on unchanged core `f1a945d5` and green
-with this change. All 19 targeted Hosting/GitSync cases and 51 existing Graph importer cases pass.
+**Initial local validation:** those six cases are red on unchanged core `f1a945d5` and green
+with the initial correction. All 19 targeted Hosting/GitSync cases and 51 existing Graph importer cases pass.
 Release builds of the touched projects and test dependencies report zero warnings and errors.
 The regression reads actual node content and checks written/pruned paths; it does not assert only
 on the sync SHA or on a success message. Production acceptance remains a separate release step.
@@ -301,7 +302,31 @@ on the sync SHA or on a success message. Production acceptance remains a separat
 retains B's root token; returning to B skips and leaves the actual root at A. Recording the root's
 current token independently of the child scope corrects this. The test checks actual root content
 and the subsequent ordinary zero-content-write repeat. The new case is red on `7aac375b` and green
-with the correction; all 20 targeted Hosting/GitSync cases pass on the corrected source.
+with the correction. This follow-up expands `ReturningSourceConvergesTest` from six to seven
+executed cases; all 20 targeted Hosting/GitSync cases pass on the corrected source. The initial
+six-case and later scoped-root red receipts describe separate validation runs.
+
+**Review controls, 2026-09-11:** a `Versioned` source's revision changes the partition fingerprint;
+the manifest deliberately stores authored-content tokens. The new
+`VersionOnlySourceRevision_DoesNotRewriteIdenticalContentOrTheOwnerClock` case passes on unchanged
+`f1ce3394`: importing identical content at revisions 42 → 43 → 42 → 43 preserves both the content
+and the mesh owner's node version. A source revision alone must not manufacture a content write.
+
+The separate `EmptyPathIgnoredByTheFingerprint_DoesNotInvalidateTheCurrentManifest` case exposes
+a real mismatch on that same baseline: the fingerprint and manifest writer omit empty paths,
+while the returning-source comparison included one. An otherwise unchanged repeat returns
+`ImportedWithContentErrors` instead of `Skipped`. Applying the same non-empty-path filter to the
+comparison keeps those three decisions consistent. Its comparison map and the test fixture's
+source list use immutable collections (correction commit `6dae9421`). All nine cases then pass: the previous seven plus these
+two review controls. The 25 existing conflict-policy, scoped-marker and sync-mode cases also pass.
+Strict Release `Hosting.Test` and `Graph.Test` builds report zero warnings and errors.
+The distinct baseline and corrected receipts are
+`/tmp/core3991-review-results/core3991-review-before.trx` and
+`/tmp/core3991-review-results/core3991-review-final.trx`; the existing controls are in
+`/tmp/core3991-review-results/core3991-review-graph.trx`. The review baseline executes the two new
+controls: the version-only case passes and the empty-path case fails.
+The strict `Documentation.Test` build and 12 release-note, link and embed integrity cases also pass;
+their receipt is `/tmp/core3991-review-results/core3991-review-doc.trx`.
 
 **Removal review:** adding the root to the manifest does not make it a prune candidate. `Run` reads
 existing **descendants**, and `ComputePrunableNodes` filters that existing set; manifest keys only

--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -261,7 +261,9 @@ Its success is historical evidence. Before skipping, the importer reads the curr
 `import-manifest` authoritatively and compares its source tokens with every requested node and the
 root. A mismatch clears any Git-diff scope and evaluates the full source with the existing conflict
 policy. The manifest remains the same path-to-token map; older maps without a root entry receive
-one incremental full pass before they can authorize a skip.
+one incremental full pass before they can authorize a skip. The root is always recorded as evaluated:
+`EnsureRoot` runs independently of the child Git-diff scope. Retaining its previous token after a
+scoped root change would incorrectly authorize the previous root's historical marker.
 
 `GitHubSyncService.ReconcileAtCommit` likewise evaluates the whole source, without a Git comparison
 or a per-node manifest shortcut. A recorded B SHA makes the Git diff B..B empty even if the live mesh
@@ -288,11 +290,49 @@ also verifies unchanged repeats and a person's two-way edit with its conflict ho
 concurrently importing different selected publications; durable delivery still requires the intended
 publication and actual final source fingerprints to agree.
 
-**Local validation:** the final six-case regression is red on unchanged core `f1a945d5` and green
+**Initial local validation:** the six-case regression is red on unchanged core `f1a945d5` and green
 with this change. All 19 targeted Hosting/GitSync cases and 51 existing Graph importer cases pass.
 Release builds of the touched projects and test dependencies report zero warnings and errors.
 The regression reads actual node content and checks written/pruned paths; it does not assert only
 on the sync SHA or on a success message. Production acceptance remains a separate release step.
+
+**Scoped-root follow-up:** `ScopedRootChange_CannotLeaveThePreviousRootsMarkerCurrent` fails on
+`7aac375b`: a full B import, followed by A with only `index.json` in the Git diff, writes root A but
+retains B's root token; returning to B skips and leaves the actual root at A. Recording the root's
+current token independently of the child scope corrects this. The test checks actual root content
+and the subsequent ordinary zero-content-write repeat. The new case is red on `7aac375b` and green
+with the correction; all 20 targeted Hosting/GitSync cases pass on the corrected source.
+
+**Removal review:** adding the root to the manifest does not make it a prune candidate. `Run` reads
+existing **descendants**, and `ComputePrunableNodes` filters that existing set; manifest keys only
+narrow ownership in Additive mode. Claims, incomplete-listing refusal, protected local edits, held
+NodeTypes and their source subtrees retain their existing guards. Removing an entire compiled
+source partition still uses the independent `Admin/_SourceOwnedCatalogs` registry. Removing its
+root index file instead restores the standard synthesized root; it does not remove the partition.
+
+A separate pre-existing boundary remains outside this fix: `Run` derives touched partitions solely
+from the current child nodes. If a source removes its **last** child, that list is empty and the
+existing-subtree read is empty, so old children are not presented to the prune. The root-inclusive
+manifest does not introduce that omission or repair it. This is a source-path finding; no new
+runtime test or production claim accompanies it here.
+
+**Integration review, 2026-09-10:** main `89c914b64e6b5ff4c70f36de8604ac84c7c6e29b` changes
+`DataExtensions` and read-visibility tests through #3976; PR #3981 head
+`b7d011dd2cddb5c105e87c77420fc519d2575938` adds the content-workflow admission gate and adjusts
+its webhook fixtures. Neither changes this patch's importer/service/test files. The complete
+importer patch, including the scoped-root correction, applies cleanly to each tree and their clean combined tree
+`58d388500f458e2a51ba38d4314b7a1e83585be0`, checked with a temporary Git index without changing
+any checkout. The two fixes govern different decisions: #3981 determines which CI completion may
+request an import; this fix determines whether the requested source is already present.
+
+After the coordinated release hold is lifted, transplant both importer commits in order onto a
+fresh checkout of the then-current main; do not cherry-pick only `7aac375b` and lose the scoped-root
+correction. Re-read main and the owner's final source first, preserve #3981's workflow-path fields
+in the existing webhook fixtures, and rerun the Hosting/GitSync regression selection, Graph importer
+selection and documentation/reactive guards on the combined tree. A clean patch application is not
+a compiled or tested integration receipt. Ship through the normal core/CD and sealed-publication
+workflow; verify the selected publication plus actual Store source/compiled fingerprints after
+normal reconciliation. No force import or conflict-policy bypass is part of the transplant.
 
 ## 🚨 A CONTENT verdict is final for its fingerprint; a transient failure is not
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -54,7 +54,7 @@ meshHub.GetHostedHub(
 
 1. **Resolve the Space root** — `source.PartitionRoot` or a synthesized generic `Space` — and fold it into the source node set.
 2. **Provision the partition schema** (`IPartitionStorageProvider.EnsurePartitionProvisioned`, lowercased, idempotent/promise-cached) **before** anything is written — the marker node in step 4 lives at `{P}/_Activity/…`, *inside* the partition schema, so a fresh partition would otherwise fault (42P01 — there is no lazy schema create; see [GhostSchemaInvariantTests]).
-3. **Fingerprint + short-circuit** — `PartitionSourceFingerprint.Compute(nodes + root)`. If a `Succeeded` activity at `{P}/_Activity/import-{fingerprint}` already exists, **stop** (the common case on every boot).
+3. **Fingerprint + short-circuit** — `PartitionSourceFingerprint.Compute(nodes + root)`. A converged `Succeeded` activity at `{P}/_Activity/import-{fingerprint}` may skip only when the current authoritative import manifest matches the source, including its root (the common case on every boot).
 4. **Stamp the marker, then open a fresh attempt** — upsert `{P}/_Activity/import-{fingerprint}` to `Running`. That deterministic node is the durable "version vN imported at T" record — nothing else. It is **not** a lock: a marker left `Running` is deliberately *reclaimed* rather than obeyed, so two replicas booting together can both import. That is safe because every write on the path is an upsert. The run's own log goes to a **fresh** `{P}/_Activity/import-{fingerprint}-{timestamp}-{rand}` node, one per attempt. See *Content-addressed Activity — the marker + the short-circuit* below for why the two roles are split.
 5. **Ensure the Space root** (standard step) via the canonical upsert — creating a `Space` triggers eager schema provisioning + the `Admin/Partition/{P}` routing prime + the admin grant; an existing root is updated. This makes the partition routable, listed in `public.top_level_index`, and gives it a landing page. **Exception — a *claimed* root is left untouched:** if the existing root carries `SyncBehavior != Include` (i.e. an admin set `ExcludeThisAndChildren` = "sync: none"), `EnsureRoot` does **not** re-materialise it. Re-materialising would reset the root's `SyncBehavior` back to `Include` and silently re-enable sync — see *Decoupling a partition (sync: none)* below.
 6. **Upsert every source node** through **`CreateOrUpdateNodeRequest`** — the single canonical verb (the same one `NodeCopyHelper` uses). It **creates** absent nodes and **updates** existing ones (the owner **re-stamps Version**), running the full pipeline: prerender (`MarkdownContent.Parse`), embedding, satellites, access. **Claimed subtrees are skipped** — both a **child** claimed in the snapshot (`SyncBehavior != Include`) and an **entire partition whose root is claimed** (`ExcludeThisAndChildren`). The partition-root claim is read **authoritatively** (`GetMeshNodeStream`), NOT from the eventually-consistent query snapshot, so a *just-set* decouple is honoured before the read-model catches up (the snapshot lags writes — reading the claim from it re-synced the partition and clobbered the admin's edits: a production `Provider/Anthropic` key reset, 2026-06-25). **Each upsert is independently guarded** (per-file `try/catch`): a single node faulting (bad content, a validator reject, a transient owner timeout) logs a `⚠ Failed to import {path}` line **into the import activity** and the import **continues** — the first failure never aborts the rest of the partition. Failures are tallied. 🚨 The writes are **ORDERED, not a flat fan-out**: a NodeType node lands before every instance that names it, and a type's `Source`/`Test` nodes land before the type — see [Import Write Ordering](../ImportWriteOrdering), which also settles what happens to a type that arrives from another partition or repo, and the cycle policy. Without it a repo shipping an instance of a type it introduces was refused `NodeType 'X' is not registered` and the retry re-ran the identical ordering forever (issue #2556: 6,902 refusals in 90 minutes on memex-cloud).
@@ -234,7 +234,7 @@ The import is governed by TWO [Activity](/Doc/Architecture/ActivityControlPlane)
 
 **The marker** — `{Partition}/_Activity/import-{fingerprint}`, id = the fingerprint:
 
-- **A `Succeeded` activity for the fingerprint is the durable "already imported" record** — the boot short-circuit reads it; equal fingerprint ⇒ no work. This is the marker's whole job, and it is why the id must be derived from the content.
+- **A `Succeeded` activity records that this fingerprint was imported previously.** The skip also checks its convergence verdict and the current authoritative import manifest; a historical marker alone does not establish the partition's current source. This is the marker's whole job, and it is why the id must be derived from the content.
 - **Changed source ⇒ new id** ⇒ a fresh import runs. Old `import-{prevHash}` markers remain as a visible import history.
 - It is written **only** through the idempotent upsert (`CreateOrUpdateNodeRequest`), twice per run: `Running` at the start, then the terminal verdict. That verb floors the version on the durable row it just read, so a forked/ghost row is repaired in place rather than silently discarded (#902/#909).
 - 🚨 **It is not a lock, and nothing else serialises replicas.** A marker left `Running` — by a crashed import, or by a rollout briefly running two pods — is *reclaimed*, not obeyed: the guard re-imports on anything that is not `Succeeded`. Obeying it was the old behaviour and it wedged a partition into "AlreadyRunning, 0 nodes" forever (the prod Agent/Harness/Command wedge). So two replicas on the same fingerprint can import concurrently. That is safe **only** because every write on the path is an upsert of byte-identical content — do not add a step here that is not idempotent, and do not treat "the lock protects me" as an available argument.
@@ -252,6 +252,47 @@ The SQL migration (`Memex.Database.Migration`) is a standalone process with **no
 ## Distributed serving (why this matters)
 
 In the **distributed (Orleans/PG) portal, routing does not consult the in-memory `EmbeddedResourceStorageAdapter`** — so a partition that is only served from the embedded overlay 404s / hangs. The static-repo import is what makes built-in partitions (Doc/Agent/Model) **served from the DB** there. The monolith (in-process embedded routing) works either way, so the cutover is gated by `Features:StaticRepoSync:Partitions` (default `["Doc","Agent","Model"]` for the distributed portal; monolith leaves it empty and keeps in-memory serving).
+
+## Returning to a previously imported source
+
+A source can move **B → A → B** during a rollback or a change of sealed publication. The old
+`import-{B}` activity survives the A import because import history is outside the content prune.
+Its success is historical evidence. Before skipping, the importer reads the current
+`import-manifest` authoritatively and compares its source tokens with every requested node and the
+root. A mismatch clears any Git-diff scope and evaluates the full source with the existing conflict
+policy. The manifest remains the same path-to-token map; older maps without a root entry receive
+one incremental full pass before they can authorize a skip.
+
+`GitHubSyncService.ReconcileAtCommit` likewise evaluates the whole source, without a Git comparison
+or a per-node manifest shortcut. A recorded B SHA makes the Git diff B..B empty even if the live mesh
+contains A. Reconciliation preserves two-way human edits and claims; it never sets `Force`. A
+subsequent ordinary import of a converged, unchanged source skips with no content writes.
+
+**Measured failure, memex-cloud, 2026-09-10 UTC.** Store imported the new coupon/course-size source
+at 18:55 (`Store/_Activity/9817ab34`, commit `06d8187049f38aa8831a423ed64f32965af424cb`).
+A sealed-source reconciliation then imported `f4570459a34a64c4edd9b17a4a9b59a62a50165e` at
+19:10 (`Store/_Activity/3f12d540`), restoring the previous source and pruning six new nodes.
+At 21:07, attempts `Store/_Activity/a24af2d7` and `Store/_Activity/e348d6d8` targeted the new
+Store-equivalent commit `8ee8a1928d278aa74a162353dfa663ffac44c28c` but explicitly skipped on
+historical marker `Store/_Activity/import-1c252ab2c7141f07`. `_GitSync` recorded that SHA as seen,
+while the actual Plugin source remained at fingerprint `cc84832d2d7d3575` and the new nodes were
+absent. This is a bounded historical observation, not a claim about production after later imports
+or replica turnover.
+
+`ReturningSourceConvergesTest` drives the real GitSync service and monolith importer, substituting
+only the GitHub I/O boundary. On unchanged core `f1a945d5`, all six cases fail: B → A → B returns `Skipped` (including
+a root-only change); both same-SHA reconciliation cases restore the missing node but leave the
+existing source stale; an ordinary import whose recorded SHA is already B skips; and explicit
+reconciliation trusts a matching manifest despite measured live drift. The corrected regression
+also verifies unchanged repeats and a person's two-way edit with its conflict horizon held. These checks do not establish distributed serialization between replicas that are
+concurrently importing different selected publications; durable delivery still requires the intended
+publication and actual final source fingerprints to agree.
+
+**Local validation:** the final six-case regression is red on unchanged core `f1a945d5` and green
+with this change. All 19 targeted Hosting/GitSync cases and 51 existing Graph importer cases pass.
+Release builds of the touched projects and test dependencies report zero warnings and errors.
+The regression reads actual node content and checks written/pruned paths; it does not assert only
+on the sync SHA or on a success message. Production acceptance remains a separate release step.
 
 ## 🚨 A CONTENT verdict is final for its fingerprint; a transient failure is not
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-returning-import-restores-source.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-returning-import-restores-source.md
@@ -1,0 +1,13 @@
+---
+Name: Returning imports restore the selected source
+Category: Fix
+Order: -20260910
+Description: Re-importing a previously used source no longer skips on an older success marker.
+---
+
+Returning a synced partition to a previously imported revision restores changed and missing nodes.
+The importer verifies its current source manifest before trusting a historical success marker.
+Reconciliation also evaluates live drift when Git records the requested commit already, while
+preserving protected local edits. An unchanged ordinary repeat remains a zero-content-write skip.
+
+See [Static Repo Import](/Doc/Architecture/StaticRepoImport) for the mechanism and regression evidence.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-returning-import-restores-source.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-10-returning-import-restores-source.md
@@ -3,6 +3,7 @@ Name: Returning imports restore the selected source
 Category: Fix
 Order: -20260910
 Description: Re-importing a previously used source no longer skips on an older success marker.
+Icon: ArrowSync
 ---
 
 Returning a synced partition to a previously imported revision restores changed and missing nodes.

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -647,7 +647,9 @@ public sealed class GitHubSyncService
             // under-import. This is what stops a routine push from re-materialising the whole
             // partition and storming the live compiler (the memex-cloud outage loop, 2026-07-23).
             var readmePolicy = ReadmeFilePolicy.From(snapshot);
-            var diff = string.IsNullOrEmpty(baseSha) || policy?.Force == true
+            // Reconciliation measures drift in the live mesh, not changes between Git commits.
+            // B..B is empty even when another import replaced the live nodes with A.
+            var diff = string.IsNullOrEmpty(baseSha) || policy?.Force == true || policy?.Reconcile == true
                 ? Observable.Return<IReadOnlyList<string>?>(null)
                 : repoClient.GetChangedPaths(repoUrl, baseSha!, snapshot.CommitSha, subdirectory, token);
             return diff.SelectMany(changedFiles =>

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -945,7 +945,10 @@ public static class StaticRepoImporter
                 // the attempt node carries the full log, and the next unscoped import re-evaluates
                 // the content instead of trusting a claim nobody checked. The routine webhook path
                 // is unaffected — it is scoped, so it never reached the short-circuit anyway.
-                var isScopedRun = changedNodePaths is not null;
+                // A measured live-source mismatch cannot be bounded by a Git diff, which only
+                // describes changes between commits and may be empty at the recorded commit.
+                var effectiveChangedNodePaths = policy?.Reconcile == true ? null : changedNodePaths;
+                var isScopedRun = effectiveChangedNodePaths is not null;
 
                 // Terminal stamp on the LOCK — through Upsert, the repair-capable verb, so it lands on a
                 // node that may not exist yet (the early-failure path) AND on one left forked by a prior
@@ -1036,7 +1039,7 @@ public static class StaticRepoImporter
                         // 2. Open a FRESH attempt node — the only node this run logs progress to (#919).
                         .SelectMany(_ => Upsert(hub, BookkeepingNode(
                             attemptId, $"{lockName} — attempt {DateTime.UtcNow:u}", ActivityStatus.Running)))
-                        .SelectMany(_ => Run(hub, source, nodes, root, attemptPath, fingerprint, syncMode, logger, policy, changedNodePaths))
+                        .SelectMany(_ => Run(hub, source, nodes, root, attemptPath, fingerprint, syncMode, logger, policy, effectiveChangedNodePaths))
                         // 3. Stamp the verdict on the lock. Succeeded here is what makes the NEXT boot
                         //    skip; ImportedWithErrors stays Warning and a guarded-to-Failed run stays
                         //    Failed, so both re-import — exactly the statuses Run wrote before the split.
@@ -1197,23 +1200,48 @@ public static class StaticRepoImporter
                 // re-import instead of skipping. Eventually-consistent query: a stale miss re-imports
                 // idempotently — wasteful, not wrong, which is the same property that lets two replicas
                 // import concurrently (nothing serialises them; every write on the path is an upsert).
-                var contentSentinel = nodes.FirstOrDefault(n =>
-                    n.NodeType != "PartitionAccessPolicy"
-                    && !n.Segments.Skip(1).Any(seg => seg.StartsWith('_')));
-                if (contentSentinel is null)
-                    return SkipWithGovernanceHeal(); // governance-only source — no content to verify
-
-                return meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{contentSentinel.Path}"))
-                    .Take(1)
-                    .SelectMany(sentinelChange =>
+                return ReadNodeManifest(hub, source.Partition).SelectMany(currentManifest =>
+                {
+                    // A success marker is history; this manifest describes the LAST evaluated
+                    // source. B -> A -> B must not skip merely because B succeeded before A
+                    // replaced its nodes. Include the root so a root-only rollback is covered too.
+                    // Older manifests omit the root and safely buy one incremental full pass.
+                    var sourceTokens = nodes.Append(root)
+                        .GroupBy(n => n.Path, StringComparer.OrdinalIgnoreCase)
+                        .ToDictionary(g => g.Key,
+                            g => PartitionSourceFingerprint.ComputeNodeToken(g.First(), hub.JsonSerializerOptions),
+                            StringComparer.OrdinalIgnoreCase);
+                    if (currentManifest.Count != sourceTokens.Count
+                        || sourceTokens.Any(entry => !currentManifest.TryGetValue(entry.Key, out var token)
+                            || !string.Equals(token, entry.Value, StringComparison.Ordinal)))
                     {
-                        if (sentinelChange.Items.Any())
-                            return SkipWithGovernanceHeal();
-                        logger?.LogWarning(
-                            "[StaticRepoImport] {Partition}: marker at {Fingerprint} says imported, but content sentinel '{Path}' is MISSING — self-healing via full re-import.",
-                            source.Partition, fingerprint, contentSentinel.Path);
+                        logger?.LogInformation(
+                            "[StaticRepoImport] {Partition}: historical marker at {Fingerprint} no longer "
+                            + "matches the current import manifest — evaluating the full source.",
+                            source.Partition, fingerprint);
+                        effectiveChangedNodePaths = null;
+                        isScopedRun = false;
                         return Reimport();
-                    });
+                    }
+
+                    var contentSentinel = nodes.FirstOrDefault(n =>
+                        n.NodeType != "PartitionAccessPolicy"
+                        && !n.Segments.Skip(1).Any(seg => seg.StartsWith('_')));
+                    if (contentSentinel is null)
+                        return SkipWithGovernanceHeal(); // governance-only source — no content to verify
+
+                    return meshService.Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{contentSentinel.Path}"))
+                        .Take(1)
+                        .SelectMany(sentinelChange =>
+                        {
+                            if (sentinelChange.Items.Any())
+                                return SkipWithGovernanceHeal();
+                            logger?.LogWarning(
+                                "[StaticRepoImport] {Partition}: marker at {Fingerprint} says imported, but content sentinel '{Path}' is MISSING — self-healing via full re-import.",
+                                source.Partition, fingerprint, contentSentinel.Path);
+                            return Reimport();
+                        });
+                });
             });
     }
 
@@ -1529,7 +1557,9 @@ public static class StaticRepoImporter
                             // expensive cross-hub upsert + owner re-render. Token is over the RAW source node,
                             // matching what the manifest stored.
                             var token = PartitionSourceFingerprint.ComputeNodeToken(sourceNode, hub.JsonSerializerOptions);
-                            if (target is not null
+                            // Reconcile was requested because this ledger disagrees with the live
+                            // sources; evaluate the write with conflict protection instead of trusting it.
+                            if (policy?.Reconcile != true && target is not null
                                 && manifest.TryGetValue(path, out var prevToken)
                                 && string.Equals(prevToken, token, StringComparison.Ordinal))
                             {
@@ -1890,7 +1920,7 @@ public static class StaticRepoImporter
                         // Persist the per-node manifest LAST (after upserts + prune) so the NEXT import's
                         // diff sees exactly what's now in the partition. One write; survives prune (_Activity).
                         return WriteContentSyncLedgers(hub, source.Partition, content, logger)
-                            .SelectMany(_ => WriteManifest(hub, source.Partition, nodes, manifest, changedNodePaths,
+                            .SelectMany(_ => WriteManifest(hub, source.Partition, nodes.Append(root).ToArray(), manifest, changedNodePaths,
                             heldPaths, hub.JsonSerializerOptions, logger)).Select(_ =>
                         {
                             // 🚨 Terminal status reflects per-file outcomes: ANY failed upsert →

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -2968,7 +2968,11 @@ public static class StaticRepoImporter
             var builder = map.ToBuilder();
             foreach (var path in map.Keys)
             {
-                if (evaluatedPaths.Contains(path))
+                // EnsureRoot evaluates the root on every import, independently of the child
+                // Git-diff scope. Keeping its old token would let a historical root skip win
+                // after a scoped root change (B -> A -> B).
+                if (string.Equals(path, partition, StringComparison.OrdinalIgnoreCase)
+                    || evaluatedPaths.Contains(path))
                     continue;
                 // Not evaluated: report what we actually know, which is whatever the last run that
                 // DID look at this node recorded — nothing, if none ever did.

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -1207,8 +1207,9 @@ public static class StaticRepoImporter
                     // replaced its nodes. Include the root so a root-only rollback is covered too.
                     // Older manifests omit the root and safely buy one incremental full pass.
                     var sourceTokens = nodes.Append(root)
+                        .Where(n => !string.IsNullOrEmpty(n.Path))
                         .GroupBy(n => n.Path, StringComparer.OrdinalIgnoreCase)
-                        .ToDictionary(g => g.Key,
+                        .ToImmutableDictionary(g => g.Key,
                             g => PartitionSourceFingerprint.ComputeNodeToken(g.First(), hub.JsonSerializerOptions),
                             StringComparer.OrdinalIgnoreCase);
                     if (currentManifest.Count != sourceTokens.Count

--- a/test/MeshWeaver.Hosting.Test/ReturningSourceConvergesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ReturningSourceConvergesTest.cs
@@ -70,6 +70,25 @@ public class ReturningSourceConvergesTest(ITestOutputHelper output) : MonolithMe
         await AssertUnchangedRepeat(space);
     }
 
+    [Fact(Timeout = 240_000)]
+    public async Task ScopedRootChange_CannotLeaveThePreviousRootsMarkerCurrent()
+    {
+        repoClient.RootOnly = true;
+        var space = await Prepare();
+        await Import(space, RevisionB);
+        repoClient.ScopedRootChanges = true;
+
+        await Import(space, RevisionA);
+        (await RootName(space)).Should().Be("Root revision A",
+            "the scoped import really refreshed the root before the return to B");
+
+        var restored = await Import(space, RevisionB);
+        (await RootName(space)).Should().Be("Root revision B",
+            "the A import evaluated its root even though Git's index.json path is outside the child scope");
+        restored.Outcome.Should().Be("Imported");
+        await AssertUnchangedRepeat(space);
+    }
+
     [Theory(Timeout = 240_000)]
     [InlineData(false, false)]
     [InlineData(true, false)]
@@ -209,6 +228,7 @@ public class ReturningSourceConvergesTest(ITestOutputHelper output) : MonolithMe
     private sealed class ScriptedRepoClient : IGitHubRepoClient
     {
         public bool RootOnly { get; set; }
+        public bool ScopedRootChanges { get; set; }
         public IObservable<RepoSnapshot> Fetch(
             string repositoryUrl, string commitish, string? subdirectory, string accessToken)
         {
@@ -230,7 +250,9 @@ public class ReturningSourceConvergesTest(ITestOutputHelper output) : MonolithMe
 
         public IObservable<IReadOnlyList<string>?> GetChangedPaths(
             string repositoryUrl, string baseSha, string headSha, string? subdirectory, string accessToken)
-            => Observable.Return<IReadOnlyList<string>?>(baseSha == headSha ? Array.Empty<string>() : null);
+            => Observable.Return<IReadOnlyList<string>?>(baseSha == headSha
+                ? Array.Empty<string>()
+                : ScopedRootChanges ? new[] { "index.json" } : null);
 
         public IObservable<GitHubPushResult> Push(GitHubPushRequest request) => NotUsed<GitHubPushResult>();
 

--- a/test/MeshWeaver.Hosting.Test/ReturningSourceConvergesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ReturningSourceConvergesTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -161,6 +162,77 @@ public class ReturningSourceConvergesTest(ITestOutputHelper output) : MonolithMe
         await AssertUnchangedRepeat(space);
     }
 
+    [Fact(Timeout = 240_000)]
+    public async Task VersionOnlySourceRevision_DoesNotRewriteIdenticalContentOrTheOwnerClock()
+    {
+        var partition = "VersionReturn" + Guid.NewGuid().ToString("N")[..8];
+        var firstSource = new StaticSource(partition, Versioned: true,
+            ImmutableList.Create(new MeshNode("Page", partition)
+            {
+                NodeType = "Markdown", Name = "Unchanged source", Version = 42,
+                Content = new MarkdownContent { Content = "Identical authored content" },
+            }));
+        var first = await StaticRepoImporter.ImportSource(Mesh, firstSource)
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        first.Outcome.Should().Be("Imported");
+        var path = $"{partition}/Page";
+        var before = await Mesh.GetWorkspace().GetMeshNodeStream(path).Where(n => n is not null)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var nextSource = firstSource with
+        {
+            Nodes = firstSource.Nodes.SetItem(0, firstSource.Nodes[0] with { Version = 43 }),
+        };
+        var next = await StaticRepoImporter.ImportSource(Mesh, nextSource)
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        next.Fingerprint.Should().NotBe(first.Fingerprint,
+            "Versioned sources use their revision in the import fingerprint");
+        next.Outcome.Should().Be("Imported");
+        next.WrittenPaths.Should().BeEmpty(
+            "source revision alone is not an authored content change or an owner-clock assignment");
+
+        foreach (var source in ImmutableList.Create(firstSource, nextSource))
+        {
+            var repeat = await StaticRepoImporter.ImportSource(Mesh, source)
+                .Should().Within(TestTimeouts.Convergence * 2).Emit();
+            repeat.Outcome.Should().Be("Skipped");
+            var after = await Mesh.GetWorkspace().GetMeshNodeStream(path).Where(n => n is not null)
+                .Should().Within(TestTimeouts.Convergence).Emit();
+            after.Version.Should().Be(before.Version,
+                "the owner clocks writes; imported source revisions must not create a write of identical content");
+            after.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)!.Content
+                .Should().Be("Identical authored content");
+        }
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task EmptyPathIgnoredByTheFingerprint_DoesNotInvalidateTheCurrentManifest()
+    {
+        var partition = "EmptyPathReturn" + Guid.NewGuid().ToString("N")[..8];
+        var source = new StaticSource(partition, Versioned: false,
+            ImmutableList.Create(new MeshNode("Page", partition)
+            {
+                NodeType = "Markdown", Name = "Valid source",
+                Content = new MarkdownContent { Content = "Preserved source" },
+            }));
+        var first = await StaticRepoImporter.ImportSource(Mesh, source)
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        first.Outcome.Should().Be("Imported");
+
+        var repeat = await StaticRepoImporter.ImportSource(Mesh,
+                source with { Nodes = source.Nodes.Add(new MeshNode(string.Empty)) })
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        repeat.Fingerprint.Should().Be(first.Fingerprint,
+            "the fingerprint and manifest writer both omit empty source paths");
+        repeat.Outcome.Should().Be("Skipped");
+        (await Body($"{partition}/Page")).Should().Be("Preserved source");
+    }
+
+    private sealed record StaticSource(string Partition, bool Versioned, ImmutableList<MeshNode> Nodes)
+        : IStaticRepoSource
+    {
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+    }
+
     private async Task<string> Prepare(bool twoWay = false)
     {
         var space = "Return" + Guid.NewGuid().ToString("N")[..8];
@@ -238,13 +310,11 @@ public class ReturningSourceConvergesTest(ITestOutputHelper output) : MonolithMe
                     new RepoFile("index.json", $$"""{"nodeType":"Space","name":"Root revision {{(commitish == RevisionB ? "B" : "A")}}"}"""),
                     new RepoFile("Existing.md", "# Existing\n\nUnchanged source"),
                 }));
-            var files = new List<RepoFile>
-            {
-                new("Existing.md", $"# Existing\n\nrevision {(commitish == RevisionB ? "B" : "A")}"),
-                new("Authored.md", "# Authored\n\nRepository copy"),
-            };
+            var files = ImmutableList.Create(
+                new RepoFile("Existing.md", $"# Existing\n\nrevision {(commitish == RevisionB ? "B" : "A")}"),
+                new RepoFile("Authored.md", "# Authored\n\nRepository copy"));
             if (commitish == RevisionB)
-                files.Add(new RepoFile("Added.md", "# Added\n\nOnly in B"));
+                files = files.Add(new RepoFile("Added.md", "# Added\n\nOnly in B"));
             return Observable.Return(new RepoSnapshot(commitish, files));
         }
 

--- a/test/MeshWeaver.Hosting.Test/ReturningSourceConvergesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ReturningSourceConvergesTest.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// A historical success marker cannot describe the current partition after another source was
+/// imported. Exercises the real GitSync service and importer; only GitHub's transport is scripted.
+/// </summary>
+public class ReturningSourceConvergesTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RepoUrl = "https://github.com/test/returning-source";
+    private const string RevisionA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string RevisionB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private readonly ScriptedRepoClient repoClient = new();
+    private static string UserId => TestUsers.Admin.ObjectId!;
+    private GitHubSyncService Sync => Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGitHubSyncTypes().ConfigureServices(services =>
+        {
+            services.AddGitHubSyncServices();
+            services.AddSingleton<IGitHubRepoClient>(repoClient);
+            return services;
+        });
+
+    [Theory(Timeout = 240_000)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReturningToAnEarlierImportedSource_RestoresChangedAndPrunedNodes_ThenSkips(bool rootOnly)
+    {
+        repoClient.RootOnly = rootOnly;
+        var space = await Prepare();
+        await Import(space, RevisionB);
+        var rollback = await Import(space, RevisionA);
+        if (rootOnly)
+            (await RootName(space)).Should().Be("Root revision A");
+        else
+        {
+            rollback.PrunedPaths.Should().Contain($"{space}/Added");
+            (await Body($"{space}/Existing")).Should().Contain("revision A");
+        }
+
+        var restored = await Import(space, RevisionB);
+        restored.Outcome.Should().Be("Imported",
+            "the historical B marker survived the A import, but the current manifest describes A");
+        if (rootOnly)
+            (await RootName(space)).Should().Be("Root revision B");
+        else
+        {
+            restored.WrittenPaths.Should().Contain($"{space}/Existing");
+            restored.WrittenPaths.Should().Contain($"{space}/Added");
+            await AssertRevisionB(space);
+        }
+        await AssertUnchangedRepeat(space);
+    }
+
+    [Theory(Timeout = 240_000)]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ImportAtTheRecordedCommit_EvaluatesStaleNodesOutsideAnEmptyGitDiff(
+        bool reconcile, bool protectHumanEdit)
+    {
+        var space = await Prepare(twoWay: protectHumanEdit);
+        await Import(space, RevisionB);
+        await Import(space, RevisionA);
+        var configPath = GitHubSyncService.ConfigPath(space);
+        // This is the persisted production shape after a false skip: Git says B was seen,
+        // while the authoritative import manifest and actual source nodes still describe A.
+        await Mesh.GetWorkspace().GetMeshNodeStream(configPath).Update(node => node with
+        {
+            Content = node.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions)! with
+            {
+                LastSyncCommitSha = RevisionB,
+                LastSyncOutcome = "Skipped",
+            },
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+        var before = await Config(space);
+
+        if (protectHumanEdit)
+            await Mesh.GetWorkspace().GetMeshNodeStream($"{space}/Authored").Update(node => node with
+            {
+                Content = new MarkdownContent { Content = "A person's uncommitted revision" },
+            }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var result = await (reconcile
+                ? Sync.ReconcileAtCommit(space, RevisionB, UserId)
+                : Sync.ReimportAtCommit(space, RevisionB, UserId))
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        result.WrittenPaths.Should().Contain($"{space}/Existing",
+            "an empty B..B Git diff cannot describe drift in the live partition");
+        result.WrittenPaths.Should().Contain($"{space}/Added");
+        await AssertRevisionB(space);
+        if (protectHumanEdit)
+        {
+            result.Preserved.Should().Be(1);
+            (await Body($"{space}/Authored")).Should().Contain("uncommitted revision");
+            (await Config(space)).LastSyncedAt.Should().Be(before.LastSyncedAt,
+                "reconciliation must keep the two-way conflict horizon while a person's edit remains");
+        }
+        else
+            await AssertUnchangedRepeat(space);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task Reconcile_EvaluatesLiveSourceEvenWhenItsManifestStillMatches()
+    {
+        var space = await Prepare(twoWay: true);
+        await Import(space, RevisionB);
+        // Reproduce a system-written source changing after the ledger was recorded. This is
+        // measured live drift, not a person's edit and not a change between Git commits.
+        IObservable<MeshNode> write;
+        using (Mesh.ServiceProvider.GetRequiredService<AccessService>().ImpersonateAsSystem())
+            write = Mesh.GetWorkspace().GetMeshNodeStream($"{space}/Existing").Update(node => node with
+            {
+                Content = new MarkdownContent { Content = "System-written stale revision A" },
+            });
+        await write.Should().Within(TestTimeouts.Convergence).Emit();
+        (await Body($"{space}/Existing")).Should().Contain("revision A");
+
+        var result = await Sync.ReconcileAtCommit(space, RevisionB, UserId)
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        result.WrittenPaths.Should().Contain($"{space}/Existing",
+            "reconciliation evaluates the measured live mismatch even when the source ledger matches B");
+        await AssertRevisionB(space);
+        await AssertUnchangedRepeat(space);
+    }
+
+    private async Task<string> Prepare(bool twoWay = false)
+    {
+        var space = "Return" + Guid.NewGuid().ToString("N")[..8];
+        await NodeFactory.CreateNode(new MeshNode(space)
+        {
+            NodeType = "Space", Name = "Returning source", State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+        var node = await Sync.SaveConfig(space, RepoUrl, "main", null, false, false,
+                direction: SyncDirection.ImportOnly, twoWay: twoWay)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var owner = node.CreatedBy is { Length: > 0 } creator ? creator : UserId;
+        await Mesh.ServiceProvider.GetRequiredService<GitHubCredentialService>()
+            .Save(owner, new GitHubToken("ghp_test_token", null, "bearer", "repo", null), "octocat")
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        return space;
+    }
+
+    private async Task<StaticRepoImportResult> Import(string space, string revision)
+    {
+        var result = await Sync.ReimportAtCommit(space, revision, UserId)
+            .Should().Within(TestTimeouts.Convergence * 2).Emit();
+        Output.WriteLine($"{revision[0]}: {result.Outcome}; written={string.Join(',', result.WrittenPaths)}; "
+            + $"pruned={string.Join(',', result.PrunedPaths)}; preserved={result.Preserved}");
+        result.Failed.Should().Be(0);
+        return result;
+    }
+
+    private async Task AssertRevisionB(string space)
+    {
+        (await Body($"{space}/Existing")).Should().Contain("revision B");
+        (await Body($"{space}/Added")).Should().Contain("Only in B");
+    }
+
+    private async Task AssertUnchangedRepeat(string space)
+    {
+        var repeated = await Import(space, RevisionB);
+        repeated.Outcome.Should().Be("Skipped");
+        repeated.Count.Should().Be(0);
+        repeated.WrittenPaths.Should().BeEmpty();
+        repeated.PrunedPaths.Should().BeEmpty();
+    }
+
+    private async Task<string> Body(string path)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(path).Where(n => n is not null)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        return node.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)?.Content ?? "";
+    }
+
+    private async Task<string?> RootName(string space)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(space).Where(n => n is not null)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        return node.Name;
+    }
+
+    private async Task<GitHubSyncConfig> Config(string space)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(GitHubSyncService.ConfigPath(space))
+            .Where(n => n is not null).Should().Within(TestTimeouts.Convergence).Emit();
+        return node.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions)!;
+    }
+
+    private sealed class ScriptedRepoClient : IGitHubRepoClient
+    {
+        public bool RootOnly { get; set; }
+        public IObservable<RepoSnapshot> Fetch(
+            string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+        {
+            if (RootOnly)
+                return Observable.Return(new RepoSnapshot(commitish, new[]
+                {
+                    new RepoFile("index.json", $$"""{"nodeType":"Space","name":"Root revision {{(commitish == RevisionB ? "B" : "A")}}"}"""),
+                    new RepoFile("Existing.md", "# Existing\n\nUnchanged source"),
+                }));
+            var files = new List<RepoFile>
+            {
+                new("Existing.md", $"# Existing\n\nrevision {(commitish == RevisionB ? "B" : "A")}"),
+                new("Authored.md", "# Authored\n\nRepository copy"),
+            };
+            if (commitish == RevisionB)
+                files.Add(new RepoFile("Added.md", "# Added\n\nOnly in B"));
+            return Observable.Return(new RepoSnapshot(commitish, files));
+        }
+
+        public IObservable<IReadOnlyList<string>?> GetChangedPaths(
+            string repositoryUrl, string baseSha, string headSha, string? subdirectory, string accessToken)
+            => Observable.Return<IReadOnlyList<string>?>(baseSha == headSha ? Array.Empty<string>() : null);
+
+        public IObservable<GitHubPushResult> Push(GitHubPushRequest request) => NotUsed<GitHubPushResult>();
+
+        public IObservable<GitHubBranchResult> CreateBranch(GitHubCreateBranchRequest request)
+            => NotUsed<GitHubBranchResult>();
+
+        public IObservable<GitHubPullRequestInfo> OpenPullRequest(GitHubOpenPullRequestRequest request)
+            => NotUsed<GitHubPullRequestInfo>();
+
+        public IObservable<GitHubPullRequestInfo> GetPullRequestStatus(
+            string repositoryUrl, int number, string accessToken) => NotUsed<GitHubPullRequestInfo>();
+
+        public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+            string repositoryUrl, GitHubIssueState? state, string accessToken)
+            => NotUsed<IReadOnlyList<GitHubIssue>>();
+
+        public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken)
+            => NotUsed<GitHubIssue>();
+
+        public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request) => NotUsed<GitHubIssue>();
+
+        public IObservable<GitHubIssueComment> CommentIssue(
+            string repositoryUrl, int number, string body, string accessToken)
+            => NotUsed<GitHubIssueComment>();
+
+        public IObservable<GitHubIssue> SetIssueState(
+            string repositoryUrl, int number, GitHubIssueState state, string accessToken)
+            => NotUsed<GitHubIssue>();
+
+        public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+            string repositoryUrl, PullRequestStatus? state, string accessToken)
+            => NotUsed<IReadOnlyList<GitHubPullRequestSummary>>();
+
+        public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+            string repositoryUrl, int number, string accessToken) => NotUsed<GitHubPullRequestDetail>();
+
+        public IObservable<GitHubIssueComment> CommentPullRequest(
+            string repositoryUrl, int number, string body, string accessToken)
+            => NotUsed<GitHubIssueComment>();
+
+        public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request)
+            => NotUsed<GitHubMergeResult>();
+
+        private static IObservable<T> NotUsed<T>() => Observable.Throw<T>(
+            new NotSupportedException(
+                "ReturningSourceConvergesTest's repo client answers only Fetch."));
+    }
+}


### PR DESCRIPTION
After source B is replaced by A, returning to B could trust B’s old success marker and leave A’s content live. The importer now compares the requested source, including its root, against the current import manifest before skipping. Explicit reconciliation evaluates live drift even when the recorded Git SHA makes the Git diff empty; scoped imports record the root they actually evaluated.

Existing claims, local-edit conflict protection and governance pruning guards remain in place. Content tokens deliberately exclude the mesh owner’s version clock. An executed version-only 42 → 43 → 42 → 43 control confirms distinct import fingerprints, zero writes for identical content, successful historical skips and an unchanged owner clock. The manifest comparison also ignores empty paths, matching the fingerprint and manifest writer; this review regression failed on the previous head and now passes.

Validation: strict Release builds of Hosting.Test, Graph.Test and Documentation.Test report zero warnings and errors. All 9 returning-source cases, 25 existing conflict/scope/sync controls and 12 documentation integrity cases passed. Historical six-case and later scoped-root red/green receipts, plus the distinct review controls, are preserved in Doc/Architecture/StaticRepoImport. CI run 34548770649 passed on the review-corrected head 2b875623 (19/19 jobs). Its shard-5 TRX confirms all 9 ReturningSourceConvergesTest cases executed and passed; Hosting.Test totals 601/601 passed with zero not executed. Production acceptance remains outstanding.

Based on core main 45306a33 after #3968. This draft does not include the separate workflow admission change in core #3981. The preceding #3985 delivery was reported sealed; the current coordinated merge and release hold remains in force while the release owner settles the active generation.

Mirror-sync: none — no UI catalog keys or localized values change.
