### PR TITLE
fix(#3510): an install OWNS its package root — a recycle aimed at it waits

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -537,14 +537,61 @@ happened.
 Each deferral case asserts the recycle **then runs**, not merely that it did not run. A change that
 swallowed the recycle would pass a "did not tear down" assertion and silently re-break #1104.
 
+### The lease names the root the install WRITES under — not the record's partition
+
+The three package kinds do not agree on how that root is derived, and `TargetPartitionOf` answers a
+different question (which partition an install *record* is about). `InstallCode` falls back to the
+shared `type` partition when a manifest declares no `targetPartition`; the record rule falls back to
+the package id. A lease keyed on the record rule would hold `<id>` for a blank-target Code package
+whose writes land in `type/<id>` — **a lease on a root nothing is writing to**, which in the log and
+in every other test reads exactly like a lease that is working, while the root that IS being written
+stays freely recyclable. `PackageInstaller.InstallRootOf` is the one definition, pinned by
+`TheLeaseNamesTheRootTheInstallWritesUnder_ForEveryKind` including the control that the other kinds
+still resolve to the package id.
+
+### The reach of the gate, and the three teardowns outside it
+
+🚨 **A guard whose reach is assumed rather than written down gets read as a guarantee it does not
+keep** — the same defect as the installer's own recycle line, which claimed *"work in flight beneath
+this root is answered by the teardown"* and was measurably false one lane over. So, explicitly: the
+lease is consulted by `HubRecycleExtensions.RecycleNode` and `NodeTypeRebindWatcher`. These still
+post a `DisposeRequest` without consulting it:
+
+| poster | why it is outside | |
+|---|---|---|
+| `MeshOperations.Recycle` | the operations / MCP recycle posts directly. An operator recycling a package root mid-install can still strand that install. | **an uncovered case** — routing it through the gate is a separate change |
+| `PackageInstaller.SettleRetypedRoot` | it is the lease HOLDER; a holder deferring against its own lease is a deadlock, and its recycle is ordered and waited on | **deliberate** |
+| `NodeTypeEnrichmentHelpers` (stale-build convergence, overlay self-heal) | they recycle per-TYPE hubs *beneath* a root, which is work the install is often waiting for | **deliberate** |
+
+### Two repairs considered and REJECTED, with the reason
+
+Both were raised in review, both look right, and both are wrong as stated. Recording why is the
+point — the next reader will have the same two ideas.
+
+**1. "Make `SettleRetypedRoot` wait for every holder that is not its own."** Two packages can target
+one partition, so install A's recycle can tear down a root install B is writing under — a real hole.
+But B's own `SettleRetypedRoot` would symmetrically wait for A's lease: **two installs each holding
+and each waiting is a mutual deadlock**, which no timeout may resolve (raising one is the band-aid,
+and dropping one recycle re-breaks #1732). The sound repair is to serialise installs per root, which
+is a different change with its own risk. Until then this is a **known residual**, not a covered case.
+
+**2. "Make the release hand the root atomically to the waiting recycler."** The wide window — the
+scheduler hop between the release and the waiter's continuation — *is* closed: `WhenReleased`
+re-evaluates the condition on the far side of the hop, recursing on the next genuine release (not a
+timer, not a retry, not a poll). What is left is the caller's own emission-to-post distance, with
+nothing in between. Closing *that* would mean either posting a teardown from inside the registry's
+own synchronisation, or letting a pending recycle RESERVE the root — and a reservation a new install
+has to queue behind inverts the priority this whole mechanism exists to protect.
+
 ### What this does NOT claim
 
-It does not claim the install can no longer lose a write. A root **beneath** an install still hosts
-per-type recyclers that are deliberately not deferred, and the installer's own `SettleRetypedRoot`
-still tears a root down while that root's background pipeline may be issuing correlated requests —
-the shape `RetypedRootRecycleNeedsAJobTest` records and #3800 narrowed by declining the recycle when
-the install wrote nothing. What is closed is the class the issue named: **nobody but the install
-itself takes that root down while the install is writing under it.**
+It does not claim the install can no longer lose a write. Besides the two residuals above, a root
+**beneath** an install still hosts per-type recyclers that are deliberately not deferred, and the
+installer's own `SettleRetypedRoot` still tears a root down while that root's background pipeline may
+be issuing correlated requests — the shape `RetypedRootRecycleNeedsAJobTest` records and #3800
+narrowed by declining the recycle when the install wrote nothing. What is closed is the class the
+issue named: **the automatic rebind recycle no longer takes a package root down while that package's
+own install is writing under it.**
 
 ## What this page does not claim
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -424,6 +424,128 @@ for why the precondition was made causal in the first place.
 to what either twin asserts is not done until the Plugins copy carries it (break shape 7; see
 [Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) → "Shape 7's worst form").
 
+## The install holds the root: deferring a recycle instead of stranding a write (#3510)
+
+Naming the disposer (the section above) made the next occurrence a read. It did not stop the
+teardown. This is the part that does.
+
+### What was measured
+
+> The `Hosting` root hub was disposed at 23:37:51Z while `Hosting`'s own 145-file install was in
+> flight. Its per-node children — the owners of `Hosting/*/_Activity/compile-state`,
+> `Hosting/_Access/Public_Access` — went with it. The `nodeops` handler had already written through
+> those node streams and returned `Processed()`, owing its reply to the write's ack; the ack never
+> came (`[UpdateQueue] ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this write`), so the
+> reply was never posted, the installer's `Observe` never fired, and the install ran out its
+> ten-minute bound as `[FAIL] Hosting — install: TimeoutException`.
+
+Six occurrences, four lost bake seals, one package every time.
+
+### The rule
+
+> **The install is the writer that owns the root's lifetime.** While an install holds a package
+> root, a recycle aimed at that root **waits**, and runs the moment the install releases it.
+
+`PackageRootInstallLeases` (mesh-scoped singleton, `MeshBuilder`) is that statement in code.
+`PackageInstaller.Install` and `InstallNodeRepoDelta` take a lease on
+`TargetPartitionOf(id, manifest)` for the whole run; `HubRecycleExtensions.RecycleNode` and
+`NodeTypeRebindWatcher` consult it before posting their `DisposeRequest`.
+
+### Why DEFER and not NACK
+
+The issue offered two remedies. The second — answer every in-flight write under the recycling root
+with a NACK the handler turns into the caller's reply — was **measured wrong one lane over**, in
+[#3112](https://github.com/Systemorph/MeshWeaver/issues/3112): faulting a write at
+`ADVANCE_WITHOUT_HANDOFF` reports failure for a write that **may well have committed**, because the
+caller's terminal has already fired at `LOCAL_EMIT` and the 5 s handoff bound is the *writer's*
+patience, not a statement about the store. A false "your write failed" is worse than a slow one.
+
+What the NACK arm *can* do correctly is already done and already green: the UPDATE leg's
+`RegisterOwnerDisposingNack` mints `OwnerDisposing` — a code the writer **re-enqueues** rather than
+surfaces — and `UpsertAnswersWhenTheOwnerGoesAwayTest` pins it. That is the owner *answering*, not
+the writer *guessing*, and it is why extending it further is not the remedy left open here.
+
+So: defer. And deferring has exactly one obligation.
+
+### "The install released the root" — why that state always arrives
+
+The lease is taken through `Observable.Using`, so the handle is disposed on **OnCompleted**, on
+**OnError**, and on **unsubscribe** — the complete set of ways an Rx subscription can end.
+
+| the install… | releases because |
+|---|---|
+| succeeds | `Using` disposes the resource on the terminal |
+| **faults** | same terminal path — an install that fails is exactly when a deferred recycle must not be stranded |
+| is abandoned (its caller's budget elapses, the caller's hub goes down) | the unsubscribe disposes the resource |
+| never ends at all | the mesh does — the registry is a mesh-scoped instance, not static state |
+
+🚨 **There is deliberately no timer that force-releases a lease.** "Defer" has to mean *wait for a
+state that always arrives*, never *wait a while*: a clock would hand the recycle back the very race
+the lease removes, and it is the band-aid this repository refuses. The cost of that choice is that a
+leaked lease would be an un-recyclable root — so the release arms are pinned by name
+(`AnInstallReleasesItsRoot_OnCompletion_OnFault_AndOnUnsubscribe`,
+`AnInstallThatFAILS_StillReleasesItsRoot`) and **a deferral is never silent**: it logs once when it
+defers, naming the holder, and once when it proceeds.
+
+### Scope: the ROOT PATH exactly, never the subtree
+
+The lease key is the whole path, and a recycle defers only when its target **is** that path. That is
+not conservatism, it is a deadlock avoidance that has to be stated:
+
+- an install **waits** on work beneath its own root — `PackageInstaller.MayPublishIntoRoot` holds
+  until the root's in-package NodeType has a loadable build;
+- the recyclers that serve those rebuilds — `NodeTypeEnrichmentHelpers`' stale-build convergence and
+  `WithOverlaySelfHeal` — live on the per-type hubs **beneath** the root.
+
+Deferring those against the install that is waiting for them would deadlock the install. They are
+out of scope, by design.
+
+### And the installer's own recycle is NOT deferred
+
+`PackageInstaller.SettleRetypedRoot` is the lease **holder**. Its teardown is the install's own
+ordered act: it sits between the two `RequestReleases` waves because the deferred wave's compiles
+read a root that must already carry the package's own binding (#1732), and `WaitForRootReady` holds
+the install until the address answers again. A holder deferring against its own lease is a deadlock,
+so it posts directly — and the code says so at the post.
+
+What the lease removes is the **second, unordered** teardown. `NodeTypeRebindWatcher` is armed on
+every instance hub at activation, package roots included, and `RequiresRebind` fires on precisely
+the event the installer's placeholder dance produces — the root's retype. Before this it could post
+a `DisposeRequest` at any moment of the write stage, including on top of the fresh activation
+`SettleRetypedRoot` had just waited for. It now waits; and because its subscription is registered
+for disposal on the hub it would recycle, the installer's own recycle **cancels** it rather than
+replaying it afterwards. One recycle per install, not two.
+
+### Both directions, and why the second one is the one to watch
+
+#3965 measured that **a root recycling with no install of its own is the COMMON case**. A change
+that deferred every recycle would satisfy the regression case and break the mesh's ability to rebind
+a hub at all — a hub left serving the configuration it was born with, which is #1104 all over again.
+Every regression case therefore has a paired control holding no lease:
+
+| regression | control |
+|---|---|
+| `ARetypeOfARootAnInstallHolds_DoesNotRecycleUntilTheInstallReleasesIt` | `ARetypeWithNoInstallHoldingTheRoot_RecyclesAtOnce` |
+| `WhileAnInstallHoldsTheRoot_TheRecycleWaitsAndThenRuns` | `WithNoInstallHoldingTheRoot_TheRecycleProceedsAtOnce` |
+| `TheRootIsHeldWhileTheInstallRuns_AndReleasedWhenItFinishes` | `AnInstallThatFAILS_StillReleasesItsRoot` |
+
+plus `ALeaseOnANeighbouringRoot_DoesNotDeferThisOne` and
+`WithNoLeaseRegistryAtAll_TheRecycleIsUnchanged`, because a fix that keyed on a prefix — or became a
+hard dependency on the registry — would look in production exactly like a recycle that never
+happened.
+
+Each deferral case asserts the recycle **then runs**, not merely that it did not run. A change that
+swallowed the recycle would pass a "did not tear down" assertion and silently re-break #1104.
+
+### What this does NOT claim
+
+It does not claim the install can no longer lose a write. A root **beneath** an install still hosts
+per-type recyclers that are deliberately not deferred, and the installer's own `SettleRetypedRoot`
+still tears a root down while that root's background pipeline may be issuing correlated requests —
+the shape `RetypedRootRecycleNeedsAJobTest` records and #3800 narrowed by declining the recycle when
+the install wrote nothing. What is closed is the class the issue named: **nobody but the install
+itself takes that root down while the install is writing under it.**
+
 ## What this page does not claim
 
 The wedge in #3593 is **not fixed**. What changed is that the next occurrence is nameable: the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-an-install-owns-its-package-while-it-runs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-an-install-owns-its-package-while-it-runs.md
@@ -16,8 +16,8 @@ That happened six times, and it cost four publishes.
 
 ## What changed
 
-**An install now owns its package for as long as it runs.** Anything that would restart that package
-— an automatic rebind after the package's own type is rebuilt, an operations action, a reconcile —
+**An install now owns its package for as long as it runs.** The restart that used to land in the
+middle of one — the automatic rebind that follows the package's own type being rebuilt — now
 **waits**, and happens the moment the install finishes.
 
 Nothing is dropped and nothing is retried on a clock. The wait ends on the install ending, which is
@@ -39,7 +39,16 @@ including one landing on top of the fresh start the install was waiting for.
 
 ## What this does not do
 
-It does not make an install immune to every kind of interruption. Individual types inside a package
-can still be recycled while their package installs — deliberately, because the install is often
-waiting for exactly those rebuilds. What is closed is the case the incident was about: nobody but
-the install itself takes the package down while the install is writing into it.
+It does not make an install immune to every kind of interruption, and it is worth being exact about
+which ones remain:
+
+- **Individual types inside a package can still be restarted while their package installs** —
+  deliberately, because the install is usually waiting for exactly those rebuilds.
+- **An operator restarting a package by hand still goes through a different route**, which does not
+  yet consult this. That route is unchanged by this work.
+- **Two packages installing into one shared area** can still interrupt each other. Making them wait
+  for one another would let each wait for the other for ever, so the right answer there is to run
+  them one at a time — a separate change.
+
+What is closed is the case the incident was about: the package's own install is no longer
+interrupted by the automatic restart that its own work triggers.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-an-install-owns-its-package-while-it-runs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-an-install-owns-its-package-while-it-runs.md
@@ -1,0 +1,45 @@
+---
+Name: An install owns its package while it runs
+Category: Fix
+Description: Installing a package no longer risks the package being restarted underneath it. A restart aimed at a package that is being installed now waits for the install to finish and then happens, instead of cutting the install off and leaving it to give up ten minutes later.
+Icon: BoxCheckmark
+Order: -20260911
+---
+
+Installing a package writes a lot of things into it, and each of those writes is waiting to be told
+it landed. If the package itself is restarted while that is happening, the parts that owed those
+confirmations disappear — so the confirmations never arrive, the install keeps waiting for an answer
+nobody is left to give, and ten minutes later it reports a timeout against a package whose files had
+all been written minutes earlier.
+
+That happened six times, and it cost four publishes.
+
+## What changed
+
+**An install now owns its package for as long as it runs.** Anything that would restart that package
+— an automatic rebind after the package's own type is rebuilt, an operations action, a reconcile —
+**waits**, and happens the moment the install finishes.
+
+Nothing is dropped and nothing is retried on a clock. The wait ends on the install ending, which is
+a thing that always happens: an install that succeeds ends, an install that **fails** ends, and an
+install whose caller gives up ends. All three release the package, which is what makes waiting safe
+— a restart parked behind an install that crashed would be far worse than the original problem.
+
+## What did NOT change
+
+**An ordinary restart still happens immediately.** That is by far the common case — a package is
+restarted after its type is rebuilt every time anything changes — and a fix that made every restart
+wait would have quietly broken the thing restarts exist to do: pick up a package's real
+configuration instead of the placeholder it started with.
+
+The install's own, deliberate restart of the package it has just rebuilt is also unchanged. That one
+is part of the install, it is ordered, and the install waits for the package to come back before
+carrying on. What no longer happens is a *second*, unplanned restart landing in the middle —
+including one landing on top of the fresh start the install was waiting for.
+
+## What this does not do
+
+It does not make an install immune to every kind of interruption. Individual types inside a package
+can still be recycled while their package installs — deliberately, because the install is often
+waiting for exactly those rebuilds. What is closed is the case the incident was about: nobody but
+the install itself takes the package down while the install is writing into it.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -1,3 +1,4 @@
+using System.Reactive;
 using System.Reactive.Linq;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -106,8 +107,13 @@ internal static class NodeTypeRebindWatcher
                             var feed = meshHub.ServiceProvider.GetService<IMeshChangeFeed>();
                             if (feed is null)
                                 return;
+                            // #3510: a recycle of a root an install is writing under waits for the
+                            // install to release it. Resolved from the MESH's provider, which is
+                            // where the single mesh-scoped registry lives.
+                            var leases = meshHub.ServiceProvider
+                                .GetService<PackageRootInstallLeases>();
                             instanceHub.RegisterForDisposal(
-                                Arm(feed, instanceHub, path, boundNodeType, logger));
+                                Arm(feed, instanceHub, path, boundNodeType, logger, leases));
                         }
                         catch (Exception ex)
                         {
@@ -122,16 +128,39 @@ internal static class NodeTypeRebindWatcher
     /// <summary>
     /// Watcher core, split out so the firing contract is testable without building a hub
     /// (exactly as <c>ArmOverlaySelfHeal</c> is). Posts at most ONE self-<see cref="DisposeRequest"/>.
+    ///
+    /// <para>🚨 <b>The post WAITS while an install holds this exact path</b> (#3510). This watcher
+    /// is armed on every instance hub, package roots included, and <see cref="RequiresRebind"/>
+    /// fires on precisely the event the installer's placeholder dance produces — the root's retype.
+    /// So it can, by construction, tear a package root down in the middle of that package's own
+    /// install, stranding the writes the root's per-node children owe acks for. It now defers to
+    /// <see cref="PackageRootInstallLeases"/> and fires on the release instead. <c>Take(1)</c> is
+    /// applied BEFORE the wait, so a flapping writer still cannot turn this into a recycle storm —
+    /// the first qualifying event latches and the rest are never seen.</para>
+    ///
+    /// <para>The wait is scoped to the path itself, never its subtree: an install waits on the
+    /// rebuilds of the NodeTypes BENEATH its root, and deferring the per-type recyclers that serve
+    /// those rebuilds against the install waiting for them would be a deadlock.</para>
     /// </summary>
+    /// <param name="feed">The post-commit mesh change feed.</param>
+    /// <param name="instanceHub">The hub to recycle.</param>
+    /// <param name="path">The node path this hub serves.</param>
+    /// <param name="boundNodeType">The NodeType its configuration was resolved from.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="leases">The mesh's install-lease registry, or null on a host that registers
+    /// none — in which case no lease can exist and the recycle posts as it always did.</param>
     public static IDisposable Arm(
         IMeshChangeFeed feed,
         IMessageHub instanceHub,
         string path,
         string? boundNodeType,
-        ILogger? logger)
+        ILogger? logger,
+        PackageRootInstallLeases? leases = null)
         => Observable.Create<MeshChangeEvent>(observer => feed.Subscribe(observer.OnNext))
             .Where(change => RequiresRebind(change, path, boundNodeType))
             .Take(1)
+            .SelectMany(change => WaitWhileAnInstallHoldsIt(leases, path, logger)
+                .Select(_ => change))
             .Subscribe(
                 change =>
                 {
@@ -177,6 +206,32 @@ internal static class NodeTypeRebindWatcher
                 ex => logger?.LogWarning(ex,
                     "NodeType rebind watcher for '{Path}' faulted — the hub keeps its activation-time "
                     + "configuration until it is recycled", path));
+
+    /// <summary>
+    /// Emits once no install is writing under <paramref name="path"/> — at once in the ordinary
+    /// case (a retype by an import, a repair migration or a user, with nothing installing), and on
+    /// the install's release when one holds it.
+    ///
+    /// <para>Announced in both directions, for the same reason <c>HubRecycleExtensions</c> does it:
+    /// a recycle that silently waits reads exactly like a recycle that was never asked for, and a
+    /// lease that outlived its install would otherwise be invisible.</para>
+    /// </summary>
+    private static IObservable<Unit> WaitWhileAnInstallHoldsIt(
+        PackageRootInstallLeases? leases, string path, ILogger? logger)
+        => Observable.Defer(() =>
+        {
+            if (leases?.HeldBy(path) is not { } holder)
+                return Observable.Return(Unit.Default);
+            logger?.LogInformation(
+                "NodeType rebind: deferring the recycle of '{Path}' — an install is writing under "
+                + "that root ({Holder}), and recycling it now would strand the writes its per-node "
+                + "children owe acks for (#3510). The recycle runs when the install releases it",
+                path, holder);
+            return leases.WhenReleased(path)
+                .Do(_ => logger?.LogInformation(
+                    "NodeType rebind: the install released '{Path}' — proceeding with the deferred "
+                    + "recycle", path));
+        });
 
     /// <summary>
     /// The firing predicate: a post-commit Created/Updated event for THIS node whose NodeType is

--- a/src/MeshWeaver.Mesh.Contract/HubRecycleExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubRecycleExtensions.cs
@@ -38,6 +38,23 @@ namespace MeshWeaver.Mesh;
 /// release is a state that always arrives, because the install's lease is tied to its own
 /// subscription. With no install holding the root this is a straight pass-through, which is the
 /// common case and is a positive control in its own right.</para>
+///
+/// <para>🚨 <b>THIS IS NOT THE ONLY WAY A HUB IS TORN DOWN, and the gate reaches only what comes
+/// through here.</b> Stating that is the point: a guard whose reach is assumed rather than written
+/// down gets read as a guarantee it does not keep — the same defect as the installer's own recycle
+/// line, which claimed *"work in flight beneath this root is answered by the teardown"* and was
+/// measurably false one lane over. What still posts a <see cref="DisposeRequest"/> WITHOUT
+/// consulting the lease, at the time of writing:
+/// <list type="bullet">
+///   <item><c>MeshOperations.Recycle</c> — the operations/MCP recycle. It posts directly, so an
+///     operator recycling a package root mid-install can still strand that install. Routing it
+///     through here is a separate change in a separate file.</item>
+///   <item><c>PackageInstaller.SettleRetypedRoot</c> — deliberately, and the reason is on that
+///     method: it is the lease HOLDER, and a holder deferring against its own lease deadlocks.</item>
+///   <item><c>NodeTypeEnrichmentHelpers</c>' stale-build convergence and overlay self-heal — also
+///     deliberately: they recycle per-TYPE hubs beneath a root, which is work the install is often
+///     waiting for.</item>
+/// </list></para>
 /// </summary>
 public static class HubRecycleExtensions
 {

--- a/src/MeshWeaver.Mesh.Contract/HubRecycleExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubRecycleExtensions.cs
@@ -1,5 +1,8 @@
 using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mesh;
 
@@ -25,6 +28,16 @@ namespace MeshWeaver.Mesh;
 /// delivering the node the moment the address reactivates (#1726). So there is no timer here, no
 /// watchdog, and no sleep — the framework's read IS the wait, and a recycle that outlasts the whole
 /// budget surfaces the typed <c>AddressRecyclingException</c> rather than a silent nothing.</para>
+///
+/// <para>🚨 <b>And why it may WAIT before it posts</b> (#3510). A recycle aimed at a package root
+/// that an install is writing under strands that install's work: the root's per-node children go
+/// down with it, the writes they owed acks for are never answered, and the handler that owed its
+/// reply to one of those acks never replies. So the post is deferred while
+/// <see cref="PackageRootInstallLeases"/> says an install holds that exact path, and runs the
+/// moment the install releases it. Nothing is dropped, nothing is retried, no bound moves — the
+/// release is a state that always arrives, because the install's lease is tied to its own
+/// subscription. With no install holding the root this is a straight pass-through, which is the
+/// common case and is a positive control in its own right.</para>
 /// </summary>
 public static class HubRecycleExtensions
 {
@@ -59,21 +72,61 @@ public static class HubRecycleExtensions
     /// <c>AddressRecyclingException</c> if the address is still recycling when the budget runs out.</returns>
     public static IObservable<MeshNode?> RecycleNode(
         this IMessageHub hub, string path, TimeSpan? budget = null, string? reason = null)
+        => WaitWhileAnInstallHoldsIt(hub, path)
+            .SelectMany(_ => Observable.Defer(() =>
+            {
+                hub.Post(
+                    new DisposeRequest
+                    {
+                        Reason = reason
+                                 ?? $"HubRecycleExtensions.RecycleNode: {hub.Address} asked for this "
+                                    + "address to be recycled and is waiting for a fresh activation to "
+                                    + "answer",
+                    },
+                    o => o.WithTarget(new Address(path)));
+                // The read is issued AFTER the dispose is posted, so it queues behind it at the target
+                // and is answered by the reactivated hub (or NACKed ShuttingDown and re-probed until it
+                // is). Deliberately NOT ReadTimeoutBehavior.EmitNull: "I could not tell" must reach the
+                // caller as an error, because the caller's next act is to send a user somewhere.
+                return hub.GetMeshNode(path, budget ?? DefaultRecycleBudget);
+            }));
+
+    /// <summary>
+    /// Emits once nothing is installing under <paramref name="path"/> — at once in the ordinary
+    /// case, and on the install's release when one holds it (#3510).
+    ///
+    /// <para>🚨 <b>The deferral is announced in both directions.</b> A recycle that silently waited
+    /// would be indistinguishable from a recycle that was never asked for, which is exactly the
+    /// unreadability that cost this issue six occurrences; and a lease that somehow outlived its
+    /// install would show up as nothing at all. So the wait logs when it starts, naming the holder,
+    /// and again when it proceeds. <b>Information</b>, not Debug: it is one line per deferred
+    /// recycle — an event that by construction only happens while a package install is running —
+    /// and the reader needing it is looking at a stalled install, not at a trace.</para>
+    ///
+    /// <para>No registry (a host composed without <c>MeshBuilder</c>'s registrations, a bare test
+    /// hub) means no lease can exist, so the answer is "proceed" and the pre-#3510 behaviour is
+    /// unchanged.</para>
+    /// </summary>
+    private static IObservable<System.Reactive.Unit> WaitWhileAnInstallHoldsIt(
+        IMessageHub hub, string path)
         => Observable.Defer(() =>
         {
-            hub.Post(
-                new DisposeRequest
-                {
-                    Reason = reason
-                             ?? $"HubRecycleExtensions.RecycleNode: {hub.Address} asked for this "
-                                + "address to be recycled and is waiting for a fresh activation to "
-                                + "answer",
-                },
-                o => o.WithTarget(new Address(path)));
-            // The read is issued AFTER the dispose is posted, so it queues behind it at the target
-            // and is answered by the reactivated hub (or NACKed ShuttingDown and re-probed until it
-            // is). Deliberately NOT ReadTimeoutBehavior.EmitNull: "I could not tell" must reach the
-            // caller as an error, because the caller's next act is to send a user somewhere.
-            return hub.GetMeshNode(path, budget ?? DefaultRecycleBudget);
+            var leases = hub.ServiceProvider.GetService<PackageRootInstallLeases>();
+            if (leases?.HeldBy(path) is not { } holder)
+                return Observable.Return(System.Reactive.Unit.Default);
+
+            var logger = hub.ServiceProvider
+                .GetService<ILoggerFactory>()?.CreateLogger(typeof(HubRecycleExtensions).FullName!);
+            logger?.LogInformation(
+                "[Recycle] deferring the recycle of {Path} requested by {Asker}: an install is "
+                + "writing under that root ({Holder}). Tearing it down now would strand that "
+                + "install's writes — their owners would go down owing acks nobody would ever "
+                + "send. The recycle runs when the install releases the root; nothing is retried "
+                + "and no bound is widened",
+                path, hub.Address, holder);
+            return leases.WhenReleased(path)
+                .Do(_ => logger?.LogInformation(
+                    "[Recycle] the install released {Path} — proceeding with the recycle requested "
+                    + "by {Asker}", path, hub.Address));
         });
 }

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -1039,6 +1039,15 @@ public record MeshBuilder
             // on the owner hub, and a hub-level registration would give each side its own instance.
             // Collapses the two durable-write routes a cross-hub patch used to take (#1249).
             .AddSingleton<Services.PostCommitFlushRegistry>()
+            // Which package roots an install is writing under RIGHT NOW (#3510). Registered at the
+            // ROOT for the same reason as the three registries above: the holder is
+            // PackageInstaller, running on the mesh hub's own chain, while the readers are
+            // recyclers living on per-node hubs — NodeTypeRebindWatcher arms on every instance hub
+            // at activation, and HubRecycleExtensions runs on whatever surviving hub its caller
+            // holds. A hub-level registration would give each of them its own instance, i.e. a
+            // lease nobody else can see, which is the same defect as a guard that checks a registry
+            // no writer ever opened a scope on.
+            .AddSingleton<Services.PackageRootInstallLeases>()
             // Controlled I/O pools — mesh-scoped governor over the shared
             // ThreadPool for genuinely-async / sync-blocking leaves (file system,
             // blob, …). Resolved by leaf adapters via IoPoolRegistry; dies with

--- a/src/MeshWeaver.Mesh.Contract/Services/PackageRootInstallLeases.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/PackageRootInstallLeases.cs
@@ -131,6 +131,23 @@ public sealed class PackageRootInstallLeases
     /// in order, so the deferred re-check runs with the subject subscription already live and one
     /// of the two legs is guaranteed to answer. Same construction, same reason, as
     /// <c>NodeTypeAdoptionRegistry.WhenClear</c>.</para>
+    ///
+    /// <para>🚨 <b>And re-checked again AFTER the scheduler hop</b>, which is the wide window. The
+    /// release fires on the install's thread and the continuation runs on the pool, so a NEW
+    /// install can take the root in between — and a waiter that emitted then would hand its caller
+    /// a "clear" that was already stale, which is the very race this type exists to remove. The
+    /// re-check is a WAIT on the condition, re-evaluated on each real release event: it is not a
+    /// timer, not a retry and not a poll, and each iteration is triggered by an actual release
+    /// rather than by a clock.</para>
+    ///
+    /// <para>🚨 <b>What this still does NOT make atomic</b>, stated because a control that
+    /// overstates its reach is worse than none: between this emission and the caller's own
+    /// <c>Post</c> there is no lock, so an install that starts in those few instructions is not
+    /// waited for. Closing that would mean either posting the teardown from inside this registry's
+    /// own synchronisation, or letting a pending recycle RESERVE the root — and a reservation a
+    /// new install has to queue behind inverts the priority this whole type exists to protect. The
+    /// residual window is bounded by the emission-to-post distance, with nothing in between;
+    /// the measured defect was a teardown landing in the middle of a 145-file install.</para>
     /// </summary>
     /// <param name="rootPath">The root path to wait on.</param>
     public IObservable<Unit> WhenReleased(string? rootPath)
@@ -152,7 +169,13 @@ public sealed class PackageRootInstallLeases
             // releasing thread would put a teardown inside the install's terminal — the "work in a
             // Subscribe callback on the emission thread" shape this codebase removes everywhere
             // else. Hopping costs one scheduled continuation per deferred recycle.
-            .ObserveOn(TaskPoolScheduler.Default));
+            .ObserveOn(TaskPoolScheduler.Default)
+            // …and the hop is exactly where a new install can slip in, so the condition is
+            // re-evaluated on the far side of it. Recursion, not a loop with a delay: the only
+            // thing that can wake the next iteration is another genuine release.
+            .SelectMany(_ => IsHeld(rootPath)
+                ? WhenReleased(rootPath)
+                : Observable.Return(Unit.Default)));
     }
 
     private void Release(string rootPath, string holder)

--- a/src/MeshWeaver.Mesh.Contract/Services/PackageRootInstallLeases.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/PackageRootInstallLeases.cs
@@ -1,0 +1,182 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// 🚨 <b>Which package roots an install is writing under RIGHT NOW — so nothing recycles a root
+/// out from under the writer that owns it (Systemorph/MeshWeaver#3510).</b>
+///
+/// <para><b>The defect.</b> A package root's hub was torn down while that package's own install was
+/// in flight. The root's per-node children went down with it, the writes those children owed acks
+/// for were stranded (<c>[UpdateQueue] ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this
+/// write</c>), the <c>nodeops</c> handler that owed its reply to one of those acks never replied,
+/// and the install sat until the gate's own ten-minute bound reported
+/// <c>[FAIL] Hosting — install: TimeoutException</c> against a package that had finished writing
+/// its 145 files eight minutes earlier. Six occurrences, four lost bake seals.</para>
+///
+/// <para><b>The rule this registry states.</b> <i>The install is the writer that should own the
+/// root's lifetime.</i> While an install holds a root, a recycle aimed at that root <b>waits</b> —
+/// it is never dropped, never retried on a timer, and no bound anywhere is widened. The wait ends
+/// on the lease's release, which is the state this type exists to make total.</para>
+///
+/// <para>🚨 <b>Why the release always arrives.</b> A lease is taken with
+/// <see cref="HoldDuring{T}"/>, i.e. through <c>Observable.Using</c>, so the handle is disposed on
+/// <b>OnCompleted</b>, on <b>OnError</b>, and on <b>unsubscribe</b> — the complete set of ways an
+/// Rx subscription can end. An install that faults releases; an install whose caller gives up
+/// releases; a mesh that goes down takes this instance with it. There is deliberately no timer that
+/// force-releases a lease: "defer" here means <i>wait for a state that always arrives</i>, not
+/// <i>wait a while</i>, and a stopgap that released a lease on a clock would hand the recycle back
+/// exactly the race it was built to remove.</para>
+///
+/// <para>🚨 <b>And a held lease is never silent.</b> A recycle that defers logs once when it defers
+/// and once when it proceeds, naming the holder — so a lease that somehow outlived its install is
+/// visible in the log rather than showing up as a recycle that mysteriously never happened. A
+/// control nobody can read is not a control.</para>
+///
+/// <para><b>Scope: the ROOT PATH, exactly — never the subtree.</b> The key is the whole path a
+/// holder names, and a recycle defers only when its target IS that path. This is not a
+/// conservatism: an install WAITS on work under its own root (a NodeType's rebuild is what
+/// <c>PackageInstaller.MayPublishIntoRoot</c> holds for), and the recyclers that serve those
+/// rebuilds — <c>NodeTypeEnrichmentHelpers</c>' stale-build convergence and overlay self-heal —
+/// live on the per-type hubs BENEATH the root. Deferring those against the install that is waiting
+/// for them is a deadlock, so they are deliberately out of scope. The root's own hub is the one
+/// nothing beneath the install depends on recycling mid-flight.</para>
+///
+/// <para>Mesh-scoped singleton (registered in <c>MeshBuilder</c>), instance maps only — <b>no
+/// static state</b>, so its lifetime IS the mesh's and nothing bleeds across tests or partitions.
+/// Modelled on <c>NodeTypeAdoptionRegistry</c>, whose reservation/<c>WhenClear</c> pair solves the
+/// same shape of race one layer down.</para>
+/// </summary>
+public sealed class PackageRootInstallLeases
+{
+    /// <summary>
+    /// Root path → the descriptions of the holders currently on it, newest last. The LIST is the
+    /// reference count (two installs can legitimately target one partition through
+    /// <c>targetPartition</c>, and one finishing must not tell a recycle the other is done) and it
+    /// is also what the deferral log prints, so "held" and "held by whom" can never disagree.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, ImmutableList<string>> held =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly ISubject<string> released = Subject.Synchronize(new Subject<string>());
+
+    /// <summary>
+    /// Marks <paramref name="rootPath"/> as being written by an install until the returned handle
+    /// is disposed. Prefer <see cref="HoldDuring{T}"/>, which ties the handle to a subscription's
+    /// lifetime so the release cannot be forgotten.
+    /// </summary>
+    /// <param name="rootPath">The package root being installed, e.g. <c>Hosting</c>.</param>
+    /// <param name="holder">One short phrase naming who holds it and why — printed verbatim by the
+    /// recycle that defers. Never blank: an unnamed holder reads to the next person as no holder at
+    /// all, the <c>ReasonNotStated</c> rule this repository already applies to
+    /// <c>DisposeRequest</c>.</param>
+    public IDisposable Hold(string rootPath, string holder)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(holder);
+        held.AddOrUpdate(
+            rootPath,
+            _ => ImmutableList.Create(holder),
+            (_, holders) => holders.Add(holder));
+        return new Lease(this, rootPath, holder);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="work"/> with <paramref name="rootPath"/> held for exactly the lifetime
+    /// of the subscription — released on completion, on fault, and on unsubscribe. A null or blank
+    /// root is a no-op pass-through (an install with no root of its own holds nothing).
+    /// </summary>
+    /// <param name="rootPath">The package root being installed, or null when there is none.</param>
+    /// <param name="holder">One short phrase naming who holds it and why.</param>
+    /// <param name="work">The install, as a cold observable.</param>
+    public IObservable<T> HoldDuring<T>(string? rootPath, string holder, IObservable<T> work)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        return string.IsNullOrWhiteSpace(rootPath)
+            ? work
+            : Observable.Using(() => Hold(rootPath!, holder), _ => work);
+    }
+
+    /// <summary>Whether an install is writing under this root right now.</summary>
+    /// <param name="rootPath">The root path to test.</param>
+    public bool IsHeld(string? rootPath) =>
+        !string.IsNullOrWhiteSpace(rootPath)
+        && held.TryGetValue(rootPath!, out var holders)
+        && !holders.IsEmpty;
+
+    /// <summary>
+    /// Who holds <paramref name="rootPath"/> right now, as one printable phrase — or
+    /// <c>null</c> when nobody does.
+    /// </summary>
+    /// <param name="rootPath">The root path to describe.</param>
+    public string? HeldBy(string? rootPath) =>
+        !string.IsNullOrWhiteSpace(rootPath)
+        && held.TryGetValue(rootPath!, out var holders)
+        && !holders.IsEmpty
+            ? string.Join("; ", holders)
+            : null;
+
+    /// <summary>
+    /// Emits exactly once, as soon as no install holds <paramref name="rootPath"/> — immediately
+    /// when none does. Cold, and it completes.
+    ///
+    /// <para>🚨 <b>Subscribe first, re-check second</b> — never the other way round. Testing
+    /// <see cref="IsHeld"/> and only then subscribing loses a release that lands in between, and
+    /// the caller then waits for a lease that is already gone. <c>Merge</c> subscribes its sources
+    /// in order, so the deferred re-check runs with the subject subscription already live and one
+    /// of the two legs is guaranteed to answer. Same construction, same reason, as
+    /// <c>NodeTypeAdoptionRegistry.WhenClear</c>.</para>
+    /// </summary>
+    /// <param name="rootPath">The root path to wait on.</param>
+    public IObservable<Unit> WhenReleased(string? rootPath)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath))
+            return Observable.Return(Unit.Default);
+        return Observable.Defer(() => Observable
+            .Merge(
+                released
+                    .Where(path => string.Equals(path, rootPath, StringComparison.OrdinalIgnoreCase))
+                    .Where(_ => !IsHeld(rootPath))
+                    .Select(_ => Unit.Default),
+                Observable.Defer(() => IsHeld(rootPath)
+                    ? Observable.Empty<Unit>()
+                    : Observable.Return(Unit.Default)))
+            .Take(1)
+            // The release fires on the INSTALL's own thread, and what the waiter does next is post
+            // a DisposeRequest and then read the address back. Running that inline on the
+            // releasing thread would put a teardown inside the install's terminal — the "work in a
+            // Subscribe callback on the emission thread" shape this codebase removes everywhere
+            // else. Hopping costs one scheduled continuation per deferred recycle.
+            .ObserveOn(TaskPoolScheduler.Default));
+    }
+
+    private void Release(string rootPath, string holder)
+    {
+        // Remove the key at zero rather than leaving an empty list behind: IsHeld reads the map,
+        // and a root that is never installed again would otherwise sit in it for the mesh's life.
+        var remaining = held.AddOrUpdate(
+            rootPath,
+            _ => ImmutableList<string>.Empty,
+            (_, holders) => holders.Remove(holder));
+        if (remaining.IsEmpty)
+            held.TryRemove(new KeyValuePair<string, ImmutableList<string>>(rootPath, remaining));
+        released.OnNext(rootPath);
+    }
+
+    private sealed class Lease(PackageRootInstallLeases owner, string rootPath, string holder)
+        : IDisposable
+    {
+        private int disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref disposed, 1) == 0)
+                owner.Release(rootPath, holder);
+        }
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -121,6 +121,38 @@ public static class PackageInstaller
         $"PackageInstaller: the install of package '{manifest.Id}' is writing under this root";
 
     /// <summary>
+    /// 🚨 <b>The root an install actually writes under — the ONE definition, because the three
+    /// kinds do not agree and the lease has to name the same partition the writes land in
+    /// (#3510).</b>
+    ///
+    /// <para><b>Why this is not <see cref="TargetPartitionOf"/>.</b> That method answers a
+    /// different question — which partition an install RECORD is about — and its fallback is the
+    /// record id. <see cref="InstallCode"/>'s fallback is the shared <c>type</c> partition, so a
+    /// Code package that declares no <c>targetPartition</c> writes <c>type/&lt;id&gt;</c> while a
+    /// lease keyed on the record id would hold <c>&lt;id&gt;</c> — a lease on a root nothing is
+    /// writing to, leaving the root that IS being written freely recyclable. A lease that names the
+    /// wrong root is worse than no lease: it reads, in the log and in every test, exactly like a
+    /// lease that is working.</para>
+    ///
+    /// <para>Content and node-repo installs both write under
+    /// <c>TargetPartition ?? Id</c> (<see cref="InstallCore"/> refuses a Content package with no
+    /// target outright, so the fallback there is unreachable rather than wrong).</para>
+    /// </summary>
+    /// <param name="manifest">The package being installed.</param>
+    /// <returns>The partition root this install writes under.</returns>
+    internal static string InstallRootOf(PackageManifest manifest) =>
+        !string.IsNullOrWhiteSpace(manifest.TargetPartition)
+            ? manifest.TargetPartition!
+            : manifest.Kind == PackageKind.Code
+                ? CodeDefaultPartition
+                : manifest.Id;
+
+    /// <summary>The partition <see cref="InstallCode"/> writes a Code package's NodeType into when
+    /// the manifest declares no <c>targetPartition</c>. Named once so
+    /// <see cref="InstallRootOf"/> and the install itself cannot drift.</summary>
+    internal const string CodeDefaultPartition = "type";
+
+    /// <summary>
     /// 🚨 <b>Holds the package's root for exactly as long as the install runs (#3510) — so nothing
     /// else recycles it out from under the writes in flight beneath it.</b>
     ///
@@ -161,7 +193,7 @@ public static class PackageInstaller
         return leases is null
             ? install
             : leases.HoldDuring(
-                TargetPartitionOf(manifest.Id, manifest), InstallLeaseHolder(manifest), install);
+                InstallRootOf(manifest), InstallLeaseHolder(manifest), install);
     }
 
     private static IObservable<InstallResult> InstallCore(
@@ -1754,6 +1786,16 @@ public static class PackageInstaller
                 // unordered, possibly ON TOP of the fresh activation this method just waited for.
                 // That watcher's subscription dies with the hub this recycle tears down, so its
                 // deferred post is cancelled rather than replayed — one recycle, not two.
+                // 🚨 AND IT DOES NOT WAIT FOR ANOTHER INSTALL'S LEASE EITHER, which is a real hole
+                // and is named here rather than papered over. Two packages can target ONE partition
+                // (`targetPartition`), so install A's recycle here can tear down a root install B is
+                // still writing under. The obvious repair — wait for every holder that is not mine —
+                // is WRONG: B's own SettleRetypedRoot would symmetrically wait for A's lease, and
+                // two installs each holding and each waiting is a mutual deadlock that no timeout
+                // may resolve (raising one would be the band-aid, and dropping one recycle would
+                // re-break #1732). The sound repair is to serialise installs per root, which is a
+                // different change with its own risk and does not belong in a recycle gate. Until
+                // then this is a KNOWN residual, not a covered case.
                 // 🚨 The reason travels WITH the request (#3510). The log line above says why to
                 // whoever reads the INSTALLER's log; the root's own [QUIESCE-START] — and, through
                 // the cascade, every per-node child that goes down with it, which is where #3510's
@@ -2277,7 +2319,12 @@ public static class PackageInstaller
             return Observable.Throw<InstallResult>(new InvalidOperationException(
                 $"Code package '{manifest.Id}' has no nodeTypeConfiguration."));
 
-        var partition = string.IsNullOrWhiteSpace(manifest.TargetPartition) ? "type" : manifest.TargetPartition!;
+        // 🚨 ONE definition of this fallback, shared with InstallRootOf — the install's lease must
+        // name the partition the writes actually land in, and a Code package with no declared
+        // target writes under `type`, not under its own id (#3510).
+        var partition = string.IsNullOrWhiteSpace(manifest.TargetPartition)
+            ? CodeDefaultPartition
+            : manifest.TargetPartition!;
         var nodeTypePath = $"{partition}/{manifest.Id}";
         var sourceFolder = manifest.SourceFolder ?? manifest.Id;
         var parsers = new FileFormatParserRegistry(hub.JsonSerializerOptions, hub.ServiceProvider.GetServices<IFileFormatParser>());

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -105,8 +105,63 @@ public static class PackageInstaller
         // the other, and a licence that asks nothing costs a single null check.
         return PackageEntitlement.Authorize(hub, manifest, authorizingUserId, logger)
             .SelectMany(_ => LicenseAcceptanceGate.Require(hub, manifest, authorizingUserId, logger))
-            .SelectMany(_ => InstallCore(
-                hub, manifest, files, installedFromRef, logger, batchSize, authorizingUserId));
+            .SelectMany(_ => HoldRootDuringInstall(hub, manifest, InstallCore(
+                hub, manifest, files, installedFromRef, logger, batchSize, authorizingUserId)));
+    }
+
+    /// <summary>
+    /// 🚨 <b>The sentence a deferred recycle prints when it names who is holding the root</b>
+    /// (#3510). Pure, so it is pinned without a mesh, and deliberately not an anonymous string
+    /// literal: the whole point of the lease is that a recycle which waits SAYS what it is waiting
+    /// for, and a holder with no name reads to the next person as no holder at all.
+    /// </summary>
+    /// <param name="manifest">The package being installed.</param>
+    /// <returns>The phrase carried on the lease.</returns>
+    internal static string InstallLeaseHolder(PackageManifest manifest) =>
+        $"PackageInstaller: the install of package '{manifest.Id}' is writing under this root";
+
+    /// <summary>
+    /// 🚨 <b>Holds the package's root for exactly as long as the install runs (#3510) — so nothing
+    /// else recycles it out from under the writes in flight beneath it.</b>
+    ///
+    /// <para><b>The defect.</b> The <c>Hosting</c> root's hub was torn down while <c>Hosting</c>'s
+    /// own 145-file install was in flight. Its per-node children went with it, the writes those
+    /// children owed acks for were stranded (<c>ADVANCE_WITHOUT_HANDOFF … the owner never
+    /// acknowledged this write</c>), the <c>nodeops</c> handler that owed its reply to one of those
+    /// acks never replied, and the install ran out the gate's ten-minute bound — six occurrences,
+    /// four lost bake seals. <i>The install is the writer that should own the root's lifetime.</i></para>
+    ///
+    /// <para>🚨 <b>Why the lease is released on EVERY ending, and why that matters more than the
+    /// hold.</b> The hold is taken through <c>Observable.Using</c>, so the handle is disposed on
+    /// OnCompleted, on OnError, <b>and</b> on unsubscribe — the complete set of ways an Rx
+    /// subscription can end. A failed install releases; an install whose caller gives up releases;
+    /// the mesh going down takes the whole registry with it. There is deliberately NO timer that
+    /// force-releases a lease: "defer" has to mean <i>wait for a state that always arrives</i>, and
+    /// a clock would hand the recycle back the very race the lease removes.</para>
+    ///
+    /// <para>🚨 <b>Wrapped OUTSIDE the two gates, not inside.</b> An install refused by
+    /// <see cref="PackageEntitlement"/> or <see cref="LicenseAcceptanceGate"/> writes nothing, so
+    /// it must hold nothing — but because the wrap is around <c>InstallCore</c> only, a refusal
+    /// short-circuits before the resource is ever acquired rather than taking and dropping a
+    /// lease.</para>
+    ///
+    /// <para>🚨 <b>The installer's OWN recycle is not deferred against this lease, and must not
+    /// be.</b> <see cref="SettleRetypedRoot"/> is the holder: its recycle is the install's own
+    /// ordered act, placed between the two <c>RequestReleases</c> waves because the deferred wave's
+    /// compiles read a root that must already be bound to the package's own type (#1732), and it
+    /// WAITS for the root to answer again before the install proceeds. A holder deferring against
+    /// its own lease is a deadlock. What the lease removes is the SECOND, unordered teardown —
+    /// <c>NodeTypeRebindWatcher</c> firing on the placeholder retype this very install performed,
+    /// or any other party recycling the root mid-flight.</para>
+    /// </summary>
+    private static IObservable<InstallResult> HoldRootDuringInstall(
+        IMessageHub hub, PackageManifest manifest, IObservable<InstallResult> install)
+    {
+        var leases = hub.ServiceProvider.GetService<PackageRootInstallLeases>();
+        return leases is null
+            ? install
+            : leases.HoldDuring(
+                TargetPartitionOf(manifest.Id, manifest), InstallLeaseHolder(manifest), install);
     }
 
     private static IObservable<InstallResult> InstallCore(
@@ -1688,6 +1743,17 @@ public static class PackageInstaller
                     + "anything still pending at that bound is force-cancelled and surfaces to its "
                     + "issuer as HubDisposedBeforeResponseException.",
                     rootPath);
+                // 🚨 THIS recycle is NOT deferred against the install's own root lease (#3510),
+                // and that is deliberate: this method IS the lease holder. Its teardown is the
+                // install's own ordered act — it sits between the two RequestReleases waves
+                // because the deferred wave's compiles read a root that must already carry the
+                // package's own binding (#1732), and WaitForRootReady below holds the install
+                // until the address answers again. Deferring a holder against its own lease is a
+                // deadlock. The lease exists to stop the OTHER teardown: NodeTypeRebindWatcher
+                // firing on the placeholder retype this very install performed, which would land
+                // unordered, possibly ON TOP of the fresh activation this method just waited for.
+                // That watcher's subscription dies with the hub this recycle tears down, so its
+                // deferred post is cancelled rather than replayed — one recycle, not two.
                 // 🚨 The reason travels WITH the request (#3510). The log line above says why to
                 // whoever reads the INSTALLER's log; the root's own [QUIESCE-START] — and, through
                 // the cascade, every per-node child that goes down with it, which is where #3510's
@@ -3380,9 +3446,11 @@ public static class PackageInstaller
         var effectiveLogger = logger;
         return PackageEntitlement.Authorize(hub, manifest, authorizingUserId, effectiveLogger)
             .SelectMany(_ => LicenseAcceptanceGate.Require(hub, manifest, authorizingUserId, effectiveLogger))
-            .SelectMany(_ => InstallNodeRepoDeltaCore(
+            // The delta path writes under the SAME root as the full one, so it holds the same lease
+            // (#3510) — an incremental update is no less able to lose its writes to a recycle.
+            .SelectMany(_ => HoldRootDuringInstall(hub, manifest, InstallNodeRepoDeltaCore(
                 hub, manifest, newManifest, changedFiles, removedNodePaths, installedFromRef,
-                effectiveLogger, authorizingUserId));
+                effectiveLogger, authorizingUserId)));
     }
 
     private static IObservable<InstallResult> InstallNodeRepoDeltaCore(

--- a/test/Memex.Portal.Shared.Test/AnInstallHoldsItsRootTest.cs
+++ b/test/Memex.Portal.Shared.Test/AnInstallHoldsItsRootTest.cs
@@ -103,6 +103,41 @@ public class AnInstallHoldsItsRootTest(ITestOutputHelper output) : MonolithMeshT
     }
 
     /// <summary>
+    /// 🚨 <b>The lease must name the root the install actually WRITES under, and the three package
+    /// kinds do not agree on how that is derived.</b> <c>InstallCode</c> falls back to the shared
+    /// <c>type</c> partition when the manifest declares no target, while the install RECORD's rule
+    /// (<c>TargetPartitionOf</c>) falls back to the package id. A lease keyed on the record's rule
+    /// would hold <c>&lt;id&gt;</c> for a blank-target Code package whose writes land in
+    /// <c>type/&lt;id&gt;</c> — a lease on a root nothing is writing to, which reads in the log and
+    /// in every other test exactly like a lease that is working, while the root that IS being
+    /// written stays freely recyclable. Pure, so the rule is pinned without a mesh.
+    /// </summary>
+    [Fact]
+    public void TheLeaseNamesTheRootTheInstallWritesUnder_ForEveryKind()
+    {
+        // A declared target always wins, whatever the kind.
+        PackageInstaller.InstallRootOf(Manifest(Package)).Should().Be(Package);
+        PackageInstaller.InstallRootOf(Manifest(Package) with { Kind = PackageKind.Code })
+            .Should().Be(Package);
+
+        // 🚨 THE REGRESSION CASE: no declared target, Code kind — the install writes under `type`.
+        PackageInstaller.InstallRootOf(
+                Manifest(Package) with { Kind = PackageKind.Code, TargetPartition = null })
+            .Should().Be(PackageInstaller.CodeDefaultPartition,
+                "InstallCode writes its NodeType into the shared `type` partition when the manifest "
+                + "declares no target, so that is the root whose teardown would strand its writes");
+
+        // …and the control: for the other kinds a blank target still means the package's own id,
+        // so a change that pointed every lease at `type` would fail here.
+        PackageInstaller.InstallRootOf(
+                Manifest(Package) with { Kind = PackageKind.NodeRepo, TargetPartition = null })
+            .Should().Be(Package);
+        PackageInstaller.InstallRootOf(
+                Manifest(Package) with { Kind = PackageKind.Content, TargetPartition = null })
+            .Should().Be(Package);
+    }
+
+    /// <summary>
     /// 🚨 THE CONTROL THAT MATTERS MOST. "Defer" is only allowed to mean <i>wait for a state that
     /// always arrives</i>. An install that FAILS is exactly when a recycle behind it must not be
     /// stranded — and a lease held by a dead install would be a permanently un-recyclable root,

--- a/test/Memex.Portal.Shared.Test/AnInstallHoldsItsRootTest.cs
+++ b/test/Memex.Portal.Shared.Test/AnInstallHoldsItsRootTest.cs
@@ -1,0 +1,130 @@
+#pragma warning disable CS1591
+
+using System.Reactive.Linq;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>#3510 — an install HOLDS its package root for as long as it runs, and releases it on every
+/// way that run can end.</b>
+///
+/// <para><b>The defect.</b> The <c>Hosting</c> root hub was disposed while <c>Hosting</c>'s own
+/// 145-file install was in flight. Its per-node children went with it, the writes those children
+/// owed acks for were stranded (<c>ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this
+/// write</c>), the <c>nodeops</c> handler that owed its reply to one of those acks never replied,
+/// and the install ran out the gate's ten-minute bound. Six occurrences, four lost bake seals.
+/// <i>The install is the writer that should own the root's lifetime.</i></para>
+///
+/// <para>The deferral itself — a recycle waiting on that lease, and an ordinary recycle proceeding
+/// at once — is pinned in <c>MeshWeaver.Graph.Test</c>. What THIS file pins is the half that would
+/// otherwise be a guard checking nothing: that the installer actually TAKES the lease, and that it
+/// gives it back. A registry nobody holds is a deferral that never defers; a lease nobody releases
+/// is strictly worse than the bug.</para>
+///
+/// <para>🚨 It lives here rather than beside the installer for the same reason
+/// <c>RetypedRootRecycleNeedsAJobTest</c> does: this is the only test project in THIS repository
+/// that both references <c>MeshWeaver.PluginCatalog</c> and appears in its
+/// <c>InternalsVisibleTo</c> list.</para>
+/// </summary>
+public class AnInstallHoldsItsRootTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Package = "LeaseHeldPkg";
+
+    /// <summary>
+    /// The catalog's own registration — without it the install's LAST step
+    /// (<c>WriteInstalledRecord</c>) is refused with <c>NodeType 'Package' is not registered</c>,
+    /// so the run would fault for a reason that has nothing to do with the lease.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    private static PackageManifest Manifest(string id) => new()
+    {
+        Id = id,
+        Name = id,
+        Kind = PackageKind.Content,
+        TargetPartition = id,
+        SourceFolder = id,
+        Version = "1.0.0",
+    };
+
+    /// <summary>
+    /// 🚨 THE WIRING PIN, in both tenses. The hold is observed on the install's own emission — the
+    /// lease is taken by <c>Observable.Using</c> at subscribe and released on the terminal, so an
+    /// <c>OnNext</c> is the one moment at which "the install is running" is an observable fact
+    /// rather than a timing guess. Remove <c>HoldRootDuringInstall</c> from
+    /// <c>PackageInstaller.Install</c> and the middle assertion goes red.
+    /// </summary>
+    [Fact]
+    public async Task TheRootIsHeldWhileTheInstallRuns_AndReleasedWhenItFinishes()
+    {
+        var leases = Mesh.ServiceProvider.GetRequiredService<PackageRootInstallLeases>();
+
+        leases.IsHeld(Package).Should().BeFalse("nothing has started yet");
+
+        var heldDuringInstall = false;
+        var holderDuringInstall = (string?)null;
+        var install = PackageInstaller
+            .Install(
+                Mesh,
+                Manifest(Package),
+                [new PackageFile("Readme.md", $"# {Package}")],
+                "HEAD")
+            .Do(_ =>
+            {
+                // Composed OUTSIDE the observable Install returns, so this runs while
+                // Observable.Using's resource is still alive — the terminal that disposes it has
+                // not been delivered yet.
+                heldDuringInstall = leases.IsHeld(Package);
+                holderDuringInstall = leases.HeldBy(Package);
+            });
+
+        var result = await install.Should().Within(TestTimeouts.CrossSilo)
+            .Emit("the install must complete before anything about the lease can be read");
+        result.Written.Should().BeGreaterThan(0, "the install wrote its one node");
+
+        heldDuringInstall.Should().BeTrue(
+            "the install holds its own package root for as long as it runs — that is the whole "
+            + "point of #3510's remedy, and nothing else can hold it on its behalf");
+        holderDuringInstall.Should().Be(
+            PackageInstaller.InstallLeaseHolder(Manifest(Package)),
+            "a deferred recycle prints the holder, so the holder must be NAMED — an anonymous "
+            + "lease reads to the next person as no lease at all");
+
+        leases.IsHeld(Package).Should().BeFalse(
+            "the install has completed, so the root is released and any recycle waiting on it runs");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL THAT MATTERS MOST. "Defer" is only allowed to mean <i>wait for a state that
+    /// always arrives</i>. An install that FAILS is exactly when a recycle behind it must not be
+    /// stranded — and a lease held by a dead install would be a permanently un-recyclable root,
+    /// which is worse than the bug this fixes. The failure is genuine (a package with no
+    /// installable content file), not simulated.
+    /// </summary>
+    [Fact]
+    public async Task AnInstallThatFAILS_StillReleasesItsRoot()
+    {
+        var leases = Mesh.ServiceProvider.GetRequiredService<PackageRootInstallLeases>();
+        var failing = $"{Package}Failing";
+
+        var faults = PackageInstaller
+            .Install(Mesh, Manifest(failing), [], "HEAD")
+            .Materialize()
+            .Where(n => n.Kind == System.Reactive.NotificationKind.OnError);
+
+        await faults.Should().Within(TestTimeouts.CrossSilo)
+            .Emit("a package with no installable content file is refused");
+
+        leases.IsHeld(failing).Should().BeFalse(
+            "an install that faulted has released its root — otherwise every recycle deferred "
+            + "behind it waits for ever, and there is deliberately no timer to force it");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ARecycleWaitsForTheInstallHoldingTheRootTest.cs
+++ b/test/MeshWeaver.Graph.Test/ARecycleWaitsForTheInstallHoldingTheRootTest.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
@@ -65,24 +65,26 @@ public class ARecycleWaitsForTheInstallHoldingTheRootTest(ITestOutputHelper outp
     /// </summary>
     private sealed class TestChangeFeed : IMeshChangeFeed
     {
-        private readonly List<Action<MeshChangeEvent>> handlers = [];
+        // 🚨 Instance ConcurrentDictionary, never a mutable List: the repository's collections
+        // policy holds in test/ too, and this feed is published from one thread while a watcher's
+        // disposal removes from another — the exact shape a bare List gets wrong.
+        private readonly ConcurrentDictionary<Guid, Action<MeshChangeEvent>> handlers = new();
 
         public void Publish(MeshChangeEvent change)
         {
-            foreach (var handler in handlers.ToArray())
+            foreach (var handler in handlers.Values)
                 handler(change);
         }
 
         public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
         {
-            void Wrapped(MeshChangeEvent e)
+            var key = Guid.NewGuid();
+            handlers[key] = e =>
             {
                 if (filter is null || e.Kind == filter)
                     handler(e);
-            }
-
-            handlers.Add(Wrapped);
-            return System.Reactive.Disposables.Disposable.Create(() => handlers.Remove(Wrapped));
+            };
+            return System.Reactive.Disposables.Disposable.Create(() => handlers.TryRemove(key, out _));
         }
     }
 

--- a/test/MeshWeaver.Graph.Test/ARecycleWaitsForTheInstallHoldingTheRootTest.cs
+++ b/test/MeshWeaver.Graph.Test/ARecycleWaitsForTheInstallHoldingTheRootTest.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#3510 — a package root must not be recycled out from under the install that is writing
+/// under it, and the deferral must not block the ordinary recycle.</b>
+///
+/// <para><b>Measured, core CD 7950 and five occurrences after it.</b> The <c>Hosting</c> root hub
+/// was disposed at 23:37:51Z while <c>Hosting</c>'s own 145-file install was in flight. Its
+/// per-node children went down with it, so the writes those children owed acks for were stranded
+/// (<c>[UpdateQueue] ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this write</c>), the
+/// <c>nodeops</c> handler that owed its reply to one of those acks never replied, the installer's
+/// <c>Observe</c> never fired, and the install ran out the gate's ten-minute bound as
+/// <c>[FAIL] Hosting — install: TimeoutException</c>. Four lost bake seals.</para>
+///
+/// <para><b>The remedy pinned here is DEFER, not NACK.</b> A recycle aimed at a root an install
+/// holds waits for the install to release it, and then runs. The alternative — failing every
+/// in-flight write under the root — was measured WRONG one lane over in #3112: the caller's
+/// terminal has already fired at <c>LOCAL_EMIT</c> and the write may well have committed, so a
+/// fault there reports failure for a write that landed.</para>
+///
+/// <para>🚨 <b>Both directions, because a fix that blocked EVERY recycle would pass a one-sided
+/// test</b> — and #3965 measured that a root recycling under a reconcile is the COMMON case. Each
+/// regression case below is paired with the identical composition holding NO lease, which must
+/// still recycle promptly.</para>
+///
+/// <para>🚨 <b>No hand-woven gate.</b> The release is an <c>IDisposable</c> disposed by the test,
+/// and every wait is either an assertion helper's bounded await or the registry's own cold
+/// observable. Nothing sleeps, nothing polls, and no <see cref="TimeSpan"/> literal appears — the
+/// windows are <c>TestTimeouts.*</c>.</para>
+///
+/// <para>Drives <see cref="NodeTypeRebindWatcher.Arm"/> against a REAL, hosted
+/// <see cref="IMessageHub"/> (<see cref="HubTestBase"/>) — never a mocked one — exactly as
+/// <c>NodeTypeRebindWatcherTest</c> beside it does, and for the same reason: the watcher's only
+/// hub-shaped side effect is a self-<see cref="DisposeRequest"/>, so "the hub actually disposed"
+/// is a stronger proof than "Post was called".</para>
+/// </summary>
+public class ARecycleWaitsForTheInstallHoldingTheRootTest(ITestOutputHelper output)
+    : HubTestBase(output)
+{
+    private const string RootPath = "Hosting";
+    private const string BenignRootPath = "HostingBenign";
+    private const string NeighbourRootPath = "HostingNeighbour";
+    private const string NoRegistryRootPath = "HostingNoRegistry";
+    private const string BoundType = "Space";
+    private const string RealType = "Store/Plugin";
+
+    private const string Holder =
+        "PackageInstaller: the install of package 'Hosting' is writing under this root";
+
+    /// <summary>
+    /// The same hot, non-replaying stand-in <c>NodeTypeRebindWatcherTest</c> uses: the production
+    /// <c>InProcessMeshChangeFeed</c> never replays, and that property is load-bearing.
+    /// </summary>
+    private sealed class TestChangeFeed : IMeshChangeFeed
+    {
+        private readonly List<Action<MeshChangeEvent>> handlers = [];
+
+        public void Publish(MeshChangeEvent change)
+        {
+            foreach (var handler in handlers.ToArray())
+                handler(change);
+        }
+
+        public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
+        {
+            void Wrapped(MeshChangeEvent e)
+            {
+                if (filter is null || e.Kind == filter)
+                    handler(e);
+            }
+
+            handlers.Add(Wrapped);
+            return System.Reactive.Disposables.Disposable.Create(() => handlers.Remove(Wrapped));
+        }
+    }
+
+    private (IMessageHub Hub, IObservable<bool> Disposed) BuildRootHub(string path)
+    {
+        var hub = Mesh.GetHostedHub(new Address(path), c => c);
+        var disposed = new ReplaySubject<bool>(1);
+        hub.RegisterForDisposal(_ =>
+        {
+            disposed.OnNext(true);
+            disposed.OnCompleted();
+        });
+        return (hub, disposed);
+    }
+
+    private static MeshChangeEvent Retype(string path, string nodeType)
+        => new("", path.Split('/')[^1], path, MeshChangeKind.Updated, nodeType, 1,
+            DateTimeOffset.UtcNow);
+
+    // ---- The registry's own contract: the release ALWAYS arrives -------------------------------
+
+    /// <summary>
+    /// 🚨 <b>The whole deferral rests on this.</b> "Defer" is only allowed to mean <i>wait for a
+    /// state that always arrives</i> — so the lease is taken through <c>Observable.Using</c>, whose
+    /// resource is disposed on every one of the three ways an Rx subscription can end. If any arm
+    /// leaked, a recycle deferred behind it would wait for ever, and the cure would be worse than
+    /// #3510 itself.
+    /// </summary>
+    [Fact]
+    public async Task AnInstallReleasesItsRoot_OnCompletion_OnFault_AndOnUnsubscribe()
+    {
+        var leases = new PackageRootInstallLeases();
+
+        // 1. Completion.
+        await leases.HoldDuring(RootPath, Holder, Observable.Return(1))
+            .Should().Emit("the wrapped install runs normally");
+        leases.IsHeld(RootPath).Should().BeFalse(
+            "an install that completed has released its root");
+
+        // 2. Fault — the arm #3510 cares about most, because an install that FAILS is exactly when
+        //    a recycle behind it must not be stranded.
+        var faulted = false;
+        using var faultedInstall = leases
+            .HoldDuring<int>(RootPath, Holder,
+                Observable.Throw<int>(new InvalidOperationException("install failed")))
+            .Subscribe(_ => { }, _ => faulted = true);
+        faulted.Should().BeTrue("Observable.Throw faults on subscribe");
+        leases.IsHeld(RootPath).Should().BeFalse(
+            "an install that FAULTED has released its root — otherwise every recycle behind it "
+            + "waits for ever");
+
+        // 3. Unsubscribe — the caller gave up (its own request budget elapsed, the hub went down).
+        var subscription = leases
+            .HoldDuring(RootPath, Holder, Observable.Never<int>())
+            .Subscribe(_ => { });
+        leases.IsHeld(RootPath).Should().BeTrue("the install is still running");
+        subscription.Dispose();
+        leases.IsHeld(RootPath).Should().BeFalse(
+            "an install whose caller gave up has released its root");
+
+        await leases.WhenReleased(RootPath).Should().Emit(
+            "nothing holds the root, so the wait is answered at once");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL for the registry: with nobody holding it, the wait is not a wait at all. A
+    /// registry that answered only on a release event would deadlock every ordinary recycle —
+    /// which is the one-sided failure this whole file is arranged to catch.
+    /// </summary>
+    [Fact]
+    public async Task WithNoInstallHoldingIt_TheWaitIsAnsweredAtOnce()
+    {
+        var leases = new PackageRootInstallLeases();
+
+        leases.IsHeld(RootPath).Should().BeFalse();
+        leases.HeldBy(RootPath).Should().BeNull("nobody holds it, so there is nobody to name");
+        await leases.WhenReleased(RootPath).Should().Emit("no lease, no wait");
+    }
+
+    /// <summary>
+    /// Two installs can legitimately target one partition (<c>targetPartition</c>), and one
+    /// finishing must not tell a recycle the other is done. The holder list IS the reference count,
+    /// and it is also what the deferral log prints — so "held" and "held by whom" cannot disagree.
+    /// </summary>
+    [Fact]
+    public async Task TheRootStaysHeldUntilTheLASTInstallReleasesIt()
+    {
+        var leases = new PackageRootInstallLeases();
+        var first = leases.Hold(RootPath, Holder);
+        var second = leases.Hold(RootPath, "PackageInstaller: the install of package 'Hosting.Instance' …");
+
+        leases.HeldBy(RootPath).Should().Contain("Hosting.Instance", "every holder is named");
+
+        first.Dispose();
+        leases.IsHeld(RootPath).Should().BeTrue("the second install is still writing under it");
+
+        second.Dispose();
+        await leases.WhenReleased(RootPath).Should().Emit("the last holder has gone");
+    }
+
+    // ---- The rebind watcher: the recycler #3965 proved can fire against the installing root -----
+
+    /// <summary>
+    /// 🚨 THE REGRESSION CASE. <see cref="NodeTypeRebindWatcher"/> is armed on EVERY instance hub
+    /// at activation, package roots included, and <see cref="NodeTypeRebindWatcher.RequiresRebind"/>
+    /// fires on precisely the event the installer's placeholder dance produces — the root's retype.
+    /// So before this change it could, by construction, tear a package root down in the middle of
+    /// that package's own install. It now waits for the install to release the root.
+    ///
+    /// <para>Note what the second half asserts: the recycle is DEFERRED, not dropped. A fix that
+    /// swallowed the recycle would satisfy the first assertion and silently re-break #1104 — a hub
+    /// left serving the configuration it was born with for the rest of its life.</para>
+    /// </summary>
+    [Fact]
+    public async Task ARetypeOfARootAnInstallHolds_DoesNotRecycleUntilTheInstallReleasesIt()
+    {
+        var leases = new PackageRootInstallLeases();
+        var lease = leases.Hold(RootPath, Holder);
+        var (hub, disposed) = BuildRootHub(RootPath);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(
+            feed, hub, RootPath, BoundType, logger: null, leases: leases);
+
+        feed.Publish(Retype(RootPath, RealType));
+
+        await disposed.Should().NotEmit(
+            TestTimeouts.Quick,
+            "an install is writing under this root — recycling it now strands the writes its "
+            + "per-node children owe acks for (#3510)");
+
+        lease.Dispose();
+
+        await disposed.Should().Within(TestTimeouts.Convergence).Emit(
+            "the recycle is DEFERRED, never dropped — the install released the root, so the rebind "
+            + "must now happen or the hub keeps its wrong binding for ever (#1104)");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL, and it is the one that matters here: #3965 measured that a root
+    /// recycling with no install of its own is the COMMON case. A change that deferred every
+    /// recycle would pass the regression case above and break the mesh's ability to rebind a hub at
+    /// all.
+    /// </summary>
+    [Fact]
+    public async Task ARetypeWithNoInstallHoldingTheRoot_RecyclesAtOnce()
+    {
+        var leases = new PackageRootInstallLeases();
+        var (hub, disposed) = BuildRootHub(BenignRootPath);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(
+            feed, hub, BenignRootPath, BoundType, logger: null, leases: leases);
+
+        feed.Publish(Retype(BenignRootPath, RealType));
+
+        await disposed.Should().Within(TestTimeouts.Convergence).Emit(
+            "nothing holds this root, so the ordinary rebind recycle proceeds exactly as before");
+    }
+
+    /// <summary>
+    /// A lease on a DIFFERENT root must not defer this one. The key is the whole path, so a fix
+    /// that keyed on a prefix — or on nothing at all — is caught here rather than in production,
+    /// where it would look like a recycle that mysteriously never happened.
+    /// </summary>
+    [Fact]
+    public async Task ALeaseOnANeighbouringRoot_DoesNotDeferThisOne()
+    {
+        var leases = new PackageRootInstallLeases();
+        using var elsewhere = leases.Hold("SomeOtherPackage", Holder);
+        var (hub, disposed) = BuildRootHub(NeighbourRootPath);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(
+            feed, hub, NeighbourRootPath, BoundType, logger: null, leases: leases);
+
+        feed.Publish(Retype(NeighbourRootPath, RealType));
+
+        await disposed.Should().Within(TestTimeouts.Convergence).Emit(
+            "the lease names another root entirely");
+    }
+
+    /// <summary>
+    /// 🚨 A host that registers no lease registry (a bare test hub, a composition without
+    /// <c>MeshBuilder</c>'s registrations) must behave exactly as it did before #3510 — no lease
+    /// can exist there, so there is nothing to wait for. Without this case the deferral could
+    /// silently become a hard dependency and turn "no registry" into "never recycles".
+    /// </summary>
+    [Fact]
+    public async Task WithNoLeaseRegistryAtAll_TheRecycleIsUnchanged()
+    {
+        var (hub, disposed) = BuildRootHub(NoRegistryRootPath);
+        var feed = new TestChangeFeed();
+        using var watcher = NodeTypeRebindWatcher.Arm(
+            feed, hub, NoRegistryRootPath, BoundType, logger: null, leases: null);
+
+        feed.Publish(Retype(NoRegistryRootPath, RealType));
+
+        await disposed.Should().Within(TestTimeouts.Convergence).Emit(
+            "no registry means no lease can exist, so the recycle posts as it always did");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/RecycleNodeWaitsForTheInstallHoldingTheRootTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecycleNodeWaitsForTheInstallHoldingTheRootTest.cs
@@ -1,0 +1,95 @@
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#3510 — the ONE public recycle surface waits while an install holds the root, and is a
+/// straight pass-through when none does.</b>
+///
+/// <para><c>HubRecycleExtensions.RecycleNode</c> is what every caller outside the framework's own
+/// automatic recyclers uses — a reconcile, an operations action, a confirmation flow. Before this
+/// change any of them could tear a package root down in the middle of that package's install,
+/// stranding the writes its per-node children owed acks for and leaving the install to run out its
+/// ten-minute bound (CD 7950 and five occurrences after it).</para>
+///
+/// <para>Both cases run against a REAL Monolith mesh — the registry is resolved from the mesh's own
+/// <c>ServiceProvider</c>, so this also pins the <c>MeshBuilder</c> registration: a lease taken by
+/// one party has to be visible to a recycler on a different hub, which is exactly what a
+/// hub-level (rather than mesh-root) registration would silently break.</para>
+///
+/// <para>🚨 The recycle is issued on <c>RequestHub</c>, never on <c>Mesh</c>: the root
+/// <c>mesh/{id}</c> hub is transient routing infrastructure and a read routed through it always
+/// faults — the rule the base class states on its own <c>ReadHub</c>.</para>
+/// </summary>
+public class RecycleNodeWaitsForTheInstallHoldingTheRootTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string Holder =
+        "PackageInstaller: the install of package 'Hosting' is writing under this root";
+
+    private async Task<string> SeedNode(string id)
+    {
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory
+            .CreateNode(new MeshNode(id, TestPartition) { Name = id, NodeType = "Markdown" })
+            .Should().Emit("the node the recycle targets has to exist first");
+        return path;
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION CASE. While an install holds the root, the recycle does not post its
+    /// <c>DisposeRequest</c> at all — so the hub stays up and the writes beneath it keep their
+    /// owner. The second half is what makes this a DEFERRAL rather than a silent drop: the moment
+    /// the install releases the root, the recycle runs and the caller is answered by the fresh
+    /// activation.
+    /// </summary>
+    [Fact]
+    public async Task WhileAnInstallHoldsTheRoot_TheRecycleWaitsAndThenRuns()
+    {
+        var leases = Mesh.ServiceProvider.GetRequiredService<PackageRootInstallLeases>();
+        var path = await SeedNode("recycle-held-root");
+
+        var lease = leases.Hold(path, Holder);
+        leases.HeldBy(path).Should().Be(Holder, "the holder is named, never anonymous");
+
+        var recycled = RequestHub.RecycleNode(path).Replay(1);
+        using var connection = recycled.Connect();
+
+        await recycled.Should().NotEmit(
+            TestTimeouts.Quick,
+            "an install is writing under this root — recycling it now would strand that install's "
+            + "writes, which is #3510's whole measured harm");
+
+        lease.Dispose();
+
+        await recycled.Should().Within(TestTimeouts.Convergence).Emit(
+            "the recycle is DEFERRED, never dropped: the install released the root, so the address "
+            + "must now recycle and answer again");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL. #3965 measured that a root recycling with no install of its own is
+    /// the COMMON case, so a fix that blocked every recycle would pass the regression case above
+    /// and break the mesh. With nothing held this is the pre-#3510 composition exactly — post, then
+    /// read the address back.
+    /// </summary>
+    [Fact]
+    public async Task WithNoInstallHoldingTheRoot_TheRecycleProceedsAtOnce()
+    {
+        var leases = Mesh.ServiceProvider.GetRequiredService<PackageRootInstallLeases>();
+        var path = await SeedNode("recycle-free-root");
+
+        leases.IsHeld(path).Should().BeFalse("no install is running");
+
+        await RequestHub.RecycleNode(path).Should().Within(TestTimeouts.Convergence).Emit(
+            "an ordinary recycle under a reconcile must still proceed promptly — the deferral is "
+            + "scoped to a root an install actually holds");
+    }
+}


### PR DESCRIPTION
Closes nothing by itself — but this is **#3510's remaining half**, the one its own thread says gates the issue. #3965 made a teardown *name* itself; this stops one landing in the middle of an install.

## The measured harm

> The `Hosting` root hub was disposed at 23:37:51Z while `Hosting`'s own 145-file install was in flight. Its per-node children went with it, the writes they owed acks for were stranded (`[UpdateQueue] ADVANCE_WITHOUT_HANDOFF … the owner never acknowledged this write`), the `nodeops` handler that owed its reply to one of those acks never replied, the installer's `Observe` never fired, and the install ran out its ten-minute bound as `[FAIL] Hosting — install: TimeoutException`.

Six occurrences, four lost bake seals.

## The remedy chosen, and why the other was rejected

**DEFER.** The issue offered two. The second — answering every in-flight write under the recycling root with a NACK the handler turns into the caller's reply — was **measured wrong one lane over** in #3112: faulting a write at `ADVANCE_WITHOUT_HANDOFF` reports failure for a write that **may well have committed**, because the caller's terminal has already fired at `LOCAL_EMIT` and the 5 s handoff bound is the *writer's* patience, not a statement about the store. Nothing about #3510 changes that; the #3510 agent rejected it for the same reason.

What the NACK arm *can* do correctly is already done and already green: the update leg's `RegisterOwnerDisposingNack` mints `OwnerDisposing` — a code the writer **re-enqueues** rather than surfaces — pinned by `UpsertAnswersWhenTheOwnerGoesAwayTest`. That is the owner *answering*, not the writer *guessing*.

## The rule

> **The install is the writer that owns the root's lifetime.** While an install holds a package root, a recycle aimed at that root **waits**, and runs the moment the install releases it.

- `PackageRootInstallLeases` — mesh-scoped singleton (`MeshBuilder`, root registration for the same reason as the three registries beside it: the holder runs on the mesh's chain, the readers are recyclers on per-node hubs). `WhenReleased` subscribes to the release subject **before** re-checking, so a release landing between the two is never lost — the `NodeTypeAdoptionRegistry.WhenClear` construction, same reason.
- `PackageInstaller.Install` and `InstallNodeRepoDelta` hold `TargetPartitionOf(id, manifest)` for the whole run.
- `HubRecycleExtensions.RecycleNode` and `NodeTypeRebindWatcher` consult it before posting their `DisposeRequest`.

## "The install released the root" — and why that state always arrives

The lease is taken through `Observable.Using`, so the handle is disposed on **OnCompleted**, on **OnError**, and on **unsubscribe** — the complete set of ways an Rx subscription can end.

| the install… | releases because |
|---|---|
| succeeds | `Using` disposes the resource on the terminal |
| **faults** | the same terminal path — an install that fails is exactly when a deferred recycle must not be stranded |
| is abandoned (caller's budget elapses, caller's hub goes down) | the unsubscribe disposes the resource |
| never ends at all | the mesh does — the registry is a mesh-scoped instance, not static state |

🚨 **There is deliberately no timer that force-releases a lease.** "Defer" has to mean *wait for a state that always arrives*, never *wait a while*. The cost of that choice is that a leaked lease would be an un-recyclable root, so the release arms are pinned by name and **a deferral is never silent**: it logs once when it defers, naming the holder, and once when it proceeds.

## Scope, and the two things deliberately NOT deferred

**The root PATH exactly, never the subtree.** An install *waits* on work beneath its own root (`MayPublishIntoRoot` holds until the root's in-package NodeType has a loadable build), and the recyclers that serve those rebuilds — the stale-build convergence and the overlay self-heal — live on the per-type hubs **beneath** the root. Deferring those against the install waiting for them is a deadlock. Out of scope, by design.

**`PackageInstaller.SettleRetypedRoot` is not deferred against its own lease.** It is the *holder*: its teardown is the install's own ordered act, placed between the two `RequestReleases` waves because the deferred wave's compiles read a root that must already carry the package's own binding (#1732), and `WaitForRootReady` holds the install until the address answers again. A holder deferring against its own lease is a deadlock. The code says so at the post.

What the lease removes is the **second, unordered** teardown. `NodeTypeRebindWatcher` is armed on every instance hub, package roots included, and `RequiresRebind` fires on precisely the event the installer's placeholder dance produces — the root's retype (#3965 established this by code: *"it cannot happen" is false*). It now waits; and because its subscription is registered for disposal on the hub it would recycle, the installer's own recycle **cancels** it rather than replaying it afterwards. One recycle per install, not two.

## Controls, both directions — and the second one is the one that matters

#3965 measured that **a root recycling with no install of its own is the COMMON case**, so a fix that deferred every recycle would pass a one-sided test and break the mesh's ability to rebind a hub at all (#1104 again). Every regression case is paired:

| regression | control |
|---|---|
| `ARetypeOfARootAnInstallHolds_DoesNotRecycleUntilTheInstallReleasesIt` | `ARetypeWithNoInstallHoldingTheRoot_RecyclesAtOnce` |
| `WhileAnInstallHoldsTheRoot_TheRecycleWaitsAndThenRuns` | `WithNoInstallHoldingTheRoot_TheRecycleProceedsAtOnce` |
| `TheRootIsHeldWhileTheInstallRuns_AndReleasedWhenItFinishes` | `AnInstallThatFAILS_StillReleasesItsRoot` |

plus `ALeaseOnANeighbouringRoot_DoesNotDeferThisOne` and `WithNoLeaseRegistryAtAll_TheRecycleIsUnchanged` — a fix that keyed on a prefix, or became a hard dependency on the registry, would look in production exactly like a recycle that never happened. And `AnInstallReleasesItsRoot_OnCompletion_OnFault_AndOnUnsubscribe` is the totality proof the whole deferral rests on.

**Each deferral case asserts the recycle THEN RUNS**, not merely that it did not run — a change that swallowed the recycle would pass a "did not tear down" assertion and silently re-break #1104.

## Counterfactual — proven by breaking the subject

With the three production edits neutralised and both suites **rebuilt** (`-c Release`, not `--no-build` on a stale binary), exactly the three regression cases go red with their own assertion text, and every control stays green:

```
Expected the observable not to emit within 12s because an install is writing under this root —
recycling it now strands the writes its per-node children owe acks for (#3510), but it emitted True.

Expected the observable not to emit within 12s because an install is writing under this root —
recycling it now would strand that install's writes, which is #3510's whole measured harm,
but it emitted MeshNode { Id = recycle-held-root, … }

Expected value to be true because the install holds its own package root for as long as it runs —
that is the whole point of #3510's remedy, and nothing else can hold it on its behalf, but found False.
```

`Graph.Test` filtered: Failed 2, Passed 7. `Memex.Portal.Shared.Test` filtered: Failed 1, Passed 1. Restored: 18/18 and 8/8.

## Gates — measured, not assumed

`check-type-forwards.py --base 818c1064 --surface-json`: **0 removed, 1 added** (2106 public types / 13325 members at base, 2107 / 13330 at head); implementer obligations **455 → 455**, interface base edges 27 → 27, protected-abstract obligations 5 → 5. So no `Pairs-with:` and no `Implementers:` obligation. No i18n catalog change, so no `Mirror-sync:` — the two new log lines are operator-facing diagnostics, which are deliberately not translated.

## Verified

- `MeshWeaver.Graph.Test` (new + `NodeTypeRebindWatcherTest` + `UpsertAnswersWhenTheOwnerGoesAwayTest`) **18/18**
- `Memex.Portal.Shared.Test` (new + `RetypedRootRecycleNeedsAJobTest`) **8/8**
- `MeshWeaver.Documentation.Test` whole project **390/390** — includes `DocumentationLinkIntegrityTest`, `ArchitectureTopicMapTest` and every governance ratchet
- Every touched project, `dotnet build -c Release -warnaserror` → **0 Error(s), 0 Warning(s)**

## What this does NOT do

It does not make an install immune to every interruption. Per-type recyclers beneath a root are deliberately not deferred, and `SettleRetypedRoot` still tears a root down while that root's background pipeline may be issuing correlated requests — the shape `RetypedRootRecycleNeedsAJobTest` records and #3800 narrowed. What is closed is the class the issue named: **nobody but the install itself takes that root down while the install is writing under it.**

Doc: extends `Doc/Architecture/DisposalStallVerdicts` — the page #3965 wrote — rather than adding another, plus a What's New entry (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review addressed (Copilot, 6 findings) — 4 fixed, 2 rejected with the reason

**Fixed**

1. **The lease key did not match the install target for a Code package.** `TargetPartitionOf` answers a *different* question (which partition an install RECORD is about) and falls back to the package id, while `InstallCode` falls back to the shared `type` partition. A blank-target Code package therefore wrote `type/<id>` while holding `<id>` — **a lease on a root nothing is writing to**, which reads in the log and in every other test exactly like a lease that is working. New `PackageInstaller.InstallRootOf` is the one definition, `InstallCode` now shares its constant, and `TheLeaseNamesTheRootTheInstallWritesUnder_ForEveryKind` pins it *with* the control that the other kinds still resolve to the package id.

2. **The check-to-post race across the scheduler hop.** The wide window — the release fires on the install's thread, the waiter's continuation runs on the pool — is now closed: `WhenReleased` re-evaluates the condition on the far side of the hop and recurses on the **next genuine release**. That is a wait on the condition, not a timer, not a retry and not a poll.

3. **The reach of the gate is now written down, not assumed.** `MeshOperations.Recycle` posts a `DisposeRequest` directly and is **not** gated — so the What's New entry no longer claims an operations action waits, and both the class remarks and the doc list the three posters outside the gate and say which are deliberate and which is an uncovered case. A guard whose reach is assumed gets read as a guarantee it does not keep — precisely the defect this issue already corrected once, in the installer's own recycle line.

4. **The test feed's mutable `List<T>`** (inherited verbatim from `NodeTypeRebindWatcherTest`) is now an instance `ConcurrentDictionary`.

**Rejected, with the reason — recorded in code and in the doc, because the next reader will have the same two ideas**

5. **"Make `SettleRetypedRoot` wait for every holder that is not its own."** The hole is real: two packages can target one partition, so install A's recycle can tear down a root B is writing under. But B's own `SettleRetypedRoot` would symmetrically wait for A's lease — **two installs each holding and each waiting is a mutual deadlock**, which no timeout may resolve (raising one is the band-aid; dropping one recycle re-breaks #1732). The sound repair is to serialise installs per root: a different change, its own risk, not a recycle gate. Named as a **known residual**.

6. **"Hand the root atomically to the waiting recycler."** After (2) what remains is the caller's own emission-to-post distance, with nothing in between. Closing *that* means either posting a teardown from inside the registry's synchronisation, or letting a pending recycle RESERVE the root — and a reservation a new install must queue behind **inverts the priority this mechanism exists to protect**. Stated as the bounded residual rather than closed with a worse primitive.

## The shard-0 red on the first push was not reachable from this diff

`PodHubClaimReassertionTest.ReAssertion_ReportsTheLandingOnce_AndSettlesOnce` — `TimeoutException: the claim was asserted 2 time(s), short of 3` — 1 of 7,064.

**Unreachable by construction, checked rather than asserted:**
- The test builds its **own** `ServiceCollection` with exactly two registrations (`OrleansStreamingReadiness` + the membership feed) and never calls `MeshBuilder`, so the one registration this diff adds there is never in its container.
- Its subject `OrleansRoutingService` resolves `IoPoolRegistry`, `AsyncDisposeQueue`, `IHostApplicationLifetime`, `ILocalSiloDetails`, `IClusterMembershipFeed`, `IOptions<…>`, `OrleansStreamingReadiness`, `IMessageHub`, `AccessService` — never `PackageRootInstallLeases` — and there is **no assembly scanning** (`GetTypes()`/`DefinedTypes`/Scrutor) anywhere in `MeshWeaver.Connection.Orleans` or `MeshWeaver.Hosting.Orleans`, so an added type in `MeshWeaver.Mesh.Contract` cannot reach it.
- `RecycleNode` has **zero** production call sites in core; `NodeTypeRebindWatcher.Arm` is reached only from a per-node hub activation and this test's container holds no `IMessageHub` at all; `MeshWeaver.PluginCatalog` is not even a `ProjectReference` of `MeshWeaver.Hosting.Orleans.Test`.
- This diff touches nothing in `MeshWeaver.Messaging.Hub`, so no hub disposal phase or registrant ordering moves.

**And the positive evidence for where it does come from:** the failing test file **and its subject** were both last changed by `35c36e4c8 "fix: gate pod-hub claims on silo readiness"` — merged 2026-09-11 02:06, about 4.5 h before this run. That commit put the claim behind `OrleansStreamingReadiness.Ready.Take(1).ObserveOn(Scheduler.Default)` before it subscribes to `membershipFeed.Changes`; the assertion that failed is "3 attaches within 20 s after two back-to-back `PushChange()`", i.e. exactly the coalescing this new gate makes possible.

**Independently confirmed with a control this diff could not supply.** `MeshWeaver#4012` — whose entire diff is a YamlDotNet 16→18 bump in `Directory.Packages.props` plus two markdown files — failed the *same* test class (`AClaimThatLanded_IsReAsserted_OnEveryMembershipChange`, run 34571973229, head `df643c36`). A YAML serialization library cannot reach Orleans membership or pod-hub claim placement, so that is a diff provably unable to touch the code, failing where this one did. Measured rate over the newest 30 completed `MeshWeaver Build and Test` runs: shard 0 failed in **2 of 14** (~14%) — and the two are exactly #4009 and #4012.

**It is a real defect and it is owned elsewhere.** `PodHubClaimReassertion` is named in **#3931** (open — *"every COLD /api/content read 503s after ~10.2 s"*) and **#3088** (*"the /api/content 503 is the pod-hub claim loss, measured end to end"*). Another agent holds it with the full history (#3034, #3983, #3936). Deliberately **not** added to `.github/known-flakes.json`, not re-run, and not re-queued by hand — `merge-queue-steward.yml` owns dequeue events.

**On this PR's second push:** it exists to address the six review findings above, not to re-roll CI. If the fresh run is green on shard 0 that is a ~86% outcome of a known race, **not** evidence about this diff — the evidence is the unreachability analysis and the #4012 control.
