### PR TITLE
Hold the BlazorMonaco pin in the repo that owns it (#3378)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SecurityScanning.md
@@ -96,6 +96,20 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
 - **Nothing here scans dependencies at rest.** Dependabot covers declared packages; a library
   inlined into a NuGet package's static assets (the Monaco bundle) is visible to neither Dependabot
   nor a source build — only to a scan of what is served.
+- 🚨 **And the pin that decides which bundled assets exist lives in a repository that cannot build
+  them.** `BlazorMonaco` is pinned in **core's** `Directory.Packages.props`, **no core project
+  references it** (the Blazor surface is in MeshWeaver.Plugins), and MeshWeaver.Plugins has no
+  `Directory.Packages.props` of its own — its `src/MeshWeaver.Blazor/MeshWeaver.Blazor.csproj`
+  carries a **versionless** `<PackageReference Include="BlazorMonaco" />`. So editing one line in
+  core changes what the portal's editor is built from, and core's build and CI are green by
+  construction whatever the new version ships. The satellite's `MonacoBundleGuard` does check the
+  properties the #3378 remedy rests on, but it runs against the core commit the satellite **pins**
+  (`MW_PLATFORM_REF`), so it reacts at the next pin move rather than at the bump — the documented
+  cross-repo lag. The `Satellite package pins (removal declared)` gate covers a pin being REMOVED;
+  a pin being BUMPED was uncovered, and `BlazorMonacoPinGuard`
+  (`test/MeshWeaver.Documentation.Test/`) is that cover: it fails on any change to the pin with the
+  re-verification checklist, and asserts its own premise — that nothing in core references the
+  package — so the guard cannot go quietly wrong if that ever changes.
 - 🚨 **Dropping a `<script>` removes the LOAD, not the ASSET.** Measured on both portals
   2026-09-07, after MeshWeaver.Plugins#1393 stopped `App.razor` loading BlazorMonaco's `min/vs`
   tree, a plain `GET` of
@@ -123,6 +137,138 @@ FAIL-NEW: 0	FAIL-INPROG: 0	WARN-NEW: 9	WARN-INPROG: 0	INFO: 0	IGNORE: 0	PASS: 58
   general rule the other way round too: **a bundle a page stops loading does not leave the origin**,
   so an inventory taken from `App.razor` is not an inventory of what is served.
 
+## Verifying the editor still works — the positive control for the Monaco remedy
+
+🚨 **Removing a vulnerable bundle and breaking the editor is a worse outcome than the finding.**
+Monaco is the portal's code and markdown edit surface, and every measurement in the section above
+stops at the asset boundary: a file answering 200 is not an editor that runs, and no test in either
+repository executes this shell's editor JavaScript. So the remedy needs a **positive** control, and
+it has to run against the bytes the portal actually serves rather than a local build.
+
+**The enabling fact is a side effect of the fix.** BlazorMonaco's AMD loader fetched the editor
+lazily, when an editor was created, which needs a signed-in page — that is why this rule used to be
+authenticated-only. The bundle the portal builds itself is loaded **eagerly by the app shell on
+every page, `/login` included**, so the whole editor is reachable **anonymously**. The positive
+control therefore needs no session, no test account and no OIDC cookie, and can be run against
+production at any time.
+
+Drive a headless browser at the anonymous shell, wait for `window.monacoReady` (the promise
+`App.razor` publishes and `MonacoEditorView` awaits), then exercise the editor through the same
+APIs the Blazor interop uses. The checks that matter, and what each one would catch:
+
+| check | how | what a failure means |
+|---|---|---|
+| the bundle loads | `await window.monacoReady`; `window.monaco` is defined | a 404 or a parse error — the dead-editor case the asset check cannot see |
+| the interop's contract holds | `monaco.editor` / `monaco.languages` / `monaco.Uri` present | BlazorMonaco's `jsInterop.js` drives the editor through these only |
+| values round-trip | `editor.create(...)`, `getValue()`, `setValue()` | the Blazor interop's read/write path |
+| **syntax highlighting** | `monaco.editor.tokenize(src, 'csharp')` returns real token types, and the view carries several distinct `mtk*` classes | grammars are **lazily registered** — tokenize immediately after load returns one null-state token, so poll until it changes or the check is vacuous |
+| **squiggles** | `setModelMarkers` then `getModelMarkers`, and a rendered `.squiggly-error` | the exact API the LSP diagnostics path paints through |
+| **workers answer** | a deliberately invalid JSON model produces a marker | a worker URL the bundle got wrong 404s silently |
+| **DOMPurify sanitises** | a hover whose markdown carries `javascript:` hrefs and `onerror`/`onload` attributes | the rule-10003 exposure itself |
+
+🚨 **The sanitisation check needs its own positive control.** "No `onerror` in the output" is also
+what a renderer that rendered *nothing* produces. Include a benign `**bold**` in the same payload
+and assert it survives as `<strong>`: that distinguishes *sanitised* from *broken*.
+
+```js
+// npm i playwright && npx playwright install chromium — run from a scratch directory, never
+// committed (one-off diagnostics rot; this table and recipe are the durable form).
+import { chromium } from 'playwright';
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const errors = []; const failed = [];
+page.on('pageerror', e => errors.push(e.message));
+page.on('console', m => m.type() === 'error' && errors.push(m.text()));
+page.on('response', r => r.status() >= 400 && failed.push(`${r.url()} ${r.status()}`));
+
+await page.goto('https://memex.meshweaver.cloud/login', { waitUntil: 'load' });
+await page.evaluate(() => window.monacoReady);
+
+console.log(await page.evaluate(async () => {
+  const m = window.monaco, out = {};
+  const src = 'public record Foo(int Bar)\n{\n    // c\n    public string B => "s";\n}\n';
+  const host = document.createElement('div');
+  host.style.cssText = 'width:1000px;height:400px;position:absolute;top:0;left:0';
+  document.body.appendChild(host);
+  const ed = m.editor.create(host, { value: src, language: 'csharp' });
+  out.roundTrip = ed.getValue() === src;
+
+  // the csharp grammar registers lazily — poll, or this assertion is vacuous
+  const t0 = Date.now(); let types = [];
+  while (Date.now() - t0 < 20000 &&
+         (types = [...new Set(m.editor.tokenize(src, 'csharp').flat().map(t => t.type))]).length < 2)
+    await new Promise(r => setTimeout(r, 200));
+  out.tokens = types;
+  await new Promise(r => setTimeout(r, 600));
+  out.colourClasses = new Set([...host.querySelectorAll('.view-line span[class^="mtk"]')]
+    .map(s => s.className)).size;
+
+  m.editor.setModelMarkers(ed.getModel(), 'probe', [{
+    startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 7,
+    message: 'probe', severity: m.MarkerSeverity.Error }]);
+  out.markers = m.editor.getModelMarkers({ owner: 'probe' }).length;
+  out.rendered = host.querySelectorAll('.squiggly-error').length;
+
+  m.languages.registerHoverProvider('csharp', { provideHover: () => ({ contents: [{
+    value: '[x](javascript:alert(1))\n\n<img src=x onerror="alert(2)">\n\n'
+         + '<svg onload="alert(3)"></svg>\n\n**bold survives**',
+    supportHtml: true, isTrusted: false }] }) });
+  return out;
+}));
+
+// open the hover with a real mouse move, then read what was rendered
+const at = await page.evaluate(() => { const r = document.querySelector('.view-line')
+  .getBoundingClientRect(); return { x: r.x + 40, y: r.y + r.height / 2 }; });
+await page.mouse.move(at.x, at.y); await page.waitForTimeout(1800);
+console.log(await page.evaluate(() => {
+  const html = document.querySelector('.monaco-hover')?.innerHTML ?? '';
+  return { onerror: /onerror/i.test(html), onload: /onload/i.test(html),
+           jsHref: /href\s*=\s*["']?javascript:/i.test(html),
+           boldSurvived: /<strong>bold survives<\/strong>/.test(html) };
+}));
+console.log({ errors, failed });
+await browser.close();
+```
+
+### 2026-09-11 — run against both portals
+
+`curl` on the served bytes, then the headless run above against
+`https://memex.meshweaver.cloud/login`:
+
+| | memex.meshweaver.cloud | memex.systemorph.com |
+|---|---|---|
+| `/api/version` | `3.0.0+6231c4da` | `3.0.0+45306a33` |
+| `…/MeshWeaver.Blazor/lib/monaco-editor/monaco.js` | 200 · 4,483,269 B · `sha256:8e991296…b039e846` | 200 · 4,483,269 B · **same sha256** |
+| its DOMPurify banners | exactly one: **3.4.14** | exactly one: **3.4.14** |
+| `versions.json` | `monaco-editor 0.56.0 · dompurify 3.4.14 · dompurify-vendored-by-monaco 3.4.8` | identical |
+| `…/BlazorMonaco/…/min/vs/editor.api-CalNCsUg.js` | **404** | **404** |
+| `…/BlazorMonaco/…/min/vs/loader.js` | **404** | **404** |
+| `…/BlazorMonaco/jsInterop.js` | 200 · 41,627 B | 200 · 41,627 B |
+
+🚨 **memex.systemorph.com has now rolled.** On 2026-09-08 it was still on `ci.8059` and still served
+the flagged 3.6 MB chunk; it no longer does. The pre-fix control described in the previous section
+is therefore **expired** — the fleet no longer has a portal on the old side of the filter, and
+reconstructing it now means pulling an old image.
+
+The headless run, against the anonymous shell:
+
+- `window.monacoReady` resolved; **91** languages registered, `csharp` among them.
+- An editor created on a real DOM node; value round-trip and `setValue` both correct.
+- **Syntax highlighting**: the grammar registered after 203 ms, then tokenized to
+  `keyword.public.cs`, `keyword.int.cs`, `keyword.string.cs`, `identifier.cs`, `comment.cs`,
+  `string.quote.cs`, `string.cs`, `delimiter*.cs` — and the rendered view carried **5 distinct
+  `mtk*` colour classes**.
+- **Squiggles**: `setModelMarkers` → `getModelMarkers` round-tripped one `Error` marker, and one
+  `.squiggly-error` was rendered in the view.
+- **Workers**: an invalid JSON model was answered by the JSON worker in **152 ms** (`Trailing comma`).
+- **DOMPurify**: the hover rendered `[x](javascript:alert(1))` as bare text, `<img src=x
+  onerror=…>` as `<img>` with both attributes gone, and dropped `<svg onload=…>` entirely — while
+  `**bold survives**` came through as `<strong>`, so the sanitiser ran rather than the renderer
+  failing. Nothing executed.
+- **Zero** console errors and **zero** failed or 4xx requests across the whole run.
+
+So the editor the portal serves is intact end to end, on the same bytes the scanner reads.
+
 ## Findings by release
 
 ### 3.0.0 — scanned 2026-09-06 against memex.meshweaver.cloud, ZAP 2.17.0
@@ -136,7 +282,7 @@ The full report of this scan — coverage, attack classes exercised, the delta a
 
 | rule | level | run | instances | disposition |
 |---|---|---|---|---|
-| Vulnerable JS Library [10003] — DOMPurify 3.2.7 inside BlazorMonaco's Monaco bundle | Medium | authenticated | 1 | **Fixed and DELIVERED, re-scan still owed**: MeshWeaver#3378 — the portal builds its own Monaco with DOMPurify 3.4.14 (MeshWeaver.Plugins#1393, `tools/monaco-editor`), guarded by `MonacoBundleGuard`. Delivery measured 2026-09-07 on the served bytes, not on the merge: `GET /_content/MeshWeaver.Blazor/lib/monaco-editor/monaco.js` answers 200 / 4,483,269 bytes / `sha256:8e991296e5e49dca83a02afa00a0eca20128a5c530b9996ce00830e6b039e846` on **both** memex.meshweaver.cloud and memex.systemorph.com — byte-identical to the committed bundle on MeshWeaver.Plugins `main` — carrying `/*! @license DOMPurify 3.4.14` (`versions.json`: monaco-editor 0.56.0, dompurify 3.4.14). Corroborated by an anonymous re-scan on 2026-09-07 that provably reached the bundle (10003 PASS over 1330 URLs, 10096 on `monaco.js`); the issue still closes on the AUTHENTICATED re-scan. Residue CLOSED by MeshWeaver#3617 (MeshWeaver.Plugins#1482): the retired `min/vs` tree is no longer published, measured 2026-09-08 on the shipped image (366 files under `_content/BlazorMonaco` → 3; 726 retired endpoints → 0) and on the wire (the flagged `editor.api-CalNCsUg.js` answers **404** on a portal running ≥ `ci.8079`) — see *What the scanner cannot see*. That removes the URL the alert instanced, and with it the only DOMPurify 3.2.7 the origin served; it does NOT by itself settle rule 10003, which is a verdict over every library the signed-in portal loads. |
+| Vulnerable JS Library [10003] — DOMPurify 3.2.7 inside BlazorMonaco's Monaco bundle | Medium | authenticated | 1 | **Fixed and DELIVERED, re-scan still owed**: MeshWeaver#3378 — the portal builds its own Monaco with DOMPurify 3.4.14 (MeshWeaver.Plugins#1393, `tools/monaco-editor`), guarded by `MonacoBundleGuard`. Delivery measured 2026-09-07 on the served bytes, not on the merge: `GET /_content/MeshWeaver.Blazor/lib/monaco-editor/monaco.js` answers 200 / 4,483,269 bytes / `sha256:8e991296e5e49dca83a02afa00a0eca20128a5c530b9996ce00830e6b039e846` on **both** memex.meshweaver.cloud and memex.systemorph.com — byte-identical to the committed bundle on MeshWeaver.Plugins `main` — carrying `/*! @license DOMPurify 3.4.14` (`versions.json`: monaco-editor 0.56.0, dompurify 3.4.14). Corroborated by an anonymous re-scan on 2026-09-07 that provably reached the bundle (10003 PASS over 1330 URLs, 10096 on `monaco.js`); the issue still closes on the AUTHENTICATED re-scan. Residue CLOSED by MeshWeaver#3617 (MeshWeaver.Plugins#1482): the retired `min/vs` tree is no longer published, measured 2026-09-08 on the shipped image (366 files under `_content/BlazorMonaco` → 3; 726 retired endpoints → 0) and on the wire (the flagged `editor.api-CalNCsUg.js` answers **404** on a portal running ≥ `ci.8079`) — see *What the scanner cannot see*. That removes the URL the alert instanced, and with it the only DOMPurify 3.2.7 the origin served; it does NOT by itself settle rule 10003, which is a verdict over every library the signed-in portal loads. 🚨 **A package bump is still not an alternative remedy, re-measured against the live registry 2026-09-11**: the NuGet flat-container index for `blazormonaco` answers HTTP 200 with **3.5.0 still the newest release**, and `blazormonaco.3.5.0.nupkg` (HTTP 200, 4,514,906 B) still carries `min/vs/loader.js` declaring Monaco **0.42.0-dev-20230906** and an `editor.api` banner-stamped **DOMPurify 3.2.7**. Upstream `monaco-editor` is 0.56.0 — the version the portal already builds — and it vendors DOMPurify 3.4.8, below the retire.js floor, so even a hypothetical BlazorMonaco carrying current Monaco would not by itself clear the rule. The pin is now held by `BlazorMonacoPinGuard` (core, `test/MeshWeaver.Documentation.Test/`). 2026-09-11: **both** portals answer **404** on the flagged URL (memex.systemorph.com has rolled), and the editor is verified working end to end — see *Verifying the editor still works*. |
 | Backup File Disclosure [10095] | Medium | public | 21 | **False positive, measured**: every instance is `/static/NodeTypeIcons/Copy (n) of <icon>.svg`, and that route synthesises an icon for ANY name — a nonsense name answers 200 with a 547-byte SVG of its own, while `bot.svg.bak` is 404 — so no file is disclosed; the rule keys on "a variant of the URL also answers 200". Carried: the fallback icon is the feature. |
 | Proxy Disclosure [40025] | Medium | public | systemic | **False positive, measured**: `TRACE` and `OPTIONS` answer 405 (`allow: GET, POST`) with no `Server`/`Via` header; the "Unknown proxy" is ZAP's inference from the refusal. Carried. |
 | CSP: Failure to Define Directive with No Fallback [10055] | Medium | both | 15 / 10 | **Carried by design** — see the row below; `form-action 'self' https:` is declared on every response measured (`/`, `/login`), so the missing directive the rule names is to be re-read on the next scan. |
@@ -216,8 +362,10 @@ executes this shell's editor JavaScript — measured, not assumed: `MonacoBundle
 suites render the component tree without a browser, and the fleet's only Playwright project
 (`clients/portal-next/e2e`) drives the separate Next.js client, which serves no
 `_content/BlazorMonaco` at all. A dead editor caused by a missing static asset would be caught by
-none of them; the last end-to-end verification on record is the manual headless check reported on
-MeshWeaver.Plugins#1393.
+none of them. That remains true of the automated suites — but the manual control is no longer a
+one-off buried in a pull request: *Verifying the editor still works* above carries the recipe and a
+2026-09-11 run of it against both portals, and it needs no session because the fix made the editor
+load on the anonymous shell.
 
 Three method notes, each of which was needed to reach that verdict:
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-the-editors-sanitizer-cannot-quietly-go-stale-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-the-editors-sanitizer-cannot-quietly-go-stale-again.md
@@ -1,0 +1,24 @@
+---
+Name: The code editor's sanitizer cannot quietly go stale again
+Category: Fix
+Description: The editor package's pinned version is now held in place with the checks a change to it requires, so the HTML sanitizer inside the editor cannot fall behind again without anyone noticing.
+Icon: Shield
+Order: -20260911
+---
+
+# The code editor's sanitizer cannot quietly go stale again
+
+The code and markdown editor sanitizes the HTML it renders in hovers and suggestions. The editor
+package the platform depends on carries its own copy of that sanitizer inside its assets rather
+than declaring it as a dependency — so the copy the portal was serving had fallen three years
+behind its upstream, and neither the automated dependency updates nor a normal build could see it.
+The portal now builds and serves its own current editor instead, and the outdated files are no
+longer published at all.
+
+What was still missing was anything that would notice the problem coming back. The version of that
+package is chosen in one place, nothing in that part of the platform is built against it, and the
+part of the platform that does use it takes whatever version it is given — so changing one line
+could have quietly changed what the editor is built from. That version is now held in place
+together with the checks a change to it requires, and the editor itself has a documented,
+repeatable end-to-end verification: highlighting, error squiggles, language services and sanitizing
+are all exercised against the running portal rather than inferred from the files it ships.

--- a/test/MeshWeaver.Documentation.Test/BlazorMonacoPinGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/BlazorMonacoPinGuard.cs
@@ -1,0 +1,196 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>This repository pins a package it does not build with, and the pin is a security decision.</b>
+/// <c>BlazorMonaco</c> ships the code editor's Blazor wrapper AND, inside its static web assets, a
+/// whole prebuilt Monaco with a DOMPurify inlined into it. That inlined copy is what OWASP ZAP's
+/// retire.js rule 10003 flagged as MeshWeaver#3378 — and neither Dependabot nor <c>dotnet build</c>
+/// can see it, because it is a JavaScript library inside a NuGet package's assets rather than a
+/// declared dependency.
+///
+/// <para><b>Why the guard lives HERE, in a repository with no editor in it.</b> Three facts compose
+/// into a blind spot, and each one is individually reasonable:</para>
+///
+/// <list type="number">
+///   <item>The pin lives in this repository's <c>Directory.Packages.props</c>.</item>
+///   <item><b>No project in this repository references it</b> — the Blazor surface moved to
+///   MeshWeaver.Plugins. So a bump here changes nothing this repository compiles, and core CI is
+///   green by construction whatever the new version does.</item>
+///   <item>MeshWeaver.Plugins has <b>no <c>Directory.Packages.props</c> of its own</b>. Its
+///   <c>src/MeshWeaver.Blazor/MeshWeaver.Blazor.csproj</c> carries a VERSIONLESS
+///   <c>&lt;PackageReference Include="BlazorMonaco" /&gt;</c>, so the version it restores is whatever
+///   this file says.</item>
+/// </list>
+///
+/// <para>Put together: <b>editing one line here changes what a different repository's editor is
+/// built from, with nothing in this repository able to notice.</b> The satellite's own
+/// <c>MonacoBundleGuard</c> does check the properties below — but it runs against the core commit
+/// the satellite PINS (<c>MW_PLATFORM_REF</c>), so it reacts at the next pin move rather than at the
+/// bump, which is the documented cross-repo lag (AGENTS.md: "the pin bump IS its integration test").
+/// The existing <c>Satellite package pins (removal declared)</c> gate covers a pin being REMOVED;
+/// a pin being BUMPED is uncovered, and this is that cover.</para>
+///
+/// <para><b>What the audited version was measured to contain</b> — against the live registry on
+/// 2026-09-11, not read off a changelog: the NuGet flat-container index for <c>blazormonaco</c>
+/// answered HTTP 200 with 3.5.0 as the newest release (no 3.6 exists), and
+/// <c>blazormonaco.3.5.0.nupkg</c> (HTTP 200, 4,514,906 bytes) carries
+/// <c>staticwebassets/lib/monaco-editor/min/vs/loader.js</c> declaring Monaco
+/// <b>0.42.0-dev-20230906</b> and <c>editor.api-CalNCsUg.js</c> banner-stamped
+/// <c>/*! @license DOMPurify 3.2.7</c>. Both are far below the scanner's floors. <b>So a bump is
+/// not the fix and never was</b>, which is precisely why the portal builds its own bundle instead.</para>
+///
+/// <para>See <c>Doc/Architecture/SecurityScanning</c> for the finding, the remedy and the
+/// end-to-end verification; <c>tools/monaco-editor/README.md</c> in MeshWeaver.Plugins for the build.</para>
+/// </summary>
+public class BlazorMonacoPinGuard
+{
+    /// <summary>
+    /// The version whose bundled assets were audited for MeshWeaver#3378. Moving this is a
+    /// deliberate act with a checklist, not a routine dependency bump — see
+    /// <see cref="ThePinIsTheAuditedVersion"/> for what to re-verify.
+    /// </summary>
+    private const string AuditedVersion = "3.5.0";
+
+    private const string PackageId = "BlazorMonaco";
+
+    /// <summary>The directories that hold this repository's projects — never the whole tree, which
+    /// contains sibling git worktrees under <c>.claude/</c>.</summary>
+    private static readonly string[] ProjectRoots = ["src", "test", "tools", "samples", "memex"];
+
+    private static string PropsPath() =>
+        Path.Combine(FindRepoRoot(), "Directory.Packages.props");
+
+    /// <summary>Every <c>PackageVersion</c> entry as (id, version).</summary>
+    private static List<(string Id, string Version)> Pins() =>
+        Regex.Matches(File.ReadAllText(PropsPath()),
+                @"<PackageVersion\s+Include=""([^""]+)""\s+Version=""([^""]+)""")
+            .Select(m => (m.Groups[1].Value, m.Groups[2].Value))
+            .ToList();
+
+    private static List<string> ProjectFiles() =>
+        ProjectRoots
+            .Select(r => Path.Combine(FindRepoRoot(), r))
+            .Where(Directory.Exists)
+            .SelectMany(d => Directory.EnumerateFiles(d, "*.csproj", SearchOption.AllDirectories))
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToList();
+
+    /// <summary>
+    /// 🚨 The tripwire. It fires on ANY change to the pin, because there is no version of this
+    /// package whose bundled Monaco can be trusted without being looked at, and nothing else in
+    /// this repository will look.
+    /// </summary>
+    [Fact]
+    public void ThePinIsTheAuditedVersion()
+    {
+        var pinned = Pins().Where(p => p.Id == PackageId).Select(p => p.Version).ToList();
+
+        Assert.True(pinned.Count == 1,
+            $"expected exactly one {PackageId} pin in Directory.Packages.props; saw {pinned.Count}");
+
+        Assert.True(pinned[0] == AuditedVersion,
+            $"""
+             {PackageId} is pinned at {pinned[0]}, audited at {AuditedVersion} (MeshWeaver#3378).
+
+             This is not a routine bump. No project in THIS repository references {PackageId}, so
+             this repository's build and CI cannot tell you anything about the new version — but
+             MeshWeaver.Plugins consumes this pin VERSIONLESS (src/MeshWeaver.Blazor/*.csproj), so
+             the portal's editor is now built from it.
+
+             Before moving this line, check the new package's static web assets and record what you
+             found on Doc/Architecture/SecurityScanning:
+
+               1. Does it still inline a DOMPurify below the retire.js floor (3.4.13)?
+                  unzip -p <pkg>.nupkg 'staticwebassets/lib/monaco-editor/min/vs/editor.api-*.js' \
+                    | grep -o '@license DOMPurify [0-9.]*'
+                  If yes, the portal must go on building its own bundle (tools/monaco-editor in
+                  MeshWeaver.Plugins) — the package bump is NOT a remedy for #3378.
+
+               2. Does its jsInterop.js still only DECLARE the AMD path and never resolve it?
+                  MeshWeaver#3617 stopped PUBLISHING lib/monaco-editor/** on exactly that premise.
+                  A version that starts loading from that path 404s every editor at first use with
+                  a green build. MonacoBundleGuard (MeshWeaver.Plugins) asserts this — make its
+                  run part of the bump, do not wait for the next MW_PLATFORM_REF move.
+
+               3. Does BlazorMonaco still drive the editor through window.monaco only? That is what
+                  lets our own bundle satisfy it.
+
+             Then update AuditedVersion here in the same change.
+             """);
+    }
+
+    /// <summary>
+    /// 🚨 THE PREMISE OF THIS GUARD'S EXISTENCE. The pin is invisible to this repository's build
+    /// only for as long as nothing here references the package. If a project ever does, the compiler
+    /// and CI start covering some of what the message above asks a human to check by hand — and the
+    /// guard's reasoning, which says they cannot, becomes wrong in a way that reads as reassuring.
+    /// So the premise is asserted rather than remembered.
+    /// </summary>
+    [Fact]
+    public void NoProjectInThisRepositoryReferencesTheEditorPackage()
+    {
+        var referencing = ProjectFiles()
+            .Where(p => Regex.IsMatch(File.ReadAllText(p),
+                $@"<PackageReference\s+[^>]*Include\s*=\s*""{PackageId}"""))
+            .Select(p => Path.GetRelativePath(FindRepoRoot(), p))
+            .ToList();
+
+        Assert.True(referencing.Count == 0,
+            $"""
+             {string.Join(", ", referencing)} now reference(s) {PackageId}.
+
+             This guard's failure message tells the next person that this repository's build cannot
+             see a {PackageId} bump. That is true only while this list is empty. Re-read
+             ThePinIsTheAuditedVersion and Doc/Architecture/SecurityScanning and say what the build
+             now covers — and note that a project here referencing the package will also PUBLISH its
+             static web assets, which is the stale-published-asset problem MeshWeaver#3617 closed on
+             the portal side.
+             """);
+    }
+
+    /// <summary>
+    /// 🚨 A guard that cannot find its subject must fail, not pass. The pin regex is attribute-order
+    /// sensitive and the project scan depends on a directory layout; either going quiet would make
+    /// both facts above vacuous — the same shape of defect they exist to prevent.
+    /// </summary>
+    [Fact]
+    public void TheGuardSeesTheThingsItPolices()
+    {
+        var pins = Pins();
+        Assert.True(pins.Count > 100, $"expected the full CPM pin list; saw {pins.Count}");
+        Assert.Contains(pins, p => p.Id == PackageId);
+
+        var projects = ProjectFiles();
+        Assert.True(projects.Count > 30,
+            $"expected this repository's projects; saw {projects.Count} .csproj files. A scan that "
+            + "finds (almost) nothing would report 'nothing references BlazorMonaco' having looked "
+            + "nowhere.");
+        // And the scan must be able to SEE a PackageReference at all — otherwise "no matches" is
+        // indistinguishable from a broken matcher.
+        Assert.Contains(projects, p => Regex.IsMatch(File.ReadAllText(p), @"<PackageReference\s"));
+    }
+
+    /// <summary>
+    /// 🚨 Anchors on the SOLUTION file, not on Directory.Packages.props. There are two of the
+    /// latter — the root one, and test/Directory.Packages.props with 6 pins — and walking up from
+    /// the test binary reaches the test one FIRST.
+    /// </summary>
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (no MeshWeaver.slnx found)");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Closes the open half of #3378: the remedy shipped months ago, but nothing in **this** repository would notice it being undone.

## First, the two registry facts the issue turns on — re-measured today

The issue says a package bump is not the fix. That was worth re-checking rather than inherited, because if a newer BlazorMonaco had shipped a current Monaco, **the bump would have been the fix**. Measured 2026-09-11 against the live registries, HTTP status and byte count gated:

| question | measurement |
|---|---|
| Is BlazorMonaco 3.5.0 still the newest? | **Yes.** NuGet flat-container index for `blazormonaco` → HTTP **200**, 319 B, newest entry `3.5.0`. No 3.6 exists. |
| Does 3.5.0 still bundle the flagged editor? | **Yes.** `blazormonaco.3.5.0.nupkg` → HTTP **200**, 4,514,906 B. `staticwebassets/lib/monaco-editor/min/vs/loader.js` declares Monaco **0.42.0-dev-20230906**; `editor.api-CalNCsUg.js` is banner-stamped **DOMPurify 3.2.7**. |
| Would a refreshed package have sufficed? | **No.** Upstream `monaco-editor` is 0.56.0 and vendors DOMPurify **3.4.8** — still under retire.js's 3.4.13 floor (CVE-2026-75838). The bundle has to be ours either way. |

## Which remedy, and why not the other

Remedy **(1)** — ship our own current Monaco — is the one taken, and it was **already delivered**: MeshWeaver.Plugins#1393 builds Monaco 0.56.0 from the ESM sources with DOMPurify **3.4.14** swapped in for Monaco's vendored 3.4.8, and #3617 / Plugins#1482 stopped publishing the retired tree.

Remedy **(2)** — patch the DOMPurify inside BlazorMonaco's bundle at build time — is rejected, and the measurements above are why it is a band-aid rather than a cheaper fix: it would leave Monaco **0.42.0-dev-20230906** in place, carrying three years of everything else, and would have to be re-applied on every package bump with nothing to fail if it were forgotten.

## The gap this PR closes

Three individually reasonable facts compose into a blind spot:

1. `BlazorMonaco` is pinned in **core's** `Directory.Packages.props`.
2. **No core project references it** — the Blazor surface is in MeshWeaver.Plugins. A bump changes nothing core compiles, so core CI is green by construction whatever the new version's bundled assets contain.
3. MeshWeaver.Plugins has **no `Directory.Packages.props` of its own**; its `src/MeshWeaver.Blazor/MeshWeaver.Blazor.csproj` carries a **versionless** `<PackageReference Include="BlazorMonaco" />`.

So editing one line here changes what another repository's editor is built from, invisibly. `MonacoBundleGuard` does check the properties the remedy rests on — but it runs against the core commit the satellite **pins**, so it reacts at the next `MW_PLATFORM_REF` move, not at the bump. The `Satellite package pins (removal declared)` gate covers a pin being **removed**; a pin being **bumped** was uncovered.

`BlazorMonacoPinGuard` is that cover. It fails on any change to the pin with the re-verification checklist inline (the DOMPurify floor; whether `jsInterop.js` still only *declares* the AMD path rather than resolving it — the premise #3617's deletion rests on; whether the package still drives the editor through `window.monaco`), and it asserts **its own premise** — that nothing here references the package — so its reasoning cannot go quietly wrong.

**Both facts were negative-controlled**, because a guard that has never been seen to fail is not a guard: setting the pin to `3.6.0` reds `ThePinIsTheAuditedVersion` with the checklist, and injecting a `PackageReference` reds `NoProjectInThisRepositoryReferencesTheEditorPackage`. Restored and verified clean afterwards. A third fact floors the scan itself (>100 pins, >30 projects, and the matcher must be able to see a `PackageReference` at all) so neither can pass having looked nowhere.

## The editor is verified working — which the docs said nothing did

`SecurityScanning.md` recorded that **no test in either repository executes the editor's JavaScript**, so a dead editor would be caught by nothing, and the last end-to-end check was a one-off in a pull request. The fix itself made that cheap to close: because the portal's own bundle loads **eagerly on the anonymous shell**, the editor can be exercised with **no session at all**. The page now carries the recipe (inline, not a committed script) and a run of it against production:

- `window.monacoReady` resolved; 91 languages registered, `csharp` among them; editor created, value round-trips through `getValue`/`setValue`.
- **Syntax highlighting**: grammar registered after 203 ms, then real tokens — `keyword.public.cs`, `comment.cs`, `string.quote.cs`, `identifier.cs` … — and **5 distinct `mtk*` colour classes** rendered in the view.
- **Squiggles**: `setModelMarkers` → `getModelMarkers` round-tripped an `Error` marker, and one `.squiggly-error` painted.
- **Workers**: the JSON worker answered an invalid model in **152 ms** (`Trailing comma`).
- **DOMPurify**: a hover carrying `javascript:` hrefs, `<img onerror>` and `<svg onload>` rendered fully inert — while `**bold survives**` came through as `<strong>`, so the sanitiser *ran* rather than the renderer failing. Nothing executed. **0** console errors, **0** failed/4xx requests.

Served bytes, both portals: `monaco.js` 200 · 4,483,269 B · `sha256:8e991296…b039e846`, exactly one banner `@license DOMPurify 3.4.14`, `versions.json` = `monaco-editor 0.56.0 · dompurify 3.4.14`. The flagged `editor.api-CalNCsUg.js` and `min/vs/loader.js` are **404 on both** — memex.systemorph.com has now rolled, so the pre-fix control noted on 2026-09-08 has expired.

## Scope

No i18n catalog keys, no public surface removed, no package pin removed or added, no workflow change — so no `Mirror-sync`, `Pairs-with`, `Implementers` or `Satellite-pins` declaration applies.

**This does not close #3378 by itself**: its acceptance criterion is an *authenticated* ZAP baseline reading rule 10003 PASS, which needs a human sign-in. The exact operator command is on `Doc/Architecture/SecurityScanning`.

**Two follow-ups worth naming, neither in this repo:** DOMPurify **3.4.15** shipped 2026-09-06 and `tools/monaco-editor` pins 3.4.14 — above the retire.js floor, so freshness rather than exposure, and a MeshWeaver.Plugins change set with its own bundle rebuild. And `Systemorph/Memex` still holds a frozen `App.razor` copy loading the retired tree; it ships to nobody today.

### Verification
- `dotnet build src/MeshWeaver.Documentation/MeshWeaver.Documentation.csproj -c Release -warnaserror` → **0 Error(s)**, 0 Warning(s)
- `dotnet build test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release -warnaserror` → **0 Error(s)**, 0 Warning(s) (58.9 s — rebuilt after the doc edits, since the docs are embedded resources and `--no-build` would have been a false pass)
- Full `MeshWeaver.Documentation.Test` suite → **393 passed, 0 failed**, including `DocumentationLinkIntegrityTest`, `ArchitectureTopicMapTest` and `WhatsNewEntryIntegrityTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
