### PR TITLE
fix(#3931): the pod-hub claim dropped membership changes in two windows

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -328,6 +328,31 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     /// first claim is therefore scheduled away from that thread, just like the sibling stream
     /// subscription's <c>ConfigureAwait(false)</c> continuation.</para>
     ///
+    /// <para>🚨 <b><c>Merge</c>, never <c>StartWith</c> — the ordering IS the correctness (#3931).</b>
+    /// <c>StartWith</c> is a <c>Concat</c>: the feed is subscribed only once the prefix has been
+    /// fully PROCESSED, and processing the prefix runs the entire initial claim round synchronously
+    /// on the subscribing thread, <c>grain.Attach()</c> included.
+    /// <see cref="IClusterMembershipFeed.Changes"/> is hot and deliberately does not replay, so
+    /// every membership change that lands in that window was delivered to every OTHER subscriber
+    /// and DISCARDED here — silently, and permanently, because the feed is the only thing that can
+    /// ever re-assert. The window is the first claim of a hub's life, i.e. the pod's boot, which is
+    /// exactly when membership moves (#3983 measured 34 placement failures in 65 s across two pods,
+    /// all inside it). <c>Merge</c> subscribes the DURABLE source first and then adds the one-shot
+    /// initial trigger, so no change can arrive before anyone is listening; it also serialises the
+    /// two, so a change arriving mid-round queues behind it rather than racing it.</para>
+    ///
+    /// <para><b>Measured on System.Reactive 6.1.0 — the pinned version — with this exact shape</b>
+    /// (<c>…ObserveOn(Scheduler.Default).SelectMany(_ =&gt; triggers).Select(round).Switch()</c>) and a
+    /// round that parks inside its subscribe, so the window is observable rather than inferred:</para>
+    /// <code>
+    /// StartWith: ROUND-0-enter -&gt; PUSH-enter -&gt; PUSH-leave -&gt; RELEASE -&gt; ROUND-0-leave -&gt; SUBSCRIBE-feed
+    /// Merge    : SUBSCRIBE-feed -&gt; ROUND-0-enter -&gt; PUSH-enter -&gt; RELEASE -&gt; ROUND-0-leave -&gt; ROUND-42-enter
+    /// </code>
+    /// <para>Under <c>StartWith</c> the push completes with the feed still unsubscribed and no round
+    /// for it ever runs — the change is dropped where it is published. Under <c>Merge</c> the feed is
+    /// subscribed first, the push waits at the merge gate for the round in progress, and its round
+    /// then runs. <c>PodHubClaimReassertionTest</c> pins both directions.</para>
+    ///
     /// <para>Where there is no feed the post-readiness sequence is a single emission: assert once,
     /// never re-assert.</para>
     /// </summary>
@@ -339,11 +364,17 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 .Take(1)
                 .ObserveOn(Scheduler.Default)
                 .SelectMany(_ => membershipFeed is null
-                    ? Observable.Return(0L)
+                    ? Observable.Return(InitialClaim)
                     : membershipFeed.Changes
                         .Do(seq => OrleansRouteTrace.Write(
                             $"OrleansRoutingService.AttachPodHub REASSERT addr={addressPath} membershipChange={seq}"))
-                        .StartWith(0L)));
+                        .Merge(Observable.Return(InitialClaim))));
+
+    /// <summary>
+    /// The sequence number the INITIAL claim trigger carries. Membership changes carry the feed's
+    /// own 1-based sequence, so zero is unambiguously "this is the first assertion, not a change".
+    /// </summary>
+    private const long InitialClaim = 0L;
 
     /// <summary>
     /// Routes a message delivery to its target. Locally registered streams are invoked
@@ -1295,16 +1326,28 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         var landedOnce = 0;
         // Claim/dispose handshake. Disposal can race the synchronous interval between selecting a
         // grain and actually invoking Attach(): it must neither Detach a claim that was never made
-        // nor Detach first and let that already-reserved Attach run afterwards. The STARTING state
-        // hands release ownership to the thread making the Attach call; that thread invokes Attach
-        // first and only then honours a concurrent disposal request.
-        const int WaitingForFirstAttempt = 0;
-        const int StartingAttempt = 1;
-        const int AttachWasInvoked = 2;
-        const int DisposedBeforeAnyAttempt = 3;
-        const int DisposeRequestedWhileStarting = 4;
-        const int DisposedAfterAttempt = 5;
-        var claimState = 0;
+        // nor Detach first and let that already-reserved Attach run afterwards.
+        //
+        // 🚨 It is a LEDGER, not a mutex (#3931). It used to be a single token whose "someone is
+        // already starting an attempt" value was answered with Observable.Empty — a TERMINAL answer
+        // to a TRANSIENT condition, and the round it discarded was the one carrying the newest
+        // membership information. A round started by a retry timer runs on the timer's thread while
+        // a round started by a membership change runs on the feed's, so the overlap is ordinary and
+        // the claim simply went missing: no attach, no retry, no log, and nothing to re-trigger it
+        // until the NEXT membership change. Disposal is the only reason to refuse a round.
+        //
+        // claimActivity packs both facts a release decision needs into one interlocked word: bit 0
+        // is "disposal has been requested", the rest is how many rounds are currently inside their
+        // synchronous attach window. The release is owned by whoever observes "disposed AND the
+        // window is empty" — Dispose itself when no round is in flight, otherwise the last round
+        // out — so Detach can never overtake an Attach that is still being invoked.
+        const int DisposeRequested = 1;
+        const int OneRoundInTheAttachWindow = 2;
+        var claimActivity = 0;
+        // Set immediately BEFORE an Attach invocation is entered, never after: a call that throws
+        // may still have landed on the remote runtime, so it counts as a claim needing release.
+        var claimAttempted = 0;
+        var claimReleased = 0;
         var attach = new SingleAssignmentDisposable();
         // Armed BEFORE the claim is subscribed, so there is no window in which the claim could
         // terminate unobserved. AsyncSubject: it completes once and replays that completion to
@@ -1347,6 +1390,49 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             }
         }
 
+        // The disposal half of the ledger, run by whichever thread observes "disposed AND no round
+        // is inside its attach window" — Dispose when it finds the window empty, otherwise the last
+        // round out of it. Exactly one of them wins, and by the time either runs every Attach that
+        // was ever invoked has returned, so a Detach can never overtake one.
+        void ReleaseClaimOnDisposal(IPodHubGrain? selectedGrain = null)
+        {
+            if (Volatile.Read(ref claimAttempted) == 0)
+            {
+                logger.LogDebug(
+                    "Pod-hub claim for {Address} not released — its registration ended before Orleans "
+                    + "reached Active, so no claim was ever attempted.",
+                    addressPath);
+                return;
+            }
+
+            if (Interlocked.Exchange(ref claimReleased, 1) == 0)
+                ReleaseClaim(selectedGrain);
+        }
+
+        // Enter a round's synchronous attach window, refusing ONLY once disposal has been requested.
+        // A round that finds another round already in the window is NOT refused: it carries a
+        // membership change that one predates, and discarding it is what left claims stranded.
+        bool TryEnterAttachWindow()
+        {
+            while (true)
+            {
+                var activity = Volatile.Read(ref claimActivity);
+                if ((activity & DisposeRequested) != 0)
+                    return false;
+                if (Interlocked.CompareExchange(
+                        ref claimActivity, activity + OneRoundInTheAttachWindow, activity) == activity)
+                    return true;
+            }
+        }
+
+        void LeaveAttachWindow(IPodHubGrain? selectedGrain)
+        {
+            // Interlocked.Add returns the NEW value, so "only the DisposeRequested bit is left"
+            // reads as "disposal was requested and I am the last round out of the window".
+            if (Interlocked.Add(ref claimActivity, -OneRoundInTheAttachWindow) == DisposeRequested)
+                ReleaseClaimOnDisposal(selectedGrain);
+        }
+
         // ONE ROUND of the claim: ask, retry the bounce, and complete when it lands. Composed per
         // subscription so its retry state is genuinely per-round.
         IObservable<bool> ClaimOnce()
@@ -1358,15 +1444,11 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             return Observable
                 .Defer(() =>
                 {
-                    var previousState = Interlocked.CompareExchange(
-                        ref claimState, StartingAttempt, WaitingForFirstAttempt);
-                    if (previousState == AttachWasInvoked)
-                        previousState = Interlocked.CompareExchange(
-                            ref claimState, StartingAttempt, AttachWasInvoked);
-                    if (previousState >= DisposedBeforeAnyAttempt || previousState == StartingAttempt)
+                    // 🚨 The ONLY reason a round may refuse to claim is that the registration is
+                    // being disposed. "Another round is mid-attach" is transient and is precisely
+                    // the case that must still claim — see the claimActivity remarks (#3931).
+                    if (!TryEnterAttachWindow())
                         return Observable.Empty<bool>();
-
-                    var hadEarlierAttempt = previousState == AttachWasInvoked;
 
                     IPodHubGrain? grain = null;
                     var attachCallEntered = false;
@@ -1386,34 +1468,17 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                             return Observable.Empty<bool>();
                         }
 
-                        // The call itself is inside the handshake. If disposal changes STARTING to
-                        // DISPOSE_REQUESTED while this synchronous invocation is in progress, the
-                        // finally below becomes the sole release owner and therefore Detach cannot
-                        // overtake Attach.
+                        // The call itself is inside the window, and claimAttempted is written BEFORE
+                        // it: a disposal racing this invocation cannot release until the window is
+                        // left, so Detach can never overtake Attach, and an Attach that throws still
+                        // counts as a claim because the remote runtime may have accepted it.
                         attachCallEntered = true;
+                        Volatile.Write(ref claimAttempted, 1);
                         return grain.Attach().ToObservable();
                     }
                     finally
                     {
-                        // Restore the retryable stable state even when GetGrain/Attach throws. A
-                        // failed first call was still INVOKED and must count as a claim for teardown:
-                        // the remote runtime may have accepted it before surfacing the exception.
-                        var stableState = attachCallEntered || hadEarlierAttempt
-                            ? AttachWasInvoked
-                            : WaitingForFirstAttempt;
-                        var stateAfterInvocation = Interlocked.CompareExchange(
-                            ref claimState, stableState, StartingAttempt);
-                        if (stateAfterInvocation == DisposeRequestedWhileStarting)
-                        {
-                            var anyAttempt = attachCallEntered || hadEarlierAttempt;
-                            Interlocked.Exchange(
-                                ref claimState,
-                                anyAttempt ? DisposedAfterAttempt : DisposedBeforeAnyAttempt);
-                            if (attachCallEntered)
-                                ReleaseClaim(grain);
-                            else if (hadEarlierAttempt)
-                                ReleaseClaim();
-                        }
+                        LeaveAttachWindow(attachCallEntered ? grain : null);
                     }
                 })
                 // `false` is "landed on a silo that is not the owner". Turning it into an error is what
@@ -1516,40 +1581,25 @@ public class OrleansRoutingService : IRoutingService, IDisposable
 
         return Disposable.Create(() =>
         {
-            var releaseHere = false;
-            var endedBeforeAnyAttempt = false;
+            int activityBeforeDisposal;
             while (true)
             {
-                var state = Volatile.Read(ref claimState);
-                var next = state switch
-                {
-                    WaitingForFirstAttempt => DisposedBeforeAnyAttempt,
-                    StartingAttempt => DisposeRequestedWhileStarting,
-                    AttachWasInvoked => DisposedAfterAttempt,
-                    _ => state
-                };
-                if (next == state || Interlocked.CompareExchange(ref claimState, next, state) == state)
-                {
-                    endedBeforeAnyAttempt = state == WaitingForFirstAttempt;
-                    releaseHere = state == AttachWasInvoked;
+                activityBeforeDisposal = Volatile.Read(ref claimActivity);
+                if (Interlocked.CompareExchange(
+                        ref claimActivity,
+                        activityBeforeDisposal | DisposeRequested,
+                        activityBeforeDisposal) == activityBeforeDisposal)
                     break;
-                }
             }
             inFlight.Remove(attach);
             podHubClaimSettled.TryRemove(address, out _);
             attach.Dispose();
-            if (endedBeforeAnyAttempt)
-            {
-                logger.LogDebug(
-                    "Pod-hub claim for {Address} not released — its registration ended before Orleans "
-                    + "reached Active, so no claim was ever attempted.",
-                    addressPath);
+            // A round inside its attach window owns the release: it has not returned from Attach()
+            // yet, and the CAS above guarantees it will see the DisposeRequested bit on its way out.
+            // Every round entering after this point is refused, so the ownership is unambiguous.
+            if (activityBeforeDisposal >= OneRoundInTheAttachWindow)
                 return;
-            }
-            // StartingAttempt handed release ownership to the Attach caller; terminal states have
-            // already been handled. Only a fully-invoked claim is released on this disposing thread.
-            if (releaseHere)
-                ReleaseClaim();
+            ReleaseClaimOnDisposal();
         });
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PodHubClaimReassertion.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PodHubClaimReassertion.md
@@ -160,6 +160,77 @@ fast membership churns, so a scale event cannot become a claim storm.
 Where no feed is registered — an Orleans client, the Monolith, a bare mesh in a test — membership
 cannot change under the process, so the claim is asserted once, exactly as before.
 
+## Two windows in which the trigger was dropped anyway (#3931)
+
+Re-asserting on the right event is necessary and was not sufficient. The trigger could be lost in two
+places *after* the design above was in, and in both the outcome is indistinguishable from never having
+had re-assertion at all: no claim, no retry, no log line, and nothing left to re-make the mapping
+until the next membership change — the #2938 state this page exists to remove.
+
+> 🚨 **Both are DROPS, not delays.** The grain-side attach count never moves, so "the claim was made
+> and its result went unobserved" is excluded by the instrument itself: the count is published from
+> inside `IPodHubGrain.Attach`.
+
+### Window one — `StartWith` subscribed the feed only after the first claim round had run
+
+`ClaimTriggers` composed the initial assertion as `Changes.StartWith(0L)`. **`StartWith` is a
+`Concat`**: the source is subscribed only once the prefix has been fully *processed*, and processing
+that prefix runs the entire first claim round — `Attach` included — on the subscribing thread.
+`IClusterMembershipFeed.Changes` is hot and deliberately does not replay, so a change arriving in
+that window was dropped **where it was published**: `Subject.OnNext` with no observer is a no-op.
+
+The window is the first claim of a hub's life — i.e. the pod's boot, which is exactly when membership
+moves. #3983 measured 34 placement failures in 65 s across two pods, all inside it.
+
+Measured on System.Reactive 6.1.0 (the pinned version) with the real shape
+(`…ObserveOn(Scheduler.Default).SelectMany(_ => triggers).Select(round).Switch()`) and a round that
+parks inside its subscribe, so the window is observable rather than inferred:
+
+```
+StartWith: ROUND-0-enter -> PUSH-enter -> PUSH-leave -> RELEASE -> ROUND-0-leave -> SUBSCRIBE-feed
+Merge    : SUBSCRIBE-feed -> ROUND-0-enter -> PUSH-enter -> RELEASE -> ROUND-0-leave -> ROUND-42-enter
+```
+
+Under `StartWith` the push completes with the feed still unsubscribed and no round for it ever runs.
+The fix is `Changes.Merge(Observable.Return(InitialClaim))`: `Merge` subscribes its sources
+left-to-right, so the **durable** source is listening before the one-shot initial trigger can start
+any work, and the merge gate then serialises the two — a change arriving mid-round queues behind it
+instead of racing it.
+
+### Window two — the claim/dispose handshake answered a transient condition terminally
+
+The handshake protecting `Attach`/`Detach` ordering was a single token. A round that found the token
+at "someone is already starting an attempt" answered `Observable.Empty` — a **terminal** answer to a
+**transient** condition. A retry round re-subscribes on its backoff timer's thread while a membership
+round arrives on the feed's, so the overlap is ordinary, and it is most likely exactly during churn,
+because churn is what makes a claim bounce in the first place.
+
+It is worse than a dropped trigger: `Switch` has already cancelled the round it overlapped, so the
+membership change **destroyed an in-flight claim and made none of its own**.
+
+The handshake is now a **ledger, not a mutex**. One interlocked word carries "disposal has been
+requested" in bit 0 and the number of rounds currently inside their synchronous attach window in the
+rest. The only reason a round may refuse to claim is disposal; whoever observes "disposed **and** the
+window is empty" owns the release — `Dispose` when it finds the window empty, otherwise the last
+round out — so `Detach` can never overtake an `Attach` that is still being invoked, and concurrent
+rounds are ordinary rather than an error.
+
+### What pins it
+
+`PodHubClaimReassertionTest` carries both directions, and both are deterministic rather than
+probabilistic: the test grain PARKS inside a nominated `Attach` call, so the contention is created
+rather than waited for.
+
+| Test | Direction |
+|---|---|
+| `AMembershipChangeDuringTheInitialClaim_IsStillAsserted` | window one |
+| `AMembershipChangeDuringARetryingClaim_IsStillAsserted` | window two |
+| `AContendedMembershipChange_IsAssertedExactlyOnce` | the opposite failure — one change is one claim |
+
+The third is not decoration. A "fix" that merely re-triggered the round would satisfy both positive
+pins and reintroduce the claim storm `Switch` exists to bound: every attempt makes the owning silo
+log a line, which is the log-storm shape #2426/#2546 exist to remove.
+
 ## The diagnosability that was missing
 
 For twelve hours the production line read:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-an-image-no-longer-breaks-on-first-view.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-an-image-no-longer-breaks-on-first-view.md
@@ -1,0 +1,27 @@
+---
+Name: A page no longer goes dark on the first view after a restart
+Category: Fix
+Description: A portal replica could stop being reachable from its peers after a cluster change, so a content read timed out and the page came back empty until the next change repaired it.
+Icon: Sparkle
+Order: -20260911
+---
+
+# A page no longer goes dark on the first view after a restart
+
+Each portal replica announces which addresses it serves, so its peers can reach it directly. That
+announcement is republished whenever the cluster's shape moves — a replica starting, stopping or
+being rescheduled — because moving the cluster is exactly what can lose it.
+
+Two narrow windows let one of those republish signals go missing. Both fell inside the moments right
+after a replica starts, which is when the cluster's shape is most likely to move, and in both the
+signal was dropped rather than delayed: nothing retried it and nothing recorded it. The replica then
+kept an announcement that no longer matched where its peers thought it lived, and nothing would
+repair that until the cluster happened to move again.
+
+What you could see when it happened: a read that should be instant instead ran to its time limit and
+came back as an error, so an image or a document was blank on first view and fine on a refresh —
+because the refresh took a different route. It looked like a slow network and was not.
+
+Both windows are closed, and the announcement is now made on every cluster change including the ones
+that arrive while an announcement is already in progress — still exactly once per change, so nothing
+announces more often than before.

--- a/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimReassertionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimReassertionTest.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Fixture;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,7 +59,32 @@ public class PodHubClaimReassertionTest
 {
     private static readonly Address Hub = new("portal", "reassert");
 
+    /// <summary>
+    /// The backstop EVERY wait in this file is bounded by. A hang bound, never the measurement:
+    /// with the claim behaving, each of these tests settles in milliseconds.
+    ///
+    /// <para>🚨 <b>It must stay strictly BELOW the runner's <c>methodTimeout</c></b> — 30 s, in this
+    /// project's own <c>xunit.runner.json</c> — and that is why it is not a
+    /// <see cref="TestTimeouts"/> value. Those scale by the CI factor (<c>Convergence</c> reaches
+    /// 108 s on a runner, <c>Quick</c> 36 s), so on CI xunit would kill the test FIRST and report an
+    /// anonymous timeout in place of the assertion naming what did not converge — the precise
+    /// inversion <see cref="TestTimeouts"/> itself exists to prevent. Nothing here waits on a
+    /// convergence whose cost scales with the machine: there is no cluster, no IO and no clock in
+    /// these tests, only an in-process claim that either fires or does not.</para>
+    /// </summary>
     private static readonly TimeSpan Budget = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// How long a "no further claim arrives" reading watches for. Negative assertions are the one
+    /// place a fixed wait is correct — there is no positive signal to filter for — so it is kept
+    /// short, and derived from <see cref="Budget"/> rather than written as a second literal.
+    /// </summary>
+    private static TimeSpan StormWindow => Budget / 10;
+
+    /// <summary>Attach-call ordinals no run reaches: the grain's default, unmodified behaviour.</summary>
+    private const int NeverPark = -1;
+
+    private const int NeverRefuse = -1;
 
     private static IObservable<IMessageDelivery> Ignore(IMessageDelivery d, CancellationToken _) =>
         Observable.Return(d);
@@ -141,6 +168,149 @@ public class PodHubClaimReassertionTest
         await WaitForAttaches(factory, 4,
             "EVERY membership change, not just the first — the ClientDirectory prior art republishes "
             + "its whole routing table on each one");
+    }
+
+    /// <summary>
+    /// 🚨 THE PIN, half one: a membership change that arrives while the INITIAL claim is still
+    /// inside its attach window must still be asserted.
+    ///
+    /// <para><b>What it caught.</b> <c>ClaimTriggers</c> composed the initial assertion as
+    /// <c>Changes.StartWith(0L)</c>, and <c>StartWith</c> is a <c>Concat</c>: the feed is subscribed
+    /// only once the prefix has been fully PROCESSED, and processing it runs the whole first round —
+    /// <c>Attach</c> included — on the subscribing thread. <see cref="IClusterMembershipFeed.Changes"/>
+    /// is hot and does not replay, so a change landing in that window was dropped WHERE IT WAS
+    /// PUBLISHED: <c>Subject.OnNext</c> with no observer is a no-op. The claim then stood against a
+    /// directory partitioning that had already moved, with nothing left to re-make it until the next
+    /// change — the #2938 state that #3034 was supposed to have removed.</para>
+    ///
+    /// <para><b>Why this is deterministic and not a race the test usually wins.</b> The grain PARKS
+    /// inside the first <c>Attach</c>, so the push below is made while the initial round is provably
+    /// still in its window. On the unfixed composition the feed cannot yet be subscribed at that
+    /// instant — <c>Concat</c> has not reached it — so the change is dropped every time, not
+    /// sometimes.</para>
+    ///
+    /// <para><b>Why the count discriminates a MISSED assertion from an unobserved one.</b> The
+    /// number this waits on is published by the GRAIN, from inside <c>Attach</c> itself. A claim
+    /// that was made but whose result went unobserved still moves it; only a claim that was never
+    /// made leaves it where it was.</para>
+    /// </summary>
+    [Fact]
+    public async Task AMembershipChangeDuringTheInitialClaim_IsStillAsserted()
+    {
+        using var feed = new TestMembershipFeed();
+        var factory = new AcceptingGrainFactory(parkOnCall: 1);
+        await using var sp = await Services(feed);
+        using var routing = Router(factory, sp, new RecordingLogger());
+
+        using var registration = routing.RegisterStream(Hub, Ignore);
+        try
+        {
+            SpinWait.SpinUntil(() => factory.IsParked, Budget).Should().BeTrue(
+                "the initial claim must reach its attach window before this test can contend with "
+                + "it — without that the contention is a coin toss and the reading below measures "
+                + "nothing");
+
+            // The contended push: a real membership change while the initial claim is demonstrably
+            // mid-attach — the interleaving the shard-0 failures hit. It does not block, because the
+            // feed hands its subscriber the same Scheduler.Default hop production's does.
+            feed.PushChange();
+        }
+        finally
+        {
+            // Release into a worker the test deliberately parked, from a finally so a failing
+            // assertion above can never strand the claim thread.
+            factory.Release();
+        }
+
+        await WaitForAttaches(factory, 2,
+            "a membership change that lands while the INITIAL claim is still in its attach window is "
+            + "the one the grain directory most needs re-asserted against, and on the unfixed "
+            + "composition the claim's own feed was not yet subscribed to hear it (#3931)");
+    }
+
+    /// <summary>
+    /// 🚨 THE PIN, half two: the same obligation for a claim that is RETRYING — a DIFFERENT defect
+    /// with the same symptom, which is why it needs its own reading.
+    ///
+    /// <para>Here the feed is demonstrably subscribed: the first attempt has already bounced, and
+    /// the trigger sequence's prefix completed when it did. So the change reaches the claim. It was
+    /// then thrown away one layer further in, by the claim/dispose handshake: a round that found
+    /// <c>claimState == StartingAttempt</c> answered <c>Observable.Empty</c> — a TERMINAL answer to
+    /// a TRANSIENT condition. Worse, <c>Switch</c> had already cancelled the round it found in
+    /// progress, so the membership change DESTROYED an in-flight claim and made none of its own.</para>
+    ///
+    /// <para>A retry round re-subscribes on its backoff timer's thread while a membership round
+    /// arrives on the feed's, so the overlap is ordinary — and it is at its most likely precisely
+    /// during churn, because churn is what makes a claim bounce in the first place.</para>
+    /// </summary>
+    [Fact]
+    public async Task AMembershipChangeDuringARetryingClaim_IsStillAsserted()
+    {
+        using var feed = new TestMembershipFeed();
+        // Refuse the first attempt so the round retries, and park on the retry: by then the initial
+        // trigger has been processed and the feed is subscribed, so this isolates the handshake.
+        var factory = new AcceptingGrainFactory(parkOnCall: 2, refuseCall: 1);
+        await using var sp = await Services(feed);
+        using var routing = Router(factory, sp, new RecordingLogger());
+
+        using var registration = routing.RegisterStream(Hub, Ignore);
+        try
+        {
+            SpinWait.SpinUntil(() => factory.IsParked, Budget).Should().BeTrue(
+                "the RETRY must reach its attach window before this test can contend with it — the "
+                + "park is what makes the overlap certain rather than occasional");
+            feed.PushChange();
+        }
+        finally
+        {
+            factory.Release();
+        }
+
+        await WaitForAttaches(factory, 3,
+            "a membership change that lands while a RETRYING round is in its attach window carries "
+            + "cluster shape that round predates, so it must make its own claim rather than be "
+            + "discarded as 'someone is already starting one' — and Switch has already cancelled "
+            + "the round it overlapped, so discarding it leaves NO claim at all (#3931)");
+    }
+
+    /// <summary>
+    /// 🚨 THE OPPOSITE DIRECTION, and the reason the pins above cannot be satisfied by simply
+    /// firing more often: ONE membership change is ONE claim, contended or not.
+    ///
+    /// <para>A fix that re-triggered the round — on the retry, on the trigger it could not place,
+    /// on anything — would satisfy both pins above and reintroduce the claim storm
+    /// <c>Switch</c> exists to bound: every attempt makes the owning silo log a line, so an
+    /// over-asserting claim is the #2426/#2546 log-storm shape wearing a repair's colours.</para>
+    /// </summary>
+    [Fact]
+    public async Task AContendedMembershipChange_IsAssertedExactlyOnce()
+    {
+        using var feed = new TestMembershipFeed();
+        var factory = new AcceptingGrainFactory(parkOnCall: 1);
+        await using var sp = await Services(feed);
+        using var routing = Router(factory, sp, new RecordingLogger());
+
+        using var registration = routing.RegisterStream(Hub, Ignore);
+        try
+        {
+            SpinWait.SpinUntil(() => factory.IsParked, Budget).Should().BeTrue(
+                "the initial claim must reach its attach window before this test can contend with "
+                + "it — this is the SAME interleaving as the positive pin, read the other way round");
+            feed.PushChange();
+        }
+        finally
+        {
+            factory.Release();
+        }
+
+        await WaitForAttaches(factory, 2, "the contended change is asserted");
+
+        // Negative, with no positive signal to filter for: a THIRD claim is the storm, and the only
+        // honest instrument is to wait a bounded while and require it never to arrive.
+        await factory.Attaches.Where(count => count >= 3).Should().NotEmit(StormWindow,
+            "one membership change is one claim: the initial assertion plus this change is exactly "
+            + "two, and a third would mean the contended round was re-fired rather than made once — "
+            + "which is the claim storm Switch bounds and the log storm #2426/#2546 removed");
     }
 
     /// <summary>
@@ -236,13 +406,21 @@ public class PodHubClaimReassertionTest
     /// <summary>
     /// A membership feed a test drives directly — the same shape
     /// <c>OrleansClusterMembershipFeed</c> presents when Orleans' silo-status oracle notifies it.
+    ///
+    /// <para>🚨 <b>The <c>ObserveOn</c> is part of that shape, not decoration.</b> Production hands
+    /// every subscriber <c>changes.ObserveOn(Scheduler.Default)</c> precisely so a subscriber's work
+    /// — here, a grain call per registered address — can never delay Orleans' own membership
+    /// processing. A test feed without it publishes INLINE on the pushing thread, so
+    /// <see cref="PushChange"/> would block at the trigger sequence's merge gate whenever a claim
+    /// round is in progress. That is the interleaving these tests deliberately create, so a feed
+    /// that lacked the hop could not push into it at all.</para>
     /// </summary>
     private sealed class TestMembershipFeed : IClusterMembershipFeed, IDisposable
     {
         private readonly Subject<long> changes = new();
         private long sequence;
 
-        public IObservable<long> Changes => changes;
+        public IObservable<long> Changes => changes.ObserveOn(Scheduler.Default);
 
         public void PushChange() => changes.OnNext(Interlocked.Increment(ref sequence));
 
@@ -258,27 +436,51 @@ public class PodHubClaimReassertionTest
     /// what <c>PodHubGrain.Attach</c> returns on the silo that owns the address. Counting happens on
     /// the GRAIN, so a <c>Detach</c> during teardown can never be mistaken for another assertion.
     /// </summary>
-    private sealed class AcceptingPodHubGrain : IPodHubGrain, IDisposable
+    private sealed class AcceptingPodHubGrain(int parkOnCall = NeverPark, int refuseCall = NeverRefuse)
+        : IPodHubGrain, IDisposable
     {
         // 🚨 A BehaviorSubject, so a waiter that subscribes AFTER the count already reached its
         // target still sees it. With a plain Subject the test would be a race it usually wins,
         // which is the worst kind of green.
         private readonly BehaviorSubject<int> attaches = new(0);
         private int attachCalls;
+        private int parked;
+        private int released;
         public int AttachCalls => Volatile.Read(ref attachCalls);
 
         /// <summary>The running attach count — the CONDITION the tests wait on.</summary>
         public IObservable<int> Attaches => attaches;
 
+        /// <summary>True once the nominated <c>Attach</c> call is parked inside the grain.</summary>
+        public bool IsParked => Volatile.Read(ref parked) == 1;
+
+        /// <summary>
+        /// Lets the parked <c>Attach</c> return. A plain volatile write into a worker the test
+        /// deliberately parked — never a gate, and always called from a <c>finally</c> so a failing
+        /// assertion cannot strand the claim thread.
+        /// </summary>
+        public void Release() => Volatile.Write(ref released, 1);
+
         public Task<bool> Attach()
         {
-            // Switch keeps exactly one claim in flight per address, so these are serialised.
-            attaches.OnNext(Interlocked.Increment(ref attachCalls));
+            var call = Interlocked.Increment(ref attachCalls);
+            attaches.OnNext(call);
+            // "Landed on a silo that is not the owner" — the answer that makes the round RETRY, so
+            // a test can reach the retry window without a clock.
+            if (call == refuseCall)
+                return Task.FromResult(false);
+            if (call == parkOnCall)
+            {
+                Volatile.Write(ref parked, 1);
+                // Bounded, so a defect cannot hang the suite; the release is the real terminal.
+                SpinWait.SpinUntil(() => Volatile.Read(ref released) == 1, Budget);
+            }
             return Task.FromResult(true);
         }
 
         public void Dispose()
         {
+            Release();
             attaches.OnCompleted();
             attaches.Dispose();
         }
@@ -293,11 +495,18 @@ public class PodHubClaimReassertionTest
     /// because it is the only shape the mesh uses — every other member throws, so a new call shape
     /// fails loudly here instead of passing silently.
     /// </summary>
-    private sealed class AcceptingGrainFactory : IGrainFactory
+    private sealed class AcceptingGrainFactory(int parkOnCall = NeverPark, int refuseCall = NeverRefuse)
+        : IGrainFactory
     {
-        private readonly AcceptingPodHubGrain podHub = new();
+        private readonly AcceptingPodHubGrain podHub = new(parkOnCall, refuseCall);
 
         public int AttachCalls => podHub.AttachCalls;
+
+        /// <inheritdoc cref="AcceptingPodHubGrain.IsParked"/>
+        public bool IsParked => podHub.IsParked;
+
+        /// <inheritdoc cref="AcceptingPodHubGrain.Release"/>
+        public void Release() => podHub.Release();
 
         /// <summary>The running attach count — see <see cref="AcceptingPodHubGrain.Attaches"/>.</summary>
         public IObservable<int> Attaches => podHub.Attaches;


### PR DESCRIPTION
## What this fixes

Re-asserting the pod-hub claim on every cluster membership change (#3034) was necessary and **not sufficient**. The trigger could still be **lost** in two places, and in both the outcome is indistinguishable from never having had re-assertion at all: no claim, no retry, no log line, and nothing left to re-make the mapping until the next membership change. That is the #2938 state — the measured cause of the `/api/content` 503 (#3088), which #3931 reports as live again on `memex.meshweaver.cloud`.

### Window one — `StartWith` subscribed the feed only after the first claim round had run

`ClaimTriggers` composed the initial assertion as `Changes.StartWith(0L)`. **`StartWith` is a `Concat`**: the source is subscribed only once the prefix has been fully *processed*, and processing the prefix runs the entire first claim round — `Attach` included — on the subscribing thread. `IClusterMembershipFeed.Changes` is hot and deliberately does not replay, so a change arriving in that window was dropped **where it was published** (`Subject.OnNext` with no observer is a no-op).

The window is the first claim of a hub's life — the pod's boot — which is exactly when membership moves. #3983 measured 34 placement failures in 65 s across two pods, all inside it.

Fixed with `Changes.Merge(Observable.Return(InitialClaim))`: `Merge` subscribes its sources left-to-right, so the **durable** source is listening before the one-shot initial trigger can start any work; the merge gate then serialises the two.

Measured on System.Reactive 6.1.0 (the pinned version) with the real shape and a round that parks inside its subscribe, so the window is observable rather than inferred:

```
StartWith: ROUND-0-enter -> PUSH-enter -> PUSH-leave -> RELEASE -> ROUND-0-leave -> SUBSCRIBE-feed
Merge    : SUBSCRIBE-feed -> ROUND-0-enter -> PUSH-enter -> RELEASE -> ROUND-0-leave -> ROUND-42-enter
```

### Window two — the claim/dispose handshake answered a transient condition terminally

A round that found the single-token handshake at *"someone is already starting an attempt"* answered `Observable.Empty` — a **terminal** answer to a **transient** condition. A retry round re-subscribes on its backoff timer's thread while a membership round arrives on the feed's, so the overlap is ordinary, and most likely during churn — because churn is what makes a claim bounce in the first place.

It is worse than a dropped trigger: `Switch` has already cancelled the round it overlapped, so the membership change **destroyed an in-flight claim and made none of its own**.

The handshake is now a **ledger, not a mutex**: one interlocked word carrying "disposal requested" in bit 0 and the number of rounds inside their synchronous attach window in the rest. Disposal is the only reason to refuse a round; whoever observes *"disposed **and** the window is empty"* owns the release, so `Detach` can never overtake an `Attach` still being invoked.

## It also fixes the shard-0 intermittent

`PodHubClaimReassertionTest.ReAssertion_ReportsTheLandingOnce_AndSettlesOnce` and `AClaimThatLanded_IsReAsserted_OnEveryMembershipChange` failed in **2 of 14** completed `MeshWeaver Build and Test` runs — including on #4012, whose entire diff is a YamlDotNet pin plus two markdown files. That was window one: the test's push raced the feed subscription, and a dropped push leaves the count one short.

**Deliberately NOT added to `.github/known-flakes.json`** — the race is the product defect, and a catalogue entry would teach the steward to re-queue past it. This unblocks #4012 and any other PR whose group build lands on it.

## MISSED, not merely unobserved

The number the tests wait on is published by the **grain**, from inside `Attach` itself. A claim that was made but whose result went unobserved still moves it. It did not move — so no claim was made.

## Controls, each falsified by reverting only its own half

| Reverted | Result |
|---|---|
| `Merge` → `StartWith` | `AMembershipChangeDuringTheInitialClaim_IsStillAsserted` **RED** — *"the claim was asserted 1 time(s), short of 2: a membership change that lands while the INITIAL claim is still in its attach window…"*. The retry pin stayed **GREEN**. |
| the ledger (`Merge` kept) | `AMembershipChangeDuringARetryingClaim_IsStillAsserted` **RED** — *"the claim was asserted 2 time(s), short of 3: … and Switch has already cancelled the round it overlapped, so discarding it leaves NO claim at all"*. 6 others **GREEN**. |
| initial trigger made to fire twice — a "fix" that merely fires more often | `AContendedMembershipChange_IsAssertedExactlyOnce` **RED on its own `NotEmit`** — *"Expected the observable not to emit within 1.2s because one membership change is one claim … but it emitted 3"*. |

Both positive pins are **deterministic, not probabilistic**: the test grain parks inside a nominated `Attach` call, so the contention is created rather than waited for.

## Verification

Release, `-warnaserror`, `0 Error(s)` on every build:

| Suite | Result |
|---|---|
| `MeshWeaver.Hosting.Orleans.Test` | 259/259 |
| `MeshWeaver.Documentation.Test` | 396/396 (link integrity, What's New, every ratchet guard) |
| `MeshWeaver.ContentCollections.Test` | 28/28 |
| `MeshWeaver.Messaging.Hub.Test` | 409/409 |

## Notes

- Doc: the existing `Doc/Architecture/PodHubClaimReassertion` page gains a "Two windows in which the trigger was dropped anyway" section — extended, not duplicated.
- What's New: `Category: Fix` — a user sees an image or document blank on first view and fine on refresh.
- The unreviewed rescue of the in-flight work this builds on is preserved verbatim at `origin/fix/3931-podhub-claim-reassertion-dropped`.

Refs #3931, refs #3088, refs #2938, refs #3034, refs #3983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### One more thing the controls surfaced

Every wait in `PodHubClaimReassertionTest` is now bounded by a single `Budget`, and it deliberately is **not** a `TestTimeouts` value. This project's own `xunit.runner.json` sets `methodTimeout: 30000`, while `TestTimeouts.Convergence` reaches **108 s** on a runner and `Quick` **36 s** — so a `TestTimeouts`-derived bound would have xunit kill the test *first* on CI and report an anonymous timeout in place of the assertion naming what did not converge. That is the exact inversion `TestTimeouts` itself exists to prevent, and it is why the pre-existing 20 s value is kept rather than "modernised". The reasoning is written onto the field so the next reader does not undo it.

The control re-runs above were all taken under that bound: the two positive pins fail at **20 s**, named.

### Shard co-tenancy is ruled out, not assumed away

`SHARD_INDEX=0 SHARD_TOTAL=6 .github/scripts/shard-assign.sh` →

```
shard-assign: shard 0/6, weighted loads: 269 92 92 91 91 91
test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
```

Shard 0 carries **exactly one project** — this one, deliberately given its own shard at weight 269. So no other project's state, and no shared on-disk cache filled by a co-tenant, can select which code path runs there. The only co-tenants are this assembly's own 259 tests under `maxParallelThreads: 4`, and the defect reproduces deterministically **locally with no co-tenants at all**.
