### PR TITLE
fix(#3768): the bundle index answers the CALLER's lane, served from the publication sealed for it

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -138,8 +138,18 @@ public static class PluginBundleEndpoints
         // IMessageHub makes an UNAUTHENTICATED request depend on the mesh being resolvable — it
         // throws (500) instead of the 401 the filter would have returned. The rejection path must
         // not need anything but the header.
+        // 🚨 `identity`/`arch` are the CONSUMER's lane here for exactly the reason they are on the
+        // bundle route below (#1751) — and until #3768 the index did NOT read them, which made that
+        // route's lane-awareness unreachable: the index announced the registry's OWN bake, and
+        // `PluginBundleClient.Adopt` declines the whole index on a mismatch before it ever asks for
+        // a package. Absent ⇒ this instance's own lane, which is what every pre-#3768 client asks
+        // for, so the answer for them is unchanged.
         group.MapGet("/index.json", (HttpContext http, CancellationToken ct) =>
-            Index(http, RootHub(http), Caller(http), ct));
+            Index(
+                http, RootHub(http),
+                Requested(http, "identity", FrameworkMvid),
+                Requested(http, "arch", ReleaseArchitecture.Live),
+                Caller(http), ct));
 
         // 🚨 `identity`/`arch` are the CONSUMER's lane (#1751), not a filter the caller invents: they
         // say which framework build identity and which architecture the caller can actually run, and
@@ -895,10 +905,23 @@ public static class PluginBundleEndpoints
     /// <summary>
     /// What this instance can serve, and the framework identity it serves it for.
     ///
-    /// <para>The framework MVID is at the TOP, not per-bundle: every assembly here was produced by
-    /// this portal's own bake, so they all share it. A consumer compares it once and skips the whole
-    /// fetch when it does not match — downloading bundles it is then obliged to decline is pure
-    /// waste, and the decline itself is silent (see <see cref="PrebuiltAssemblySeeder"/>).</para>
+    /// <para>The framework MVID is at the TOP, not per-bundle: every bundle listed here is resolved
+    /// for ONE lane, so a consumer compares it once and skips the whole fetch when it does not
+    /// match — downloading bundles it is then obliged to decline is pure waste, and the decline
+    /// itself is silent (see <see cref="PrebuiltAssemblySeeder"/>).</para>
+    ///
+    /// <para>🚨 <b>That lane is the one the CALLER asked for, not this portal's own bake</b>
+    /// (#3768). It used to be <see cref="FrameworkMvid"/> unconditionally, on the premise that
+    /// "every assembly here was produced by this portal's own bake" — a premise #1751 retired when
+    /// the bundle route learned to resolve another lane, and #3244 retired again for the module
+    /// half. The consequence was measured on 2026-09-09 and again on 2026-09-11: a consumer one
+    /// image ahead of its registry declined the whole index — 25 attempts, 0 adopted, 25
+    /// <c>FrameworkDeclined</c> — while the publication sealed for its identity sat on the very
+    /// share this registry mounts. The stamp now names the lane the answer is FOR, which is the
+    /// same value each served bundle's own manifest carries, and it is claimed only when this
+    /// registry HOLDS a sealed publication for it: with none, the caller is told this portal's own
+    /// identity and declines exactly as before, because a bake that does not exist here is a bake
+    /// gap and must not read as a serving offer.</para>
     ///
     /// <para>Absolute URLs are built from the REQUEST rather than configuration: an instance reached
     /// through an ingress, a port-forward or a custom domain must advertise the host the caller
@@ -917,10 +940,21 @@ public static class PluginBundleEndpoints
     /// download route records every decision it makes — one per actual fetch.</para>
     /// </summary>
     private static Task<IResult> Index(
-        HttpContext http, IMessageHub rootHub, AuthenticatedInstance? caller, CancellationToken ct)
+        HttpContext http, IMessageHub rootHub, string identity, string architecture,
+        AuthenticatedInstance? caller, CancellationToken ct)
     {
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
         var ledger = Ledger(http);
+        // The lane this answer is FOR. On this instance's own lane it is FrameworkMvid and every
+        // bundle resolves from LastCompiledVersion, exactly as before. Off it, the claim is only
+        // made when a sealed publication for that identity is on the share this registry mounts —
+        // the one durable cross-lane source it has (SealedLaneBundles).
+        var servesOwnLane =
+            string.Equals(identity, FrameworkMvid, StringComparison.Ordinal)
+            && ReleaseArchitecture.Matches(ReleaseArchitecture.Live, architecture);
+        var servedLane = servesOwnLane
+            ? new ServedLane(FrameworkMvid, ReleaseArchitecture.Live)
+            : ServableLane(http, identity, architecture, caller);
         // Resolved NOW, while the request scope is alive: a late fault arrives after
         // HttpContext.RequestServices has been disposed, so resolving inside the lambda would throw
         // exactly when the report is needed.
@@ -948,14 +982,14 @@ public static class PluginBundleEndpoints
             .SelectMany(packages => ServableModules(rootHub, packages)
                 .SelectMany(modules => artifacts.Select(pushed => Results.Json(new
                 {
-                    frameworkMvid = FrameworkMvid,
+                    frameworkMvid = servedLane.Identity,
                     // The architecture that identity belongs to (#1751). The identity already FOLDS
                     // the architecture in — the amd64 and arm64 variants of one image resolve
                     // different identities — but it is opaque, so a consumer on the other variant
                     // sees only "not adoptable" with no way to tell an incompatible framework from
                     // the wrong lane. Stating the architecture makes that miss diagnosable. Additive:
                     // a pre-#1751 client ignores it, and its BundleIndex simply reads null.
-                    architecture = ReleaseArchitecture.Live,
+                    architecture = servedLane.Architecture,
                     bundles = packages.Select(p => new
                     {
                         plugin = p.PluginId,
@@ -994,6 +1028,60 @@ public static class PluginBundleEndpoints
                 ex => lateFaultLogger?.LogWarning(ex,
                     "Plugin bundles: the index faulted after the response had already been sent"),
                 ct)!;
+    }
+
+    /// <summary>The lane an index answer is for: the framework build identity its bundles resolve
+    /// against, and the architecture that identity belongs to.</summary>
+    private readonly record struct ServedLane(string Identity, string Architecture);
+
+    /// <summary>
+    /// 🚨 The OFF-LANE half of the index's stamp (#3768): the caller's lane when this registry
+    /// holds a sealed publication for it, this instance's own lane when it does not.
+    ///
+    /// <para><b>Why holding a publication is the right evidence, and the only cheap one.</b> Off
+    /// this instance's lane the bundle route serves from
+    /// <see cref="SealedLaneBundles"/> — the publication the producing repo's bake sealed for that
+    /// identity, on the share this registry already mounts and already serves at
+    /// <c>…/prebuilt/{identity}/{source}/{bundle}</c>. Its presence is one directory enumeration
+    /// and one seal read per source, and it answers exactly the question the stamp asks. The
+    /// alternative — resolving every package's <c>Release</c> artifacts — is a subtree query per
+    /// package on an endpoint every consumer polls, AND it cannot find bytes anyway: an artifact
+    /// for a lane this portal does not run was minted by a compile in a pod that has been replaced,
+    /// and its assembly is <c>collection: "local"</c> to that pod.</para>
+    ///
+    /// <para>🚨 <b>Claiming the caller's lane with nothing sealed for it would be worse than the
+    /// decline it replaces</b>: the consumer would fetch every package, each resolving no
+    /// assemblies, and a cheap named <c>FrameworkDeclined</c> would become N empty downloads. A
+    /// bake gap must keep reading as a bake gap.</para>
+    /// </summary>
+    private static ServedLane ServableLane(
+        HttpContext http, string identity, string architecture, AuthenticatedInstance? caller)
+    {
+        var logger = Log(http);
+        var publishedRoot = http.RequestServices.GetService<IConfiguration>()
+            ?[PublishedBundleCatalogue.PublishedRootConfigKey];
+        var sealedBundles = SealedLaneBundles.ServableFor(publishedRoot, identity, logger);
+        if (sealedBundles.IsEmpty)
+        {
+            // Named, because this is the state that makes a consumer compile everything on every
+            // boot and it is otherwise visible only from the consumer's own health payload.
+            logger?.LogInformation(
+                "Plugin bundles: {Instance} asks on framework {Identity}/{Architecture}; this "
+                + "registry bakes {OwnIdentity}/{OwnArchitecture} and holds no sealed publication "
+                + "for the caller's lane, so the index states its own — every package will be "
+                + "declined there and COMPILED. Publishing a bake for the caller's identity is "
+                + "what closes it.",
+                caller?.Instance.InstanceId ?? "an unauthenticated caller", identity, architecture,
+                FrameworkMvid, ReleaseArchitecture.Live);
+            return new ServedLane(FrameworkMvid, ReleaseArchitecture.Live);
+        }
+
+        logger?.LogInformation(
+            "Plugin bundles: serving {Instance} on framework {Identity}/{Architecture} from the "
+            + "{Count} bundle(s) sealed for that lane (this registry bakes {OwnIdentity})",
+            caller?.Instance.InstanceId ?? "an unauthenticated caller", identity, architecture,
+            sealedBundles.Count, FrameworkMvid);
+        return new ServedLane(identity, architecture);
     }
 
     /// <summary>
@@ -1407,6 +1495,26 @@ public static class PluginBundleEndpoints
             string.Equals(identity, FrameworkMvid, StringComparison.Ordinal)
             && ReleaseArchitecture.Matches(ReleaseArchitecture.Live, architecture);
 
+        // 🚨 OFF THIS INSTANCE'S LANE, the publication SEALED for the caller's identity is the
+        // answer — not a reconstruction from this mesh's Release records (#3768). Those records are
+        // right about WHICH build proves a lane and stay the rule below; what they cannot do off
+        // this lane is FIND bytes. A ReleaseArtifact is minted in exactly one place — a compile, in
+        // this mesh, stamping the compiling process's own identity — and an in-portal compile
+        // writes `collection: "local"`, the pod's own cache. So every artifact recorded for a lane
+        // this portal no longer runs points at a pod that has been replaced. Measured on the fleet
+        // registry 2026-09-11: `Store/Plugin` did hold an artifact for the consumer's identity, and
+        // it was `local`. The sealed publication is the same bytes the consumer's own boot seeder
+        // reads off the share and the same bytes this registry already serves at
+        // `…/prebuilt/{identity}/{source}/{bundle}` — reachable here under the PER-PACKAGE grant
+        // the caller already passed, which is why the decision is taken server-side (the reasoning
+        // ServedModuleBytes records for the module half: fetching the prebuilt route directly needs
+        // a whole-source grant, and a whole-source grant bypasses plan tiering).
+        if (!servesOwnLane
+            && SealedLaneBundles.Locate(publishedRoot, identity, package.PluginId, logger)
+                is { } sealedLane)
+            return FromSealedLane(
+                rootHub, package, sealedLane, identity, architecture, publishedRoot, logger);
+
         return meshService
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
                 $"namespace:{package.PluginId} scope:subtree"))
@@ -1433,13 +1541,14 @@ public static class PluginBundleEndpoints
                         .TryGetAssemblyPath(x.Node.Path, x.Version!.Value)
                         .Take(1)
                         .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
-                        .Select(path => (x.Node.Path, Path: path,
-                            Dependencies: (IReadOnlyDictionary<string, string>?)x.Definition!.CompiledDependencies)))
+                        .Select(path => new ServedAssembly(
+                            x.Node.Path,
+                            path is null ? null : () => File.OpenRead(path),
+                            x.Definition!.CompiledDependencies)))
                     .ToArray();
 
                 var assemblies = lookups.Length == 0
-                    ? Observable.Return(
-                        Array.Empty<(string NodePath, string? Path, IReadOnlyDictionary<string, string>? Dependencies)>())
+                    ? Observable.Return(Array.Empty<ServedAssembly>())
                     : lookups.CombineLatest().Select(x => x.ToArray());
 
                 if (misses.Count > 0)
@@ -1461,7 +1570,7 @@ public static class PluginBundleEndpoints
                     // located contributes no bytes, so its record must not vote on which module
                     // rides beside bytes that are not there.
                     var recorded = ServedModuleBytes.RecordedFor(
-                        found.Where(a => a.Path is not null).Select(a => a.Dependencies),
+                        found.Where(a => a.Open is not null).Select(a => a.Dependencies),
                         package.Module ?? "");
                     return ModuleFiles(rootHub, package, recorded, publishedRoot, identity)
                         .Select(module =>
@@ -1480,6 +1589,96 @@ public static class PluginBundleEndpoints
     /// <summary>How many per-type misses the warning names before it truncates — enough to diagnose,
     /// bounded so a wholesale lane mismatch cannot write a log line per type.</summary>
     private const int MissesReported = 10;
+
+    /// <summary>
+    /// One assembly this bundle will carry: the NodeType it implements, how to open its bytes
+    /// (null = it could not be located and it contributes nothing), the dependency record the
+    /// producer wrote beside it, and the producer's source fingerprint when one is recorded.
+    /// </summary>
+    /// <remarks>A <see cref="Func{TResult}"/> rather than a path so the two producers can be the
+    /// same shape: this instance's assembly store hands back a file, a sealed publication hands
+    /// back bytes already inflated from its archive.</remarks>
+    private sealed record ServedAssembly(
+        string NodePath,
+        Func<Stream>? Open,
+        IReadOnlyDictionary<string, string>? Dependencies,
+        string? SourceFingerprint = null);
+
+    /// <summary>
+    /// The bundle for a caller on ANOTHER lane, taken from the publication this registry holds
+    /// SEALED for that caller's framework identity (#3768) — the NodeType counterpart of the
+    /// module half's sealed read (#3244).
+    ///
+    /// <para>The assemblies come out of the sealed archive verbatim, with the dependency records
+    /// and source fingerprints its producer wrote; the MODULE section is composed exactly as on
+    /// every other serve, so an off-lane consumer keeps landing modules as it does today. Nothing
+    /// here decides adoption: the archive this writes states <paramref name="identity"/>, the
+    /// consumer re-checks it with the unchanged <c>PrebuiltAssemblySeeder.DeclineReason</c>, and
+    /// then again per assembly as it seeds.</para>
+    ///
+    /// <para>An unreadable or empty sealed bundle answers <see cref="NoSuchBundle"/> rather than
+    /// falling through to the Release-record path: falling through would hand back an archive with
+    /// no assemblies and a manifest claiming the caller's lane, which reads as a successful
+    /// adoption of nothing. A 404 is the one answer the consumer already turns into a NAMED miss
+    /// (<c>NotServed</c>) and a compile.</para>
+    /// </summary>
+    private static IObservable<IResult> FromSealedLane(
+        IMessageHub rootHub, BundleEntry package, SealedLaneBundle sealedLane,
+        string identity, string architecture, string? publishedRoot, ILogger? logger)
+    {
+        BundleReader.Manifest? manifest;
+        IReadOnlyList<BundleReader.Payload> payloads;
+        try
+        {
+            (manifest, payloads) = BundleReader.ReadFile(sealedLane.Path);
+        }
+        catch (Exception exception)
+            when (exception is IOException or InvalidDataException or JsonException)
+        {
+            logger?.LogWarning(exception,
+                "Plugin bundles: {Plugin} — the bundle sealed for framework {Identity} by source "
+                + "'{Source}' ({Bundle}) is unreadable; serving nothing for that lane, the consumer "
+                + "will compile", package.PluginId, identity, sealedLane.Source,
+                sealedLane.BundleName);
+            return Observable.Return(NoSuchBundle());
+        }
+
+        if (manifest is null || payloads.Count == 0)
+        {
+            logger?.LogWarning(
+                "Plugin bundles: {Plugin} — the bundle sealed for framework {Identity} by source "
+                + "'{Source}' ({Bundle}) carries no assemblies; serving nothing for that lane, the "
+                + "consumer will compile", package.PluginId, identity, sealedLane.Source,
+                sealedLane.BundleName);
+            return Observable.Return(NoSuchBundle());
+        }
+
+        var served = payloads
+            .Select(payload => new ServedAssembly(
+                payload.NodePath,
+                () => new MemoryStream(payload.Assembly, writable: false),
+                payload.Dependencies,
+                payload.SourceFingerprint))
+            .ToArray();
+
+        logger?.LogInformation(
+            "Plugin bundles: {Plugin} served on framework {Identity}/{Architecture} from the "
+            + "publication source '{Source}' sealed for that lane ({Bundle}, generation "
+            + "{Generation}) — {Count} assembly/assemblies",
+            package.PluginId, identity, architecture, sealedLane.Source, sealedLane.BundleName,
+            sealedLane.Generation ?? "(unrecorded)", served.Length);
+
+        var recorded = ServedModuleBytes.RecordedFor(
+            served.Select(a => a.Dependencies), package.Module ?? "");
+        IReadOnlyList<string> sealedMisses = manifest.Misses ?? [];
+        return ModuleFiles(rootHub, package, recorded, publishedRoot, identity)
+            .Select(module => BuildResult(
+                package, served, module, identity, architecture,
+                module.Divergence is null
+                    ? sealedMisses
+                    : sealedMisses.Append($"module '{package.Module}': {module.Divergence}")
+                        .ToArray()));
+    }
 
     /// <summary>
     /// The <c>Release</c> nodes from a package's subtree, grouped by the NodeType they belong to.
@@ -1617,7 +1816,7 @@ public static class PluginBundleEndpoints
     /// </summary>
     private static IResult BuildResult(
         BundleEntry package,
-        IReadOnlyList<(string NodePath, string? Path, IReadOnlyDictionary<string, string>? Dependencies)> assemblies,
+        IReadOnlyList<ServedAssembly> assemblies,
         ServedModule module,
         string identity,
         string architecture,
@@ -1628,17 +1827,31 @@ public static class PluginBundleEndpoints
         var entries = new List<NuGetPackageWriter.Entry>();
         var assemblyRecords = new List<object>();
 
-        foreach (var (nodePath, path, dependencies) in assemblies.Where(a => a.Path is not null))
+        foreach (var served in assemblies.Where(a => a.Open is not null))
         {
             // EntryPathFor states the naming rule (and why it is not slash-replaced) once, shared
             // with the reader. The manifest still carries the mapping — the consumer must read the
             // node path the producer wrote, never recover it from a file name.
-            var local = path!;
+            var nodePath = served.NodePath;
+            var dependencies = served.Dependencies;
             entries.Add(new NuGetPackageWriter.Entry(
-                NuGetPackageWriter.EntryPathFor(nodePath), () => File.OpenRead(local)));
+                NuGetPackageWriter.EntryPathFor(nodePath), served.Open!));
             // The per-type dependency record (#1707 slice 2) rides the manifest so the consumer
             // validates module/toolchain bindings before adopting and stamps them on adopt.
-            assemblyRecords.Add(new { nodePath, assembly = $"{nodePath}.dll", dependencies });
+            //
+            // 🚨 The producer's SOURCE FINGERPRINT rides it too, but ONLY when these bytes came
+            // with one — a sealed publication's manifest carries it, this instance's own store does
+            // not record one per assembly. It is what lets the consuming hub refuse an adoption
+            // whose source disagrees with the source that mesh holds (#2813); passing a value this
+            // route invented would be worse than passing none, and passing none is exactly what
+            // every own-lane serve did before and still does.
+            assemblyRecords.Add(served.SourceFingerprint is null
+                ? new { nodePath, assembly = $"{nodePath}.dll", dependencies }
+                : (object)new
+                {
+                    nodePath, assembly = $"{nodePath}.dll", dependencies,
+                    sourceFingerprint = served.SourceFingerprint,
+                });
         }
 
         // The module closure, under its own folder (#1664): these bytes land beside the consumer's

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -4,6 +4,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Plugin.Packaging;
 using MeshWeaver.PluginCatalog;
 using MeshWeaver.Messaging;
@@ -145,11 +146,13 @@ public static class PluginBundleEndpoints
         // a package. Absent ⇒ this instance's own lane, which is what every pre-#3768 client asks
         // for, so the answer for them is unchanged.
         group.MapGet("/index.json", (HttpContext http, CancellationToken ct) =>
-            Index(
-                http, RootHub(http),
-                Requested(http, "identity", FrameworkMvid),
-                Requested(http, "arch", ReleaseArchitecture.Live),
-                Caller(http), ct));
+            RefuseMalformedIdentity(http) is { } refused
+                ? Task.FromResult(refused)
+                : Index(
+                    http, RootHub(http),
+                    Requested(http, "identity", FrameworkMvid),
+                    Requested(http, "arch", ReleaseArchitecture.Live),
+                    Caller(http), ct));
 
         // 🚨 `identity`/`arch` are the CONSUMER's lane (#1751), not a filter the caller invents: they
         // say which framework build identity and which architecture the caller can actually run, and
@@ -158,12 +161,14 @@ public static class PluginBundleEndpoints
         // route's behaviour for them is unchanged.
         group.MapGet("/{plugin}/{version}",
             (HttpContext http, string plugin, string version, CancellationToken ct) =>
-                Bundle(
-                    http, RootHub(http), plugin, version,
-                    Requested(http, "identity", FrameworkMvid),
-                    Requested(http, "arch", ReleaseArchitecture.Live),
-                    Caller(http),
-                    ct));
+                RefuseMalformedIdentity(http) is { } refused
+                    ? Task.FromResult(refused)
+                    : Bundle(
+                        http, RootHub(http), plugin, version,
+                        Requested(http, "identity", FrameworkMvid),
+                        Requested(http, "arch", ReleaseArchitecture.Live),
+                        Caller(http),
+                        ct));
 
         MapPrebuilt(group);
         MapPublish(endpoints);
@@ -857,6 +862,31 @@ public static class PluginBundleEndpoints
     /// <summary>One query-string value, or the serving instance's own value when the caller did not
     /// state one. Blank is treated as absent — an empty <c>?identity=</c> is a client bug, and
     /// answering it with "nothing resolves" would look identical to an incompatible lane.</summary>
+    /// <summary>
+    /// 🚨 Refuses a STATED framework identity that is not a bare name, before anything composes a
+    /// path with it — <c>400</c>, the same answer and the same rule the prebuilt routes apply to
+    /// their <c>{identity}</c> segment.
+    ///
+    /// <para>The identity used to be compared as an opaque string and nothing else; since #3768 it
+    /// selects a directory under the mounted publication root, so <c>?identity=../…</c> would reach
+    /// outside the lane it names. <see cref="SealedLaneBundles.IsBareName"/> restates the check at
+    /// the layer that builds the path; this one makes a malformed request an ERROR rather than a
+    /// silent fallback, so a client bug is visible instead of looking like an unbaked lane. A
+    /// caller that states no identity is untouched — that is every consumer older than #3768.</para>
+    /// </summary>
+    private static IResult? RefuseMalformedIdentity(HttpContext http)
+    {
+        var stated = http.Request.Query["identity"].ToString();
+        if (string.IsNullOrWhiteSpace(stated) || SealedLaneBundles.IsBareName(stated))
+            return null;
+        Log(http)?.LogWarning(
+            "Plugin bundles: refused {Path} — the stated framework identity is not a bare name",
+            http.Request.Path);
+        return Results.Json(
+            new { error = "identity must be a bare name" },
+            statusCode: StatusCodes.Status400BadRequest);
+    }
+
     private static string Requested(HttpContext http, string key, string fallback) =>
         http.Request.Query[key].ToString() is { Length: > 0 } value && !string.IsNullOrWhiteSpace(value)
             ? value
@@ -1435,7 +1465,14 @@ public static class PluginBundleEndpoints
                 ledger?.Record(decision);
 
                 if (asked is not null && decision.Serves)
-                    return Assemble(rootHub, asked, identity, architecture, publishedRoot);
+                    // 🚨 The source the ENTITLEMENT decision resolved, not the entry's cached stamp
+                    // — the anchor is the authority on which source carries a package, and the
+                    // sealed-lane lookup must not be able to cross the (source, package) pair this
+                    // caller was granted. Falls back to the cached binding only where the decision
+                    // states none.
+                    return Assemble(
+                        rootHub, asked, identity, architecture, publishedRoot,
+                        decision.Source ?? asked.Source);
 
                 // The refusal is uniform on the wire; the LOG is where it is diagnosable, naming
                 // which instance asked, what the entitlement answer actually was, and whether this
@@ -1484,7 +1521,7 @@ public static class PluginBundleEndpoints
     /// </summary>
     private static IObservable<IResult> Assemble(
         IMessageHub rootHub, BundleEntry package, string identity, string architecture,
-        string? publishedRoot)
+        string? publishedRoot, string? source)
     {
         var meshService = rootHub.ServiceProvider.GetRequiredService<IMeshService>();
         var store = rootHub.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
@@ -1510,7 +1547,7 @@ public static class PluginBundleEndpoints
         // ServedModuleBytes records for the module half: fetching the prebuilt route directly needs
         // a whole-source grant, and a whole-source grant bypasses plan tiering).
         if (!servesOwnLane
-            && SealedLaneBundles.Locate(publishedRoot, identity, package.PluginId, logger)
+            && SealedLaneBundles.Locate(publishedRoot, identity, package.PluginId, source, logger)
                 is { } sealedLane)
             return FromSealedLane(
                 rootHub, package, sealedLane, identity, architecture, publishedRoot, logger);
@@ -1626,59 +1663,103 @@ public static class PluginBundleEndpoints
         IMessageHub rootHub, BundleEntry package, SealedLaneBundle sealedLane,
         string identity, string architecture, string? publishedRoot, ILogger? logger)
     {
-        BundleReader.Manifest? manifest;
-        IReadOnlyList<BundleReader.Payload> payloads;
+        // 🚨 The archive is opened, parsed and inflated on the FILESYSTEM pool, never on the
+        // request thread: this is a mounted network share and a bundle is the whole weight of a
+        // package, so several concurrent boot downloads would otherwise hold request threads on a
+        // slow mount. The same discipline PublishedBundleCatalogue.Observe applies to this read.
+        var pool = rootHub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.FileSystem)
+                   ?? IoPool.Unbounded;
+
+        return pool.InvokeBlocking(_ => ReadSealed(sealedLane, identity))
+            .SelectMany(read =>
+            {
+                if (read.Refusal is not null)
+                {
+                    // Not a fall-through to the release-record path: that would hand back an
+                    // archive with no assemblies and a manifest claiming the caller's lane, which
+                    // reads as a successful adoption of nothing. A 404 is the one answer the
+                    // consumer already turns into a NAMED miss (NotServed) and a compile.
+                    logger?.LogWarning(
+                        "Plugin bundles: {Plugin} — the bundle sealed for framework {Identity} by "
+                        + "source '{Source}' ({Bundle}) is not servable: {Reason}. Serving nothing "
+                        + "for that lane; the consumer will compile.",
+                        package.PluginId, identity, sealedLane.Source, sealedLane.BundleName,
+                        read.Refusal);
+                    return Observable.Return(NoSuchBundle());
+                }
+
+                var served = read.Assemblies
+                    .Select(payload => new ServedAssembly(
+                        payload.NodePath,
+                        () => new MemoryStream(payload.Assembly, writable: false),
+                        payload.Dependencies,
+                        payload.SourceFingerprint))
+                    .ToArray();
+
+                logger?.LogInformation(
+                    "Plugin bundles: {Plugin} served on framework {Identity}/{Architecture} from "
+                    + "the publication source '{Source}' sealed for that lane ({Bundle}, generation "
+                    + "{Generation}) — {Count} assembly/assemblies",
+                    package.PluginId, identity, architecture, sealedLane.Source,
+                    sealedLane.BundleName, sealedLane.Generation ?? "(unrecorded)", served.Length);
+
+                var recorded = ServedModuleBytes.RecordedFor(
+                    served.Select(a => a.Dependencies), package.Module ?? "");
+                IReadOnlyList<string> sealedMisses = read.Misses ?? [];
+                return ModuleFiles(rootHub, package, recorded, publishedRoot, identity)
+                    .Select(module => BuildResult(
+                        package, served, module, identity, architecture,
+                        module.Divergence is null
+                            ? sealedMisses
+                            : sealedMisses
+                                .Append($"module '{package.Module}': {module.Divergence}")
+                                .ToArray()));
+            });
+    }
+
+    /// <summary>
+    /// Reads one sealed bundle and says whether it may be served for <paramref name="identity"/>.
+    /// The file read; everything else is a decision.
+    ///
+    /// <para>🚨 <b>The archive's OWN framework identity is checked before anything is served</b>,
+    /// through the very function the consumer applies to the same bytes
+    /// (<see cref="PrebuiltAssemblySeeder.DeclineReason(string?, string)"/>, ordinal equality). The
+    /// directory a bundle sits in is a filing convention; the manifest is the producer's claim, and
+    /// only the claim may be believed. Without this a bundle mislabelled into an identity directory
+    /// would be RESTAMPED with the requested identity by <see cref="BuildResult"/> — and the
+    /// consumer's gate, seeing a manifest that agrees with its own live identity, would adopt bytes
+    /// baked for another framework. That is the one outcome this lane exists to prevent, and it is
+    /// why the check reads the claim rather than inferring it from where the file was found.</para>
+    /// </summary>
+    private static SealedRead ReadSealed(SealedLaneBundle sealedLane, string identity)
+    {
         try
         {
-            (manifest, payloads) = BundleReader.ReadFile(sealedLane.Path);
+            var (manifest, assemblies) = BundleReader.ReadFile(sealedLane.Path);
+            if (manifest is null)
+                return new SealedRead([], null, "it carries no manifest");
+            if (PrebuiltAssemblySeeder.DeclineReason(manifest.FrameworkMvid, identity)
+                is { } mismatch)
+                return new SealedRead([], null,
+                    $"the archive's own manifest says it was {mismatch} — the directory it is "
+                    + "filed under is not evidence of what it was built against");
+            if (assemblies.Count == 0)
+                return new SealedRead([], null, "it carries no assemblies");
+            return new SealedRead(assemblies, manifest.Misses, null);
         }
         catch (Exception exception)
             when (exception is IOException or InvalidDataException or JsonException)
         {
-            logger?.LogWarning(exception,
-                "Plugin bundles: {Plugin} — the bundle sealed for framework {Identity} by source "
-                + "'{Source}' ({Bundle}) is unreadable; serving nothing for that lane, the consumer "
-                + "will compile", package.PluginId, identity, sealedLane.Source,
-                sealedLane.BundleName);
-            return Observable.Return(NoSuchBundle());
+            return new SealedRead([], null, $"it is unreadable: {exception.Message}");
         }
-
-        if (manifest is null || payloads.Count == 0)
-        {
-            logger?.LogWarning(
-                "Plugin bundles: {Plugin} — the bundle sealed for framework {Identity} by source "
-                + "'{Source}' ({Bundle}) carries no assemblies; serving nothing for that lane, the "
-                + "consumer will compile", package.PluginId, identity, sealedLane.Source,
-                sealedLane.BundleName);
-            return Observable.Return(NoSuchBundle());
-        }
-
-        var served = payloads
-            .Select(payload => new ServedAssembly(
-                payload.NodePath,
-                () => new MemoryStream(payload.Assembly, writable: false),
-                payload.Dependencies,
-                payload.SourceFingerprint))
-            .ToArray();
-
-        logger?.LogInformation(
-            "Plugin bundles: {Plugin} served on framework {Identity}/{Architecture} from the "
-            + "publication source '{Source}' sealed for that lane ({Bundle}, generation "
-            + "{Generation}) — {Count} assembly/assemblies",
-            package.PluginId, identity, architecture, sealedLane.Source, sealedLane.BundleName,
-            sealedLane.Generation ?? "(unrecorded)", served.Length);
-
-        var recorded = ServedModuleBytes.RecordedFor(
-            served.Select(a => a.Dependencies), package.Module ?? "");
-        IReadOnlyList<string> sealedMisses = manifest.Misses ?? [];
-        return ModuleFiles(rootHub, package, recorded, publishedRoot, identity)
-            .Select(module => BuildResult(
-                package, served, module, identity, architecture,
-                module.Divergence is null
-                    ? sealedMisses
-                    : sealedMisses.Append($"module '{package.Module}': {module.Divergence}")
-                        .ToArray()));
     }
+
+    /// <summary>What a sealed bundle yielded: its assemblies and the per-type misses its producer
+    /// recorded, or the NAMED reason it may not be served.</summary>
+    private sealed record SealedRead(
+        IReadOnlyList<BundleReader.Payload> Assemblies,
+        IReadOnlyList<string>? Misses,
+        string? Refusal);
 
     /// <summary>
     /// The <c>Release</c> nodes from a package's subtree, grouped by the NodeType they belong to.

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -288,6 +288,36 @@ Both directions are pinned by `test/Memex.Portal.Shared.Test/PluginBundleSealedL
 asks the same endpoint with a sealed lane and an unsealed one and asserts the two different answers
 — a change that served everybody would pass only the first.
 
+### Three refusals the lookup carries, and why each is not optional
+
+Reaching the share from the PACKAGE route turns a value that used to be compared into a value that
+selects a directory and a file. Each of the three checks below closes something that the route did
+not previously have, and each has a control that reddens when it is removed.
+
+1. **The identity must be a bare name.** It arrives on a query string and is composed under the
+   published root, so `?identity=../…` would read outside the lane it names. The route answers
+   `400` — the same rule and the same answer the `/prebuilt/{identity}/{source}` segments already
+   applied — and `SealedLaneBundles.IsBareName` restates it at the layer that builds the path, so an
+   entry point added later inherits the check rather than the hole.
+2. **The lookup is scoped to the source the ENTITLEMENT decision resolved.** The grant is a
+   `(source, package)` pair and `PackageOriginAnchor` is the authority on which source carries a
+   package. A lookup that scanned every source directory and took the first matching file name would
+   let a caller granted one source receive another's bytes whenever two sources publish the same
+   package id — a grant boundary crossed inside something shaped like a file search. Only a
+   genuinely unknown binding (no anchor, no stamped record) widens the scan; a named source that
+   matches no directory answers "nothing sealed for you here", and the caller compiles.
+3. **The archive's OWN manifest identity is checked before anything is served**, through
+   `PrebuiltAssemblySeeder.DeclineReason` — the same function the consumer applies to the same
+   bytes. The directory a bundle is filed under is a filing convention; the manifest is the
+   producer's claim, and only the claim may be believed. Without this a mislabelled archive would be
+   restamped with the requested identity on the way out, and the consumer's gate — seeing a manifest
+   that agrees with its own live framework — would adopt bytes baked for another one. That is the
+   single outcome this entire lane exists to prevent.
+
+The read itself runs on the filesystem `IIoPool`, not the request thread: the publication is a
+mounted share and a bundle is the whole weight of a package, so concurrent boot downloads would
+otherwise hold request threads on a slow mount.
+
 ## How many writers, measured
 
 The issue that opened this ([#3461](https://github.com/Systemorph/MeshWeaver/issues/3461)) names two

--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -179,13 +179,14 @@ Every consumer of a sealed publication obeys the same four rules.
 *guaranteed red* on every overlapping publish — a satellite's pin-move PR going red for a defect
 that is not in it. Detecting the move and continuing on the half already fetched is worse still.
 
-### The three consumers
+### The four consumers
 
 | consumer | reads | lives in |
 |---|---|---|
 | `node-repo-gate.yml`, the upstream seed | the bundle index + each bundle | this repo, pinned by each satellite's `uses:` |
 | `.github/scripts/compose-sealed-modules.sh` | the module-set index + each module | this repo, fetched at each satellite's `platform-ref` |
 | `memex build plugin` (`BuildPluginCommand`) | both | `src/MeshWeaver.Cli` |
+| the REGISTRY, on behalf of a consumer one lane ahead of it | one package's bundle, for the CALLER's identity | `memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs` |
 
 The `registry_get` backoff is **duplicated on purpose** between the workflow and the script: the
 workflow is pinned by the caller's `uses:` while the script is fetched at `platform-ref`, so a
@@ -205,6 +206,87 @@ dependency record mismatch — built against mvid:…, live is mvid:…
 — which is invisible in CI and surfaces only when a portal boots and renders nothing. That is the
 failure `assert-bake-consumption.sh` exists to catch, and it is why the module lane is pinned even
 though its window is the same size as the bundle lane's.
+
+### The fourth consumer: a portal one image ahead of its registry
+
+The first three read the share directly, over a credential of their own. The fourth reads it
+**server-side, inside the registry**, on behalf of a portal that has none — and it exists because a
+sealed publication is the only thing a registry can hand a consumer whose framework build identity
+is not its own.
+
+**Why a registry cannot answer an off-lane caller from its mesh.** Since #1751 the bundle route
+resolves an off-lane caller's assemblies through each NodeType's `Release` node, which records, per
+`(identity, architecture)`, which assembly-store version holds bytes *proven* built for that lane.
+That rule is right and it stays. What it cannot do is FIND bytes:
+
+- a `ReleaseArtifact` is minted in exactly ONE place — a compile, in this mesh, stamping the
+  compiling process's own `FrameworkVersion` and `ReleaseArchitecture.Live`
+  (`NodeTypeBuildState.TryCreateReleaseNode`). There is no append path and no route by which a
+  portal records an artifact for an identity it does not run;
+- adoption mints none at all: `PrebuiltAssemblySeeder.Seed` writes `LastCompiledVersion` and never a
+  release, which is precisely why the own-lane branch reads `LastCompiledVersion` rather than a
+  release;
+- so the only artifacts that exist for a lane the registry no longer runs were written by a compile
+  **in a pod that has since been replaced** — and an in-portal compile writes
+  `collection: "local"`, which `FileSystemAssemblyStore` defines as *"the bytes live in the local
+  filesystem cache only; cross-silo readers must recompile"*.
+
+Measured on the fleet registry on 2026-09-11: `Store/Plugin` did hold a release naming the
+consumer's identity — `s3e3c8023…`, written 01:11Z — and its artifact was
+`collection: "local", contentPath: "Store_Plugin/v13725-s3e3c802-…dll"`. Resolvable, and
+unreachable. **Off-lane serving out of the mesh is empty by construction, not by accident.**
+
+**What the registry does have** is the publication the producing repo's bake sealed for that
+identity, on the share it already mounts and already serves at
+`…/prebuilt/{identity}/{source}/{bundle}`. `SealedLaneBundles` (in `MeshWeaver.PluginCatalog`) is the
+lookup that lets the PACKAGE route reach it, so the decision stays inside the per-package grant —
+the same reasoning `ServedModuleBytes` records for the module half (#3244): a consumer
+fetching the prebuilt route itself would need a whole-source grant, and a whole-source grant
+deliberately bypasses plan tiering.
+
+### The stamp the index puts on that answer
+
+The index's top-level `frameworkMvid` says **which lane the bundles listed under it resolve for**. It
+used to say something narrower and, since #1751, untrue: *this portal's own bake*. Because
+`PluginBundleClient.Adopt` compares that value ONCE and declines the whole index before requesting
+any package, the download route's lane-awareness and the module half's sealed read were both
+unreachable for exactly the consumer they exist for.
+
+Measured on the fleet's own portals, twice, with a different identity pair each time:
+
+| when | consumer | registry | `bundle_adoption` |
+|---|---|---|---|
+| 2026-09-09 | memex.systemorph.com `s414bfb2…` | memex.meshweaver.cloud `s72c27af…` | 25 attempts, **0 adopted**, 25 `FrameworkDeclined` |
+| 2026-09-11 | memex.systemorph.com `s3e3c802…` | memex.meshweaver.cloud `s01d65c9…` | 25 attempts, **0 adopted**, 25 `FrameworkDeclined` |
+
+Both readings are the whole population of that process's attempts, not a truncation: the ledger's
+capacity is 500 and the payload names ten then counts the rest. The second was taken on portals
+already running #3946, which fixed a *different* decline (a dependency record's module entry) — so
+that fix does not touch this one, and the count did not move.
+
+On 2026-09-11 the registry's share held **561** identity directories, and
+`s3e3c80238a740a8cb895a72b0bfb9cd6` — the consumer's own live identity — was among them with
+`plugins` sealed at 00:33Z. **The bytes were on the registry's own disk while every consumer
+adoption was declined.**
+
+So the rule is now:
+
+1. a caller that states no lane gets this portal's identity, byte for byte as before — which is
+   every already-deployed consumer;
+2. a caller that states its lane and for which this registry **holds a sealed publication** is told
+   THAT lane, and each package is served out of that publication;
+3. a caller that states a lane this registry holds nothing for is told **this portal's own
+   identity** — so it declines and compiles, exactly as before.
+
+🚨 **Rule 3 is not a leftover, it is the point.** Claiming the caller's lane with nothing sealed for
+it would turn one cheap, named `FrameworkDeclined` into N downloads that each resolve nothing — a
+bake gap wearing a serving offer's colours. And nothing in any of this relaxes the adoption gate:
+the archive states the identity it was sealed for, and `PrebuiltAssemblySeeder.DeclineReason`
+(ordinal equality) still decides, first for the archive and then per assembly as it seeds.
+
+Both directions are pinned by `test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs`, which
+asks the same endpoint with a sealed lane and an unsealed one and asserts the two different answers
+— a change that served everybody would pass only the first.
 
 ## How many writers, measured
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-registry-can-serve-an-installation-that-is-a-build-ahead-of-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-registry-can-serve-an-installation-that-is-a-build-ahead-of-it.md
@@ -1,0 +1,31 @@
+---
+Name: A registry can now serve an installation that is a build ahead of it
+Category: Fix
+Description: An installation running a newer platform build than the registry it installs from used to be refused every prebuilt bundle and had to compile all of its plugin content on every start. It is now served the content baked for its own build, whenever the registry holds it.
+Icon: Checkmark
+Order: -20260911
+---
+
+# A registry can now serve an installation that is a build ahead of it
+
+Plugin content arrives at an installation as ready-compiled bundles, so a fresh start does not have
+to compile everything itself. Those bundles are only ever used with the exact platform build they
+were compiled against — that has not changed, and it is what keeps a page from loading code that
+does not match the platform underneath it.
+
+What had gone wrong was one step earlier. When an installation asked its registry what it could be
+given, the registry answered with the build **it** happened to be running, rather than the build the
+installation asked about. Because the two portals in a fleet roll at slightly different times, that
+is the normal state for part of every day — and during it every bundle was refused in one go, before
+any of them was even requested. The content still appeared, because the installation compiled it
+instead; the cost was a slower start and, on a multi-replica installation, pages that could render
+empty until the replica that served them had compiled the type for itself.
+
+The registry now answers for the build the caller asked about, and serves that build's content from
+the publication it already holds for it. When it holds none, it answers with its own build exactly
+as before — so an installation whose build has genuinely not been baked yet is told so, and compiles,
+rather than being offered content that is not there.
+
+Nothing about which bundles may be used has been loosened: an installation still uses only bundles
+compiled for its own platform build, and still checks that for the bundle as a whole and again for
+every assembly in it.

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -156,7 +156,20 @@ public sealed class PluginBundleClient
     public IObservable<BundleIndex> FetchIndex() =>
         _httpPool.Invoke(async ct =>
         {
-            using var request = Request(HttpMethod.Get, $"{_registryUrl}{RoutePrefix}/index.json");
+            // 🚨 The index is asked IN THIS INSTANCE'S LANE, exactly as the download route has been
+            // asked since #1751 — and until #3768 it was not, which is what made the download
+            // route's lane-awareness unreachable. The registry answered with its OWN bake identity,
+            // <see cref="Adopt"/> compared that once and declined the whole index, and no package
+            // was ever requested. Measured twice on the fleet's own portals (2026-09-09 and
+            // 2026-09-11, a different identity pair each time): 25 attempts, 0 adopted, 25
+            // FrameworkDeclined, while the publication sealed for the consumer's identity sat on
+            // the share the registry mounts. A registry that holds nothing for this lane still
+            // answers with its own identity, so the decline — and its cost argument — is unchanged
+            // in exactly the case it is right.
+            var url = $"{_registryUrl}{RoutePrefix}/index.json"
+                      + $"?identity={Uri.EscapeDataString(PrebuiltAssemblySeeder.LiveFrameworkMvid)}"
+                      + $"&arch={Uri.EscapeDataString(ReleaseArchitecture.Live)}";
+            using var request = Request(HttpMethod.Get, url);
             using var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
 
             if (resp.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/src/MeshWeaver.PluginCatalog/SealedLaneBundles.cs
+++ b/src/MeshWeaver.PluginCatalog/SealedLaneBundles.cs
@@ -50,7 +50,9 @@ public static class SealedLaneBundles
     /// </summary>
     public static ImmutableHashSet<string> ServableFor(
         string? publishedRoot, string? identity, ILogger? logger = null) =>
-        PublishedBundleCatalogue.SealedBundlesForIdentity(publishedRoot, identity, logger);
+        IsBareName(identity)
+            ? PublishedBundleCatalogue.SealedBundlesForIdentity(publishedRoot, identity, logger)
+            : [];
 
     /// <summary>
     /// The sealed bundle carrying <paramref name="packageId"/>'s NodeType assemblies under
@@ -65,19 +67,21 @@ public static class SealedLaneBundles
     /// tried — one source being replaced must never hide another's sealed bundles.</para>
     /// </summary>
     public static SealedLaneBundle? Locate(
-        string? publishedRoot, string? identity, string packageId, ILogger? logger = null)
+        string? publishedRoot, string? identity, string packageId, string? source,
+        ILogger? logger = null)
     {
         if (string.IsNullOrWhiteSpace(publishedRoot)
-            || string.IsNullOrWhiteSpace(identity)
+            || !IsBareName(identity)
             || string.IsNullOrWhiteSpace(packageId))
             return null;
 
-        var identityDirectory = Path.Combine(publishedRoot, identity);
+        var identityDirectory = Path.Combine(publishedRoot, identity!);
         if (!Directory.Exists(identityDirectory))
             return null;
 
         foreach (var sourceDirectory in Directory
                      .EnumerateDirectories(identityDirectory)
+                     .Where(d => Serves(d, source))
                      .OrderBy(d => d, StringComparer.Ordinal))
         {
             var reading = PublishedBundleCatalogue.SealedPublicationOf(sourceDirectory, logger);
@@ -99,6 +103,43 @@ public static class SealedLaneBundles
 
         return null;
     }
+
+    /// <summary>
+    /// 🚨 Whether this publication source may answer for the package — the (source, package) half of
+    /// the entitlement decision, carried down so the lookup cannot cross it.
+    ///
+    /// <para>The caller passes the AUTHORITATIVE source the entitlement decision resolved
+    /// (<c>EntitlementDecision.Source</c>, the registry's own catalog before the install record's
+    /// cached stamp). Without it this scanned every source directory and returned the first bundle
+    /// whose file name matched, so two sources publishing the same package id would let a caller
+    /// granted one receive the other's bytes under a response restamped with the requested package
+    /// — a grant boundary crossed inside a lookup that looked like a file search. Compared
+    /// case-insensitively because the publication PREFIX is lowercase while a registry source name
+    /// need not be.</para>
+    ///
+    /// <para>A null source means the binding is genuinely unknown (no anchor, no stamped record),
+    /// and only then is every source considered — the same "the absence of an answer is never a
+    /// yes" discipline the entitlement decision itself follows, applied in the direction that costs
+    /// a compile rather than the one that discloses bytes. When a source IS named and no directory
+    /// carries it, the answer is "nothing sealed for you here": the caller falls through to the
+    /// release-record path and compiles, which is what it did before this lookup existed.</para>
+    /// </summary>
+    private static bool Serves(string sourceDirectory, string? source) =>
+        string.IsNullOrWhiteSpace(source)
+        || string.Equals(
+            Path.GetFileName(sourceDirectory), source, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// 🚨 One path segment, and nothing that can leave the published root — the identity arrives on
+    /// a QUERY STRING and is composed into a filesystem path here, so this is the boundary. Same
+    /// rule as the prebuilt routes' own <c>IsBareName</c>, restated at the layer that builds the
+    /// path rather than trusted from the layer that read the request: a second entry point added
+    /// later would otherwise inherit the hole rather than the check.
+    /// </summary>
+    public static bool IsBareName(string? segment) =>
+        segment is { Length: > 0 }
+        && segment.IndexOfAny(['/', '\\', ':']) < 0
+        && segment != "." && segment != "..";
 
     /// <summary>A sealed bundle's id as the seal lists it, minus the <c>.zip</c> the bake writes —
     /// the package id (<c>RequiredPackage.BundleName</c>).</summary>

--- a/src/MeshWeaver.PluginCatalog/SealedLaneBundles.cs
+++ b/src/MeshWeaver.PluginCatalog/SealedLaneBundles.cs
@@ -1,0 +1,121 @@
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// WHICH BYTES a registry can serve a consumer whose framework build identity is not its own —
+/// the NodeType counterpart of <see cref="ServedModuleBytes"/> (#3244), which answered the same
+/// question for a package's compiled MODULE.
+///
+/// <para>🚨 <b>The asymmetry this closes.</b> Since #1751 the bundle route resolves an off-lane
+/// caller's assemblies through each NodeType's <c>Release</c> node, which records per
+/// (identity, architecture) which assembly-store version holds bytes proven built for that lane.
+/// That is the right rule and it stays; what it cannot do is FIND bytes. A
+/// <c>ReleaseArtifact</c> is minted in exactly one place — a compile, in this mesh, stamping the
+/// COMPILING process's own identity (<c>NodeTypeBuildState.TryCreateReleaseNode</c>) — and an
+/// in-portal compile writes its assembly to the pod's local cache
+/// (<c>collection: "local"</c>, which <c>FileSystemAssemblyStore</c> documents as "the bytes live
+/// in the local filesystem cache only; cross-silo readers must recompile"). So the only artifacts
+/// that exist for a lane the registry is NOT running were written by a pod that has since been
+/// replaced, and they point at bytes no later pod can open. Adoption is never unsafe, but it is
+/// structurally empty.</para>
+///
+/// <para><b>The bytes that ARE durable are the sealed publication the registry already mounts</b> —
+/// <c>&lt;root&gt;/&lt;identity&gt;/&lt;source&gt;/&lt;package&gt;.zip</c>, the exact artifact the
+/// consumer's own boot seeder reads off the share and the exact artifact this registry already
+/// serves at <c>…/prebuilt/{identity}/{source}/{bundle}</c>. This class is the lookup that lets the
+/// PACKAGE route reach them, so the decision stays server-side under the per-package grant
+/// (<c>ServedModuleBytes</c> records why that matters: fetching from the prebuilt route directly
+/// needs a whole-source grant, and a whole-source grant deliberately bypasses plan tiering).</para>
+///
+/// <para><b>Nothing here decides adoption.</b> A sealed bundle states its own producer's
+/// <c>frameworkMvid</c> in its manifest, and the consumer re-checks it with the unchanged
+/// <c>PrebuiltAssemblySeeder.DeclineReason</c> — first for the archive as a whole, then per
+/// assembly as it seeds. This only decides WHICH bytes are offered; ordinal identity equality
+/// still decides whether they land.</para>
+/// </summary>
+public static class SealedLaneBundles
+{
+    /// <summary>
+    /// The package bundle ids this root has SEALED for one framework identity — i.e. the lane a
+    /// consumer running that identity can actually be served from here. Extension stripped,
+    /// case-insensitive.
+    ///
+    /// <para>Empty means the same thing everywhere it is read: this root holds no COMPLETE
+    /// publication for that identity — no such identity directory, a publication being replaced
+    /// right now (its seal removed), or one torn beyond its seal. All three are "cannot serve this
+    /// lane", which is the answer the index must give, and none of them is an error.</para>
+    /// </summary>
+    public static ImmutableHashSet<string> ServableFor(
+        string? publishedRoot, string? identity, ILogger? logger = null) =>
+        PublishedBundleCatalogue.SealedBundlesForIdentity(publishedRoot, identity, logger);
+
+    /// <summary>
+    /// The sealed bundle carrying <paramref name="packageId"/>'s NodeType assemblies under
+    /// <paramref name="identity"/>, or null when no complete publication for that identity lists
+    /// one.
+    ///
+    /// <para>🚨 Resolved through <see cref="PublishedBundleCatalogue.SealedPublicationOf"/>, never
+    /// by composing a path and testing it: that reader applies THE completeness rule (sentinel
+    /// present AND every listed bundle on disk) and resolves the generation pointer (#3461), so a
+    /// consumer can never be handed a bundle out of a publication the boot seeder itself would
+    /// refuse. A source whose publication is torn contributes nothing and the next source is
+    /// tried — one source being replaced must never hide another's sealed bundles.</para>
+    /// </summary>
+    public static SealedLaneBundle? Locate(
+        string? publishedRoot, string? identity, string packageId, ILogger? logger = null)
+    {
+        if (string.IsNullOrWhiteSpace(publishedRoot)
+            || string.IsNullOrWhiteSpace(identity)
+            || string.IsNullOrWhiteSpace(packageId))
+            return null;
+
+        var identityDirectory = Path.Combine(publishedRoot, identity);
+        if (!Directory.Exists(identityDirectory))
+            return null;
+
+        foreach (var sourceDirectory in Directory
+                     .EnumerateDirectories(identityDirectory)
+                     .OrderBy(d => d, StringComparer.Ordinal))
+        {
+            var reading = PublishedBundleCatalogue.SealedPublicationOf(sourceDirectory, logger);
+            if (reading.Bundles is not { Count: > 0 })
+                continue;
+
+            var listed = reading.Bundles.FirstOrDefault(
+                name => string.Equals(BaseNameOf(name), packageId, StringComparison.OrdinalIgnoreCase));
+            if (listed is null)
+                continue;
+
+            return new SealedLaneBundle(
+                identity!,
+                Path.GetFileName(sourceDirectory)!,
+                listed,
+                Path.Combine(reading.Directory ?? sourceDirectory, listed),
+                reading.Generation);
+        }
+
+        return null;
+    }
+
+    /// <summary>A sealed bundle's id as the seal lists it, minus the <c>.zip</c> the bake writes —
+    /// the package id (<c>RequiredPackage.BundleName</c>).</summary>
+    private static string BaseNameOf(string bundleFileName) =>
+        bundleFileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
+            ? bundleFileName[..^4]
+            : bundleFileName;
+}
+
+/// <summary>One package's bundle inside a sealed publication.</summary>
+/// <param name="Identity">The framework build identity the publication was sealed for — the lane
+/// these bytes are provably for, and what the bundle's own manifest states.</param>
+/// <param name="Source">The producing repo's publication prefix (<c>plugins</c>, <c>crm</c>, …).</param>
+/// <param name="BundleName">The file name the seal lists.</param>
+/// <param name="Path">The resolved full path, composed under the publication's own directory so a
+/// generation-pointer layout reads the generation's bytes rather than the flat layout's.</param>
+/// <param name="Generation">The publication INSTANCE these bytes came out of, or null when the
+/// reading could not derive one.</param>
+public readonly record struct SealedLaneBundle(
+    string Identity, string Source, string BundleName, string Path, string? Generation);

--- a/test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs
@@ -191,6 +191,117 @@ public class PluginBundleSealedLaneTest(ITestOutputHelper output) : MonolithMesh
         }
     }
 
+    /// <summary>
+    /// 🚨 The stated identity composes a PATH under the mounted publication root, so a request that
+    /// is not a bare name is refused outright rather than resolved. Without this, an identity like
+    /// <c>../..</c> reaches outside the lane it names — a traversal the route did not have while
+    /// the identity was only ever string-compared.
+    /// </summary>
+    [Theory(Timeout = 120_000)]
+    [InlineData("../../etc")]
+    [InlineData("..")]
+    [InlineData("a/b")]
+    [InlineData("c:evil")]
+    public async Task AnIdentityThatIsNotABareNameIsRefused_OnBothRoutes(string identity)
+    {
+        var root = NewRoot();
+        try
+        {
+            SealPublication(root, ConsumerIdentity);
+            await InstallPackage();
+            var key = await RegisterInstance($"{Source}/*");
+            await using var app = await StartHost(root);
+
+            var lane = $"?identity={Uri.EscapeDataString(identity)}"
+                       + $"&arch={Uri.EscapeDataString(ReleaseArchitecture.Live)}";
+
+            using var index = await Get(
+                app, PluginBundleEndpoints.RoutePrefix + "/index.json" + lane, key);
+            Assert.Equal(HttpStatusCode.BadRequest, index.StatusCode);
+
+            using var bundle = await Get(
+                app, $"{PluginBundleEndpoints.RoutePrefix}/{Package}/{Version}{lane}", key);
+            Assert.Equal(HttpStatusCode.BadRequest, bundle.StatusCode);
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 The lookup may not cross the (source, package) pair the entitlement decision resolved.
+    /// Two sources seal a bundle of the SAME package id under the same identity; the one this
+    /// caller is bound to must be the one served, and the other must not become reachable by being
+    /// alphabetically first.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheBundleComesFromTheSourceTheEntitlementResolved_NotWhicheverSortsFirst()
+    {
+        var root = NewRoot();
+        try
+        {
+            // "education" sorts BEFORE "plugins", so a lookup that scanned every source and took
+            // the first match would serve this one.
+            SealPublication(
+                root, ConsumerIdentity, source: "education",
+                nodeTypePath: Package + "/FromTheOtherSource", fingerprint: "fp-other");
+            SealPublication(root, ConsumerIdentity);      // the granted source, "plugins"
+            await InstallPackage();                       // its install record says Source = plugins
+            var key = await RegisterInstance($"{Source}/*");
+            await using var app = await StartHost(root);
+
+            var index = await ReadIndex(app, key, ConsumerIdentity);
+            var url = BundleUrl(index);
+            Assert.NotNull(url);
+
+            using var response = await Get(app, url! + LaneQuery(ConsumerIdentity), key);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var (_, assemblies) = BundleReader.Read(await response.Content.ReadAsByteArrayAsync());
+            var served = Assert.Single(assemblies);
+            Assert.Equal(NodeTypePath, served.NodePath);
+            Assert.Equal("fp-sealed", served.SourceFingerprint);
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 THE safety property, asserted where this change could have broken it. The directory a
+    /// bundle is filed under is a convention; its manifest is the producer's claim. A bundle whose
+    /// own manifest names a DIFFERENT framework must never be served as the requested lane — if it
+    /// were, the outgoing manifest would be restamped with the requested identity and the
+    /// consumer's gate would see bytes that agree with its live framework and adopt them.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ABundleFiledUnderALaneButBuiltForAnotherIsRefused_NeverRestamped()
+    {
+        var root = NewRoot();
+        try
+        {
+            SealPublication(
+                root, ConsumerIdentity,
+                manifestIdentity: "s99999999999999999999999999999999");   // mislabelled
+            await InstallPackage();
+            var key = await RegisterInstance($"{Source}/*");
+            await using var app = await StartHost(root);
+
+            var index = await ReadIndex(app, key, ConsumerIdentity);
+            var url = BundleUrl(index);
+            Assert.NotNull(url);
+
+            using var response = await Get(app, url! + LaneQuery(ConsumerIdentity), key);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
     // ───────────────────────────── harness ─────────────────────────────
 
     private static string NewRoot() =>
@@ -211,21 +322,26 @@ public class PluginBundleSealedLaneTest(ITestOutputHelper output) : MonolithMesh
 
     /// <summary>Writes a complete publication — one real bundle plus the seal that lists it, in the
     /// layout <c>&lt;root&gt;/&lt;identity&gt;/&lt;source&gt;/</c> the bake produces.</summary>
-    private static void SealPublication(string root, string identity)
+    /// <param name="manifestIdentity">What the BUNDLE's own manifest claims it was built against,
+    /// when that must differ from the directory it is filed under — the mislabelled case.</param>
+    private static void SealPublication(
+        string root, string identity, string source = Source,
+        string nodeTypePath = NodeTypePath, string fingerprint = "fp-sealed",
+        string? manifestIdentity = null)
     {
-        var directory = Path.Combine(root, identity, Source);
+        var directory = Path.Combine(root, identity, source);
         Directory.CreateDirectory(directory);
         var bundle = Path.Combine(directory, $"{Package}.zip");
         using (var file = File.Create(bundle))
             BundleWriter.Write(
-                file, Package, Version, identity,
+                file, Package, Version, manifestIdentity ?? identity,
                 [
                     new BundleWriter.AssemblyEntry(
-                        NodeTypePath,
+                        nodeTypePath,
                         () => new MemoryStream(AssemblyBytes()),
                         Dependencies: new Dictionary<string, string>(StringComparer.Ordinal))
                     {
-                        SourceFingerprint = "fp-sealed",
+                        SourceFingerprint = fingerprint,
                     },
                 ]);
         File.WriteAllText(

--- a/test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs
@@ -255,7 +255,7 @@ public class PluginBundleSealedLaneTest(ITestOutputHelper output) : MonolithMesh
                 [new PackageFile($"{Package}/Doc.md", $"# {Package}")],
                 "HEAD")
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(120))
+            .Timeout(TestTimeouts.CrossSilo)
             .Await();
 
     private Task<string> RegisterInstance(params string[] defaultGrants) =>
@@ -271,7 +271,7 @@ public class PluginBundleSealedLaneTest(ITestOutputHelper output) : MonolithMesh
             .Register("sealed-lane-owner", "Owner", "owner@test.com", Instance, Instance)
             .Select(r => r.RawKey)
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(60))
+            .Timeout(TestTimeouts.Convergence)
             .Await();
 
     private async Task<WebApplication> StartHost(string publishedRoot)

--- a/test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs
+++ b/test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs
@@ -1,0 +1,323 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A registry serves the lane the CALLER asked for, when it holds a publication sealed for
+/// it — and its OWN lane when it does not</b> (MeshWeaver#3768).
+///
+/// <para>The defect: the index stamped <c>frameworkMvid</c> with the registry's own bake
+/// unconditionally, and <c>PluginBundleClient.Adopt</c> compares that ONCE and declines the whole
+/// index before requesting any package. So the download route's lane-awareness (#1751) and the
+/// module half's sealed read (#3244) were both unreachable for exactly the consumer they exist for.
+/// Measured on the fleet's own portals twice, with a different identity pair each time — 25
+/// adoption attempts, 0 adopted, 25 <c>FrameworkDeclined</c> — while the publication sealed for the
+/// consumer's identity sat on the share the registry mounts.</para>
+///
+/// <para><b>Both directions are asserted here, because a change that serves everybody passes a
+/// one-sided test.</b> A caller whose lane IS sealed here must be told so and handed THOSE bytes; a
+/// caller whose lane is NOT must still be told this registry's own identity — which is what keeps
+/// it declining and compiling — and must never be handed another identity's bundle in its place.
+/// The adoption gate itself (<see cref="PrebuiltAssemblySeeder.DeclineReason"/>, ordinal equality)
+/// is untouched by the change and asserted here as the thing that still holds.</para>
+/// </summary>
+public class PluginBundleSealedLaneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The lane the CONSUMER runs — not this test host's, which is what makes it "off
+    /// lane". A fixed literal: the value must not be whatever the process happens to resolve.</summary>
+    private const string ConsumerIdentity = "s11111111111111111111111111111111";
+
+    /// <summary>A third lane nothing is sealed for — the negative control's ask.</summary>
+    private const string UnsealedIdentity = "s22222222222222222222222222222222";
+
+    private const string Package = "SealedLanePackage";
+    private const string NodeTypePath = Package + "/Widget";
+    private const string Source = "plugins";
+    private const string Version = "3.2.1";
+    private const string Instance = "sealed-lane-consumer";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    /// <summary>
+    /// POSITIVE CONTROL — the caller's lane IS sealed here, so the index claims it and the bundle
+    /// carries the sealed publication's own bytes, stamped with the caller's identity.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ACallerWhoseLaneIsSealedHere_IsToldThatLane_AndServedThePublicationsBytes()
+    {
+        var root = NewRoot();
+        try
+        {
+            SealPublication(root, ConsumerIdentity);
+            await InstallPackage();
+            var key = await RegisterInstance($"{Source}/*");
+            await using var app = await StartHost(root);
+
+            var index = await ReadIndex(app, key, ConsumerIdentity);
+
+            Assert.Equal(ConsumerIdentity, index.GetProperty("frameworkMvid").GetString());
+            Assert.Equal(
+                ReleaseArchitecture.Live, index.GetProperty("architecture").GetString());
+
+            var url = BundleUrl(index);
+            Assert.NotNull(url);
+
+            using var response = await Get(app, url! + LaneQuery(ConsumerIdentity), key);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var (manifest, assemblies) = BundleReader.Read(
+                await response.Content.ReadAsByteArrayAsync());
+
+            Assert.Equal(ConsumerIdentity, manifest?.FrameworkMvid);
+            Assert.Equal(NodeTypePath, Assert.Single(assemblies).NodePath);
+            // The producer's source fingerprint rides through, so the consuming hub can still
+            // refuse an adoption whose source disagrees with the source that mesh holds (#2813).
+            Assert.Equal("fp-sealed", Assert.Single(assemblies).SourceFingerprint);
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL — nothing is sealed for the caller's lane, so the index keeps stating THIS
+    /// registry's own identity. That is what makes the consumer decline and compile, and it is the
+    /// assertion a fix that simply echoed the request back would fail.
+    ///
+    /// <para>The second half matters as much: a publication sealed for a DIFFERENT identity is
+    /// present on the same root, and it must not be handed over in place of the lane that was
+    /// asked for. Serving bytes baked for another framework is the outage this gate exists to
+    /// prevent.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ACallerWhoseLaneIsNotSealedHere_IsToldThisRegistrysOwnLane_AndGetsNoOtherLanesBytes()
+    {
+        var root = NewRoot();
+        try
+        {
+            SealPublication(root, ConsumerIdentity);          // a lane that is NOT the one asked for
+            await InstallPackage();
+            var key = await RegisterInstance($"{Source}/*");
+            await using var app = await StartHost(root);
+
+            var index = await ReadIndex(app, key, UnsealedIdentity);
+
+            Assert.Equal(
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                index.GetProperty("frameworkMvid").GetString());
+            Assert.NotEqual(UnsealedIdentity, index.GetProperty("frameworkMvid").GetString());
+
+            // …and the consumer's unchanged gate turns exactly that into a decline naming both.
+            var decline = PrebuiltAssemblySeeder.DeclineReason(
+                index.GetProperty("frameworkMvid").GetString(), UnsealedIdentity);
+            Assert.NotNull(decline);
+            Assert.Contains(UnsealedIdentity, decline);
+
+            var url = BundleUrl(index);
+            Assert.NotNull(url);
+
+            using var response = await Get(app, url! + LaneQuery(UnsealedIdentity), key);
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var (manifest, assemblies) = BundleReader.Read(
+                    await response.Content.ReadAsByteArrayAsync());
+                Assert.NotEqual(ConsumerIdentity, manifest?.FrameworkMvid);
+                Assert.Empty(assemblies);
+            }
+            else
+            {
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            }
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    /// <summary>
+    /// A caller that states NO lane is answered exactly as before — the shape every already
+    /// deployed consumer asks in, which must not move when a newer one starts stating its lane.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ACallerThatStatesNoLane_IsAnsweredWithThisRegistrysOwnIdentity()
+    {
+        var root = NewRoot();
+        try
+        {
+            SealPublication(root, ConsumerIdentity);
+            await InstallPackage();
+            var key = await RegisterInstance($"{Source}/*");
+            await using var app = await StartHost(root);
+
+            var index = await ReadIndex(app, key, identity: null);
+
+            Assert.Equal(
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                index.GetProperty("frameworkMvid").GetString());
+            Assert.Equal(
+                ReleaseArchitecture.Live, index.GetProperty("architecture").GetString());
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    // ───────────────────────────── harness ─────────────────────────────
+
+    private static string NewRoot() =>
+        Path.Combine(Path.GetTempPath(), "mw3768-" + Guid.NewGuid().ToString("N"));
+
+    private static void Delete(string root)
+    {
+        try
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A temp tree that will not delete must never fail the assertion that already passed.
+        }
+    }
+
+    /// <summary>Writes a complete publication — one real bundle plus the seal that lists it, in the
+    /// layout <c>&lt;root&gt;/&lt;identity&gt;/&lt;source&gt;/</c> the bake produces.</summary>
+    private static void SealPublication(string root, string identity)
+    {
+        var directory = Path.Combine(root, identity, Source);
+        Directory.CreateDirectory(directory);
+        var bundle = Path.Combine(directory, $"{Package}.zip");
+        using (var file = File.Create(bundle))
+            BundleWriter.Write(
+                file, Package, Version, identity,
+                [
+                    new BundleWriter.AssemblyEntry(
+                        NodeTypePath,
+                        () => new MemoryStream(AssemblyBytes()),
+                        Dependencies: new Dictionary<string, string>(StringComparer.Ordinal))
+                    {
+                        SourceFingerprint = "fp-sealed",
+                    },
+                ]);
+        File.WriteAllText(
+            Path.Combine(directory, ShippedPrebuiltBundles.CompletionSentinelFileName),
+            $"{Package}.zip\n");
+    }
+
+    /// <summary>Real PE bytes — a bundle carrying something that is not an assembly would be a
+    /// weaker subject than the one this route actually serves.</summary>
+    private static byte[] AssemblyBytes() =>
+        File.ReadAllBytes(typeof(BundleWriter).Assembly.Location);
+
+    private Task<InstallResult> InstallPackage() =>
+        PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = Package,
+                    Name = Package,
+                    Kind = PackageKind.Content,
+                    TargetPartition = Package,
+                    SourceFolder = Package,
+                    Version = "1.0.0",
+                    ReleasedVersion = Version,
+                    Source = Source,
+                },
+                [new PackageFile($"{Package}/Doc.md", $"# {Package}")],
+                "HEAD")
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(120))
+            .Await();
+
+    private Task<string> RegisterInstance(params string[] defaultGrants) =>
+        new MeshWeaverInstanceService(
+                Mesh.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Services.IMeshService>(),
+                Mesh,
+                Mesh.ServiceProvider.GetRequiredService<ILogger<MeshWeaverInstanceService>>(),
+                new ConfigurationBuilder()
+                    .AddInMemoryCollection(defaultGrants.Select((entry, i) =>
+                        new KeyValuePair<string, string?>(
+                            $"{MeshWeaverInstanceService.DefaultGrantsConfigKey}:{i}", entry)))
+                    .Build())
+            .Register("sealed-lane-owner", "Owner", "owner@test.com", Instance, Instance)
+            .Select(r => r.RawKey)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(60))
+            .Await();
+
+    private async Task<WebApplication> StartHost(string publishedRoot)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [PublishedBundleCatalogue.PublishedRootConfigKey] = publishedRoot,
+        });
+        builder.Services.AddSingleton<IMessageHub>(Mesh);
+        builder.Services.AddSingleton(new InstanceRegistryAuthenticator(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>()));
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static string LaneQuery(string identity) =>
+        $"?identity={Uri.EscapeDataString(identity)}"
+        + $"&arch={Uri.EscapeDataString(ReleaseArchitecture.Live)}";
+
+    private static async Task<JsonElement> ReadIndex(
+        WebApplication app, string key, string? identity)
+    {
+        var route = PluginBundleEndpoints.RoutePrefix + "/index.json"
+                    + (identity is null ? "" : LaneQuery(identity));
+        using var response = await Get(app, route, key);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync()).RootElement.Clone();
+    }
+
+    /// <summary>The relative bundle route the index advertises for the package under test.</summary>
+    private static string? BundleUrl(JsonElement index) =>
+        index.GetProperty("bundles").EnumerateArray()
+            .Where(b => string.Equals(
+                b.GetProperty("plugin").GetString(), Package, StringComparison.OrdinalIgnoreCase))
+            .Select(b => new Uri(b.GetProperty("url").GetString()!).PathAndQuery)
+            .FirstOrDefault();
+
+    private static async Task<HttpResponseMessage> Get(
+        WebApplication app, string route, string key)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {key}");
+        return await app.GetTestClient().SendAsync(request);
+    }
+}


### PR DESCRIPTION
Fixes #3768.

## It still reproduces — measured today, on code that already carries #3946

`https://memex.systemorph.com/health`, 2026-09-11 ~05:35Z, image `3.0.0+45306a33e` (which **does**
contain #3934/#3946 — verified by `git merge-base --is-ancestor 26bf0a60c 45306a33e`):

```
bundle_adoption: Degraded — 25 adoption attempt(s), 0 assembly/assemblies adopted, 25 MISS(es)
  AI: FrameworkDeclined (built against framework s01d65c9542e19652c09f851ffb6bf92a,
                         live framework is s3e3c80238a740a8cb895a72b0bfb9cd6)
  …25 of them, the same pair
```

Same count, same kind, a **different identity pair** from the one this issue was filed on. #3946
changed a different comparison (a dependency record's module entry, `CompiledDependencies`); this
one is `PrebuiltAssemblySeeder.DeclineReason` against the INDEX's single top-level stamp, and it is
untouched by it — correctly, and it stays untouched here too.

**Denominator:** 25 is the whole population of that process's adoption attempts, not a truncation —
`BundleAdoptionLedger.Capacity` is 500 and the payload names ten then counts the rest. The
installation holds 63 `Package` records and its seed ledger lists 61; 25 is what the default-install
lane processed on that boot, and 0 of 25 adopted.

## What decides which bundles a consumer is handed

`Index()` stamped `frameworkMvid = FrameworkMvid` — *this portal's own bake* — and
`PluginBundleClient.Adopt` compares that ONCE and declines the whole index before requesting any
package. `DownloadOverHttp` has stated the consumer's lane since #1751 and `ServedModuleBytes` has
read the sealed publication for it since #3244, but neither is reachable: `FetchIndex` asked with no
lane at all, so the registry answered about itself and the consumer walked away.

## Why the issue's own proposed fix is not sufficient on its own

A registry cannot answer an off-lane caller out of its **mesh**. A `ReleaseArtifact` is minted in
exactly one place — a compile, in that mesh, stamping the compiling process's own identity
(`NodeTypeBuildState.TryCreateReleaseNode`); adoption mints none (`PrebuiltAssemblySeeder.Seed`
writes `LastCompiledVersion` only); and an in-portal compile writes `collection: "local"`, which
`FileSystemAssemblyStore` defines as pod-local. Measured on memex-cloud 2026-09-11:
`Store/Plugin/Release/20260911011107-Br61zt34` **does** name the consumer's identity
`s3e3c80238a740a8cb895a72b0bfb9cd6` — and its artifact is
`collection: "local", contentPath: "Store_Plugin/v13725-s3e3c802-…dll"`, written by a pod that has
been replaced. So stamping the index alone would turn one cheap named decline into N downloads that
each resolve nothing.

The durable cross-lane source is the publication the bake sealed, on the share the registry already
mounts. Measured the same morning: 561 identity directories, with
`s3e3c80238a740a8cb895a72b0bfb9cd6 09-11 00:13Z: crm(sealed 00:38Z), meshweaver-content(sealed
00:13Z), plugins(sealed 00:33Z)`. **The bytes were on the registry's own disk while every adoption
was declined.**

## What changed

1. `PluginBundleClient.FetchIndex` states this instance's lane (`?identity=&arch=`), exactly as
   `DownloadOverHttp` already does.
2. `Index` answers for the requested lane **when this registry holds a sealed publication for it**,
   and its own identity when it does not — so a bake gap keeps reading as a bake gap. A caller that
   states no lane (every already-deployed consumer) gets today's answer byte for byte.
3. `Assemble`, off-lane, serves that publication's bundle — its assemblies, dependency records and
   source fingerprints (#2813) — with the module section composed as on every other serve. New
   `SealedLaneBundles` is the lookup, reading through `PublishedBundleCatalogue.SealedPublicationOf`
   so a torn publication is never served and the generation pointer (#3461) is honoured.

**No gate is widened, no retry, no fallback, no catch.** The served archive states the identity it
was sealed for, and `PrebuiltAssemblySeeder.DeclineReason` (ordinal equality) still decides — first
for the archive as a whole, then per assembly as it seeds.

## Control, both directions

`test/Memex.Portal.Shared.Test/PluginBundleSealedLaneTest.cs`, 3 tests, asking the SAME endpoint
with three different asks:

- **positive** — `ACallerWhoseLaneIsSealedHere_IsToldThatLane_AndServedThePublicationsBytes`:
  `Assert.Equal(ConsumerIdentity, index.GetProperty("frameworkMvid").GetString());` and, on the
  bundle, `Assert.Equal(ConsumerIdentity, manifest?.FrameworkMvid);` /
  `Assert.Equal(NodeTypePath, Assert.Single(assemblies).NodePath);` /
  `Assert.Equal("fp-sealed", Assert.Single(assemblies).SourceFingerprint);`
- **negative** — `ACallerWhoseLaneIsNotSealedHere_IsToldThisRegistrysOwnLane_AndGetsNoOtherLanesBytes`:
  `Assert.Equal(PrebuiltAssemblySeeder.LiveFrameworkMvid, index.GetProperty("frameworkMvid").GetString());`
  `Assert.NotEqual(UnsealedIdentity, …);` then `Assert.NotEqual(ConsumerIdentity, manifest?.FrameworkMvid);`
  and `Assert.Empty(assemblies);` — a publication for a different identity is present on the same
  root and must not be substituted.
- **unchanged shape** — `ACallerThatStatesNoLane_IsAnsweredWithThisRegistrysOwnIdentity`.

**Proven falsifiable** rather than assumed: with the positive expectation replaced by a probe the
run went red with `Expected: "FALSIFICATION-PROBE" / Actual: "s11111111111111111111111111111111"`,
i.e. the index really returned the caller's lane. `DocumentationLinkIntegrityTest` was falsified the
same way (a deliberate broken link reddened it) before being run green.

## Verification

- `dotnet build -c Release -warnaserror`: `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`,
  `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`, `MeshWeaver.Compiler.Pipeline.Test`,
  `tools/MeshWeaver.PluginTester` — each `0 Error(s)`, `0 Warning(s)`.
- `Memex.Portal.Shared.Test` in full: **1275 passed, 0 failed** (2 m 52 s) — no regression in
  `PrebuiltPublicationTest`, `SealedModuleCompositionTest`, `PluginBundleIndexArtifactTest`,
  `PluginBundleArtifactFetchTest` or `PluginBundleLaneResolutionTest`.
- `MeshWeaver.Documentation.Test` in full: **374 passed, 0 failed**.

## Work product

`Doc/Architecture/SealedPublicationReads` is EXTENDED (not a fifth page): "The four consumers" now
names the registry serving an off-lane caller, with the `ReleaseArtifact`/`collection: "local"`
finding, both live measurements with their denominators, and the three-rule statement of what the
index stamp means. Plus a What's New entry (`Category: Fix`).

Pairs-with: none — no public top-level type or member is removed from `src/`; the change adds
`SealedLaneBundles`/`SealedLaneBundle` and edits private handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
