### PR TITLE
Verify #3954's fix end to end, and document it on the cache's own page

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
@@ -348,6 +348,67 @@ The primary rule still stands: **optional / maybe-absent nodes are read via a qu
 
 A failure that is *not* a genuine missing node — a transient reactivation miss, a request timeout, a lost database connection, or anything else the classifier does not recognise — is recorded in the **transient breaker** instead. Its first `TransientGraceFailures` (3) faults open no window at all (the just-idle-page case keeps its instant re-probe); beyond the grace, re-probes back off 1 s doubling to a 60 s cap. Every fault lands in exactly one of the two breakers — there is no un-broker'd bucket where a fault can repeat unbounded.
 
+### An invalidation is authoritative over a miss that was already in flight
+
+The breaker's failure state is **invalidated by the change feed**: a published change for a path — a
+post-commit write, or the `Updated` broadcast `MeshOperations.RecycleCore` publishes — reaches
+`OnMeshChange` → `ResetFailureState`, which drops the negative entry and evicts a faulted read entry.
+That much always worked. What did not was the **ordering** (#3954):
+
+1. A read — or a queued write — at `P` probes the owner, which answers `NotFound`.
+2. `CreateNode(P)` commits and publishes `Created`; the reset drops a negative entry that is *not
+   there yet*, so it clears nothing.
+3. The `NotFound` from step 1 lands and records a negative **for a path that now exists**.
+4. Reads fast-fail `Not found` and writes are suppressed — the breaker gates both — until the
+   backoff elapses or *another* change event for `P` arrives.
+
+Step 4 is why the production symptom read as *"only `recycle` fixes it"*: a recycle publishes exactly
+such an event. On memex at 05:40Z the `create` succeeded and `search` returned the new row while `get`
+kept answering `Not found`, produced from cache without ever reaching the owner.
+
+The fix is the mechanism `PathResolutionService` already uses for the identical fill-after-invalidate
+race (`_pendingFills` / `ClaimStillHeld`) — **not** a shorter window, a sweeper, a timer or a retry.
+The invalidation already happened at the right time; it simply was not authoritative.
+
+**A probe claims the path before it opens its owner round-trip.** `BeginNegativeProbe` is called by
+`CreateEntry` (reads) and by the update queue's dispatch (writes). `_negativeClaims` holds **one
+current claim per path**: a new probe *replaces* the previous claim and invalidates it, carrying the
+old `FailCount` forward as `PriorFailCount` so a natural re-probe keeps the established exponential
+backoff instead of restarting at the 2 s base.
+
+**A negative entry belongs to a generation.** `NegativeEntry` carries the `Claim` it was recorded
+under, and every consumer — `GetStreamRaw`'s fast-fail, `UpdateRaw`'s write-side fast-fail and
+`IsStormWindowOpen` — checks `IsCurrentNegative` and evicts an entry whose claim is no longer current.
+So even an entry that is briefly published by a losing probe can never fast-fail a caller.
+
+**Admission is a compare-and-swap loop.** `TryRecordNegative` validates the claim, builds the entry,
+validates again, publishes pair-exact (`TryAdd` / `TryUpdate` against the exact expected pair), and
+re-validates once more — retracting pair-exact if an invalidation landed in between. That closes both
+interleavings: an invalidation that runs before the write is caught by the checks, and one that runs
+between the check and the write swept an empty slot, so the retraction is what stops the entry
+outliving it. The symmetric rule holds for clearing: `TryRemoveNegativeGeneration` removes only the
+entry belonging to the generation just invalidated, so a path-wide clear can never erase a *newer*
+probe's genuine miss or its grown backoff.
+
+**Claims are not a second permanent path cache.** A successful or transient probe completes its claim;
+a pending probe torn down before any terminal releases it; only a genuine miss retains one, and then
+just for the lifetime of the negative entry it recorded. Cardinality is therefore in-flight probes
+plus `_negative`, never one per path ever read. Disposal invalidates and clears the registry with the
+rest of the breaker state.
+
+**Consequently `recycle` is no longer load-bearing for this symptom.** It still does what it always
+did — publish an `Updated` for the path, which resets the failure state, and that remains the cure for
+a genuinely failed era (the 2026-07-19 compile-error wedge). It is now a redundant second cure rather
+than the only escape from a window the create should already have closed.
+
+Pinned from both sides: `NegativeCacheInvalidationRaceTest` (MeshWeaver.Hosting.Test) holds one probe
+open across the invalidation with a substituted gated owner and covers the CAS interleavings and claim
+lifetime; `StaleNegativeAfterARealCreateTest` (MeshWeaver.Graph.Test) drives the same race through the
+ordinary pipeline — a real `CreateNode`, the real change-feed broadcast, several probes in flight —
+and asserts the user-visible half: `get` answers the node and a follow-up write lands, with no recycle.
+Both carry the positive controls, because an admission path that refused *every* verdict would pass a
+one-directional test while deleting the storm protection this section exists to describe.
+
 ### A faulted entry is never served twice
 
 Both breakers *suppress* while their window is open. When no window is open, the opposite must hold: the read has to actually re-probe. `GetStreamRaw`'s third guard enforces that — an entry whose hydration terminated with an error is evicted before the read resolves, so `SharedView` opens a fresh upstream.

--- a/test/MeshWeaver.Graph.Test/StaleNegativeAfterARealCreateTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleNegativeAfterARealCreateTest.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>THE #3954 RACE, END TO END ON A REAL MESH.</b> The negative-probe claim protocol is pinned
+/// close-up by <c>NegativeCacheInvalidationRaceTest</c> (MeshWeaver.Hosting.Test), which substitutes
+/// a gated owner so one probe can be held open across the invalidation. These arms are the other
+/// half of the evidence: the same race driven through the <b>ordinary</b> pipeline — a real
+/// <c>CreateNode</c>, the real <see cref="IMeshChangeFeed"/> broadcast, several probes in flight at
+/// once — asserting the thing a user actually observes.
+///
+/// <para><b>The incident.</b> At 05:40Z on memex (the third symptom of #3894) a <c>create</c>
+/// succeeded and <c>search</c> returned the new row, while <c>get</c> kept answering
+/// <c>Not found</c> until somebody issued a <c>recycle</c>. The cached miss lives in
+/// <c>MeshNodeStreamCache._negative</c>; the create's <c>Created</c> broadcast already reset it, but
+/// a <c>NotFound</c> from a probe that had subscribed <em>earlier</em> landed <em>afterwards</em> and
+/// re-armed a window of up to five minutes. The breaker fast-fails <b>reads and writes alike</b>, so
+/// the stale negative also suppressed the writes that would have cleared it, and the only thing that
+/// closed it again was a further change event for the path — which is exactly what <c>recycle</c>
+/// publishes.</para>
+///
+/// <para><b>Why this is deterministic.</b> The race is an ORDERING, so the test imposes one. A probe
+/// stakes its claim through the production seam (<c>BeginNegativeProbe</c>) before the create, and
+/// delivers its verdict through the production admission path afterwards — the two instants the live
+/// race orders by accident. Everything between them is real: a real <c>CreateNode</c> publishing the
+/// real post-commit <c>Created</c> event into the real change feed.</para>
+///
+/// <para>🚨 <b>Controls run in BOTH directions</b>, because a fence that simply stopped recording
+/// negatives would delete the storm protection this cache exists to provide.
+/// <see cref="AGenuineMiss_OnAPathThatNeverExisted_OpensTheWindow"/> is the organic positive control
+/// on the live read path, and
+/// <see cref="ALateMiss_WithNoInvalidationInBetween_IsStillAdmitted"/> is the positive control on the
+/// seam itself — without it the negative arm would pass just as happily against an admission path
+/// that refused everything, i.e. it would assert an absence nothing could falsify.</para>
+/// </summary>
+public class StaleNegativeAfterARealCreateTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    private static string NewPath(string prefix) => $"{TestPartition}/{prefix}-{Guid.NewGuid():N}";
+
+    private static MeshNode Node(string path, string name) => MeshNode.FromPath(path) with
+    {
+        Name = name,
+        NodeType = "Markdown",
+        State = MeshNodeState.Active,
+    };
+
+    /// <summary>
+    /// Reads <paramref name="path"/> through the cache and returns the owner's REAL missing-node
+    /// failure, so the arms below carry the exception class production mints rather than a
+    /// hand-written stand-in. The classifier agreement is asserted, so a classifier change cannot
+    /// silently hollow these tests out.
+    /// </summary>
+    private async Task<Exception> RealMissingNodeFailure(string path)
+    {
+        var failure = await Cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(TestTimeouts.Convergence).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "reading a path that does not exist must surface the owner's NotFound as OnError");
+        MeshNodeStreamCache.IsMissingNodeFailure(failure.Exception!).Should().BeTrue(
+            "precondition: the organic failure must be the class the storm breaker records");
+        return failure.Exception!;
+    }
+
+    /// <summary>
+    /// 🚨 POSITIVE CONTROL, organic and first: the live read path must still arm the breaker on a
+    /// path that genuinely does not exist. This is the protection the class exists for, and the
+    /// thing an over-eager fence would silently remove.
+    /// </summary>
+    [Fact]
+    public async Task AGenuineMiss_OnAPathThatNeverExisted_OpensTheWindow()
+    {
+        var path = NewPath("really-absent");
+
+        await RealMissingNodeFailure(path);
+
+        Cache.IsStormWindowOpen(path).Should().BeTrue(
+            "a point read of a path that really does not exist must open the breaker window — the "
+            + "#3954 claim protocol refuses only a verdict an invalidation has already staled, and "
+            + "nothing invalidated this path");
+
+        await Cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(TestTimeouts.Quick).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "the open window must fast-fail the re-read from cache instead of re-probing the owner");
+    }
+
+    /// <summary>
+    /// 🚨 THE REPRO. Several probes are in flight at <c>P</c> when a REAL <c>CreateNode(P)</c> lands,
+    /// and their misses arrive afterwards. Every one must be refused, the window must stay shut, and
+    /// — the user-visible half — <c>get</c> must answer the node and a follow-up write must land,
+    /// with <b>no recycle published anywhere in this test</b>.
+    /// </summary>
+    [Fact]
+    public async Task MissesThatLandAfterARealCreate_DoNotReArmTheWindow_AndNoRecycleIsNeeded()
+    {
+        var cache = Cache;
+        var path = NewPath("late-miss");
+
+        // The real owner error those probes are carrying, and the control that the window DOES open
+        // when nothing has invalidated the path yet.
+        var missing = await RealMissingNodeFailure(path);
+        cache.IsStormWindowOpen(path).Should().BeTrue(
+            "control: before the create, a miss on this path is genuine and arms the breaker — so a "
+            + "closed window at the end can only be the claim protocol's doing");
+
+        // The readers that went out BEFORE the create — the shape of a page whose bindings all read
+        // the same path. Each stakes its claim through the production seam; a later probe replaces
+        // an earlier one, exactly as concurrent reads do.
+        var probes = Enumerable.Range(0, 5).Select(_ => cache.BeginNegativeProbe(path)).ToArray();
+
+        // The create: the ordinary pipeline, whose post-commit Created publish IS the invalidation.
+        await NodeFactory.CreateNode(Node(path, "NowExists")).Should().Within(TestTimeouts.Convergence).Emit();
+
+        // …and now every one of those misses lands, after the invalidation has already run.
+        foreach (var probe in probes)
+            cache.TryRecordNegativeForTest(path, missing, probe, static () => { }).Should().BeFalse(
+                "a miss minted by a probe that was already in flight when the create invalidated the "
+                + "path is stale on arrival — admitting it re-arms a window that only another change "
+                + "event, i.e. a recycle, would close again (#3954)");
+
+        cache.IsStormWindowOpen(path).Should().BeFalse(
+            "no stale miss may leave a fast-fail window on a path that now exists");
+
+        // The user-visible consequence: `get` answers the node, WITHOUT a recycle.
+        var node = await cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Where(n => n is not null)
+            .Should().Within(TestTimeouts.Convergence).Emit(
+                "the node exists, so `get` must answer it — this is the read that kept saying "
+                + "'Not found' on memex at 05:40Z until somebody recycled");
+        node!.Path.Should().Be(path);
+
+        // …and the other half the breaker gates. A stale negative fast-fails WRITES too
+        // (MeshNodeStreamCache.UpdateRaw), so it suppressed the write that would have cleared it.
+        await Mesh.GetMeshNodeStream(path)
+            .Update(n => n with { Name = "WrittenWithoutARecycle" })
+            .Should().Within(TestTimeouts.Convergence).Emit(
+                "the breaker fast-fails writes on a windowed path as well, so the same stale verdict "
+                + "suppressed the write that would have cleared it");
+    }
+
+    /// <summary>
+    /// 🚨 POSITIVE CONTROL on the SEAM. Identical to the repro except that nothing invalidates the
+    /// path in between — so the miss IS admitted. Without this arm the repro would pass against an
+    /// admission path that refused every verdict, and would be asserting nothing.
+    /// </summary>
+    [Fact]
+    public async Task ALateMiss_WithNoInvalidationInBetween_IsStillAdmitted()
+    {
+        var cache = Cache;
+        var path = NewPath("no-invalidation");
+
+        var missing = await RealMissingNodeFailure(path);
+
+        // A fresh probe supersedes the organic read's claim, as a natural re-probe does…
+        var probe = cache.BeginNegativeProbe(path);
+        // …and NOTHING happens here. No create, no write, no change event of any kind.
+        cache.TryRecordNegativeForTest(path, missing, probe, static () => { }).Should().BeTrue(
+            "a verdict from a probe whose claim is still current must be admitted exactly as before "
+            + "#3954 — the refusal is conditional on an invalidation having run, and this is the "
+            + "control that proves the negative arm could have failed");
+
+        cache.IsStormWindowOpen(path).Should().BeTrue(
+            "an admitted miss opens the fast-fail window, which is the storm protection this cache "
+            + "exists to provide");
+    }
+}


### PR DESCRIPTION
Relates to #3954 — **which is already fixed on `main` by #3980** (merged 05:27Z, `13fb079d` + `7b8df6cb`). **This PR changes no production code.**

I picked #3954 up concurrently and had an independent fix ready before noticing #3980 had landed. Shipping a competing rewrite of merged work would be the wrong move, so the source change is dropped and the effort is redirected to the two things genuinely missing around the landed fix.

## 1. Verification, from the other side

#3980's `NegativeCacheInvalidationRaceTest` substitutes a gated owner so a single probe can be held open across the invalidation — close-up coverage of the CAS interleavings, generation ordering and claim lifetime.

`StaleNegativeAfterARealCreateTest` (MeshWeaver.Graph.Test) drives the **same race through the ordinary pipeline**: a real `CreateNode`, the real `IMeshChangeFeed` post-commit broadcast, **five** probes claimed before the create, and assertions on the half a user actually observes — `get` answers the node and a follow-up `Update` lands, with **no recycle published anywhere in the test**. That is the 05:40Z memex shape end to end.

**Controls in both directions**, because an admission path that refused *every* verdict would pass a one-directional test while deleting the storm protection the breaker exists to provide:

| Arm | Asserts |
|---|---|
| `MissesThatLandAfterARealCreate_DoNotReArmTheWindow_AndNoRecycleIsNeeded` | five late misses all refused, window shut, `get` emits the node, `Update` lands — no recycle |
| `AGenuineMiss_OnAPathThatNeverExisted_OpensTheWindow` | organic positive control — the live read path still arms the breaker, and the re-read still fast-fails from cache |
| `ALateMiss_WithNoInvalidationInBetween_IsStillAdmitted` | seam positive control — refusal is conditional on an invalidation having run, so the negative arm could have failed |

**Falsified rather than assumed.** With `InvalidateNegativeProbe` neutered, the repro arm reds on its own assertion and both controls stay green:

```
Expected value to be false because a miss minted by a probe that was already in flight
when the create invalidated the path is stale on arrival — admitting it re-arms a window
that only another change event, i.e. a recycle, would close again (#3954), but found True.
```

So the arms measure the fence, not something incidental. **Verdict: #3980's fix is verified end to end, and `recycle` is no longer load-bearing for this symptom.**

## 2. The mechanism, on the cache's own page

#3980 recorded it on `Doc/Architecture/NodeIdentityAndPathKeying`, where it is an aside on a page about `(namespace, id)` keying. `Doc/Architecture/MeshNodeStreamCache` — the class's manual — said nothing, so a reader learned about the storm breaker without learning that its invalidation is generation-scoped.

New section under *The storm breaker*: the ordering that failed, the claim protocol (`BeginNegativeProbe` / one current claim per path / `PriorFailCount` carry-over), generation-scoped entries (`IsCurrentNegative` at every consumer), pair-exact admission and clearing, why claims are not a second permanent path cache, and why `recycle` stops being load-bearing. It names both test suites and says what each covers.

## Not included, deliberately

- **No production code change.** Main's implementation is sound and, on two points, better than mine: it uses an atomic per-path claim slot rather than a sweep over a claim set, and it replaces claims per probe so backoff survives a re-probe.
- **No What's New entry** — #3980 already shipped *"A created node no longer stays 'not found' until restart"*, and this PR alters no behaviour.

## One observation, flagged not changed

`OnMeshChange` invalidates the claim for **every** kind, `Deleted` included. A `NotFound` in flight when a node is deleted is *true*, so that verdict is refused and the delete-storm protection (#3517's shape — a view re-binding a just-deleted path 3–5× per render) costs one grace read before the next probe re-arms. Bounded, and possibly deliberate. Raised on #3954 rather than changed here.

## Verified locally

- `dotnet build -c Release -warnaserror` — `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test`: **0 Error(s), 0 Warning(s)**.
- `StaleNegativeAfterARealCreateTest` + `NodeBoundBindingToleratesAnAbsentNodeTest` — 6 passed.
- `MeshWeaver.Documentation.Test` full (incl. `DocumentationLinkIntegrityTest`, `ArchitectureTopicMapTest`, every ratchet guard) — 390 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
