### PR TITLE
docs(#3888): the /code pre-flight loop has THREE answers, not two

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LanguageServices.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LanguageServices.md
@@ -158,10 +158,23 @@ Before any non-trivial source change, an agent operating under the [/code skill]
 
 1. Read current source (`Get` if not already in context).
 2. Call `LspCheckNode({nodeTypePath, sourcePath, proposedCode})`.
-   - `{ok: true, diagnostics: []}` → safe; persist via `Patch`.
-   - `{ok: false, diagnostics: [errors...]}` → fix in head, re-call.
 3. Once clean, issue `Patch` / `Update`.
 4. `Compile` + `GetDiagnostics` for the real emit.
+
+🚨 **Step 2 has THREE answers, not two, and the third is not about your code.** Reading it as
+one of the other two is how #3888 hurt: an answer that never compiled anything used to be spelled
+exactly like a clean one, and the loop above said what to do with two shapes only.
+
+| Answer | What happened | What to do |
+|---|---|---|
+| `{ok: true, status: "Compiled", diagnostics: []}` | it compiled, and it is clean | persist via `Patch` |
+| `{ok: false, status: "Compiled", diagnostics: […]}` | it compiled, and **your source** is wrong | fix in head, re-call |
+| `{ok: false, status: "Absent" \| "NotCompilable" \| "Unavailable", error: "…"}` | **nothing was compiled** — the path did not resolve, the node has nothing to compile, or its owner never answered | fix the PATH or the ACCESS, then ask again — never edit the source in response, and never proceed |
+
+`status` is present on every answer, the clean one included: a success shape that omitted it would
+leave `{ok: true, diagnostics: []}` indistinguishable from a silent answer to anything keying on the
+field, which is the defect in miniature. The same three shapes come back from
+`LspDiagnosticsForNode` and `GetDiagnostics`, through the same renderer.
 
 This loop replaces the old blind `Patch → Compile → Recycle → fix` cycle that previously dominated CI failures.
 


### PR DESCRIPTION
Doc-only follow-up to #3912 / #3916, on the same page they extended. Refs #3888.

## What is still wrong after #3912

#3912 gave the speculative check a return type that can say *"I did not check"*, and documented that
contract in `LanguageServices.md`'s surface section. It did **not** touch the same page's own
**`## The /code Pre-Flight Loop`**, which still describes step 2 as having **two** answers — the two
that existed before the fix:

```
2. Call `LspCheckNode({nodeTypePath, sourcePath, proposedCode})`.
   - `{ok: true, diagnostics: []}` → safe; persist via `Patch`.
   - `{ok: false, diagnostics: [errors...]}` → fix in head, re-call.
```

That is the page an agent is pointed at by the `/code` skill, and it is now the last place in the
tree that still says the answer is binary.

## Why it is not cosmetic

A reader who meets the third shape has to classify it as one of the two that are written down, and
**both readings are wrong in a way that matters**:

- reading it as *clean* is exactly the defect #3888 reported;
- reading it as *your code is broken* is the other way to be wrong, and the more likely one now that
  the answer says `ok: false` — the agent starts editing source that was never compiled, against a
  path that never resolved.

## What changes

The loop keeps its four steps and gains a table under step 2 stating all three shapes, what each one
means, and what to do about it — the third row being `fix the PATH or the ACCESS, never edit the
source in response`. It also records why `status` is on the **success** shape too: a clean answer
that omitted it would be indistinguishable from a silent one to anything keying on the field, which
is the reported defect in miniature.

## Verification

- `DocumentationLinkIntegrityTest` + `ArchitectureTopicMapTest` → `Passed! - Failed: 0, Passed: 5`.
- `test/MeshWeaver.Documentation.Test` built `-c Release -warnaserror` → `0 Error(s) 0 Warning(s)`
  (the doc is an embedded asset, so it is a real rebuild, not a `--no-build`).

Doc-only: no `src/` code, no public surface added or removed, no interface member, no i18n catalog
key. Pairs-with: none — the diff touches one markdown file and removes no public type or member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
