### PR TITLE
fix(#3978): a repository whose content CI cannot be found says so

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SyncRefContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SyncRefContract.md
@@ -21,6 +21,117 @@ guards. This matters in both directions: a scheduled PR updater once authorized 
 tree more than twenty times, while a green core Chart Gate could have masked a red build-and-test
 run (#3978).
 
+## Which workflow proves a repository — the declaration, and what happens when it is missing
+
+The `workflow_run` payload carries two facts that are easy to confuse. `event` is **how** the run
+started; `path` is **what** ran. Keying the publish signal on the first is a proxy, and the proxy
+came apart in both directions:
+
+- A `*/10` cron called **Auto-update green armed PRs** — present in Reinsurance, SocialMedia and Crm,
+  and whose whole body is `gh pr list` → `gh api -X PUT …/update-branch` — checks out nothing and
+  builds nothing. Measured over 48 h to 2026-09-10T19:36Z it recorded **20** build completions at
+  `MeshWeaver.Reinsurance@7d29a303` and **40+** at `MeshWeaver.SocialMedia@07cc155e`, both commits
+  whose own content CI had **failed**.
+- Narrowing the trigger set does not close it. On core `192a60d84a36`, `push Chart Gate` and
+  `push Hosting Operator` both concluded `success` in the second that
+  `push MeshWeaver Build and Test` **failed**.
+- And narrowing has already misfired the other way: the pre-2026-09-02 `event == "push"` test
+  discarded Reinsurance's three green `repository_dispatch` runs and left `Underwriting/_GitSync`
+  **38 h** behind a merged `main` with every delivery answering 200 OK
+  (`Systemorph/MeshWeaver.Plugins#1194`).
+
+So the trigger allow-list stays exactly as wide as it was — it answers a different question, and
+narrowing it is what caused #1194 — and a third, independent guard answers the one that matters.
+
+**Re-measured 2026-09-11, and the premise needed correcting.** #3978 stated that every repository's
+content CI fires on `push` *and* `repository_dispatch` *and* `schedule`. Over the eight live
+repositories (the ninth record, `Systemorph/education`, is a stale pre-rename alias last written
+2026-08-14):
+
+| repository | content CI | `push` | `repository_dispatch` | `schedule` |
+|---|---|:--:|:--:|:--:|
+| MeshWeaver.Plugins · .Education · .Reinsurance · .SocialMedia · .Manufacturing · .Crm | `ci.yml` | ✅ | ✅ | ✅ |
+| Systemorph/MeshWeaver | `dotnet-test.yml` | ✅ | ✗ | ✗ (`merge_group`, `workflow_dispatch`) |
+| Systemorph/Memex | `build.yml` | ✅ | ✗ | ✗ (`pull_request`, `workflow_dispatch`) |
+
+Six of eight fire on all three; core and Memex publish on `push` alone. That changes nothing about
+keying on the path — the two guards are orthogonal — but it does mean the allow-list is carrying
+`repository_dispatch` and `schedule` **for the six satellites specifically**, which is exactly the
+population #1194 was measured on. Dropping either would take their release-follow and cron signals
+away again.
+
+### Where the declaration lives
+
+`GitHubWebhookProcessor.ContentWorkflowFor` resolves one repository's content-CI path, **and says
+where that answer came from**, in this order:
+
+| source | what declares it | why |
+|---|---|---|
+| `Configured` | `GitHub:ContentWorkflows:Repositories` — `{ Repository: "owner/repo", Path: ".github/workflows/x.yml" }` | a deployment's own escape hatch for a repository the platform does not know |
+| `Platform` | the fleet's own table: `Systemorph/MeshWeaver` → `dotnet-test.yml`, `Systemorph/Memex` → `build.yml` | the platform ships the declaration, so it needs no portal's settings edited |
+| `Convention` | `.github/workflows/ci.yml` | every node repo, enforced by the shared lane's `check-content-ci-path.py` |
+
+**It is a fact about the REPOSITORY, not about one Space's source.** A field on `GitHubSyncConfig`
+would be the wrong home: several Spaces sync the same repository, and they must not be able to
+disagree about what proved it — 34 sources on memex.meshweaver.cloud point at MeshWeaver.Plugins
+alone. The declaration therefore sits beside the platform, next to the `Admin/_Build/{owner}.{repo}`
+record it governs, and is keyed by `owner/repo`.
+
+**Why `Platform` exists rather than "convention plus config".** Measured 2026-09-11, with the
+denominator: **nine** repositories hold an `Admin/_Build/{owner}.{repo}` record — the same nine on
+memex.meshweaver.cloud and on memex.systemorph.com, both listings `truncated:false`. Eight satisfy
+the convention or core's exception. The ninth, `Systemorph/Memex`, has **no `ci.yml` at all** (its
+workflows are `build.yml`, `config-key-coverage.yml`, `deploy-drift.yml`, `helm-release.yml`,
+`image-pins.yml`, `smoke.yml`), and two portals sync its `mesh/Deployments` tree. On the convention
+alone it would have frozen on both, silently, the moment this shipped — #1194 recreated by the change
+meant to prevent it. A configuration override would have fixed it only on portals whose settings
+somebody edited; a platform declaration ships with the platform.
+
+### 🚨 What happens when the declaration is absent or wrong
+
+This is the whole risk of a fail-closed gate, and it is why the refusal is **reported**. A repository
+whose content CI is somewhere the platform does not expect has every delivery refused, GitHub
+answered 200, and every Space that syncs it silently stops advancing. #1194's entire cost was that
+nothing said so.
+
+The refusal is therefore classified, not just taken:
+
+| the run's path | the repository | reported at |
+|---|---|---|
+| absent from the payload | any | **Warning** — the payload did not say what ran; that is the absence of evidence, not a verdict on it |
+| not the expected path | nothing syncs it | Debug — no Space can be frozen, so the refusal cost nothing |
+| not the expected path | synced, and a run at the expected path **has** been accepted before | Debug — routine: some other workflow finished green |
+| not the expected path | synced, and **no** run at the expected path has ever been accepted | **Warning** — `I COULD NOT DETERMINE THIS REPOSITORY'S CONTENT CI` |
+
+The Warning names both paths, the count and names of the frozen Spaces, that they are frozen and that
+GitHub is answered 200, and the configuration section that fixes it. It **self-clears**: the
+repository's next genuine content-CI run records `BuildCompletion.WorkflowPath`, and every later
+refusal drops to Debug.
+
+The conditioning is load-bearing rather than tidy. An unconditional Warning would fire on roughly
+200 of core's refusals a day plus 144 from the PR-updater cron in each of three satellites, and
+burying the one line that matters is the same failure as not emitting it. The precedent is
+`ConfigsTargeting`'s zero-match Warning, which reports a delivery that matches no sync config for the
+same reason and with the same reasoning.
+
+**The residual, stated rather than implied.** A repository that has already published and *then*
+moves its content CI keeps a record whose path still equals the expected one, so this stays quiet.
+That case is covered a layer up instead: the shared `node-repo-validate` lane runs
+`check-content-ci-path.py` against every satellite's tree, so moving the file reds that repository's
+own CI, and `CoreContentCiRemainsAtThePublishSignalPath` does the same for core. Neither covers a
+repository that calls neither — which is exactly why the two such repositories in the fleet are
+`Platform`-declared rather than left to the convention.
+
+### The build record says what proved it
+
+`BuildCompletion` already carried `WorkflowName`; it now also carries **`WorkflowPath`**. The name is
+a display string a maintainer can change in a one-line diff, and measured 2026-09-11 no consumer ever
+keyed on it — its two readers are a log line in `PluginUpdateWatcher` and the identity comparison in
+`MissedBuildFact`. The path is the identity the webhook actually admitted the run on, so recording it
+makes the record self-describing, and it is what makes "this repository's content CI has never been
+seen" an answerable question rather than a time-based guess. A record written before #3978 carries
+`null`; the repository's next content-CI run fills it in.
+
 ## The two refs, and why they are not the same ref
 
 A GitSync'd Space is configured with a repository and a **branch**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-repository-whose-content-ci-cannot-be-found-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-repository-whose-content-ci-cannot-be-found-says-so.md
@@ -1,0 +1,18 @@
+---
+Name: A repository whose content CI cannot be found now says so
+Category: Fix
+Description: Requiring the content CI to publish could have frozen a synced Space silently; a Space that stops receiving content because its repository's build workflow was not recognised is now reported, and the deployment repository is recognised again.
+Icon: Checkmark
+Order: -20260911
+---
+
+Accepting a build only from a repository's content-CI workflow has one way to go wrong: the platform
+looks for that workflow where the repository does not keep it. Every delivery is then refused, GitHub
+is answered normally, and every Space syncing that repository quietly stops receiving content — the
+failure that once left a Space 38 hours behind with nothing reporting a problem.
+
+Two changes close that. `Systemorph/Memex`, whose deployment records two portals sync, has no
+`ci.yml` and is now declared by the platform, so it keeps publishing. And when a repository that a
+Space actually syncs has a green run refused while no run of its expected content CI has ever been
+accepted, the portal logs a warning naming the workflow it found, the one it expected, the Spaces
+that are frozen, and how to declare the right one — instead of failing silently.

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -593,26 +593,78 @@ public sealed class GitHubWebhookProcessor
     /// than a display name a maintainer can casually edit.</summary>
     internal const string StandardContentWorkflowPath = ".github/workflows/ci.yml";
 
-    /// <summary>Core predates the node-repo convention and is the one intentional exception.</summary>
+    /// <summary>Core predates the node-repo convention and is one of the platform exceptions.</summary>
     internal const string CoreContentWorkflowPath = ".github/workflows/dotnet-test.yml";
 
-    private static readonly RepoIdentity CoreRepository = new("Systemorph", "MeshWeaver");
+    /// <summary><c>Systemorph/Memex</c> — the deployment-configuration repository whose
+    /// <c>mesh/Deployments</c> tree two portals sync — predates the convention exactly as core does,
+    /// and its content CI is <c>Memex Build</c>.</summary>
+    internal const string MemexContentWorkflowPath = ".github/workflows/build.yml";
 
     /// <summary>
-    /// The one workflow whose green verdict proves a repository's CONTENT. A trigger says why a
-    /// workflow ran; it does not say what that workflow checked. GitHub sends the stable workflow
-    /// file path in every <c>workflow_run</c> payload, so identity is keyed on that path rather than
-    /// on the mutable display name.
+    /// 🚨 <b>The platform's OWN repositories whose content CI predates the node-repo convention.</b>
+    /// These are DECLARATIONS, not special cases: the fleet ships the platform, so the fact "this
+    /// repository's content CI is at P" travels with the platform rather than waiting for every
+    /// portal's configuration to be edited. An override under
+    /// <see cref="GitHubContentWorkflowOptions"/> still wins, for a repository the platform does not
+    /// know about.
     ///
-    /// <para>Fail-closed by construction: ordinary content/node repositories use
-    /// <c>.github/workflows/ci.yml</c>; <c>Systemorph/MeshWeaver</c> uses its established
-    /// <c>.github/workflows/dotnet-test.yml</c>; and an arbitrary repository with a different path
-    /// declares one repository-level <see cref="GitHubContentWorkflowOptions"/> override. A
-    /// repository with no workflow at its expected path has no automatic publish signal — exactly
-    /// like a repository with no content CI at all. An unrelated green workflow can never stand in
-    /// for it.</para>
+    /// <para><b>Measured 2026-09-11, with the denominator.</b> Nine repositories hold an
+    /// <c>Admin/_Build/{owner}.{repo}</c> record — the same nine on memex.meshweaver.cloud and on
+    /// memex.systemorph.com, both listings <c>truncated:false</c>. Eight satisfy the convention or
+    /// core's exception. The ninth, <c>Systemorph/Memex</c>, has NO <c>.github/workflows/ci.yml</c>
+    /// at all (its workflows are <c>build.yml</c>, <c>config-key-coverage.yml</c>,
+    /// <c>deploy-drift.yml</c>, <c>helm-release.yml</c>, <c>image-pins.yml</c>, <c>smoke.yml</c>) —
+    /// so on the convention alone every one of its deliveries would be refused and
+    /// <c>Deployments/_GitSync</c> would freeze on BOTH portals, silently, which is precisely the
+    /// MeshWeaver.Plugins#1194 shape #3978 exists to avoid recreating.</para>
     /// </summary>
-    internal static string ExpectedContentWorkflowPath(
+    private static readonly ImmutableArray<(RepoIdentity Repository, string Path)> PlatformContentWorkflows =
+    [
+        (new RepoIdentity("Systemorph", "MeshWeaver"), CoreContentWorkflowPath),
+        (new RepoIdentity("Systemorph", "Memex"), MemexContentWorkflowPath),
+    ];
+
+    /// <summary>Where a repository's content-CI path came from — the third state made nameable.</summary>
+    internal enum ContentWorkflowSource
+    {
+        /// <summary>A deployment declared it under <c>GitHub:ContentWorkflows:Repositories</c>.</summary>
+        Configured,
+
+        /// <summary>The platform declares it for one of its own repositories
+        /// (<see cref="PlatformContentWorkflows"/>).</summary>
+        Platform,
+
+        /// <summary>Nobody declared anything: the node-repo CONVENTION is being presumed. Correct for
+        /// every repository whose CI calls the shared <c>node-repo-validate</c> lane, because that
+        /// lane's <c>check-content-ci-path.py</c> reds if the file moves — and a PRESUMPTION for
+        /// anything else, which is why a refusal under this source is reported differently.</summary>
+        Convention,
+    }
+
+    /// <summary>One repository's content-CI path and where that path came from.</summary>
+    internal sealed record ContentWorkflowDeclaration(string Path, ContentWorkflowSource Source);
+
+    /// <summary>
+    /// The one workflow whose green verdict proves a repository's CONTENT, <b>and where that claim
+    /// comes from</b>. A trigger says why a workflow ran; it does not say what that workflow
+    /// checked. GitHub sends the stable workflow file path in every <c>workflow_run</c> payload, so
+    /// identity is keyed on that path rather than on the mutable display name.
+    ///
+    /// <para>🚨 <b>Returning the SOURCE, not just the path, is the point.</b> A bare path collapses
+    /// "this deployment declared <c>ci.yml</c>" into "nobody declared anything and <c>ci.yml</c> was
+    /// presumed" — the same two-answers-in-one shape as the trigger proxy #3978 removed, one level
+    /// down. They must stay apart because they have OPPOSITE failure modes: a refusal under a
+    /// declaration is routine (some other workflow finished green), while a refusal under a
+    /// presumption may be a repository whose content CI is somewhere else entirely and whose every
+    /// Space is therefore frozen. <see cref="ReportRefusedWorkflow"/> is what acts on the
+    /// difference.</para>
+    ///
+    /// <para>Fail-closed by construction: a repository with no workflow at its expected path has no
+    /// automatic publish signal — exactly like a repository with no content CI at all. An unrelated
+    /// green workflow can never stand in for it.</para>
+    /// </summary>
+    internal static ContentWorkflowDeclaration ContentWorkflowFor(
         RepoIdentity repository,
         IEnumerable<GitHubContentWorkflow>? overrides = null)
     {
@@ -620,11 +672,19 @@ public sealed class GitHubWebhookProcessor
             GitHubRepoIdentityResolver.Parse(entry.Repository)?.Matches(repository) == true
             && !string.IsNullOrWhiteSpace(entry.Path));
         if (configured is not null)
-            return configured.Path.Trim();
-        return CoreRepository.Matches(repository)
-            ? CoreContentWorkflowPath
-            : StandardContentWorkflowPath;
+            return new ContentWorkflowDeclaration(configured.Path.Trim(), ContentWorkflowSource.Configured);
+        foreach (var (declared, path) in PlatformContentWorkflows)
+            if (declared.Matches(repository))
+                return new ContentWorkflowDeclaration(path, ContentWorkflowSource.Platform);
+        return new ContentWorkflowDeclaration(
+            StandardContentWorkflowPath, ContentWorkflowSource.Convention);
     }
+
+    /// <summary>The path <see cref="ContentWorkflowFor"/> resolves, without its source.</summary>
+    internal static string ExpectedContentWorkflowPath(
+        RepoIdentity repository,
+        IEnumerable<GitHubContentWorkflow>? overrides = null)
+        => ContentWorkflowFor(repository, overrides).Path;
 
     /// <summary>Whether this run is the repository's declared-by-convention content CI. Paths are
     /// Git paths and therefore compared case-sensitively; a missing path means nothing was proved.</summary>
@@ -739,24 +799,22 @@ public sealed class GitHubWebhookProcessor
         // red (#3978). The workflow FILE is the repository-level identity: display names are mutable,
         // while the fleet's content-CI path is part of the node-repo contract.
         var workflowPath = GetString(run, "path");
+        var declaration = ContentWorkflowFor(target, contentWorkflows);
         if (!IsRepositoryContentWorkflow(target, workflowPath, contentWorkflows))
         {
-            var expected = ExpectedContentWorkflowPath(target, contentWorkflows);
             if (string.IsNullOrWhiteSpace(workflowPath))
             {
+                // "The payload did not say WHAT ran" is its own answer and always deserves a human:
+                // it is not a refusal on the evidence, it is the absence of evidence.
                 logger?.LogWarning(
                     "workflow_run webhook for {Repo}: green '{Workflow}' run carried no workflow path, "
                     + "so it cannot be verified as the repository content CI at '{Expected}' — no build record.",
-                    repoUrl, GetString(run, "name"), expected);
+                    repoUrl, GetString(run, "name"), declaration.Path);
+                return Observable.Return(0);
             }
-            else
-            {
-                logger?.LogDebug(
-                    "workflow_run webhook for {Repo}: green '{Workflow}' is '{Actual}', not the repository "
-                    + "content CI at '{Expected}' — not a publish signal.",
-                    repoUrl, GetString(run, "name"), workflowPath, expected);
-            }
-            return Observable.Return(0);
+            return ReportRefusedWorkflow(
+                    target, repoUrl, GetString(run, "name"), workflowPath, declaration)
+                .Select(_ => 0);
         }
 
         var completion = new BuildCompletion
@@ -765,6 +823,10 @@ public sealed class GitHubWebhookProcessor
             Branch = GetString(run, "head_branch") ?? "",
             HeadSha = headSha,
             WorkflowName = GetString(run, "name"),
+            // The path the run was ADMITTED on, not the name it happens to display. This is what
+            // lets a later refusal tell "this repository's content CI has never been seen" from
+            // "some other workflow finished green" — see ReportRefusedWorkflow.
+            WorkflowPath = workflowPath,
             RunId = GetLong(run, "id"),
             RunNumber = GetLong(run, "run_number"),
             CompletedAtUtc = GetDate(run, "updated_at"),
@@ -900,6 +962,167 @@ public sealed class GitHubWebhookProcessor
                     path, completion.RepositoryUrl, completion.HeadSha);
                 return Observable.Return(System.Reactive.Unit.Default);
             });
+    }
+
+    /// <summary>
+    /// 🚨 <b>The positive signal for the one failure mode this gate can cause: a SILENT freeze.</b>
+    ///
+    /// <para>#3978 made the repository's own content CI the publish signal, which is correct and
+    /// which has exactly one way to go wrong — the platform expects a path the repository does not
+    /// use. Then every delivery is refused, GitHub is answered 200, every Space that syncs the
+    /// repository stops advancing, and nothing says so. That is MeshWeaver.Plugins#1194 verbatim,
+    /// whose ENTIRE cost was that 38 h of deliveries all reported success while nothing arrived. A
+    /// gate whose failure is indistinguishable from its success is not a gate.</para>
+    ///
+    /// <para><b>The report is CONDITIONED, because an unconditional one would be noise and noise is
+    /// how a real line gets missed.</b> Refusing a green run is the NORMAL case: core refuses ~200 a
+    /// day (Chart Gate, Hosting Operator, the synthetic probe), and the <c>*/10</c> PR-updater cron
+    /// alone is 144 a day in three satellites. Two facts narrow it to the shape that is actually an
+    /// outage:</para>
+    /// <list type="number">
+    ///   <item><b>Does anything sync this repository?</b> No sync config ⇒ no Space can be frozen,
+    ///   so the refusal cost nothing. Matched on the STORED url only — no canonical resolution, and
+    ///   deliberately not <see cref="ConfigsTargeting"/>, whose zero-match Warning would then fire
+    ///   on every refused run of every repository this mesh does not sync.</item>
+    ///   <item><b>Has the expected content CI EVER been accepted for it?</b> Read off
+    ///   <see cref="BuildCompletion.WorkflowPath"/> — the path the last accepted run was admitted
+    ///   on. If it equals what is expected today, the content CI exists and is arriving, and this
+    ///   refusal is some other workflow finishing green. If it does not — or there is no record at
+    ///   all — the mesh has never once identified this repository's content CI.</item>
+    /// </list>
+    ///
+    /// <para>So the Warning fires exactly when a repository the mesh SYNCS has had a publishable
+    /// green run refused while no run has ever been accepted at the expected path, and it SELF-
+    /// CLEARS the moment one is: the repository's next genuine content-CI build writes the path and
+    /// every later refusal drops back to Debug. It is the same read the gate itself makes, so the
+    /// two cannot disagree.</para>
+    ///
+    /// <para><b>The residual, stated rather than implied.</b> A repository that has already
+    /// published, and THEN moves its content CI, keeps a record whose path still equals the expected
+    /// one, so this stays quiet. That case is covered a layer up instead: the shared
+    /// <c>node-repo-validate</c> lane runs <c>check-content-ci-path.py</c> against every satellite's
+    /// tree, so moving the file reds that repository's own CI, and
+    /// <c>CoreContentCiRemainsAtThePublishSignalPath</c> does the same for core. Neither covers a
+    /// repository that calls neither — which is why <see cref="PlatformContentWorkflows"/> declares
+    /// those rather than leaving them to the convention.</para>
+    ///
+    /// <para>Reactive end-to-end and never faulting: this runs on a delivery that has already
+    /// decided its outcome, so a failure to REPORT must not change that outcome (and must not turn
+    /// a 200 into the redelivery storm a non-2xx would cause).</para>
+    /// </summary>
+    /// <param name="target">The repository the refused run belongs to.</param>
+    /// <param name="repoUrl">Its url, as the log lines name it.</param>
+    /// <param name="workflowName">The refused run's display name — copy for the log line only.</param>
+    /// <param name="actualPath">The refused run's stable workflow path.</param>
+    /// <param name="declaration">The path expected for this repository, and where that came from.</param>
+    /// <returns>Always one <c>Unit</c>; the refusal itself is the caller's answer.</returns>
+    private IObservable<System.Reactive.Unit> ReportRefusedWorkflow(
+        RepoIdentity target,
+        string repoUrl,
+        string? workflowName,
+        string actualPath,
+        ContentWorkflowDeclaration declaration)
+        => SpacesSyncingByStoredUrl(target)
+            .SelectMany(spaces => spaces.Count == 0
+                ? Observable.Return(System.Reactive.Unit.Default).Do(_ => logger?.LogDebug(
+                    "workflow_run webhook for {Repo}: green '{Workflow}' is '{Actual}', not the "
+                    + "repository content CI at '{Expected}' — not a publish signal. No sync "
+                    + "config targets this repository, so nothing was withheld.",
+                    repoUrl, workflowName, actualPath, declaration.Path))
+                : ContentCiHasEverBeenAccepted(target, declaration.Path).Select(seen =>
+                {
+                    if (seen)
+                        logger?.LogDebug(
+                            "workflow_run webhook for {Repo}: green '{Workflow}' is '{Actual}', not "
+                            + "the repository content CI at '{Expected}' — not a publish signal. "
+                            + "That content CI has published before, so this is a routine refusal.",
+                            repoUrl, workflowName, actualPath, declaration.Path);
+                    else
+                        logger?.LogWarning(
+                            "workflow_run webhook for {Repo}: I COULD NOT DETERMINE THIS "
+                            + "REPOSITORY'S CONTENT CI. A green '{Workflow}' ('{Actual}') on the "
+                            + "default branch was refused because the content CI is expected at "
+                            + "'{Expected}' ({Source}), and NO run has ever been accepted at that "
+                            + "path. {SpaceCount} Space(s) sync this repository ({Spaces}) and every "
+                            + "one of them is FROZEN until a green run arrives from '{Expected}' — "
+                            + "GitHub is answered 200, so nothing else will report this. Either the "
+                            + "repository's content CI is elsewhere, in which case declare it under "
+                            + "'{Section}:Repositories' as {{ Repository: '{Repo}', Path: '<its "
+                            + "path>' }}, or it has no content CI, in which case it has no automatic "
+                            + "publish signal.",
+                            repoUrl, workflowName, actualPath, declaration.Path, declaration.Source,
+                            spaces.Count, string.Join(", ", spaces), declaration.Path,
+                            GitHubContentWorkflowOptions.ConfigSection, repoUrl);
+                    return System.Reactive.Unit.Default;
+                }))
+            .Catch((Exception ex) =>
+            {
+                // The refusal already stands; failing to CLASSIFY it must not change the delivery's
+                // outcome. Said at Warning rather than swallowed, because the thing that just failed
+                // is the freeze detector itself.
+                logger?.LogWarning(ex,
+                    "workflow_run webhook for {Repo}: green '{Workflow}' ('{Actual}') was refused as "
+                    + "not the content CI at '{Expected}', but whether that refusal freezes a synced "
+                    + "Space could not be determined.",
+                    repoUrl, workflowName, actualPath, declaration.Path);
+                return Observable.Return(System.Reactive.Unit.Default);
+            });
+
+    /// <summary>
+    /// The distinct Space paths whose sync config names <paramref name="incoming"/> by its STORED
+    /// url — no canonical resolution and, deliberately, no zero-match report.
+    ///
+    /// <para>This is the cheap half of <see cref="ConfigsTargeting"/> and it is used only to decide
+    /// whether a REFUSAL cost anything. Using the full matcher here would fire its zero-match
+    /// Warning on every refused run of every repository the mesh does not sync — hundreds a day —
+    /// and burying that Warning is exactly the outcome it exists to prevent. The cost of the
+    /// narrower match is that a repository whose configs still store an OLD name reads as unsynced
+    /// and is reported at Debug; its first accepted delivery repoints those urls, after which the
+    /// stored match succeeds.</para>
+    /// </summary>
+    private IObservable<IReadOnlyList<string>> SpacesSyncingByStoredUrl(RepoIdentity incoming)
+        => QueryConfigNodesAsSystem().Select(c => (IReadOnlyList<string>)c.Items
+            .Select(node => GitHubRepoIdentityResolver.Parse(
+                node.ContentAs<GitHubSyncConfig>(hub.JsonSerializerOptions, logger)?.RepositoryUrl) is { } id
+                && incoming.Matches(id)
+                    ? node.Path.Split('/', 2)[0]
+                    : null)
+            .Where(s => s is { Length: > 0 })
+            .Select(s => s!)
+            .Distinct(StringComparer.Ordinal)
+            .ToImmutableArray());
+
+    /// <summary>
+    /// Whether a run at <paramref name="expectedPath"/> has ever been ACCEPTED for this repository —
+    /// read off the build record's own <see cref="BuildCompletion.WorkflowPath"/>.
+    ///
+    /// <para>🚨 A <c>scope:children</c> LISTING of <c>Admin/_Build</c>, never a point read of
+    /// <c>Admin/_Build/{owner}.{repo}</c>. The whole question here is about a repository that may
+    /// have NO record, and a point read of an absent node makes its owner answer a routing NotFound
+    /// that terminates the stream and opens the storm-breaker on that path — which would then
+    /// fast-fail the WRITES the next genuine build needs. The listing answers existence and content
+    /// in one query, which is what the CQRS rule asks for.</para>
+    ///
+    /// <para>The listing is path-scoped because the Admin partition is invisible to an unscoped
+    /// query — <see cref="BuildCompletion.WatchQuery"/> carries that reasoning and its measurement,
+    /// and is reused here rather than restated.</para>
+    /// </summary>
+    private IObservable<bool> ContentCiHasEverBeenAccepted(RepoIdentity target, string expectedPath)
+    {
+        var recordPath = BuildCompletion.PathFor(target.Owner, target.Repo);
+        var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // RunAsSystem, never Observable.Using(ImpersonateAsSystem): store and restore of the
+        // identity must land on the same thread (AGENTS.md; #1790). The webhook request is
+        // anonymous, so there is no ambient identity that could read the Admin partition.
+        return accessService.RunAsSystem(() => meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(BuildCompletion.WatchQuery).Complete())
+                .Where(c => c.ChangeType == QueryChangeType.Initial)
+                .Take(1))
+            .Select(c => c.Items
+                .Where(n => string.Equals(n.Path, recordPath, StringComparison.Ordinal))
+                .Select(n => n.ContentAs<BuildCompletion>(hub.JsonSerializerOptions, logger))
+                .Any(b => b is not null
+                          && string.Equals(b.WorkflowPath, expectedPath, StringComparison.Ordinal)));
     }
 
     /// <summary>The distinct Space paths whose GitHub sync config targets <paramref name="repo"/>.</summary>

--- a/src/MeshWeaver.Graph/BuildCompletion.cs
+++ b/src/MeshWeaver.Graph/BuildCompletion.cs
@@ -103,9 +103,27 @@ public record BuildCompletion
     /// so it reads exactly the tree that was proven green.</summary>
     public string HeadSha { get; init; } = "";
 
-    /// <summary>The workflow's display name (e.g. <c>MeshWeaver Build and Test</c>). A repo may run
-    /// several workflows; a consumer that only trusts one filters on this.</summary>
+    /// <summary>The workflow's display name (e.g. <c>MeshWeaver Build and Test</c>). DISPLAY COPY
+    /// ONLY — a display name is mutable and a maintainer may edit it in a one-line diff, so nothing
+    /// may key on it. Measured 2026-09-11: no consumer ever did (the two readers are a log line in
+    /// <c>PluginUpdateWatcher</c> and the identity comparison in <c>MissedBuildFact</c>), which is
+    /// why the stable <see cref="WorkflowPath"/> was added rather than this field being trusted.</summary>
     public string? WorkflowName { get; init; }
+
+    /// <summary>
+    /// The stable Git path of the workflow whose green run produced this record — the identity the
+    /// webhook ADMITTED the run on (#3978), recorded so the record says what proved it rather than
+    /// leaving a reader to infer it from a mutable display name.
+    ///
+    /// <para>🚨 It is also the field that makes "this repository's content CI has never been seen"
+    /// an ANSWERABLE question. Absent, or different from the path the platform expects for the
+    /// repository today, means every publish signal for it is being refused — which is a SILENT
+    /// freeze of every Space that syncs it unless something says so. <c>GitHubWebhookProcessor</c>
+    /// reads exactly this to decide whether a refused green run deserves a Warning or a Debug line.
+    /// A record written before #3978 carries <see langword="null"/> here; the repository's next
+    /// genuine content-CI run fills it in.</para>
+    /// </summary>
+    public string? WorkflowPath { get; init; }
 
     /// <summary>GitHub's numeric run id — the stable handle for fetching logs or artifacts.</summary>
     public long RunId { get; init; }

--- a/test/MeshWeaver.Documentation.Test/GreenBuildPublishSignalTest.cs
+++ b/test/MeshWeaver.Documentation.Test/GreenBuildPublishSignalTest.cs
@@ -260,6 +260,97 @@ public class GreenBuildPublishSignalTest
                 new RepoIdentity("Systemorph", "MeshWeaver")));
     }
 
+    // ── the declaration, and its THIRD state ─────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>"This deployment declared <c>ci.yml</c>" and "nobody declared anything and
+    /// <c>ci.yml</c> was presumed" must not be the same answer.</b>
+    ///
+    /// <para>That collapse is the exact shape #3978 removed one level up — the trigger was a proxy
+    /// for a proposition it could not express — and returning a bare path would rebuild it here.
+    /// The two have OPPOSITE failure modes: a refusal under a declaration is routine, while a
+    /// refusal under a presumption may be a repository whose content CI is somewhere else entirely
+    /// and whose every Space is therefore frozen. The webhook reports them differently, which it can
+    /// only do if the resolver keeps them apart.</para>
+    /// </summary>
+    [Fact]
+    public void TheContentCiDeclarationSaysWhereItCameFrom_SoPresumedNeverReadsAsDeclared()
+    {
+        var convention = GitHubWebhookProcessor.ContentWorkflowFor(
+            new RepoIdentity("someone", "a-repo-nobody-declared"));
+        Assert.Equal(ContentWorkflow, convention.Path);
+        Assert.Equal(GitHubWebhookProcessor.ContentWorkflowSource.Convention, convention.Source);
+
+        var platform = GitHubWebhookProcessor.ContentWorkflowFor(
+            new RepoIdentity("Systemorph", "MeshWeaver"));
+        Assert.Equal(".github/workflows/dotnet-test.yml", platform.Path);
+        Assert.Equal(GitHubWebhookProcessor.ContentWorkflowSource.Platform, platform.Source);
+
+        var configured = GitHubWebhookProcessor.ContentWorkflowFor(
+            new RepoIdentity("customer", "knowledge"),
+            [new GitHubContentWorkflow
+            {
+                Repository = "customer/knowledge", Path = ".github/workflows/content.yml",
+            }]);
+        Assert.Equal(".github/workflows/content.yml", configured.Path);
+        Assert.Equal(GitHubWebhookProcessor.ContentWorkflowSource.Configured, configured.Source);
+    }
+
+    /// <summary>
+    /// 🚨 <b><c>Systemorph/Memex</c> has no <c>ci.yml</c>, and two portals sync it.</b>
+    ///
+    /// <para>Measured 2026-09-11, with the denominator, over the REST workflow listing of every
+    /// repository holding an <c>Admin/_Build/{owner}.{repo}</c> record — the same nine on
+    /// memex.meshweaver.cloud and on memex.systemorph.com, both listings <c>truncated:false</c>.
+    /// Eight of the nine satisfy the convention or core's exception. The ninth is
+    /// <c>Systemorph/Memex</c>, whose six workflows are <c>build.yml</c> (<i>Memex Build</i>),
+    /// <c>config-key-coverage.yml</c>, <c>deploy-drift.yml</c>, <c>helm-release.yml</c>,
+    /// <c>image-pins.yml</c> and <c>smoke.yml</c> — no <c>ci.yml</c> among them.</para>
+    ///
+    /// <para>On the convention alone, every Memex delivery would be refused and
+    /// <c>Deployments/_GitSync</c> would freeze on BOTH portals with every delivery answering 200 OK:
+    /// MeshWeaver.Plugins#1194 recreated by the very change meant to prevent it. So the platform
+    /// DECLARES it, the same way it declares core's — a declaration ships with the platform, while a
+    /// configuration override waits for every portal's settings to be edited.</para>
+    /// </summary>
+    [Fact]
+    public void MemexContentCiIsDeclaredByThePlatform_BecauseItHasNoCiYml()
+    {
+        var memex = GitHubWebhookProcessor.ContentWorkflowFor(new RepoIdentity("Systemorph", "Memex"));
+        Assert.Equal(".github/workflows/build.yml", memex.Path);
+        Assert.Equal(GitHubWebhookProcessor.ContentWorkflowSource.Platform, memex.Source);
+
+        Assert.True(GitHubWebhookProcessor.IsRepositoryContentWorkflow(
+                new RepoIdentity("Systemorph", "Memex"), ".github/workflows/build.yml"),
+            "Memex Build is the run that proves the mesh/Deployments tree two portals sync");
+        Assert.False(GitHubWebhookProcessor.IsRepositoryContentWorkflow(
+                new RepoIdentity("Systemorph", "Memex"), ".github/workflows/smoke.yml"),
+            "Deployment Smoke probes a RUNNING deployment over the public internet — it asserts a "
+            + "live service, not a commit, and must never publish a tree");
+        Assert.False(GitHubWebhookProcessor.IsRepositoryContentWorkflow(
+                new RepoIdentity("Systemorph", "Memex"), ContentWorkflow),
+            "a declaration REPLACES the convention; leaving both admissible would let any repository "
+            + "publish from whichever of the two it happened to have");
+    }
+
+    /// <summary>
+    /// A deployment's override outranks the platform's own declaration — otherwise a fleet
+    /// repository that moves its content CI could not be corrected without shipping a platform
+    /// release, which is the freeze this whole mechanism exists to avoid.
+    /// </summary>
+    [Fact]
+    public void AConfiguredOverrideOutranksThePlatformDeclaration()
+    {
+        var overridden = GitHubWebhookProcessor.ContentWorkflowFor(
+            new RepoIdentity("Systemorph", "Memex"),
+            [new GitHubContentWorkflow
+            {
+                Repository = "Systemorph/Memex", Path = ".github/workflows/content-ci.yml",
+            }]);
+        Assert.Equal(".github/workflows/content-ci.yml", overridden.Path);
+        Assert.Equal(GitHubWebhookProcessor.ContentWorkflowSource.Configured, overridden.Source);
+    }
+
     // ── the composition is the processor's, not this file's ──────────────────
 
     /// <summary>
@@ -282,6 +373,13 @@ public class GreenBuildPublishSignalTest
         // The conclusion gate is the fourth leg of the same decision and is asserted end-to-end by the
         // mesh suite; pinned here too because losing it would publish RED builds, silently.
         Assert.Contains("\"success\"", body, StringComparison.Ordinal);
+        // 🚨 …and the refusal must still REPORT. A fail-closed gate whose refusal is invisible is
+        // the MeshWeaver.Plugins#1194 shape, and dropping this call would leave every assertion in
+        // this file green while a synced repository froze silently (#3978, design question 2).
+        Assert.Contains("ReportRefusedWorkflow(", body, StringComparison.Ordinal);
+        // The record must carry the path it was ADMITTED on: that is what lets a later refusal tell
+        // "never seen this repository's content CI" from "some other workflow finished green".
+        Assert.Contains("WorkflowPath = workflowPath", body, StringComparison.Ordinal);
     }
 
     /// <summary>The braces-balanced body of the method whose signature line is given.</summary>

--- a/test/MeshWeaver.Hosting.Test/AFrozenContentCiIsReportedTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AFrozenContentCiIsReportedTest.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>The publish gate's one failure mode is a SILENT freeze, and this is the control that it is
+/// not silent.</b>
+///
+/// <para>#3978 made the repository's own content CI the publish signal — a green run of any other
+/// workflow no longer records a build or authorises an import. That is correct, and it has exactly
+/// one way to go wrong: the platform expects a workflow path the repository does not use. Then every
+/// delivery is refused, GitHub is answered 200, every Space that syncs the repository silently stops
+/// advancing, and nothing anywhere reports it. That is MeshWeaver.Plugins#1194 verbatim — 38 hours
+/// behind a merged main, every delivery 200 OK — and the whole reason design question 2 of #3978
+/// says a fail-closed gate MUST carry a positive signal.</para>
+///
+/// <para><b>Both directions, because a signal that always fires is noise and noise is how a real
+/// line gets missed.</b> Core refuses roughly 200 green runs a day and the <c>*/10</c> PR-updater
+/// cron alone is 144 a day in three satellites; a Warning on each would bury the one that matters.
+/// So the assertions are paired: a repository whose content CI has NEVER been accepted gets the
+/// Warning, and the same repository — same refused workflow, same payload shape — gets NO Warning
+/// once its content CI has published, which is what proves the report discriminates rather than
+/// fires unconditionally.</para>
+/// </summary>
+public class AFrozenContentCiIsReportedTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string SyncedRepo = "test/frozen-content-ci";
+    private const string SyncedRepoUrl = $"https://github.com/{SyncedRepo}";
+    private const string ForeignRepo = "test/nobody-syncs-this";
+
+    /// <summary>The path the platform presumes for a repository nothing declares.</summary>
+    private const string ContentCi = ".github/workflows/ci.yml";
+
+    /// <summary>The live #3978 shape: a cron that checks out nothing and builds nothing.</summary>
+    private const string PrUpdater = ".github/workflows/auto-update-green-prs.yml";
+
+    private readonly ConcurrentQueue<(string Category, LogLevel Level, string Message)> logs = new();
+
+    private static string UserId => TestUsers.Admin.ObjectId!;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGitHubSyncTypes()
+            .ConfigureServices(services =>
+            {
+                services.AddGitHubSyncServices();
+                services.AddLogging(logging =>
+                    logging.Services.AddSingleton<ILoggerProvider>(new QueueLoggerProvider(logs)));
+                return services;
+            });
+
+    private GitHubSyncService Sync => Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
+
+    private GitHubWebhookProcessor Webhooks =>
+        Mesh.ServiceProvider.GetRequiredService<GitHubWebhookProcessor>();
+
+    // 120_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant, and
+    // the inner waits carry the adaptive bound. This outer one only has to stop a WEDGE.
+    [Fact(Timeout = 120_000)]
+    public async Task ARefusedWorkflow_IsReportedWhenItFreezesASyncedSpace_AndNotOtherwise()
+    {
+        var space = "Frozen" + Guid.NewGuid().ToString("N")[..8];
+        await NodeFactory.CreateNode(new MeshNode(space)
+        {
+            NodeType = "Space",
+            Name = "Frozen content CI",
+            State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Timeout(TestTimeouts.Convergence).Await();
+
+        await Sync.SaveConfig(space, SyncedRepoUrl, "main", null,
+                createBranchIfMissing: false, createRepoIfMissing: false)
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        // ── 1. The repository NOTHING syncs: refusing its green run withheld nothing ──────────
+        //
+        // Asserted FIRST and from the same code path, because it is what makes the Warning below a
+        // discriminator instead of a constant. Without it, a report that fired on every refusal
+        // would pass this test's positive arm just as well.
+        (await Deliver(ForeignRepo, PrUpdater, "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111"))
+            .Should().Be(0, "a refused workflow never records, whoever the repository is");
+        Warnings().Should().NotContain(
+            line => line.Contains(ForeignRepo, StringComparison.Ordinal),
+            "no sync config targets this repository, so the refusal froze nothing and a Warning "
+            + "here would be pure noise — hundreds a day, which is how the one that matters is lost");
+
+        // ── 2. A SYNCED repository whose content CI has never been accepted: the Warning ──────
+        (await Deliver(SyncedRepo, PrUpdater, "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222"))
+            .Should().Be(0, "the PR updater checks out nothing and builds nothing (#3978)");
+
+        var frozen = Warnings()
+            .Where(line => line.Contains(SyncedRepo, StringComparison.Ordinal))
+            .ToList();
+        frozen.Should().ContainSingle(
+            "a green default-branch run refused for a SYNCED repository whose content CI has never "
+            + "been accepted is the silent-freeze shape, and it must not be silent");
+
+        var reported = frozen[0];
+        reported.Should().Contain("COULD NOT DETERMINE THIS REPOSITORY'S CONTENT CI",
+            "'I could not determine this repository's content CI' and 'its content CI was green' are "
+            + "different answers, and collapsing them is the defect #3978 fixed one level up");
+        reported.Should().Contain(ContentCi,
+            "the line must name the path that IS expected, or the reader cannot act on it");
+        reported.Should().Contain(PrUpdater,
+            "…and the path that actually arrived, which is the other half of the comparison");
+        reported.Should().Contain(space,
+            "naming the frozen Space is what turns a log line into an outage report");
+        reported.Should().Contain("FROZEN",
+            "the consequence, not just the decision: every delivery is answered 200 and nothing "
+            + "else will report this (MeshWeaver.Plugins#1194)");
+        reported.Should().Contain(GitHubContentWorkflowOptions.ConfigSection,
+            "a report that does not say how to fix it leaves the reader where #1194 left them");
+        Output.WriteLine(reported);
+
+        // ── 3. Once the content CI HAS published, the same refusal is routine ─────────────────
+        //
+        // The record is seeded rather than produced by a real delivery: this file is about the
+        // REPORT, and driving an import here would pull the git transport in for nothing. That the
+        // real gate still publishes — under push, repository_dispatch AND schedule — is the subject
+        // of BuildTriggeredSyncPinsTheBuiltCommitTest.
+        var recordPath = BuildCompletion.PathFor("test", "frozen-content-ci");
+        var slash = recordPath.LastIndexOf('/');
+        await NodeFactory.CreateNode(new MeshNode(recordPath[(slash + 1)..], recordPath[..slash])
+        {
+            NodeType = BuildCompletion.NodeType,
+            Name = $"{SyncedRepo} build",
+            State = MeshNodeState.Active,
+            Content = new BuildCompletion
+            {
+                RepositoryUrl = SyncedRepoUrl,
+                Branch = "main",
+                HeadSha = "cccc3333cccc3333cccc3333cccc3333cccc3333",
+                WorkflowName = "Content CI",
+                WorkflowPath = ContentCi,
+                Conclusion = "success",
+            },
+        }).Timeout(TestTimeouts.Convergence).Await();
+
+        (await Deliver(SyncedRepo, PrUpdater, "dddd4444dddd4444dddd4444dddd4444dddd4444"))
+            .Should().Be(0, "still not a publish signal — nothing about the gate changed");
+
+        Warnings()
+            .Where(line => line.Contains(SyncedRepo, StringComparison.Ordinal))
+            .Should().ContainSingle(
+                "the content CI has now published AT THE EXPECTED PATH, so this refusal is some "
+                + "other workflow finishing green — a second report here would be the noise that "
+                + "buries the one in arm 2; the single line is still arm 2's");
+    }
+
+    /// <summary>
+    /// Delivers one green, completed, default-branch <c>workflow_run</c> and returns how many sync
+    /// sources it triggered. The webhook request is ANONYMOUS — its authorization is the verified
+    /// HMAC signature — so every ambient identity is dropped first and the processor's own System
+    /// impersonation is what carries the reads and the write, exactly as on an access-gated portal.
+    /// </summary>
+    private async Task<int> Deliver(string repoFullName, string workflowPath, string headSha)
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.ClearHostIdentity();
+        accessService.SetHostIdentity(null);
+        accessService.SetContext(null);
+        try
+        {
+            return await Webhooks
+                .Process("workflow_run", Payload(repoFullName, workflowPath, headSha))
+                .Timeout(TestTimeouts.Convergence).Await();
+        }
+        finally
+        {
+            accessService.SetHostIdentity(
+                new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
+        }
+    }
+
+    private static JsonElement Payload(string repoFullName, string workflowPath, string headSha)
+        => JsonDocument.Parse($$"""
+        {
+          "action": "completed",
+          "repository": { "full_name": "{{repoFullName}}", "default_branch": "main" },
+          "workflow_run": {
+            "conclusion": "success", "head_branch": "main", "head_sha": "{{headSha}}",
+            "id": 34061098155, "run_number": 2026, "name": "Some Workflow", "event": "schedule",
+            "path": "{{workflowPath}}",
+            "updated_at": "2026-09-11T06:00:00Z"
+          }
+        }
+        """).RootElement;
+
+    /// <summary>Every Warning the webhook processor has emitted so far.</summary>
+    private System.Collections.Generic.List<string> Warnings() => logs
+        .Where(r => r.Level >= LogLevel.Warning
+                    && r.Category.Contains(nameof(GitHubWebhookProcessor), StringComparison.Ordinal))
+        .Select(r => r.Message)
+        .ToList();
+
+    /// <summary>Captures every record, with its category, into the owning test's instance queue.</summary>
+    private sealed class QueueLoggerProvider(
+        ConcurrentQueue<(string Category, LogLevel Level, string Message)> sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new QueueLogger(categoryName, sink);
+
+        public void Dispose() { }
+
+        private sealed class QueueLogger(
+            string category,
+            ConcurrentQueue<(string Category, LogLevel Level, string Message)> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => sink.Enqueue((category, logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/BuildTriggeredSyncPinsTheBuiltCommitTest.cs
+++ b/test/MeshWeaver.Hosting.Test/BuildTriggeredSyncPinsTheBuiltCommitTest.cs
@@ -195,15 +195,123 @@ public class BuildTriggeredSyncPinsTheBuiltCommitTest(ITestOutputHelper output)
         await noFetch;
     }
 
+    /// <summary>
+    /// 🚨 <b>The POSITIVE control for #3978, and it needs all THREE trigger kinds to be one.</b>
+    ///
+    /// <para>Keying the publish signal on the repository's content CI is only safe while every way
+    /// that CI can START still publishes. Narrowing the admitted triggers is the mistake this fleet
+    /// has ALREADY made, in the opposite direction: on 2026-09-02 the test was <c>event == "push"</c>
+    /// alone, <c>MeshWeaver.Reinsurance</c>'s three green <c>repository_dispatch</c> runs at
+    /// <c>636ebd5</c> were all discarded, and <c>Underwriting/_GitSync</c> sat <b>38 hours</b> behind
+    /// a merged main with every delivery answering 200 OK and nothing reporting a fault
+    /// (MeshWeaver.Plugins#1194). A content-CI run reaches this webhook as <c>push</c> when the
+    /// branch moves, as <c>repository_dispatch</c> when a platform release re-verifies the satellite
+    /// with no commit to push, and as <c>schedule</c> on its own cron — so all three are asserted,
+    /// separately, at their own shas.</para>
+    ///
+    /// <para><b>And it carries its own negative control, in the same mesh.</b> The fourth delivery
+    /// is a green <c>schedule</c> run of the PR-updater — the live #3978 shape — which must record
+    /// nothing and fetch nothing. An absence assertion goes vacuous the moment the setup around it
+    /// stops working, so the three deliveries that DID import are what stop
+    /// <c>NotEmit</c> from passing on a mesh where no import could have happened at all.</para>
+    /// </summary>
+    // 120_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a
+    // constant, and the inner waits below already carry the adaptive bound.
+    [Fact(Timeout = 120_000)]
+    public async Task AGreenContentCiRun_Publishes_UnderEveryAdmittedTriggerKind()
+    {
+        var space = "GbTrig" + Guid.NewGuid().ToString("N")[..8];
+        await NodeFactory.CreateNode(new MeshNode(space)
+        {
+            NodeType = "Space",
+            Name = "Every admitted trigger",
+            State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Timeout(TestTimeouts.Convergence).Await();
+
+        var configNode = await Sync
+            .SaveConfig(space, RepoUrl, "main", null,
+                createBranchIfMissing: false, createRepoIfMissing: false)
+            .Timeout(TestTimeouts.Convergence).Await();
+        var syncOwner = configNode.CreatedBy is { Length: > 0 } creator ? creator : UserId;
+        await Credentials
+            .Save(syncOwner, new GitHubToken("ghp_test_token", null, "bearer", "repo", null), "octocat")
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        // One distinct sha per trigger kind, so no delivery can be satisfied by another's import and
+        // #3945's "already attempted these exact bytes" skip cannot mask a dropped signal.
+        var shas = new (string Trigger, string Sha, string Why)[]
+        {
+            ("push", "1111111111111111111111111111111111111111",
+                "the branch moved and its content CI ran — the original case"),
+            ("repository_dispatch", "2222222222222222222222222222222222222222",
+                "a platform release re-verifies the satellite with no commit to push — the exact "
+                + "signal MeshWeaver.Plugins#1194 discarded for 38 hours"),
+            ("schedule", "3333333333333333333333333333333333333333",
+                "the content CI's own cron run, which only ever exists on the default branch"),
+        };
+
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        foreach (var (trigger, sha, why) in shas)
+        {
+            // Arm the observation BEFORE the delivery: the fetch happens on a background activity.
+            var fetched = repoClient.FetchedRefs.Where(r => r == sha)
+                .Should().Within(TestTimeouts.Convergence * 2)
+                .Emit($"a green content-CI run started by '{trigger}' is a publish signal — {why}");
+
+            // The webhook request is ANONYMOUS; drop every ambient identity so the processor's own
+            // System impersonation is what carries the lookups and the write.
+            accessService.ClearHostIdentity();
+            accessService.SetHostIdentity(null);
+            accessService.SetContext(null);
+            int triggered;
+            try
+            {
+                triggered = await Webhooks
+                    .Process("workflow_run", GreenBuildPayload(sha, trigger: trigger))
+                    .Timeout(TestTimeouts.Convergence).Await();
+            }
+            finally
+            {
+                accessService.SetHostIdentity(
+                    new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
+            }
+
+            triggered.Should().Be(1,
+                $"the one sync source of this repository must be selected by a green content-CI run "
+                + $"started by '{trigger}' — {why}");
+            (await fetched).Should().Be(sha,
+                $"the '{trigger}' delivery must import the tree ITS run proved");
+            Output.WriteLine($"{trigger} @ {sha[..8]} → triggered={triggered}, fetched={sha[..8]}");
+        }
+
+        // ── the negative half, on a mesh the three deliveries above have proven can import ──
+        const string UpdaterSha = "4444444444444444444444444444444444444444";
+        var neverFetched = repoClient.FetchedRefs.Where(r => r == UpdaterSha)
+            .Should().NotEmit(within: TestTimeouts.Quick);
+
+        var refused = await Webhooks
+            .Process("workflow_run", GreenBuildPayload(
+                UpdaterSha, ".github/workflows/auto-update-green-prs.yml", trigger: "schedule"))
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        refused.Should().Be(0,
+            "a green scheduled PR updater checks out nothing and builds nothing; the SAME trigger "
+            + "that just published a real content-CI run must not publish this one — the trigger "
+            + "says how a workflow started, never what it proved (#3978)");
+        await neverFetched;
+    }
+
     private static JsonElement GreenBuildPayload(
         string headSha,
-        string workflowPath = ".github/workflows/ci.yml") => JsonDocument.Parse($$"""
+        string workflowPath = ".github/workflows/ci.yml",
+        string trigger = "push") => JsonDocument.Parse($$"""
         {
           "action": "completed",
           "repository": { "full_name": "{{RepoFullName}}", "default_branch": "main" },
           "workflow_run": {
             "conclusion": "success", "head_branch": "main", "head_sha": "{{headSha}}",
-            "id": 34061098155, "run_number": 2026, "name": "Content CI", "event": "push",
+            "id": 34061098155, "run_number": 2026, "name": "Content CI", "event": "{{trigger}}",
             "path": "{{workflowPath}}",
             "updated_at": "2026-09-06T22:38:18Z"
           }


### PR DESCRIPTION
Fixes #3978 (the half #3981 left open).

#3981 built the discriminator: a `workflow_run` must be the repository's own content CI, keyed on
the stable workflow path. Correct. But it also introduced the single failure mode design question 2
of #3978 called "the whole risk" — a repository whose content CI is not where the platform looks
stops syncing **silently**, and #3981 reports that at `LogDebug`, which production does not emit.
That is MeshWeaver.Plugins#1194 verbatim: every delivery 200 OK, nothing arrives, nothing to grep.

## Re-measured premise, with the denominator

**Nine** repositories hold an `Admin/_Build/{owner}.{repo}` record — the same nine on
memex.meshweaver.cloud and memex.systemorph.com, both listings `truncated:false`. The ninth,
`Systemorph/education`, is a stale pre-rename alias (last written 2026-08-14).

| repository | content CI | convention holds? | `push` | `repository_dispatch` | `schedule` |
|---|---|:--:|:--:|:--:|:--:|
| MeshWeaver.Plugins · .Education · .Reinsurance · .SocialMedia · .Manufacturing · .Crm | `ci.yml` | ✅ | ✅ | ✅ | ✅ |
| Systemorph/MeshWeaver | `dotnet-test.yml` | ✅ (declared) | ✅ | ✗ | ✗ |
| **Systemorph/Memex** | **`build.yml`** | ❌ **no `ci.yml` exists** | ✅ | ✗ | ✗ |

Two corrections to the issue's stated premise:

1. 🚨 **`Systemorph/Memex` has no `.github/workflows/ci.yml`** (its six workflows are `build.yml`,
   `config-key-coverage.yml`, `deploy-drift.yml`, `helm-release.yml`, `image-pins.yml`,
   `smoke.yml`), and **two portals sync its `mesh/Deployments` tree** — `Deployments/_GitSync` at
   version 96 (memex-cloud) and 156 (systemorph), both written 2026-09-11T03:39:49Z. On the
   convention alone it freezes on both the moment #3981's image deploys.
2. **Only six of eight fire on all three triggers.** Core and Memex publish on `push` alone. That
   changes nothing about keying on the path — the guards are orthogonal — but it means the
   allow-list carries `repository_dispatch`/`schedule` *for the six satellites specifically*, which
   is the population #1194 was measured on.

## Answers to the four design questions

**1. Where does the declaration live?** With the REPOSITORY, never a sync config — 34 sources point
at MeshWeaver.Plugins alone and they must not be able to disagree about what proved it.
`ContentWorkflowFor` resolves, in order: a deployment override (`GitHub:ContentWorkflows:Repositories`),
the **platform's own table** (`Systemorph/MeshWeaver` → `dotnet-test.yml`, `Systemorph/Memex` →
`build.yml`), then the `ci.yml` convention. #3981 chose convention + override; the platform tier is
the addition, because a configuration override would have fixed Memex only on portals whose settings
somebody edited, while a declaration ships with the platform.

**2. Absent or wrong — THE WHOLE RISK.** Fail-closed is kept, and it now carries a positive signal
conditioned so it cannot become noise:

| the run's path | the repository | reported at |
|---|---|---|
| absent from the payload | any | **Warning** (already in #3981) |
| not the expected path | nothing syncs it | Debug — no Space can be frozen |
| not the expected path | synced, a run at the expected path **has** been accepted | Debug — routine |
| not the expected path | synced, **no** run at the expected path ever accepted | **Warning** |

The Warning reads `I COULD NOT DETERMINE THIS REPOSITORY'S CONTENT CI`, and names the workflow that
arrived, the one expected and its source, the count and names of the FROZEN Spaces, that GitHub is
answered 200 so nothing else will report it, and `GitHub:ContentWorkflows:Repositories` as the fix.
It **self-clears** on the repository's next genuine content-CI run. The conditioning is load-bearing:
core refuses ~200 green runs a day and the `*/10` PR-updater cron is 144 a day in three satellites —
burying the one line that matters is the same failure as not emitting it. Precedent:
`ConfigsTargeting`'s zero-match Warning, and the matcher used here is deliberately the cheap
stored-url one so that Warning does not fire on every refusal of a repository nothing syncs.

**3. Does the build record change shape?** Yes, minimally. `WorkflowName` is a **mutable display
string**, and measured 2026-09-11 no consumer ever keyed on it despite its doc claiming one might —
its two readers are a `PluginUpdateWatcher` log line and `MissedBuildFact`'s identity comparison.
`BuildCompletion` gains `WorkflowPath`: the identity the run was ADMITTED on. That is what makes
"this repository's content CI has never been seen" answerable exactly, instead of by a staleness
threshold. Pre-#3978 records carry `null`; the next content-CI run fills it in.

**4. Does the trigger allow-list survive?** Yes, unchanged and unnarrowed. It answers HOW a run
started; the path answers WHAT it proved; the branch answers WHICH tree. None subsumes another, and
narrowing the trigger set is what caused #1194. The measurement above is why: strip `schedule` or
`repository_dispatch` and the six satellites lose their cron and release-follow signals.

## Controls, both directions

**(a) Negative** — `AFrozenContentCiIsReportedTest.ARefusedWorkflow_IsReportedWhenItFreezesASyncedSpace_AndNotOtherwise`
and `BuildTriggeredSyncPinsTheBuiltCommitTest.GreenUnrelatedWorkflow_DoesNotRecordOrTriggerAnImport`:

> `"a workflow's trigger says how it started, not that it compiled this repository's content"`
> `"no sync config targets this repository, so the refusal froze nothing and a Warning here would be pure noise — hundreds a day, which is how the one that matters is lost"`

**(b) POSITIVE, all three trigger kinds** — `AGreenContentCiRun_Publishes_UnderEveryAdmittedTriggerKind`
delivers a green `ci.yml` run as `push`, as `repository_dispatch` and as `schedule`, each at its own
sha, and each must record AND import at that sha:

> `"the one sync source of this repository must be selected by a green content-CI run started by '{trigger}' — {why}"`
> `"a green content-CI run started by '{trigger}' is a publish signal — a platform release re-verifies the satellite with no commit to push — the exact signal MeshWeaver.Plugins#1194 discarded for 38 hours"`
> `"the '{trigger}' delivery must import the tree ITS run proved"`

**Neither absence assertion can go vacuous.** The PR-updater refusal runs in the SAME mesh, after the
three deliveries that did import, under the SAME `schedule` trigger that just published:

> `"a green scheduled PR updater checks out nothing and builds nothing; the SAME trigger that just published a real content-CI run must not publish this one — the trigger says how a workflow started, never what it proved (#3978)"`

And the "nothing syncs it ⇒ no Warning" arm is paired with the "synced ⇒ Warning" arm in one test
through one code path, so a report that fired unconditionally would fail the first and a report that
never fired would fail the second.

`ProcessWorkflowRunStillRunsAllThreeGuards` now also pins `ReportRefusedWorkflow(` and
`WorkflowPath = workflowPath`, so dropping either leaves a red rather than a silent freeze.

## Not done, on purpose

**No satellite repository's CI is touched.** The only repository that needed a declaration is
`Systemorph/Memex`, and it gets one in the platform rather than by renaming its workflow. Stated
residual (also in the doc): a repository that has already published and *then* moves its content CI
keeps a matching record, so this Warning stays quiet — covered for the six satellites by the shared
lane's `check-content-ci-path.py` and for core by `CoreContentCiRemainsAtThePublishSignalPath`, and
covered for Memex by the platform declaration precisely because it calls neither.

## Documentation

`Doc/Architecture/SyncRefContract` is EXTENDED (no new page): the declaration table and why the fact
belongs to the repository, the measured premise with its denominator, the four-row refusal
classification with its self-clearing property and its residual, and why the record gained
`WorkflowPath`.

## Evidence

- `dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.GitSync` (46 s),
  `MeshWeaver.Graph`, `MeshWeaver.PluginCatalog`, `MeshWeaver.Documentation`,
  `MeshWeaver.Documentation.Test`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Graph.Test` — every one
  `0 Warning(s)` / `0 Error(s)`.
- `MeshWeaver.Hosting.Test` **610/610** (1 m 13 s) · `MeshWeaver.Documentation.Test` **393/393**
  (16 s) · `MeshWeaver.Graph.Test` **1533/1533** (3 m 31 s).

Pairs-with: none — nothing public is removed; `BuildCompletion.WorkflowPath` is an addition and
`ExpectedContentWorkflowPath` keeps its signature.

Mirror-sync: none — no `strings.{en,de}.json` key is added or re-worded; the new text is an operator
log line, which this codebase does not localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
