### PR TITLE
Record how to verify the prebuilt seal reads in PRODUCTION (#3876)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SealedPublicationReads.md
@@ -557,5 +557,40 @@ the pin is removed:
   adoption path where an incumbent predates stamping and the check reports — with numbers — that it
   proved nothing.
 
+### In production — and why a retrospective log sweep cannot settle it
+
+The harnesses above prove the three answers in a TestServer. They cannot prove a deployed portal
+stopped throwing, and #3876 stayed open on exactly that bar after its four readers and two route
+opens were fixed. What the portal can and cannot answer, measured 2026-09-11:
+
+- **The durable counter is the incident node, not the log.** `Admin/_LogIncident/<fingerprint>` on
+  the **control instance** (memex.systemorph.com — the same path on memex.meshweaver.cloud answers
+  `Not found`) carries `occurrences`, `firstSeen`, `lastSeen` and the pod names, and it outlives
+  Loki's retention. For `af1ee515fdf60bd1` it read **7 occurrences, last 2026-09-10T02:35:29Z**.
+- 🚨 **The ISSUE is not that counter, and can silently stop tracking it.** The node also carries
+  `occurrencesAtLastComment` plus, when the automation cannot post, `status: "Failed"` and the
+  reason — here `"Resource not accessible by integration"`, stuck at **5** while the count had
+  reached 7. Two recurrences after the issue was filed were never folded into it, so **a quiet
+  issue thread is not a quiet incident**. Read the node, never the thread.
+- **What discriminates a pre-fix occurrence from a live one is the pod's ReplicaSet hash**, not the
+  timestamp. All 7 fall on `77cfc55bfc` and `bf77c847`, while the fixes merged 2026-09-10 00:47Z
+  (#3877), 12:07Z (#3885) and 18:57Z (#3957) — the last occurrence is 1 h 48 m after the first of
+  those and still on the *previous day's* ReplicaSet, so it ran an image predating it. Confirm what
+  a replica carries by FILE/SYMBOL against the commit `/api/version` reports, never by merge
+  ancestry (a queue-merged commit fails `is-ancestor`).
+- 🚨 **`Logs`' `sinceMinutes` is a REQUEST, not a coverage guarantee, and the run never reports the
+  window it actually covered.** `{ "requestedAction": "Logs", "query": "_complete",
+  "sinceMinutes": 2880 }` against `memex-cloud` returned `entryCount: 0` carrying its `logQl` — an
+  answer by the rule in [Operating From The Portal](../OperatingFromThePortal), and still worth
+  nothing here: the positive control, the same query for a string that *does* occur, landed **21
+  lines spanning only 05:29Z–06:24Z**. The zero evidences under an hour rather than the two days
+  asked for, and the known occurrences are simply outside what Loki still holds. **Date the oldest
+  line a positive control returns before reading any `Logs` zero as absence** — against a window a
+  ~90 s republish can hide in, a retrospective sweep cannot settle this at all.
+
+So the verification that remains is a **live** one — a satellite gate reading the route through a
+real mid-replace window, or through a pruned identity, which is permanent and never self-heals —
+and the instrument that records it either way is the incident node's own counter.
+
 Related: [CI Content Bake](../CiContentBake) · [Plugin Build Contract](../PluginBuildContract) ·
 [Bake Identity Mismatch](../BakeIdentityMismatch) · [Module Build Architecture](../ModuleBuildArchitecture)


### PR DESCRIPTION
Extends `Doc/Architecture/SealedPublicationReads` → Verification with the **production**
verification method for #3876, which is the only bar that issue is still open on.

## Why this and not code

All four `_complete` readers and both route opens are already fixed and merged — #3877
(three catalogue readers), #3885 (the boot seeder) and #3957 (the module index and the
serve itself). I verified that on `main` by FILE/SYMBOL rather than by PR state, and
verified the **running** portal carries it the same way: memex.meshweaver.cloud reports
commit `6231c4da`, whose `PluginBundleEndpoints` carries `SealedBytes` opening with
`FileShare.Delete` and no surviving `Results.File(path, …)`.

The three controls the issue asks for already ship in
`test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs`, including the header assertion
and the positive control:

- `Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);` with
  `Assert.Equal("30", response.Headers.RetryAfter?.ToString());`
- `Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);` with
  `Assert.Null(response.Headers.RetryAfter);`
- the healthy publication still serving — `Assert.Equal(HttpStatusCode.OK, healthy.StatusCode);`
  plus "a healthy sealed publication must serve the bundle's BYTES"

So there was no defect left to fix. What was missing is how anyone verifies the deployed
portal, which is what keeps the issue open and what three colliding sessions each had to
re-derive.

## What the measurement found

- **The durable counter is the incident node on the CONTROL instance**, not the issue.
  `Admin/_LogIncident/af1ee515fdf60bd1` reads **7 occurrences, last 2026-09-10T02:35:29Z**;
  the same path on memex.meshweaver.cloud answers `Not found`.
- **The issue stopped tracking it silently.** That node carries `occurrencesAtLastComment`
  stuck at **5**, with `status: Failed` and `Resource not accessible by integration` — so
  the two recurrences after the issue was filed were never folded in. A quiet issue thread
  is not a quiet incident. (No existing issue covers this automation failure.)
- **All 7 occurrences are pre-fix**, discriminated by the pod's ReplicaSet hash rather than
  the timestamp: they fall on `77cfc55bfc` and `bf77c847`, and the last is 1h48m after
  #3877 merged but still on the previous day's ReplicaSet.
- 🚨 **A retrospective log sweep cannot settle this.** `Logs`' `sinceMinutes` is a request,
  not a coverage guarantee, and the run never reports the window it actually covered: a
  `_complete` query over a requested 2880 minutes returned `entryCount: 0` carrying its
  `logQl`, while the positive control — the same query for a string that does occur —
  landed 21 lines spanning only 05:29Z–06:24Z. The zero evidences under an hour against a
  defect whose window is ~90 s.

Both `Logs` runs and the `Sample` went through the control instance's Hosting API as
read-only `Hosting/InstanceAction` nodes, not the cluster.

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release -warnaserror` → `0 Error(s)`
- `DocumentationLinkIntegrityTest` + `ArchitectureTopicMapTest` → **5 passed, 0 failed**
  (rebuilt first — the edited page is an embedded asset, where `--no-build` is a false pass)

Doc-only: no public surface removed, no interface member added, no i18n catalog change.
No What's New entry — the shipped fix already has one
(`2026-09-10-publication-updates-return-a-retry-response.md`, Category: Fix); a second for
the same change would duplicate it.

Refs #3876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
