### PR TITLE
Keep newer module heads over late publishes

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -659,7 +659,14 @@ public static class PluginBundleEndpoints
                         statusCode: StatusCodes.Status409Conflict);
                 }
 
-                if (outcome.Held)
+                if (!outcome.SelectedAsHead)
+                    logger?.LogInformation(
+                        "Module publish: SHELVED '{Module}' for {Plugin} ({Files} file(s), version "
+                        + "{Version}) as older warehouse stock; activation stays on newer head "
+                        + "{HeadVersion}, so no restart or module-set change is required",
+                        accepted.Module, plugin, accepted.Files.Count,
+                        accepted.Version ?? "(unversioned)", outcome.HeadVersion ?? "(unversioned)");
+                else if (outcome.Held)
                     logger?.LogInformation(
                         "Module publish: SHELVED '{Module}' for {Plugin} ({Files} file(s), version "
                         + "{Version}) — HELD from local activation ({Reason}); it serves from this "
@@ -711,8 +718,10 @@ public static class PluginBundleEndpoints
                 BroadcastPublished(http, plugin, accepted, logger);
 
                 // held/holdReason let the publisher tell "shelved, will serve" apart from
-                // "activated here"; pendingRestart is honest for the held case — a restart of
-                // THIS instance would not load a held module, so nothing is pending on one.
+                // "activated here". selectedAsHead/headVersion make the #3996 third outcome
+                // explicit: an older upload is valid warehouse stock but does not move activation
+                // backwards. pendingRestart is honest for BOTH non-activation cases — a restart
+                // neither loads a held module nor changes anything for an older shelf-only one.
                 return Results.Json(new
                 {
                     plugin,
@@ -721,7 +730,9 @@ public static class PluginBundleEndpoints
                     files = accepted.Files.Count,
                     held = outcome.Held,
                     holdReason = outcome.HoldReason,
-                    pendingRestart = !outcome.Held,
+                    selectedAsHead = outcome.SelectedAsHead,
+                    headVersion = outcome.HeadVersion,
+                    pendingRestart = outcome.SelectedAsHead && !outcome.Held,
                 });
             })
             .AllowAnonymous();
@@ -965,7 +976,7 @@ public static class PluginBundleEndpoints
                         // instance can actually serve its bytes, so a consumer never downloads for
                         // a module section that will not be there. Additive: an older client's
                         // BundleRef simply ignores it.
-                        module = modules.TryGetValue(p.PluginId, out var servable)
+                        module = modules.TryGetValue(BundleVersionKey(p.PluginId, p.Version), out var servable)
                             ? servable.Name : null,
                         // The module's declared platform FLOOR — the consumer's gate (a semver
                         // floor, never MVID equality; the index-level frameworkMvid above stays
@@ -1043,8 +1054,10 @@ public static class PluginBundleEndpoints
                 .SelectMany(snapshot => WithAnchoredPackages(rootHub, local, snapshot)
                     .Select(entries => (Entries: entries, Anchor: snapshot))));
 
-    /// <summary>Contributor (2): the modules published onto this instance that no install record
-    /// already covers.</summary>
+    /// <summary>Contributor (2): the modules published onto this instance. Both the activation
+    /// head and its retained fallback are advertised when they carry distinct versions; the
+    /// versioned download route resolves the matching generation. An install record still wins an
+    /// identical package/version entry.</summary>
     private static IObservable<IReadOnlyList<BundleEntry>> WithPublishedModules(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> records)
     {
@@ -1053,23 +1066,62 @@ public static class PluginBundleEndpoints
             return Observable.Return(records);
         return landing.GetActivation().Take(1).Select(activation =>
         {
-            var recorded = records.Select(r => r.PluginId)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             var published = activation.Entries
                 .Where(e => e.Enabled
                     && !string.IsNullOrWhiteSpace(e.Version)
-                    && e.PackagePath?.Split('/') is { Length: 2 } segments
-                    && !recorded.Contains(segments[1]))
-                .Select(e =>
+                    && e.PackagePath?.Split('/') is { Length: 2 })
+                .SelectMany(e => PublishedVersions(e));
+
+            // Head before fallback, and newer before older for every package. PluginBundleClient
+            // selects the first entry of a package for the ordinary update path; listing an older
+            // retained generation first would reintroduce #3996 at the index boundary. A local
+            // install record wins an identical package/version because `OrderBy` is stable and the
+            // records enter the sequence first. When an identical install record exists, keep its
+            // entitlement/package metadata but join it to the published generation pointer.
+            var ordered = records.Concat(published)
+                .OrderBy(p => p.PluginId, StringComparer.OrdinalIgnoreCase)
+                .ThenByDescending(p => p.Version, NuGetVersionComparer.Instance);
+            var unique = new List<BundleEntry>();
+            foreach (var candidate in ordered)
+            {
+                var match = unique.FindIndex(current =>
+                    string.Equals(current.PluginId, candidate.PluginId,
+                        StringComparison.OrdinalIgnoreCase)
+                    && NuGetVersionComparer.Instance.Compare(
+                        current.Version, candidate.Version) == 0);
+                if (match < 0)
+                    unique.Add(candidate);
+                else if (candidate.ShelfVersion is not null
+                         && unique[match].ShelfVersion is null)
+                    unique[match] = unique[match] with
+                    {
+                        Module = candidate.Module ?? unique[match].Module,
+                        ShelfVersion = candidate.ShelfVersion,
+                    };
+            }
+            return (IReadOnlyList<BundleEntry>)unique;
+
+            static IEnumerable<BundleEntry> PublishedVersions(ModuleActivationEntry head)
+            {
+                yield return ToBundle(head, head.MinMeshVersion);
+                var previous = ModuleActivationBoot.PreviousGeneration(head);
+                if (previous is { Version.Length: > 0 })
+                    // The activation record predates a previous-floor field. Null is the honest
+                    // answer; copying the head's floor would state a claim the older bytes did not.
+                    yield return ToBundle(previous, minMeshVersion: null);
+
+                static BundleEntry ToBundle(
+                    ModuleActivationEntry entry, string? minMeshVersion)
                 {
-                    var segments = e.PackagePath!.Split('/');
+                    var segments = entry.PackagePath!.Split('/');
                     return new BundleEntry(
-                        segments[1], e.Version!, segments[1],
-                        Module: e.Name,
-                        MinMeshVersion: e.MinMeshVersion,
-                        Source: segments[0]);
-                });
-            return (IReadOnlyList<BundleEntry>)records.Concat(published).ToArray();
+                        segments[1], entry.Version!, segments[1],
+                        Module: entry.Name,
+                        MinMeshVersion: minMeshVersion,
+                        Source: segments[0],
+                        ShelfVersion: entry.Version);
+                }
+            }
         });
     }
 
@@ -1243,12 +1295,13 @@ public static class PluginBundleEndpoints
 
     /// <summary>
     /// Which of the installed packages' declared modules this instance can serve right now:
-    /// plugin id → module assembly name, for exactly the entries whose bytes exist under
+    /// (plugin id, version) → module assembly name, for exactly the entries whose bytes exist under
     /// <c>modules/&lt;name&gt;/</c> and were not uninstalled (<see cref="ModuleBundleSource"/>).
     /// A HELD landing — floor above THIS instance's platform, the registry-shelf state (2026-08-22) —
     /// is listed too, deliberately: the index surfaces its <c>minMeshVersion</c> and each
-    /// consumer's own gate decides loadability THERE, before a byte travels. One
-    /// activation-sidecar read for the whole index.
+    /// consumer's own gate decides loadability THERE, before a byte travels. Both retained
+    /// generations can be listed under their own versions; one activation-sidecar read resolves
+    /// the whole index.
     ///
     /// <para>🚨 Each entry also carries the framework identity the SHELF recorded for those module
     /// bytes (Plugins#931). It is the producer's value, written when the owning repo's CI published
@@ -1271,19 +1324,22 @@ public static class PluginBundleEndpoints
 
         return landing.GetActivation().Take(1)
             .Select(activation => (IReadOnlyDictionary<string, ServableModule>)declaring
-                .Where(p => ModuleBundleSource.Collect(
-                        landing.BaseDirectory, p.Module!, activation)
+                .Where(p => ModuleBundleSource.CollectVersion(
+                        landing.BaseDirectory, p.Module!, activation, p.ShelfVersion)
                     .DeclineReason is null)
                 .ToDictionary(
-                    p => p.PluginId,
+                    p => BundleVersionKey(p.PluginId, p.Version),
                     p => new ServableModule(
                         p.Module!,
-                        activation.Entries
-                            .FirstOrDefault(e => string.Equals(
-                                e.Name, p.Module, StringComparison.OrdinalIgnoreCase))
+                        ModuleBundleSource.ResolveEntry(activation, p.Module!, p.ShelfVersion)
                             ?.FrameworkMvid),
                     StringComparer.OrdinalIgnoreCase));
     }
+
+    /// <summary>A stable dictionary key for a package VERSION. The separator cannot occur in a
+    /// package id or NuGet version, so case-insensitive package identity cannot conflate releases.</summary>
+    private static string BundleVersionKey(string pluginId, string version) =>
+        pluginId + "\u001f" + version;
 
     /// <summary>One servable module on the index: its assembly name and the framework identity the
     /// shelf recorded for its bytes (null = the producer stated none).</summary>
@@ -1567,8 +1623,8 @@ public static class PluginBundleEndpoints
         return landing.GetActivation().Take(1)
             .Select(activation =>
             {
-                var (files, assets, decline) = ModuleBundleSource.Collect(
-                    landing.BaseDirectory, package.Module!, activation);
+                var (files, assets, decline) = ModuleBundleSource.CollectVersion(
+                    landing.BaseDirectory, package.Module!, activation, package.ShelfVersion);
                 if (decline is not null)
                     logger?.LogInformation(
                         "Plugin bundles: {Plugin} declares module '{Module}' but it is not served: {Reason}",
@@ -1779,7 +1835,12 @@ public static class PluginBundleEndpoints
     /// <param name="Tier">The plan the package declares (<see cref="PackageManifest.Tier"/>), or
     /// null for a baseline package — the cached observation; <see cref="Decide"/> prefers the
     /// anchor's, exactly as it does for <paramref name="Source"/>.</param>
+    /// <param name="ShelfVersion">The retained published generation this entry resolves, or null
+    /// for an installed/anchored entry that follows the ordinary activation head or image module.
+    /// Kept separate from <paramref name="Version"/> because an install record's package version
+    /// is not evidence that a sidecar generation with that version exists.</param>
     private sealed record BundleEntry(
         string PackageId, string Version, string PluginId, string? Module = null,
-        string? MinMeshVersion = null, string? Source = null, string? Tier = null);
+        string? MinMeshVersion = null, string? Source = null, string? Tier = null,
+        string? ShelfVersion = null);
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -711,6 +711,23 @@ download loop:**
 | any | **unknown** | **Skip**, and the reason SAYS the identity could not be checked. Landing could never turn "the registry states nothing" into evidence — it would state nothing next time too — so answering Land there re-downloads every module on every reconcile, forever, against any registry that predates the field. |
 | known | known, equal | **Skip** — the genuine no-op, with the framework named. |
 
+#### Publication arrival order is not version order
+
+The registry can receive one module from both the module repository's publication and a slower core
+CD that baked an earlier repository commit. Both uploads are valid warehouse stock, but the one that
+arrives last is not necessarily the newest. On 2026-09-11 `MeshWeaver.Mail.MicrosoftGraph` 1.7.0
+landed at 02:49Z; core CD then delivered 1.6.1 at 03:00Z, the old last-writer rule moved the head to
+1.6.1, and the next restart silently un-shipped the release (#3996).
+
+`ShelveModule` therefore applies the same no-unattended-rollback rule as the consumer decision: a
+known older version may land its content-addressed generation, but it does not replace a newer head
+whose bytes are present and link on this platform. The best older generation remains available as
+the fallback, and a registry advertises both retained versions in its bundle index; each versioned
+download resolves its own generation, so keeping the newer activation head never makes the older
+warehouse stock unreachable. A higher version string does not make a broken head immortal: if its entry assembly is
+missing or its bytes do not link, the valid incoming generation still replaces it. Unknown versions
+retain the legacy behaviour because an absent version is no evidence of an ordering.
+
 The remaining blind spot (a registry that states no identity) is closed **where it is created**, not
 by churning consumers: a bundle that cannot say what it was built against must not be publishable.
 That is #3211, and it matters more than it sounds — measured on MeshWeaver.Plugins run 33773265959

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-late-module-publishes-do-not-roll-back-newer-versions.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-late-module-publishes-do-not-roll-back-newer-versions.md
@@ -1,0 +1,19 @@
+---
+Name: Late module publishes no longer roll back newer versions
+Category: Fix
+Description: A slower release lane can still stock an older module, but it no longer makes that version replace a newer working one on the registry.
+Icon: ArrowTrendingUp
+Order: -20260911
+---
+
+# Late module publishes no longer roll back newer versions
+
+The module registry can receive the same module from more than one release lane. A slower lane could
+finish after a newer release and make its older upload the active registry version simply because it
+arrived last. The next portal restart would then load the older module and silently undo the newer
+release.
+
+The registry now compares published versions before moving its activation head. An older upload is
+still kept as warehouse stock and remains downloadable at its own version, but a newer working
+generation remains current. A missing or unusable newer generation does not block recovery: in that
+case the valid upload still replaces it.

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -178,10 +178,11 @@ public sealed record ModuleActivationList
 /// <para>So the contended cell is removed rather than guarded: each module owns
 /// <c>modules/activation.d/&lt;Name&gt;.json</c> and a writer touches ONLY its own file. Two
 /// landings of DIFFERENT modules now share no path at all — no contention, and lost updates are
-/// structurally impossible. Two landings of the SAME module are inherently ordered work whose
-/// last-writer-wins is the correct answer, and can no longer cost any OTHER module its entry.
-/// A per-entry file that cannot be read costs exactly that one entry, reported loudly, instead of
-/// the whole deployment's module set.</para>
+/// structurally impossible. Two landings of the SAME module do share that module's file, but can
+/// no longer cost any OTHER module its entry; their semantic order is decided by
+/// <see cref="ModuleLandingService"/> before it writes. On the registry shelf an older arrival
+/// cannot replace a newer, present, loadable head (#3996). A per-entry file that cannot be read
+/// costs exactly that one entry, reported loudly, instead of the whole deployment's module set.</para>
 ///
 /// <para><b>The legacy aggregate file is still READ, never written by the runtime lane.</b>
 /// <c>modules/activation.json</c> is what deployments already on disk carry, so

--- a/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleBundleSource.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using MeshWeaver.Plugin.Packaging;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -7,8 +8,10 @@ namespace MeshWeaver.PluginCatalog;
 /// files under its own <c>modules/&lt;name&gt;/</c> — the very bytes this deployment loads and runs,
 /// which is the same philosophy the NodeType bundle lane established ("the inputs ARE the storage").
 /// A module is servable exactly when its bytes are here and it was not uninstalled: entry DLL
-/// present, activation entry (if any) enabled. The MVID a landing recorded is diagnostic and never
-/// withholds a serve — modules bind by simple name.
+/// present, activation entry (if any) enabled. The ordinary call follows the activation head; the
+/// versioned call may also follow its retained fallback generation, so warehouse stock stays
+/// downloadable without becoming the runtime head (#3996). The MVID a landing recorded is
+/// diagnostic and never withholds a serve — modules bind by simple name.
 ///
 /// <para>🚨 <b>The serving side applies NO platform-floor gate of its own (2026-08-22)</b> — the shelf
 /// deliberately carries modules for platforms NEWER than the instance serving them. The old rule
@@ -44,7 +47,22 @@ public static class ModuleBundleSource
         string? DeclineReason) Collect(
         string baseDirectory,
         string moduleName,
-        ModuleActivationList activation)
+        ModuleActivationList activation) =>
+        CollectVersion(baseDirectory, moduleName, activation, version: null);
+
+    /// <summary>
+    /// Resolves one published VERSION of a module. The null version keeps the ordinary activation
+    /// behaviour and serves the head. A stated version may select either the head or its retained
+    /// previous generation (#3996), which is what makes older warehouse stock addressable without
+    /// moving activation backwards.
+    /// </summary>
+    public static (IReadOnlyList<string> Files,
+        IReadOnlyList<(string RelativePath, string FullPath)> Assets,
+        string? DeclineReason) CollectVersion(
+        string baseDirectory,
+        string moduleName,
+        ModuleActivationList activation,
+        string? version)
     {
         if (string.IsNullOrWhiteSpace(moduleName)
             || moduleName is "." or ".."
@@ -52,8 +70,9 @@ public static class ModuleBundleSource
             || moduleName.Contains('/') || moduleName.Contains('\\'))
             return ([], [], $"'{moduleName}' is not a valid module name");
 
-        var entry = activation.Entries.FirstOrDefault(e =>
-            string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
+        var entry = ResolveEntry(activation, moduleName, version);
+        if (!string.IsNullOrWhiteSpace(version) && entry is null)
+            return ([], [], $"module '{moduleName}' has no retained generation at version {version}");
         if (entry is { Enabled: false })
             return ([], [], $"module '{moduleName}' is uninstalled on this instance");
         // 🚨 Deliberately NO floor check on the entry here — a HELD landing (floor above this
@@ -62,10 +81,11 @@ public static class ModuleBundleSource
         // own gate is what decides loadability THERE. See the type doc for why a serve-side floor
         // was the deadlock.
 
-        // The entry's GENERATION directory is the newest landed content — the one resolution
-        // rule (ModuleDirectoryFor), shared with boot. Serving follows the pointer immediately,
-        // so consumers fetch what was PUBLISHED even while this process still runs an older
-        // generation it loaded at ITS boot (or, for a held landing, none at all).
+        // The selected entry's GENERATION directory is the requested landed content — the one
+        // resolution rule (ModuleDirectoryFor), shared with boot. The ordinary null-version call
+        // follows the head immediately; a versioned bundle route may follow its retained fallback.
+        // Consumers therefore fetch exactly what the index named even while this process still
+        // runs an older generation it loaded at ITS boot (or, for a held landing, none at all).
         var folder = ModuleLandingService.ModuleDirectoryFor(baseDirectory, moduleName, entry);
         var entryDll = Path.Combine(folder, moduleName + ".dll");
         if (!File.Exists(entryDll))
@@ -103,5 +123,27 @@ public static class ModuleBundleSource
             : [];
 
         return (files, assets, null);
+    }
+
+    /// <summary>The activation entry whose bytes represent <paramref name="version"/>: the head
+    /// for a null or matching version, the retained previous generation for its matching version,
+    /// or null when this deployment retains neither. Version equality uses the canonical NuGet
+    /// comparer, so 1.2 and 1.2.0 cannot disagree between index and download.</summary>
+    public static ModuleActivationEntry? ResolveEntry(
+        ModuleActivationList activation, string moduleName, string? version)
+    {
+        var head = activation.Entries.FirstOrDefault(e =>
+            string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
+        if (head is null || !head.Enabled || string.IsNullOrWhiteSpace(version))
+            return head;
+        if (!string.IsNullOrWhiteSpace(head.Version)
+            && NuGetVersionComparer.Instance.Compare(version, head.Version) == 0)
+            return head;
+        var previous = ModuleActivationBoot.PreviousGeneration(head);
+        return previous is not null
+               && !string.IsNullOrWhiteSpace(previous.Version)
+               && NuGetVersionComparer.Instance.Compare(version, previous.Version) == 0
+            ? previous
+            : null;
     }
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Plugin.Packaging;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.PluginCatalog;
@@ -43,6 +44,16 @@ namespace MeshWeaver.PluginCatalog;
 /// refusing: an instance must never hold bytes its own next boot would try to load into a
 /// platform that lacks their types… which for the adopt path is the point of the install, so a
 /// hold there would be a package whose binary half silently never arrives.</para>
+///
+/// <para><b>The shelf never moves its head backwards (#3996).</b> The publish endpoint can receive
+/// the same module from more than one release lane. A slower, older build is still valid warehouse
+/// stock, but arrival order is not version order: on 2026-09-11 Mail 1.7.0 landed first and a core
+/// CD carrying 1.6.1 arrived eleven minutes later, moved the activation head, and a restart silently
+/// un-shipped 1.7.0. Shelf landings therefore compare a known incoming version with the current,
+/// present, loadable head through <see cref="NuGetVersionComparer"/>. An older upload keeps that
+/// head and is retained as its previous generation when it is the best fallback; direct adoption
+/// remains unchanged because <see cref="ModuleUpdateDecision"/> already refuses unattended
+/// downgrades before it downloads a byte.</para>
 ///
 /// <para><b>The generation a landing displaces is KEPT, as the new entry's fallback (#3649).</b>
 /// <see cref="ModuleActivationEntry.PreviousDirectory"/> names it, the GC references it, and boot
@@ -740,6 +751,25 @@ public sealed class ModuleLandingService : IDisposable
             e.Enabled
             && string.Equals(e.Name, name, StringComparison.OrdinalIgnoreCase)
             && !string.IsNullOrWhiteSpace(e.Directory));
+
+        // 🚨 #3996 — ARRIVAL ORDER IS NOT VERSION ORDER on the registry shelf. Two release
+        // lanes publish the same modules, and core CD is deliberately much slower than Plugins'
+        // own publication. The older lane can therefore arrive LAST. Before this comparison every
+        // accepted upload moved the activation pointer, so Mail 1.7.0 landed at 02:49Z and the
+        // late 1.6.1 upload moved it backwards at 03:00Z; the next restart activated 1.6.1.
+        //
+        // Only a PRESENT, LOADABLE newer head wins. A sidecar whose bytes are gone or whose head
+        // cannot load must be healed by the incoming generation even when its recorded version is
+        // higher. Unknown versions likewise keep the legacy landing behaviour: absence of a
+        // comparable version is not evidence that either side is newer. Direct-adopt landings do
+        // not enter here; ModuleUpdateDecision has already answered SkipOlder on that lane.
+        var preserveNewerShelfHead = holdUnloadable
+            && displaced is { Enabled: true, Version.Length: > 0 }
+            && !string.IsNullOrWhiteSpace(version)
+            && NuGetVersionComparer.Instance.Compare(version, displaced.Version) < 0
+            && ModuleActivationBoot.LandedModuleDllExists(baseDirectory, displaced)
+            && ModulePlatformLink.Check(
+                ModuleActivationBoot.LandedDllPath(baseDirectory, displaced), surface).MayLoad;
         var previous = displaced is null ? null : PreviousToKeep(displaced);
 
         ModuleActivationEntry? PreviousToKeep(ModuleActivationEntry current)
@@ -847,6 +877,35 @@ public sealed class ModuleLandingService : IDisposable
             PreviousVersion = previous?.Version,
             PreviousFrameworkMvid = previous?.FrameworkMvid,
         };
+
+        if (preserveNewerShelfHead)
+        {
+            // The upload is still STOCKED: its content-addressed generation is on disk. Keep the
+            // best older generation as the head's fallback so the GC references useful warehouse
+            // stock rather than reclaiming it as an orphan. A still older late upload must not
+            // displace a newer fallback any more than it may displace the head.
+            var shelfGeneration = OlderShelfGenerationToKeep(displaced!, entry);
+            var retainedHead = displaced! with
+            {
+                PreviousDirectory = shelfGeneration?.Directory,
+                PreviousVersion = shelfGeneration?.Version,
+                PreviousFrameworkMvid = shelfGeneration?.FrameworkMvid,
+            };
+            ModuleActivationSidecar.WriteEntry(baseDirectory, retainedHead);
+            logger?.LogInformation(
+                "Module '{Name}' SHELVED into modules/{Generation}/ ({Count} assemblies, version "
+                + "{Version}) without moving activation: the current loadable head is newer "
+                + "({HeadVersion}, generation {HeadGeneration}). The older upload is warehouse "
+                + "stock only; restart state and the proposed module set are unchanged",
+                name, generation, assemblies.Count, version, displaced!.Version,
+                displaced.Directory);
+            return new ModuleLandingOutcome(Held: held is not null, HoldReason: held)
+            {
+                SelectedAsHead = false,
+                HeadVersion = displaced.Version,
+            };
+        }
+
         // 🚨 THIS MODULE'S OWN FILE, and nothing else (#2090). The landing used to read the whole
         // shared activation index, append to it and rename the result over the live file — a
         // read-modify-write of state every replica shares on the RWX /data volume. Two concurrent
@@ -880,7 +939,40 @@ public sealed class ModuleLandingService : IDisposable
                 + "carries the types it links against, and that same boot then loads it",
                 name, generation, assemblies.Count, held, previous?.Directory ?? "(none)");
 
-        return new ModuleLandingOutcome(Held: held is not null, HoldReason: held);
+        return new ModuleLandingOutcome(Held: held is not null, HoldReason: held)
+        {
+            HeadVersion = version,
+        };
+
+        ModuleActivationEntry? OlderShelfGenerationToKeep(
+            ModuleActivationEntry current, ModuleActivationEntry incoming)
+        {
+            // Re-tagging identical bytes produces the same content address. It is already the
+            // head, not a fallback to itself; retain whatever real fallback the head had.
+            if (string.Equals(current.Directory, incoming.Directory, StringComparison.OrdinalIgnoreCase))
+                return ModuleActivationBoot.PreviousGeneration(current);
+
+            var existing = ModuleActivationBoot.PreviousGeneration(current);
+            if (existing is null || !ModuleActivationBoot.LandedModuleDllExists(baseDirectory, existing))
+                return incoming;
+            if (string.Equals(existing.Directory, incoming.Directory, StringComparison.OrdinalIgnoreCase))
+                return incoming;
+
+            // A fallback's first job is to LOAD. Version ordering alone cannot replace a
+            // working fallback with newer warehouse bytes this platform already measured as
+            // unloadable; conversely, a loadable incoming generation heals an unloadable one.
+            var existingLoads = ModulePlatformLink.Check(
+                ModuleActivationBoot.LandedDllPath(baseDirectory, existing), surface).MayLoad;
+            var incomingLoads = held is null;
+            if (existingLoads != incomingLoads)
+                return incomingLoads ? incoming : existing;
+            if (string.IsNullOrWhiteSpace(incoming.Version))
+                return existing;
+            if (string.IsNullOrWhiteSpace(existing.Version)
+                || NuGetVersionComparer.Instance.Compare(incoming.Version, existing.Version) > 0)
+                return incoming;
+            return existing;
+        }
     }
 
     /// <summary>
@@ -1128,4 +1220,14 @@ public sealed class ModuleLandingService : IDisposable
 /// hold — it is recorded and logged as an advisory, and bytes that link land unheld.</param>
 /// <param name="HoldReason">Why the activation is held, naming the missing type
 /// (<see cref="MeshWeaver.Mesh.ModuleLinkVerdict.Report"/>'s text), or null when not held.</param>
-public sealed record ModuleLandingOutcome(bool Held, string? HoldReason);
+public sealed record ModuleLandingOutcome(bool Held, string? HoldReason)
+{
+    /// <summary>True when this landing became the activation head. False means the bytes were
+    /// accepted as older warehouse stock while a newer, present, loadable head was retained
+    /// (#3996), so this upload neither raises restart-required nor changes the proposed set.</summary>
+    public bool SelectedAsHead { get; init; } = true;
+
+    /// <summary>The version at the activation head after the landing. For ordinary landings this
+    /// is the incoming version; for an older shelf-only upload it names the newer retained head.</summary>
+    public string? HeadVersion { get; init; }
+}

--- a/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
@@ -155,6 +155,41 @@ public class ModulePlatformLinkTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 #3996 — an older shelf-only upload is retained only when it is a useful fallback.
+    /// A numerically newer fallback that this platform cannot load must not displace the working
+    /// one: fallback ordering is loadability first, version second, just like activation itself.
+    /// </summary>
+    [Fact]
+    public async Task AnOlderUnloadablePublish_DoesNotReplaceTheWorkingFallback()
+    {
+        const string name = "MeshWeaver.Test.OrderedShelf";
+        var oldLoadable = ModuleBuiltAgainstThisPlatform(name);
+        var newestLoadable = ModuleBuiltAgainstThisPlatform(name);
+        var middleUnloadable = ModuleBuiltAgainstAFuturePlatform(name);
+
+        await landing.ShelveModule(
+                name, [(name + ".dll", oldLoadable)], version: "1.5.0")
+            .Timeout(TestTimeouts.Convergence).Await();
+        await landing.ShelveModule(
+                name, [(name + ".dll", newestLoadable)], version: "1.7.0")
+            .Timeout(TestTimeouts.Convergence).Await();
+        var outcome = await landing.ShelveModule(
+                name, [(name + ".dll", middleUnloadable)], version: "1.6.0")
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        Assert.False(outcome.SelectedAsHead);
+        Assert.True(outcome.Held);
+        var head = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal("1.7.0", head.Version);
+        Assert.Equal("1.5.0", head.PreviousVersion);
+        var fallback = ModuleActivationBoot.PreviousGeneration(head);
+        Assert.NotNull(fallback);
+        Assert.True(ModulePlatformLink.Check(
+            ModuleActivationBoot.LandedDllPath(root, fallback),
+            ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory)).MayLoad);
+    }
+
+    /// <summary>
     /// 🚨 <b>The third state, and it fails CLOSED.</b> Bytes that are not a readable managed
     /// assembly answer <see cref="ModuleLinkState.Indeterminate"/> — "I could not determine
     /// whether this loads" — and that is NEVER folded into "it loads". A gate whose unknown reads

--- a/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.Api;
@@ -57,41 +58,57 @@ public class ModulePublishShelfTest : IDisposable
     /// <summary>A packed module bundle the route can read, declaring the given floor. A null
     /// <paramref name="frameworkMvid"/> omits the field entirely — the shape a producer on a lane
     /// older than #3211 uploads, and the one the registry refuses since #3240.</summary>
-    private static byte[] Bundle(string? minMeshVersion, string? frameworkMvid = "test-build")
+    private static byte[] Bundle(
+        string? minMeshVersion,
+        string? frameworkMvid = "test-build",
+        string version = "1.0.0",
+        string? generationMarker = null)
     {
+        const string markerPath = "wwwroot/generation.txt";
         var manifestJson = JsonSerializer.Serialize(new
         {
             plugin = "SpeechPkg",
-            version = "1.0.0",
+            version,
             frameworkMvid,
             module = new
             {
                 assemblyName = "MeshWeaver.Speech",
                 assemblies = new[] { "MeshWeaver.Speech.dll" },
                 minMeshVersion,
+                staticAssets = generationMarker is null ? null : new[] { markerPath },
             },
         });
+
+        var entries = new List<NuGetPackageWriter.Entry>
+        {
+            new(
+                NuGetPackageWriter.ModuleEntryPathFor("MeshWeaver.Speech.dll"),
+                // 🚨 REAL assembly bytes since #3538: the landing MEASURES the module's link
+                // requirements against this platform, so a short literal is refused as
+                // unreadable metadata — correctly, and these tests are about the FLOOR.
+                () => new MemoryStream(
+                    File.ReadAllBytes(typeof(BundleReader).Assembly.Location))),
+        };
+        if (generationMarker is not null)
+            entries.Add(new NuGetPackageWriter.Entry(
+                NuGetPackageWriter.ModuleAssetEntryPathFor(markerPath),
+                () => new MemoryStream(Encoding.UTF8.GetBytes(generationMarker))));
 
         var buffer = new MemoryStream();
         NuGetPackageWriter.Write(
             buffer,
-            new PackagingManifest("SpeechPkg", "MeshWeaver.Plugin.SpeechPkg", "1.0.0", "SpeechPkg", null, []),
+            new PackagingManifest("SpeechPkg", "MeshWeaver.Plugin.SpeechPkg", version, "SpeechPkg", null, []),
             "3.0.0",
-            [
-                new NuGetPackageWriter.Entry(
-                    NuGetPackageWriter.ModuleEntryPathFor("MeshWeaver.Speech.dll"),
-                    // 🚨 REAL assembly bytes since #3538: the landing MEASURES the module's link
-                    // requirements against this platform, so a short literal is refused as
-                    // unreadable metadata — correctly, and these tests are about the FLOOR.
-                    () => new MemoryStream(
-                        File.ReadAllBytes(typeof(BundleReader).Assembly.Location))),
-            ],
+            entries,
             manifestJson);
         return buffer.ToArray();
     }
 
     private async Task<HttpResponseMessage> Publish(
-        string? minMeshVersion, string? frameworkMvid = "test-build")
+        string? minMeshVersion,
+        string? frameworkMvid = "test-build",
+        string version = "1.0.0",
+        string? generationMarker = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -112,8 +129,102 @@ public class ModulePublishShelfTest : IDisposable
             HttpMethod.Post,
             PluginBundleEndpoints.RoutePrefix + "/SpeechPkg?packagePath=Plugins/SpeechPkg");
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + Token);
-        request.Content = new ByteArrayContent(Bundle(minMeshVersion, frameworkMvid));
+        request.Content = new ByteArrayContent(
+            Bundle(minMeshVersion, frameworkMvid, version, generationMarker));
         return await client.SendAsync(request);
+    }
+
+    /// <summary>
+    /// 🚨 #3996 — an older publisher may STOCK its bytes after a newer publish, but it must
+    /// never move the registry's activation head backwards. Core CD takes 40–50 minutes and used
+    /// to arrive after Plugins' own publication: Mail 1.7.0 landed at 02:49Z, then the older
+    /// core-gated 1.6.1 upload landed at 03:00Z and became the head solely because it arrived last.
+    /// A restart consequently activated 1.6.1 and silently un-shipped the merge.
+    ///
+    /// <para>The two bundles deliberately carry different marker assets so they produce distinct
+    /// content-addressed generations while sharing valid, linkable assembly bytes. The assertion
+    /// is the durable activation record, not the endpoint's status code: both uploads have always
+    /// answered 200.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnOlderPublishAfterANewerOne_DoesNotMoveTheActivationHeadBackwards()
+    {
+        using var newer = await Publish(
+            minMeshVersion: null, version: "1.7.0", generationMarker: "newer");
+        Assert.Equal(HttpStatusCode.OK, newer.StatusCode);
+
+        using var older = await Publish(
+            minMeshVersion: null, version: "1.6.1", generationMarker: "older");
+        Assert.Equal(HttpStatusCode.OK, older.StatusCode);
+        using var result = JsonDocument.Parse(await older.Content.ReadAsStringAsync());
+        Assert.False(result.RootElement.GetProperty("selectedAsHead").GetBoolean());
+        Assert.Equal("1.7.0", result.RootElement.GetProperty("headVersion").GetString());
+        Assert.False(result.RootElement.GetProperty("pendingRestart").GetBoolean());
+
+        var activation = ModuleActivationSidecar.Read(root);
+        var head = Assert.Single(activation.Entries);
+        Assert.Equal("1.7.0", head.Version);
+        Assert.Equal("1.6.1", head.PreviousVersion);
+        Assert.NotEqual(head.Directory, head.PreviousDirectory);
+        Assert.True(ModuleActivationBoot.LandedModuleDllExists(root, head));
+        Assert.True(ModuleActivationBoot.PreviousLandedModuleDllExists(root, head));
+
+        var headMarker = Path.Combine(
+            ModuleLandingService.ModuleDirectoryFor(root, head.Name, head),
+            "wwwroot", "generation.txt");
+        Assert.Equal("newer", File.ReadAllText(headMarker));
+    }
+
+    /// <summary>The shelf retains the newest useful fallback too: a still older late upload may
+    /// not push 1.6.1 out from behind the 1.7.0 head. Otherwise repeated lagging publications
+    /// would preserve the head but quietly walk its fallback backwards.</summary>
+    [Fact]
+    public async Task AStillOlderPublish_DoesNotMoveTheRetainedFallbackBackwards()
+    {
+        using var newest = await Publish(
+            minMeshVersion: null, version: "1.7.0", generationMarker: "newest");
+        using var fallback = await Publish(
+            minMeshVersion: null, version: "1.6.1", generationMarker: "fallback");
+        using var oldest = await Publish(
+            minMeshVersion: null, version: "1.5.0", generationMarker: "oldest");
+        Assert.Equal(HttpStatusCode.OK, newest.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, fallback.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, oldest.StatusCode);
+
+        var head = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal("1.7.0", head.Version);
+        Assert.Equal("1.6.1", head.PreviousVersion);
+        var fallbackEntry = ModuleActivationBoot.PreviousGeneration(head);
+        Assert.NotNull(fallbackEntry);
+        var marker = Path.Combine(
+            ModuleLandingService.ModuleDirectoryFor(root, head.Name, fallbackEntry),
+            "wwwroot", "generation.txt");
+        Assert.Equal("fallback", File.ReadAllText(marker));
+    }
+
+    /// <summary>A higher VERSION string is not enough to protect a broken head. If its entry DLL
+    /// is absent, the next valid upload must heal the shelf even when its version is lower; keeping
+    /// the unusable record would turn the anti-rollback rule into a self-sealing outage.</summary>
+    [Fact]
+    public async Task AnOlderPublish_ReplacesANewerHeadWhoseBytesAreMissing()
+    {
+        using var newer = await Publish(
+            minMeshVersion: null, version: "1.7.0", generationMarker: "newer-but-broken");
+        Assert.Equal(HttpStatusCode.OK, newer.StatusCode);
+        var broken = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        File.Delete(ModuleActivationBoot.LandedDllPath(root, broken));
+        Assert.False(ModuleActivationBoot.LandedModuleDllExists(root, broken));
+
+        using var healing = await Publish(
+            minMeshVersion: null, version: "1.6.1", generationMarker: "healing");
+        Assert.Equal(HttpStatusCode.OK, healing.StatusCode);
+        using var result = JsonDocument.Parse(await healing.Content.ReadAsStringAsync());
+        Assert.True(result.RootElement.GetProperty("selectedAsHead").GetBoolean());
+        Assert.Equal("1.6.1", result.RootElement.GetProperty("headVersion").GetString());
+
+        var head = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal("1.6.1", head.Version);
+        Assert.True(ModuleActivationBoot.LandedModuleDllExists(root, head));
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/PublishedModuleVersionShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/PublishedModuleVersionShelfTest.cs
@@ -1,0 +1,182 @@
+#pragma warning disable CS1591
+
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text;
+using System.Text.Json;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #3996's registry-serving half: keeping a late older publication behind a newer activation head
+/// must not turn that retained generation into dead stock. The real authenticated bundle routes
+/// advertise both versions and return the bytes of the generation each URL names.
+/// </summary>
+public class PublishedModuleVersionShelfTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Plugin = "VersionedShelf";
+    private const string Module = "MeshWeaver.VersionedShelf";
+    private const string Source = "Plugins";
+    private const string Instance = "versioned-shelf-consumer";
+    private const string NewerVersion = "1.7.0";
+    private const string OlderVersion = "1.6.1";
+    private const string MarkerPath = "wwwroot/generation.txt";
+
+    private readonly string landingRoot = Path.Combine(
+        Path.GetTempPath(), "mw-versioned-shelf-" + Guid.NewGuid().ToString("N"));
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        Directory.CreateDirectory(landingRoot);
+        return base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                .AddSingleton(new ModuleLandingService(baseDirectory: landingRoot)));
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        try
+        {
+            if (Directory.Exists(landingRoot))
+                Directory.Delete(landingRoot, recursive: true);
+        }
+        catch
+        {
+            // Best-effort temp cleanup must never turn a passing distribution assertion red.
+        }
+    }
+
+    private Task<string> RegisterInstance() =>
+        new MeshWeaverInstanceService(
+                Mesh.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IMeshService>(),
+                Mesh,
+                Mesh.ServiceProvider.GetRequiredService<ILogger<MeshWeaverInstanceService>>(),
+                new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{MeshWeaverInstanceService.DefaultGrantsConfigKey}:0"] = $"{Source}/*",
+                    })
+                    .Build())
+            .Register("shelf-owner", "Shelf Owner", "owner@test.com", Instance, Instance)
+            .Select(result => result.RawKey)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+
+    private async Task<WebApplication> StartBundleHost()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<IMessageHub>(Mesh);
+        builder.Services.AddSingleton(
+            Mesh.ServiceProvider.GetRequiredService<InstanceRegistryAuthenticator>());
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+        return app;
+    }
+
+    private async Task Shelve(string version, string marker)
+    {
+        var assembly = File.ReadAllBytes(typeof(BundleReader).Assembly.Location);
+        await Mesh.ServiceProvider.GetRequiredService<ModuleLandingService>()
+            .ShelveModule(
+                Module,
+                [(Module + ".dll", assembly)],
+                frameworkMvid: "framework-" + version,
+                packagePath: $"{Source}/{Plugin}",
+                version: version,
+                staticAssets: [(MarkerPath, Encoding.UTF8.GetBytes(marker))])
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence);
+    }
+
+    private Task<InstallResult> InstallOlderRecord() =>
+        PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = Plugin,
+                    Name = Plugin,
+                    Kind = PackageKind.Content,
+                    TargetPartition = Plugin,
+                    SourceFolder = Plugin,
+                    Version = "older-source-commit",
+                    ReleasedVersion = OlderVersion,
+                    Source = Source,
+                    Module = Module,
+                },
+                [new PackageFile($"{Plugin}/Doc.md", "# Versioned shelf")],
+                "HEAD")
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+
+    private static async Task<HttpResponseMessage> Get(
+        WebApplication app, string route, string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {key}");
+        return await app.GetTestClient().SendAsync(request);
+    }
+
+    [Fact(Timeout = 300_000)]
+    public async Task HeadAndFallback_AreIndexedNewestFirst_AndEachUrlServesItsGeneration()
+    {
+        await Shelve(NewerVersion, "newer");
+        await Shelve(OlderVersion, "older");
+        await InstallOlderRecord();
+        var activation = Assert.Single(ModuleActivationSidecar.Read(landingRoot).Entries);
+        Assert.Equal(NewerVersion, activation.Version);
+        Assert.Equal(OlderVersion, activation.PreviousVersion);
+
+        var key = await RegisterInstance();
+        await using var app = await StartBundleHost();
+
+        using var indexResponse = await Get(
+            app, PluginBundleEndpoints.RoutePrefix + "/index.json", key);
+        Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
+        using var index = JsonDocument.Parse(await indexResponse.Content.ReadAsStringAsync());
+        var entries = index.RootElement.GetProperty("bundles").EnumerateArray()
+            .Where(bundle => string.Equals(
+                bundle.GetProperty("plugin").GetString(), Plugin,
+                StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        Assert.Equal(2, entries.Length);
+        Assert.Equal(NewerVersion, entries[0].GetProperty("version").GetString());
+        Assert.Equal(OlderVersion, entries[1].GetProperty("version").GetString());
+        Assert.All(entries, entry => Assert.Equal(Module,
+            entry.GetProperty("module").GetString()));
+
+        Assert.Equal("newer", await ServedMarker(app, NewerVersion, key));
+        Assert.Equal("older", await ServedMarker(app, OlderVersion, key));
+    }
+
+    private static async Task<string> ServedMarker(
+        WebApplication app, string version, string key)
+    {
+        using var response = await Get(
+            app, $"{PluginBundleEndpoints.RoutePrefix}/{Plugin}/{version}", key);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var assets = BundleReader.ReadModuleAssets(await response.Content.ReadAsByteArrayAsync());
+        var marker = Assert.Single(assets, asset => asset.RelativePath == MarkerPath);
+        return Encoding.UTF8.GetString(marker.Bytes);
+    }
+}


### PR DESCRIPTION
## What changed

- compare a shelf upload with the current present, loadable module head using the canonical NuGet/SemVer comparer
- keep a known older upload as fallback warehouse stock instead of moving activation backwards
- advertise both retained versions newest-first and resolve each versioned download to its own generation
- preserve install-record entitlement metadata when it overlaps a retained published version
- prefer loadability before version when choosing the retained fallback
- report the shelf-only outcome explicitly without claiming a restart or module-set change
- document the production failure and the ordering rule

## Root cause

The registry publish endpoint accepted every upload and moved the activation pointer unconditionally. Core CD can deliver an older Plugins commit after the faster Plugins publication, so arrival order selected the version. In production, Mail 1.7.0 landed first and a later 1.6.1 upload became the head; the next restart silently activated 1.6.1.

## Verification

- red-before/green-after HTTP regression: 1.7.0 followed by 1.6.1 leaves 1.7.0 at the durable head
- authenticated index/download regression: 1.7.0 and retained 1.6.1 are both listed, newest first, and each URL returns its own marker bytes
- an identical older install record keeps its entitlement metadata while the download resolves the retained shelf generation
- an even older 1.5.0 upload cannot displace the 1.6.1 fallback
- a missing 1.7.0 head is repaired by a valid 1.6.1 upload
- an unloadable 1.6.0 upload cannot replace a working 1.5.0 fallback
- Memex.Portal.Shared.Test: 1,277 passed, 0 failed, 0 skipped
- all touched Release builds: 0 warnings, 0 errors

Fixes #3996
