### PR TITLE
fix(ci): the permission-pairing guard could not see the outage it was written for (#3989 audit)

### DIFF
--- a/.github/lane-caller-grants.yml
+++ b/.github/lane-caller-grants.yml
@@ -1,0 +1,264 @@
+# lane-caller-grants.yml — what every repository in the fleet grants the lanes it calls.
+#
+# 🚨 WHY A COMMITTED ROSTER EXISTS AT ALL, AND WHY IT IS NOT A CACHE.
+#
+# A `workflow_call` workflow's `permissions:` block — job-level or workflow-level — is not a grant.
+# It is a HARD REQUIREMENT on every caller, because a called workflow can only ever NARROW what its
+# caller handed it. A caller that does not grant what the lane demands does not get a permission
+# error: the run graph is rejected before a job is scheduled. `startup_failure`, ZERO jobs, no
+# check-run published at all — and under classic branch protection an ABSENT required context blocks
+# forever rather than failing visibly.
+#
+# MeshWeaver#3933 did exactly that on 2026-09-10 and MeshWeaver.Plugins was dark for five hours,
+# unable to merge even the two-line fix for the thing that broke it (28 zero-job runs,
+# 18:59:37Z → 22:56:49Z).
+#
+# THE REASON THIS FILE, AND NOT A LIVE LOOKUP:
+#
+#   1. The callers that break live in repositories core's own pull request CANNOT READ. `dotnet-test`
+#      has no checkout of them, and a fork PR has no credential for them. A gate that needs a secret
+#      to run is a gate that skips on forks — AGENTS.md forbids exactly that.
+#   2. The pairing check that DOES run in the satellites is hosted in `node-repo-validate.yml`, which
+#      every satellite calls from THE SAME `ci.yml` that calls the other lanes. A `startup_failure`
+#      rejects the whole file's graph, so on a recurrence the guard's own job is never scheduled. It
+#      cannot report the outage it is standing in.
+#   3. Measured 2026-09-11: five of the six satellites call the lanes at `@main`, so a core merge
+#      reaches them within seconds. There is no pin between core's `main` and the fleet breaking.
+#
+# So the roster is how core's own pull request SEES the fleet. It is the same inverted-ordering
+# device as `Pairs-with:` and `Implementers:` — the core half lands first, so the coupling has to be
+# declared rather than discovered.
+#
+# 🚨 A ROSTER THAT IS NOT RE-MEASURED IS A MEMORY, NOT A MEASUREMENT. Every row carries
+# `asserted-by:`, naming the run that re-derives it. `node-repo-validate` means that repository's own
+# CI runs `--assert-fleet-row` on every pull request and fails closed when its real callers stop
+# matching this file. A row asserted by `none — <reason>` is PRINTED with the verdict as NOT
+# RE-MEASURED; it is never silently folded into a green.
+#
+# TO REGENERATE A ROW, in a checkout of that repository:
+#     python3 check-workflow-permission-pairing.py --root . --emit-fleet-row Systemorph/<repo>
+#
+# Measured 2026-09-11 against each repository's LIVE default branch via the contents API. (A local
+# checkout is NOT a valid source here: every satellite clone on this machine was days stale and
+# reported pinned `uses:` refs and narrower grants than the live tree actually carries.)
+
+repos:
+
+  # ── MeshWeaver.Plugins ────────────────────────────────────────────────────────────────────────
+  # 🚨 THE REPOSITORY #3933 TOOK DOWN, and `modules-floor` is still the exact caller that broke:
+  # it grants `{contents: read, actions: read}` and NOTHING else, so any `id-token: write` a future
+  # commit puts on a `node-repo-module-pack.yml` job reproduces the outage verbatim. That pair is
+  # what the `--self-test` real-tree control injects and requires this check to name.
+  Systemorph/MeshWeaver.Plugins:
+    asserted-by: node-repo-validate
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}
+      - workflow: ci.yml
+        job: modules-floor
+        lane: node-repo-module-pack.yml
+        grants: {contents: read, actions: read}
+      - workflow: ci.yml
+        job: publish-bake
+        lane: node-repo-publish-bake.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: supersede
+        lane: node-repo-supersede.yml
+        grants: {actions: write, contents: read}
+      - workflow: ci.yml
+        job: test-repos
+        lane: node-repo-gate.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: validate
+        lane: node-repo-validate.yml
+        grants: {contents: read}
+
+  # ── MeshWeaver.Education ──────────────────────────────────────────────────────────────────────
+  # The ONE satellite that still pins its lanes to a platform sha rather than `@main`, so a core
+  # merge reaches it only when its pin moves. That makes its pin-bump pull request the place a new
+  # demand would surface — later than the others, not never.
+  Systemorph/MeshWeaver.Education:
+    asserted-by: node-repo-validate
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}
+      - workflow: ci.yml
+        job: publish-bake
+        lane: node-repo-publish-bake.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: supersede
+        lane: node-repo-supersede.yml
+        grants: {actions: write, contents: read}
+      - workflow: ci.yml
+        job: tag-modules
+        lane: node-repo-tag-modules.yml
+        grants: {contents: write}
+      - workflow: ci.yml
+        job: test-repos
+        lane: node-repo-gate.yml
+        grants: {contents: read, id-token: write}
+      # `inherit` means the caller writes no `permissions:` block at all and takes the repository
+      # default. It is satisfied only up to DEFAULT_FLOOR (contents/packages/metadata read) — never
+      # `id-token`, which always needs an explicit grant.
+      - workflow: ci.yml
+        job: validate
+        lane: node-repo-validate.yml
+        grants: inherit
+
+  # ── MeshWeaver.Reinsurance ────────────────────────────────────────────────────────────────────
+  Systemorph/MeshWeaver.Reinsurance:
+    asserted-by: node-repo-validate
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}
+      - workflow: ci.yml
+        job: compile-check
+        lane: node-repo-compile-check.yml
+        grants: inherit
+      - workflow: ci.yml
+        job: publish-bake
+        lane: node-repo-publish-bake.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: supersede
+        lane: node-repo-supersede.yml
+        grants: {actions: write, contents: read}
+      - workflow: ci.yml
+        job: tag-modules
+        lane: node-repo-tag-modules.yml
+        grants: {contents: write}
+      - workflow: ci.yml
+        job: test-repos
+        lane: node-repo-gate.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: validate
+        lane: node-repo-validate.yml
+        grants: inherit
+
+  # ── MeshWeaver.SocialMedia ────────────────────────────────────────────────────────────────────
+  # Its `module` caller ALREADY grants `id-token: write`, which is why #3933 did not break this repo
+  # the way it broke Plugins. Two repos calling the same lane with different grants is precisely the
+  # state that makes "we updated the caller" an unsafe thing to believe.
+  Systemorph/MeshWeaver.SocialMedia:
+    asserted-by: node-repo-validate
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}
+      - workflow: ci.yml
+        job: compile-check
+        lane: node-repo-compile-check.yml
+        grants: inherit
+      - workflow: ci.yml
+        job: module
+        lane: node-repo-module-pack.yml
+        grants: {contents: read, actions: read, id-token: write}
+      - workflow: ci.yml
+        job: publish-bake
+        lane: node-repo-publish-bake.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: supersede
+        lane: node-repo-supersede.yml
+        grants: {actions: write, contents: read}
+      - workflow: ci.yml
+        job: tag-modules
+        lane: node-repo-tag-modules.yml
+        grants: {contents: write}
+      - workflow: ci.yml
+        job: test-repos
+        lane: node-repo-gate.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: validate
+        lane: node-repo-validate.yml
+        grants: inherit
+
+  # ── MeshWeaver.Manufacturing ──────────────────────────────────────────────────────────────────
+  Systemorph/MeshWeaver.Manufacturing:
+    asserted-by: node-repo-validate
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}
+      - workflow: ci.yml
+        job: compile-check
+        lane: node-repo-compile-check.yml
+        grants: inherit
+      - workflow: ci.yml
+        job: publish-bake
+        lane: node-repo-publish-bake.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: supersede
+        lane: node-repo-supersede.yml
+        grants: {actions: write, contents: read}
+      - workflow: ci.yml
+        job: test-repos
+        lane: node-repo-gate.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: validate
+        lane: node-repo-validate.yml
+        grants: {contents: read}
+
+  # ── MeshWeaver.Crm ────────────────────────────────────────────────────────────────────────────
+  Systemorph/MeshWeaver.Crm:
+    asserted-by: node-repo-validate
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}
+      - workflow: ci.yml
+        job: compile-check
+        lane: node-repo-compile-check.yml
+        grants: inherit
+      - workflow: ci.yml
+        job: publish-bake
+        lane: node-repo-publish-bake.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: supersede
+        lane: node-repo-supersede.yml
+        grants: {actions: write, contents: read}
+      - workflow: ci.yml
+        job: tag-modules
+        lane: node-repo-tag-modules.yml
+        grants: {contents: write}
+      - workflow: ci.yml
+        job: test-repos
+        lane: node-repo-gate.yml
+        grants: {contents: read, id-token: write}
+      - workflow: ci.yml
+        job: validate
+        lane: node-repo-validate.yml
+        grants: inherit
+
+  # ── Systemorph/Memex (the private deployment-config repository) ───────────────────────────────
+  # 🚨 THE ONE ROW NOTHING RE-MEASURES, AND IT SAYS SO. Memex calls exactly one platform lane —
+  # `auto-arm.yml`, whose demand is WORKFLOW-level — and it does NOT call `node-repo-validate.yml`,
+  # so no run anywhere executes `--assert-fleet-row Systemorph/Memex`. This row is therefore a
+  # snapshot that can go stale silently, which is why `asserted-by: none` prints it under
+  # "NOT COVERED" on every fleet run instead of letting it pass for a measurement. Closing this
+  # needs a step in Memex's own CI; it is a change in a different repository, tracked separately.
+  Systemorph/Memex:
+    asserted-by: none — Memex calls only auto-arm.yml and has no node-repo-validate caller to run
+      --assert-fleet-row, so this row is a 2026-09-11 snapshot rather than a re-measured fact.
+    callers:
+      - workflow: auto-arm.yml
+        job: arm
+        lane: auto-arm.yml
+        grants: {contents: write, pull-requests: write}

--- a/.github/scripts/check-workflow-permission-pairing.py
+++ b/.github/scripts/check-workflow-permission-pairing.py
@@ -10,12 +10,14 @@ WHY THIS EXISTS (measured 2026-09-10, a five-hour fleet-wide outage)
 A called workflow's job can NEVER hold a permission its caller did not grant. So a job-level
 `permissions:` block inside a `workflow_call` workflow is not a grant — it is a HARD REQUIREMENT
 imposed on every caller, in every repository, including repositories the lane's own repo cannot see.
+The SAME is true of a `workflow_call` workflow's WORKFLOW-level `permissions:` block.
 
-MeshWeaver#3933 added `permissions: {contents: read, id-token: write}` to three jobs of
-node-repo-module-pack.yml so core's CD could authenticate to ACR over OIDC, and updated core's own
-caller in the same commit. It updated no satellite. From 2026-09-10T18:59:37Z every run of
-MeshWeaver.Plugins' `Plugin Catalog CI` — main, every PR, every trigger — ended `startup_failure`
-with ZERO jobs.
+MeshWeaver#3933 (merged 2026-09-10T18:57:53Z, commit 846bfbc90/d540b0dca) added
+`permissions: {contents: read, id-token: write}` to three jobs of node-repo-module-pack.yml so core's
+CD could authenticate to ACR over OIDC, and updated core's own caller in the same commit. It updated
+no satellite. 104 seconds later, at 2026-09-10T18:59:37Z, MeshWeaver.Plugins' `Plugin Catalog CI`
+began ending `startup_failure` with ZERO jobs — 28 runs, every trigger, until MeshWeaver#3968 removed
+the blocks at 23:47:56Z.
 
 🚨 THE SYMPTOM IS AN ABSENCE, WHICH IS WHY IT COST FIVE HOURS. There is no permission error. The run
 graph is rejected before a job is scheduled, so NO check-run is published at all — and under classic
@@ -26,30 +28,49 @@ startup_failure", one permission-shaped step sideways.
 
 THE RULE
 --------
-For every job in this repository that `uses:` a reusable workflow whose definition this checkout can
-read, the caller's effective permissions must be a SUPERSET of every job-level `permissions:` the
-called workflow declares.
+A caller's effective permissions must be a SUPERSET of every `permissions:` block — job-level and
+workflow-level — that the lane it calls declares.
 
 Effective permissions of a caller job = its own `permissions:` if it has one, else the workflow-level
-`permissions:`, else GitHub's default — which this check treats as UNKNOWN and reports, because a
-default that happens to be permissive today is not a pairing.
+`permissions:`, else GitHub's default, which this check treats as the DEFAULT_FLOOR below.
 
-WHERE IT RUNS
--------------
-Core runs it on itself (its own `main-cd.yml` calls the same lanes). Every satellite runs it through
-node-repo-validate.yml against the platform checkout at its own platform-ref, which is the run that
-matters: that is the moment a satellite's caller meets the lane version it is about to call, and the
-only place the pair is visible at all.
+THE THREE MODES, AND WHY THERE ARE THREE (MeshWeaver#4011, the audit of #3989)
+------------------------------------------------------------------------------
+#3989 shipped only the first of these, and the first alone cannot see the outage it was written for:
+
+  --root R [--platform-root P]        PAIRING. Both halves in one checkout. This is what a satellite
+                                      runs: its callers here, the platform's lanes fetched there.
+  --fleet ROSTER --root R             FLEET. The lanes in R against the committed grants of every
+                                      caller in the repositories R CANNOT READ. This is the only
+                                      mode that runs in core's own pull request, and therefore the
+                                      only one that PREVENTS rather than reports.
+  --assert-fleet-row REPO --fleet F   ROSTER TRUTH. This repo's real callers equal its roster row.
+                                      Runs in every satellite. Without it the roster is a snapshot
+                                      that silently goes stale, and FLEET becomes an instrument that
+                                      answers confidently from memory.
+
+🚨 WHY FLEET HAD TO EXIST: THE PAIRING MODE IS INSIDE THE RUN THE DEFECT KILLS. Measured
+2026-09-11 on the live fleet — MeshWeaver.Plugins calls `node-repo-module-pack.yml@main` from job
+`modules-floor` of `.github/workflows/ci.yml` granting only `{contents: read, actions: read}`, and
+calls `node-repo-validate.yml` — which hosts this guard — from job `validate` of THE SAME FILE.
+A `startup_failure` rejects the whole workflow file's graph: run 34517698518 reports
+`path=.github/workflows/ci.yml`, `total_count=0` jobs. So on a recurrence the guard's own job is
+never scheduled. Five of six satellites call at `@main`, so a core merge reaches them in seconds and
+no pin stands between the two. Pairing mode would have caught #3933 in exactly zero repositories.
 
 WHAT IT DELIBERATELY DOES NOT DO
 --------------------------------
-It does not forbid job-level permissions in a reusable lane. Measured on core 2026-09-11: eleven of
-twelve `workflow_call` workflows declare them, and `node-repo-gate` and `node-repo-publish-bake` both
-demand `id-token: write` with all twelve of their fleet callers correctly paired. Demanding a
-permission is legitimate; demanding it without pairing the callers is the defect.
+It does not forbid `permissions:` in a reusable lane. Measured on core 2026-09-11: eleven of twelve
+`workflow_call` workflows declare them, and `node-repo-gate` and `node-repo-publish-bake` both demand
+`id-token: write` with every one of their fleet callers correctly paired. Demanding a permission is
+legitimate; demanding it without pairing the callers is the defect.
+
+It does not claim to cover a lane nobody is recorded as calling. Those are PRINTED with the verdict,
+never silently folded into a green (`--fleet` names them), because a lane with zero known callers is
+a coverage gap, not a clean measurement.
 """
 from __future__ import annotations
-import argparse, os, sys, glob
+import argparse, copy, os, sys, glob, tempfile
 try:
     import yaml
 except ImportError:
@@ -69,6 +90,13 @@ except ImportError:
 # is likewise not safe to assume.
 DEFAULT_FLOOR = {"contents": "read", "packages": "read", "metadata": "read"}
 
+WORKFLOW_LEVEL = "«workflow»"           # the pseudo-job name a workflow-level demand is reported as
+
+# Scopes the real-tree control below strengthens a lane with, in order. The first one the caller
+# demonstrably does not grant is used, so the control mutates a lane the repo ACTUALLY calls rather
+# than a fixture that can drift away from it.
+_MUTATION_SCOPES = ("id-token", "packages", "issues", "pull-requests", "actions", "contents")
+
 
 def _load(path: str):
     try:
@@ -83,7 +111,7 @@ def _perm_map(value) -> dict | None:
     if value is None:
         return None
     if isinstance(value, str):
-        return {"*": value}                                     # read-all / write-all satisfy anything
+        return {"*": value}                                     # read-all / write-all
     if isinstance(value, dict):
         return {str(k): str(v) for k, v in value.items()}
     return None
@@ -91,6 +119,15 @@ def _perm_map(value) -> dict | None:
 
 def _satisfies(granted: dict | None, demanded: dict) -> list[str]:
     """Which demanded scopes the grant does not cover. `write` is required where `write` is demanded."""
+    # A lane demanding a BLANKET is demanding it on every scope; only an equal-or-wider blanket from
+    # the caller covers that. Zero lanes do this today — it is here so the shape cannot arrive
+    # silently, the way the workflow-level block below did.
+    if "*" in demanded:
+        want = demanded["*"]
+        have = (granted or {}).get("*")
+        if have == "write-all" or (want == "read-all" and have in ("read-all", "write-all")):
+            return []
+        return [want]
     if granted is None:
         # inherits the repo/org default — satisfied only up to the floor above
         return sorted(k for k, v in demanded.items()
@@ -105,23 +142,74 @@ def _satisfies(granted: dict | None, demanded: dict) -> list[str]:
     return sorted(missing)
 
 
-def _local_lane_path(uses: str, root: str) -> str | None:
-    """The lane's definition inside THIS checkout, when `uses:` names one we can read."""
+def _is_workflow_call(doc: dict) -> bool:
+    # YAML 1.1 reads the bare key `on:` as the boolean True; both spellings occur in the wild.
+    trig = doc.get(True, doc.get("on"))
+    return isinstance(trig, dict) and "workflow_call" in trig
+
+
+def _lane_demands(lane: dict) -> dict[str, dict]:
+    """Every `permissions:` block the lane imposes on its callers, keyed by where it is written.
+
+    🚨 The WORKFLOW-level block counts. #3989 read only job-level blocks, and core carries two lanes
+    whose demand is workflow-level — `auto-arm.yml` (`contents: write`, `pull-requests: write`,
+    called by all six satellites AND Memex) and `plugin-build.yml`. Moving a job-level demand up one
+    level is a one-line edit that made the guard go silent while the requirement stayed.
+    """
+    demands: dict[str, dict] = {}
+    wf = _perm_map(lane.get("permissions"))
+    if wf:
+        demands[WORKFLOW_LEVEL] = wf
+    for lane_job, lane_def in (lane.get("jobs") or {}).items():
+        if not isinstance(lane_def, dict):
+            continue
+        d = _perm_map(lane_def.get("permissions"))
+        if d:
+            demands[str(lane_job)] = d
+    return demands
+
+
+def _startup_failure_note() -> str:
+    return ("\n      A called job can never hold a permission its caller did not grant, so this run is "
+            "rejected before ANY job is scheduled: `startup_failure`, zero jobs, and NO check-run "
+            "published — which blocks forever under classic protection rather than failing visibly "
+            "(MeshWeaver#3933, five hours dark).")
+
+
+def _local_lane_path(uses: str, root: str, platform_root: str | None = None) -> str | None:
+    """The lane's definition this run can read, or None.
+
+    🚨 WHERE A REFERENCE RESOLVES IS PART OF ITS MEANING, and conflating the two roots reads the
+    WRONG DOCUMENT as the lane. A `./x.yml` reference is a lane in the CALLING repository. An
+    `owner/repo/.github/workflows/x.yml` reference is a lane in the PLATFORM checkout and resolves
+    only there — matching it inside `root` by basename finds a same-named file in the calling repo
+    and compares a caller against itself. That is not hypothetical: every satellite carries its own
+    `.github/workflows/auto-arm.yml` — a two-line CALLER wrapper — whose basename equals the core
+    lane it calls, so the earlier basename-in-root lookup checked Plugins' wrapper against Plugins'
+    wrapper and called it a pair.
+    """
     ref = uses.split("@", 1)[0]
     if ref.startswith("./"):
-        return os.path.join(root, ref[2:])
-    # owner/repo/.github/workflows/x.yml — readable only if it is this platform checkout's own lane
+        candidate = os.path.join(root, ref[2:])
+        return candidate if os.path.isfile(candidate) else None
     parts = ref.split("/")
     if len(parts) >= 4 and parts[2] == ".github" and parts[3] == "workflows":
-        candidate = os.path.join(root, ".github", "workflows", parts[-1])
+        if not platform_root:
+            return None
+        candidate = os.path.join(platform_root, ".github", "workflows", parts[-1])
         return candidate if os.path.isfile(candidate) else None
     return None
 
 
-def check(root: str, platform_root: str | None) -> tuple[list[str], int]:
-    problems: list[str] = []
-    pairs = 0
-    for wf_path in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.yml"))):
+def _workflow_files(root: str) -> list[str]:
+    return sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.yml"))
+                  + glob.glob(os.path.join(root, ".github", "workflows", "*.yaml")))
+
+
+def _callers(root: str) -> list[dict]:
+    """Every job in `root` that calls a reusable workflow, with the grant it actually makes."""
+    out = []
+    for wf_path in _workflow_files(root):
         doc = _load(wf_path)
         if isinstance(doc, Exception) or not isinstance(doc, dict):
             continue
@@ -132,65 +220,438 @@ def check(root: str, platform_root: str | None) -> tuple[list[str], int]:
             uses = str(job.get("uses") or "")
             if not uses:
                 continue
-            lane_path = _local_lane_path(uses, root)
-            if lane_path is None and platform_root:
-                lane_path = _local_lane_path(uses, platform_root)
-            if lane_path is None or not os.path.isfile(lane_path):
-                continue                                        # a lane we cannot read says nothing
-            lane = _load(lane_path)
-            if isinstance(lane, Exception) or not isinstance(lane, dict):
-                problems.append(f"{os.path.basename(wf_path)}: job '{job_name}' calls "
-                                f"{os.path.basename(lane_path)}, which does not parse: {lane}")
-                continue
-            granted = _perm_map(job.get("permissions"))
-            if granted is None:
-                granted = wf_default
-            for lane_job, lane_def in (lane.get("jobs") or {}).items():
-                if not isinstance(lane_def, dict):
-                    continue
-                demanded = _perm_map(lane_def.get("permissions"))
-                if not demanded or "*" in demanded:
-                    continue
-                pairs += 1
-                missing = _satisfies(granted, demanded)
-                if missing:
-                    problems.append(
-                        f"{os.path.basename(wf_path)}: job '{job_name}' calls "
-                        f"{os.path.basename(lane_path)}, whose job '{lane_job}' demands "
-                        f"{demanded} — this caller grants "
-                        f"{granted if granted is not None else 'only the inherited default (no explicit block)'}, "
-                        f"missing: {', '.join(missing)}.\n"
-                        f"      A called job can never hold a permission its caller did not grant, so "
-                        f"this run is rejected before ANY job is scheduled: `startup_failure`, zero "
-                        f"jobs, and NO check-run published — which blocks forever under classic "
-                        f"protection rather than failing visibly (MeshWeaver#3933, five hours dark)."
-                    )
+            explicit = _perm_map(job.get("permissions"))
+            out.append({
+                "workflow": os.path.basename(wf_path),
+                "workflow_path": wf_path,
+                "job": str(job_name),
+                "uses": uses,
+                "lane": uses.split("@", 1)[0].split("/")[-1],
+                "grants": explicit if explicit is not None else wf_default,
+            })
+    return out
+
+
+# ─────────────────────────────── MODE 1: PAIRING (both halves in one checkout) ───────────────────
+
+def check(root: str, platform_root: str | None) -> tuple[list[str], int]:
+    problems: list[str] = []
+    pairs = 0
+    for caller in _callers(root):
+        lane_path = _local_lane_path(caller["uses"], root, platform_root)
+        if lane_path is None or not os.path.isfile(lane_path):
+            continue                                            # a lane we cannot read says nothing
+        lane = _load(lane_path)
+        if isinstance(lane, Exception) or not isinstance(lane, dict):
+            problems.append(f"{caller['workflow']}: job '{caller['job']}' calls "
+                            f"{os.path.basename(lane_path)}, which does not parse: {lane}")
+            continue
+        granted = caller["grants"]
+        for lane_job, demanded in _lane_demands(lane).items():
+            pairs += 1
+            missing = _satisfies(granted, demanded)
+            if missing:
+                where = ("its WORKFLOW-level permissions block" if lane_job == WORKFLOW_LEVEL
+                         else f"whose job '{lane_job}'")
+                problems.append(
+                    f"{caller['workflow']}: job '{caller['job']}' calls "
+                    f"{os.path.basename(lane_path)}, {where} demands {demanded} — this caller grants "
+                    f"{granted if granted is not None else 'only the inherited default (no explicit block)'}, "
+                    f"missing: {', '.join(missing)}." + _startup_failure_note())
     return problems, pairs
 
 
-def self_test() -> int:
-    """The check must FAIL on the 2026-09-10 shape and PASS on the paired one. A guard that cannot
-    fail is not a guard (AGENTS.md)."""
-    unpaired = _satisfies({"contents": "read", "actions": "read"},
-                          {"contents": "read", "id-token": "write"})
-    paired = _satisfies({"contents": "read", "actions": "read", "id-token": "write"},
-                        {"contents": "read", "id-token": "write"})
-    blanket = _satisfies({"*": "write-all"}, {"id-token": "write"})
-    absent = _satisfies(None, {"contents": "read"})
-    weaker = _satisfies({"contents": "read"}, {"contents": "write"})
-    cases = [
-        ("the 2026-09-10 outage shape is caught", unpaired == ["id-token"]),
-        ("a correctly paired caller passes", paired == []),
-        ("write-all satisfies anything", blanket == []),
-        ("an absent block still covers the default floor", absent == []),
-        ("an absent block does NOT cover id-token", _satisfies(None, {"id-token": "write"}) == ["id-token"]),
+# ─────────────────────── MODE 2: FLEET (lanes here vs callers core cannot read) ──────────────────
+
+def _load_roster(path: str) -> dict:
+    doc = _load(path)
+    if isinstance(doc, Exception):
+        raise SystemExit(f"::error::check-workflow-permission-pairing: cannot read the fleet roster "
+                         f"{path}: {doc}")
+    if not isinstance(doc, dict) or not isinstance(doc.get("repos"), dict):
+        raise SystemExit(f"::error::check-workflow-permission-pairing: {path} has no `repos:` mapping "
+                         f"— a roster that parses to nothing would make the fleet check vacuous")
+    return doc
+
+
+def _roster_grants(value) -> dict | None:
+    """A roster `grants:` value. `inherit` means the caller writes no block at all."""
+    if value in (None, "inherit"):
+        return None
+    return _perm_map(value)
+
+
+def check_fleet(root: str, roster_path: str) -> tuple[list[str], int, list[str]]:
+    """The lanes in THIS checkout against every caller recorded in repositories it cannot read.
+
+    This is the mode that runs in core's own pull request. It is the only one that can turn a
+    recurrence of #3933 into a red BEFORE the commit merges, because the callers that break live in
+    repositories `dotnet-test.yml` has no checkout of and no credential for.
+    """
+    roster = _load_roster(roster_path)
+    problems: list[str] = []
+    notes: list[str] = []
+    pairs = 0
+
+    lanes: dict[str, dict] = {}
+    for wf_path in _workflow_files(root):
+        doc = _load(wf_path)
+        if isinstance(doc, Exception) or not isinstance(doc, dict) or not _is_workflow_call(doc):
+            continue
+        lanes[os.path.basename(wf_path)] = doc
+
+    called: dict[str, int] = {name: 0 for name in lanes}
+    for repo, entry in sorted(roster["repos"].items()):
+        entry = entry or {}
+        asserted = str(entry.get("asserted-by") or "")
+        if not asserted:
+            problems.append(f"fleet roster: {repo} has no `asserted-by:` — every row must say what "
+                            f"re-measures it, or `none — <reason>`; an unasserted row is a memory, "
+                            f"not a measurement")
+        for caller in entry.get("callers") or []:
+            lane_name = str(caller.get("lane") or "")
+            grants = _roster_grants(caller.get("grants"))
+            label = f"{repo} {caller.get('workflow')}#{caller.get('job')}"
+            if lane_name not in lanes:
+                problems.append(
+                    f"fleet roster: {label} calls `{lane_name}`, which this checkout does not have as "
+                    f"a `workflow_call` workflow. A lane RENAMED or REMOVED here is the same "
+                    f"fleet-wide `startup_failure` as an unpaired permission — every caller's run "
+                    f"graph is rejected with zero jobs. Land the caller move first, or restore the "
+                    f"name.")
+                continue
+            called[lane_name] += 1
+            for lane_job, demanded in _lane_demands(lanes[lane_name]).items():
+                pairs += 1
+                missing = _satisfies(grants, demanded)
+                if missing:
+                    where = ("its WORKFLOW-level permissions block" if lane_job == WORKFLOW_LEVEL
+                             else f"its job '{lane_job}'")
+                    problems.append(
+                        f"{lane_name}: {where} demands {demanded}, which {label} does NOT grant "
+                        f"(it grants "
+                        f"{grants if grants is not None else 'only the inherited default (no explicit block)'}"
+                        f"), missing: {', '.join(missing)}." + _startup_failure_note() +
+                        f"\n      Pair the caller in {repo} FIRST, or leave the lane inheriting its "
+                        f"caller's permissions the way MeshWeaver#3968 restored it.")
+        if asserted.startswith("none"):
+            notes.append(f"{repo}: row NOT re-measured by any run — {asserted}")
+
+    for lane_name in sorted(lanes):
+        demands = _lane_demands(lanes[lane_name])
+        if demands and called.get(lane_name, 0) == 0:
+            notes.append(f"{lane_name}: demands {sorted(demands)} and has ZERO recorded fleet callers "
+                         f"— NOT covered by this check")
+    return problems, pairs, notes
+
+
+# ──────────────────── MODE 3: ROSTER TRUTH (this repo's callers == its roster row) ───────────────
+
+def _row_for(root: str, platform_repo: str) -> list[dict]:
+    """This checkout's callers OF THE PLATFORM's lanes, in roster shape."""
+    rows = []
+    for caller in _callers(root):
+        ref = caller["uses"].split("@", 1)[0]
+        if not ref.startswith(platform_repo + "/.github/workflows/"):
+            continue
+        rows.append({"workflow": caller["workflow"], "job": caller["job"], "lane": caller["lane"],
+                     "grants": caller["grants"] if caller["grants"] is not None else "inherit"})
+    return sorted(rows, key=lambda r: (r["workflow"], r["job"]))
+
+
+def _row_key(row: dict) -> tuple:
+    grants = row.get("grants")
+    grants = "inherit" if grants in (None, "inherit") else tuple(sorted(_perm_map(grants).items()))
+    return (str(row.get("workflow")), str(row.get("job")), str(row.get("lane")), grants)
+
+
+def assert_fleet_row(root: str, repo: str, roster_path: str, platform_repo: str) -> list[str]:
+    """The committed roster still describes this repository. Fail closed on any difference.
+
+    🚨 This is what stops the roster being a stale snapshot. The two drift directions that make the
+    FLEET check answer a confident green on a broken fleet are (a) a satellite ADDS a caller the
+    roster does not know and (b) a satellite LOWERS a grant the roster still records — both of them
+    "the roster overstates", both caught here, in a job that DOES run (a roster mismatch is not a
+    permission escalation, so the graph is accepted and the red is visible).
+    """
+    roster = _load_roster(roster_path)
+    entry = roster["repos"].get(repo)
+    actual = _row_for(root, platform_repo)
+    recipe = (f"      Re-measure with: python3 check-workflow-permission-pairing.py --root . "
+              f"--emit-fleet-row {repo}\n      and land the printed block in "
+              f"{platform_repo}/.github/lane-caller-grants.yml.")
+    if entry is None:
+        return [f"fleet roster: {repo} is not in {platform_repo}'s .github/lane-caller-grants.yml, so "
+                f"a change to a lane it calls is checked against NOTHING in that repo's own pull "
+                f"request — which is how MeshWeaver#3933 reached 28 zero-job runs.\n" + recipe]
+    want = sorted((entry.get("callers") or []), key=lambda r: (str(r.get("workflow")), str(r.get("job"))))
+    if [_row_key(r) for r in want] == [_row_key(r) for r in actual]:
+        return []
+    out = [f"fleet roster: {repo}'s recorded callers no longer match this repository.\n"
+           f"      recorded: {[_row_key(r) for r in want]}\n"
+           f"      actual:   {[_row_key(r) for r in actual]}\n" + recipe]
+    return out
+
+
+def emit_fleet_row(root: str, repo: str, platform_repo: str) -> int:
+    rows = _row_for(root, platform_repo)
+    print(yaml.safe_dump({repo: {"asserted-by": "node-repo-validate", "callers": rows}},
+                         sort_keys=False, default_flow_style=False))
+    return 0
+
+
+# ─────────────────────────────────────────── SELF-TEST ──────────────────────────────────────────
+
+def _mutate_lane(src_root: str, lane_name: str, lane_job: str, scope: str, level: str) -> str:
+    """A COPY of `src_root`'s workflows with one extra demand on one lane job. The copy is written
+    from the parsed document, which is exactly what every mode reads, so the control cannot drift
+    away from the file the guard actually sees."""
+    tmp = tempfile.mkdtemp(prefix="wfperm-")
+    dest = os.path.join(tmp, ".github", "workflows")
+    os.makedirs(dest)
+    for wf_path in _workflow_files(src_root):
+        doc = _load(wf_path)
+        if isinstance(doc, Exception) or not isinstance(doc, dict):
+            continue
+        if os.path.basename(wf_path) == lane_name:
+            doc = copy.deepcopy(doc)
+            if lane_job == WORKFLOW_LEVEL:
+                perms = dict(_perm_map(doc.get("permissions")) or {})
+                perms[scope] = level
+                doc["permissions"] = perms
+            else:
+                target = (doc.get("jobs") or {}).get(lane_job)
+                perms = dict(_perm_map(target.get("permissions")) or {})
+                perms[scope] = level
+                target["permissions"] = perms
+        with open(os.path.join(dest, os.path.basename(wf_path)), "w", encoding="utf-8") as fh:
+            yaml.safe_dump(doc, fh, sort_keys=False)
+    return tmp
+
+
+def _pick_scope(granted: dict | None) -> str | None:
+    for scope in _MUTATION_SCOPES:
+        if _satisfies(granted, {scope: "write"}):
+            return scope
+    return None
+
+
+def _unit_cases() -> list[tuple[str, bool]]:
+    lane_wf_level = {"jobs": {"a": {}}, "permissions": {"contents": "write"}}
+    lane_job_level = {"jobs": {"pack": {"permissions": {"id-token": "write"}}}}
+    return [
+        ("the 2026-09-10 outage shape is caught",
+         _satisfies({"contents": "read", "actions": "read"},
+                    {"contents": "read", "id-token": "write"}) == ["id-token"]),
+        ("a correctly paired caller passes",
+         _satisfies({"contents": "read", "actions": "read", "id-token": "write"},
+                    {"contents": "read", "id-token": "write"}) == []),
+        ("write-all satisfies anything", _satisfies({"*": "write-all"}, {"id-token": "write"}) == []),
+        ("an absent block still covers the default floor", _satisfies(None, {"contents": "read"}) == []),
+        ("an absent block does NOT cover id-token",
+         _satisfies(None, {"id-token": "write"}) == ["id-token"]),
         ("an absent block does NOT cover a write beyond the floor",
          _satisfies(None, {"contents": "write"}) == ["contents"]),
-        ("read does not satisfy a write demand", weaker == ["contents"]),
+        ("read does not satisfy a write demand",
+         _satisfies({"contents": "read"}, {"contents": "write"}) == ["contents"]),
+        # the widening this audit added — each of these was silently unseen by #3989
+        ("a lane's WORKFLOW-level block is a demand",
+         list(_lane_demands(lane_wf_level)) == [WORKFLOW_LEVEL]),
+        ("a lane's job-level block is still a demand",
+         list(_lane_demands(lane_job_level)) == ["pack"]),
+        ("a lane demanding write-all is not satisfied by a scoped grant",
+         _satisfies({"contents": "write", "id-token": "write"}, {"*": "write-all"}) == ["write-all"]),
+        ("a lane demanding read-all is satisfied by a caller's write-all",
+         _satisfies({"*": "write-all"}, {"*": "read-all"}) == []),
+        ("a scope the caller lacks is always findable for the real-tree control",
+         _pick_scope({"contents": "read"}) is not None and _pick_scope({"*": "write-all"}) is None),
     ]
-    bad = [name for name, ok in cases if not ok]
+
+
+def _owns_lanes(root: str, roster_path: str) -> bool:
+    """Does THIS checkout hold the lanes the roster describes? True in core, False in a satellite."""
+    doc = _load(roster_path)
+    if isinstance(doc, Exception) or not isinstance(doc, dict):
+        return False
+    wanted = {str(c.get("lane")) for e in (doc.get("repos") or {}).values()
+              for c in ((e or {}).get("callers") or [])}
+    have = {os.path.basename(p) for p in _workflow_files(root)
+            if isinstance(_load(p), dict) and _is_workflow_call(_load(p))}
+    return bool(wanted) and wanted.issubset(have)
+
+
+def _materialize_row(rows: list[dict], platform_repo: str) -> str:
+    """A throwaway checkout whose callers ARE the roster's recorded rows."""
+    tmp = tempfile.mkdtemp(prefix="wfperm-row-")
+    dest = os.path.join(tmp, ".github", "workflows")
+    os.makedirs(dest)
+    by_file: dict[str, dict] = {}
+    for r in rows:
+        job = {"uses": f"{platform_repo}/.github/workflows/{r['lane']}@main"}
+        if r.get("grants") not in (None, "inherit"):
+            job["permissions"] = r["grants"]
+        by_file.setdefault(str(r["workflow"]), {})[str(r["job"])] = job
+    for fname, jobs in by_file.items():
+        with open(os.path.join(dest, fname), "w", encoding="utf-8") as fh:
+            yaml.safe_dump({"on": {"pull_request": {}}, "jobs": jobs}, fh, sort_keys=False)
+    return tmp
+
+
+def _roster_roundtrip_cases(fleet: str) -> list[tuple[str, bool]]:
+    """🚨 CONTROLS ON THE ANTI-STALENESS HALF, derived from the REAL roster.
+
+    `--assert-fleet-row` is what stops the roster becoming a memory, so it needs its own proof that
+    it can fail. These build a throwaway checkout FROM THE COMMITTED ROWS and then break it the two
+    ways a real repository drifts — both of which make the fleet check answer a confident green on a
+    broken fleet. Reading the real roster means the control dies loudly if the roster's shape moves,
+    rather than quietly passing against a fixture nobody updated.
+    """
+    doc = _load(fleet)
+    if isinstance(doc, Exception) or not isinstance(doc, dict) or not (doc.get("repos") or {}):
+        return [("the fleet roster parses and has rows to build a control from", False)]
+    repo, entry = sorted((doc.get("repos") or {}).items())[0]
+    rows = (entry or {}).get("callers") or []
+    if not rows:
+        return [(f"the roster's first row ({repo}) has callers to build a control from", False)]
+
+    cases = [(f"a checkout built from {repo}'s recorded row matches it "
+              f"({len(rows)} caller(s))",
+              assert_fleet_row(_materialize_row(rows, "Systemorph/MeshWeaver"), repo, fleet,
+                               "Systemorph/MeshWeaver") == [])]
+
+    # (a) the repository LOWERS a grant the roster still records
+    lowered = copy.deepcopy(rows)
+    victim = next((r for r in lowered if isinstance(r.get("grants"), dict) and r["grants"]), None)
+    if victim is None:
+        cases.append((f"{repo} has an explicit grant to lower — otherwise this control is vacuous",
+                      False))
+    else:
+        victim["grants"] = {k: v for k, v in list(victim["grants"].items())[1:]} or "inherit"
+        cases.append((f"a repository that LOWERS a recorded grant is caught",
+                      assert_fleet_row(_materialize_row(lowered, "Systemorph/MeshWeaver"), repo,
+                                       fleet, "Systemorph/MeshWeaver") != []))
+
+    # (b) the repository ADDS a caller the roster does not know
+    added = copy.deepcopy(rows) + [{"workflow": "ci.yml", "job": "unrecorded-caller",
+                                    "lane": "node-repo-gate.yml", "grants": {"contents": "read"}}]
+    cases.append((f"a repository that ADDS an unrecorded caller is caught",
+                  assert_fleet_row(_materialize_row(added, "Systemorph/MeshWeaver"), repo, fleet,
+                                   "Systemorph/MeshWeaver") != []))
+
+    # (c) a repository absent from the roster entirely
+    cases.append(("a repository missing from the roster is caught",
+                  assert_fleet_row(_materialize_row(rows, "Systemorph/MeshWeaver"),
+                                   "Systemorph/NotInTheRoster", fleet,
+                                   "Systemorph/MeshWeaver") != []))
+    return cases
+
+
+def _real_tree_cases(root: str, platform_root: str | None, fleet: str | None) -> list[tuple[str, bool]]:
+    """🚨 CONTROLS DERIVED FROM THE REAL TREE, IN BOTH DIRECTIONS.
+
+    #3989's self-test asserted "the 2026-09-10 outage shape is caught" against a hand-written pair of
+    dicts, and passed, while injecting that exact shape into the real node-repo-module-pack.yml
+    changed nothing — because core's own caller grants `id-token: write` and the callers that break
+    are in repositories core cannot read. A fixture that can be right while the tree is wrong is the
+    guard-whose-subject-moved shape AGENTS.md names. These cases mutate the REAL lane files.
+    """
+    cases: list[tuple[str, bool]] = []
+
+    base_problems, base_pairs = check(root, platform_root)
+    cases.append((f"the unmodified tree pairs cleanly ({base_pairs} pair(s))",
+                  not base_problems and base_pairs > 0))
+
+    # NEGATIVE CONTROL, pairing mode: strengthen a lane THIS repo really calls with a scope its real
+    # caller really lacks, and require the guard to name it.
+    mutated_any = False
+    for caller in _callers(root):
+        lane_path = _local_lane_path(caller["uses"], root, platform_root)
+        if lane_path is None or not os.path.isfile(lane_path):
+            continue
+        in_platform = bool(platform_root) and os.path.abspath(lane_path).startswith(
+            os.path.abspath(platform_root) + os.sep)
+        src_root = platform_root if in_platform else root
+        lane = _load(lane_path)
+        if isinstance(lane, Exception) or not isinstance(lane, dict) or not (lane.get("jobs") or {}):
+            continue
+        scope = _pick_scope(caller["grants"])
+        if scope is None:
+            continue
+        lane_job = sorted((lane.get("jobs") or {}))[0]
+        tmp = _mutate_lane(src_root, os.path.basename(lane_path), lane_job, scope, "write")
+        probs, pairs = check(root, tmp) if in_platform else check(tmp, platform_root)
+        hit = any(scope in p and caller["job"] in p for p in probs)
+        cases.append((f"injecting `{scope}: write` into {os.path.basename(lane_path)}#{lane_job} is "
+                      f"caught and names {caller['workflow']}#{caller['job']} ({pairs} pair(s))", hit))
+        mutated_any = True
+        break
+    if not mutated_any:
+        cases.append(("a real caller/lane pair exists to mutate — otherwise this control is vacuous",
+                      False))
+
+    if fleet:
+        cases += _roster_roundtrip_cases(fleet)
+
+    # 🚨 THE FLEET CONTROLS BELONG TO THE CHECKOUT THAT OWNS THE LANES, and asking a satellite to run
+    # them reds it for a true statement. A satellite's `--root` holds callers and no lane at all, so
+    # `check_fleet` there resolves ZERO pairs and every roster row reports its lane missing. This is
+    # NOT a skip-trapdoor: ownership is a property of the tree, not of a secret or an event, it is
+    # PRINTED either way, and core — the one checkout that does own them — runs these on every pull
+    # request. Measured while writing this: without the gate, simulating the satellite lane failed
+    # three controls at once and would have reddened `Validate node repos` in all six repositories.
+    if fleet and _owns_lanes(root, fleet):
+        fleet_problems, fleet_pairs, _ = check_fleet(root, fleet)
+        cases.append((f"the unmodified tree passes the fleet roster ({fleet_pairs} pair(s))",
+                      not fleet_problems and fleet_pairs > 0))
+
+        # 🚨 THE 2026-09-10 SHAPE, ON THE REAL TREE. #3933 put `id-token: write` on
+        # node-repo-module-pack.yml's `pack`. Core's own caller grants it; MeshWeaver.Plugins'
+        # `modules-floor` does not. This control asserts the guard now says so.
+        lane_name, lane_job, scope = "node-repo-module-pack.yml", "pack", "id-token"
+        lane_file = os.path.join(root, ".github", "workflows", lane_name)
+        lane_doc = _load(lane_file)
+        if isinstance(lane_doc, dict) and lane_job in (lane_doc.get("jobs") or {}):
+            tmp = _mutate_lane(root, lane_name, lane_job, scope, "write")
+            probs, pairs, _ = check_fleet(tmp, fleet)
+            named = [p for p in probs if scope in p and lane_name in p]
+            cases.append((f"#3933's exact shape (`{scope}: write` on {lane_name}#{lane_job}) reds the "
+                          f"fleet check and names {len(named)} ungranting caller(s): "
+                          f"{'; '.join(sorted({p.split(' does NOT grant')[0].split('demands ')[-1].split(', which ')[-1] for p in named})) or '—'}",
+                          bool(named)))
+        else:
+            cases.append((f"{lane_name} still has a `{lane_job}` job to inject #3933's shape into — "
+                          f"otherwise this control checks nothing", False))
+    return cases
+
+
+def self_test(root: str | None, platform_root: str | None, fleet: str | None) -> int:
+    """The check must FAIL on the 2026-09-10 shape and PASS on the paired one. A guard that cannot
+    fail is not a guard (AGENTS.md)."""
+    cases = _unit_cases()
+    if root:
+        # 🚨 SAY WHICH CONTROLS RAN. A self-test whose coverage silently depends on where it is
+        # invoked is the instrument that answers confidently from memory — the same defect this
+        # whole change is about. The mode is a property of the TREE (does this checkout hold the
+        # lanes?), never of a secret or an event, and the fleet controls always run in core.
+        owns = bool(fleet) and _owns_lanes(root, fleet)
+        if not fleet:
+            print("  MODE: pairing controls only — no --fleet roster given, so neither the fleet "
+                  "check nor the roster-truth controls ran.")
+        elif owns:
+            print("  MODE: this checkout OWNS the lanes — unit + pairing + roster-truth + FLEET "
+                  "controls, including #3933's exact shape injected into the real lane file.")
+        else:
+            print("  MODE: this checkout CALLS the lanes but does not own them — unit + pairing + "
+                  "roster-truth controls. The fleet controls run in Systemorph/MeshWeaver, whose "
+                  "checkout holds the lane definitions they mutate.")
+        cases += _real_tree_cases(root, platform_root, fleet)
+    else:
+        print("  NOTE: no --root given — only the unit cases ran. A caller that can pass --root "
+              "should: the real-tree controls are the ones that cannot drift away from the tree.")
     for name, ok in cases:
         print(f"  {'ok  ' if ok else 'FAIL'} {name}")
+    bad = [n for n, ok in cases if not ok]
+    print(f"  {len(cases) - len(bad)}/{len(cases)} control(s) passed")
     return 1 if bad else 0
 
 
@@ -199,13 +660,55 @@ def main() -> int:
     ap.add_argument("--root", default=".", help="repository to check (its callers)")
     ap.add_argument("--platform-root", default=None,
                     help="platform checkout at platform-ref, where the shared lanes live")
+    ap.add_argument("--fleet", default=None,
+                    help="the committed fleet roster (.github/lane-caller-grants.yml): the grants of "
+                         "callers in repositories this checkout cannot read")
+    ap.add_argument("--assert-fleet-row", default=None, metavar="OWNER/REPO",
+                    help="assert the roster's row for this repository still matches its real callers")
+    ap.add_argument("--emit-fleet-row", default=None, metavar="OWNER/REPO",
+                    help="print this repository's row for the platform's fleet roster")
+    ap.add_argument("--platform-repo", default="Systemorph/MeshWeaver",
+                    help="the repository whose lanes the roster describes")
     ap.add_argument("--self-test", action="store_true")
     args = ap.parse_args()
+
+    if args.emit_fleet_row:
+        return emit_fleet_row(args.root, args.emit_fleet_row, args.platform_repo)
+
     if args.self_test:
-        return self_test()
+        return self_test(args.root, args.platform_root, args.fleet)
+
+    if args.assert_fleet_row:
+        if not args.fleet:
+            print("::error::--assert-fleet-row needs --fleet <roster>; without it the assertion would "
+                  "check nothing", file=sys.stderr)
+            return 2
+        problems = assert_fleet_row(args.root, args.assert_fleet_row, args.fleet, args.platform_repo)
+        print(f"check-workflow-permission-pairing: roster row for {args.assert_fleet_row} — "
+              f"{len(_row_for(args.root, args.platform_repo))} caller(s) measured, "
+              f"{len(problems)} mismatch(es)")
+        for p in problems:
+            print(f"::error::{p}")
+        return 1 if problems else 0
+
+    if args.fleet:
+        problems, pairs, notes = check_fleet(args.root, args.fleet)
+        # 🚨 The DENOMINATOR is printed on every run, green or red. A check pointed at the wrong root
+        # resolves no lanes, reports zero problems, and ticks exactly like a clean measurement.
+        print(f"check-workflow-permission-pairing (fleet): {pairs} roster caller/lane pair(s) "
+              f"resolved, {len(problems)} violation(s), root={os.path.abspath(args.root)}, "
+              f"roster={os.path.abspath(args.fleet)}")
+        for n in notes:
+            print(f"  NOT COVERED: {n}")
+        if pairs == 0:
+            print("  NOTE: zero roster pairs resolved — the roster is empty or names no lane this "
+                  "checkout has. Zero is not a pass.")
+            problems = problems or ["fleet roster resolved ZERO pairs — the check ran against nothing"]
+        for p in problems:
+            print(f"::error::{p}")
+        return 1 if problems else 0
+
     problems, pairs = check(args.root, args.platform_root)
-    # 🚨 The DENOMINATOR is printed on every run, green or red. A check pointed at the wrong root
-    # resolves no lanes, reports zero problems, and ticks exactly like a clean measurement.
     print(f"check-workflow-permission-pairing: {pairs} caller/lane permission pair(s) resolved, "
           f"{len(problems)} violation(s), root={os.path.abspath(args.root)}")
     if pairs == 0:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1976,10 +1976,25 @@ jobs:
       run: python3 .github/scripts/check-workflow-timeouts.py --self-test
     - name: "Every job is capped at 45 minutes"
       run: python3 .github/scripts/check-workflow-timeouts.py --root .
+    # 🚨 THE SELF-TEST TAKES --root AND --fleet ON PURPOSE. Without them only the unit cases run,
+    # and those pass against hand-written dicts while the real tree is broken — which is exactly
+    # what happened: #3989's self-test asserted "the 2026-09-10 outage shape is caught" and was
+    # green, while injecting that literal shape into node-repo-module-pack.yml changed nothing.
+    # With them, the controls MUTATE THE REAL LANE FILES in both directions, so a fixture can no
+    # longer be right while the tree is wrong.
     - name: "A caller grants what its lane demands — the gate can fail (self-test)"
-      run: python3 .github/scripts/check-workflow-permission-pairing.py --self-test
+      run: python3 .github/scripts/check-workflow-permission-pairing.py --self-test --root . --fleet .github/lane-caller-grants.yml
     - name: "Core's own callers grant every permission their lanes demand"
       run: python3 .github/scripts/check-workflow-permission-pairing.py --root .
+    # 🚨 THIS IS THE STEP THAT PREVENTS RATHER THAN REPORTS, and the step above cannot do its job.
+    # Core has exactly TWO caller→lane edges of its own (both in main-cd.yml), and #3933 updated
+    # core's own caller in the same commit that broke the fleet — so the line above was green for
+    # the commit that caused a five-hour outage, and would be green for a recurrence. The callers
+    # that break live in repositories this checkout cannot read, so their committed grants are
+    # recorded in .github/lane-caller-grants.yml and checked here. Reading a file needs no
+    # credential, so this runs on forks and on Dependabot exactly as it runs on main.
+    - name: "Every lane this repo publishes is paired in every repository that calls it"
+      run: python3 .github/scripts/check-workflow-permission-pairing.py --root . --fleet .github/lane-caller-grants.yml
 
     # 🚨 `yaml.safe_load` accepts a DUPLICATE MAPPING KEY silently and keeps the LAST one — and
     # every guard in this fleet, the one directly above included, reads workflows through it. So a

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -149,24 +149,61 @@ jobs:
           # which is the failure mode it exists to prevent (AGENTS.md — a gate never tests its own
           # inputs).
           mkdir -p "$RUNNER_TEMP/platform/.github/workflows"
+          # 🚨 `auto-arm` is in this list because its demand is WORKFLOW-level and every repository in
+          # the fleet calls it. It was absent while the guard resolved a cross-repo `uses:` by
+          # BASENAME inside the calling repo — which found each satellite's own two-line `auto-arm.yml`
+          # CALLER wrapper and compared it against itself, reporting a pair that was never checked.
+          # With that fixed the lane must actually be fetched, or the caller is silently uncovered.
           for lane in node-repo-validate node-repo-compile-check node-repo-gate node-repo-module-pack \
                       node-repo-module-publish node-repo-publish-bake node-repo-tag-modules \
-                      node-repo-platform-canary node-repo-platform-ref-bump node-repo-supersede; do
+                      node-repo-platform-canary node-repo-platform-ref-bump node-repo-supersede \
+                      auto-arm; do
             gh api "repos/Systemorph/MeshWeaver/contents/.github/workflows/${lane}.yml?ref=${SCRIPTS_REF}" --jq .content \
               | base64 -d > "$RUNNER_TEMP/platform/.github/workflows/${lane}.yml" \
               || { echo "::error::could not fetch .github/workflows/${lane}.yml at ${SCRIPTS_REF} — the permission-pairing guard cannot read the lane this repo calls, and a guard that cannot read its subject must not pass"; exit 1; }
           done
+          # 🚨 THE FLEET ROSTER. Core's own pull request checks a lane change against the committed
+          # grants of every repository it cannot read (.github/lane-caller-grants.yml), because the
+          # pairing check below is hosted in THIS lane — which every satellite calls from the same
+          # ci.yml that calls the other lanes — and a `startup_failure` rejects that whole file's
+          # graph. On a recurrence this job is never scheduled, so it cannot report the outage it is
+          # standing in. That makes the roster the load-bearing half, and a roster nobody
+          # re-measures is a memory: this lane asserts THIS repository's row still matches reality.
+          # The fetch fails RED like every other one here — never "skipped".
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/lane-caller-grants.yml?ref=${SCRIPTS_REF}" --jq .content \
+            | base64 -d > "$RUNNER_TEMP/lane-caller-grants.yml" \
+            || { echo "::error::could not fetch .github/lane-caller-grants.yml at ${SCRIPTS_REF} — the fleet roster this repo's row is asserted against is unreadable, and a guard that cannot read its subject must not pass"; exit 1; }
+          grep -q "^repos:" "$RUNNER_TEMP/lane-caller-grants.yml" || { echo "::error::the fetched lane-caller-grants.yml at ${SCRIPTS_REF} has no \`repos:\` mapping"; exit 1; }
           python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --disable-pip-version-check 'PyYAML==6.0.2'
+      # 🚨 --root AND --fleet are passed on purpose: without them only the unit cases run, and those
+      # pass against hand-written dicts while the real tree is broken. With them the controls mutate
+      # THIS repo's real callers and the real lane files, in both directions.
       - name: "A caller grants what its lane demands — the gate can fail (self-test)"
-        run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --self-test
+        run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --self-test --root . --platform-root "$RUNNER_TEMP/platform" --fleet "$RUNNER_TEMP/lane-caller-grants.yml"
       # 🚨 MeshWeaver#3933 added `id-token: write` to three jobs of the module-pack lane and paired
       # only core's own caller. Every satellite run became `startup_failure` with ZERO jobs — no
       # permission error, no check-run, and under classic protection an ABSENT required context
       # blocks forever. MeshWeaver.Plugins was dark for five hours and could not merge the two-line
-      # fix for the thing that broke it. This is the check that would have caught it, and this is
-      # the only place it CAN be caught: the caller lives here, the lane lives there.
+      # fix for the thing that broke it.
+      #
+      # 🚨 THIS STEP WOULD NOT HAVE CAUGHT THAT, and this comment used to claim it would ("the only
+      # place it CAN be caught"). Measured wrong in MeshWeaver#4011: the check lives in a job the
+      # caller's own ci.yml declares, and a `startup_failure` rejects that whole FILE's graph — so
+      # on a recurrence this job is never scheduled and cannot report the outage it is standing in.
+      # Five of six satellites call at `@main`, so no pin stands in between either. What prevents a
+      # recurrence is core's `--fleet` run against .github/lane-caller-grants.yml, before the lane
+      # change merges. This step covers the OTHER direction: a change made on THIS side of the pair.
       - name: "This repo's callers grant every permission their platform lanes demand"
         run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --root . --platform-root "$RUNNER_TEMP/platform"
+      # 🚨 THE ANTI-STALENESS HALF. The platform's fleet roster is what core's own pull request
+      # checks a lane change against, and it can only be trusted while every row is re-derived from
+      # the repository it describes. Both drift directions make the fleet check answer a confident
+      # green on a broken fleet — this repo ADDS a caller the roster does not know, or LOWERS a
+      # grant the roster still records — and both are caught here, in a job that DOES run (a roster
+      # mismatch is not a permission escalation, so the run graph is accepted and the red is
+      # visible). Re-measure with `--emit-fleet-row` and land the printed block in core.
+      - name: "This repo's callers still match the platform's fleet roster"
+        run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --root . --fleet "$RUNNER_TEMP/lane-caller-grants.yml" --assert-fleet-row "${{ github.repository }}"
       - name: "Every job is capped at 45 minutes — the gate can fail (self-test)"
         run: python3 "$RUNNER_TEMP/check-workflow-timeouts.py" --self-test
       - name: "Every job in this repo's workflows is capped at 45 minutes"

--- a/src/MeshWeaver.Documentation/Data/Architecture/WorkflowPermissionPairing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WorkflowPermissionPairing.md
@@ -1,8 +1,8 @@
 # A caller grants what its lane demands
 
-🚨 **A job-level `permissions:` block inside a `workflow_call` workflow is not a grant. It is a
-requirement imposed on every caller, in every repository — including repositories the lane's own repo
-cannot see.**
+🚨 **A `permissions:` block inside a `workflow_call` workflow is not a grant. It is a requirement
+imposed on every caller, in every repository — including repositories the lane's own repo cannot
+see.** This is true of a **job-level** block and equally of a **workflow-level** one.
 
 A called workflow's job can never hold a permission its caller did not grant. So adding
 `permissions:` to a shared lane silently makes it a precondition fleet-wide, and a caller that does
@@ -17,6 +17,11 @@ repository cannot merge anything — including the fix for the thing that broke 
 
 There is no error text naming the permission. The symptom is an absence.
 
+🚨 **A `startup_failure` rejects the WHOLE WORKFLOW FILE's graph, not the offending job.** Every
+satellite calls its lanes from one `ci.yml`, so one unpaired caller takes down every other job in
+that file — including the jobs that publish the repository's required contexts. This is also why the
+guard cannot rescue the satellite it runs in; see "What the guard does not see" below.
+
 ## The incident this is written from (2026-09-10)
 
 MeshWeaver#3933 added `permissions: {contents: read, id-token: write}` to three jobs of
@@ -26,8 +31,9 @@ credential. It updated core's own caller in the same commit, and **no satellite*
 | | |
 |---|---|
 | 18:54:37Z | run resolves core `@main` = `756d6d99e` (pre-#3933) → jobs ran |
-| **18:59:37Z** | run resolves `d540b0dca` → **0 jobs** |
-| 18:59Z → 23:5xZ | MeshWeaver.Plugins dark: main, every PR, every trigger |
+| 18:57:53Z | #3933 merges as `846bfbc90` / `d540b0dca` |
+| **18:59:37Z** | run `34517698518` resolves `d540b0dca` → `startup_failure`, **`total_count: 0` jobs**, `path=.github/workflows/ci.yml` |
+| 18:59Z → 22:56Z | MeshWeaver.Plugins dark: **28** zero-job runs, main, every PR, every trigger |
 | — | MeshWeaver.SocialMedia had the identical gap, unfired only because its lane had not run |
 
 `id-token` is used only on the opt-in `acr-login: oidc` path; the default is `basic`. So every
@@ -35,22 +41,114 @@ satellite was made to require a permission for a code path none of them take.
 
 Fixed by MeshWeaver#3968, which removed the job-level blocks and restored caller inheritance.
 
-## The rule, and the guard
+## The rule
 
 For every job in a repository that `uses:` a shared lane, the caller's effective permissions must be
-a **superset** of every job-level `permissions:` that lane declares.
+a **superset** of every `permissions:` block — job-level *and* workflow-level — that the lane
+declares. `.github/scripts/check-workflow-permission-pairing.py` enforces it.
 
-`.github/scripts/check-workflow-permission-pairing.py` enforces it. Core runs it on itself;
-**every satellite runs it through `node-repo-validate.yml`** against the lane definitions fetched at
-its own `platform-ref` — which is the only place the pair is visible at all, because the caller lives
-in one repository and the lane in another.
+## 🚨 The audit that corrected this page (MeshWeaver#4011)
 
-### Two things the guard deliberately gets right
+The guard as first shipped (#3989) ran in one mode: **pairing** — both halves in one checkout. That
+mode is real and still runs, but on its own **it would have caught the outage in exactly zero
+repositories**, and this page previously implied otherwise. Three measurements settle it.
 
-**It does not ban job-level permissions in a lane.** Measured on core 2026-09-11: eleven of twelve
+**1. In core's own pull request the pairing check is silent, and correctly so.** Core holds exactly
+**two** caller→lane edges in its whole workflow tree, both in `main-cd.yml`, and both already grant
+`id-token: write`. Re-injecting #3933's literal shape (`permissions: {id-token: write}` on
+`node-repo-module-pack.yml`'s `pack` job) leaves the pairing check at **exit 0** — it resolves the new
+demand as a *third* pair and finds core's caller satisfies it. Nothing is wrong with that verdict;
+the callers that break are simply not in core. Both #3933 and its predecessor updated core's own
+caller in the same commit, which is what makes this silence systematic rather than unlucky.
+
+**2. The satellite run cannot rescue the satellite.** The pairing check is hosted in
+`node-repo-validate.yml`, which every satellite calls from a `validate` job in **the same `ci.yml`**
+that calls the other lanes. A `startup_failure` rejects that file's entire graph, so on a recurrence
+the guard's own job is never scheduled. The guard cannot report the outage it is standing in.
+
+**3. There is no pin to slow it down.** Measured 2026-09-11 on live default branches: **five of the
+six satellites call the lanes at `@main`** (only MeshWeaver.Education still pins a platform sha). A
+core merge therefore reaches them within seconds.
+
+So for #3989's guard a recurrence was **MISSED** — not prevented, and not merely detected late.
+
+### 🚨 But a DIFFERENT guard did cover the narrow case, and that must not be misread either
+
+`.github/scripts/test-cd-steps.py` — added by MeshWeaver#3968's follow-up, not by #3989 — asserts
+that `node-repo-module-pack.yml` declares **no** `permissions:` at all, workflow- or job-level. It
+runs in core's `dotnet-test.yml` on every pull request, and re-injecting #3933's exact shape does red
+it. So the literal recurrence *was* prevented in core's own PR, by that check.
+
+Its cover is narrow by construction: it hard-codes **one lane** and **three job names**
+(`prepare`, `build-workspace`, `pack`). Measured on this tree by mutating every job of every
+`workflow_call` lane in core and asking each guard:
+
+| | lane jobs it reds on |
+|---|---|
+| `test-cd-steps.py` | **3** of 22 (`node-repo-module-pack.yml` only, and only 3 of its 6 jobs) |
+| the fleet roster | **16** of 22 — every lane job that has a recorded caller |
+
+`node-repo-module-pack.yml`'s `select`, `tests` and `verify` are in that lane, break the fleet
+identically, and were covered by neither before this change.
+
+## What closes it: the fleet roster
+
+The callers that break live in repositories core's pull request cannot read, and reaching them with a
+credential would make the gate skip on forks — which
+AGENTS.md forbids outright. So their committed grants are recorded in
+**`.github/lane-caller-grants.yml`** and checked in core's own PR. It is the same inverted-ordering
+device as `Pairs-with:` and `Implementers:`: the core half lands first, so the coupling is *declared*
+rather than discovered.
+
+The guard has three modes:
+
+| mode | runs in | answers |
+|---|---|---|
+| `--root R [--platform-root P]` | every satellite | do *this repo's* callers pair with the lanes it calls? |
+| `--fleet ROSTER --root R` | **core** | does a lane change break a caller in a repo core cannot read? |
+| `--assert-fleet-row REPO --fleet F` | every satellite | does the roster still describe *this* repo? |
+
+🚨 **The third mode is what keeps the second honest.** A roster nobody re-measures is a memory, not a
+measurement — the instrument that answers confidently from stale knowledge. Both drift directions
+would make the fleet check green on a broken fleet (a repo **adds** a caller the roster does not know;
+a repo **lowers** a grant the roster still records), and both red in a job that *does* run, because a
+roster mismatch is not a permission escalation and so the run graph is accepted.
+
+**Regenerate a row** in a checkout of that repository:
+
+```bash
+python3 check-workflow-permission-pairing.py --root . --emit-fleet-row Systemorph/<repo>
+```
+
+## What the guard does not see
+
+A reader should not leave this page believing it covers more than it does.
+
+- **It does not see a repository that is not in the roster.** Coverage is exactly the roster's rows.
+- **It does not see a lane with no recorded caller.** Four lanes / **6 of 22 lane jobs** are in
+  that state today (`node-repo-module-publish`, `node-repo-platform-canary`,
+  `node-repo-platform-ref-bump`, `plugin-build`). They are **printed as `NOT COVERED` on every run**
+  rather than folded into the green, because a lane with zero known callers is a coverage gap, not a
+  clean measurement.
+- **A silent lane job is not always a gap, and the two causes must not be conflated.** Adding
+  `id-token: write` to `node-repo-gate.yml#gate` reds nothing — correctly, because all six of its
+  recorded callers already grant it. Adding `packages: write` to the same job reds. A green there
+  means *this demand is already paired*, never *this job is unchecked*; the `NOT COVERED` lines are
+  what name the genuinely unchecked ones.
+- **`Systemorph/Memex` is recorded but not re-measured.** It calls only `auto-arm.yml` and has no
+  `node-repo-validate` caller to run `--assert-fleet-row`, so its row is a snapshot. It carries
+  `asserted-by: none — …` and prints under `NOT COVERED`. Closing that needs a step in Memex's own CI.
+- **It does not see a caller in a repository outside the fleet**, nor a private fork.
+- **It is a static read of committed YAML.** It does not resolve `${{ }}` expressions, and it cannot
+  know what a repository-level default permission is actually set to — which is why absence is scored
+  against a conservative floor rather than assumed permissive.
+
+## Two things the guard deliberately gets right
+
+**It does not ban `permissions:` in a lane.** Measured on core 2026-09-11: eleven of twelve
 `workflow_call` workflows declare them, and `node-repo-gate` and `node-repo-publish-bake` both demand
-`id-token: write` with **all twelve** of their fleet callers correctly paired. Demanding a permission
-is legitimate; demanding it without pairing the callers is the defect.
+`id-token: write` with every one of their fleet callers correctly paired. Demanding a permission is
+legitimate; demanding it without pairing the callers is the defect.
 
 **An absent `permissions:` block is not "grants nothing".** The job inherits the repository default,
 whose floor is `contents`/`packages`/`metadata: read`. The first version of this guard treated
@@ -59,16 +157,51 @@ a guard that fires on working lanes gets muted, which is how the next real one g
 the default can *never* provide is `id-token`, which always needs an explicit grant — and that is
 exactly the scope this incident turned on.
 
-### Verified in three directions, on real repositories
+## The controls, and why they are derived from the real tree
 
-| | |
+🚨 **#3989's self-test asserted `"the 2026-09-10 outage shape is caught"` and passed, while injecting
+that exact shape into the real lane file changed nothing.** Both were true at once: the case tested
+`_satisfies()` against two hand-written dicts, and the tree it claimed to be about was never read.
+That is the textbook *guard whose subject moved and whose roots did not* — it passed having checked
+nothing about the thing it names.
+
+`--self-test` now takes `--root` and `--fleet`, and its controls **mutate the real lane files**:
+
+| control | direction |
 |---|---|
-| satellite at its pre-fix commit + the demanding lane | **1 violation** — the incident, and nothing else |
-| the same satellite after its fix | **0** — the positive control |
-| core against itself | **0** — correct; core's own caller *was* paired |
+| the unmodified tree pairs cleanly, with a non-zero pair count | green must be earned |
+| a scope the real caller lacks, injected into a lane it really calls, is caught **and names that caller** | red |
+| the unmodified tree passes the fleet roster (45 pairs) | green must be earned |
+| **`id-token: write` on `node-repo-module-pack.yml#pack`** reds the fleet check and names the ungranting callers | red |
+| a checkout rebuilt from a recorded roster row matches it | green must be earned |
+| a repo that lowers a grant / adds a caller / is missing entirely | red |
 
-The denominator (`N caller/lane permission pair(s) resolved`) prints on every run, green or red, so a
-check pointed at the wrong root cannot tick like a clean measurement. Zero pairs says so explicitly.
+The falsification that closes the loop, run on this tree:
+
+| | pairing mode | fleet mode |
+|---|---|---|
+| `id-token: write` injected on `pack` | **exit 0** (3 pairs, 0 violations) | **exit 1** — names `node-repo-module-pack.yml#pack` and `MeshWeaver.Plugins ci.yml#modules-floor` |
+| tree restored | exit 0 | **exit 0** (45 pairs) |
+
+The mode the self-test ran in is **printed**, and so is the denominator (`N pair(s) resolved`), green
+or red — a check pointed at the wrong root cannot tick like a clean measurement.
+
+🚨 **The fleet controls run only in the checkout that owns the lanes.** A satellite's `--root` holds
+callers and no lane, so asking it to run them reds it for a true statement. That is a property of the
+*tree*, not of a secret or an event; it is printed either way; and core runs them on every pull
+request. This is not a skip-trapdoor — it was found by simulating the satellite lane before merging,
+which failed three controls at once and would have reddened `Validate node repos` in all six
+repositories.
+
+## A defect this audit found in the guard itself
+
+A cross-repo reference — `Systemorph/MeshWeaver/.github/workflows/auto-arm.yml@…` — was resolved by
+**basename inside the calling repository first**. Every satellite carries its own two-line
+`.github/workflows/auto-arm.yml` *caller wrapper* whose basename equals the core lane it calls, so
+the guard read the wrapper as if it were the lane and **compared a caller against itself**, reporting
+a pair that was never checked. A `./x.yml` reference now resolves only in the calling repo and an
+`owner/repo/...` reference only in the platform checkout, and `auto-arm` was added to the lane set
+the satellite fetches so that caller is genuinely covered.
 
 ## Related
 


### PR DESCRIPTION
Audit of #3989, which I wrote and described as preventing the #3933 class of outage. **That description was wrong, and this PR settles it with evidence rather than defending it.**

## The finding

#3989 shipped one mode — PAIRING, both halves in one checkout. Measured against live data, it would have caught #3933 in **zero repositories**.

**1. In core's own PR the pairing check is silent, and correctly so.** Core holds exactly **two** caller→lane edges in its entire workflow tree (both in `main-cd.yml`), and both already grant `id-token: write`. Re-injecting the literal shape of `846bfbc9` — `permissions: {id-token: write}` on `node-repo-module-pack.yml`'s `pack` job — leaves the check at **exit 0**, resolving it as a *third* pair that core's caller satisfies. Nothing is wrong with that verdict; the callers that break are not in core. Both #3933 and its predecessor updated core's own caller in the same commit, which makes the silence systematic, not unlucky.

> The "seven workflow files reference `node-repo-module-pack`" figure was a miscount — six are comments or a bash string listing lane names. There is exactly **one** real `uses:` of it in core.

**2. The satellite run cannot rescue the satellite.** The pairing check is hosted in `node-repo-validate.yml`, which every satellite calls from a `validate` job in **the same `ci.yml`** that calls the other lanes. A `startup_failure` rejects that whole file's graph — run `34517698518` reports `path=.github/workflows/ci.yml`, `total_count: 0` — so on a recurrence the guard's own job is never scheduled. It cannot report the outage it is standing in.

**3. There is no pin in between.** Measured on live default branches 2026-09-11: **five of six satellites call at `@main`** (only Education still pins a sha). A core merge reaches them in seconds. *(Local satellite clones on this machine were days stale and said the opposite — every one showed a pinned sha. The roster is built from the contents API, not from a checkout.)*

**So `846bfbc9`'s shape was MISSED by this guard** — not prevented, not merely detected late.

### One important correction in the other direction

A **different** check, `.github/scripts/test-cd-steps.py` (added by #3968's follow-up, not by #3989), asserts that `node-repo-module-pack.yml` declares no `permissions:` at all. It runs in core's `dotnet-test.yml` on every PR and **does** red on the literal shape. So the narrow recurrence *was* covered — just not by the guard that claimed it.

Its cover is narrow by construction: one hard-coded lane, three hard-coded job names. Measured by mutating every job of every `workflow_call` lane in core:

| | lane jobs it reds on |
|---|---|
| `test-cd-steps.py` | **3** of 22 |
| this PR's fleet roster | **16** of 22 — every lane job with a recorded caller |

`node-repo-module-pack.yml`'s `select`, `tests` and `verify` break the fleet identically and were covered by neither.

## What this adds

- **`.github/lane-caller-grants.yml`** — the committed grants of every caller in the repositories core cannot read, measured against each repo's **live** default branch. Checked in core's own PR via `--fleet`, which is the only place a recurrence can be stopped *before* it merges. Reading a file needs no credential, so it runs on forks and Dependabot exactly as on main. **45 pairs**, against pairing mode's 2.
- **`--assert-fleet-row`**, run by every satellite, so the roster is re-measured rather than remembered. Both drift directions — a repo **adds** a caller the roster does not know, or **lowers** a grant it still records — red in a job that *does* run.
- **Workflow-level `permissions:` now counts as a demand.** `auto-arm.yml`'s demand is workflow-level and all seven repos call it; #3989 read only job-level blocks.
- The 6 lane jobs with **zero recorded callers** are **printed as `NOT COVERED` on every run**, never folded into the green.

## Two defects found in the guard itself

- **A cross-repo `uses:` was resolved by basename inside the calling repo first.** Every satellite carries its own two-line `auto-arm.yml` *caller wrapper* whose basename equals the core lane it calls — so the guard read the wrapper as the lane and **compared a caller against itself**, reporting a pair it never checked. `./x.yml` now resolves only in the caller and `owner/repo/...` only in the platform checkout, and `auto-arm` was added to the fetched lane set so that caller is genuinely covered.
- **The fleet controls assumed the checkout owns the lanes.** Simulating the satellite lane before merging failed three controls at once and **would have reddened `Validate node repos` in all six satellites.**

## The fixture that had diverged

#3989's self-test asserted `"the 2026-09-10 outage shape is caught"` and **passed**, while injecting that exact shape into the real lane file changed nothing. Both were true: the case tested `_satisfies()` against two hand-written dicts and never read the tree it named — the textbook *guard whose subject moved and whose roots did not*.

`--self-test` now takes `--root` and `--fleet`, and its controls **mutate the real lane files** in both directions, including `846bfbc9`'s exact shape, which must red the fleet check **and name the ungranting caller**. 20/20 controls pass. The mode the self-test ran in, and the denominator, are printed on every run.

## Falsification

Same injected tree, this worktree:

| | pairing mode | fleet mode |
|---|---|---|
| `id-token: write` on `pack` | **exit 0** (3 pairs, 0 violations) — reproduces the original measurement | **exit 1** — names `node-repo-module-pack.yml#pack` and `MeshWeaver.Plugins ci.yml#modules-floor` |
| restored (sha verified identical) | exit 0 | **exit 0** (45 pairs) |

All six satellites pass all three steps against their **live** default branches — no false positives anywhere in the fleet. Every workflow guard core runs on itself is green; `DocumentationLinkIntegrityTest` passes 1/1.

## Safety of the satellite rollout

The new roster fetch happens at `SCRIPTS_REF`, and the roster lands in the **same commit** as the step that reads it. Measured: five satellites resolve `SCRIPTS_REF=main` (fetch resolves immediately on merge); Education runs an older pinned lane that does not contain the step. No satellite has the dangerous combination of a `@main` lane with an older scripts-ref.

## Docs

`Doc/Architecture/WorkflowPermissionPairing.md` now records the 2026-09-10 recurrence with its measured timeline, states plainly what the guard does and does **not** see, and corrects the claim this audit falsified. A reader should not come away believing it covers more than it does.

Rescued WIP preserved on `wip/3989-permission-pairing-rescue`; its diagnosis was correct and is verified here.

Refs #3989, #3933, #3968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
