### PR TITLE
fix: keep catalog clicks attached to the selected package

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -223,6 +223,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [The Apps Home](AppsHome)
 - [Content Favicon Rasterization](ContentFaviconRasterization)
 - [Controls That Cannot Fail](ControlsThatCannotFail)
+- [Catalog Action Identity](CatalogActionIdentity) — a retained click keeps its package when the catalog refreshes
 - [Link Previews](LinkPreviews)
 - [Local-First Client & Bootstrap](LocalFirstClient)
 - [PDF Export — one browser, two fidelities](PixelFaithfulExport)

--- a/src/MeshWeaver.Documentation/Data/Architecture/CatalogActionIdentity.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CatalogActionIdentity.md
@@ -1,0 +1,41 @@
+---
+Name: Catalog action identity
+Description: A catalog refresh must preserve the package and action addressed by a retained click.
+---
+
+# Catalog action identity
+
+`ClickedEvent` carries a layout area path. `LayoutAreaHost` resolves that path against the
+owner's **current** controls when it handles the event. A catalog row's position is therefore
+not a safe identity: a package inserted or renamed between rendering and dispatch can occupy
+the old row's path and receive its click.
+
+Catalog cards now use the package ID, encoded as a single collision-free Base64URL path segment,
+instead of an incrementing row number. Available packages and orphaned installation records have
+separate prefixes. The install/update command and the orphan removal command also have explicit
+area names, so an optional description cannot move a command to another address.
+
+The existing owner dispatch remains authoritative. When the intended package disappears or its
+install action is no longer available, the old action path resolves to no control and does
+nothing. This change does not alter package sources, installation permissions, version selection,
+or the installation engine.
+
+## Evidence and verification
+
+The original projection reproduced the defect through a real `LayoutAreaHost`: insert Package A
+before Package B, then dispatch B's retained Install or Update path. Both cases fetched A.
+The unchanged-order controls fetched B. The recording package source completed without emitting
+any files, so these tests exercised the real owner dispatch without writing installed content.
+
+`CatalogActionIdentityTest` lives in the existing Layout test suite. Ten cases cover Install and
+Update with unchanged cards, insertion, a rename that changes ordering, and an optional
+description, plus disappearing and newly installed packages. All ten pass with the correction;
+the full Layout suite passes 486 tests with no failures or skips. The Release build passes with
+warnings treated as errors.
+
+The investigation followed an unintended local catalog installation whose click-time DOM and
+owner trace were unavailable. The reproduced identity defect and a separate broad test locator
+defect are established independently; neither is asserted to be the cause of that untraced click.
+
+See [User Interface](../UserInterface) for layout ownership and
+[Controls That Cannot Fail](../ControlsThatCannotFail) for control identity and binding rules.

--- a/src/MeshWeaver.Documentation/Data/Architecture/CatalogActionIdentity.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CatalogActionIdentity.md
@@ -27,11 +27,26 @@ before Package B, then dispatch B's retained Install or Update path. Both cases 
 The unchanged-order controls fetched B. The recording package source completed without emitting
 any files, so these tests exercised the real owner dispatch without writing installed content.
 
-`CatalogActionIdentityTest` lives in the existing Layout test suite. Ten cases cover Install and
+`CatalogActionIdentityTest` lives in the existing Layout test suite. Twelve cases cover Install and
 Update with unchanged cards, insertion, a rename that changes ordering, and an optional
-description, plus disappearing and newly installed packages. All ten pass with the correction;
-the full Layout suite passes 486 tests with no failures or skips. The Release build passes with
-warnings treated as errors.
+description, plus disappearing and newly installed packages. The additional special-character
+cases dispatch `Plugins/Store` beside `Plugins` and `Plugins-Store`, retaining one card path segment
+and the intended package for both Install and Update. All twelve pass with the correction;
+the full Layout suite passes 488 tests with no failures or skips.
+
+`CatalogOrphanActionIdentityTest` exercises the actual catalog and its live installed-record
+query in an isolated Monolith fixture. Two cases retain B's Remove click while A is inserted
+before it or removed from before it. Actual owner dispatch removes B's record through the
+installer, keeps neighboring records and leaves B's content present. Fixture package files are
+supplied locally; no external source is contacted. Both cases pass. Removal is observed through
+the inventory query's `Removed` change: an individual node stream cannot emit a deletion frame
+after its owner is gone.
+
+The dependent category-first catalog suite now expects CfGamma's encoded card identity instead
+of `pkg-1`; all eight existing cases pass. The full portal Shared suite passes 1,274 tests in
+168.162 seconds with no failures, errors, skips or unrun cases. Both affected test projects build
+in Release with warnings treated as errors and report zero warnings/errors. Rebuilt documentation
+embed, link, topic-map and What's New integrity checks pass all 16 cases.
 
 The investigation followed an unintended local catalog installation whose click-time DOM and
 owner trace were unavailable. The reproduced identity defect and a separate broad test locator

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-catalog-actions-follow-the-selected-package.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-catalog-actions-follow-the-selected-package.md
@@ -1,0 +1,16 @@
+---
+Name: Catalog actions follow the selected package
+Category: Fix
+Description: Catalog refreshes preserve the package selected by an Install or Update click.
+Icon: Apps
+Order: -20260911
+---
+
+# Catalog actions follow the selected package
+
+An Install or Update click now keeps the identity of the selected package when the catalog
+refreshes. Adding or renaming another package, or updating a card's description, cannot redirect
+the click to a neighboring card.
+
+If that action is no longer available, the old click has no effect. Orphaned installation cards
+also retain their package identity when their list changes.

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
+using System.Buffers.Text;
 using System.ComponentModel;
 using System.Reactive.Linq;
+using System.Text;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
@@ -591,15 +593,13 @@ public static class CatalogLayoutAreas
         // hand; the installed set is the shell listing plus the records this page read.
         var knownInstalled = installedIds.Union(installedById.Keys);
 
-        var n = 0;
         foreach (var pkg in plan.Packages)
         {
-            n++;
             installedById.TryGetValue(pkg.Id, out var inst);
             container = container.WithView(
                 BuildCard(host, source, sourceRef, pkg, inst, viewerIsGlobalAdmin, plan.Available, knownInstalled,
                     activation),
-                $"pkg-{n}");
+                CardId("pkg", pkg.Id));
         }
 
         if (plan.Kind != CatalogPage.All)
@@ -612,17 +612,21 @@ public static class CatalogLayoutAreas
                 .WithStyle("margin: 24px 0 4px 0;"));
             container = container.WithView(Controls.Markdown(host.Localize("ui.mdOrphanedInstallRecords"))
                 .WithStyle("margin-bottom: 8px;"));
-            var o = 0;
             foreach (var orphan in orphans)
             {
-                o++;
                 container = container.WithView(
-                    BuildOrphanCard(host, orphan, viewerIsGlobalAdmin), $"orphan-{o}");
+                    BuildOrphanCard(host, orphan, viewerIsGlobalAdmin), CardId("orphan", orphan.Id));
             }
         }
 
         return container;
     }
+
+    // ClickedEvent carries an area path; the owner resolves it against CURRENT controls. A row
+    // position can belong to another package after a refresh. Encode the package identity as one
+    // collision-free path segment, and name actions independently of optional card text.
+    private static string CardId(string kind, string packageId) =>
+        $"{kind}-{Base64Url.EncodeToString(Encoding.UTF8.GetBytes(packageId))}";
 
     /// <summary>
     /// The install records this source no longer offers — a record whose package left the registry
@@ -677,7 +681,7 @@ public static class CatalogLayoutAreas
             {
                 RemoveInstallRecord(host, orphan.Id);
                 return Task.CompletedTask;
-            }));
+            }), "remove");
     }
 
     /// <summary>
@@ -749,7 +753,7 @@ public static class CatalogLayoutAreas
                 {
                     InstallPackage(host, source, sourceRef, pkg, catalog, installedIds);
                     return Task.CompletedTask;
-                }));
+                }), "install");
         }
 
         // 🚨 The LAST STEP of the install, said out loud (#1979). Loading a module is

--- a/test/Memex.Portal.Shared.Test/CatalogCategoryFirstTest.cs
+++ b/test/Memex.Portal.Shared.Test/CatalogCategoryFirstTest.cs
@@ -228,7 +228,7 @@ public class CatalogCategoryFirstTest(ITestOutputHelper output) : MonolithMeshTe
             .Where(f => f.Value.ToString().Contains(InstalledFragment, StringComparison.Ordinal))
             .FirstAsync().Timeout(RenderBudget).Await();
 
-        Cards(frame).Should().Equal(["pkg-1"], "one member, one card");
+        Cards(frame).Should().Equal(["pkg-Q2ZHYW1tYQ"], "the sole card retains the identity of CfGamma");
         var json = frame.Value.ToString();
         json.Should().Contain("Gamma Cover")
             .And.NotContain("Alpha Course").And.NotContain("Beta Course")

--- a/test/Memex.Portal.Shared.Test/CatalogOrphanActionIdentityTest.cs
+++ b/test/Memex.Portal.Shared.Test/CatalogOrphanActionIdentityTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Retained orphan-removal clicks run through the actual catalog, owner dispatch and installer
+/// against records in the isolated test mesh. Package files are local fixture content only.
+/// </summary>
+public class CatalogOrphanActionIdentityTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string CatalogNode = "OrphanIdentityCatalog";
+    private const string Area = CatalogLayoutAreas.CatalogArea;
+    private readonly AsyncSubject<LayoutAreaHost> owner = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog().AddMeshNodes(
+            new MeshNode("OrphanIdentityCatalogType")
+            {
+                HubConfiguration = config => config.AddDefaultLayoutAreas().AddLayout(layout =>
+                    layout.WithView(Area, (host, _) =>
+                    {
+                        owner.OnNext(host);
+                        owner.OnCompleted();
+                        return CatalogLayoutAreas.RenderFromSource(host, new FixtureSource(), "HEAD", null, "fixture");
+                    }))
+            },
+            new MeshNode(CatalogNode) { NodeType = "OrphanIdentityCatalogType" });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    private static PackageManifest Package(string id, string name) => new()
+    {
+        Id = id, Name = name, Version = "1.0.0", Kind = PackageKind.Content,
+        Category = "Fixtures", TargetPartition = id, SourceFolder = id,
+    };
+
+    private Task<InstallResult> Install(PackageManifest manifest)
+        => PackageInstaller.Install(Mesh, manifest,
+                [new PackageFile($"{manifest.Id}/Doc.md", $"# {manifest.Name}")], "HEAD")
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+    private static IObservable<T> ReadOwner<T>(LayoutAreaHost host, Func<T> read)
+        => Observable.Create<T>(observer =>
+        {
+            host.Update(LayoutAreaReference.Data, data =>
+            {
+                try { observer.OnNext(read()); observer.OnCompleted(); }
+                catch (Exception error) { observer.OnError(error); }
+                return data;
+            });
+            return Disposable.Empty;
+        });
+
+    private static IEnumerable<string> OrphanCards(LayoutAreaHost host)
+        => host.GetControl(Area) is StackControl root
+            ? root.Areas.Where(child => child.Id is string id && id.StartsWith("orphan-", StringComparison.Ordinal))
+                .Select(child => Area + "/" + child.Id)
+            : [];
+
+    private static string FindAction(LayoutAreaHost host, string name)
+    {
+        var card = OrphanCards(host).Single(path => ((StackControl)host.GetControl(path)!).Areas
+            .Any(child => host.GetControl(path + "/" + child.Id) is LabelControl label && Equals(label.Data, name)));
+        var action = ((StackControl)host.GetControl(card)!).Areas
+            .Single(child => host.GetControl(card + "/" + child.Id) is ButtonControl { IsClickable: true });
+        return card + "/" + action.Id;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RetainedRemoveClick_KeepsItsOrphanWhenANeighborIsInsertedOrRemoved(bool insert)
+    {
+        var first = Package("OrphanA", "Package A");
+        var intended = Package("OrphanB", "Package B");
+        var last = Package("OrphanC", "Package C");
+        await Install(intended);
+        await Install(last);
+        if (!insert)
+            await Install(first);
+
+        var stream = GetClient().GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(CatalogNode), new LayoutAreaReference(Area) { Id = Area + "?all=true" });
+        using var subscription = stream.Subscribe();
+        var host = await owner.Should().Within(TestTimeouts.Convergence).Emit();
+        await stream.SelectMany(_ => ReadOwner(host, () => OrphanCards(host).Count()))
+            .Where(count => count == (insert ? 2 : 3))
+            .Take(1).Should().Within(TestTimeouts.Convergence).Emit();
+        var retained = await ReadOwner(host, () => FindAction(host, intended.Name!))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        if (insert)
+            await Install(first);
+        else
+            Assert.True(await PackageInstaller.RemoveInstalledRecord(Mesh, first.Id)
+                .Should().Within(TestTimeouts.Convergence).Emit());
+
+        await stream.SelectMany(_ => ReadOwner(host, () => OrphanCards(host).Count()))
+            .Where(count => count == (insert ? 3 : 2))
+            .Take(1).Should().Within(TestTimeouts.Convergence).Emit();
+        var current = await ReadOwner(host, () => FindAction(host, intended.Name!))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        Assert.Equal(retained, current);
+
+        // A per-node stream does not emit a deletion frame after its owner disappears. Observe
+        // the actual install-registry query, whose Removed change is the catalog's own signal.
+        var records = CatalogLayoutAreas.ObserveInstalledManifests(host).Replay(1);
+        using var recordSubscription = records.Connect();
+        await records.Where(items => items.Any(item => item.Id == intended.Id))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var streamHub = host.Stream.Hub;
+        streamHub.Post(new ClickedEvent(retained, host.Stream.ClientId), options => options.WithTarget(streamHub.Address));
+        var remaining = await records.Where(items => items.All(item => item.Id != intended.Id))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        Assert.Contains(remaining, item => item.Id == last.Id);
+        if (insert)
+            Assert.Contains(remaining, item => item.Id == first.Id);
+        // Removing the record must leave the package's installed content in place.
+        Assert.NotNull(await Mesh.GetMeshNode(intended.Id + "/Doc")
+            .Should().Within(TestTimeouts.Convergence).Emit());
+    }
+
+    private sealed class FixtureSource : IPackageSource
+    {
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef)
+            => Observable.Return<IReadOnlyList<PackageManifest>>([Package("AvailableFixture", "Available package")]);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef)
+            => Observable.Throw<IReadOnlyList<PackageFile>>(new InvalidOperationException("Orphan removal must never fetch package files."));
+    }
+}

--- a/test/MeshWeaver.Layout.Test/CatalogActionIdentityTest.cs
+++ b/test/MeshWeaver.Layout.Test/CatalogActionIdentityTest.cs
@@ -1,0 +1,189 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Actual catalog projection and owner ClickedEvent dispatch, with
+/// file fetch intercepted before the real installer can receive any payload or write any node.
+/// </summary>
+public class CatalogActionIdentityTest : HubTestBase
+{
+    private const string Area = "CatalogActions";
+    private readonly AsyncSubject<LayoutAreaHost> owner = new();
+
+    public CatalogActionIdentityTest(ITestOutputHelper output) : base(output)
+        => Services.AddSingleton<AccessService>();
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).AddLayout(layout => layout.WithView(Area, (host, _) =>
+        {
+            owner.OnNext(host);
+            owner.OnCompleted();
+            return Controls.Stack;
+        }));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    private static PackageManifest Package(string id, string name) => new()
+    {
+        Id = id, Name = name, Version = "2.0.0", Kind = PackageKind.Content,
+        Category = "Fixtures", TargetPartition = "Fixture" + id,
+    };
+
+    private static UiControl Project(LayoutAreaHost host, IPackageSource source,
+        IReadOnlyList<PackageManifest> packages, IReadOnlyList<MeshNode> installed)
+        => Assert.IsAssignableFrom<UiControl>(typeof(CatalogLayoutAreas)
+            .GetMethod("BuildPackages", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, [host, source, "HEAD", null, "Fixture source",
+                CatalogLayoutAreas.Plan("Fixtures", null, packages), installed,
+                ImmutableHashSet<string>.Empty, false, new ModuleActivationReport([])]));
+
+    private static IObservable<T> ReadOwner<T>(LayoutAreaHost host, Func<T> read)
+        => Observable.Create<T>(observer =>
+        {
+            host.Update(LayoutAreaReference.Data, data =>
+            {
+                try { observer.OnNext(read()); observer.OnCompleted(); }
+                catch (Exception error) { observer.OnError(error); }
+                return data;
+            });
+            return Disposable.Empty;
+        });
+
+    private static IEnumerable<(string Path, object? Control)> Children(LayoutAreaHost host, string path)
+        => ((StackControl)host.GetControl(path)!).Areas.Select(child =>
+        {
+            var childPath = path + "/" + child.Id;
+            return (childPath, host.GetControl(childPath));
+        });
+
+    private static (string Card, string Action, string Label) FindAction(LayoutAreaHost host, string name)
+    {
+        var card = Children(host, Area).Single(child => child.Control is StackControl
+            && Children(host, child.Path).Any(grandchild =>
+                grandchild.Control is LabelControl label && Equals(label.Data, name))).Path;
+        var action = Children(host, card).Single(child => child.Control is ButtonControl { IsClickable: true });
+        return (card, action.Path, ((ButtonControl)action.Control!).Data.ToString()!);
+    }
+
+    [Theory]
+    [InlineData(false, "same")]
+    [InlineData(false, "insert")]
+    [InlineData(false, "rename")]
+    [InlineData(false, "description")]
+    [InlineData(true, "same")]
+    [InlineData(true, "insert")]
+    [InlineData(true, "rename")]
+    [InlineData(true, "description")]
+    public async Task RetainedInstallOrUpdateClick_MustKeepItsPackage(bool update, string change)
+    {
+        var stream = GetClient().GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(Area));
+        await stream.GetControlStream(Area).Where(c => c is StackControl)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var host = await owner.Should().Within(TestTimeouts.Convergence).Emit();
+        using var fetched = new ReplaySubject<string>();
+        var first = Package("package-a", "Package A");
+        var intended = Package("package-b", "Package B");
+        var last = Package("package-c", "Package C");
+        var source = new RecordingSource(fetched);
+        IReadOnlyList<MeshNode> installed = update
+            ? [new MeshNode(intended.Id, PackageInstaller.InstalledPartition)
+                { Content = intended with { Version = "1.0.0" } }]
+            : [];
+
+        host.UpdateArea(Area, Project(host, source, [intended, last], installed));
+        var retained = await ReadOwner(host, () => FindAction(host, intended.Name!))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        retained.Label.Should().Contain(update ? "Update" : "Install");
+
+        var revised = change switch
+        {
+            "rename" => intended with { Name = "Package Z" },
+            "description" => intended with { Description = "New description shifts optional content" },
+            _ => intended
+        };
+        if (change == "rename")
+        {
+            Assert.Equal([intended.Id, last.Id], CatalogLayoutAreas.InCategory([intended, last], "Fixtures").Select(p => p.Id));
+            Assert.Equal([last.Id, intended.Id], CatalogLayoutAreas.InCategory([revised, last], "Fixtures").Select(p => p.Id));
+        }
+        host.UpdateArea(Area, Project(host, source,
+            change == "insert" ? [first, revised, last] : [revised, last], installed));
+        var current = await ReadOwner(host, () => FindAction(host, revised.Name!))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        Output.WriteLine("Retained {0} ({1}); current intended {2}; change={3}",
+            retained.Action, retained.Label, current.Action, change);
+        Assert.Equal(retained.Action, current.Action);
+
+        // The actual owner dispatch resolves the retained event.Area against its CURRENT controls.
+        // No action delegate is invoked directly by this test.
+        var streamHub = host.Stream.Hub;
+        streamHub.Post(new ClickedEvent(retained.Action, host.Stream.ClientId),
+            options => options.WithTarget(streamHub.Address));
+        var requested = await fetched.Take(1).Should().Within(TestTimeouts.Convergence).Emit();
+        Output.WriteLine("Actual source FetchPackageFiles target: {0}; intended: {1}", requested, intended.Id);
+        Assert.Equal(intended.Id, requested);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task A_removed_or_now_installed_package_has_no_retained_install_target(bool nowInstalled)
+    {
+        var stream = GetClient().GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(Area));
+        await stream.GetControlStream(Area).Where(c => c is StackControl)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var host = await owner.Should().Within(TestTimeouts.Convergence).Emit();
+        using var fetched = new ReplaySubject<string>();
+        var intended = Package("package-b", "Package B");
+        var other = Package("package-c", "Package C");
+        var source = new RecordingSource(fetched);
+        host.UpdateArea(Area, Project(host, source, [intended, other], []));
+        var retained = await ReadOwner(host, () => FindAction(host, intended.Name!))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        host.UpdateArea(Area, Project(host, source, nowInstalled ? [intended, other] : [other],
+            nowInstalled ? [new MeshNode(intended.Id, PackageInstaller.InstalledPartition) { Content = intended }] : []));
+        // This is the exact current-control lookup OnClick uses. A missing action must not be
+        // reoccupied by the neighboring package or a different command on the same card.
+        Assert.True(await ReadOwner(host, () => host.GetControl(retained.Action) is null)
+            .Should().Within(TestTimeouts.Convergence).Emit());
+        var next = await ReadOwner(host, () => FindAction(host, other.Name!))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var streamHub=host.Stream.Hub;
+        streamHub.Post(new ClickedEvent(retained.Action,host.Stream.ClientId),o=>o.WithTarget(streamHub.Address));
+        streamHub.Post(new ClickedEvent(next.Action,host.Stream.ClientId),o=>o.WithTarget(streamHub.Address));
+        Assert.Equal(other.Id,await fetched.Take(1).Should().Within(TestTimeouts.Convergence).Emit());
+    }
+
+    private sealed class RecordingSource(IObserver<string> fetched) : IPackageSource
+    {
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef)
+            => Observable.Return<IReadOnlyList<PackageManifest>>([]);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef)
+            => Observable.Defer(() =>
+            {
+                fetched.OnNext(package.Id);
+                // Not even an empty payload is emitted: SelectMany cannot invoke PackageInstaller.
+                return Observable.Empty<IReadOnlyList<PackageFile>>();
+            });
+    }
+}

--- a/test/MeshWeaver.Layout.Test/CatalogActionIdentityTest.cs
+++ b/test/MeshWeaver.Layout.Test/CatalogActionIdentityTest.cs
@@ -87,10 +87,12 @@ public class CatalogActionIdentityTest : HubTestBase
     [InlineData(false, "insert")]
     [InlineData(false, "rename")]
     [InlineData(false, "description")]
+    [InlineData(false, "slash")]
     [InlineData(true, "same")]
     [InlineData(true, "insert")]
     [InlineData(true, "rename")]
     [InlineData(true, "description")]
+    [InlineData(true, "slash")]
     public async Task RetainedInstallOrUpdateClick_MustKeepItsPackage(bool update, string change)
     {
         var stream = GetClient().GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
@@ -99,9 +101,9 @@ public class CatalogActionIdentityTest : HubTestBase
             .Should().Within(TestTimeouts.Convergence).Emit();
         var host = await owner.Should().Within(TestTimeouts.Convergence).Emit();
         using var fetched = new ReplaySubject<string>();
-        var first = Package("package-a", "Package A");
-        var intended = Package("package-b", "Package B");
-        var last = Package("package-c", "Package C");
+        var first = Package(change == "slash" ? "Plugins-Store" : "package-a", "Package A");
+        var intended = Package(change == "slash" ? "Plugins/Store" : "package-b", "Package B");
+        var last = Package(change == "slash" ? "Plugins" : "package-c", "Package C");
         var source = new RecordingSource(fetched);
         IReadOnlyList<MeshNode> installed = update
             ? [new MeshNode(intended.Id, PackageInstaller.InstalledPartition)
@@ -125,12 +127,14 @@ public class CatalogActionIdentityTest : HubTestBase
             Assert.Equal([last.Id, intended.Id], CatalogLayoutAreas.InCategory([revised, last], "Fixtures").Select(p => p.Id));
         }
         host.UpdateArea(Area, Project(host, source,
-            change == "insert" ? [first, revised, last] : [revised, last], installed));
+            change is "insert" or "slash" ? [first, revised, last] : [revised, last], installed));
         var current = await ReadOwner(host, () => FindAction(host, revised.Name!))
             .Should().Within(TestTimeouts.Convergence).Emit();
         Output.WriteLine("Retained {0} ({1}); current intended {2}; change={3}",
             retained.Action, retained.Label, current.Action, change);
         Assert.Equal(retained.Action, current.Action);
+        if (change == "slash")
+            Assert.Equal(3, retained.Action.Split('/').Length); // Area / encoded card / install.
 
         // The actual owner dispatch resolves the retained event.Area against its CURRENT controls.
         // No action delegate is invoked directly by this test.

--- a/test/MeshWeaver.Layout.Test/MeshWeaver.Layout.Test.csproj
+++ b/test/MeshWeaver.Layout.Test/MeshWeaver.Layout.Test.csproj
@@ -7,6 +7,9 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Data\MeshWeaver.Data.csproj" />
     <ProjectReference Include="..\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Layout\MeshWeaver.Layout.csproj" />
+    <!-- The actual catalog projection pins retained-click identity on LayoutAreaHost's owner
+         dispatch. This is a library reference, not a second catalog/installer test executable. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.PluginCatalog\MeshWeaver.PluginCatalog.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
     <ProjectReference Include="..\..\src\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
   </ItemGroup>


### PR DESCRIPTION
An Install or Update click retained during a catalog refresh can resolve against a different package’s positional control path. Inserting Package A before Package B reproduced both actions fetching A through the real LayoutAreaHost owner dispatch.

Cards now use encoded package IDs and explicit command area names. The selected package keeps its action address across insertion, category sorting after a rename, and optional description changes. Removed or newly installed packages leave no stale install target. Orphan removal cards use the same identity rule. Installation permissions and the package engine are unchanged.

Validation:
- Original projection: two failing insertion cases and two passing unchanged-order controls through actual owner dispatch.
- **12/12** Install/Update and retained-target cases pass, including `Plugins/Store` beside `Plugins` and `Plugins-Store`. Full native Layout suite: **488/488 passed**.
- Existing category-first suite: **8/8 passed**, with CfGamma’s stable card identity replacing its outdated positional expectation.
- **2/2** orphan cases use the actual catalog, live registry query and owner ClickedEvent to remove B after A is inserted or removed. They verify neighboring records and B’s content remain present. Fixture files are local; no external package source is contacted.
- Full native portal Shared suite: **1,274/1,274 passed** in 168.162 seconds, no errors, failures, skips or unrun cases.
- Rebuilt documentation embed, link, topic-map and What’s New integrity: **16/16 passed**. Strict Release builds of Layout, Shared and Documentation test projects: zero warnings/errors; `git diff --check` clean.

Install/Update regression sources complete without emitting files, so those clicks cannot invoke the installer. Orphan fixtures exercise sanctioned record removal in an isolated test mesh. `CatalogActionIdentity.md` conserves the evidence and distinguishes the reproduced identity defect from a separate local click incident whose dispatch trace was unavailable.

Kept draft while the coordinated SAV release dependencies and normal CI complete. No runtime mutation or deployment is included in these validation claims.
