### PR TITLE
fix(compiler): reject cached bytes from an earlier source snapshot

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
@@ -428,6 +428,10 @@ internal class MeshNodeCompilationService(
                         ? node.LastModified
                         : maxSourceLastModified;
 
+                    IObservable<CompileAttempt> CompileSnapshot() =>
+                        CompileCore(node, ntDef, selfPath, log, sources)
+                            .Select(t => new CompileAttempt(t.Path, t.InputDigest, t.Log, sources));
+
                     if (cacheService.IsDiskCacheEnabled)
                     {
                         var cachedDllPath = cacheService.TryGetLatestCachedDllPath(nodeName, effectiveLastModified);
@@ -445,26 +449,37 @@ internal class MeshNodeCompilationService(
                             : GeneratedInputDigestFile.TryRead(cachedDllPath, logger);
                         if (cachedDllPath is not null && cachedInputDigest is not null)
                         {
-                            logger.LogDebug(
-                                "Using cached assembly for {NodePath} at {DllPath} (effectiveLastModified={EffectiveLastModified})",
-                                node.Path, cachedDllPath, effectiveLastModified);
-                            return Observable.Return(new CompileAttempt(
-                                cachedDllPath,
-                                cachedInputDigest,
-                                AppendInfo(log,
-                                        $"Cache hit — returning {cachedDllPath} (effective LastModified={effectiveLastModified:O}).",
-                                        "activity.compile.cacheHit",
-                                        ("path", cachedDllPath),
-                                        ("lastModified", effectiveLastModified.ToString("O")))
-                                    .FinishByOutcome((int)hub.Version),
-                                sources));
+                            // A source edit can land AFTER the producing snapshot but BEFORE its
+                            // DLL finishes writing. A newer DLL timestamp therefore cannot prove
+                            // that these sources were compiled. Compare the existing producing
+                            // digest with this exact snapshot's generated input before reusing it;
+                            // never stamp today's digest onto unverified earlier bytes.
+                            return RegenerateCapturedInputDigest(node, ntDef, selfPath, sources)
+                                .SelectMany(currentInputDigest =>
+                                {
+                                    if (!string.Equals(cachedInputDigest, currentInputDigest, StringComparison.Ordinal))
+                                        return CompileSnapshot();
+
+                                    logger.LogDebug(
+                                        "Using cached assembly for {NodePath} at {DllPath} (effectiveLastModified={EffectiveLastModified})",
+                                        node.Path, cachedDllPath, effectiveLastModified);
+                                    return Observable.Return(new CompileAttempt(
+                                        cachedDllPath,
+                                        cachedInputDigest,
+                                        AppendInfo(log,
+                                                $"Cache hit — returning {cachedDllPath} (effective LastModified={effectiveLastModified:O}).",
+                                                "activity.compile.cacheHit",
+                                                ("path", cachedDllPath),
+                                                ("lastModified", effectiveLastModified.ToString("O")))
+                                            .FinishByOutcome((int)hub.Version),
+                                        sources));
+                                });
                         }
                     }
 
                     // Hand the snapshot down as the override — CompileCore then short-circuits
                     // its own SnapshotSources to this authoritative point-in-time set.
-                    return CompileCore(node, ntDef, selfPath, log, sources)
-                        .Select(t => new CompileAttempt(t.Path, t.InputDigest, t.Log, sources));
+                    return CompileSnapshot();
                 });
         });
     }
@@ -1870,18 +1885,26 @@ internal class MeshNodeCompilationService(
     internal IObservable<string?> RegenerateGeneratedInputDigest(MeshNode node)
     {
         var ntDef = node.ContentAs<NodeTypeDefinition>(JsonOptions);
-        if (ntDef is null)
-            return Observable.Return<string?>(null);
+        return ntDef is null
+            ? Observable.Return<string?>(null)
+            : RegenerateCapturedInputDigest(node, ntDef, node.Path, sourcesOverride: null);
+    }
 
+    // The cache check supplies the snapshot already captured by this compile. Re-evaluation
+    // retains its existing discovery path; both callers use the same shaping and digest logic.
+    private IObservable<string?> RegenerateCapturedInputDigest(
+        MeshNode node, NodeTypeDefinition? ntDef, string selfPath,
+        IReadOnlyList<MeshNode>? sourcesOverride)
+    {
         var assemblyName = $"DynamicNode_{cacheService.SanitizeNodeName(node.Path)}";
         return BoundLeg(
-                _ => SnapshotSources(ntDef, node.Path, sourcesOverride: null)
+                _ => SnapshotSources(ntDef, selfPath, sourcesOverride)
                     .Select(matches =>
                         NodeCompileShaping.CollectCompileSources(matches, node.Path, logger).Sources)
                     .SelectMany(codeFiles => ResolveIncludesForCodeFiles(codeFiles, node.Path))
                     .Select(codeFiles => PrepareGeneratedSource(
                         node, NodeCompileShaping.CombineSources(codeFiles),
-                        ntDef.Configuration, ntDef.ContentCollections))
+                        ntDef?.Configuration, ntDef?.ContentCollections))
                     .SelectMany(prepared => prepared.NuGetReferences.Length == 0
                         ? Observable.Return(
                             GeneratedInputDigestOf(assemblyName, prepared.Source, []))
@@ -1897,8 +1920,8 @@ internal class MeshNodeCompilationService(
             {
                 logger.LogInformation(ex,
                     "Re-evaluation for {NodePath}: the compile input could not be regenerated, so "
-                    + "the content key has no live counterpart — the build is judged by the "
-                    + "metadata-only rule, exactly as before", node.Path);
+                    + "the content key has no live counterpart — no input equality is established",
+                    node.Path);
                 return Observable.Return<string?>(null);
             });
     }

--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
@@ -218,11 +218,11 @@ internal class MeshNodeCompilationService(
     /// millisecond, the five <c>@@</c> targets of <c>FutuRe/LocalAnalysis/Source/ExternalDependencies</c>
     /// in file order).</para>
     ///
-    /// <para>The scope must be established at SUBSCRIBE time, not at composition time — hence
-    /// <c>Observable.Using</c>, whose resource factory runs inside the subscribe call that posts
-    /// the <c>GetDataRequest</c>. Wrapping each read individually (rather than the whole chain)
-    /// is deliberate: a chained read — the include fallback below — is subscribed from the FIRST
-    /// read's emission, i.e. on another thread again, so an outer scope would not cover it.</para>
+    /// <para>The scope must be established at SUBSCRIBE time and closed on that same flow.
+    /// <c>RunAsSystem</c> covers the cold read and restores the caller on return and on every
+    /// downstream notification. <c>Observable.Using</c> can dispose on the response thread and
+    /// leave the subscriber elevated. Wrapping each read individually is deliberate: the include
+    /// fallback starts from the FIRST read's emission, so it needs its own system scope.</para>
     ///
     /// <para>This is the explicit infrastructure opt-in AGENTS.md sanctions
     /// (<c>ImpersonateAsSystem</c>), NOT the "silently stamp hub-self as principal" fallback that
@@ -233,9 +233,8 @@ internal class MeshNodeCompilationService(
         string path, ReadTimeoutBehavior onTimeout)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        return Observable.Using(
-            () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-            _ => hub.GetMeshNode(path, TimeSpan.FromSeconds(15), onTimeout));
+        return accessService.RunAsSystem(
+            () => hub.GetMeshNode(path, TimeSpan.FromSeconds(15), onTimeout));
     }
 
     /// <summary>
@@ -1896,6 +1895,11 @@ internal class MeshNodeCompilationService(
         MeshNode node, NodeTypeDefinition? ntDef, string selfPath,
         IReadOnlyList<MeshNode>? sourcesOverride)
     {
+        // An absent/unresolved definition is not an empty configuration. The cache cannot
+        // establish input equality until the definition itself is known; compile as before.
+        if (ntDef is null)
+            return Observable.Return<string?>(null);
+
         var assemblyName = $"DynamicNode_{cacheService.SanitizeNodeName(node.Path)}";
         return BoundLeg(
                 _ => SnapshotSources(ntDef, selfPath, sourcesOverride)
@@ -1904,7 +1908,7 @@ internal class MeshNodeCompilationService(
                     .SelectMany(codeFiles => ResolveIncludesForCodeFiles(codeFiles, node.Path))
                     .Select(codeFiles => PrepareGeneratedSource(
                         node, NodeCompileShaping.CombineSources(codeFiles),
-                        ntDef?.Configuration, ntDef?.ContentCollections))
+                        ntDef.Configuration, ntDef.ContentCollections))
                     .SelectMany(prepared => prepared.NuGetReferences.Length == 0
                         ? Observable.Return(
                             GeneratedInputDigestOf(assemblyName, prepared.Source, []))

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -234,6 +234,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Retiring a NodeType](RetiringANodeType) — the prune keeps the definition and deletes its sources
 - [Dangling NodeTypes](DanglingNodeTypes) — a node whose type resolves to nothing, and the two write paths that allowed it
 - [Node Type Compilation](NodeTypeCompilation)
+- [Compile Cache Input Freshness](CompileCacheInputFreshness) — verify the captured input before reusing a DLL that finished after a source edit
 - [Execute-Time Interlock](ExecuteTimeInterlock) — a build proven stale is never armed
 - [Emit Reference Capture](EmitReferenceCapture) — bounded, opt-in CI evidence for runtime compiler failures
 - [Graph / Compiler Layering](GraphCompilerLayering) — the four assemblies, the cycle, and the full-MVID size rule

--- a/src/MeshWeaver.Documentation/Data/Architecture/CompileCacheInputFreshness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CompileCacheInputFreshness.md
@@ -48,6 +48,16 @@ when stamping the dependency record; the regenerated candidate digest is evidenc
 comparison, never a replacement producer claim. See
 [Producer Determinism of the Dependency Record](../ProducerDeterminismOfTheDependencyRecord).
 
+An unresolved NodeType definition is also inconclusive. It cannot be substituted with an empty
+configuration to establish cache equality. A present definition whose `Configuration` is null
+remains a valid input, so unchanged types with no configuration still take warm cache hits. This
+cache guard leaves the inherited fresh-compilation behavior for an unresolved definition unchanged.
+
+The include reader uses the existing `RunAsSystem` boundary for each cold read, including the
+fallback read started by an earlier response. It restores the subscribing flow and downstream
+callbacks to their caller identity. A long-lived `Observable.Using` impersonation scope would
+instead be disposed by the response flow and can leave the subscriber elevated.
+
 The existing re-evaluation entry point keeps its signature, discovery path and inconclusive
 result semantics. Neither `CompilationCacheService`'s load-context lifecycle nor the registry's
 late hand-over machinery changes here.
@@ -97,11 +107,28 @@ explicit local `en-US` setting is a reproducible test environment, **not a claim
 actual culture was observed**. Both the default-culture failure receipt and the explicit-culture
 success receipt are retained.
 
+### Review boundary regressions
+
+PR review identified two additional boundaries in the shared regeneration path. Four cases ran
+against the unchanged PR head `96c157e3`: the present-definition/null-configuration warm-cache
+control passed, while the missing-definition case and both real mesh source-read cases failed.
+The missing definition still produced a cache hit. The direct reader and the include fallback
+both left the subscribing caller holding `system-security` after `Subscribe` returned.
+
+The amended cases require a present null configuration to keep reusing the original artifact,
+but an unresolved definition to fall through to the existing fresh compiler. The real mesh read
+cases also assert the returned node and caller identity inside the result callback, so restoring
+an identity by preventing the read from working cannot pass. They invoke the existing private
+reader boundary through reflection without exposing a new production API. The amended focused
+selection passed **54/54** after a strict Release build with zero warnings or errors. The
+amended full compiler suite passed **849/849** with explicit `en-US`, zero errors, skips or unrun
+tests. The earlier default-culture failure and pre-review receipts above remain historical evidence.
+
 Reproduce with the normal SDK fixture:
 
 ```bash
 dotnet build test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj -c Release -warnaserror
-dotnet test test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj -c Release --no-build --no-restore --filter 'FullyQualifiedName~CompileCacheInputFreshnessTest|FullyQualifiedName~CacheHitStampsTheSameRecordTest|FullyQualifiedName~ContentKeyReevaluationTest|FullyQualifiedName~GeneratedInputIdentityTest' --logger trx
+dotnet test test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj -c Release --no-build --no-restore --filter 'FullyQualifiedName~CompileCacheInputFreshnessTest|FullyQualifiedName~CompileSourceReadIdentityTest|FullyQualifiedName~CacheHitStampsTheSameRecordTest|FullyQualifiedName~ContentKeyReevaluationTest|FullyQualifiedName~GeneratedInputIdentityTest' --logger trx
 cd test/MeshWeaver.Compiler.Pipeline.Test/bin/Release/net10.0
 dotnet MeshWeaver.Compiler.Pipeline.Test.dll -culture en-US -trx compiler-suite-en-US.trx -showLiveOutput -longRunning 60
 ```

--- a/src/MeshWeaver.Documentation/Data/Architecture/CompileCacheInputFreshness.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CompileCacheInputFreshness.md
@@ -1,0 +1,129 @@
+---
+Name: Compile Cache Input Freshness
+Category: Architecture
+Description: A cached NodeType assembly must describe the captured source and configuration inputs, even when an edit landed before an earlier compilation finished writing its DLL.
+Icon: Code
+---
+
+# Compile Cache Input Freshness
+
+A DLL's completion time does not establish which source snapshot it compiled. The runtime
+compiler therefore compares a cached artifact's **persisted producing input digest** with the
+generated input for the candidate snapshot before it reuses the artifact. Identical inputs still
+reuse their existing DLL and producer digest. Missing, different or inconclusive input identity
+follows the normal compilation path.
+
+This is the same `MeshNodeCompilationService` path used by automatic compilation and the
+NodeType's normal Compile action. It does not add a second compiler, disable caching, modify
+source timestamps, or alter registry adoption and release hand-over policy.
+
+## The failure
+
+The previous disk-cache predicate required a complete artifact set and a DLL write time at least
+as recent as the maximum source/NodeType LastModified and the framework timestamp. That allows
+this ordinary ordering:
+
+1. A compilation captures source snapshot A.
+2. An edit produces snapshot B while that compilation is running.
+3. The A DLL finishes writing after B's LastModified.
+4. The next compilation accepts the A DLL for B because its write time is newer.
+
+The false hit also returned the **current B source stamps** beside A's bytes and producing digest.
+`CompiledSources` could consequently claim the new source had compiled while the emitted methods
+still implemented A. Automatic dirty detection then had a misleading success record to compare.
+
+The normal forced Compile request bypasses dirty/prebuilt short-circuits but still enters this
+disk-cache path. Forcing a request alone did not repair its freshness predicate.
+
+## One captured snapshot, one input comparison
+
+`GetAssemblyLocationWithLog` retains its single captured Source/Test snapshot and timestamp-based
+candidate lookup. For a candidate with a persisted digest it calls the existing generated-input
+regeneration logic with that exact snapshot. The shared path applies the canonical source/test
+shaping, include resolution, configuration skeleton, NuGet directive handling and input digest.
+It does not independently rediscover source nodes for the comparison.
+
+Only a matching digest permits the hit. The successful hit still uses the **persisted digest**
+when stamping the dependency record; the regenerated candidate digest is evidence for the
+comparison, never a replacement producer claim. See
+[Producer Determinism of the Dependency Record](../ProducerDeterminismOfTheDependencyRecord).
+
+The existing re-evaluation entry point keeps its signature, discovery path and inconclusive
+result semantics. Neither `CompilationCacheService`'s load-context lifecycle nor the registry's
+late hand-over machinery changes here.
+
+## Executed regression
+
+The original regression ran against unmodified core
+`6231c4da4c1baa5dbcc9e44b43020006583fcb2c` on 2026-09-11. It uses the real
+`IMeshNodeCompilationService.CompileAndGetConfigurations` and its existing `sourcesOverride`
+fixture seam, then invokes methods from the emitted assembly under the real scan pin.
+
+The test derives B's LastModified as one tick before the first actual DLL's recorded completion
+time. This fixes the interleaving without a sleep, mocked compiler, or file timestamp edit. The
+before result was:
+
+```text
+Expected: 43|new-case;stampsCurrent=True
+Actual:   42|original-case;stampsCurrent=True
+Second compiler transcript: Cache hit
+```
+
+The source method and test-registration method both remained old while the returned source stamps
+claimed B. One case executed and failed; fixture teardown completed cleanly. That historical red
+predates the expanded case matrix and is not a claim that every later case was run red.
+
+The final `CompileCacheInputFreshnessTest` checks Source-only, Test-only, combined Source/Test and
+NodeType configuration-only changes. Every case owns a distinct type path because the standard
+fixture shares disk cache across instances of a test class. The configuration case invokes the
+actual emitted `HubConfiguration`, and the source cases inspect both emitted methods and
+`CompiledSources`.
+
+The focused selection passed **50/50**, including those four cases and the existing
+`CacheHitStampsTheSameRecordTest`, `ContentKeyReevaluationTest` and `GeneratedInputIdentityTest`
+controls. The compiler test project built in Release with warnings as errors, with zero warnings
+and errors. The unchanged-input control requires a real first emit, a subsequent actual cache
+hit, the same artifact path and an identical producer dependency record.
+
+The full compiler suite first ran with the machine's default culture: **842/845 passed**. The
+three failures were unchanged `ShortWriteIsNotAPublicationTest` assertions that require comma
+grouping (`65,536`, `4,096`, `16,384`) while the local runtime formatted Swiss apostrophes. The test
+and the relevant numeric-message formatter files are byte-identical to the baseline. With native
+xUnit's explicit `-culture en-US`, those three controls passed **3/3**, then the full compiler
+suite passed **845/845**, with no errors, skips or unrun tests. No assertion or formatter was changed.
+
+The CI workflow runs the native xUnit host on `ubuntu-latest` without a culture override. The
+explicit local `en-US` setting is a reproducible test environment, **not a claim that a CI job's
+actual culture was observed**. Both the default-culture failure receipt and the explicit-culture
+success receipt are retained.
+
+Reproduce with the normal SDK fixture:
+
+```bash
+dotnet build test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj -c Release -warnaserror
+dotnet test test/MeshWeaver.Compiler.Pipeline.Test/MeshWeaver.Compiler.Pipeline.Test.csproj -c Release --no-build --no-restore --filter 'FullyQualifiedName~CompileCacheInputFreshnessTest|FullyQualifiedName~CacheHitStampsTheSameRecordTest|FullyQualifiedName~ContentKeyReevaluationTest|FullyQualifiedName~GeneratedInputIdentityTest' --logger trx
+cd test/MeshWeaver.Compiler.Pipeline.Test/bin/Release/net10.0
+dotnet MeshWeaver.Compiler.Pipeline.Test.dll -culture en-US -trx compiler-suite-en-US.trx -showLiveOutput -longRunning 60
+```
+
+## The local sighting and what it does not prove
+
+The local 8339 Store preview supplied a separate production-code observation: a new native test
+class was present in a PDB-matched emitted source, while its test-area registration remained old.
+A later forced Compile at 04:43:49 returned a disk-cache hit on the 04:41 DLL and failed while
+pinning an unloading assembly context. A separately authorized normal retry later loaded the same
+DLL; its PDB still showed the old registration while the live/current and compiled source stamps
+agreed. The cache/compiler files were byte-identical at that preview's core `508aeb6` and the
+regression baseline `6231c4da`.
+
+The executed regression proves the cache's stale-byte/current-stamp mismatch. It does **not**
+establish which import/query boundary first supplied the preview's mixed snapshot, nor which
+operation caused the three failed scan-pin attempts. The unloading failure is a separate lifecycle
+investigation. Recycle unloads contexts but deliberately retains disk artifacts, so its success
+alone cannot certify source freshness.
+
+Original local evidence is retained at `/private/tmp/roadmap-compile-cache-investigation`
+(`before.trx`, `before-test.log`, `before-receipt.json`, exact baseline source copies and subsequent
+test receipts). The preview's PDB and activity receipts remain under
+`/private/tmp/coupon-input-preview-adoption-plan/post-cta-retry-pdb`. These paths are local evidence,
+not dependencies of the committed test. No deployment or production verification is claimed here.

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -296,6 +296,11 @@ node, its version bumps. The mismatch against the snapshot marks the NodeType
 dirty and triggers a recompile automatically — you never invalidate a cache by
 hand.
 
+A disk-cache candidate must also match the generated input for the captured source/test and
+configuration snapshot. Its DLL completion time alone cannot cover an edit made while an earlier
+compile was running. See [Compile Cache Input Freshness](../CompileCacheInputFreshness) for the
+executed stale-byte/current-stamp regression and the unchanged-input cache control.
+
 ### Source and test queries — and naming them
 
 Which Code nodes feed a compile is declared on `NodeTypeDefinition.Sources` /

--- a/src/MeshWeaver.Documentation/Data/Architecture/ProducerDeterminismOfTheDependencyRecord.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ProducerDeterminismOfTheDependencyRecord.md
@@ -67,6 +67,13 @@ real difference — which is what it is for.
 
 ## The fix: persist the digest, do not recompute it
 
+**Current cache contract:** the producing digest remains persisted and is never replaced by a
+newly computed claim. Cache reuse also compares it with the generated input for the captured
+candidate snapshot; a mismatch compiles normally. The distinction between **comparing** a candidate
+digest and **stamping** it onto earlier bytes is essential. See
+[Compile Cache Input Freshness](../CompileCacheInputFreshness) for the later source-edit regression.
+The timestamp-only rules discussed below describe the original producer-determinism investigation.
+
 The stage-1 digest is written into the emit's **staging directory** as `{nodeName}.inputdigest`,
 beside `{nodeName}.dll` and `{nodeName}.pdb`, before the directory rename that publishes the
 artifact under the cache's discovery glob. A cache hit reads it back and stamps the record with it.
@@ -83,7 +90,7 @@ Three properties follow from where it is written:
   type, for artifacts published by a build predating the sidecar — and the framework-timestamp check
   beside it usually invalidates those anyway.
 
-### Why not recompute the digest at the hit site?
+### Why not replace the producing digest at the hit site?
 
 It is available: `GeneratedInputDigestOf(assemblyName, source, nugetAssemblyPaths)` is a pure
 function of values the pipeline already has there, and `RegenerateGeneratedInputDigest` exists to
@@ -94,20 +101,24 @@ for the sidecar read, and both produce the identical `g…` digest. So cost is n
 **The argument is that a recomputed digest answers a different question.** The digest folds
 `EmitPipeline.OptionsFingerprint`, `GeneratedInputIdentity.CompilerIdentity` and the file identities
 of the **generator assemblies on disk** — properties of the process doing the computing, not of the
-bytes. Recomputing it describes *"what a compile RIGHT HERE would be fed"* and stamps that onto bytes
-some earlier process emitted.
+bytes. Recomputing it describes *"what a compile RIGHT HERE would be fed"*. Stamping that value
+onto an earlier artifact without establishing equality would misdescribe those bytes.
 
-That difference is reachable. The cache's validity rules are source-mtime and framework-mtime; they
-do not see a `#r "nuget:"` resolving to a different generator version, and they do not see a process
-restart on the same image. In either case a recomputed key would claim an equality that was never
-established — and because a matching content key DEMOTES the toolchain entry, it would license an
-adoption across precisely the change the toolchain entry exists to catch. Reading the producing
-compile's own digest off the disk cannot say anything the producing compile did not.
+That difference was reachable under the original source-mtime and framework-mtime cache predicate:
+it did not compare the generator or process compiler identities represented by the input digest.
+Replacing the producing key with a recomputed one could therefore claim equality that had never
+been established. Because a matching content key DEMOTES the toolchain entry, that would license
+adoption across precisely the change the toolchain entry exists to catch.
 
-Cost, meanwhile, is *not* uniformly small for the recompute option: on a real mesh the same
-regeneration performs source discovery (measured ~0.25 s per query on memex, four queries per type)
-and, for any type declaring `#r "nuget:"`, a NuGet restore — network IO, on every cache hit, per
-type at boot.
+The current cache path instead regenerates the candidate input and **compares** its digest with the
+persisted producing digest. Only equality permits reuse; a different generator/compiler identity,
+changed source or configuration, or an inconclusive comparison follows normal compilation. The
+successful hit still stamps the producing digest read from disk.
+
+Cost is not uniformly small: the original independent regeneration measured source discovery at
+~0.25 s per query on memex, four queries per type, plus NuGet resolution for types declaring
+`#r "nuget:"`. The cache comparison now reuses its already captured Source/Test snapshot, avoiding
+another discovery of those nodes; include and NuGet resolution retain their existing behavior.
 
 ## Where the code lives
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-recompile-keeps-edits-made-during-an-earlier-build.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-recompile-keeps-edits-made-during-an-earlier-build.md
@@ -1,0 +1,13 @@
+---
+Name: Recompile keeps edits made during an earlier build
+Category: Fix
+Description: Recompiling a NodeType now checks the cached assembly's actual inputs, so a source or test edit cannot disappear behind an earlier build that finished later.
+Icon: Code
+Order: -20260911
+---
+
+# Recompile keeps edits made during an earlier build
+
+An edit made while a NodeType was compiling could leave the next compile using the earlier code,
+even though its source status appeared current. Cached assemblies now have to match the captured
+source, test and configuration inputs before they are reused. Unchanged inputs still use the cache.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/CompileCacheInputFreshnessTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/CompileCacheInputFreshnessTest.cs
@@ -1,0 +1,159 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reactive.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// An artifact's completion time cannot prove that it contains an edit made after its source
+/// snapshot. Exercises the real compiler and emitted methods, including the test registration
+/// source, without a sleep, mocked compiler, or altered file timestamp.
+/// </summary>
+public class CompileCacheInputFreshnessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // The real fixture shares disk cache per test class; each case owns a distinct artifact.
+    private readonly string typePath = "type/CompileCacheInputFreshness" + Guid.NewGuid().ToString("N");
+    private IMeshNodeCompilationService Compiler =>
+        Mesh.ServiceProvider.GetRequiredService<IMeshNodeCompilationService>();
+
+    private MeshNode TypeNode(DateTimeOffset modified, string marker = "original") => MeshNode.FromPath(typePath) with
+    {
+        NodeType = MeshNode.NodeTypePath,
+        Name = "Compile cache input freshness",
+        LastModified = modified,
+        Content = new NodeTypeDefinition
+        {
+            Configuration = $"config => config.WithContentType<CacheFreshnessContent>().Set(\"{marker}\", \"cache-input-probe\")",
+        },
+    };
+
+    private ImmutableArray<MeshNode> Sources(DateTimeOffset modified, int answer, string testCase) =>
+    [
+        new MeshNode("Probe", typePath + "/Source")
+        {
+            NodeType = "Code", LastModified = modified,
+            Content = new CodeConfiguration
+            {
+                Language = "csharp",
+                Code = $$"""
+                    public record CacheFreshnessContent { public string Title { get; init; } = ""; }
+                    public static class CacheFreshnessApi { public static int Answer() => {{answer}}; }
+                    """,
+            },
+        },
+        new MeshNode("Registration", typePath + "/Test")
+        {
+            NodeType = "Code", LastModified = modified,
+            Content = new CodeConfiguration
+            {
+                Language = "csharp",
+                Code = $$"""
+                    public static class CacheFreshnessRegistration
+                    {
+                        public static string RegisteredCase() => "{{testCase}}";
+                    }
+                    """,
+            },
+        },
+    ];
+
+    private static string Transcript(NodeCompilationResult result) =>
+        string.Join(" | ", result.Log?.Messages.Select(m => m.Message) ?? []);
+
+    private string EmittedBehavior(NodeCompilationResult result)
+    {
+        var cache = Mesh.ServiceProvider.GetRequiredService<ICompilationCacheService>();
+        using var pinned = cache.PinForScan(cache.SanitizeNodeName(typePath), result.AssemblyLocation);
+        var assembly = Assert.IsAssignableFrom<Assembly>(pinned.Context.LoadNodeAssembly());
+        var api = Assert.IsAssignableFrom<Type>(assembly.GetType("CacheFreshnessApi"));
+        var registration = Assert.IsAssignableFrom<Type>(assembly.GetType("CacheFreshnessRegistration"));
+        return $"{api.GetMethod("Answer")!.Invoke(null, null)}|"
+            + registration.GetMethod("RegisteredCase")!.Invoke(null, null);
+    }
+
+    [Theory(Timeout = 300_000)]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task SourceAndTestEditsBeforeThePreviousEmitFinished_MustNotReuseItsBytes(
+        bool changeSource, bool changeTest)
+    {
+        var capturedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var type = TypeNode(capturedAt);
+        var before = Sources(capturedAt, 42, "original-case");
+        var first = Assert.IsAssignableFrom<NodeCompilationResult>(await Compiler.CompileAndGetConfigurations(type, before)
+            .Take(1).Should().Within(TestTimeouts.Convergence).Emit());
+        Transcript(first).Should().Contain("Compiled assembly written to");
+        EmittedBehavior(first).Should().Be("42|original-case");
+
+        // Model an edit that landed after the immutable snapshot was captured, but before its
+        // DLL finished writing. Control the snapshot timestamp from that actual artifact; never
+        // change the artifact's clock, sleep, or race a fast machine against wall time.
+        var finishedAt = new DateTimeOffset(File.GetLastWriteTimeUtc(first.AssemblyLocation!), TimeSpan.Zero);
+        var editedAt = finishedAt.AddTicks(-1);
+        editedAt.Should().BeAfter(capturedAt);
+        var answer = changeSource ? 43 : 42;
+        var testCase = changeTest ? "new-case" : "original-case";
+        var changed = Sources(editedAt, answer, testCase);
+        var after = ImmutableArray.Create(changeSource ? changed[0] : before[0],
+            changeTest ? changed[1] : before[1]);
+        var second = Assert.IsAssignableFrom<NodeCompilationResult>(await Compiler.CompileAndGetConfigurations(type, after)
+            .Take(1).Should().Within(TestTimeouts.Convergence).Emit());
+        var behavior = EmittedBehavior(second);
+        var stampedCurrentSources = after.All(source => second.CompiledSources is { } snapshot
+            && snapshot.TryGetValue(source.Path, out var stamp)
+            && stamp == NodeTypeDefinition.SourceVersionOf(source));
+        Output.WriteLine("First DLL finished {0:O}; edit {1:O}; second artifact {2}; emitted={3}; stampsCurrent={4}",
+            finishedAt, editedAt, second.AssemblyLocation ?? "(none)", behavior, stampedCurrentSources);
+        Output.WriteLine("Second compiler transcript: {0}", Transcript(second));
+
+        // Before the fix this says 42|original-case while claiming the new source stamps. The
+        // failure names BOTH the stale behavior and the false provenance, not only a path choice.
+        Assert.Equal($"{answer}|{testCase};stampsCurrent=True", $"{behavior};stampsCurrent={stampedCurrentSources}");
+        second.AssemblyLocation.Should().NotBe(first.AssemblyLocation);
+        second.CompiledDependencies![CompiledDependencies.ContentKey]
+            .Should().NotBe(first.CompiledDependencies![CompiledDependencies.ContentKey]);
+    }
+
+    private string? EmittedConfiguration(NodeCompilationResult result)
+    {
+        var configure = Assert.Single(result.NodeTypeConfigurations).HubConfiguration;
+        Assert.NotNull(configure);
+        return configure(new MessageHubConfiguration(Mesh.ServiceProvider, Mesh.Address))
+            .Get<string>("cache-input-probe");
+    }
+
+    [Fact(Timeout = 300_000)]
+    public async Task ConfigurationEditBeforeThePreviousEmitFinished_MustNotReuseItsConfiguration()
+    {
+        var capturedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var before = TypeNode(capturedAt);
+        var sources = Sources(capturedAt, 42, "original-case");
+        var first = Assert.IsAssignableFrom<NodeCompilationResult>(await Compiler
+            .CompileAndGetConfigurations(before, sources).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit());
+        Transcript(first).Should().Contain("Compiled assembly written to");
+        EmittedConfiguration(first).Should().Be("original");
+        var editedAt = new DateTimeOffset(File.GetLastWriteTimeUtc(first.AssemblyLocation!), TimeSpan.Zero)
+            .AddTicks(-1);
+        editedAt.Should().BeAfter(capturedAt);
+
+        var second = Assert.IsAssignableFrom<NodeCompilationResult>(await Compiler
+            .CompileAndGetConfigurations(TypeNode(editedAt, "changed"), sources).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit());
+        EmittedConfiguration(second).Should().Be("changed");
+        EmittedBehavior(second).Should().Be("42|original-case", "only the configuration changed");
+        second.AssemblyLocation.Should().NotBe(first.AssemblyLocation);
+        second.CompiledDependencies![CompiledDependencies.ContentKey]
+            .Should().NotBe(first.CompiledDependencies![CompiledDependencies.ContentKey]);
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/CompileCacheInputFreshnessTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/CompileCacheInputFreshnessTest.cs
@@ -156,4 +156,50 @@ public class CompileCacheInputFreshnessTest(ITestOutputHelper output) : Monolith
         second.CompiledDependencies![CompiledDependencies.ContentKey]
             .Should().NotBe(first.CompiledDependencies![CompiledDependencies.ContentKey]);
     }
+
+    [Theory(Timeout = 300_000)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ADefinitionWithNullConfiguration_CanMatchButAnUnresolvedDefinitionCannot(
+        bool definitionBecomesUnresolved)
+    {
+        var capturedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+        // The first call has an explicit definition. The second can resolve neither a definition
+        // in Content nor this deliberately absent owning type. Keep every other generated input
+        // unchanged so the old null-as-empty path would certify exactly the first artifact.
+        var before = TypeNode(capturedAt) with
+        {
+            NodeType = "type/AbsentDefinition" + Guid.NewGuid().ToString("N"),
+            Content = new NodeTypeDefinition(),
+        };
+        var sources = Sources(capturedAt, 42, "original-case");
+        var first = Assert.IsAssignableFrom<NodeCompilationResult>(await Compiler
+            .CompileAndGetConfigurations(before, sources).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit());
+        Transcript(first).Should().Contain("Compiled assembly written to");
+        EmittedBehavior(first).Should().Be("42|original-case");
+
+        var next = definitionBecomesUnresolved ? before with { Content = null } : before;
+        var second = Assert.IsAssignableFrom<NodeCompilationResult>(await Compiler
+            .CompileAndGetConfigurations(next, sources).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit());
+        Output.WriteLine("Second compiler transcript: {0}", Transcript(second));
+        EmittedBehavior(second).Should().Be("42|original-case");
+        if (definitionBecomesUnresolved)
+        {
+            Transcript(second).Should().Contain("NULL — the read stalled or the node is absent");
+            Transcript(second).Should().NotContain("Cache hit",
+                "an unestablished definition cannot certify equality with the producing input");
+            second.AssemblyLocation.Should().NotBe(first.AssemblyLocation);
+        }
+        else
+        {
+            Transcript(second).Should().Contain("Cache hit",
+                "a present definition with a legitimately null Configuration is conclusive");
+            second.AssemblyLocation.Should().Be(first.AssemblyLocation);
+            second.CompiledDependencies![CompiledDependencies.ContentKey]
+                .Should().Be(first.CompiledDependencies![CompiledDependencies.ContentKey]);
+        }
+    }
+
 }

--- a/test/MeshWeaver.Compiler.Pipeline.Test/CompileSourceReadIdentityTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/CompileSourceReadIdentityTest.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// Executes the compiler's actual cold reader against a real mesh. A successful infrastructure
+/// read must leave both the subscribing flow and its downstream callback under their own identity.
+/// The fallback case starts a second read from the first response, preserving the per-read scope.
+/// </summary>
+public class CompileSourceReadIdentityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Theory(Timeout = 120_000)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ACompileSourceRead_DoesNotGiveItsSystemIdentityToItsCaller(bool useFallback)
+    {
+        var path = "type/CompileReadIdentity" + Guid.NewGuid().ToString("N");
+        await Mesh.ServiceProvider.GetRequiredService<IMeshService>().CreateNode(MeshNode.FromPath(path) with
+            { NodeType = "Markdown", Content = "Compiler read identity probe" })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var compiler = Mesh.ServiceProvider.GetRequiredService<IMeshNodeCompilationService>();
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        using var caller = access.SwitchAccessContext(new AccessContext
+            { ObjectId = "compile-read-caller", Name = "Compile read caller" });
+
+        // Invoke the existing private boundary rather than duplicate its scoping idiom in a test.
+        // Reflection keeps this regression from widening a production API solely for tests.
+        IObservable<MeshNode?> read;
+        if (useFallback)
+        {
+            var method = Assert.IsAssignableFrom<MethodInfo>(compiler.GetType().GetMethod(
+                "ReadIncludeNode", BindingFlags.Instance | BindingFlags.NonPublic));
+            var fallbackRead = Assert.IsAssignableFrom<IObservable<(MeshNode? Node, string Path)>>(
+                method.Invoke(compiler, [path + "-absent", path]));
+            read = fallbackRead.Do(found => found.Path.Should().Be(path)).Select(found => found.Node);
+        }
+        else
+        {
+            var method = Assert.IsAssignableFrom<MethodInfo>(compiler.GetType().GetMethod(
+                "ReadCompileSourceNode", BindingFlags.Instance | BindingFlags.NonPublic));
+            read = Assert.IsAssignableFrom<IObservable<MeshNode?>>(
+                method.Invoke(compiler, [path, ReadTimeoutBehavior.Throw]));
+        }
+
+        using var outcome = new AsyncSubject<(MeshNode? Node, string? Identity)>();
+        using var subscription = read.Select(node => (node, access.Context?.ObjectId)).Subscribe(outcome);
+        access.Context?.ObjectId.Should().Be("compile-read-caller",
+            "the synchronous Subscribe must close the infrastructure identity on this flow");
+        var result = await outcome.Should().Within(TestTimeouts.Convergence).Emit();
+        result.Node.Should().NotBeNull("the scoped infrastructure read still has to reach the node");
+        result.Node!.Path.Should().Be(path);
+        result.Identity.Should().Be("compile-read-caller",
+            "a caller composed after the read must not inherit its system privilege");
+    }
+}


### PR DESCRIPTION
A source edit can arrive after a compilation captures its inputs but before its DLL finishes writing. The former timestamp-only cache check then returned the earlier DLL with current `CompiledSources`, although its emitted code and test registration still implemented the earlier snapshot.

Before reusing a disk artifact, the existing compiler compares its persisted producing digest with generated input from the exact captured Source/Test snapshot and NodeType configuration. Different, missing or inconclusive input identity takes the normal compilation path. Identical inputs still reuse the original artifact and its producing digest.

An unresolved NodeType definition now remains inconclusive; a present definition with legitimately null Configuration still supports warm-cache reuse. Each include/source read uses the existing per-read `RunAsSystem` boundary so the read remains privileged while its subscribing flow and downstream callbacks keep their caller identity. Assembly-load-context handling, registry adoption and release hand-over are unchanged.

Validation:

- The original actual-compiler regression failed on unmodified core with `42|original-case;stampsCurrent=True` instead of `43|new-case;stampsCurrent=True`. The final cases cover Source-only, Test-only, combined and configuration-only edits.
- Review regressions against unchanged head `96c157e3`: three failures reproduced (unresolved definition incorrectly reused the artifact; direct and fallback real mesh reads left the subscribing caller as system-security). The present-null-configuration warm-cache control passed.
- Amended focused compiler tests: **54/54 passed**. Full compiler suite with explicit native xUnit `-culture en-US`: **849/849 passed**, zero errors/skips/unrun tests.
- Existing messaging identity controls: **20/20 passed**. Rebuilt documentation embedding, release-note integrity and architecture map checks: **15/15 passed**.
- Compiler, messaging test and documentation test projects built in Release with warnings as errors: zero warnings/errors.

The earlier default-culture compiler run was 842/845: three unchanged numeric-message assertions expected comma separators while this machine rendered Swiss apostrophes. The formatter and tests matched the baseline; no assertion or formatter was changed. Explicit en-US is the local test environment, not a claim about an observed CI culture.

[Committed investigation and reproduction](https://github.com/Systemorph/MeshWeaver/blob/62b7b736682ad7510d0ceba815fb2e683baa520f/src/MeshWeaver.Documentation/Data/Architecture/CompileCacheInputFreshness.md) preserve historical evidence and distinguish the proven cache defect from the separate preview unloading failure. Exact local TRX counts and tested source/artifact hashes are recorded in `/private/tmp/roadmap-compile-cache-investigation/review-final-receipt.json`; the original `final-receipt.json` is retained.

**Draft hold for the amended CI run and coordinated release.** The previous head passed CI; that result does not certify this amendment. No ready, merge, queue, runtime or production action is included.
