### PR TITLE
fix(#4003, #4013): only a PUBLISH supersedes a generation, and the script memo refuses per-generation files

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -216,8 +216,52 @@ internal interface ICompilationCacheService
     /// Gets or creates an AssemblyLoadContext keyed by the exact DLL path.
     /// Used for release-per-compile: each unique compiled DLL lives in its own
     /// ALC so V1 and V2 assemblies coexist without overwriting each other.
+    ///
+    /// <para>🚨 <b>A READ. It never supersedes another generation</b> — see
+    /// <see cref="PublishLoadContextForPath"/> for why that distinction is load-bearing (#4013).
+    /// Resolving an assembly PATH is what a hub activation, a cell-surface session and an
+    /// assembly-hydration scan all do, and none of them is evidence about which build is
+    /// current.</para>
     /// </summary>
     NodeAssemblyLoadContext GetOrCreateLoadContextForPath(string nodeName, string dllPath);
+
+    /// <summary>
+    /// <see cref="GetOrCreateLoadContextForPath"/> for the ONE caller that is publishing a build:
+    /// the post-emit scan of a compile that just produced <paramref name="dllPath"/>. As well as
+    /// resolving the context it EVICTS every other context for this NodeType, which is what bounds
+    /// <c>_loadContexts</c> to the current generation instead of one entry per recompile — the
+    /// native-memory accumulation described on <c>EvictSupersededContexts</c>.
+    ///
+    /// <para>🚨 <b>Why only here (#4013).</b> The eviction used to ride on <i>every</i> newly
+    /// created path-keyed context, taking "somebody asked for a path I had not seen" as proof that
+    /// that path is the current build. For a reader it is not: a hydration scan of a package's
+    /// SHIPPED assembly, or a kernel session resolving a cell-surface pack, would then supersede
+    /// the generation a concurrent rebuild had just published. Worse, the recovery loop in
+    /// <see cref="CompilationCacheService.PinForScan(string,string?,bool)"/> re-resolves on a
+    /// refused pin — so two scans of two generations of ONE NodeType each destroyed the context
+    /// the other had just resolved, ping-ponging until the 3-attempt cap turned it into an
+    /// <see cref="ObjectDisposedException"/> that <c>CompileResultFromAssembly</c> records as a
+    /// compile error and the watcher PARKS. That is the merge-queue dequeue reported in #4013
+    /// (<c>PluginGateRunnerTest.SelfTypedRootWithStaleCompileStamp</c>: the rebuild publishes while
+    /// the shipped stale stamp is being read — exactly two generations, exactly two scans).
+    /// Reads no longer re-order generations; a publish still does, so it fires where a new
+    /// generation is actually born.</para>
+    ///
+    /// <para>🚨 <b>What the narrowed trigger costs, stated rather than claimed away.</b> The
+    /// UNBOUNDED key space — one never-reused <c>{nodeName}_{ticks}_{guid}/</c> directory per emit
+    /// (<c>EmitToDiskWithRetry</c>) — is still evicted, because every emit publishes. What is no
+    /// longer evicted at the moment it appears is a generation this process only HYDRATED: an
+    /// <c>IAssemblyStore</c> path is keyed <c>v{version}-{frameworkTag}-{hash}.dll</c>
+    /// (first-write-wins per version), so a silo that reads a version another silo compiled now
+    /// keeps the previous version's context until the NodeType hub disposes
+    /// (<see cref="UnloadNodeContexts"/>, which <c>Modules:AutoRecycleOnStaleBuild</c> drives on a
+    /// stale build). That residue is bounded by the number of VERSIONS a hub outlives, not by
+    /// recompiles, and it is the deliberate price of the correctness clause: a read that
+    /// superseded would re-create the CURRENT generation's context under its own path, putting two
+    /// live ALCs behind one file — the two-generations split #3911 describes, manufactured by the
+    /// reclaim itself.</para>
+    /// </summary>
+    NodeAssemblyLoadContext PublishLoadContextForPath(string nodeName, string dllPath);
 
     /// <summary>
     /// Resolves a LIVE context for a scan and returns it already pinned — the atomic form of
@@ -234,12 +278,20 @@ internal interface ICompilationCacheService
     /// good, because a hub resolves its configuration exactly once, at activation).</para>
     /// <para>Only this service can close that window: it owns the dictionary, so it is the only
     /// component that can re-resolve. The loop terminates because the evictor removes the key
-    /// BEFORE disposing, so the next resolve constructs a fresh context.</para>
+    /// BEFORE disposing, so the next resolve constructs a fresh context — and, since #4013,
+    /// because neither the retry nor any reader EVICTS while doing so. The old loop could not
+    /// terminate under two concurrent scans of two generations: each re-resolve created a context
+    /// that evicted the peer's, so both kept being refused until the attempt cap rethrew. See
+    /// <see cref="PublishLoadContextForPath"/>.</para>
     /// </summary>
-    PinnedScanContext PinForScan(string nodeName, string? dllPath);
+    /// <param name="publishesTheBuild">True for the ONE caller that just emitted
+    /// <paramref name="dllPath"/> (the post-emit scan) — its first resolve supersedes the older
+    /// generations of this NodeType. Every other scan is a READ and leaves the set alone; a RETRY
+    /// never supersedes, whoever asked.</param>
+    PinnedScanContext PinForScan(string nodeName, string? dllPath, bool publishesTheBuild = false);
 
     /// <summary>
-    /// <see cref="PinForScan(string, string?)"/> for a release-keyed context.
+    /// <see cref="PinForScan(string, string?, bool)"/> for a release-keyed context.
     /// </summary>
     PinnedScanContext PinForScanOfRelease(NodeTypeRelease release, string releaseFolder);
 
@@ -1174,6 +1226,14 @@ internal class CompilationCacheService(
 
     /// <inheritdoc />
     public NodeAssemblyLoadContext GetOrCreateLoadContextForPath(string nodeName, string dllPath)
+        => ResolveLoadContextForPath(nodeName, dllPath, supersedeOlderBuilds: false);
+
+    /// <inheritdoc />
+    public NodeAssemblyLoadContext PublishLoadContextForPath(string nodeName, string dllPath)
+        => ResolveLoadContextForPath(nodeName, dllPath, supersedeOlderBuilds: true);
+
+    private NodeAssemblyLoadContext ResolveLoadContextForPath(
+        string nodeName, string dllPath, bool supersedeOlderBuilds)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -1188,17 +1248,28 @@ internal class CompilationCacheService(
             return c;
         });
 
-        // A genuinely NEW path-keyed context means a fresh compile/release just superseded any
-        // prior assembly for this NodeType. Each recompile writes to a unique
-        // {nodeName}_{timestamp}_{guid} directory (see EmitToDiskWithRetry), so the OLD entries —
-        // same NodeName, different key — are never reused. Left in place they pin their collectible
-        // NodeAssemblyLoadContext (and its native metadata/JIT images) for the ENTIRE life of the
-        // (long-lived) NodeType hub, unloaded only on hub teardown (UnloadNodeContexts). That
-        // per-recompile accumulation is the native-memory leak that drove memex to the server-GC
-        // hard limit (~21 GB at the 28 Gi cap) and its GC-thrash crashes. Evict them now — but only
-        // when WE added the current context (created), so a re-request of an already-cached path can
-        // never evict the live assembly. See EvictSupersededContexts for why this is safe mid-recompile.
-        if (created)
+        // A PUBLISHED build supersedes every prior assembly for this NodeType. Each recompile
+        // writes to a unique {nodeName}_{timestamp}_{guid} directory (see EmitToDiskWithRetry), so
+        // the OLD entries — same NodeName, different key — are never reused. Left in place they pin
+        // their collectible NodeAssemblyLoadContext (and its native metadata/JIT images) for the
+        // ENTIRE life of the (long-lived) NodeType hub, unloaded only on hub teardown
+        // (UnloadNodeContexts). That per-recompile accumulation is the native-memory leak that drove
+        // memex to the server-GC hard limit (~21 GB at the 28 Gi cap) and its GC-thrash crashes.
+        // Evict them now — but only when WE added the current context (created), so a re-request of
+        // an already-cached path can never evict the live assembly. See EvictSupersededContexts for
+        // why this is safe mid-recompile.
+        //
+        // 🚨 supersedeOlderBuilds is FALSE for every reader (#4013). "A path I had not seen yet" is
+        // not evidence that the path is the current build — a hydration scan of a package's shipped
+        // assembly and a kernel session resolving a cell-surface pack both create one, and letting
+        // either supersede the generation a concurrent rebuild had just published is what let two
+        // scans of one NodeType destroy each other's contexts until PinForScan's attempt cap
+        // rethrew. The UNBOUNDED half of the key space is unaffected — every emit publishes, and
+        // the per-emit {nodeName}_{ticks}_{guid} directory is the set that grows without bound. A
+        // generation this process merely HYDRATED from the assembly store is now reclaimed on hub
+        // disposal instead of on the next reader's resolve; see PublishLoadContextForPath for why
+        // that trade is the right way round.
+        if (created && supersedeOlderBuilds)
             EvictSupersededContexts(nodeName, keepKey: dllPath);
 
         return ctx;
@@ -1212,30 +1283,35 @@ internal class CompilationCacheService(
     private const int ScanPinReResolveAttempts = 3;
 
     /// <inheritdoc />
-    public PinnedScanContext PinForScan(string nodeName, string? dllPath)
+    public PinnedScanContext PinForScan(string nodeName, string? dllPath, bool publishesTheBuild = false)
         => PinResolved(
             cacheKey: string.IsNullOrEmpty(dllPath) ? nodeName : dllPath!,
-            resolve: () => string.IsNullOrEmpty(dllPath)
+            // 🚨 `attempt` is the parameter, not a captured flag: ONLY the first resolve of a
+            // PUBLISHING scan may supersede. A retry is a recovery, and a recovery that destroys
+            // its peers' freshly created contexts is what turned a one-shot supersession into the
+            // ping-pong of #4013.
+            resolve: attempt => string.IsNullOrEmpty(dllPath)
                 ? GetOrCreateLoadContext(nodeName)
-                : GetOrCreateLoadContextForPath(nodeName, dllPath!));
+                : ResolveLoadContextForPath(
+                    nodeName, dllPath!, supersedeOlderBuilds: publishesTheBuild && attempt == 1));
 
     /// <inheritdoc />
     public PinnedScanContext PinForScanOfRelease(NodeTypeRelease release, string releaseFolder)
         => PinResolved(
             // Same key GetOrCreateLoadContextForRelease adds under.
             cacheKey: release.Path,
-            resolve: () => GetOrCreateLoadContextForRelease(release, releaseFolder));
+            resolve: _ => GetOrCreateLoadContextForRelease(release, releaseFolder));
 
     /// <summary>
     /// Resolve → Pin as ONE operation, re-resolving when the context we resolved is already
     /// unloading. See <see cref="ICompilationCacheService.PinForScan"/> for why two steps is a
     /// race and why losing it is not survivable downstream.
     /// </summary>
-    private PinnedScanContext PinResolved(string cacheKey, Func<NodeAssemblyLoadContext> resolve)
+    private PinnedScanContext PinResolved(string cacheKey, Func<int, NodeAssemblyLoadContext> resolve)
     {
         for (var attempt = 1; ; attempt++)
         {
-            var context = resolve();
+            var context = resolve(attempt);
             try
             {
                 return new PinnedScanContext(context, context.Pin());
@@ -1271,8 +1347,9 @@ internal class CompilationCacheService(
     /// context's <c>Unloading</c> handler (<c>ReflectionCacheEviction.EvictFor</c>) purges Autofac's
     /// shared reflection cache so the freed context is neither rooted nor left as a dangling key.
     /// Mirrors the match in <see cref="UnloadNodeContexts"/>/<see cref="InvalidateCache"/> (both key
-    /// on <see cref="NodeAssemblyLoadContext.NodeName"/>), just triggered per recompile rather than
-    /// only on hub teardown.
+    /// on <see cref="NodeAssemblyLoadContext.NodeName"/>), just triggered per PUBLISHED build
+    /// rather than only on hub teardown — see <see cref="PublishLoadContextForPath"/> for why the
+    /// trigger is a publish and not merely "a path-keyed context was created" (#4013).
     /// </remarks>
     private void EvictSupersededContexts(string nodeName, string keepKey)
     {

--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeCompilationService.cs
@@ -1261,7 +1261,10 @@ internal class MeshNodeCompilationService(
                 .SelectMany(snapshot => BoundLeg(
                     _ => OnThreadPool(() =>
                         CompileResultFromAssembly(
-                            node, assemblyLocation, log, snapshot, attempt.InputDigest)),
+                            node, assemblyLocation, log, snapshot, attempt.InputDigest,
+                            // This IS the publish: the emit that produced assemblyLocation just
+                            // finished, so its context supersedes the older generations (#4013).
+                            publishesTheBuild: true)),
                     _cacheOptions.AssemblyLoadTimeout, "assembly-load", node.Path))
                 // Re-Finish the log after CompileResultFromAssembly. CompileCore already
                 // finished it, but CompileResultFromAssembly's downstream steps
@@ -1602,10 +1605,19 @@ internal class MeshNodeCompilationService(
     /// no <c>CompiledSources</c>, which is why stamping it would be catastrophic and nothing
     /// does). Null simply leaves the record without a content key; the toolchain entry still
     /// governs.</para></param>
+    /// <param name="publishesTheBuild">🚨 True on the POST-EMIT path only — the compile that just
+    /// produced <paramref name="assemblyLocation"/>, i.e. the one moment a new generation of this
+    /// NodeType exists and the older ones are genuinely superseded. False on the
+    /// assembly-HYDRATION shortcut (<see cref="GetConfigurationsFromExistingAssembly"/>), which is
+    /// a READER of bytes an <c>IAssemblyStore</c> handed over. Reads must not re-order generations:
+    /// a hydration scan that superseded a concurrently published rebuild is half of the
+    /// ping-pong #4013 reports (the other half being the rebuild's own scan superseding the
+    /// hydration's). See <c>ICompilationCacheService.PublishLoadContextForPath</c>.</param>
     private NodeCompilationResult? CompileResultFromAssembly(
         MeshNode node, string assemblyLocation, ActivityLog log,
         ImmutableDictionary<string, long> compiledSources,
-        string? generatedInputDigest = null)
+        string? generatedInputDigest = null,
+        bool publishesTheBuild = false)
     {
 
             var nodeName = cacheService.SanitizeNodeName(node.Path);
@@ -1637,7 +1649,8 @@ internal class MeshNodeCompilationService(
                     nodeName,
                     assemblyLocation.StartsWith("memory://", StringComparison.Ordinal)
                         ? null
-                        : assemblyLocation);
+                        : assemblyLocation,
+                    publishesTheBuild);
                 var context = pinned.Context;
                 var assembly = context.LoadNodeAssembly();
                 if (assembly == null)

--- a/src/MeshWeaver.Documentation/Data/Architecture/NoStaticState.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NoStaticState.md
@@ -7,7 +7,7 @@ Description: "Why static collection and cache fields are forbidden in MeshWeaver
 
 > **The rule in one sentence:** any `static` field that holds a collection or cache is forbidden. Every cache and every repository must be an **instance owned by the mesh**, so its lifetime is bounded and it can never bleed across tests, users, or partitions.
 
-This is an absolute architectural invariant — equal in weight to "nothing async ever" and "`GetMeshNodeStream().Update()` is the only mutation API". It is checked by **`NoStaticCollectionsTest`** (`test/MeshWeaver.PathResolution.Test/NoStaticCollectionsTest.cs`), which reflects over the `MeshWeaver.*.dll` files and fails on any static mutable-collection field not recorded in its `Allowed` map, each entry carrying a one-word `CONST`/`MEMO`/`CACHE`/`PROC` reason. That map is the single source of truth for permitted static state; this document explains the categories and shows you what to do instead.
+This is an absolute architectural invariant — equal in weight to "nothing async ever" and "`GetMeshNodeStream().Update()` is the only mutation API". It is checked by **`NoStaticCollectionsTest`**, which reflects over the `MeshWeaver.*.dll` files and fails on any static mutable-collection field not recorded in its `Allowed` map, each entry carrying a one-word `CONST`/`MEMO`/`CACHE`/`PROC` reason. 🚨 **That test no longer lives in this repository** — it travelled to `MeshWeaver.Plugins` with the emigrated mesh suites (#2276), which keeps TWO copies of it (`src/MeshWeaver.PathResolution.Test/` and `src/Memex.Hosts.Test/`, each with its own `Allowed` map). So a core change that adds a static collection, or that invalidates an existing entry's stated reason, reddens in the PLUGINS repo and not here, and updating the allowlist is a change to that repo. That map is the single source of truth for permitted static state; this document explains the categories and shows you what to do instead.
 
 🚨 **The check is a test, not a compiler rule, and its reach is the test project's own output directory** — i.e. the transitive closure of `MeshWeaver.PathResolution.Test`'s project references, not all 76 `MeshWeaver.*` projects. A static cache added in an assembly that closure does not pull in **will not be caught**. Treat the rule as binding everywhere and the test as a backstop over part of the tree; if you add a static field in a peripheral project, the absence of a red test is not evidence you are allowed to.
 
@@ -156,6 +156,28 @@ Current MEMO caches:
 - `MarkdownExtensions.PipelineCache` — keyed by content
 - `DynamicTypeGenerator.TypeCache` — keyed by property schema
 - `DefaultImplementationOfInterfacesExtensions.NonVirtualInvocationThunks` — keyed by `MethodInfo`
+- `KernelScriptReferences.Materialized` — keyed by absolute assembly path (see the caveat below)
+
+> 🚨 **A MEMO's key space is a claim, and it has to be ENFORCED — `Materialized` is why (#4003).**
+> This entry was allowlisted on the words *"bounded by the set of assemblies on disk … it can pin
+> neither meshes nor collectible NodeType contexts"*. The second half was true of the OBJECT GRAPH
+> and stayed true: no `Type`, no `AssemblyLoadContext` is retained, which is exactly why nothing
+> here ever appeared as a pinned ALC. The first half was **false**, because the key space was not
+> bounded: every NodeType recompile emits into a brand-new `{nodeName}_{ticks}_{guid}/` directory
+> that is never reused, the kernel's cell-surface seam feeds those paths straight in, and
+> `MetadataReference.CreateFromFile` memory-maps the PE — so each recompile left one more native
+> metadata mapping alive for the life of the process, surviving both the ALC's `Unload()` and the
+> file's deletion.
+>
+> The lesson generalises to every entry on this list: **"pure by key" is only half the test; the
+> other half is whether the KEY SPACE is finite, and a memo that cannot answer that is a leak with
+> a reason attached.** `Materialized` now refuses admission to any file belonging to a collectible
+> load context — the reference is still produced, but unmemoized, so its lifetime is the kernel
+> session that asked (which already holds that generation's ALC lease). `IsMemoized(path)` exists
+> so a control test can assert the bound from outside instead of trusting the prose — per PATH, not
+> as an entry count, because the count moves with whatever else the shard has loaded. Full
+> derivation:
+> [NodeType Compilation](../NodeTypeCompilation) → "A THIRD root holds a generation".
 
 ### PROC — Process-global resource registrations
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -1820,6 +1820,137 @@ pods far above their siblings in BOTH memory and CPU in `kubectl top pods` is th
 `Hosting/InstanceAction` (the rolling restart grace-drains each pod and the Deployment replaces
 it), and read #2194.
 
+### 🚨 A THIRD root holds a generation, and neither eviction reaches it — the kernel's reference memo
+
+`CompilationCacheService` evicts superseded `NodeAssemblyLoadContext`s, and
+`Modules:AutoRecycleOnStaleBuild` converges the instances that root them. Both act on the ALC.
+Neither touches the **native metadata mapping** a Roslyn `PortableExecutableReference` owns — and
+`KernelScriptReferences.Materialized`, the process-global memo that makes ~350 script references
+cost one materialization instead of one per kernel session (#2480 / #2578), was keyed by absolute
+path with no eviction and no bound.
+
+For framework assemblies that is exactly right: their paths are stable, so the key space is the
+assembly set. For NodeType assemblies it is not a bound at all. `EmitPipeline.EmitToDiskWithRetry`
+publishes every recompile into a brand-new `{nodeName}_{ticks}_{guid}/` directory that is never
+reused, and the cell-surface seam (`KernelExecutor.EnsureCellSurfaceReferences`, #1649) feeds
+exactly those paths in through `GetOrCreateFromFile`. `MetadataReference.CreateFromFile`
+memory-maps the PE, and the entry survives **both** the ALC's `Unload()` **and** the file's
+deletion — so one recompile of a `cellSurface: true` NodeType that any session had referenced left
+one more mapping alive for the life of the process, in the same class of memory the eviction above
+exists to reclaim.
+
+The class doc's own NoStaticState compliance claim was half right and half wrong, and the half that
+was wrong is the one the allowlist rested on. *"Holds no `Type`s and no AssemblyLoadContexts — it
+can pin neither meshes nor collectible NodeType contexts"* is true of the **object graph**: no
+managed reference into the collectible context is retained, which is why nothing here ever showed
+up as a pinned ALC. *"Bounded by the set of assemblies on disk"* is true only if that set is
+bounded, and for per-recompile release directories it is not. **The fix makes the claim true rather
+than restating it**: a file that belongs to a COLLECTIBLE load context is materialized as an
+ordinary, UNMEMOIZED reference whose lifetime is the caller's — for the cell-surface seam that is
+the kernel SESSION, which already holds the generation's `CellSurfaceAssembly.Lease` and drops both
+when the session dies. The memo keeps exactly the sharing it was written for, over stable paths
+only, and `KernelScriptReferences.IsMemoized(path)` makes the bound assertable from a test — per
+PATH rather than as an entry count, because the count moves with whatever else the shard loaded.
+
+The same file carried a second generation-ambiguity: `TryResolveByIdentity` matched the live
+AppDomain on **simple name only**, without the `IsCollectible` filter its sibling at
+`MaterializeCurrentAssemblies` carries for a documented reason. Superseded generations linger in
+`GetAssemblies()` until they are collected, so which one a script compilation got was whichever the
+enumeration reached first — arbitrary, possibly stale, and indistinguishable from the current one
+at the call site (the `CS0433`-between-two-generations shape). It now declines collectible
+assemblies and answers `null`, which sends the caller to the sibling probe and then to Roslyn's own
+resolver. A cell-surface set a session legitimately sees is declared per session and added to its
+`ScriptOptions` explicitly, so it never needed this path.
+
+### 🚨 A READ must never re-order generations — only a PUBLISH supersedes
+
+`EvictSupersededContexts` is what bounds `_loadContexts` to the current generation per NodeType, and
+its trigger used to be *"a path-keyed context was newly created"*. That is a proxy for *"a recompile
+published"*, and it is wrong for every **reader**: an assembly-hydration scan of a package's SHIPPED
+build (`GetConfigurationsFromExistingAssembly`) and a kernel session resolving a cell-surface pack
+(`CellSurfaceAssemblyProvider`) both create a path-keyed context, and neither is evidence about
+which build is current. Under the old trigger either would supersede the generation a concurrent
+rebuild had just published.
+
+That alone would be a correctness wart. What made it an outage-shaped defect is that `PinForScan`
+**re-resolves** when a pin is refused — the recovery loop that exists so a transient supersession
+cannot park a NodeType (#1151). The re-resolve created a context, and creating a context evicted the
+peers. So two scans of two generations of ONE NodeType each destroyed the context the other had just
+created:
+
+| step | scan A (`pathA`) | scan B (`pathB`) |
+|---|---|---|
+| 1 | resolves → creates ctxA, evicts ctxB | |
+| 2 | | resolves → creates ctxB, evicts ctxA |
+| 3 | `Pin()` refused → re-resolves, evicts ctxB again | |
+| 4 | | `Pin()` refused → re-resolves, evicts ctxA again |
+| … | | |
+| n | attempt 3 → `ObjectDisposedException` escapes | |
+
+`CompileResultFromAssembly` catches that throw, records `CompilationStatus.Error`, and the watcher
+**PARKS** the NodeType — a millisecond-wide race turned into `compile:Failed` for a package whose
+source is fine. Measured as #4013: `PluginGateRunnerTest.SelfTypedRootWithStaleCompileStamp` (the
+rebuild publishes while the shipped stale stamp is read — exactly two generations, exactly two
+scans) failed **1 of 362** in a merge-queue group build whose PR run was 7 049 tests / 0 failed on
+the same commit, dequeuing a documentation-only PR.
+
+The fix names the trigger honestly. `ICompilationCacheService` now has two doors:
+`GetOrCreateLoadContextForPath` is a READ and supersedes nothing, and `PublishLoadContextForPath`
+supersedes — reached only through `PinForScan(..., publishesTheBuild: true)` from the post-emit scan,
+the one moment a new generation actually exists. A **retry never supersedes**, whoever asked: a
+recovery that destroys its peers is what turned one supersession into a ping-pong. The eviction now
+fires where a generation is born rather than wherever somebody happened to ask for an unfamiliar
+path.
+
+🚨 **What the narrowed trigger costs — stated, not claimed away.** The key space that grows
+*without bound* is the per-emit `{nodeName}_{ticks}_{guid}/` directory set, and every emit
+publishes, so that half is evicted exactly as before. What is no longer evicted the moment it
+appears is a generation a process only **hydrated**: an `IAssemblyStore` path is keyed
+`v{version}-{frameworkTag}-{hash}.dll` and is first-write-wins per version, so a silo reading a
+version another silo compiled keeps the previous version's context until the NodeType hub disposes
+(`UnloadNodeContexts`, which `Modules:AutoRecycleOnStaleBuild` drives on a stale build). That
+residue is bounded by the number of VERSIONS one hub outlives, not by recompiles — and it is the
+deliberate price of the correctness clause. A read that superseded would evict the CURRENT
+generation's context and then re-create one under the same path, putting **two live ALCs behind one
+file**: the two-generations split the section below is about, manufactured by the reclaim itself.
+
+🚨 **What was NOT changed, deliberately.** The issue's suggested shape was *"treat an unloading
+context as a cache miss in `Pin()`"*. `PinForScan` already does exactly that — twice — and the
+residue was the exhaustion, not the refusal. Making `Pin()` itself succeed on an unloading context
+would be the wrong repair in the other direction: `Pin()`'s two-state test and `IsClosedToLoads()`'s
+three-state test answer **different questions** (*may I START a scan?* vs *may I LOAD inside a scan
+I already hold?*), and both are right. With a pin outstanding, `Dispose` is provably still waiting,
+which is why a LOAD is safe; with none, the drain may already be over, so a new scan would be the
+`TypeLoadException '…format is invalid'` tear the pin exists to prevent. The refusal is the
+contract; the recovery was the defect.
+
+### 🚨 Reading a node's content ACROSS two generations already works — #3911's headline, re-measured
+
+The 2026-09-10 control-instance incident (#3911) reported two collectible builds of
+`Hosting/InstanceAction` in one pod and attributed the dead control plane to
+`node.ContentAs<InstanceActionContent>(…)` returning `null` across them —
+*"`null → Observable.Empty → silence`"*. **That link does not survive measurement.**
+`ObjectAsExtensions.As<T>` recovers a same-SHORT-NAMED foreign type by a JSON round-trip, and it
+does so on the collectible path too, in both directions — asserted against two genuinely
+collectible generations in `TwoCollectibleGenerationsContentReadTest`, which is the case
+`ContentAsForeignAssemblyContentTest` (two static types in one non-collectible assembly) does not
+reach. The collectible branch is the one worth checking, because `PolymorphicTypeInfoResolver`
+deliberately refuses to auto-register a collectible type and formats the discriminator without
+registering it; the round-trip survives that.
+
+So the cross-generation READ was never the silence, and a change aimed at `ContentAs` would have
+moved nothing. The part of #3911 that HAS been answered is the recompile LOOP that produced two
+generations in the first place: a process running a module generation other than the one its
+activation record names ([Module Generation Substitution](../ModuleGenerationSubstitution) —
+`Assembly.LoadFrom` silently returns an already-loaded byte-identical copy from another path, which
+is why `compiledDependencies` disagreed with the runtime and the stale-build kick fired after every
+activation restart).
+
+**#3911 is therefore not closed by either page.** Its third ask — *the NodeType compiler must
+reference the LOADED module generation, not the image's `/app` copy* — is still open, and that page
+is explicit that it does not assert the MVID/generation pairing #3911 reported. What the two pages
+together do settle is which hypotheses are dead: not the read, and not `ContentAs`.
+
 ### 🚨 A LEAVING pod never touches shared NodeType state — the adoption sweep observes host shutdown
 
 The NodeType node is **one record for the whole deployment**. Every generation of pods reads its

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-rebuild-no-longer-parks-the-type-it-was-rebuilding.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-rebuild-no-longer-parks-the-type-it-was-rebuilding.md
@@ -1,0 +1,61 @@
+---
+Name: A rebuild no longer parks the type it was rebuilding
+Category: Fix
+Description: When a type was rebuilt while something else was still reading the previous build, the two could cancel each other out and the type was marked broken — even though its code was fine. Reading a build is now just reading; only a rebuild replaces one.
+Icon: Checkmark
+Order: -20260911
+---
+
+# A rebuild no longer parks the type it was rebuilding
+
+When a type in your space is rebuilt, the new build replaces the old one — and for a moment both
+exist, because whatever was already using the old build has to finish first. That handover was
+fine on its own. What was not fine is that **merely reading a build counted as replacing it**.
+
+So if a rebuild landed while something else was still reading the previous build — an app that
+ships its own compiled code being checked, a code cell picking up a package's functions — the two
+took turns replacing each other's build. After a few rounds the rebuild gave up and the type was
+marked **broken**, with a red *compile failed* against code that was perfectly correct. Nothing in
+the type's source had anything to do with it: it depended entirely on what else happened to be
+running at that second.
+
+## What changes
+
+**Reading a build is now just reading.** Only an actual rebuild replaces the previous one. Two
+things looking at two different builds of the same type no longer knock each other over, so the
+handover finishes the way it was always meant to.
+
+**A retry never takes something else down with it.** When a read has to be retried because the
+build it asked for is being retired, that retry now leaves everything else alone — a recovery that
+breaks its neighbours is what turned a momentary overlap into a stuck type.
+
+**A type is no longer marked broken for a reason that is not in its code.** The failure this fixes
+was permanent until someone rebuilt the type by hand: once marked broken, further use served the
+stored error instead of trying again.
+
+## Also in this release
+
+**Code cells stop quietly holding on to memory after a rebuild.** When a package publishes its
+functions to code cells, every rebuild of that package used to leave a copy of the previous build's
+metadata in memory for as long as the server ran — it was never released, even after the build
+itself was retired and its files removed. Each of those copies is held only for as long as a
+session that uses it now, and released with it. Long-running servers that rebuild often were the
+ones paying for this.
+
+**A code cell can no longer be handed the wrong build of a package.** When two builds of the same
+package were briefly in memory, resolving one by name could return either — arbitrarily, with no
+way to tell which. It now declines to guess.
+
+## What this does not change
+
+**Rebuilds still replace what they supersede.** A rebuild retires the build it replaces exactly as
+before, and the memory that build used is reclaimed as soon as nothing is using it. What changed is
+only *who* gets to declare a build retired: the rebuild, never a reader. On a multi-server portal
+that means a server which only *received* a new build — rather than producing it — now lets go of
+the previous one when the type is next reloaded, instead of at the moment it first reads the new
+one. That is at most one extra build held per version, and it is what keeps two copies of the same
+build from existing at once.
+
+**A genuine compile error is still a compile error.** Only the failures that came from this overlap
+stop happening. A type whose code does not compile still says so, in the same place, with the same
+diagnostics.

--- a/src/MeshWeaver.Kernel.Hub/KernelScriptReferences.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelScriptReferences.cs
@@ -37,12 +37,36 @@ namespace MeshWeaver.Kernel.Hub;
 /// shares the underlying <c>AssemblyMetadata</c> across compilations that use the
 /// same reference instance, so the per-session metadata cost drops to ~zero.</para>
 ///
-/// <para><b>NoStaticState.md compliance:</b> <see cref="Materialized"/> is a
-/// process-global MEMO — pure-by-key (absolute file path → immutable reference over
-/// immutable on-disk bytes), bounded by the set of assemblies on disk, and holding
-/// NO <see cref="Type"/>s and NO AssemblyLoadContexts — it can pin neither meshes
-/// nor collectible NodeType contexts. Allowlisted in <c>NoStaticCollectionsTest</c>
-/// next to the other MEMO entries.</para>
+/// <para><b>NoStaticState.md compliance — and the half of it that was WRONG until #4003:</b>
+/// <see cref="Materialized"/> is a process-global MEMO — pure-by-key (absolute file path →
+/// immutable reference over immutable on-disk bytes) and holding NO <see cref="Type"/>s and NO
+/// AssemblyLoadContexts. The object-graph half of the old claim held: no mesh and no collectible
+/// <c>NodeAssemblyLoadContext</c> is rooted by an entry. The BYTES half did not. The old text said
+/// the memo was <i>"bounded by the set of assemblies on disk"</i>, which is only a bound if that
+/// set is bounded — and for NodeType assemblies it is not. Every recompile emits to a brand-new
+/// <c>{nodeName}_{ticks}_{guid}/</c> directory (<c>EmitPipeline.EmitToDiskWithRetry</c>) that is
+/// never reused, and <c>KernelExecutor.EnsureCellSurfaceReferences</c> feeds exactly those paths
+/// in. <see cref="MetadataReference.CreateFromFile"/> memory-maps the PE, so a memoized entry kept
+/// that generation's native metadata mapped for the life of the PROCESS — surviving the ALC's
+/// <c>Unload()</c> and surviving the file's deletion, and therefore outliving the eviction
+/// <c>CompilationCacheService.EvictSupersededContexts</c> performs to reclaim precisely this
+/// memory ("the native-memory leak that drove memex to the server-GC hard limit").</para>
+///
+/// <para><b>The bound is now ENFORCED, not assumed</b> (see
+/// <see cref="IsPerGeneration(Assembly)"/> / <see cref="IsPerGenerationPath"/>): a file that
+/// belongs to a COLLECTIBLE load context is materialized as an ordinary, UNMEMOIZED reference and
+/// the caller's own lifetime owns it — for the cell-surface seam that is the kernel SESSION, which
+/// already holds the matching <c>CellSurfaceAssembly.Lease</c> and drops both when the session
+/// dies. So the memo's key space is the set of assemblies at STABLE paths (the framework set, the
+/// module set, NuGet's global packages folder), which is what "bounded by the set of assemblies on
+/// disk" always meant to say. <see cref="IsMemoized"/> makes that bound assertable.</para>
+///
+/// <para>The field is allowlisted in <c>NoStaticCollectionsTest</c>, which travels with the
+/// emigrated mesh suites in MeshWeaver.Plugins (two copies there — <c>MeshWeaver.PathResolution.Test</c>
+/// and <c>Memex.Hosts.Test</c>). Its entry reads, in both, exactly <c>"MEMO: assembly path -&gt;
+/// shared PE reference"</c> — still true word for word, so no allowlist edit is owed. The FALSE
+/// claim was never in the allowlist: it was the prose here and in <c>Doc/Architecture/NoStaticState</c>,
+/// and the enforcement above is what makes that prose true rather than merely re-worded.</para>
 /// </summary>
 internal static class KernelScriptReferences
 {
@@ -53,6 +77,15 @@ internal static class KernelScriptReferences
     /// </summary>
     private static readonly ConcurrentDictionary<string, PortableExecutableReference> Materialized =
         new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether <paramref name="path"/> holds a PERMANENT entry in the memo — the instrument the
+    /// bound is asserted through (#4003), and deliberately a PER-PATH question rather than an entry
+    /// COUNT: the count moves with whatever else the process is loading, so a test written against
+    /// it would be measuring the shard's load order. A per-generation NodeType assembly must answer
+    /// false; an assembly at a stable path must answer true.
+    /// </summary>
+    internal static bool IsMemoized(string path) => Materialized.ContainsKey(path);
 
     // 🚨 Task, not a bare value — see GetReferencesAsync. The materialization below is
     // synchronous, uncancellable (no CancellationToken overload exists for
@@ -151,20 +184,64 @@ internal static class KernelScriptReferences
         if (asm.IsDynamic) return null;
         var location = asm.Location;
         if (string.IsNullOrEmpty(location)) return null;
-        return TryGetOrCreate(location);
+        // The caller already HOLDS the assembly, so classify from it directly and spare the
+        // memo-miss scan below — this is the warm-up path (~350 assemblies on a cold process).
+        return TryGetOrCreate(location, IsPerGeneration(asm));
     }
 
-    private static PortableExecutableReference? TryGetOrCreate(string location)
+    /// <summary>
+    /// 🚨 <b>A PER-GENERATION build: loaded into a COLLECTIBLE
+    /// <see cref="AssemblyLoadContext"/>.</b> Every NodeType recompile mints a fresh collectible
+    /// context over a brand-new, never-reused release directory, so "the same" assembly name has
+    /// as many files as it has had recompiles. Such a file must never enter
+    /// <see cref="Materialized"/>: the entry would outlive the context's <c>Unload()</c> AND the
+    /// file's deletion, pinning that generation's memory-mapped metadata for the life of the
+    /// process (#4003). A reference for one belongs to whoever asked — the kernel session, which
+    /// already holds the generation's <c>CellSurfaceAssembly.Lease</c> — and dies with it.
+    /// </summary>
+    private static bool IsPerGeneration(Assembly assembly)
+        => AssemblyLoadContext.GetLoadContext(assembly)?.IsCollectible == true;
+
+    /// <summary>
+    /// The same question asked of a PATH, for the entry points that have no <see cref="Assembly"/>
+    /// in hand (<see cref="GetOrCreateFromFile"/> — the cell-surface seam and the
+    /// <c>#r "nuget: …"</c> restore — and <see cref="Share"/>). A per-generation file is by
+    /// construction one somebody LOADED, so the live assembly list answers it without a heuristic
+    /// about directory names; a stable file (framework, module, package) matches nothing
+    /// collectible and is memoized as before. Only ever reached on a memo MISS.
+    /// </summary>
+    private static bool IsPerGenerationPath(string location)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (asm.IsDynamic) continue;
+            if (!string.Equals(asm.Location, location, StringComparison.OrdinalIgnoreCase)) continue;
+            if (IsPerGeneration(asm)) return true;
+        }
+        return false;
+    }
+
+    /// <param name="location">Absolute path of the PE to materialize.</param>
+    /// <param name="perGeneration">Known classification, when the caller holds the assembly;
+    /// <c>null</c> to have the memo-miss path work it out from the live assembly list.</param>
+    private static PortableExecutableReference? TryGetOrCreate(string location, bool? perGeneration = null)
     {
         if (Materialized.TryGetValue(location, out var existing))
             return existing;
         try
         {
             if (!File.Exists(location)) return null;
+            var reference = MetadataReference.CreateFromFile(location);
+            // 🚨 THE MEMO'S BOUND, ENFORCED (#4003). A per-generation file is handed back
+            // unmemoized: the caller's lifetime owns the mmap, so the metadata is reclaimed when
+            // the session that asked for it dies, instead of accumulating one block per recompile
+            // for the life of the process.
+            if (perGeneration ?? IsPerGenerationPath(location))
+                return reference;
             // GetOrAdd with a freshly created value: a concurrent racer's loser copy
             // is dropped and collected — at most a transient double-materialization,
             // never a leak.
-            return Materialized.GetOrAdd(location, MetadataReference.CreateFromFile(location));
+            return Materialized.GetOrAdd(location, reference);
         }
         catch
         {
@@ -256,6 +333,19 @@ internal static class KernelScriptReferences
     /// this code), fall back to a file next to the referencing assembly. Returns
     /// null when neither matches — only then may the caller consult Roslyn's own
     /// (eagerly materializing) resolver.
+    ///
+    /// <para>🚨 <b>Collectible assemblies are skipped, for the reason written at
+    /// <see cref="MaterializeCurrentAssemblies"/> (#4003).</b> This scan matches on SIMPLE NAME
+    /// only, and superseded generations of a recompiled NodeType linger in
+    /// <c>GetAssemblies()</c> until they are collected — so without the guard the generation
+    /// returned is whichever the enumeration reaches first: arbitrary, possibly stale, and
+    /// impossible to tell apart from the current one at the call site. An arbitrary generation is
+    /// never a right answer here (it is the CS0433-between-two-generations shape, and #3911's
+    /// "two collectible builds of one NodeType in one pod" read from the other side), so answering
+    /// <c>null</c> — which sends the caller to the sibling probe and then to Roslyn's own
+    /// resolver — is strictly better than answering confidently wrong. The cell-surface set a
+    /// session legitimately sees is declared per session and added to <c>scriptOptions</c>
+    /// explicitly, so it never needs resolving through this path.</para>
     /// </summary>
     public static PortableExecutableReference? TryResolveByIdentity(
         AssemblyIdentity identity,
@@ -264,6 +354,7 @@ internal static class KernelScriptReferences
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (asm.IsDynamic) continue;
+            if (IsPerGeneration(asm)) continue;
             var name = asm.GetName();
             if (!string.Equals(name.Name, identity.Name, StringComparison.OrdinalIgnoreCase))
                 continue;

--- a/src/MeshWeaver.Kernel.Hub/MeshWeaver.Kernel.Hub.csproj
+++ b/src/MeshWeaver.Kernel.Hub/MeshWeaver.Kernel.Hub.csproj
@@ -12,6 +12,11 @@
     <!-- KernelScriptReferencesFreshnessTest: the reference set is internal, and the freshness
          invariant (#2616) is only testable from inside. -->
     <InternalsVisibleTo Include="MeshWeaver.Kernel.Test" />
+    <!-- ScriptReferenceMemoIsGenerationBoundedTest: the memo and its entry count are internal,
+         and the bound (#4003 — a recompiled cell-surface NodeType must leave no permanent entry,
+         while the ~350 framework assemblies stay de-duplicated across sessions) can only be
+         asserted from inside. -->
+    <InternalsVisibleTo Include="MeshWeaver.Compiler.Pipeline.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MeshWeaver.Compiler.Pipeline.Test/AssemblyLoadContextLeakTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/AssemblyLoadContextLeakTest.cs
@@ -178,14 +178,19 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
 
     /// <summary>
     /// Load an emitted assembly through the path-keyed context (the live recompile path,
-    /// <c>CompileResultFromAssembly</c> → <c>GetOrCreateLoadContextForPath</c>), USE its type, and
+    /// <c>CompileResultFromAssembly</c> → <c>PublishLoadContextForPath</c>), USE its type, and
     /// return ONLY a weak ref to the context. Locals die with this <see cref="MethodImplOptions.NoInlining"/>
     /// frame so no strong ref survives on the caller's stack.
+    ///
+    /// <para>🚨 The PUBLISH door, because this models a recompile that just emitted these bytes.
+    /// Since #4013 the plain <c>GetOrCreateLoadContextForPath</c> is a READ and supersedes nothing:
+    /// a reader's resolve is no evidence about which build is current, and letting it evict is what
+    /// let two concurrent scans destroy each other's contexts until the pin retry cap rethrew.</para>
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private WeakReference LoadPathAndWeakRef(string nodeName, string dllPath)
     {
-        var context = _service.GetOrCreateLoadContextForPath(nodeName, dllPath);
+        var context = _service.PublishLoadContextForPath(nodeName, dllPath);
         var assembly = context.LoadNodeAssembly();
         assembly.Should().NotBeNull("the emitted assembly must load from its path-keyed context");
         var type = assembly!.GetTypes().FirstOrDefault(t => t.IsClass);
@@ -197,7 +202,7 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
     /// <summary>
     /// 🚨 The per-recompile reclaim (the memex native-memory leak). A long-lived NodeType hub is
     /// recompiled repeatedly WITHOUT tearing down; each recompile writes a new unique path and loads
-    /// it via <see cref="CompilationCacheService.GetOrCreateLoadContextForPath"/>. Loading the NEW
+    /// it via <see cref="CompilationCacheService.PublishLoadContextForPath"/>. Publishing the NEW
     /// path must evict + collect the SUPERSEDED context for the same NodeType then and there — not
     /// only on hub teardown (<c>UnloadNodeContexts</c>). If RED, every recompile pins another
     /// collectible ALC + its native metadata/JIT for the hub's whole life → unbounded growth to the

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ScanPinSupersessionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ScanPinSupersessionTest.cs
@@ -75,8 +75,10 @@ public sealed class ScanPinSupersessionTest : IDisposable
         var readersContext = _service.GetOrCreateLoadContextForPath(NodeName, first);
         readersContext.IsDisposed.Should().BeFalse();
 
-        // …and the recompile lands, superseding it.
-        _service.GetOrCreateLoadContextForPath(NodeName, second);
+        // …and the recompile lands and PUBLISHES its build, superseding it. Publishing is the
+        // trigger since #4013 — a mere read no longer supersedes anything (see
+        // AReadOfASupersededBuildDoesNotDoomTheBuildThatSupersededIt below).
+        _service.PublishLoadContextForPath(NodeName, second);
 
         readersContext.IsDisposed.Should().BeTrue(
             "a fresh path-keyed context for the same NodeType evicts every superseded one — "
@@ -97,7 +99,7 @@ public sealed class ScanPinSupersessionTest : IDisposable
         var second = EmitAssembly("v8");
 
         _service.GetOrCreateLoadContextForPath(NodeName, first);
-        _service.GetOrCreateLoadContextForPath(NodeName, second);   // evicts + disposes the first
+        _service.PublishLoadContextForPath(NodeName, second);       // evicts + disposes the first
 
         // The reader now asks for the assembly the NodeType still points at. Resolve-then-pin
         // would hand back the doomed context above; PinForScan must not.
@@ -130,6 +132,124 @@ public sealed class ScanPinSupersessionTest : IDisposable
         pinned.Context.Should().NotBeSameAs(stale);
         pinned.Context.IsDisposed.Should().BeFalse();
         pinned.Context.LoadNodeAssembly().Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// 🚨 #4013 — the defect direction. A READ of a superseded generation must not doom the
+    /// generation that superseded it.
+    ///
+    /// <para>The eviction that bounds <c>_loadContexts</c> used to ride on <i>every</i> newly
+    /// created path-keyed context, taking "somebody asked for a path I had not seen" as proof that
+    /// that path is the current build. A hydration scan of a package's SHIPPED assembly is not
+    /// that proof — and because <c>PinForScan</c> RE-RESOLVES on a refused pin, two scans of two
+    /// generations of one NodeType each destroyed the context the other had just created, until
+    /// the 3-attempt cap rethrew <c>ObjectDisposedException</c>, <c>CompileResultFromAssembly</c>
+    /// recorded it as a compile error and the watcher PARKED the type. That is the merge-queue
+    /// dequeue in #4013: <c>PluginGateRunnerTest.SelfTypedRootWithStaleCompileStamp</c> rebuilds
+    /// while the shipped stale stamp is read — exactly two generations, exactly two scans, and
+    /// only under the co-tenancy of a group build did they overlap.</para>
+    /// </summary>
+    [Fact]
+    public void AReadOfASupersededBuildDoesNotDoomTheBuildThatSupersededIt()
+    {
+        var shipped = EmitAssembly("v3");
+        var rebuilt = EmitAssembly("v8");
+
+        // The rebuild publishes, and its post-emit scan is in flight.
+        using var publishScan = _service.PinForScan(NodeName, rebuilt, publishesTheBuild: true);
+
+        // The other half of #4013: a hydration scan READS the shipped generation.
+        using var readScan = _service.PinForScan(NodeName, shipped);
+        readScan.Context.LoadNodeAssembly().Should().NotBeNull(
+            "the read must still get its own generation — it is not asked to give that up");
+
+        // The published generation must be untouched: still the cache's context for its path, and
+        // still open to new scans. Before the fix the read's resolve evicted it, so this resolves
+        // to a DIFFERENT instance — which is precisely what makes the next pin fail and, with two
+        // scans doing it to each other, exhausts the retry cap.
+        using var secondPublishScan = _service.PinForScan(NodeName, rebuilt);
+        secondPublishScan.Context.Should().BeSameAs(publishScan.Context,
+            "a READ of a superseded generation must not supersede the published one — reads never "
+            + "re-order generations, only a publish does (#4013)");
+    }
+
+    /// <summary>
+    /// 🚨 #4013 — the RETRY clause, isolated. A refused pin re-resolves, and that recovery must not
+    /// supersede anybody: a recovery that destroys its peers' freshly created contexts is what
+    /// turns one supersession into a ping-pong.
+    ///
+    /// <para>The setup makes attempt 1 resolve an EXISTING (doomed-in-place) context, so attempt 1
+    /// creates nothing and evicts nothing whoever asked; the fresh context is created by the RETRY.
+    /// Under the old rule that create evicted the concurrent scan's context even though the retry
+    /// is a recovery, not a publication.</para>
+    /// </summary>
+    [Fact]
+    public void ARefusedPinRetriesWithoutSupersedingTheScanAlreadyUnderWay()
+    {
+        var published = EmitAssembly("v8");
+        var peer = EmitAssembly("v3");
+
+        // A doomed context left under the published path: attempt 1 will resolve it (created ==
+        // false, so nothing is superseded there) and its pin will be refused.
+        var doomed = _service.GetOrCreateLoadContextForPath(NodeName, published);
+        doomed.Dispose();
+        _service.GetOrCreateLoadContextForPath(NodeName, published).Should().BeSameAs(doomed,
+            "the cache still holds the disposed instance — this is the state under test");
+
+        // A scan of ANOTHER generation is already under way.
+        using var peerScan = _service.PinForScan(NodeName, peer);
+
+        // The publishing scan is refused on attempt 1 and recovers on the retry.
+        using var publishScan = _service.PinForScan(NodeName, published, publishesTheBuild: true);
+        publishScan.Context.Should().NotBeSameAs(doomed);
+        publishScan.Context.IsDisposed.Should().BeFalse();
+
+        using var peerAgain = _service.PinForScan(NodeName, peer);
+        peerAgain.Context.Should().BeSameAs(peerScan.Context,
+            "the RETRY after a refused pin must supersede nothing — only the FIRST resolve of a "
+            + "publishing scan may, or two scans re-resolving against each other never terminate "
+            + "(#4013)");
+    }
+
+    /// <summary>
+    /// 🚨 #4013 — the POSITIVE control, in the opposite direction. Teaching reads not to supersede
+    /// must not cost the bound: a published build still evicts every older generation of its
+    /// NodeType, which is the whole reason <c>EvictSupersededContexts</c> exists ("the
+    /// native-memory leak that drove memex to the server-GC hard limit"). If this ever goes green
+    /// by accident — because eviction was removed rather than re-triggered — the per-recompile
+    /// accumulation is back.
+    /// </summary>
+    [Fact]
+    public void APublishedBuildStillEvictsEveryOlderGenerationOfItsNodeType()
+    {
+        var firstGeneration = EmitAssembly("v1");
+        var secondGeneration = EmitAssembly("v2");
+        var published = EmitAssembly("v9");
+
+        var older1 = _service.GetOrCreateLoadContextForPath(NodeName, firstGeneration);
+        var older2 = _service.GetOrCreateLoadContextForPath(NodeName, secondGeneration);
+        // Premise, and it is the FIX that makes it hold: two READS leave both generations alive.
+        // Under the old evict-on-any-create rule the second read already disposed the first, so a
+        // bare BeFalse() here would red on the setup and hide which half moved. Say so.
+        older1.IsDisposed.Should().BeFalse(
+            "a READ must not supersede — this is the setup, and if it reds the reader rule moved, "
+            + "not the bound");
+        older2.IsDisposed.Should().BeFalse(
+            "a READ must not supersede — this is the setup, and if it reds the reader rule moved, "
+            + "not the bound");
+
+        using var publishScan = _service.PinForScan(NodeName, published, publishesTheBuild: true);
+
+        older1.IsDisposed.Should().BeTrue(
+            "a PUBLISHED build must still evict the generations it supersedes — that eviction is "
+            + "the bound on _loadContexts, and without it every recompile leaves one more "
+            + "collectible context (and its native metadata) alive for the life of the hub");
+        older2.IsDisposed.Should().BeTrue(
+            "a PUBLISHED build must still evict the generations it supersedes — that eviction is "
+            + "the bound on _loadContexts, and without it every recompile leaves one more "
+            + "collectible context (and its native metadata) alive for the life of the hub");
+        publishScan.Context.IsDisposed.Should().BeFalse(
+            "the published generation is the one that is KEPT");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ScriptReferenceMemoIsGenerationBoundedTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ScriptReferenceMemoIsGenerationBoundedTest.cs
@@ -1,0 +1,244 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Kernel.Hub;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🚨 The BOUND on <c>KernelScriptReferences.Materialized</c> (issue #4003), asserted in BOTH
+/// directions.
+///
+/// <para><b>What was wrong.</b> The memo maps an absolute assembly path to the ONE
+/// <see cref="PortableExecutableReference"/> — and thus the one memory-mapped native metadata
+/// block — for that file in this process. It has no eviction and no bound, and it was allowlisted
+/// in <c>NoStaticCollectionsTest</c> on the claim that it is <i>"bounded by the set of assemblies
+/// on disk"</i> and <i>"can pin neither meshes nor collectible NodeType contexts"</i>. The second
+/// clause is true of the OBJECT GRAPH (no <see cref="Type"/>, no <see cref="AssemblyLoadContext"/>
+/// is held). The first is false for NodeType assemblies: every recompile emits into a brand-new
+/// <c>{nodeName}_{ticks}_{guid}/</c> directory that is never reused
+/// (<c>EmitPipeline.EmitToDiskWithRetry</c>), and <c>KernelExecutor.EnsureCellSurfaceReferences</c>
+/// feeds exactly those paths in through <c>GetOrCreateFromFile</c>. So each recompile of a
+/// <c>cellSurface: true</c> NodeType that any kernel session referenced pinned one more native
+/// metadata mapping for the life of the PROCESS — surviving both the ALC's <c>Unload()</c> and the
+/// file's deletion, and therefore outliving the eviction <c>CompilationCacheService</c> performs to
+/// reclaim precisely that memory.</para>
+///
+/// <para><b>Why both directions are mandatory.</b> The memo exists for a measured reason
+/// (#2480 / #2578 / #2769): without it a kernel session re-materializes ~350 native metadata
+/// blocks — ~150-200 MiB of unreclaimable native memory PER SESSION. A "fix" that stopped sharing
+/// would trade an unbounded leak for the original one and look just as green against the first
+/// assertion alone. So the per-generation assertion below is paired with a de-duplication
+/// assertion over the real, live assembly set.</para>
+/// </summary>
+public sealed class ScriptReferenceMemoIsGenerationBoundedTest : IDisposable
+{
+    private readonly string _root;
+    private readonly AssemblyLoadContext[] _contexts;
+
+    public ScriptReferenceMemoIsGenerationBoundedTest()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"script-ref-memo-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+        _contexts = new AssemblyLoadContext[2];
+    }
+
+    public void Dispose()
+    {
+        foreach (var ctx in _contexts)
+        {
+            try { ctx?.Unload(); } catch { /* best effort */ }
+        }
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// 🚨 THE DEFECT DIRECTION. Two generations of one cell-surface NodeType assembly — the exact
+    /// shape a recompile produces — must leave the memo exactly as they found it. Reverting the
+    /// enforcement in <c>TryGetOrCreate</c> reddens this on its own assertion: each generation's
+    /// path acquires a permanent entry that nothing ever removes.
+    /// </summary>
+    [Fact]
+    public void ARecompiledCellSurfaceAssemblyLeavesNoPermanentEntry()
+    {
+        var first = PublishGeneration(index: 0, "v1");
+        var second = PublishGeneration(index: 1, "v2");
+
+        // Premise: these really are per-GENERATION builds — distinct never-reused paths, each in
+        // its own collectible context. If that ever stops being true this test is measuring
+        // something else and must be rebuilt rather than trusted.
+        first.Path.Should().NotBe(second.Path);
+        AssemblyLoadContext.GetLoadContext(first.Assembly)!.IsCollectible.Should().BeTrue(
+            "a NodeType generation is loaded into a collectible context — that is what makes its "
+            + "path unrepeatable and its metadata reclaimable");
+        AssemblyLoadContext.GetLoadContext(second.Assembly)!.IsCollectible.Should().BeTrue();
+
+        // This is what KernelExecutor.EnsureCellSurfaceReferences does with entry.AssemblyPath.
+        var firstReference = KernelScriptReferences.GetOrCreateFromFile(first.Path);
+        var secondReference = KernelScriptReferences.GetOrCreateFromFile(second.Path);
+
+        firstReference.Should().NotBeNull(
+            "the session still needs a metadata reference for the generation it binds — the fix "
+            + "changes the reference's LIFETIME, never whether it is produced");
+        secondReference.Should().NotBeNull();
+        secondReference.Should().NotBeSameAs(firstReference,
+            "two generations are two different files and must never collapse onto one reference");
+
+        // 🚨 Per PATH, not by a count delta: the process runs other tests concurrently, and a count
+        // that another test can move measures the wrong thing. These two paths are ours alone.
+        KernelScriptReferences.IsMemoized(first.Path).Should().BeFalse(
+            "a per-generation NodeType assembly must leave NO permanent entry in the process-wide "
+            + "memo — every recompile mints a path that is never reused, so one entry per recompile "
+            + "is an unbounded mmap leak that outlives both the ALC unload and the file (#4003)");
+        KernelScriptReferences.IsMemoized(second.Path).Should().BeFalse(
+            "a per-generation NodeType assembly must leave NO permanent entry in the process-wide "
+            + "memo — every recompile mints a path that is never reused, so one entry per recompile "
+            + "is an unbounded mmap leak that outlives both the ALC unload and the file (#4003)");
+    }
+
+    /// <summary>
+    /// 🚨 THE POSITIVE CONTROL — the one #2480 / #2578 make mandatory. The whole point of the memo
+    /// is that the ~350 assemblies a script session compiles against are materialized ONCE per
+    /// process and shared by every session. A fix that re-materializes per session reintroduces the
+    /// ~200 MiB-per-session native leak the memo was written to remove, so this asserts the sharing
+    /// directly: two independent "sessions" must get back the SAME reference instances.
+    /// </summary>
+    [Fact]
+    public async Task TheFrameworkReferenceSetIsStillDeduplicatedAcrossSessions()
+    {
+        using var cts = new CancellationTokenSource(TestTimeouts.Convergence);
+
+        var sessionOne = await KernelScriptReferences.GetReferencesAsync([], cts.Token);
+        var sessionTwo = await KernelScriptReferences.GetReferencesAsync([], cts.Token);
+
+        // 🚨 The premise is stated by CONTENT, not by a count. A count is a knife edge: how many
+        // assemblies this process has loaded depends on which other tests ran first, and a
+        // threshold near that number turns the control into a load-order lottery (measured: 48 in a
+        // filtered run, ~350 in a portal). Naming two assemblies the set must contain says the same
+        // thing — this is the live production reference set — and cannot drift.
+        var paths = sessionOne.OfType<PortableExecutableReference>()
+            .Select(r => r.FilePath)
+            .Where(p => p is { Length: > 0 })
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        paths.Contains(typeof(object).Assembly.Location).Should().BeTrue(
+            "the reference set must be the live production assembly list — without the framework "
+            + "itself in it this is no longer measuring the sharing it exists to measure");
+        paths.Contains(typeof(MeshWeaver.Mesh.MeshNode).Assembly.Location).Should().BeTrue(
+            "…and without the MeshWeaver graph in it either");
+
+        // 🚨 Asserted in the direction that cannot race: assemblies only ever LOAD, so a second
+        // session may legitimately see MORE than the first — but every reference the first session
+        // used must come back as the SAME INSTANCE, or nothing is being shared.
+        var sharedByIdentity = sessionOne
+            .Count(first => sessionTwo.Any(second => ReferenceEquals(first, second)));
+        sharedByIdentity.Should().Be(sessionOne.Length,
+            "every reference a second session re-uses must be the SAME INSTANCE the first session "
+            + "used — Roslyn shares the underlying AssemblyMetadata across compilations only when "
+            + "the reference instance is shared, so instance identity IS the de-duplication that "
+            + "keeps ~350 native metadata blocks from being re-created per kernel session "
+            + "(#2480/#2578)");
+    }
+
+    /// <summary>
+    /// The other half of the positive control, at the memo's own door: an ordinary assembly at a
+    /// STABLE path (the framework set, the module set, NuGet's packages folder) is still memoized,
+    /// so repeated resolution is a dictionary hit rather than a fresh mmap.
+    /// </summary>
+    [Fact]
+    public void AStablePathIsStillMemoized()
+    {
+        var stable = typeof(KernelScriptReferences).Assembly.Location;
+        stable.Should().NotBeNullOrEmpty();
+
+        var first = KernelScriptReferences.GetOrCreateFromFile(stable);
+        var second = KernelScriptReferences.GetOrCreateFromFile(stable);
+
+        first.Should().NotBeNull();
+        second.Should().BeSameAs(first,
+            "a stable assembly path must resolve to the ONE shared materialization — that sharing "
+            + "is the memo's entire purpose");
+        KernelScriptReferences.IsMemoized(stable).Should().BeTrue(
+            "a stable assembly path IS what the memo is for — the bound narrows its key space, it "
+            + "must not empty it");
+    }
+
+    /// <summary>
+    /// 🚨 #4003's second defect: <c>TryResolveByIdentity</c> matched on SIMPLE NAME against the
+    /// whole live AppDomain, with none of the <c>IsCollectible</c> filtering its sibling carries —
+    /// so a superseded generation of a recompiled NodeType, which lingers in
+    /// <c>GetAssemblies()</c> until it is collected, could be handed to a script compilation as
+    /// "the" assembly of that name. Which generation you got was whichever the enumeration reached
+    /// first: arbitrary, unknowable at the call site, and the CS0433-between-two-generations shape.
+    /// </summary>
+    [Fact]
+    public void ResolutionByIdentityNeverAnswersWithACollectibleGeneration()
+    {
+        var generation = PublishGeneration(index: 0, "v1");
+        var simpleName = generation.Assembly.GetName().Name!;
+
+        // Premise: the collectible generation IS reachable by simple name from the live AppDomain —
+        // otherwise the guard below would be asserting an absence that nothing could produce.
+        AppDomain.CurrentDomain.GetAssemblies()
+            .Any(a => !a.IsDynamic
+                      && string.Equals(a.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase)
+                      && AssemblyLoadContext.GetLoadContext(a)?.IsCollectible == true)
+            .Should().BeTrue("the loaded generation is the thing the resolver must decline to return");
+
+        var resolved = KernelScriptReferences.TryResolveByIdentity(
+            new AssemblyIdentity(simpleName), referencingAssemblyPath: null);
+
+        resolved.Should().BeNull(
+            "a collectible per-generation assembly must never be returned by a SIMPLE-NAME scan — "
+            + "superseded generations linger in GetAssemblies(), so the one the enumeration reaches "
+            + "first is arbitrary and possibly stale; answering null sends the caller to the "
+            + "sibling probe and Roslyn's own resolver instead of answering confidently wrong");
+
+        // …and the guard must not have shut the door on the non-collectible set the resolver exists
+        // to serve.
+        var framework = KernelScriptReferences.TryResolveByIdentity(
+            new AssemblyIdentity(typeof(object).Assembly.GetName().Name!),
+            referencingAssemblyPath: null);
+        framework.Should().NotBeNull(
+            "an ordinary loaded assembly must still resolve by identity — that is the path that "
+            + "keeps the script compilation's missing-assembly closure off Roslyn's eagerly "
+            + "materializing resolver");
+    }
+
+    private sealed record Generation(string Path, Assembly Assembly);
+
+    /// <summary>
+    /// Emits one generation of a NodeType-shaped assembly into its own never-reused directory —
+    /// the layout <c>EmitToDiskWithRetry</c> produces — and loads it into its own COLLECTIBLE
+    /// context, exactly as <c>CompilationCacheService</c> does.
+    /// </summary>
+    private Generation PublishGeneration(int index, string version)
+    {
+        var name = "DynamicNode_ScriptRefMemoProbe";
+        var dir = Path.Combine(_root, $"{name}_{DateTime.UtcNow.Ticks:x}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var dll = Path.Combine(dir, $"{name}.dll");
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: name,
+            syntaxTrees: [CSharpSyntaxTree.ParseText(
+                $"public sealed class ProbeContent {{ public string Version => \"{version}\"; }}")],
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var emitted = compilation.Emit(dll);
+        emitted.Success.Should().BeTrue(
+            string.Join("; ", emitted.Diagnostics.Select(d => d.ToString())));
+
+        var context = new AssemblyLoadContext($"{name}-{index}", isCollectible: true);
+        _contexts[index] = context;
+        return new Generation(dll, context.LoadFromAssemblyPath(dll));
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/TwoCollectibleGenerationsContentReadTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/TwoCollectibleGenerationsContentReadTest.cs
@@ -1,0 +1,228 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🚨 #3911's headline mechanism, put under an experiment instead of an inference — and the
+/// answer is that the trap-door is ALREADY CLOSED at this seam.
+///
+/// <para><b>What #3911 claimed.</b> During the 2026-09-10 control-instance incident, two
+/// collectible builds of <c>Hosting/InstanceAction</c> were alive in one pod; the node stream
+/// materialized content with the NEWER build while the per-node hubs' watcher ran in the OLDER one,
+/// so <c>node.ContentAs&lt;InstanceActionContent&gt;(…)</c> was said to return <c>null</c> —
+/// "<c>null → Observable.Empty → silence</c>" — taking the InstanceAction control plane down with
+/// no log line.</para>
+///
+/// <para><b>Why it needed re-measuring.</b> <c>ContentAsForeignAssemblyContentTest</c> already
+/// pins the cross-assembly recovery, but with two statically compiled same-named types in ONE
+/// non-collectible assembly. That is not the case #3911 describes: a COLLECTIBLE assembly takes a
+/// different path through the serializer — <c>PolymorphicTypeInfoResolver</c> deliberately refuses
+/// to auto-register a collectible type (it would poison the hub's registry and pin the context) and
+/// formats the discriminator without registering it. Whether the recovery round-trip survives THAT
+/// branch is the question, and it can only be answered by loading two genuine collectible
+/// generations — which is what this test does.</para>
+///
+/// <para><b>Measured answer: it survives.</b> <see cref="ObjectAsExtensions"/>'s same-short-name
+/// JSON round-trip recovers a value typed by another generation, in both directions, and a
+/// DIFFERENTLY-named type still answers <c>null</c> so probe-dispatch call sites keep working. So a
+/// cross-generation read is not where #3911's silence came from, and a fix aimed at
+/// <c>ContentAs</c> would have changed nothing. This test exists so that conclusion is a standing,
+/// falsifiable control rather than a claim in an issue thread: if the recovery ever regresses for
+/// collectible generations, the silence #3911 describes becomes reachable again and this goes red.
+/// </para>
+/// </summary>
+public class TwoCollectibleGenerationsContentReadTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string AssemblyName = "DynamicNode_Hosting_InstanceAction";
+
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), $"two-generations-{Guid.NewGuid():N}");
+    private readonly AssemblyLoadContext[] _contexts = new AssemblyLoadContext[2];
+
+    public override async ValueTask DisposeAsync()
+    {
+        foreach (var ctx in _contexts)
+        {
+            try { ctx?.Unload(); } catch { /* best effort */ }
+        }
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+        await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// The exact #3911 read: a watcher compiled in build A reads its own node's content, which the
+    /// stream materialized in build B. Driven through the GENERIC <c>As&lt;T&gt;</c> — the overload
+    /// production uses — by closing it over the runtime-emitted generation, so no second code path
+    /// is being measured.
+    /// </summary>
+    [Fact]
+    public void ContentTypedByAnotherCollectibleGenerationIsRecovered()
+    {
+        var buildA = LoadGeneration(index: 0);
+        var buildB = LoadGeneration(index: 1);
+
+        var typeA = buildA.GetType("InstanceActionContent")!;
+        var typeB = buildB.GetType("InstanceActionContent")!;
+
+        // Premise of the experiment. If any of this stops holding, the test is measuring something
+        // other than the incident and must be rebuilt rather than trusted.
+        typeA.Should().NotBeSameAs(typeB,
+            "two collectible generations of one NodeType are two distinct CLR types");
+        typeA.Name.Should().Be(typeB.Name,
+            "a dynamic node assembly compiles without a namespace, so the bare names are identical "
+            + "on both sides — which is exactly why `is T` / `as T` fails silently here");
+        typeA.Assembly.IsCollectible.Should().BeTrue("this must be the COLLECTIBLE path, not a "
+            + "second copy of the static-assembly case ContentAsForeignAssemblyContentTest covers");
+        typeB.Assembly.IsCollectible.Should().BeTrue();
+
+        var fromBuildB = Activator.CreateInstance(typeB)!;
+        typeB.GetProperty("RequestedAction")!.SetValue(fromBuildB, "Restart");
+        typeB.GetProperty("Attempt")!.SetValue(fromBuildB, 4);
+
+        var node = MeshNode.FromPath("Deployments/memex-restart-20260910-1140") with
+        {
+            NodeType = "Hosting/InstanceAction",
+            Content = fromBuildB,
+        };
+
+        // The trap-door the rule names, demonstrated: the older build's type does not match.
+        typeA.IsInstanceOfType(node.Content).Should().BeFalse(
+            "`node.Content is MyType` across two collectible generations is the silent-null "
+            + "trap-door — this is the value every reader of this node receives");
+
+        var recovered = ReadContentAs(node, typeA);
+
+        recovered.Should().NotBeNull(
+            "ContentAs must recover content typed by ANOTHER collectible generation of the same "
+            + "NodeType — a null here is #3911's `null → Observable.Empty → silence`, which takes "
+            + "an entire control plane down with no exception and no log line");
+        recovered!.GetType().Should().BeSameAs(typeA,
+            "the reader must get ITS OWN generation's type back, not the foreign one");
+        typeA.GetProperty("RequestedAction")!.GetValue(recovered).Should().Be("Restart",
+            "the recovery must carry the values across, not just produce an empty instance");
+        typeA.GetProperty("Attempt")!.GetValue(recovered).Should().Be(4);
+    }
+
+    /// <summary>
+    /// The OTHER direction — the newer build reading content the older one produced. A recompile
+    /// wave leaves readers on both sides of the split, so a recovery that only worked one way
+    /// would still strand half of them.
+    /// </summary>
+    [Fact]
+    public void TheRecoveryWorksFromEitherGenerationTowardTheOther()
+    {
+        var buildA = LoadGeneration(index: 0);
+        var buildB = LoadGeneration(index: 1);
+
+        var typeA = buildA.GetType("InstanceActionContent")!;
+        var typeB = buildB.GetType("InstanceActionContent")!;
+
+        var fromBuildA = Activator.CreateInstance(typeA)!;
+        typeA.GetProperty("RequestedAction")!.SetValue(fromBuildA, "Sample");
+
+        var node = MeshNode.FromPath("Deployments/memex-sample-20260910-1156") with
+        {
+            NodeType = "Hosting/InstanceAction",
+            Content = fromBuildA,
+        };
+
+        var recovered = ReadContentAs(node, typeB);
+
+        recovered.Should().NotBeNull(
+            "the recovery must be symmetric — a recompile wave leaves readers on BOTH sides of the "
+            + "generation split, and either side reading null is the same silence");
+        recovered!.GetType().Should().BeSameAs(typeB);
+        typeB.GetProperty("RequestedAction")!.GetValue(recovered).Should().Be("Sample");
+    }
+
+    /// <summary>
+    /// 🚨 The control in the opposite direction. Recovery is for the SAME short name only: a
+    /// differently-named type must still answer <c>null</c>, because call sites probe-dispatch on
+    /// exactly that (<c>x.As&lt;Index&gt;() ?? treat x as the item itself</c>) and shape-recovering
+    /// across unrelated types once broke every API-token login. Without this, "make ContentAs
+    /// recover more" would pass the tests above while re-opening a worse hole.
+    /// </summary>
+    [Fact]
+    public void ADifferentlyNamedTypeFromAnotherGenerationStaysNull()
+    {
+        var buildA = LoadGeneration(index: 0);
+        var buildB = LoadGeneration(index: 1);
+
+        var unrelated = buildB.GetType("InstanceActionIndex")!;
+        var fromBuildB = Activator.CreateInstance(unrelated)!;
+        unrelated.GetProperty("RequestedAction")!.SetValue(fromBuildB, "Roll");
+
+        var node = MeshNode.FromPath("Deployments/memex-logs-20260910-1153") with
+        {
+            NodeType = "Hosting/InstanceAction",
+            Content = fromBuildB,
+        };
+
+        var recovered = ReadContentAs(node, buildA.GetType("InstanceActionContent")!);
+
+        recovered.Should().BeNull(
+            "recovery is for the SAME short name only — a differently-named typed content must "
+            + "stay null so probe-dispatch call sites fall through to their next interpretation, "
+            + "even when its shape happens to fit");
+    }
+
+    /// <summary>
+    /// Reads <c>node.Content</c> as <paramref name="target"/> through the GENERIC
+    /// <c>ObjectAsExtensions.As&lt;T&gt;</c> closed over a runtime-emitted type — the same overload
+    /// <c>MeshNodeContentExtensions.ContentAs&lt;T&gt;</c> forwards to, so the branch under test is
+    /// the production one rather than the runtime-Type sibling.
+    /// </summary>
+    private object? ReadContentAs(MeshNode node, Type target)
+    {
+        var options = GetHost().JsonSerializerOptions;
+        var generic = typeof(ObjectAsExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(ObjectAsExtensions.As) && m.IsGenericMethodDefinition)
+            .MakeGenericMethod(target);
+        return generic.Invoke(null, [node.Content, options, null, node.Path]);
+    }
+
+    /// <summary>
+    /// Emits one generation of a namespace-less, NodeType-shaped assembly into its own never-reused
+    /// directory and loads it into its own COLLECTIBLE context — the layout and the load
+    /// <c>EmitToDiskWithRetry</c> + <c>CompilationCacheService</c> produce for every recompile.
+    /// </summary>
+    private Assembly LoadGeneration(int index)
+    {
+        if (_contexts[index] is not null)
+            return _contexts[index].Assemblies.First();
+
+        Directory.CreateDirectory(_root);
+        var dir = Path.Combine(_root, $"{AssemblyName}_{DateTime.UtcNow.Ticks:x}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var dll = Path.Combine(dir, $"{AssemblyName}.dll");
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: AssemblyName,
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(
+                    "public sealed class InstanceActionContent { public string RequestedAction { get; set; } = \"\"; public int Attempt { get; set; } }"
+                    + " public sealed class InstanceActionIndex { public string RequestedAction { get; set; } = \"\"; }")
+            ],
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var emitted = compilation.Emit(dll);
+        emitted.Success.Should().BeTrue(
+            string.Join("; ", emitted.Diagnostics.Select(d => d.ToString())));
+
+        var context = new AssemblyLoadContext($"{AssemblyName}-{index}", isCollectible: true);
+        _contexts[index] = context;
+        return context.LoadFromAssemblyPath(dll);
+    }
+}


### PR DESCRIPTION
Fixes #4003
Fixes #4013
Refs #3911

Two generation-lifetime defects at one seam, plus an experiment that removes a hypothesis from a third issue.

## #4003 — the script reference memo had no bound, only a claim that it had one

`KernelScriptReferences.Materialized` is a process-global, never-evicted memo from absolute assembly path to `PortableExecutableReference`, allowlisted in `NoStaticCollectionsTest` on the words *"bounded by the set of assemblies on disk … it can pin neither meshes nor collectible NodeType contexts"*.

The second clause was true of the **object graph** and stays true — no `Type`, no `AssemblyLoadContext` is retained, which is why nothing here ever showed up as a pinned ALC. The first was **false**: `EmitPipeline.EmitToDiskWithRetry` publishes every recompile into a brand-new `{nodeName}_{ticks}_{guid}/` directory that is never reused, and `KernelExecutor.EnsureCellSurfaceReferences` feeds exactly those paths in through `GetOrCreateFromFile`. `MetadataReference.CreateFromFile` memory-maps the PE, so each recompile of a `cellSurface: true` NodeType left one more native metadata block mapped **for the life of the process** — surviving the ALC's `Unload()` and the file's deletion, and therefore outliving the eviction `CompilationCacheService` performs to reclaim precisely that memory.

**The bound is now enforced instead of asserted.** A file that belongs to a COLLECTIBLE load context is materialized as an ordinary, UNMEMOIZED reference whose lifetime is the caller's — for the cell-surface seam that is the kernel SESSION, which already holds the generation's `CellSurfaceAssembly.Lease` and drops both when the session dies. Assemblies at stable paths (framework, modules, NuGet) are memoized exactly as before, which is the entire point of #2480 / #2578.

`TryResolveByIdentity` also gains the `IsCollectible` guard its sibling at `MaterializeCurrentAssemblies` has carried, with a written reason, since #2769 — it matched on SIMPLE NAME against the whole live AppDomain, so which generation of a recompiled NodeType a script compilation got was whichever the enumeration reached first.

## #4013 — a READ was being treated as a publication

`EvictSupersededContexts` is what bounds `_loadContexts`, and its trigger was *"a path-keyed context was newly created"*. That is a proxy for *"a recompile published"*, and it is wrong for every reader: a hydration scan of a package's shipped assembly (`GetConfigurationsFromExistingAssembly`) and a kernel session resolving a cell-surface pack (`CellSurfaceAssemblyProvider`) both create one.

Because `PinForScan` **re-resolves** on a refused pin — the recovery loop from #1151 — two scans of two generations of one NodeType each destroyed the context the other had just created, until the 3-attempt cap rethrew `ObjectDisposedException`, `CompileResultFromAssembly` recorded it as a compile error and the watcher **PARKED** the NodeType. That is the merge-queue dequeue reported on #4013.

Reads no longer supersede, and a **retry never supersedes whoever asked**; only the first resolve of the post-emit scan does (`PinForScan(..., publishesTheBuild: true)`). `Pin()` and `IsClosedToLoads()` are deliberately untouched — the issue suggested treating an unloading context as a miss, but `PinForScan` already does that twice; the refusal was the contract and the exhaustion was the defect.

**What the narrowed trigger costs, stated rather than claimed away** (documented in both the code and `NodeTypeCompilation.md`): the *unbounded* key space is the per-emit directory set, and every emit publishes, so that half is evicted as before. A generation a process only **hydrated** — an `IAssemblyStore` path keyed `v{version}-{frameworkTag}-{hash}.dll`, first-write-wins per version — is now reclaimed on hub disposal (`UnloadNodeContexts`, which `Modules:AutoRecycleOnStaleBuild` drives) rather than at the next reader's resolve. That residue is bounded by the number of VERSIONS a hub outlives, not by recompiles, and it is the deliberate price: a read that superseded would evict the CURRENT generation's context and re-create one under the same path, putting two live ALCs behind one file — the two-generations split #3911 describes, manufactured by the reclaim itself.

## #3911 — re-measured, not fixed

Its headline mechanism (*`ContentAs<InstanceActionContent>` returns null across two collectible builds → `Observable.Empty` → silence*) was put under an experiment and **does not reproduce**. `ObjectAsExtensions.As<T>` recovers a same-short-named foreign type by JSON round-trip on the COLLECTIBLE path too — the branch `ContentAsForeignAssemblyContentTest` does not reach, because `PolymorphicTypeInfoResolver` refuses to auto-register a collectible type — in both directions, while a differently-named type still answers `null`. `TwoCollectibleGenerationsContentReadTest` makes that a standing, falsifiable control rather than a claim in a thread. **#3911 stays open**: its third ask (the NodeType compiler must reference the LOADED module generation) is untouched here.

## Controls, each shown to red on its own assertion

Every new or changed control was falsified by reverting the fix it covers and confirming it reds on *its own* `because`, with a clean Release build in between (a `Build FAILED` followed by a green `--no-build` run was caught and redone twice):

| revert | what reds |
|---|---|
| memo admission check | `ARecompiledCellSurfaceAssemblyLeavesNoPermanentEntry` only (1 of 4) |
| memoization disabled entirely | `TheFrameworkReferenceSetIsStillDeduplicatedAcrossSessions` — *"Expected 48 … found 0"* — and `AStablePathIsStillMemoized` |
| `IsCollectible` guard dropped | `ResolutionByIdentityNeverAnswersWithACollectibleGeneration` only |
| evict-on-any-create restored | `AReadOfASupersededBuildDoesNotDoomTheBuildThatSupersededIt`, `ARefusedPinRetriesWithoutSupersedingTheScanAlreadyUnderWay` |
| eviction removed | `APublishedBuildStillEvictsEveryOlderGenerationOfItsNodeType` + the two pre-existing leak/supersession tests |
| `IsClosedToLoads` third clause collapsed | `PinnedScan_StillLoadsTheAssembly_WhileTheUnloadIsDeferred` (the park-the-type damage in miniature) |
| `As<T>` same-name recovery disabled / made shape-based | the two recovery tests / the differently-named negative control |

The second row is the control #2480 / #2578 make **mandatory**: without the memo, two sessions shared **0 of 48** reference instances instead of 48, i.e. ~350 native metadata blocks re-materialized per kernel session on a portal. A fix that traded the unbounded leak for the original one cannot pass.

## Allowlist and doc claims

The `NoStaticCollectionsTest` entry itself reads, in both copies (`MeshWeaver.PathResolution.Test` and `Memex.Hosts.Test`, in MeshWeaver.Plugins), exactly `"MEMO: assembly path -> shared PE reference"` — still true word for word, so **no allowlist edit is owed and none is made**. The false claim lived in the class doc and in `Doc/Architecture/NoStaticState`; both are corrected, and `NoStaticState.md` now says where the test actually lives (it left this repo with #2276) instead of pointing at a path that no longer exists here.

## Verification

- Every touched project built `-c Release -warnaserror`, one per invocation: `0 Error(s), 0 Warning(s)`.
- `MeshWeaver.Compiler.Pipeline.Test` — **851 passed, 0 failed**.
- `MeshWeaver.Documentation.Test` — **390 passed, 0 failed** (`DocumentationLinkIntegrityTest` + `ArchitectureTopicMapTest` confirmed present: 5 tests under that filter).
- `PluginGateRunnerTest.SelfTypedRootWithStaleCompileStamp_ServesItsTypesAreas` passes — but it passes on `main` too (the race is intermittent), so the deterministic evidence for #4013 is `ScanPinSupersessionTest`, not this.
- Cross-repo: the surface report is **0 public types removed, 0 added, 0 obliging interface members added** over 2107 types / 13326 members, so neither cross-repo gate has anything to declare. `TryResolveByIdentity` has one production caller, in the same file; MeshWeaver.Plugins' three `KernelScriptReferences` consumers all exercise NON-collectible assemblies and are unaffected.

Pairs-with: none — the surface report measures 0 public top-level types and 0 public members removed from `src/`; the changed surfaces (`KernelScriptReferences`, `ICompilationCacheService`) are `internal`.
Mirror-sync: none — no i18n catalog key was added and no value changed (`check-i18n-mirror-sync.py` vs the merge base: 1483 keys, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
