### PR TITLE
fix(layout): drain accepted user actions before teardown

### DIFF
--- a/src/MeshWeaver.Data.Contract/Messages.cs
+++ b/src/MeshWeaver.Data.Contract/Messages.cs
@@ -154,11 +154,13 @@ public abstract record StreamMessage(string StreamId) : IDiagnosticKeyed
 /// +175 ms, the event dropped 5 s after that, <c>InstallPackage</c> never invoked, and the only
 /// record a Warning on the server that reads like routine stream churn.</para>
 ///
-/// <para>Implementing this interface changes nothing about how a message is routed or handled. It
-/// marks the message as one whose loss is REFUSED VISIBLY rather than logged as churn — see
-/// <c>DataExtensions.RefuseStreamMessage</c>.</para>
+/// <para>The action is also an <see cref="IRequest{TResponse}"/> for a
+/// <see cref="UserActionAccepted"/> receipt. A UI sender observes that receipt so its existing hub
+/// quiesce cannot release the synchronization stream until the owner-side action handler has
+/// accepted the action. Fire-and-forget senders remain wire-compatible; an unmatched receipt is
+/// simply processed by the sender hub's ordinary response path.</para>
 /// </summary>
-public interface IUserAction
+public interface IUserAction : IRequest<UserActionAccepted>
 {
     /// <summary>
     /// What the person acted ON — the layout-area key for a click, a blur or a dialog. Named in the
@@ -166,6 +168,13 @@ public interface IUserAction
     /// </summary>
     string ActionArea { get; }
 }
+
+/// <summary>
+/// Receipt posted by the owner-side synchronization hub after a user action has reached its
+/// stream-scoped handler. Observing this response makes an accepted click, blur, or dialog close
+/// part of the sender hub's quiesce drain instead of allowing stream teardown to overtake it.
+/// </summary>
+public sealed record UserActionAccepted;
 
 /// <summary>
 /// Base type for stream messages that carry a versioned JSON change.

--- a/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
@@ -88,7 +88,7 @@ is looking at a page that silently did nothing.
 ## The one line that separates the two classes
 
 ```csharp
-public interface IUserAction
+public interface IUserAction : IRequest<UserActionAccepted>
 {
     string ActionArea { get; }
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
@@ -1,7 +1,7 @@
 ---
 Name: Refusing a Lost User Action
 Category: Architecture
-Description: A click whose stream is gone used to be dropped with a warning that reads like routine data-sync churn, while the action it would have run was perfectly capable of outliving the circuit. Why "deliver it anyway" is not implementable as stated, what a visible refusal is instead, and the one line that separates a person's action from a data frame.
+Description: A user action is refused visibly when its stream is already gone, and an accepted action now holds the sender's ordinary quiesce drain until its owner-side handler acknowledges it.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11.5 4.5 7 6 5.5 9 8.5 15 2.5l1.5 1.5z"/><path d="M3 13a9 9 0 1 0 9-9"/><line x1="12" y1="12" x2="12" y2="12.01"/></svg>
 ---
 
@@ -131,12 +131,26 @@ rises.
 which on Blazor Server is the container's and identical for every simultaneous viewer. See
 [Localization](/Doc/Architecture/Localization).
 
-## What this deliberately does not fix
+## The ordering fix that followed
 
-- **The ordering that loses the click in the first place.** The per-circuit portal hub released its
-  stream while an inbound user action it had already accepted was still in flight to the owner. Its
-  disposal lives in the Blazor portal (MeshWeaver.Plugins), not here, so draining accepted user
-  actions before releasing subscriptions is a cross-repo change with its own design.
+The visible refusal closed the silent-failure half, but it did not stop an accepted action losing a
+race with circuit teardown. That second half is issue #3986 and is now an acknowledgement protocol:
+
+1. `IUserAction` is an `IRequest<UserActionAccepted>`.
+2. The Blazor sync hub uses `Observe` to register the response callback **before** it posts the
+   click, blur, or dialog dismissal.
+3. The owner-side `LayoutAreaHost` posts `UserActionAccepted` only after its stream-scoped handler
+   has accepted the action.
+4. A circuit close reaches the sync hub's existing **Quiescing** phase and sees that callback as
+   pending. It therefore keeps the stream subscription alive until the receipt lands, then disposes
+   normally.
+
+There is no retry, grace extension, timer, or second disposal gate. The receipt makes the accepted
+action part of the lifecycle mechanism the hub already drains. An action whose stream was genuinely
+gone before it arrived is still refused by the path documented above.
+
+## What this deliberately does not do
+
 - **Any retry, resubscribe or widened grace.** The issue rules all three out and so does this: an
   event that is genuinely undeliverable is not made deliverable by polling for a stream that is gone,
   and moving the 5-second grace only moves the cliff.
@@ -149,4 +163,6 @@ which on Blazor Server is the container's and identical for every simultaneous v
   NACKed during teardown, which is the rule this change makes one exception to and states.
 - [Stream Liveness and the Hub Reference](../StreamLivenessAndTheHubReference) — how a stream and its
   sub-hub come apart, which is the state this page starts from.
+- [Hub Disposal Model](../HubDisposalModel) — the Quiescing callback drain that now retains accepted
+  user actions until their owner-side receipt lands.
 - [Localization](../Localization) — the catalog and the explicit-locale rule.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-click-finishes-crossing-before-its-page-closes.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-click-finishes-crossing-before-its-page-closes.md
@@ -1,0 +1,19 @@
+---
+Name: A click finishes crossing before its page closes
+Category: Fix
+Description: Clicks, field exits, and dialog choices now keep their live page connection until the owner has accepted them, so navigating immediately cannot discard an action the portal already took.
+Icon: Sparkle
+Order: -20260911
+---
+
+# A click finishes crossing before its page closes
+
+A quick click followed by immediate navigation could close the page's live connection while the
+click was still travelling to the part of the portal that owned its action. The interface accepted
+the click, but the owner no longer had the page-scoped handler when it arrived, so the requested
+work did not run.
+
+User actions now carry an owner-side acceptance receipt. Page teardown already waits for unfinished
+receipts, so it keeps the action's connection alive just long enough for the owner to accept the
+click, field exit, or dialog choice. Once accepted, teardown continues normally; genuinely stale
+actions are still refused rather than retried against an obsolete page.

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -611,9 +611,17 @@ public record LayoutAreaHost : IDisposable
     private IMessageDelivery OnCloseDialog(IMessageDelivery<CloseDialogEvent> request)
     {
         if (GetControl(request.Message.Area) is DialogControl { CloseAction: not null } control)
-            InvokeAsync(() => control.CloseAction.Invoke(
-                new(request.Message.Area, request.Message.State, request.Message.Payload ?? new object(), Hub, this)
-            ), ex => FailRequest(ex, request));
+        {
+            InvokeAsync(() =>
+            {
+                control.CloseAction.Invoke(
+                    new(request.Message.Area, request.Message.State,
+                        request.Message.Payload ?? new object(), Hub, this));
+                AcceptUserAction(request);
+            }, ex => FailRequest(ex, request));
+            return request.Processed();
+        }
+
         return AcceptUserAction(request);
     }
 

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -603,8 +603,9 @@ public record LayoutAreaHost : IDisposable
             catch (Exception ex)
             {
                 FailRequest(ex, request);
+                return request.Processed();
             }
-        return request.Processed();
+        return AcceptUserAction(request);
     }
 
     private IMessageDelivery OnCloseDialog(IMessageDelivery<CloseDialogEvent> request)
@@ -613,7 +614,7 @@ public record LayoutAreaHost : IDisposable
             InvokeAsync(() => control.CloseAction.Invoke(
                 new(request.Message.Area, request.Message.State, request.Message.Payload ?? new object(), Hub, this)
             ), ex => FailRequest(ex, request));
-        return request.Processed();
+        return AcceptUserAction(request);
     }
 
     private IMessageDelivery OnBlur(IMessageDelivery<BlurEvent> request)
@@ -628,7 +629,22 @@ public record LayoutAreaHost : IDisposable
             catch (Exception ex)
             {
                 FailRequest(ex, request);
+                return request.Processed();
             }
+        return AcceptUserAction(request);
+    }
+
+    /// <summary>
+    /// Completes the sender-side receipt only after this stream-scoped handler has accepted the
+    /// action. <c>Observe</c> registers that receipt before posting, so an immediate circuit dispose
+    /// sees the callback as pending and the existing Quiescing phase drains it before releasing the
+    /// synchronization stream. This is ordering, not retry: a genuinely gone stream is still
+    /// refused by <c>DataExtensions.RefuseUserAction</c>.
+    /// </summary>
+    private IMessageDelivery AcceptUserAction<TAction>(IMessageDelivery<TAction> request)
+        where TAction : IUserAction
+    {
+        Hub.Post(new UserActionAccepted(), options => options.ResponseFor(request));
         return request.Processed();
     }
 

--- a/src/MeshWeaver.Layout/LayoutExtensions.cs
+++ b/src/MeshWeaver.Layout/LayoutExtensions.cs
@@ -192,6 +192,7 @@ public static class LayoutExtensions
                 typeof(LayoutAreasReference),
                 typeof(GetLayoutAreasRequest),
                 typeof(LayoutAreasResponse),
+                typeof(UserActionAccepted),
                 typeof(DataGridCellClick),
                 // Non-IUiControl content/config records serialised INSIDE control state (so the reflection
                 // sweep above misses them) — they came back untyped on sync hubs and churned the layout:

--- a/test/MeshWeaver.Layout.Test/DroppedUserActionIsRefusedTest.cs
+++ b/test/MeshWeaver.Layout.Test/DroppedUserActionIsRefusedTest.cs
@@ -124,6 +124,7 @@ public class DroppedUserActionIsRefusedTest : HubTestBase
         new ClickedEvent("a", "s").Should().BeAssignableTo<IUserAction>();
         new BlurEvent("a", "s").Should().BeAssignableTo<IUserAction>();
         new CloseDialogEvent("a", "s", DialogCloseState.OK).Should().BeAssignableTo<IUserAction>();
+        new ClickedEvent("a", "s").Should().BeAssignableTo<IRequest<UserActionAccepted>>();
         ((IUserAction)new ClickedEvent("some/area", "s")).ActionArea.Should().Be("some/area");
         return Task.CompletedTask;
     }

--- a/test/MeshWeaver.Layout.Test/UserActionAcceptedTest.cs
+++ b/test/MeshWeaver.Layout.Test/UserActionAcceptedTest.cs
@@ -1,0 +1,71 @@
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Pins the owner-side half of issue #3986. A user action is an observed request: the owner-side
+/// <c>sync/{id}</c> handler invokes the action and only then answers
+/// <see cref="UserActionAccepted"/>. The Blazor sender can therefore let the ordinary hub quiesce
+/// drain this receipt instead of releasing the stream while the click is still in flight.
+/// </summary>
+public class UserActionAcceptedTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string Area = "ActionReceipt";
+    private const string ButtonArea = Area + "/Button";
+    private readonly AsyncSubject<string> invoked = new();
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddLayout(layout => layout.WithView(
+                Area,
+                Controls.Stack.WithView(
+                    Controls.Button("Run").WithClickAction(_ =>
+                    {
+                        invoked.OnNext(ButtonArea);
+                        invoked.OnCompleted();
+                    }),
+                    "Button")));
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    [HubFact]
+    public async Task ClickReceipt_IsPostedOnlyAfterTheStreamScopedActionWasInvoked()
+    {
+        var client = GetClient();
+        var reference = new LayoutAreaReference(Area);
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), reference);
+
+        await stream.GetControlStream(ButtonArea).Should().Within(10.Seconds()).Match(
+            control => control is ButtonControl,
+            "the owner-side LayoutAreaHost and its stream-scoped ClickedEvent handler must exist");
+
+        var receipt = await client
+            .Observe<UserActionAccepted>(
+                new ClickedEvent(ButtonArea, stream.StreamId),
+                options => options.WithTarget(CreateHostAddress()))
+            .Should().Within(10.Seconds()).Emit(
+                "an accepted click must answer the callback the sender uses as its teardown drain");
+
+        receipt.Message.Should().BeOfType<UserActionAccepted>();
+        await invoked.Should().Within(10.Seconds()).Emit(
+            "the receipt cannot precede invocation of the stream-scoped action it acknowledges");
+    }
+
+    [Fact]
+    public void EveryUserActionCarriesTheSameReceiptContract()
+    {
+        new ClickedEvent("a", "s").Should().BeAssignableTo<IRequest<UserActionAccepted>>();
+        new BlurEvent("a", "s").Should().BeAssignableTo<IRequest<UserActionAccepted>>();
+        new CloseDialogEvent("a", "s", DialogCloseState.OK)
+            .Should().BeAssignableTo<IRequest<UserActionAccepted>>();
+    }
+}

--- a/test/MeshWeaver.Layout.Test/UserActionAcceptedTest.cs
+++ b/test/MeshWeaver.Layout.Test/UserActionAcceptedTest.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
 using MeshWeaver.Data;
@@ -17,7 +18,12 @@ public class UserActionAcceptedTest(ITestOutputHelper output) : HubTestBase(outp
 {
     private const string Area = "ActionReceipt";
     private const string ButtonArea = Area + "/Button";
-    private readonly AsyncSubject<string> invoked = new();
+    private const string BlurArea = Area + "/Blur";
+    private const string DialogArea = Area + "/Dialog";
+    private readonly AsyncSubject<long> clickInvoked = new();
+    private readonly AsyncSubject<long> blurInvoked = new();
+    private readonly AsyncSubject<long> closeInvoked = new();
+    private long ordering;
 
     /// <inheritdoc />
     protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
@@ -27,10 +33,15 @@ public class UserActionAcceptedTest(ITestOutputHelper output) : HubTestBase(outp
                 Controls.Stack.WithView(
                     Controls.Button("Run").WithClickAction(_ =>
                     {
-                        invoked.OnNext(ButtonArea);
-                        invoked.OnCompleted();
+                        Signal(clickInvoked);
                     }),
-                    "Button")));
+                    "Button")
+                    .WithView(
+                        Controls.Text("draft").WithBlurAction(_ => Signal(blurInvoked)),
+                        "Blur")
+                    .WithView(
+                        Controls.Dialog("Body").WithCloseAction(_ => Signal(closeInvoked)),
+                        "Dialog")));
 
     /// <inheritdoc />
     protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
@@ -38,26 +49,60 @@ public class UserActionAcceptedTest(ITestOutputHelper output) : HubTestBase(outp
 
     [HubFact]
     public async Task ClickReceipt_IsPostedOnlyAfterTheStreamScopedActionWasInvoked()
+        => await ReceiptFollowsInvocation(
+            ButtonArea,
+            streamId => new ClickedEvent(ButtonArea, streamId),
+            clickInvoked);
+
+    [HubFact]
+    public async Task BlurReceipt_IsPostedOnlyAfterTheStreamScopedActionWasInvoked()
+        => await ReceiptFollowsInvocation(
+            BlurArea,
+            streamId => new BlurEvent(BlurArea, streamId),
+            blurInvoked);
+
+    [HubFact]
+    public async Task DialogCloseReceipt_IsPostedOnlyAfterTheQueuedCloseActionWasInvoked()
+        => await ReceiptFollowsInvocation(
+            DialogArea,
+            streamId => new CloseDialogEvent(DialogArea, streamId, DialogCloseState.OK),
+            closeInvoked);
+
+    private async Task ReceiptFollowsInvocation(
+        string controlArea,
+        Func<string, IUserAction> action,
+        AsyncSubject<long> invoked)
     {
         var client = GetClient();
         var reference = new LayoutAreaReference(Area);
         var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
             CreateHostAddress(), reference);
 
-        await stream.GetControlStream(ButtonArea).Should().Within(10.Seconds()).Match(
-            control => control is ButtonControl,
-            "the owner-side LayoutAreaHost and its stream-scoped ClickedEvent handler must exist");
+        await stream.GetControlStream(controlArea).Should().Within(10.Seconds()).Match(
+            control => control is not null,
+            "the owner-side LayoutAreaHost and its stream-scoped action handler must exist");
 
+        long receiptOrder = 0;
         var receipt = await client
             .Observe<UserActionAccepted>(
-                new ClickedEvent(ButtonArea, stream.StreamId),
+                action(stream.StreamId),
                 options => options.WithTarget(CreateHostAddress()))
+            .Do(_ => receiptOrder = Interlocked.Increment(ref ordering))
             .Should().Within(10.Seconds()).Emit(
-                "an accepted click must answer the callback the sender uses as its teardown drain");
+                "an accepted user action must answer the callback the sender uses as its teardown drain");
 
         receipt.Message.Should().BeOfType<UserActionAccepted>();
-        await invoked.Should().Within(10.Seconds()).Emit(
+        var invocationOrder = await invoked.Should().Within(10.Seconds()).Emit(
             "the receipt cannot precede invocation of the stream-scoped action it acknowledges");
+        receiptOrder.Should().BeGreaterThan(invocationOrder,
+            "the owner must not release the sender's quiesce drain before its handler accepts the action");
+    }
+
+    private Task Signal(AsyncSubject<long> invoked)
+    {
+        invoked.OnNext(Interlocked.Increment(ref ordering));
+        invoked.OnCompleted();
+        return Task.CompletedTask;
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #3986

## What changed

- make every `IUserAction` an observed `IRequest<UserActionAccepted>`
- acknowledge clicks, blurs, and dialog closes only after the owner-side stream handler accepts them
- let the sender hub's existing quiesce callback drain retain `sync/{id}` through immediate circuit teardown
- add a real-hub regression test and document the lifecycle ordering

## Why

The visible refusal from #3566 made a late action diagnosable, but did not order an already-accepted action ahead of releasing its owner stream. Registering the response callback before the post closes that race without a retry, timer, grace period, or second disposal gate.

## Verification

- `MeshWeaver.Data.Contract`, `MeshWeaver.Layout`, and `MeshWeaver.Documentation`: Release warnings-as-errors builds
- `MeshWeaver.Layout.Test`: 478/478 passed
- focused owner-side receipt tests: 5/5 passed

Implementers: IUserAction : IRequest<UserActionAccepted> — `IRequest<T>` is a marker interface with no members, so the three existing action records and outside implementers acquire no implementation obligation; the staged MeshWeaver.Plugins sender half compiles against this core commit and its full Blazor Views suite passes 198/198.

The dependent MeshWeaver.Plugins half is staged locally and will be opened after this core API is merged and sealed, so that repository's CI can compile against an available platform set.
