### PR TITLE
fix(#3986): the stream release orders BEHIND an accepted user action

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -649,11 +649,38 @@ public static class JsonSynchronizationStream
                 )
             );
 
-        reduced.RegisterForDisposal(
-            new AnonymousDisposable(
-                () => hub.Post(new UnsubscribeRequest(reduced.StreamId), o => o.WithTarget(owner))
-            )
-        );
+        // 🚨 THE RELEASE IS REGISTERED ON THE STREAM'S HUB, NOT ON THE STREAM (#3986) — and the
+        // difference is the whole ordering fix.
+        //
+        // This `UnsubscribeRequest` is what kills the owner-side `sync/{id}` sub-hub, which is the
+        // ONLY place a `ClickedEvent` / `BlurEvent` / `CloseDialogEvent` is handled and the only
+        // place the `ClickAction` closure lives. A user action still crossing to the owner when it
+        // lands is refused: it did not run and never will (#3566 / #3986).
+        //
+        // Registered on the STREAM, it ran from `SynchronizationStream.Dispose()`, which disposes
+        // `streamDisposables` SYNCHRONOUSLY and deliberately BEFORE `Hub.Dispose()` (#1613) — so
+        // the release overtook every accepted-but-unacknowledged action with no phase in between
+        // that could have waited. Registered on the HUB it runs from `DisposeImpl` in the ShutDown
+        // phase, i.e. strictly AFTER **Quiescing**, whose entire job is draining this hub's pending
+        // response callbacks. An action submitted through `stream.SubmitUserAction(...)` holds one
+        // of those callbacks until the owner acknowledges it, so the release now ORDERS BEHIND the
+        // action by construction — through the lifecycle the hub already has, with no timer, no
+        // grace, no retry and no second disposal gate. (See `UserActionSubmission`.)
+        //
+        // The other teardown route — the per-circuit portal hub disposing its hosted `sync/{id}` —
+        // already ran this from the hub's ShutDown phase, because `RegisterForDisposal` hooks
+        // `streamDisposables` onto the hub. So both routes now release at the SAME point.
+        //
+        // 🚨 The fallback is not optional: a stream that has already released its hub (#3321
+        // step 3) has no ShutDown phase left to run in, and an owner never told to unsubscribe
+        // keeps a per-subscriber stream alive until its heartbeat lapses. Registering on the
+        // stream there preserves exactly today's behaviour for that case.
+        var release = new AnonymousDisposable(
+            () => hub.Post(new UnsubscribeRequest(reduced.StreamId), o => o.WithTarget(owner)));
+        if (reducedHub is not null)
+            reducedHub.RegisterForDisposal(release);
+        else
+            reduced.RegisterForDisposal(release);
 
 
         // Keep the remote owner grain alive while this subscription exists.

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1444,7 +1444,21 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                     logger.LogWarning("Stream {StreamId} received DeliveryFailure: {Message}", StreamId, failure.Message);
                     OnError(new DeliveryFailureException(failure));
                     return delivery.Processed();
-                }
+                },
+                // 🚨 AWAITED failures are excluded, and this filter is the #3986 half nobody had
+                // measured. `HandleCallbacks` runs first in the rule chain and stamps
+                // `CallbackDispatched` on a response a live `hub.Observe` callback consumed — that
+                // call site's `OnError` has already dealt with it. Without the gate the failure was
+                // ALSO handled here, and this handler's answer is `OnError` on the STREAM: one
+                // refused click (`stream.SubmitUserAction`, or any awaited post from this hub)
+                // faulted the whole mirror and every view bound to it died. Measured on a real
+                // fixture: the stream terminated with `DeliveryFailureException: Your last action
+                // (“…/Button”) did not run …`. Exactly the gate `PortalErrorSink` already applies
+                // for the same reason, and for the same reason the filter REPLACES the default
+                // target-address check: a response's target is always this hub, so the stamp is the
+                // only gate needed. An UN-awaited failure — the subscribe protocol, an RLS denial,
+                // a NotFound — still faults the stream, unchanged.
+                (_, delivery) => !delivery.Properties.ContainsKey(PostOptions.CallbackDispatched)
             ).WithHandler<StreamErrorEvent>((_, delivery) =>
                 {
                     var evt = delivery.Message;

--- a/src/MeshWeaver.Data/UserActionSubmission.cs
+++ b/src/MeshWeaver.Data/UserActionSubmission.cs
@@ -34,11 +34,13 @@ namespace MeshWeaver.Data;
 /// <para><b>An action that genuinely cannot run is still refused — and now it stops killing the
 /// page.</b> The owner answers <see cref="UserActionAccepted"/> only from its stream-scoped
 /// handler; a stream that is already gone answers a <see cref="DeliveryFailure"/> carrying
-/// <see cref="ErrorType.Rejected"/> and the localized <c>error.userActionNotRun</c> sentence.
-/// Because the callback is registered, that refusal is matched to THIS action instead of falling
-/// through to the mirror's blanket <c>DeliveryFailure</c> handler, which answers <c>OnError</c> and
-/// faults the whole synchronization stream — every view bound to it dying over one lost click. The
-/// <c>onRefused</c> callback is where a UI puts the sentence in front of the person.</para>
+/// <see cref="ErrorType.Rejected"/> and the localized <c>error.userActionNotRun</c> sentence, which
+/// arrives on this submission's error arm — <c>onRefused</c> is where a UI puts it in front of the
+/// person. 🚨 The match also stamps <c>PostOptions.CallbackDispatched</c>, which is what stops the
+/// mirror's blanket <c>DeliveryFailure</c> handler ALSO answering <c>OnError</c> and faulting the
+/// whole synchronization stream — every view bound to it dying over one lost click. Measured: the
+/// stamp alone is not consulted by anything until a handler filters on it, so that filter is part
+/// of this change (<c>SynchronizationStream.ConfigureSynchronizationHub</c>).</para>
 ///
 /// <para>See <c>Doc/Architecture/RefusingALostUserAction</c>.</para>
 /// </summary>

--- a/src/MeshWeaver.Data/UserActionSubmission.cs
+++ b/src/MeshWeaver.Data/UserActionSubmission.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Data;
+
+/// <summary>
+/// The ONE way a client submits a person's action — a click, a blur, a dialog dismissal — on a
+/// synchronization stream (issue #3986).
+///
+/// <para>🚨 <b>Why this is not <c>Stream.Hub.Post(…)</c>.</b> A bare <c>Post</c> is
+/// fire-and-forget: the sender owes nothing and therefore WAITS for nothing, so its stream is free
+/// to be released while the action is still crossing to the owner. When it lands, the owner's
+/// per-stream <c>sync/{id}</c> sub-hub — the only place <c>ClickedEvent</c>, <c>BlurEvent</c> and
+/// <c>CloseDialogEvent</c> are handled, and the only place the <c>ClickAction</c> closure lives —
+/// has already been torn down by the <c>UnsubscribeRequest</c> that release posted, and the action
+/// is refused: it did not run and never will (<c>DataExtensions.RefuseStreamMessage</c>,
+/// issue #3566). Measured in production 2026-09-10 on memex-cloud
+/// (<c>Catalog/Categories/Cat-Insurance</c>): one click accepted by the portal, discarded, and
+/// nothing shown to the person who made it.</para>
+///
+/// <para><b>What this changes, and the one mechanism it uses.</b> The action is posted through
+/// <c>Observe</c>, which registers the response callback BEFORE the post. That single fact is the
+/// whole fix: a pending response callback is exactly what the hub's own <b>Quiescing</b> phase
+/// drains, and the <c>UnsubscribeRequest</c> that releases the owner-side stream is posted from the
+/// stream's disposables, which run later still — in <c>ShutDown</c>'s <c>DisposeImpl</c>. So an
+/// accepted-but-unacknowledged action ORDERS AHEAD of the release by construction, through the
+/// lifecycle the hub already has. No timer, no grace period, no retry, no watchdog, no second
+/// disposal gate — the things #3566 rules out and this keeps ruling out. Teardown lets owed work
+/// FINISH; it is never delayed and hoped over.</para>
+///
+/// <para><b>An action that genuinely cannot run is still refused — and now it stops killing the
+/// page.</b> The owner answers <see cref="UserActionAccepted"/> only from its stream-scoped
+/// handler; a stream that is already gone answers a <see cref="DeliveryFailure"/> carrying
+/// <see cref="ErrorType.Rejected"/> and the localized <c>error.userActionNotRun</c> sentence.
+/// Because the callback is registered, that refusal is matched to THIS action instead of falling
+/// through to the mirror's blanket <c>DeliveryFailure</c> handler, which answers <c>OnError</c> and
+/// faults the whole synchronization stream — every view bound to it dying over one lost click. The
+/// <c>onRefused</c> callback is where a UI puts the sentence in front of the person.</para>
+///
+/// <para>See <c>Doc/Architecture/RefusingALostUserAction</c>.</para>
+/// </summary>
+public static class UserActionSubmission
+{
+    /// <summary>
+    /// Submits <paramref name="action"/> to the stream's owner and holds the stream's release until
+    /// the owner has accepted it. Posts immediately — <c>Observe</c> registers the callback and
+    /// posts eagerly — and owns its own subscription, so callers subscribe to nothing.
+    /// </summary>
+    /// <param name="stream">The stream the person acted on.</param>
+    /// <param name="action">The click, blur or dialog dismissal.</param>
+    /// <param name="actingUser">
+    /// The acting person's <see cref="AccessContext"/>, which also decides the language of the
+    /// refusal sentence. A user action must carry the CLICKING user's identity: the stream's sync
+    /// hub has none of its own, so a context-less post fails closed in <c>PostPipeline</c> and the
+    /// action's downstream write is denied. Pass <see langword="null"/> only where no user identity
+    /// exists (infrastructure, tests).
+    /// </param>
+    /// <param name="onRefused">
+    /// Receives the already-localized sentence explaining that the action did not run — the stream
+    /// was gone, or the owner NACKed. This is the surface that tells the person their click did not
+    /// happen; when it is <see langword="null"/> the refusal is logged and nothing else.
+    /// </param>
+    /// <returns>
+    /// The subscription to the receipt. Disposing it cancels the pending callback — and with it the
+    /// ordering guarantee — so a UI normally ignores it; it exists so a caller that outlives the
+    /// action can release the wait deliberately.
+    /// </returns>
+    public static IDisposable SubmitUserAction(
+        this ISynchronizationStream stream,
+        IUserAction action,
+        AccessContext? actingUser = null,
+        Action<string>? onRefused = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(action);
+
+        // 🚨 PRESENCE (HubIfHeld), not liveness: this refuses in exactly the cases a bare Post
+        // would have been dropped anyway, and never one more. A stream that has released its hub
+        // has nothing to post FROM — #3321 step 3 made that a state the contract admits — and the
+        // honest answer is the same sentence a gone owner-side stream produces.
+        if (stream.HubIfHeld() is not { } hub)
+        {
+            onRefused?.Invoke(LocalizationCatalog.Get(
+                "error.userActionNotRun", actingUser?.Locale, action.ActionArea));
+            return System.Reactive.Disposables.Disposable.Empty;
+        }
+
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(UserActionSubmission).FullName!);
+
+        return hub.Observe<UserActionAccepted>(
+                action,
+                o => actingUser is null
+                    ? o.WithTarget(stream.Owner)
+                    : o.WithTarget(stream.Owner).WithAccessContext(actingUser))
+            .Subscribe(
+                _ => { },
+                ex =>
+                {
+                    // The owner's own sentence when it produced one (it is resolved off the acting
+                    // user's locale at the refusal site); the catalog otherwise. Never a literal.
+                    var sentence = (ex as DeliveryFailureException)?.Failure.Message
+                        ?? LocalizationCatalog.Get(
+                            "error.userActionNotRun", actingUser?.Locale, action.ActionArea);
+                    logger?.LogWarning(ex,
+                        "User action {Action} on area {Area} of stream {StreamId} was refused by owner {Owner}",
+                        action.GetType().Name, action.ActionArea, stream.StreamId, stream.Owner);
+                    onRefused?.Invoke(sentence);
+                });
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
@@ -149,6 +149,89 @@ There is no retry, grace extension, timer, or second disposal gate. The receipt 
 action part of the lifecycle mechanism the hub already drains. An action whose stream was genuinely
 gone before it arrived is still refused by the path documented above.
 
+### 🚨 Step 4 was only half true, and the half that was missing is the one that loses the click
+
+A pending callback is drained in **Quiescing**, and Quiescing is a phase of the HUB. So the
+acknowledgement orders ahead of the release only if the release is posted from a point that comes
+*after* Quiescing. It was not.
+
+The release is one line — the `UnsubscribeRequest` that destroys the owner-side `sync/{id}` sub-hub,
+registered in `JsonSynchronizationStream.CreateExternalClient`. It was registered on the **stream**:
+
+```csharp
+reduced.RegisterForDisposal(new AnonymousDisposable(
+    () => hub.Post(new UnsubscribeRequest(reduced.StreamId), o => o.WithTarget(owner))));
+```
+
+and `SynchronizationStream.Dispose()` disposes its registrants **synchronously, and deliberately
+before `Hub.Dispose()`** — that ordering is [#1613's own fix](../StreamLivenessAndTheHubReference)
+and is correct for what it was for (it is what removes the pending `SubscribeRequest` callback
+promptly). Its cost here is that **the whole disposal ordering runs before the hub has a phase in
+which to wait**. So the two teardown routes behaved differently:
+
+| route | what disposes first | did the receipt order ahead? |
+|---|---|---|
+| the per-circuit portal hub disposes its hosted `sync/{id}` | the HUB — `streamDisposables` run from its `DisposeImpl` in ShutDown | yes, Quiescing came first |
+| the STREAM is disposed directly — a workspace eviction, `ReclaimIfUnheld`, `EvictClientSubscriptions`, a consumer's `.Finally(stream.Dispose)` | the STREAM — synchronously, ahead of `Hub.Dispose()` | **no** |
+
+The second route is not an edge: *released read stream* is one of the three ways into
+`RefuseStreamMessage` this page already names, and it is the one where the person is still sitting
+in front of the page.
+
+**The fix is where the line is registered, not what it does.** It now goes on the stream's hub, so it
+runs from `DisposeImpl` in ShutDown — strictly after Quiescing — on **both** routes:
+
+```csharp
+var release = new AnonymousDisposable(
+    () => hub.Post(new UnsubscribeRequest(reduced.StreamId), o => o.WithTarget(owner)));
+if (reducedHub is not null) reducedHub.RegisterForDisposal(release);
+else                        reduced.RegisterForDisposal(release);   // no hub left to wait in
+```
+
+Nothing new waits, nothing is delayed "to be safe": the release simply sits behind the drain the hub
+already performs.
+
+### The sender is a surface, not a call shape — `stream.SubmitUserAction(...)`
+
+The ordering above is only armed if the sender registered the callback, which `Post` does not do. So
+the acknowledged send is a named surface — `UserActionSubmission.SubmitUserAction`, an
+`ISynchronizationStream` extension — rather than an `Observe` incantation copied into every view
+that raises a click. It carries the acting user's `AccessContext` (a user action must; the sync hub
+has no identity of its own), owns its own subscription, and hands a refusal to the caller as the
+already-localized `error.userActionNotRun` sentence.
+
+That last part is also a behaviour change worth stating: with no callback registered, a refusal's
+`DeliveryFailure` fell through to the mirror's blanket `DeliveryFailure` handler, which answers
+`OnError` — **faulting the whole synchronization stream**, so every view bound to it died over one
+lost click. Matched to the action it belongs to, it stops being a page-level fault and becomes a
+sentence about that action.
+
+### The measurement
+
+`UserActionOutlivesStreamReleaseTest` asserts both directions against real hubs and a real remote
+stream, with the owner-side `sync/{id}` sub-hub's own `DisposalCompleted` as the instrument:
+
+| test | asserts | goes red on |
+|---|---|---|
+| `AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers` | the owner's sub-hub does not die while an action is owed, and does die once it is answered | the defect |
+| `AnOrdinaryReleaseIsPrompt` | a release with nothing owed still reaches the owner | "never release the stream", which would satisfy the first test alone |
+| `AnActionOnALiveStreamStillRuns` | the acknowledged path still INVOKES the action | an ordering guarantee that stopped delivering clicks |
+
+The owed-work window is made deterministic rather than raced: the action names a stream id with no
+`sync/{id}` on the owner, so the owner holds it for `SyncStreamOptions.SyncHubRegistrationGrace`
+(400 ms in the test, well inside the hub's 2 s Quiescing budget) and then refuses — the real
+reaped-sync-hub shape. **Falsified by re-registering the release on the stream and rerunning:
+`AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers` fails at 200 ms** — *"Expected the observable
+not to emit … but it emitted ()"* — while the other two stay green.
+
+### What is still owed, and where
+
+The **Blazor sender** (`BlazorView.OnClick` / `OnBlur` / the dialog close handlers, plus
+`GoogleMapView` and `AppleMapView`) still calls `Stream.Hub.Post(new ClickedEvent(...))`. Until those
+call sites move to `SubmitUserAction`, the portal registers no callback and the ordering above is
+armed but unused. That half lives in MeshWeaver.Plugins and needs a platform pin carrying this
+commit.
+
 ## What this deliberately does not do
 
 - **Any retry, resubscribe or widened grace.** The issue rules all three out and so does this: an

--- a/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
@@ -200,11 +200,43 @@ that raises a click. It carries the acting user's `AccessContext` (a user action
 has no identity of its own), owns its own subscription, and hands a refusal to the caller as the
 already-localized `error.userActionNotRun` sentence.
 
-That last part is also a behaviour change worth stating: with no callback registered, a refusal's
-`DeliveryFailure` fell through to the mirror's blanket `DeliveryFailure` handler, which answers
-`OnError` — **faulting the whole synchronization stream**, so every view bound to it died over one
-lost click. Matched to the action it belongs to, it stops being a page-level fault and becomes a
-sentence about that action.
+### 🚨 And a second thing the refusal was doing, which nobody had measured
+
+A refusal is a `DeliveryFailure` posted back to the **sender**, and the sender of a click is the
+stream's own `sync/{id}` hub — whose `ConfigureSynchronizationHub` carries a blanket
+`DeliveryFailure` handler that answers `OnError` for anything that is not a transient
+`ShuttingDown`. So a bare `Post` of a click that cannot be delivered does not merely lose the click:
+it **faults the whole synchronization stream**, and every view bound to that mirror dies with it.
+Measured on a real fixture — the stream terminated with
+
+```
+DeliveryFailureException: Your last action (“ProbeArea/Button”) did not run — the view it was
+sent from had already closed. Nothing was changed; please try again.
+```
+
+`DroppedUserActionIsRefusedTest` could not see this: it posts from the client HUB, so its refusal
+never reaches a stream's handler.
+
+🚨 **Registering the callback is not on its own enough, and assuming it was cost one wrong claim.**
+`HandleCallbacks` runs FIRST in the rule chain and then the chain keeps running, so a matched
+response reaches the blanket handler as well — the fault still fired. What the match does leave
+behind is the flag the framework already uses for exactly this: `PostOptions.CallbackDispatched`,
+which `PortalErrorSink` has long consulted so a failure the call site's `OnError` handled is not
+*also* popped as a modal. The sync hub's `DeliveryFailure` handler simply never adopted it. It does
+now, as the same one-line filter:
+
+```csharp
+(_, delivery) => !delivery.Properties.ContainsKey(PostOptions.CallbackDispatched)
+```
+
+An **un-awaited** failure — the subscribe protocol, an RLS denial, a `NotFound` — still faults the
+stream exactly as before. Only a failure somebody is already holding is left to them.
+
+The order in which this was found is worth keeping: the "does not fault" half **passed in a filtered
+run and failed in the full suite**, because the test's fault probe was a bare `Subject` and the fault
+landed before the assertion window opened. A replay-backed subject made the observation honest, and
+the honest observation falsified the claim.
+`ARefusedActionSurfacesToTheCallerWithoutFaultingTheView` pins both halves.
 
 ### The measurement
 
@@ -216,6 +248,7 @@ stream, with the owner-side `sync/{id}` sub-hub's own `DisposalCompleted` as the
 | `AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers` | the owner's sub-hub does not die while an action is owed, and does die once it is answered | the defect |
 | `AnOrdinaryReleaseIsPrompt` | a release with nothing owed still reaches the owner | "never release the stream", which would satisfy the first test alone |
 | `AnActionOnALiveStreamStillRuns` | the acknowledged path still INVOKES the action | an ordering guarantee that stopped delivering clicks |
+| `ARefusedActionSurfacesToTheCallerWithoutFaultingTheView` | a refusal reaches the caller as the catalog sentence, and the mirror stays live | a refusal that is swallowed, re-worded, or still faults the stream |
 
 The owed-work window is made deterministic rather than raced: the action names a stream id with no
 `sync/{id}` on the owner, so the owner holds it for `SyncStreamOptions.SyncHubRegistrationGrace`

--- a/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RefusingALostUserAction.md
@@ -226,11 +226,25 @@ not to emit … but it emitted ()"* — while the other two stay green.
 
 ### What is still owed, and where
 
-The **Blazor sender** (`BlazorView.OnClick` / `OnBlur` / the dialog close handlers, plus
-`GoogleMapView` and `AppleMapView`) still calls `Stream.Hub.Post(new ClickedEvent(...))`. Until those
-call sites move to `SubmitUserAction`, the portal registers no callback and the ordering above is
-armed but unused. That half lives in MeshWeaver.Plugins and needs a platform pin carrying this
-commit.
+The **Blazor sender** still calls `Stream.Hub.Post(...)`. Until it moves to `SubmitUserAction` the
+portal registers no callback and the ordering above is armed but unused. Measured in
+MeshWeaver.Plugins on 2026-09-11 — **eight call sites in seven files**, and the list is here so the
+next session does not have to rediscover it:
+
+| file | action |
+|---|---|
+| `MeshWeaver.Blazor/BlazorView.razor.cs` | `ClickedEvent` — the one every control inherits |
+| `MeshWeaver.Blazor/Components/FormComponentBase.cs` | `BlurEvent` |
+| `MeshWeaver.Blazor/Components/DialogView.razor.cs` | `CloseDialogEvent`, twice (OK and the dismiss path) |
+| `MeshWeaver.Blazor.Views/Components/DataGridView.razor.cs` | `ClickedEvent` carrying a `DataGridCellClick` payload |
+| `MeshWeaver.Blazor.GoogleMaps/GoogleMapView.razor.cs` | `ClickedEvent` |
+| `MeshWeaver.Blazor.AppleMaps/AppleMapView.razor.cs` | `ClickedEvent` |
+| `MeshWeaver.Blazor.OpenStreetMap/OpenStreetMapView.razor.cs` | `ClickedEvent` |
+
+Each already resolves the hub defensively and already stamps the circuit user's `AccessContext`, so
+the move is `hub.Post(evt, o => …)` → `Stream.SubmitUserAction(evt, userContext, ErrorSink.Report)`
+— the refusal sentence going where that view already surfaces errors. That half needs a platform pin
+carrying this commit.
 
 ## What this deliberately does not do
 

--- a/test/MeshWeaver.Layout.Test/UserActionOutlivesStreamReleaseTest.cs
+++ b/test/MeshWeaver.Layout.Test/UserActionOutlivesStreamReleaseTest.cs
@@ -124,6 +124,54 @@ public class UserActionOutlivesStreamReleaseTest(ITestOutputHelper output) : Hub
     }
 
     /// <summary>
+    /// 🚨 The second thing a registered callback fixes, measured rather than reasoned. A refusal is
+    /// a <c>DeliveryFailure</c> posted back to the SENDER, and the sender of a click is the
+    /// stream's own <c>sync/{id}</c> hub — whose <c>ConfigureSynchronizationHub</c> carries a
+    /// blanket <c>DeliveryFailure</c> handler that answers <c>OnError</c> for anything that is not
+    /// a transient <c>ShuttingDown</c>. So a bare <c>Post</c> of a click that cannot be delivered
+    /// FAULTS THE WHOLE MIRROR: every view bound to that stream dies over one lost click. (Probed
+    /// on this fixture: the stream terminated with
+    /// <c>DeliveryFailureException: Your last action (“ProbeArea/Button”) did not run …</c>.)
+    /// <c>DroppedUserActionIsRefusedTest</c> could not see it — it posts from the client HUB, so
+    /// the refusal never reaches a stream's handler.
+    ///
+    /// <para>Matched to the action it belongs to, the refusal becomes a sentence about that action
+    /// instead of a page-level fault.</para>
+    /// </summary>
+    [HubFact]
+    public async Task ARefusedActionSurfacesToTheCallerWithoutFaultingTheView()
+    {
+        var (stream, _) = await SubscribedStreamWithLiveOwnerHandler();
+
+        // 🚨 REPLAY, not a bare Subject. The fault this asserts against travels the same path as
+        // the refusal awaited below, so it can land BEFORE the NotEmit window opens — a bare
+        // Subject drops it and the test passes having observed nothing. That is exactly how this
+        // case passed in a filtered run and failed in the full suite before it was replay-backed.
+        var faults = new ReplaySubject<Exception>(1);
+        using var live = stream.Subscribe(_ => { }, faults.OnNext);
+
+        var refusals = new ReplaySubject<string>(1);
+        stream.SubmitUserAction(
+            new ClickedEvent(ButtonArea, "no-sync-hub-for-this-stream-id"),
+            onRefused: refusals.OnNext);
+
+        var sentence = await refusals.Should().Within(TestTimeouts.Convergence).Emit(
+            "a person whose action could not run must be told so — the refusal is the whole reason "
+            + "IUserAction exists (#3566), and it is worth nothing if the caller never sees it");
+
+        sentence.Should().Be(
+            LocalizationCatalog.Get("error.userActionNotRun", locale: null, ButtonArea),
+            "the sentence is the owner's, resolved from the catalog off the ACTING USER's locale — "
+            + "never re-worded, never a literal, never an ambient culture");
+
+        await faults.Should().NotEmit(
+            OwnerHoldsAnUnroutableAction,
+            "and one refused action must not fault the synchronization stream: a fault travels the "
+            + "same path as the refusal that just arrived, and it would kill every view bound to "
+            + "this mirror over a single lost click");
+    }
+
+    /// <summary>
     /// A client stream whose owner-side <c>sync/{id}</c> sub-hub — the thing a release destroys —
     /// is live and holding the layout area's action handlers.
     /// </summary>

--- a/test/MeshWeaver.Layout.Test/UserActionOutlivesStreamReleaseTest.cs
+++ b/test/MeshWeaver.Layout.Test/UserActionOutlivesStreamReleaseTest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Reactive;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Regression guard for issue #3986 — <b>a stream must not be released while a user action it
+/// already accepted is still owed</b>.
+///
+/// <para>The owner-side <c>sync/{id}</c> sub-hub is the ONLY place a <see cref="ClickedEvent"/>,
+/// <see cref="BlurEvent"/> or <see cref="CloseDialogEvent"/> is handled, and the only place the
+/// <c>ClickAction</c> closure lives. The client's <c>UnsubscribeRequest</c> destroys it. Until this
+/// change that request was registered on the STREAM, and
+/// <c>SynchronizationStream.Dispose()</c> disposes its registrants SYNCHRONOUSLY and deliberately
+/// BEFORE <c>Hub.Dispose()</c> (#1613) — so the release overtook every in-flight action with no
+/// phase in between that could have waited, and the action was refused: it did not run and never
+/// will. Measured in production 2026-09-10 on memex-cloud, area
+/// <c>Catalog/Categories/Cat-Insurance</c>.</para>
+///
+/// <para>It is now registered on the stream's HUB, so it runs from <c>DisposeImpl</c> in the
+/// ShutDown phase — strictly after <b>Quiescing</b>, whose whole job is draining this hub's pending
+/// response callbacks. <c>SubmitUserAction</c> holds one of those until the owner acknowledges the
+/// action, so the release orders behind it by construction. No timer, no grace, no retry.</para>
+///
+/// <para><b>Both directions are asserted, and they fail for opposite reasons.</b>
+/// <see cref="AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers"/> goes red on the defect — the
+/// owner-side handler is destroyed while the action is owed. <see cref="AnOrdinaryReleaseIsPrompt"/>
+/// goes red on the lazy "fix" of simply never releasing the stream, which would satisfy the first
+/// test on its own.</para>
+/// </summary>
+public class UserActionOutlivesStreamReleaseTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string Area = "ReleaseOrdering";
+    private const string ButtonArea = Area + "/Button";
+
+    /// <summary>
+    /// How long the OWNER holds a stream message whose <c>sync/{id}</c> is not registered before
+    /// refusing it (<c>SyncStreamOptions.SyncHubRegistrationGrace</c>). This is a framework OPTION,
+    /// not a test wait: it is what makes the "action still owed" window DETERMINISTIC instead of a
+    /// race, and it is deliberately well under the hub's 2 s Quiescing budget so the drain ends by
+    /// the owner answering rather than by the budget expiring.
+    /// </summary>
+    private static readonly TimeSpan OwnerHoldsAnUnroutableAction = TimeSpan.FromMilliseconds(400);
+
+    private readonly AsyncSubject<Unit> clicked = new();
+
+    private UiControl ClickArea()
+        => Controls.Stack.WithView(
+            Controls.Html("Run").WithClickAction(_ =>
+            {
+                clicked.OnNext(Unit.Default);
+                clicked.OnCompleted();
+                return Task.CompletedTask;
+            }), "Button");
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithServices(services => services.Configure<SyncStreamOptions>(
+                o => o.SyncHubRegistrationGrace = OwnerHoldsAnUnroutableAction))
+            .AddLayout(layout => layout.WithView(Area, ClickArea()));
+
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    [HubFact]
+    public async Task AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers()
+    {
+        var (stream, ownerSyncHub) = await SubscribedStreamWithLiveOwnerHandler();
+
+        // An action the owner cannot acknowledge at once: no sync/{id} is registered for THIS
+        // stream id, so the owner holds it for SyncHubRegistrationGrace and then refuses. That is
+        // a real production shape — a reaped sync hub, or a released read stream, on a client that
+        // is still there — and it is what makes the owed-work window deterministic.
+        stream.SubmitUserAction(new ClickedEvent(ButtonArea, "no-sync-hub-for-this-stream-id"));
+
+        stream.Dispose();
+
+        await ownerSyncHub.DisposalCompleted.Should().NotEmit(
+            OwnerHoldsAnUnroutableAction / 2,
+            "releasing a stream must not destroy the owner-side handler while a user action it "
+            + "accepted is still owed — a click discarded there did not run and never will (#3986)");
+
+        await ownerSyncHub.DisposalCompleted.Should().Within(TestTimeouts.Convergence).Emit(
+            "and once the owner has answered, the release must go through: teardown lets owed work "
+            + "FINISH, it never cancels it and never waits on a timer");
+    }
+
+    [HubFact]
+    public async Task AnOrdinaryReleaseIsPrompt()
+    {
+        var (stream, ownerSyncHub) = await SubscribedStreamWithLiveOwnerHandler();
+
+        // Nothing owed. This is the control that a fix which simply never releases the stream must
+        // fail: it would satisfy the ordering test above on its own.
+        stream.Dispose();
+
+        await ownerSyncHub.DisposalCompleted.Should().Within(TestTimeouts.Quick).Emit(
+            "a release with nothing owed must still reach the owner promptly — holding the "
+            + "subscription open would leak a per-subscriber stream on every navigation");
+    }
+
+    [HubFact]
+    public async Task AnActionOnALiveStreamStillRuns()
+    {
+        var (stream, _) = await SubscribedStreamWithLiveOwnerHandler();
+
+        stream.SubmitUserAction(new ClickedEvent(ButtonArea, stream.StreamId));
+
+        await clicked.Should().Within(TestTimeouts.Convergence).Emit(
+            "the acknowledged submission path must still INVOKE the action — an ordering guarantee "
+            + "that stopped delivering clicks would pass both tests above");
+    }
+
+    /// <summary>
+    /// A client stream whose owner-side <c>sync/{id}</c> sub-hub — the thing a release destroys —
+    /// is live and holding the layout area's action handlers.
+    /// </summary>
+    private async Task<(ISynchronizationStream<JsonElement> Stream, IMessageHub OwnerSyncHub)>
+        SubscribedStreamWithLiveOwnerHandler()
+    {
+        var client = GetClient();
+        var stream = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(Area));
+
+        await stream.GetControlStream(ButtonArea).Should().Within(TestTimeouts.Convergence)
+            .Match(c => c is not null,
+                "the owner-side LayoutAreaHost and its stream-scoped action handlers must be live "
+                + "before anything about releasing them can be measured");
+
+        var ownerSyncHub = GetHost().GetHostedHub(
+            SynchronizationAddress.Create(stream.StreamId), HostedHubCreation.Never);
+        ownerSyncHub.Should().NotBeNull(
+            "the owner hosts one sync/{id} sub-hub per subscriber, and it is what the "
+            + "UnsubscribeRequest disposes — without it this test measures nothing");
+
+        return (stream, ownerSyncHub!);
+    }
+}


### PR DESCRIPTION
Refs #3986. Follows #3992 (owner-side receipt), which merged at 05:51Z.

## What I re-measured, and what the premise turned out to be

#3992 added the receipt and stated step 4 as: *"A circuit close reaches the sync hub's existing
Quiescing phase and sees that callback as pending. It therefore keeps the stream subscription alive
until the receipt lands."*

That holds only on the route where the **hub** is disposed. A pending response callback is drained
in **Quiescing**, which is a phase of the HUB — so the acknowledgement orders ahead of the release
only if the release is posted after Quiescing. It was not.

The release is one line, in `JsonSynchronizationStream.CreateExternalClient` — the
`UnsubscribeRequest` that destroys the owner-side `sync/{id}` sub-hub (the only place a
`ClickedEvent` / `BlurEvent` / `CloseDialogEvent` is handled, and the only place the `ClickAction`
closure lives). It was registered on the **stream**, and `SynchronizationStream.Dispose()` disposes
its registrants **synchronously and deliberately before `Hub.Dispose()`** — that ordering is #1613's
own fix and is right for what it was for. Its cost here is that a direct stream disposal runs the
whole release before the hub has any phase in which to wait:

| route | disposes first | did the receipt order ahead? |
|---|---|---|
| per-circuit portal hub disposes its hosted `sync/{id}` | the HUB (`streamDisposables` run from `DisposeImpl`) | yes |
| the STREAM is disposed directly — workspace eviction, `ReclaimIfUnheld`, `EvictClientSubscriptions`, a consumer's `.Finally(stream.Dispose)` | the STREAM, ahead of `Hub.Dispose()` | **no** |

The second route is not an edge case: *released read stream* is one of the three ways into
`RefuseStreamMessage` that `RefusingALostUserAction` already names, and it is the one where the
person is still sitting in front of the page.

## What changed

**Register the release on the stream's hub**, so it runs from `DisposeImpl` in ShutDown — strictly
after Quiescing — on both routes. Nothing new waits: the release sits behind the drain the hub
already performs. No timer, no grace, no retry, no watchdog, no second disposal gate. A stream that
has already released its hub (#3321 step 3) keeps the old stream registration, so an owner is still
told to unsubscribe rather than holding a per-subscriber stream until its heartbeat lapses.

**`UserActionSubmission.SubmitUserAction`** — the sender surface that arms it. `Post` registers no
callback, so the ordering above is inert without one. The extension registers the receipt callback
before posting, carries the acting user's `AccessContext` (a user action must; the sync hub has no
identity of its own), owns its subscription, and hands a refusal back as the already-localized
`error.userActionNotRun` sentence.

## A second defect the control found, and one claim it falsified

A refusal is a `DeliveryFailure` posted back to the **sender**, and the sender of a click is the
stream's own `sync/{id}` hub — whose `ConfigureSynchronizationHub` carries a blanket
`DeliveryFailure` handler that answers `OnError` for anything that is not a transient
`ShuttingDown`. So a click that cannot be delivered does not merely go missing: it **faults the whole
synchronization stream**, and every view bound to that mirror dies with it. `DroppedUserActionIsRefusedTest`
could not see it — it posts from the client HUB, so its refusal never reaches a stream's handler.

🚨 **Registering the callback is not on its own enough**, and this branch's first draft said it was.
`HandleCallbacks` runs first and the rule chain keeps running, so the matched response reaches the
blanket handler too. What the match leaves behind is the flag the framework already has for exactly
this — `PostOptions.CallbackDispatched`, which `PortalErrorSink` has long consulted so a failure the
call site's `OnError` handled is not *also* popped as a modal. The sync hub's handler never adopted
it; it does now, as the same one-line filter. An un-awaited failure — the subscribe protocol, an RLS
denial, a `NotFound` — still faults the stream, unchanged.

The order in which this surfaced is worth stating: the "does not fault" assertion **passed in a
filtered run and failed in the full suite**, because its fault probe was a bare `Subject` and the
fault landed before the assertion window opened. Replay-backing the probe made the observation
honest, and the honest observation falsified the claim.

## The control, in both directions

`UserActionOutlivesStreamReleaseTest`, against real hubs and a real remote stream, using the
owner-side `sync/{id}` sub-hub's own `DisposalCompleted` as the instrument:

| test | assertion text | goes red on |
|---|---|---|
| `AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers` | *"releasing a stream must not destroy the owner-side handler while a user action it accepted is still owed — a click discarded there did not run and never will (#3986)"*, then *"and once the owner has answered, the release must go through: teardown lets owed work FINISH, it never cancels it and never waits on a timer"* | the defect |
| `AnOrdinaryReleaseIsPrompt` | *"a release with nothing owed must still reach the owner promptly — holding the subscription open would leak a per-subscriber stream on every navigation"* | "never release the stream", which would satisfy the first test alone |
| `AnActionOnALiveStreamStillRuns` | *"the acknowledged submission path must still INVOKE the action — an ordering guarantee that stopped delivering clicks would pass both tests above"* | "stop delivering" |
| `ARefusedActionSurfacesToTheCallerWithoutFaultingTheView` | *"a person whose action could not run must be told so …"*, *"the sentence is the owner's, resolved from the catalog off the ACTING USER's locale — never re-worded, never a literal, never an ambient culture"*, and *"one refused action must not fault the synchronization stream: … it would kill every view bound to this mirror over a single lost click"* | a refusal that is swallowed, re-worded, or still faults the stream |

The owed-work window is deterministic, not raced: the action names a stream id with no `sync/{id}`
on the owner, so the owner holds it for `SyncStreamOptions.SyncHubRegistrationGrace` (400 ms here,
well inside the hub's 2 s Quiescing budget) and then refuses — the real reaped-sync-hub shape.

**Falsification, both ways.** Re-registering the release on the stream (today's behaviour):
`AnAcceptedActionHoldsTheReleaseUntilTheOwnerAnswers` fails at 200 ms — *"Expected the observable not
to emit within 200ms … but it emitted ()"* — while the others stay green. Removing the
`CallbackDispatched` filter: `ARefusedActionSurfacesToTheCallerWithoutFaultingTheView` fails with
*"but it emitted DeliveryFailureException: Your last action (“ReleaseOrdering/Button”) did not
run …"* while the other three stay green.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, all `0 Error(s)`:
  `MeshWeaver.Data`, `MeshWeaver.Documentation`, `MeshWeaver.Layout.Test`
- `MeshWeaver.Layout.Test` 484/484 · `MeshWeaver.Data.Test` 508/508 ·
  `MeshWeaver.Documentation.Test` 390/390
- No `MeshWeaver.Mesh.RequireSubscribe` warning in any run — the silence in #3986 is not an
  unsubscribed cold observable; it is the ordering.

## What is still owed, and where

The **Blazor sender** still calls `Stream.Hub.Post(...)`. Measured in MeshWeaver.Plugins today:
**eight call sites in seven files** — `BlazorView.razor.cs` (the `ClickedEvent` every control
inherits), `FormComponentBase.cs` (`BlurEvent`), `DialogView.razor.cs` (`CloseDialogEvent`, twice),
`DataGridView.razor.cs` (`ClickedEvent` + `DataGridCellClick` payload), and `GoogleMapView`,
`AppleMapView`, `OpenStreetMapView`. Until those move to `SubmitUserAction` the portal registers no
callback and the ordering is armed but unused. That half needs a platform pin carrying this commit;
the full list is in the doc page so the next session does not have to rediscover it.

No new What's New entry: #3992 already shipped
`2026-09-11-a-click-finishes-crossing-before-its-page-closes.md` for this change set, and this half
alone is not yet visible to a user.

Mirror-sync: none — no catalog key is added or reworded; the refusal reuses the existing
error.userActionNotRun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
